### PR TITLE
feat(shell): template-mode menu in panel panes and tabs

### DIFF
--- a/frontend/src/components/ModeSwitcher.tsx
+++ b/frontend/src/components/ModeSwitcher.tsx
@@ -15,7 +15,8 @@ export interface ModeSwitcherEntry<M extends string> {
 
 // Human-readable tooltip for a mode name: the "_render" sentinel reads as
 // "Rendered", ordinary mode names are capitalized ("code" → "Code").
-function modeTitle(mode: string): string {
+// Exported for PaneModeMenu (pane/tab chrome shares the naming).
+export function modeTitle(mode: string): string {
   if (mode === "_render") return "Rendered";
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }

--- a/frontend/src/components/PaneModeMenu.tsx
+++ b/frontend/src/components/PaneModeMenu.tsx
@@ -1,0 +1,124 @@
+// Mode menu for pane/tab chrome (Panel's pane bar, Tabs' active tab): the
+// trigger shows the pane's ACTIVE template-mode icon; clicking opens a
+// dropdown of every available mode (icon + name) for the pane's live
+// location. Selecting one rewrites the pane-local `_mode` (same
+// default-deletes rule as Preview's setMode, PT-9) and hands the new query to
+// the caller, which reloads its iframe imperatively (crumb-click discipline —
+// no React re-render may touch a live iframe).
+//
+// Rendered entirely with spans, not buttons: in tab mode the trigger lives
+// INSIDE the tab's <button>, and nested buttons are invalid HTML.
+import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { statPath, type TemplateEntry } from "../lib/api";
+import { templateModeIcon, modeTitle } from "./ModeSwitcher";
+
+// Split a pane query at its raw `_layout=(...)` span (kept byte-identical —
+// it may contain literal `&`), so the head is plain params URLSearchParams
+// can edit. Same discipline as Tabs' composeFolderTabsUrl.
+function splitAtLayout(query: string): [string, string] {
+  const s = (query || "").replace(/^\?/, "");
+  const i = s.indexOf("_layout=(");
+  if (i === -1) return [s, ""];
+  return [s.slice(0, i).replace(/&$/, ""), s.slice(i)];
+}
+
+interface PaneModeMenuProps {
+  path: string;
+  query: string;
+  // Receives the pane's new query (leading "?" or empty); the caller writes
+  // iframe.src = embedSrc(path, query) itself — it owns the iframe ref.
+  onNavigate: (query: string) => void;
+}
+
+export default function PaneModeMenu({ path, query, onNavigate }: PaneModeMenuProps) {
+  const [templates, setTemplates] = useState<TemplateEntry[]>([]);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null); // non-null = open
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+
+  // Re-stat on every path change (pane navigation) so the menu tracks the
+  // live location's modes. Sentinel paths (/_panel, /_tab) and stat errors
+  // yield no templates — the menu hides itself below.
+  useEffect(() => {
+    let stale = false;
+    setTemplates([]);
+    setPos(null);
+    statPath(path)
+      .then((s) => {
+        // Same defensive sentinel filter as Preview's dispatch (PT-12).
+        if (!stale) setTemplates(s.templates.filter((t) => t.path !== null || t.mode === "_render"));
+      })
+      .catch(() => {});
+    return () => {
+      stale = true;
+    };
+  }, [path]);
+
+  // Close on outside pointerdown, or on window blur — a click landing in any
+  // iframe never reaches this document, but it does blur the shell window.
+  useEffect(() => {
+    if (!pos) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setPos(null);
+    };
+    const onBlur = () => setPos(null);
+    document.addEventListener("pointerdown", onDown);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [pos]);
+
+  if (templates.length < 2) return null;
+
+  const activeMode = new URLSearchParams(splitAtLayout(query)[0]).get("_mode");
+  const active = templates.find((t) => t.mode === activeMode) || templates[0];
+
+  const toggle = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (pos) {
+      setPos(null);
+      return;
+    }
+    // position:fixed — .panel-pane clips overflow, so the dropdown can't be
+    // absolutely positioned inside the bar. Clamped to the viewport's right edge.
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setPos({ top: r.bottom + 4, left: Math.max(0, Math.min(r.left, window.innerWidth - 150)) });
+  };
+
+  const select = (e: MouseEvent, mode: string) => {
+    e.stopPropagation();
+    setPos(null);
+    if (mode === active.mode) return;
+    const [head, tail] = splitAtLayout(query);
+    const params = new URLSearchParams(head);
+    // Selecting the default mode DELETES _mode (clean URLs, PT-9).
+    if (mode === templates[0].mode) params.delete("_mode");
+    else params.set("_mode", mode);
+    const qs = params.toString();
+    const q = qs + (tail ? (qs ? "&" : "") + tail : "");
+    onNavigate(q ? "?" + q : "");
+  };
+
+  return (
+    <span className="pane-mode-menu" ref={rootRef}>
+      <span className="pane-mode-btn" title={"Mode: " + modeTitle(active.mode)} onClick={toggle}>
+        {templateModeIcon(active)}
+      </span>
+      {pos && (
+        <span className="pane-mode-dropdown" style={{ top: pos.top, left: pos.left }}>
+          {templates.map((t) => (
+            <span
+              key={t.mode}
+              className={"pane-mode-item" + (t.mode === active.mode ? " active" : "")}
+              onClick={(e) => select(e, t.mode)}
+            >
+              {templateModeIcon(t)}
+              <span>{modeTitle(t.mode)}</span>
+            </span>
+          ))}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1200,6 +1200,80 @@ body.embed .preview-browse-chip:hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
+/* Pane/tab template-mode menu: the trigger shows the active mode's icon; the
+   dropdown lists icon + name per mode. Dropdown is position:fixed (inline
+   top/left from the trigger's rect) — .panel-pane clips overflow, and the tab
+   bar would too. */
+.pane-mode-menu {
+  display: inline-flex;
+  flex: 0 0 auto;
+}
+
+.pane-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--fg-muted);
+  cursor: pointer;
+  padding: 4px 5px;
+  border-radius: 4px;
+}
+
+.pane-mode-btn:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--fg);
+}
+
+/* Inside a tab button: match the tab-open-plain / tab-close chrome sizing. */
+.tab .pane-mode-btn {
+  width: 15px;
+  height: 15px;
+  padding: 0;
+}
+
+.tab .pane-mode-btn .mode-icon-mask,
+.tab .pane-mode-btn .mode-icon-placeholder,
+.tab .pane-mode-btn svg {
+  width: 13px;
+  height: 13px;
+}
+
+.pane-mode-dropdown {
+  position: fixed;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 120px;
+  padding: 4px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+
+.pane-mode-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.pane-mode-item:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--fg);
+}
+
+.pane-mode-item.active {
+  color: var(--fg);
+}
+
 .tab-add {
   flex: 0 0 auto;
   background: none;

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -31,6 +31,7 @@ import {
 import type { Config } from "../lib/api";
 import { ShareIcon } from "../components/ShareIcon";
 import { SplitRightIcon, SplitDownIcon } from "../components/SplitIcons";
+import PaneModeMenu from "../components/PaneModeMenu";
 
 // Panel mode lives under the page's own prefix (`/view/_panel` or
 // `/embed/_panel`), so entering/refreshing/exiting stays in the active mode.
@@ -211,6 +212,16 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
             <ShareIcon size={14} />
           </button>
         </div>
+        {/* Template-mode menu for the pane's live location. Mode switch is an
+            imperative src write (same as crumb clicks); onLoad then re-syncs
+            the leaf + `_layout` from the reloaded pane. */}
+        <PaneModeMenu
+          path={loc.path}
+          query={loc.query}
+          onNavigate={(q) => {
+            if (iframeRef.current) iframeRef.current.src = embedSrc(loc.path, q);
+          }}
+        />
         <button className="panel-btn split-right" title="Split right" onClick={() => ctx.split(node.id, "row")}>
           {ICONS.splitRight}
         </button>

--- a/frontend/src/views/Tabs.tsx
+++ b/frontend/src/views/Tabs.tsx
@@ -32,6 +32,7 @@ import {
 import type { Config } from "../lib/api";
 import type { Bookmark } from "../lib/bookmarks";
 import { ShareIcon } from "../components/ShareIcon";
+import PaneModeMenu from "../components/PaneModeMenu";
 
 // Tab mode lives under the page's own prefix, like panel mode.
 const TAB_PATH = (IS_EMBED ? "/embed/" : "/view/") + "_tab";
@@ -114,7 +115,19 @@ function tabLabel(t: LayoutLeaf): string {
 // One keep-alive tab iframe. src frozen at mount; visibility via display so
 // hidden tabs keep receiving fused:urlchange (the runtime listens on the top
 // window, D46) and stay param-synced while hidden.
-function TabFrame({ tab, active, onLocSync }: { tab: LayoutLeaf; active: boolean; onLocSync: () => void }) {
+function TabFrame({
+  tab,
+  active,
+  onLocSync,
+  onFrame,
+}: {
+  tab: LayoutLeaf;
+  active: boolean;
+  onLocSync: () => void;
+  // Registers the iframe with the tab bar's frame map so the bar's mode menu
+  // can write src imperatively (the iframe must never re-render).
+  onFrame: (el: HTMLIFrameElement | null) => void;
+}) {
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const hookRef = useRef<UrlChangeHook | null>(null);
   const srcRef = useRef<string | null>(null);
@@ -147,7 +160,10 @@ function TabFrame({ tab, active, onLocSync }: { tab: LayoutLeaf; active: boolean
 
   return (
     <iframe
-      ref={iframeRef}
+      ref={(el) => {
+        iframeRef.current = el;
+        onFrame(el);
+      }}
       src={srcRef.current}
       onLoad={onLoad}
       style={active ? undefined : { display: "none" }}
@@ -189,6 +205,10 @@ export default function Tabs({ config }: { config: Config }) {
 
   const tabsRef = useRef<LayoutLeaf[]>(tabs);
   tabsRef.current = tabs;
+
+  // Live iframe per tab id, registered by TabFrame — the bar's mode menu
+  // writes src on these imperatively (never through React).
+  const framesRef = useRef<Map<number, HTMLIFrameElement | null>>(new Map());
 
   // Tab list encodes as a flat comma row (TM-2). Re-encode `_layout`, passing
   // the remaining top-level params through (no user params live there in tab
@@ -284,6 +304,19 @@ export default function Tabs({ config }: { config: Config }) {
             }}
           >
             <span className="tab-label">{tabLabel(t)}</span>
+            {/* Template-mode menu, active tab only (its iframe is always
+                mounted). Mode switch writes the tab iframe's src imperatively;
+                the load re-syncs the leaf + `_layout` (onLocSync). */}
+            {t.id === activeId && (
+              <PaneModeMenu
+                path={t.path}
+                query={t.query}
+                onNavigate={(q) => {
+                  const f = framesRef.current.get(t.id);
+                  if (f) f.src = embedSrc(t.path, q);
+                }}
+              />
+            )}
             <span
               className="tab-open-plain"
               title="Open in a new tab"
@@ -318,7 +351,13 @@ export default function Tabs({ config }: { config: Config }) {
         {tabs
           .filter((t) => mountedIds.includes(t.id))
           .map((t) => (
-            <TabFrame key={t.id} tab={t} active={t.id === activeId} onLocSync={onLocSync} />
+            <TabFrame
+              key={t.id}
+              tab={t}
+              active={t.id === activeId}
+              onLocSync={onLocSync}
+              onFrame={(el) => framesRef.current.set(t.id, el)}
+            />
           ))}
       </div>
     </div>


### PR DESCRIPTION
## What

Adds a mode switcher to panel pane bars and the tab bar: a trigger showing the **current template mode's icon**, opening a dropdown of all available modes (icon + name) for that pane's live location.

## How

- New `PaneModeMenu` component: stats the pane's live path to get `stat.templates` (re-stats on pane navigation); hides itself when fewer than 2 modes. Selecting a mode rewrites the pane-local `_mode` — default mode deletes the param (clean-URL rule, PT-9) — preserving `_label` and any raw `_layout=(...)` span byte-identical.
- **Panel**: menu sits between crumbs and split buttons. Mode switch is an imperative `iframe.src` write (same discipline as crumb clicks); `onLoad` re-syncs the leaf + `_layout`.
- **Tabs**: menu on the active tab only (its iframe is always mounted). The bar reaches the iframe through a `framesRef` map registered by `TabFrame`'s new `onFrame` prop — React never touches a live iframe.
- Rendered as spans, not buttons — the trigger nests inside the tab `<button>`, and nested buttons are invalid HTML.
- Dropdown is `position: fixed` (`.panel-pane` clips overflow); closes on outside pointerdown and window blur (clicks landing in iframes never reach the shell document, but do blur the window).
- `modeTitle` exported from `ModeSwitcher` for shared naming (`_render` → "Rendered"); icons reuse `templateModeIcon`.

`_mode` rides the pane's embed URL → captured into the leaf by `readEmbedLoc` → encoded in `_layout`, so the selected mode is bookmarkable/refreshable like any pane state.

## Testing

- `npm run build` (tsc + vite) clean.
- Manually exercised via `scripts/dev.sh`: mode menu in panel panes and active tab, switch reloads pane with new mode, `_layout` re-encodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches panel/tab URL sync and iframe navigation discipline; mistakes could reload panes incorrectly or corrupt `_layout` query encoding, but changes follow existing crumb-click and preview mode patterns.
> 
> **Overview**
> Adds **template mode switching** to panel pane bars and the active tab’s chrome, matching preview’s `_mode` behavior (default mode drops the param per PT-9) while keeping `_layout` spans intact.
> 
> New **`PaneModeMenu`** stats the pane’s live path for available modes, shows the active mode icon as a trigger, and opens a fixed-position dropdown (icon + label). It uses **span-based** controls so the trigger can sit inside a tab `<button>` without invalid nesting. Mode changes call **`onNavigate`** with an updated query; **Panel** and **Tabs** apply them via **imperative `iframe.src`** (same rule as crumb navigation—React must not re-render live embeds). **Tabs** registers iframes through **`framesRef`** / **`TabFrame`’s `onFrame`** so only the active tab’s frame is updated.
> 
> **`modeTitle`** is exported from **`ModeSwitcher`** for shared labels; **`shell.css`** adds pane/tab menu styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ab42ef6fb77b01ac918277af4ab7d46d98bd7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->