### PR TITLE
feat(mounts): built-in public-buckets remote (anonymous S3, no credentials)

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -414,6 +414,9 @@ export interface RemoteSuggestion {
   id: string;
   label: string;
   remote_name: string;
+  // "public" = anonymous, no-credentials remote (public buckets); "detected" =
+  // materialized from the user's own AWS/gcloud credentials. Groups the dropdown.
+  kind: "public" | "detected";
 }
 
 export interface MountsResult {

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -203,8 +203,9 @@ function AddMount({
     <section className="prefs-section">
       <h2>Add mount</h2>
       <p className="deploy-muted">
-        Surface an rclone remote as a local folder. Pick a remote you created, or one under{" "}
-        <b>Detected credentials</b> (from your AWS / gcloud config — no keys stored).
+        Surface an rclone remote as a local folder. Pick a remote you created, one under{" "}
+        <b>Detected credentials</b> (from your AWS / gcloud config — no keys stored), or{" "}
+        <b>Public buckets</b> for anonymous access to open data (no credentials needed).
       </p>
       <div style={{ display: "flex", gap: 10, alignItems: "flex-end", flexWrap: "wrap" }}>
         <Field label="Name">
@@ -226,13 +227,26 @@ function AddMount({
                 ))}
               </optgroup>
             )}
