### PR TITLE
fix(mounts): share one VFS between mount and serve, route DuckDB CSV/JSON through it

### DIFF
--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -7,12 +7,10 @@
 // follow views/Preferences.tsx.
 import { useEffect, useState, type ReactNode } from "react";
 import {
-  attachMount,
   createDetectedRemote,
   createMount,
   createRemote,
   deleteMount,
-  detachMount,
   getMounts,
   reconnectMount,
 } from "../lib/api";
@@ -132,37 +130,22 @@ function MountRow({
           </div>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          {conn.state === "mounted" && (
-            <>
-              <button type="button" disabled={busy} onClick={() => navigate(conn.mountpoint)}>
-                Open
-              </button>
-              <button type="button" disabled={busy} onClick={() => act(() => detachMount(conn.id))}>
-                Unmount
-              </button>
-            </>
-          )}
-          {conn.state === "disconnected" && (
-            <>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => act(() => reconnectMount(conn.id))}
-              >
-                {busy ? "Reconnecting…" : "Reconnect"}
-              </button>
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => act(() => detachMount(conn.id, true))}
-              >
-                Unmount
-              </button>
-            </>
-          )}
-          {conn.state === "unmounted" && (
-            <button type="button" disabled={busy} onClick={() => act(() => attachMount(conn.id))}>
-              Mount
+          {conn.state === "mounted" ? (
+            <button type="button" disabled={busy} onClick={() => navigate(conn.mountpoint)}>
+              Open
+            </button>
+          ) : (
+            // Both "disconnected" and "unmounted" recover the same way: there is
+            // no unmount action (mounts automount and stay up), so Reconnect is
+            // the single "something's wrong" repair — it force-clears any dead
+            // mountpoint and mounts fresh (reconnect_mount also handles the
+            // never-mounted case, where it just attaches).
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => act(() => reconnectMount(conn.id))}
+            >
+              {busy ? "Reconnecting…" : "Reconnect"}
             </button>
           )}
         </div>
@@ -423,8 +406,8 @@ export default function Mounts() {
         Remote storage mounted as local folders
         {state.rclone.version ? ` (${state.rclone.version})` : ""}. The <b>first</b> open of a
         large remote file downloads what it needs and can be slow; repeat opens are served from
-        a local cache and are fast. Mounts stay up until you unmount them — including across
-        restarts.
+        a local cache and are fast. Mounts stay up automatically, including across restarts;
+        if one stops responding, use <b>Reconnect</b>.
       </p>
       {state.mounts.length === 0 ? (
         <p className="deploy-muted">No mounts yet.</p>

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -52,12 +52,20 @@ router = APIRouter()
 # across N connections — unlike read-ahead it fetches no extra bytes (so it
 # doesn't hurt the random-access COG/parquet case), it just saturates the link
 # on the big-file cold read that one serial S3 range GET leaves idle.
+# CacheMaxSize is the soft LRU cap on the on-disk cache (open files never
+# evicted); it lives here — not only on the serve — because the mount and the
+# serve share ONE VFS (see SERVE_VFS_OPT), so both must carry the same cap or
+# the option sets diverge and rcd splits them into two VFS instances.
+#
+# This is the CANONICAL option set: SERVE_VFS_OPT is derived from it below so
+# the two can never drift out of sync (drift is what split the VFS in two).
 VFS_OPT = {
     "CacheMode": "full",
     "ChunkSize": "8M",
     "ChunkSizeLimit": "64M",
     "ChunkStreams": 4,
     "CacheMaxAge": "24h",
+    "CacheMaxSize": "20Gi",
     "FastFingerprint": True,
     "DirCacheTime": "30s",
 }
@@ -87,7 +95,52 @@ VFS_OPT = {
 # vfs_cache_mode). An unknown `vfsOpt` key is silently ignored — the serve
 # then runs with the cache OFF and every read, warm or not, goes to the
 # store (measured: 1MB re-read 4.4s uncached vs 2ms cached).
-SERVE_VFS_OPT = {"vfs_cache_mode": "full", "vfs_cache_max_size": "20Gi"}
+#
+# The serve and the mount MUST be given the same vfs option set: rcd keeps one
+# VFS per (fs, options) and reuses it across mount/mount and serve/start only
+# when the options match EXACTLY (verified — matching options yield a single
+# entry in vfs/list, and a range cached via the serve then reads in ~0.00s
+# through the mount path; mismatched options give two VFS instances that share
+# the on-disk cache dir but not their in-memory range state, so a serve-warmed
+# range costs a fresh ~0.8s S3 fetch when read through the mount). So the flat
+# serve params are DERIVED from VFS_OPT, not hand-written — the two literals
+# silently drifting is precisely the bug. Values are stringified because
+# serve/list echoes params back as strings (bool -> "true", int -> "4"), and
+# sync_serves' drift check compares SERVE_VFS_OPT against that echo.
+_VFS_OPT_TO_SERVE_PARAM = {
+    "CacheMode": "vfs_cache_mode",
+    "ChunkSize": "vfs_read_chunk_size",
+    "ChunkSizeLimit": "vfs_read_chunk_size_limit",
+    "ChunkStreams": "vfs_read_chunk_streams",
+    "CacheMaxAge": "vfs_cache_max_age",
+    "CacheMaxSize": "vfs_cache_max_size",
+    "FastFingerprint": "vfs_fast_fingerprint",
+    "DirCacheTime": "dir_cache_time",
+}
+# KeyError here on import is deliberate: a VFS_OPT key with no serve mapping
+# must not silently fall out of the serve's option set (that would re-split
+# the VFS) — add the mapping instead.
+SERVE_VFS_OPT = {
+    _VFS_OPT_TO_SERVE_PARAM[k]: ("true" if v else "false") if isinstance(v, bool) else str(v)
+    for k, v in VFS_OPT.items()
+}
+
+# macOS mounts rclone's nfsmount through the loopback NFS client, whose
+# request timeout defaults aggressively low — a single slow 8M chunk fetch
+# overruns it and the kernel drops the WHOLE mount ("server connections
+# interrupted"; this is the failure the HTTP serve was added to route
+# analytical reads around). `timeo` is in DECISECONDS on macOS/BSD, so
+# timeo=600 raises the per-request ceiling to 60s (vs the ~1s default), and
+# retrans allows a couple of tries before the mount is declared dead — enough
+# that a genuinely slow read is merely slow, not fatal, for the local-path
+# readers that can't go through the serve (the geotiff/grid tile daemons,
+# rasterio/PIL/laspy). A truly dead mount still fails, and the health probe
+# (mount_state) runs timeout-isolated in its own thread, so a high ceiling
+# never blocks a request. Passed via mountOpt.ExtraOptions, which rclone
+# forwards verbatim as `-o` flags to the macOS `mount` command (verified in
+# the rcd -vv log). nfsmount only — the Linux path uses FUSE `mount`, which
+# ignores these NFS options.
+NFS_MOUNT_OPT = {"ExtraOptions": ["timeo=600", "retrans=2"]}
 
 # Tile-server daemon state files — the two parallel implementations that can
 # hold files open under a mount (geotiff, and the grid server shared by
@@ -311,7 +364,11 @@ def serves_path() -> str:
 
 def _http_serves(port: int) -> dict:
     """{fs: {"addr", "id", "vfs"}} for every live rc HTTP serve. "vfs" is the
-    flat vfs_* params the serve was started with (drift check input)."""
+    vfs option params the serve was started with (every param except the
+    type/fs/addr infra keys — i.e. the vfs_* flags AND dir_cache_time, which
+    has no vfs_ prefix but is part of the shared option set). This is the
+    drift-check input, compared against SERVE_VFS_OPT; capturing only vfs_*
+    keys would drop dir_cache_time and make the check always report drift."""
     try:
         listed = _rc(port, "serve/list").get("list", [])
     except RuntimeError:
@@ -319,7 +376,7 @@ def _http_serves(port: int) -> dict:
     return {
         s["params"]["fs"]: {"addr": s.get("addr", ""), "id": s.get("id", ""),
                             "vfs": {k: v for k, v in s["params"].items()
-                                    if k.startswith("vfs_")}}
+                                    if k not in ("type", "fs", "addr")}}
         for s in listed
         if isinstance(s, dict) and s.get("params", {}).get("type") == "http"
         and s.get("params", {}).get("fs")
@@ -541,12 +598,19 @@ def attach_mount(m: dict) -> str | None:
         return None
     try:
         port = ensure_rcd()
-        _rc(port, "mount/mount", {
+        params = {
             "fs": m["remote"],
             "mountPoint": mp,
             "mountType": "nfsmount" if sys.platform == "darwin" else "mount",
             "vfsOpt": VFS_OPT,
-        }, timeout=60)
+        }
+        # macOS only: raise the loopback NFS client's timeout (see NFS_MOUNT_OPT).
+        # mountOpt is the NFS transport layer, not a vfs option, so it does NOT
+        # affect the (fs, vfsOpt) VFS-reuse key — the mount still shares its VFS
+        # with the serve.
+        if sys.platform == "darwin":
+            params["mountOpt"] = NFS_MOUNT_OPT
+        _rc(port, "mount/mount", params, timeout=60)
     except RuntimeError as e:
         return str(e)
     sync_serves()
@@ -634,6 +698,22 @@ def detach_mount(m: dict, force: bool = False) -> str | None:
         return f"unmount failed (a preview may still hold a file open): {e}"
 
 
+def _stop_serve_for(port: int, fs: str) -> None:
+    """Stop the HTTP serve for `fs`, if one is live. Used by reconnect: rcd
+    shares ONE VFS between a mount and its serve, and `mount/unmount` shuts
+    that VFS down regardless of the serve's reference to it — verified: after
+    unmounting, the serve still replays disk-cached ranges but hangs on any
+    uncached read (vfs/list drops to 0). Dropping the serve here lets the
+    following sync_serves start a fresh one that re-binds to the remounted
+    VFS. Best-effort: a missing serve or a failed stop is fine."""
+    serve = _http_serves(port).get(fs)
+    if serve and serve["id"]:
+        try:
+            _rc(port, "serve/stop", {"id": serve["id"]})
+        except RuntimeError:
+            pass
+
+
 def reconnect_mount(m: dict) -> str | None:
     """Repair a disconnected mount: clear whatever is wedged at the
     mountpoint, then mount fresh. Returns an error string or None.
@@ -642,7 +722,10 @@ def reconnect_mount(m: dict) -> str | None:
     lists the mount), force-unmount whatever kernel mount remains (a dead
     NFS mount rejects plain umount — the state this whole path exists for),
     ask rcd once more so a force-cleared mount doesn't linger in its
-    listmounts and block the remount, then attach as usual."""
+    listmounts and block the remount, drop the HTTP serve (it shares the
+    mount's VFS, which the unmount just tore down — see _stop_serve_for),
+    then attach as usual (attach_mount's sync_serves starts a fresh serve
+    that re-binds to the remounted VFS)."""
     mp = mountpoint(m)
     port = _live_rcd_port()
     if port is not None:
@@ -659,6 +742,8 @@ def reconnect_mount(m: dict) -> str | None:
                 _rc(port, "mount/unmount", {"mountPoint": mp})
             except RuntimeError:
                 pass  # "mount not found" once the kernel mount is gone — fine
+    if port is not None:
+        _stop_serve_for(port, m["remote"])
     return attach_mount(m)
 
 

--- a/fused_render/templates/duckdb/reader.py
+++ b/fused_render/templates/duckdb/reader.py
@@ -431,9 +431,15 @@ def main(file: str, table: str = "", offset: int = 0, limit: int = 100,
         return out if mode == "count" else _fs_gate(file, out)
 
     # Remote fast path: scan the URL the page handed us on the shared
-    # connection. Any failure — httpfs unavailable, the URL gone stale, a
-    # network-level error mid-query — falls back to reading the path itself.
-    if ext == ".parquet" and source_url.startswith(("http://", "https://")):
+    # connection, for every flat format (.duckdb/.ddb already returned above).
+    # Reading a mount-backed file over the serve — parquet, CSV/TSV or JSON —
+    # keeps DuckDB's concurrent range reads off the NFS mount, whose 1s RPC
+    # timeout drops the whole mount under an analytical scan. CSV/JSON can't
+    # prune like parquet and re-scan the file per page, but the serve's shared
+    # VFS cache (mounts.SERVE_VFS_OPT) makes the repeat reads local-disk-cheap,
+    # so slow-but-safe beats fast-but-fatal. Any failure — httpfs unavailable,
+    # the URL gone stale, a network error mid-query — falls back to the path.
+    if source_url.startswith(("http://", "https://")):
         try:
             cur = _http_connection()
         except Exception:

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -751,12 +751,52 @@ def test_source_url_ignored_unless_http(parquet_file):
     assert len(out["rows"]) == 3
 
 
-def test_source_url_ignored_for_csv(csv_file):
-    # The fast path is parquet-only; CSV keeps reading the file even when a
-    # URL is offered (its streaming scan can't prune and sniffing over HTTP
-    # would read the whole file anyway).
-    out = reader.main(csv_file, limit=3, source_url="http://127.0.0.1:1/s.csv")
+def test_source_url_reads_csv_over_http(csv_file):
+    # CSV/TSV/JSON take the URL too, not just parquet: a mount-backed file is
+    # scanned over the serve where hammering the NFS mount with the scan risks
+    # dropping the whole mount. Reading the whole file over HTTP is slow-but-
+    # safe (and the serve's shared VFS cache makes the repeat reads cheap).
+    srv, hits = _serve_dir(os.path.dirname(csv_file))
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/s.csv"
+        try:
+            out = reader.main(csv_file, limit=3, source_url=url)
+        except Exception:
+            pytest.skip("duckdb httpfs extension unavailable")
+        assert out["rows"][0]["zip"] == "00000"   # all-varchar preserved
+        assert any("s.csv" in h for h in hits), "reader never hit the URL"
+    finally:
+        srv.shutdown()
+
+
+def test_source_url_reads_json_over_http(tmp_path):
+    p = _make(tmp_path, "s.json",
+              "SELECT range AS id, 'n'||range AS name FROM range(5)")
+    srv, hits = _serve_dir(os.path.dirname(p))
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/s.json"
+        try:
+            out = reader.main(p, limit=3, source_url=url)
+        except Exception:
+            pytest.skip("duckdb httpfs extension unavailable")
+        assert [r["id"] for r in out["rows"]] == [0, 1, 2]
+        assert out["editable"] is False           # JSON stays view-only
+        assert any("s.json" in h for h in hits), "reader never hit the URL"
+    finally:
+        srv.shutdown()
+
+
+def test_source_url_csv_falls_back_when_dead(csv_file):
+    # A dead serve URL must not error the CSV read — fall back to the path.
+    import socket
+
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        dead = s.getsockname()[1]
+    out = reader.main(csv_file, limit=3,
+                      source_url=f"http://127.0.0.1:{dead}/s.csv")
     assert out["rows"][0]["zip"] == "00000"
+    assert out["total_rows"] == 250
 
 
 # ------------------------------------- schema mode / per-column projection

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -166,6 +166,37 @@ def test_mount_calls_rc_with_vfs_options(home, rcd):
     assert body["mountPoint"] == mounts_mod.mountpoint(c)
     assert body["vfsOpt"]["CacheMode"] == "full"
     assert body["vfsOpt"]["CacheMaxAge"] == "24h"
+    # The mount carries the same on-disk cache cap as the serve — both must
+    # hold every vfs option or rcd splits them into two VFS instances.
+    assert body["vfsOpt"]["CacheMaxSize"] == "20Gi"
+
+
+def test_serve_vfs_opt_derived_from_mount_vfs_opt():
+    # The mount (vfsOpt object) and the serve (flat vfs_* params) must describe
+    # the SAME option set or rcd builds two independent VFS instances that don't
+    # share cached ranges — the whole reason this bug existed. SERVE_VFS_OPT is
+    # DERIVED from VFS_OPT to guarantee it; assert every key maps and the values
+    # agree (bools -> "true"/"false", ints -> str, as serve/list echoes them).
+    assert set(mounts_mod._VFS_OPT_TO_SERVE_PARAM) == set(mounts_mod.VFS_OPT)
+    for obj_key, flat_key in mounts_mod._VFS_OPT_TO_SERVE_PARAM.items():
+        v = mounts_mod.VFS_OPT[obj_key]
+        expected = ("true" if v else "false") if isinstance(v, bool) else str(v)
+        assert mounts_mod.SERVE_VFS_OPT[flat_key] == expected
+
+
+@pytest.mark.skipif(mounts_mod.sys.platform != "darwin",
+                    reason="nfsmount timeo override is macOS-only")
+def test_mount_raises_nfs_timeout_on_macos(home, rcd):
+    # The loopback NFS client's low default timeout drops the whole mount on a
+    # slow chunk fetch; attach must pass a raised timeo so local-path reads are
+    # slow, not fatal. mountOpt is NFS transport, not a vfs option, so it does
+    # not affect VFS sharing with the serve.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    assert mounts_mod.attach_mount(c) is None
+    [(_, body)] = [x for x in rcd.calls if x[0] == "mount/mount"]
+    assert body["mountType"] == "nfsmount"
+    assert body["mountOpt"]["ExtraOptions"] == mounts_mod.NFS_MOUNT_OPT["ExtraOptions"]
+    assert any(o.startswith("timeo=") for o in body["mountOpt"]["ExtraOptions"])
 
 
 def test_mount_surfaces_rc_error(home, rcd):
@@ -638,6 +669,22 @@ def test_reconnect_force_unmounts_dead_mount_then_remounts(home, rcd, monkeypatc
     assert any(m == "mount/mount" for m, _ in rcd.calls)
 
 
+def test_reconnect_stops_serve_so_it_rebinds_to_fresh_vfs(home, rcd):
+    # rcd shares one VFS between a mount and its serve; unmounting tears that
+    # VFS down and leaves the serve wedged on uncached reads (verified against
+    # real rclone). Reconnect must stop the serve so the following sync_serves
+    # starts a fresh one bound to the remounted VFS. The serve's options match
+    # SERVE_VFS_OPT, so the ONLY serve/stop here is reconnect's, not a drift.
+    c, mp = _make_mount(home, rcd, served=False)
+    rcd.responses["serve/list"] = {"list": [{
+        "id": "http-live", "addr": "127.0.0.1:41000",
+        "params": {"type": "http", "fs": "remote:bucket",
+                   **mounts_mod.SERVE_VFS_OPT}}]}
+    assert mounts_mod.reconnect_mount(c) is None
+    assert ("serve/stop", {"id": "http-live"}) in rcd.calls
+    assert any(m == "mount/mount" for m, _ in rcd.calls)
+
+
 def test_reconnect_reports_force_unmount_failure(home, rcd, monkeypatch):
     c, mp = _make_mount(home, rcd, served=False)
     monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
@@ -749,7 +796,11 @@ def test_attach_starts_http_serve_and_writes_map(home, rcd):
     # object is mount/mount-only and gets silently ignored (cache stays off).
     assert "vfsOpt" not in body
     assert body["vfs_cache_mode"] == "full"
-    assert body["vfs_cache_max_size"] == "5Gi"
+    assert body["vfs_cache_max_size"] == "20Gi"
+    # The serve is started with the FULL derived option set (not just cache
+    # mode/size) so it shares the mount's VFS — every SERVE_VFS_OPT key present.
+    for k, v in mounts_mod.SERVE_VFS_OPT.items():
+        assert body[k] == v
     serves = json.load(open(mounts_mod.serves_path()))
     assert serves == {mounts_mod.mountpoint(c): "http://127.0.0.1:59999"}
 
@@ -795,7 +846,7 @@ def test_sync_serves_restarts_serve_with_stale_vfs_opts(home, rcd):
     assert stop == {"id": "http-stale"}
     [(_, start)] = [x for x in rcd.calls if x[0] == "serve/start"]
     assert start["vfs_cache_mode"] == "full"
-    assert start["vfs_cache_max_size"] == "5Gi"
+    assert start["vfs_cache_max_size"] == "20Gi"
     serves = json.load(open(mounts_mod.serves_path()))
     assert serves == {mounts_mod.mountpoint(c): "http://127.0.0.1:59999"}
 


### PR DESCRIPTION
## Problem

Each rclone mount ran **two independent VFS instances** inside one rcd — the
`nfsmount` backing the local filesystem path and the HTTP serve backing
`/api/fs/raw` + the DuckDB reader + prefetch. They shared a cache directory but
kept **separate in-memory range bookkeeping**, so bytes fetched by one were
re-fetched by the other (measured: a range warmed via the serve still took a
full S3 fetch when read back through the mount). See
`docs/HANDOFF-vfs-mount-serve-duplication.md` for the full investigation.

## Changes

Two commits, two directions of the same fix:

### 1. Share one VFS between `mount/mount` and `serve/start` (`71c5896`)

rcd reuses a single VFS per `(fs, options)` across mount and serve **only when
options match exactly**. `VFS_OPT` and `SERVE_VFS_OPT` differed, guaranteeing
two instances. Validated in a clean-room rcd that aligning them collapses to one
shared VFS with cross-visible cached ranges, then implemented:

- Derive `SERVE_VFS_OPT` from the canonical `VFS_OPT` via an object→flat param
  map so the two dialects can never drift apart again.
- Widen `_http_serves` capture to non-(`type`/`fs`/`addr`) keys so
  `dir_cache_time` is in the drift check.
- Raise the macOS `nfsmount` timeout via `mountOpt.ExtraOptions`
  (`timeo`/`retrans`, ~1s → 60s) so a slow chunk fetch no longer drops the mount.
- `reconnect_mount` stops the serve first so it rebinds to the fresh VFS.
- **UI:** removed the user-facing Unmount button (shared-VFS unmount tears down
  the VFS the serve depends on). Actions are now Open + ✕ / Reconnect + ✕;
  mounts stay up automatically across restarts.

### 2. Route mount-backed CSV/TSV/JSON through the serve (`52a44b9`)

The DuckDB reader's HTTP fast path was gated to parquet only, so a mounted
CSV/TSV/JSON fell back to scanning the local NFS mount — the exact
concurrent-range-read pattern that drops the mount. The frontend already sends
`source_url` for any remote file and the server rewrite is format-agnostic; only
`reader.py` restricted the URL scan. Relaxed the gate to every flat format
(`.duckdb/.ddb` handled earlier; parquet-only branches stay guarded). Falls back
to the local path on any httpfs error, unchanged.

## Testing

- `tests/test_shell_mounts.py` — 73 pass (incl. 3 new: derivation invariant,
  macOS timeo, reconnect-stops-serve).
- `tests/test_duckdb_reader.py` — 70 pass (incl. 3 new: CSV over HTTP, JSON over
  HTTP, CSV dead-URL fallback; replaced the test encoding the old parquet-only
  restriction).
- Clean-room rcd cross-visibility validation of the shared VFS.
- Live e2e through the running dev server: a CSV routes over the HTTP
  `source_url`, all-varchar preserved, correct totals.

## Not included

Direction 3 (teach prefetch about mount readers) was investigated and closed as
obsolete — the shared VFS already removed the byte-duplication it hedged, every
server-observable read already touches `_touched`, and the remaining readers are
cross-process with no bridge back to the server. Details in the handoff doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)