### PR TITLE
shell: support Windows drive-letter paths in the URL codec

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -195,9 +195,14 @@ export function Breadcrumb({ fsPath }: { fsPath: string }) {
       /
     </a>,
   ];
+  // A Windows path's first segment is the drive ("C:"); its crumb must target
+  // "C:/" (bare "C:" is cwd-relative to os.stat) and later segments append
+  // without re-rooting at "/".
+  const isDrive = /^[A-Za-z]:$/.test(parts[0] || "");
   let acc = "";
   parts.forEach((part, i) => {
-    acc += "/" + part;
+    if (i === 0 && isDrive) acc = part + "/";
+    else acc = acc + (acc.endsWith("/") ? "" : "/") + part;
     const target = acc;
     const isLast = i === parts.length - 1;
     // Separator only between segments (root already carries the leading

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 // Sidebar UI: brand, Home entry, bookmark rows with hover card + inline rename.
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
-import { navigate, navigateUrl, currentUrl, VIEW_PREFIX } from "../lib/router";
+import { navigate, navigateUrl, currentUrl, rootedFsPath, VIEW_PREFIX } from "../lib/router";
 // Folder-as-tabs entry (TM-8): composeFolderTabsUrl builds the `/view/_tab` url
 // from a folder's children. This sidebar -> views/Tabs.jsx import is the
 // documented acyclic exception (Tabs.jsx never imports back), mirroring
@@ -33,7 +33,7 @@ function bookmarkFsPath(url: string): string {
   const qIdx = url.indexOf("?");
   const pathname = qIdx !== -1 ? url.slice(0, qIdx) : url;
   return pathname.startsWith(VIEW_PREFIX)
-    ? "/" + pathname.slice(VIEW_PREFIX.length).split("/").map(decodeURIComponent).join("/")
+    ? rootedFsPath(pathname.slice(VIEW_PREFIX.length).split("/").map(decodeURIComponent).join("/"))
     : pathname;
 }
 

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -22,9 +22,12 @@ function notifyNavigate(): void {
 
 // Windows fs paths are rooted at a drive letter ("C:/…"), not at "/" — the
 // shell's canonical form keeps forward slashes and adds a leading slash only
-// for POSIX paths.
+// for POSIX paths. A bare drive ("C:", how a drive root decodes from a URL,
+// whose segment split drops the trailing slash) canonicalizes to "C:/" —
+// bare "C:" is cwd-relative for os.stat on Windows.
 export function rootedFsPath(joined: string): string {
-  return /^[A-Za-z]:(\/|$)/.test(joined) ? joined : "/" + joined;
+  if (/^[A-Za-z]:$/.test(joined)) return joined + "/";
+  return /^[A-Za-z]:\//.test(joined) ? joined : "/" + joined;
 }
 
 export function fsPathFromLocation(): string | null {

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -20,6 +20,13 @@ function notifyNavigate(): void {
   window.dispatchEvent(new Event(NAV_EVENT));
 }
 
+// Windows fs paths are rooted at a drive letter ("C:/…"), not at "/" — the
+// shell's canonical form keeps forward slashes and adds a leading slash only
+// for POSIX paths.
+export function rootedFsPath(joined: string): string {
+  return /^[A-Za-z]:(\/|$)/.test(joined) ? joined : "/" + joined;
+}
+
 export function fsPathFromLocation(): string | null {
   const p = location.pathname;
   if (!p.startsWith(PREFIX)) return null;
@@ -29,11 +36,16 @@ export function fsPathFromLocation(): string | null {
     .filter((s) => s.length > 0)
     .map(decodeURIComponent)
     .join("/");
-  return "/" + decoded;
+  return rootedFsPath(decoded);
 }
 
 export function urlForFsPath(fsPath: string, search?: string): string {
-  const rest = fsPath.replace(/^\/+/, "");
+  // Windows callers (server stat/list results, bookmarks) may carry
+  // backslashes; the URL codec speaks forward slashes only. Normalize ONLY
+  // drive-letter paths — on POSIX a backslash is a legal filename character
+  // and must round-trip untouched.
+  const norm = /^[A-Za-z]:[\\/]/.test(fsPath) ? fsPath.replace(/\\/g, "/") : fsPath;
+  const rest = norm.replace(/^\/+/, "");
   const encoded = rest
     .split("/")
     .filter((s) => s.length > 0)

--- a/frontend/src/views/Tabs.tsx
+++ b/frontend/src/views/Tabs.tsx
@@ -13,7 +13,7 @@
 // appends (new tab) or removes (close); src is frozen at mount and never
 // written again by React.
 import { useEffect, useRef, useState } from "react";
-import { navigateUrl, urlForFsPath, IS_EMBED, VIEW_PREFIX } from "../lib/router";
+import { navigateUrl, rootedFsPath, urlForFsPath, IS_EMBED, VIEW_PREFIX } from "../lib/router";
 import { basename } from "../lib/format";
 import {
   leaf,
@@ -69,13 +69,14 @@ export function composeFolderTabsUrl(children: Bookmark[]): string {
     // Sentinel pathnames (/view/_panel, /view/_tab) decode to segment paths
     // "/_panel" / "/_tab" — round-trips through embedSrc/readEmbedLoc (TM-4).
     const fsPath = pathname.startsWith(VIEW_PREFIX)
-      ? "/" +
-        pathname
-          .slice(VIEW_PREFIX.length)
-          .split("/")
-          .filter((s) => s.length > 0)
-          .map(decodeURIComponent)
-          .join("/")
+      ? rootedFsPath(
+          pathname
+            .slice(VIEW_PREFIX.length)
+            .split("/")
+            .filter((s) => s.length > 0)
+            .map(decodeURIComponent)
+            .join("/"),
+        )
       : pathname;
     return encodePaneSegment(fsPath, search);
   });


### PR DESCRIPTION
## Problem

On native Windows the shell cannot open any file: every URL->path decode prepended a POSIX /, so `/embed/C:/work/...` resolved to the fs path `/C:/work/...` and the server answered `Failed to stat ... no such file or directory`. Four call sites shared the assumption:

- `router.ts fsPathFromLocation()` — the main URL->path codec
- `views/Tabs.tsx composeFolderTabsUrl()` — bookmark-folder tabs
- `components/Sidebar.tsx bookmarkFsPath()` — bookmark hover/search
- `components/Breadcrumb.tsx` — ancestor crumbs accumulated from /, producing `/C:` targets

## Fix

New shared `rootedFsPath()` in `router.ts`: a decoded path whose first segment is a drive letter (`C:`) stays unrooted; everything else gets the leading slash exactly as before. The three decode sites use it. Breadcrumb roots drive paths at `C:/` (bare `C:` is cwd-relative for `os.stat` on Windows). `urlForFsPath()` also normalizes `\` -> `/` so server-supplied Windows paths (stat/list results, bookmarks) build valid URLs.

## macOS/Linux safety

Every behavior change is gated on a `^[A-Za-z]:` drive-letter test that POSIX absolute paths cannot match, so existing platforms take the identical code path byte-for-byte:

- `rootedFsPath` prepends / for anything that is not drive-rooted — same output as before.
- The backslash normalization in `urlForFsPath` is applied ONLY to drive-letter paths; a POSIX filename containing a literal `\` (legal there) still round-trips untouched.
- Breadcrumb accumulation for non-drive paths reduces to the previous `acc += / + part`.
- Known theoretical edge: a root-level entry literally named like `C:` on POSIX would now be treated as a drive root (previously `/C:`). No sane layout hits this.

Verified on Windows 11 against a live server: `/embed/C:/...` and `/view/C:/...` render, `/api/fs/stat?path=C:/...` resolves, breadcrumbs navigate to each ancestor, sidebar bookmarks decode. `tsc --noEmit` + `vite build` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches central routing/navigation used on every view; changes are gated on drive-letter regex so POSIX paths should be unchanged, but path canonicalization bugs could break opens or bookmarks on Windows.
> 
> **Overview**
> Fixes native Windows browsing where every `/view` and `/embed` URL was decoded as a POSIX path (`/C:/work/…`), so `stat` failed and the shell could not open files.
> 
> Introduces shared **`rootedFsPath()`** in `router.ts`: drive-letter roots (`C:` → `C:/`, `C:/…` unchanged) skip the leading `/`; POSIX paths still get `/` as before. **`fsPathFromLocation()`**, sidebar **`bookmarkFsPath()`**, and **`composeFolderTabsUrl()`** now use it instead of blindly prepending `/`.
> 
> **`urlForFsPath()`** converts `\` to `/` only for drive-letter paths so server/bookmark paths build valid URLs without touching POSIX filenames that may contain `\`.
> 
> **`Breadcrumb`** detects a drive first segment and accumulates targets as `C:/…` rather than `/C:…`, so ancestor navigation matches what `os.stat` expects on Windows.
> 
> POSIX behavior is unchanged except the documented edge case of a root entry literally named `C:`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df49d2afe486034a130c831b8d9055a523fbc9a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->