### PR TITLE
Read-only file detection across templates

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -335,7 +335,7 @@ Goal: a live-preview loop. Edit a file (in our editor or externally) → it save
 
 ### 13.1 Autosave (code editor)
 
-Applies to the `code` template (`templates/code/`), the only editable surface (D37).
+Applies to the `code` template (`templates/code/`), the only free-text editable surface (D37; the sqlite/duckdb grids added structured cell editing later via their own writer.py — see §13.5 for the read-only contract all edit surfaces share).
 
 - **AS-1** The editor autosaves **250 ms after the last edit** (debounced). Manual Save / Cmd+S remain and save immediately, cancelling any pending autosave timer.
 - **AS-2** Autosave uses the same optimistic lock as manual save (`expected_mtime`). On 409 the existing conflict banner shows and **autosave suspends** until the user resolves via Reload or Overwrite. Autosave must never auto-overwrite a conflict — that would reduce the lock to decoration.
@@ -368,6 +368,17 @@ The reload logic lives **entirely in the injected runtime** — the shell needs 
 - **LS-1** The directory listing view watches the directory path via the same endpoint; on change it re-fetches `/api/fs/list` and re-renders, preserving sort params.
 - **LS-2** Known limitation, accepted: a directory's mtime changes on create/delete/rename of entries — not when a child file's content or size changes. Stale sizes in an open listing are fine.
 - **LS-3** The shell closes the listing's watch `WebSocket` when navigating away (to a preview or another directory).
