### PR TITLE
ci: use OIDC role for S3 dmg upload instead of static AWS keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: macos-14
     permissions:
       contents: write # needed to attach the DMG to a GitHub Release
+      id-token: write # needed to assume the AWS role via OIDC
     env:
       KEYCHAIN_PATH: ${{ github.workspace }}/ci-signing.keychain-db
       NOTARY_PROFILE: ci-notary
@@ -79,14 +80,14 @@ jobs:
         if: always()
         run: security delete-keychain "$KEYCHAIN_PATH" || true
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
+          role-session-name: GithubFusedRenderRelease
+          aws-region: us-west-2
+
       - name: Upload DMG to S3
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          # Only needed if AWS_ACCESS_KEY_ID/SECRET are STS temporary
-          # credentials (e.g. an assumed-role session) rather than a
-          # permanent IAM user's keys; empty is a no-op for the AWS CLI.
-          AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
         run: |
           set -euo pipefail
           # Not `brew install awscli`: GH's macos-14 image doesn't have the


### PR DESCRIPTION
## Summary
- `release.yml`'s "Upload DMG to S3" step now assumes `github_fused_render_role` via `aws-actions/configure-aws-credentials` (OIDC) instead of reading `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` secrets.
- Role is scoped to `s3:PutObject` on `fused-magic/fused-render-dmgs/*` only, trusted for `repo:fusedio/fused-render:*` via GitHub's OIDC provider — added in fusedlabs/application#7860.

## Test plan
- [ ] fusedlabs/application#7860 merged + `terraform apply`d so the role exists
- [ ] Push a `v*` tag and confirm `release dmg` workflow assumes the role and uploads successfully
- [ ] Remove now-unused `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`/`AWS_SESSION_TOKEN` repo secrets once confirmed working

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release-time AWS authentication; a misconfigured trust policy or role could block DMG uploads until infra from the companion change is applied.
> 
> **Overview**
> The **release dmg** workflow no longer passes long-lived `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` secrets into the S3 upload step. It now grants **`id-token: write`**, runs **`aws-actions/configure-aws-credentials@v4`** to assume **`arn:aws:iam::926411091187:role/github_fused_render_role`**, and leaves the existing `aws s3 cp` upload logic unchanged so credentials come from the short-lived OIDC session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c92cf6b20ac6a55c4cfc6ca21503e436bcb1ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->