### PR TITLE
Sidebar: show package version next to the brand

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -638,6 +638,7 @@ export default function Sidebar({ config }: SidebarProps) {
           </svg>
         </span>{" "}
         fused-render
+        <span className="brand-version">v{config.version}</span>
       </div>
       <div className="sidebar-section">
         <a href="#" id="home-link" className="sidebar-item" onClick={onHomeClick}>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,7 @@
 export interface Config {
   start_dir: string;
   home: string;
+  version: string;
 }
 
 export interface FsEntry {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -59,6 +59,13 @@ body {
   align-items: center;
 }
 
+/* Package version after the name — smaller and muted grey. */
+.sidebar-brand .brand-version {
+  font-size: 10.5px;
+  font-weight: 500;
+  color: var(--fg-muted);
+}
+
 .sidebar-section {
   padding: 8px;
 }

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -27,6 +27,7 @@ from fastapi import Body, FastAPI, Header, WebSocket, WebSocketDisconnect
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
+from fused_render import __version__
 from fused_render.deploy import router as deploy_router
 from fused_render.executor import run_python
 from fused_render.shell import prefs as shell_prefs
@@ -492,6 +493,8 @@ def create_app(start_dir: str) -> FastAPI:
         return {
             "start_dir": start_dir,
             "home": os.path.expanduser("~"),
+            # The fused-render package version, surfaced in the sidebar brand.
+            "version": __version__,
             # Which /api/run engine is in effect (D69/§20): "fused" | "builtin".
             # Read per request — it can change under the Preferences switch.
             "engine": current_engine(),


### PR DESCRIPTION
## What

Show the fused-render package version in the sidebar brand — a small, muted-grey `v<version>` badge after the **fused-render** name.

## How

- **Backend** (`server.py`): `/api/config` now returns `version` from `fused_render.__version__` (source of truth: `fused_render/__init__.py`).
- **Types** (`api.ts`): `Config` gains `version: string`.
- **UI** (`Sidebar.tsx` + `shell.css`): renders `v{config.version}` after the name; new `.sidebar-brand .brand-version` rule (10.5px, weight 500, `--fg-muted`). Flex `gap` spaces logo / name / version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only config field and cosmetic UI; no auth, execution, or data-path changes.
> 
> **Overview**
> The sidebar brand now shows a muted **`v<version>`** label after **fused-render**, so users can see which build is running without digging elsewhere.
> 
> **`/api/config`** adds a **`version`** field sourced from **`fused_render.__version__`**. The frontend **`Config`** type includes **`version`**, and **`Sidebar`** renders it via **`.brand-version`** styling (smaller type, **`--fg-muted`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d537a4f6edb93b60cb0c6ec6577b6073655a283. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->