### PR TITLE
feat(shell): background whole-file prefetch for mount-backed files

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1254,6 +1254,7 @@ def create_app(start_dir: str) -> FastAPI:
     # (shell/mounts.py). startup() remounts every mount in a background
     # thread; mounts deliberately survive server restarts.
     from fused_render.shell import mounts as shell_mounts
+    from fused_render.shell import prefetch as shell_prefetch
 
     app.include_router(shell_mounts.router)
     shell_mounts.startup()
@@ -1446,6 +1447,11 @@ def create_app(start_dir: str) -> FastAPI:
         # would run the full upstream GET just to drop the body.
         upstream = shell_mounts.serve_url_for(path)
         if upstream is not None:
+            # Every remote read flows through here, so this is where the
+            # shell learns a mounted file is in use: kick off (or just
+            # touch) its background whole-file prefetch. Cheap no-op after
+            # the first call; templates stay mount-agnostic (prefetch.py).
+            shell_prefetch.schedule(path, upstream)
             resp = await asyncio.to_thread(_proxy_raw, upstream, request)
             if resp is not None:
                 return resp  # upstream unreachable -> plain file read below

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -1,0 +1,170 @@
+"""Background whole-file prefetch for mount-backed files.
+
+Cold analytical reads on a mounted file are latency-bound, not
+bandwidth-bound: DuckDB's sorted/filtered scans issue hundreds of tiny
+scattered range reads, and rclone's VFS cache serializes concurrent
+uncached reads of one file at roughly one seek per half-second (measured:
+a cold sort on a 644MB parquet moves ~3MB but takes ~30s, and a filtered
+count pays the same again). The same serve streams sequential reads an
+order of magnitude faster per byte (4.7-12MB/s measured). So: the first
+time a mount-backed file is read at all, stream the whole thing through
+the HTTP serve in the background and throw the bytes away. The side
+effect is the point — rclone's vfs cache (see mounts.SERVE_VFS_OPT)
+keeps a sparse on-disk copy of every range that passes through it, so
+once the stream completes every scattered read the file will ever see is
+a local disk hit. There is no second copy and no storage owned here: the
+serve's LRU-capped cache is the store, it survives server restarts, and
+rclone's fingerprint check invalidates it if the object changes upstream.
+
+Triggered from the /api/fs/raw proxy (the one path every remote byte
+already flows through — templates stay mount-agnostic), so scheduling
+must be cheap, non-blocking, and never raise. Everything slow (the HEAD
+for the size gate, the download) happens on a daemon worker thread; a
+process-wide semaphore keeps at most one file prefetching at a time.
+
+The serve surfaces transient store errors as HTTP 500s mid-stream
+(observed on S3), so the worker fetches in ranged chunks and resumes with
+backoff — ranges already cached replay from disk, so a retried chunk
+costs nothing. A completed file is remembered for this server run only;
+re-prefetching after a restart re-streams from the local cache in
+seconds without touching the store.
+"""
+import logging
+import os
+import threading
+import time
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+# Skip files larger than this: the serve cache is LRU-capped at 5Gi
+# (SERVE_VFS_OPT) and one giant file would evict everything else. Beyond
+# the cap the on-demand path still works exactly as before.
+MAX_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_BYTES",
+                               1024 * 1024 * 1024))
+ENABLED = os.environ.get("FUSED_RENDER_PREFETCH", "1") != "0"
+
+CHUNK_BYTES = 32 * 1024 * 1024
+# Let the interactive load that triggered us win the first cold seeks.
+START_DELAY_S = 5.0
+# Between chunks, hold off while the file is being read interactively —
+# but never indefinitely: prefetching IS the fix for those slow reads.
+IDLE_WAIT_S = 2.0
+MAX_IDLE_HOLD_S = 30.0
+MAX_CONSECUTIVE_ERRORS = 30
+FAILED_RETRY_COOLDOWN_S = 60.0
+
+_lock = threading.Lock()
+_jobs: dict = {}     # path -> {"status", "size", "done", "at"}
+_touched: dict = {}  # path -> monotonic time of last interactive access
+_worker_slot = threading.Semaphore(1)
+
+
+def status() -> dict:
+    """Snapshot of all jobs (introspection/tests)."""
+    with _lock:
+        return {p: dict(j) for p, j in _jobs.items()}
+
+
+def schedule(path: str, url: str) -> None:
+    """Note that `path` (served at `url`) is being read; start a background
+    prefetch unless one already ran. Called on the raw-proxy hot path:
+    cheap, non-blocking, never raises."""
+    try:
+        if not ENABLED:
+            return
+        now = time.monotonic()
+        with _lock:
+            _touched[path] = now
+            job = _jobs.get(path)
+            if job is not None:
+                retry = (job["status"] == "failed"
+                         and now - job["at"] >= FAILED_RETRY_COOLDOWN_S)
+                if not retry:
+                    return
+            _jobs[path] = {"status": "queued", "size": None, "done": 0,
+                           "at": now}
+        threading.Thread(target=_run, args=(path, url), daemon=True).start()
+    except Exception:                                  # pragma: no cover
+        logger.warning("prefetch schedule failed for %r", path, exc_info=True)
+
+
+def _run(path: str, url: str) -> None:
+    try:
+        _prefetch(path, url)
+    except Exception:
+        logger.warning("prefetch of %r died", path, exc_info=True)
+        _finish(path, "failed")
+
+
+def _finish(path: str, status_: str) -> None:
+    with _lock:
+        job = _jobs.get(path)
+        if job is not None:
+            job["status"] = status_
+            job["at"] = time.monotonic()
+
+
+def _head_size(url: str) -> int | None:
+    req = urllib.request.Request(url, method="HEAD")
+    with urllib.request.urlopen(req, timeout=30) as r:
+        cl = r.headers.get("Content-Length")
+        return int(cl) if cl is not None else None
+
+
+def _wait_for_lull(path: str) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < MAX_IDLE_HOLD_S:
+        with _lock:
+            last = _touched.get(path, 0.0)
+        if time.monotonic() - last >= IDLE_WAIT_S:
+            return
+        time.sleep(0.5)
+
+
+def _prefetch(path: str, url: str) -> None:
+    time.sleep(START_DELAY_S)
+    with _worker_slot:
+        try:
+            size = _head_size(url)
+        except Exception:
+            _finish(path, "failed")
+            return
+        if size is None or size > MAX_BYTES:
+            _finish(path, "skipped")
+            return
+        with _lock:
+            job = _jobs.get(path)
+            if job is not None:
+                job.update(status="running", size=size)
+
+        off, errors = 0, 0
+        while off < size:
+            _wait_for_lull(path)
+            end = min(off + CHUNK_BYTES, size) - 1
+            try:
+                req = urllib.request.Request(url)
+                req.add_header("Range", f"bytes={off}-{end}")
+                with urllib.request.urlopen(req, timeout=120) as r:
+                    while True:
+                        b = r.read(1024 * 1024)
+                        if not b:
+                            break
+                        off += len(b)
+                        with _lock:
+                            if path in _jobs:
+                                _jobs[path]["done"] = off
+                errors = 0
+            except Exception:
+                errors += 1
+                if errors > MAX_CONSECUTIVE_ERRORS:
+                    logger.warning("prefetch of %r gave up at %d/%d bytes",
+                                   path, off, size)
+                    _finish(path, "failed")
+                    return
+                # Resume at `off`: everything fetched so far is already in
+                # the serve's cache, so a re-request of it replays locally.
+                time.sleep(min(2.0 * errors, 30.0))
+        _finish(path, "done")
+        logger.info("prefetched %r (%d bytes) into the serve cache",
+                    path, size)

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -33,6 +33,7 @@ import logging
 import os
 import threading
 import time
