### PR TITLE
fix(mounts): serve-side vfs cache was never enabled

### DIFF
--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -79,9 +79,15 @@ VFS_OPT = {
 # the whole of every touched file, hence the LRU size cap (soft — checked
 # every poll interval, open files never evicted). Fingerprints (size+modtime,
 # with --use-server-modtime from rcd) invalidate cached files that change
-# in the store. sync_serves restarts any serve whose vfsOpt drifts from
+# in the store. sync_serves restarts any serve whose vfs options drift from
 # this, so edits here roll out to serves adopted from an older server.
-SERVE_VFS_OPT = {"CacheMode": "full", "CacheMaxSize": "5Gi"}
+#
+# Unlike mount/mount's `vfsOpt` object, serve/start takes vfs options as
+# FLAT rc parameters named after the CLI flags (--vfs-cache-mode ->
+# vfs_cache_mode). An unknown `vfsOpt` key is silently ignored — the serve
+# then runs with the cache OFF and every read, warm or not, goes to the
+# store (measured: 1MB re-read 4.4s uncached vs 2ms cached).
+SERVE_VFS_OPT = {"vfs_cache_mode": "full", "vfs_cache_max_size": "5Gi"}
 
 # Tile-server daemon state files — the two parallel implementations that can
 # hold files open under a mount (geotiff, and the grid server shared by
@@ -292,14 +298,16 @@ def serves_path() -> str:
 
 
 def _http_serves(port: int) -> dict:
-    """{fs: {"addr", "id"}} for every live rc HTTP serve."""
+    """{fs: {"addr", "id", "vfs"}} for every live rc HTTP serve. "vfs" is the
+    flat vfs_* params the serve was started with (drift check input)."""
     try:
         listed = _rc(port, "serve/list").get("list", [])
     except RuntimeError:
         return {}
     return {
         s["params"]["fs"]: {"addr": s.get("addr", ""), "id": s.get("id", ""),
-                            "vfsOpt": s["params"].get("vfsOpt")}
+                            "vfs": {k: v for k, v in s["params"].items()
+                                    if k.startswith("vfs_")}}
         for s in listed
         if isinstance(s, dict) and s.get("params", {}).get("type") == "http"
         and s.get("params", {}).get("fs")
@@ -359,7 +367,7 @@ def _sync_serves_locked() -> None:
     for m in mounts:
         fs = m["remote"]
         serve = serves.get(fs)
-        if serve is not None and serve["vfsOpt"] != SERVE_VFS_OPT:
+        if serve is not None and serve["vfs"] != SERVE_VFS_OPT:
             # Stale cache options (serves outlive server runs, so a config
             # change here never reaches an already-running serve otherwise).
             if serve["id"]:
@@ -374,7 +382,7 @@ def _sync_serves_locked() -> None:
                     "type": "http",
                     "fs": fs,
                     "addr": "127.0.0.1:0",
-                    "vfsOpt": SERVE_VFS_OPT,
+                    **SERVE_VFS_OPT,
                 }, timeout=30).get("addr", "")
             except RuntimeError as e:
                 logger.warning("http serve for %r failed: %s", m["name"], e)

