### PR TITLE
feat(dmg): app icon sparkle in Fused yellow #E5FF44

### DIFF
--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -156,7 +156,7 @@ for i in range(4):
         y = (1 - t) ** 2 * tip[1] + 2 * (1 - t) * t * ctrl[1] + t**2 * nxt[1]
         poly.append((x, y))
 
-draw.polygon(poly, fill=(91, 157, 255, 255))  # --accent
+draw.polygon(poly, fill=(229, 255, 68, 255))  # Fused yellow #E5FF44
 
 sizes = [16, 32, 128, 256, 512]
 for size in sizes:


### PR DESCRIPTION
## What

App icon sparkle now renders in **Fused yellow `#E5FF44`** `(229, 255, 68)` instead of the blue `--accent` `(91, 157, 255)`.

Dark rounded-card background (`--bg-alt`) unchanged. The icon is generated inline by `scripts/build_dmg.sh` at build time (build artifact, gitignored), so this is a one-line fill change in that generator.

## Test

Run `./scripts/build_dmg.sh` — produces `dist/FusedRender-<ver>.dmg` with the yellow sparkle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single cosmetic fill change in a gitignored build-time icon generator with no runtime or security impact.
> 
> **Overview**
> The **py2app/DMG** pipeline’s inline icon generator in `scripts/build_dmg.sh` now fills the four-pointed sparkle with **Fused yellow `#E5FF44`** `(229, 255, 68)` instead of the previous blue accent `(91, 157, 255)`. The dark rounded-card background and sparkle geometry are unchanged; only the polygon fill color and comment were updated so the built `.icns` matches the product’s **`--accent`** branding used in the shell UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6d9ad304a97ca1de83d753e5763915e31b29ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->