+import urllib.error
 import urllib.request
 
 logger = logging.getLogger(__name__)
@@ -105,6 +106,18 @@ def _finish(path: str, status_: str) -> None:
             job["at"] = time.monotonic()
 
 
+def _release(exc: BaseException) -> None:
+    """Close the response an HTTPError carries. Raised before the `with`
+    block takes ownership, it would otherwise hold its serve connection
+    open for as long as the exception stays referenced — which in the
+    retry loop below spans the whole backoff sleep."""
+    if isinstance(exc, urllib.error.HTTPError):
+        try:
+            exc.close()
+        except Exception:
+            pass
+
+
 def _head_size(url: str) -> int | None:
     req = urllib.request.Request(url, method="HEAD")
     with urllib.request.urlopen(req, timeout=30) as r:
@@ -127,7 +140,8 @@ def _prefetch(path: str, url: str) -> None:
     with _worker_slot:
         try:
             size = _head_size(url)
-        except Exception:
+        except Exception as exc:
+            _release(exc)
             _finish(path, "failed")
             return
         if size is None or size > MAX_BYTES:
@@ -155,7 +169,8 @@ def _prefetch(path: str, url: str) -> None:
                             if path in _jobs:
                                 _jobs[path]["done"] = off
                 errors = 0
-            except Exception:
+            except Exception as exc:
+                _release(exc)
                 errors += 1
                 if errors > MAX_CONSECUTIVE_ERRORS:
                     logger.warning("prefetch of %r gave up at %d/%d bytes",

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -1,0 +1,204 @@
+"""Tests for the background whole-file prefetcher (shell/prefetch.py) and
+its trigger in the /api/fs/raw proxy. A stub HTTP server stands in for the
+rclone serve; no rclone and no real mount is involved."""
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+import fused_render.shell.prefetch as prefetch_mod
+
+
+class StubServe:
+    """Range-capable HTTP stand-in for an rclone serve. Serves `data` at
+    every path, records requests, and can fail the first N GETs with a 500
+    (the transient store errors the real serve surfaces mid-stream)."""
+
+    def __init__(self, data: bytes, fail_first_gets: int = 0):
+        self.data = data
+        self.requests = []          # (method, range_header)
+        self.fail_remaining = fail_first_gets
+        stub = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_HEAD(self):
+                stub.requests.append(("HEAD", None))
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(stub.data)))
+                self.send_header("Accept-Ranges", "bytes")
+                self.end_headers()
+
+            def do_GET(self):
+                rng = self.headers.get("Range")
+                stub.requests.append(("GET", rng))
+                if stub.fail_remaining > 0:
+                    stub.fail_remaining -= 1
+                    self.send_response(500)
+                    self.send_header("Content-Length", "0")
+                    self.end_headers()
+                    return
+                body = stub.data
+                status = 200
+                if rng:
+                    lo, hi = rng.removeprefix("bytes=").split("-")
+                    body = stub.data[int(lo):int(hi) + 1]
+                    status = 206
+                self.send_response(status)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}/f.bin"
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self.server.shutdown()
+
+
+@pytest.fixture()
+def fast(monkeypatch):
+    """Reset module state and collapse the politeness delays so tests run
+    in milliseconds; shrink the chunk so multi-chunk paths are exercised."""
+    monkeypatch.setattr(prefetch_mod, "_jobs", {})
+    monkeypatch.setattr(prefetch_mod, "_touched", {})
+    monkeypatch.setattr(prefetch_mod, "_worker_slot", threading.Semaphore(1))
+    monkeypatch.setattr(prefetch_mod, "START_DELAY_S", 0.0)
+    monkeypatch.setattr(prefetch_mod, "IDLE_WAIT_S", 0.0)
+    monkeypatch.setattr(prefetch_mod, "MAX_IDLE_HOLD_S", 0.0)
+    monkeypatch.setattr(prefetch_mod, "CHUNK_BYTES", 1024)
+    monkeypatch.setattr(prefetch_mod, "ENABLED", True)
+
+
+def wait_status(path, want, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        st = prefetch_mod.status().get(path, {}).get("status")
+        if st == want:
+            return prefetch_mod.status()[path]
+        time.sleep(0.01)
+    raise AssertionError(
+        f"prefetch of {path} never reached {want!r}: {prefetch_mod.status()}")
+
+
+def test_streams_whole_file_in_sequential_chunks(fast):
+    stub = StubServe(os.urandom(3000))          # 3 chunks at CHUNK_BYTES=1024
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        job = wait_status("/m/f.bin", "done")
+        assert job["done"] == job["size"] == 3000
+        gets = [r for r in stub.requests if r[0] == "GET"]
+        assert [r[1] for r in gets] == [
+            "bytes=0-1023", "bytes=1024-2047", "bytes=2048-2999"]
+    finally:
+        stub.close()
+
+
+def test_size_gate_skips_large_files(fast, monkeypatch):
+    monkeypatch.setattr(prefetch_mod, "MAX_BYTES", 100)
+    stub = StubServe(b"x" * 3000)
+    try:
+        prefetch_mod.schedule("/m/big.bin", stub.url)
+        wait_status("/m/big.bin", "skipped")
+        assert not any(r[0] == "GET" for r in stub.requests)
+    finally:
+        stub.close()
+
+
+def test_schedule_is_idempotent(fast):
+    stub = StubServe(b"y" * 500)
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        wait_status("/m/f.bin", "done")
+        n = len(stub.requests)
+        prefetch_mod.schedule("/m/f.bin", stub.url)   # already done -> no-op
+        time.sleep(0.1)
+        assert len(stub.requests) == n
+    finally:
+        stub.close()
+
+
+def test_resumes_after_transient_errors(fast):
+    stub = StubServe(os.urandom(2500), fail_first_gets=2)
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        job = wait_status("/m/f.bin", "done", timeout=15.0)
+        assert job["done"] == 2500
+    finally:
+        stub.close()
+
+
+def test_gives_up_after_sustained_errors_then_retries(fast, monkeypatch):
+    monkeypatch.setattr(prefetch_mod, "MAX_CONSECUTIVE_ERRORS", 2)
+    stub = StubServe(b"z" * 100, fail_first_gets=10 ** 6)
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        wait_status("/m/f.bin", "failed", timeout=30.0)
+        # within the cooldown a re-schedule must NOT restart the download
+        n = len(stub.requests)
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        time.sleep(0.1)
+        assert len(stub.requests) == n
+        # after the cooldown it retries (and now succeeds)
+        stub.fail_remaining = 0
+        monkeypatch.setattr(prefetch_mod, "FAILED_RETRY_COOLDOWN_S", 0.0)
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        wait_status("/m/f.bin", "done", timeout=15.0)
+    finally:
+        stub.close()
+
+
+def test_disabled_by_env(fast, monkeypatch):
+    monkeypatch.setattr(prefetch_mod, "ENABLED", False)
+    stub = StubServe(b"q" * 100)
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        time.sleep(0.1)
+        assert prefetch_mod.status() == {} and stub.requests == []
+    finally:
+        stub.close()
+
+
+# -- trigger: /api/fs/raw schedules a prefetch for mount-backed files --------
+
+
+def test_fs_raw_schedules_prefetch_for_mount_backed_file(
+        fast, tmp_path, monkeypatch):
+    from fastapi.testclient import TestClient
+    from fused_render.server import create_app
+    import fused_render.shell.mounts as mounts_mod
+
+    home = tmp_path / "home"
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    mp = home / "mounts" / "data"
+    mp.mkdir(parents=True)
+    f = mp / "table.parquet"
+    f.write_bytes(b"PAR1 not really parquet")
+
+    stub = StubServe(f.read_bytes())
+    (home).mkdir(exist_ok=True)
+    (home / "serves.json").write_text(json.dumps(
+        {str(mp): stub.url.rsplit("/", 1)[0]}))
+
+    scheduled = []
+    monkeypatch.setattr(prefetch_mod, "schedule",
+                        lambda path, url: scheduled.append((path, url)))
+    try:
+        client = TestClient(create_app(str(tmp_path)))
+        r = client.get("/api/fs/raw", params={"path": str(f)})
+        assert r.status_code == 200
+        assert scheduled == [(str(f), mounts_mod.serve_url_for(str(f)))]
+
+        # a local (non-mount) file must not schedule anything
+        local = tmp_path / "plain.txt"
+        local.write_text("hi")
+        client.get("/api/fs/raw", params={"path": str(local)})
+        assert len(scheduled) == 1
+    finally:
+        stub.close()


### PR DESCRIPTION
## Why

Cold scattered reads on a mounted parquet are latency-bound, not bandwidth-bound: rclone's VFS cache serializes uncached seeks at ~0.5s each, so a cold sort on a 644MB file moves only ~3MB of data but takes ~30s — and a filtered count pays the same again. The same serve streams sequential reads an order of magnitude faster per byte.

## What

The first time a mount-backed file is read through `/api/fs/raw`, stream the whole file through the HTTP serve in the background and discard the bytes. The side effect is the point: the serve's sparse on-disk VFS cache (enabled in #117) keeps every range that passes through it, so once the stream completes, every scattered read the file will ever see is a local disk hit. No second copy, no storage owned here — the LRU-capped serve cache is the store, it survives restarts, and rclone's fingerprint check invalidates it if the object changes upstream.

- `fused_render/shell/prefetch.py` — the worker: `schedule()` is cheap/non-blocking/never-raises (called on the proxy hot path); one file prefetches at a time; 32MB ranged chunks with retry/resume for the transient 500s the serve surfaces from S3; waits for lulls in interactive reads between chunks; skips files over 1GiB (`FUSED_RENDER_PREFETCH_MAX_BYTES`); `FUSED_RENDER_PREFETCH=0` disables.
- `fused_render/server.py` — the trigger lives in the `/api/fs/raw` proxy, the one path every remote byte already flows through. Templates stay fully mount-agnostic.
- `tests/test_shell_prefetch.py` — 7 tests against a range-capable HTTP stub: chunk coverage, size gate, idempotence, resume after transient 500s, give-up + cooldown + retry, env kill-switch, and an integration test that the raw proxy schedules prefetches for mount-backed files only.

## Measured

End to end on the 644MB overture addresses parquet: one page view triggers the prefetch, full file streamed in ~92s (~7MB/s, zero retries). Cold sort+filter positions query drops from ~30s to **0.01s**; filtered count over 10.7M rows from ~30s to **0.02s**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)