--- a/prototypes/coalesced_fetch_bench.py
+++ b/prototypes/coalesced_fetch_bench.py
@@ -1,0 +1,177 @@
+"""Prototype: coalesced/parallel column-chunk fetch vs DuckDB ranged HTTP.
+
+Finding so far (via query profiling): DuckDB DOES prune row groups on a
+file_row_number IN-list (it rewrites it to a >=/<= range filter) and reads
+exactly one column chunk (~17.4MB). The cost is throughput: a single stream
+through the rclone serve to S3 runs at only ~1.5-2.5MB/s. So the lever is
+PARALLELISM over the chunk's byte range, not just coalescing.
+
+Method (fresh DuckDB connection per phase; each variant targets a DIFFERENT
+row group so the serve's VFS cache can't cross-warm them):
+  A. baseline  - reader.py phase-two style over HTTP: WHERE file_row_number
+                 IN (<100 positions in row group RG_A>) projecting BIG_COL
+  B. coalesced-1 - one contiguous range GET of BIG_COL's chunk in RG_B ->
+                 sparse local file -> same IN-list query locally
+  C. coalesced-8 - same as B for RG_C but the chunk is fetched with 8
+                 concurrent range GETs
+  verify       - re-fetch variant C's rows over HTTP and compare
+"""
+import os
+import sys
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+
+import duckdb
+
+URL = ("http://127.0.0.1:53529/year=2024/quarter=3/"
+       "2024-07-01_performance_fixed_tiles.parquet")
+BIG_COL = "tile"
+RG_A = 2          # row group for the HTTP baseline
+RG_B = 5          # row group for single-stream coalesced
+RG_C = 8          # row group for 8-stream coalesced
+N_STREAMS = 8
+N_ROWS = 100
+SPARSE = "/tmp/coalesced_proto_sparse.parquet"
+
+
+def http_con():
+    con = duckdb.connect(":memory:")
+    con.execute("LOAD httpfs")
+    con.execute("SET enable_object_cache=true")
+    con.execute("SET threads=32")
+    return con
+
+
+def range_get(url, start, length):
+    req = urllib.request.Request(url)
+    req.add_header("Range", f"bytes={start}-{start + length - 1}")
+    with urllib.request.urlopen(req) as r:
+        data = r.read()
+    assert len(data) == length, (len(data), length)
+    return data
+
+
+def head_size(url):
+    req = urllib.request.Request(url, method="HEAD")
+    with urllib.request.urlopen(req) as r:
+        return int(r.headers["Content-Length"])
+
+
+def parallel_get(url, start, length, streams):
+    part = (length + streams - 1) // streams
+    def piece(i):
+        off = start + i * part
+        return range_get(url, off, min(part, start + length - off))
+    with ThreadPoolExecutor(streams) as ex:
+        return b"".join(ex.map(piece, range(streams)))
+
+
+def timed(label, fn, nbytes=None):
+    t0 = time.time()
+    out = fn()
+    dt = time.time() - t0
+    rate = f"  ({nbytes / dt / 1e6:5.1f} MB/s)" if nbytes else ""
+    print(f"{label:<28} {dt:8.2f}s{rate}")
+    return out, dt
+
+
+def main():
+    # -- 1. metadata over HTTP (footer read; both paths pay this once) -------
+    def read_meta():
+        con = http_con()
+        rows = con.execute(
+            "SELECT row_group_id, row_group_num_rows, path_in_schema,"
+            "       data_page_offset, dictionary_page_offset,"
+            "       total_compressed_size "
+            "FROM parquet_metadata(?)", [URL]).fetchall()
+        con.close()
+        return rows
+
+    meta, t_meta = timed("metadata (HTTP footer)", read_meta)
+
+    # row-group start positions (file_row_number space) and chunk ranges
+    rg_rows = {}          # rg_id -> num_rows
+    chunks = {}           # (rg_id, col) -> (start_byte, length)
+    for rg, nrows, col, dpo, dico, size in meta:
+        rg_rows[rg] = nrows
+        start = min(x for x in (dpo, dico) if x is not None and x > 0)
+        chunks[(rg, col)] = (start, size)
+
+    rg_start = {}
+    pos = 0
+    for rg in sorted(rg_rows):
+        rg_start[rg] = pos
+        pos += rg_rows[rg]
+
+    for rg in (RG_A, RG_B, RG_C):
+        s, ln = chunks[(rg, BIG_COL)]
+        print(f"  rg{rg} '{BIG_COL}' chunk: offset={s} size={ln/1e6:.1f}MB "
+              f"rows={rg_rows[rg]}")
+
+    def in_list(rg):
+        base = rg_start[rg]
+        return ",".join(str(base + i) for i in range(N_ROWS))
+
+    def http_query(rg):
+        con = http_con()
+        q = (f"SELECT file_row_number, {BIG_COL} "
+             f"FROM read_parquet('{URL}', file_row_number=true) "
+             f"WHERE file_row_number IN ({in_list(rg)})")
+        out = con.execute(q).fetchall()
+        con.close()
+        return out
+
+    size = head_size(URL)
+    tail = range_get(URL, size - 8, 8)
+    assert tail[4:] == b"PAR1"
+    footer_len = int.from_bytes(tail[:4], "little")
+    footer = range_get(URL, size - 8 - footer_len, footer_len + 8)
+
+    def coalesced(rg, streams):
+        cstart, clen = chunks[(rg, BIG_COL)]
+        if streams == 1:
+            chunk = range_get(URL, cstart, clen)
+        else:
+            chunk = parallel_get(URL, cstart, clen, streams)
+
+        with open(SPARSE, "wb") as f:
+            f.write(b"PAR1")
+            f.seek(cstart)
+            f.write(chunk)
+            f.seek(size - 8 - footer_len)
+            f.write(footer)
+
+        con = duckdb.connect(":memory:")
+        q = (f"SELECT file_row_number, {BIG_COL} "
+             f"FROM read_parquet('{SPARSE}', file_row_number=true) "
+             f"WHERE file_row_number IN ({in_list(rg)})")
+        out = con.execute(q).fetchall()
+        con.close()
+        return out
+
+    csize = lambda rg: chunks[(rg, BIG_COL)][1]
+
+    base_rows, t_base = timed(f"A: duckdb HTTP (rg{RG_A})",
+                              lambda: http_query(RG_A), csize(RG_A))
+    coal1_rows, t_coal1 = timed(f"B: coalesced x1 (rg{RG_B})",
+                                lambda: coalesced(RG_B, 1), csize(RG_B))
+    coal8_rows, t_coal8 = timed(f"C: coalesced x{N_STREAMS} (rg{RG_C})",
+                                lambda: coalesced(RG_C, N_STREAMS),
+                                csize(RG_C))
+    for r in (base_rows, coal1_rows, coal8_rows):
+        assert len(r) == N_ROWS
+
+    ref_rows, _ = timed("verify HTTP (rg{}, warm)".format(RG_C),
+                        lambda: http_query(RG_C))
+    match = sorted(coal8_rows) == sorted(ref_rows)
+    print(f"\ncorrectness: {'MATCH' if match else 'MISMATCH'}")
+    print(f"A -> B speedup: {t_base / t_coal1:.1f}x | "
+          f"A -> C speedup: {t_base / t_coal8:.1f}x")
+    if not match:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    os.path.exists(SPARSE) and os.remove(SPARSE)
+    main()

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -716,9 +716,11 @@ def test_attach_starts_http_serve_and_writes_map(home, rcd):
     assert body["fs"] == "remote:bucket/prefix"
     # Serve-side vfs cache is a capped on-disk range cache: unlike DuckDB's
     # in-RAM external file cache it survives reconnects and server restarts.