-            {suggested.length > 0 && (
+            {suggested.some((s) => s.kind === "public") && (
+              <optgroup label="Public buckets (no credentials)">
+                {suggested
+                  .filter((s) => s.kind === "public")
+                  .map((s) => (
+                    <option key={s.id} value={`suggest:${s.id}`}>
+                      {s.label}
+                    </option>
+                  ))}
+              </optgroup>
+            )}
+            {suggested.some((s) => s.kind === "detected") && (
               <optgroup label="Detected credentials">
-                {suggested.map((s) => (
-                  <option key={s.id} value={`suggest:${s.id}`}>
-                    {s.label}
-                  </option>
-                ))}
+                {suggested
+                  .filter((s) => s.kind === "detected")
+                  .map((s) => (
+                    <option key={s.id} value={`suggest:${s.id}`}>
+                      {s.label}
+                    </option>
+                  ))}
               </optgroup>
             )}
           </select>

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -416,10 +416,24 @@ def _aws_profiles() -> list[str]:
 
 
 def _credential_suggestions() -> list[dict]:
-    """Remotes offerable from already-present credentials. Full specs (rclone
-    backend + params) — the endpoint consumes these; the API view (below)
-    exposes only id/label/remote_name."""
-    out: list[dict] = []
+    """Remotes offerable without re-entering keys. Full specs (rclone backend +
+    params) — the endpoint consumes these; the API view (below) exposes only
+    id/label/remote_name/kind.
+
+    The first entry is always present: an anonymous S3 remote for public buckets
+    (AWS Open Data, etc.). It needs no credentials — env_auth=false with blank
+    keys makes rclone send unsigned requests — so it works even when the user
+    has no (or expired) AWS creds. region is just the endpoint rclone starts at;
+    it follows S3's region redirect to reach buckets in any region. The rest are
+    credential-backed (kind="detected", defaulted in _suggestions_view)."""
+    out: list[dict] = [{
+        "id": "aws-open-public",
+        "label": "AWS S3 — public buckets (no credentials)",
+        "remote_name": "aws-open",
+        "backend": "s3",
+        "kind": "public",
+        "params": {"provider": "AWS", "env_auth": "false", "region": "us-west-2"},
+    }]
     for prof in _aws_profiles():
         out.append({
             "id": f"aws-profile:{prof}",
@@ -449,9 +463,13 @@ def _credential_suggestions() -> list[dict]:
 
 
 def _suggestions_view(remotes: list[str]) -> list[dict]:
-    """Public shape, minus any suggestion already materialized as a remote."""
+    """Public shape, minus any suggestion already materialized as a remote (so
+    the built-in aws-open drops out of the suggestions once created and shows
+    under Remotes instead). `kind` groups them in the dropdown: 'public' vs the
+    default 'detected'."""
     return [
-        {"id": s["id"], "label": s["label"], "remote_name": s["remote_name"]}
+        {"id": s["id"], "label": s["label"], "remote_name": s["remote_name"],
+         "kind": s.get("kind", "detected")}
         for s in _credential_suggestions()
         if f'{s["remote_name"]}:' not in remotes
     ]

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -316,9 +316,55 @@ def test_suggestions_view_hides_already_materialized(monkeypatch):
         {"id": "aws-env", "label": "L", "remote_name": "aws-env",
          "backend": "s3", "params": {"provider": "AWS", "env_auth": "true"}},
     ])
+    # kind defaults to "detected" for entries that don't set it.
     assert mounts_mod._suggestions_view([]) == [
-        {"id": "aws-env", "label": "L", "remote_name": "aws-env"}]
+        {"id": "aws-env", "label": "L", "remote_name": "aws-env",
+         "kind": "detected"}]
     assert mounts_mod._suggestions_view(["aws-env:"]) == []
+
+
+def test_public_bucket_suggestion_always_present(monkeypatch):
+    """The anonymous public-bucket remote is offered even with no AWS/gcloud
+    credentials at all — it's what lets a user mount open data without keys."""
+    monkeypatch.setattr(mounts_mod, "_aws_profiles", lambda: [])
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setattr(mounts_mod.os.path, "exists", lambda p: False)
+
+    by_id = {s["id"]: s for s in mounts_mod._credential_suggestions()}
+    pub = by_id["aws-open-public"]
+    assert pub["remote_name"] == "aws-open"
+    assert pub["kind"] == "public"
+    # anonymous: env_auth off, no key material anywhere in the spec
+    assert pub["params"]["env_auth"] == "false"
+    assert not any("secret" in k or "key" in k for k in pub["params"])
+
+
+def test_public_suggestion_hidden_once_materialized(monkeypatch):
+    monkeypatch.setattr(mounts_mod, "_aws_profiles", lambda: [])
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setattr(mounts_mod.os.path, "exists", lambda p: False)
+    # not yet created → shown under kind="public"
+    assert any(s["id"] == "aws-open-public" and s["kind"] == "public"
+               for s in mounts_mod._suggestions_view([]))
+    # once aws-open: exists it drops out (shows under Remotes instead)
+    assert not any(s["id"] == "aws-open-public"
+                   for s in mounts_mod._suggestions_view(["aws-open:"]))
+
+
+def test_detect_materializes_public_anonymous_remote(client, monkeypatch):
+    """Selecting the built-in public option creates an anonymous S3 remote —
+    no secret material, env_auth=false — so unsigned requests reach open data."""
+    created = []
+    _fake_rclone(monkeypatch, existing_remotes=(), record=created)
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-open-public"}, headers=FUSED)
+    assert r.status_code == 200
+    assert r.json()["name"] == "aws-open:"
+    [cmd] = created
+    assert cmd[:5] == ["/usr/bin/rclone", "config", "create", "aws-open", "s3"]
+    assert "env_auth" in cmd and "false" in cmd
+    assert not any("secret" in str(x).lower() for x in cmd)
 
 
 def _fake_rclone(monkeypatch, existing_remotes=(), record=None):


### PR DESCRIPTION
## Summary

- Adds an always-present **"Public buckets (no credentials)"** option to the Add-mount remote dropdown, so open data (AWS Open Data, etc.) can be mounted **without any AWS credentials**. This unblocks users whose only creds are missing or expired — credential-backed remotes (`aws`, a `nasa2`-style profile mount) fail for them, while this anonymous option just works, the same way a hand-rolled `aws-open` remote does today.
- It materializes through the **existing detect pipeline** into a keyless remote (`provider=AWS`, `env_auth=false`, blank keys → rclone sends **unsigned** requests). `region` is only the starting endpoint; S3's region redirect carries it to buckets in any region.
- Suggestions now carry a **`kind`** field (`"public"` vs `"detected"`), grouping the dropdown into **Public buckets** and **Detected credentials**. Idempotent: once created, `aws-open` drops out of the suggestions and shows under **Remotes** instead.

## Visuals

```mermaid
flowchart TD
    subgraph dropdown["Add-mount remote dropdown"]
        R["Remotes<br/>(already created)"]
        P["Public buckets (no credentials)<br/>← NEW: always present"]
        D["Detected credentials<br/>(AWS/gcloud dotfiles)"]
    end
    P -->|select 'aws-open-public'| DET["POST /api/mounts/remotes/detect"]
    D -->|select 'suggest:id'| DET
    DET --> CFG["rclone config create aws-open s3<br/>provider=AWS env_auth=false<br/>(no keys → unsigned/anonymous)"]
    CFG --> MOUNT["mount aws-open:bucket/prefix<br/>as a local folder"]
    CFG -.->|remote now exists| HIDE["hidden from suggestions,<br/>shows under Remotes"]
```

## Usage

Sidebar → cloud icon → **Mounts** → **Add mount**:

1. **Name:** e.g. `ookla`
2. **Remote:** under **Public buckets (no credentials)** pick *AWS S3 — public buckets*.
3. **Path:** `ookla-open-data/parquet/performance/type=fixed` (or any public bucket/prefix — `sentinel-cogs/sentinel-s2-l2a-cogs`, `nyc-tlc/trip data`, `nasa-power/…`).
4. **Add & mount** → browses like any local folder, no credentials required.

## Test Plan

- [x] `tests/test_shell_mounts.py` — added: public suggestion always present with no AWS/gcloud creds (`test_public_bucket_suggestion_always_present`); anonymous spec has no key material; hidden once materialized (`test_public_suggestion_hidden_once_materialized`); detect creates an anonymous `aws-open:` remote with `env_auth=false` and no secrets (`test_detect_materializes_public_anonymous_remote`); updated the view-shape test for the new `kind` field. Full suite: **38 passed**.
- [x] `cd frontend && bun run build` — clean (tsc + vite).
- [x] Manually verified against the running app that the anonymous config (`provider=AWS`, blank keys, `env_auth=false`, `region=us-west-2`) mounts public buckets across regions (ookla us-east-1, sentinel-cogs us-west-2) via S3 region redirect.

## Notes / follow-ups (not in this PR)

- The underlying "mount with bad/expired credentials fails unhelpfully" behavior is unchanged — this PR gives a credential-free path around it rather than improving the credentialed-failure error surface. Worth a separate look if we want clearer feedback when a signed mount can't authenticate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
