### PR TITLE
feat: install default data-stack deps into every script venv

### DIFF
--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -26,6 +26,25 @@ _FRAME_LINE = re.compile(r'^  File "(?P<file>[^"]*)", line (?P<line>\d+)(?P<rest
 
 _backend = None
 
+# Installed into every script's venv on top of its PEP 723 dependencies.
+# Mirrors the `bundled` extra in pyproject.toml (SPEC DM-2): the packaged
+# .app's wheelhouse ships exactly these wheels (+ pyarrow), so the one-time
+# venv build resolves offline. Keep the two lists in sync.
+DEFAULT_REQUIREMENTS = [
+    "numpy",
+    "pandas",
+    "pyarrow",
+    "requests",
+    "duckdb",
+    "polars",
+    "matplotlib",
+    "scipy",
+    "pillow",
+    "openpyxl",
+    "shapely",
+    "geopandas",
+]
+
 
 def get_backend():
     # Lazy singleton: importing the backend pulls in the fused package tree,
@@ -175,10 +194,14 @@ async def run_python(path: str, params: dict) -> dict:
     except ValueError as e:
         return _error(str(e))
 
+    # Sorted union so the venv cache key is stable regardless of how a script
+    # orders its PEP 723 block; scripts with no block all share one defaults venv.
+    requirements = sorted(set(DEFAULT_REQUIREMENTS) | set(reqs))
+
     code = build_code(user_code, os.path.dirname(os.path.abspath(path)))
     r = await get_backend().execute(
         code=code,
-        requirements=reqs or None,
+        requirements=requirements,
         input_files={"_params.json": json.dumps(params or {}).encode()},
     )
     # The backend hands return_value back JSON-encoded; decode it here so the


### PR DESCRIPTION
## Summary
- Add `DEFAULT_REQUIREMENTS` constant in `fused_render/engine.py` mirroring the pyproject `bundled` extra + pyarrow (SPEC DM-2) — the packaged .app's wheelhouse ships exactly these wheels, so the one-time venv build resolves offline.
- `run_python` now passes the sorted union of defaults and the script's PEP 723 dependencies to the openfused backend. The sorted set makes the venv cache key stable, so every script without an inline block shares a single cached defaults venv.

Result: `import pandas` (and numpy, duckdb, polars, matplotlib, scipy, pillow, openpyxl, shapely, geopandas, pyarrow, requests) works in any script without a `# /// script` header, while PEP 723 blocks keep working and simply add to the defaults.

## Testing
- Smoke-tested via `run_python`: script with no PEP 723 block imports pandas and runs (defaults venv built and cached).
- Script with `dependencies = ["tabulate"]` gets tabulate *and* pandas — merge path verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dependency resolution for all script executions (larger venvs, new cache keys); behavior depends on wheelhouse staying in sync with `DEFAULT_REQUIREMENTS`.
> 
> **Overview**
> Every Python script run now gets a **stable, sorted union** of a new `DEFAULT_REQUIREMENTS` list and any PEP 723 `dependencies`, instead of only passing script-specific reqs (or `None` when the block is empty).
> 
> `DEFAULT_REQUIREMENTS` mirrors the pyproject **`bundled`** extra plus **pyarrow**, aligned with the packaged app wheelhouse (SPEC DM-2) so the one-time venv build can resolve offline. Scripts with no `# /// script` header share one cached defaults venv; scripts with extra deps still merge on top of the defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06f47e9ef4ad8f517d36d3a51e32ca45ef95d1dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->