### PR TITLE
fix(shell): bookmark hover card parses _layout grammar instead of raw query split

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -25,6 +25,7 @@ import { FolderIcon } from "./FileIcons";
 import type { Bookmark, BookmarkFolder } from "../lib/bookmarks";
 import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "../lib/hooks";
 import type { Config } from "../lib/api";
+import { splitShellSearch } from "../lib/layout-codec";
 import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 import type { FuzzyResult } from "../lib/fuzzy";
 import { startTour } from "../lib/tour";
@@ -59,15 +60,17 @@ const FOLDER_ICON = (
   </svg>
 );
 
-// Hover card content: target fs path + saved params, decoded like the
-// vanilla shell (raw URLSearchParams on the saved search — bookmark
-// tooltips predate the `_layout` grammar; parity over cleverness).
+// Hover card content: target fs path + saved params. The saved search is
+// split via splitShellSearch so the literal `&` inside the `_layout=(...)`
+// span doesn't leak bogus param rows (D51).
 function TooltipContent({ bookmark }: { bookmark: Bookmark }) {
   const qIdx = bookmark.url.indexOf("?");
   const search = qIdx !== -1 ? bookmark.url.slice(qIdx) : "";
   const fsPath = bookmarkFsPath(bookmark.url);
 
-  const params = [...new URLSearchParams(search)];
+  const { layout, params: rest } = splitShellSearch(search);
+  const params: [string, string][] = [...rest];
+  if (layout !== null) params.push(["_layout", "(" + layout + ")"]);
   return (
     <>
       <div className="tip-path">{fsPath}</div>


### PR DESCRIPTION
## Problem

Hovering a bookmark whose URL carries a `_layout=(...)` span showed garbage param rows. The span contains **literal `&`** inside its parens (D51 grammar), but `TooltipContent` parsed the saved search with raw `URLSearchParams`, splitting mid-span:

```
_layout  (/Users/.../sine.html?freq=2.6
_mode    code,/Users/.../sine.html?freq=2.6)
```

## Fix

Route the read through `splitShellSearch()` — the documented rule in `layout-codec.ts` ("every read of a shell query goes through splitShellSearch()"). The hover card now shows any top-level params plus a single `_layout` row with the full decoded value, emitted last to match the layout-last URL convention.

Verified: `tsc --noEmit && vite build` passes; parse simulated against the reported URL yields one correct `_layout` row.

Note: `frontend/package-lock.json` is out of sync with `package.json` (missing `driver.js`) — left untouched here, worth a separate sync commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only change in sidebar tooltip parsing; no navigation, auth, or persistence behavior.
> 
> **Overview**
> **Bookmark hover tooltips** no longer mis-parse URLs that include a `_layout=(...)` span.
> 
> `TooltipContent` previously fed the saved query string to `URLSearchParams`, which treated `&` inside the parenthesized layout value as param separators and produced bogus key/value rows. It now uses **`splitShellSearch`** from `layout-codec.ts` (the same D51 rule used elsewhere for shell queries), shows normal top-level params from the remainder, and appends a single **`_layout`** row with the full `(…)` value last, matching layout-last URL convention.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e9044b70cd569c613fe4cdf9ccf820a0c21737c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->