### PR TITLE
feat(pdf_studio): flat PDF library instead of projects, default to View mode

### DIFF
--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -10,28 +10,22 @@ ops, PyMuPDF handles text extraction/editing and rasterization. Every action
 returns JSON so an AI agent can drive the whole app headlessly exactly as the
 UI does.
 
-The source of truth is the .pdf files on disk, wherever they live — projects
-link imported files instead of copying them. Edits never touch the original
-directly: each open doc gets a working copy under .work/ that mutations (and
-undo/redo snapshots) apply to; an explicit save writes the working copy back
-over the original. Each call is a fresh process, so no in-memory state
-survives.
+The source of truth is the .pdf files on disk, wherever they live. A flat
+library (a single JSON file of absolute paths) just remembers which files the
+user added — it never copies them. Edits never touch the original directly:
+each open doc gets a working copy under .work/ that mutations (and undo/redo
+snapshots) apply to; an explicit save writes the working copy back over the
+original. Each call is a fresh process, so no in-memory state survives.
 
 Actions
   health                                   -> {ok, pymupdf, pikepdf}
-  list_projects                            -> {projects:[...], dir}
-  new_project(title)                       -> {slug}
-  rename_project(slug,title)               -> {slug}
-  duplicate_project(slug,title)            -> {slug}
-  delete_project(slug)                     -> {ok}
-  open_project(slug)                       -> {slug, title, docs:[...]}
+  list_library                             -> {docs:[...]}
+  add_to_library(src)                      -> {name, path}  (references src in place, no copy)
+  remove_from_library(doc)                 -> {ok}  (drops the reference; file on disk is kept)
+  import_url(url,name)                     -> {name, path}
   open_doc(doc)                            -> docinfo + {work, dirty, has_text, undo_depth, redo_depth}
-  which_project(doc)                       -> {slug}  ("" when in no project)
   listdir(path)                            -> {path, parent, dirs, files}
-  import_doc(project,src)                  -> {name, path}  (links src in place, no copy)
-  import_url(project,url,name)             -> {name, path}
-  delete_doc(doc,project)                  -> {ok}  (linked docs are only unlinked)
-  rename_doc(doc,name,project)             -> {name, path}
+  rename_doc(doc,name)                     -> {name, path}
   save(doc,force)                          -> {ok, file} or {conflict}
   revert(doc)                              -> mutation contract shape
   save_as(doc,directory,name)              -> {file}
@@ -43,7 +37,7 @@ Actions
   compress(doc,level,...)                           |  or {conflict, mtime}
   edit_text(doc,page,bbox,...,...)                 /
   extract_pages(doc,pages,name)            -> {name, path, size, dir}
-  merge(project,sources,name,directory)    -> {name, path, dir}
+  merge(sources,name,directory)            -> {name, path, dir}
   split(doc,mode,ranges,prefix,directory)  -> {files:[...], dir}
   reveal(path)                             -> {ok}  (opens the OS file explorer)
   page_text(doc,page)                      -> {width, height, rotation, spans:[...]}
@@ -54,41 +48,31 @@ import json
 import os
 import re
 import shutil
-import time
 
 # NOTE: bare `def main` (no @fused.udf) is deliberate — under the built-in
 # executor the worker calls main() by its own signature; @fused.udf hides that
 # signature and triggers a hosted-auth flow that times out.
 
 # State lives under the user home dir, never inside the installed template
-# package (D76-adjacent). The project library holds primary, non-regenerable
-# content (merge output, URL imports) so it gets its own `data/` root rather
-# than sitting under `cache/`, which a future clear-cache action could sweep;
+# package (D76-adjacent). The library index and URL downloads hold primary,
+# non-regenerable content so they get their own `data/` root rather than
+# sitting under `cache/`, which a future clear-cache action could sweep;
 # working copies and undo snapshots are transient and belong under `cache/`.
 DATA_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "data", "pdf_studio"))
 CACHE_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "cache", "pdf_studio"))
-PROJECTS = os.path.join(DATA_ROOT, "projects")
+LIBRARY = os.path.join(DATA_ROOT, "library.json")   # flat list of PDF paths the user added
+DOWNLOADS = os.path.join(DATA_ROOT, "downloads")    # PDFs fetched via import_url
 EXPORTS = os.path.join(CACHE_ROOT, "exports")
-SNAPSHOTS = os.path.join(CACHE_ROOT, "snapshots")   # undo stacks for out-of-library docs
+SNAPSHOTS = os.path.join(CACHE_ROOT, "snapshots")   # undo stacks, keyed by doc path
 WORKDIR = os.path.join(CACHE_ROOT, "work")          # per-doc working copies (unsaved edits)
-DEMO_SLUG = "pdf-studio-demo"
 
 UNDO_CAP = 10
 
 
 # ---------------------------------------------------------------------- helpers
-def _safe_slug(s: str) -> str:
-    slug = re.sub(r"[^A-Za-z0-9_-]", "-", (s or "").strip())[:64].strip("-")
-    return slug or "untitled"
-
-
 def _safe_name(name, default):
     name = re.sub(r'[\\/:*?"<>|]', "-", (name or "").strip()).strip(". ")
     return name or default
-
-
-def _project_dir(slug: str) -> str:
-    return os.path.join(PROJECTS, _safe_slug(slug))
 
 
 def _fwd(p: str) -> str:
@@ -269,13 +253,7 @@ def _revert(doc):
 # --------------------------------------------------------- undo/redo snapshots
 def _hist_dir(doc):
     doc = os.path.realpath(os.path.abspath(doc))
-    proj = os.path.realpath(PROJECTS)
-    if doc.startswith(proj + os.sep):
-        rel = os.path.relpath(doc, proj)
-        slug = rel.split(os.sep)[0]
-        d = os.path.join(proj, slug, ".history", os.path.basename(doc))
-    else:
-        d = os.path.join(SNAPSHOTS, hashlib.sha1(doc.encode()).hexdigest()[:16])
+    d = os.path.join(SNAPSHOTS, hashlib.sha1(doc.encode()).hexdigest()[:16])
     os.makedirs(d, exist_ok=True)
     return d
 
