### PR TITLE
feat(release): build wheel, upload to S3, attach to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
           role-session-name: GithubFusedRenderRelease
           aws-region: us-west-2
 
-      - name: Upload DMG to S3
+      - name: Upload DMG + wheel to S3
         run: |
           set -euo pipefail
           # Not `brew install awscli`: GH's macos-14 image doesn't have the
@@ -97,9 +97,12 @@ jobs:
           fi
           DMG_PATH="$(ls dist/*.dmg)"
           DMG_SHA256="$(shasum -a 256 "$DMG_PATH" | cut -d' ' -f1)"
+          WHL_PATH="$(ls dist/*.whl)"
           echo "DMG_PATH=$DMG_PATH" >> "$GITHUB_ENV"
           echo "DMG_SHA256=$DMG_SHA256" >> "$GITHUB_ENV"
+          echo "WHL_PATH=$WHL_PATH" >> "$GITHUB_ENV"
           aws s3 cp "$DMG_PATH" "s3://fused-magic/fused-render-dmgs/$(basename "$DMG_PATH")"
+          aws s3 cp "$WHL_PATH" "s3://fused-magic/fused-render-wheels/$(basename "$WHL_PATH")"
 
       - name: Find previous tag
         id: prev_tag
@@ -118,7 +121,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: ${{ env.DMG_PATH }}
+          files: |
+            ${{ env.DMG_PATH }}
+            ${{ env.WHL_PATH }}
           name: FusedRender ${{ github.ref_name }}
           generate_release_notes: true
           previous_tag: ${{ steps.prev_tag.outputs.tag }}

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -2,9 +2,10 @@
 # Build FusedRender.app + a distributable DMG via py2app (SPEC §12, D33-D35).
 #
 # Pipeline: pick/bootstrap a FRAMEWORK-build python (py2app needs one to
-# produce a real standalone bundle, see the note below) -> build a venv on it
-# -> pip install fused-render[bundled,app] + py2app + dmgbuild into that venv
-# -> generate the app icon -> run py2app -> codesign -> dmgbuild -> notarize.
+# produce a real standalone bundle, see the note below) -> build the wheel
+# once (dist/*.whl) -> build a venv on it -> pip install that wheel
+# [bundled,app] + py2app + dmgbuild into the venv -> generate the app icon ->
+# run py2app -> codesign -> dmgbuild -> notarize.
 #
 # Signing (step 5, D73) is credential-driven: with a Developer ID identity in
 # your keychain the bundle is signed with the hardened runtime (and optionally
@@ -94,26 +95,41 @@ fi
 echo "==> using framework python: $FRAMEWORK_PYTHON (PYTHONFRAMEWORK=$FRAMEWORK_TAG)"
 
 # ---------------------------------------------------------------------------
-# 2. Build venv: fused-render[bundled,app,fused] + py2app + dmgbuild
+# 2. Build the wheel (dist/*.whl), then a venv: that wheel[bundled,app,fused]
+#    + py2app + dmgbuild.
+#
+#    The wheel is built ONCE here and reused for both installs below, rather
+#    than each `pip install "${REPO_ROOT}[...]"` re-triggering
+#    scripts/hatch_build.py's `npm install && npm run build` frontend step
+#    from source. Installing an already-built .whl is a plain unpack — no
+#    build hook runs — so this also gives the release pipeline a real
+#    dist/*.whl artifact to upload/attach, instead of one pip builds
+#    internally and discards after install.
 # ---------------------------------------------------------------------------
+
+export FUSED_RENDER_BRANCH="$REF"
+
+echo "==> building wheel"
+python3 -m pip install --quiet --upgrade build
+python3 -m build --quiet --wheel --outdir "$DIST_DIR" "$REPO_ROOT"
+WHEEL_PATH="$(ls "$DIST_DIR"/*.whl)"
 
 if [[ ! -x "$BUILD_VENV/bin/python" ]]; then
   echo "==> creating build venv"
   "$FRAMEWORK_PYTHON" -m venv "$BUILD_VENV"
 fi
 
-echo "==> installing fused-render[bundled,app,fused] + py2app + dmgbuild into the build venv"
-export FUSED_RENDER_BRANCH="$REF"
+echo "==> installing ${WHEEL_PATH##*/} [bundled,app,fused] + py2app + dmgbuild into the build venv"
 "$BUILD_VENV/bin/pip" install --quiet --upgrade pip
 # [fused] bakes the deploy CLI into the bundle (SPEC §19 DP-3): the .app has
 # no pip and no console scripts, so the Deploy surface runs the package
 # in-interpreter via fused_render/_fused_cli.py under the bundled python.
