### PR TITLE
Search hidden entries on dot-prefixed queries

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fused-render-shell",
-  "version": "0.0.0",
+  "version": "file:../../../private/tmp/fr-hidden-pr/frontend",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -19,7 +19,7 @@
         "vite": "^6.0.7"
       }
     },
-    "node_modules/@babel/code-frame": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
@@ -34,7 +34,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/compat-data": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/compat-data": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
@@ -44,7 +44,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/core": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/core": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
@@ -76,7 +76,7 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "node_modules/@babel/generator": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
@@ -93,7 +93,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-compilation-targets": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
@@ -110,7 +110,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-globals": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-globals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
@@ -120,7 +120,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-imports": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
@@ -134,7 +134,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-transforms": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
@@ -152,7 +152,7 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
@@ -162,7 +162,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-string-parser": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
@@ -172,7 +172,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-identifier": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
@@ -182,7 +182,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-validator-option": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
@@ -192,7 +192,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helpers": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helpers": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
@@ -206,7 +206,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/parser": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
@@ -222,7 +222,7 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
@@ -238,7 +238,7 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
@@ -254,7 +254,7 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/template": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
@@ -269,7 +269,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/traverse": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/traverse": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
@@ -288,7 +288,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/types": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
@@ -302,7 +302,7 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
@@ -319,7 +319,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/android-arm": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-arm": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
@@ -336,7 +336,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
@@ -353,7 +353,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/android-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
@@ -370,7 +370,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/darwin-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
@@ -387,7 +387,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/darwin-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/darwin-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
@@ -404,7 +404,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/freebsd-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
@@ -421,7 +421,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/freebsd-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
@@ -438,7 +438,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-arm": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-arm": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
@@ -455,7 +455,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
@@ -472,7 +472,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-ia32": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-ia32": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
@@ -489,7 +489,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-loong64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-loong64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
@@ -506,7 +506,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-mips64el": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
@@ -523,7 +523,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-ppc64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
@@ -540,7 +540,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-riscv64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
@@ -557,7 +557,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-s390x": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-s390x": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
@@ -574,7 +574,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/linux-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
@@ -591,7 +591,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
@@ -608,7 +608,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/netbsd-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
@@ -625,7 +625,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
@@ -642,7 +642,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openbsd-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
@@ -659,7 +659,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/openharmony-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
@@ -676,7 +676,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/sunos-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/sunos-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
@@ -693,7 +693,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/win32-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
@@ -710,7 +710,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/win32-ia32": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-ia32": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
@@ -727,7 +727,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@esbuild/win32-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
@@ -744,7 +744,7 @@
         "node": ">=18"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
@@ -755,7 +755,7 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/remapping": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
@@ -766,7 +766,7 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "node_modules/@jridgewell/resolve-uri": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
@@ -776,14 +776,14 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/sourcemap-codec": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jridgewell/trace-mapping": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
@@ -794,14 +794,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
       "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
@@ -815,7 +815,7 @@
         "android"
       ]
     },
-    "node_modules/@rollup/rollup-android-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
       "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
@@ -829,7 +829,7 @@
         "android"
       ]
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
       "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
@@ -843,7 +843,7 @@
         "darwin"
       ]
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
       "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
@@ -857,7 +857,7 @@
         "darwin"
       ]
     },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
       "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
@@ -871,7 +871,7 @@
         "freebsd"
       ]
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
       "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
@@ -885,7 +885,7 @@
         "freebsd"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
@@ -899,7 +899,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
@@ -913,7 +913,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
       "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
@@ -927,7 +927,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
@@ -941,7 +941,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
       "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
@@ -955,7 +955,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
@@ -969,7 +969,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
       "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
@@ -983,7 +983,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
@@ -997,7 +997,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
       "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
@@ -1011,7 +1011,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
@@ -1025,7 +1025,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
       "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
@@ -1039,7 +1039,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
@@ -1053,7 +1053,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
@@ -1067,7 +1067,7 @@
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-openbsd-x64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
       "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
@@ -1081,7 +1081,7 @@
         "openbsd"
       ]
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
       "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
@@ -1095,7 +1095,7 @@
         "openharmony"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
       "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
@@ -1109,7 +1109,7 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
       "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
@@ -1123,7 +1123,7 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
@@ -1137,7 +1137,7 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
       "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
@@ -1151,7 +1151,7 @@
         "win32"
       ]
     },
-    "node_modules/@types/babel__core": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
@@ -1165,7 +1165,7 @@
         "@types/babel__traverse": "*"
       }
     },
