### PR TITLE
Register geo/sci file extensions as Finder document types

### DIFF
--- a/scripts/setup_py2app.py
+++ b/scripts/setup_py2app.py
@@ -44,13 +44,21 @@ if not ICONFILE or not os.path.isfile(ICONFILE):
 
 APP = [os.path.join(SCRIPT_DIR, "app_entry.py")]
 
-# Extensions the built-in template registry (server.py TEMPLATES) previews.
-# Kept in sync by hand — see ARCHITECTURE.md §7 for the source of truth.
+# Extensions the built-in template registry (server.py TEMPLATES) previews,
+# kept in sync by hand (see ARCHITECTURE.md §7), plus geo/sci extras with no
+# built-in key — users can bind those via the runtime template registry, and
+# extra Finder associations are harmless at Alternate rank.
 _PREVIEWABLE_EXTENSIONS = [
     "html", "htm", "csv", "tsv", "json", "geojson", "md", "txt", "log",
     "yaml", "yml", "toml", "py", "js", "ts", "sh", "css",
     "png", "jpg", "jpeg", "gif", "webp", "svg", "xlsx", "pdf",
     "mp4", "mov", "m4v", "webm", "mp3", "wav", "m4a", "ogg", "flac",
+    "tif", "tiff", "geotiff",  # GeoTIFF rasters (server.py "geotiff" template)
+    "nc", "nc4", "cdf",  # NetCDF (server.py "netcdf" template)
+    # geo/sci formats with no built-in template key — bindable via the
+    # runtime template registry:
+    "gpkg", "shp", "fgb", "kml", "kmz", "gpx", "las", "laz",
+    "pmtiles", "mbtiles", "zarr", "h5", "grib2", "jp2",
 ]
 
 DOCUMENT_TYPES = [


### PR DESCRIPTION
## What

Extends the app bundle's `CFBundleDocumentTypes` (generated from `scripts/setup_py2app.py`, no static Info.plist) so Finder offers "Open with FusedRender" for geo/sci files:

- **GeoTIFF**: `.tif`, `.tiff`, `.geotiff` — rendered by the built-in `geotiff` template
- **NetCDF**: `.nc`, `.nc4`, `.cdf` — rendered by the built-in `netcdf` template (were missing from the plist list despite being in `server.py` TEMPLATES)
- **Geo/sci extras with no built-in template key**: `.gpkg`, `.shp`, `.fgb`, `.kml`, `.kmz`, `.gpx`, `.las`, `.laz`, `.pmtiles`, `.mbtiles`, `.zarr`, `.h5`, `.grib2`, `.jp2` — users can bind these via the runtime template registry; unbound ones still open as a view

All at `LSHandlerRank: Alternate` — never steals the user's default app. `.geojson`, `.csv` already registered; `.parquet` keeps its own Default-rank entry.

## Why no app-code change

The Finder open handler (`app.py` `application_openFiles_`) is extension-agnostic — it passes any path to `/view`. Only the plist doc-type list gated Finder integration.

## Notes

- Takes effect after a DMG rebuild + reinstall (LaunchServices re-reads doc types from the new app copy).
- `.zarr` is registered as a plain file extension only; no `LSTypeIsPackage`, so `.zarr` directories still browse normally in Finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only plist extension list changes with Alternate handler rank; no runtime open or rendering logic is modified.
> 
> **Overview**
> Expands the py2app **Alternate** `CFBundleDocumentTypes` list in `scripts/setup_py2app.py` so macOS Finder can offer **Open with FusedRender** for more geo/science formats.
> 
> Adds **GeoTIFF** (`.tif`, `.tiff`, `.geotiff`) and **NetCDF** (`.nc`, `.nc4`, `.cdf`) alongside existing previewable types, plus extra extensions (e.g. `.gpkg`, `.shp`, `.kml`, `.zarr`, `.h5`, `.grib2`) that can be wired through the runtime template registry. Comments clarify that these plist entries do not change open behavior beyond LaunchServices registration—`.parquet` stays on its separate **Default** entry.
> 
> Takes effect after a DMG rebuild and reinstall when LaunchServices picks up the new bundle metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07a1a7fd3b8a5139743c39ec9974fde533c2d7f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->