-"$BUILD_VENV/bin/pip" install --quiet "${REPO_ROOT}[bundled,app,fused]" py2app dmgbuild
-# Force a fresh rebuild+reinstall of fused-render itself every run so the branch
-# ref is re-baked to match $REF. The build venv is reused across builds, so pip
-# would otherwise treat an unchanged version as already-satisfied (or reuse a
-# cached wheel) and ship a stale _baked_branch.py from a previous ref.
-"$BUILD_VENV/bin/pip" install --quiet --force-reinstall --no-deps --no-cache-dir "${REPO_ROOT}"
+"$BUILD_VENV/bin/pip" install --quiet "${WHEEL_PATH}[bundled,app,fused]" py2app dmgbuild
+# Force a fresh reinstall of fused-render itself every run so the branch ref
+# baked into $WHEEL_PATH is picked up. The build venv is reused across builds,
+# so pip would otherwise treat an unchanged version as already-satisfied and
+# keep a stale _baked_branch.py from a previous ref/wheel.
+"$BUILD_VENV/bin/pip" install --quiet --force-reinstall --no-deps --no-cache-dir "${WHEEL_PATH}"
 
 # ---------------------------------------------------------------------------
 # 2b. Stage rclone (D103): mounts (shell/mounts.py, D102) shell out to a real

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -109,18 +109,25 @@ echo "==> using framework python: $FRAMEWORK_PYTHON (PYTHONFRAMEWORK=$FRAMEWORK_
 
 export FUSED_RENDER_BRANCH="$REF"
 
-echo "==> building wheel"
-python3 -m pip install --quiet --upgrade build
-python3 -m build --quiet --wheel --outdir "$DIST_DIR" "$REPO_ROOT"
-WHEEL_PATH="$(ls "$DIST_DIR"/*.whl)"
-
 if [[ ! -x "$BUILD_VENV/bin/python" ]]; then
   echo "==> creating build venv"
   "$FRAMEWORK_PYTHON" -m venv "$BUILD_VENV"
 fi
+"$BUILD_VENV/bin/pip" install --quiet --upgrade pip
+
+echo "==> building wheel"
+# Build via the venv's pip/python, not host python3 -m pip: on Homebrew python
+# (and most other PEP 668 "externally managed" installs) a bare host-level
+# `pip install` refuses to run, which would break the documented plain
+# `bash scripts/build_dmg.sh` local path. A venv is always installable into.
+# Clear stale dist/*.whl first so the glob below can't pick up a leftover
+# wheel from an earlier version/run and resolve to more than one path.
+rm -f "$DIST_DIR"/*.whl
+"$BUILD_VENV/bin/pip" install --quiet --upgrade build
+"$BUILD_VENV/bin/python" -m build --quiet --wheel --outdir "$DIST_DIR" "$REPO_ROOT"
+WHEEL_PATH="$(ls "$DIST_DIR"/*.whl)"
 
 echo "==> installing ${WHEEL_PATH##*/} [bundled,app,fused] + py2app + dmgbuild into the build venv"
-"$BUILD_VENV/bin/pip" install --quiet --upgrade pip
 # [fused] bakes the deploy CLI into the bundle (SPEC §19 DP-3): the .app has
 # no pip and no console scripts, so the Deploy surface runs the package
 # in-interpreter via fused_render/_fused_cli.py under the bundled python.


### PR DESCRIPTION
## Summary
- `scripts/build_dmg.sh` builds `dist/*.whl` once and installs that wheel into the py2app build venv, instead of two separate `pip install "${REPO_ROOT}[...]"` calls each re-triggering `hatch_build.py`'s `npm install && npm run build` frontend step from source (installing a prebuilt `.whl` is a plain unpack — no build hook runs).
- `.github/workflows/release.yml` picks up that same `dist/*.whl`, uploads it to `s3://fused-magic/fused-render-wheels/`, and attaches it to the GitHub Release alongside the DMG.

## Test plan
- [x] Ran `python -m build --wheel` against this repo locally (py3.12 venv) — confirms the frontend build hook still succeeds and produces `fused_render-0.2.5-py3-none-any.whl`.
- [x] Confirmed `pip install "path/to/wheel.whl[extras]"` syntax installs correctly (verified in a scratch venv).
- [ ] Tag-push a release (or `workflow_dispatch`) to confirm the full CI job succeeds and both artifacts land in S3 + the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and packaging script changes only; DMG signing/notarization and Homebrew cask bump are unchanged.
> 
> **Overview**
> **`scripts/build_dmg.sh`** now builds a single **`dist/*.whl`** (via the build venv’s `python -m build`, with stale wheels cleared first) and installs that wheel into the py2app venv instead of two **`pip install "${REPO_ROOT}[...]"`** passes. That avoids running **`hatch_build.py`**’s frontend/npm build twice per DMG build and leaves a wheel on disk for release.
> 
> **`.github/workflows/release.yml`** picks up **`dist/*.whl`**, uploads it to **`s3://fused-magic/fused-render-wheels/`**, and attaches it to the GitHub Release alongside the DMG.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16638e25d3757c4aa31821c84786e5ff696396fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->