### PR TITLE
feat(templates): duckdb grid reads compressed files & .duckdb databases

### DIFF
--- a/fused_render/templates/duckdb/reader.py
+++ b/fused_render/templates/duckdb/reader.py
@@ -1,5 +1,7 @@
 """Reader backing duckdb/template.html — one tabular viewer/editor for every
-flat file DuckDB can read: Parquet, CSV/TSV and JSON/JSONL.
+flat file DuckDB can read: Parquet, CSV/TSV and JSON/JSONL, including their
+gzip/zstd-compressed forms (data.csv.gz, data.json.zst, …) which DuckDB's
+read_*_auto scans decompress transparently.
 
 DuckDB does the COUNT(*) and LIMIT/OFFSET paging *in-engine*, so paging a huge
 CSV never loads the whole file into memory. Reads are non-mutating (the file
@@ -20,8 +22,14 @@ Returns {columns, types, rows, ids, total_rows, editable}. `types` maps each
 column to its DuckDB type name (BIGINT, VARCHAR, …) for the header label.
 `editable` is false for
 JSON — rewriting a flattened JSON grid would corrupt nested structure, so the
-JSON grid is view-only. `tables`/`table` are absent (single-relation files);
-the grid hides its relation selector when they're missing.
+JSON grid is view-only.
+
+Flat files are single-relation, so `tables`/`table` are absent and the grid
+hides its relation selector. A DuckDB **database** file (.duckdb/.ddb) is the
+exception: it holds many tables/views, so the reader ATTACHes it, returns the
+full `tables` list plus the selected `table`, and keys edits by DuckDB's real
+`rowid` (edited in place by writer.py, not rewritten). Views have no rowid and
+stay read-only.
 """
 import datetime
 import decimal
@@ -33,6 +41,27 @@ MAX_LIMIT = 1000
 
 # Extensions the grid can safely edit (rewrite in place). JSON is read-only.
 _EDITABLE_EXTS = {".parquet", ".csv", ".tsv"}
+
+# DuckDB database files: multi-table, edited in place by rowid (not rewritten
+# like a flat file). Handled by a separate ATTACH-based path below.
+_DB_EXTS = {".duckdb", ".ddb"}
+
+# Compression suffixes DuckDB transparently decodes; a file's *logical* format
+# is the extension underneath (data.csv.gz reads as CSV). read_*_auto detect the
+# codec from the .gz/.zst suffix, so no explicit COMPRESSION arg is needed here.
+_COMPRESSION_SUFFIXES = (".gz", ".zst")
+
+
+def _logical_ext(file: str) -> str:
+    """Format extension, seeing past a trailing compression suffix:
+    'a.csv.gz' -> '.csv', 'a.parquet' -> '.parquet'."""
+    base = file
+    low = base.lower()
+    for comp in _COMPRESSION_SUFFIXES:
+        if low.endswith(comp):
+            base = base[: -len(comp)]
+            break
+    return os.path.splitext(base)[1].lower()
 
 # Physical-position column injected into the page query. row_number() over the
 # raw scan is the 0-based file position — the same key the writer's rowid uses —
@@ -118,24 +147,92 @@ def relation_for(file: str) -> str:
     """The read-only table-function that reads `file` by extension. Shared with
     writer.py so read and write agree on how each format is parsed."""
     lit = _quote_str(os.path.abspath(file))
-    ext = os.path.splitext(file)[1].lower()
+    ext = _logical_ext(file)
     if ext == ".parquet":
         return f"read_parquet({lit})"
     if ext == ".tsv":
         return f"read_csv_auto({lit}, delim='\t', all_varchar=true)"
     if ext == ".csv":
         return f"read_csv_auto({lit}, all_varchar=true)"
-    # .json / .jsonl / .ndjson
+    # .json / .jsonl / .ndjson (optionally .gz/.zst — DuckDB auto-decompresses)
     return f"read_json_auto({lit})"
 
 
