### PR TITLE
First-run onboarding: default ~/Documents/Fused, seeded examples + bookmarks

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-// Sidebar UI: brand, Home entry, bookmark rows with hover card + inline rename.
+// Sidebar UI: brand, Fused-dir entry, bookmark rows with hover card + inline rename.
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { navigate, navigateUrl, currentUrl, VIEW_PREFIX } from "../lib/router";
 // Folder-as-tabs entry (TM-8): composeFolderTabsUrl builds the `/view/_tab` url
@@ -367,9 +367,9 @@ export default function Sidebar({ config }: SidebarProps) {
     else rowRefs.current.delete(id);
   };
 
-  const onHomeClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const onFusedClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (config && config.home) navigate(config.home);
+    if (config && config.fused_dir) navigate(config.fused_dir);
   };
 
   // --- bookmark row handlers -------------------------------------------------
@@ -641,8 +641,8 @@ export default function Sidebar({ config }: SidebarProps) {
         <span className="brand-version">v{config.version}</span>
       </div>
       <div className="sidebar-section">
-        <a href="#" id="home-link" className="sidebar-item" onClick={onHomeClick}>
-          <span className="icon">🏠</span> Home
+        <a href="#" id="fused-link" className="sidebar-item" onClick={onFusedClick}>
+          <span className="icon">📁</span> Fused
         </a>
       </div>
       <div className="sidebar-section sidebar-bookmarks">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2,6 +2,8 @@
 export interface Config {
   start_dir: string;
   home: string;
+  // The Fused workspace dir (~/Documents/Fused) — the sidebar's "Fused" entry.
+  fused_dir: string;
   version: string;
 }
 

--- a/frontend/src/lib/bookmarks.ts
+++ b/frontend/src/lib/bookmarks.ts
@@ -15,6 +15,30 @@ import { getBookmarks, putBookmarks } from "./api";
 // dormant as a fallback (never written again).
 const LS_KEY = "fused.bookmarks";
 
+// One-time-migration marker. The original gate was the server `exists` flag, but
+// startup seeding (shell/seed.py, D81) writes a starter bookmarks.json, so an
+// upgrading user's server store already `exists` on first run — the legacy import
+// would never fire and their localStorage bookmarks would be silently dropped.
+// This persistent marker decouples "have we imported legacy yet" from `exists`:
+// the import/merge runs at most once regardless of whether the file was pre-seeded.
+const MIGRATED_KEY = "fused.bookmarks.migrated";
+
+function legacyMigrated(): boolean {
+  try {
+    return localStorage.getItem(MIGRATED_KEY) === "1";
+  } catch {
+    return true; // no localStorage -> nothing to migrate, treat as done
+  }
+}
+
+function markLegacyMigrated(): void {
+  try {
+    localStorage.setItem(MIGRATED_KEY, "1");
+  } catch {
+    /* ignore — a blocked write just means we may re-attempt a no-op merge */
+  }
+}
+
 export interface Bookmark {
   id: string;
   name: string;
@@ -84,26 +108,66 @@ function readLegacy(): BookmarkItem[] | null {
   }
 }
 
+// Merge legacy localStorage items into the server tree: append every legacy
+// top-level entry whose id (and, for bookmarks, url) isn't already present
+// anywhere in the server tree. Non-destructive — server items win, legacy adds
+// only what's missing. Used both for a fresh install (server tree empty) and an
+// upgrade over a pre-seeded store (starter bookmarks already present).
+function mergeLegacy(
+  server: BookmarkItem[],
+  legacy: BookmarkItem[]
+): BookmarkItem[] {
+  const ids = new Set<string>();
+  const urls = new Set<string>();
+  const collect = (items: BookmarkItem[]): void => {
+    for (const it of items) {
+      ids.add(it.id);
+      if (isFolder(it)) collect(it.children);
+      else urls.add(it.url);
+    }
+  };
+  collect(server);
+  const out = clone(server);
+  for (const it of legacy) {
+    if (ids.has(it.id)) continue;
+    if (!isFolder(it) && urls.has(it.url)) continue;
+    out.push(it);
+  }
+  return out;
+}
+
 // Load the cache from the server once at boot (idempotent; enqueued so it wins
-// the race against any early mutation). If the file was never written (`exists`
-// false) and legacy localStorage has data, import it once (PUT it so `exists`
-// flips true and this never re-imports — even after the user later deletes
-// every bookmark). Failure leaves the cache empty and `hydrated` false; a later
-// mutation still tries to persist.
+// the race against any early mutation). Then run the one-time legacy import:
+// guarded by MIGRATED_KEY (not the `exists` flag) so it works even when startup
+// seeding pre-created bookmarks.json — any legacy localStorage bookmarks not
+// already in the server tree are merged in and PUT once. The marker is set only
+// after a successful commit (or when there is nothing to import), so a failed
+// PUT retries on the next boot. Failure leaves the cache empty and `hydrated`
+// false; a later mutation still tries to persist.
 export function hydrateBookmarks(): Promise<void> {
   return enqueue(async () => {
     if (hydrated) return;
     try {
       const { exists, bookmarks } = await getBookmarks();
-      if (!exists) {
+      const server = (exists ? (bookmarks as BookmarkItem[]) : []);
+      if (!legacyMigrated()) {
         const legacy = readLegacy();
         if (legacy) {
-          await commit(legacy);
-          hydrated = true;
-          return;
+          const merged = mergeLegacy(server, legacy);
+          // Persist only when the merge actually added something (or the server
+          // file was never written) — otherwise skip the redundant PUT.
+          if (!exists || merged.length !== server.length) {
+            await commit(merged);
+            markLegacyMigrated();
+            hydrated = true;
+            return;
+          }
         }
+        // Nothing to import, or everything already present: mark done so we
+        // never re-read localStorage on future boots.
+        markLegacyMigrated();
       }
-      cache = bookmarks as BookmarkItem[];
+      cache = server;
       hydrated = true;
     } catch (e) {
       console.error("[fused] failed to load bookmarks:", e);

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -116,11 +116,10 @@ def _remove_pidfile() -> None:
 
 
 def _start_server_thread(port: int) -> uvicorn.Server:
-    """Start uvicorn serving create_app(start_dir=home) on a daemon thread."""
+    """Start uvicorn serving create_app(start_dir=Fused dir) on a daemon thread."""
     # First-run onboarding (D81): create ~/Documents/Fused and seed it once.
-    ensure_fused_dir()
-    home = os.path.expanduser("~")
-    app = create_app(start_dir=home)
+    start_dir = ensure_fused_dir()
+    app = create_app(start_dir=start_dir)
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -23,6 +23,7 @@ import uvicorn
 
 from fused_render.logs import log_path, setup_logging
 from fused_render.server import create_app
+from fused_render.shell.seed import ensure_fused_dir
 
 logger = logging.getLogger("fused_render")
 
@@ -116,6 +117,8 @@ def _remove_pidfile() -> None:
 
 def _start_server_thread(port: int) -> uvicorn.Server:
     """Start uvicorn serving create_app(start_dir=home) on a daemon thread."""
+    # First-run onboarding (D81): create ~/Documents/Fused and seed it once.
+    ensure_fused_dir()
     home = os.path.expanduser("~")
     app = create_app(start_dir=home)
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")

--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -17,6 +17,7 @@ import threading
 import webbrowser
 
 from fused_render.logs import setup_logging
+from fused_render.shell.seed import ensure_fused_dir, fused_dir
 
 logger = logging.getLogger("fused_render")
 
@@ -34,8 +35,8 @@ def _build_parser() -> argparse.ArgumentParser:
     serve = sub.add_parser("serve", help="run the local file explorer (default)")
     serve.add_argument(
         "--start-dir",
-        default=os.path.expanduser("~"),
-        help="initial directory shown in the browser (default: home). "
+        default=fused_dir(),
+        help="initial directory shown in the browser (default: ~/Documents/Fused). "
         "The whole filesystem remains browsable.",
     )
     serve.add_argument(
@@ -53,6 +54,9 @@ def _run_serve(args: argparse.Namespace) -> None:
     from fused_render.server import create_app
 
     log_file = setup_logging()
+    # First-run onboarding (D81): create ~/Documents/Fused and seed it once. Runs
+    # regardless of --start-dir — seeding is about the Fused dir, not the start dir.
+    ensure_fused_dir()
     start_dir = os.path.abspath(os.path.expanduser(args.start_dir))
     app = create_app(start_dir=start_dir)
 

--- a/fused_render/examples_seed/how_it_works/demo.py
+++ b/fused_render/examples_seed/how_it_works/demo.py
@@ -1,0 +1,20 @@
+def main(peak: float = 30.0, spread: float = 15.0, bars: int = 28):
+    """A tiny stand-in for 'real work'. Given a peak position and spread,
+    compute a bell curve and hand the numbers back as JSON for the page to draw.
+    Move the sliders -> the shape of the curve visibly changes."""
+    import math
+    import platform
+
+    values = []
+    for i in range(bars):
+        x = i / (bars - 1) * 100          # x from 0..100 across the bars
+        y = math.exp(-((x - peak) ** 2) / (2 * spread ** 2))
+        values.append(round(y, 3))
+
+    tallest = max(range(bars), key=lambda i: values[i])
+    return {
+        "values": values,                 # bar heights 0..1
+        "peak_bar": tallest,               # which bar is the tallest
+        "peak_x": round(tallest / (bars - 1) * 100),
+        "python": platform.python_version(),  # proof this ran in real local Python
+    }

--- a/fused_render/examples_seed/how_it_works/explainer.html
+++ b/fused_render/examples_seed/how_it_works/explainer.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>How Fused Render works</title>
+<style>
+  :root {
+    /* Fused brand: dark grey + white, one yellow accent */
+    --bg:#141414; --panel:#1c1c1e; --panel2:#252527; --border:#333333;
+    --text:#ffffff; --dim:#a6a6ab; --mut:#77777c;
+    --yellow:#E5FF44;
+    --html:#ffffff;   /* the page side  → white  */
+    --py:#E5FF44;     /* the python side → yellow */
+    --code-bg:#0f0f10;
+  }
+  * { box-sizing:border-box; }
+  body { margin:0; padding:44px 30px 70px; background:var(--bg); color:var(--text);
+         font:14px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; }
+  .wrap { max-width:900px; margin:0 auto; }
+  h1 { font-size:27px; margin:0 0 10px; letter-spacing:-.4px; }
+  .tag { color:var(--dim); font-size:15.5px; margin:0 0 30px; max-width:640px; }
+  .tag b { color:var(--text); font-weight:600; }
+  .tag .y { color:var(--yellow); font-weight:600; }
+  code, .mono { font-family:"SF Mono",ui-monospace,Menlo,monospace; }
+  h2 { font-size:12px; text-transform:uppercase; letter-spacing:.7px; color:var(--mut);
+       margin:36px 0 6px; font-weight:700; }
+  .h2sub { color:var(--dim); font-size:13.5px; margin:0 0 16px; }
+
+  /* ---------- flow diagram (the hero) ---------- */
+  .flow { background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:26px 26px 20px; }
+  .row { display:grid; grid-template-columns:1fr 156px 1fr; align-items:center; }
+  .side { border-radius:12px; padding:18px 20px; border:1px solid var(--border); background:var(--panel2);
+          min-height:118px; display:flex; flex-direction:column; position:relative; }
+  .side.html { border-top:3px solid var(--html); }
+  .side.py   { border-top:3px solid var(--py); transition:box-shadow .25s, border-color .25s; }
+  .side.py.busy { box-shadow:0 0 0 1px var(--py), 0 0 26px -4px var(--py); }
+  .side h3 { margin:0 0 6px; font-size:16px; display:flex; align-items:center; gap:9px; }
+  .side h3 .dot { width:9px; height:9px; border-radius:3px; flex:0 0 auto; }
+  .side .what { color:var(--text); font-size:13.5px; font-weight:600; }
+  .side .eg { color:var(--dim); font-size:12.5px; margin-top:2px; }
+  .side .loc { color:var(--mut); font-size:11.5px; margin-top:auto; padding-top:10px; transition:opacity .2s; }
+  /* absolutely positioned so swapping in "running…" never changes the box height */
+  .side .busytag { color:var(--py); font-size:12px; font-weight:600; opacity:0;
+                   transition:opacity .2s; position:absolute; left:20px; bottom:18px; }
+  .side.py.busy .busytag { opacity:1; animation:blink 1s ease-in-out infinite; }
+  .side.py.busy .loc { opacity:0; }
+  @keyframes blink { 0%,100%{opacity:.35} 50%{opacity:1} }
+
+  .conn { display:flex; flex-direction:column; gap:22px; padding:0 16px; }
+  .arrow { display:flex; flex-direction:column; align-items:center; }
+  .arrow .lbl { font-size:11px; color:var(--dim); margin-bottom:6px; white-space:nowrap; }
+  .track { position:relative; width:100%; height:2px; border-radius:2px; }
+  .track.fwd { background:linear-gradient(90deg,rgba(255,255,255,.35),var(--py)); }
+  .track.back { background:linear-gradient(90deg,var(--py),rgba(255,255,255,.35)); }
+  .track .head { position:absolute; top:50%; width:0; height:0;
+                 border-top:5px solid transparent; border-bottom:5px solid transparent;
+                 transform:translateY(-50%); }
+  .track.fwd .head { right:-6px; border-left:8px solid var(--py); }
+  .track.back .head { left:-6px; border-right:8px solid var(--html); }
+  .pulse { position:absolute; top:50%; width:9px; height:9px; border-radius:50%;
+           transform:translate(-50%,-50%); opacity:0; box-shadow:0 0 9px 2px currentColor; }
+  .track.fwd .pulse, .track.back .pulse { color:var(--py); background:var(--py); }
+  @keyframes fwd { 0%{left:0;opacity:0} 12%{opacity:1} 88%{opacity:1} 100%{left:100%;opacity:0} }
+  @keyframes back{ 0%{left:100%;opacity:0} 12%{opacity:1} 88%{opacity:1} 100%{left:0;opacity:0} }
+  .pulse.run-fwd { animation:fwd .9s ease-in-out; }
+  .pulse.run-back{ animation:back .9s ease-in-out; }
+  .bridge { text-align:center; color:var(--mut); font-size:12px; margin-top:16px; }
+  .bridge code { color:var(--yellow); }
+
+  /* ---------- live demo ---------- */
+  .demo { display:grid; grid-template-columns:230px 1fr; gap:16px; align-items:stretch; }
+  .card { background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:18px 20px; }
+  .card h4 { margin:0 0 4px; font-size:14px; }
+  .card .hint { color:var(--dim); font-size:12px; margin:0 0 16px; }
+  .ctrl { margin-bottom:18px; }
+  .ctrl label { display:flex; justify-content:space-between; font-size:13px; margin-bottom:7px; }
+  .ctrl label b { color:var(--yellow); font-variant-numeric:tabular-nums; }
+  input[type=range]{ width:100%; accent-color:var(--yellow); }
+  .chartwrap { display:flex; flex-direction:column; height:100%; }
+  .chart { display:flex; align-items:flex-end; gap:3px; height:180px; flex:1; }
+  .chart .b { flex:1; background:#3a3a3d; border-radius:2px 2px 0 0; min-height:2px;
+              transition:height .3s ease, background .3s ease; }
+  .chart .b.peak { background:var(--yellow); }
+  .status { color:var(--mut); font-size:12px; margin-top:12px; min-height:16px; }
+  .status .y { color:var(--yellow); }
+
+  /* mode toggle */
+  .modehdr { display:flex; align-items:flex-end; justify-content:space-between; gap:16px; flex-wrap:wrap; }
+  .modes { display:inline-flex; background:var(--panel2); border:1px solid var(--border);
+           border-radius:9px; padding:3px; gap:2px; }
+  .modes button { appearance:none; border:0; background:transparent; color:var(--dim); cursor:pointer;
+                  font:600 12px/1 -apple-system,BlinkMacSystemFont,sans-serif; padding:7px 13px;
+                  border-radius:6px; transition:background .15s, color .15s; }
+  .modes button:hover { color:var(--text); }
+  .modes button.on { background:var(--yellow); color:#141414; }
+
+  /* ---------- expandable details ---------- */
+  details { border-top:1px solid var(--border); margin-top:14px; padding-top:12px; }
+  .peek { margin-top:16px; }
+  summary { cursor:pointer; font-size:12.5px; color:var(--dim); list-style:none;
+            display:flex; align-items:center; gap:8px; user-select:none; }
+  summary::-webkit-details-marker { display:none; }
+  summary .tw { transition:transform .15s; color:var(--mut); font-size:9px; }
+  details[open] summary .tw { transform:rotate(90deg); }
+  summary b { color:var(--text); font-weight:600; }
+  .body { padding:12px 0 2px; }
+  pre { margin:0; background:var(--code-bg); border:1px solid var(--border); border-radius:9px;
+        padding:13px 15px; font-size:12px; overflow-x:auto; color:#d0d0d4;
+        transition:box-shadow .2s, border-color .2s; position:relative; }
+  pre.running { border-color:var(--py); box-shadow:0 0 0 1px var(--py), 0 0 20px -4px var(--py); }
+  pre.running::before { content:"● running"; position:absolute; top:9px; right:13px; font-size:10px;
+        color:var(--py); font-weight:700; animation:blink 1s ease-in-out infinite; }
+  pre .k { color:#c7c7cc; } pre .s { color:#e4e4e7; } pre .f { color:var(--yellow); } pre .c { color:var(--mut); }
+  .url { font-size:12px; color:var(--dim); word-break:break-all; margin-top:8px; }
+  .url b { color:var(--yellow); }
+  ul.rules { margin:12px 0 0; padding-left:18px; color:var(--dim); font-size:12.5px; }
+  ul.rules li { margin:5px 0; }
+  ul.rules code { color:var(--text); }
+  @media (max-width:760px){ .row,.demo{ grid-template-columns:1fr; } .conn{ flex-direction:row; padding:16px 0; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <h1>How Fused Render works</h1>
+  <p class="tag">A project is just a <b>web page</b> and a <b>Python file</b> in a folder. The page is what you <b>see</b>; Python does the <b>work</b> — on your own machine. One line connects them: <span class="y mono">fused.runPython()</span>.</p>
+
+  <!-- FLOW DIAGRAM -->
+  <div class="flow">
+    <div class="row">
+      <div class="side html">
+        <h3><span class="dot" style="background:var(--html)"></span>The page</h3>
+        <div class="what">What you see</div>
+        <div class="eg">Sliders, maps, charts — the interface.</div>
+        <div class="loc">runs in the browser</div>
+      </div>
+
+      <div class="conn">
+        <div class="arrow">
+          <div class="lbl">your inputs →</div>
+          <div class="track fwd"><span class="head"></span><span class="pulse" id="pf"></span></div>
+        </div>
+        <div class="arrow">
+          <div class="lbl">← the result</div>
+          <div class="track back"><span class="head"></span><span class="pulse" id="pb"></span></div>
+        </div>
+      </div>
+
+      <div class="side py" id="pyPanel">
+        <h3><span class="dot" style="background:var(--py)"></span>The Python</h3>
+        <div class="what">What does the work</div>
+        <div class="eg">pandas, DuckDB, your files &amp; APIs.</div>
+        <div class="loc" id="pyver">runs on your machine</div>
+        <div class="busytag">⚙︎ running…</div>
+      </div>
+    </div>
+    <div class="bridge">The page hands inputs to Python and gets JSON back — that whole arrow is one call to <code>fused.runPython()</code>.</div>
+  </div>
+
+  <!-- LIVE DEMO -->
+  <div class="modehdr">
+    <div>
+      <h2>See it happen</h2>
+      <p class="h2sub" id="h2sub">Move a slider. Your input goes to Python, Python recomputes the curve, and the result is drawn here — for real.</p>
+    </div>
+    <div class="modes">
+      <button data-mode="explainer">Explainer</button>
+      <button data-mode="realtime">Realtime</button>
+    </div>
+  </div>
+  <div class="demo">
+    <div class="card">
+      <h4>You control</h4>
+      <p class="hint">These become Python's inputs.</p>
+      <div class="ctrl"><label>Peak position <b id="vPeak">30</b></label>
+        <input type="range" id="peak" min="0" max="100" step="1"></div>
+      <div class="ctrl"><label>Spread <b id="vSpread">15</b></label>
+        <input type="range" id="spread" min="4" max="40" step="1"></div>
+    </div>
+
+    <div class="card">
+      <div class="chartwrap">
+        <h4 style="margin-bottom:12px">Python draws this</h4>
+        <div class="chart" id="chart"></div>
+        <div class="status" id="status"></div>
+      </div>
+    </div>
+  </div>
+
+  <!-- optional detail, collapsed by default -->
+  <div class="peek">
+    <details>
+      <summary><span class="tw">▶</span><b>Peek under the hood</b> — the call, the data, and the Python</summary>
+      <div class="body">
+        <div style="color:var(--dim);font-size:12px;margin-bottom:6px">The exact call the page just made:</div>
+        <pre id="call"></pre>
+        <div class="url" id="url"></div>
+
+        <div style="color:var(--dim);font-size:12px;margin:16px 0 6px">The whole <code>demo.py</code> — one function, plain Python:</div>
+        <pre id="pySrc"><span class="k">def</span> <span class="f">main</span>(peak: float, spread: float, bars: int = 28):
+    <span class="k">import</span> math
+    values = []
+    <span class="k">for</span> i <span class="k">in</span> range(bars):
+        x = i / (bars - 1) * 100
+        values.append(math.exp(-((x - peak)**2) / (2 * spread**2)))
+    <span class="k">return</span> {<span class="s">"values"</span>: values}   <span class="c"># plain JSON back to the page</span></pre>
+        <ul class="rules">
+          <li>One function named <code>main()</code> — no decorator, no server, no registration.</li>
+          <li>Inputs are type-annotated, so URL values arrive as real numbers.</li>
+          <li>Returns plain JSON — the page draws whatever comes back.</li>
+        </ul>
+      </div>
+    </details>
+  </div>
+</div>
+
+<script>
+const $ = id => document.getElementById(id);
+const P = fused.params;
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+function pulse(el, cls){ el.classList.remove(cls); void el.offsetWidth; el.classList.add(cls); }
+const mode = () => P.get("mode") === "realtime" ? "realtime" : "explainer";
+
+function renderChart(data){
+  $("pyver").textContent = "Python " + data.python;
+  $("chart").innerHTML = data.values
+    .map((v,i) => '<div class="b'+(i===data.peak_bar?' peak':'')+'" style="height:'+(v*100)+'%"></div>').join("");
+}
+
+let seq = 0;
+async function draw(){
+  const peak   = P.get("peak")   || "30";
+  const spread = P.get("spread") || "15";
+  const rt = mode() === "realtime";
+
+  // reflect state into controls, the code snippet, and the mode buttons
+  $("peak").value=peak; $("spread").value=spread;
+  $("vPeak").textContent=peak; $("vSpread").textContent=spread;
+  document.querySelectorAll(".modes button").forEach(b => b.classList.toggle("on", b.dataset.mode === mode()));
+  $("h2sub").textContent = rt
+    ? "Realtime: effects off. Drag a slider — this is the true speed of the round-trip on your machine."
+    : "Move a slider. Your input goes to Python, Python recomputes the curve, and the result is drawn here — for real.";
+  $("url").innerHTML = "?<b>peak</b>="+peak+"&<b>spread</b>="+spread;
+  $("call").innerHTML =
+    '<span class="k">const</span> data = <span class="k">await</span> fused.<span class="f">runPython</span>(<span class="s">"./demo.py"</span>, {\n' +
+    '  peak: <span class="s">"'+peak+'"</span>, spread: <span class="s">"'+spread+'"</span>\n});';
+
+  const my = ++seq;
+  try {
+    if (rt) {
+      // Realtime: no artificial delays, no pulse/glow — just call and draw as fast as Python returns.
+      $("pyPanel").classList.remove("busy"); $("pySrc").classList.remove("running");
+      $("status").innerHTML = "running…";
+      const t0 = performance.now();
+      const data = await fused.runPython("./demo.py", {peak, spread});
+      if (my !== seq) return;
+      renderChart(data);
+      $("status").innerHTML = '<span class="y">✓</span> real round-trip in '+Math.round(performance.now()-t0)+' ms · peak at x='+data.peak_x;
+      return;
+    }
+
+    // Explainer: paced so the three phases read clearly on a screen-share.
+    pulse($("pf"), "run-fwd");                       // 1 · inputs travel to Python
+    $("status").innerHTML = "sending your inputs to Python…";
+    await sleep(900);
+    if (my !== seq) return;
+
+    $("pyPanel").classList.add("busy");              // 2 · Python runs
+    $("pySrc").classList.add("running");
+    $("status").innerHTML = "Python is computing…";
+    const [data] = await Promise.all([
+      fused.runPython("./demo.py", {peak, spread}),
+      sleep(900),
+    ]);
+    $("pyPanel").classList.remove("busy");
+    $("pySrc").classList.remove("running");
+    if (my !== seq) return;
+
+    pulse($("pb"), "run-back");                       // 3 · result travels back
+    $("status").innerHTML = "returning result to the page…";
+    await sleep(900);                                 // wait for the ball to land on "The page"
+    if (my !== seq) return;
+    renderChart(data);                                // …only then draw
+    $("status").innerHTML = '<span class="y">✓</span> Python returned '+data.values.length+' numbers · peak at x='+data.peak_x;
+  } catch(e){
+    $("pyPanel").classList.remove("busy");
+    $("pySrc").classList.remove("running");
+    $("status").textContent = "error: " + e.message;
+  }
+}
+
+["peak","spread"].forEach(id =>
+  $(id).addEventListener("input", e => P.set(id, String(e.target.value))));
+document.querySelectorAll(".modes button").forEach(b =>
+  b.addEventListener("click", () => P.set("mode", b.dataset.mode)));
+P.onChange(draw);
+draw();
+</script>
+</body>
+</html>

--- a/fused_render/examples_seed/sine/sine.html
+++ b/fused_render/examples_seed/sine/sine.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Sine wave</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 24px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #e8eaed;
+    background: #131417;
+  }
+  #controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+  #controls label {
+    color: #9aa0a6;
+    font-size: 13px;
+  }
+  #freq {
+    width: 260px;
+  }
+  #freqValue {
+    font-variant-numeric: tabular-nums;
+    min-width: 3em;
+  }
+  svg {
+    border: 1px solid #2a2d33;
+    border-radius: 8px;
+    background: #1b1d21;
+  }
+</style>
+</head>
+<body>
+  <div id="controls">
+    <label for="freq">freq</label>
+    <input id="freq" type="range" min="0.1" max="5" step="0.1" value="1.0" />
+    <span id="freqValue"></span>
+  </div>
+  <svg id="chart" width="640" height="280" viewBox="0 0 640 280"></svg>
+
+  <script>
+    const slider = document.getElementById("freq");
+    const freqValueEl = document.getElementById("freqValue");
+    const svg = document.getElementById("chart");
+
+    const W = 640, H = 280, PAD = 20;
+
+    function currentFreq() {
+      const raw = fused.params.get("freq");
+      return raw !== undefined ? parseFloat(raw) : 1.0;
+    }
+
+    function pointsToPolyline(points) {
+      // points: [[x in 0..1, y in -1..1], ...]
+      return points
+        .map(([x, y]) => {
+          const px = PAD + x * (W - 2 * PAD);
+          const py = H / 2 - y * (H / 2 - PAD);
+          return `${px.toFixed(1)},${py.toFixed(1)}`;
+        })
+        .join(" ");
+    }
+
+    async function draw() {
+      const freq = currentFreq();
+      slider.value = String(freq);
+      freqValueEl.textContent = freq.toFixed(1);
+
+      const { points } = await fused.runPython("./sine.py", { n: "160", freq: String(freq) });
+
+      const axis = `<line x1="${PAD}" y1="${H / 2}" x2="${W - PAD}" y2="${H / 2}" stroke="#3a3d44" />`;
+      const line = `<polyline points="${pointsToPolyline(points)}" fill="none" stroke="#5b9dff" stroke-width="2" />`;
+      svg.innerHTML = axis + line;
+    }
+
+    slider.addEventListener("input", () => {
+      fused.params.set("freq", slider.value);
+    });
+    fused.params.onChange(draw);
+    draw();
+  </script>
+</body>
+</html>

--- a/fused_render/examples_seed/sine/sine.py
+++ b/fused_render/examples_seed/sine/sine.py
@@ -1,0 +1,12 @@
+"""Example runPython target: computes a sine wave. Stdlib only."""
+import math
+
+
+def main(n: int = 80, freq: float = 1.0) -> dict:
+    print(f"computing {n} points at freq={freq}")
+    points = []
+    for i in range(n):
+        x = i / (n - 1) if n > 1 else 0.0
+        y = math.sin(2 * math.pi * freq * x)
+        points.append([x, y])
+    return {"points": points}

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -34,6 +34,7 @@ from fused_render.executor import run_python
 from fused_render.shell import prefs as shell_prefs
 from fused_render.shell.bookmarks import router as bookmarks_router
 from fused_render.shell.prefs import router as prefs_router
+from fused_render.shell.seed import fused_dir
 from fused_render.shell.storage import home_dir
 
 logger = logging.getLogger(__name__)
@@ -498,6 +499,10 @@ def create_app(start_dir: str) -> FastAPI:
         return {
             "start_dir": start_dir,
             "home": os.path.expanduser("~"),
+            # The Fused workspace dir (~/Documents/Fused, D81) — the sidebar's
+            # "Fused" entry navigates here. Path only; the dir is created + seeded
+            # at the process entry points (cli/app), not on this read.
+            "fused_dir": fused_dir(),
             # The fused-render package version, surfaced in the sidebar brand.
             "version": __version__,
             # Which /api/run engine is in effect (D69/§20): "fused" | "builtin".

--- a/fused_render/shell/seed.py
+++ b/fused_render/shell/seed.py
@@ -122,7 +122,9 @@ def _seed_examples(fdir: str) -> bool:
     """Copy the packaged seed set into fdir iff it is empty. Returns True when it
     copied, False when the dir already had content (never re-seed)."""
     try:
-        nonempty = any(os.scandir(fdir))
+        # Hidden metadata (.DS_Store etc.) is not user content: a dir holding
+        # only dot-entries still counts as empty and gets seeded.
+        nonempty = any(not entry.name.startswith(".") for entry in os.scandir(fdir))
     except FileNotFoundError:
         nonempty = False
     if nonempty:

--- a/fused_render/shell/seed.py
+++ b/fused_render/shell/seed.py
@@ -122,9 +122,43 @@ def _examples_present(fdir: str) -> bool:
     )
 
 
+def _remove(path: str) -> None:
+    """Best-effort delete of a file or directory tree; silent on absence."""
+    if os.path.isdir(path) and not os.path.islink(path):
+        shutil.rmtree(path, ignore_errors=True)
+    else:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def _clear_partials(fdir: str) -> None:
+    """Remove any ".<name>.partial" leftovers from a previously interrupted seed.
+    These are the temp targets a crash can strand mid-copy; they are hidden so
+    they never counted as user content, but they must be cleared before a retry
+    so the atomic os.rename below lands on a clean name."""
+    try:
+        entries = list(os.scandir(fdir))
+    except FileNotFoundError:
+        return
+    for entry in entries:
+        if entry.name.endswith(".partial"):
+            _remove(entry.path)
+
+
 def _seed_examples(fdir: str) -> bool:
     """Copy the packaged seed set into fdir iff it is empty. Returns True when it
-    copied, False when the dir already had content (never re-seed)."""
+    copied, False when the dir already had content (never re-seed).
+
+    Each example is materialized atomically: fully copied under a hidden
+    ".<name>.partial" sibling inside fdir, then os.rename'd into place. A crash
+    mid-copy therefore leaves only a hidden ".*.partial" (cleaned on the next
+    run), never a half-written example dir that would make fdir look non-empty
+    and wedge seeding off forever."""
+    # Clear stale partials FIRST, before the emptiness check, so an interrupted
+    # prior run can be retried instead of being skipped as "already seeded".
+    _clear_partials(fdir)
     try:
         # Hidden metadata (.DS_Store etc.) is not user content: a dir holding
         # only dot-entries still counts as empty and gets seeded.
@@ -133,8 +167,15 @@ def _seed_examples(fdir: str) -> bool:
         nonempty = False
     if nonempty:
         return False
-    # dirs_exist_ok: fdir was just makedirs'd (empty), so it exists.
-    shutil.copytree(PACKAGE_SEED_DIR, fdir, dirs_exist_ok=True)
+    for entry in os.scandir(PACKAGE_SEED_DIR):
+        dest = os.path.join(fdir, entry.name)
+        partial = os.path.join(fdir, "." + entry.name + ".partial")
+        _remove(partial)  # defensive: no residue from this same run
+        if entry.is_dir():
+            shutil.copytree(entry.path, partial)
+        else:
+            shutil.copy2(entry.path, partial)
+        os.rename(partial, dest)
     return True
 
 

--- a/fused_render/shell/seed.py
+++ b/fused_render/shell/seed.py
@@ -40,8 +40,12 @@ _EXPLAINER_HTML = os.path.join("how_it_works", "explainer.html")
 
 def fused_dir() -> str:
     """The user's Fused workspace: ~/Documents/Fused. FUSED_RENDER_DIR overrides
-    it (tests set it so they never touch the real dir). Path only — no I/O."""
-    return os.environ.get("FUSED_RENDER_DIR") or os.path.expanduser("~/Documents/Fused")
+    it (tests set it so they never touch the real dir). Path only — no I/O.
+    Normalized (expanduser + abspath) so a tilde or relative override yields the
+    same path everywhere: seeding, bookmark URLs, and /api/config's fused_dir."""
+    return os.path.abspath(
+        os.path.expanduser(os.environ.get("FUSED_RENDER_DIR") or "~/Documents/Fused")
+    )
 
 
 def _view_url(abs_path: str) -> str:

--- a/fused_render/shell/seed.py
+++ b/fused_render/shell/seed.py
@@ -1,0 +1,173 @@
+"""First-run onboarding: the ~/Documents/Fused workspace, its seeded examples,
+and starter bookmarks (D81).
+
+Called from the real process entry points (cli._run_serve, app._start_server_thread)
+— NOT from create_app, so importing the server in tests never touches a user's
+real Fused dir. The whole thing is idempotent and non-destructive on upgrades:
+
+  * the dir is created if missing;
+  * the bundled examples are copied in ONLY when the dir is empty (an existing,
+    non-empty dir is left completely alone — user edits are sacred, we never
+    re-seed);
+  * starter bookmarks are written ONLY when ~/.fused-render/bookmarks.json is
+    absent AND the examples are present — an existing bookmarks.json is never
+    touched.
+
+Seeding concerns the Fused dir, independent of the server's --start-dir.
+"""
+import os
+import shutil
+import time
+import uuid
+from urllib.parse import quote
+
+from fused_render.shell import storage
+
+# Seed examples ship inside the wheel at fused_render/examples_seed/, packaged
+# by the same mechanism as fused_render/templates/ (pyproject packages =
+# ["fused_render"] — every committed file under the package ships).
+PACKAGE_SEED_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "examples_seed"
+)
+
+# The two example pages the starter bookmarks point at; both existing is the
+# "examples are present" signal that gates bookmark seeding. Sine ships in its
+# own subfolder (sine/sine.html + sine/sine.py) so nothing lands loose at the
+# workspace root and sine.py's __pycache__ stays inside the subfolder.
+_SINE_HTML = os.path.join("sine", "sine.html")
+_EXPLAINER_HTML = os.path.join("how_it_works", "explainer.html")
+
+
+def fused_dir() -> str:
+    """The user's Fused workspace: ~/Documents/Fused. FUSED_RENDER_DIR overrides
+    it (tests set it so they never touch the real dir). Path only — no I/O."""
+    return os.environ.get("FUSED_RENDER_DIR") or os.path.expanduser("~/Documents/Fused")
+
+
+def _view_url(abs_path: str) -> str:
+    """Build a /view/ URL for an absolute fs path, encoding each segment exactly
+    as the frontend's urlForFsPath (lib/router.ts): drop the leading slash(es),
+    split on '/', URL-encode each non-empty segment (encodeURIComponent parity —
+    quote already keeps A-Za-z0-9_.-~, so add !*'() to match), join with '/'."""
+    rest = abs_path.lstrip("/")
+    segs = [quote(seg, safe="!*'()") for seg in rest.split("/") if seg]
+    return "/view/" + "/".join(segs)
+
+
+# --- Panel `_layout` codec (mirror of frontend/src/lib/layout-codec.ts) -------
+# The Sine demo bookmark opens panel mode split into two panes of the SAME page
+# — left in the default render mode, right in `code` mode — exactly the URL the
+# app itself produces when you open sine/sine.html, click Split right, then set
+# the right pane to code mode. The panel URL is NOT the /view/ codec above: the
+# layout codec keeps `/ ? & =` literal and escapes only its own delimiters, so
+# it must be replicated here rather than reusing _view_url.
+
+
+def _enc_path(s: str) -> str:
+    """encPath(): escape `%` first, then the codec delimiters `, ; ( )` and `?`
+    (so a path can never contain the path/query separator)."""
+    return (
+        s.replace("%", "%25")
+        .replace(",", "%2C")
+        .replace(";", "%3B")
+        .replace("(", "%28")
+        .replace(")", "%29")
+        .replace("?", "%3F")
+    )
+
+
+def _enc_query(s: str) -> str:
+    """encQuery(): same as _enc_path but keep `?` literal (the leading `?` is the
+    path/query separator inside a segment)."""
+    return (
+        s.replace("%", "%25")
+        .replace(",", "%2C")
+        .replace(";", "%3B")
+        .replace("(", "%28")
+        .replace(")", "%29")
+    )
+
+
+def _encode_pane_segment(path: str, query: str = "") -> str:
+    """encodePaneSegment(): one pane = escaped fs path + escaped query (query
+    includes its leading `?`)."""
+    return _enc_path(path) + _enc_query(query)
+
+
+def _url_safe_layout(s: str) -> str:
+    """urlSafeLayout(): escape only `%`, `#` and space when placing the codec
+    string inside the `_layout=(...)` parens (splitShellSearch reverses it with
+    one decodeURIComponent pass)."""
+    return s.replace("%", "%25").replace("#", "%23").replace(" ", "%20")
+
+
+def _sine_panel_url(abs_path: str) -> str:
+    """The two-pane split-view URL for the Sine demo: `/view/_panel?_layout=(L,R)`
+    where L = the page in default render mode and R = the same page with
+    `_mode=code`. `,` is the row (side-by-side) separator; the whole layout is
+    parenthesized and emitted last, per the D51 grammar in buildSentinelUrl()."""
+    left = _encode_pane_segment(abs_path, "")
+    right = _encode_pane_segment(abs_path, "?_mode=code")
+    codec = left + "," + right
+    return "/view/_panel?_layout=(" + _url_safe_layout(codec) + ")"
+
+
+def _examples_present(fdir: str) -> bool:
+    return os.path.isfile(os.path.join(fdir, _SINE_HTML)) and os.path.isfile(
+        os.path.join(fdir, _EXPLAINER_HTML)
+    )
+
+
+def _seed_examples(fdir: str) -> bool:
+    """Copy the packaged seed set into fdir iff it is empty. Returns True when it
+    copied, False when the dir already had content (never re-seed)."""
+    try:
+        nonempty = any(os.scandir(fdir))
+    except FileNotFoundError:
+        nonempty = False
+    if nonempty:
+        return False
+    # dirs_exist_ok: fdir was just makedirs'd (empty), so it exists.
+    shutil.copytree(PACKAGE_SEED_DIR, fdir, dirs_exist_ok=True)
+    return True
+
+
+def _seed_bookmarks(fdir: str) -> None:
+    """Write the two starter bookmarks iff ~/.fused-render/bookmarks.json does
+    not exist. An existing file (even a corrupt one) is never overwritten — the
+    one-time-write gate the store already relies on (D75)."""
+    path = os.path.join(storage.home_dir(), "bookmarks.json")
+    if os.path.exists(path):
+        return
+    now = int(time.time() * 1000)  # ms, matching the frontend's Date.now()
+    bookmarks = [
+        {
+            "id": str(uuid.uuid4()),  # same UUIDv4 shape as crypto.randomUUID()
+            "name": "Sine demo",
+            # Split view: rendered sine page beside its source (code mode).
+            "url": _sine_panel_url(os.path.join(fdir, _SINE_HTML)),
+            "created_at": now,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "name": "How it works",
+            "url": _view_url(os.path.join(fdir, _EXPLAINER_HTML)),
+            "created_at": now,
+        },
+    ]
+    storage.write_json(path, bookmarks)
+
+
+def ensure_fused_dir() -> str:
+    """Create ~/Documents/Fused, seed examples into it once (empty dir only), and
+    seed starter bookmarks once (absent bookmarks.json + examples present).
+    Idempotent, non-destructive on upgrades. Returns the abs Fused dir."""
+    fdir = os.path.abspath(fused_dir())
+    os.makedirs(fdir, exist_ok=True)
+
+    seeded = _seed_examples(fdir)
+    # Bookmarks ride alongside a fresh example set — or an existing one the user
+    # kept — but never onto an unrelated dir the user filled with their own work.
+    if seeded or _examples_present(fdir):
+        _seed_bookmarks(fdir)
+    return fdir

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-"""Redirect the shell home dir to a throwaway tmp dir for the whole test run.
+"""Redirect the shell home dir + Fused workspace dir to throwaway tmp dirs for
+the whole test run.
 
 Importing fused_render.server / .executor now stages the core templates into
 home_dir()/.core-templates on import (core_templates.ensure_core_templates).
@@ -6,16 +7,21 @@ This runs at collection time — before any fixture — so the redirect must be
 set here at conftest import, ahead of the first test-module import, or the
 copy would land in the real ~/.fused-render.
 
-Only allocate + register cleanup when FUSED_RENDER_HOME is unset, so a caller
-that set it (CI pointing at a real dir) still wins and we don't eagerly leak a
-mkdtemp we never use. The dir we create is removed at process exit.
+FUSED_RENDER_DIR is redirected for the same reason: /api/config reads it (D81)
+and the seed tests write into it, so no test may see the real ~/Documents/Fused.
+
+Only allocate + register cleanup when the var is unset, so a caller that set it
+(CI pointing at a real dir) still wins and we don't eagerly leak a mkdtemp we
+never use. The dirs we create are removed at process exit.
 """
 import atexit
 import os
 import shutil
 import tempfile
 
-if "FUSED_RENDER_HOME" not in os.environ:
-    _home = tempfile.mkdtemp(prefix="fused-render-tests-")
-    os.environ["FUSED_RENDER_HOME"] = _home
-    atexit.register(shutil.rmtree, _home, ignore_errors=True)
+for _var, _prefix in (("FUSED_RENDER_HOME", "fused-render-tests-"),
+                       ("FUSED_RENDER_DIR", "fused-render-tests-dir-")):
+    if _var not in os.environ:
+        _tmp = tempfile.mkdtemp(prefix=_prefix)
+        os.environ[_var] = _tmp
+        atexit.register(shutil.rmtree, _tmp, ignore_errors=True)

--- a/tests/test_shell_seed.py
+++ b/tests/test_shell_seed.py
@@ -198,6 +198,27 @@ def test_bookmarks_not_seeded_without_examples(tmp_path, monkeypatch):
     assert not (home / "bookmarks.json").exists()
 
 
+def test_partial_seed_leftover_is_cleaned_and_reseeded(tmp_path, monkeypatch):
+    # An interrupted first run can strand a hidden ".<name>.partial" temp dir and
+    # leave the real examples missing. The next start must clear the leftover and
+    # complete seeding (the partial must not wedge seeding off forever).
+    fdir, home = _setup(tmp_path, monkeypatch)
+    fdir.mkdir(parents=True)
+    partial = fdir / ".sine.partial"
+    partial.mkdir()
+    (partial / "sine.html").write_text("half-copied", encoding="utf-8")
+
+    ensure_fused_dir()
+
+    # Leftover gone; both examples fully seeded; nothing else at the root.
+    assert not partial.exists()
+    assert (fdir / "sine" / "sine.html").is_file()
+    assert (fdir / "how_it_works" / "explainer.html").is_file()
+    assert sorted(p.name for p in fdir.iterdir()) == ["how_it_works", "sine"]
+    # Bookmarks ride along with the completed seed.
+    assert (home / "bookmarks.json").is_file()
+
+
 def test_idempotent_second_run_is_noop(tmp_path, monkeypatch):
     fdir, home = _setup(tmp_path, monkeypatch)
     ensure_fused_dir()

--- a/tests/test_shell_seed.py
+++ b/tests/test_shell_seed.py
@@ -51,6 +51,23 @@ def test_non_empty_dir_is_left_untouched(tmp_path, monkeypatch):
     assert not (fdir / "how_it_works").exists()
 
 
+def test_dir_with_only_ds_store_still_seeds(tmp_path, monkeypatch):
+    # macOS drops .DS_Store into ~/Documents/Fused as soon as Finder looks at
+    # it; hidden metadata must not count as user content blocking the seed.
+    fdir, home = _setup(tmp_path, monkeypatch)
+    fdir.mkdir(parents=True)
+    (fdir / ".DS_Store").write_bytes(b"\x00")
+
+    ensure_fused_dir()
+
+    assert (fdir / "sine" / "sine.html").is_file()
+    assert (fdir / "how_it_works" / "explainer.html").is_file()
+    # The hidden file survives — seeding never deletes anything.
+    assert (fdir / ".DS_Store").read_bytes() == b"\x00"
+    # Bookmarks ride along with the fresh seed as usual.
+    assert (home / "bookmarks.json").is_file()
+
+
 def test_bookmarks_created_when_absent_with_view_urls(tmp_path, monkeypatch):
     fdir, home = _setup(tmp_path, monkeypatch)
     ensure_fused_dir()

--- a/tests/test_shell_seed.py
+++ b/tests/test_shell_seed.py
@@ -1,0 +1,194 @@
+"""Tests for first-run onboarding (fused_render/shell/seed.py, D81): the
+~/Documents/Fused workspace, its seeded examples, and starter bookmarks.
+
+FUSED_RENDER_DIR (the Fused dir) and FUSED_RENDER_HOME (~/.fused-render, holding
+bookmarks.json) are both redirected to tmp dirs so no test touches a real dir.
+"""
+import json
+import re
+from urllib.parse import unquote
+
+from fused_render.shell.seed import _sine_panel_url, ensure_fused_dir
+
+
+def _setup(tmp_path, monkeypatch):
+    fdir = tmp_path / "Documents" / "Fused"
+    home = tmp_path / "home"
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    return fdir, home
+
+
+def _bookmarks(home):
+    return json.loads((home / "bookmarks.json").read_text(encoding="utf-8"))
+
+
+def test_seeds_examples_into_empty_dir(tmp_path, monkeypatch):
+    fdir, _ = _setup(tmp_path, monkeypatch)
+    returned = ensure_fused_dir()
+
+    assert returned == str(fdir)
+    # All four packaged seed files land, each inside its own subfolder — nothing
+    # loose at the workspace root.
+    assert (fdir / "sine" / "sine.html").is_file()
+    assert (fdir / "sine" / "sine.py").is_file()
+    assert (fdir / "how_it_works" / "demo.py").is_file()
+    assert (fdir / "how_it_works" / "explainer.html").is_file()
+    # Nothing spilled to the root: only the two example subfolders exist.
+    assert sorted(p.name for p in fdir.iterdir()) == ["how_it_works", "sine"]
+
+
+def test_non_empty_dir_is_left_untouched(tmp_path, monkeypatch):
+    fdir, _ = _setup(tmp_path, monkeypatch)
+    fdir.mkdir(parents=True)
+    (fdir / "my_work.html").write_text("mine", encoding="utf-8")
+
+    ensure_fused_dir()
+
+    # Existing content preserved; no examples copied in over a user's own dir.
+    assert (fdir / "my_work.html").read_text(encoding="utf-8") == "mine"
+    assert not (fdir / "sine").exists()
+    assert not (fdir / "how_it_works").exists()
+
+
+def test_bookmarks_created_when_absent_with_view_urls(tmp_path, monkeypatch):
+    fdir, home = _setup(tmp_path, monkeypatch)
+    ensure_fused_dir()
+
+    marks = _bookmarks(home)
+    assert [m["name"] for m in marks] == ["Sine demo", "How it works"]
+    # Sine demo opens a two-pane panel split (render | code) — parses back under
+    # the layout codec to the SAME sine page in both panes, right in code mode.
+    left, right = _parse_panel(marks[0]["url"])
+    assert left == (str(fdir / "sine" / "sine.html"), "")
+    assert right == (str(fdir / "sine" / "sine.html"), "?_mode=code")
+    # How it works stays a plain /view/ + per-segment-encoded absolute path.
+    assert marks[1]["url"] == "/view" + _encoded(
+        str(fdir / "how_it_works" / "explainer.html")
+    )
+    # UUIDv4 ids + a numeric created_at, matching the store's shape.
+    for m in marks:
+        assert len(m["id"]) == 36 and m["id"].count("-") == 4
+        assert isinstance(m["created_at"], int)
+
+
+def _encoded(abs_path: str) -> str:
+    # Mirror seed._view_url without importing it: leading slash kept as the
+    # /view join, each segment percent-encoded (round-trip check below covers
+    # the encoding rule itself).
+    from urllib.parse import quote
+
+    return "/" + "/".join(quote(s, safe="!*'()") for s in abs_path.lstrip("/").split("/") if s)
+
+
+def _dec_seg(s: str) -> str:
+    # layout-codec.ts decSeg: reverse only the structural escapes in one pass.
+    return re.sub(r"%(25|2C|3B|28|29|3F)", lambda m: chr(int(m.group(1), 16)), s)
+
+
+def _split_top(s: str, sep: str) -> list:
+    # layout-codec.ts splitDepthAware: split on sep only at paren depth 0.
+    out, depth, cur = [], 0, ""
+    for ch in s:
+        if ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        if ch == sep and depth == 0:
+            out.append(cur)
+            cur = ""
+        else:
+            cur += ch
+    out.append(cur)
+    return out
+
+
+def _parse_panel(url: str) -> list:
+    # Faithful mini-port of splitShellSearch + parseLayout for a flat row split:
+    # balanced-paren extract the _layout span, one decodeURIComponent pass, then
+    # depth-aware split on ';' (rows) and ',' (columns), un-escaping each leaf.
+    assert url.startswith("/view/_panel?_layout=(") and url.endswith(")")
+    inner = unquote(url[len("/view/_panel?_layout=("):-1])
+    rows = _split_top(inner, ";")
+    assert len(rows) == 1  # single row, panes side by side
+    leaves = []
+    for cell in _split_top(rows[0], ","):
+        q = cell.find("?")
+        if q == -1:
+            leaves.append((_dec_seg(cell), ""))
+        else:
+            leaves.append((_dec_seg(cell[:q]), "?" + _dec_seg(cell[q + 1:])))
+    return leaves
+
+
+def test_sine_panel_url_exact_split_encoding():
+    # Exact expected string for a fake home: the panel codec keeps `/ ? & =`
+    # literal (it is NOT the /view/ per-segment encoding) and emits render|code.
+    p = "/fake/Documents/Fused/sine/sine.html"
+    assert _sine_panel_url(p) == (
+        "/view/_panel?_layout=("
+        "/fake/Documents/Fused/sine/sine.html,"
+        "/fake/Documents/Fused/sine/sine.html?_mode=code)"
+    )
+    # A space in the path is escaped by urlSafeLayout (%20), not left literal,
+    # and round-trips back through the codec to the original path.
+    spaced = "/fake/My Dir/sine/sine.html"
+    url = _sine_panel_url(spaced)
+    assert " " not in url and "My%20Dir" in url
+    left, right = _parse_panel(url)
+    assert left == (spaced, "") and right == (spaced, "?_mode=code")
+
+
+def test_bookmark_urls_encode_special_segments(tmp_path, monkeypatch):
+    # A dir with a space proves the plain /view/ bookmark segments are
+    # URL-encoded (not left literal) and decode back to the real fs path.
+    fdir = tmp_path / "My Fused Dir"
+    home = tmp_path / "home"
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    ensure_fused_dir()
+
+    url = _bookmarks(home)[1]["url"]  # "How it works" — a plain /view/ URL
+    assert "My%20Fused%20Dir" in url  # space encoded, not literal
+    assert " " not in url
+    # Decoding the /view/ path yields the real absolute file path.
+    decoded = "/" + "/".join(unquote(s) for s in url[len("/view/"):].split("/"))
+    assert decoded == str(fdir / "how_it_works" / "explainer.html")
+
+
+def test_existing_bookmarks_never_overwritten(tmp_path, monkeypatch):
+    fdir, home = _setup(tmp_path, monkeypatch)
+    home.mkdir(parents=True)
+    existing = [{"id": "keep", "name": "mine", "url": "/view/x", "created_at": 1}]
+    (home / "bookmarks.json").write_text(json.dumps(existing), encoding="utf-8")
+
+    ensure_fused_dir()
+
+    # Examples still seeded, but the pre-existing bookmarks file is untouched.
+    assert (fdir / "sine" / "sine.html").is_file()
+    assert _bookmarks(home) == existing
+
+
+def test_bookmarks_not_seeded_without_examples(tmp_path, monkeypatch):
+    # A non-empty dir with no example pages: examples aren't present, so starter
+    # bookmarks must not be written onto the user's unrelated workspace.
+    fdir, home = _setup(tmp_path, monkeypatch)
+    fdir.mkdir(parents=True)
+    (fdir / "notes.txt").write_text("hi", encoding="utf-8")
+
+    ensure_fused_dir()
+
+    assert not (home / "bookmarks.json").exists()
+
+
+def test_idempotent_second_run_is_noop(tmp_path, monkeypatch):
+    fdir, home = _setup(tmp_path, monkeypatch)
+    ensure_fused_dir()
+    first = _bookmarks(home)
+
+    # User edits a seeded example; a second startup must not re-seed or reset it.
+    (fdir / "sine" / "sine.html").write_text("edited", encoding="utf-8")
+    ensure_fused_dir()
+
+    assert (fdir / "sine" / "sine.html").read_text(encoding="utf-8") == "edited"
+    assert _bookmarks(home) == first


### PR DESCRIPTION
## What

- **Default directory**: the server now starts in `~/Documents/Fused` (created at startup; `FUSED_RENDER_DIR` env override; explicit `--start-dir` still wins). `/api/config` exposes `fused_dir`.
- **Seed examples once**: `fused_render/examples_seed/` ships in the package (`sine/sine.html|py`, `how_it_works/demo.py|explainer.html`). An empty or missing Fused dir is seeded on startup; a non-empty dir is skipped silently — upgrades never re-copy, user edits are safe. Each example lives in its own subfolder (keeps `__pycache__` contained, no loose root files).
- **Seed bookmarks**: only when `~/.fused-render/bookmarks.json` is absent AND examples are present, two bookmarks are written — "Sine demo" opens a split view (rendered html pane + `_mode=code` pane) via a Python mirror of the frontend layout codec (`encodePaneSegment`/`panelUrl` parity), "How it works" a plain `/view/` URL. URLs are built at runtime from the real home path with frontend-equivalent segment encoding, so they're portable across usernames. An existing bookmarks.json (even corrupt) is never touched.
- **Sidebar**: Home button → "Fused", navigating to the workspace dir.
- Seeding runs only at process entry points (`cli`, app launcher) — importing/creating the app in tests never writes to real user dirs; `conftest.py` also redirects `FUSED_RENDER_DIR` to tmp.

## Testing

- `tests/test_shell_seed.py` (8 tests): empty-dir seed, non-empty untouched, idempotent re-run, bookmarks only-when-absent, never-overwrite, exact split-URL literal for a fake home, special-char segment encoding round-trip.
- Full suite 156 passed (2 pre-existing `test_deploy` failures = venv without pip, fail on HEAD too). tsc + vite clean.
- End-to-end: built the DMG, fresh-installed twice (real machine + scratch `$HOME`) — dir seeded once, bookmarks seeded with correct paths, Sine split view renders, re-launch doesn't re-seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Writes under the user's Documents and shell config at startup and changes default browse roots; bookmark merge touches persisted state but is gated and non-destructive.
> 
> **Overview**
> **First-run onboarding** creates `~/Documents/Fused` (override via `FUSED_RENDER_DIR`) at CLI and menu-bar startup only—not when importing the server. An empty workspace gets packaged examples (`sine/`, `how_it_works/`) via atomic copy; non-empty dirs are never overwritten. Starter bookmarks are written once when `bookmarks.json` is missing and examples exist, including a split-panel Sine URL built with a Python mirror of the frontend layout codec.
> 
> **Defaults and UI:** `--start-dir` and the packaged app now default to the Fused dir after `ensure_fused_dir()`. `/api/config` exposes `fused_dir`; the sidebar **Home** entry becomes **Fused** and navigates there.
> 
> **Bookmark upgrade fix:** Legacy localStorage import no longer gates on the server `exists` flag (which broke when seeding pre-created `bookmarks.json`). A `fused.bookmarks.migrated` marker plus non-destructive `mergeLegacy` runs the import at most once.
> 
> Tests redirect `FUSED_RENDER_DIR` in `conftest` and add `test_shell_seed.py` for seeding idempotency and URL encoding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8b13a392a24f9ea5f464b4fff5b0e5a34e539c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->