### PR TITLE
feat(templates): read-only file gating for the new viewer templates

### DIFF
--- a/fused_render/templates/docs/docs.py
+++ b/fused_render/templates/docs/docs.py
@@ -129,6 +129,16 @@ def _typst_install():
     return _typst_status()
 
 
+def _editability(file: str):
+    """Editability verdict for the reader (SPEC RO-4): fold fs writability into
+    editable + readonly_message (badge) + readonly_tooltip (hover)."""
+    if not os.access(file, os.W_OK):
+        return (False, "Read-only",
+                "The file is read-only — its permissions don't allow "
+                "writing, so it can't be edited here.")
+    return True, "", ""
+
+
 def _cache_dir(file: str) -> str:
     # One subfolder per document (keyed by its own path) so exports from
     # different documents never collide; lives outside the template folder.
@@ -175,10 +185,13 @@ def main(action: str = "export", file: str = "", html: str = "", title: str = ""
     if action == "import":
         if not file or not os.path.isfile(file):
             raise FileNotFoundError(f"file not found: {file}")
+        editable, ro_msg, ro_tip = _editability(file)
         out = _pandoc(["-f", "docx", "-t", "html+tex_math_dollars", "--mathjax",
                        "--track-changes=all", "--embed-resources",
                        "--wrap=none", file])
-        return {"html": out.decode("utf-8", "replace"), "mtime": os.path.getmtime(file)}
+        return {"html": out.decode("utf-8", "replace"), "mtime": os.path.getmtime(file),
+                "editable": editable, "readonly_message": ro_msg,
+                "readonly_tooltip": ro_tip}
 
     # ---- export/convert: browser sends serialized HTML, we fan out to formats
     if action == "export":
@@ -218,6 +231,11 @@ def main(action: str = "export", file: str = "", html: str = "", title: str = ""
         if not html:
             raise ValueError("nothing to save")
         file = os.path.abspath(file)
+        # FS gate before any tmp-write (SPEC RO-3): the tmp + os.replace
+        # pipeline below goes through the parent directory, so a chmod -w
+        # file bit would otherwise be silently overwritten.
+        if os.path.exists(file) and not os.access(file, os.W_OK):
+            raise PermissionError(f"{file!r} is read-only")
         if expected_mtime and os.path.exists(file):
             on_disk = os.path.getmtime(file)
             if abs(on_disk - float(expected_mtime)) > 1e-6:

--- a/fused_render/templates/docs/template.html
+++ b/fused_render/templates/docs/template.html
@@ -189,7 +189,9 @@
     padding: 10px 16px; border-radius: var(--radius); display: none; z-index: 60; box-shadow: var(--shadow-2); max-width: 80vw; }
   #boot, #nofile { padding: 44px; color: var(--ink-3); }
   .kbd { font-family: ui-monospace, monospace; background: var(--hair-2); border-radius: 4px; padding: 1px 5px; font-size: 11px; color: var(--ink-2); margin-left: auto; }
+  /* .ro-badge / .ro-tip styles inject from /template-shared/ro-badge.js. */
 </style>
+<script src="/template-shared/ro-badge.js"></script>
 </head>
 <body class="mode-view">
   <div id="boot">Loading the editor…</div>
@@ -222,6 +224,7 @@
     </div>
     <span id="docTitle"></span>
     <span id="savedTag" class="saved-tag"></span>
+    <span id="ro" hidden></span>
     <span class="spacer"></span>
     <button id="btnComments" class="btn ghost" title="Comments"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></button>
     <button id="btnHistory" class="btn ghost" title="Version history"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg></button>
@@ -1137,8 +1140,27 @@
     setMode("edit"); S.dirty = true; updateSavedTag(); toast("Version restored — save to keep it.");
   }
 