-def main(file: str, offset: int = 0, limit: int = 100,
+def _db_tables(con):
+    """(names, {name: type}) for the attached `db` — base tables and views,
+    sorted by name so the relation selector is stable."""
+    rows = con.execute(
+        "SELECT table_name, table_type FROM information_schema.tables "
+        "WHERE table_catalog = 'db' ORDER BY table_name").fetchall()
+    return [r[0] for r in rows], {r[0]: r[1] for r in rows}
+
+
+def _read_database(file, table, offset, limit, sort, filters):
+    """Page one relation of a DuckDB database file. Unlike the flat-file path,
+    row identity is DuckDB's real `rowid` pseudo-column (the key writer.py edits
+    by), and nothing is rewritten. Views have no rowid, so they're view-only —
+    the same rule the SQLite grid applies."""
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(f"ATTACH {_quote_str(os.path.abspath(file))} AS db (READ_ONLY)")
+        tables, kinds = _db_tables(con)
+        if not tables:
+            return {"columns": [], "types": {}, "rows": [], "ids": [],
+                    "total_rows": 0, "editable": False, "tables": [], "table": "",
+                    "readonly_message": "", "readonly_tooltip": ""}
+        # An unknown/stale table param falls back to the first real table
+        # rather than erroring the whole view.
+        sel = table if table in tables else tables[0]
+        is_view = kinds[sel] != "BASE TABLE"
+        relation = f"db.{_quote_ident(sel)}"
+
+        types = {r[0]: r[1] for r in
+                 con.execute(f"DESCRIBE SELECT * FROM {relation}").fetchall()}
+        where, wbinds = _build_where(filters, types)
+        order = _build_order(sort, types)
+        total_rows = con.execute(
+            f"SELECT COUNT(*) FROM {relation}{where}", wbinds).fetchone()[0]
+
+        # Base tables carry rowid (the edit key); a view has none, so it pages
+        # without ids and stays read-only.
+        pos = "rowid AS " + _POS if not is_view else f"CAST(NULL AS BIGINT) AS {_POS}"
+        paged = (f"SELECT {pos}, * FROM {relation}{where}{order} LIMIT ? OFFSET ?")
+        cur = con.execute(paged, wbinds + [limit, offset])
+        desc = [d[0] for d in cur.description] if cur.description else []
+        columns = desc[1:]
+        rows, ids = [], []
+        for raw in cur.fetchall():
+            if not is_view:
+                ids.append(raw[0])
+            rows.append({columns[j] if j < len(columns) else f"col{j}": _jsonify(v)
+                         for j, v in enumerate(raw[1:])})
+        return {
+            "columns": columns,
+            "types": types,
+            "rows": rows,
+            "ids": ids,
+            "total_rows": total_rows,
+            "editable": not is_view,
+            "tables": tables,
+            "table": sel,
+            "readonly_message": "" if not is_view else "View",
+            "readonly_tooltip": "" if not is_view else (
+                "Read-only. A view has no stored rows of its own to edit — "
+                "change the underlying table instead."),
+        }
+    finally:
+        con.close()
+
+
+def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
          sort: "dict | None" = None, filters: "list | None" = None) -> dict:
     # Clamp so a hostile/negative limit can't turn LIMIT ? into an unbounded
     # fetch, and a negative offset can't error out mid-query.
     limit = max(1, min(int(limit), MAX_LIMIT))
     offset = max(0, int(offset))
-    ext = os.path.splitext(file)[1].lower()
+    ext = _logical_ext(file)
+    if ext in _DB_EXTS:
+        return _read_database(file, table, offset, limit, sort, filters)
     relation = relation_for(file)
 
     con = duckdb.connect(":memory:")

