### PR TITLE
fix(shell): contain file-explorer search overflow + accent loading spinner

### DIFF
--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -600,6 +600,7 @@ a.bookmark-name::after {
 
 #content {
   flex: 1 1 auto;
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -610,6 +611,7 @@ a.bookmark-name::after {
    listing and results. */
 .listing {
   flex: 1 1 auto;
+  min-width: 0;
   min-height: 0;
   display: flex;
   flex-direction: column;
@@ -667,7 +669,7 @@ a.bookmark-name::after {
   height: 11px;
   margin-top: -5.5px;
   border: 1.5px solid var(--border);
-  border-top-color: var(--fg-muted);
+  border-top-color: var(--accent);
   border-radius: 50%;
   pointer-events: none;
   animation: listing-search-spin 0.6s linear infinite;


### PR DESCRIPTION
## Summary

- **Fixes horizontal page overflow in the native file explorer search.** When search results included long file paths, the entire page — search bar included — scrolled sideways and slid the UI out of view mid-search. Now only the results list scrolls; the search bar, header, and controls stay pinned.
- **Root cause:** `#content` and `.listing` are `flex-direction: column` items that had only `min-height: 0`. Their default `min-width: auto` resolves to the `white-space: nowrap` results table's min-content width, so they grew past `#main` instead of letting `.listing-scroll`'s `overflow: auto` engage. Adding `min-width: 0` confines overflow to the scroll region — the same technique the preview template's `.list-pane` already uses.
- **Loading spinner is now accent-colored.** The search spinner's moving arc changed from `--fg-muted` (grey) to `--accent`, so an in-flight scan is clearly identifiable as loading. The track ring stays grey so the accent sweep stands out.

## Visuals

Flex min-width behavior — before vs. after:

```mermaid
flowchart TB
    subgraph After["After — min-width:0 added"]
        A1["#main (min-width:0)"] --> A2["#content (min-width:0)"]
        A2 --> A3[".listing (min-width:0)"]
        A3 --> A4[".listing-scroll<br/>overflow:auto ✅ engages"]
        A4 --> A5["wide table scrolls<br/>INSIDE the explorer"]
    end
    subgraph Before["Before — min-width:auto (bug)"]
        B1["#main (min-width:0)"] --> B2["#content (min-width:auto)"]
        B2 --> B3[".listing (min-width:auto)"]
        B3 --> B4[".listing-scroll<br/>overflow never triggers"]
        B4 --> B5["table grows past #main →<br/>whole PAGE scrolls, search bar lost ❌"]
    end
```

Measured with a real `.parquet` search (longest path 649px in a 626px container):

| | Page overflow | Search bar visible | Overflow contained in explorer |
|---|---|---|---|
| Before (`min-width:auto`) | 530px ❌ | no ❌ | 0px |
| After (`min-width:0`) | 0px ✅ | yes ✅ | 530px ✅ |

## Usage

No new API. Open the native file explorer, search for a term that matches deeply-nested files (e.g. `.parquet`). The results list scrolls horizontally on its own while the search bar stays fixed, and the loading spinner shows in the accent color while the recursive scan is in flight.

## Test Plan

- [x] `tsc --noEmit` (frontend typecheck) passes
- [x] `vite build` succeeds (via `scripts/dev.sh` startup build)
- [x] Manual: searched `.parquet` from the home directory in a running dev server; confirmed `pageOverflowPx = 0`, search bar fully visible, overflow trapped in `.listing-scroll`
- [x] Counterfactual: reverting `min-width` to `auto` in-DOM reproduces `pageOverflowPx = 530` and hides the search bar, confirming the fix is responsible
- [x] Manual: verified spinner `border-top-color` computes to `rgb(229, 255, 68)` (`--accent`) during an active scan
