### PR TITLE
Sort dot entries last in directory listings

### DIFF
--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -23,7 +23,10 @@ function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEnt
   const flip = order === "desc" ? -1 : 1;
   const byName = (a: FsEntry, b: FsEntry) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
   return [...entries].sort((a, b) => {
-    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1; // dirs always group first
+    const aDot = a.name.startsWith(".");
+    const bDot = b.name.startsWith(".");
+    if (aDot !== bDot) return aDot ? 1 : -1; // dot entries always group last
+    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1; // dirs group first within each
     let cmp: number;
     if (sort === "size") cmp = (a.size ?? -1) - (b.size ?? -1);
     else if (sort === "mtime") cmp = (a.mtime ?? 0) - (b.mtime ?? 0);


### PR DESCRIPTION
Listing sort now groups hidden entries (names starting with `.`) at the end: dirs, files, .dirs, .files. Dot grouping is applied before the dirs-first grouping and, like it, is unaffected by the sort column and asc/desc order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side display sort only in the listing view; no API, auth, or data changes.
> 
> **Overview**
> Directory listings now **pin hidden entries** (names starting with `.`) to the bottom of the table, independent of sort column and asc/desc.
> 
> `sortEntries` in `Listing.tsx` applies this grouping **before** the existing dirs-first rule, so visible items appear as dirs then files, then dot-prefixed dirs and files, with name/size/mtime sorting unchanged within each group.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba875fe5269c1c594697be078e7a84adfa72bd82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->