### PR TITLE
feat(h3): only show the H3 template for parquets with a real H3 column

### DIFF
--- a/fused_render/templates/h3/condition.py
+++ b/fused_render/templates/h3/condition.py
@@ -1,0 +1,68 @@
+"""Gate for the H3 template (SPEC CT-12).
+
+`method(path)` returns True only when the parquet actually carries an H3
+cell-index column, so the template stops showing for every parquet
+unconditionally. The detection mirrors `h3_reader.py` — a name match against
+the known H3 column names, else a uint64/hex-string bit-pattern sniff — so the
+gate agrees with what the reader would pick once opened.
+
+Self-contained on purpose: the condition module is loaded standalone (not part
+of a package), so it cannot rely on importing `h3_reader`. Fails closed — any
+read error means "cannot prove it's H3" and the template is dropped quietly.
+"""
+
+H3_NAMES = ("hex", "h3", "h3_index", "h3index", "h3_cell", "cell", "cell_id",
+            "hex_id", "h3_id", "index")
+
+
+def _looks_h3_int(v):
+    # H3 cell index: mode field (bits 59-62) == 1, high bit 0
+    try:
+        v = int(v)
+    except (TypeError, ValueError):
+        return False
+    return v > 0 and (v >> 63) == 0 and ((v >> 59) & 0xF) == 1
+
+
+def _looks_h3_str(v):
+    s = str(v).strip().lower()
+    if not (8 <= len(s) <= 16):
+        return False
+    try:
+        return _looks_h3_int(int(s, 16))
+    except ValueError:
+        return False
+
+
+def method(path: str) -> bool:
+    import os
+
+    path = os.path.abspath(os.path.expanduser(path or ""))
+    if not os.path.isfile(path):
+        return False
+
+    try:
+        import duckdb
+        con = duckdb.connect()
+        src = path.replace("'", "''")
+        schema = con.execute(f"DESCRIBE SELECT * FROM '{src}'").fetchall()
+        names = [s[0] for s in schema]
+        sample = con.execute(f"SELECT * FROM '{src}' LIMIT 200").fetchall()
+    except Exception:  # noqa: BLE001 — unreadable/not-parquet: fail closed, quietly
+        return False
+
+    def col_ok(i):
+        vals = [r[i] for r in sample if r[i] is not None][:50]
+        if not vals:
+            return False
+        good = sum(1 for v in vals
+                   if (_looks_h3_str(v) if isinstance(v, str) else _looks_h3_int(v)))
+        return good >= max(1, int(len(vals) * 0.9))
+
+    lower = [n.lower() for n in names]
+    # name match first (cheap, matches reader precedence), still validated by values
+    for n in H3_NAMES:
+        if n in lower and col_ok(lower.index(n)):
+            return True
+    # value sniff any remaining column
+    return any(col_ok(i) for i in range(len(names)))


### PR DESCRIPTION
## Summary

- The **H3 template used to show for every `.parquet` file** — even ones with no H3 data — because the registry maps it to `.parquet` unconditionally.
- Adds `fused_render/templates/h3/condition.py`, a `condition.py` gate (SPEC CT-12) so the H3 template appears **only when the parquet actually carries an H3 cell-index column**.
- Detection **mirrors `h3_reader.py`**: a name match against the known H3 column names (`hex`, `h3`, `h3_index`, `cell_id`, …), each validated against real values, then a value sniff of the remaining columns using the same uint64 / hex-string H3 bit-pattern check. So the gate agrees with what the reader would pick once opened.
- **Fails closed**: unreadable or non-parquet files quietly return `False` — the other `.parquet` templates (`duckdb`, `structure`, …) still handle those.
- No engine changes needed — the gate mechanism (`_condition_file` / `_run_condition` / `_apply_conditions` in `server.py`) already existed; this just adds the gate file.

## Visuals

Per-`.parquet` template resolution, before vs. after the gate:

```mermaid
flowchart LR
    P[".parquet stat"] --> R["registry: duckdb, structure, h3, claude, annotate, history"]
    R --> AC{"_apply_conditions"}
    AC -->|"h3/condition.py: method(path)"| M{"H3 column present?"}
    M -->|yes| KEEP["h3 template kept"]
    M -->|"no / unreadable"| DROP["h3 template dropped (fail-closed)"]
    AC -->|no condition.py| PASS["duckdb, structure, claude, annotate, history kept as-is"]
```

## Usage

Not directly user-invocable — it changes which templates the file explorer offers:

- Stat a parquet **with** an H3 column (named or sniffed) → the H3 hexagon preview appears in the template list.
- Stat a parquet **without** one → the H3 template is hidden; the rest are unaffected.

The gate is loaded fresh per stat, so edits apply live with no restart (set `FUSED_RENDER_CORE_TEMPLATES` to the repo templates dir when testing against a running server).

## Test Plan

- [x] Existing condition/template tests pass: `pytest tests/test_templates.py tests/test_templates_api.py -k condition` → 10 passed.
- [x] Unit-tested `method(path)` directly across cases: H3 uint64 in a `hex` column → `True`; H3 hex-string in an oddly-named column → `True` (sniffed); plain ints/strings → `False`; large non-H3 bigints → `False`; non-parquet / missing file → `False`.
- [x] Verified live via `dev.sh` + `/api/fs/stat`:
  - `with_h3.parquet` → `['duckdb', 'structure', 'h3', 'claude', 'annotate', 'history']` (h3 shown)
  - `plain.parquet` → `['duckdb', 'structure', 'claude', 'annotate', 'history']` (h3 gated out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