+  // ---- read-only lock (SPEC §13.5) ----
+  // The import action's verdict (RO-4); applied at boot, or mid-session when a
+  // save trips the writer's fs gate (RO-3 — a chmod -w that happened after
+  // load). Viewing stays fully functional; only writes to FILE are suppressed
+  // ("Save a copy…" writes elsewhere and keeps working).
+  const RO_TOOLTIP_DEFAULT = "The file is read-only — its permissions don't allow writing, so it can't be edited here.";
+  let RO = false;
+  function applyReadonly(message, tooltip) {
+    if (RO) return;
+    RO = true;
+    clearTimeout(saveTimer);   // a pending autosave must not fire after the lock
+    fusedRoBadge.update($("ro"), message || "Read-only", tooltip || RO_TOOLTIP_DEFAULT);
+    const editBtn = $("modeSeg").querySelector('[data-mode="edit"]');
+    editBtn.disabled = true;
+    editBtn.title = tooltip || RO_TOOLTIP_DEFAULT;
+    if (S.mode === "edit") setMode("view");
+  }
+
   // ---- mode switch ----
   function setMode(mode) {
+    if (RO) mode = "view";   // honest lock: a read-only file has no edit mode
     S.mode = mode;
     document.body.classList.toggle("mode-view", mode === "view");
     document.body.classList.toggle("mode-edit", mode === "edit");
@@ -1151,6 +1173,9 @@
   // ---- save / export ----
   function updateSavedTag() { $("savedTag").textContent = S.saving ? "Saving…" : S.dirty ? "Unsaved changes" : (S.savedMtime ? "All changes saved" : ""); }
   async function doSave(kind = "auto", label = "") {
+    // Suppressed entirely on a read-only file (manual Save, ⌘S, autosave) —
+    // the badge explains why; only the deliberate paths get a toast too.
+    if (RO) { if (kind === "manual") toast("This file is read-only — use “Save a copy…” to keep changes."); return; }
     if (!S.view || S.saving) return;
     S.saving = true; updateSavedTag();
     try {
@@ -1168,6 +1193,9 @@
       await recordVersion(res.version_sha, html.length, kind, label);   // best-effort, never rejects
     } catch (e) {
       toast("Save failed: " + e.message);
+      // Mid-session chmod fallback: the writer's PermissionError arrives as a
+      // generic Error carrying its message — lock the UI like a boot verdict.
+      if (/is read-only/.test(e.message)) applyReadonly("Read-only", RO_TOOLTIP_DEFAULT);
     } finally { S.saving = false; updateSavedTag(); }
   }
   async function ensureTypst() {
@@ -1413,6 +1441,9 @@
   $("docTitle").textContent = BASENAME;
   $("topbar").classList.remove("hidden"); $("toolbar").classList.remove("hidden"); $("main").classList.remove("hidden");
   mountEditor(importedDoc);
+  // The reader's editability verdict (RO-4): lock before the initial setMode
+  // so a ?mode=edit URL lands in view mode with the badge explaining why.
+  if (res.editable === false) applyReadonly(res.readonly_message, res.readonly_tooltip);
   setMode(fused.params.get("mode") || "view");
   const panelParam = fused.params.get("panel");
   if (panelParam === "comments" || panelParam === "history") openPanel(panelParam);

--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -401,6 +401,22 @@ def _table_with_edits(con, pq, edits, ncols):
 
 # ---------- load ----------
 
+def _ro_verdict(file):
+    """Editability verdict for the viewed file (SPEC §13.5 RO-4).
+
+    Folded into every load payload so the UI can badge read-only files and
+    disable in-place saving while keeping viewing/export/save-as working.
+    """
+    if os.path.exists(file) and not os.access(file, os.W_OK):
+        return {
+            "editable": False,
+            "readonly_message": "Read-only",
+            "readonly_tooltip": "The file is read-only — its permissions "
+                                "don't allow writing, so it can't be edited here.",
+        }
+    return {"editable": True, "readonly_message": "", "readonly_tooltip": ""}
+
+
 def _sheet_view_out(ws):
     """Column widths (px) and frozen-row count from a worksheet."""
     from openpyxl.utils import column_index_from_string
@@ -444,7 +460,8 @@ def _load_rich(file):
         colw, freeze = _sheet_view_out(ws)
         sheets.append({"name": name, "rows": rows, "styles": styles, "big": False,
                        "colw": colw, "freeze": freeze})
-    return {"sheets": sheets, "mtime": os.path.getmtime(file), "rich": True}
+    return {"sheets": sheets, "mtime": os.path.getmtime(file), "rich": True,
+            **_ro_verdict(file)}
 
 
 def _load(file):
@@ -480,7 +497,8 @@ def _load(file):
             rows = [["" if v is None else v for v in r] for r in data] or [[""]]
             sheets.append({"name": sh["name"], "rows": rows, "styles": None, "big": False,
                            "kind": sh["kind"], "header": sh["header"]})
-    return {"sheets": sheets, "mtime": os.path.getmtime(file), "rich": False}
+    return {"sheets": sheets, "mtime": os.path.getmtime(file), "rich": False,
+            **_ro_verdict(file)}
 
 
 # ---------- save ----------
@@ -574,6 +592,14 @@ def _write_xlsx_streamed(dest, file, sheets_payload, meta):
 
 def _save(file, sheets_payload, expected_mtime):
     file = os.path.abspath(file)
+    # SPEC §13.5 RO-3: every branch below writes via tmp + os.replace, which
+    # goes through the (writable) parent dir and would silently bypass a
+    # chmod -w bit on the file itself — gate explicitly, before the conflict
+    # check (offering "Overwrite" on an unwritable file would be a lie).
+    # Existence-qualified: _save_as points here at a fresh dest, and
+    # os.access on a nonexistent path is False.
+    if os.path.exists(file) and not os.access(file, os.W_OK):
+        raise PermissionError(f"{file!r} is read-only")
     if expected_mtime and os.path.exists(file):
         on_disk = os.path.getmtime(file)
         if abs(on_disk - float(expected_mtime)) > 1e-6:

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -898,11 +898,13 @@ function restore(snap) {
   markDirty(); renderGrid();
 }
 function undo() {
+  if (roBlocked()) return;   // restore() mutates — only reachable after a mid-session RO flip
   if (!undoStack.length) return;
   redoStack.push(snapshot());
   restore(undoStack.pop());
 }
 function redo() {
+  if (roBlocked()) return;
   if (!redoStack.length) return;
   undoStack.push(snapshot());
   restore(redoStack.pop());
@@ -1242,6 +1244,7 @@ function renderTabs() {
     }
     t.onclick = () => { if (i !== cur) switchSheet(i); };
     t.ondblclick = () => {          // rename inline, no popup
+      if (roBlocked()) return;
       const inp = document.createElement("input");
       inp.value = sh.name;
       label.style.display = "none";
@@ -1318,10 +1321,7 @@ $("gridWrap").addEventListener("scroll", () => {
 function tdAt(r, c) { return tds.get(r + "," + c); }
 function startEdit(initial) {
   if (!book || editing) return;
-  if (readOnly) {
-    setStatus("Read-only — editing is disabled. Use File ▸ Save as… to edit a copy.", "err");
-    return;
-  }
+  if (roBlocked()) return;
   const { ar, ac } = sel;
   const td = tdAt(ar, ac); if (!td) return;
   const input = document.createElement("input");
@@ -1480,6 +1480,7 @@ function bigGuard(what) {
   return false;
 }
 function applyStyle(key, value) {
+  if (roBlocked()) return;
   if (bigGuard("Formatting")) return;
   pushUndo();
   const { r1, c1, r2, c2 } = normSel();
@@ -1516,6 +1517,9 @@ function sortSheet(dir) {
     return;
   }
   if (dir === "off") { setStatus("Clear sort applies to large sheets (small sheets sort in place).", ""); return; }
+  // Big-sheet sort above is a server-side view op and stays available on a
+  // read-only file; small sheets sort the model in place, so gate it (RO-5).
+  if (roBlocked()) return;
   pushUndo();
   ensureValues();
   const col = sel.ac;
@@ -1603,6 +1607,16 @@ function setReadOnly(ro, message, tooltip) {
   }
 }
 
+// Central RO gate (SPEC RO-5): every model-mutating entry point checks this,
+// so a read-only workbook can't accumulate edits it can never persist —
+// cell edits, formula bar, paste/cut/clear, fill, styles, row/col/sheet ops,
+// scripts. Viewing (sort on big sheets, filter, export, Save-as) stays open.
+function roBlocked() {
+  if (!readOnly) return false;
+  setStatus("Read-only — editing is disabled. Use File ▸ Save as… to edit a copy.", "err");
+  return true;
+}
+
 async function save(force) {
   const file = currentFile();
   if (!file || !book) return;
@@ -1645,6 +1659,12 @@ async function save(force) {
     setStatus(`Saved · ${new Date().toLocaleTimeString()}`, "ok");
   } catch (err) {
     setStatus(`${err.type || "error"}: ${err.message}`, "err");
+    // Mid-session chmod: the reader gate's PermissionError arrives as a
+    // generic error carrying its message — lock the UI like a load verdict.
+    if (/is read-only/.test(err.message || "")) {
+      setReadOnly(true, "Read-only",
+        "The file is read-only — its permissions don't allow writing, so it can't be edited here.");
+    }
   }
 }
 
@@ -1716,6 +1736,9 @@ function sheetApi(sh) {
   };
 }
 function runJs(code, out) {
+  // Scripts get live sheet references and mutate freely — the whole run is
+  // blocked on a read-only file rather than letting edits pile up unsaveable.
+  if (roBlocked()) { out.className = "err"; out.textContent = "Read-only file — scripts are disabled (they can edit the workbook)."; return; }
   pushUndo();
   const logs = [];
   const log = (...a) => logs.push(a.map((x) => (typeof x === "object" ? JSON.stringify(x) : String(x))).join(" "));
@@ -1739,6 +1762,7 @@ function runJs(code, out) {
   }
 }
 async function runPy(code, out) {
+  if (roBlocked()) { out.className = "err"; out.textContent = "Read-only file — scripts are disabled (they can edit the workbook)."; return; }
   out.className = ""; out.textContent = "Running…";
   const smalls = book.sheets.filter((sh) => !sh.big);
   if (!smalls.length) {
@@ -2039,6 +2063,13 @@ async function act(name) {
     },
     scripts: openScriptEditor,
   };
+  // View-safe actions only on a read-only file; everything else in the table
+  // above mutates the model (RO-5). `save` keeps its own, more specific gate;
+  // sort routes through sortSheet, which blocks only the in-place small-sheet
+  // branch (big-sheet sort is a server-side view op).
+  const RO_SAFE = new Set(["save", "saveAs", "dlCsv", "dlXlsx", "dlPdf", "dlParquet",
+                           "sortAsc", "sortDesc", "sortOff", "toggleFilter", "loadAll"]);
+  if (readOnly && !RO_SAFE.has(name) && roBlocked()) return;
   if (book) {
     if (!["save", "undo", "redo"].includes(name)) commitEdit();
     await acts[name]?.();
@@ -2123,7 +2154,9 @@ document.addEventListener("mouseup", () => {
     grip.classList.remove("on");
     S().colw = S().colw || {};
     S().colw[c] = parseFloat(colEl.style.width) || 90;
-    if (!isBig()) markDirty();   // widths persist into the xlsx on save
+    // Resizing stays available read-only (viewing convenience), but must not
+    // flip the dirty flag — widths only persist via a save that can't happen.
+    if (!isBig() && !readOnly) markDirty();   // widths persist into the xlsx on save
     colResizing = null;
   }
   dragging = false;
@@ -2158,6 +2191,7 @@ function jumpEdge(dr, dc, extend) {
 }
 // Ctrl+D / Ctrl+R: fill down/right from the selection's first row/column
 function fillShortcut(axis) {
+  if (roBlocked()) return;
   const { r1, c1, r2, c2 } = normSel();
   if (axis === "v" ? r2 === r1 : c2 === c1) return;
   const base = axis === "v" ? { r1, r2: r1, c1, c2 } : { r1, r2, c1, c2: c1 };
@@ -2208,12 +2242,14 @@ function selTSV() {
   return out.join("\n");
 }
 function clearSelCells() {
+  if (roBlocked()) return;   // cut degrades to copy on a read-only file
   pushUndo();
   const { r1, c1, r2, c2 } = normSel();
   for (let r = r1; r <= r2; r++) for (let c = c1; c <= c2; c++) setCell(r, c, "");
   markDirty(); paint();
 }
 function pasteText(text) {
+  if (roBlocked()) return;
   pushUndo();
   const lines = text.replace(/\r/g, "").split("\n");
   if (lines[lines.length - 1] === "") lines.pop();
@@ -2324,7 +2360,7 @@ $("fxInput").addEventListener("keydown", (e) => {
     if (editing) { editing.input.value = $("fxInput").value; commitEdit(); }
     else {
       const v = $("fxInput").value;
-      if (v !== raw(sel.ar, sel.ac)) { pushUndo(); setCell(sel.ar, sel.ac, v); markDirty(); paint(); }
+      if (v !== raw(sel.ar, sel.ac) && !roBlocked()) { pushUndo(); setCell(sel.ar, sel.ac, v); markDirty(); paint(); }
     }
     $("gridWrap").focus();
   } else if (e.key === "Escape") { acClose(); paintSel(); $("gridWrap").focus(); }

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <title>Excel editor</title>
+<script src="/template-shared/ro-badge.js"></script>
 <style>
   :root {
     --bg: #131417; --panel: #1b1d21; --panel2: #17181c; --head: #1e2025;
@@ -57,6 +58,9 @@
   .mi { padding: 6px 12px; border-radius: 5px; white-space: nowrap; display: flex; }
   .mi:hover { background: var(--accent); color: var(--on-accent); }
   .mi .kbd { margin-left: auto; color: var(--faint); font-size: 11px; padding-left: 24px; }
+  .mi.disabled { color: var(--faint); }
+  .mi.disabled:hover { background: none; color: var(--faint); }
+  /* .ro-badge / .ro-tip styles inject from /template-shared/ro-badge.js. */
   .mi:hover .kbd { color: var(--on-accent); opacity: .8; }
   .msep { border-top: 1px solid var(--border); margin: 5px 8px; }
   /* ---- toolbar ---- */
@@ -243,6 +247,7 @@
 <body>
   <div id="topbar">
     <span id="fileName">Excel editor</span>
+    <span id="ro" hidden></span>
     <span id="savedState"></span><span id="status"></span>
     <button class="tb" id="themeBtn" title="Toggle light / dark theme">◐ Light</button>
   </div>
@@ -374,6 +379,7 @@ let book = null;          // { sheets: [...] }  — small: {rows, styles}; big: 
 let cur = 0;
 let mtime = null;
 let dirty = false;
+let readOnly = false;      // reader verdict (SPEC §13.5): blocks in-place save + edit entry, never viewing
 let sel = { ar: 0, ac: 0, r1: 0, c1: 0, r2: 0, c2: 0 };
 let editing = null;
 let undoStack = [], redoStack = [];
@@ -1312,6 +1318,10 @@ $("gridWrap").addEventListener("scroll", () => {
 function tdAt(r, c) { return tds.get(r + "," + c); }
 function startEdit(initial) {
   if (!book || editing) return;
+  if (readOnly) {
+    setStatus("Read-only — editing is disabled. Use File ▸ Save as… to edit a copy.", "err");
+    return;
+  }
   const { ar, ac } = sel;
   const td = tdAt(ar, ac); if (!td) return;
   const input = document.createElement("input");
@@ -1553,6 +1563,7 @@ async function load() {
   $("fileName").title = file || "";
   if (!file) {
     book = null; markDirty(false);
+    setReadOnly(false, "", "");
     $("gridWrap").innerHTML = `<div id="emptyState">No workbook selected.<br><br>
       Open an .xlsx file from the explorer to edit it here.</div>`;
     $("tabs").innerHTML = "";
@@ -1566,6 +1577,7 @@ async function load() {
     if (seq !== loadSeq) return;
     normalizeLoaded(res);
     mtime = res.mtime;
+    setReadOnly(res.editable === false, res.readonly_message || "", res.readonly_tooltip || "");
     undoStack = []; redoStack = []; renderLimit = RENDER_CAP; invalidateValues();
     const want = fused.params.get("sheet");
     cur = Math.max(0, book.sheets.findIndex((s2) => s2.name === want));
@@ -1579,9 +1591,25 @@ async function load() {
   }
 }
 
+// Reader verdict → badge + disabled in-place save (SPEC §13.5 RO-4/RO-5).
+// Viewing, sort/filter, export and Save-as all stay available.
+function setReadOnly(ro, message, tooltip) {
+  readOnly = ro;
+  fusedRoBadge.update($("ro"), ro ? (message || "Read-only") : "", tooltip || "");
+  const mi = document.querySelector('#menubar .mi[data-act="save"]');
+  if (mi) {
+    mi.classList.toggle("disabled", ro);
+    mi.title = ro ? (tooltip || "") : "";
+  }
+}
+
 async function save(force) {
   const file = currentFile();
   if (!file || !book) return;
+  if (readOnly) {
+    setStatus("Read-only — the file can't be saved in place. Use File ▸ Save as… for a copy.", "err");
+    return;
+  }
   commitEdit();
   setStatus("Saving…");
   try {
@@ -1756,7 +1784,17 @@ async function loadScripts() {
 async function saveScripts(scripts) {
   const data = await loadSidecar();
   data.excel = { ...(data.excel || {}), scripts };
-  await fused.writeFile(sidecarPath(), JSON.stringify(data, null, 2));
+  try {
+    await fused.writeFile(sidecarPath(), JSON.stringify(data, null, 2));
+  } catch (err) {
+    // A read-only `<file>.json` sidecar 403s (SPEC RO-2); scripts still run,
+    // they just won't persist — non-fatal.
+    if (err && err.type === "readonly") {
+      setStatus("Script not saved — the scripts sidecar file is read-only.", "err");
+      return;
+    }
+    throw err;
+  }
 }
 
 async function openScriptEditor() {

--- a/fused_render/templates/latex/template.html
+++ b/fused_render/templates/latex/template.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>LaTeX</title>
+<script src="/template-shared/ro-badge.js"></script>
 <style>
   /* ---- Light Airtable-flavored design system (matches the source app) ---- */
   :root {
@@ -254,6 +255,7 @@
         <div id="gutterbar">
           <span class="fname" id="curFile">main.tex</span>
           <span class="dirty hidden" id="dirtyDot" title="Unsaved changes">●</span>
+          <span id="ro" hidden></span>
           <div class="spacer" style="flex:1"></div>
           <span class="muted" id="cursorPos" style="font-size:11px"></span>
         </div>
@@ -337,6 +339,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
     mainAbs: FILE,          // the entrypoint this template was opened for (fixed for its lifetime)
     fileAbs: "",            // currently open buffer (abs) — may be an \input child
     mtime: 0,               // optimistic-lock mtime of the open buffer
+    writable: true,         // stat.writable of the open buffer — false locks the editor (SPEC §13.5)
     tree: [], outline: null, bib: [],
     pdf: null, scale: 1.0, lastPdf: "",
     compiling: false, pendingCompile: false,
@@ -421,29 +424,37 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
   const editParent = $("editor");
   function makeEditor(doc) {
     if (S.view) { S.view.destroy(); S.view = null; }
-    const state = CM.EditorState.create({
-      doc,
-      extensions: [
-        CM.lineNumbers(), CM.highlightActiveLine(), CM.highlightActiveLineGutter(),
-        CM.history(), CM.drawSelection(), CM.dropCursor(),
-        CM.bracketMatching(), CM.closeBrackets(), CM.codeFolding(), CM.foldGutter(),
-        CM.highlightSelectionMatches(),
-        CM.StreamLanguage.define(CM.stex),
-        CM.syntaxHighlighting(stexHL),
-        CM.autocompletion({ override: [latexCompletions] }),
-        CM.keymap.of([
-          { key: "Mod-s", preventDefault: true, run: () => { saveNow(); return true; } },
-          { key: "Mod-Enter", preventDefault: true, run: () => { compile(); return true; } },
-          ...CM.closeBracketsKeymap, ...CM.defaultKeymap, ...CM.historyKeymap,
-          ...CM.searchKeymap, ...CM.completionKeymap, ...CM.foldKeymap, CM.indentWithTab,
-        ]),
-        lightTheme, CM.syntaxHighlighting(stexHL),
-        CM.EditorView.updateListener.of((u) => {
-          if (u.docChanged) onEdit();
-          if (u.selectionSet || u.docChanged) { updateCursor(); scheduleSync(); }
-        }),
-      ],
-    });
+    const extensions = [
+      CM.lineNumbers(), CM.highlightActiveLine(), CM.highlightActiveLineGutter(),
+      CM.history(), CM.drawSelection(), CM.dropCursor(),
+      CM.bracketMatching(), CM.closeBrackets(), CM.codeFolding(), CM.foldGutter(),
+      CM.highlightSelectionMatches(),
+      CM.StreamLanguage.define(CM.stex),
+      CM.syntaxHighlighting(stexHL),
+      CM.autocompletion({ override: [latexCompletions] }),
+      CM.keymap.of([
+        { key: "Mod-s", preventDefault: true, run: () => { saveNow(); return true; } },
+        { key: "Mod-Enter", preventDefault: true, run: () => { compile(); return true; } },
+        ...CM.closeBracketsKeymap, ...CM.defaultKeymap, ...CM.historyKeymap,
+        ...CM.searchKeymap, ...CM.completionKeymap, ...CM.foldKeymap, CM.indentWithTab,
+      ]),
+      lightTheme, CM.syntaxHighlighting(stexHL),
+      CM.EditorView.updateListener.of((u) => {
+        if (u.docChanged) onEdit();
+        if (u.selectionSet || u.docChanged) { updateCursor(); scheduleSync(); }
+      }),
+    ];
+    // Read-only file (SPEC §13.5): lock the buffer so dirty can never flip and
+    // no save path (autosave, Mod-s) ever fires. The server refuses the write
+    // anyway (403 readonly); this makes the UI honest up front. Both facets:
+    // editable=false locks the DOM (caret, typing), readOnly=true rejects the
+    // transactions synthesized input can still smuggle past it. The editor is
+    // rebuilt per openFile, so the facets are simply included conditionally.
+    if (!S.writable) {
+      extensions.push(CM.EditorView.editable.of(false));
+      extensions.push(CM.EditorState.readOnly.of(true));
+    }
+    const state = CM.EditorState.create({ doc, extensions });
     S.view = new CM.EditorView({ state, parent: editParent });
   }
   function updateCursor() {
@@ -456,12 +467,15 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
   // =========================================================== edit / save
   const scheduleSave = debounce(() => saveNow(), 1200);
   const scheduleCompileAfterSave = debounce(() => compile(), 1600);
+  const RO_TOOLTIP = "The file is read-only — its permissions don't allow writing, so it can't be edited here.";
+  const showRoBadge = (on) => fusedRoBadge.update($("ro"), on ? "Read-only" : "", on ? RO_TOOLTIP : "");
   function onEdit() {
+    if (!S.writable) return;  // read-only buffer never arms autosave (belt — the locked facets are braces)
     S.dirty = true; $("dirtyDot").classList.remove("hidden");
     scheduleSave(); scheduleCompileAfterSave();
   }
   async function saveNow() {
-    if (!S.view || !S.fileAbs || !S.dirty) return;
+    if (!S.view || !S.fileAbs || !S.dirty || !S.writable) return;
     const text = S.view.state.doc.toString();
     try {
       const st = await fused.writeFile(S.fileAbs, text, S.mtime ? { expectedMtime: S.mtime } : undefined);
@@ -470,6 +484,13 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
       if (err.type === "conflict") {
         // The file changed on disk (an AI/agent or git edit) — reload it.
         toast("File changed on disk — reloaded external edits."); await openFile(S.fileAbs);
+      } else if (err.type === "readonly") {
+        // chmod -w mid-session: the buffer was built writable, so lock the save
+        // paths (S.writable gates onEdit/saveNow) and surface the state. The
+        // buffer stays editable until the next openFile re-checks stat.writable.
+        S.writable = false;
+        showRoBadge(true);
+        toast("File is read-only — not saved.");
       } else { toast("Save failed: " + err.message); }
     }
   }
@@ -687,6 +708,8 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
       const st = await fused.stat(abs);
       const text = await fused.readFile(abs);
       S.fileAbs = abs; S.mtime = st.mtime; S.dirty = false; $("dirtyDot").classList.add("hidden");
+      S.writable = st.writable !== false; // absent field (older server) → editable
+      showRoBadge(!S.writable);           // badge tracks the OPEN buffer; hide again on a writable file
       $("curFile").textContent = baseName(abs);
       makeEditor(text); updateCursor();
       addOpenFile(abs); renderTree();

--- a/fused_render/templates/latex/template.html
+++ b/fused_render/templates/latex/template.html
@@ -485,11 +485,15 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
         // The file changed on disk (an AI/agent or git edit) — reload it.
         toast("File changed on disk — reloaded external edits."); await openFile(S.fileAbs);
       } else if (err.type === "readonly") {
-        // chmod -w mid-session: the buffer was built writable, so lock the save
-        // paths (S.writable gates onEdit/saveNow) and surface the state. The
-        // buffer stays editable until the next openFile re-checks stat.writable.
+        // chmod -w mid-session: the buffer was built writable. Flag it and
+        // rebuild the editor from the CURRENT buffer text (not disk) so the
+        // read-only facets actually lock typing — otherwise edits would look
+        // accepted while onEdit/saveNow silently no-op, and be lost on the
+        // next buffer switch. Unsaved text stays on screen for copy-out; the
+        // dirty dot stays lit because those edits genuinely aren't on disk.
         S.writable = false;
         showRoBadge(true);
+        makeEditor(S.view.state.doc.toString());  // live doc, not the snapshot — keeps edits typed during the failed write
         toast("File is read-only — not saved.");
       } else { toast("Save failed: " + err.message); }
     }

--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -245,6 +245,11 @@ def _save(doc, force):
         raise ValueError("open the document first")
     if not meta.get("dirty"):
         return {"ok": True, "dirty": False, "file": _fwd(src), "unchanged": True}
+    # RO gate (SPEC §13.5 RO-3) before the conflict check: the write below goes
+    # through the parent directory (`os.replace`) and would silently overwrite
+    # a chmod -w original — and the conflict dialog's "force" must not either.
+    if os.path.isfile(src) and not os.access(src, os.W_OK):
+        raise PermissionError(f"{src!r} is read-only")
     if not force and os.path.isfile(src) and os.path.getmtime(src) != meta["base_mtime"]:
         return {"conflict": True}
     tmp = src + ".tmp"
@@ -1055,6 +1060,14 @@ def main(
         else:
             info["has_text"] = False
         info["undo_depth"], info["redo_depth"] = _stack_depths(p)
+        # RO verdict (SPEC §13.5 RO-4): fs writability of the ORIGINAL. Edits
+        # keep working (they hit the working copy) — only save/rename/delete
+        # back to the original are gated, so the tooltip points at Save a copy.
+        info["writable"] = os.access(p, os.W_OK)
+        info["readonly_message"] = "" if info["writable"] else "Read-only"
+        info["readonly_tooltip"] = "" if info["writable"] else (
+            "The file is read-only — edits can't be saved back to it. "
+            "Use Save a copy.")
         return info
     if action == "which_project":
         p = os.path.normcase(os.path.realpath(os.path.abspath(doc)))
@@ -1085,6 +1098,11 @@ def main(
         else:
             if not os.path.isfile(p):
                 raise ValueError(f"no such file: {p}")
+            # RO gate (SPEC §13.5 RO-3): os.remove is a parent-directory op and
+            # would silently delete a chmod -w file. Linked docs (branch above)
+            # only edit project metadata, so they are not gated.
+            if not os.access(p, os.W_OK):
+                raise PermissionError(f"{p!r} is read-only")
             os.remove(p)
         shutil.rmtree(_hist_dir(p), ignore_errors=True)
         _work_drop(p)
@@ -1096,6 +1114,10 @@ def main(
             raise ValueError("rename needs a name")
         if not n.lower().endswith(".pdf"):
             n += ".pdf"
+        # RO gate (SPEC §13.5 RO-3): os.rename is a parent-directory op and
+        # would silently move a chmod -w file.
+        if os.path.isfile(p) and not os.access(p, os.W_OK):
+            raise PermissionError(f"{p!r} is read-only")
         dest = _unique_path(os.path.dirname(p), n)
         os.rename(p, dest)
         _work_rename(p, dest)

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -218,6 +218,7 @@
   #banner { background: #fff7e8; border-bottom: 1px solid #f2dfb8; color: #8a6116; padding: 7px 14px;
     font-size: 12.5px; flex: 0 0 auto; }
 </style>
+<script src="/template-shared/ro-badge.js"></script>
 </head>
 <body class="mode-edit">
 <div id="boot">Loading PDF Studio…</div>
@@ -233,6 +234,7 @@
     <div class="pop hidden" id="projMenu"></div>
   </div>
   <span id="docName"></span>
+  <span id="ro" hidden></span>
   <span id="docPages"></span>
   <div class="spacer"></div>
   <div id="status"><span class="dot"></span><span class="txt">idle</span></div>
@@ -252,7 +254,7 @@
     <div class="mi" data-act="importUrl">Import from URL…</div>
     <div class="mi" data-act="openPath">Open anywhere… <span class="kbd">Ctrl+O</span></div>
     <div class="divider"></div>
-    <div class="mi" data-act="save">Save <span class="kbd">Ctrl+S</span></div>
+    <div class="mi" data-act="save" id="miSave">Save <span class="kbd">Ctrl+S</span></div>
     <div class="mi" data-act="revert">Revert to saved</div>
     <div class="mi" data-act="saveAs">Save a copy… <span class="kbd">Ctrl+Shift+S</span></div>
     <div class="divider"></div>
@@ -322,6 +324,7 @@ const state = {
   docs: [], doc: "", work: "", info: null, mtime: 0, dirty: false,
   pdf: null, curPage: 1, zoom: 100,
   standalone: false, undoDepth: 0, redoDepth: 0,
+  writable: true,     // fs writability of the ORIGINAL (open_doc verdict)
   spans: {},          // pageNo -> {mtime, spans}
   editing: null,      // the floating text input, if any
 };
@@ -791,10 +794,14 @@ function renderDocList() {
     row.className = "doc-row" + (d.path === state.doc ? " on" : "");
     const meta = d.missing ? `<span class="meta" style="color:var(--danger)">missing</span>`
       : `<span class="meta">${d.page_count ?? "?"}p · ${fmtSize(d.size)}</span>`;
+    // Writability is only known for the open doc (open_doc's verdict). Hide
+    // rename/delete for a read-only original; unlink (linked docs) only edits
+    // project metadata, so it stays available.
+    const ro = d.path === state.doc && !state.writable;
     row.innerHTML = `<span class="nm"></span>${meta}
       <span class="ops">
-        <button title="Rename" data-op="rename">${icoPen}</button>
-        <button title="${d.linked ? "Remove from project" : "Delete"}" data-op="delete" class="danger">${icoTrash}</button>
+        ${ro ? "" : `<button title="Rename" data-op="rename">${icoPen}</button>`}
+        ${ro && !d.linked ? "" : `<button title="${d.linked ? "Remove from project" : "Delete"}" data-op="delete" class="danger">${icoTrash}</button>`}
       </span>`;
     row.title = d.path;
     row.querySelector(".nm").textContent = d.name;
@@ -817,6 +824,12 @@ async function openDoc(path) {
   state.undoDepth = info.undo_depth; state.redoDepth = info.redo_depth;
   setStatus(state.dirty ? "unsaved changes" : "", state.dirty ? "warn" : "");
   $("docName").textContent = info.name;
+  // Read-only original (§13.5): viewing and working-copy edits (rotate, text,
+  // undo/redo, revert, export, save-a-copy) stay fully allowed — only writes
+  // back to the original (Save, Rename, Delete) are blocked.
+  state.writable = info.writable !== false;
+  fusedRoBadge.update($("ro"), info.readonly_message || "", info.readonly_tooltip || "");
+  $("miSave").classList.toggle("off", !state.writable);
   $("banner").classList.toggle("hidden", info.has_text);
   if (!info.has_text) $("banner").textContent =
     "This PDF has no text layer (likely scanned) — page operations work, text editing won't find anything to edit.";
@@ -964,6 +977,8 @@ const acts = {
     toast("Added to project");
   },
   renameDoc: async (d) => {
+    if (d.path === state.doc && !state.writable)
+      return toast("The file is read-only — it can't be renamed", true);
     const name = await dialog({ title: "Rename PDF", value: d.name, okText: "Rename" });
     if (!name || name === d.name) return;
     const res = await py({ action: "rename_doc", doc: d.path, name, project: state.project });
@@ -971,6 +986,8 @@ const acts = {
     await refreshDocList();
   },
   deleteDoc: async (d) => {
+    if (d.path === state.doc && !state.writable && !d.linked)
+      return toast("The file is read-only — it can't be deleted", true);
     const ok = await dialog({
       title: d.linked ? `Remove ${d.name}?` : `Delete ${d.name}?`,
       input: false, danger: true, okText: d.linked ? "Remove" : "Delete",
@@ -988,6 +1005,8 @@ const acts = {
   },
   save: async () => {
     needDoc();
+    if (!state.writable)  // also covers the Ctrl+S path (keydown → act("save"))
+      return toast("The file is read-only — edits can't be saved back to it. Use Save a copy.", true);
     let res = await py({ action: "save", doc: state.doc });
     if (res.conflict) {
       const ok = await dialog({ title: "Overwrite changed file?", input: false, danger: true, okText: "Overwrite",

--- a/fused_render/templates/slides/slides.py
+++ b/fused_render/templates/slides/slides.py
@@ -151,6 +151,31 @@ def _save_sidecar(file, data):
         raise
 
 
+def _sidecar_writable(file):
+    """True iff _save_sidecar would succeed (SPEC RO-3, annotate's rule): an
+    existing sidecar needs W_OK on itself (the mkstemp + os.replace above would
+    otherwise bypass its read-only bit via the directory), a fresh one needs
+    W_OK on the directory (mkstemp and replace both land there)."""
+    path = _sidecar_path(os.path.abspath(file))
+    if os.path.exists(path):
+        return os.access(path, os.W_OK)
+    return os.access(os.path.dirname(path), os.W_OK)
+
+
+_READONLY_TOOLTIP = ("The file is read-only — its permissions don't allow "
+                     "writing, so it can't be edited here.")
+
+
+def _editability(file):
+    """RO-4 verdict folded into the open response:
+    (editable, readonly_message, readonly_tooltip). Read-only gates only the
+    explicit save-overwrite of the .pptx — model edits live in the cache and
+    stay allowed — but the UI surfaces the verdict up front."""
+    if os.path.exists(file) and not os.access(file, os.W_OK):
+        return False, "Read-only", _READONLY_TOOLTIP
+    return True, "", ""
+
+
 def _get_title(file):
     return _load_sidecar(file).get("slides", {}).get("title") or None
 
@@ -204,9 +229,13 @@ def main(action: str = "open",
             model = engine.parse_pptx(file, media_dir, "media")
             with open(mp, "w", encoding="utf-8") as f:
                 json.dump(model, f, ensure_ascii=False)
+        editable, ro_msg, ro_tip = _editability(file)
         return {"doc": d, "model": model, "mtime": os.path.getmtime(mp),
                 "media_dir": _media_dir(d).replace(os.sep, "/"),
-                "title": _get_title(file)}
+                "title": _get_title(file),
+                "editable": editable, "readonly_message": ro_msg,
+                "readonly_tooltip": ro_tip,
+                "sidecar_writable": _sidecar_writable(file)}
 
     # ----------------------------------------- directory browser (Save as)
     if action == "listdir":
@@ -531,6 +560,11 @@ def main(action: str = "open",
     # --------- Save = materialize model -> `file` itself (atomic overwrite)
     if action == "save":
         file = _to_native_path(file)
+        # RO-3 fs gate FIRST (before _load_model and the mkstemp below): the
+        # atomic tempfile-in-parent-dir + os.replace would otherwise silently
+        # overwrite a chmod -w file via the directory's write bit.
+        if os.path.exists(file) and not os.access(file, os.W_OK):
+            raise PermissionError(f"{file!r} is read-only")
         model = _load_model(doc)
         tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(file) or ".", suffix=".pptx.tmp")
         os.close(tmp_fd)
@@ -566,6 +600,10 @@ def main(action: str = "open",
     # ---------------------------------------------------------------- sidecar
     if action == "set_title":
         file = _to_native_path(file)
+        # RO-3 gate on the actual write target (RO-6): the title lives in the
+        # <file>.json sidecar, so it's the sidecar's writability that counts.
+        if not _sidecar_writable(file):
+            raise PermissionError(f"{_sidecar_path(file)!r} is read-only")
         _set_title(file, title)
         return {"ok": True, "title": title or None}
 

--- a/fused_render/templates/slides/template.html
+++ b/fused_render/templates/slides/template.html
@@ -4,6 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Slides Studio</title>
+<script src="/template-shared/ro-badge.js"></script>
 <style>
   :root{
     /* Svelte/D3-flavored: recessive neutral chrome, one warm flame accent
@@ -306,6 +307,7 @@
       <button class="btn ghost icon" id="redoBtn" title="Redo (Ctrl+Y)"><svg viewBox="0 0 24 24"><path d="M15 14l5-5-5-5"/><path d="M20 9H9a5 5 0 0 0 0 10h1"/></svg></button>
       <div id="deckName" contenteditable="true" spellcheck="false" title="Rename deck"></div>
       <div class="spacer"></div>
+      <span id="ro" hidden></span>
       <span class="saved" id="saved"></span>
       <button class="btn" id="presentBtn" title="Present (from current slide)"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>Present</button>
       <div class="seg" id="modeSeg">
@@ -450,7 +452,8 @@
 
   // ---------------- state ----------------
   const S={ doc:null, title:null, model:null, mediaDir:"", mtime:0, cur:0, sel:null, selIds:[],
-            tcell:null, scale:1, mode:"view", undo:[], redo:[], dirty:false };
+            tcell:null, scale:1, mode:"view", undo:[], redo:[], dirty:false,
+            editable:true, sidecarWritable:true };
   window.__S=S;   // exposed for programmatic / AI-driven inspection of live state
 
   // ---------------- small utils ----------------
@@ -1024,6 +1027,16 @@
     $("welcome").classList.add("hidden");
     $("app").classList.remove("home");
     $("deckName").textContent=S.title||DEFAULT_TITLE;
+    // Read-only verdict (SPEC RO-4/RO-5): viewing and model editing (cache
+    // autosave) stay live; only the explicit .pptx overwrite is refused.
+    S.editable=p.editable!==false; S.sidecarWritable=p.sidecar_writable!==false;
+    fusedRoBadge.update($("ro"), S.editable?"":(p.readonly_message||"Read-only"),
+      S.editable?"":((p.readonly_tooltip||"")+" Changes can be saved to a new file via File ▸ Save as."));
+    document.querySelector('#fileMenu [data-file="save"]').disabled=!S.editable;
+    // The deck title lives in the <file>.json sidecar — gate the rename UI on
+    // ITS writability (RO-6), independent of the .pptx verdict.
+    $("deckName").contentEditable=S.sidecarWritable?"true":"false";
+    $("deckName").title=S.sidecarWritable?"Rename deck":"Rename disabled — the deck's sidecar file is read-only";
     $("saved").textContent="All changes saved";
     preloadFonts(S.model);
     setMode(fused.params.get("mode")||"view");
@@ -1045,6 +1058,7 @@
     else if(a==="saveas") saveAsDeck();
   }
   async function saveDeck(){ if(!S.doc)return;
+    if(!S.editable){ toast("Read-only — the file can't be overwritten. Use File ▸ Save as."); return; }
     await doSave();
     try{ $("saved").textContent="Saving…"; const r=await py({action:"save",doc:S.doc,file:FILE});
       S.doc=r.doc;
@@ -1155,6 +1169,10 @@
     document.addEventListener("fullscreenchange",()=>{ if(P.on&&!document.fullscreenElement)exitPresent(); });
     window.addEventListener("resize",()=>{ if(P.on)renderPresent(); });
     $("deckName").onblur=async()=>{ const n=$("deckName").textContent.trim();
+      if(!S.sidecarWritable){ // belt-and-braces: contentEditable is already off
+        $("deckName").textContent=S.title||DEFAULT_TITLE;
+        if(n!==(S.title||DEFAULT_TITLE)) toast("Read-only — the deck can't be renamed");
+        return; }
       const t=(n&&n!==DEFAULT_TITLE)?n:"";
       try{ await py({action:"set_title",file:FILE,title:t}); S.title=t||null; }
       catch(e){ toast("Rename failed: "+e.message); } };

--- a/fused_render/templates/usd/reader.py
+++ b/fused_render/templates/usd/reader.py
@@ -47,6 +47,16 @@ def _cache_dir(source):
     return os.path.join(CACHE_ROOT, f"{safe}-{key}")
 
 
+def _sidecar_writable(file):
+    """True iff the JS-side settings sidecar (`<file>.json`, SPEC §13.5 RO-6)
+    can be written: an existing sidecar needs W_OK on itself, a fresh one
+    needs W_OK on the directory the write would land in."""
+    path = os.path.abspath(file) + ".json"
+    if os.path.exists(path):
+        return os.access(path, os.W_OK)
+    return os.access(os.path.dirname(path), os.W_OK)
+
+
 def _read_json(path):
     try:
         with open(path) as f:
@@ -112,13 +122,17 @@ def main(action: str = "inspect", file: str = "", budget: int = 1000000,
     direct = direct_splat or direct_mesh
 
     if action == "inspect":
+        # Remote URLs have no on-disk sidecar target — report writable so the
+        # template never shows a spurious read-only badge for them.
+        sidecar_ok = True if is_url else _sidecar_writable(file)
         if direct:
             return {"kind": "mesh-direct" if direct_mesh else "splat-direct",
                     "ext": ext, "ready": True,
-                    "size": None if is_url else os.path.getsize(file)}
+                    "size": None if is_url else os.path.getsize(file),
+                    "sidecar_writable": sidecar_ok}
         cd = _cache_dir(file)
         out = _state(cd, budget, crop)
-        out.update({"kind": "usd", "ext": ext})
+        out.update({"kind": "usd", "ext": ext, "sidecar_writable": sidecar_ok})
         return out
 
     if action == "prepare":

--- a/fused_render/templates/usd/template.html
+++ b/fused_render/templates/usd/template.html
@@ -184,6 +184,7 @@
   ::-webkit-scrollbar-thumb { background: #3a3a40; border-radius: 4px; }
   ::-webkit-scrollbar-track { background: transparent; }
 </style>
+<script src="/template-shared/ro-badge.js"></script>
 </head>
 <body>
   <div id="topbar">
@@ -335,6 +336,7 @@
 
   <div id="statusbar">
     <span id="statusMsg">booting…</span>
+    <span id="ro" hidden></span>
     <div id="statusProg"><div id="statusProgFill"></div></div>
     <span id="fps"></span>
   </div>
@@ -434,6 +436,18 @@
   let pendingCamera = null;
   let initialCameraApplied = false;
 
+  // Read-only sidecar (SPEC §13.5 RO-6): the viewed asset is never written,
+  // so read-onlyness never blocks viewing — settings/camera just stop being
+  // remembered, with a visible warning instead of doomed 403 writes.
+  let sidecarWritable = true;
+  function markSidecarReadonly() {
+    sidecarWritable = false;
+    const name = sidecarPath.split(/[\\/]/).pop();
+    fusedRoBadge.update(document.getElementById("ro"), "Settings not saved",
+      "The file's settings sidecar (" + name + ") is read-only, so viewer " +
+      "settings and camera position won't be remembered.");
+  }
+
   async function loadSidecar() {
     if (!sidecarPath) return;
     let saved;
@@ -450,7 +464,7 @@
     sidecarSaveTimer = setTimeout(saveSidecar, 800);
   }
   async function saveSidecar() {
-    if (!sidecarPath) return;
+    if (!sidecarPath || !sidecarWritable) return;
     let doc = {};
     try { doc = JSON.parse(await fused.readFile(sidecarPath)) || {}; }
     catch (e) { /* new sidecar */ }
@@ -460,7 +474,12 @@
     } };
     for (const k of SIDECAR_FIELDS) doc.usd[k] = P.get(k);
     try { await fused.writeFile(sidecarPath, JSON.stringify(doc, null, 2)); }
-    catch (e) { console.warn("usd sidecar save failed:", e.message); }
+    catch (e) {
+      // Mid-session chmod: the server's 403 backstop (RO-2) surfaces as a
+      // typed error — flip the badge on and stop retrying doomed saves.
+      if (e.type === "readonly") markSidecarReadonly();
+      else console.warn("usd sidecar save failed:", e.message);
+    }
   }
 
   // ------------------------------------------------------------ three.js ---
@@ -1040,6 +1059,9 @@
     catch (e) { setOverlay("Inspect failed", e.message, 0); removeScene(s); return; }
     if (token !== loadToken) { removeScene(s); return; }
     if (info.error) { setOverlay("Cannot load", info.error, 0); removeScene(s); return; }
+    // Only the target file's inspect speaks for the sidecar (`FILE + ".json"`)
+    // — extra imported scenes don't gate settings persistence.
+    if (file === FILE && info.sidecar_writable === false) markSidecarReadonly();
     s.kind = info.kind;
 
     // .splat/.ksplat: feed straight to the splat renderer

--- a/tests/test_docs_readonly.py
+++ b/tests/test_docs_readonly.py
@@ -1,0 +1,63 @@
+"""Read-only file support in the docs template (SPEC §13.5).
+
+docs.py is a runPython target, loaded here via importlib like
+test_annotate_comments.py. The test venv has no pypandoc/pandoc, so every test
+exercises only code paths that raise or return BEFORE any pandoc call:
+
+- RO-3: the "save" action must gate on os.access(file, W_OK) and raise
+  PermissionError before writing anything (its tmp + os.replace pipeline goes
+  through the parent directory and would silently bypass a chmod -w file bit).
+- RO-4: the reader verdict — extracted as the _editability() helper used by the
+  "import" action — folds fs writability into editable/readonly_message/
+  readonly_tooltip.
+"""
+import importlib.util
+import os
+
+import pytest
+
+
+def _load_docs():
+    path = os.path.join("fused_render", "templates", "docs", "docs.py")
+    spec = importlib.util.spec_from_file_location("docs_target", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def docs():
+    return _load_docs()
+
+
+@pytest.fixture
+def docx(tmp_path):
+    """A fake .docx target; chmod is restored on teardown so tmp cleanup works."""
+    f = tmp_path / "doc.docx"
+    f.write_bytes(b"original-docx-bytes")
+    yield str(f)
+    os.chmod(str(f), 0o644)
+
+
+def test_save_readonly_file_raises_permission_error(docs, docx):
+    os.chmod(docx, 0o444)
+    with pytest.raises(PermissionError):
+        docs.main(action="save", file=docx, html="<p>hello</p>")
+    # The guard fired before any tmp-write/os.replace: bytes untouched, no tmp left.
+    assert open(docx, "rb").read() == b"original-docx-bytes"
+    assert not os.path.exists(docx + ".tmp")
+
+
+def test_editability_writable(docs, docx):
+    editable, message, tooltip = docs._editability(docx)
+    assert editable is True
+    assert message == ""
+    assert tooltip == ""
+
+
+def test_editability_readonly(docs, docx):
+    os.chmod(docx, 0o444)
+    editable, message, tooltip = docs._editability(docx)
+    assert editable is False
+    assert message == "Read-only"
+    assert "read-only" in tooltip

--- a/tests/test_excel_readonly.py
+++ b/tests/test_excel_readonly.py
@@ -1,0 +1,94 @@
+"""Read-only-file contract for the excel template (SPEC §13.5).
+
+reader.py is a runPython target, not a package module, so — like
+test_annotate_comments.py — these load it via importlib and drive its
+functions directly against tmp_path files.
+
+Under test:
+* RO-3 writer gate: `_save` refuses a chmod -w viewed file with
+  PermissionError BEFORE any tmp-write (the tmp + os.replace path goes
+  through the parent dir and would silently bypass the file's read-only bit).
+  A NONEXISTENT dest (the save_as flow) is NOT gated — os.access(missing,
+  W_OK) is False, so the gate must be existence-qualified.
+* RO-4 reader verdict: `_load` folds fs writability into
+  editable/readonly_message/readonly_tooltip.
+
+Test-env note: no openpyxl/fpdf2 here, so everything runs through .csv
+(stdlib csv for small saves; duckdb — which IS installed — for _load's cache).
+"""
+import importlib.util
+import os
+import stat
+
+import pytest
+
+
+def _load_reader():
+    path = os.path.join("fused_render", "templates", "excel", "reader.py")
+    spec = importlib.util.spec_from_file_location("excel_reader", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+CSV_BODY = "a,b\n1,2\n3,4\n"
+
+
+def _csv(tmp_path, name="data.csv"):
+    f = tmp_path / name
+    f.write_text(CSV_BODY)
+    return f
+
+
+def _small_payload():
+    return [{"name": "data", "big": False, "rows": [["x", "y"], ["9", "8"]]}]
+
+
+def test_save_readonly_csv_raises_and_leaves_bytes_untouched(tmp_path):
+    rd = _load_reader()
+    f = _csv(tmp_path)
+    os.chmod(f, 0o444)
+    try:
+        with pytest.raises(PermissionError, match="read-only"):
+            rd._save(str(f), _small_payload(), "")
+        assert f.read_text() == CSV_BODY
+        # no tmp turd left behind either
+        assert not os.path.exists(str(f) + ".tmp")
+    finally:
+        os.chmod(f, stat.S_IWUSR | stat.S_IRUSR)
+
+
+def test_save_to_nonexistent_dest_is_not_gated(tmp_path):
+    # save_as calls _save on a fresh user-chosen dest; os.access on a missing
+    # file is False, so an unqualified gate would break save_as entirely.
+    rd = _load_reader()
+    dest = tmp_path / "copy.csv"
+    out = rd._save(str(dest), _small_payload(), "")
+    assert out.get("ok") is True
+    assert dest.exists()
+    assert dest.read_text().splitlines() == ["x,y", "9,8"]
+
+
+def test_load_writable_csv_is_editable(tmp_path):
+    rd = _load_reader()
+    f = _csv(tmp_path)
+    res = rd._load(str(f))
+    assert res["editable"] is True
+    assert res["readonly_message"] == ""
+    assert res["readonly_tooltip"] == ""
+
+
+def test_load_readonly_csv_reports_readonly_verdict(tmp_path):
+    rd = _load_reader()
+    f = _csv(tmp_path)
+    os.chmod(f, 0o444)
+    try:
+        res = rd._load(str(f))
+        assert res["editable"] is False
+        assert res["readonly_message"] == "Read-only"
+        assert "read-only" in res["readonly_tooltip"]
+        assert "permissions" in res["readonly_tooltip"]
+        # read-only never blocks viewing: rows still come back
+        assert res["sheets"] and res["sheets"][0]["rows"]
+    finally:
+        os.chmod(f, stat.S_IWUSR | stat.S_IRUSR)

--- a/tests/test_pdf_studio_readonly.py
+++ b/tests/test_pdf_studio_readonly.py
@@ -1,0 +1,123 @@
+"""Read-only-file gating for the pdf_studio template (SPEC §13.5, RO-3).
+
+pdf.py is a stdlib-at-import runPython target (pikepdf/pymupdf are lazy
+imports), so — like test_annotate_comments.py — these load it via importlib and
+drive `_save`/`main` directly. The write model: edits go to a working copy
+under WORKDIR; only save/rename/delete touch the ORIGINAL, and all three do it
+via parent-directory-level ops (`os.replace`, `os.rename`, `os.remove`) that
+silently succeed on a chmod -w file — hence the explicit `os.access(..., W_OK)`
+gate must raise PermissionError BEFORE the operation.
+
+The module keeps state dirs under ~/.fused-render at module level; every test
+repoints those attributes at tmp_path so nothing touches the real home.
+"""
+import importlib.util
+import os
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PDF_PY = os.path.join(HERE, os.pardir, "fused_render", "templates",
+                      "pdf_studio", "pdf.py")
+
+
+def _load_pdf(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location("pdf_studio_target", PDF_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # Repoint every module-level state dir into tmp_path (never the real home).
+    data_root = str(tmp_path / "data")
+    cache_root = str(tmp_path / "cache")
+    monkeypatch.setattr(mod, "DATA_ROOT", data_root)
+    monkeypatch.setattr(mod, "CACHE_ROOT", cache_root)
+    monkeypatch.setattr(mod, "PROJECTS", os.path.join(data_root, "projects"))
+    monkeypatch.setattr(mod, "EXPORTS", os.path.join(cache_root, "exports"))
+    monkeypatch.setattr(mod, "SNAPSHOTS", os.path.join(cache_root, "snapshots"))
+    monkeypatch.setattr(mod, "WORKDIR", os.path.join(cache_root, "work"))
+    return mod
+
+
+def _original(tmp_path, content=b"%PDF-original"):
+    f = tmp_path / "docs" / "sample.pdf"
+    f.parent.mkdir()
+    f.write_bytes(content)
+    return f
+
+
+def test_save_readonly_original_raises_and_leaves_file(tmp_path, monkeypatch):
+    mod = _load_pdf(tmp_path, monkeypatch)
+    f = _original(tmp_path)
+    src = str(f)
+    # Fabricate an opened, dirty doc without pikepdf: working copy + state.
+    os.makedirs(mod.WORKDIR, exist_ok=True)
+    wpath, _ = mod._work_paths(src)
+    with open(wpath, "wb") as out:
+        out.write(b"%PDF-edited-working-copy")
+    mod._work_save_state(src, {"src": src.replace(os.sep, "/"),
+                               "base_mtime": os.path.getmtime(src),
+                               "dirty": True})
+    os.chmod(src, 0o444)
+    try:
+        with pytest.raises(PermissionError):
+            mod._save(src, force=0)
+        assert f.read_bytes() == b"%PDF-original"  # untouched
+        assert not os.path.exists(src + ".tmp")    # gated before the tmp copy
+    finally:
+        os.chmod(src, 0o644)
+
+
+def test_save_readonly_beats_conflict_force(tmp_path, monkeypatch):
+    # Even force=1 (the conflict dialog's override) can't write a read-only
+    # file — the gate sits before the conflict check.
+    mod = _load_pdf(tmp_path, monkeypatch)
+    f = _original(tmp_path)
+    src = str(f)
+    os.makedirs(mod.WORKDIR, exist_ok=True)
+    wpath, _ = mod._work_paths(src)
+    with open(wpath, "wb") as out:
+        out.write(b"%PDF-edited")
+    mod._work_save_state(src, {"src": src.replace(os.sep, "/"),
+                               "base_mtime": 0.0,  # stale on purpose
+                               "dirty": True})
+    os.chmod(src, 0o444)
+    try:
+        with pytest.raises(PermissionError):
+            mod._save(src, force=1)
+        assert f.read_bytes() == b"%PDF-original"
+    finally:
+        os.chmod(src, 0o644)
+
+
+def test_rename_doc_readonly_raises_and_keeps_name(tmp_path, monkeypatch):
+    mod = _load_pdf(tmp_path, monkeypatch)
+    f = _original(tmp_path)
+    os.chmod(f, 0o444)
+    try:
+        with pytest.raises(PermissionError):
+            mod.main(action="rename_doc", doc=str(f), name="x", project="")
+        assert f.exists()
+        assert not (f.parent / "x.pdf").exists()
+    finally:
+        os.chmod(f, 0o644)
+
+
+def test_delete_doc_readonly_raises_and_keeps_file(tmp_path, monkeypatch):
+    mod = _load_pdf(tmp_path, monkeypatch)
+    f = _original(tmp_path)
+    os.chmod(f, 0o444)
+    try:
+        with pytest.raises(PermissionError):
+            mod.main(action="delete_doc", doc=str(f), project="")
+        assert f.exists()
+    finally:
+        os.chmod(f, 0o644)
+
+
+def test_rename_doc_writable_file_still_works(tmp_path, monkeypatch):
+    # Sanity: the guard isn't over-broad — a 0o644 file renames fine.
+    mod = _load_pdf(tmp_path, monkeypatch)
+    f = _original(tmp_path)
+    out = mod.main(action="rename_doc", doc=str(f), name="x", project="")
+    assert out["name"] == "x.pdf"
+    assert (f.parent / "x.pdf").exists()
+    assert not f.exists()

--- a/tests/test_slides_readonly.py
+++ b/tests/test_slides_readonly.py
@@ -1,0 +1,148 @@
+"""Read-only-file gates for the slides template (SPEC §13.5, RO-3/RO-4/RO-6).
+
+slides.py is a runPython target (not a package module) that does `import engine`
+at module top; engine.py needs python-pptx, which isn't in the test venv. So —
+like test_annotate_comments.py — slides.py is loaded via importlib, but with a
+stub `engine` module injected into sys.modules first. Every gated path must
+raise BEFORE any engine call, so the stub's build/parse functions raise if
+touched: the tests prove both the PermissionError and the ordering.
+
+Gates under test:
+  * action="save" refuses a chmod -w .pptx up front (before _load_model /
+    mkstemp — the atomic tempfile+os.replace would silently bypass the file's
+    read-only bit via the parent directory).
+  * action="set_title" refuses when its `<file>.json` sidecar isn't writable:
+    an EXISTING sidecar needs W_OK on itself, a fresh one W_OK on the parent
+    directory (same rule as annotate's _sidecar_writable).
+  * _editability(file) is the RO-4 verdict the open action folds into its
+    response (editable / readonly_message / readonly_tooltip).
+Read-only never blocks viewing or the cache-model autosave — only the explicit
+overwrite of the .pptx and the sidecar title write are gated.
+"""
+import importlib.util
+import json
+import os
+import sys
+import types
+
+import pytest
+
+SLIDES_PY = os.path.join(os.path.dirname(__file__), "..",
+                         "fused_render", "templates", "slides", "slides.py")
+
+# os.access always says yes for root, so the chmod-based gates can't trip.
+pytestmark = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
+
+def _boom(*args, **kwargs):
+    raise AssertionError(
+        "engine must not be called — the read-only gate has to fire first")
+
+
+@pytest.fixture
+def slides(tmp_path):
+    """Load slides.py with a stub engine module and a tmp cache root."""
+    saved = sys.modules.get("engine")
+    stub = types.ModuleType("engine")
+    stub.ENGINE_V = 0            # referenced by _content_hash at runtime
+    stub.build_pptx = _boom
+    stub.parse_pptx = _boom
+    stub.build_pdf = _boom
+    stub.build_html = _boom
+    stub.build_md = _boom
+    sys.modules["engine"] = stub
+    try:
+        spec = importlib.util.spec_from_file_location("slides_target", SLIDES_PY)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.CACHE_ROOT = str(tmp_path / "cache")   # keep main() away from ~
+        # pre-create: main()'s makedirs must survive tests that chmod tmp_path
+        os.makedirs(mod.CACHE_ROOT, exist_ok=True)
+        yield mod
+    finally:
+        if saved is not None:
+            sys.modules["engine"] = saved
+        else:
+            sys.modules.pop("engine", None)
+
+
+def _deck(tmp_path):
+    f = tmp_path / "deck.pptx"
+    f.write_bytes(b"not-a-real-pptx")
+    return f
+
+
+# --------------------------------------------------------------- save gate
+def test_save_on_readonly_pptx_raises_before_engine(slides, tmp_path):
+    f = _deck(tmp_path)
+    os.chmod(f, 0o444)
+    try:
+        # doc "deadbeef" has no cached model on purpose: the guard must run
+        # BEFORE _load_model (guard-first), or this raises FileNotFoundError.
+        with pytest.raises(PermissionError, match="read-only"):
+            slides.main(action="save", file=str(f), doc="deadbeef")
+        assert f.read_bytes() == b"not-a-real-pptx"
+    finally:
+        os.chmod(f, 0o644)
+
+
+# ------------------------------------------------------------ sidecar gate
+def test_set_title_readonly_sidecar_raises_and_preserves_bytes(slides, tmp_path):
+    f = _deck(tmp_path)
+    sidecar = tmp_path / "deck.pptx.json"
+    original = b'{"slides": {"title": "Old"}}'
+    sidecar.write_bytes(original)
+    os.chmod(sidecar, 0o444)
+    try:
+        with pytest.raises(PermissionError, match="read-only"):
+            slides.main(action="set_title", file=str(f), title="New")
+        assert sidecar.read_bytes() == original
+    finally:
+        os.chmod(sidecar, 0o644)
+
+
+def test_set_title_readonly_dir_without_sidecar_raises(slides, tmp_path):
+    f = _deck(tmp_path)
+    os.chmod(tmp_path, 0o555)
+    try:
+        with pytest.raises(PermissionError, match="read-only"):
+            slides.main(action="set_title", file=str(f), title="New")
+        assert not (tmp_path / "deck.pptx.json").exists()
+    finally:
+        os.chmod(tmp_path, 0o755)
+
+
+def test_set_title_creates_sidecar_in_writable_dir(slides, tmp_path):
+    f = _deck(tmp_path)
+    res = slides.main(action="set_title", file=str(f), title="My Deck")
+    assert res == {"ok": True, "title": "My Deck"}
+    data = json.loads((tmp_path / "deck.pptx.json").read_text())
+    assert data["slides"]["title"] == "My Deck"
+
+
+# --------------------------------------------------------- open verdict (RO-4)
+def test_editability_verdict(slides, tmp_path):
+    f = _deck(tmp_path)
+    assert slides._editability(str(f)) == (True, "", "")
+    os.chmod(f, 0o444)
+    try:
+        editable, message, tooltip = slides._editability(str(f))
+        assert editable is False
+        assert message == "Read-only"
+        assert "read-only" in tooltip
+    finally:
+        os.chmod(f, 0o644)
+
+
+def test_sidecar_writable_helper(slides, tmp_path):
+    f = _deck(tmp_path)
+    assert slides._sidecar_writable(str(f)) is True   # fresh sidecar, writable dir
+    sidecar = tmp_path / "deck.pptx.json"
+    sidecar.write_text("{}")
+    os.chmod(sidecar, 0o444)
+    try:
+        assert slides._sidecar_writable(str(f)) is False
+    finally:
+        os.chmod(sidecar, 0o644)

--- a/tests/test_usd_readonly.py
+++ b/tests/test_usd_readonly.py
@@ -1,0 +1,92 @@
+"""Read-only sidecar gating for the usd template (SPEC §13.5, RO-6).
+
+reader.py is a stdlib-at-import runPython target (numpy/msgpack/usd-core are
+convert-time deps, not import-time), so — like test_annotate_comments.py —
+these load it via importlib and drive `_sidecar_writable`/`main` directly.
+
+The usd template never writes the viewed asset; its only write target is the
+settings sidecar `<file>.json` saved from JS via fused.writeFile. The reader's
+`inspect` action reports `sidecar_writable` so the template can stop firing
+doomed saves and show the shared ro-badge. Writability rule: existing sidecar
+→ W_OK on itself; absent → W_OK on the parent dir (the JS write lands there).
+
+Tests use a `.splat` target: inspect's direct branch needs only os.path, no
+cache dir and no heavy deps. CACHE_ROOT is repointed at tmp_path anyway so
+nothing can touch the real home.
+"""
+import importlib.util
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+READER_PY = os.path.join(HERE, os.pardir, "fused_render", "templates",
+                         "usd", "reader.py")
+
+
+def _load_reader(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location("usd_reader_target", READER_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    monkeypatch.setattr(mod, "CACHE_ROOT", str(tmp_path / "cache"))
+    return mod
+
+
+def _asset(tmp_path):
+    f = tmp_path / "scene.splat"
+    f.write_bytes(b"\x00" * 32)
+    return f
+
+
+# ---------------------------------------------------------- _sidecar_writable
+
+def test_sidecar_writable_no_sidecar_writable_dir(tmp_path, monkeypatch):
+    mod = _load_reader(tmp_path, monkeypatch)
+    f = _asset(tmp_path)
+    assert mod._sidecar_writable(str(f)) is True
+
+
+def test_sidecar_writable_existing_readonly_sidecar(tmp_path, monkeypatch):
+    mod = _load_reader(tmp_path, monkeypatch)
+    f = _asset(tmp_path)
+    sidecar = tmp_path / "scene.splat.json"
+    sidecar.write_text("{}")
+    os.chmod(sidecar, 0o444)
+    try:
+        assert mod._sidecar_writable(str(f)) is False
+    finally:
+        os.chmod(sidecar, 0o644)
+
+
+def test_sidecar_writable_readonly_parent_no_sidecar(tmp_path, monkeypatch):
+    mod = _load_reader(tmp_path, monkeypatch)
+    d = tmp_path / "locked"
+    d.mkdir()
+    f = d / "scene.splat"
+    f.write_bytes(b"\x00" * 32)
+    os.chmod(d, 0o555)
+    try:
+        assert mod._sidecar_writable(str(f)) is False
+    finally:
+        os.chmod(d, 0o755)
+
+
+# ------------------------------------------------------------ inspect action
+
+def test_inspect_reports_sidecar_writable_true(tmp_path, monkeypatch):
+    mod = _load_reader(tmp_path, monkeypatch)
+    f = _asset(tmp_path)
+    out = mod.main(action="inspect", file=str(f))
+    assert out.get("kind") == "splat-direct"
+    assert out["sidecar_writable"] is True
+
+
+def test_inspect_reports_sidecar_writable_false(tmp_path, monkeypatch):
+    mod = _load_reader(tmp_path, monkeypatch)
+    f = _asset(tmp_path)
+    sidecar = tmp_path / "scene.splat.json"
+    sidecar.write_text("{}")
+    os.chmod(sidecar, 0o444)
+    try:
+        out = mod.main(action="inspect", file=str(f))
+        assert out["sidecar_writable"] is False
+    finally:
+        os.chmod(sidecar, 0o644)


### PR DESCRIPTION
## Summary

Applies the SPEC §13.5 editability contract to the templates added in #88 that write to the viewed file or its sidecar. Follow-up to #102, which established the contract (server `writable` flag, 403 `readonly`, shared ro-badge) for code/sqlite/duckdb/annotate.

Audit of all 9 new templates: **pano, photos, map** only write derived caches under `~/.fused-render` — no gating needed. The other six now conform:

| Template | Python enforcement (RO-3) | Reader verdict (RO-4) | UI (RO-5/6) |
|---|---|---|---|
| **docs** | `PermissionError` gate before the pandoc tmp+`os.replace` save | in `import` payload | lock-to-view, Edit toggle disabled, autosave suppressed, badge; "Save a copy" keeps working |
| **excel** | gate at top of `_save` (xlsx/csv/parquet all save via `os.replace`) | in both load payloads | cell-edit entry blocked, File▸Save disabled, badge; scripts-sidecar 403 non-fatal |
| **latex** | n/a — writes via `fused.writeFile`, server 403s | per-buffer `stat.writable` | CodeMirror locked with both read-only facets, badge, `err.type === "readonly"` branch in `saveNow` for mid-session chmods |
| **pdf_studio** | gates on save/rename/delete of the original (all parent-dir-level ops) | in `open_doc` | Save/rename/delete disabled with badge; working-copy edits, undo/redo, revert, export, save-a-copy stay allowed |
| **slides** | guard-first gate on the .pptx overwrite; annotate-style sidecar gate on `set_title` | in `open` payload (+ `sidecar_writable`) | explicit Save blocked; deck rename gated on sidecar writability; cache-model autosave stays allowed |
| **usd** | n/a — sidecar written from JS | `sidecar_writable` in `inspect` | "Settings not saved" badge, doomed sidecar writes skipped, `readonly` 403 backstop |

The explicit `os.access(W_OK)` guards are load-bearing: every one of these writers saves via tempfile-in-parent-dir + `os.replace`, which silently overwrites a `chmod -w` file through the directory's write bit — no exception would ever fire without the gate.

## Tests

23 new tests across 5 files (`test_{docs,excel,pdf_studio,slides,usd}_readonly.py`), following the annotate/sqlite pattern: importlib-loaded template modules, chmod-0444 fixtures with teardown; slides tests stub the `engine` module so no heavy deps are needed. Full suite: 457 passed, 3 skipped, 2 failed (the two pre-existing `test_templates_api` failures, present on main).

Live browser verification (server on this branch's templates): latex on a chmod-444 `.tex` shows the badge, locks CodeMirror (`contenteditable=false`, synthesized `insertText` rejected); writable file stays editable with no badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)