--- a/fused_render/templates/duckdb/writer.py
+++ b/fused_render/templates/duckdb/writer.py
@@ -1,5 +1,6 @@
 """Writer backing duckdb/template.html's Save — applies a batch of edits,
-deletes and inserts to a Parquet/CSV/TSV file and rewrites it atomically.
+deletes and inserts to a Parquet/CSV/TSV file (optionally .gz/.zst compressed)
+and rewrites it atomically, keeping the same format and compression codec.
 
 Flat files can't be edited in place, so the whole file is rewritten: load it
 into an in-memory DuckDB table (whose `rowid` pseudo-column is the 0-based file
@@ -12,23 +13,63 @@ Row identity is file position (`row`), matching reader.py's `ids`. Edits and
 deletes key off the ORIGINAL positions (rowids are assigned at load and don't
 shift as we mutate); inserts append.
 
+A DuckDB **database** file (.duckdb/.ddb) is the exception: it isn't rewritten
+but edited in place, ATTACHed read-write and mutated by `rowid` inside one
+transaction (like the SQLite writer). `table` names which relation to write;
+views are rejected.
+
 Called by fused.runPython with structured params:
+  table:   "<table name>" (database files only; ignored for flat files)
   edits:   [{"row": <int>, "column": <name>, "value": <str|None>}, ...]
   deletes: [<int>, ...]
   inserts: [{<column>: <value>, ...}, ...]
-Returns {"total_rows": <int>} — the row count after the rewrite.
+Returns {"total_rows": <int>} — the row count after the batch.
 """
 import os
 
 import duckdb
 
-# COPY options per extension. CSV/TSV are written with a header; the reader
-# reads them all-VARCHAR, so values round-trip as the exact text typed.
+# Base COPY options per logical format. CSV/TSV are written with a header; the
+# reader reads them all-VARCHAR, so values round-trip as the exact text typed.
 _COPY_OPTS = {
-    ".parquet": "(FORMAT parquet)",
-    ".csv": "(FORMAT csv, HEADER)",
-    ".tsv": "(FORMAT csv, HEADER, DELIMITER '\t')",
+    ".parquet": ["FORMAT parquet"],
+    ".csv": ["FORMAT csv", "HEADER"],
+    ".tsv": ["FORMAT csv", "HEADER", "DELIMITER '\t'"],
 }
+
+# A trailing .gz/.zst suffix means the source was compressed; the rewrite keeps
+# it compressed with the matching codec so the file's format never changes.
+_COMPRESSION_SUFFIXES = (".gz", ".zst")
+_COMPRESSION = {".gz": "gzip", ".zst": "zstd"}
+
+
+def _logical_ext(file: str) -> str:
+    """Format extension seen past a trailing compression suffix (kept in step
+    with reader.py): 'a.csv.gz' -> '.csv'."""
+    base, low = file, file.lower()
+    for comp in _COMPRESSION_SUFFIXES:
+        if low.endswith(comp):
+            base = base[: -len(comp)]
+            break
+    return os.path.splitext(base)[1].lower()
+
+
+def _compression(file: str) -> "str | None":
+    low = file.lower()
+    for comp in _COMPRESSION_SUFFIXES:
+        if low.endswith(comp):
+            return _COMPRESSION[comp]
+    return None
+
+
+def _copy_clause(file: str) -> str:
+    """The `(FORMAT …, COMPRESSION …)` COPY options for `file`, appending the
+    compression codec when the name carries a .gz/.zst suffix."""
+    opts = list(_COPY_OPTS[_logical_ext(file)])
+    codec = _compression(file)
+    if codec:
+        opts.append(f"COMPRESSION {codec}")
+    return "(" + ", ".join(opts) + ")"
 
 
 def _quote_ident(name: str) -> str:
