### PR TITLE
feat(release): add public S3 download links to release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,9 @@ jobs:
           echo "DMG_PATH=$DMG_PATH" >> "$GITHUB_ENV"
           echo "DMG_SHA256=$DMG_SHA256" >> "$GITHUB_ENV"
           echo "WHL_PATH=$WHL_PATH" >> "$GITHUB_ENV"
+          # Bucket is public read; plain https S3 URL works with no signing.
+          echo "DMG_URL=https://fused-magic.s3.us-west-2.amazonaws.com/fused-render-dmgs/$(basename "$DMG_PATH")" >> "$GITHUB_ENV"
+          echo "WHL_URL=https://fused-magic.s3.us-west-2.amazonaws.com/fused-render-wheels/$(basename "$WHL_PATH")" >> "$GITHUB_ENV"
           aws s3 cp "$DMG_PATH" "s3://fused-magic/fused-render-dmgs/$(basename "$DMG_PATH")"
           aws s3 cp "$WHL_PATH" "s3://fused-magic/fused-render-wheels/$(basename "$WHL_PATH")"
 
@@ -125,6 +128,12 @@ jobs:
             ${{ env.DMG_PATH }}
             ${{ env.WHL_PATH }}
           name: FusedRender ${{ github.ref_name }}
+          # body is prepended before the auto-generated notes (GH Releases
+          # API behavior), so this ends up as the first section.
+          body: |
+            ## Downloads
+            - [DMG](${{ env.DMG_URL }})
+            - [Wheel](${{ env.WHL_URL }})
           generate_release_notes: true
           previous_tag: ${{ steps.prev_tag.outputs.tag }}
 


### PR DESCRIPTION
## Summary
- Export public S3 https URLs for the built DMG and wheel in the release workflow (bucket is already public, plain URL, no signing).
- Set them as the `body` of the GitHub release, which the Releases API prepends before `generate_release_notes` output — lands as the first section, PR/commit auto-notes unchanged below it.

## Test plan
- [ ] Push a `v*` tag, confirm release notes show a "Downloads" section with working DMG/wheel links above the auto-generated changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release workflow changes; links point at an already-public bucket with no new secrets or app runtime impact.
> 
> **Overview**
> Release workflow now writes **`DMG_URL`** and **`WHL_URL`** to `GITHUB_ENV` as stable public HTTPS links to the artifacts in `fused-magic` (same paths as the existing `aws s3 cp` step).
> 
> The **Create GitHub Release** step sets a **`body`** with a **Downloads** section (DMG and wheel markdown links) that GitHub prepends ahead of auto-generated release notes, so changelog generation is unchanged and only gains a top section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 514a05f5d9b93e20cb189bfaf8e80072aaad1c86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->