### PR TITLE
feat(listing): remember each folder's sort as per-path view state

### DIFF
--- a/frontend/src/lib/viewstate.ts
+++ b/frontend/src/lib/viewstate.ts
@@ -1,0 +1,41 @@
+// Per-path view state — currently the directory listing's sort (?sort/&order).
+// A folder remembers how it was last viewed, so returning to it (clicking in,
+// a breadcrumb, the browser Back button, or a fresh URL) restores that folder's
+// own state rather than inheriting the previous view's. Keyed by canonical fs
+// path; the value is a query string INCLUDING its leading "?" (or "" = none).
+//
+// This is deliberately a plain path->search store, not a param-carry across
+// navigation: two sibling folders keep independent sorts (Desktop by Modified,
+// fused by Size) and neither leaks into the other.
+const KEY = "fused-render:viewstate";
+
+function load(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {}; // private-mode / quota / malformed JSON — behave as empty
+  }
+}
+
+function save(map: Record<string, string>): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(map));
+  } catch {
+    // storage unavailable — state is best-effort, so a failed write is fine
+  }
+}
+
+// Saved search string for `path` ("" when nothing is stored). Carries a leading
+// "?" so callers can hand it straight to urlForFsPath.
+export function getViewState(path: string): string {
+  return load()[path] || "";
+}
+
+// Persist (or, with an empty search, clear) the saved state for `path`.
+export function setViewState(path: string, search: string): void {
+  const map = load();
+  if (search) map[path] = search;
+  else delete map[path];
+  save(map);
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -130,14 +130,19 @@ body {
   padding: 6px 10px;
   border-radius: 8px;
   cursor: pointer;
+  /* Opaque equivalent of this row's background, for the hover actions' fade
+     mask (see .bookmark-actions). Kept in sync with the state rules below. */
+  --row-bg: var(--bg-alt);
 }
 
 .bookmark-row:hover {
   background: rgba(255, 255, 255, 0.06);
+  --row-bg: #26282c; /* bg-alt composited with the white 0.06 hover layer */
 }
 
 .bookmark-row.active {
   background: rgba(229, 255, 68, 0.13);
+  --row-bg: #353a25; /* bg-alt composited with the accent 0.13 active layer */
 }
 
 .bookmark-row.active .bookmark-name {
@@ -254,14 +259,21 @@ a.bookmark-name::after {
 }
 
 .bookmark-actions {
-  /* visibility (not display) so the buttons always occupy layout space —
-     display:none → flex on hover made the bookmark name shift width. */
+  /* Absolutely positioned (out of the flex flow) so the name occupies the full
+     row width by default instead of permanently reserving space for the icons.
+     On hover the buttons overlay the name's right end; a gradient the color of
+     the row fades the underlying text out beneath them so it stays readable and
+     nothing reflows. Same overlay trick as .folder-count. */
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
   display: flex;
   visibility: hidden;
-  flex: 0 0 auto;
   gap: 2px;
-  position: relative;
   z-index: 1;
+  padding-left: 26px;
+  background: linear-gradient(to right, transparent, var(--row-bg) 26px);
 }
 
 .bookmark-row:hover .bookmark-actions {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -15,6 +15,7 @@ import type { FsEntry, WalkEntry } from "../lib/api";
 import { formatSize, formatMtime } from "../lib/format";
 import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 import { iconForEntry } from "../components/FileIcons";
+import { getViewState, setViewState } from "../lib/viewstate";
 
 const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
 type SortKey = keyof typeof SORT_KEYS;
@@ -38,11 +39,18 @@ const URL_SYNC_MS = 200;
 // flushes immediately (lastFlush starts at 0), so first paint isn't delayed.
 const STREAM_FLUSH_MS = 200;
 
-function currentSort(): { sort: SortKey; order: SortOrder } {
-  const q = new URLSearchParams(location.search);
-  const key = q.get("sort");
+// Effective sort for a folder. An explicit `?sort` in the URL wins — a shared
+// or hand-typed link is authoritative — otherwise fall back to this folder's
+// own saved state (lib/viewstate), otherwise the default name/asc. So each
+// folder shows its own remembered order regardless of how it was reached
+// (clicked into, a breadcrumb, Back, or a fresh URL), and sibling folders keep
+// independent sorts.
+function resolveSort(fsPath: string): { sort: SortKey; order: SortOrder } {
+  const url = new URLSearchParams(location.search);
+  const src = url.get("sort") ? url : new URLSearchParams(getViewState(fsPath));
+  const key = src.get("sort");
   const sort: SortKey = key && key in SORT_KEYS ? (key as SortKey) : "name";
-  const order: SortOrder = q.get("order") === "desc" ? "desc" : "asc";
+  const order: SortOrder = src.get("order") === "desc" ? "desc" : "asc";
   return { sort, order };
 }
 
@@ -178,7 +186,24 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const [state, setState] = useState<ListingState>({ status: "loading" });
   // Sort lives in the URL; mirror it in state so clicks re-render without a
   // navigation (vanilla re-ran renderListing after its replaceState).
-  const [{ sort, order }, setSortState] = useState<{ sort: SortKey; order: SortOrder }>(currentSort);
+  const [{ sort, order }, setSortState] = useState<{ sort: SortKey; order: SortOrder }>(() =>
+    resolveSort(fsPath)
+  );
+  // When the sort was restored from saved state (URL carried none), reflect it
+  // in the URL so the address bar, bookmarks, and Back-button history match
+  // what's shown — as if the column had been clicked. Only syncs a genuinely
+  // saved order; an unsorted folder keeps its clean, param-free URL. replaceState
+  // (not navigate) so the view doesn't remount.
+  useEffect(() => {
+    if (new URLSearchParams(location.search).get("sort")) return; // URL is authoritative
+    const saved = getViewState(fsPath);
+    if (!saved) return; // nothing stored → leave default sort + clean URL
+    const s = new URLSearchParams(saved);
+    const params = new URLSearchParams(location.search);
+    params.set("sort", s.get("sort") || "name");
+    params.set("order", s.get("order") === "desc" ? "desc" : "asc");
+    history.replaceState(null, "", location.pathname + "?" + params.toString());
+  }, [fsPath]);
   const [refresh, setRefresh] = useState(0); // bumped by the dir watch socket
   const [query, setQueryState] = useState<string>(currentQuery);
   const [walk, setWalk] = useState<WalkState>(IDLE_WALK);
@@ -463,6 +488,9 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     params.set("order", next.order);
     history.replaceState(null, "", location.pathname + "?" + params.toString());
     setSortState(next);
+    // Remember this folder's choice so returning to it later restores this sort.
+    // Only sort/order are persisted — the in-folder search `q` stays transient.
+    setViewState(fsPath, "?sort=" + next.sort + "&order=" + next.order);
   };
 
   const setSearchSortKey = (key: SortKey) => {


### PR DESCRIPTION
Two related file-explorer UX fixes.

## 1. Remember each folder's sort (per-path view state)

The directory listing's sort lived only on the current URL, so any navigation that built a fresh URL dropped it: clicking into a subfolder, a breadcrumb, or the browser **Back** button. Returning to a folder always reverted to the default **Name** order.

Now the sort is stored **per canonical fs path** (localStorage) and restored on arrival, so each folder keeps its own order and siblings stay independent (e.g. `Desktop` by Modified, `fused` by Size).

Resolution order on mount:
1. explicit `?sort` in the URL wins — shared / hand-typed links stay authoritative
2. else the folder's saved state
3. else the default (Name / asc)

The restored order is written back into the URL (`replaceState`) so the address bar, bookmarks, and Back-button history all match what's shown.

- **new** `frontend/src/lib/viewstate.ts` — `get/setViewState(path)` store
- `frontend/src/views/Listing.tsx` — `resolveSort()`, mount effect to sync the restored sort into the URL, `setSort` persists the choice (only `sort`/`order`; the in-folder search `q` stays transient)

## 2. Bookmark name takes full row width; hover icons overlay

The sidebar bookmark row's action buttons (save/rename/delete) sat in the flex flow with `visibility:hidden`, permanently reserving ~60px — so the name was truncated even at rest and hard to read without hovering.

The actions are now absolutely positioned (out of the flow, same trick as `.folder-count`), so the name occupies the full width by default. On hover the icons overlay the name's right end with a gradient the color of the row fading the text beneath them for readability; nothing reflows.

- `frontend/src/shell.css` — `.bookmark-actions` overlay + per-state `--row-bg` for the fade

## Verification
`npm run build` (tsc + vite) passes. Verified end-to-end with Playwright against a live server:
- two sibling folders keep independent sorts (Modified vs Size); a never-sorted subfolder shows the default, no leak
- breadcrumb back and browser Back both restore each folder's own sort and its `?sort=` param
- bookmark name renders full-width by default; on hover the action icons overlay with a readable fade, no layout shift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only UX: localStorage for sort preferences and CSS layout for bookmarks; no auth, API, or data-model changes.
> 
> **Overview**
> Adds **per-folder sort memory** for directory listings and fixes **sidebar bookmark row** layout so names use the full width.
> 
> **Listing sort** is now stored in `localStorage` keyed by canonical fs path (`viewstate.ts`). On open, sort resolves as URL `?sort` first, then saved state, then default Name/asc. Column clicks persist `sort`/`order` only (search `q` stays ephemeral). When sort comes from storage, a mount `replaceState` updates the address bar without remounting.
> 
> **Bookmark rows** move action buttons out of the flex flow (absolute overlay + `--row-bg` gradient), matching the folder-count pattern—no permanent width reserved for hidden icons and no hover reflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc12cb2101f5f385fef0c574c6791798510f382. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->