### PR TITLE
Fix ascii decode crash in claude template polling

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -71,7 +71,7 @@ def _sidecar_path(file: str) -> str:
 
 def _load_sidecar(file: str) -> dict:
     try:
-        with open(_sidecar_path(file)) as fh:
+        with open(_sidecar_path(file), encoding="utf-8") as fh:
             data = json.load(fh)
         if isinstance(data, dict) and isinstance(data.get("sessions"), list):
             return data
@@ -84,7 +84,7 @@ def _save_sidecar(file: str, data: dict) -> None:
     path = _sidecar_path(file)
     fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
     try:
-        with os.fdopen(fd, "w") as fh:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
             json.dump(data, fh, indent=2)
         os.replace(tmp, path)
     except OSError:
@@ -200,24 +200,24 @@ def _start(file: str, message: str, session_id: str, model: str,
 
     # poll() records the session into the sidecar once claude reports its id;
     # it needs the file + first message, so stash them with the run.
-    with open(os.path.join(run_dir, "meta.json"), "w") as f:
+    with open(os.path.join(run_dir, "meta.json"), "w", encoding="utf-8") as f:
         json.dump({"file": file, "message": message,
                    "resumed_from": session_id}, f)
 
-    with open(os.path.join(run_dir, "out.jsonl"), "w") as out, \
-         open(os.path.join(run_dir, "err.log"), "w") as err:
+    with open(os.path.join(run_dir, "out.jsonl"), "w", encoding="utf-8") as out, \
+         open(os.path.join(run_dir, "err.log"), "w", encoding="utf-8") as err:
         proc = subprocess.Popen(cmd, stdout=out, stderr=err,
                                 cwd=os.path.dirname(file),
                                 stdin=subprocess.DEVNULL,
                                 start_new_session=True)
-    with open(os.path.join(run_dir, "pid"), "w") as f:
+    with open(os.path.join(run_dir, "pid"), "w", encoding="utf-8") as f:
         f.write(str(proc.pid))
     return {"run_id": run_id}
 
 
 def _alive(run_dir: str) -> bool:
     try:
-        pid = int(open(os.path.join(run_dir, "pid")).read())
+        pid = int(open(os.path.join(run_dir, "pid"), encoding="utf-8").read())
         os.kill(pid, 0)
         return True
     except (OSError, ValueError):
@@ -239,7 +239,8 @@ def _poll(run_id: str) -> dict:
     phase = "thinking"
 
     try:
-        lines = open(os.path.join(run_dir, "out.jsonl")).read().splitlines()
+        lines = open(os.path.join(run_dir, "out.jsonl"), encoding="utf-8",
+                     errors="replace").read().splitlines()
     except FileNotFoundError:
         lines = []
 
@@ -285,7 +286,8 @@ def _poll(run_id: str) -> dict:
         # clean success and the sidecar-record guard below skips it.
         done = True
         try:
-            tail = open(os.path.join(run_dir, "err.log")).read().strip()
+            tail = open(os.path.join(run_dir, "err.log"), encoding="utf-8",
+                        errors="replace").read().strip()
         except FileNotFoundError:
             tail = ""
         error = tail or ("claude exited before completing the reply"
@@ -296,11 +298,11 @@ def _poll(run_id: str) -> dict:
     marker = os.path.join(run_dir, "recorded")
     if new_session and not error and not os.path.exists(marker):
         try:
-            with open(os.path.join(run_dir, "meta.json")) as f:
+            with open(os.path.join(run_dir, "meta.json"), encoding="utf-8") as f:
                 meta = json.load(f)
             _record_session(meta["file"], new_session, meta["message"],
                             meta.get("resumed_from", ""))
-            open(marker, "w").close()
+            open(marker, "w", encoding="utf-8").close()
         except (OSError, json.JSONDecodeError, KeyError):
             pass  # sidecar bookkeeping must never break the chat itself
 
@@ -339,7 +341,7 @@ def _history(file: str, session_id: str) -> dict:
         return {"turns": []}
 
     turns = []
-    for line in open(path, errors="replace"):
+    for line in open(path, encoding="utf-8", errors="replace"):
         try:
             row = json.loads(line)
         except json.JSONDecodeError:
@@ -376,7 +378,7 @@ def _cancel(run_id: str) -> dict:
     if "/" in run_id or run_id.startswith(".") or not os.path.isdir(run_dir):
         return {"cancelled": run_id}
     try:
-        pid = int(open(os.path.join(run_dir, "pid")).read())
+        pid = int(open(os.path.join(run_dir, "pid"), encoding="utf-8").read())
         os.killpg(pid, signal.SIGTERM)  # start_new_session=True -> pid is pgid
     except (OSError, ValueError):
         pass


### PR DESCRIPTION
## Root cause

`templates/claude/agent.py` opened every file — the stream-json `out.jsonl` it polls, `err.log`, `meta.json`, the session sidecar — without an `encoding=` argument. The runPython exec engine runs under a POSIX/C locale, so Python's default text encoding resolves to **ascii** there (not utf-8 like an interactive shell). The first time Claude's reply contained a multibyte character (an em-dash, `0xe2 0x80 0x94`), `poll`'s `open(out.jsonl).read()` raised:

```
'ascii' codec can't decode byte 0xe2 in position 7351: ordinal not in range(128)
```

and the chat UI surfaced the decode error instead of the reply.

## Fix

- `encoding="utf-8"` on all 14 `open()`/`os.fdopen()` calls in `agent.py`.
- The two reads of files that grow while being read (`out.jsonl`, `err.log`) additionally get `errors="replace"`: `poll` re-reads the log while the subprocess is mid-write, so the file can legitimately end in a partial multibyte sequence — that must degrade to a replacement char, not an exception. (The transcript iteration already had `errors="replace"`; it now gets the explicit encoding too.)

No logic changes.

## Testing

- `py_compile` clean; full pytest suite 82 passed.
- Reproduced the crash by prompting the claude view on an html file until the reply contained an em-dash; after the fix the same flow streams the reply correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Encoding-only changes with no control-flow or API changes; reduces failure risk in non-UTF-8 default locales.
> 
> **Overview**
> Fixes chat polling crashes when Claude replies contain non-ASCII text under a POSIX/C locale, where Python defaults to **ascii** for `open()` without `encoding=`.
> 
> All `open()` / `os.fdopen()` calls in `agent.py` now use **`encoding="utf-8"`** for sidecars, run metadata, stream logs, PID files, and session transcripts. **`out.jsonl`** and **`err.log`** reads during `_poll` also use **`errors="replace"`** so partially written multibyte sequences at EOF do not raise while the subprocess is still streaming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d5de9c397e07ada27e261c70d4b9a300621b0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->