-    "node_modules/@types/babel__generator": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__generator": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
@@ -1175,7 +1175,7 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "node_modules/@types/babel__template": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
@@ -1186,7 +1186,7 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "node_modules/@types/babel__traverse": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__traverse": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
@@ -1196,21 +1196,21 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "node_modules/@types/estree": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/react": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
@@ -1222,7 +1222,7 @@
         "csstype": "^3.2.2"
       }
     },
-    "node_modules/@types/react-dom": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/react-dom": {
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
@@ -1232,7 +1232,7 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@vitejs/plugin-react": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
@@ -1253,7 +1253,7 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "node_modules/baseline-browser-mapping": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
@@ -1266,7 +1266,7 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/browserslist": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/browserslist": {
       "version": "4.28.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
       "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
@@ -1301,7 +1301,7 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/caniuse-lite": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/caniuse-lite": {
       "version": "1.0.30001802",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
       "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
@@ -1322,21 +1322,21 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/convert-source-map": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/csstype": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/debug": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -1354,14 +1354,14 @@
         }
       }
     },
-    "node_modules/electron-to-chromium": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/electron-to-chromium": {
       "version": "1.5.387",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
       "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/esbuild": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
@@ -1403,7 +1403,7 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "node_modules/escalade": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
@@ -1413,7 +1413,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/fdir": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
@@ -1431,7 +1431,7 @@
         }
       }
     },
-    "node_modules/fsevents": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
@@ -1446,7 +1446,7 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/gensync": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
@@ -1456,13 +1456,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/js-tokens": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "node_modules/jsesc": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
@@ -1475,7 +1475,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/json5": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
@@ -1488,7 +1488,7 @@
         "node": ">=6"
       }
     },
-    "node_modules/loose-envify": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -1500,7 +1500,7 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/lru-cache": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
@@ -1510,14 +1510,14 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/ms": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nanoid": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
@@ -1536,7 +1536,7 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/node-releases": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
@@ -1546,14 +1546,14 @@
         "node": ">=18"
       }
     },
-    "node_modules/picocolors": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/picomatch": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
@@ -1567,7 +1567,7 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/postcss": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
@@ -1596,7 +1596,7 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/react": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
@@ -1609,7 +1609,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dom": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
@@ -1622,7 +1622,7 @@
         "react": "^18.3.1"
       }
     },
-    "node_modules/react-refresh": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
@@ -1632,7 +1632,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
@@ -1677,7 +1677,7 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/scheduler": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
@@ -1686,7 +1686,7 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "node_modules/semver": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
@@ -1696,7 +1696,7 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/source-map-js": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
@@ -1706,7 +1706,7 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tinyglobby": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
@@ -1723,7 +1723,7 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/typescript": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
@@ -1737,7 +1737,7 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/update-browserslist-db": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
@@ -1768,7 +1768,7 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "node_modules/vite": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/vite": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
@@ -1844,7 +1844,7 @@
         }
       }
     },
