### PR TITLE
Browser history for layout ops and param changes

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -29,7 +29,7 @@ A fully local file explorer: a Python server on `127.0.0.1` + a browser UI to br
 | D5 | Python execution | Fresh subprocess per call, 30 s timeout | Rejected warm pool (later upgrade, API-compatible) and in-process (crash risk) |
 | D6 | Return types | JSON-native only; DataFrame/bytes → clear error telling user to convert | Arrow/DataFrame encoding = follow-up for data-heavy templates |
 | D7 | Param values | Strings only. `set()` rejects non-strings. User JSON-encodes himself | Rejected auto-typing (footguns) and JSON escape hatch (unneeded now) |
-| D8 | Param↔URL sync | URL wins on load; `history.replaceState` always; no history entries from param changes | pushState opt-in possible later without API break |
+| D8 | Param↔URL sync | URL wins on load; first param write on a pristine history entry pushes one entry (flagged `fusedParamEntry` on `history.state`), every later write replaces — Back restores the as-loaded params, churn costs at most one entry per visit | Was "`replaceState` always, no entries". First-change-push chosen over settle-debounce (timers/heuristics) and per-param opt-in (config burden). Flag on `history.state` travels with the entry, so after Back to the pristine entry the next write correctly pushes again |
 | D9 | Py path resolution | Relative → against the HTML file's dir; absolute → anywhere on disk (consistent with D2) | |
 | D10 | Re-run on param change | Manual: author calls `runPython` inside `params.onChange` | Declarative binding = possible later layer |
 | D11 | Template registry | **Server-side** (single source of truth). `stat` response carries `template` field; shell obeys | Rejected shell-side JS registry (migration pain once user overrides exist) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -403,7 +403,7 @@ Goal: the same URL-is-state model as §14, but as **tabs instead of a grid**: on
 ### 15.2 Tabs
 
 - **TM-5** A tab is an **`/embed/<path>` iframe**, mounted **lazily on first activation** and kept alive afterwards (`display:none` when inactive) — scroll/editor state survives switching, and hidden tabs keep receiving `fused:urlchange` (the runtime listens on the top window, LM-8), so param sync is live while hidden.
-- **TM-6** Tab bar (top of the layout area): one button per tab — label = basename of the tab's **current** path (sentinel paths label as `Panel` / `Tabs`) — plus a close `×` per tab and a trailing `+` that opens a new tab at the configured start dir. Click activates. The **active tab index is NOT encoded in the URL**: refresh/bookmark restores the first tab (avoids "Update bookmark" churn on every switch).
+- **TM-6** Tab bar (top of the layout area): one button per tab — label = basename of the tab's **current** path (sentinel paths label as `Panel` / `Tabs`) — plus a close `×` per tab and a trailing `+` that opens a new tab at the configured start dir. Click activates. The **active tab index is NOT encoded in the URL** (avoids "Update bookmark" churn on every switch): bookmarks and fresh loads open the first tab; refresh and Back/Forward restore the last active tab via `history.state` (`fusedActiveTab` — rides the entry, never the URL).
 - **TM-7** URL sync up, same machinery as LM-6: iframe `load` + tab-window `fused:urlchange` → read the tab's live location → re-encode `_layout` via guarded `replaceState`. Closing a tab removes its segment; closing the **last** tab exits to a plain view of its location (active prefix, like LM-5).
 
 ### 15.3 Entry — bookmark folders

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -292,6 +292,20 @@ export default function Panel({ config }: { config: Config }) {
     }
   };
 
+  // Structural ops (split/close) get a real history entry: pushState the
+  // re-encoded `_layout` at op time, so Back/Forward walk the arrangement
+  // history. Plain history.pushState (not navigate()) — no NAV_EVENT, so the
+  // grid doesn't remount now; on an actual popstate App's nav epoch remounts
+  // Panel, which re-parses the entry's `_layout`. The version-effect syncUrl
+  // that follows sees an unchanged URL and no-ops (LM-6 guard).
+  const pushUrl = () => {
+    const { params } = splitShellSearch(location.search);
+    const next = panelUrl(encodeNode(treeRef.current!), params);
+    if (location.pathname + location.search !== next) {
+      history.pushState(history.state, "", next);
+    }
+  };
+
   const split = (id: number, dir: "row" | "col") => {
     const tree = treeRef.current!;
     const l = findLeaf(tree, id);
@@ -307,6 +321,7 @@ export default function Panel({ config }: { config: Config }) {
       if (!parent) treeRef.current = splitNode;
       else parent.children[parent.children.indexOf(l)] = splitNode;
     }
+    pushUrl();
     setVersion((v) => v + 1);
   };
 
@@ -338,6 +353,7 @@ export default function Panel({ config }: { config: Config }) {
       navigateUrl(urlForFsPath(root.path, root.query));
       return;
     }
+    pushUrl();
     setVersion((v) => v + 1);
   };
 