@@ -484,14 +462,13 @@ def _extract_pages(doc, pages, name):
             "size": os.path.getsize(dest), "dir": _fwd(os.path.dirname(dest))}
 
 
-def _merge(project, sources, name, directory=""):
+def _merge(sources, name, directory=""):
     import pikepdf
 
     paths = [os.path.abspath(p) for p in json.loads(sources)]
     if len(paths) < 2:
         raise ValueError("merge needs at least two PDFs")
-    out_dir = _out_dir(directory,
-                       _project_dir(project) if project else os.path.dirname(paths[0]))
+    out_dir = _out_dir(directory, os.path.dirname(paths[0]))
     dst = pikepdf.Pdf.new()
     for p in paths:
         with pikepdf.open(_cur_path(p)) as src:
@@ -649,124 +626,10 @@ def _edit_text(doc, page, bbox, origin, old_text, new_text, font, size, flags, c
     return fn(doc)
 
 
-# ------------------------------------------------------------------- projects
-def _demo_pdf(dest):
-    import fitz
-
-    blue, ink, ink2 = (0.09, 0.43, 0.88), (0.11, 0.13, 0.15), (0.35, 0.4, 0.46)
-    d = fitz.open()
-    w, h = 612, 792
-    m = 64
-
-    p = d.new_page(width=w, height=h)
-    p.draw_rect(fitz.Rect(0, 0, w, 8), color=None, fill=blue)
-    p.insert_text((m, 130), "PDF Studio", fontname="hebo", fontsize=34, color=ink)
-    p.insert_text((m, 158), "A demo document you can safely mangle", fontname="helv",
-                  fontsize=14, color=ink2)
-    p.insert_textbox(fitz.Rect(m, 200, w - m, 340),
-                     "This three-page PDF was generated locally so the studio has "
-                     "something to open on first run. Try the page operations from "
-                     "the Page menu, merge it with another file, or switch to Edit "
-                     "mode and click any line of text to rewrite it in place.",
-                     fontname="tiro", fontsize=12.5, color=ink, lineheight=1.5)
-    p.insert_text((m, 380), "What to try", fontname="hebo", fontsize=16, color=ink)
-    for i, tip in enumerate(["Rotate or delete pages from the thumbnail rail",
-                             "Split this file into one PDF per page",
-                             "Compress it and compare the size",
-                             "Edit this very line of text"]):
-        y = 410 + i * 26
-        p.draw_circle(fitz.Point(m + 4, y - 4), 2.5, color=None, fill=blue)
-        p.insert_text((m + 18, y), tip, fontname="helv", fontsize=12, color=ink)
-
-    p = d.new_page(width=w, height=h)
-    p.insert_text((m, 90), "2. Tables survive page ops", fontname="hebo",
-                  fontsize=18, color=ink)
-    rows = [("Operation", "Library", "Speed"),
-            ("Merge / split / rotate", "pikepdf (qpdf)", "instant"),
-            ("Compress", "pikepdf / PyMuPDF", "fast"),
-            ("Text editing", "PyMuPDF", "per edit"),
-            ("Rendering", "pdf.js (browser)", "local")]
-    x0, y0, rh, cw = m, 130, 30, [200, 170, 114]
-    for r, row in enumerate(rows):
-        y = y0 + r * rh
-        if r == 0:
-            p.draw_rect(fitz.Rect(x0, y, x0 + sum(cw), y + rh), color=None,
-                        fill=(0.91, 0.94, 1.0))
-        x = x0
-        for c, cell in enumerate(row):
-            p.insert_text((x + 10, y + 20), cell,
-                          fontname="hebo" if r == 0 else "helv",
-                          fontsize=11.5, color=ink if r else (0.06, 0.36, 0.77))
-            x += cw[c]
-        p.draw_line(fitz.Point(x0, y), fitz.Point(x0 + sum(cw), y), color=(0.88, 0.89, 0.91))
-    y = y0 + len(rows) * rh
-    p.draw_line(fitz.Point(x0, y), fitz.Point(x0 + sum(cw), y), color=(0.88, 0.89, 0.91))
-    p.insert_textbox(fitz.Rect(m, y + 40, w - m, y + 160),
-                     "Every mutation snapshots the file first, so undo and redo "
-                     "work across sessions. External edits are caught by an mtime "
-                     "check before each write.",
-                     fontname="tiro", fontsize=12.5, color=ink, lineheight=1.5)
-
-    p = d.new_page(width=w, height=h)
-    p.insert_text((m, 90), "3. Vector art is preserved", fontname="hebo",
-                  fontsize=18, color=ink)
-    vals = [0.35, 0.6, 0.45, 0.8, 0.65, 0.95]
-    bw, gap, base_y, max_h = 48, 22, 420, 220
-    for i, v in enumerate(vals):
-        x = m + i * (bw + gap)
-        p.draw_rect(fitz.Rect(x, base_y - v * max_h, x + bw, base_y),
-                    color=None, fill=(0.09 + 0.1 * i / 6, 0.43, 0.88 - 0.06 * i))
-        p.insert_text((x + 12, base_y + 18), f"Q{i + 1}", fontname="helv",
-                      fontsize=10, color=ink2)
-    p.draw_line(fitz.Point(m, base_y), fitz.Point(w - m, base_y), color=ink2)
-    p.insert_textbox(fitz.Rect(m, 470, w - m, 570),
-                     "Text edits use redaction plus re-insertion, scoped so "
-                     "drawings and images on the page are left untouched.",
-                     fontname="tiro", fontsize=12.5, color=ink, lineheight=1.5)
-    d.save(dest, deflate=True)
-    d.close()
-
-
-def _ensure_demo():
-    os.makedirs(PROJECTS, exist_ok=True)
-    marker = os.path.join(PROJECTS, ".demo_seeded")
-    if os.path.exists(marker):
-        return
-    dest = _project_dir(DEMO_SLUG)
-    try:
-        if not os.path.exists(dest):
-            os.makedirs(dest)
-            _demo_pdf(os.path.join(dest, "welcome.pdf"))
-            with open(os.path.join(dest, "meta.json"), "w", encoding="utf-8") as f:
-                json.dump({"title": "PDF Studio — Demo", "created": time.time(),
-                           "demo": True}, f)
-        with open(marker, "w", encoding="utf-8") as f:
-            f.write("1")
-    except Exception as e:
-        print(f"[python] demo seed failed: {e}")
-
-
-def _meta(d):
-    mp = os.path.join(d, "meta.json")
-    if os.path.exists(mp):
-        try:
-            with open(mp, encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
-            pass
-    return {}
-
-
-def _write_meta(d, meta):
-    with open(os.path.join(d, "meta.json"), "w", encoding="utf-8") as f:
-        json.dump(meta, f)
-
-
-def _doc_entry(path, linked=False):
+# -------------------------------------------------------------------- library
+def _doc_entry(path):
     entry = {"name": os.path.basename(path), "path": _fwd(path),
              "size": os.path.getsize(path), "mtime": os.path.getmtime(path)}
-    if linked:
-        entry["linked"] = True
     try:
         import pikepdf
         with pikepdf.open(_cur_path(path)) as pdf:
@@ -777,89 +640,64 @@ def _doc_entry(path, linked=False):
     return entry
 
 
-def _project_docs(d):
+def _lib_load():
+    if os.path.exists(LIBRARY):
+        try:
+            with open(LIBRARY, encoding="utf-8") as f:
+                data = json.load(f)
+            return data.get("paths", [])
+        except Exception:
+            pass
+    return []
+
+
+def _lib_save(paths):
+    os.makedirs(DATA_ROOT, exist_ok=True)
+    tmp = LIBRARY + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump({"paths": paths}, f)
+    os.replace(tmp, LIBRARY)
+
+
+def _list_library():
     docs = []
-    for name in sorted(os.listdir(d), key=str.lower):
-        full = os.path.join(d, name)
-        if not name.lower().endswith(".pdf") or not os.path.isfile(full):
-            continue
-        docs.append(_doc_entry(full))
-    for link in _meta(d).get("links", []):
-        full = os.path.abspath(link)
+    for path in _lib_load():
+        full = os.path.abspath(path)
         if not os.path.isfile(full):
             docs.append({"name": os.path.basename(full), "path": _fwd(full),
-                         "size": 0, "mtime": 0, "page_count": None,
-                         "linked": True, "missing": True})
+                         "size": 0, "mtime": 0, "page_count": None, "missing": True})
             continue
