### PR TITLE
Fix bookmark icon-picker click; Finder glyph on reveal button

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -15,7 +15,6 @@ import {
 import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "../lib/hooks";
 import { encodePaneSegment, splitShellSearch } from "../lib/layout-codec";
 import { panelUrl } from "../views/Panel";
-import { ShareIcon } from "./ShareIcon";
 import { SplitRightIcon, SplitDownIcon } from "./SplitIcons";
 
 // True when two query strings carry the same decoded `_layout` and the same
@@ -86,8 +85,19 @@ function revealInFileManager(path: string): void {
   });
 }
 
-// Share glyph (arrow leaving a rounded box), sits at the end of the crumb
-// trail and reveals the current path in the OS file manager.
+// Finder glyph (streamline-logos:mac-finder-logo, MIT-licensed line version).
+function FinderIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24">
+      <g fill="none" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M12.5 1.5c-.833 2-2.5 7.2-2.5 12h3c0 2.537.2 6.6 1 9m-7.5-15v2m10-2v2" />
+        <path d="M5.5 15.5c.667 1 2.9 3 6.5 3s5.667-2 6.5-3" />
+        <path d="M1.5 18.5v-13a4 4 0 0 1 4-4h13a4 4 0 0 1 4 4v13a4 4 0 0 1-4 4h-13a4 4 0 0 1-4-4" />
+      </g>
+    </svg>
+  );
+}
+
 function RevealButton({ fsPath }: { fsPath: string }) {
   return (
     <button
@@ -96,7 +106,7 @@ function RevealButton({ fsPath }: { fsPath: string }) {
       title="Open in Finder"
       onClick={() => revealInFileManager(fsPath)}
     >
-      <ShareIcon />
+      <FinderIcon />
     </button>
   );
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -143,6 +143,8 @@ body {
   cursor: pointer;
   width: 14px;
   text-align: center;
+  position: relative;
+  z-index: 1;
 }
 
 /* Custom emoji icons render at natural color, slightly larger than the star. */


### PR DESCRIPTION
## What

- **Bookmark icon picker was dead**: the stretched-link overlay (`a.bookmark-name::after`, added for whole-row bookmark clicks) covered the star glyph, so its click handler never fired — clicks navigated instead of opening the picker. The glyph now gets `position: relative; z-index: 1`, the same layering the row action buttons already had.
- **Reveal button icon**: the breadcrumb's "Open in Finder" button now shows a Finder-face glyph (line-art `mac-finder-logo` from streamline-logos, vendored inline as `FinderIcon`) instead of the generic share arrow. `ShareIcon` remains where Panel/Tabs use it.

## Testing

- tsc + vite build clean.
- Verified in the running app: star click opens the icon picker again (and picked icons render), whole-row bookmark click/cmd-click still navigates, reveal button opens Finder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/CSS and icon-only breadcrumb change with no auth, API, or data-path impact.
> 
> **Overview**
> **Bookmark sidebar:** Clicks on the star/glyph were swallowed by the whole-row stretched link (`a.bookmark-name::after`), so the icon picker never opened. `.bookmark-glyph` now uses `position: relative` and `z-index: 1`, matching the row action buttons so the glyph sits above the overlay.
> 
> **Breadcrumb reveal:** The "Open in Finder" control no longer uses the generic `ShareIcon`; it renders an inline **Finder** line-art SVG (`FinderIcon`). `ShareIcon` is unchanged for panel/tab "open in new tab" actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd2a8f0049c61111a00a4f22ae3e752a69c03e1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->