--- a/frontend/src/views/Tabs.tsx
+++ b/frontend/src/views/Tabs.tsx
@@ -172,9 +172,17 @@ export default function Tabs({ config }: { config: Config }) {
   const [tabs, setTabs] = useState<LayoutLeaf[]>(() =>
     parseTabs(splitShellSearch(location.search).layout, config.start_dir)
   );
-  const [activeId, setActiveId] = useState<number>(() => tabs[0].id);
+  // `_layout` never encodes activation (TM-2 — URL shape untouched), so the
+  // active tab rides on the history entry's state object instead: pushHistory
+  // stamps `{fusedActiveTab: index}` and this remount (App re-keys Tabs on the
+  // popstate nav epoch) reads it back, making Back/Forward restore which tab
+  // was active. Fresh loads have no state → first tab, as before.
+  const [activeId, setActiveId] = useState<number>(() => {
+    const idx = (history.state as { fusedActiveTab?: unknown } | null)?.fusedActiveTab;
+    return typeof idx === "number" && tabs[idx] ? tabs[idx].id : tabs[0].id;
+  });
   // Lazy mount (TM-5): a tab's iframe exists only once it has been activated.
-  const [mountedIds, setMountedIds] = useState<number[]>(() => [tabs[0].id]);
+  const [mountedIds, setMountedIds] = useState<number[]>(() => [activeId]);
   // Leaf objects are mutated in place by the URL sync (path/query); this
   // counter re-renders the bar so labels track live locations.
   const [, bumpLabels] = useState(0);
@@ -194,6 +202,21 @@ export default function Tabs({ config }: { config: Config }) {
     if (location.pathname + location.search !== next) {
       history.replaceState(history.state, "", next);
     }
+  };
+
+  // Tab ops (add/switch/close) get a real history entry. Pushed even when the
+  // URL is unchanged (a switch moves no URL bits — activation lives only in
+  // the entry's state, see the activeId initializer): the entry carries
+  // `{fusedActiveTab: index}` so Back/Forward restore the active tab. Index,
+  // not id — leaf ids are per-mount and don't survive the popstate remount.
+  // Plain history.pushState (not navigate()) — no NAV_EVENT, so no remount
+  // now; main.tsx's wrapper still fires fused:urlchange for the chrome.
+  const pushHistory = (nextActiveId: number) => {
+    const { params } = splitShellSearch(location.search);
+    const codecStr = tabsRef.current.map((t) => encodePaneSegment(t.path, t.query)).join(",");
+    const next = buildSentinelUrl(TAB_PATH, codecStr, params);
+    const idx = tabsRef.current.findIndex((t) => t.id === nextActiveId);
+    history.pushState({ fusedActiveTab: idx === -1 ? 0 : idx }, "", next);
   };
 
   const onLocSync = () => {
@@ -216,9 +239,9 @@ export default function Tabs({ config }: { config: Config }) {
     const t = leaf(config.start_dir, "");
     setTabs((ts) => [...ts, t]);
     activate(t.id);
-    // syncUrl reads tabsRef — update it eagerly so the sync sees the new tab.
+    // pushHistory reads tabsRef — update it eagerly so the push sees the new tab.
     tabsRef.current = [...tabsRef.current, t];
-    syncUrl();
+    pushHistory(t.id);
   };
 
   const closeTab = (id: number) => {
@@ -237,12 +260,13 @@ export default function Tabs({ config }: { config: Config }) {
     tabsRef.current = next;
     setTabs(next);
     setMountedIds((ids) => ids.filter((x) => x !== id));
+    let nextActive = activeId;
     if (activeId === id) {
       // Activate a neighbor (prefer the one now at this slot, else the last).
-      const neighbor = next[Math.min(idx, next.length - 1)].id;
-      activate(neighbor);
+      nextActive = next[Math.min(idx, next.length - 1)].id;
+      activate(nextActive);
     }
-    syncUrl();
+    pushHistory(nextActive);
   };
 
   return (
@@ -252,7 +276,12 @@ export default function Tabs({ config }: { config: Config }) {
           <button
             key={t.id}
             className={"tab" + (t.id === activeId ? " active" : "")}
-            onClick={() => activate(t.id)}
+            onClick={() => {
+              // Re-clicking the active tab is a no-op — no history entry.
+              if (t.id === activeId) return;
+              activate(t.id);
+              pushHistory(t.id);
+            }}
           >
             <span className="tab-label">{tabLabel(t)}</span>
             <span

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -194,9 +194,25 @@
     let search = params.toString();
     if (layoutSpan) search += (search ? "&" : "") + layoutSpan;
     const newUrl = target.location.pathname + (search ? "?" + search : "");
-    target.history.replaceState(target.history.state, "", newUrl);
+    // First-change-push: the first param write on a pristine history entry
+    // pushes a new entry (preserving the as-loaded state for Back), every
+    // later write replaces on top of it — so param churn costs at most one
+    // entry per visit. "Pristine" is tracked via a flag on history.state, not
+    // a JS variable: the flag travels with the entry, so after Back to the
+    // pristine entry the next write correctly pushes again (truncating the
+    // old forward branch), and it survives reloads. Existing state (e.g. the
+    // tab shell's fusedActiveTab) is merged, not clobbered.
+    const prevState = target.history.state;
+    const unchanged =
+      newUrl === target.location.pathname + target.location.search;
+    if (unchanged || (prevState && prevState.fusedParamEntry)) {
+      target.history.replaceState(prevState, "", newUrl);
+    } else {
+      const nextState = Object.assign({}, prevState, { fusedParamEntry: true });
+      target.history.pushState(nextState, "", newUrl);
+    }
     // Notify via the event path only (no direct notify(), D46). When the shell
-    // wrapper exists it also fires fused:urlchange on replaceState — the
+    // wrapper exists it also fires fused:urlchange on the history write — the
     // snapshot diff in notifyIfChanged() makes the duplicate harmless; this
     // explicit dispatch covers standalone /render pages that have no wrapper.
     target.dispatchEvent(new Event("fused:urlchange"));


### PR DESCRIPTION
## What

Two related history improvements (previously: structural layout ops and param changes never created history entries — Back/Forward were blind to both):

### 1. Layout structural ops push history entries (`ce3279d`)

- **Panel**: `split()` / `close()` now `pushState` the re-encoded `_layout` at op time. Back/Forward walk the arrangement history: popstate bumps the nav epoch, `Panel` remounts and re-parses `_layout` from the restored entry's URL.
- **Tabs**: tab add / switch / close push an entry. Tab activation isn't encoded in `_layout` (URL shape untouched), so the active tab index rides the entry's `history.state` (`{fusedActiveTab}`); restored on remount. Re-clicking the active tab pushes nothing. Bookmarks/fresh loads still open the first tab; refresh restores the last active tab (`history.state` survives reload — accepted behavior change, TM-6 amended in `a8bdaed`).
- Ops use raw `history.pushState` (no `NAV_EVENT`), so nothing remounts at op time — only a real Back/Forward remounts the layout view (pane iframes reload then, matching vanilla route-rebuild semantics).
- Pane live-location sync stays `replaceState`.

### 2. First-change-push for param writes (`00d33b0`, updates D8)

`fused.params.set()` pushes **one** entry on the first write over a pristine entry — preserving the as-loaded params for Back — then replaces on every later write. Rapid param churn (sliders etc.) costs at most one entry per visit.

- Pristine tracking is a flag on `history.state` (`{fusedParamEntry: true}`), not a JS variable: it travels with the entry, so after Back to the pristine entry the next write correctly pushes again (truncating the forward branch), and it survives reloads. Merged into existing entry state, never clobbers it.
- Unchanged-URL writes never push.
- Covers standard view (target = top window) and layout panes (target = pane embed shell; push lands as a joint session-history entry, the pane's own popstate remount restores it).

## Semantics

- Back over a param entry = "reset params to as-loaded" (chosen over settle-debounce and per-param opt-in — see updated D8 rationale).
- Back over a structural op remounts the layout view, so pane/tab iframes reload.

## Known gaps (deliberate, out of scope)

- Standalone `/render?path=...` pages (no shell): Back pops the param entry but nothing re-reads params — page shows stale state until a popstate handler is added.
- No popstate soft-restore yet: Back over a param-only entry does a full view remount instead of updating the iframe in place.

## Testing

- `tsc --noEmit` + `vite build` clean.
- Manual via dev server: panel splits unwind one-by-one on Back; tab switch/add restored via Back/Forward; param tweaks collapse to one entry, Back restores as-loaded params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches history semantics for all param-synced views and panel/tab shells; standalone `/render` pages still do not re-hydrate params on popstate (documented gap).
> 
> **Overview**
> **Browser history** now records layout and param changes that used to be invisible to Back/Forward.
> 
> **Panel** `split` / `close` call `history.pushState` with the re-encoded `_layout` (live pane navigation still `replaceState`). **Tabs** push on add, switch, and close; because the active tab is not in the URL, each entry carries `history.state.fusedActiveTab` so refresh and Back/Forward restore the last active tab while bookmarks and cold loads still open the first tab.
> 
> **`fused.params.set()`** (D8) uses **first-change-push**: the first write on a pristine entry `pushState`s once (flag `fusedParamEntry` on `history.state`), then later writes `replaceState`, so slider churn costs at most one entry and Back can reset to as-loaded params. Existing state such as `fusedActiveTab` is merged, not overwritten.
> 
> **DECISIONS.md** and **SPEC.md** (TM-6, D8) are updated to match. Structural ops use raw `pushState` without the shell nav event so the grid does not remount until a real popstate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8bdaed397abdc9b134d332708e5bf26be782f82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
