### PR TITLE
fix(grid): crisp paging chevrons, cleaner discard icon, view-mode chrome

### DIFF
--- a/fused_render/templates/duckdb/template.html
+++ b/fused_render/templates/duckdb/template.html
@@ -64,6 +64,10 @@
     width: 28px; padding: 0; font-size: 15px; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
   }
+  /* display:inline-flex above beats the `hidden` attribute's UA display:none,
+     so a hidden Save/Discard (e.g. a read-only view) would otherwise stay
+     visible — re-hide them explicitly. */
+  #bar .icon-btn[hidden], #filterbar .icon-btn[hidden] { display: none; }
   #save { border-color: #2f6f4f; position: relative; }
   #save:not(:disabled) { background: #1e5138; color: #eafff2; }
   /* Discard mirrors Save with a red accent — only lit while there's something
@@ -94,7 +98,7 @@
   }
   /* Custom tooltip: appears instantly on hover, unlike the native title's delay. */
   .ro-tip {
-    position: absolute; bottom: calc(100% + 6px); left: 0; z-index: 10;
+    position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 10;
     width: max-content; max-width: 280px;
     padding: 6px 9px; border-radius: 6px;
     background: #24262b; color: #cfd3d7; border: 1px solid #33363c;
@@ -221,16 +225,16 @@
   <div id="bar">
     <div class="bar-group side">
       <select id="table" hidden></select>
-      <span id="ro" class="ro-badge" hidden></span>
     </div>
     <div class="bar-group bar-page">
-      <button id="prev" class="icon-btn" title="Previous page">‹</button>
+      <button id="prev" class="icon-btn" title="Previous page" aria-label="Previous page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M10 3.5 5.5 8 10 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <span id="rowcount"></span>
-      <button id="next" class="icon-btn" title="Next page">›</button>
+      <button id="next" class="icon-btn" title="Next page" aria-label="Next page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6 3.5 10.5 8 6 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
     </div>
     <div class="bar-group side right">
+      <span id="ro" class="ro-badge" hidden></span>
       <button id="add" hidden>+ Add row</button>
-      <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M4.5 3.5V6H7a4 4 0 1 1-3.6 5.7l-1.34.67A5.5 5.5 0 1 0 7 4.5h2.3L6.5 1.7 3.7 4.5z" fill="currentColor"/></svg></button>
+      <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
     </div>
   </div>

--- a/fused_render/templates/duckdb/template.html
+++ b/fused_render/templates/duckdb/template.html
@@ -44,7 +44,19 @@
     border: 1px solid #2a2d33; border-radius: 6px;
     background: #131417; color: #e8eaed;
   }
-  #bar button, #filterbar button { cursor: pointer; }
+  #bar button, #filterbar button { cursor: pointer; white-space: nowrap; }
+  /* Keep the paging group and its row count on one line, and let the table
+     selector give up width first so nothing wraps as the bar narrows. */
+  #bar .bar-page { flex: 0 0 auto; }
+  #rowcount { white-space: nowrap; }
+  #table { min-width: 0; max-width: 160px; text-overflow: ellipsis; }
+  #add { flex: 0 0 auto; }
+  /* Narrow bar: tighten spacing and collapse "+ Add row" to just "+" so the
+     action buttons never wrap onto a second line. */
+  @media (max-width: 560px) {
+    #bar { gap: 6px; padding: 8px; }
+    #add .add-label { display: none; }
+  }
   #bar button:disabled, #filterbar button:disabled { opacity: 0.4; cursor: default; }
   #filterbar select:disabled, #filterbar input:disabled { opacity: 0.4; }
   /* Strip the native <select> chrome (WebKit otherwise ignores our radius &
@@ -233,7 +245,7 @@
     </div>
     <div class="bar-group side right">
       <span id="ro" class="ro-badge" hidden></span>
-      <button id="add" hidden>+ Add row</button>
+      <button id="add" hidden title="Add row" aria-label="Add row">+<span class="add-label">&nbsp;Add row</span></button>
       <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
     </div>

--- a/fused_render/templates/sqlite/template.html
+++ b/fused_render/templates/sqlite/template.html
@@ -64,6 +64,10 @@
     width: 28px; padding: 0; font-size: 15px; line-height: 1;
     display: inline-flex; align-items: center; justify-content: center;
   }
+  /* display:inline-flex above beats the `hidden` attribute's UA display:none,
+     so a hidden Save/Discard (e.g. a read-only view) would otherwise stay
+     visible — re-hide them explicitly. */
+  #bar .icon-btn[hidden], #filterbar .icon-btn[hidden] { display: none; }
   #save { border-color: #2f6f4f; position: relative; }
   #save:not(:disabled) { background: #1e5138; color: #eafff2; }
   /* Discard mirrors Save with a red accent — only lit while there's something
@@ -94,7 +98,7 @@
   }
   /* Custom tooltip: appears instantly on hover, unlike the native title's delay. */
   .ro-tip {
-    position: absolute; bottom: calc(100% + 6px); left: 0; z-index: 10;
+    position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 10;
     width: max-content; max-width: 280px;
     padding: 6px 9px; border-radius: 6px;
     background: #24262b; color: #cfd3d7; border: 1px solid #33363c;
@@ -221,16 +225,16 @@
   <div id="bar">
     <div class="bar-group side">
       <select id="table" hidden></select>
-      <span id="ro" class="ro-badge" hidden></span>
     </div>
     <div class="bar-group bar-page">
-      <button id="prev" class="icon-btn" title="Previous page">‹</button>
+      <button id="prev" class="icon-btn" title="Previous page" aria-label="Previous page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M10 3.5 5.5 8 10 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <span id="rowcount"></span>
-      <button id="next" class="icon-btn" title="Next page">›</button>
+      <button id="next" class="icon-btn" title="Next page" aria-label="Next page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6 3.5 10.5 8 6 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
     </div>
     <div class="bar-group side right">
+      <span id="ro" class="ro-badge" hidden></span>
       <button id="add" hidden>+ Add row</button>
-      <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M4.5 3.5V6H7a4 4 0 1 1-3.6 5.7l-1.34.67A5.5 5.5 0 1 0 7 4.5h2.3L6.5 1.7 3.7 4.5z" fill="currentColor"/></svg></button>
+      <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
     </div>
   </div>

--- a/fused_render/templates/sqlite/template.html
+++ b/fused_render/templates/sqlite/template.html
@@ -44,7 +44,19 @@
     border: 1px solid #2a2d33; border-radius: 6px;
     background: #131417; color: #e8eaed;
   }
