### PR TITLE
fix(map): quoted paths, KML rendering, and multi-layer files

### DIFF
--- a/fused_render/templates/map/geo_classify.py
+++ b/fused_render/templates/map/geo_classify.py
@@ -50,7 +50,24 @@ def route_target(target):
     return "vector"
 
 
-def vector_meta(target):
+def list_layers(target):
+    """Layer names for a multi-layer vector source (GPKG/KML/GML); [] for a
+    single-layer source, which is rendered as one target."""
+    low = target.lower().split("?")[0]
+    if not low.endswith(VECTOR_EXT):
+        return []
+    import pyogrio
+    try:
+        rows = pyogrio.list_layers(target)
+    except Exception:
+        return []
+    if rows is None:
+        return []
+    names = [str(row[0]) for row in rows]
+    return names if len(names) > 1 else []
+
+
+def vector_meta(target, layer=None):
     """Fast metadata for the MVT descriptor: 4326 bounds, geometry type,
     attribute columns and source CRS — read without materializing geometry."""
     low = target.lower().split("?")[0]
@@ -77,15 +94,15 @@ def vector_meta(target):
                 "geometry_type": "Point", "columns": cols, "crs_original": "EPSG:4326"}
 
     import pyogrio
-    layer = None
-    layers = pyogrio.list_layers(target)
-    if layers is not None and len(layers) > 1:
-        best, bestn = None, -1
-        for lname in [row[0] for row in layers]:
-            ni = pyogrio.read_info(target, layer=lname).get("features", 0)
-            if ni > bestn:
-                best, bestn = lname, ni
-        layer = best
+    if layer is None:
+        layers = pyogrio.list_layers(target)
+        if layers is not None and len(layers) > 1:
+            best, bestn = None, -1
+            for lname in [row[0] for row in layers]:
+                ni = pyogrio.read_info(target, layer=lname).get("features", 0)
+                if ni > bestn:
+                    best, bestn = lname, ni
+            layer = best
     info = pyogrio.read_info(target, layer=layer) if layer else pyogrio.read_info(target)
     crs = info.get("crs")
     w, s, e, n = (float(v) for v in info["total_bounds"])

--- a/fused_render/templates/map/map_render.py
+++ b/fused_render/templates/map/map_render.py
@@ -30,36 +30,43 @@ def _err(msg):
             "bounds": None, "data": {}, "warnings": []}
 
 
-def _vector_tiles(target):
-    """Ensure the MVT daemon is running, start warm-up for `target`, and return
-    the tile descriptor with quick metadata for immediate framing."""
+def _union_bounds(boxes):
+    return [min(b[0] for b in boxes), min(b[1] for b in boxes),
+            max(b[2] for b in boxes), max(b[3] for b in boxes)]
+
+
+def _vector_layer(target, port, layer):
+    """MVT tile descriptor for one layer of `target` (layer=None for a
+    single-layer file). Kicks off the daemon's warm-up for that layer."""
     import geo_classify
-    import vector_tile_server as vts
-
-    ensured = vts.main("ensure")
-    port = ensured.get("port")
-    if not port:
-        return _err(ensured.get("error", "tile daemon failed to start"))
-
     import urllib.parse
     import urllib.request
-    qs = urllib.parse.urlencode({"file": target})
+
+    params = {"file": target}
+    if layer:
+        params["layer"] = layer
+    qs = urllib.parse.urlencode(params)
+
+    meta = geo_classify.vector_meta(target, layer)
+    b = meta.get("bounds")
+    if b and (abs(b[0]) > 180 or abs(b[2]) > 180 or abs(b[1]) > 90 or abs(b[3]) > 90):
+        return {**_err("coordinates fall outside the valid lon/lat range — this file doesn't look "
+                       "georeferenced (e.g. image/pixel coordinates)"),
+                "status": "not_georeferenced", "layer": layer,
+                "name": layer or os.path.basename(target)}
     try:
         urllib.request.urlopen(f"http://127.0.0.1:{port}/open?{qs}", timeout=5).read()
     except Exception:
         pass
 
