### PR TITLE
feat(duckdb): show load indicator during remote sort/filter scans

### DIFF
--- a/fused_render/templates/duckdb/template.html
+++ b/fused_render/templates/duckdb/template.html
@@ -93,6 +93,27 @@
     font-size: 10px; line-height: 15px; text-align: center;
   }
   .save-count[hidden] { display: none; }
+  /* Indeterminate load bar between the filter bar and the grid. A sort/filter
+     change on a remote file keeps the old grid up (no "Loading…" wipe) and then
+     awaits a multi-second row-positions scan before anything repaints — so
+     without this the UI looks frozen. The bar turns on the instant load()
+     starts and off as soon as rows or skeletons paint. Always 2px tall so
+     toggling it never shifts the layout. */
+  #loadbar { flex: 0 0 auto; height: 2px; overflow: hidden; background: transparent; }
+  #loadbar::before {
+    content: ""; display: block; height: 100%; width: 40%;
+    border-radius: 2px;
+    background: linear-gradient(90deg, transparent, #4a9eff, transparent);
+    transform: translateX(-100%); opacity: 0;
+  }
+  #loadbar.active::before {
+    opacity: 1;
+    animation: loadbar-slide 1.1s ease-in-out infinite;
+  }
+  @keyframes loadbar-slide {
+    from { transform: translateX(-100%); }
+    to { transform: translateX(350%); }
+  }
   #tablewrap { flex: 1 1 auto; min-height: 0; overflow: auto; }
   #rowcount { color: #9aa0a6; }
   /* .ro-badge / .ro-tip styles inject from /template-shared/ro-badge.js. */
@@ -227,6 +248,7 @@
       <button id="reset" class="fr-clear" title="Clear sort &amp; filters" aria-label="Clear sort and filters" hidden><svg viewBox="0 0 16 16" width="12" height="12" aria-hidden="true"><path d="M3.28 2.22 8 6.94l4.72-4.72 1.06 1.06L9.06 8l4.72 4.72-1.06 1.06L8 9.06l-4.72 4.72-1.06-1.06L6.94 8 2.22 3.28z" fill="currentColor"/></svg></button>
     </div>
   </div>
+  <div id="loadbar"></div>
   <div id="tablewrap"></div>
   <div id="bar">
     <div class="bar-group side">
@@ -256,6 +278,13 @@
           discardBtn = el("discard"), wrap = el("tablewrap"), resetBtn = el("reset");
     const filterbar = el("filterbar"), frows = el("frows"), applyBtn = el("apply");
     const ctxmenu = el("ctxmenu"), ctxNull = el("ctx-null");
+    const loadbar = el("loadbar");
+
+    // Indeterminate load indicator. On from the moment a load starts until the
+    // grid next paints rows or skeletons — this is the only signal during the
+    // serial row-positions scan a remote sort/filter runs before its first
+    // repaint (renderAll turns it off; see load()).
+    const setLoading = (on) => loadbar.classList.toggle("active", !!on);
 
     // Server state for the current page, and the client-side staged mutations.
     let state = null;
@@ -568,6 +597,10 @@
         wrap.innerHTML = `<table><thead>${head}</thead><tbody>${placeholderRows}${bodyRows}${insRows}</tbody></table>`;
       }
       updateBars(offset);
+      // Rows or skeletons are now on screen (or an empty/"nothing to show"
+      // state) — the shimmer/placeholders take over as the in-flight signal,
+      // so drop the load bar. renderAll during editing is a no-op here.
+      setLoading(false);
     }
 
     function updateBars(offset) {
@@ -675,6 +708,9 @@
     let schemaCache = null;
     async function load() {
       const seq = ++loadSeq;
+      // Signal immediately — before any await — so a remote sort/filter shows
+      // motion during its positions scan instead of a frozen grid.
+      setLoading(true);
       const file = fused.params.get("_file");
       const offset = currentOffset();
       const table = fused.params.get("table") || "";
@@ -691,6 +727,7 @@
         && wrap.querySelector("tbody tr[data-id]");
       if (!keepGrid) wrap.innerHTML = `<div id="status">Loading…</div>`;
       if (!file) {
+        setLoading(false);
         wrap.innerHTML = `<div id="status" class="error">No file selected (missing _file param).</div>`;
         return;
       }
@@ -827,6 +864,7 @@
         renderAll();
       } catch (err) {
         if (seq !== loadSeq) return;
+        setLoading(false);
         wrap.innerHTML = `<div id="status" class="error"><strong>${escapeHtml(err.type || "Error")}</strong>: ${escapeHtml(err.message || "")}</div>`;
       }
     }
