### PR TITLE
feat(mounts): raise serve VFS cache cap from 5Gi to 20Gi

### DIFF
--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -87,7 +87,7 @@ VFS_OPT = {
 # vfs_cache_mode). An unknown `vfsOpt` key is silently ignored — the serve
 # then runs with the cache OFF and every read, warm or not, goes to the
 # store (measured: 1MB re-read 4.4s uncached vs 2ms cached).
-SERVE_VFS_OPT = {"vfs_cache_mode": "full", "vfs_cache_max_size": "5Gi"}
+SERVE_VFS_OPT = {"vfs_cache_mode": "full", "vfs_cache_max_size": "20Gi"}
 
 # Tile-server daemon state files — the two parallel implementations that can
 # hold files open under a mount (geotiff, and the grid server shared by

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -38,7 +38,7 @@ import urllib.request
 
 logger = logging.getLogger(__name__)
 
-# Skip files larger than this: the serve cache is LRU-capped at 5Gi
+# Skip files larger than this: the serve cache is LRU-capped at 20Gi
 # (SERVE_VFS_OPT) and one giant file would evict everything else. Beyond
 # the cap the on-demand path still works exactly as before.
 MAX_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_BYTES",


### PR DESCRIPTION
## What

Raise the per-mount rclone HTTP serve VFS cache cap (`SERVE_VFS_OPT.vfs_cache_max_size`) from **5Gi → 20Gi**.

## Why

The serve's on-disk VFS cache is what turns DuckDB's cold, scattered range reads over a mount into local-disk hits. At 5Gi, a modest working set (one large parquet plus a few others) can evict still-warm bytes, forcing re-fetches over the slow store link. 20Gi gives interactive/repeated multi-file workloads a lot more headroom before the LRU starts churning.

## Notes

- `sync_serves()` restarts any serve whose vfs options drift from `SERVE_VFS_OPT`, so the new cap rolls out to already-running serves on the next server start.
- Also updates the now-stale `5Gi` reference in `prefetch.py`'s `MAX_BYTES` comment. The 1 GB whole-file prefetch skip is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)