### PR TITLE
ci(release): switch notarization to App Store Connect API key

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,6 @@ jobs:
       KEYCHAIN_PATH: ${{ github.workspace }}/ci-signing.keychain-db
       NOTARY_PROFILE: ci-notary
       AWS_DEFAULT_REGION: us-west-2
-      # Team ID embedded in the "Developer ID Application: Fused Labs, Inc.
-      # (L5CL3594R4)" identity — not sensitive, ships inside every signed
-      # binary already, so no need to route it through a secret.
-      NOTARY_TEAM_ID: L5CL3594R4
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,8 +34,9 @@ jobs:
           CODESIGN_CERT_P12: ${{ secrets.CODESIGN_CERT_P12 }}
           CODESIGN_CERT_PASSWORD: ${{ secrets.CODESIGN_CERT_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
-          NOTARY_APPLE_ID: ${{ secrets.NOTARY_APPLE_ID }}
-          NOTARY_APP_SPECIFIC_PASSWORD: ${{ secrets.NOTARY_APP_SPECIFIC_PASSWORD }}
+          NOTARY_API_KEY_P8: ${{ secrets.NOTARY_API_KEY_P8 }}
+          NOTARY_API_KEY_ID: ${{ secrets.NOTARY_API_KEY_ID }}
+          NOTARY_API_ISSUER_ID: ${{ secrets.NOTARY_API_ISSUER_ID }}
         run: |
           set -euo pipefail
 
@@ -57,14 +54,14 @@ jobs:
 
           # notarytool profiles live in a keychain too; store into the same
           # ephemeral one so it's gone with the runner, nothing persists.
-          # apple-id + app-specific-password (not an App Store Connect API
-          # key): that key type needs an org Account Holder to flip on API
-          # access first, which app-specific passwords sidestep entirely —
-          # switch to a --key/--key-id/--issuer API key later if that access
-          # gets granted, it's the more idiomatic CI credential long-term.
+          # App Store Connect API key: no personal Apple ID tied to CI, and
+          # unlike an app-specific password it doesn't expire.
+          API_KEY_PATH="$RUNNER_TEMP/notary-api-key.p8"
+          printf '%s' "$NOTARY_API_KEY_P8" > "$API_KEY_PATH"
           xcrun notarytool store-credentials "$NOTARY_PROFILE" \
-            --apple-id "$NOTARY_APPLE_ID" --team-id "$NOTARY_TEAM_ID" --password "$NOTARY_APP_SPECIFIC_PASSWORD" \
+            --key "$API_KEY_PATH" --key-id "$NOTARY_API_KEY_ID" --issuer "$NOTARY_API_ISSUER_ID" \
             --keychain "$KEYCHAIN_PATH"
+          rm -f "$API_KEY_PATH"
 
           rm -f "$CERT_PATH"
 


### PR DESCRIPTION
## Summary
- Notarization now authenticates via an App Store Connect API key (`--key`/`--key-id`/`--issuer`) instead of an Apple ID + app-specific password, as `docs/signing.md`'s CI notes already recommended once org API access was granted.
- Repo secrets rotated: added `NOTARY_API_KEY_P8`, `NOTARY_API_KEY_ID`, `NOTARY_API_ISSUER_ID`; deleted now-unused `NOTARY_APPLE_ID` and `NOTARY_APP_SPECIFIC_PASSWORD`.
- Dropped `NOTARY_TEAM_ID` env var — not needed for API-key auth (team is derived from the key/issuer).

## Test plan
- [ ] Push a `v*` tag and confirm `build-sign-notarize-release` job's "Import signing cert + notary credentials" step succeeds with the API key
- [ ] Confirm notarization + stapling still succeeds end to end (Build, sign, notarize, staple DMG step)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing/notarization credentials; a misconfigured secret breaks tagged releases until secrets are fixed, but scope is limited to CI credential setup.
> 
> **Overview**
> **Release CI** now stores `notarytool` credentials with an **App Store Connect API key** (`--key` / `--key-id` / `--issuer`) instead of Apple ID, team ID, and an app-specific password.
> 
> The import step writes the `.p8` from `NOTARY_API_KEY_P8` into a temp file, calls `store-credentials`, then deletes it; **`NOTARY_TEAM_ID` is removed** from job env. Downstream **build/sign/notarize** still uses the same `NOTARY_PROFILE` and `build_dmg.sh` — only how CI authenticates to Apple for notarization changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9d76754ddc6992b9e53ab20e63ff81ac1d0ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->