### PR TITLE
feat: bind api template to .py by default

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -51,10 +51,9 @@ TEMPLATES = {
     ".flac": ["media"],
     # source code — CodeMirror, mode chosen by extension (note: .json routes to
     # the JSON tree template above, not here)
-    # python — editable buffer only. The swagger-style `api` run form (D63)
-    # is unbound by default to keep the header to code + annotate; rebind via
-    # the user registry (`".py": ["code", "api"]` in ~/.fused-render/registry.json).
-    ".py": ["code"],
+    # python — code default, with the swagger-style `api` run form (D63)
+    # available as a second mode.
+    ".py": ["code", "api"],
     ".js": ["code"],
     ".ts": ["code"],
     ".sh": ["code"],


### PR DESCRIPTION
Python files now resolve to `["code", "api"]` in the built-in `TEMPLATES` table, so the swagger-style run form (D63) is available as a second mode out of the box — no `~/.fused-render/registry.json` rebind needed. `code` stays the default mode.

Verified via dev server: `/api/fs/stat` on a `.py` file returns both template entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single built-in template list change; `code` remains the default mode with no impact on auth, writes, or execution paths.
> 
> **Overview**
> **`.py` files now advertise two preview modes by default** — `code` (still first/default) and the swagger-style **`api` run form** (D63).
> 
> Previously only `code` was in the built-in `TEMPLATES` map; enabling `api` required a user override in `~/.fused-render/registry.json`. That registry rebind is no longer needed for Python: `/api/fs/stat` on a `.py` path will include both resolved template entries like other multi-mode extensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f72b4fd91bb76e1a2306c5e37606969f0d0fece. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->