### PR TITLE
Add fused-render-usage skill; default to embed mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "fused-render",
       "source": "./",
-      "description": "Skills for authoring fused-render views: HTML pages with a fused.runPython() bridge to local Python, URL-synced params, file IO helpers, and custom preview templates.",
+      "description": "Skills for using and authoring fused-render: running the local explorer and opening views, plus authoring HTML pages with a fused.runPython() bridge to local Python, URL-synced params, file IO helpers, and custom preview templates.",
       "author": {
         "name": "Fused"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fused-render",
   "displayName": "Fused Render",
-  "description": "Skills for authoring fused-render views: HTML pages with a fused.runPython() bridge to local Python, URL-synced params, file IO helpers, and custom preview templates.",
+  "description": "Skills for using and authoring fused-render: running the local explorer and opening views, plus authoring HTML pages with a fused.runPython() bridge to local Python, URL-synced params, file IO helpers, and custom preview templates.",
   "author": {
     "name": "Fused",
     "url": "https://github.com/fusedio"

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ See `examples/sine.py` + `examples/sine.html` for a complete working example.
 ## Claude Code plugin
 
 This repo doubles as a [Claude Code](https://code.claude.com/docs) plugin
-marketplace. Installing the plugin adds skills that teach Claude how to author
-fused-render views (the `fused.runPython` bridge, URL-synced params, file IO
-helpers) and custom preview templates.
+marketplace. Installing the plugin adds skills that teach Claude how to use a fused-render
+project (running the explorer, opening views by URL), author fused-render
+views (the `fused.runPython` bridge, URL-synced params, file IO helpers), and
+build custom preview templates.
 
 This is a **private repo**, so add the marketplace by its **SSH git URL**
 (the `owner/repo` shorthand only works for public repos). You need SSH access

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fused-render-authoring
-description: How to author HTML views and Python data files for fused-render — the local file explorer that live-renders HTML with a fused.runPython() bridge to local Python, URL-synced params, and file IO helpers (fused.readFile/writeFile/stat/rawUrl). Use this whenever the user asks to create, edit, or debug an .html view, a .py data file, or a preview template for fused-render; mentions fused.runPython, fused.params, fused.readFile, fused.writeFile, renderable HTML, preview templates, or _file; or asks for "a view for <some file/data>" or an editor for a file format inside a fused-render project. Also use it when a fused-render view renders blank, shows a red traceback overlay, or params don't sync to the URL.
+description: How to author HTML views and Python data files for fused-render (the local HTML explorer with a fused.runPython() bridge, URL-synced params, and file IO helpers). Use when creating, editing, or debugging an .html view, a .py data file, or a preview template; when a view renders blank, shows a traceback overlay, or params don't sync to the URL; or when the user mentions fused.runPython/params/readFile/writeFile or asks for "a view for <file/data>".
 ---
 
 # Authoring fused-render views

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -205,14 +205,16 @@ Verify a view by opening it in a real browser against the running server — do 
 | Path | What it renders | Use it to |
 |---|---|---|
 | `/` | The explorer at `start_dir` — file listing with chrome. | Browse to a file by clicking. |
-| `/view/<abs-path-without-leading-slash>` | **Normal view mode**: the file inside the full shell — sidebar, breadcrumb, preview header — with your page in an iframe. | The default way to open and test a view. |
-| `/embed/<abs-path-without-leading-slash>` | **Embed mode**: the exact same page and routing, but chrome-free (no sidebar/breadcrumb/header). | Test how the view looks when iframed into a dashboard or another view. |
+| `/embed/<abs-path-without-leading-slash>` | **Embed mode**: the page chrome-free (no sidebar/breadcrumb/header). | **The default way to open and test a view** — you see just the view itself. |
+| `/view/<abs-path-without-leading-slash>` | **Full-shell mode**: the same page inside the explorer shell — sidebar, breadcrumb, preview header — with your page in an iframe. | Check how the view sits inside the explorer chrome, or when browsing. |
 
-Path encoding: the fs path rides in the URL after the prefix with its **leading slash dropped** and each segment URL-encoded. `/Users/me/proj/dash.html` → `http://127.0.0.1:8765/view/Users/me/proj/dash.html`. A space becomes `%20`, etc.
+**Default to embed.** When you open a link to test a view or show it to the user, use `/embed/` — it renders the view alone, which is what you're iterating on. Reach for `/view/` only to inspect the surrounding chrome or when the user is browsing.
+
+Path encoding: the fs path rides in the URL after the prefix with its **leading slash dropped** and each segment URL-encoded. `/Users/me/proj/dash.html` → `http://127.0.0.1:8765/embed/Users/me/proj/dash.html`. A space becomes `%20`, etc.
 
 **View vs embed** is a fixed page-load mode (the prefix picks it; it cannot toggle without a full navigation). Both serve the same shell and route identically — embed just hides chrome. Params sync the same way in both; in nested embeds, param sync stops at each embed shell boundary so a tab's params stay tab-independent.
 
-**Preview templates** open at the target file's path (`/view/<abs path to the data file>`) — the shell resolves the template by extension and hands it the file via the read-only `_file` param. To test a template's html directly, open it and pass the target yourself: `/view/<abs path to template>.html?_file=<abs target path>`.
+**Preview templates** open at the target file's path (`/embed/<abs path to the data file>`) — the shell resolves the template by extension and hands it the file via the read-only `_file` param. To test a template's html directly, open it and pass the target yourself: `/embed/<abs path to template>.html?_file=<abs target path>`.
 
 **API endpoints** (`/api/config`, `/api/fs/stat|list|raw|events`, `/api/fs/write`, `/api/run`) back the runtime — reach them only through the `fused.*` helpers, never by hand (see the note above). They're listed here only so you recognize them in the network tab while debugging.
 

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: fused-render-usage
+description: How to run and use a fused-render project — start the local server, browse the filesystem, and open views/files in the browser. Use this whenever the user wants to open, run, launch, start, serve, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
+---
+
+# Using a fused-render project
+
+fused-render is a **local file explorer** that runs entirely on `127.0.0.1` — no accounts, no cloud. It browses any directory in the browser, previews files, and live-renders `.html` views that call local Python. This skill covers **running and using** an existing project; it does not cover writing views (that's `fused-render-authoring`).
+
+## Running the server
+
+```
+fused-render                                    # opens a tab at http://127.0.0.1:8765/, starting in $HOME
+fused-render --start-dir ~/data --port 9000     # different start dir + port
+fused-render --port 8765 --no-browser           # don't steal focus (best when driving it yourself)
+```
+
+`--start-dir` only sets the initial location; the whole filesystem stays browsable from there. When you launch it to open something for the user or to test a change, prefer `--no-browser` and open the specific URL yourself (see below) rather than landing them on the home directory.
+
+Source checkout only: the React shell must be built once before the server starts (`cd frontend && bun install && bun run build`, Node 22), or use `scripts/dev.sh` for the watch+server dev loop. Wheels and the `.app` ship the shell prebuilt.
+
+## Opening files and views by URL
+
+The filesystem path rides in the URL after a mode prefix, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `.../embed/Users/me/proj/dash.html`.
+
+| Path | Renders |
+|---|---|
+| `/` | The explorer at `start_dir` — click to browse. |
+| `/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). **Default for opening a specific view.** |
+| `/view/<path>` | **Full-shell mode** — the same page wrapped in the explorer chrome (sidebar, breadcrumb, preview header). |
+
+### Default to embed mode
+
+**When you open a link to a specific view/file for the user or to show a change, use `/embed/` by default.** Embed shows only the view itself — the thing the user actually cares about — without the explorer chrome around it. Reach for `/view/` only when the user is *browsing* (wants the sidebar/breadcrumb to navigate) or explicitly asks to see the file inside the full explorer shell.
+
+View vs embed is a fixed page-load mode set by the prefix — it cannot toggle without a full navigation. Both serve the same page, route identically, and sync URL params the same way; embed just hides the chrome.
+
+**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `/embed/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. You don't point at the template html; you point at the data file.
+
+## Where things live in a project
+
+- A **view** is usually a sibling pair: an `.html` page (UI) + a `.py` file (data it fetches via `fused.runPython`).
+- Built-in preview templates live under `fused_render/templates/<name>/`; user-owned ones under `~/.fused-render/` (see `fused-render-custom-templates`).
+- View state lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to share the exact state.
+
+## When to switch skills
+
+- Creating, editing, or debugging an `.html` view or `.py` data file, or a blank/errored view → **`fused-render-authoring`**.
+- Registering a custom preview template for a file extension → **`fused-render-custom-templates`**.

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -17,6 +17,10 @@ fused-render --port 8765 --no-browser           # don't steal focus (best when d
 
 `--start-dir` only sets the initial location; the whole filesystem stays browsable from there. When you launch it to open something for the user or to test a change, prefer `--no-browser` and open the specific URL yourself (see below) rather than landing them on the home directory.
 
+### macOS desktop app
+
+On macOS, fused-render also ships as a standalone **`FusedRender.app`** (packaged as `dist/FusedRender-<version>.dmg` via `bash scripts/build_dmg.sh`). It bundles Python and a prebuilt shell — no `pip install`, no Node — so a non-developer just double-clicks it to launch the same local server and browser tab. The `.app` also ships an offline wheelhouse (numpy, pandas, requests, duckdb, polars, matplotlib, scipy, pillow, openpyxl, shapely, geopandas + pyarrow), so views built on those packages work with no network. Everything below — URLs, modes, params — is identical whether the server was started by the CLI or the app.
+
 Source checkout only: the React shell must be built once before the server starts (`cd frontend && bun install && bun run build`, Node 22), or use `scripts/dev.sh` for the watch+server dev loop. Wheels and the `.app` ship the shell prebuilt.
 
 ## Opening files and views by URL


### PR DESCRIPTION
## Summary

- Adds a new lightweight **`fused-render-usage`** skill for *running and using* a fused-render project (start the server, browse, open views/files by URL). Previously the only project skill was `fused-render-authoring`, which is scoped to creating/editing/debugging code — so a user who just wants to open or run a project loaded nothing relevant and the agent was prone to hallucinating behavior.
- Makes **`/embed`** the default mode for opening a specific view across both skills. Embed renders the view alone (chrome-free), which is what the user actually cares about; `/view` (full explorer shell) is now reserved for browsing or inspecting chrome.
- Updates `plugin.json`, `marketplace.json`, and the README plugin section to mention the using-a-project skill.

## Visuals

Skill routing after this change — the new usage skill catches the "open/run" intent that previously had no home:

```mermaid
flowchart TD
    U[User request in a fused-render project] --> Q{Intent?}
    Q -->|open / run / browse / show a view| USAGE[fused-render-usage NEW]
    Q -->|create / edit / debug .html or .py| AUTH[fused-render-authoring]
    Q -->|register a custom preview template| TMPL[fused-render-custom-templates]
    USAGE -.default open mode.-> EMBED["/embed/&lt;path&gt; (chrome-free)"]
    AUTH -.default open mode.-> EMBED
    USAGE -.->|hands off for authoring| AUTH
    TMPL -.->|hands off for html/py| AUTH
```

## Usage

Nothing is code-invocable — this is skills/docs. The behavior change reviewers will observe:

- Ask the agent to "open this view in fused-render" → it launches `fused-render --no-browser` and opens `http://127.0.0.1:8765/embed/<path>` (embed) rather than `/view/<path>`.
- Ask to "browse the project" → `/view/` or `/` (explorer chrome) is still used.

## Test Plan

- [ ] No automated tests — change is skill markdown + plugin/README metadata; repo has no test suite covering these.
- [ ] Manual: skills are auto-discovered from `skills/`; after reinstalling the plugin from this branch, `fused-render-usage` appears in the skill list.
- [ ] Manual: verify the authoring skill's testing section now leads with `/embed/` and example URLs use the embed prefix.
- [ ] Manual: `plugin.json` / `marketplace.json` remain valid JSON.
