### PR TITLE
feat(listing): keyboard-navigate the folder preview

### DIFF
--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -5,6 +5,7 @@
   --border: #2a2d33;
   --bg: #131417;
   --bg-alt: #1b1d21;
+  --sel: #2b3a52;
   --accent: #E5FF44;
   --error: #ff6b6b;
 }
@@ -776,6 +777,14 @@ table.listing-table tr.row.ignored {
 
 table.listing-table tr.row:hover {
   background: var(--bg-alt);
+  opacity: 1;
+}
+
+/* Keyboard-selected row (arrow-key navigation). Distinct from :hover so the
+   selection stays visible while the cursor is elsewhere; full opacity so a
+   selected .ignored row is still readable. */
+table.listing-table tr.row.selected {
+  background: var(--sel);
   opacity: 1;
 }
 

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -220,13 +220,20 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // Bound to `document` so it also drives the plain listing with nothing focused.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
+      // While an IME is composing, Enter confirms a candidate and the arrows
+      // move through the candidate list — never repurpose them for navigation.
+      if (e.isComposing) return;
       const el = document.activeElement as HTMLElement | null;
       const inSearch = el === searchInputRef.current;
-      const inEditable =
-        !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
+      // Only drive navigation from the search box or when nothing in particular
+      // is focused (body). If focus is on a chrome control — a breadcrumb link,
+      // the bookmark/mode-switch buttons, another input — leave its keys alone
+      // (otherwise Enter would open a file instead of activating that control).
+      const navActive =
+        inSearch || !el || el === document.body || el === document.documentElement;
 
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        if (inEditable && !inSearch) return; // don't hijack other inputs
+        if (!navActive) return;
         const rows = navRowsRef.current;
         if (!rows.length) return;
         e.preventDefault();
@@ -241,7 +248,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         return;
       }
       if (e.key === "Enter") {
-        if (inEditable && !inSearch) return;
+        if (!navActive) return;
         const rows = navRowsRef.current;
         if (!rows.length) return;
         const idx = rows.indexOf(selectedPathRef.current ?? "");
@@ -249,9 +256,14 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         navigate(idx === -1 ? rows[0] : rows[idx]);
         return;
       }
-      // Start typing anywhere → focus the search box. Plain printable keys only
-      // (no modifiers), and never while another editable field has focus.
-      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey && !inEditable) {
+      // Start typing → focus the search box so the character lands there. Only
+      // when nothing else is focused (not the search box already, not a chrome
+      // control) and only plain printable keys (no modifiers), so Space on a
+      // focused button and app shortcuts keep working.
+      if (
+        navActive && !inSearch &&
+        e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey
+      ) {
         searchInputRef.current?.focus(); // keystroke falls through into the input
       }
     }

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -702,7 +702,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
           ref={searchInputRef}
           type="search"
           className="listing-search-input"
