### PR TITLE
Search in explorer listing + bookmarks sidebar

### DIFF
--- a/docs/superpowers/specs/2026-07-08-search-design.md
+++ b/docs/superpowers/specs/2026-07-08-search-design.md
@@ -1,0 +1,41 @@
+# Search: bookmarks + file explorer — design
+
+Date: 2026-07-08. Branch `agent/20260708-search`.
+
+Two independent searches, approved by Akshil:
+
+## Shared: fuzzy scorer — `frontend/src/lib/fuzzy.ts`
+
+- Dep-free case-insensitive subsequence matcher: `fuzzyMatch(query, text): { score: number; positions: number[] } | null`.
+- Null when query chars don't appear in order. Score bonuses: consecutive matches, segment-start chars (after `/`, `.`, `-`, `_`, space, camelCase boundary). Positions drive highlight rendering.
+- Shared `highlight(text, positions)` helper (or inline) renders matched chars in `<mark>`-style span.
+
+## Explorer search (recursive, current folder subtree)
+
+**Server** — `GET /api/fs/walk?path=<abs dir>` in `fused_render/server.py`:
+- `os.walk(..., followlinks=False)`, prune hidden entries (leading `.`) and `node_modules`, `__pycache__`, `venv` from descent; skip hidden files too.
+- Cap: stop after 20,000 entries collected; response `{path, entries: [{rel, is_dir, size, mtime}], truncated: bool}`. `rel` is posix-style relative to `path`. Unreadable entries skipped silently (match `/api/fs/list`).
+- 400 if not a directory. pytest coverage in `tests/` (tmp_path tree: nesting, hidden/ignored pruned, truncation flag).
+
+**Client** — `Listing.tsx` + `lib/api.ts` `walkDir()`:
+- Always-visible slim search input above the table, placeholder “Search this folder…”. Focus prefetches walk; cached per `fsPath`, invalidated when the SSE dir watch fires.
+- Empty query → existing listing untouched. Non-empty → flat result rows (same 3 columns), name cell = relative path with match highlight, dir/file icon kept, click navigates, sorting header hidden or inert while searching (results are rank-ordered).
+- Rank: fuzzy score desc → fewer path segments → alpha.
+- `q` synced to URL via `history.replaceState` (same pattern as `sort`). Esc clears + blurs.
+- Footer line: “N results” + “ — truncated at 20,000 entries” when `truncated`. No matches → “No matches”.
+- Walk error → inline error message; input stays usable.
+
+## Bookmarks search (sidebar)
+
+- Small search input atop bookmarks section in `Sidebar.tsx` (render only when bookmarks exist). Pure client over localStorage data.
+- Match against bookmark display name AND target path; folder-name match includes its child bookmarks.
+- Non-empty query → flat list of matching bookmark rows (highlighted), folder chrome hidden. Clear/Esc restores tree. “No matches” empty state.
+- Existing row actions (open, rename, delete, context menu) keep working on filtered rows.
+
+## Non-goals
+
+- No vitest (repo has no frontend test runner). No recursive search from bookmarks. No content/grep search. No hidden-files toggle (later if wanted).
+
+## Verification
+
+- `npm run build` (tsc gate) green, pytest green, feature exercised in running app on port 8798 via Playwright.

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -182,16 +182,30 @@ function enterPanel(fsPath: string, dir: "row" | "col"): void {
 
 export function Breadcrumb({ fsPath }: { fsPath: string }) {
   const parts = fsPath.split("/").filter((s) => s.length > 0);
-  const pieces: React.ReactNode[] = [];
+  const pieces: React.ReactNode[] = [
+    <a
+      key="root"
+      href="#"
+      className={"path-crumb" + (parts.length === 0 ? " last" : "")}
+      onClick={(e) => {
+        e.preventDefault();
+        navigate("/");
+      }}
+    >
+      /
+    </a>,
+  ];
   let acc = "";
   parts.forEach((part, i) => {
     acc += "/" + part;
     const target = acc;
     const isLast = i === parts.length - 1;
-    pieces.push(<span key={"sep" + i} className="sep">/</span>);
+    // Separator only between segments (root already carries the leading
+    // slash) — matches the panel path bar's tight `/Users/name/...` format.
+    if (i > 0) pieces.push(<span key={"sep" + i} className="path-crumb-sep">/</span>);
     if (isLast) {
       pieces.push(
-        <span key={target} className="current">
+        <span key={target} className="path-crumb last">
           {part}
         </span>
       );
@@ -200,6 +214,7 @@ export function Breadcrumb({ fsPath }: { fsPath: string }) {
         <a
           key={target}
           href="#"
+          className="path-crumb"
           onClick={(e) => {
             e.preventDefault();
             navigate(target);
@@ -214,15 +229,6 @@ export function Breadcrumb({ fsPath }: { fsPath: string }) {
   return (
     <>
       <div className="crumbs">
-        <a
-          href="#"
-          onClick={(e) => {
-            e.preventDefault();
-            navigate("/");
-          }}
-        >
-          /
-        </a>
         {pieces}
         <RevealButton fsPath={fsPath} />
       </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,8 +20,31 @@ import {
   getArmedBookmark,
 } from "../lib/bookmarks";
 import type { Bookmark, BookmarkFolder } from "../lib/bookmarks";
-import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "../lib/hooks";
+import { useUrlVersion, useBookmarksVersion, useSearchFuzzyVersion, notifyBookmarksChanged } from "../lib/hooks";
 import type { Config } from "../lib/api";
+import { fuzzyMatch, substringMatch, highlightSegments, isFuzzyEnabled, setFuzzyEnabled } from "../lib/fuzzy";
+
+// The fs path a bookmark targets, decoded from its /view/ url (same rule as
+// the hover card). Used for search matching and the tooltip.
+function bookmarkFsPath(url: string): string {
+  const qIdx = url.indexOf("?");
+  const pathname = qIdx !== -1 ? url.slice(0, qIdx) : url;
+  return pathname.startsWith(VIEW_PREFIX)
+    ? "/" + pathname.slice(VIEW_PREFIX.length).split("/").map(decodeURIComponent).join("/")
+    : pathname;
+}
+
+function renderHighlight(text: string, positions: number[]) {
+  return highlightSegments(text, positions).map((seg, i) =>
+    seg.match ? (
+      <mark key={i} className="search-mark">
+        {seg.text}
+      </mark>
+    ) : (
+      <span key={i}>{seg.text}</span>
+    )
+  );
+}
 
 // Folder shape drawn inline so it inherits currentColor — an emoji folder
 // ignores the theme and looks heavy at this size.
@@ -35,16 +58,9 @@ const FOLDER_ICON = (
 // vanilla shell (raw URLSearchParams on the saved search — bookmark
 // tooltips predate the `_layout` grammar; parity over cleverness).
 function TooltipContent({ bookmark }: { bookmark: Bookmark }) {
-  let pathname = bookmark.url;
-  let search = "";
   const qIdx = bookmark.url.indexOf("?");
-  if (qIdx !== -1) {
-    pathname = bookmark.url.slice(0, qIdx);
-    search = bookmark.url.slice(qIdx);
-  }
-  const fsPath = pathname.startsWith(VIEW_PREFIX)
-    ? "/" + pathname.slice(VIEW_PREFIX.length).split("/").map(decodeURIComponent).join("/")
-    : pathname;
+  const search = qIdx !== -1 ? bookmark.url.slice(qIdx) : "";
+  const fsPath = bookmarkFsPath(bookmark.url);
 
   const params = [...new URLSearchParams(search)];
   return (
@@ -129,6 +145,7 @@ interface BookmarkRowProps {
   child?: boolean;
   parentId?: string;
   isRenaming: boolean;
+  namePositions?: number[]; // search-match highlight positions in b.name
   onNameClick: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   onRename: (e: React.MouseEvent<HTMLButtonElement>) => void;
   onDelete: (e: React.MouseEvent<HTMLButtonElement>) => void;
@@ -141,7 +158,7 @@ interface BookmarkRowProps {
 }
 
 // Template for a bookmark row (top-level or, with child=true, inside a folder).
-function BookmarkRow({ b, child, parentId, isRenaming, onNameClick, onRename, onDelete, onCommitRename, onCancelRename, onMouseEnter, onMouseLeave, registerRef, dragProps }: BookmarkRowProps) {
+function BookmarkRow({ b, child, parentId, isRenaming, namePositions, onNameClick, onRename, onDelete, onCommitRename, onCancelRename, onMouseEnter, onMouseLeave, registerRef, dragProps }: BookmarkRowProps) {
   return (
     <div
       className={"bookmark-row" + (child ? " child-row" : "") + (b.url === currentUrl() ? " active" : "")}
@@ -158,7 +175,7 @@ function BookmarkRow({ b, child, parentId, isRenaming, onNameClick, onRename, on
         <RenameInput initialName={b.name} onCommit={onCommitRename} onCancel={onCancelRename} />
       ) : (
         <a className="bookmark-name" href={b.url} draggable={false} onClick={onNameClick}>
-          {b.name}
+          {namePositions && namePositions.length ? renderHighlight(b.name, namePositions) : b.name}
         </a>
       )}
       <span className="bookmark-actions">
@@ -235,8 +252,11 @@ export default function Sidebar({ config }: SidebarProps) {
   // of the store it renders).
   useUrlVersion();
   useBookmarksVersion();
+  useSearchFuzzyVersion();
+  const fuzzyOn = isFuzzyEnabled();
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [bmQuery, setBmQuery] = useState("");
   const [hover, setHover] = useState<HoverState | null>(null);
   const tooltipRef = useRef<HTMLDivElement | null>(null);
   // id -> row DOM node, for imperative drag-class toggling (mirrors the
@@ -251,6 +271,41 @@ export default function Sidebar({ config }: SidebarProps) {
   const items = loadBookmarks(); // top-level items: bookmarks and folders
   const folderById = new Map<string, BookmarkFolder>(items.filter(isFolder).map((f) => [f.id, f]));
   const topOrder = items.map((it) => it.id); // top-level display order
+
+  // Bookmark search: a non-empty query flattens the tree to matching rows.
+  // Matches a bookmark on its name OR target path; a folder-name match pulls in
+  // all of that folder's children. Highlight positions come from the name match
+  // (a path-only or folder-name hit shows the name unhighlighted).
+  const bq = bmQuery.trim();
+  const bmSearching = bq !== "";
+  const matched: { b: Bookmark; namePositions: number[] }[] = [];
+  const matcher = fuzzyOn ? fuzzyMatch : substringMatch;
+  if (bmSearching) {
+    for (const it of items) {
+      if (isFolder(it)) {
+        const folderHit = matcher(bq, it.name) !== null;
+        for (const c of it.children) {
+          const nameM = matcher(bq, c.name);
+          const pathHit = matcher(bq, bookmarkFsPath(c.url)) !== null;
+          if (folderHit || nameM || pathHit) matched.push({ b: c, namePositions: nameM ? nameM.positions : [] });
+        }
+      } else {
+        const nameM = matcher(bq, it.name);
+        const pathHit = matcher(bq, bookmarkFsPath(it.url)) !== null;
+        if (nameM || pathHit) matched.push({ b: it, namePositions: nameM ? nameM.positions : [] });
+      }
+    }
+  }
+
+  // Rows in search results are not reorderable; a no-op drag keeps the shared
+  // BookmarkRow contract without letting a filtered view mutate the store order.
+  const noDrag: DragProps = {
+    onDragStart: (e) => e.preventDefault(),
+    onDragOver: () => {},
+    onDragLeave: () => {},
+    onDrop: () => {},
+    onDragEnd: () => {},
+  };
 
   // Position the tooltip after its content has rendered, same timing as the
   // vanilla code reading tooltipEl.offsetHeight right after setting innerHTML.
@@ -533,8 +588,55 @@ export default function Sidebar({ config }: SidebarProps) {
         {items.length === 0 ? (
           <div className="sidebar-empty">No bookmarks yet</div>
         ) : (
-          items.map((it) => {
-            if (isFolder(it)) {
+          <>
+            <div className="bookmark-search">
+              <input
+                type="search"
+                className="bookmark-search-input"
+                placeholder="Search bookmarks…"
+                value={bmQuery}
+                onChange={(e) => setBmQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setBmQuery("");
+                    e.currentTarget.blur();
+                  }
+                }}
+              />
+              <button
+                className={"search-fuzzy-toggle bookmark-search-fuzzy-toggle" + (fuzzyOn ? " active" : "")}
+                title="Fuzzy matching on/off"
+                onClick={() => setFuzzyEnabled(!fuzzyOn)}
+              >
+                fuzzy
+              </button>
+            </div>
+            {bmSearching ? (
+              matched.length ? (
+                matched.map(({ b, namePositions }) => (
+                  <BookmarkRow
+                    key={b.id}
+                    b={b}
+                    namePositions={namePositions}
+                    isRenaming={renamingId === b.id}
+                    registerRef={() => {}}
+                    onNameClick={(e) => onBookmarkNameClick(e, b)}
+                    onRename={(e) => onRenameBookmark(e, b.id)}
+                    onDelete={(e) => onDeleteBookmark(e, b.id)}
+                    onCommitRename={(value) => commitRename(b.id, value, b.name)}
+                    onCancelRename={cancelRename}
+                    onMouseEnter={(e) => onRowMouseEnter(e, b)}
+                    onMouseLeave={hideTooltip}
+                    dragProps={noDrag}
+                  />
+                ))
+              ) : (
+                <div className="sidebar-empty">No matches</div>
+              )
+            ) : (
+              items.map((it) => {
+                if (isFolder(it)) {
               const activeHint = it.collapsed && it.children.some((c) => c.url === currentUrl());
               return (
                 <React.Fragment key={it.id}>
@@ -594,8 +696,10 @@ export default function Sidebar({ config }: SidebarProps) {
                 onMouseLeave={hideTooltip}
                 dragProps={dragProps(it.id, false, false)}
               />
-            );
-          })
+                );
+              })
+            )}
+          </>
         )}
       </div>
       <div id="bookmark-tooltip" ref={tooltipRef} style={hover ? { display: "block" } : undefined}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,21 @@ export interface ListResult {
   entries: FsEntry[];
 }
 
+// One entry from GET /api/fs/walk. `rel` is a posix path relative to the
+// walked directory; dir entries carry size null (same convention as FsEntry).
+export interface WalkEntry {
+  rel: string;
+  is_dir: boolean;
+  size: number | null;
+  mtime: number | null;
+}
+
+export interface WalkResult {
+  path: string;
+  entries: WalkEntry[];
+  truncated: boolean; // hit the server's entry cap
+}
+
 // One entry per resolved template mode (SPEC PT-8), in order, first = default.
 // path is null for a sentinel mode (PT-12, e.g. "_render") — no template
 // folder backs it, the shell knows what to do from the mode name alone.
@@ -48,6 +63,10 @@ export function getConfig(): Promise<Config> {
 
 export function listDir(fsPath: string): Promise<ListResult> {
   return getJson<ListResult>("/api/fs/list?path=" + encodeURIComponent(fsPath));
+}
+
+export function walkDir(fsPath: string): Promise<WalkResult> {
+  return getJson<WalkResult>("/api/fs/walk?path=" + encodeURIComponent(fsPath));
 }
 
 export function statPath(fsPath: string): Promise<StatResult> {

--- a/frontend/src/lib/fuzzy.ts
+++ b/frontend/src/lib/fuzzy.ts
@@ -1,0 +1,111 @@
+// Dependency-free, case-insensitive fuzzy subsequence matcher shared by the
+// explorer and bookmark searches. Greedy left-to-right matching finds a
+// subsequence whenever one exists (taking the earliest occurrence of each
+// query char never blocks a later one); the score is a heuristic, not an
+// optimum. Returns null when the query's chars don't all appear in order.
+export interface FuzzyResult {
+  score: number;
+  positions: number[]; // indices in `text` of the matched chars, ascending
+}
+
+// Chars that open a new "segment" in a path/name; a match right after one of
+// these reads as the start of a word and scores higher.
+const SEPARATORS = new Set(["/", ".", "-", "_", " "]);
+
+function isUpper(ch: string): boolean {
+  return ch >= "A" && ch <= "Z";
+}
+
+// Segment start = index 0, the char after a separator, or a camelCase hump
+// (a non-upper followed by an upper). Uses the original-case text so the
+// camelCase test survives the lowercasing done for matching.
+function isSegmentStart(text: string, i: number): boolean {
+  if (i === 0) return true;
+  const prev = text[i - 1];
+  if (SEPARATORS.has(prev)) return true;
+  return isUpper(text[i]) && !isUpper(prev);
+}
+
+export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
+  if (query === "") return { score: 0, positions: [] };
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  const positions: number[] = [];
+  let qi = 0;
+  let score = 0;
+  let prev = -2; // index of the previously matched char, for the consecutive test
+  for (let ti = 0; ti < t.length && qi < q.length; ti++) {
+    if (t[ti] !== q[qi]) continue;
+    positions.push(ti);
+    score += 1;
+    if (ti === prev + 1) score += 3; // consecutive run
+    if (isSegmentStart(text, ti)) score += 5; // landed on a word boundary
+    prev = ti;
+    qi++;
+  }
+  if (qi < q.length) return null; // ran out of text before matching every char
+  return { score, positions };
+}
+
+// Plain case-insensitive substring matcher — the "fuzzy off" mode. Same
+// result shape as fuzzyMatch so callers can swap matchers without branching:
+// positions are the contiguous run covering the first occurrence of `query`
+// in `text`. Score favors an earlier match and a match landing on a segment
+// start, mirroring fuzzyMatch's weighting so the two scales feel consistent
+// (each mode only ever ranks its own results, so exact cross-mode parity
+// isn't required).
+export function substringMatch(query: string, text: string): FuzzyResult | null {
+  if (query === "") return { score: 0, positions: [] };
+  const q = query.toLowerCase();
+  const t = text.toLowerCase();
+  const index = t.indexOf(q);
+  if (index === -1) return null;
+  const positions: number[] = [];
+  for (let i = 0; i < q.length; i++) positions.push(index + i);
+  let score = q.length * 4; // consecutive run: 1 (char) + 3 (consecutive) per char, as in fuzzyMatch
+  if (isSegmentStart(text, index)) score += 5; // landed on a word boundary
+  score -= index; // earlier position scores higher
+  return { score, positions };
+}
+
+// Whether fuzzy (subsequence) matching is on; off falls back to
+// substringMatch. Persisted so the choice survives a reload; both the
+// explorer and sidebar searches read/write this single shared pref.
+const FUZZY_PREF_KEY = "fused.searchFuzzy";
+export const SEARCH_FUZZY_EVENT = "fused:searchFuzzy";
+
+export function isFuzzyEnabled(): boolean {
+  return localStorage.getItem(FUZZY_PREF_KEY) !== "false"; // default true
+}
+
+export function setFuzzyEnabled(value: boolean): void {
+  localStorage.setItem(FUZZY_PREF_KEY, String(value));
+  window.dispatchEvent(new Event(SEARCH_FUZZY_EVENT));
+}
+
+export interface HighlightSegment {
+  text: string;
+  match: boolean;
+}
+
+// Split `text` into alternating matched / unmatched runs for highlight
+// rendering. Positions are the ascending indices returned by fuzzyMatch.
+export function highlightSegments(text: string, positions: number[]): HighlightSegment[] {
+  if (!positions.length) return text ? [{ text, match: false }] : [];
+  const marked = new Set(positions);
+  const segments: HighlightSegment[] = [];
+  let run = "";
+  let runMatch = marked.has(0);
+  for (let i = 0; i < text.length; i++) {
+    const m = marked.has(i);
+    if (m === runMatch) {
+      run += text[i];
+    } else {
+      segments.push({ text: run, match: runMatch });
+      run = text[i];
+      runMatch = m;
+    }
+  }
+  segments.push({ text: run, match: runMatch });
+  return segments;
+}

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -14,6 +14,7 @@
 // layout modes and the update-bookmark flow, not just for these hooks.
 import { useEffect, useState } from "react";
 import { NAV_EVENT } from "./router";
+import { SEARCH_FUZZY_EVENT } from "./fuzzy";
 
 function useEventCounter(events: readonly string[]): number {
   const [n, setN] = useState(0);
@@ -48,4 +49,10 @@ export function notifyBookmarksChanged(): void {
 
 export function useBookmarksVersion(): number {
   return useEventCounter([BOOKMARKS_EVENT]);
+}
+
+// Fuzzy-on/off pref change signal (lib/fuzzy.ts setFuzzyEnabled). Both search
+// surfaces subscribe so toggling in one re-renders the other immediately.
+export function useSearchFuzzyVersion(): number {
+  return useEventCounter([SEARCH_FUZZY_EVENT]);
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -108,11 +108,13 @@ body {
 }
 
 .bookmark-row {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 7px;
   padding: 6px 10px;
   border-radius: 8px;
+  cursor: pointer;
 }
 
 .bookmark-row:hover {
@@ -215,8 +217,15 @@ body {
   font-size: 13px;
 }
 
-.bookmark-name:hover {
-  color: var(--accent);
+/* Stretched-link pattern: the anchor's ::after covers the whole row so the
+   entire .bookmark-row hover affordance is also clickable (cmd-click,
+   middle-click included), not just the name text. Scoped to `a.bookmark-name`
+   so folder rows — which reuse .bookmark-name on a plain span and already
+   have their own row-level click handler — aren't affected. */
+a.bookmark-name::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .bookmark-actions {
@@ -226,6 +235,8 @@ body {
   visibility: hidden;
   flex: 0 0 auto;
   gap: 2px;
+  position: relative;
+  z-index: 1;
 }
 
 .bookmark-row:hover .bookmark-actions {
@@ -327,34 +338,50 @@ body {
   background: var(--bg-alt);
 }
 
-#breadcrumb .crumbs {
+/* Shared with the panel path bar (.panel-crumbs/.panel-crumb*, Panel.tsx):
+   same monospace, tight slash-separated segment styling, muted with the last
+   segment emphasized. Only the hover affordance differs per surface — this
+   bar avoids the accent-yellow the panel pane hover uses (see
+   #breadcrumb .path-crumb:hover below); the panel's own hover rule further
+   down is untouched. */
+#breadcrumb .crumbs,
+.panel-crumbs {
   display: flex;
   align-items: center;
-  gap: 4px;
   min-width: 0;
   overflow-x: auto;
   white-space: nowrap;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 12px;
 }
 
-#breadcrumb a {
+.path-crumb,
+.panel-crumb {
   color: var(--fg-muted);
   text-decoration: none;
-  padding: 2px 4px;
-  border-radius: 4px;
+  cursor: pointer;
+  padding: 2px 1px;
+  border-radius: 3px;
 }
 
-#breadcrumb a:hover {
-  background: var(--border);
-  color: var(--fg);
-}
-
-#breadcrumb .sep {
-  color: var(--fg-muted);
-}
-
+.path-crumb.last,
+.panel-crumb.last,
 #breadcrumb .current {
+  color: var(--fg);
   font-weight: 600;
-  padding: 2px 4px;
+}
+
+.path-crumb-sep,
+.panel-crumb-sep {
+  color: var(--border);
+  margin: 0 1px;
+}
+
+/* Main breadcrumb hover only — subtle fg brighten + underline, no accent
+   yellow. */
+#breadcrumb .path-crumb:hover {
+  color: var(--fg);
+  text-decoration: underline;
 }
 
 /* Share/export glyph at the end of the crumb trail (reveal in file manager). */
@@ -436,10 +463,181 @@ body {
   flex-direction: column;
 }
 
-/* Listing view */
+/* Listing view — a fixed search header above a scrolling table, so the search
+   box stays put as the table scrolls and the columns never jump between
+   listing and results. */
 .listing {
-  overflow: auto;
   flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.listing-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.listing-search {
+  flex: 0 0 auto;
+  position: relative;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.listing-search .listing-search-input {
+  width: 100%;
+  /* Reserves room for, right to left: fuzzy toggle (right:10), count chip /
+     spinner (right:64) — sized for the longest count text
+     ("showing 250 of 7734 matches"). Esc clears the query. */
+  padding-right: 170px;
+}
+
+/* Native WebKit cancel × collides with the absolutely-positioned count chip;
+   hidden (Esc clears the query instead). */
+.listing-search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+/* Match count pinned inside the input's right edge (no layout shift). Shifted
+   left of the fuzzy toggle (right:10). */
+.listing-search-count {
+  position: absolute;
+  right: 80px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--fg-muted);
+  font-size: 12px;
+  white-space: nowrap;
+  pointer-events: none;
+}
+
+/* Small spinner shown while the recursive walk is still in flight, so a
+   search on a huge folder doesn't look stalled while the input stays
+   fully interactive. */
+.listing-search-spinner {
+  position: absolute;
+  right: 80px;
+  top: 50%;
+  width: 11px;
+  height: 11px;
+  margin-top: -5.5px;
+  border: 1.5px solid var(--border);
+  border-top-color: var(--fg-muted);
+  border-radius: 50%;
+  pointer-events: none;
+  animation: listing-search-spin 0.6s linear infinite;
+}
+
+@keyframes listing-search-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Dims the results briefly while a background render (React's deferred
+   value) is catching up to the latest keystroke on a large search. */
+.listing-stale {
+  opacity: 0.6;
+  transition: opacity 0.1s ease-out;
+}
+
+/* Fuzzy-match toggle pill, shared chrome between the explorer search bar and
+   the sidebar bookmark search. Active state reuses the input's own focus
+   accent so "fuzzy on" reads with the same accent language as everything
+   else, rather than inventing a new on-state color. */
+.search-fuzzy-toggle {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  font: inherit;
+  font-size: 10.5px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.02em;
+  padding: 3px 7px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.search-fuzzy-toggle:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.search-fuzzy-toggle.active {
+  color: var(--accent);
+  border-color: rgba(229, 255, 68, 0.45);
+  background: rgba(229, 255, 68, 0.08);
+}
+
+.search-fuzzy-toggle.active:hover {
+  background: rgba(229, 255, 68, 0.14);
+}
+
+.listing-search-fuzzy-toggle {
+  /* 16px container padding + 10px inset from the input's own right edge. */
+  right: 26px;
+}
+
+.bookmark-search-fuzzy-toggle {
+  /* 8px container padding + 8px inset from the input's own right edge. */
+  right: 16px;
+}
+
+/* Shared search-input chrome (explorer header + sidebar bookmarks). */
+.listing-search-input,
+.bookmark-search-input {
+  width: 100%;
+  font: inherit;
+  font-size: 13px;
+  color: var(--fg);
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 10px;
+}
+
+.listing-search-input::placeholder,
+.bookmark-search-input::placeholder {
+  color: var(--fg-muted);
+}
+
+.listing-search-input:focus,
+.bookmark-search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+/* Matched-substring highlight in search results (explorer + bookmarks). */
+.search-mark {
+  background: rgba(229, 255, 68, 0.22);
+  color: var(--fg);
+  border-radius: 2px;
+}
+
+/* Relative path shown in an explorer search row, in place of a bare name. */
+.search-path {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Sidebar bookmark search box: sits just under the "Bookmarks" heading,
+   aligned with the row padding. Relative so the fuzzy toggle can pin to its
+   right edge like the explorer search bar. */
+.bookmark-search {
+  position: relative;
+  padding: 0 8px 6px;
+}
+
+/* Reserve room for the fuzzy toggle pinned inside the input's right edge. */
+.bookmark-search .bookmark-search-input {
+  padding-right: 52px;
 }
 
 table.listing-table {
@@ -455,10 +653,14 @@ table.listing-table th {
   text-transform: uppercase;
   letter-spacing: 0.03em;
   padding: 8px 16px;
-  border-bottom: 1px solid var(--border);
   position: sticky;
   top: 0;
+  z-index: 1; /* stay above rows scrolling underneath */
   background: var(--bg);
+  /* border-collapse drops the sticky cell's own border as rows scroll under
+     it, leaving a 1px bleed gap — paint the divider as an inset shadow so it
+     rides with the header instead. */
+  box-shadow: inset 0 -1px 0 var(--border);
   cursor: pointer;
   user-select: none;
 }
@@ -477,7 +679,7 @@ table.listing-table .sort-arrow {
 }
 
 table.listing-table td {
-  padding: 7px 16px;
+  padding: 9px 16px;
   border-bottom: 1px solid var(--border);
   white-space: nowrap;
   overflow: hidden;
@@ -496,6 +698,7 @@ table.listing-table td.name {
   display: flex;
   align-items: center;
   gap: 8px;
+  font-size: 14px;
 }
 
 table.listing-table .icon {
@@ -722,8 +925,23 @@ table.listing-table td.mtime {
   color: var(--fg-muted);
 }
 
+/* Error panel: dark maroon card + red border + mono red text, matching the
+   fused_render/static/runtime.js overlay reference. Canonical error style —
+   every error rendered in the shell (stat/preview failures, listing/search
+   failures, config-load failures) uses this class so the visual language
+   stays consistent. */
 .status-message.error {
-  color: var(--error);
+  background: rgba(30, 5, 5, 0.9);
+  border: 2px solid #c0392b;
+  border-radius: 10px;
+  padding: 14px 16px;
+  color: #ffdede;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 13px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: visible;
+  text-overflow: clip;
 }
 
 /* Embed mode (/embed/<path>): content only — all shell chrome hidden.
@@ -830,14 +1048,15 @@ body.embed .preview-browse-chip:hover {
   user-select: none;
 }
 
+/* Base layout/color rules for .panel-crumbs/.panel-crumb/.panel-crumb-sep/
+   .panel-crumb.last are shared with the main breadcrumb above (search
+   "Shared with the panel path bar"). Only what's genuinely panel-specific
+   lives here: pane-local flex sizing, a tighter font-size, hidden scrollbar,
+   and the accent-yellow hover (left as-is — the main breadcrumb gets its own
+   non-yellow hover instead of reusing this one). */
 .panel-crumbs {
   flex: 1 1 auto;
-  display: flex;
-  align-items: center;
-  overflow-x: auto;
   scrollbar-width: none;
-  white-space: nowrap;
-  font-family: ui-monospace, Menlo, Consolas, monospace;
   font-size: 11px;
 }
 
@@ -845,25 +1064,9 @@ body.embed .preview-browse-chip:hover {
   display: none;
 }
 
-.panel-crumb {
-  color: var(--fg-muted);
-  cursor: pointer;
-  padding: 2px 1px;
-  border-radius: 3px;
-}
-
 .panel-crumb:hover {
   color: var(--accent);
   text-decoration: underline;
-}
-
-.panel-crumb.last {
-  color: var(--fg);
-}
-
-.panel-crumb-sep {
-  color: var(--border);
-  margin: 0 1px;
 }
 
 .panel-btn {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -1,15 +1,27 @@
-// Directory listing view with sortable columns.
+// Directory listing view with sortable columns and an in-folder search.
 // Sort state lives in the URL (?sort=name|size|mtime&order=asc|desc) so a
-// sorted listing is refresh-proof and bookmarkable like any other view state.
-import { useEffect, useState } from "react";
+// sorted listing is refresh-proof and bookmarkable like any other view state;
+// the search query rides the URL the same way (?q=…). A non-empty query swaps
+// the listing for flat, rank-ordered results over a recursive walk of the
+// folder (fetched lazily on first focus, cached until the dir watch fires).
+import { useDeferredValue, useEffect, useMemo, useState } from "react";
 import { navigate } from "../lib/router";
-import { listDir } from "../lib/api";
-import type { FsEntry } from "../lib/api";
+import { listDir, walkDir } from "../lib/api";
+import type { FsEntry, WalkEntry, WalkResult } from "../lib/api";
 import { formatSize, formatMtime } from "../lib/format";
+import { fuzzyMatch, substringMatch, highlightSegments, isFuzzyEnabled, setFuzzyEnabled } from "../lib/fuzzy";
+import type { FuzzyResult } from "../lib/fuzzy";
+import { useSearchFuzzyVersion } from "../lib/hooks";
 
 const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
 type SortKey = keyof typeof SORT_KEYS;
 type SortOrder = "asc" | "desc";
+
+// Cap on rendered search-result rows. Fuzzy-scoring can match thousands of
+// entries in a large tree; rendering all of them as <tr>s is what actually
+// jams the main thread (scoring itself is comparatively cheap). The full
+// ranked list still exists in memory for the count text.
+const MAX_RESULTS = 250;
 
 function currentSort(): { sort: SortKey; order: SortOrder } {
   const q = new URLSearchParams(location.search);
@@ -17,6 +29,10 @@ function currentSort(): { sort: SortKey; order: SortOrder } {
   const sort: SortKey = key && key in SORT_KEYS ? (key as SortKey) : "name";
   const order: SortOrder = q.get("order") === "desc" ? "desc" : "asc";
   return { sort, order };
+}
+
+function currentQuery(): string {
+  return new URLSearchParams(location.search).get("q") || "";
 }
 
 function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEntry[] {
@@ -36,9 +52,56 @@ function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEnt
   });
 }
 
+// Match a query against every walked entry's relative path, then rank: higher
+// fuzzy score first, then fewer path segments (shallower = closer to hand),
+// then alphabetical for a stable order.
+interface SearchHit {
+  entry: WalkEntry;
+  positions: number[];
+}
+function searchWalk(
+  query: string,
+  entries: WalkEntry[],
+  matcher: (query: string, text: string) => FuzzyResult | null
+): SearchHit[] {
+  const hits: { entry: WalkEntry; positions: number[]; score: number }[] = [];
+  for (const entry of entries) {
+    const m = matcher(query, entry.rel);
+    if (m) hits.push({ entry, positions: m.positions, score: m.score });
+  }
+  hits.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const ad = a.entry.rel.split("/").length;
+    const bd = b.entry.rel.split("/").length;
+    if (ad !== bd) return ad - bd;
+    return a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
+  });
+  return hits.map(({ entry, positions }) => ({ entry, positions }));
+}
+
+function renderHighlight(text: string, positions: number[]) {
+  return highlightSegments(text, positions).map((seg, i) =>
+    seg.match ? (
+      <mark key={i} className="search-mark">
+        {seg.text}
+      </mark>
+    ) : (
+      <span key={i}>{seg.text}</span>
+    )
+  );
+}
+
 type ListingState =
   | { status: "loading" }
   | { status: "ok"; entries: FsEntry[] }
+  | { status: "error"; message: string };
+
+// Cached recursive walk. Reset to "idle" whenever the folder changes or the dir
+// watch fires; a focus/search then re-fetches it fresh.
+type WalkState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ok"; result: WalkResult }
   | { status: "error"; message: string };
 
 export default function Listing({ fsPath }: { fsPath: string }) {
@@ -47,6 +110,27 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // navigation (vanilla re-ran renderListing after its replaceState).
   const [{ sort, order }, setSortState] = useState<{ sort: SortKey; order: SortOrder }>(currentSort);
   const [refresh, setRefresh] = useState(0); // bumped by the dir watch socket
+  const [query, setQueryState] = useState<string>(currentQuery);
+  const [walk, setWalk] = useState<WalkState>({ status: "idle" });
+  // Sort applied to search results. null = relevance (fuzzy rank). Deliberately
+  // NOT URL-synced (unlike the normal-mode sort) — it resets on every query
+  // change, so persisting it would fight that reset.
+  const [searchSort, setSearchSort] = useState<{ sort: SortKey; order: SortOrder } | null>(null);
+  // Fuzzy on/off is a shared pref (lib/fuzzy.ts), not local state; this hook
+  // just forces a re-render when it changes so the toggle takes effect
+  // immediately, including when flipped from the sidebar's own toggle.
+  useSearchFuzzyVersion();
+  const fuzzyOn = isFuzzyEnabled();
+
+  // The input echoes `query` (immediate) so keystrokes never wait on the
+  // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
+  // load — React commits a cheap render with the old deferred value first
+  // (echoing the keystroke), then a low-priority render picks up the new
+  // value and redoes the expensive work, interruptible by further typing.
+  const deferredQuery = useDeferredValue(query);
+  const q = deferredQuery.trim();
+  const searching = q !== "";
+  const isStale = query.trim() !== q;
 
   useEffect(() => {
     let alive = true;
@@ -98,69 +182,259 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     };
   }, [fsPath]);
 
+  // Drop the cached walk when the folder changes or the dir watch fires so the
+  // next search reflects the current tree (mirrors the listing's invalidation).
+  useEffect(() => {
+    setWalk({ status: "idle" });
+  }, [fsPath, refresh]);
+
+  // Fetch when a walk is requested (focus or a URL-seeded query). Reading
+  // "loading" as the trigger keeps the fetch out of a state updater.
+  useEffect(() => {
+    if (walk.status !== "loading") return;
+    let alive = true;
+    walkDir(fsPath).then(
+      (result) => alive && setWalk({ status: "ok", result }),
+      (err: Error) => alive && setWalk({ status: "error", message: err.message })
+    );
+    return () => {
+      alive = false;
+    };
+  }, [walk.status, fsPath]);
+
+  // A query restored from the URL needs the walk even without a focus event.
+  useEffect(() => {
+    if (searching) setWalk((prev) => (prev.status === "idle" ? { status: "loading" } : prev));
+  }, [searching, walk.status]);
+
+  const prefetchWalk = () => setWalk((prev) => (prev.status === "idle" ? { status: "loading" } : prev));
+
+  const setQuery = (value: string) => {
+    setQueryState(value);
+    setSearchSort(null); // a new query drops back to relevance order
+    const params = new URLSearchParams(location.search);
+    if (value) params.set("q", value);
+    else params.delete("q");
+    const qs = params.toString();
+    history.replaceState(null, "", location.pathname + (qs ? "?" + qs : ""));
+  };
+
   const setSort = (key: SortKey) => {
     const next: { sort: SortKey; order: SortOrder } = {
       sort: key,
       order: key === sort && order === "asc" ? "desc" : "asc",
     };
-    const q = new URLSearchParams(location.search);
-    q.set("sort", next.sort);
-    q.set("order", next.order);
-    history.replaceState(null, "", location.pathname + "?" + q.toString());
+    const params = new URLSearchParams(location.search);
+    params.set("sort", next.sort);
+    params.set("order", next.order);
+    history.replaceState(null, "", location.pathname + "?" + params.toString());
     setSortState(next);
   };
 
-  if (state.status === "loading") return <div className="status-message">Loading…</div>;
-  if (state.status === "error")
-    return (
-      <div className="status-message error">
-        Failed to list {fsPath}: {state.message}
-      </div>
+  const setSearchSortKey = (key: SortKey) => {
+    setSearchSort((prev) =>
+      prev && prev.sort === key
+        ? { sort: key, order: prev.order === "asc" ? "desc" : "asc" }
+        : { sort: key, order: "asc" }
     );
+  };
 
-  const rows = sortEntries(state.entries, sort, order).map((entry) => {
-    const childPath = fsPath.replace(/\/$/, "") + "/" + entry.name;
-    return (
-      <tr key={entry.name} className="row" onClick={() => navigate(childPath)}>
-        <td className="name">
-          <span className="icon">{entry.is_dir ? "\u{1F4C1}" : "\u{1F4C4}"}</span>
-          {entry.name}
+  // Keyed on `q`/`searching` (both deferred) so the 20k-entry fuzzy scan runs
+  // on React's low-priority schedule, not synchronously on every keystroke.
+  const hits = useMemo(() => {
+    if (!(searching && walk.status === "ok")) return [];
+    const matcher = fuzzyOn ? fuzzyMatch : substringMatch;
+    const ranked = searchWalk(q, walk.result.entries, matcher);
+    if (!searchSort) return ranked; // relevance order
+    const { sort, order } = searchSort;
+    const flip = order === "desc" ? -1 : 1;
+    const byName = (a: SearchHit, b: SearchHit) =>
+      a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
+    return [...ranked].sort((a, b) => {
+      let cmp: number;
+      if (sort === "size") cmp = (a.entry.size ?? -1) - (b.entry.size ?? -1);
+      else if (sort === "mtime") cmp = (a.entry.mtime ?? 0) - (b.entry.mtime ?? 0);
+      else cmp = byName(a, b);
+      if (cmp === 0) cmp = byName(a, b);
+      return cmp * flip;
+    });
+  }, [searching, q, walk, searchSort, fuzzyOn]);
+
+  // Rendering every match as a <tr> is the other half of the per-keystroke
+  // jank on huge trees (thousands of rows synchronously mounted). Cap what
+  // actually hits the DOM; the count text below still reflects the full total.
+  const visibleHits = useMemo(() => hits.slice(0, MAX_RESULTS), [hits]);
+
+  // Same idea for the plain (non-search) listing: re-sorting on every render
+  // (e.g. a keystroke that flips `searching` before this branch even
+  // displays) was pure waste when `state`/sort/order hadn't changed.
+  const sortedEntries = useMemo(
+    () => (state.status === "ok" ? sortEntries(state.entries, sort, order) : []),
+    [state, sort, order]
+  );
+
+  const base = fsPath.replace(/\/$/, "");
+  const fileIcon = "\u{1F4C4}";
+  const dirIcon = "\u{1F4C1}";
+
+  // --- table body -----------------------------------------------------------
+
+  let body: React.ReactNode;
+  if (searching) {
+    if (walk.status === "error") {
+      body = (
+        <tr>
+          <td colSpan={3} className="status-message error">
+            Search failed: {walk.message}
+          </td>
+        </tr>
+      );
+    } else if (walk.status === "ok") {
+      body = hits.length ? (
+        visibleHits.map(({ entry, positions }) => {
+          const childPath = base + "/" + entry.rel;
+          return (
+            <tr key={entry.rel} className="row" onClick={() => navigate(childPath)}>
+              <td className="name">
+                <span className="icon">{entry.is_dir ? dirIcon : fileIcon}</span>
+                <span className="search-path">{renderHighlight(entry.rel, positions)}</span>
+              </td>
+              <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
+              <td className="mtime">{formatMtime(entry.mtime)}</td>
+            </tr>
+          );
+        })
+      ) : (
+        <tr>
+          <td colSpan={3} className="status-message">
+            No matches
+          </td>
+        </tr>
+      );
+    } else {
+      body = (
+        <tr>
+          <td colSpan={3} className="status-message">
+            Searching…
+          </td>
+        </tr>
+      );
+    }
+  } else if (state.status === "loading") {
+    body = (
+      <tr>
+        <td colSpan={3} className="status-message">
+          Loading…
         </td>
-        <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
-        <td className="mtime">{formatMtime(entry.mtime)}</td>
       </tr>
     );
-  });
+  } else if (state.status === "error") {
+    body = (
+      <tr>
+        <td colSpan={3} className="status-message error">
+          Failed to list {fsPath}: {state.message}
+        </td>
+      </tr>
+    );
+  } else {
+    const rows = sortedEntries.map((entry) => {
+      const childPath = base + "/" + entry.name;
+      return (
+        <tr key={entry.name} className="row" onClick={() => navigate(childPath)}>
+          <td className="name">
+            <span className="icon">{entry.is_dir ? dirIcon : fileIcon}</span>
+            {entry.name}
+          </td>
+          <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
+          <td className="mtime">{formatMtime(entry.mtime)}</td>
+        </tr>
+      );
+    });
+    body = rows.length ? (
+      rows
+    ) : (
+      <tr>
+        <td colSpan={3} className="status-message">
+          Empty directory
+        </td>
+      </tr>
+    );
+  }
+
+  // --- search match count (inline in the search row) ------------------------
+
+  let searchCount: string | null = null;
+  if (searching && walk.status === "ok" && hits.length > 0) {
+    searchCount =
+      hits.length > MAX_RESULTS
+        ? `showing ${MAX_RESULTS} of ${hits.length} matches`
+        : `${hits.length} match${hits.length === 1 ? "" : "es"}`;
+  }
 
   return (
     <div className="listing">
-      <table className="listing-table">
-        <thead>
-          <tr>
-            {(Object.entries(SORT_KEYS) as [SortKey, string][]).map(([key, label]) => (
-              <th
-                key={key}
-                className={"sortable" + (key === sort ? " sorted" : "")}
-                onClick={() => setSort(key)}
-              >
-                {label}
-                {key === sort && <span className="sort-arrow">{order === "asc" ? "▲" : "▼"}</span>}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {rows.length ? (
-            rows
-          ) : (
+      <div className="listing-search">
+        <input
+          type="search"
+          className="listing-search-input"
+          placeholder="Search this folder…"
+          value={query}
+          onFocus={prefetchWalk}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              e.preventDefault();
+              setQuery("");
+              e.currentTarget.blur();
+            }
+          }}
+        />
+        <button
+          className={"search-fuzzy-toggle listing-search-fuzzy-toggle" + (fuzzyOn ? " active" : "")}
+          title="Fuzzy matching on/off"
+          onClick={() => setFuzzyEnabled(!fuzzyOn)}
+        >
+          fuzzy
+        </button>
+        {searching && (walk.status === "idle" || walk.status === "loading") && (
+          <span className="listing-search-spinner" aria-hidden="true" />
+        )}
+        {searchCount !== null && <span className="listing-search-count">{searchCount}</span>}
+      </div>
+      <div className={"listing-scroll" + (isStale ? " listing-stale" : "")}>
+        <table className="listing-table">
+          <thead>
             <tr>
-              <td colSpan={3} className="status-message">
-                Empty directory
-              </td>
+              {(Object.entries(SORT_KEYS) as [SortKey, string][]).map(([key, label]) =>
+                searching ? (
+                  // While searching, headers sort the results; no active arrow
+                  // means relevance (fuzzy-rank) order.
+                  <th
+                    key={key}
+                    className={"sortable" + (searchSort?.sort === key ? " sorted" : "")}
+                    onClick={() => setSearchSortKey(key)}
+                  >
+                    {label}
+                    {searchSort?.sort === key && (
+                      <span className="sort-arrow">{searchSort.order === "asc" ? "▲" : "▼"}</span>
+                    )}
+                  </th>
+                ) : (
+                  <th
+                    key={key}
+                    className={"sortable" + (key === sort ? " sorted" : "")}
+                    onClick={() => setSort(key)}
+                  >
+                    {label}
+                    {key === sort && <span className="sort-arrow">{order === "asc" ? "▲" : "▼"}</span>}
+                  </th>
+                )
+              )}
             </tr>
-          )}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>{body}</tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -96,13 +96,19 @@ type ListingState =
   | { status: "ok"; entries: FsEntry[] }
   | { status: "error"; message: string };
 
-// Cached recursive walk. Reset to "idle" whenever the folder changes or the dir
-// watch fires; a focus/search then re-fetches it fresh.
+// Cached recursive walk. Non-idle states are tagged with the (fsPath, refresh)
+// they were fetched for; `validWalk` below compares that tag against the
+// current fsPath/refresh at render time so a stale walk (folder changed, dir
+// watch fired) is treated as idle synchronously — no waiting on an effect to
+// clear it, which would otherwise let one render score search results
+// against the previous tree.
 type WalkState =
   | { status: "idle" }
-  | { status: "loading" }
-  | { status: "ok"; result: WalkResult }
-  | { status: "error"; message: string };
+  | { status: "loading"; forPath: string; forRefresh: number }
+  | { status: "ok"; result: WalkResult; forPath: string; forRefresh: number }
+  | { status: "error"; message: string; forPath: string; forRefresh: number };
+
+const IDLE_WALK: WalkState = { status: "idle" };
 
 export default function Listing({ fsPath }: { fsPath: string }) {
   const [state, setState] = useState<ListingState>({ status: "loading" });
@@ -131,6 +137,14 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const q = deferredQuery.trim();
   const searching = q !== "";
   const isStale = query.trim() !== q;
+
+  // Synchronous validity check: a non-idle walk only counts if it was fetched
+  // for the folder/refresh generation we're currently rendering. This makes
+  // invalidation immediate on the render where `refresh` bumps, instead of
+  // depending on the clearing effect below to run first (which left one
+  // render scoring search results against the stale tree).
+  const validWalk: WalkState =
+    walk.status === "idle" || (walk.forPath === fsPath && walk.forRefresh === refresh) ? walk : IDLE_WALK;
 
   useEffect(() => {
     let alive = true;
@@ -189,41 +203,56 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   }, [fsPath, refresh]);
 
   // Fetch when a walk is requested (focus or a URL-seeded query). Reading
-  // "loading" as the trigger keeps the fetch out of a state updater.
+  // "loading" as the trigger keeps the fetch out of a state updater. Gated on
+  // validWalk (not the raw status) so a loading state that goes stale
+  // mid-flight (fsPath/refresh changed again before it resolved) doesn't
+  // have its result tagged as current — the alive-cleanup still discards it,
+  // and the effect below will re-request against the new generation.
   useEffect(() => {
-    if (walk.status !== "loading") return;
+    if (validWalk.status !== "loading") return;
     let alive = true;
+    const forPath = fsPath;
+    const forRefresh = refresh;
     walkDir(fsPath).then(
-      (result) => alive && setWalk({ status: "ok", result }),
-      (err: Error) => alive && setWalk({ status: "error", message: err.message })
+      (result) => alive && setWalk({ status: "ok", result, forPath, forRefresh }),
+      (err: Error) => alive && setWalk({ status: "error", message: err.message, forPath, forRefresh })
     );
     return () => {
       alive = false;
     };
-  }, [walk.status, fsPath]);
+  }, [validWalk.status, fsPath, refresh]);
 
-  // A query restored from the URL needs the walk even without a focus event.
-  // Deliberately keyed off "idle" only (not "error") — this effect re-runs
-  // whenever walk.status changes, so retrying "error" here would loop forever
-  // (loading -> error -> retry -> loading -> error -> ...) with no user
-  // action in between. Error retries are wired to real user gestures instead:
-  // prefetchWalk (focus) and setQuery (typing) below.
+  // A query restored from the URL needs the walk even without a focus event;
+  // this also covers refetch-on-refresh while search is active, since a
+  // refresh bump makes validWalk go stale->"idle" synchronously, which this
+  // effect (keyed on validWalk.status) picks up immediately. Deliberately
+  // keyed off "idle" only (not "error") — retrying "error" here would loop
+  // forever (loading -> error -> retry -> loading -> error -> ...) with no
+  // user action in between. Error retries are wired to real user gestures
+  // instead: prefetchWalk (focus) and setQuery (typing) below.
   useEffect(() => {
-    if (searching) setWalk((prev) => (prev.status === "idle" ? { status: "loading" } : prev));
-  }, [searching, walk.status]);
+    if (searching && validWalk.status === "idle") {
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+    }
+  }, [searching, validWalk.status, fsPath, refresh]);
 
   // Retry from "idle" (first focus) or "error" (a prior fetch failed) — treat
   // both as "no usable walk cached yet". Called from onFocus, a genuine user
   // gesture, so this can't spin in a loop the way an effect could.
-  const prefetchWalk = () =>
-    setWalk((prev) => (prev.status === "idle" || prev.status === "error" ? { status: "loading" } : prev));
+  const prefetchWalk = () => {
+    if (validWalk.status === "idle" || validWalk.status === "error") {
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+    }
+  };
 
   const setQuery = (value: string) => {
     setQueryState(value);
     setSearchSort(null); // a new query drops back to relevance order
     // Editing the query is also a user gesture: if the last walk attempt
     // failed, give it another shot instead of leaving search dead forever.
-    setWalk((prev) => (prev.status === "error" ? { status: "loading" } : prev));
+    if (validWalk.status === "error") {
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+    }
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);
     else params.delete("q");
@@ -254,9 +283,9 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // Keyed on `q`/`searching` (both deferred) so the 20k-entry fuzzy scan runs
   // on React's low-priority schedule, not synchronously on every keystroke.
   const hits = useMemo(() => {
-    if (!(searching && walk.status === "ok")) return [];
+    if (!(searching && validWalk.status === "ok")) return [];
     const matcher = fuzzyOn ? fuzzyMatch : substringMatch;
-    const ranked = searchWalk(q, walk.result.entries, matcher);
+    const ranked = searchWalk(q, validWalk.result.entries, matcher);
     if (!searchSort) return ranked; // relevance order
     const { sort, order } = searchSort;
     const flip = order === "desc" ? -1 : 1;
@@ -270,7 +299,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
       if (cmp === 0) cmp = byName(a, b);
       return cmp * flip;
     });
-  }, [searching, q, walk, searchSort, fuzzyOn]);
+  }, [searching, q, validWalk, searchSort, fuzzyOn]);
 
   // Rendering every match as a <tr> is the other half of the per-keystroke
   // jank on huge trees (thousands of rows synchronously mounted). Cap what
@@ -293,15 +322,15 @@ export default function Listing({ fsPath }: { fsPath: string }) {
 
   let body: React.ReactNode;
   if (searching) {
-    if (walk.status === "error") {
+    if (validWalk.status === "error") {
       body = (
         <tr>
           <td colSpan={3} className="status-message error">
-            Search failed: {walk.message}
+            Search failed: {validWalk.message}
           </td>
         </tr>
       );
-    } else if (walk.status === "ok") {
+    } else if (validWalk.status === "ok") {
       body = hits.length ? (
         visibleHits.map(({ entry, positions }) => {
           const childPath = base + "/" + entry.rel;
@@ -377,12 +406,12 @@ export default function Listing({ fsPath }: { fsPath: string }) {
 
   let searchCount: string | null = null;
   let searchCountTitle: string | undefined;
-  if (searching && walk.status === "ok" && hits.length > 0) {
+  if (searching && validWalk.status === "ok" && hits.length > 0) {
     // A truncated walk (20k-entry server cap) means `hits` undercounts the
     // real tree. Signal that without new UI: a "+" on the number plus a
     // tooltip on the existing chip, rather than separate "truncated" text
     // that would shift layout.
-    const truncated = walk.result.truncated;
+    const truncated = validWalk.result.truncated;
     const suffix = truncated ? "+" : "";
     searchCount =
       hits.length > MAX_RESULTS
@@ -416,7 +445,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         >
           fuzzy
         </button>
-        {searching && (walk.status === "idle" || walk.status === "loading") && (
+        {searching && (validWalk.status === "idle" || validWalk.status === "loading") && (
           <span className="listing-search-spinner" aria-hidden="true" />
         )}
         {searchCount !== null && (

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -203,15 +203,27 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   }, [walk.status, fsPath]);
 
   // A query restored from the URL needs the walk even without a focus event.
+  // Deliberately keyed off "idle" only (not "error") — this effect re-runs
+  // whenever walk.status changes, so retrying "error" here would loop forever
+  // (loading -> error -> retry -> loading -> error -> ...) with no user
+  // action in between. Error retries are wired to real user gestures instead:
+  // prefetchWalk (focus) and setQuery (typing) below.
   useEffect(() => {
     if (searching) setWalk((prev) => (prev.status === "idle" ? { status: "loading" } : prev));
   }, [searching, walk.status]);
 
-  const prefetchWalk = () => setWalk((prev) => (prev.status === "idle" ? { status: "loading" } : prev));
+  // Retry from "idle" (first focus) or "error" (a prior fetch failed) — treat
+  // both as "no usable walk cached yet". Called from onFocus, a genuine user
+  // gesture, so this can't spin in a loop the way an effect could.
+  const prefetchWalk = () =>
+    setWalk((prev) => (prev.status === "idle" || prev.status === "error" ? { status: "loading" } : prev));
 
   const setQuery = (value: string) => {
     setQueryState(value);
     setSearchSort(null); // a new query drops back to relevance order
+    // Editing the query is also a user gesture: if the last walk attempt
+    // failed, give it another shot instead of leaving search dead forever.
+    setWalk((prev) => (prev.status === "error" ? { status: "loading" } : prev));
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);
     else params.delete("q");
@@ -364,11 +376,19 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // --- search match count (inline in the search row) ------------------------
 
   let searchCount: string | null = null;
+  let searchCountTitle: string | undefined;
   if (searching && walk.status === "ok" && hits.length > 0) {
+    // A truncated walk (20k-entry server cap) means `hits` undercounts the
+    // real tree. Signal that without new UI: a "+" on the number plus a
+    // tooltip on the existing chip, rather than separate "truncated" text
+    // that would shift layout.
+    const truncated = walk.result.truncated;
+    const suffix = truncated ? "+" : "";
     searchCount =
       hits.length > MAX_RESULTS
-        ? `showing ${MAX_RESULTS} of ${hits.length} matches`
-        : `${hits.length} match${hits.length === 1 ? "" : "es"}`;
+        ? `showing ${MAX_RESULTS} of ${hits.length}${suffix} matches`
+        : `${hits.length}${suffix} match${hits.length === 1 ? "" : "es"}`;
+    if (truncated) searchCountTitle = "Search covers the first 20,000 entries of this folder tree";
   }
 
   return (
@@ -399,7 +419,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         {searching && (walk.status === "idle" || walk.status === "loading") && (
           <span className="listing-search-spinner" aria-hidden="true" />
         )}
-        {searchCount !== null && <span className="listing-search-count">{searchCount}</span>}
+        {searchCount !== null && (
+          <span className="listing-search-count" title={searchCountTitle}>
+            {searchCount}
+          </span>
+        )}
       </div>
       <div className={"listing-scroll" + (isStale ? " listing-stale" : "")}>
         <table className="listing-table">

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -93,6 +93,13 @@ BUILTIN_REGISTRY = os.path.join(TEMPLATES_DIR, "registry.json")
 # reference (D73); any other `_` name is invalid (CT-6).
 KNOWN_SENTINELS = {"_render"}
 
+# Recursive-walk cap (/api/fs/walk): stop collecting after this many entries so
+# a search over a huge tree stays bounded. Module-level so tests can shrink it.
+WALK_MAX_ENTRIES = 20000
+# Directories never descended into by the walk (nor emitted as entries): heavy,
+# machine-managed trees that only add noise to a file search.
+WALK_IGNORE_DIRS = {"node_modules", "__pycache__", "venv"}
+
 
 def _error(message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"error": message}, status_code=status)
@@ -504,6 +511,48 @@ def create_app(start_dir: str) -> FastAPI:
             )
         entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower()))
         return {"path": path, "entries": entries}
+
+    @app.get("/api/fs/walk")
+    def api_fs_walk(path: str):
+        # Recursive listing of a directory subtree, for the explorer search
+        # (flat, ranked client-side). Prunes hidden entries (leading `.`) and
+        # WALK_IGNORE_DIRS from descent, skips hidden files, and never follows
+        # symlinks. Capped at WALK_MAX_ENTRIES; `rel` is posix-relative to
+        # `path`. Unreadable entries are skipped silently (matches /api/fs/list).
+        if not os.path.isdir(path):
+            return _error(f"not a directory: {path}", status=400)
+        entries = []
+        truncated = False
+        for root, dirs, files in os.walk(path, followlinks=False):
+            # Mutating dirs in place both drops them from descent and, since we
+            # emit from the (already pruned) list, keeps them out of the results.
+            dirs[:] = sorted(
+                d for d in dirs if not d.startswith(".") and d not in WALK_IGNORE_DIRS
+            )
+            batch = [(d, True) for d in dirs] + [
+                (f, False) for f in sorted(files) if not f.startswith(".")
+            ]
+            for name, is_dir in batch:
+                full = os.path.join(root, name)
+                try:
+                    st = os.stat(full)
+                except OSError:
+                    continue  # unreadable entries skipped silently
+                rel = os.path.relpath(full, path).replace(os.sep, "/")
+                entries.append(
+                    {
+                        "rel": rel,
+                        "is_dir": is_dir,
+                        "size": None if is_dir else st.st_size,
+                        "mtime": st.st_mtime,
+                    }
+                )
+                if len(entries) >= WALK_MAX_ENTRIES:
+                    truncated = True
+                    break
+            if truncated:
+                break
+        return {"path": path, "entries": entries, "truncated": truncated}
 
     @app.get("/api/fs/raw")
     def api_fs_raw(path: str):

--- a/tests/test_server_walk.py
+++ b/tests/test_server_walk.py
@@ -1,0 +1,65 @@
+"""Tests for GET /api/fs/walk (fused_render/server.py) — the recursive listing
+backing the explorer search."""
+from fastapi.testclient import TestClient
+
+from fused_render import server
+from fused_render.server import create_app
+
+
+def _client(tmp_path):
+    app = create_app(start_dir=str(tmp_path))
+    return TestClient(app)
+
+
+def _make_tree(tmp_path):
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "b.txt").write_text("b", encoding="utf-8")
+    (tmp_path / "sub" / "deep").mkdir()
+    (tmp_path / "sub" / "deep" / "c.txt").write_text("c", encoding="utf-8")
+    # hidden file + hidden dir + ignored dir — all pruned
+    (tmp_path / ".secret").write_text("x", encoding="utf-8")
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / ".hidden" / "nope.txt").write_text("x", encoding="utf-8")
+    (tmp_path / "node_modules").mkdir()
+    (tmp_path / "node_modules" / "pkg.js").write_text("x", encoding="utf-8")
+
+
+def test_walk_not_a_directory(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("a", encoding="utf-8")
+    resp = _client(tmp_path).get("/api/fs/walk", params={"path": str(f)})
+    assert resp.status_code == 400
+    assert "not a directory" in resp.json()["error"]
+
+
+def test_walk_recurses_and_reports_rels(tmp_path):
+    _make_tree(tmp_path)
+    resp = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["truncated"] is False
+    rels = {e["rel"] for e in data["entries"]}
+    assert rels == {"a.txt", "sub", "sub/b.txt", "sub/deep", "sub/deep/c.txt"}
+    by_rel = {e["rel"]: e for e in data["entries"]}
+    assert by_rel["sub"]["is_dir"] is True
+    assert by_rel["sub"]["size"] is None
+    assert by_rel["a.txt"]["is_dir"] is False
+    assert by_rel["a.txt"]["size"] == 1
+
+
+def test_walk_prunes_hidden_and_ignored(tmp_path):
+    _make_tree(tmp_path)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    rels = {e["rel"] for e in data["entries"]}
+    assert not any(r.startswith(".") or "/." in r for r in rels)  # no hidden entries
+    assert not any("node_modules" in r for r in rels)  # ignored dir never descended
+
+
+def test_walk_truncation_flag(tmp_path, monkeypatch):
+    for i in range(10):
+        (tmp_path / f"f{i}.txt").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(server, "WALK_MAX_ENTRIES", 3)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    assert data["truncated"] is True
+    assert len(data["entries"]) == 3


### PR DESCRIPTION
## What

- **Explorer search** (always-visible box above the listing): recursive fuzzy search over the current folder's subtree via new `GET /api/fs/walk` (prunes hidden dirs + `node_modules`/`__pycache__`/`venv`, 20k-entry cap, `truncated` flag). Relevance-ranked flat results with match highlighting, header sorting on results (component-state only, URL untouched), top-250 render cap, instant input echo (`useDeferredValue`), spinner + match-count chip, `?q=` synced to URL.
- **Bookmarks search** (sidebar): filters by name or target path, flattens folders while searching, highlights matches; all row actions keep working.
- **Fuzzy toggle**: shared `fuzzy` pill in both search bars — off = plain substring match; persisted in `localStorage`, synced live between the two.
- **Bookmark row UX**: whole row clickable (stretched-anchor, cmd/middle-click preserved), removed yellow-on-hover name.
- **Error style**: shell inline errors (`.status-message.error`) adopt the render-overlay maroon panel (dark red bg, `#c0392b` border, mono text).
- **Breadcrumb**: main bar restyled to match the panel path bar (monospace, tight slashes, emphasized last segment), CSS shared with the panel.

## Testing

- `tests/test_server_walk.py`: recursion/rel paths, hidden+ignored pruning, truncation, non-dir 400 (4 tests; full suite 82 passed).
- `tsc --noEmit` + vite build clean.
- Exercised end-to-end in the browser (Playwright): search/sort/toggle flows, bookmark actions on filtered rows, sticky-header opacity, error panel, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read-only FS walk endpoint can be expensive on huge trees (20k cap mitigates); explorer search adds substantial client state and rendering logic, but no auth or mutation paths change.
> 
> **Overview**
> Adds **recursive in-folder search** in the explorer: new `GET /api/fs/walk` returns a capped, pruned flat tree; `Listing.tsx` shows ranked, highlighted results with `?q=` in the URL, deferred typing, a 250-row render cap, and walk cache invalidation on dir watch.
> 
> Adds **bookmarks sidebar search** that filters by name or target path (folder name includes children), flattens the tree while searching, and keeps row actions; drag is disabled in filter mode.
> 
> Introduces shared **`lib/fuzzy.ts`** (fuzzy + substring matchers, highlights, `localStorage` fuzzy pref synced via `useSearchFuzzyVersion`) with a **fuzzy** pill in both search bars.
> 
> **Shell polish:** breadcrumb aligned with panel path bar; bookmark rows fully clickable; `.status-message.error` maroon panel style; listing search header + sticky table fixes. Design doc and `test_server_walk.py` added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f69cccacd4c869d8360486c760454d149729587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->