### PR TITLE
feat(fs): dim gitignored files/folders in the listing

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -10,6 +10,7 @@ export interface FsEntry {
   is_dir: boolean;
   size: number | null;
   mtime: number | null;
+  ignored?: boolean; // matched by .gitignore inside a git repo (dimmed in the UI)
 }
 
 export interface ListResult {
@@ -24,6 +25,7 @@ export interface WalkEntry {
   is_dir: boolean;
   size: number | null;
   mtime: number | null;
+  ignored?: boolean; // matched by .gitignore inside a git repo (dimmed in the UI)
 }
 
 export interface WalkResult {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -756,8 +756,15 @@ table.listing-table tr.row {
   cursor: pointer;
 }
 
+/* Files matched by .gitignore inside a git repo: dimmed, but still clickable
+   and readable on hover (the row keeps full opacity while hovered). */
+table.listing-table tr.row.ignored {
+  opacity: 0.45;
+}
+
 table.listing-table tr.row:hover {
   background: var(--bg-alt);
+  opacity: 1;
 }
 
 table.listing-table td.name {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -376,7 +376,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         visibleHits.map(({ entry, positions }) => {
           const childPath = base + "/" + entry.rel;
           return (
-            <tr key={entry.rel} className="row" onClick={() => navigate(childPath)}>
+            <tr
+              key={entry.rel}
+              className={entry.ignored ? "row ignored" : "row"}
+              onClick={() => navigate(childPath)}
+            >
               <td className="name">
                 <span className="icon">{entry.is_dir ? dirIcon : fileIcon}</span>
                 <span className="search-path">{renderHighlight(entry.rel, positions)}</span>
@@ -422,7 +426,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     const rows = sortedEntries.map((entry) => {
       const childPath = base + "/" + entry.name;
       return (
-        <tr key={entry.name} className="row" onClick={() => navigate(childPath)}>
+        <tr
+          key={entry.name}
+          className={entry.ignored ? "row ignored" : "row"}
+          onClick={() => navigate(childPath)}
+        >
           <td className="name">
             <span className="icon">{entry.is_dir ? dirIcon : fileIcon}</span>
             {entry.name}

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -128,6 +128,11 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
     One batched call covers a whole listing. Returns an empty set when `cwd`
     is not in a work tree, git is missing, or anything else goes wrong:
     dimming is a display hint, never a hard dependency on git.
+
+    The `.git` directory (or the gitfile of a worktree/submodule) is folded in
+    too: git never reports it via check-ignore, but it is repository plumbing
+    the user rarely wants to browse, so we dim it exactly when we know git is
+    present and `cwd` is a work tree — i.e. only after a successful call.
     """
     if not rel_names:
         return set()
@@ -148,7 +153,12 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
         return set()
     if proc.returncode not in (0, 1):
         return set()
-    return {os.fsdecode(chunk) for chunk in proc.stdout.split(b"\0") if chunk}
+    ignored = {os.fsdecode(chunk) for chunk in proc.stdout.split(b"\0") if chunk}
+    # Return code 0/1 (not 128) proves this is a work tree with git available,
+    # so dim `.git` itself. Match the basename so both the top-level entry
+    # (".git", from /api/fs/list) and a nested one ("sub/.git", from walk) go.
+    ignored.update(n for n in rel_names if n == ".git" or n.endswith("/.git"))
+    return ignored
 
 
 def _require_fused(x_fused: str | None) -> JSONResponse | None:

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -120,6 +120,37 @@ def _error(message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"error": message}, status_code=status)
 
 
+def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
+    """Return the subset of `rel_names` git would ignore, relative to `cwd`.
+
+    Shells out to `git check-ignore` — the authority on gitignore semantics
+    (nested .gitignore, .git/info/exclude, the global excludesfile, negation).
+    One batched call covers a whole listing. Returns an empty set when `cwd`
+    is not in a work tree, git is missing, or anything else goes wrong:
+    dimming is a display hint, never a hard dependency on git.
+    """
+    if not rel_names:
+        return set()
+    try:
+        # --stdin -z: NUL-separated in and out, so names with newlines or
+        # non-UTF-8 bytes round-trip intact. check-ignore exits 0 when some
+        # path is ignored, 1 when none are (not an error), 128 on real
+        # failure incl. "not a git repository".
+        payload = b"".join(os.fsencode(n) + b"\0" for n in rel_names)
+        proc = subprocess.run(
+            ["git", "-C", cwd, "check-ignore", "--stdin", "-z"],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return set()
+    if proc.returncode not in (0, 1):
+        return set()
+    return {os.fsdecode(chunk) for chunk in proc.stdout.split(b"\0") if chunk}
+
+
 def _require_fused(x_fused: str | None) -> JSONResponse | None:
     # Guard for the mutating/executing POSTs. Read endpoints are already safe
     # cross-origin because the browser blocks a foreign page from reading our
@@ -620,6 +651,9 @@ def create_app(start_dir: str) -> FastAPI:
                     "mtime": st.st_mtime,
                 }
             )
+        ignored = _git_ignored(path, [e["name"] for e in entries])
+        for e in entries:
+            e["ignored"] = e["name"] in ignored
         entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower()))
         return {"path": path, "entries": entries}
 
@@ -671,6 +705,9 @@ def create_app(start_dir: str) -> FastAPI:
                     break
             if truncated:
                 break
+        ignored = _git_ignored(path, [e["rel"] for e in entries])
+        for e in entries:
+            e["ignored"] = e["rel"] in ignored
         return {"path": path, "entries": entries, "truncated": truncated}
 
     @app.get("/api/fs/raw")

--- a/tests/test_server_gitignore.py
+++ b/tests/test_server_gitignore.py
@@ -55,9 +55,20 @@ def test_walk_flags_gitignored_entries(tmp_path):
     assert by_rel["src/main.py"]["ignored"] is False
 
 
+def test_list_flags_dot_git_directory(tmp_path):
+    # git never reports `.git` via check-ignore, but inside a work tree we dim
+    # it anyway — it's repo plumbing, not user data.
+    _make_repo(tmp_path)
+    data = _client(tmp_path).get("/api/fs/list", params={"path": str(tmp_path)}).json()
+    by_name = {e["name"]: e for e in data["entries"]}
+    assert by_name[".git"]["ignored"] is True
+
+
 def test_list_outside_git_repo_flags_nothing(tmp_path):
     # No `git init` — check-ignore exits 128, we swallow it and flag nothing.
+    # A stray `.git`-named file here must NOT be dimmed: no work tree, no git.
     (tmp_path / "a.txt").write_text("a", encoding="utf-8")
     (tmp_path / "b.log").write_text("b", encoding="utf-8")
+    (tmp_path / ".git").write_text("not a repo", encoding="utf-8")
     data = _client(tmp_path).get("/api/fs/list", params={"path": str(tmp_path)}).json()
     assert all(e["ignored"] is False for e in data["entries"])

--- a/tests/test_server_gitignore.py
+++ b/tests/test_server_gitignore.py
@@ -1,0 +1,63 @@
+"""Tests for the `ignored` field on GET /api/fs/list and /api/fs/walk
+(fused_render/server.py) — files matched by .gitignore inside a git work tree
+are flagged so the shell can dim them. Non-repos, and installs without git,
+degrade to `ignored: False` everywhere (dimming is a hint, never required)."""
+import shutil
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render.server import create_app
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None, reason="git binary not available"
+)
+
+
+def _client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _git_init(path):
+    # Minimal repo: no commits needed — check-ignore only reads the rules.
+    subprocess.run(["git", "init", "-q", str(path)], check=True)
+
+
+def _make_repo(tmp_path):
+    _git_init(tmp_path)
+    (tmp_path / ".gitignore").write_text("build/\n*.log\n", encoding="utf-8")
+    (tmp_path / "keep.txt").write_text("k", encoding="utf-8")
+    (tmp_path / "debug.log").write_text("l", encoding="utf-8")
+    (tmp_path / "build").mkdir()
+    (tmp_path / "build" / "out.o").write_text("o", encoding="utf-8")
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.log").write_text("l", encoding="utf-8")
+    (tmp_path / "src" / "main.py").write_text("m", encoding="utf-8")
+
+
+def test_list_flags_gitignored_entries(tmp_path):
+    _make_repo(tmp_path)
+    data = _client(tmp_path).get("/api/fs/list", params={"path": str(tmp_path)}).json()
+    by_name = {e["name"]: e for e in data["entries"]}
+    assert by_name["debug.log"]["ignored"] is True
+    assert by_name["build"]["ignored"] is True  # an ignored directory is flagged
+    assert by_name["keep.txt"]["ignored"] is False
+    assert by_name["src"]["ignored"] is False
+    assert by_name[".gitignore"]["ignored"] is False
+
+
+def test_walk_flags_gitignored_entries(tmp_path):
+    _make_repo(tmp_path)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    by_rel = {e["rel"]: e for e in data["entries"]}
+    assert by_rel["src/app.log"]["ignored"] is True  # nested match
+    assert by_rel["src/main.py"]["ignored"] is False
+
+
+def test_list_outside_git_repo_flags_nothing(tmp_path):
+    # No `git init` — check-ignore exits 128, we swallow it and flag nothing.
+    (tmp_path / "a.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "b.log").write_text("b", encoding="utf-8")
+    data = _client(tmp_path).get("/api/fs/list", params={"path": str(tmp_path)}).json()
+    assert all(e["ignored"] is False for e in data["entries"])


### PR DESCRIPTION
## Summary

- **Dims gitignored files/folders in the listing** when browsing inside a git work tree, so machine-managed clutter (`build/`, `*.log`, `node_modules`, …) recedes visually while staying clickable.
- Each `/api/fs/list` and `/api/fs/walk` entry now carries an `ignored` boolean; the shell renders those rows at 45% opacity (full opacity restored on hover).
- Detection defers entirely to `git check-ignore` (one batched, NUL-delimited call per listing), so full gitignore semantics — nested `.gitignore`, `.git/info/exclude`, the global excludesfile, negation rules — come for free rather than being re-implemented.
- **Never a hard dependency on git**: if the directory is not a repo, git is missing, or the call errors/times out, nothing is dimmed. Dimming is a display hint only.

## Visuals

<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/885697bf-91a0-4ca3-b591-ab0663b93fc9" />


## Usage

Not directly user-invocable — it is automatic. Browse any directory inside a git repository in the shell and gitignored entries appear dimmed in both the plain listing and search results. Hover a dimmed row to bring it back to full opacity. Outside a git repo (or on a machine without `git`), listings look exactly as before.

## Test Plan

- [x] Automated: `tests/test_server_gitignore.py` — flags ignored files/dirs in `/api/fs/list`, nested matches in `/api/fs/walk`, and asserts nothing is flagged outside a repo. Skips cleanly when `git` is unavailable.
- [x] Full backend suite: **175 passed, 2 skipped**.
- [x] Frontend `tsc --noEmit` clean; `vite build` succeeds.
- [x] Manual: served `/api/fs/list` against a real repo dir — `node_modules` correctly flagged `ignored: true`, tracked files `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
