### PR TITLE
Search polish: always-fuzzy, contiguous-run ranking, quieter chrome

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -50,6 +50,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1215,6 +1216,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1284,6 +1286,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1556,6 +1559,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1597,6 +1601,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1769,6 +1774,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,9 +22,10 @@ import {
 } from "../lib/bookmarks";
 import IconPicker from "./IconPicker";
 import type { Bookmark, BookmarkFolder } from "../lib/bookmarks";
-import { useUrlVersion, useBookmarksVersion, useSearchFuzzyVersion, notifyBookmarksChanged } from "../lib/hooks";
+import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "../lib/hooks";
 import type { Config } from "../lib/api";
-import { fuzzyMatch, substringMatch, highlightSegments, isFuzzyEnabled, setFuzzyEnabled } from "../lib/fuzzy";
+import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
+import type { FuzzyResult } from "../lib/fuzzy";
 
 // The fs path a bookmark targets, decoded from its /view/ url (same rule as
 // the hover card). Used for search matching and the tooltip.
@@ -261,8 +262,6 @@ export default function Sidebar({ config }: SidebarProps) {
   // of the store it renders).
   useUrlVersion();
   useBookmarksVersion();
-  useSearchFuzzyVersion();
-  const fuzzyOn = isFuzzyEnabled();
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [bmQuery, setBmQuery] = useState("");
@@ -286,28 +285,59 @@ export default function Sidebar({ config }: SidebarProps) {
   const topOrder = items.map((it) => it.id); // top-level display order
 
   // Bookmark search: a non-empty query flattens the tree to matching rows.
-  // Matches a bookmark on its name OR target path; a folder-name match pulls in
-  // all of that folder's children. Highlight positions come from the name match
-  // (a path-only or folder-name hit shows the name unhighlighted).
+  // Matches a bookmark fuzzily on its name (or its folder's name — a folder
+  // match pulls in all children), or on its target path as a contiguous
+  // case-insensitive substring (fuzzy on a long path matched nearly anything).
+  // Highlight positions come from the name match (a path-only or folder-name
+  // hit shows the name unhighlighted). Ranked like the explorer search within
+  // name matches: longest consecutive matched run first (a contiguous
+  // substring hit beats a scattered subsequence one), then higher fuzzy score,
+  // then alphabetical. Path-substring-only matches always rank below name
+  // matches, alphabetically.
   const bq = bmQuery.trim();
   const bmSearching = bq !== "";
   const matched: { b: Bookmark; namePositions: number[] }[] = [];
-  const matcher = fuzzyOn ? fuzzyMatch : substringMatch;
   if (bmSearching) {
+    const bqLower = bq.toLowerCase();
+    const pathHit = (url: string) => bookmarkFsPath(url).toLowerCase().includes(bqLower);
+    const ranked: { b: Bookmark; namePositions: number[]; nameHit: boolean; longestRun: number; score: number }[] = [];
+    // The strength of a match across all name fields that hit, for ranking. A
+    // folder name match contributes its own run/score to every child it pulls in.
+    const rank = (folderM: FuzzyResult | null, ...ms: (FuzzyResult | null)[]) => {
+      let longestRun = 0;
+      let score = -Infinity;
+      for (const m of [folderM, ...ms]) {
+        if (!m) continue;
+        if (m.longestRun > longestRun) longestRun = m.longestRun;
+        if (m.score > score) score = m.score;
+      }
+      return { longestRun, score };
+    };
     for (const it of items) {
       if (isFolder(it)) {
-        const folderHit = matcher(bq, it.name) !== null;
+        const folderM = fuzzyMatch(bq, it.name);
         for (const c of it.children) {
-          const nameM = matcher(bq, c.name);
-          const pathHit = matcher(bq, bookmarkFsPath(c.url)) !== null;
-          if (folderHit || nameM || pathHit) matched.push({ b: c, namePositions: nameM ? nameM.positions : [] });
+          const nameM = fuzzyMatch(bq, c.name);
+          if (folderM || nameM || pathHit(c.url)) {
+            const { longestRun, score } = rank(folderM, nameM);
+            ranked.push({ b: c, namePositions: nameM ? nameM.positions : [], nameHit: !!(folderM || nameM), longestRun, score });
+          }
         }
       } else {
-        const nameM = matcher(bq, it.name);
-        const pathHit = matcher(bq, bookmarkFsPath(it.url)) !== null;
-        if (nameM || pathHit) matched.push({ b: it, namePositions: nameM ? nameM.positions : [] });
+        const nameM = fuzzyMatch(bq, it.name);
+        if (nameM || pathHit(it.url)) {
+          const { longestRun, score } = rank(null, nameM);
+          ranked.push({ b: it, namePositions: nameM ? nameM.positions : [], nameHit: !!nameM, longestRun, score });
+        }
       }
     }
+    ranked.sort((a, b) => {
+      if (a.nameHit !== b.nameHit) return a.nameHit ? -1 : 1;
+      if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
+      if (b.score !== a.score) return b.score - a.score;
+      return a.b.name.localeCompare(b.b.name, undefined, { sensitivity: "base" });
+    });
+    for (const { b, namePositions } of ranked) matched.push({ b, namePositions });
   }
 
   // Rows in search results are not reorderable; a no-op drag keeps the shared
@@ -631,13 +661,6 @@ export default function Sidebar({ config }: SidebarProps) {
                   }
                 }}
               />
