### PR TITLE
Compact registry.json formatting

### DIFF
--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -1,173 +1,55 @@
 {
-  ".parquet": [
-    "table"
-  ],
-  ".csv": [
-    "csv",
-    "code"
-  ],
-  ".tsv": [
-    "csv",
-    "code"
-  ],
-  ".xlsx": [
-    "xlsx"
-  ],
-  ".json": [
-    "tree",
-    "code"
-  ],
-  ".geojson": [
-    "vector",
-    "tree",
-    "code"
-  ],
-  ".md": [
-    "markdown",
-    "code"
-  ],
-  ".svg": [
-    "image",
-    "code"
-  ],
-  ".png": [
-    "image"
-  ],
-  ".jpg": [
-    "image"
-  ],
-  ".jpeg": [
-    "image"
-  ],
-  ".gif": [
-    "image"
-  ],
-  ".webp": [
-    "image"
-  ],
-  ".pdf": [
-    "pdf"
-  ],
-  ".mp4": [
-    "media"
-  ],
-  ".mov": [
-    "media"
-  ],
-  ".m4v": [
-    "media"
-  ],
-  ".webm": [
-    "media"
-  ],
-  ".mp3": [
-    "media"
-  ],
-  ".wav": [
-    "media"
-  ],
-  ".m4a": [
-    "media"
-  ],
-  ".ogg": [
-    "media"
-  ],
-  ".flac": [
-    "media"
-  ],
-  ".py": [
-    "code",
-    "api"
-  ],
-  ".js": [
-    "code"
-  ],
-  ".ts": [
-    "code"
-  ],
-  ".sh": [
-    "code"
-  ],
-  ".yaml": [
-    "code"
-  ],
-  ".yml": [
-    "code"
-  ],
-  ".toml": [
-    "code"
-  ],
-  ".css": [
-    "code"
-  ],
-  ".txt": [
-    "text",
-    "code"
-  ],
-  ".log": [
-    "text",
-    "code"
-  ],
-  ".tif": [
-    "geotiff"
-  ],
-  ".tiff": [
-    "geotiff"
-  ],
-  ".nc": [
-    "netcdf"
-  ],
-  ".nc4": [
-    "netcdf"
-  ],
-  ".cdf": [
-    "netcdf"
-  ],
-  ".html": [
-    "_render",
-    "code"
-  ],
-  ".htm": [
-    "_render",
-    "code"
-  ],
-  ".zarr/": [
-    "zarr"
-  ],
-  ".shp": [
-    "vector"
-  ],
-  ".kml": [
-    "vector"
-  ],
-  ".kmz": [
-    "vector"
-  ],
-  ".gpx": [
-    "vector"
-  ],
-  ".gpkg": [
-    "vector"
-  ],
-  ".fgb": [
-    "vector"
-  ],
-  ".pmtiles": [
-    "pmtiles"
-  ],
-  ".las": [
-    "las"
-  ],
-  ".laz": [
-    "las"
-  ],
-  ".zgroup": [
-    "zarr"
-  ],
-  ".zattrs": [
-    "zarr"
-  ],
-  ".zmetadata": [
-    "zarr"
-  ]
+  ".parquet": ["table"],
+  ".csv": ["csv", "code"],
+  ".tsv": ["csv", "code"],
+  ".xlsx": ["xlsx"],
+  ".json": ["tree", "code"],
+  ".geojson": ["vector", "tree", "code"],
+  ".md": ["markdown", "code"],
+  ".svg": ["image", "code"],
+  ".png": ["image"],
+  ".jpg": ["image"],
+  ".jpeg": ["image"],
+  ".gif": ["image"],
+  ".webp": ["image"],
+  ".pdf": ["pdf"],
+  ".mp4": ["media"],
+  ".mov": ["media"],
+  ".m4v": ["media"],
+  ".webm": ["media"],
+  ".mp3": ["media"],
+  ".wav": ["media"],
+  ".m4a": ["media"],
+  ".ogg": ["media"],
+  ".flac": ["media"],
+  ".py": ["code", "api"],
+  ".js": ["code"],
+  ".ts": ["code"],
+  ".sh": ["code"],
+  ".yaml": ["code"],
+  ".yml": ["code"],
+  ".toml": ["code"],
+  ".css": ["code"],
+  ".txt": ["text", "code"],
+  ".log": ["text", "code"],
+  ".html": ["_render", "code"],
+  ".htm": ["_render", "code"],
+  ".tif": ["geotiff"],
+  ".tiff": ["geotiff"],
+  ".nc": ["netcdf"],
+  ".nc4": ["netcdf"],
+  ".cdf": ["netcdf"],
+  ".zarr/": ["zarr"],
+  ".zgroup": ["zarr"],
+  ".zattrs": ["zarr"],
+  ".zmetadata": ["zarr"],
+  ".shp": ["vector"],
+  ".kml": ["vector"],
+  ".kmz": ["vector"],
+  ".gpx": ["vector"],
+  ".gpkg": ["vector"],
+  ".fgb": ["vector"],
+  ".pmtiles": ["pmtiles"],
+  ".las": ["las"],
+  ".laz": ["las"]
 }


### PR DESCRIPTION
One line per extension (matching the pre-#42 style), geo formats grouped together. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatting and key order only in a static registry file; template bindings are unchanged.
> 
> **Overview**
> **Cosmetic-only** update to `fused_render/templates/registry.json`: each extension→template list is on a single line (pre-#42 style), and geo-related suffixes are grouped together for readability.
> 
> **No functional change** — every extension still maps to the same ordered template name list as before; only JSON layout and key ordering in the file differ.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07da8edb79a35667bc143178a16d210f6b145059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->