### PR TITLE
Annotation UX polish + Fused branding

### DIFF
--- a/frontend/src/components/ModeSwitcher.tsx
+++ b/frontend/src/components/ModeSwitcher.tsx
@@ -13,6 +13,13 @@ export interface ModeSwitcherEntry<M extends string> {
   icon: React.ReactNode;
 }
 
+// Human-readable tooltip for a mode name: the "_render" sentinel reads as
+// "Rendered", ordinary mode names are capitalized ("code" → "Code").
+function modeTitle(mode: string): string {
+  if (mode === "_render") return "Rendered";
+  return mode.charAt(0).toUpperCase() + mode.slice(1);
+}
+
 interface ModeSwitcherProps<M extends string> {
   entries: ModeSwitcherEntry<M>[];
   active: M;
@@ -28,7 +35,7 @@ export default function ModeSwitcher<M extends string>({ entries, active, onSele
           key={e.mode}
           type="button"
           className={"mode-switcher-btn" + (e.mode === active ? " active" : "")}
-          title={e.mode}
+          title={modeTitle(e.mode)}
           onClick={() => onSelect(e.mode)}
         >
           {e.icon}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -510,7 +510,18 @@ export default function Sidebar({ config }: SidebarProps) {
   return (
     <nav id="sidebar">
       <div className="sidebar-brand">
-        <span className="logo">✦</span> fused-render
+        {/* Fused cube mark (brand asset logo-black-bg-transparent.svg), stroke
+            follows .logo's color so it stays on the accent token. */}
+        <span className="logo">
+          <svg width="20" height="20" viewBox="0 0 233 233" fill="none" aria-hidden="true">
+            <path
+              d="M43.916 84.6995L80.0899 105.742M43.916 84.6995L80.0899 64.13M43.916 84.6995V126.548M80.0899 105.742L114.383 125.69C115.548 126.368 116.264 127.613 116.264 128.96V162.056C116.264 164.973 113.101 166.793 110.579 165.326L43.916 126.548M80.0899 105.742V182.862C80.0899 185.779 76.9269 187.598 74.405 186.131L45.7968 169.49C44.6324 168.813 43.916 167.567 43.916 166.22V126.548M80.0899 105.742L152.674 64.13M80.0899 64.13L114.4 44.6204C115.556 43.9629 116.973 43.961 118.131 44.6152L152.674 64.13M80.0899 64.13L150.785 104.659C151.955 105.329 153.392 105.327 154.559 104.652L183.353 88.0121C185.887 86.5475 185.869 82.883 183.321 81.4432L152.674 64.13"
+              stroke="currentColor"
+              strokeWidth="12"
+            />
+          </svg>
+        </span>{" "}
+        fused-render
       </div>
       <div className="sidebar-section">
         <a href="#" id="home-link" className="sidebar-item" onClick={onHomeClick}>

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -558,9 +558,29 @@ table.listing-table td.mtime {
 }
 
 /* Annotate toggle (AN-2): same icon-button family as .mode-switcher-btn, but
-   position:relative for the badge. */
+   position:relative for the badge, and separated from the mode switcher by a
+   hairline divider — it is an orthogonal on/off, not a fourth mode. */
 .preview-actions .annotate-toggle {
   position: relative;
+  margin-left: 10px;
+}
+.preview-actions .annotate-toggle::before {
+  content: "";
+  position: absolute;
+  left: -10px;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--border);
+}
+
+/* Solid accent fill is reserved for the single-select mode switcher; the
+   binary annotate toggle gets a tinted-outline on-state so "armed to comment"
+   and "active mode" never read as the same thing. */
+.preview-actions .mode-switcher-btn.annotate-toggle.active {
+  background: color-mix(in srgb, var(--accent) 18%, var(--bg));
+  border-color: var(--accent);
+  color: var(--accent);
 }
 
 /* Template-mode icon: monochrome SVG tinted via mask-image + currentColor

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -5,7 +5,7 @@
   --border: #2a2d33;
   --bg: #131417;
   --bg-alt: #1b1d21;
-  --accent: #5b9dff;
+  --accent: #E5FF44;
   --error: #ff6b6b;
 }
 
@@ -55,6 +55,8 @@ body {
 
 .sidebar-brand .logo {
   color: var(--accent);
+  display: flex;
+  align-items: center;
 }
 
 .sidebar-section {
@@ -118,7 +120,7 @@ body {
 }
 
 .bookmark-row.active {
-  background: rgba(91, 157, 255, 0.13);
+  background: rgba(229, 255, 68, 0.13);
 }
 
 .bookmark-row.active .bookmark-name {
@@ -383,7 +385,7 @@ body {
 .star-btn.starred {
   color: var(--accent);
   border-color: var(--accent);
-  background: rgba(91, 157, 255, 0.13);
+  background: rgba(229, 255, 68, 0.13);
 }
 
 #content {

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -72,7 +72,7 @@ def script_requirements(text: str) -> list[str]:
     return []
 
 
-def build_code(user_code: str, script_dir: str) -> str:
+def build_code(user_code: str, script_dir: str, script_path: str) -> str:
     """Wrap user code so its imports and data paths resolve next to the .py.
 
     Preamble is ONE physical line so user tracebacks are offset by exactly 1.
@@ -81,10 +81,16 @@ def build_code(user_code: str, script_dir: str) -> str:
     until then. The epilogue instead wraps the registered UDF so the chdir to
     the script's dir happens just before main() runs — relative data paths in
     main() resolve against the script, params still get found.
+
+    `__file__` is set to the script's real path: the backend exec()s the code
+    as "<lambda_exec>" where Python defines no __file__ at all, but scripts
+    legitimately use it (os.path.dirname(__file__)) — the old subprocess
+    executor ran the real file, so this keeps that contract.
     """
     preamble = (
         f"import os as _fused_os, sys as _fused_sys; "
-        f"_fused_sys.path.insert(0, {script_dir!r})\n"
+        f"_fused_sys.path.insert(0, {script_dir!r}); "
+        f"__file__ = {script_path!r}\n"
     )
     epilogue = f"""
 try:
@@ -175,7 +181,8 @@ async def run_python(path: str, params: dict) -> dict:
     except ValueError as e:
         return _error(str(e))
 
-    code = build_code(user_code, os.path.dirname(os.path.abspath(path)))
+    abs_path = os.path.abspath(path)
+    code = build_code(user_code, os.path.dirname(abs_path), abs_path)
     r = await get_backend().execute(
         code=code,
         requirements=reqs or None,

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -72,7 +72,7 @@ def script_requirements(text: str) -> list[str]:
     return []
 
 
-def build_code(user_code: str, script_dir: str, script_path: str) -> str:
+def build_code(user_code: str, script_dir: str) -> str:
     """Wrap user code so its imports and data paths resolve next to the .py.
 
     Preamble is ONE physical line so user tracebacks are offset by exactly 1.
@@ -81,16 +81,10 @@ def build_code(user_code: str, script_dir: str, script_path: str) -> str:
     until then. The epilogue instead wraps the registered UDF so the chdir to
     the script's dir happens just before main() runs — relative data paths in
     main() resolve against the script, params still get found.
-
-    `__file__` is set to the script's real path: the backend exec()s the code
-    as "<lambda_exec>" where Python defines no __file__ at all, but scripts
-    legitimately use it (os.path.dirname(__file__)) — the old subprocess
-    executor ran the real file, so this keeps that contract.
     """
     preamble = (
         f"import os as _fused_os, sys as _fused_sys; "
-        f"_fused_sys.path.insert(0, {script_dir!r}); "
-        f"__file__ = {script_path!r}\n"
+        f"_fused_sys.path.insert(0, {script_dir!r})\n"
     )
     epilogue = f"""
 try:
@@ -181,8 +175,7 @@ async def run_python(path: str, params: dict) -> dict:
     except ValueError as e:
         return _error(str(e))
 
-    abs_path = os.path.abspath(path)
-    code = build_code(user_code, os.path.dirname(abs_path), abs_path)
+    code = build_code(user_code, os.path.dirname(os.path.abspath(path)))
     r = await get_backend().execute(
         code=code,
         requirements=reqs or None,

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -52,9 +52,10 @@ TEMPLATES = {
     ".flac": ["media"],
     # source code — CodeMirror, mode chosen by extension (note: .json routes to
     # the JSON tree template above, not here)
-    # python — editable buffer first; `api` is the swagger-style run form
-    # over the @fused.udf entry point (D63)
-    ".py": ["code", "api"],
+    # python — editable buffer only. The swagger-style `api` run form (D63)
+    # is unbound by default to keep the header to code + annotate; rebind via
+    # the user registry (`".py": ["code", "api"]` in ~/.fused-render/registry.json).
+    ".py": ["code"],
     ".js": ["code"],
     ".ts": ["code"],
     ".sh": ["code"],

--- a/fused_render/static/annotate.js
+++ b/fused_render/static/annotate.js
@@ -468,9 +468,22 @@
        so it never mutates the user's layout (AN-10). */
     #__fa_hl {
       position: fixed; pointer-events: none; z-index: ${Z};
-      border: 2px solid var(--fa-accent);
-      background: color-mix(in srgb, var(--fa-accent) 12%, transparent);
+      border: 1.5px solid var(--fa-accent);
+      background: color-mix(in srgb, var(--fa-accent) 8%, transparent);
       border-radius: 3px; display: none;
+      transition: left 90ms cubic-bezier(0.4, 0, 0.2, 1),
+                  top 90ms cubic-bezier(0.4, 0, 0.2, 1),
+                  width 90ms cubic-bezier(0.4, 0, 0.2, 1),
+                  height 90ms cubic-bezier(0.4, 0, 0.2, 1);
+    }
+    /* Anchor dot: while a draft is open, marks the exact click point so the
+       composer is visually tethered to what it annotates. */
+    #__fa_dot {
+      position: fixed; pointer-events: none; z-index: ${Z};
+      width: 10px; height: 10px; border-radius: 50%;
+      background: var(--fa-accent); border: 2px solid var(--fa-bg);
+      transform: translate(-50%, -50%); display: none;
+      box-shadow: 0 0 0 2px color-mix(in srgb, var(--fa-accent) 40%, transparent);
     }
     /* Pins live in document coords (absolute, scroll with content — AN-11). */
     #__fa_pins { position: absolute; top: 0; left: 0; pointer-events: none; }
@@ -509,7 +522,11 @@
     }
     .__fa_pop textarea:focus { border-color: var(--fa-accent); }
     .__fa_draftwrap, .__fa_replywrap { padding: 8px; }
-    .__fa_hint { color: var(--fa-muted); font-size: 10px; margin-top: 4px; }
+    .__fa_hint { color: var(--fa-muted); font-size: 11px; margin-top: 4px; }
+    .__fa_btn.__fa_primary {
+      background: var(--fa-accent); color: #10131a; border-color: var(--fa-accent);
+    }
+    .__fa_btn.__fa_primary:hover { filter: brightness(1.1); }
     .__fa_footer {
       display: flex; gap: 8px; padding: 8px 12px;
       border-top: 1px solid var(--fa-border); background: var(--fa-bg-alt);
@@ -561,6 +578,7 @@
   root.id = "__fa_root";
   root.innerHTML = `
     <div id="__fa_hl"></div>
+    <div id="__fa_dot"></div>
     <div id="__fa_pins"></div>
     <div id="__fa_tray"><div id="__fa_tray_title">Detached comments</div><div id="__fa_tray_list"></div></div>
     <div id="__fa_toast"></div>
@@ -615,6 +633,13 @@
   function pageAnchorPoint(el) {
     const r = el.getBoundingClientRect();
     return { x: r.right + window.scrollX, y: r.top + window.scrollY };
+  }
+
+  // Clamp a pin's document coords so it never straddles/overruns the page edge
+  // (a full-width element's top-right corner sits exactly on the boundary).
+  function clampPin(x, y) {
+    const maxX = Math.max(document.documentElement.scrollWidth, window.innerWidth) - 12;
+    return { x: Math.max(12, Math.min(x, maxX)), y: Math.max(12, y) };
   }
 
   // ===========================================================================
@@ -699,12 +724,26 @@
     const anchor = anchorFields || buildAnchor(el, pageX, pageY);
     hlEl().style.display = "none";
 
+    // Tether the composer to what it annotates: an anchor dot at the click
+    // point, removed when the popover closes.
+    const dot = root.querySelector("#__fa_dot");
+    dot.style.left = clientX + "px";
+    dot.style.top = clientY + "px";
+    dot.style.display = "block";
+
     const pop = document.createElement("div");
     pop.className = "__fa_pop";
+    // The composer needs a VISIBLE primary action, not just the keyboard hint
+    // — the thread popover already has a button footer; mirror it.
     pop.innerHTML = `
       <div class="__fa_draftwrap">
         <textarea placeholder="Add a comment…"></textarea>
         <div class="__fa_hint">Enter to save · Shift+Enter for newline · Esc to cancel</div>
+      </div>
+      <div class="__fa_footer">
+        <span class="__fa_spacer"></span>
+        <button class="__fa_btn" data-act="cancel">Cancel</button>
+        <button class="__fa_btn __fa_primary" data-act="save">Comment</button>
       </div>`;
     root.appendChild(pop);
     positionPopover(pop, clientX, clientY);
@@ -712,12 +751,18 @@
     const ta = pop.querySelector("textarea");
     ta.focus();
 
+    const submit = () => {
+      const content = ta.value.trim();
+      if (!content) return; // empty submit = ignore (AN-10)
+      submitDraft(anchor, content);
+    };
+    pop.querySelector('[data-act="save"]').addEventListener("click", submit);
+    pop.querySelector('[data-act="cancel"]').addEventListener("click", () => closePopover());
+
     ta.addEventListener("keydown", (ev) => {
       if (ev.key === "Enter" && !ev.shiftKey) {
         ev.preventDefault();
-        const content = ta.value.trim();
-        if (!content) return; // empty submit = ignore (AN-10)
-        submitDraft(anchor, content);
+        submit();
       } else if (ev.key === "Escape") {
         ev.preventDefault();
         closePopover();
@@ -936,6 +981,8 @@
   function closePopover() {
     if (openPopover && openPopover.el) openPopover.el.remove();
     openPopover = null;
+    const dot = root.querySelector("#__fa_dot");
+    if (dot) dot.style.display = "none";
   }
 
   // ===========================================================================
@@ -944,7 +991,9 @@
 
   function pinGlyph(thread) {
     if (thread.status === "resolved") return "✓"; // ✓
-    return thread.replies.length > 0 ? String(thread.replies.length) : "•"; // •
+    // Zero replies: empty — the teardrop pin shape itself is the comment
+    // marker ("•" read as a stray bullet). Reply count carries thread size.
+    return thread.replies.length > 0 ? String(thread.replies.length) : "";
   }
 
   // Full render: place a pin for every attached/free thread, dock detached ones
@@ -975,8 +1024,9 @@
       }
       const pin = document.createElement("div");
       pin.className = "__fa_pin" + (thread.status === "resolved" ? " __fa_resolved" : "");
-      pin.style.left = x + "px";
-      pin.style.top = y + "px";
+      const cp = clampPin(x, y);
+      pin.style.left = cp.x + "px";
+      pin.style.top = cp.y + "px";
       pin.textContent = pinGlyph(thread);
       pin.title = thread.content;
       // pointerup, not click: if an async page mutation rebuilds pins between
@@ -1041,8 +1091,9 @@
         x = p.x;
         y = p.y;
       }
-      pin.style.left = x + "px";
-      pin.style.top = y + "px";
+      const cp = clampPin(x, y);
+      pin.style.left = cp.x + "px";
+      pin.style.top = cp.y + "px";
     }
     if (i !== pins.length) render(); // count mismatch → rebuild
     // Keep an open thread popover glued to its anchor while scrolling.
@@ -1149,6 +1200,12 @@
     elementModeWired = true;
     document.body.classList.add("__fa_active"); // crosshair cursor (AN-10)
     render();
+
+    // First-run guidance: with zero comments the mode is just a crosshair —
+    // say what clicking does. (Editor surfaces show their own status line.)
+    if (comments.length === 0) {
+      showToast("Click any element to leave a comment");
+    }
 
     document.addEventListener("mousemove", onMouseMove, true);
     window.addEventListener("click", onClickCapture, true); // capture: page clicks

--- a/fused_render/static/annotate.js
+++ b/fused_render/static/annotate.js
@@ -451,7 +451,7 @@
     #__fa_root, #__fa_root * { box-sizing: border-box; }
     #__fa_root {
       --fa-bg: #1b1d21; --fa-bg-alt: #131417; --fa-fg: #e8eaed;
-      --fa-muted: #9aa0a6; --fa-border: #2a2d33; --fa-accent: #5b9dff;
+      --fa-muted: #9aa0a6; --fa-border: #2a2d33; --fa-accent: #E5FF44;
       position: absolute; top: 0; left: 0; width: 0; height: 0;
       z-index: ${Z};
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
@@ -460,7 +460,7 @@
     @media (prefers-color-scheme: light) {
       #__fa_root {
         --fa-bg: #ffffff; --fa-bg-alt: #f2f3f5; --fa-fg: #1a1c1f;
-        --fa-muted: #6b7178; --fa-border: #d7dade; --fa-accent: #2f6bff;
+        --fa-muted: #6b7178; --fa-border: #d7dade; --fa-accent: #8a9a00;
       }
     }
     body.__fa_active { cursor: crosshair; }

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -68,7 +68,7 @@
     color: #9aa0a6;
   }
   #status.error { color: #ff6b6b; }
-  #status a { color: #5b9dff; }
+  #status a { color: #E5FF44; }
   /* Selection-anchor decorations (SPEC §17.5, AN-20). Attached comments tint
      their range; resolved comments use a muted grey. Applied to CM6 mark
      decorations built by the annotate adapter below. */
@@ -77,11 +77,11 @@
      on hover (all spans of the comment get .__fa_sel_hover via delegation,
      since one CM mark can split into several DOM spans). */
   .__fa_sel {
-    background: rgba(91, 157, 255, 0.18);
-    border-bottom: 2px solid rgba(91, 157, 255, 0.85);
+    background: rgba(229, 255, 68, 0.18);
+    border-bottom: 2px solid rgba(229, 255, 68, 0.85);
     cursor: pointer;
   }
-  .__fa_sel.__fa_sel_hover { background: rgba(91, 157, 255, 0.3); }
+  .__fa_sel.__fa_sel_hover { background: rgba(229, 255, 68, 0.3); }
   .__fa_sel_resolved {
     background: rgba(154, 160, 166, 0.08);
     border-bottom: 2px dashed rgba(154, 160, 166, 0.5);

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -77,7 +77,7 @@
      on hover (all spans of the comment get .__fa_sel_hover via delegation,
      since one CM mark can split into several DOM spans). */
   .__fa_sel {
-    background: rgba(91, 157, 255, 0.12);
+    background: rgba(91, 157, 255, 0.18);
     border-bottom: 2px solid rgba(91, 157, 255, 0.85);
     cursor: pointer;
   }

--- a/fused_render/templates/geotiff/template.html
+++ b/fused_render/templates/geotiff/template.html
@@ -22,7 +22,7 @@
     --muted-foreground:#9aa0a6;
     --border:#2a2d33;
     --input:#2a2d33;
-    --ring:#5b9dff;
+    --ring:#E5FF44;
     --primary:#e8eaed;
     --muted-30:rgba(42,45,51,0.35);
   }

--- a/fused_render/templates/markdown/template.html
+++ b/fused_render/templates/markdown/template.html
@@ -30,7 +30,7 @@
     line-height: 1.25;
     font-weight: 600;
   }
-  #doc a { color: #5b9dff; }
+  #doc a { color: #E5FF44; }
   #doc code {
     font-family: ui-monospace, Menlo, Consolas, monospace;
     font-size: 85%;
@@ -75,7 +75,7 @@
     color: #9aa0a6;
   }
   #status.error { color: #ff6b6b; }
-  #status a { color: #5b9dff; }
+  #status a { color: #E5FF44; }
 </style>
 </head>
 <body>

--- a/fused_render/templates/netcdf/template.html
+++ b/fused_render/templates/netcdf/template.html
@@ -22,7 +22,7 @@
     --muted-foreground:#9aa0a6;
     --border:#2a2d33;
     --input:#2a2d33;
-    --ring:#5b9dff;
+    --ring:#E5FF44;
     --primary:#e8eaed;
     --muted-30:rgba(42,45,51,0.35);
   }

--- a/fused_render/templates/text/template.html
+++ b/fused_render/templates/text/template.html
@@ -25,7 +25,7 @@
     color: #9aa0a6;
   }
   #status a {
-    color: #5b9dff;
+    color: #E5FF44;
   }
 </style>
 </head>

--- a/fused_render/templates/tree/template.html
+++ b/fused_render/templates/tree/template.html
@@ -28,7 +28,7 @@
     user-select: none;
   }
   .row.foldable:hover > .toggle { color: #e8eaed; }
-  .key { color: #5b9dff; }
+  .key { color: #E5FF44; }
   .punct, .count { color: #9aa0a6; }
   .count { font-style: italic; }
   .collapsed > .node { display: none; }
@@ -43,7 +43,7 @@
     white-space: normal;
   }
   #status.error { color: #ff6b6b; }
-  #status a { color: #5b9dff; }
+  #status a { color: #E5FF44; }
   pre.raw {
     margin: 16px 0 0;
     padding: 12px;

--- a/fused_render/templates/zarr/template.html
+++ b/fused_render/templates/zarr/template.html
@@ -23,7 +23,7 @@
     --muted-foreground:#9aa0a6;
     --border:#2a2d33;
     --input:#2a2d33;
-    --ring:#5b9dff;
+    --ring:#E5FF44;
     --primary:#e8eaed;
     --muted-30:rgba(42,45,51,0.35);
     --muted-50:rgba(42,45,51,0.6);


### PR DESCRIPTION
UI-only PR (design-review findings + branding). The engine `__file__` fix was removed from this branch per review scope — no backend behavior changes. The single `server.py` hunk is the `.py` template-mode list (presentation config), nothing in the execution path.

## Annotation UX (from a structured design review of live screenshots)

- **Active-state ambiguity:** annotate toggle no longer shares the mode switcher's solid accent fill — tinted-outline on-state + hairline divider separates "armed to comment" from "active mode".
- **Composer affordance:** draft popover gains visible Cancel / **Comment** buttons; keyboard hint demoted to secondary. An **anchor dot** at the click point tethers the composer to its target.
- Pins: zero-reply "•" glyph dropped (teardrop shape carries meaning), edge clamping for full-width elements.
- Hover highlight lightened (1.5px / 8%) + 90ms ease-out glide between targets.
- Editor selection wash 12% → 18%; mode tooltips humanized (`_render` → "Rendered").
- First-run toast in element mode: "Click any element to leave a comment".

## Branding

- Sidebar brand: **Fused cube logo** (from the official `logo-black-bg-transparent.svg` asset), stroke on the accent token.
- Accent: `#5b9dff` blue → **Fused lime `#E5FF44`** across the shell, annotate overlay (light-page variant uses darker `#8a9a00` for contrast), and template accent colors.
- `.py` previews map to `["code"]` only — the swagger-style `api` run form (D63) is unbound by default so the header reads code + annotate; users can rebind via `~/.fused-render/registry.json`.

## Testing

All annotate flows re-verified in-browser with real pointer events on this branch (toast, tinted toggle, anchor dot, Comment/Cancel, pin save + clamp, decoration contrast, branding screenshots). Frontend `tsc --noEmit` + vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic and annotate-overlay UX changes plus a reversible default template list for `.py`; no auth, execution, or data-path changes beyond hiding the built-in api mode unless re-bound in the registry.
> 
> **Overview**
> This PR is **UI and presentation config**—annotation flows, shell branding, and template accent colors—with one small **template-mode** change for Python files.
> 
> **Annotation UX** separates the annotate toggle from the mode switcher: a hairline divider plus a **tinted-outline** active state (solid accent stays for the selected preview mode). The draft composer gets **Cancel / Comment** buttons, an **anchor dot** at the click point, lighter animated hover highlight, **pin edge clamping**, and no bullet glyph on zero-reply pins. Element mode shows a first-run toast; mode tooltips use human labels (`_render` → "Rendered").
> 
> **Branding** swaps the sidebar ✦ for an inline **Fused cube** SVG on the accent token and moves the palette from blue **`#5b9dff`** to lime **`#E5FF44`** in `shell.css`, `annotate.js` (with a darker light-scheme accent), and preview templates (links, rings, code comment highlights).
> 
> **`.py` default modes** in `server.py` change from `["code", "api"]` to **`["code"]`** so the preview header stays code + annotate; users can restore the swagger **`api`** run form via `~/.fused-render/registry.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9465f4ff606925549bcb24d3a987038d2945374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->