### PR TITLE
feat(registry): add claude template for .parquet

### DIFF
--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -2,6 +2,7 @@
   ".parquet": [
     "table",
     "h3",
+    "claude",
     "annotate"
   ],
   ".csv": [


### PR DESCRIPTION
## What

Add `claude` as a template option for `.parquet` files in `registry.json`, placed after `h3`.

`.parquet` templates: `["table", "h3", "claude", "annotate"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line registry change; reuses an existing template and does not alter execution or security paths.
> 
> **Overview**
> **Parquet previews** can now use the existing **`claude`** view mode: it is registered for **`.parquet`** in `registry.json`, ordered after `table` and `h3` and before `annotate`.
> 
> The default mode stays **`table`** (first entry in the list). No new template code—only the built-in extension→mode binding is updated so users can open Parquet files in the same Claude chat agent used for HTML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344b4ffec51c380ea216d40bfd1156e23358a9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->