-    try:
-        meta = geo_classify.vector_meta(target)
-    except Exception as e:  # noqa: BLE001
-        return _err(f"couldn't read vector file: {type(e).__name__}: {e}")
-
     return {
         "status": "ok",
         "kind": "vector_tiles_mvt",
+        "layer": layer,
+        "name": layer or os.path.basename(target),
         "crs_original": meta.get("crs_original"),
         "bounds": meta.get("bounds"),
-        "data": {"port": port, "file": target,
+        "data": {"port": port, "file": target, "layer": layer,
                  "tile_url": f"http://127.0.0.1:{port}/tile/{{z}}/{{x}}/{{y}}.mvt?{qs}",
                  "status_url": f"http://127.0.0.1:{port}/status?{qs}",
                  "meta_url": f"http://127.0.0.1:{port}/meta?{qs}"},
@@ -72,6 +79,38 @@ def _vector_tiles(target):
         "warnings": [],
         "detected_type": "vector",
     }
+
+
+def _vector_tiles(target):
+    """Ensure the MVT daemon is running and return a tile descriptor. A
+    multi-layer source (GPKG/KML/GML) returns a `vector_group` listing one
+    child descriptor per layer; a single-layer source returns the child."""
+    import geo_classify
+    import vector_tile_server as vts
+
+    ensured = vts.main("ensure")
+    port = ensured.get("port")
+    if not port:
+        return _err(ensured.get("error", "tile daemon failed to start"))
+
+    layers = geo_classify.list_layers(target)
+    if not layers:
+        try:
+            return _vector_layer(target, port, None)
+        except Exception as e:  # noqa: BLE001
+            return _err(f"couldn't read vector file: {type(e).__name__}: {e}")
+
+    children = []
+    for lname in layers:
+        try:
+            children.append(_vector_layer(target, port, lname))
+        except Exception as e:  # noqa: BLE001
+            children.append({**_err(f"{type(e).__name__}: {e}"),
+                             "layer": lname, "name": lname})
+    ok = [c["bounds"] for c in children if c.get("status") == "ok" and c.get("bounds")]
+    return {"status": "ok", "kind": "vector_group", "file": target,
+            "bounds": _union_bounds(ok) if ok else None,
+            "layers": children, "detected_type": "vector"}
 
 
 def _raster_tiles(target, colormap, rescale):

--- a/fused_render/templates/map/map_render.py
+++ b/fused_render/templates/map/map_render.py
@@ -49,7 +49,9 @@ def _vector_layer(target, port, layer):
 
     meta = geo_classify.vector_meta(target, layer)
     b = meta.get("bounds")
-    if b and (abs(b[0]) > 180 or abs(b[2]) > 180 or abs(b[1]) > 90 or abs(b[3]) > 90):
+    # Latitude is the hard bound; longitude allows both the -180..180 and the
+    # 0..360 (Pacific/marine) conventions before a file is called non-geographic.
+    if b and (b[0] < -180 or b[2] > 360 or b[1] < -90 or b[3] > 90):
         return {**_err("coordinates fall outside the valid lon/lat range — this file doesn't look "
                        "georeferenced (e.g. image/pixel coordinates)"),
                 "status": "not_georeferenced", "layer": layer,

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -98,6 +98,19 @@
   .lc-msg { font-size: 11px; color: var(--muted); padding: 0 10px 8px 32px; line-height: 1.45; word-break: break-word; }
   .lc .spin { width: 13px; height: 13px; border: 2px solid #00000014; border-top-color: var(--accent); border-radius: 50%; flex: none; animation: spin .7s linear infinite; }
 
+  /* multi-layer file -> grouped sub-layers */
+  .lgroup { margin-bottom: 6px; }
+  .lg-head { display: flex; align-items: center; gap: 7px; padding: 7px 8px; border-radius: 8px; cursor: pointer; }
+  .lg-head:hover { background: var(--panel-2); }
+  .lg-chev { display: flex; color: var(--faint); transition: transform .15s; flex: none; }
+  .lg-chev.open { transform: rotate(90deg); }
+  .lg-head .ic { display: flex; color: var(--muted); flex: none; }
+  .lg-nm { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12.5px; font-weight: 620; }
+  .lg-head .lc-eye, .lg-head .lc-dots { opacity: 0; }
+  .lg-head:hover .lc-eye, .lg-head:hover .lc-dots, .lg-head .lc-eye.off { opacity: 1; }
+  .lg-children { padding-left: 10px; margin-left: 11px; border-left: 1px solid var(--border); }
+  .lg-children .lc { margin-bottom: 4px; }
+
   #lmenu {
     position: fixed; z-index: 40; min-width: 156px; padding: 4px;
     background: var(--panel); border: 1px solid var(--border); border-radius: 10px;
@@ -447,6 +460,10 @@ loadScript("https://unpkg.com/@highlightjs/cdn-assets@11.9.0/highlight.min.js").
 const qs = id => document.getElementById(id);
 const P = fused.params;
 
+// Windows "Copy as path" wraps the path in double quotes; a quoted path isn't
+// absolute, so os.path.abspath would join it onto the template dir. Strip them.
+const cleanPath = s => String(s || "").trim().replace(/^["']|["']$/g, "").trim();
+
 /* ---- colormaps (for legends + vector color-by) ------------------------ */
 const CMAPS = {
   viridis: [[68,1,84],[59,82,139],[33,145,140],[94,201,98],[253,231,37]],
@@ -523,6 +540,7 @@ const KIND_ICON = {
 const dirBase = p => { const parts = String(p).replace(/\/+$/, "").split("/"); return parts[parts.length - 1] || p; };
 
 async function loadDir(dir) {
+  dir = cleanPath(dir);
   try {
     const res = await fused.runPython("./discover.py", dir ? { dir } : {});
     if (res.error) { toast("bad", "Can't list folder", res.error); return; }
@@ -555,10 +573,12 @@ function renderFileList() {
     return;
   }
 
+  const selL = state.selected ? state.layers.get(state.selected) : null;
+  const selPath = selL ? (selL.group || selL.target) : state.selected;
   for (const e of items) {
-    const L = state.layers.get(e.path);
+    const L = entryLayer(e.path);
     const div = document.createElement("div");
-    div.className = "file" + (state.selected === e.path ? " selected" : "") + (L && L.loading ? " loading" : "");
+    div.className = "file" + (selPath === e.path ? " selected" : "") + (L && L.loading ? " loading" : "");
 
     if (e.kind === "dir") {
       div.innerHTML = `<span class="ic">${KIND_ICON.dir}</span><span class="nm">${e.name}</span><span class="kd">open</span>`;
@@ -577,6 +597,15 @@ function renderFileList() {
     box.appendChild(div);
   }
 }
+// A browse row's on-map state: its own layer, or the merged state of a file's grouped sub-layers.
+function entryLayer(path) {
+  const direct = state.layers.get(path);
+  if (direct) return direct;
+  const grp = [...state.layers.values()].filter(x => x.group === path);
+  if (!grp.length) return undefined;
+  const ok = grp.some(x => x.descriptor && x.descriptor.status === "ok");
+  return { loading: grp.some(x => x.loading), descriptor: { status: ok ? "ok" : "error" } };
+}
 function statusColor(d) {
   return d.status === "ok" ? "var(--good)" : d.status === "not_georeferenced" ? "var(--warn)" : "var(--bad)";
 }
@@ -590,6 +619,8 @@ async function selectFile(entry) {
   const L = state.layers.get(key);
   if (L && L.loading) return;
   if (L && L.descriptor) { selectLayer(key); return; }
+  const grouped = [...state.layers.values()].find(x => x.group === key);
+  if (grouped) { selectLayer(grouped.target); return; }
   await loadTarget(key, entry.name);
 }
 
@@ -602,7 +633,47 @@ function selectLayer(key) {
   refreshCode();
 }
 
+// Apply a rendered descriptor to a layer entry — shared by single files and group sub-layers.
+function hydrate(L, desc) {
+  L.loading = false;
+  L.descriptor = desc;
+  if (desc.status !== "ok") { L.visible = false; return; }
+  const touched = L.style && L.style._touched;
+  L.style = touched ? Object.assign({}, desc.style, L.style) : Object.assign({}, desc.style);
+  if (desc.kind === "vector_tiles_mvt") {
+    L.mvt = { tileUrl: desc.data.tile_url, statusUrl: desc.data.status_url,
+              metaUrl: desc.data.meta_url, minzoom: desc.minzoom ?? 0,
+              maxzoom: desc.maxzoom ?? 18, geometry_type: desc.geometry_type,
+              version: 0, ready: false, phase: "reading", pct: 0,
+              detail_zoom: null, count: null };
+  }
+  L.visible = true;
+}
+
+// A multi-layer file (GPKG/KML/GML) → one layer entry per sub-layer, grouped under the file.
+function loadGroup(file, name, desc) {
+  const base = state.layers.size;
+  const kids = [];
+  desc.layers.forEach((child, i) => {
+    const key = file + "::" + (child.layer ?? i);
+    const L = { target: key, file, layer: child.layer, group: file, groupName: name,
+                name: child.name || child.layer || name, visible: true, opacity: 1,
+                style: {}, defaultColor: CATEGORICAL[(base + i) % CATEGORICAL.length] };
+    state.layers.set(key, L);
+    hydrate(L, child);
+    if (child.status === "ok") kids.push(L);
+  });
+  if (kids.length) state.selected = kids[0].target;
+  else toast("bad", "Couldn't render " + name, "No layers could be read.");
+  persistOpen();
+  renderAll();
+  fitTo(desc.bounds);
+  refreshCode();
+  for (const L of kids) if (L.mvt) pollMvtStatus(L.target);
+}
+
 async function loadTarget(target, name) {
+  target = cleanPath(target);
   name = name || target.split(/[\\/]/).pop();
   const L = state.layers.get(target) || { target, name, visible: true, opacity: 1, style: {}, geojson: null };
   if (!L.defaultColor) L.defaultColor = CATEGORICAL[state.layers.size % CATEGORICAL.length];
@@ -614,25 +685,19 @@ async function loadTarget(target, name) {
       target, colormap: (L.style && L.style.colormap) || "viridis",
       rescale: (L.style && L.style.rescale) ? L.style.rescale.join(",") : "",
     });
-    L.loading = false; L.descriptor = desc;
+    if (desc.kind === "vector_group") {
+      state.layers.delete(target);
+      loadGroup(target, name, desc);
+      return;
+    }
+    hydrate(L, desc);
     if (desc.status !== "ok") {
-      L.visible = false;
       state.selected = target;   // still let the user read its code / message
       const kind = desc.status === "not_georeferenced" ? "warn" : "bad";
       toast(kind, desc.status === "not_georeferenced" ? "Not georeferenced" : "Couldn't render " + name,
             desc.message || (desc.error && desc.error.message) || "unknown error");
       renderAll(); refreshCode(); return;
     }
-    const touched = L.style && L.style._touched;
-    L.style = touched ? Object.assign({}, desc.style, L.style) : Object.assign({}, desc.style);
-    if (desc.kind === "vector_tiles_mvt") {
-      L.mvt = { tileUrl: desc.data.tile_url, statusUrl: desc.data.status_url,
-                metaUrl: desc.data.meta_url, minzoom: desc.minzoom ?? 0,
-                maxzoom: desc.maxzoom ?? 18, geometry_type: desc.geometry_type,
-                version: 0, ready: false, phase: "reading", pct: 0,
-                detail_zoom: null, count: null };
-    }
-    L.visible = true;
     state.selected = target;
     persistOpen();
     renderAll();
@@ -789,6 +854,8 @@ function swatchStyle(L) {
   return `background:rgb(${c[0]},${c[1]},${c[2]})`;
 }
 
+const collapsedGroups = new Set();
+
 function renderLayerCards() {
   const box = qs("layercards");
   const all = [...state.layers.values()];
@@ -797,11 +864,57 @@ function renderLayerCards() {
     return;
   }
   box.innerHTML = "";
-  for (const L of all.reverse()) box.appendChild(layerCard(L));   // topmost card = topmost on map
+  const done = new Set();
+  for (const L of [...all].reverse()) {   // topmost card = topmost on map
+    if (done.has(L.target)) continue;
+    if (L.group) {
+      const members = all.filter(x => x.group === L.group);
+      members.forEach(m => done.add(m.target));
+      box.appendChild(groupCard(L.group, L.groupName, members));
+    } else {
+      done.add(L.target);
+      box.appendChild(layerCard(L));
+    }
+  }
+}
+
+const CHEV = '<svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M9 18l6-6-6-6"/></svg>';
+
+function groupCard(groupKey, groupName, members) {
+  const collapsed = collapsedGroups.has(groupKey);
+  const anyVisible = members.some(m => m.visible);
+  const wrap = document.createElement("div"); wrap.className = "lgroup";
+  const head = document.createElement("div"); head.className = "lg-head";
+  head.innerHTML =
+    `<span class="lg-chev ${collapsed ? "" : "open"}">${CHEV}</span>` +
+    `<span class="ic">${KIND_ICON.dir}</span>` +
+    `<span class="lg-nm" title="${groupKey}">${groupName}</span>` +
+    `<span class="lc-badge">${members.length} layers</span>` +
+    `<button class="lc-eye ${anyVisible ? "" : "off"}" title="Toggle all layers">${anyVisible ? EYE : EYEOFF}</button>` +
+    `<button class="lc-dots" title="More">${DOTS}</button>`;
+  head.onclick = ev => {
+    if (ev.target.closest(".lc-eye") || ev.target.closest(".lc-dots")) return;
+    collapsed ? collapsedGroups.delete(groupKey) : collapsedGroups.add(groupKey);
+    renderLayerCards();
+  };
+  head.querySelector(".lc-eye").onclick = ev => {
+    ev.stopPropagation();
+    const on = !anyVisible;
+    members.forEach(m => { m.visible = on; });
+    renderLayerCards(); rebuildDeck();
+  };
+  head.querySelector(".lc-dots").onclick = ev => { ev.stopPropagation(); openGroupMenu(ev.currentTarget, groupKey, members); };
+  wrap.appendChild(head);
+  const kids = document.createElement("div"); kids.className = "lg-children";
+  if (collapsed) kids.style.display = "none";
+  for (const m of [...members].reverse()) kids.appendChild(layerCard(m));
+  wrap.appendChild(kids);
+  return wrap;
 }
 
 function layerCard(L) {
   const d = L.descriptor;
+  const tp = L.file || L.target;
   const card = document.createElement("div");
   card.className = "lc" + (state.selected === L.target ? " selected" : "") + (L.visible ? "" : " off");
   if (d && d.status === "error") card.classList.add("bad-tint");
@@ -809,17 +922,17 @@ function layerCard(L) {
 
   const h = document.createElement("div"); h.className = "lc-h";
   if (L.loading) {
-    h.innerHTML = `<span class="spin"></span><span class="lc-nm" title="${L.target}">${L.name}</span><span class="lc-badge">loading</span>`;
+    h.innerHTML = `<span class="spin"></span><span class="lc-nm" title="${tp}">${L.name}</span><span class="lc-badge">loading</span>`;
   } else if (d && d.status !== "ok") {
     h.innerHTML =
       `<span class="lc-swatch" style="background:${d.status === "error" ? "var(--bad)" : "var(--warn)"}"></span>` +
-      `<span class="lc-nm" title="${L.target}">${L.name}</span>` +
+      `<span class="lc-nm" title="${tp}">${L.name}</span>` +
       `<button class="lc-dots" title="More">${DOTS}</button>`;
   } else {
     const preparing = d.kind === "vector_tiles_mvt" && L.mvt && !L.mvt.ready && L.mvt.phase !== "error";
     h.innerHTML =
       (preparing ? `<span class="spin"></span>` : `<span class="lc-swatch" style="${swatchStyle(L)}"></span>`) +
-      `<span class="lc-nm" title="${L.target}">${L.name}</span>` +
+      `<span class="lc-nm" title="${tp}">${L.name}</span>` +
       `<span class="lc-badge">${preparing ? "tiles " + (L.mvt.pct || 0) + "%" : kindBadge(d)}</span>` +
       `<button class="lc-eye ${L.visible ? "" : "off"}" title="Toggle visibility">${L.visible ? EYE : EYEOFF}</button>` +
       `<button class="lc-dots" title="More">${DOTS}</button>`;
@@ -844,17 +957,9 @@ let menuEl = null;
 function closeMenu() { if (menuEl) { menuEl.remove(); menuEl = null; } }
 document.addEventListener("click", closeMenu);
 
-function openLayerMenu(btn, L) {
+function showMenu(btn, items) {
   closeMenu();
   menuEl = document.createElement("div"); menuEl.id = "lmenu";
-  const items = [];
-  if (L.descriptor && L.descriptor.status === "ok") {
-    items.push(["Zoom to layer", () => fitTo(L.descriptor.bounds)]);
-    items.push(["Move up", () => moveLayer(L.target, +1)]);
-    items.push(["Move down", () => moveLayer(L.target, -1)]);
-  }
-  items.push(["View source", () => { state.selected = L.target; renderFileList(); renderLayerCards(); openCodePanel(); }]);
-  items.push(["Remove", () => removeLayer(L.target), "danger"]);
   for (const [label, fn, cls] of items) {
     const b = document.createElement("button");
     b.textContent = label; if (cls) b.className = cls;
@@ -865,6 +970,42 @@ function openLayerMenu(btn, L) {
   const r = btn.getBoundingClientRect(), mw = menuEl.offsetWidth, mh = menuEl.offsetHeight;
   menuEl.style.left = Math.min(r.left, window.innerWidth - mw - 8) + "px";
   menuEl.style.top = (r.bottom + mh + 8 > window.innerHeight ? r.top - mh - 4 : r.bottom + 4) + "px";
+}
+
+function openLayerMenu(btn, L) {
+  const items = [];
+  if (L.descriptor && L.descriptor.status === "ok") {
+    items.push(["Zoom to layer", () => fitTo(L.descriptor.bounds)]);
+    items.push(["Move up", () => moveLayer(L.target, +1)]);
+    items.push(["Move down", () => moveLayer(L.target, -1)]);
+  }
+  items.push(["View source", () => { state.selected = L.target; renderFileList(); renderLayerCards(); openCodePanel(); }]);
+  items.push(["Remove", () => removeLayer(L.target), "danger"]);
+  showMenu(btn, items);
+}
+
+function openGroupMenu(btn, groupKey, members) {
+  showMenu(btn, [
+    ["Zoom to group", () => fitGroup(members)],
+    ["Remove group", () => removeGroup(groupKey), "danger"],
+  ]);
+}
+
+function fitGroup(members) {
+  const bs = members.map(m => m.descriptor).filter(d => d && d.status === "ok" && d.bounds).map(d => d.bounds);
+  if (bs.length) fitTo([Math.min(...bs.map(b => b[0])), Math.min(...bs.map(b => b[1])),
+                        Math.max(...bs.map(b => b[2])), Math.max(...bs.map(b => b[3]))]);
+}
+
+function removeGroup(groupKey) {
+  for (const [k, L] of [...state.layers]) {
+    if (L.group !== groupKey) continue;
+    if (state.selected === k) state.selected = null;
+    state.layers.delete(k);
+  }
+  persistOpen();
+  renderAll();
+  refreshCode();
 }
 
 // Reorder within state.layers (insertion order = z-order); dir +1 = up the stack.
@@ -901,7 +1042,7 @@ function renderStyleDock() {
     return;
   }
   const d = L.descriptor;
-  qs("sp-nm").textContent = L.name; qs("sp-nm").title = L.target;
+  qs("sp-nm").textContent = L.name; qs("sp-nm").title = L.file || L.target;
   qs("sp-kind").textContent = d.kind ? kindBadge(d) : "";
   body.innerHTML = "";
   if (d.status !== "ok") {
@@ -1041,10 +1182,16 @@ qs("sp-close").onclick = () => {
 const TEXT_EXT = ["py","json","geojson","csv","txt","md","yaml","yml","toml","cfg","ini","js","ts","html","css","sh","sql"];
 const LANG_ALIAS = { py: "python", geojson: "json", yml: "yaml", sh: "bash", ts: "typescript" };
 
+// A group sub-layer is keyed by a synthetic id; the code viewer needs the real file path.
+function selectedFile() {
+  const L = state.selected ? state.layers.get(state.selected) : null;
+  return L ? (L.file || L.target) : state.selected;
+}
+
 function openCodePanel() {
   qs("codepanel").classList.remove("hidden"); qs("btn-code").classList.add("on");
   setTimeout(() => map.resize(), 60);
-  updateCodeViewer(state.selected);
+  updateCodeViewer(selectedFile());
 }
 qs("btn-code").onclick = () => {
   if (qs("codepanel").classList.contains("hidden")) { openCodePanel(); return; }
@@ -1057,7 +1204,7 @@ qs("cp-close").onclick = () => {
 };
 
 function refreshCode() {
-  if (!qs("codepanel").classList.contains("hidden")) updateCodeViewer(state.selected);
+  if (!qs("codepanel").classList.contains("hidden")) updateCodeViewer(selectedFile());
 }
 
 async function updateCodeViewer(path) {
@@ -1176,8 +1323,8 @@ map.on("moveend", () => { const c = map.getCenter(); P.set("cam", `${c.lat.toFix
 qs("filter").oninput = renderFileList;
 qs("btn-up").onclick = () => { if (state.parent && state.parent !== state.dir) loadDir(state.parent); };
 qs("btn-reload").onclick = () => loadDir(state.dir);
-qs("dir").onkeydown = e => { if (e.key === "Enter") loadDir(e.target.value.trim()); };
-qs("importpath").onkeydown = e => { if (e.key === "Enter" && e.target.value.trim()) { loadTarget(e.target.value.trim()); e.target.value = ""; } };
+qs("dir").onkeydown = e => { if (e.key === "Enter") loadDir(cleanPath(e.target.value)); };
+qs("importpath").onkeydown = e => { if (e.key === "Enter" && cleanPath(e.target.value)) { loadTarget(cleanPath(e.target.value)); e.target.value = ""; } };
 
 /* toast */
 let toastTimer = null;
@@ -1192,8 +1339,12 @@ function toast(kind, title, msg) {
 
 /* open-layer persistence in URL (keeps z-order) */
 function persistOpen() {
-  const targets = [...state.layers.keys()].filter(k => { const L = state.layers.get(k); return L.descriptor && L.descriptor.status === "ok"; });
-  if (targets.length) P.set("open", targets.map(encodeURIComponent).join("~"));
+  const seen = new Set();
+  for (const L of state.layers.values()) {
+    if (!(L.descriptor && L.descriptor.status === "ok")) continue;
+    seen.add(L.group || L.target);   // a group re-opens from its file path
+  }
+  if (seen.size) P.set("open", [...seen].map(encodeURIComponent).join("~"));
 }
 
 /* ---- boot ------------------------------------------------------------- */

--- a/fused_render/templates/map/vector_tile_server.py
+++ b/fused_render/templates/map/vector_tile_server.py
@@ -124,8 +124,9 @@ def _serve():
     con.execute("PRAGMA threads=8")
     con.execute("LOAD spatial")
 
-    files = {}                       # path -> file-state dict
+    files = {}                       # (path, layer) -> file-state dict
     files_lock = threading.Lock()
+    warm_lock = threading.Lock()     # serialize warm-up DDL (one DuckDB con)
 
     tile_cache = {}                  # (path,z,x,y) -> bytes
     tile_order = []
@@ -243,9 +244,12 @@ def _serve():
     # ---------------- warm-up (background thread) ----------------
     def _warm(path, layer):
         f = files[(path, layer)]
-        cur = con.cursor()
         tid = f["tid"]
+        # DuckDB can't run concurrent DDL on one database, so a multi-layer group
+        # builds its per-layer tables one at a time.
+        warm_lock.acquire()
         try:
+            cur = con.cursor()
             f["phase"] = "reading"
             rel, geom_sql, attrs, crs, gtype, count = _load_source(cur, path, tid, layer)
             f["columns"] = attrs
@@ -325,6 +329,8 @@ def _serve():
             traceback.print_exc()
             f["error"] = f"{type(e).__name__}: {e}"
             f["phase"] = "error"
+        finally:
+            warm_lock.release()
 
     def _detail_zoom(f, n, cap):
         bb = f.get("merc_bbox")

--- a/fused_render/templates/map/vector_tile_server.py
+++ b/fused_render/templates/map/vector_tile_server.py
@@ -38,6 +38,9 @@ CAP_AREA = 4000        # per tile-cell feature cap (polygons / lines)
 CAP_POINT = 12000      # generous cap for points
 OVERVIEW_ZOOM_STRIDE = 3   # build an overview every N zooms below detail_zoom
 SIMPLIFY_PX = 2            # geometry simplify tolerance, in tile pixels
+# ST_AsMVT only accepts these property types; everything else (timestamps,
+# dates, decimals from e.g. KML/GPKG) is cast to VARCHAR before tiling.
+_MVT_OK = {"BOOLEAN", "INTEGER", "BIGINT", "FLOAT", "DOUBLE", "VARCHAR"}
 
 
 def _me():
@@ -135,8 +138,8 @@ def _serve():
     rtile_order = []
     rtile_lock = threading.Lock()
 
-    def _tid(path):
-        return "f" + hashlib.sha1(path.encode()).hexdigest()[:12]
+    def _tid(path, layer):
+        return "f" + hashlib.sha1(f"{path}\x00{layer or ''}".encode()).hexdigest()[:12]
 
     def _merc_to_lonlat(x, y):
         lon = x / MERC_MAX * 180.0
@@ -151,26 +154,26 @@ def _serve():
     # ---------------- load an arbitrary vector file -> registered relation ----
     GDAL_EXT = (".gpkg", ".shp", ".geojson", ".json", ".fgb", ".kml", ".gml")
 
-    def _load_source(cur, path, tid):
-        """Register a source relation for `path`; return
-        (relname, geom_sql, attrs, src_crs, geometry_type, count)."""
+    def _load_source(cur, path, tid, layer=None):
+        """Register a source relation for `path` (optionally a named layer);
+        return (relname, geom_sql, attrs, src_crs, geometry_type, count)."""
         low = path.lower()
         rel = tid + "_src"
         if low.endswith(GDAL_EXT):
             import pyogrio
             from pyogrio.raw import read_arrow
-            layer = None
-            try:
-                layers = pyogrio.list_layers(path)
-                if layers is not None and len(layers) > 1:
-                    best, bestn = None, -1
-                    for lname in [row[0] for row in layers]:
-                        ni = pyogrio.read_info(path, layer=lname).get("features", 0)
-                        if ni > bestn:
-                            best, bestn = lname, ni
-                    layer = best
-            except Exception:
-                layer = None
+            if layer is None:
+                try:
+                    layers = pyogrio.list_layers(path)
+                    if layers is not None and len(layers) > 1:
+                        best, bestn = None, -1
+                        for lname in [row[0] for row in layers]:
+                            ni = pyogrio.read_info(path, layer=lname).get("features", 0)
+                            if ni > bestn:
+                                best, bestn = lname, ni
+                        layer = best
+                except Exception:
+                    layer = None
             meta, tbl = read_arrow(path, layer=layer) if layer else read_arrow(path)
             fields = [str(f) for f in list(meta.get("fields", []))]
             gname = meta.get("geometry_name") or ""
@@ -238,20 +241,24 @@ def _serve():
         return [f'"{a}"' for a in attrs]
 
     # ---------------- warm-up (background thread) ----------------
-    def _warm(path):
-        f = files[path]
+    def _warm(path, layer):
+        f = files[(path, layer)]
         cur = con.cursor()
         tid = f["tid"]
         try:
             f["phase"] = "reading"
-            rel, geom_sql, attrs, crs, gtype, count = _load_source(cur, path, tid)
+            rel, geom_sql, attrs, crs, gtype, count = _load_source(cur, path, tid, layer)
             f["columns"] = attrs
             f["geometry_type"] = gtype
             f["count"] = count
             fam = _fam(gtype)
             f["fam"] = fam
             qa = _qattrs(attrs)
-            sel_a = (", " + ", ".join(qa)) if qa else ""
+            coltypes = {r[0]: (r[1] or "").upper() for r in cur.execute(f"DESCRIBE {rel}").fetchall()}
+            sel_a = "".join(
+                f', "{a}" AS "{a}"' if coltypes.get(a, "VARCHAR").split("(")[0] in _MVT_OK
+                else f', "{a}"::VARCHAR AS "{a}"'
+                for a in attrs)
             base = tid + "_base"
 
             f["phase"] = "materializing"; f["pct"] = 5
@@ -267,6 +274,12 @@ def _serve():
             """)
             cur.unregister(rel)
             cur.execute(f"DELETE FROM {base} WHERE geom IS NULL OR ST_IsEmpty(geom)")
+            if not gtype or str(gtype).lower() == "unknown":
+                row = cur.execute(f"""SELECT ST_GeometryType(geom) AS g, count(*) AS c
+                                      FROM {base} GROUP BY g ORDER BY c DESC LIMIT 1""").fetchone()
+                if row and row[0]:
+                    gtype = row[0]; f["geometry_type"] = gtype
+                    fam = _fam(gtype); f["fam"] = fam
             cur.execute(f"ALTER TABLE {base} ADD COLUMN imp DOUBLE")
             if fam == "polygon":
                 cur.execute(f"UPDATE {base} SET imp = ST_Area(geom)")
@@ -303,7 +316,7 @@ def _serve():
             for i, z in enumerate(levels):                 # coarsest first
                 _build_overview(cur, f, z, fam, cap, qa)
                 f["ov_built"].append(z)
-                _drop_file_tiles(path)
+                _drop_file_tiles(path, layer)
                 f["pct"] = 20 + int(78 * (i + 1) / max(len(levels), 1))
             f["pct"] = 100
             f["phase"] = "ready"
@@ -388,12 +401,12 @@ def _serve():
         """).fetchone()
         return row[0] if row else None
 
-    def _drop_file_tiles(path):
+    def _drop_file_tiles(path, layer):
         with tile_lock:
-            keys = [k for k in tile_cache if k[0] == path]
+            keys = [k for k in tile_cache if k[0] == path and k[1] == layer]
             for k in keys:
                 tile_cache.pop(k, None)
-            tile_order[:] = [k for k in tile_order if k[0] != path]
+            tile_order[:] = [k for k in tile_order if not (k[0] == path and k[1] == layer)]
 
     # ---------------- raster tiles (rasterio WarpedVRT) ----------------
     def _ropen(path):
@@ -546,29 +559,35 @@ def _serve():
         return 200, b, PNG_CT
 
     # ---------------- request handlers ----------------
-    def _ensure_open(path):
+    def _fkey(q):
+        path = _abspath(q.get("file", [None])[0])
+        layer = (q.get("layer", [None])[0]) or None
+        return path, layer
+
+    def _ensure_open(path, layer):
+        key = (path, layer)
         with files_lock:
-            f = files.get(path)
+            f = files.get(key)
             if f is not None:
                 return f
-            f = {"tid": _tid(path), "phase": "queued", "pct": 0, "ready": False,
+            f = {"tid": _tid(path, layer), "phase": "queued", "pct": 0, "ready": False,
                  "error": None, "detail_zoom": None, "bounds_4326": None,
                  "count": None, "geometry_type": None, "columns": [],
                  "base": None, "ov_built": []}
-            files[path] = f
-        threading.Thread(target=_warm, args=(path,), daemon=True).start()
+            files[key] = f
+        threading.Thread(target=_warm, args=(path, layer), daemon=True).start()
         return f
 
     def do_open(q):
-        path = _abspath(q.get("file", [None])[0])
+        path, layer = _fkey(q)
         if not path:
             return 400, b'{"error":"missing file"}', "application/json"
-        f = _ensure_open(path)
+        f = _ensure_open(path, layer)
         return 200, json.dumps({"opening": not f["ready"], "ready": f["ready"]}).encode(), "application/json"
 
     def do_status(q):
-        path = _abspath(q.get("file", [None])[0])
-        f = files.get(path) if path else None
+        path, layer = _fkey(q)
+        f = files.get((path, layer)) if path else None
         if f is None:
             return 200, json.dumps({"phase": "unopened", "pct": 0, "ready": False,
                                     "detail_zoom": None, "error": None}).encode(), "application/json"
@@ -576,8 +595,8 @@ def _serve():
                                 "detail_zoom": f["detail_zoom"], "error": f["error"]}).encode(), "application/json"
 
     def do_meta(q):
-        path = _abspath(q.get("file", [None])[0])
-        f = _ensure_open(path) if path else None
+        path, layer = _fkey(q)
+        f = _ensure_open(path, layer) if path else None
         if f is None:
             return 400, b'{"error":"missing file"}', "application/json"
         m = {"bounds_4326": f["bounds_4326"], "count": f["count"],
@@ -590,11 +609,11 @@ def _serve():
     MVT_CT = "application/vnd.mapbox-vector-tile"
 
     def do_tile(q, z, x, y):
-        path = _abspath(q.get("file", [None])[0])
-        f = files.get(path) if path else None
-        if f is None or f["base"] is None:
+        path, layer = _fkey(q)
+        f = files.get((path, layer)) if path else None
+        if f is None or not f.get("ready") or f["base"] is None:
             return 204, b"", MVT_CT
-        key = (path, z, x, y)
+        key = (path, layer, z, x, y)
         with tile_lock:
             b = tile_cache.get(key)
         if b is not None:


### PR DESCRIPTION
## Summary

Fixes three issues in the **map** viewer template, plus a graceful failure for non-geographic vector data.

### 1. Pasted paths were prepended with the template dir
A Windows *Copy as path* value comes wrapped in double quotes (`"C:\...\file.geojson"`). A quoted string isn't absolute, so `os.path.abspath` joined it onto the template's working dir (surfacing as `…\.core-templates\map\"C:\…"` — *Not found*). A `cleanPath` helper now strips surrounding quotes at every path entry point (directory bar, "Add any file path or URL" box, and restore/`_file` hooks).

### 2. KML files didn't display
The tile daemon 500'd on `ST_AsMVT: property column "timestamp" has unsupported type "TIMESTAMP_MS"`. Attribute columns whose types `ST_AsMVT` rejects (timestamps, dates, decimals — common in KML/GPKG) are now cast to `VARCHAR` before tiling. GDAL also reports KML geometry as `Unknown`, so points were being styled as polygons; the daemon now detects the real geometry type from the materialized data.

### 3. Multi-layer files showed only one layer
A GPKG/KML/GML with more than one layer previously rendered only the layer with the most features. Every layer is now rendered, grouped under a collapsible parent card for the file (master show/hide, per-layer toggles, zoom/remove-group). A `layer` parameter is threaded through the tile daemon, classifier (`vector_meta`/new `list_layers`), and render entrypoint; the frontend expands a `vector_group` descriptor into one entry per layer.

### Bonus: non-georeferenced vector data fails cleanly
A GeoJSON in pixel/image space (declares CRS84 but has coordinates like x≈260–762, y≈−945) was crashing the tile daemon. `map_render` now detects coordinates outside the valid lon/lat range and returns a clear *"doesn't look georeferenced"* message instead.

## Testing
Verified end-to-end against the tile daemon HTTP endpoints:
- KML (2 layers) → group renders POINT + LINESTRING, non-empty tiles.
- GPKG (3 layers) → group renders points/zones/roads.
- Single-layer GeoJSON → unchanged (no regression).
- Pixel-space GeoJSON → clean `not_georeferenced` status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the local tile daemon’s open/cache keys and MVT attribute handling plus multi-layer UI state; scope is the map template only, but regressions could affect vector loading for all formats.
> 
> **Overview**
> Fixes several map viewer pain points around **paths**, **KML/GPKG tiling**, **multi-layer sources**, and **non-geographic vectors**.
> 
> **Quoted Windows paths** no longer break browse/import: `cleanPath` strips surrounding quotes before paths hit Python, so *Copy as path* values resolve correctly instead of being joined under the template directory.
> 
> **Multi-layer GPKG/KML/GML** now renders every layer, not just the largest. `list_layers` and an optional `layer` on `vector_meta` / tile URLs drive a `vector_group` descriptor from `map_render`; the UI expands that into collapsible group cards with per-layer visibility, zoom-to-group, and URL persistence by file path.
> 
> **KML (and similar) tiling** casts attribute columns that `ST_AsMVT` rejects (e.g. timestamps) to `VARCHAR`, infers geometry type when GDAL reports `Unknown`, and keys daemon state and tile cache by `(file, layer)` with serialized warm-up DDL.
> 
> **Pixel-space / invalid lon–lat bounds** return a `not_georeferenced` status with a clear message instead of crashing the tile daemon; tiles are not served until warm-up is `ready`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45c0cf4361f95a8835051f35731fcd7e7899430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->