### PR TITLE
fix: pin previous_tag_name for release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
       NOTARY_TEAM_ID: L5CL3594R4
     steps:
       - uses: actions/checkout@v4
+        with:
+          # release notes generation below needs every tag reachable, not
+          # just the one that triggered this run (default fetch-depth: 1
+          # only grabs the tagged commit itself)
+          fetch-depth: 0
 
       # build_dmg.sh's own version check needs `str | None` syntax (py>=3.10);
       # macOS runners' default `python3` can resolve to an older CLT/system
@@ -98,12 +103,23 @@ jobs:
           echo "DMG_SHA256=$DMG_SHA256" >> "$GITHUB_ENV"
           aws s3 cp "$DMG_PATH" "s3://fused-magic/fused-render-dmgs/$(basename "$DMG_PATH")"
 
+      - name: Find previous tag
+        id: prev_tag
+        run: |
+          set -euo pipefail
+          # GitHub's own previous-tag auto-detection has proven unreliable
+          # here (past releases each listed the full PR history instead of
+          # just what changed since the prior release) — pin it explicitly.
+          PREV_TAG="$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -n1)"
+          echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.DMG_PATH }}
           name: FusedRender ${{ github.ref_name }}
           generate_release_notes: true
+          previous_tag_name: ${{ steps.prev_tag.outputs.tag }}
 
       - name: Bump homebrew-tap cask
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,11 @@ jobs:
           # GitHub's own previous-tag auto-detection has proven unreliable
           # here (past releases each listed the full PR history instead of
           # just what changed since the prior release) — pin it explicitly.
-          PREV_TAG="$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -n1)"
+          # grep exits 1 (failing the pipeline under pipefail) when there's
+          # no other tag yet, e.g. on the very first release — that's a
+          # legitimate case, not an error, so tolerate it and leave PREV_TAG
+          # empty; the release action falls back to its own auto-detection.
+          PREV_TAG="$(git tag --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -n1 || true)"
           echo "tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
@@ -119,7 +123,7 @@ jobs:
           files: ${{ env.DMG_PATH }}
           name: FusedRender ${{ github.ref_name }}
           generate_release_notes: true
-          previous_tag_name: ${{ steps.prev_tag.outputs.tag }}
+          previous_tag: ${{ steps.prev_tag.outputs.tag }}
 
       - name: Bump homebrew-tap cask
         env:


### PR DESCRIPTION
## Summary
- v0.2.4's release notes repeated the entire PR history from v0.2.3 instead of just the delta — evidence: both releases' "Full Changelog" link was a plain `/commits/<tag>` link rather than a `previous...current` compare range, meaning GitHub's own previous-tag auto-detection never resolved a prior tag.
- Compute the previous tag explicitly from `git tag --sort=-v:refname` and pass it as `previous_tag_name` to `softprops/action-gh-release@v2` instead of relying on GitHub to guess it.
- `actions/checkout@v4` now uses `fetch-depth: 0` since the new step needs all tags, not just the one that triggered the run.

## Test plan
- [ ] Push a new tag (e.g. `v0.2.5`) and confirm the generated release notes only include PRs merged since `v0.2.4`, with a proper `previous_tag...v0.2.5` compare link in "Full Changelog"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes with no impact on app binaries, signing, or runtime behavior.
> 
> **Overview**
> Fixes **release notes** on tag pushes so they only cover changes since the last release, instead of repeating the full PR history when GitHub’s previous-tag guess fails.
> 
> **Checkout** now uses `fetch-depth: 0` so every tag is available on the runner. A new **Find previous tag** step picks the newest semver tag other than the one being released (`git tag --sort=-v:refname`, excluding `GITHUB_REF_NAME`), with an empty result tolerated on the first release. That value is passed to `softprops/action-gh-release@v2` as `previous_tag` alongside `generate_release_notes: true`, so notes and the “Full Changelog” compare link use an explicit `previous...current` range.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2b49bd94188c3a02480cdf15e8617a78405b50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->