### PR TITLE
fix(dmg): sign all nested Mach-O binaries (notarization was Invalid)

### DIFF
--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -208,8 +208,21 @@ test -d "$APP_DIR"
 
 echo "==> bundle sanity: Mach-O-as-.py check"
 APP_PYLIB="$APP_DIR/Contents/Resources/lib/python3.12"
-BAD_PY="$(find "$APP_PYLIB" -name '*.py' -size +1M -print0 | \
-  xargs -0 -I{} sh -c 'head -c4 "{}" | xxd -p | grep -qE "^(cffaedfe|cafebabe|feedfacf)$" && echo "{}"' || true)"
+# find -exec ... {} + (not `xargs -I{}`, which aborts with "command line
+# cannot be assembled, too long" over a large file set - see the signing loop
+# below) enumerates >1M .py files whose first 4 bytes are a Mach-O magic.
+BAD_PY=""
+while IFS= read -r -d '' f; do
+  BAD_PY+="$f"$'\n'
+done < <(
+  find "$APP_PYLIB" -name '*.py' -size +1M -exec sh -c '
+    for f do
+      case "$(head -c4 "$f" | xxd -p)" in
+        cffaedfe|cafebabe|feedfacf) printf "%s\0" "$f" ;;
+      esac
+    done
+  ' _ {} +
+)
 if [[ -n "$BAD_PY" ]]; then
   echo "FATAL: Mach-O binary shipped as .py (would shadow the real extension):" >&2
   echo "$BAD_PY" >&2
@@ -328,16 +341,33 @@ PLIST
   # `python`); we enumerate every Mach-O by magic bytes (same detection as the
   # sanity check above) and sign each, then seal the .app last.
   echo "==> signing nested Mach-O binaries"
-  while IFS= read -r macho; do
-    [[ -z "$macho" ]] && continue
+  # find -exec ... {} + emits NUL-delimited Mach-O paths, read back with
+  # `read -d ''`. NOT `find -print0 | xargs -0 -I{} sh -c ...`: BSD xargs -I{}
+  # aborts with "command line cannot be assembled, too long" over the ~375
+  # Mach-O files in this bundle and, because the old `|| true` swallowed the
+  # failure, the loop ran on an EMPTY list - shipping ad-hoc-signed nested
+  # dylibs that notarization then rejected ("not signed with a valid Developer
+  # ID certificate" / "does not include a secure timestamp").
+  signed_count=0
+  while IFS= read -r -d '' macho; do
     codesign --force --options runtime --timestamp \
       --entitlements "$ENTITLEMENTS" $KC_OPT -s "$SIGN_IDENTITY" "$macho"
+    signed_count=$((signed_count + 1))
   done < <(
-    find "$APP_DIR" -type f -print0 \
-      | xargs -0 -I{} sh -c \
-        'head -c4 "{}" | xxd -p | grep -qE "^(cffaedfe|cafebabe|feedfacf|feedface|cefaedfe|bebafeca)$" && echo "{}"' \
-      || true
+    find "$APP_DIR" -type f -exec sh -c '
+      for f do
+        case "$(head -c4 "$f" | xxd -p)" in
+          cffaedfe|cafebabe|feedfacf|feedface|cefaedfe|bebafeca) printf "%s\0" "$f" ;;
+        esac
+      done
+    ' _ {} +
   )
+  echo "    signed $signed_count nested binaries"
+  if [[ "$signed_count" -eq 0 ]]; then
+    echo "FATAL: found no nested Mach-O binaries to sign — detection is broken;" >&2
+    echo "       refusing to seal a bundle whose nested code is unsigned." >&2
+    exit 1
+  fi
   echo "==> sealing the app bundle"
   codesign --force --options runtime --timestamp \
     --entitlements "$ENTITLEMENTS" $KC_OPT -s "$SIGN_IDENTITY" "$APP_DIR"


### PR DESCRIPTION
## Problem

`bash scripts/build_dmg.sh` with a Developer ID identity + notary profile produced a DMG that Apple rejected as **Invalid**:

```
libcrypto.3.dylib: The binary is not signed with a valid Developer ID certificate.
libcrypto.3.dylib: The signature does not include a secure timestamp.
liblzma.5.dylib:   ... (same, and libssl / libsqlite3 / libmpdec / ...)
```

## Root cause

The nested-binary signing loop enumerated Mach-Os with `find -print0 | xargs -0 -I{} sh -c ...`. Over the ~375 Mach-O files in the bundle, BSD `xargs -I{}` aborts with `command line cannot be assembled, too long` and emits nothing. The trailing `|| true` swallowed that failure, so the `while read` loop signed **zero** binaries. Nested dylibs kept their ad-hoc signatures → notarization Invalid. (The top-level seal succeeded, masking it locally.)

## Fix

- Enumerate via `find -exec sh -c '...' _ {} +` emitting NUL-delimited paths; read with `read -r -d ''`. No `xargs -I{}`, no length limit.
- **Hard-fail if zero binaries match** — an empty detection can never again silently ship unsigned nested code.
- Same `find -exec` pattern applied to the Mach-O-as-.py sanity check for consistency.

## Verification

Same signing approach was run manually against the already-built bundle and re-submitted to Apple — notarization result reported in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release signing behavior for distributable DMGs; the new zero-match fatal guard is intentional but could fail builds if Mach-O detection regresses on a future macOS/tooling change.
> 
> **Overview**
> Fixes **Developer ID DMG builds** that Apple notarized as Invalid because nested dylibs (e.g. `libcrypto.3.dylib`) never received a proper signature or timestamp.
> 
> In `scripts/build_dmg.sh`, Mach-O discovery for the inside-out `codesign` loop and the Mach-O-as-`.py` sanity check no longer uses `find | xargs -I{}`, which on BSD macOS hits **"command line cannot be assembled, too long"** over ~375 bundle binaries; the old `|| true` hid that failure so **zero** nested binaries were signed while the top-level `.app` still sealed.
> 
> Both paths now use **`find -exec … {} +`** with NUL-delimited output and `read -d ''`. The signing step **counts** signed binaries, logs the count, and **fails the build** if none are found so unsigned nested code cannot ship silently again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99872f4e4c7aaa84b45e06978c4a98ed2df29278. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->