-          placeholder="Search this folder…"
+          placeholder="Start typing to search…"
           value={query}
           onFocus={prefetchWalk}
           onChange={(e) => setQuery(e.target.value)}

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -200,6 +200,64 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   // How many result rows are revealed; grows by PAGE_SIZE when the sentinel
   // row scrolls into view, resets on every query change.
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  // Path of the keyboard-selected row (arrow-key navigation); null = none.
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+
+  // Search input, so a keystroke anywhere in the listing can focus it.
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  // Latest ordered list of navigable row paths + the current selection, read by
+  // the document keydown handler (registered once, so it can't close over them).
+  const navRowsRef = useRef<string[]>([]);
+  const selectedPathRef = useRef<string | null>(null);
+  selectedPathRef.current = selectedPath;
+
+  // Keyboard navigation for the listing, whether focus is in the search box or
+  // nowhere in particular:
+  //   • a plain printable key focuses the search box so the character lands there;
+  //   • Up/Down move the selection through the rendered rows — in the search box
+  //     too, since a single-line input doesn't need them for the caret;
+  //   • Enter opens the selection, or the top row when nothing is selected yet.
+  // Bound to `document` so it also drives the plain listing with nothing focused.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const el = document.activeElement as HTMLElement | null;
+      const inSearch = el === searchInputRef.current;
+      const inEditable =
+        !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        if (inEditable && !inSearch) return; // don't hijack other inputs
+        const rows = navRowsRef.current;
+        if (!rows.length) return;
+        e.preventDefault();
+        const idx = rows.indexOf(selectedPathRef.current ?? "");
+        // Nothing selected yet: Down starts at the top, Up at the bottom.
+        let next =
+          idx === -1
+            ? e.key === "ArrowDown" ? 0 : rows.length - 1
+            : e.key === "ArrowDown" ? idx + 1 : idx - 1;
+        next = Math.max(0, Math.min(rows.length - 1, next));
+        setSelectedPath(rows[next]);
+        return;
+      }
+      if (e.key === "Enter") {
+        if (inEditable && !inSearch) return;
+        const rows = navRowsRef.current;
+        if (!rows.length) return;
+        const idx = rows.indexOf(selectedPathRef.current ?? "");
+        e.preventDefault();
+        navigate(idx === -1 ? rows[0] : rows[idx]);
+        return;
+      }
+      // Start typing anywhere → focus the search box. Plain printable keys only
+      // (no modifiers), and never while another editable field has focus.
+      if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey && !inEditable) {
+        searchInputRef.current?.focus(); // keystroke falls through into the input
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   // The input echoes `query` (immediate) so keystrokes never wait on the
   // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
@@ -482,6 +540,26 @@ export default function Listing({ fsPath }: { fsPath: string }) {
 
   const base = fsPath.replace(/\/$/, "");
 
+  // Flat, ordered list of the paths the arrow keys step through: the rendered
+  // search hits while searching, otherwise the sorted listing. Keyed off the
+  // same memoized arrays the table renders, so selection never drifts from view.
+  const navRows = useMemo(
+    () =>
+      searching
+        ? visibleHits.map(({ entry }) => base + "/" + entry.rel)
+        : sortedEntries.map((entry) => base + "/" + entry.name),
+    [searching, visibleHits, sortedEntries, base]
+  );
+  navRowsRef.current = navRows;
+
+  // Keep the keyboard selection scrolled into view as it moves.
+  useEffect(() => {
+    if (!selectedPath) return;
+    document
+      .querySelector("table.listing-table tr.row.selected")
+      ?.scrollIntoView({ block: "nearest" });
+  }, [selectedPath, navRows]);
+
   // --- table body -----------------------------------------------------------
 
   let body: React.ReactNode;
@@ -501,7 +579,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
             {visibleHits.map(({ entry, positions }) => {
               const childPath = base + "/" + entry.rel;
               return (
-                <tr key={entry.rel} className="row" onClick={() => navigate(childPath)}>
+                <tr
+                  key={entry.rel}
+                  className={childPath === selectedPath ? "row selected" : "row"}
+                  onClick={() => navigate(childPath)}
+                >
                   <td className="name">
                     <span className="icon">{iconForEntry(entry.rel.split("/").pop() ?? entry.rel, entry.is_dir)}</span>
                     <span className="search-path">{renderHighlight(entry.rel, positions)}</span>
@@ -570,7 +652,10 @@ export default function Listing({ fsPath }: { fsPath: string }) {
       return (
         <tr
           key={entry.name}
-          className={entry.ignored ? "row ignored" : "row"}
+          className={
+            (entry.ignored ? "row ignored" : "row") +
+            (childPath === selectedPath ? " selected" : "")
+          }
           onClick={() => navigate(childPath)}
         >
           <td className="name">
@@ -614,6 +699,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     <div className="listing">
       <div className="listing-search">
         <input
+          ref={searchInputRef}
           type="search"
           className="listing-search-input"
           placeholder="Search this folder…"

--- a/fused_render/templates/preview/template.html
+++ b/fused_render/templates/preview/template.html
@@ -167,7 +167,7 @@
   <div class="split">
     <div class="list-pane" id="list-pane">
       <div class="list-search">
-        <input id="search" type="search" placeholder="Search this folder…" autocomplete="off" spellcheck="false" />
+        <input id="search" type="search" placeholder="Start typing to search…" autocomplete="off" spellcheck="false" />
         <span class="count" id="search-count"></span>
       </div>
       <div class="list-body" id="list-body"><div class="status-message">Loading…</div></div>

--- a/fused_render/templates/preview/template.html
+++ b/fused_render/templates/preview/template.html
@@ -584,14 +584,23 @@
         : `${total}${suffix} match${total === 1 ? "" : "es"}`;
     }
 
-    // Arrow-key navigation over whatever is rendered (listing or search hits);
-    // Enter opens the selection. Arrows are ignored while typing in the search
-    // box so the caret still moves; Enter there opens the current selection.
+    // Arrow-key navigation over whatever is rendered (listing or search hits).
+    // Up/Down drive the selection even while the caret is in the search box (a
+    // single-line input doesn't need them for the caret), so you can type to
+    // filter and keep navigating without reaching for the mouse; Left/Right
+    // still move the caret. Enter opens the selection, or the top row when
+    // nothing is selected yet.
     function onKey(e) {
       const typing = document.activeElement === searchEl;
+      // Start typing anywhere → focus the search box so the character lands
+      // there. Only plain printable keys (no modifiers) so shortcuts still work.
+      if (!typing && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        searchEl.focus();
+        return; // let the keystroke fall through into the now-focused input
+      }
       const rows = currentRows;
       if (!rows.length) return;
-      if (!typing && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
         e.preventDefault();
         const idx = rows.findIndex((r) => r.path === selectedPath);
         // Nothing selected yet: Down starts at the top, Up starts at the bottom.
@@ -603,8 +612,9 @@
         select(entry);
         const tr = listBodyEl.querySelector(`tr.row[data-path="${CSS.escape(entry.path)}"]`);
         if (tr) tr.scrollIntoView({ block: "nearest" });
-      } else if (e.key === "Enter" && selectedPath) {
-        const entry = rows.find((r) => r.path === selectedPath);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        const entry = rows.find((r) => r.path === selectedPath) || rows[0];
         if (entry) openInShell(entry.path, entry.is_dir);
       }
     }

--- a/fused_render/templates/preview/template.html
+++ b/fused_render/templates/preview/template.html
@@ -591,16 +591,27 @@
     // still move the caret. Enter opens the selection, or the top row when
     // nothing is selected yet.
     function onKey(e) {
-      const typing = document.activeElement === searchEl;
-      // Start typing anywhere → focus the search box so the character lands
-      // there. Only plain printable keys (no modifiers) so shortcuts still work.
-      if (!typing && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      // While an IME is composing, Enter confirms a candidate and the arrows
+      // move through the candidate list — never repurpose them for navigation.
+      if (e.isComposing) return;
+      const el = document.activeElement;
+      const typing = el === searchEl;
+      // Only drive navigation from the search box or when nothing in particular
+      // is focused (body). If focus is on a control — the "Open" button in the
+      // preview pane, or the preview iframe — leave its keys alone.
+      const onBody = !el || el === document.body || el === document.documentElement;
+      const navActive = typing || onBody;
+      // Start typing → focus the search box so the character lands there. Only
+      // when nothing else is focused, and only plain printable keys (no
+      // modifiers), so Space on a focused button and shortcuts keep working.
+      if (onBody && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
         searchEl.focus();
         return; // let the keystroke fall through into the now-focused input
       }
       const rows = currentRows;
       if (!rows.length) return;
       if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        if (!navActive) return;
         e.preventDefault();
         const idx = rows.findIndex((r) => r.path === selectedPath);
         // Nothing selected yet: Down starts at the top, Up starts at the bottom.
@@ -613,6 +624,7 @@
         const tr = listBodyEl.querySelector(`tr.row[data-path="${CSS.escape(entry.path)}"]`);
         if (tr) tr.scrollIntoView({ block: "nearest" });
       } else if (e.key === "Enter") {
+        if (!navActive) return;
         e.preventDefault();
         const entry = rows.find((r) => r.path === selectedPath) || rows[0];
         if (entry) openInShell(entry.path, entry.is_dir);


### PR DESCRIPTION
## Summary

- Makes the file explorer / folder preview fully keyboard-navigable, applied to **both** mirrored implementations: the React directory listing (`views/Listing.tsx`) and the standalone vanilla folder preview (`templates/preview/template.html`).
- **Type anywhere → the search box focuses** so the character lands there — no clicking into search first.
- **↑/↓ move the row selection even while the caret is in the search box** (a single-line input doesn't need them for the caret), so you can filter and navigate hands-off; ←/→ still move the text caret.
- **Enter opens** the selected row, or the top hit when nothing is selected yet.
- Adds a `--sel` selection colour + `tr.row.selected` style to `shell.css` so the React listing highlights the keyboard selection (the template already had one).

## Visuals

Keyboard flow added to the listing/preview (`onKey` in the template, a `document` keydown effect in React):

```mermaid
flowchart TD
    K[keydown on document] --> T{caret in<br/>search box?}
    T -->|"other input focused"| X[ignore]
    K --> P{plain printable key<br/>no modifiers?}
    P -->|yes, not already in an input| F[focus search box<br/>→ char falls through]
    K --> A{Arrow Up / Down?}
    A -->|yes| S[move selection ±1<br/>works even while typing<br/>scroll into view]
    K --> E{Enter?}
    E -->|yes| O[open selected row<br/>or top row if none]
```

Selection highlight (React listing): after pressing ↓↓ the `sine` row is drawn with the new `--sel` background while the rest of the listing is unchanged. (Screenshot captured during verification; drop it in here if you want it in the PR.)

## Usage

In any folder view (both Listing and Preview modes):

1. Just **start typing** — the "Search this folder…" box focuses and captures the keystroke.
2. Press **↓ / ↑** to move the highlighted selection through the results (or the plain listing), even without leaving the search box.
3. Press **Enter** to open the highlighted file/folder (opens the top hit if you haven't moved the selection yet).
4. **Esc** still clears the query and blurs the box (unchanged).

## Test Plan

- [x] `tsc --noEmit` passes (frontend has no unit-test runner; `typecheck` is the gate).
- [x] Verified live in a browser at `http://127.0.0.1:9000` via `scripts/dev.sh`:
  - React listing: type `py` → 2 hits; ↓ selects `how_it_works/demo.py` **with caret still in the search box**; ↓ again → `sine/sine.py`; Enter opened `sine/sine.py`.
  - React plain listing (no search): ↓↓ selected `sine`, ↑ back to `how_it_works`, Enter opened the folder.
  - Vanilla `template.html` folder preview (in-iframe): ↓ selects `demo.py`, ↓ `explainer.html`; ↑ while search focused moved back to `demo.py`; Enter opened `demo.py`.
- [x] ←/→ confirmed to still move the caret (only ↑/↓ are repurposed).
- [ ] Reviewer edge cases to sanity-check: empty folder / no matches (no selection to move), and Up/Down not hijacked when focus is in an unrelated input.
