### PR TITLE
feat(shell): show ~ for home directory in top breadcrumbs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -329,7 +329,10 @@ export default function App({ config }: { config: Config }) {
       </>
     );
   } else {
-    main = <StatView key={epoch + ":" + fsPath} fsPath={fsPath} epoch={epoch} home={config.home} />;
+    // Windows expanduser returns backslashes; fsPath is always forward-slash.
+    main = (
+      <StatView key={epoch + ":" + fsPath} fsPath={fsPath} epoch={epoch} home={config.home.replace(/\\/g, "/")} />
+    );
   }
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,7 +135,7 @@ function StatErrorView({
 // Stat-backed views (listing/preview): breadcrumb + content under one hook
 // component so useStat only runs when the pathname is a real fs path, not a
 // sentinel.
-function StatView({ fsPath, epoch }: { fsPath: string; epoch: number }) {
+function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home: string }) {
   // Bumped by StatErrorView to re-stat in place after reconnecting a mount.
   const [reloadKey, setReloadKey] = useState(0);
   const stat = useStat(fsPath, epoch, reloadKey);
@@ -182,7 +182,7 @@ function StatView({ fsPath, epoch }: { fsPath: string; epoch: number }) {
   return (
     <>
       <div id="breadcrumb">
-        <Breadcrumb fsPath={fsPath} />
+        <Breadcrumb fsPath={fsPath} home={home} />
       </div>
       <div id="content">{content}</div>
     </>
@@ -329,7 +329,7 @@ export default function App({ config }: { config: Config }) {
       </>
     );
   } else {
-    main = <StatView key={epoch + ":" + fsPath} fsPath={fsPath} epoch={epoch} />;
+    main = <StatView key={epoch + ":" + fsPath} fsPath={fsPath} epoch={epoch} home={config.home} />;
   }
 
   return (

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -202,8 +202,10 @@ function navigatePreservingMode(target: string): void {
   else navigate(target);
 }
 
-export function Breadcrumb({ fsPath }: { fsPath: string }) {
-  const parts = fsPath.split("/").filter((s) => s.length > 0);
+export function Breadcrumb({ fsPath, home }: { fsPath: string; home?: string }) {
+  const underHome = home !== undefined && (fsPath === home || fsPath.startsWith(home + "/"));
+  const rest = underHome ? fsPath.slice(home.length) : fsPath;
+  const parts = rest.split("/").filter((s) => s.length > 0);
   const pieces: React.ReactNode[] = [
     <a
       key="root"
@@ -211,17 +213,17 @@ export function Breadcrumb({ fsPath }: { fsPath: string }) {
       className={"path-crumb" + (parts.length === 0 ? " last" : "")}
       onClick={(e) => {
         e.preventDefault();
-        navigatePreservingMode("/");
+        navigatePreservingMode(underHome ? home : "/");
       }}
     >
-      /
+      {underHome ? "~" : "/"}
     </a>,
   ];
   // A Windows path's first segment is the drive ("C:"); its crumb must target
   // "C:/" (bare "C:" is cwd-relative to os.stat) and later segments append
   // without re-rooting at "/".
-  const isDrive = /^[A-Za-z]:$/.test(parts[0] || "");
-  let acc = "";
+  const isDrive = !underHome && /^[A-Za-z]:$/.test(parts[0] || "");
+  let acc = underHome ? home : "";
   parts.forEach((part, i) => {
     if (i === 0 && isDrive) acc = part + "/";
     else acc = acc + (acc.endsWith("/") ? "" : "/") + part;
@@ -229,7 +231,8 @@ export function Breadcrumb({ fsPath }: { fsPath: string }) {
     const isLast = i === parts.length - 1;
     // Separator only between segments (root already carries the leading
     // slash) — matches the panel path bar's tight `/Users/name/...` format.
-    if (i > 0) pieces.push(<span key={"sep" + i} className="path-crumb-sep">/</span>);
+    // The "~" crumb carries no slash, so its first segment needs one too.
+    if (i > 0 || underHome) pieces.push(<span key={"sep" + i} className="path-crumb-sep">/</span>);
     if (isLast) {
       pieces.push(
         <span key={target} className="path-crumb last">

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -203,7 +203,8 @@ function navigatePreservingMode(target: string): void {
 }
 
 export function Breadcrumb({ fsPath, home }: { fsPath: string; home?: string }) {
-  const underHome = home !== undefined && (fsPath === home || fsPath.startsWith(home + "/"));
+  // Strictly below home only — home itself shows its full path, not a lone "~".
+  const underHome = home !== undefined && fsPath.startsWith(home + "/");
   const rest = underHome ? fsPath.slice(home.length) : fsPath;
   const parts = rest.split("/").filter((s) => s.length > 0);
   const pieces: React.ReactNode[] = [

--- a/frontend/src/lib/layout-codec.ts
+++ b/frontend/src/lib/layout-codec.ts
@@ -9,7 +9,7 @@
 //
 // Panes/tabs are /embed/<path> iframes (D39): a full chrome-free shell, so each
 // can browse dirs, open previews and use templates for free.
-import { EMBED_PREFIX } from "./router";
+import { EMBED_PREFIX, rootedFsPath } from "./router";
 
 // --- Tree codec (`_layout` param) -----------------------------------------
 // `,` = row (side by side), `;` = column (stacked), `(…)` groups for nesting.
@@ -296,13 +296,16 @@ export function readEmbedLoc(iframe: HTMLIFrameElement): EmbedLoc | null {
     const p = loc.pathname;
     if (p && p.startsWith(EMBED_PREFIX)) {
       const rest = p.slice(EMBED_PREFIX.length);
-      const path =
-        "/" +
+      // rootedFsPath keeps the shell's canonical form: leading slash for
+      // POSIX, none for Windows drive paths ("C:/…") — a bare "/"-prefixed
+      // drive path would never prefix-match home or other fs paths.
+      const path = rootedFsPath(
         rest
           .split("/")
           .filter((s) => s.length > 0)
           .map(decodeURIComponent)
-          .join("/");
+          .join("/")
+      );
       return { path, query: loc.search || "" };
     }
   } catch {

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -121,6 +121,7 @@ interface PaneCtx {
   syncUrl: () => void;
   split: (id: number, dir: "row" | "col") => void;
   close: (id: number) => void;
+  home: string;
 }
 
 // One pane: bar (crumbs + split/maximize/close buttons) over a frozen-src
@@ -171,7 +172,12 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
     if (el) el.scrollLeft = el.scrollWidth;
   }, [loc]);
 
-  const parts = loc.path.split("/").filter((s) => s.length > 0);
+  // Same "~" contraction as the top-bar Breadcrumb: strictly below home only —
+  // home itself shows its full path, not a lone "~".
+  const underHome = loc.path.startsWith(ctx.home + "/");
+  const parts = (underHome ? loc.path.slice(ctx.home.length) : loc.path)
+    .split("/")
+    .filter((s) => s.length > 0);
   const crumbs: ReactNode[] = [];
   const addCrumb = (label: string, targetPath: string, isLast: boolean, key: string) => {
     crumbs.push(
@@ -189,11 +195,12 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
       </span>
     );
   };
-  addCrumb("/", "/", parts.length === 0, "root");
-  let acc = "";
+  addCrumb(underHome ? "~" : "/", underHome ? ctx.home : "/", parts.length === 0, "root");
+  let acc = underHome ? ctx.home : "";
   parts.forEach((p, i) => {
     acc += "/" + p;
-    if (i > 0) crumbs.push(<span key={"sep" + i} className="panel-crumb-sep">/</span>);
+    // The "~" crumb carries no slash, so its first segment needs one too.
+    if (i > 0 || underHome) crumbs.push(<span key={"sep" + i} className="panel-crumb-sep">/</span>);
     addCrumb(p, acc, i === parts.length - 1, acc);
   });
 
@@ -375,7 +382,7 @@ export default function Panel({ config }: { config: Config }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [version]);
 
-  const ctx: PaneCtx = { syncUrl, split, close };
+  const ctx: PaneCtx = { syncUrl, split, close, home: config.home };
   return (
     <div className="panel-root">
       <Build node={treeRef.current} ctx={ctx} />

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -382,7 +382,8 @@ export default function Panel({ config }: { config: Config }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [version]);
 
-  const ctx: PaneCtx = { syncUrl, split, close, home: config.home };
+  // Windows expanduser returns backslashes; pane paths are always forward-slash.
+  const ctx: PaneCtx = { syncUrl, split, close, home: config.home.replace(/\\/g, "/") };
   return (
     <div className="panel-root">
       <Build node={treeRef.current} ctx={ctx} />


### PR DESCRIPTION
Breadcrumbs now display `~` in place of the home directory prefix (e.g. `~/Downloads` instead of `/Users/vasu/Downloads`). The `~` crumb navigates to home.

Display-only: crumb click targets and the browser URL keep the explicit absolute path. Paths outside home (and Windows drive paths) are unchanged. Home comes from `/api/config`'s existing `home` field, threaded via a `home` prop through `StatView` → `Breadcrumb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display and navigation-label changes in breadcrumb UI plus a path canonicalization fix in embed location reads; no auth, API, or data-layer changes.
> 
> **Overview**
> Breadcrumbs under the user’s **home** path now show a **`~`** root instead of the full absolute prefix (e.g. `~/Downloads` rather than `/Users/name/Downloads`). The **`~`** crumb still navigates to the real home path; URLs and click targets stay absolute. **Home itself** keeps the full path—contraction applies only to strict descendants of home.
> 
> **`config.home`** is passed from **`App`** through **`StatView`** into **`Breadcrumb`**, and into **panel** pane crumbs via **`PaneCtx`**, with Windows backslashes normalized to forward slashes so prefix checks match **`fsPath`**.
> 
> **`readEmbedLoc`** now builds pane paths with **`rootedFsPath`** so Windows drive paths (`C:/…`) aren’t forced to a leading `/`, which would break home prefix matching for embed panes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89e72d7b8aec27a601d59b81113607f7c4d5efd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->