+
+### 13.5 Read-only files — the editability contract
+
+Write surfaces are decentralized (the code editor via `/api/fs/write`; the sqlite/duckdb grids and the annotate sidecar via their own Python writers), so read-onlyness is decided close to whoever writes, using host primitives — never probed from JS.
+
+- **RO-1** `/api/fs/stat` (and `/api/fs/write`'s stat-shaped response) carries `writable`: an existing path needs `W_OK` on itself, a not-yet-existing file needs `W_OK` on its parent. The flag means exactly "`/api/fs/write` would accept this path" — the two must never disagree.
+- **RO-2** `/api/fs/write` refuses a non-writable target with `403 {"error": "readonly"}`. This closes the atomic-write loophole: temp-file + `os.replace` goes through the parent directory and would otherwise silently overwrite a `chmod -w` file. `runtime.js` `writeFile` surfaces the refusal as a typed error (`err.type === "readonly"`), mirroring the 409 `"conflict"` case — the backstop for a template that never checked the flag.
+- **RO-3** Any template-side Python **writer** applies the same gate itself (`os.access(file, W_OK)` → `PermissionError`) before writing, for the same reason: writers that rewrite via `os.replace` (duckdb, annotate's sidecar) bypass the read-only bit, and ones that don't (sqlite) fail late with an unhelpful mid-transaction error.
+- **RO-4** Template **readers** fold fs writability into the editability verdict they already return — `editable` + `readonly_message` (short badge text) + `readonly_tooltip` (hover explanation). Filesystem read-onlyness is just one more reason alongside content-level ones ("View", "No rowid", "JSON"); the fs gate wins over a content-level "editable".
+- **RO-5** UI treatment is shared: `/template-shared/ro-badge.js` (`fusedRoBadge.update(el, message, tooltip)`) renders the identical badge in every template with an edit surface. The code editor derives its verdict from `stat.writable` (no Python reader) and locks the CodeMirror buffer; the grids disable editing per their reader's verdict.
+- **RO-6** Read-only never blocks *viewing*, and a template whose write target differs from the viewed file gates on ITS target: annotate checks the `<file>.json` sidecar (a `status` action), keeps commenting fully functional (the URL is the live store), and only warns that history won't be recorded.
 
 ## 14. Layout Mode — Split Panes (M5)
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -913,6 +913,106 @@ def _templates_for(path: str, is_dir: bool):
     return entries, error
 
 
+def _writable(path: str) -> bool:
+    """True iff /api/fs/write would accept this path. An existing target needs
+    W_OK on itself — the atomic os.replace would otherwise bypass a read-only
+    bit via the parent directory — and a new file needs W_OK on its parent.
+    Templates read this off the stat payload to render read-only mode up
+    front; keep the two in agreement."""
+    if os.path.exists(path):
+        return os.access(path, os.W_OK)
+    return os.access(os.path.dirname(path) or ".", os.W_OK)
+
+
+def _stat_payload(path: str, is_dir: bool) -> dict:
+    """The /api/fs/stat shape. /api/fs/write returns it too, so the editor can
+    re-arm its optimistic lock from a save response."""
+    st = os.stat(path)
+    templates, template_error = _templates_for(path, is_dir)
+    payload = {
+        "path": path,
+        "name": os.path.basename(path) or path,
+        "is_dir": is_dir,
+        "size": None if is_dir else st.st_size,
+        "mtime": st.st_mtime,
+        "writable": _writable(path),
+        "templates": templates,
+    }
+    if template_error:
+        payload["template_error"] = template_error
+    return payload
+
+
+def _fs_stat(path: str):
+    if not os.path.exists(path):
+        return _error(f"no such file or directory: {path}", status=404)
+    return _stat_payload(path, os.path.isdir(path))
+
+
+def _fs_write(body: dict, x_fused: str | None):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+
+    path = body.get("path")
+    content = body.get("content")
+    expected_mtime = body.get("expected_mtime")
+
+    if not path or not os.path.isabs(path):
+        return _error("'path' must be an absolute filesystem path")
+    if not isinstance(content, str):
+        return _error("'content' must be a string")
+    if os.path.isdir(path):
+        return _error(f"path is a directory: {path}")
+    parent = os.path.dirname(path)
+    if not os.path.isdir(parent):
+        return _error(f"parent directory does not exist: {parent}", status=404)
+
+    # Read-only guard: refuse before touching anything. The atomic write
+    # below replaces the target via the PARENT directory, so without this
+    # check a chmod -w file would be silently overwritten. The bare "readonly"
+    # error string is a wire contract — runtime.js writeFile turns it into a
+    # typed error, like "conflict" below.
+    if not _writable(path):
+        return JSONResponse({"error": "readonly"}, status_code=403)
+
+    # Optimistic lock: the editor sends the mtime it last saw; if the file
+    # changed (or was deleted) underneath it, refuse so the edit doesn't
+    # clobber someone else's write. Compare against the raw st_mtime float
+    # that /api/fs/stat returns, with a tolerance for float round-tripping.
+    exists = os.path.exists(path)
+    if expected_mtime is not None:
+        if not exists:
+            return JSONResponse({"error": "conflict", "mtime": None}, status_code=409)
+        current = os.stat(path).st_mtime
+        if abs(current - expected_mtime) >= 1e-6:
+            return JSONResponse({"error": "conflict", "mtime": current}, status_code=409)
+
+    # Preserve the target's permission bits across an overwrite.
+    mode = stat_mod.S_IMODE(os.stat(path).st_mode) if exists else None
+
+    # Atomic write: land the bytes in a temp file in the same directory,
+    # fsync, then os.replace onto the target so a reader never sees a
+    # half-written file (and a crash leaves the original intact).
+    fd, tmp = tempfile.mkstemp(dir=parent)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        if mode is not None:
+            os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except OSError as e:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        return _error(f"cannot write {path}: {e}", status=400)
+
+    return _stat_payload(path, False)
+
+
 def create_app(start_dir: str) -> FastAPI:
     # Engine (D69/D70 + SPEC §20): validate any FUSED_RENDER_ENGINE override
     # ONCE at startup — this raises on a bad value and fails loudly for
@@ -1080,22 +1180,7 @@ def create_app(start_dir: str) -> FastAPI:
 
     @app.get("/api/fs/stat")
     def api_fs_stat(path: str):
-        if not os.path.exists(path):
-            return _error(f"no such file or directory: {path}", status=404)
-        is_dir = os.path.isdir(path)
-        st = os.stat(path)
-        templates, template_error = _templates_for(path, is_dir)
-        payload = {
-            "path": path,
-            "name": os.path.basename(path) or path,
-            "is_dir": is_dir,
-            "size": None if is_dir else st.st_size,
-            "mtime": st.st_mtime,
-            "templates": templates,
-        }
-        if template_error:
-            payload["template_error"] = template_error
-        return payload
+        return _fs_stat(path)
 
     @app.get("/api/fs/list")
     def api_fs_list(path: str):
@@ -1276,72 +1361,7 @@ def create_app(start_dir: str) -> FastAPI:
 
     @app.post("/api/fs/write")
     def api_fs_write(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        guard = _require_fused(x_fused)
-        if guard is not None:
-            return guard
-
-        path = body.get("path")
-        content = body.get("content")
-        expected_mtime = body.get("expected_mtime")
-
-        if not path or not os.path.isabs(path):
-            return _error("'path' must be an absolute filesystem path")
-        if not isinstance(content, str):
-            return _error("'content' must be a string")
-        if os.path.isdir(path):
-            return _error(f"path is a directory: {path}")
-        parent = os.path.dirname(path)
-        if not os.path.isdir(parent):
-            return _error(f"parent directory does not exist: {parent}", status=404)
-
-        # Optimistic lock: the editor sends the mtime it last saw; if the file
-        # changed (or was deleted) underneath it, refuse so the edit doesn't
-        # clobber someone else's write. Compare against the raw st_mtime float
-        # that /api/fs/stat returns, with a tolerance for float round-tripping.
-        exists = os.path.exists(path)
-        if expected_mtime is not None:
-            if not exists:
-                return JSONResponse({"error": "conflict", "mtime": None}, status_code=409)
-            current = os.stat(path).st_mtime
-            if abs(current - expected_mtime) >= 1e-6:
-                return JSONResponse({"error": "conflict", "mtime": current}, status_code=409)
-
-        # Preserve the target's permission bits across an overwrite.
-        mode = stat_mod.S_IMODE(os.stat(path).st_mode) if exists else None
-
-        # Atomic write: land the bytes in a temp file in the same directory,
-        # fsync, then os.replace onto the target so a reader never sees a
-        # half-written file (and a crash leaves the original intact).
-        fd, tmp = tempfile.mkstemp(dir=parent)
-        try:
-            with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(content)
-                f.flush()
-                os.fsync(f.fileno())
-            if mode is not None:
-                os.chmod(tmp, mode)
-            os.replace(tmp, path)
-        except OSError as e:
-            try:
-                os.unlink(tmp)
-            except OSError:
-                pass
-            return _error(f"cannot write {path}: {e}", status=400)
-
-        # Same shape as /api/fs/stat so the editor can re-arm its lock.
-        st = os.stat(path)
-        templates, template_error = _templates_for(path, False)
-        payload = {
-            "path": path,
-            "name": os.path.basename(path) or path,
-            "is_dir": False,
-            "size": st.st_size,
-            "mtime": st.st_mtime,
-            "templates": templates,
-        }
-        if template_error:
-            payload["template_error"] = template_error
-        return payload
+        return _fs_write(body, x_fused)
 
     @app.get("/render")
     def render(path: str):

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -369,7 +369,9 @@
   // Write UTF-8 text to a file, returning the fresh stat object. opts:
   //   { expectedMtime } — optimistic lock; omit to write unconditionally.
   // A 409 becomes an Error with `type: "conflict"` and the server's current
-  // `mtime` attached, so callers can offer reload/overwrite.
+  // `mtime` attached, so callers can offer reload/overwrite. A read-only
+  // refusal (403 {"error":"readonly"}) becomes `type: "readonly"` — the
+  // backstop for templates that never checked stat().writable.
   function writeFile(path, content, opts) {
     const payload = { path: path, content: content };
     if (opts && opts.expectedMtime !== undefined && opts.expectedMtime !== null) {
@@ -386,6 +388,11 @@
           const err = new Error("file changed on disk");
           err.type = "conflict";
           err.mtime = data && data.mtime;
+          throw err;
+        }
+        if (res.status === 403 && data && data.error === "readonly") {
+          const err = new Error("file is read-only");
+          err.type = "readonly";
           throw err;
         }
         if (!res.ok) throw new Error((data && data.error) || "HTTP " + res.status);

--- a/fused_render/templates/annotate/annotate.py
+++ b/fused_render/templates/annotate/annotate.py
@@ -24,6 +24,10 @@ Stdlib only (runs in a subprocess; cannot import fused_render.shell).
 Actions:
   main(action="record", file=..., comments=[...], deleted_ids=[...])
     -> {"recorded": True, "count": N, "deleted": M}
+  main(action="status", file=...)
+    -> {"writable": bool}  # can the sidecar be written? Commenting still
+       # works read-only (the URL is the live store); the template just warns
+       # that history won't be recorded.
 """
 import json
 import os
@@ -139,11 +143,32 @@ def _record(file: str, comments: list, deleted_ids: list) -> dict:
         return {"recorded": True, "count": 0, "deleted": 0}
 
     data["comments"] = log
+    # Honor a read-only sidecar: the os.replace in _save_sidecar goes through
+    # the directory and would silently overwrite a chmod -w file. The caller
+    # (template.html) treats record as best-effort, so this just becomes the
+    # warning badge its status probe already showed.
+    if not _sidecar_writable(file):
+        raise PermissionError(f"{_sidecar_path(file)!r} is read-only")
     _save_sidecar(file, data)
     return {"recorded": True, "count": count, "deleted": deleted}
 
 
+def _sidecar_writable(file: str) -> bool:
+    """True iff _save_sidecar would succeed: an existing sidecar needs W_OK on
+    itself (the os.replace above would otherwise bypass its read-only bit via
+    the directory), a fresh one needs W_OK on the directory (mkstemp+replace
+    both land there)."""
+    path = _sidecar_path(os.path.abspath(file))
+    if os.path.exists(path):
+        return os.access(path, os.W_OK)
+    return os.access(os.path.dirname(path), os.W_OK)
+
+
 def main(action: str = "record", file: str = "", comments=None, deleted_ids=None) -> dict:
+    if action == "status":
+        if not file:
+            return {"error": "missing target file (no _file param?)"}
+        return {"writable": _sidecar_writable(file)}
     if action == "record":
         if not file:
             return {"error": "missing target file (no _file param?)"}

--- a/fused_render/templates/annotate/template.html
+++ b/fused_render/templates/annotate/template.html
@@ -154,6 +154,7 @@
     <select id="viewsel" title="Which view to annotate"></select>
     <span id="budgetnote" style="color:#ffb64d"></span>
     <span style="margin-left:auto">comments live in the URL — share it to share the review</span>
+    <span id="ro" hidden></span>
   </div>
   <div id="main">
     <div id="stage">
@@ -174,6 +175,7 @@
       </div>
     </div>
   </div>
+  <script src="/template-shared/ro-badge.js"></script>
   <script>
     // =========================================================================
     // Annotate — a VIEW TEMPLATE of its own (same pattern as templates/claude/):
@@ -216,6 +218,19 @@
       document.body.innerHTML = `<div id="status" class="error">No file selected (missing _file param).</div>`;
       throw new Error("no _file");
     }
+
+    // Sidecar writability probe: commenting always works (the URL is the live
+    // store), but when the `<file>.json` history log can't be written, say so
+    // instead of losing history silently. Probe failure itself stays silent —
+    // same best-effort posture as the record call below.
+    fused.runPython("./annotate.py", { action: "status", file }).then((st) => {
+      if (st && st.writable === false) {
+        fusedRoBadge.update(document.getElementById("ro"), "History not saved",
+          "The file's sidecar (" + file.split("/").pop() + ".json) isn't " +
+          "writable, so this review lives only in this URL and won't be " +
+          "recorded to comment history.");
+      }
+    }).catch(() => {});
 
     // --- data ---------------------------------------------------------------
     // Legacy import: the removed built-in stored comments in the RESERVED

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -225,8 +225,11 @@
           // was up). The read-only facets live in the view's extensions, so
           // rebuild the editor from scratch — reload discards local edits
           // anyway, and load() re-reads the file and re-applies the lock/badge.
-          hideConflict();
-          await load();
+          // The banner stays up until the rebuild lands: its visibility is
+          // what holds off queued autosaves (AS-2), and a failed load() must
+          // keep the Reload/Overwrite escape hatch on screen.
+          clearTimeout(saveTimer);
+          if (await load()) hideConflict();
           return;
         }
         const text = await fused.readFile(file);
@@ -258,7 +261,7 @@
       file = fused.params.get("_file");
       if (!file) {
         root.innerHTML = `<div id="status" class="error">No file selected (missing _file param).</div>`;
-        return;
+        return false;
       }
       const rawUrl = fused.rawUrl(file);
       let text;
@@ -267,14 +270,14 @@
         if (stat.size !== null && stat.size !== undefined && stat.size > MAX_BYTES) {
           root.innerHTML = `<div id="status">File is too large to edit inline (${stat.size.toLocaleString()} bytes).
             <a href="${rawUrl}" target="_blank" rel="noopener">Open raw</a></div>`;
-          return;
+          return false;
         }
         text = await fused.readFile(file);
         mtime = stat.mtime;
         writable = stat.writable !== false; // absent field (older server) → editable
       } catch (err) {
         root.innerHTML = `<div id="status" class="error">Failed to load file: ${escapeHtml(err.message)}</div>`;
-        return;
+        return false;
       }
 
       const ext = (file.split("/").pop().split(".").pop() || "").toLowerCase();
@@ -317,6 +320,7 @@
         saveBtn.hidden = false;
         fusedRoBadge.update(document.getElementById("ro"), "", "");
       }
+      return true;
     }
 
     saveBtn.addEventListener("click", save);

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8" />
 <title>Code editor</title>
 <script src="/template-assets/codemirror.bundle.js"></script>
+<script src="/template-shared/ro-badge.js"></script>
 <style>
   :root { color-scheme: dark; }
   * { box-sizing: border-box; }
@@ -80,6 +81,7 @@
       <button id="reload">Reload</button>
       <button id="overwrite">Overwrite</button>
     </span>
+    <span id="ro" hidden></span>
     <span id="status-text">Saved</span>
     <button id="save" disabled>Save</button>
   </div>
@@ -101,6 +103,7 @@
     let view = null;
     let file = null;
     let mtime = null;   // last known on-disk mtime; the optimistic-lock token
+    let writable = true; // stat.writable — false locks the buffer read-only
     let dirty = false;
     let saveTimer = null;  // pending autosave debounce (AS-1)
     let saving = false;    // a save() write is in flight
@@ -259,6 +262,7 @@
         }
         text = await fused.readFile(file);
         mtime = stat.mtime;
+        writable = stat.writable !== false; // absent field (older server) → editable
       } catch (err) {
         root.innerHTML = `<div id="status" class="error">Failed to load file: ${escapeHtml(err.message)}</div>`;
         return;
@@ -279,12 +283,22 @@
       ];
       const lang = languageFor(ext);
       if (lang) extensions.push(lang);
+      // Read-only file: lock the buffer, so dirty can never flip and no save
+      // path (autosave, Cmd+S, flush hook) ever fires. The server refuses the
+      // write anyway (403 readonly); this makes the UI honest up front.
+      if (!writable) extensions.push(CM.EditorView.editable.of(false));
 
       root.innerHTML = "";
       view = new CM.EditorView({ doc: text, extensions, parent: root });
       filenameEl.textContent = file.split("/").pop();
       barEl.style.display = "flex";
       setDirty(false);
+      if (!writable) {
+        saveBtn.hidden = true;
+        statusTextEl.textContent = "";
+        fusedRoBadge.update(document.getElementById("ro"), "Read-only",
+          "The file's permissions don't allow writing, so it can't be edited here.");
+      }
     }
 
     saveBtn.addEventListener("click", save);

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -285,8 +285,13 @@
       if (lang) extensions.push(lang);
       // Read-only file: lock the buffer, so dirty can never flip and no save
       // path (autosave, Cmd+S, flush hook) ever fires. The server refuses the
-      // write anyway (403 readonly); this makes the UI honest up front.
-      if (!writable) extensions.push(CM.EditorView.editable.of(false));
+      // write anyway (403 readonly); this makes the UI honest up front. Both
+      // facets: editable=false locks the DOM (caret, typing), readOnly=true
+      // rejects the transactions synthesized input can still smuggle past it.
+      if (!writable) {
+        extensions.push(CM.EditorView.editable.of(false));
+        extensions.push(CM.EditorState.readOnly.of(true));
+      }
 
       root.innerHTML = "";
       view = new CM.EditorView({ doc: text, extensions, parent: root });

--- a/fused_render/templates/code/template.html
+++ b/fused_render/templates/code/template.html
@@ -220,6 +220,15 @@
     async function reloadFromDisk() {
       try {
         const st = await fused.stat(file);
+        if ((st.writable !== false) !== writable) {
+          // Writability flipped on disk (e.g. chmod while the conflict banner
+          // was up). The read-only facets live in the view's extensions, so
+          // rebuild the editor from scratch — reload discards local edits
+          // anyway, and load() re-reads the file and re-applies the lock/badge.
+          hideConflict();
+          await load();
+          return;
+        }
         const text = await fused.readFile(file);
         view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
         mtime = st.mtime;
@@ -303,6 +312,10 @@
         statusTextEl.textContent = "";
         fusedRoBadge.update(document.getElementById("ro"), "Read-only",
           "The file's permissions don't allow writing, so it can't be edited here.");
+      } else {
+        // A rebuild (reloadFromDisk after a chmod +w) must undo the lock UI.
+        saveBtn.hidden = false;
+        fusedRoBadge.update(document.getElementById("ro"), "", "");
       }
     }
 

--- a/fused_render/templates/duckdb/reader.py
+++ b/fused_render/templates/duckdb/reader.py
@@ -224,6 +224,19 @@ def _read_database(file, table, offset, limit, sort, filters):
         con.close()
 
 
+def _fs_gate(file, out):
+    """FS gate over either path's verdict: a chmod -w file beats a
+    content-level "editable" (the writer refuses it too — see writer.py).
+    Content-level read-only reasons (view, JSON) keep their own message."""
+    if out["editable"] and not os.access(file, os.W_OK):
+        out.update(
+            editable=False,
+            readonly_message="Read-only",
+            readonly_tooltip="The file is read-only — its permissions don't "
+                             "allow writing, so it can't be edited here.")
+    return out
+
+
 def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
          sort: "dict | None" = None, filters: "list | None" = None) -> dict:
     # Clamp so a hostile/negative limit can't turn LIMIT ? into an unbounded
@@ -232,7 +245,7 @@ def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
     offset = max(0, int(offset))
     ext = _logical_ext(file)
     if ext in _DB_EXTS:
-        return _read_database(file, table, offset, limit, sort, filters)
+        return _fs_gate(file, _read_database(file, table, offset, limit, sort, filters))
     relation = relation_for(file)
 
     con = duckdb.connect(":memory:")
@@ -263,7 +276,7 @@ def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
             rows.append({columns[j] if j < len(columns) else f"col{j}": _jsonify(v)
                          for j, v in enumerate(raw[1:])})
         editable = ext in _EDITABLE_EXTS
-        return {
+        return _fs_gate(file, {
             "columns": columns,
             "types": types,
             "rows": rows,
@@ -275,6 +288,6 @@ def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
             "readonly_tooltip": "" if editable else (
                 "Read-only. JSON is flattened into columns for viewing; writing "
                 "that back would lose the original nested structure."),
-        }
+        })
     finally:
         con.close()

--- a/fused_render/templates/duckdb/template.html
+++ b/fused_render/templates/duckdb/template.html
@@ -95,30 +95,7 @@
   .save-count[hidden] { display: none; }
   #tablewrap { flex: 1 1 auto; min-height: 0; overflow: auto; }
   #rowcount { color: #9aa0a6; }
-  .ro-badge {
-    position: relative;
-    display: inline-flex; align-items: center; gap: 5px;
-    color: #9aa0a6; font-size: 12px; cursor: help;
-  }
-  /* display:inline-flex above beats the `hidden` attribute's UA display:none,
-     so an editable file (parquet/csv) would otherwise show a stray info icon. */
-  .ro-badge[hidden] { display: none; }
-  .ro-badge::after {
-    content: "i"; display: inline-flex; align-items: center; justify-content: center;
-    width: 13px; height: 13px; border-radius: 50%; border: 1px solid currentColor;
-    font-size: 9px; font-style: italic; font-weight: 700; line-height: 1; opacity: 0.75;
-  }
-  /* Custom tooltip: appears instantly on hover, unlike the native title's delay. */
-  .ro-tip {
-    position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 10;
-    width: max-content; max-width: 280px;
-    padding: 6px 9px; border-radius: 6px;
-    background: #24262b; color: #cfd3d7; border: 1px solid #33363c;
-    font-size: 12px; line-height: 1.4; font-style: normal;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-    opacity: 0; visibility: hidden; pointer-events: none; transition: opacity 0.06s;
-  }
-  .ro-badge:hover .ro-tip { opacity: 1; visibility: visible; }
+  /* .ro-badge / .ro-tip styles inject from /template-shared/ro-badge.js. */
   /* Filter bar — a builder above the grid: one or more conditions
      (column ▸ operator ▸ value) ANDed together and applied server-side. The
      first row carries Add (+) and the round Apply (search) button; extra rows
@@ -244,7 +221,7 @@
       <button id="next" class="icon-btn" title="Next page" aria-label="Next page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6 3.5 10.5 8 6 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
     </div>
     <div class="bar-group side right">
-      <span id="ro" class="ro-badge" hidden></span>
+      <span id="ro" hidden></span>
       <button id="add" hidden title="Add row" aria-label="Add row">+<span class="add-label">&nbsp;Add row</span></button>
       <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
@@ -253,6 +230,7 @@
   <div id="ctxmenu" hidden>
     <button class="ctx-item" id="ctx-null">Set Null</button>
   </div>
+  <script src="/template-shared/ro-badge.js"></script>
   <script>
     const LIMIT = 100;
     const el = (id) => document.getElementById(id);
@@ -494,20 +472,11 @@
       addBtn.hidden = saveBtn.hidden = discardBtn.hidden = !editable;
 
       // Explicit read-only badge (e.g. a SQLite view, or a JSON file): says the
-      // grid can't be edited, with a tooltip explaining why. Shown only when the
-      // reader reported a reason.
-      const roEl = document.getElementById("ro");
-      if (!editable && state.readonly_message) {
-        roEl.hidden = false;
-        roEl.innerHTML = "";
-        roEl.appendChild(document.createTextNode(state.readonly_message));
-        const tip = document.createElement("span");
-        tip.className = "ro-tip";
-        tip.textContent = state.readonly_tooltip || "";
-        roEl.appendChild(tip);
-      } else {
-        roEl.hidden = true;
-      }
+      // grid can't be edited, with a tooltip explaining why. Shown only when
+      // the reader reported a reason; rendering lives in ro-badge.js.
+      fusedRoBadge.update(document.getElementById("ro"),
+                          editable ? "" : state.readonly_message,
+                          state.readonly_tooltip);
 
       if (!state.columns.length && !state.total_rows && !(state.tables && state.tables.length)) {
         rowcountEl.textContent = "";

--- a/fused_render/templates/duckdb/writer.py
+++ b/fused_render/templates/duckdb/writer.py
@@ -173,6 +173,11 @@ def main(file: str, table: str = "", edits: "list | None" = None,
     edits = edits or []
     deletes = deletes or []
     inserts = inserts or []
+    # Same fs gate as the reader: the COPY-to-temp + os.replace rewrite below
+    # goes through the parent directory, so without this a chmod -w file would
+    # be silently overwritten.
+    if not os.access(file, os.W_OK):
+        raise PermissionError(f"{file!r} is read-only")
     ext = _logical_ext(file)
     if ext in _DB_EXTS:
         # A DuckDB database file is edited in place, not rewritten.

--- a/fused_render/templates/shared/ro-badge.js
+++ b/fused_render/templates/shared/ro-badge.js
@@ -1,0 +1,68 @@
+/* Read-only badge + instant tooltip — shared by every template with an edit
+ * surface (sqlite, duckdb, code, annotate). Extracted (2026-07) from the
+ * byte-identical copies sqlite/ and duckdb/ carried; served from the
+ * /template-shared/ mount (see server.py) like sciviz.mjs.
+ *
+ * Load:  <script src="/template-shared/ro-badge.js"></script>
+ * Place: <span id="ro" hidden></span> wherever the toolbar wants it.
+ * Use:   fusedRoBadge.update(el, message, tooltip)
+ *        — non-empty message shows the badge (text + info icon, tooltip on
+ *          hover); empty/undefined hides it. Styles inject on first update.
+ */
+(function () {
+  "use strict";
+
+  var CSS = [
+    ".ro-badge {",
+    "  position: relative;",
+    "  display: inline-flex; align-items: center; gap: 5px;",
+    "  color: #9aa0a6; font-size: 12px; cursor: help;",
+    "}",
+    /* display:inline-flex above beats the `hidden` attribute's UA
+       display:none, so an editable file would otherwise show a stray icon. */
+    ".ro-badge[hidden] { display: none; }",
+    ".ro-badge::after {",
+    "  content: \"i\"; display: inline-flex; align-items: center; justify-content: center;",
+    "  width: 13px; height: 13px; border-radius: 50%; border: 1px solid currentColor;",
+    "  font-size: 9px; font-style: italic; font-weight: 700; line-height: 1; opacity: 0.75;",
+    "}",
+    /* Custom tooltip: appears instantly on hover, unlike the native title's delay. */
+    ".ro-tip {",
+    "  position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 10;",
+    "  width: max-content; max-width: 280px;",
+    "  padding: 6px 9px; border-radius: 6px;",
+    "  background: #24262b; color: #cfd3d7; border: 1px solid #33363c;",
+    "  font-size: 12px; line-height: 1.4; font-style: normal;",
+    "  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);",
+    "  opacity: 0; visibility: hidden; pointer-events: none; transition: opacity 0.06s;",
+    "}",
+    ".ro-badge:hover .ro-tip { opacity: 1; visibility: visible; }",
+  ].join("\n");
+
+  var injected = false;
+  function ensureCss() {
+    if (injected) return;
+    injected = true;
+    var style = document.createElement("style");
+    style.textContent = CSS;
+    document.head.appendChild(style);
+  }
+
+  function update(el, message, tooltip) {
+    ensureCss();
+    el.classList.add("ro-badge");
+    if (!message) {
+      el.hidden = true;
+      return;
+    }
+    el.hidden = false;
+    el.innerHTML = "";
+    el.appendChild(document.createTextNode(message));
+    var tip = document.createElement("span");
+    tip.className = "ro-tip";
+    tip.textContent = tooltip || "";
+    el.appendChild(tip);
+  }
+
+  window.fusedRoBadge = { update: update };
+})();

--- a/fused_render/templates/sqlite/reader.py
+++ b/fused_render/templates/sqlite/reader.py
@@ -164,7 +164,15 @@ def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
             types = _column_types(conn, active)
             where, wbinds = _build_where(filters, types)
             order = _build_order(sort, types)
-            editable, readonly_message, readonly_tooltip = _editability(conn, active)
+            # FS gate first: a chmod -w file beats any per-table verdict (the
+            # writer refuses it too — see writer.py). Then the per-table gates.
+            if not os.access(file, os.W_OK):
+                editable, readonly_message, readonly_tooltip = (
+                    False, "Read-only",
+                    "The file is read-only — its permissions don't allow "
+                    "writing, so it can't be edited here.")
+            else:
+                editable, readonly_message, readonly_tooltip = _editability(conn, active)
             # total_rows is the filtered count, so the grid pages within the filter.
             total_rows = conn.execute(
                 f"SELECT COUNT(*) FROM {qname}{where}", wbinds).fetchone()[0]

--- a/fused_render/templates/sqlite/template.html
+++ b/fused_render/templates/sqlite/template.html
@@ -95,30 +95,7 @@
   .save-count[hidden] { display: none; }
   #tablewrap { flex: 1 1 auto; min-height: 0; overflow: auto; }
   #rowcount { color: #9aa0a6; }
-  .ro-badge {
-    position: relative;
-    display: inline-flex; align-items: center; gap: 5px;
-    color: #9aa0a6; font-size: 12px; cursor: help;
-  }
-  /* display:inline-flex above beats the `hidden` attribute's UA display:none,
-     so an editable file (parquet/csv) would otherwise show a stray info icon. */
-  .ro-badge[hidden] { display: none; }
-  .ro-badge::after {
-    content: "i"; display: inline-flex; align-items: center; justify-content: center;
-    width: 13px; height: 13px; border-radius: 50%; border: 1px solid currentColor;
-    font-size: 9px; font-style: italic; font-weight: 700; line-height: 1; opacity: 0.75;
-  }
-  /* Custom tooltip: appears instantly on hover, unlike the native title's delay. */
-  .ro-tip {
-    position: absolute; bottom: calc(100% + 6px); right: 0; z-index: 10;
-    width: max-content; max-width: 280px;
-    padding: 6px 9px; border-radius: 6px;
-    background: #24262b; color: #cfd3d7; border: 1px solid #33363c;
-    font-size: 12px; line-height: 1.4; font-style: normal;
-    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.45);
-    opacity: 0; visibility: hidden; pointer-events: none; transition: opacity 0.06s;
-  }
-  .ro-badge:hover .ro-tip { opacity: 1; visibility: visible; }
+  /* .ro-badge / .ro-tip styles inject from /template-shared/ro-badge.js. */
   /* Filter bar — a builder above the grid: one or more conditions
      (column ▸ operator ▸ value) ANDed together and applied server-side. The
      first row carries Add (+) and the round Apply (search) button; extra rows
@@ -244,7 +221,7 @@
       <button id="next" class="icon-btn" title="Next page" aria-label="Next page"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6 3.5 10.5 8 6 12.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
     </div>
     <div class="bar-group side right">
-      <span id="ro" class="ro-badge" hidden></span>
+      <span id="ro" hidden></span>
       <button id="add" hidden title="Add row" aria-label="Add row">+<span class="add-label">&nbsp;Add row</span></button>
       <button id="discard" class="icon-btn" hidden disabled title="Discard changes" aria-label="Discard changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M2.8 8a5.2 5.2 0 1 1 1.4 3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M2.8 4.4V8h3.6" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
       <button id="save" class="icon-btn" hidden disabled title="Save changes" aria-label="Save changes"><svg viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path d="M6.2 11.4 2.8 8l1.1-1.1 2.3 2.3 5.9-5.9L13.2 4.4z" fill="currentColor"/></svg><span class="save-count" hidden></span></button>
@@ -253,6 +230,7 @@
   <div id="ctxmenu" hidden>
     <button class="ctx-item" id="ctx-null">Set Null</button>
   </div>
+  <script src="/template-shared/ro-badge.js"></script>
   <script>
     const LIMIT = 100;
     const el = (id) => document.getElementById(id);
@@ -495,20 +473,11 @@
       addBtn.hidden = saveBtn.hidden = discardBtn.hidden = !editable;
 
       // Explicit read-only badge (e.g. a SQLite view, or a JSON file): says the
-      // grid can't be edited, with a tooltip explaining why. Shown only when the
-      // reader reported a reason.
-      const roEl = document.getElementById("ro");
-      if (!editable && state.readonly_message) {
-        roEl.hidden = false;
-        roEl.innerHTML = "";
-        roEl.appendChild(document.createTextNode(state.readonly_message));
-        const tip = document.createElement("span");
-        tip.className = "ro-tip";
-        tip.textContent = state.readonly_tooltip || "";
-        roEl.appendChild(tip);
-      } else {
-        roEl.hidden = true;
-      }
+      // grid can't be edited, with a tooltip explaining why. Shown only when
+      // the reader reported a reason; rendering lives in ro-badge.js.
+      fusedRoBadge.update(document.getElementById("ro"),
+                          editable ? "" : state.readonly_message,
+                          state.readonly_tooltip);
 
       if (!state.columns.length && !state.total_rows && !(state.tables && state.tables.length)) {
         rowcountEl.textContent = "";

--- a/fused_render/templates/sqlite/writer.py
+++ b/fused_render/templates/sqlite/writer.py
@@ -55,6 +55,11 @@ def main(file: str, table: str = "", edits: "list | None" = None,
     inserts = inserts or []
     if not table:
         raise ValueError("no table specified")
+    # Same fs gate as the reader: refuse a chmod -w file up front with a clear
+    # error instead of SQLite's mid-transaction "attempt to write a readonly
+    # database".
+    if not os.access(file, os.W_OK):
+        raise PermissionError(f"{file!r} is read-only")
 
     conn = _connect_rw(file)
     try:

--- a/tests/test_annotate_comments.py
+++ b/tests/test_annotate_comments.py
@@ -194,3 +194,36 @@ def test_deleted_ids_alone_still_writes_and_unknown_ignored(tmp_path):
     resp = ann._record(str(f), [], ["ghost"])
     assert resp == {"recorded": True, "count": 0, "deleted": 0}
     assert _sidecar(tmp_path).read_text() == before
+
+
+# ------------------------------------------------------- status (writability)
+
+def test_status_writable_sidecar_dir(tmp_path):
+    ann = _load_annotate()
+    target = tmp_path / "page.html"
+    target.write_text("<html></html>")
+    assert ann.main(action="status", file=str(target)) == {"writable": True}
+
+
+def test_status_readonly_sidecar_file(tmp_path):
+    ann = _load_annotate()
+    target = tmp_path / "page.html"
+    target.write_text("<html></html>")
+    sidecar = tmp_path / "page.html.json"
+    sidecar.write_text("{}")
+    os.chmod(sidecar, 0o444)
+    try:
+        assert ann.main(action="status", file=str(target)) == {"writable": False}
+    finally:
+        os.chmod(sidecar, 0o644)
+
+
+def test_status_readonly_parent_dir(tmp_path):
+    ann = _load_annotate()
+    target = tmp_path / "page.html"
+    target.write_text("<html></html>")
+    os.chmod(tmp_path, 0o555)
+    try:
+        assert ann.main(action="status", file=str(target)) == {"writable": False}
+    finally:
+        os.chmod(tmp_path, 0o755)

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -417,3 +417,28 @@ def test_writer_rejects_readonly_format(tmp_path):
     p = _make(tmp_path, "s.json", "SELECT 1 AS id")
     with pytest.raises(ValueError):
         writer.main(p, edits=[{"row": 0, "column": "id", "value": "2"}])
+
+
+# ---------------------------------------------------- fs-level read-only file
+
+@pytest.fixture
+def readonly_parquet(parquet_file):
+    os.chmod(parquet_file, 0o444)
+    yield parquet_file
+    os.chmod(parquet_file, 0o644)  # so tmp_path cleanup works
+
+
+def test_reader_readonly_file_not_editable(readonly_parquet):
+    out = reader.main(readonly_parquet)
+    assert out["editable"] is False
+    assert out["total_rows"] == 250                  # still viewable
+    assert "read-only" in out["readonly_message"].lower()
+    assert out["readonly_tooltip"]
+
+
+def test_writer_refuses_readonly_file(readonly_parquet):
+    before = os.stat(readonly_parquet).st_size
+    with pytest.raises(PermissionError):
+        writer.main(readonly_parquet,
+                    edits=[{"row": 0, "column": "name", "value": "x"}])
+    assert os.stat(readonly_parquet).st_size == before  # bytes untouched

--- a/tests/test_server_fs_write.py
+++ b/tests/test_server_fs_write.py
@@ -1,0 +1,94 @@
+"""Tests for /api/fs/stat's `writable` flag and /api/fs/write's read-only
+guard (fused_render/server.py).
+
+The route handlers are thin wrappers over module-level _fs_stat / _fs_write,
+which these drive directly — the same "avoid starlette TestClient" discipline
+as test_server_session.py.
+
+Rationale: the atomic write lands bytes in a temp file and os.replace()s it
+over the target, which succeeds on a chmod -w file as long as the parent
+directory is writable — silently bypassing the read-only bit. The guard makes
+the write endpoint refuse instead, and `writable` on the stat payload lets
+templates render read-only mode up front.
+"""
+import json
+import os
+import stat
+
+import pytest
+from fastapi.responses import JSONResponse
+
+from fused_render.server import _fs_stat as STAT
+from fused_render.server import _fs_write as WRITE
+
+
+def _status(resp) -> int:
+    return resp.status_code if isinstance(resp, JSONResponse) else 200
+
+
+def _data(resp) -> dict:
+    if isinstance(resp, JSONResponse):
+        return json.loads(bytes(resp.body))
+    return resp
+
+
+def _write(path, content, **kw):
+    body = {"path": str(path), "content": content, **kw}
+    return WRITE(body, x_fused="1")
+
+
+@pytest.fixture
+def target(tmp_path):
+    f = tmp_path / "notes.txt"
+    f.write_text("original")
+    return f
+
+
+@pytest.fixture
+def readonly(target):
+    os.chmod(target, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+    yield target
+    os.chmod(target, stat.S_IRUSR | stat.S_IWUSR)  # so tmp_path cleanup works
+
+
+# ------------------------------------------------------------- stat.writable
+
+def test_stat_writable_true_for_writable_file(target):
+    out = _data(STAT(str(target)))
+    assert out["writable"] is True
+
+
+def test_stat_writable_false_for_readonly_file(readonly):
+    out = _data(STAT(str(readonly)))
+    assert out["writable"] is False
+
+
+def test_stat_writable_on_directory(tmp_path):
+    assert _data(STAT(str(tmp_path)))["writable"] is True
+    os.chmod(tmp_path, stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        assert _data(STAT(str(tmp_path)))["writable"] is False
+    finally:
+        os.chmod(tmp_path, stat.S_IRWXU)
+
+
+# --------------------------------------------------------- write guard (403)
+
+def test_write_refuses_readonly_target(readonly):
+    resp = _write(readonly, "clobbered")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+    assert readonly.read_text() == "original"  # bytes untouched
+
+
+def test_write_succeeds_and_reports_writable(target):
+    out = _data(_write(target, "updated"))
+    assert target.read_text() == "updated"
+    assert out["writable"] is True
+
+
+def test_write_creates_new_file_in_writable_dir(tmp_path):
+    f = tmp_path / "new.txt"
+    out = _data(_write(f, "hello"))
+    assert f.read_text() == "hello"
+    assert out["writable"] is True

--- a/tests/test_sqlite_edit.py
+++ b/tests/test_sqlite_edit.py
@@ -175,3 +175,28 @@ def test_empty_string_is_distinct_from_null(db):
     val = sc.execute("SELECT name FROM people WHERE rowid = 1").fetchone()[0]
     sc.close()
     assert val == "" and val is not None
+
+
+# ---------------------------------------------------- fs-level read-only file
+
+@pytest.fixture
+def readonly_db(db):
+    os.chmod(db, 0o444)
+    yield db
+    os.chmod(db, 0o644)  # so tmp_path cleanup works
+
+
+def test_reader_readonly_file_not_editable(readonly_db):
+    out = reader.main(readonly_db, table="people")
+    assert out["editable"] is False
+    assert out["ids"] == []                          # no rowids: nothing to key edits by
+    assert out["total_rows"] == 5                    # still viewable
+    assert "read-only" in out["readonly_message"].lower()
+    assert out["readonly_tooltip"]
+
+
+def test_writer_refuses_readonly_file(readonly_db):
+    with pytest.raises(PermissionError):
+        writer.main(readonly_db, table="people",
+                    edits=[{"row": 1, "column": "name", "value": "x"}])
+    assert _all(readonly_db)[0][1] == "p0"           # bytes untouched


### PR DESCRIPTION
## Summary

Files without write permission are now detected end-to-end and every editing surface responds honestly: the server refuses the write, the runtime surfaces a typed error, and each writing template locks or warns up front instead of failing on save.

### Server & runtime
- `/api/fs/stat` (and write responses) now include a `writable` flag — existing file needs `W_OK` on itself, new file needs `W_OK` on the parent dir.
- `/api/fs/write` refuses read-only targets with `403 {"error":"readonly"}`, closing the `os.replace` loophole where atomic writes silently bypassed a `chmod -w` file via the directory.
- `runtime.js` `writeFile` converts the 403 into a typed error (`err.type === "readonly"`), mirroring the existing 409 conflict handling.

### Templates
- **code**: read-only files open with the buffer locked (both `EditorView.editable(false)` and `EditorState.readOnly(true)` — synthesized input can bypass the DOM lock alone), Save hidden, and a "Read-only" badge.
- **sqlite**: reader reports `editable: false` with message/tooltip when the db file lacks `W_OK`; writer raises `PermissionError` before touching the file.
- **duckdb**: same gating via a `_fs_gate` wrapper on both database and flat-file reads; writer guard closes its own `os.replace` bypass.
- **annotate**: commenting stays enabled read-only (the URL is the live store) — a status probe just warns "History not saved" when the `<file>.json` sidecar can't be written, and `_record` raises instead of bypassing the sidecar's read-only bit.
- New shared `templates/shared/ro-badge.js` (served at `/template-shared/ro-badge.js`) replaces the badge CSS/JS previously duplicated in sqlite and duckdb.

### Spec & tests
- SPEC.md §13.5 documents the editability contract (RO-1..RO-6).
- New `tests/test_server_fs_write.py` plus read-only cases appended to the sqlite/duckdb/annotate suites (TDD, red-green). 434 passed; the 2 failures in `test_templates_api.py` are pre-existing on main (verified via stash).

## Verification

Beyond pytest: live server checks through dev.sh, and real-browser probes of the code editor and sqlite grid on `chmod 444` fixtures — badge shows, typing is rejected, and the server 403 backstop holds even against synthesized input (disk verified untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)