-    assert body["vfsOpt"] == mounts_mod.SERVE_VFS_OPT
-    assert body["vfsOpt"]["CacheMode"] == "full"
-    assert body["vfsOpt"]["CacheMaxSize"] == "5Gi"
+    # serve/start takes vfs options as FLAT vfs_* rc params — a `vfsOpt`
+    # object is mount/mount-only and gets silently ignored (cache stays off).
+    assert "vfsOpt" not in body
+    assert body["vfs_cache_mode"] == "full"
+    assert body["vfs_cache_max_size"] == "5Gi"
     serves = json.load(open(mounts_mod.serves_path()))
     assert serves == {mounts_mod.mountpoint(c): "http://127.0.0.1:59999"}
 
@@ -742,7 +744,7 @@ def test_sync_serves_reuses_existing_serve(home, rcd):
     rcd.responses["serve/list"] = {"list": [{
         "id": "http-live", "addr": "127.0.0.1:41000",
         "params": {"type": "http", "fs": "remote:bucket",
-                   "vfsOpt": dict(mounts_mod.SERVE_VFS_OPT)}}]}
+                   **mounts_mod.SERVE_VFS_OPT}}]}
     mounts_mod.sync_serves()
     assert not any(m == "serve/start" for m, _ in rcd.calls)
     serves = json.load(open(mounts_mod.serves_path()))
@@ -752,16 +754,19 @@ def test_sync_serves_reuses_existing_serve(home, rcd):
 def test_sync_serves_restarts_serve_with_stale_vfs_opts(home, rcd):
     # Serves outlive server runs, so a SERVE_VFS_OPT change would never reach
     # an adopted serve unless the sync notices the drift and restarts it.
+    # A serve started by the old vfsOpt-object code has NO flat vfs_* params
+    # (rcd ignored the object) — exactly this drift, so the fix self-deploys.
     c = mounts_mod.add_mount("data", "remote:bucket")
     rcd.responses["serve/list"] = {"list": [{
         "id": "http-stale", "addr": "127.0.0.1:41000",
         "params": {"type": "http", "fs": "remote:bucket",
-                   "vfsOpt": {"CacheMode": "off"}}}]}
+                   "vfsOpt": {"CacheMode": "full", "CacheMaxSize": "5Gi"}}}]}
     mounts_mod.sync_serves()
     [(_, stop)] = [x for x in rcd.calls if x[0] == "serve/stop"]
     assert stop == {"id": "http-stale"}
     [(_, start)] = [x for x in rcd.calls if x[0] == "serve/start"]
-    assert start["vfsOpt"] == mounts_mod.SERVE_VFS_OPT
+    assert start["vfs_cache_mode"] == "full"
+    assert start["vfs_cache_max_size"] == "5Gi"
     serves = json.load(open(mounts_mod.serves_path()))
     assert serves == {mounts_mod.mountpoint(c): "http://127.0.0.1:59999"}
 


### PR DESCRIPTION
## Summary
- `serve/start` takes vfs options as flat CLI-flag-style rc params (`vfs_cache_mode`), not a `vfsOpt` object — that shape is `mount/mount`-only and rclone silently ignores the unknown key. Every HTTP serve has been running with its cache **off**, so every DuckDB read — warm or not — went all the way to the store.
- Pass `SERVE_VFS_OPT` flat into `serve/start` and read the `vfs_*` params back from `serve/list` for the drift check. Serves started by the old code carry no `vfs_*` params, so the existing drift-restart path self-deploys the fix on next sync.
- Keeps the benchmark prototype (`prototypes/coalesced_fetch_bench.py`) that surfaced the bug.

## Measured impact (Ookla parquet, reader-style 100-row page of the big `tile` column)
| | broken serve | fixed serve |
|---|---|---|
| cold | 22s | 13s |
| re-read | **50s** | **0.01s** |
| raw 1MB re-read | 4.4s | 2ms |

Verified live against rclone v1.74.4: `vfs/stats` showed `CacheMode: 0` with the old param shape; with flat params the sparse cache file appears and warm reads are served from disk.

## Test plan
- [x] `tests/test_shell_mounts.py` — 61 passed (serve tests updated to assert flat `vfs_*` params and the vfsOpt-era drift restart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)