-              <button
-                className={"search-fuzzy-toggle bookmark-search-fuzzy-toggle" + (fuzzyOn ? " active" : "")}
-                title="Fuzzy matching on/off"
-                onClick={() => setFuzzyEnabled(!fuzzyOn)}
-              >
-                fuzzy
-              </button>
             </div>
             {bmSearching ? (
               matched.length ? (

--- a/frontend/src/lib/fuzzy.ts
+++ b/frontend/src/lib/fuzzy.ts
@@ -31,6 +31,18 @@ export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
   if (query === "") return { score: 0, positions: [], longestRun: 0 };
   const q = query.toLowerCase();
   const t = text.toLowerCase();
+  const sub = t.indexOf(q);
+  if (sub !== -1) {
+    const positions: number[] = [];
+    let score = 0;
+    for (let ti = sub; ti < sub + q.length; ti++) {
+      positions.push(ti);
+      score += 1;
+      if (ti > sub) score += 3; // consecutive run
+      if (isSegmentStart(text, ti)) score += 5; // landed on a word boundary
+    }
+    return { score, positions, longestRun: q.length };
+  }
   const positions: number[] = [];
   let qi = 0;
   let score = 0;

--- a/frontend/src/lib/fuzzy.ts
+++ b/frontend/src/lib/fuzzy.ts
@@ -6,6 +6,7 @@
 export interface FuzzyResult {
   score: number;
   positions: number[]; // indices in `text` of the matched chars, ascending
+  longestRun: number; // length of the longest consecutive matched stretch
 }
 
 // Chars that open a new "segment" in a path/name; a match right after one of
@@ -27,60 +28,28 @@ function isSegmentStart(text: string, i: number): boolean {
 }
 
 export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
-  if (query === "") return { score: 0, positions: [] };
+  if (query === "") return { score: 0, positions: [], longestRun: 0 };
   const q = query.toLowerCase();
   const t = text.toLowerCase();
   const positions: number[] = [];
   let qi = 0;
   let score = 0;
   let prev = -2; // index of the previously matched char, for the consecutive test
+  let run = 0; // length of the current consecutive matched stretch
+  let longestRun = 0;
   for (let ti = 0; ti < t.length && qi < q.length; ti++) {
     if (t[ti] !== q[qi]) continue;
     positions.push(ti);
     score += 1;
+    run = ti === prev + 1 ? run + 1 : 1;
+    if (run > longestRun) longestRun = run;
     if (ti === prev + 1) score += 3; // consecutive run
     if (isSegmentStart(text, ti)) score += 5; // landed on a word boundary
     prev = ti;
     qi++;
   }
   if (qi < q.length) return null; // ran out of text before matching every char
-  return { score, positions };
-}
-
-// Plain case-insensitive substring matcher — the "fuzzy off" mode. Same
-// result shape as fuzzyMatch so callers can swap matchers without branching:
-// positions are the contiguous run covering the first occurrence of `query`
-// in `text`. Score favors an earlier match and a match landing on a segment
-// start, mirroring fuzzyMatch's weighting so the two scales feel consistent
-// (each mode only ever ranks its own results, so exact cross-mode parity
-// isn't required).
-export function substringMatch(query: string, text: string): FuzzyResult | null {
-  if (query === "") return { score: 0, positions: [] };
-  const q = query.toLowerCase();
-  const t = text.toLowerCase();
-  const index = t.indexOf(q);
-  if (index === -1) return null;
-  const positions: number[] = [];
-  for (let i = 0; i < q.length; i++) positions.push(index + i);
-  let score = q.length * 4; // consecutive run: 1 (char) + 3 (consecutive) per char, as in fuzzyMatch
-  if (isSegmentStart(text, index)) score += 5; // landed on a word boundary
-  score -= index; // earlier position scores higher
-  return { score, positions };
-}
-
-// Whether fuzzy (subsequence) matching is on; off falls back to
-// substringMatch. Persisted so the choice survives a reload; both the
-// explorer and sidebar searches read/write this single shared pref.
-const FUZZY_PREF_KEY = "fused.searchFuzzy";
-export const SEARCH_FUZZY_EVENT = "fused:searchFuzzy";
-
-export function isFuzzyEnabled(): boolean {
-  return localStorage.getItem(FUZZY_PREF_KEY) !== "false"; // default true
-}
-
-export function setFuzzyEnabled(value: boolean): void {
-  localStorage.setItem(FUZZY_PREF_KEY, String(value));
-  window.dispatchEvent(new Event(SEARCH_FUZZY_EVENT));
+  return { score, positions, longestRun };
 }
 
 export interface HighlightSegment {

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -14,7 +14,6 @@
 // layout modes and the update-bookmark flow, not just for these hooks.
 import { useEffect, useState } from "react";
 import { NAV_EVENT } from "./router";
-import { SEARCH_FUZZY_EVENT } from "./fuzzy";
 
 function useEventCounter(events: readonly string[]): number {
   const [n, setN] = useState(0);
@@ -49,10 +48,4 @@ export function notifyBookmarksChanged(): void {
 
 export function useBookmarksVersion(): number {
   return useEventCounter([BOOKMARKS_EVENT]);
-}
-
-// Fuzzy-on/off pref change signal (lib/fuzzy.ts setFuzzyEnabled). Both search
-// surfaces subscribe so toggling in one re-renders the other immediately.
-export function useSearchFuzzyVersion(): number {
-  return useEventCounter([SEARCH_FUZZY_EVENT]);
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -590,10 +590,10 @@ a.bookmark-name::after {
 
 .listing-search .listing-search-input {
   width: 100%;
-  /* Reserves room for, right to left: fuzzy toggle (right:10), count chip /
-     spinner (right:64) — sized for the longest count text
-     ("showing 250 of 7734 matches"). Esc clears the query. */
-  padding-right: 170px;
+  /* Reserves room for the count chip / spinner pinned inside the right edge —
+     sized for the longest count text ("showing 250 of 7734 matches"). Esc
+     clears the query. */
+  padding-right: 116px;
 }
 
 /* Native WebKit cancel × collides with the absolutely-positioned count chip;
@@ -603,11 +603,10 @@ a.bookmark-name::after {
   appearance: none;
 }
 
-/* Match count pinned inside the input's right edge (no layout shift). Shifted
-   left of the fuzzy toggle (right:10). */
+/* Match count pinned inside the input's right edge (no layout shift). */
 .listing-search-count {
   position: absolute;
-  right: 80px;
+  right: 26px;
   top: 50%;
   transform: translateY(-50%);
   color: var(--fg-muted);
@@ -621,7 +620,7 @@ a.bookmark-name::after {
    fully interactive. */
 .listing-search-spinner {
   position: absolute;
-  right: 80px;
+  right: 26px;
   top: 50%;
   width: 11px;
   height: 11px;
@@ -646,51 +645,6 @@ a.bookmark-name::after {
   transition: opacity 0.1s ease-out;
 }
 
-/* Fuzzy-match toggle pill, shared chrome between the explorer search bar and
-   the sidebar bookmark search. Active state reuses the input's own focus
-   accent so "fuzzy on" reads with the same accent language as everything
-   else, rather than inventing a new on-state color. */
-.search-fuzzy-toggle {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  font: inherit;
-  font-size: 10.5px;
-  font-weight: 600;
-  line-height: 1;
-  letter-spacing: 0.02em;
-  padding: 3px 7px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: none;
-  color: var(--fg-muted);
-  cursor: pointer;
-}
-
-.search-fuzzy-toggle:hover {
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.search-fuzzy-toggle.active {
-  color: var(--accent);
-  border-color: rgba(229, 255, 68, 0.45);
-  background: rgba(229, 255, 68, 0.08);
-}
-
-.search-fuzzy-toggle.active:hover {
-  background: rgba(229, 255, 68, 0.14);
-}
-
-.listing-search-fuzzy-toggle {
-  /* 16px container padding + 10px inset from the input's own right edge. */
-  right: 26px;
-}
-
-.bookmark-search-fuzzy-toggle {
-  /* 8px container padding + 8px inset from the input's own right edge. */
-  right: 16px;
-}
-
 /* Shared search-input chrome (explorer header + sidebar bookmarks). */
 .listing-search-input,
 .bookmark-search-input {
@@ -709,10 +663,12 @@ a.bookmark-name::after {
   color: var(--fg-muted);
 }
 
+/* Focus affordance: a muted border brighten, not the accent yellow — still
+   clearly perceivable against the resting --border, just not loud. */
 .listing-search-input:focus,
 .bookmark-search-input:focus {
   outline: none;
-  border-color: var(--accent);
+  border-color: var(--fg-muted);
 }
 
 /* Matched-substring highlight in search results (explorer + bookmarks). */
@@ -729,16 +685,9 @@ a.bookmark-name::after {
 }
 
 /* Sidebar bookmark search box: sits just under the "Bookmarks" heading,
-   aligned with the row padding. Relative so the fuzzy toggle can pin to its
-   right edge like the explorer search bar. */
+   aligned with the row padding. */
 .bookmark-search {
-  position: relative;
   padding: 0 8px 6px;
-}
-
-/* Reserve room for the fuzzy toggle pinned inside the input's right edge. */
-.bookmark-search .bookmark-search-input {
-  padding-right: 52px;
 }
 
 table.listing-table {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -9,9 +9,7 @@ import { navigate } from "../lib/router";
 import { listDir, walkDir } from "../lib/api";
 import type { FsEntry, WalkEntry, WalkResult } from "../lib/api";
 import { formatSize, formatMtime } from "../lib/format";
-import { fuzzyMatch, substringMatch, highlightSegments, isFuzzyEnabled, setFuzzyEnabled } from "../lib/fuzzy";
-import type { FuzzyResult } from "../lib/fuzzy";
-import { useSearchFuzzyVersion } from "../lib/hooks";
+import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 
 const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
 type SortKey = keyof typeof SORT_KEYS;
@@ -52,24 +50,22 @@ function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEnt
   });
 }
 
-// Match a query against every walked entry's relative path, then rank: higher
-// fuzzy score first, then fewer path segments (shallower = closer to hand),
-// then alphabetical for a stable order.
+// Match a query against every walked entry's relative path, then rank: longest
+// consecutive matched run first (a contiguous substring hit always beats a
+// scattered subsequence one), then higher fuzzy score, then fewer path segments
+// (shallower = closer to hand), then alphabetical for a stable order.
 interface SearchHit {
   entry: WalkEntry;
   positions: number[];
 }
-function searchWalk(
-  query: string,
-  entries: WalkEntry[],
-  matcher: (query: string, text: string) => FuzzyResult | null
-): SearchHit[] {
-  const hits: { entry: WalkEntry; positions: number[]; score: number }[] = [];
+function searchWalk(query: string, entries: WalkEntry[]): SearchHit[] {
+  const hits: { entry: WalkEntry; positions: number[]; score: number; longestRun: number }[] = [];
   for (const entry of entries) {
-    const m = matcher(query, entry.rel);
-    if (m) hits.push({ entry, positions: m.positions, score: m.score });
+    const m = fuzzyMatch(query, entry.rel);
+    if (m) hits.push({ entry, positions: m.positions, score: m.score, longestRun: m.longestRun });
   }
   hits.sort((a, b) => {
+    if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
     if (b.score !== a.score) return b.score - a.score;
     const ad = a.entry.rel.split("/").length;
     const bd = b.entry.rel.split("/").length;
@@ -122,11 +118,6 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // NOT URL-synced (unlike the normal-mode sort) — it resets on every query
   // change, so persisting it would fight that reset.
   const [searchSort, setSearchSort] = useState<{ sort: SortKey; order: SortOrder } | null>(null);
-  // Fuzzy on/off is a shared pref (lib/fuzzy.ts), not local state; this hook
-  // just forces a re-render when it changes so the toggle takes effect
-  // immediately, including when flipped from the sidebar's own toggle.
-  useSearchFuzzyVersion();
-  const fuzzyOn = isFuzzyEnabled();
 
   // The input echoes `query` (immediate) so keystrokes never wait on the
   // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
@@ -284,8 +275,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // on React's low-priority schedule, not synchronously on every keystroke.
   const hits = useMemo(() => {
     if (!(searching && validWalk.status === "ok")) return [];
-    const matcher = fuzzyOn ? fuzzyMatch : substringMatch;
-    const ranked = searchWalk(q, validWalk.result.entries, matcher);
+    const ranked = searchWalk(q, validWalk.result.entries);
     if (!searchSort) return ranked; // relevance order
     const { sort, order } = searchSort;
     const flip = order === "desc" ? -1 : 1;
@@ -299,7 +289,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
       if (cmp === 0) cmp = byName(a, b);
       return cmp * flip;
     });
-  }, [searching, q, validWalk, searchSort, fuzzyOn]);
+  }, [searching, q, validWalk, searchSort]);
 
   // Rendering every match as a <tr> is the other half of the per-keystroke
   // jank on huge trees (thousands of rows synchronously mounted). Cap what
@@ -438,13 +428,6 @@ export default function Listing({ fsPath }: { fsPath: string }) {
             }
           }}
         />
-        <button
-          className={"search-fuzzy-toggle listing-search-fuzzy-toggle" + (fuzzyOn ? " active" : "")}
-          title="Fuzzy matching on/off"
-          onClick={() => setFuzzyEnabled(!fuzzyOn)}
-        >
-          fuzzy
-        </button>
         {searching && (validWalk.status === "idle" || validWalk.status === "loading") && (
           <span className="listing-search-spinner" aria-hidden="true" />
         )}


### PR DESCRIPTION
## What

- **Fuzzy toggle removed** — fuzzy matching is always on; the pill, `localStorage` pref, event plumbing, and `useSearchFuzzyVersion` hook are gone.
- **Ranking**: results order by longest consecutive matched run first (contiguous substring hits beat scattered subsequences), then score → path depth → alpha. Same ordering in the bookmarks search.
- **Bookmark path matching tightened**: target paths match by contiguous case-insensitive substring only — fuzzy over long absolute paths matched nearly any query (e.g. "sample.html" pulled in "sessions.html" via its path) and produced un-highlighted rows. Path-only matches rank below name matches.
- **Focus outline**: search inputs drop the accent-yellow focus border for a muted brighten.

## Testing

- `tsc --noEmit` + vite build clean; pytest suite 82 passed.
- Verified in the running app: ranking with contiguous queries, bookmark search no longer surfaces scattered-path matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only search UX and ranking changes; no auth, API, or data-layer impact.
> 
> **Overview**
> Removes the explorer and sidebar **fuzzy on/off** pill, the `localStorage` preference, `useSearchFuzzyVersion`, and `substringMatch` — search always uses `fuzzyMatch`.
> 
> **Ranking** now prefers **longest consecutive matched run**, then score, then (explorer) shallower paths / (bookmarks) name hits over path-only hits, then alphabetical. `FuzzyResult` gains `longestRun`; contiguous substring matches in `fuzzyMatch` short-circuit with a full-length run.
> 
> **Bookmark search** matches target paths with **case-insensitive substring only** (not fuzzy on long paths), so scattered path hits no longer flood results.
> 
> **UI**: search input focus uses a muted border instead of accent yellow; listing/bookmark search layout drops toggle padding and related CSS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50a4f90f0d892d8633f42348d9c3a489299e971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->