@@ -887,6 +925,7 @@
         // decide at the end — a later column may still bring the rows.
         if (!state.pending.size) {
           if (state.colErrors) {
+            setLoading(false);
             wrap.innerHTML = `<div id="status" class="error">Failed to load rows.</div>`;
           } else {
             state.pending = null; // drop the placeholder skeleton grid

--- a/fused_render/templates/duckdb/template.html
+++ b/fused_render/templates/duckdb/template.html
@@ -511,7 +511,12 @@
     // Rebuild toolbar affordances + the whole table from state + staged. Safe to
     // call any time except mid-typing (cell input updates the DOM in place so it
     // never yanks focus); it re-derives every row from staging, so edits persist.
-    function renderAll() {
+    // `fromLoad` is set only by the calls inside the load()/applyBatch path
+    // that paint a load's result; staging actions (add/remove row) call
+    // renderAll() with it unset, so they never clear a load bar for a reload
+    // that is still in flight (e.g. a sort's positions scan running while the
+    // user adds a row to the still-visible old grid).
+    function renderAll(fromLoad) {
       const offset = currentOffset();
       renderTableSelector();
       const editable = !!state.editable;
@@ -597,10 +602,11 @@
         wrap.innerHTML = `<table><thead>${head}</thead><tbody>${placeholderRows}${bodyRows}${insRows}</tbody></table>`;
       }
       updateBars(offset);
-      // Rows or skeletons are now on screen (or an empty/"nothing to show"
-      // state) — the shimmer/placeholders take over as the in-flight signal,
-      // so drop the load bar. renderAll during editing is a no-op here.
-      setLoading(false);
+      // A load just painted rows or skeletons (or an empty state) — the
+      // shimmer/placeholders take over as the in-flight signal, so drop the
+      // load bar. Only for load-driven renders: an editing render leaves an
+      // in-flight reload's bar alone.
+      if (fromLoad) setLoading(false);
     }
 
     function updateBars(offset) {
@@ -796,7 +802,7 @@
             // swaps in whatever has landed.
             state.deferRender = true;
           } else {
-            renderAll(); // full-skeleton grid immediately — header + shimmer rows
+            renderAll(true); // full-skeleton grid immediately — header + shimmer rows
           }
           // Sorted/filtered pages resolve their row positions ONCE before the
           // batches fan out (two-phase): each batch then point-reads exactly
@@ -835,7 +841,7 @@
               if (seq !== loadSeq || state.rowsRendered) return;
               state.deferRender = false;
               if (state.ids.length) state.rowsRendered = true;
-              if (state.pending) renderAll();
+              if (state.pending) renderAll(true);
             }, 250);
           }
           for (const cols of packColumns(schema.columns, schema.col_sizes || {})) {
@@ -861,7 +867,7 @@
         });
         rendered = true;
         renderFilterBar(); // rebuild condition rows from the (freshly loaded) param
-        renderAll();
+        renderAll(true);
       } catch (err) {
         if (seq !== loadSeq) return;
         setLoading(false);
@@ -929,7 +935,7 @@
             wrap.innerHTML = `<div id="status" class="error">Failed to load rows.</div>`;
           } else {
             state.pending = null; // drop the placeholder skeleton grid
-            renderAll(); // genuinely empty result -> headers + "rows 0–0"
+            renderAll(true); // genuinely empty result -> headers + "rows 0–0"
           }
         }
         return;
@@ -943,7 +949,7 @@
         // skeletons or the old page's rows) with the real rows — skeleton
         // cells remain for still-pending columns.
         state.rowsRendered = true;
-        renderAll();
+        renderAll(true);
       } else {
         cols.forEach((c) => (d ? fillColumn(c) : fillColumnError(c)));
       }


### PR DESCRIPTION
## Problem

Changing a filter or clicking a column to sort on an already-loaded **remote-mounted** parquet freezes the grid for several seconds with no indication anything is happening — then columns abruptly start shimmering in.

**Root cause:** for a same-file reload, `load()` takes the `keepGrid` fast path and deliberately keeps the old grid on screen (no `Loading…` wipe), since warm reloads usually land in under a repaint. But sorted/filtered pages then run a **serial `positions` await** — a multi-second remote row-positions scan — *before* anything repaints. The "break-the-hold" timer that swaps in skeletons is (intentionally) only armed *after* that await, so for the entire scan the screen is static with zero feedback.

## Fix

Add an always-present 2px indeterminate load bar between the filter bar and the grid:

- `setLoading(true)` at the very top of `load()`, before any `await` — motion appears the instant you click a header or Apply.
- `setLoading(false)` at the end of `renderAll()` — the moment rows or skeletons actually paint, handing the in-flight signal off to the existing per-column shimmer. Also covers the three paths that bypass `renderAll` (the `!file` guard, the error catch, and the failed-rows branch in `applyBatch`).

The existing `keepGrid` / `deferRender` / positions-timer logic is untouched — the bar just fills the previously-silent gap. It's pure CSS + a one-line class toggle, and the bar is always 2px tall so toggling it never shifts layout.

## Testing

Ran the worktree dev server against a mounted parquet: sorting/filtering now shows the animated bar across the top of the grid during the positions scan, then the columns shimmer in as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)