### PR TITLE
fix: declare python-multipart dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
     # csv/tsv, json) through one engine, so it's a core dependency, not an
     # optional extra — a plain `pip install fused-render` ships the viewer.
     "duckdb>=1.1",
+    # FastAPI's /api/templates/import endpoint accepts multipart form/file
+    # uploads, which requires python-multipart at import time (FastAPI raises
+    # at route registration otherwise).
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

- `fused-render` crashed on startup with `RuntimeError: Form data requires "python-multipart" to be installed` — the CLI was completely unusable after a clean install.
- The `/api/templates/import` endpoint declares FastAPI multipart form/file parameters, which FastAPI validates at **route-registration (import) time**, not request time — so the missing package took down the whole app, not just that one route.
- Declares `python-multipart>=0.0.9` as a core dependency so a plain `pip install` / `uv tool install` ships a working server.

## Visuals

```mermaid
flowchart TD
    A[fused-render start] --> B[create_app]
    B --> C[import templates_api]
    C --> D{"/api/templates/import<br/>registers multipart form"}
    D -->|python-multipart missing| E[RuntimeError at import<br/>❌ whole app dies]
    D -->|python-multipart present| F[app builds cleanly ✅]
```

## Usage

No new user-facing behavior. After this change the CLI simply starts:

```bash
uv tool install .
fused-render        # now boots instead of crashing
```

## Test Plan

- [ ] No automated test added — this is a dependency-declaration fix; the failure was an import-time crash with no code path to unit-test meaningfully.
- [x] Manual: `uv tool install . --force` then verified the app builds — `python -c "from fused_render.server import create_app; create_app(start_dir='.')"` prints `OK` (previously raised `RuntimeError`).
- [ ] Reviewer repro: on `main`, `fused-render` traceback ends in `ensure_multipart_is_installed`; on this branch it starts normally.