-        docs.append(_doc_entry(full, linked=True))
+        docs.append(_doc_entry(full))
     docs.sort(key=lambda e: e["name"].lower())
-    return docs
+    return {"docs": docs}
 
 
-def _list_projects():
-    os.makedirs(PROJECTS, exist_ok=True)
-    _ensure_demo()
-    out = []
-    for name in sorted(os.listdir(PROJECTS)):
-        d = os.path.join(PROJECTS, name)
-        if not os.path.isdir(d):
-            continue
-        meta = _meta(d)
-        pdfs = [f for f in os.listdir(d) if f.lower().endswith(".pdf")]
-        out.append({"slug": name, "title": meta.get("title", name),
-                    "ndocs": len(pdfs) + len(meta.get("links", [])),
-                    "demo": bool(meta.get("demo")),
-                    "mtime": os.path.getmtime(d)})
-    out.sort(key=lambda e: -e["mtime"])
-    return {"projects": out, "dir": _fwd(PROJECTS)}
-
-
-def _new_project(title):
-    slug = _safe_slug(title or "untitled")
-    if os.path.exists(_project_dir(slug)):
-        i = 2
-        while os.path.exists(_project_dir(f"{slug}-{i}")):
-            i += 1
-        slug = f"{slug}-{i}"
-    d = _project_dir(slug)
-    os.makedirs(d)
-    _write_meta(d, {"title": title or slug, "created": time.time()})
-    return {"slug": slug}
-
-
-def _open_project(slug):
-    d = _project_dir(slug)
-    if not os.path.isdir(d):
-        raise ValueError(f"no such project: {slug}")
-    meta = _meta(d)
-    return {"slug": _safe_slug(slug), "title": meta.get("title", slug),
-            "docs": _project_docs(d)}
-
-
-def _import_doc(project, src):
-    """Link src into the project — the original file stays where it is."""
+def _add_to_library(src):
+    """Remember src in the library — the file stays where it is, never copied."""
     src = os.path.abspath(src)
     if not os.path.isfile(src):
         raise ValueError(f"no such file: {src}")
-    d = _project_dir(project)
-    if not os.path.isdir(d):
-        raise ValueError(f"no such project: {project}")
-    if os.path.realpath(os.path.dirname(src)) == os.path.realpath(d):
-        return {"name": os.path.basename(src), "path": _fwd(src)}
-    meta = _meta(d)
-    links = meta.get("links", [])
-    if not any(_same_path(l, src) for l in links):
-        meta["links"] = links + [_fwd(src)]
-        _write_meta(d, meta)
+    paths = _lib_load()
+    if not any(_same_path(p, src) for p in paths):
+        _lib_save(paths + [_fwd(src)])
     return {"name": os.path.basename(src), "path": _fwd(src)}
 
 
-def _import_url(project, url, name):
+def _remove_from_library(doc):
+    p = os.path.abspath(doc)
+    paths = _lib_load()
+    kept = [x for x in paths if not _same_path(x, p)]
+    if len(kept) != len(paths):
+        _lib_save(kept)
+    shutil.rmtree(_hist_dir(p), ignore_errors=True)
+    _work_drop(p)
+    return {"ok": True}
+
+
+def _import_url(url, name):
     import urllib.request
 
-    d = _project_dir(project)
-    if not os.path.isdir(d):
-        raise ValueError(f"no such project: {project}")
+    os.makedirs(DOWNLOADS, exist_ok=True)
     req = urllib.request.Request(url, headers={"User-Agent": "fused-render-pdf/1.0"})
     with urllib.request.urlopen(req, timeout=25) as resp:
         data = resp.read()
@@ -868,9 +706,10 @@ def _import_url(project, url, name):
     name = _safe_name(name or os.path.basename(url.split("?")[0]), "imported")
     if not name.lower().endswith(".pdf"):
         name += ".pdf"
-    dest = _unique_path(d, name)
+    dest = _unique_path(DOWNLOADS, name)
     with open(dest, "wb") as f:
         f.write(data)