-    "node_modules/yallist": {
+    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fused-render-shell",
-  "version": "file:../../../private/tmp/fr-hidden-pr/frontend",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -19,7 +19,7 @@
         "vite": "^6.0.7"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/code-frame": {
+    "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
@@ -34,7 +34,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/compat-data": {
+    "node_modules/@babel/compat-data": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
@@ -44,7 +44,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/core": {
+    "node_modules/@babel/core": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
@@ -76,7 +76,7 @@
         "url": "https://opencollective.com/babel"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/generator": {
+    "node_modules/@babel/generator": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
@@ -93,7 +93,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-compilation-targets": {
+    "node_modules/@babel/helper-compilation-targets": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
@@ -110,7 +110,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-globals": {
+    "node_modules/@babel/helper-globals": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
@@ -120,7 +120,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-module-imports": {
+    "node_modules/@babel/helper-module-imports": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
@@ -134,7 +134,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-module-transforms": {
+    "node_modules/@babel/helper-module-transforms": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
@@ -152,7 +152,7 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-plugin-utils": {
+    "node_modules/@babel/helper-plugin-utils": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
       "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
@@ -162,7 +162,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-string-parser": {
+    "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
@@ -172,7 +172,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-validator-identifier": {
+    "node_modules/@babel/helper-validator-identifier": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
@@ -182,7 +182,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helper-validator-option": {
+    "node_modules/@babel/helper-validator-option": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
@@ -192,7 +192,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/helpers": {
+    "node_modules/@babel/helpers": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
@@ -206,7 +206,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/parser": {
+    "node_modules/@babel/parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
@@ -222,7 +222,7 @@
         "node": ">=6.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/plugin-transform-react-jsx-self": {
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
       "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
@@ -238,7 +238,7 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/plugin-transform-react-jsx-source": {
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
       "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
@@ -254,7 +254,7 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/template": {
+    "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
@@ -269,7 +269,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/traverse": {
+    "node_modules/@babel/traverse": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
@@ -288,7 +288,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@babel/types": {
+    "node_modules/@babel/types": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
@@ -302,7 +302,7 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/aix-ppc64": {
+    "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
       "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
@@ -319,7 +319,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-arm": {
+    "node_modules/@esbuild/android-arm": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
       "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
@@ -336,7 +336,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-arm64": {
+    "node_modules/@esbuild/android-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
       "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
@@ -353,7 +353,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/android-x64": {
+    "node_modules/@esbuild/android-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
       "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
@@ -370,7 +370,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/darwin-arm64": {
+    "node_modules/@esbuild/darwin-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
       "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
@@ -387,7 +387,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/darwin-x64": {
+    "node_modules/@esbuild/darwin-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
       "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
@@ -404,7 +404,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/freebsd-arm64": {
+    "node_modules/@esbuild/freebsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
       "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
@@ -421,7 +421,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/freebsd-x64": {
+    "node_modules/@esbuild/freebsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
       "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
@@ -438,7 +438,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-arm": {
+    "node_modules/@esbuild/linux-arm": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
       "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
@@ -455,7 +455,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-arm64": {
+    "node_modules/@esbuild/linux-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
       "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
@@ -472,7 +472,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-ia32": {
+    "node_modules/@esbuild/linux-ia32": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
       "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
@@ -489,7 +489,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-loong64": {
+    "node_modules/@esbuild/linux-loong64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
       "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
@@ -506,7 +506,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-mips64el": {
+    "node_modules/@esbuild/linux-mips64el": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
       "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
@@ -523,7 +523,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-ppc64": {
+    "node_modules/@esbuild/linux-ppc64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
       "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
@@ -540,7 +540,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-riscv64": {
+    "node_modules/@esbuild/linux-riscv64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
       "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
@@ -557,7 +557,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-s390x": {
+    "node_modules/@esbuild/linux-s390x": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
       "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
@@ -574,7 +574,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/linux-x64": {
+    "node_modules/@esbuild/linux-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
       "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
@@ -591,7 +591,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/netbsd-arm64": {
+    "node_modules/@esbuild/netbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
@@ -608,7 +608,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/netbsd-x64": {
+    "node_modules/@esbuild/netbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
       "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
@@ -625,7 +625,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openbsd-arm64": {
+    "node_modules/@esbuild/openbsd-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
       "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
@@ -642,7 +642,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openbsd-x64": {
+    "node_modules/@esbuild/openbsd-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
       "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
@@ -659,7 +659,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/openharmony-arm64": {
+    "node_modules/@esbuild/openharmony-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
       "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
@@ -676,7 +676,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/sunos-x64": {
+    "node_modules/@esbuild/sunos-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
       "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
@@ -693,7 +693,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-arm64": {
+    "node_modules/@esbuild/win32-arm64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
       "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
@@ -710,7 +710,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-ia32": {
+    "node_modules/@esbuild/win32-ia32": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
       "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
@@ -727,7 +727,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@esbuild/win32-x64": {
+    "node_modules/@esbuild/win32-x64": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
       "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
@@ -744,7 +744,7 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/gen-mapping": {
+    "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
@@ -755,7 +755,7 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/remapping": {
+    "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
@@ -766,7 +766,7 @@
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/resolve-uri": {
+    "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
@@ -776,14 +776,14 @@
         "node": ">=6.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/sourcemap-codec": {
+    "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@jridgewell/trace-mapping": {
+    "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
@@ -794,14 +794,14 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rolldown/pluginutils": {
+    "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-android-arm-eabi": {
+    "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
       "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
@@ -815,7 +815,7 @@
         "android"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-android-arm64": {
+    "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
       "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
@@ -829,7 +829,7 @@
         "android"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-darwin-arm64": {
+    "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
       "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
@@ -843,7 +843,7 @@
         "darwin"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-darwin-x64": {
+    "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
       "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
@@ -857,7 +857,7 @@
         "darwin"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-freebsd-arm64": {
+    "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
       "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
@@ -871,7 +871,7 @@
         "freebsd"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-freebsd-x64": {
+    "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
       "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
@@ -885,7 +885,7 @@
         "freebsd"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
       "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
@@ -899,7 +899,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm-musleabihf": {
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
       "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
@@ -913,7 +913,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm64-gnu": {
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
       "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
@@ -927,7 +927,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-arm64-musl": {
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
       "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
@@ -941,7 +941,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-loong64-gnu": {
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
       "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
@@ -955,7 +955,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-loong64-musl": {
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
       "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
@@ -969,7 +969,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-ppc64-gnu": {
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
       "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
@@ -983,7 +983,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-ppc64-musl": {
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
       "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
@@ -997,7 +997,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-riscv64-gnu": {
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
       "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
@@ -1011,7 +1011,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-riscv64-musl": {
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
       "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
@@ -1025,7 +1025,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-s390x-gnu": {
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
       "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
@@ -1039,7 +1039,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-x64-gnu": {
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
@@ -1053,7 +1053,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-linux-x64-musl": {
+    "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
       "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
@@ -1067,7 +1067,7 @@
         "linux"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-openbsd-x64": {
+    "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
       "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
@@ -1081,7 +1081,7 @@
         "openbsd"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-openharmony-arm64": {
+    "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
       "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
@@ -1095,7 +1095,7 @@
         "openharmony"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-arm64-msvc": {
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
       "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
@@ -1109,7 +1109,7 @@
         "win32"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-ia32-msvc": {
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
       "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
@@ -1123,7 +1123,7 @@
         "win32"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-x64-gnu": {
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
       "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
@@ -1137,7 +1137,7 @@
         "win32"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@rollup/rollup-win32-x64-msvc": {
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
       "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
@@ -1151,7 +1151,7 @@
         "win32"
       ]
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__core": {
+    "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
@@ -1165,7 +1165,7 @@
         "@types/babel__traverse": "*"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__generator": {
+    "node_modules/@types/babel__generator": {
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
@@ -1175,7 +1175,7 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__template": {
+    "node_modules/@types/babel__template": {
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
@@ -1186,7 +1186,7 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/babel__traverse": {
+    "node_modules/@types/babel__traverse": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
@@ -1196,21 +1196,21 @@
         "@babel/types": "^7.28.2"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/estree": {
+    "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/prop-types": {
+    "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/react": {
+    "node_modules/@types/react": {
       "version": "18.3.31",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
@@ -1222,7 +1222,7 @@
         "csstype": "^3.2.2"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@types/react-dom": {
+    "node_modules/@types/react-dom": {
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
@@ -1232,7 +1232,7 @@
         "@types/react": "^18.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/@vitejs/plugin-react": {
+    "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
@@ -1253,7 +1253,7 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/baseline-browser-mapping": {
+    "node_modules/baseline-browser-mapping": {
       "version": "2.10.42",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
       "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
@@ -1266,7 +1266,7 @@
         "node": ">=6.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/browserslist": {
+    "node_modules/browserslist": {
       "version": "4.28.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
       "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
@@ -1301,7 +1301,7 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/caniuse-lite": {
+    "node_modules/caniuse-lite": {
       "version": "1.0.30001802",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz",
       "integrity": "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==",
@@ -1322,21 +1322,21 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/convert-source-map": {
+    "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/csstype": {
+    "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/debug": {
+    "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
@@ -1354,14 +1354,14 @@
         }
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/electron-to-chromium": {
+    "node_modules/electron-to-chromium": {
       "version": "1.5.387",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz",
       "integrity": "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==",
       "dev": true,
       "license": "ISC"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/esbuild": {
+    "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
@@ -1403,7 +1403,7 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/escalade": {
+    "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
@@ -1413,7 +1413,7 @@
         "node": ">=6"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/fdir": {
+    "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
@@ -1431,7 +1431,7 @@
         }
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/fsevents": {
+    "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
@@ -1446,7 +1446,7 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/gensync": {
+    "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
@@ -1456,13 +1456,13 @@
         "node": ">=6.9.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/js-tokens": {
+    "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/jsesc": {
+    "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
@@ -1475,7 +1475,7 @@
         "node": ">=6"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/json5": {
+    "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
@@ -1488,7 +1488,7 @@
         "node": ">=6"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/loose-envify": {
+    "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
@@ -1500,7 +1500,7 @@
         "loose-envify": "cli.js"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/lru-cache": {
+    "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
@@ -1510,14 +1510,14 @@
         "yallist": "^3.0.2"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/ms": {
+    "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/nanoid": {
+    "node_modules/nanoid": {
       "version": "3.3.15",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
       "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
@@ -1536,7 +1536,7 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/node-releases": {
+    "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
       "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
@@ -1546,14 +1546,14 @@
         "node": ">=18"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/picocolors": {
+    "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/picomatch": {
+    "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
@@ -1567,7 +1567,7 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/postcss": {
+    "node_modules/postcss": {
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
@@ -1596,7 +1596,7 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react": {
+    "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
@@ -1609,7 +1609,7 @@
         "node": ">=0.10.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react-dom": {
+    "node_modules/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
@@ -1622,7 +1622,7 @@
         "react": "^18.3.1"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/react-refresh": {
+    "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
@@ -1632,7 +1632,7 @@
         "node": ">=0.10.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/rollup": {
+    "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
@@ -1677,7 +1677,7 @@
         "fsevents": "~2.3.2"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/scheduler": {
+    "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
@@ -1686,7 +1686,7 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/semver": {
+    "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
@@ -1696,7 +1696,7 @@
         "semver": "bin/semver.js"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/source-map-js": {
+    "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
@@ -1706,7 +1706,7 @@
         "node": ">=0.10.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/tinyglobby": {
+    "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
@@ -1723,7 +1723,7 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/typescript": {
+    "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
@@ -1737,7 +1737,7 @@
         "node": ">=14.17"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/update-browserslist-db": {
+    "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
       "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
@@ -1768,7 +1768,7 @@
         "browserslist": ">= 4.21.0"
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/vite": {
+    "node_modules/vite": {
       "version": "6.4.3",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
@@ -1844,7 +1844,7 @@
         }
       }
     },
-    "../../../private/tmp/fr-hidden-pr/frontend/node_modules/yallist": {
+    "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,8 +78,10 @@ export function listDir(fsPath: string): Promise<ListResult> {
   return getJson<ListResult>("/api/fs/list?path=" + encodeURIComponent(fsPath));
 }
 
-export function walkDir(fsPath: string): Promise<WalkResult> {
-  return getJson<WalkResult>("/api/fs/walk?path=" + encodeURIComponent(fsPath));
+export function walkDir(fsPath: string, opts?: { hidden?: boolean }): Promise<WalkResult> {
+  let url = "/api/fs/walk?path=" + encodeURIComponent(fsPath);
+  if (opts?.hidden) url += "&hidden=1";
+  return getJson<WalkResult>(url);
 }
 
 export function statPath(fsPath: string): Promise<StatResult> {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -33,6 +33,15 @@ function currentQuery(): string {
   return new URLSearchParams(location.search).get("q") || "";
 }
 
+// A dot-leading query segment is explicit intent to see hidden entries (the
+// walk otherwise always prunes dot-files/dot-dirs). Matches a query that
+// starts with "." (e.g. ".fused-render") or contains a "/." dot segment
+// mid-path (e.g. "sub/.fused-render").
+function queryWantsHidden(rawQuery: string): boolean {
+  const q = rawQuery.trim();
+  return q.startsWith(".") || q.includes("/.");
+}
+
 function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEntry[] {
   const flip = order === "desc" ? -1 : 1;
   const byName = (a: FsEntry, b: FsEntry) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
@@ -92,17 +101,19 @@ type ListingState =
   | { status: "ok"; entries: FsEntry[] }
   | { status: "error"; message: string };
 
-// Cached recursive walk. Non-idle states are tagged with the (fsPath, refresh)
-// they were fetched for; `validWalk` below compares that tag against the
-// current fsPath/refresh at render time so a stale walk (folder changed, dir
-// watch fired) is treated as idle synchronously — no waiting on an effect to
-// clear it, which would otherwise let one render score search results
-// against the previous tree.
+// Cached recursive walk. Non-idle states are tagged with the (fsPath, refresh,
+// hidden) they were fetched for; `validWalk` below compares that tag against
+// the current fsPath/refresh/hidden at render time so a stale walk (folder
+// changed, dir watch fired, or the query flipped between dot/non-dot) is
+// treated as idle synchronously — no waiting on an effect to clear it, which
+// would otherwise let one render score search results against the previous
+// tree (or the wrong hidden/non-hidden dataset — a hidden and non-hidden walk
+// are different datasets over the same folder).
 type WalkState =
   | { status: "idle" }
-  | { status: "loading"; forPath: string; forRefresh: number }
-  | { status: "ok"; result: WalkResult; forPath: string; forRefresh: number }
-  | { status: "error"; message: string; forPath: string; forRefresh: number };
+  | { status: "loading"; forPath: string; forRefresh: number; forHidden: boolean }
+  | { status: "ok"; result: WalkResult; forPath: string; forRefresh: number; forHidden: boolean }
+  | { status: "error"; message: string; forPath: string; forRefresh: number; forHidden: boolean };
 
 const IDLE_WALK: WalkState = { status: "idle" };
 
@@ -128,14 +139,21 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const q = deferredQuery.trim();
   const searching = q !== "";
   const isStale = query.trim() !== q;
+  // Explicit dot-intent (deferred, so it lags typing the same way `q` does):
+  // a dot-leading query or a "/." mid-path segment asks to see hidden entries.
+  const hidden = queryWantsHidden(deferredQuery);
 
   // Synchronous validity check: a non-idle walk only counts if it was fetched
-  // for the folder/refresh generation we're currently rendering. This makes
-  // invalidation immediate on the render where `refresh` bumps, instead of
-  // depending on the clearing effect below to run first (which left one
-  // render scoring search results against the stale tree).
+  // for the folder/refresh/hidden generation we're currently rendering. This
+  // makes invalidation immediate on the render where `refresh` bumps (or
+  // `hidden` flips), instead of depending on the clearing effect below to run
+  // first (which left one render scoring search results against the stale
+  // tree, or against the wrong hidden/non-hidden dataset).
   const validWalk: WalkState =
-    walk.status === "idle" || (walk.forPath === fsPath && walk.forRefresh === refresh) ? walk : IDLE_WALK;
+    walk.status === "idle" ||
+    (walk.forPath === fsPath && walk.forRefresh === refresh && walk.forHidden === hidden)
+      ? walk
+      : IDLE_WALK;
 
   useEffect(() => {
     let alive = true;
@@ -204,14 +222,15 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     let alive = true;
     const forPath = fsPath;
     const forRefresh = refresh;
-    walkDir(fsPath).then(
-      (result) => alive && setWalk({ status: "ok", result, forPath, forRefresh }),
-      (err: Error) => alive && setWalk({ status: "error", message: err.message, forPath, forRefresh })
+    const forHidden = hidden;
+    walkDir(fsPath, { hidden: forHidden }).then(
+      (result) => alive && setWalk({ status: "ok", result, forPath, forRefresh, forHidden }),
+      (err: Error) => alive && setWalk({ status: "error", message: err.message, forPath, forRefresh, forHidden })
     );
     return () => {
       alive = false;
     };
-  }, [validWalk.status, fsPath, refresh]);
+  }, [validWalk.status, fsPath, refresh, hidden]);
 
   // A query restored from the URL needs the walk even without a focus event;
   // this also covers refetch-on-refresh while search is active, since a
@@ -223,16 +242,18 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // instead: prefetchWalk (focus) and setQuery (typing) below.
   useEffect(() => {
     if (searching && validWalk.status === "idle") {
-      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: hidden });
     }
-  }, [searching, validWalk.status, fsPath, refresh]);
+  }, [searching, validWalk.status, fsPath, refresh, hidden]);
 
   // Retry from "idle" (first focus) or "error" (a prior fetch failed) — treat
   // both as "no usable walk cached yet". Called from onFocus, a genuine user
-  // gesture, so this can't spin in a loop the way an effect could.
+  // gesture, so this can't spin in a loop the way an effect could. Always
+  // non-hidden: focus fires before the user has typed a dot-leading query, so
+  // there's no hidden intent yet to honor.
   const prefetchWalk = () => {
     if (validWalk.status === "idle" || validWalk.status === "error") {
-      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: false });
     }
   };
 
@@ -241,8 +262,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     setSearchSort(null); // a new query drops back to relevance order
     // Editing the query is also a user gesture: if the last walk attempt
     // failed, give it another shot instead of leaving search dead forever.
+    // Tag with the hidden-intent of the value being typed now (not the stale
+    // `hidden` closure, which still reflects the not-yet-caught-up deferred
+    // query) so the retry doesn't fetch the wrong dataset.
     if (validWalk.status === "error") {
-      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh });
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: queryWantsHidden(value) });
     }
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -139,19 +139,43 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const q = deferredQuery.trim();
   const searching = q !== "";
   const isStale = query.trim() !== q;
-  // Explicit dot-intent (deferred, so it lags typing the same way `q` does):
-  // a dot-leading query or a "/." mid-path segment asks to see hidden entries.
-  const hidden = queryWantsHidden(deferredQuery);
+
+  // Fetch intent: which walk dataset (hidden-inclusive or not) should be
+  // loaded. Derived from the IMMEDIATE `query`, not `deferredQuery` — the
+  // input updates `query` on every keystroke, so a dot-leading query has to
+  // start the right fetch on the first keystroke instead of waiting for
+  // `deferredQuery` to catch up. Under load that lag could otherwise leave
+  // `hidden === false` (walk fetched/kept non-hidden) even though the UI
+  // already shows a dot-leading query.
+  // An empty immediate query carries no fresh signal, so it keeps the last
+  // known intent (the current walk's own tag, or false if there's no walk
+  // yet) instead of snapping to false — that avoids invalidating a good
+  // cached/in-flight walk on a boundary render where the box is momentarily
+  // empty mid-edit (e.g. select-all + retype).
+  // Note: `hits` below still scores the *deferred* `q` against whatever walk
+  // is currently valid. Right after an intent flip there's a narrow window
+  // where a hidden-superset walk has loaded (matching the fresh
+  // `fetchHidden`) while `q` still lags on pre-flip text; it can then match
+  // an extra dotted entry it wouldn't show once `q` catches up. That's an
+  // acceptable "briefly extra rows" tradeoff — not the wrong dataset, which
+  // is what the deferred-only version risked.
+  const immediateTrimmed = query.trim();
+  const fetchHidden =
+    immediateTrimmed !== ""
+      ? queryWantsHidden(immediateTrimmed)
+      : walk.status !== "idle"
+        ? walk.forHidden
+        : false;
 
   // Synchronous validity check: a non-idle walk only counts if it was fetched
   // for the folder/refresh/hidden generation we're currently rendering. This
   // makes invalidation immediate on the render where `refresh` bumps (or
-  // `hidden` flips), instead of depending on the clearing effect below to run
-  // first (which left one render scoring search results against the stale
-  // tree, or against the wrong hidden/non-hidden dataset).
+  // `fetchHidden` flips), instead of depending on the clearing effect below
+  // to run first (which left one render scoring search results against the
+  // stale tree, or against the wrong hidden/non-hidden dataset).
   const validWalk: WalkState =
     walk.status === "idle" ||
-    (walk.forPath === fsPath && walk.forRefresh === refresh && walk.forHidden === hidden)
+    (walk.forPath === fsPath && walk.forRefresh === refresh && walk.forHidden === fetchHidden)
       ? walk
       : IDLE_WALK;
 
@@ -222,7 +246,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     let alive = true;
     const forPath = fsPath;
     const forRefresh = refresh;
-    const forHidden = hidden;
+    const forHidden = fetchHidden;
     walkDir(fsPath, { hidden: forHidden }).then(
       (result) => alive && setWalk({ status: "ok", result, forPath, forRefresh, forHidden }),
       (err: Error) => alive && setWalk({ status: "error", message: err.message, forPath, forRefresh, forHidden })
@@ -230,7 +254,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     return () => {
       alive = false;
     };
-  }, [validWalk.status, fsPath, refresh, hidden]);
+  }, [validWalk.status, fsPath, refresh, fetchHidden]);
 
   // A query restored from the URL needs the walk even without a focus event;
   // this also covers refetch-on-refresh while search is active, since a
@@ -242,9 +266,9 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // instead: prefetchWalk (focus) and setQuery (typing) below.
   useEffect(() => {
     if (searching && validWalk.status === "idle") {
-      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: hidden });
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: fetchHidden });
     }
-  }, [searching, validWalk.status, fsPath, refresh, hidden]);
+  }, [searching, validWalk.status, fsPath, refresh, fetchHidden]);
 
   // Retry from "idle" (first focus) or "error" (a prior fetch failed) — treat
   // both as "no usable walk cached yet". Called from onFocus, a genuine user
@@ -262,11 +286,14 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     setSearchSort(null); // a new query drops back to relevance order
     // Editing the query is also a user gesture: if the last walk attempt
     // failed, give it another shot instead of leaving search dead forever.
-    // Tag with the hidden-intent of the value being typed now (not the stale
-    // `hidden` closure, which still reflects the not-yet-caught-up deferred
-    // query) so the retry doesn't fetch the wrong dataset.
+    // Tag with the immediate hidden-intent of the value being typed now — the
+    // same rule as `fetchHidden` above: a non-empty trimmed value wins, an
+    // empty one keeps whatever the failed walk was already tagged with — so
+    // the retry doesn't fetch the wrong dataset.
     if (validWalk.status === "error") {
-      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden: queryWantsHidden(value) });
+      const trimmed = value.trim();
+      const forHidden = trimmed !== "" ? queryWantsHidden(trimmed) : validWalk.forHidden;
+      setWalk({ status: "loading", forPath: fsPath, forRefresh: refresh, forHidden });
     }
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -522,12 +522,18 @@ def create_app(start_dir: str) -> FastAPI:
         return {"path": path, "entries": entries}
 
     @app.get("/api/fs/walk")
-    def api_fs_walk(path: str):
+    def api_fs_walk(path: str, hidden: str = "0"):
         # Recursive listing of a directory subtree, for the explorer search
         # (flat, ranked client-side). Prunes hidden entries (leading `.`) and
         # WALK_IGNORE_DIRS from descent, skips hidden files, and never follows
         # symlinks. Capped at WALK_MAX_ENTRIES; `rel` is posix-relative to
         # `path`. Unreadable entries are skipped silently (matches /api/fs/list).
+        #
+        # `hidden=1` (explicit intent: the user typed a dot-leading query)
+        # includes dot-files and descends into dot-dirs. WALK_IGNORE_DIRS is
+        # always pruned regardless — those trees are noise, not "hidden data",
+        # and letting hidden=1 descend into node_modules would blow the cap.
+        include_hidden = hidden == "1"
         if not os.path.isdir(path):
             return _error(f"not a directory: {path}", status=400)
         entries = []
@@ -536,10 +542,12 @@ def create_app(start_dir: str) -> FastAPI:
             # Mutating dirs in place both drops them from descent and, since we
             # emit from the (already pruned) list, keeps them out of the results.
             dirs[:] = sorted(
-                d for d in dirs if not d.startswith(".") and d not in WALK_IGNORE_DIRS
+                d
+                for d in dirs
+                if (include_hidden or not d.startswith(".")) and d not in WALK_IGNORE_DIRS
             )
             batch = [(d, True) for d in dirs] + [
-                (f, False) for f in sorted(files) if not f.startswith(".")
+                (f, False) for f in sorted(files) if include_hidden or not f.startswith(".")
             ]
             for name, is_dir in batch:
                 full = os.path.join(root, name)

--- a/tests/test_server_walk.py
+++ b/tests/test_server_walk.py
@@ -63,3 +63,36 @@ def test_walk_truncation_flag(tmp_path, monkeypatch):
     data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
     assert data["truncated"] is True
     assert len(data["entries"]) == 3
+
+
+def test_walk_hidden_returns_dot_entries_and_descends_dot_dirs(tmp_path):
+    _make_tree(tmp_path)
+    data = (
+        _client(tmp_path)
+        .get("/api/fs/walk", params={"path": str(tmp_path), "hidden": "1"})
+        .json()
+    )
+    rels = {e["rel"] for e in data["entries"]}
+    assert ".secret" in rels
+    assert ".hidden" in rels
+    assert ".hidden/nope.txt" in rels  # descended into the dot-dir
+    # non-hidden entries are still present alongside them
+    assert {"a.txt", "sub", "sub/b.txt", "sub/deep", "sub/deep/c.txt"} <= rels
+
+
+def test_walk_hidden_still_prunes_ignored_dirs(tmp_path):
+    _make_tree(tmp_path)
+    data = (
+        _client(tmp_path)
+        .get("/api/fs/walk", params={"path": str(tmp_path), "hidden": "1"})
+        .json()
+    )
+    rels = {e["rel"] for e in data["entries"]}
+    assert not any("node_modules" in r for r in rels)  # ignored dir never descended
+
+
+def test_walk_default_still_prunes_hidden(tmp_path):
+    _make_tree(tmp_path)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    rels = {e["rel"] for e in data["entries"]}
+    assert not any(r.startswith(".") or "/." in r for r in rels)


### PR DESCRIPTION
## What

Explorer search couldn't find hidden entries — the walk prunes dot-files/dirs unconditionally, so an explicit query like `.fused-render` from `~` returned "No matches" while the same entry is visible in the plain listing.

A dot-leading query (or one containing a `/.` segment) signals explicit intent: the walk is now fetched with a new `hidden=1` param that includes dot-files and descends dot-dirs. Everything else is unchanged — normal queries still prune hidden entries, `node_modules`/`__pycache__`/`venv` are always pruned, and the 20,000-entry cap + `truncated` flag hold in both modes.

Client side: the walk cache is keyed by the hidden flag (tagged alongside path/refresh in the walk state), so flipping between dot and non-dot queries refetches the right dataset; focus-prefetch stays non-hidden.

## Testing

- `tests/test_server_walk.py`: hidden=1 returns dot entries and descends dot-dirs, still prunes ignored dirs; default behavior unchanged (7 tests pass).
- tsc + vite build clean.
- Verified live: `.fused-render` query from `/view/Users/akshilthumar` returns the hidden dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only FS listing API plus explorer UI caching; default walk behavior is unchanged and ignored dirs stay pruned even with `hidden=1`.
> 
> **Overview**
> Explorer search could not find dot-files or contents of dot-directories because the recursive walk always pruned them. **Dot-prefixed queries** (leading `.` or a `/.` path segment) now request a separate walk with **`hidden=1`**, which includes those entries while still skipping `node_modules` / `__pycache__` / `venv` and honoring the existing entry cap.
> 
> On the client, **`walkDir`** passes `hidden=1` when needed, and the walk cache is tagged with **`forHidden`** alongside path and refresh so flipping between normal and dot queries refetches the correct dataset. Hidden intent is derived from the **immediate** search input (not the deferred value) so the right walk starts on the first keystroke; focus prefetch stays non-hidden.
> 
> Tests cover `hidden=1` behavior and unchanged default pruning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afba2fd94960558166e34af29b47d533b8331e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->