-  #bar button, #filterbar button { cursor: pointer; }
+  #bar button, #filterbar button { cursor: pointer; white-space: nowrap; }
+  /* Keep the paging group and its row count on one line, and let the table
+     selector give up width first so nothing wraps as the bar narrows. */
+  #bar .bar-page { flex: 0 0 auto; }
+  #rowcount { white-space: nowrap; }
+  #table { min-width: 0; max-width: 160px; text-overflow: ellipsis; }
+  #add { flex: 0 0 auto; }
+  /* Narrow bar: tighten spacing and collapse "+ Add row" to just "+" so the
+     action buttons never wrap onto a second line. */
+  @media (max-width: 560px) {
+    #bar { gap: 6px; padding: 8px; }
+    #add .add-label { display: none; }
+  }
   #bar button:disabled, #filterbar button:disabled { opacity: 0.4; cursor: default; }
   #filterbar select:disabled, #filterbar input:disabled { opacity: 0.4; }
   /* Strip the native <select> chrome (WebKit otherwise ignores our radius &
@@ -233,7 +245,7 @@
     </div>
     <div class="bar-group side right">
       <span id="ro" class="ro-badge" hidden></span>
-      <button id="add" hidden>+ Add row</button>
+      <button id="add" hidden title="Add row" aria-label="Add row">+<span class="add-label">&nbsp;Add row</span></button>
       <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
     </div>


### PR DESCRIPTION
## Summary

Polish the DuckDB/SQLite tabular grid's bottom action bar and fix a read-only-view chrome bug:

- **Crisp, uniform paging arrows** — the `‹`/`›` text glyphs are replaced with SVG chevrons, so the disabled and enabled paging buttons render at an identical, sharp size instead of the disabled one looking shrunken.
- **Cleaner discard icon** — the discard glyph becomes a stroke-based undo/revert arrow, consistent with the new chevrons.
- **View info now sits with the controls** — the read-only badge moves into the right-hand bar group, so a view shows its "View ⓘ" info exactly where the edit controls would be, not in a stray gap on the left.
- **Save/Discard truly hidden on views** — `.icon-btn`'s `display: inline-flex` was overriding the `hidden` attribute, leaving Save/Discard visible on read-only views; an explicit `[hidden]` guard re-hides them.

Both templates keep their `<style>` blocks byte-identical.

## Visuals

```mermaid
flowchart TD
    O[relation opened] --> V{editable?}
    V -->|table| C["right group:<br/>+ Add row · ↺ Discard · ✓ Save"]
    V -->|view| B["right group:<br/>View ⓘ badge<br/>(Add/Discard/Save hidden)"]
    subgraph bar["bottom bar (both cases)"]
      P["center: ‹ chevron · rows X–Y of N · chevron ›"]
    end
```

Before → after (view mode): the read-only info was stranded on the left while Save/Discard lingered visible on the right; now the info sits on the right in the controls' place and the edit buttons are gone.

## Usage

No new API. Open any `.duckdb`/`.ddb` (or SQLite) file:

- A **table** shows `+ Add row`, discard (undo arrow), and save on the right.
- A **view** shows only a right-aligned "View ⓘ" badge (hover for the read-only explanation); no edit controls.
- Paging arrows on either side of the row count are crisp SVG chevrons, same size enabled or disabled.

## Test Plan

- [x] `tests/test_templates.py` — 35 passed (routing unaffected; changes are HTML/CSS only).
- [x] `<style>` blocks confirmed byte-identical between the duckdb and sqlite templates (`diff` of the extracted blocks).
- [x] Manual (cmux browser, `sample.duckdb`): switching to the `active_customers` **view** hides Add/Discard/Save (`getBoundingClientRect().width === 0`) and shows the right-aligned "View ⓘ" badge; switching to the `customers` **table** shows all three controls; paging chevrons render at 28×28 in both enabled and disabled states.

---

### Update: responsive bottom bar

At narrow widths the `+ Add row` button wrapped to a second line and the three groups crowded together. The bar now degrades gracefully:

- Buttons and the row count are `white-space: nowrap` — no more two-line labels.
- The paging group holds its width; the **table selector shrinks first** (`min-width: 0; max-width: 160px`).
- Below **560px** the bar tightens its padding/gap and `+ Add row` collapses to just `+` (the label lives in a `.add-label` span hidden by a media query; `aria-label`/`title` keep it accessible).

Verified in the cmux browser at a ~490px bar: single 45px row, no wrap, `+` only; at ≥560px the full `+ Add row` label shows.
