### PR TITLE
fix(explorer): stabilize file/folder sort order across refreshes

### DIFF
--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -69,7 +69,14 @@ function isHiddenRel(rel: string): boolean {
 
 function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEntry[] {
   const flip = order === "desc" ? -1 : 1;
-  const byName = (a: FsEntry, b: FsEntry) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+  // Case-insensitive primary order, then an exact (case-sensitive) tiebreak so
+  // names differing only by case/accent get a stable, deterministic order.
+  // Without the tiebreak such names compare equal and the sort falls back to
+  // the arbitrary os.listdir() arrival order, which changes between refreshes.
+  const byName = (a: FsEntry, b: FsEntry) => {
+    const c = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    return c !== 0 ? c : a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  };
   return [...entries].sort((a, b) => {
     const aDot = a.name.startsWith(".");
     const bDot = b.name.startsWith(".");

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -808,7 +808,10 @@ def create_app(start_dir: str) -> FastAPI:
         ignored = _git_ignored(path, [e["name"] for e in entries])
         for e in entries:
             e["ignored"] = e["name"] in ignored
-        entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower()))
+        # Case-insensitive primary order, then exact name as a deterministic
+        # tiebreak so names differing only by case get a stable order instead of
+        # falling back to arbitrary os.listdir() order (which changes per call).
+        entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower(), e["name"]))
         return {"path": path, "entries": entries}
 
     def _annotate_ignored(root: str, batch: list[dict]) -> None:

--- a/fused_render/templates/preview/template.html
+++ b/fused_render/templates/preview/template.html
@@ -415,7 +415,14 @@
 
     function sortedEntries() {
       const flip = sortOrder === "desc" ? -1 : 1;
-      const byName = (a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+      // Case-insensitive primary order, then an exact (case-sensitive) tiebreak
+      // so names differing only by case/accent get a stable, deterministic
+      // order (otherwise the sort falls back to arbitrary listdir order and
+      // changes between refreshes). Mirrors views/Listing.tsx byName.
+      const byName = (a, b) => {
+        const c = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+        return c !== 0 ? c : a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+      };
       return [...ENTRIES].sort((a, b) => {
         const aDot = a.name.startsWith("."), bDot = b.name.startsWith(".");
         if (aDot !== bDot) return aDot ? 1 : -1;              // dot entries last

--- a/tests/test_server_list_sort.py
+++ b/tests/test_server_list_sort.py
@@ -1,0 +1,58 @@
+"""Tests for the entry ordering of GET /api/fs/list (fused_render/server.py).
+
+Entries are grouped dirs-first and ordered case-insensitively by name. The
+comparator carries an exact-name tiebreak so names that fold together under a
+case-insensitive comparison (case- or accent-only differences) still get a
+stable, deterministic order instead of falling back to arbitrary os.listdir()
+arrival order — otherwise the displayed order could change between refreshes.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render.server import create_app
+
+
+def _case_insensitive_fs(tmp_path):
+    (tmp_path / "CaseProbe").write_text("x", encoding="utf-8")
+    collides = (tmp_path / "caseprobe").exists()
+    (tmp_path / "CaseProbe").unlink()
+    return collides
+
+
+def _client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _names(tmp_path):
+    data = _client(tmp_path).get("/api/fs/list", params={"path": str(tmp_path)}).json()
+    return [e["name"] for e in data["entries"]]
+
+
+def test_dirs_group_before_files_then_alpha(tmp_path):
+    (tmp_path / "beta").mkdir()
+    (tmp_path / "Data").mkdir()
+    (tmp_path / "alpha.txt").write_text("a", encoding="utf-8")
+    (tmp_path / "zeta.txt").write_text("z", encoding="utf-8")
+    assert _names(tmp_path) == ["beta", "Data", "alpha.txt", "zeta.txt"]
+
+
+def test_case_colliding_names_have_deterministic_order(tmp_path):
+    # "README" and "readme" collide under the case-insensitive primary key
+    # (name.lower()); without the exact-name tiebreak the backend would fall
+    # back to arbitrary os.listdir() order for the pair. Only meaningful on a
+    # case-sensitive filesystem, where both names can coexist.
+    if _case_insensitive_fs(tmp_path):
+        pytest.skip("case-insensitive filesystem cannot hold README + readme")
+    (tmp_path / "readme").write_text("x", encoding="utf-8")
+    (tmp_path / "README").write_text("x", encoding="utf-8")
+    # Uppercase 'R' (0x52) sorts before lowercase 'r' (0x72) via the tiebreak.
+    assert _names(tmp_path) == ["README", "readme"]
+
+
+def test_order_is_stable_across_repeated_calls(tmp_path):
+    for n in ["café.txt", "cafe.txt", "résumé", "resume", "alpha.txt"]:
+        (tmp_path / n).write_text("x", encoding="utf-8")
+    for n in ["Data", "beta"]:
+        (tmp_path / n).mkdir()
+    orders = [_names(tmp_path) for _ in range(5)]
+    assert all(o == orders[0] for o in orders)


### PR DESCRIPTION
## Summary

- **Fixes file/folder sort order changing on page refresh.** The directory-listing comparators used a case/accent-insensitive name comparison (`localeCompare(..., { sensitivity: "base" })` on the frontend, `name.lower()` on the backend) as *both* the primary sort key *and* the final tiebreak. Two entries whose names differ only by case or accent therefore compared **equal**, so the sort was not a total order and silently fell back to the arbitrary `os.listdir()` arrival order — which varies between requests, so the displayed order flipped on refresh.
- **Fix:** add an exact, case-sensitive name tiebreak (unique within a directory) to all three comparators, making each a strict total order and deterministic everywhere. Primary ordering stays case-insensitive; only genuine base-equal collisions now get a stable, defined order.
- Touches the three places that share this logic: the native explorer (`Listing.tsx`), the folder preview template (`preview/template.html`), and the `/api/fs/list` backend (`server.py`).

## Visuals

```mermaid
flowchart TD
    L["os.listdir() — arbitrary order"] --> S["sort: dirs first, then name"]
    S --> T{"names equal under<br/>case/accent-insensitive key?"}
    T -->|"before: yes → tiebreak also insensitive → still equal"| U["fall back to listdir order<br/>❌ changes on refresh"]
    T -->|"after: exact case-sensitive name tiebreak"| D["deterministic total order<br/>✅ stable across refreshes"]
```

## Usage

Not user-invocable — this is a behavioral fix. To observe it: open the file explorer (or a folder preview) on a directory containing names that differ only by case (e.g. `README`/`readme` on a case-sensitive FS) or accent (`cafe`/`café`), and refresh repeatedly. Before: the order shuffled. After: the order is identical every time (`cafe` before `café`, `README` before `readme`).

## Test Plan

- [x] **Automated (backend):** `tests/test_server_list_sort.py` — dirs-before-files grouping, deterministic order for case-colliding names (runs on case-sensitive FS, skips on case-insensitive), and stability across repeated `/api/fs/list` calls. `pytest tests/test_server_list_sort.py` → 2 passed, 1 skipped on macOS (the case-collision case runs on Linux CI).
- [x] **Manual (frontend comparator):** replayed the actual `sortEntries` logic against every arrival-order permutation of a set with accent/case collisions — **old comparator produced 3 distinct displayed orders, the fixed one produces exactly 1.**
- [x] **Manual (running server):** verified `/api/fs/list` returns an identical entry order across 6 consecutive calls.
- [ ] **Note:** the frontend has no JS test harness, so the `Listing.tsx` / `template.html` change is covered by manual verification rather than an automated test; the backend change is covered automatically.
