### PR TITLE
shell: hide sidebar on narrow (phone) viewports

### DIFF
--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -42,6 +42,13 @@ body {
   overflow-y: auto;
 }
 
+/* Phones: give the whole width to the rendered view */
+@media (max-width: 700px) {
+  #sidebar {
+    display: none;
+  }
+}
+
 .sidebar-brand {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## What
Hide the sidebar below 700px so the rendered view gets the full width on phones.

## Why
`shell.css` currently has no `@media` queries — the only sidebar-hide rule is `body.embed #sidebar` (embed mode). On a phone the fixed 232px sidebar eats most of the viewport and squeezes the preview. This adds a single narrow-viewport rule.

```css
@media (max-width: 700px) {
  #sidebar { display: none; }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only responsive layout change with no auth, data, or JS behavior changes; narrow screens lose in-shell sidebar navigation until viewport widens.
> 
> **Overview**
> Adds a **`@media (max-width: 700px)`** rule in `shell.css` that sets **`#sidebar`** to **`display: none`**, so the main column and preview use the full width on phone-sized screens instead of losing ~232px to the fixed sidebar.
> 
> This is separate from **`body.embed #sidebar`** (embed mode still hides chrome the same way). There is no drawer or toggle—bookmarks and preferences are unavailable in the shell UI until the viewport is wider than 700px.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e1a3d9301f49f1f41adc959d8bd6ad36bf4b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->