@@ -45,7 +86,7 @@ def _relation_for(file: str) -> str:
     so the writer loads each format exactly as the viewer showed it: CSV/TSV
     all-VARCHAR for exact text round-trip, Parquet with its real types."""
     lit = _quote_str(os.path.abspath(file))
-    ext = os.path.splitext(file)[1].lower()
+    ext = _logical_ext(file)
     if ext == ".parquet":
         return f"read_parquet({lit})"
     if ext == ".tsv":
@@ -58,14 +99,86 @@ def _column_types(con) -> dict:
     return {r[0]: r[1] for r in con.execute("DESCRIBE t").fetchall()}
 
 
-def main(file: str, edits: "list | None" = None, deletes: "list | None" = None,
-         inserts: "list | None" = None) -> dict:
-    ext = os.path.splitext(file)[1].lower()
-    if ext not in _COPY_OPTS:
-        raise ValueError(f"{ext} files are read-only in the DuckDB grid")
+# DuckDB database files: edited transactionally in place by rowid, like the
+# SQLite writer — not rewritten via COPY like a flat file.
+_DB_EXTS = {".duckdb", ".ddb"}
+
+
+def _cast_fragment(types, col, value):
+    """SQL fragment + binds for a value cast to col's type (shared by both write
+    paths). A JSON null -> SQL NULL; anything else is CAST from the grid's
+    string, so a bad value raises before any row is touched."""
+    if col not in types:
+        raise ValueError(f"unknown column {col!r}")
+    if value is None:
+        return "NULL", []
+    return f"CAST(? AS {types[col]})", [value]
+
+
+def _write_database(file, table, edits, deletes, inserts):
+    """Apply a batch to one table of a DuckDB database file, transactionally.
+    ATTACH read-write, key every edit/delete by rowid, COMMIT once; any error
+    rolls the whole batch back, so a rejected save leaves the db untouched.
+    Only base tables are writable — a view (no rowid) is rejected up front."""
+    if not table:
+        raise ValueError("no table specified")
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(f"ATTACH {_quote_str(os.path.abspath(file))} AS db")
+        kind = con.execute(
+            "SELECT table_type FROM information_schema.tables "
+            "WHERE table_catalog = 'db' AND table_name = ?", [table]).fetchone()
+        if not kind or kind[0] != "BASE TABLE":
+            raise ValueError(f"{table!r} is not an editable table")
+        qtable = f"db.{_quote_ident(table)}"
+        types = {r[0]: r[1] for r in con.execute(f"DESCRIBE {qtable}").fetchall()}
+
+        con.execute("BEGIN TRANSACTION")
+        try:
+            for e in edits:
+                frag, binds = _cast_fragment(types, e["column"], e.get("value"))
+                con.execute(
+                    f"UPDATE {qtable} SET {_quote_ident(e['column'])} = {frag} "
+                    f"WHERE rowid = ?", binds + [int(e["row"])])
+            if deletes:
+                placeholders = ", ".join("?" for _ in deletes)
+                con.execute(f"DELETE FROM {qtable} WHERE rowid IN ({placeholders})",
+                            [int(d) for d in deletes])
+            for row in inserts:
+                cols, frags, binds = [], [], []
+                for col, value in row.items():
+                    frag, b = _cast_fragment(types, col, value)
+                    cols.append(_quote_ident(col))
+                    frags.append(frag)
+                    binds.extend(b)
+                if cols:
+                    con.execute(
+                        f"INSERT INTO {qtable} ({', '.join(cols)}) "
+                        f"VALUES ({', '.join(frags)})", binds)
+                else:
+                    con.execute(f"INSERT INTO {qtable} DEFAULT VALUES")
+            con.execute("COMMIT")
+        except BaseException:
+            con.execute("ROLLBACK")
+            raise
+
+        total = con.execute(f"SELECT COUNT(*) FROM {qtable}").fetchone()[0]
+        return {"total_rows": total}
+    finally:
+        con.close()
+
+
+def main(file: str, table: str = "", edits: "list | None" = None,
+         deletes: "list | None" = None, inserts: "list | None" = None) -> dict:
     edits = edits or []
     deletes = deletes or []
     inserts = inserts or []
+    ext = _logical_ext(file)
+    if ext in _DB_EXTS:
+        # A DuckDB database file is edited in place, not rewritten.
+        return _write_database(file, table, edits, deletes, inserts)
+    if ext not in _COPY_OPTS:
+        raise ValueError(f"{ext} files are read-only in the DuckDB grid")
 
     con = duckdb.connect(":memory:")
     try:
@@ -74,15 +187,7 @@ def main(file: str, edits: "list | None" = None, deletes: "list | None" = None,
         types = _column_types(con)
 
         def cast(col, value):
-            """SQL fragment + bind list for a value cast to col's type. A JSON
-            null becomes SQL NULL; everything else is CAST from the string the
-            grid sent, so a bad value (letters into a number column) raises here
-            — before any rewrite — instead of silently corrupting data."""
-            if col not in types:
-                raise ValueError(f"unknown column {col!r}")
-            if value is None:
-                return "NULL", []
-            return f"CAST(? AS {types[col]})", [value]
+            return _cast_fragment(types, col, value)
 
         for e in edits:
             frag, binds = cast(e["column"], e.get("value"))
@@ -116,7 +221,7 @@ def main(file: str, edits: "list | None" = None, deletes: "list | None" = None,
         # and a crash mid-COPY leaves the original intact.
         tmp = f"{os.path.abspath(file)}.fused-tmp.{os.getpid()}"
         try:
-            con.execute(f"COPY t TO {_quote_str(tmp)} {_COPY_OPTS[ext]}")
+            con.execute(f"COPY t TO {_quote_str(tmp)} {_copy_clause(file)}")
             os.replace(tmp, os.path.abspath(file))
         except BaseException:
             if os.path.exists(tmp):

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -44,6 +44,56 @@
     "duckdb",
     "annotate"
   ],
+  ".csv.gz": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".csv.zst": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".tsv.gz": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".tsv.zst": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".json.gz": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".json.zst": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".jsonl.gz": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".jsonl.zst": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".ndjson.gz": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
+  ".ndjson.zst": [
+    "duckdb",
+    "tar",
+    "annotate"
+  ],
   ".geojson": [
     "vector",
     "tree",
@@ -344,6 +394,12 @@
   ],
   ".db": [
     "sqlite"
+  ],
+  ".duckdb": [
+    "duckdb"
+  ],
+  ".ddb": [
+    "duckdb"
   ],
   ".plist": [
     "plist",

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -51,6 +51,40 @@ def csv_file(tmp_path):
                  "SELECT range AS id, printf('%05d', range) AS zip FROM range(250)")
 
 
+def _make_compressed(tmp_path, name, sql, opts):
+    """Write a gzip/zstd-compressed csv/tsv/json via DuckDB COPY, matching what
+    the grid must read back through the same auto-decompressing scan."""
+    p = tmp_path / name
+    con = duckdb.connect()
+    con.execute(f"COPY ({sql}) TO '{p}' {opts}")
+    con.close()
+    return str(p)
+
+
+@pytest.fixture
+def csv_gz_file(tmp_path):
+    return _make_compressed(
+        tmp_path, "s.csv.gz",
+        "SELECT range AS id, printf('%05d', range) AS zip FROM range(250)",
+        "(FORMAT csv, HEADER, COMPRESSION gzip)")
+
+
+@pytest.fixture
+def duckdb_db(tmp_path):
+    """A .duckdb database file with two base tables and a view — the multi-
+    relation, edit-in-place case (vs the single-relation flat files above)."""
+    p = tmp_path / "s.duckdb"
+    con = duckdb.connect(str(p))
+    con.execute("CREATE TABLE actor(first_name TEXT, last_name TEXT)")
+    con.executemany("INSERT INTO actor VALUES (?, ?)",
+                    [(f"F{i}", f"L{i}") for i in range(5)])
+    con.execute("CREATE TABLE film(title TEXT)")
+    con.execute("INSERT INTO film VALUES ('x')")
+    con.execute("CREATE VIEW adults AS SELECT * FROM actor")
+    con.close()
+    return str(p)
+
+
 # ------------------------------------------------------------------ reader
 
 def test_parquet_shape(parquet_file):
@@ -156,10 +190,157 @@ def test_json_is_read_only(tmp_path):
     assert "read-only" in out["readonly_tooltip"].lower()
 
 
+# ----------------------------------------------------- compressed variants
+
+def test_csv_gz_reads_as_editable_text(csv_gz_file):
+    # A gzip-compressed CSV is the same tabular data behind a compression
+    # suffix — DuckDB auto-decompresses, so it reads all-VARCHAR and stays
+    # editable just like a plain .csv.
+    out = reader.main(csv_gz_file)
+    assert out["total_rows"] == 250
+    assert out["rows"][0]["zip"] == "00000"       # leading zero preserved
+    assert set(out["types"].values()) == {"VARCHAR"}
+    assert out["editable"] is True
+
+
+def test_csv_zst_reads(tmp_path):
+    p = _make_compressed(
+        tmp_path, "s.csv.zst",
+        "SELECT range AS id, printf('%05d', range) AS zip FROM range(10)",
+        "(FORMAT csv, HEADER, COMPRESSION zstd)")
+    out = reader.main(p)
+    assert out["total_rows"] == 10
+    assert out["editable"] is True
+
+
+def test_json_gz_is_read_only(tmp_path):
+    # JSON stays view-only whether or not it's compressed.
+    p = _make_compressed(
+        tmp_path, "s.json.gz", "SELECT range AS id FROM range(3)",
+        "(FORMAT json, ARRAY true, COMPRESSION gzip)")
+    out = reader.main(p)
+    assert out["total_rows"] == 3
+    assert out["editable"] is False
+    assert out["readonly_message"] == "JSON"
+
+
+def test_csv_gz_edit_round_trips_compressed(csv_gz_file):
+    # Editing a compressed CSV rewrites it still-compressed; the leading-zero
+    # text of untouched rows survives and the new value reads back exactly.
+    writer.main(csv_gz_file, edits=[{"row": 1, "column": "zip", "value": "07001"}])
+    out = reader.main(csv_gz_file)
+    assert out["rows"][1]["zip"] == "07001"
+    assert out["rows"][0]["zip"] == "00000"
+    # still gzip on disk (magic bytes 1f 8b), not a plain-text CSV.
+    with open(csv_gz_file, "rb") as f:
+        assert f.read(2) == b"\x1f\x8b"
+
+
 def test_limit_clamped(tmp_path):
     p = _make(tmp_path, "big.parquet", f"SELECT range AS id FROM range({reader.MAX_LIMIT + 500})")
     out = reader.main(p, limit=10 ** 9)
     assert len(out["rows"]) == reader.MAX_LIMIT
+
+
+# --------------------------------------------------- .duckdb database reader
+
+def test_duckdb_lists_tables_and_defaults_to_first(duckdb_db):
+    out = reader.main(duckdb_db)
+    # Base tables and the view are all selectable; sorted by name.
+    assert out["tables"] == ["actor", "adults", "film"]
+    assert out["table"] == "actor"               # first table, no param
+    assert out["columns"] == ["first_name", "last_name"]
+    assert out["ids"] == [0, 1, 2, 3, 4]         # duckdb rowids (0-based)
+    assert out["rows"][0] == {"first_name": "F0", "last_name": "L0"}
+    assert out["editable"] is True
+
+
+def test_duckdb_table_param_selects_relation(duckdb_db):
+    out = reader.main(duckdb_db, table="film")
+    assert out["table"] == "film"
+    assert out["total_rows"] == 1
+    assert out["rows"][0] == {"title": "x"}
+
+
+def test_duckdb_view_is_read_only(duckdb_db):
+    out = reader.main(duckdb_db, table="adults")
+    assert out["editable"] is False
+    assert out["ids"] == []
+    assert out["total_rows"] == 5                 # still viewable
+    assert "view" in out["readonly_message"].lower()
+    assert out["readonly_tooltip"]
+
+
+def test_duckdb_sort_desc_keeps_rowids(duckdb_db):
+    out = reader.main(duckdb_db, table="actor",
+                      sort={"column": "first_name", "dir": "desc"})
+    assert out["rows"][0]["first_name"] == "F4"
+    assert out["ids"][0] == 4                     # rowid tracks physical row
+
+
+def test_duckdb_filter_narrows(duckdb_db):
+    out = reader.main(duckdb_db, table="actor",
+                      filters=[{"column": "first_name", "op": "contains", "value": "3"}])
+    assert out["ids"] == [3]
+    assert out["rows"][0]["first_name"] == "F3"
+
+
+def test_duckdb_unknown_table_falls_back_to_first(duckdb_db):
+    # A stale/garbled table param must not error — fall back to a real one.
+    out = reader.main(duckdb_db, table="does_not_exist")
+    assert out["table"] == "actor"
+
+
+# --------------------------------------------------- .duckdb database writer
+
+def _db_rows(path, table="actor"):
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute(f"ATTACH '{path}' AS db (READ_ONLY)")
+        return con.execute(f"SELECT rowid, * FROM db.{table} ORDER BY rowid").fetchall()
+    finally:
+        con.close()
+
+
+def test_duckdb_edit_delete_insert(duckdb_db):
+    writer.main(duckdb_db, table="actor",
+                edits=[{"row": 0, "column": "first_name", "value": "EDITED"}],
+                deletes=[1, 2],
+                inserts=[{"first_name": "new", "last_name": "row"}])
+    vals = [(r[1], r[2]) for r in _db_rows(duckdb_db)]
+    assert ("EDITED", "L0") in vals
+    assert ("F1", "L1") not in vals and ("F2", "L2") not in vals
+    assert ("new", "row") in vals
+    assert len(vals) == 5 - 2 + 1
+
+
+def test_duckdb_edit_casts_and_null(duckdb_db):
+    writer.main(duckdb_db, table="actor",
+                edits=[{"row": 0, "column": "last_name", "value": None}])
+    con = duckdb.connect(":memory:")
+    con.execute(f"ATTACH '{duckdb_db}' AS db (READ_ONLY)")
+    val = con.execute("SELECT last_name FROM db.actor WHERE rowid = 0").fetchone()[0]
+    con.close()
+    assert val is None
+
+
+def test_duckdb_writer_rejects_view(duckdb_db):
+    with pytest.raises(ValueError):
+        writer.main(duckdb_db, table="adults",
+                    edits=[{"row": 0, "column": "first_name", "value": "x"}])
+
+
+def test_duckdb_writer_rolls_back_on_bad_cast(tmp_path):
+    p = tmp_path / "n.duckdb"
+    con = duckdb.connect(str(p))
+    con.execute("CREATE TABLE t(id INTEGER)")
+    con.execute("INSERT INTO t VALUES (1), (2)")
+    con.close()
+    before = _db_rows(str(p), "t")
+    with pytest.raises(Exception):
+        writer.main(str(p), table="t",
+                    edits=[{"row": 0, "column": "id", "value": "not-a-number"}])
+    assert _db_rows(str(p), "t") == before        # transaction rolled back
 
 
 # ------------------------------------------------------------------ writer

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -76,6 +76,26 @@ def test_builtin_parquet_default_is_duckdb():
     assert entries[0]["path"].endswith("duckdb/template.html")
 
 
+def test_compressed_tabular_routes_to_duckdb():
+    # A gzip/zstd-compressed CSV/JSON is still tabular data DuckDB reads through
+    # its auto-decompressing scan, so the 2-segment compound key (.csv.gz) wins
+    # over the generic 1-segment .gz archive binding.
+    assert modes("/x/data.csv.gz")[0][0] == "duckdb"
+    assert modes("/x/data.tsv.zst")[0][0] == "duckdb"
+    assert modes("/x/data.json.gz")[0][0] == "duckdb"
+    assert modes("/x/data.ndjson.gz")[0][0] == "duckdb"
+    # A real archive (or a bare .gz) still opens in the tar viewer, untouched.
+    assert modes("/x/bundle.tar.gz") == (["tar"], None)
+    assert modes("/x/blob.gz") == (["tar"], None)
+
+
+def test_duckdb_database_files_route_to_duckdb():
+    # .duckdb/.ddb open in the tabular grid; .db stays with the sqlite viewer.
+    assert modes("/x/warehouse.duckdb") == (["duckdb"], None)
+    assert modes("/x/warehouse.ddb") == (["duckdb"], None)
+    assert modes("/x/legacy.db") == (["sqlite"], None)
+
+
 def test_builtin_zarr_directory_key():
     # zarr dir carries the map preview plus the raw member listing as a peer
     # mode (D81 — replaces the old `?listing=1` escape hatch)


### PR DESCRIPTION
## Summary

Broaden the DuckDB tabular viewer/editor to more of what DuckDB can actually read, with **no new runtime dependencies** (core engine only):

- **Compressed CSV/TSV/JSON** — `.csv.gz/.zst`, `.tsv.gz/.zst`, `.json.gz/.zst`, and `.jsonl/.ndjson` variants. DuckDB's `read_*_auto` scans decompress transparently, so they read exactly like their plain forms. CSV/TSV stay **editable**: the writer rewrites keeping the same format *and* compression codec, so a `.csv.gz` stays gzip on disk. Registry compound keys (`.csv.gz`) outrank the generic `.gz` archive binding; a real archive (`.tar.gz`) or a bare `.gz` still opens in the `tar` viewer.
- **DuckDB database files** — `.duckdb` / `.ddb`. Multi-table, so the reader ATTACHes the file, lists every table + view in the relation selector, and keys edits by DuckDB's real `rowid`. Edits apply **in place, transactionally** (ATTACH read-write → mutate by rowid → COMMIT/ROLLBACK) — not the flat-file COPY-rewrite. Views have no rowid and stay read-only, matching the SQLite grid.
- `reader.main`/`writer.main` gain a `table` param (already sent by the template, previously ignored). Flat-file behavior is unchanged.

Deliberately **not** included: Arrow/Feather and Excel — both need a DuckDB extension downloaded at runtime (which failed in the dev sandbox), so they'd add a fragile dependency.

## Visuals

Two read paths now feed one grid, chosen by the file's logical extension:

```mermaid
flowchart TD
    F[file opened in duckdb grid] --> E{logical extension}
    E -->|.parquet / .csv / .tsv / .json<br/>+ .gz/.zst| FLAT[flat-file path]
    E -->|.duckdb / .ddb| DB[database path]

    FLAT --> FR["read_*_auto scan<br/>(auto-decompress)"]
    FR --> FW["edit: rewrite whole file via COPY<br/>keep format + compression codec"]

    DB --> DR["ATTACH read-only<br/>list tables/views · page by rowid"]
    DR --> DW["edit: ATTACH read-write<br/>UPDATE/DELETE/INSERT by rowid<br/>one transaction, COMMIT/ROLLBACK"]
    DR -->|view = no rowid| RO[read-only badge]
```

Live check — a `.duckdb` file with two tables and a view (relation selector, typed headers, view read-only badge; edits persisted to disk) and `data.csv.gz` opening editable with leading zeros intact:

- `warehouse.duckdb` → selector `[actor, film, recent]`, `actor` editable (60 rows), `recent` (view) shows *"View — Read-only. A view has no stored rows of its own to edit…"*, Add row hidden.
- `data.csv.gz` → `id`/`zip` all-VARCHAR, `zip` = `00000` (leading zero kept), editable.

## Usage

Open any of the new file types in fused-render — they get the same grid as `.parquet`/`.csv`:

- **Compressed table** — open `data.csv.gz` (or `.tsv.gz`, `.json.gz`, `.zst`, …). Edit/add/delete rows and Save; the file is rewritten still-compressed in the same format.
- **DuckDB database** — open `warehouse.duckdb` (or `.ddb`). Pick a table from the bottom-bar selector; edit cells, add/delete rows, and Save to commit in one transaction. Views open read-only with an explanatory badge.

## Test Plan

- [x] `tests/test_duckdb_reader.py` — compressed: `.csv.gz` reads all-VARCHAR + editable, `.csv.zst`, `.json.gz` read-only, edit round-trips *still gzip on disk* (magic-byte check).
- [x] `tests/test_duckdb_reader.py` — database: lists tables/views + defaults to first, `table` param selects a relation, view is read-only (empty ids + reason), sort/filter keep rowids, unknown-table falls back, writer edit/delete/insert, cast + NULL, view rejection, bad-cast transaction rollback.
- [x] `tests/test_templates.py` — routing: compressed tabular → `duckdb` (compound key beats `.gz`), `.tar.gz`/bare `.gz` still → `tar`; `.duckdb`/`.ddb` → `duckdb`, `.db` still → `sqlite`.
- [x] Full suite: **211 passed, 2 skipped** (7 TestClient files excluded — pre-existing missing-`httpx` env issue, unrelated).
- [x] Manual (in-app via browser): `.duckdb` relation switch + view read-only badge + an edit saved and confirmed on disk; `data.csv.gz` opens editable with leading zeros preserved.