+    _add_to_library(dest)
     return {"name": os.path.basename(dest), "path": _fwd(dest)}
 
 
@@ -965,11 +804,8 @@ def _health():
 
 # ----------------------------------------------------------------- dispatcher
 def main(
-    action: str = "list_projects",
-    slug: str = "",
-    title: str = "",
+    action: str = "list_library",
     doc: str = "",
-    project: str = "",
     src: str = "",
     url: str = "",
     name: str = "",
@@ -999,45 +835,14 @@ def main(
     expected_mtime: str = "",
     force: int = 0,
 ):
-    os.makedirs(PROJECTS, exist_ok=True)
-
     if action == "health":
         return _health()
-    if action == "list_projects":
-        return _list_projects()
-    if action == "new_project":
-        return _new_project(title)
-    if action == "rename_project":
-        d = _project_dir(slug)
-        if not os.path.isdir(d):
-            raise ValueError(f"no such project: {slug}")
-        meta = _meta(d)
-        meta["title"] = title or slug
-        _write_meta(d, meta)
-        return {"slug": _safe_slug(slug)}
-    if action == "duplicate_project":
-        srcd = _project_dir(slug)
-        if not os.path.isdir(srcd):
-            raise ValueError(f"no such project: {slug}")
-        out = _new_project(title or (_meta(srcd).get("title", slug) + " copy"))
-        dstd = _project_dir(out["slug"])
-        for f in os.listdir(srcd):
-            if f.lower().endswith(".pdf"):
-                shutil.copyfile(os.path.join(srcd, f), os.path.join(dstd, f))
-        links = _meta(srcd).get("links", [])
-        if links:
-            meta = _meta(dstd)
-            meta["links"] = links
-            _write_meta(dstd, meta)
-        return out
-    if action == "delete_project":
-        d = _project_dir(slug)
-        if not os.path.isdir(d):
-            raise ValueError(f"no such project: {slug}")
-        shutil.rmtree(d)
-        return {"ok": True}
-    if action == "open_project":
-        return _open_project(slug)
+    if action == "list_library":
+        return _list_library()
+    if action == "add_to_library":
+        return _add_to_library(src)
+    if action == "remove_from_library":
+        return _remove_from_library(doc)
     if action == "open_doc":
         p = os.path.abspath(doc)
         wpath, wmeta = _open_work(p)
@@ -1056,39 +861,10 @@ def main(
             info["has_text"] = False
         info["undo_depth"], info["redo_depth"] = _stack_depths(p)
         return info
-    if action == "which_project":
-        p = os.path.normcase(os.path.realpath(os.path.abspath(doc)))
-        for name in sorted(os.listdir(PROJECTS)):
-            d = os.path.join(PROJECTS, name)
-            if not os.path.isdir(d):
-                continue
-            if p.startswith(os.path.normcase(os.path.realpath(d)) + os.sep):
-                return {"slug": name}
-            if any(_same_path(l, doc) for l in _meta(d).get("links", [])):
-                return {"slug": name}
-        return {"slug": ""}
     if action == "listdir":
         return _listdir(path)
-    if action == "import_doc":
-        return _import_doc(project, src)
     if action == "import_url":
-        return _import_url(project, url, name)
-    if action == "delete_doc":
-        p = os.path.abspath(doc)
-        d = _project_dir(project) if project else ""
-        meta = _meta(d) if d and os.path.isdir(d) else {}
-        links = meta.get("links", [])
-        kept = [l for l in links if not _same_path(l, p)]
-        if len(kept) != len(links):
-            meta["links"] = kept
-            _write_meta(d, meta)
-        else:
-            if not os.path.isfile(p):
-                raise ValueError(f"no such file: {p}")
-            os.remove(p)
-        shutil.rmtree(_hist_dir(p), ignore_errors=True)
-        _work_drop(p)
-        return {"ok": True}
+        return _import_url(url, name)
     if action == "rename_doc":
         p = os.path.abspath(doc)
         n = _safe_name(name, "")
@@ -1099,13 +875,9 @@ def main(
         dest = _unique_path(os.path.dirname(p), n)
         os.rename(p, dest)
         _work_rename(p, dest)
-        if project:
-            d = _project_dir(project)
-            meta = _meta(d) if os.path.isdir(d) else {}
-            links = meta.get("links", [])
-            if any(_same_path(l, p) for l in links):
-                meta["links"] = [_fwd(dest) if _same_path(l, p) else l for l in links]
-                _write_meta(d, meta)
+        paths = _lib_load()
+        if any(_same_path(l, p) for l in paths):
+            _lib_save([_fwd(dest) if _same_path(l, p) else l for l in paths])
         return {"name": os.path.basename(dest), "path": _fwd(dest)}
     if action == "save":
         return _save(doc, force)
@@ -1143,7 +915,7 @@ def main(
     if action == "extract_pages":
         return _extract_pages(doc, pages, name)
     if action == "merge":
-        return _merge(project, sources, name, directory)
+        return _merge(sources, name, directory)
     if action == "split":
         return _split(doc, mode, ranges, prefix, directory)
     if action == "reveal":

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -45,8 +45,6 @@
   .btn.ghost { border-color: transparent; background: transparent; }
   .btn.ghost:hover { background: var(--hair-2); }
   .btn svg { width: 15px; height: 15px; }
-  #projBtn { max-width: 240px; }
-  #projBtn span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
   #docName { font-weight: 600; font-size: 13.5px; max-width: 26vw; overflow: hidden;
     text-overflow: ellipsis; white-space: nowrap; color: var(--ink); }
   #docPages { color: var(--ink-3); font-size: 12px; white-space: nowrap; }
@@ -65,19 +63,6 @@
     padding: 5px 12px; font-weight: 600; display: inline-flex; align-items: center; gap: 6px; }
   .seg button.on { background: #fff; color: var(--blue); box-shadow: var(--shadow-1); }
   .seg button svg { width: 15px; height: 15px; }
-
-  /* dropdown menus (topbar project menu) */
-  .menu-wrap { position: relative; }
-  .pop { position: absolute; top: calc(100% + 4px); left: 0; background: #fff; border: 1px solid var(--hair);
-    border-radius: var(--radius); box-shadow: var(--shadow-2); padding: 5px; min-width: 220px; z-index: 60; }
-  .pop button { display: flex; align-items: center; gap: 9px; width: 100%; text-align: left; border: none;
-    background: none; color: var(--ink); padding: 7px 10px; border-radius: 5px; font-size: 13px; }
-  .pop button:hover { background: var(--hair-2); }
-  .pop .sub { color: var(--ink-3); font-size: 11px; padding: 6px 10px 3px; text-transform: uppercase; letter-spacing: .5px; }
-  .pop .divider { height: 1px; background: var(--hair-2); margin: 5px 4px; }
-  .pop .scrolllist { max-height: 260px; overflow-y: auto; }
-  .pop .pj.now { background: var(--blue-soft); color: var(--blue-ink); font-weight: 600; }
-  .pop .pj .pjm { margin-left: auto; color: var(--ink-3); font-size: 11px; font-weight: 400; }
 
   /* ---- menubar ---- */
   #menubar { display: flex; padding: 0 8px; user-select: none; background: var(--chrome);
@@ -219,26 +204,18 @@
     font-size: 12.5px; flex: 0 0 auto; }
 </style>
 </head>
-<body class="mode-edit">
+<body class="mode-view">
 <div id="boot">Loading PDF Studio…</div>
 
 <div id="topbar">
   <div class="brand"><span class="mark">PDF</span><span>PDF Studio</span></div>
-  <div class="menu-wrap">
-    <button class="btn" id="projBtn">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
-      <span id="projLabel">Projects</span>
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" style="width:13px;height:13px;opacity:.6"><path d="M6 9l6 6 6-6"/></svg>
-    </button>
-    <div class="pop hidden" id="projMenu"></div>
-  </div>
   <span id="docName"></span>
   <span id="docPages"></span>
   <div class="spacer"></div>
   <div id="status"><span class="dot"></span><span class="txt">idle</span></div>
   <div class="seg" id="modeSeg">
-    <button data-mode="edit" class="on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg> Edit</button>
-    <button data-mode="view"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z"/><circle cx="12" cy="12" r="3"/></svg> View</button>
+    <button data-mode="edit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg> Edit</button>
+    <button data-mode="view" class="on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z"/><circle cx="12" cy="12" r="3"/></svg> View</button>
   </div>
   <button class="btn primary" id="exportBtn">
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>
@@ -248,9 +225,8 @@
 
 <div id="menubar">
   <div class="menu" data-menu>File<div class="dropdown">
-    <div class="mi" data-act="importPdf">Import PDF…</div>
-    <div class="mi" data-act="importUrl">Import from URL…</div>
-    <div class="mi" data-act="openPath">Open anywhere… <span class="kbd">Ctrl+O</span></div>
+    <div class="mi" data-act="addPdf">Add PDF… <span class="kbd">Ctrl+O</span></div>
+    <div class="mi" data-act="importUrl">Add from URL…</div>
     <div class="divider"></div>
     <div class="mi" data-act="save">Save <span class="kbd">Ctrl+S</span></div>
     <div class="mi" data-act="revert">Revert to saved</div>
@@ -295,7 +271,7 @@
 <div id="main">
   <div id="side">
     <div>
-      <h4>Documents <button class="add" id="importBtn" title="Import a PDF into this project">＋</button></h4>
+      <h4>Documents <button class="add" id="importBtn" title="Add a PDF">＋</button></h4>
       <div id="docList"></div>
     </div>
     <div>
@@ -318,10 +294,9 @@ const MAX_PAGES = 100;
 const $ = (id) => document.getElementById(id);
 
 const state = {
-  projects: [], project: "", projTitle: "",
   docs: [], doc: "", work: "", info: null, mtime: 0, dirty: false,
   pdf: null, curPage: 1, zoom: 100,
-  standalone: false, undoDepth: 0, redoDepth: 0,
+  undoDepth: 0, redoDepth: 0,
   spans: {},          // pageNo -> {mtime, spans}
   editing: null,      // the floating text input, if any
 };
@@ -735,7 +710,7 @@ async function applyMut(res) {
   state.undoDepth = res.undo_depth; state.redoDepth = res.redo_depth;
   updateUndoUi();
   await renderAll();
-  refreshDocList().catch(() => {});
+  refreshLib().catch(() => {});
 }
 
 async function mutate(action, params = {}) {
@@ -757,33 +732,17 @@ function updateUndoUi() {
   $("miRedo").classList.toggle("off", !state.redoDepth);
 }
 
-async function refreshDocList() {
-  if (state.standalone || !state.project) return renderDocList();
-  const res = await py({ action: "open_project", slug: state.project });
-  state.docs = res.docs; state.projTitle = res.title;
+async function refreshLib() {
+  const res = await py({ action: "list_library" });
+  state.docs = res.docs;
   renderDocList();
 }
 
 function renderDocList() {
-  $("projLabel").textContent = state.standalone ? "No project" : (state.projTitle || "Projects");
   const list = $("docList");
   list.innerHTML = "";
-  if (state.standalone) {
-    const row = document.createElement("div");
-    row.className = "doc-row on";
-    row.innerHTML = `<span class="nm"></span>`;
-    row.querySelector(".nm").textContent = state.doc.split("/").pop();
-    list.appendChild(row);
-    const add = document.createElement("button");
-    add.className = "btn ghost";
-    add.style.margin = "6px 2px";
-    add.textContent = "＋ Add to a project";
-    add.onclick = () => act("addToLibrary");
-    list.appendChild(add);
-    return;
-  }
   if (!state.docs.length) {
-    list.innerHTML = `<div class="side-empty">No PDFs yet — use ＋ to import one.</div>`;
+    list.innerHTML = `<div class="side-empty">No PDFs yet — use ＋ to add one.</div>`;
     return;
   }
   for (const d of state.docs) {
@@ -794,13 +753,13 @@ function renderDocList() {
     row.innerHTML = `<span class="nm"></span>${meta}
       <span class="ops">
         <button title="Rename" data-op="rename">${icoPen}</button>
-        <button title="${d.linked ? "Remove from project" : "Delete"}" data-op="delete" class="danger">${icoTrash}</button>
+        <button title="Remove from list" data-op="remove" class="danger">${icoTrash}</button>
       </span>`;
     row.title = d.path;
     row.querySelector(".nm").textContent = d.name;
     row.addEventListener("click", (e) => {
       const op = e.target.closest("[data-op]");
-      if (op) { act(op.dataset.op === "rename" ? "renameDoc" : "deleteDoc", d); return; }
+      if (op) { act(op.dataset.op === "rename" ? "renameDoc" : "removeDoc", d); return; }
       if (d.path !== state.doc) act("openDoc", d.path);
     });
     list.appendChild(row);
@@ -826,57 +785,13 @@ async function openDoc(path) {
   await renderAll();
 }
 
-async function openProject(slug, docPath = "") {
-  const res = await py({ action: "open_project", slug });
-  state.project = res.slug; state.projTitle = res.title;
-  state.docs = res.docs; state.standalone = false;
-  fused.params.set("project", res.slug);
-  renderProjMenu();
-  if (docPath || res.docs.length) await openDoc(docPath || res.docs[0].path);
-  else {
-    state.doc = ""; state.pdf?.destroy(); state.pdf = null;
-    $("pages").innerHTML = ""; $("thumbs").innerHTML = "";
-    $("docName").textContent = ""; $("docPages").textContent = "";
-    renderDocList();
-  }
-}
-
-// ---------- project menu ----------
-function renderProjMenu() {
-  const menu = $("projMenu");
-  menu.innerHTML = `
-    <button data-p="new">${icoPlus} New project…</button>
-    <button data-p="rename">${icoPen} Rename project…</button>
-    <button data-p="dup">${icoCopy} Duplicate project</button>
-    <button data-p="del" style="color:var(--danger)">${icoTrash} Delete project…</button>
-    <div class="divider"></div><div class="sub">Projects</div><div class="scrolllist"></div>`;
-  const list = menu.querySelector(".scrolllist");
-  for (const p of state.projects) {
-    const b = document.createElement("button");
-    b.className = "pj" + (p.slug === state.project ? " now" : "");
-    b.innerHTML = `<span class="nm"></span><span class="pjm">${p.ndocs} PDF${p.ndocs === 1 ? "" : "s"}</span>`;
-    b.querySelector(".nm").textContent = p.title;
-    b.onclick = () => { hideProjMenu(); act("switchProject", p.slug); };
-    list.appendChild(b);
-  }
-  menu.querySelectorAll("[data-p]").forEach((b) => b.addEventListener("click", () => {
-    hideProjMenu();
-    act({ new: "newProject", rename: "renameProject", dup: "duplicateProject", del: "deleteProject" }[b.dataset.p]);
-  }));
-}
-const hideProjMenu = () => $("projMenu").classList.add("hidden");
-$("projBtn").addEventListener("click", (e) => {
-  e.stopPropagation();
-  $("projMenu").classList.toggle("hidden");
-});
-document.addEventListener("click", (e) => {
-  if (!e.target.closest(".menu-wrap")) hideProjMenu();
-});
-
-async function reloadProjects() {
-  const res = await py({ action: "list_projects" });
-  state.projects = res.projects;
-  renderProjMenu();
+function clearOpenDoc() {
+  cancelEdit();
+  state.doc = ""; state.pdf?.destroy(); state.pdf = null;
+  $("pages").innerHTML = ""; $("thumbs").innerHTML = "";
+  $("docName").textContent = ""; $("docPages").textContent = "";
+  fused.params.set("doc", "");
+  renderDocList();
 }
 
 // ---------- downloads ----------
@@ -891,99 +806,43 @@ function download(path) {
 const needDoc = () => { if (!state.doc) throw new Error("open a PDF first"); };
 
 const acts = {
-  switchProject: (slug) => openProject(slug),
   openDoc: (path) => openDoc(path),
 
-  newProject: async () => {
-    const title = await dialog({ title: "New project", label: "Project name", okText: "Create" });
-    if (!title) return;
-    const res = await py({ action: "new_project", title });
-    await reloadProjects();
-    await openProject(res.slug);
-    toast(`Project “${title}” created`);
-  },
-  renameProject: async () => {
-    if (state.standalone) return;
-    const title = await dialog({ title: "Rename project", value: state.projTitle, okText: "Rename" });
-    if (!title) return;
-    await py({ action: "rename_project", slug: state.project, title });
-    state.projTitle = title;
-    await reloadProjects();
-    renderDocList();
-  },
-  duplicateProject: async () => {
-    if (state.standalone) return;
-    const res = await py({ action: "duplicate_project", slug: state.project, title: state.projTitle + " copy" });
-    await reloadProjects();
-    await openProject(res.slug);
-    toast("Project duplicated");
-  },
-  deleteProject: async () => {
-    if (state.standalone) return;
-    const ok = await dialog({
-      title: `Delete “${state.projTitle}”?`, input: false, danger: true, okText: "Delete",
-      message: "The project folder and every PDF in it are removed. This cannot be undone.",
-    });
-    if (!ok) return;
-    await py({ action: "delete_project", slug: state.project });
-    await reloadProjects();
-    const next = state.projects[0];
-    if (next) await openProject(next.slug);
-    else { fused.params.set("project", ""); location.reload(); }
-  },
-
-  importPdf: async () => {
-    if (state.standalone) return acts.addToLibrary();
-    const src = await browseModal({ title: "Import a PDF into this project" });
+  addPdf: async () => {
+    const src = await browseModal({ title: "Add a PDF" });
     if (!src) return;
-    const res = await py({ action: "import_doc", project: state.project, src });
-    await refreshDocList();
+    const res = await py({ action: "add_to_library", src });
+    await refreshLib();
     await openDoc(res.path);
-    toast(`Linked ${res.name} — the file stays where it is`);
+    toast(`Added ${res.name}`);
   },
   importUrl: async () => {
-    if (state.standalone) return toast("Add this file to a project first");
-    const url = await dialog({ title: "Import from URL", label: "https://…/file.pdf", okText: "Import" });
+    const url = await dialog({ title: "Add from URL", label: "https://…/file.pdf", okText: "Add" });
     if (!url) return;
-    setStatus("importing…", "busy");
-    const res = await py({ action: "import_url", project: state.project, url });
-    await refreshDocList();
+    setStatus("downloading…", "busy");
+    const res = await py({ action: "import_url", url });
+    await refreshLib();
     await openDoc(res.path);
-    setStatus("imported", "ok");
-  },
-  openPath: async () => {
-    const src = await browseModal({ title: "Open a PDF from anywhere" });
-    if (src) await bootDoc(src);
-  },
-  addToLibrary: async () => {
-    const choice = await projectPickModal();
-    if (!choice) return;
-    const res = await py({ action: "import_doc", project: choice, src: state.doc });
-    await reloadProjects();
-    await openProject(choice, res.path);
-    toast("Added to project");
+    setStatus("added", "ok");
   },
   renameDoc: async (d) => {
     const name = await dialog({ title: "Rename PDF", value: d.name, okText: "Rename" });
     if (!name || name === d.name) return;
-    const res = await py({ action: "rename_doc", doc: d.path, name, project: state.project });
+    const res = await py({ action: "rename_doc", doc: d.path, name });
     if (state.doc === d.path) { state.doc = res.path; fused.params.set("doc", res.path); $("docName").textContent = res.name; }
-    await refreshDocList();
+    await refreshLib();
   },
-  deleteDoc: async (d) => {
+  removeDoc: async (d) => {
     const ok = await dialog({
-      title: d.linked ? `Remove ${d.name}?` : `Delete ${d.name}?`,
-      input: false, danger: true, okText: d.linked ? "Remove" : "Delete",
-      message: d.linked ? "The document is removed from this project — the file on disk is kept."
-        : "The file and its undo history are removed from the project.",
+      title: `Remove ${d.name}?`, input: false, danger: true, okText: "Remove",
+      message: "The PDF is removed from this list — the file on disk is kept.",
     });
     if (!ok) return;
-    await py({ action: "delete_doc", doc: d.path, project: state.project });
-    await refreshDocList();
+    await py({ action: "remove_from_library", doc: d.path });
+    await refreshLib();
     if (state.doc === d.path) {
-      state.doc = "";
       if (state.docs.length) await openDoc(state.docs[0].path);
-      else await openProject(state.project);
+      else clearOpenDoc();
     }
   },
   save: async () => {
@@ -1077,7 +936,6 @@ const acts = {
       message: "The pages are copied into a new PDF next to this one." });
     if (!pages) return;
     const res = await py({ action: "extract_pages", doc: state.doc, pages });
-    await refreshDocList();
     await resultModal({ title: "Pages extracted",
       note: `Pages ${pages} were copied into a new PDF in ${res.dir}. The original document is unchanged.`,
       files: [res], dir: res.dir });
@@ -1088,11 +946,10 @@ const acts = {
     const picked = await mergeModal();
     if (!picked) return;
     setStatus("merging…", "busy");
-    const res = await py({ action: "merge", project: state.standalone ? "" : state.project,
+    const res = await py({ action: "merge",
       sources: JSON.stringify(picked.sources), name: picked.name, directory: picked.dir });
-    if (!state.standalone && state.project)
-      await py({ action: "import_doc", project: state.project, src: res.path });
-    await refreshDocList();
+    await py({ action: "add_to_library", src: res.path });
+    await refreshLib();
     await openDoc(res.path);
     setStatus("merged", "ok");
     toast(`Created ${res.name} in ${res.dir}`);
@@ -1104,7 +961,6 @@ const acts = {
     setStatus("splitting…", "busy");
     const res = await py({ action: "split", doc: state.doc, mode: opt.mode,
       ranges: opt.ranges, prefix: opt.prefix, directory: opt.dir });
-    await refreshDocList();
     setStatus("done", "ok");
     await resultModal({ title: "Split complete",
       note: `${state.info.name} was split into ${res.files.length} file${res.files.length === 1 ? "" : "s"} in ${res.dir}. The original document is unchanged.`,
@@ -1163,29 +1019,6 @@ function setZoom(z) {
 }
 
 // ---------- specialized modals ----------
-async function projectPickModal() {
-  await reloadProjects();
-  const m = modal(`<h3>Add to a project</h3><div class="checklist" id="ppList"></div>
-    <div class="row"><button class="btn" data-x="new">New project…</button>
-    <button class="btn" data-x="cancel">Cancel</button></div>`);
-  const list = m.el.querySelector("#ppList");
-  for (const p of state.projects) {
-    const b = document.createElement("label");
-    b.textContent = p.title;
-    b.style.cursor = "pointer";
-    b.onclick = () => m.close(p.slug);
-    list.appendChild(b);
-  }
-  m.el.querySelector("[data-x=cancel]").onclick = () => m.close(null);
-  m.el.querySelector("[data-x=new]").onclick = () => m.close("__new__");
-  const slug = await m.done;
-  if (slug !== "__new__") return slug;
-  const title = await dialog({ title: "New project", label: "Project name", okText: "Create" });
-  if (!title) return null;
-  const res = await py({ action: "new_project", title });
-  return res.slug;
-}
-
 async function mergeModal() {
   const m = modal(`<h3>Merge PDFs</h3>
     <p>Pick the documents to combine, in order. The current document is included first.</p>
@@ -1333,8 +1166,6 @@ const icoRotR = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stro
 const icoTrash = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h18"/><path d="M8 6V4h8v2"/><path d="M19 6l-1 14H6L5 6"/></svg>`;
 const icoExtract = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="M12 18v-6"/><path d="m9 15 3 3 3-3"/></svg>`;
 const icoPen = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg>`;
-const icoPlus = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg>`;
-const icoCopy = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="12" height="12" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>`;
 const icoDir = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>`;
 const icoFile = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg>`;
 const icoDown = `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v12"/><path d="m7 10 5 5 5-5"/><path d="M5 21h14"/></svg>`;
@@ -1373,7 +1204,7 @@ function setMode(mode) {
 }
 
 $("exportBtn").addEventListener("click", () => act("export"));
-$("importBtn").addEventListener("click", () => act("importPdf"));
+$("importBtn").addEventListener("click", () => act("addPdf"));
 
 $("pages").addEventListener("click", (e) => {
   const wrap = e.target.closest(".pdf-page");
@@ -1412,19 +1243,15 @@ document.addEventListener("keydown", (e) => {
   if (mod && e.key.toLowerCase() === "z" && !e.shiftKey) { e.preventDefault(); act("undo"); }
   else if (mod && (e.key.toLowerCase() === "y" || (e.key.toLowerCase() === "z" && e.shiftKey))) { e.preventDefault(); act("redo"); }
   else if (mod && e.key.toLowerCase() === "s") { e.preventDefault(); act(e.shiftKey ? "saveAs" : "save"); }
-  else if (mod && e.key.toLowerCase() === "o") { e.preventDefault(); act("openPath"); }
+  else if (mod && e.key.toLowerCase() === "o") { e.preventDefault(); act("addPdf"); }
   else if (mod && e.key === "\\") { e.preventDefault(); act("togglePanel"); }
 });
 
 // ---------- boot ----------
 async function bootDoc(path) {
-  const res = await py({ action: "which_project", doc: path });
-  if (res.slug) await openProject(res.slug, path);
-  else {
-    state.standalone = true; state.project = "";
-    renderProjMenu();
-    await openDoc(path);
-  }
+  await py({ action: "add_to_library", src: path });
+  await refreshLib();
+  await openDoc(path);
 }
 
 async function boot() {
@@ -1444,18 +1271,18 @@ async function boot() {
     }
     state.zoom = +(fused.params.get("zoom") || 100) || 100;
     if (fused.params.get("panel") === "0") document.body.classList.add("panel-off");
-    await reloadProjects();
+    await refreshLib();
     const wanted = fused.params.get("doc") || fused.params.get("_file") || "";
     let opened = false;
     if (wanted && wanted.toLowerCase().endsWith(".pdf")) {
       try { await bootDoc(wanted); opened = true; }
       catch (err) { console.error(err); toast(`Could not open ${wanted.split("/").pop()}: ${err?.message || err}`, true); }
     }
-    if (!opened) {
-      const slug = fused.params.get("project") || state.projects[0]?.slug;
-      if (slug) await openProject(slug);
+    if (!opened && state.docs.length) {
+      try { await openDoc(state.docs[0].path); }
+      catch (err) { console.error(err); }
     }
-    setMode(fused.params.get("mode") === "view" ? "view" : "edit");
+    setMode(fused.params.get("mode") === "edit" ? "edit" : "view");
     $("boot").remove();
   } catch (err) {
     console.error(err);

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -855,8 +855,10 @@ const acts = {
     await py({ action: "remove_from_library", doc: d.path });
     await refreshLib();
     if (state.doc === d.path) {
+      // Clear the removed doc first so a failed open of the next one (missing/
+      // encrypted) leaves an empty viewer, not the just-removed file.
+      clearOpenDoc();
       if (state.docs.length) await openDoc(state.docs[0].path);
-      else clearOpenDoc();
     }
   },
   save: async () => {


### PR DESCRIPTION
## What

Reworks the built-in **PDF Studio** template to drop the "project" concept in favor of a flat, persisted list of PDFs, and defaults the app to **View** mode.

### Before → After
- **Projects removed.** No more topbar project dropdown (New/Rename/Duplicate/Delete), no auto-seeded demo project.
- **Flat library.** Documents now live in a single `~/.fused-render/data/pdf_studio/library.json` (`{"paths": [...]}`) of absolute paths. Entries are *references* — files are never copied, and "Remove from list" keeps the file on disk.
- **Add via the file browser.** The sidebar **＋** and **File ▸ Add PDF… (Ctrl+O)** both open the existing browser modal, which lets you paste a full path or navigate the filesystem. "Import from URL" is kept as **Add from URL…** (downloads into `data/pdf_studio/downloads`, then adds to the list).
- **Defaults to View mode** on load; Edit is still one click away (or `?mode=edit`).

### Backend (`pdf.py`)
- New actions: `list_library`, `add_to_library`, `remove_from_library`.
- `import_url` no longer needs a project; `merge` / `rename_doc` drop the `project` arg.
- `_hist_dir` always uses the snapshots dir (undo/redo unchanged otherwise).
- Removed the demo generator, project/meta helpers, and now-unused `import time`.

## Why
The project layer added ceremony without much payoff for a local single-user PDF tool. A flat "add a PDF, it's remembered" model is simpler and matches how people actually reach for files.

## Notes for reviewers
- Net change is mostly deletions (~533 removed vs ~132 added).
- Working-copy / undo-redo / save / merge / split / compress / text-edit machinery is untouched — it was always keyed by file path, not project.
- Verified end-to-end: drove the `pdf.py` dispatcher directly (add/dedupe/list/open/rotate+save/merge/rename/remove) and exercised the same flow through a running server's engine via `fused.runPython`, plus the file browser's `listdir`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large API and persistence change for pdf_studio (library index vs projects) with behavior shifts (no on-disk delete, no demo project), though core edit/save/undo paths stay path-keyed.
> 
> **Overview**
> **PDF Studio** drops the project model for a single persisted library and simplifies the UI around “add a PDF, remember the path.”
> 
> The backend replaces project folders, `meta.json`, and demo seeding with `library.json` (`paths` of absolute references), `list_library` / `add_to_library` / `remove_from_library`, URL downloads under `data/pdf_studio/downloads`, and undo history always under `cache/snapshots` (no per-project `.history`). `merge`, `rename_doc`, and `import_url` no longer take a `project` argument; default action is `list_library`. Disk **delete** is gone — removal only unlinks from the library and clears work/undo for that path.
> 
> The template removes the project dropdown and standalone flows, drives the sidebar from `list_library`, renames **Add PDF** / **Add from URL**, uses **Remove from list** (file kept), auto-adds merged outputs to the library, and boots by adding deep-linked PDFs to the library. **View** mode is the default (Edit via toggle or `?mode=edit`).
> 
> Read-only tests now target `LIBRARY` instead of `PROJECTS` and replace `delete_doc` RO coverage with `remove_from_library` (no file delete).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 003700ba20849a11226e69ff557df26b05e63220. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->