### PR TITLE
zarr_aoi template: stream AOIs from huge hosted Zarr stores

### DIFF
--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -372,6 +372,7 @@
     "preview"
   ],
   ".zarr/": [
+    "zarr_aoi",
     "zarr",
     "_listing"
   ],

--- a/fused_render/templates/zarr_aoi/README.md
+++ b/fused_render/templates/zarr_aoi/README.md
@@ -1,0 +1,44 @@
+# zarr_aoi — hosted-Zarr AOI streaming preview for Fused Render
+
+Preview terabyte-scale Zarr stores (local, mounted, or `s3://...`) by streaming
+only the chunk byte-ranges that intersect the current viewport. Includes a
+"📊 stats" panel showing exactly how many requests/bytes were streamed vs the
+logical dataset size, native-pixel click probes with per-read cost, a time/level
+slider with background next-chunk prefetch, and shareable view URLs
+(`?ll=lon,lat&z=6&index=...&stretch=lo,hi&cmap=turbo`).
+
+## Install
+
+1. Copy (or symlink) this folder to `~/.fused-render/templates/zarr_aoi/`
+2. In `~/.fused-render/templates/registry.json`, add:
+
+   ```json
+   ".zarr":  ["zarr_aoi"],
+   ".zarr/": ["zarr_aoi"]
+   ```
+
+3. Open any `.zarr` store in Fused Render (double-click in the file explorer,
+   or paste an `s3://bucket/store.zarr` URL in the template's path box).
+
+No manual Python setup: the tile daemon builds its own venv on first run via
+`uv` (`~/.cache/fused-render-zarraoi/venv` — zarr 3, s3fs, numpy, crc32c), so
+zarr v2 + v3, sharding, and zstd all work regardless of what's bundled with
+the app. Requires `uv` on PATH or at `~/.local/bin/uv`.
+
+## Files
+
+- `template.html` — MapLibre viewer UI
+- `tile_server.py` — persistent localhost tile daemon (instrumented, caching,
+  parallel ranged fetch for big chunks)
+- `browse.py` — file-explorer helper
+- `icon.svg`
+
+## Good public test stores (anonymous S3, us-west-2)
+
+- 2D + pyramid: `s3://us-west-2.opendata.source.coop/mindearth/wsf/World_WSF_20160701-20260101.zarr` (8 TB, zarr v3, sharded)
+- 3D multi-var timeseries: `s3://mur-sst/zarr-v1` (SST, 6,443 daily steps)
+- 4D: `s3://cmip6-pds/CMIP6/CMIP/NCAR/CESM2/historical/r10i1p1f1/Amon/ua/gn/v20190313`
+
+Note: stores without overview pyramids can't stream a world view (the template
+shows a "zoom in" banner instead), and time-jump latency is dictated by the
+store's chunk size — the stats panel warns when chunks exceed 32 MB.

--- a/fused_render/templates/zarr_aoi/browse.py
+++ b/fused_render/templates/zarr_aoi/browse.py
@@ -1,0 +1,74 @@
+"""Directory listing for the nc_preview file explorer.
+
+Returns the sub-directories and files of `dir` so the HTML can render a
+navigable picker — no need to type paths by hand. Stdlib only.
+"""
+
+
+def main(dir: str = "~", exts: str = ".zarr", show_all: bool = False,
+         store_exts: str = ".zarr"):
+    import os
+
+    dir = os.path.abspath(os.path.expanduser(dir or "~"))
+    if not os.path.isdir(dir):
+        dir = os.path.dirname(dir) or "/"
+
+    allow = tuple(e.strip().lower() for e in exts.split(",") if e.strip())
+    stores = tuple(e.strip().lower() for e in store_exts.split(",") if e.strip())
+    dirs, files = [], []
+    try:
+        names = os.listdir(dir)
+    except OSError as e:
+        return {"error": f"cannot list {dir}: {e}", "dir": dir,
+                "parent": os.path.dirname(dir)}
+
+    for name in names:
+        if name.startswith("."):            # hide dotfiles
+            continue
+        full = os.path.join(dir, name)
+        try:
+            is_dir = os.path.isdir(full)
+            size = None if is_dir else os.path.getsize(full)
+        except OSError:
+            continue
+        if is_dir:
+            # a directory whose name ends in a store extension (e.g. .zarr) is a
+            # loadable store, not just a folder to descend into.
+            if any(name.lower().endswith(s) for s in stores):
+                files.append({"name": name, "path": full, "is_dir": True,
+                              "size": None, "ext": ".zarr", "loadable": True})
+            else:
+                dirs.append({"name": name, "path": full, "is_dir": True})
+        else:
+            ext = os.path.splitext(name)[1].lower()
+            loadable = ext in allow
+            if loadable or show_all:
+                files.append({"name": name, "path": full, "is_dir": False,
+                              "size": size, "ext": ext, "loadable": loadable})
+
+    dirs.sort(key=lambda e: e["name"].lower())
+    files.sort(key=lambda e: e["name"].lower())
+
+    # breadcrumb segments: [(label, path), ...] from root to here
+    parts, acc = [], ""
+    for seg in dir.strip("/").split("/"):
+        acc += "/" + seg
+        parts.append({"label": seg, "path": acc})
+
+    return {
+        "dir": dir,
+        "parent": os.path.dirname(dir),
+        "crumbs": parts,
+        "dirs": dirs,
+        "files": files,
+        "n_hidden_files": 0 if show_all else None,
+    }
+
+
+# The fused-render runner (app >= Jul 2026) only invokes @fused.udf-registered
+# entrypoints; a bare main() silently returns null. Register main via the shim.
+try:
+    import fused as _fused
+    _udf_main = _fused.udf(main)
+except ImportError:
+    pass

--- a/fused_render/templates/zarr_aoi/icon.svg
+++ b/fused_render/templates/zarr_aoi/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><rect x="3" y="3" width="8" height="8" rx="1"/><rect x="13" y="3" width="8" height="8" rx="1"/><rect x="3" y="13" width="8" height="8" rx="1"/><rect x="14.5" y="14.5" width="8" height="8" rx="1" opacity="0.4"/></svg>

--- a/fused_render/templates/zarr_aoi/template.html
+++ b/fused_render/templates/zarr_aoi/template.html
@@ -1,0 +1,590 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Hosted Zarr — AOI streaming preview</title>
+<link rel="stylesheet" href="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.css">
+<script src="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.js"></script>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; height: 100%; overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    color: #e8eaed; background: #131417; font-size: 13px; }
+  #map { position: absolute; inset: 0; }
+  .panel { position: absolute; background: rgba(19,20,23,.92); border: 1px solid #2a2d33;
+    border-radius: 10px; padding: 10px 12px; backdrop-filter: blur(6px); z-index: 10; }
+  #topbar { top: 10px; left: 10px; right: 10px; display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+  #topbar label { color: #9aa0a6; margin: 0 2px 0 6px; }
+  input[type=text], select { font: inherit; color: #e8eaed; background: #1b1d21;
+    border: 1px solid #2a2d33; border-radius: 6px; padding: 4px 8px; }
+  #path { flex: 1; min-width: 200px; }
+  input.num { width: 58px; font: inherit; color: #e8eaed; background: #1b1d21;
+    border: 1px solid #2a2d33; border-radius: 6px; padding: 4px 6px; }
+  button { font: inherit; color: #e8eaed; background: #2b5fd9; border: 1px solid #2b5fd9;
+    border-radius: 6px; padding: 4px 10px; cursor: pointer; }
+  button:hover { background: #3a6ee8; }
+  button.ghost { background: transparent; border-color: #2a2d33; color: #9aa0a6; }
+  button.ghost:hover { color: #e8eaed; border-color: #4a4d55; }
+  #status { position: absolute; left: 50%; top: 64px; transform: translateX(-50%);
+    background: rgba(19,20,23,.9); border: 1px solid #2a2d33; border-radius: 999px;
+    padding: 4px 14px; color: #9aa0a6; z-index: 20; display: none; }
+  #status.err { color: #ff7b72; display: block; }
+  #metaPanel { left: 10px; top: 58px; width: 380px; max-height: 65vh; overflow: auto; display: none; }
+  #metaPanel table { border-collapse: collapse; width: 100%; font-size: 12px; }
+  #metaPanel td { padding: 3px 6px; border-bottom: 1px solid #23262c; vertical-align: top; word-break: break-all; }
+  #metaPanel td:first-child { color: #9aa0a6; white-space: nowrap; }
+  #metaPanel h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+    color: #9aa0a6; margin: 0 0 6px; display: flex; justify-content: space-between; }
+  #explorer { left: 10px; top: 58px; width: 420px; max-height: 65vh; display: none; z-index: 30; }
+  #crumbs { font-size: 12px; margin-bottom: 8px; color: #9aa0a6; }
+  #crumbs a { color: #8ab4ff; cursor: pointer; }
+  #explorerList { max-height: 48vh; overflow: auto; border: 1px solid #23262c; border-radius: 6px; }
+  .row { display: flex; align-items: center; gap: 8px; padding: 5px 10px; cursor: pointer;
+    font-size: 13px; border-bottom: 1px solid #1e2025; }
+  .row:hover { background: #23262c; }
+  .row .ic { width: 18px; text-align: center; }
+  .row .nm { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .row .sz { color: #6b7178; font-size: 11px; }
+  input[type=range] { vertical-align: middle; }
+  #readout { left: 10px; bottom: 26px; font-size: 12px; font-variant-numeric: tabular-nums;
+    color: #cdd0d4; max-width: 520px; }
+  #readout b { color: #8ab4ff; }
+  #readout .cost { color: #7ee787; }
+
+  /* --- streaming panel (the point of this template) --- */
+  #streamPanel { right: 10px; top: 58px; width: 360px; font-variant-numeric: tabular-nums; }
+  #streamPanel h2 { font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+    color: #9aa0a6; margin: 0 0 8px; display: flex; justify-content: space-between; align-items: center; }
+  #streamPanel h2 button { font-size: 10px; padding: 1px 7px; }
+  .bignum { font-size: 22px; font-weight: 600; color: #7ee787; line-height: 1.1; }
+  .bigsub { color: #9aa0a6; font-size: 11.5px; margin: 2px 0 10px; }
+  .kv { display: grid; grid-template-columns: auto 1fr; gap: 2px 10px; font-size: 12px; margin-bottom: 8px; }
+  .kv .k { color: #9aa0a6; white-space: nowrap; }
+  .kv .v { color: #e8eaed; text-align: right; }
+  #dsFacts { border-bottom: 1px solid #23262c; padding-bottom: 8px; margin-bottom: 8px;
+    color: #cdd0d4; font-size: 12px; line-height: 1.45; }
+  #dsFacts b { color: #ffcf70; }
+  #opLog { max-height: 24vh; overflow: auto; font-size: 11px; color: #9aa0a6;
+    border-top: 1px solid #23262c; padding-top: 6px; }
+  #opLog .op { display: flex; gap: 6px; padding: 1.5px 0; white-space: nowrap; }
+  #opLog .op .knd { color: #8ab4ff; width: 78px; }
+  #opLog .op .net { color: #7ee787; }
+  #opLog .op .cch { color: #6b7178; }
+  #levelLine { font-size: 11.5px; color: #9aa0a6; margin-bottom: 8px; }
+  #levelLine b { color: #e8eaed; }
+</style>
+</head>
+<body>
+  <div id="map"></div>
+
+  <div class="panel" id="topbar">
+    <button id="browse" class="ghost">📁</button>
+    <input type="text" id="path" placeholder="/path/to/store.zarr — or s3://bucket/store.zarr" />
+    <button id="load">Load</button>
+    <span><label for="var">variable</label><select id="var"></select></span>
+    <span id="idxRow" style="display:none"><label id="idxName">index</label>
+      <input type="range" id="idxRange" min="0" max="0" value="0" />
+      <span id="idxLabel"></span></span>
+    <span><label for="cmap">cmap</label>
+      <select id="cmap"><option>viridis</option><option>magma</option><option>turbo</option><option value="rdbu">RdBu</option><option value="grays">grays</option></select></span>
+    <span><label>stretch</label>
+      <input class="num" id="vLo" placeholder="lo" /><input class="num" id="vHi" placeholder="hi" />
+      <button id="stretchAuto" class="ghost" title="2–98th percentile of the current viewport">auto</button></span>
+    <span><label for="nofill" title="Render the fill value as transparent">hide fill</label>
+      <input type="checkbox" id="nofill" checked /></span>
+    <span><label for="opacity">opacity</label><input type="range" id="opacity" min="0" max="100" value="90" style="width:80px" /></span>
+    <span><label for="basemap">basemap</label><input type="checkbox" id="basemap" checked /></span>
+    <button id="metaBtn" class="ghost">info</button>
+    <button id="statsBtn" class="ghost" title="Streaming stats for nerds">📊 stats</button>
+    <button id="fitBtn" class="ghost">⤢ fit</button>
+  </div>
+
+  <div id="status"></div>
+  <div id="tileSpin" style="display:none; position:absolute; left:50%; top:64px; transform:translateX(-50%);
+    background:rgba(19,20,23,.92); border:1px solid #2a2d33; border-radius:999px; padding:4px 14px;
+    color:#8ab4ff; z-index:20; font-variant-numeric:tabular-nums"></div>
+  <div class="panel" id="zoomHint" style="display:none; left:50%; transform:translateX(-50%);
+    bottom:60px; color:#ffcf70; font-size:12.5px; z-index:15; text-align:center"></div>
+
+  <div class="panel" id="explorer">
+    <div id="crumbs"></div>
+    <div id="explorerList"></div>
+    <label style="display:block;margin-top:8px;color:#9aa0a6;font-size:12px">
+      <input type="checkbox" id="showAll" /> show all files</label>
+  </div>
+
+  <div class="panel" id="metaPanel"><h2>Dataset info <a id="metaClose" style="cursor:pointer;color:#8ab4ff">×</a></h2><div id="metaBody"></div></div>
+
+  <div class="panel" id="readout">click the map to probe a native-resolution pixel</div>
+
+  <div class="panel" id="streamPanel" style="display:none">
+    <h2>Streaming <span><button id="resetStats" class="ghost">reset</button>
+      <button id="statsClose" class="ghost">×</button></span></h2>
+    <div id="dsFacts">…</div>
+    <div class="bignum" id="netBig">0 B</div>
+    <div class="bigsub" id="netSub">streamed this session</div>
+    <div id="levelLine">…</div>
+    <div class="kv" id="counters"></div>
+    <div id="opLog"></div>
+  </div>
+
+<script>
+"use strict";
+const $ = id => document.getElementById(id);
+const els = ['path','load','var','idxRow','idxName','idxRange','idxLabel','cmap','vLo','vHi','stretchAuto',
+  'nofill','opacity','basemap','metaBtn','metaPanel','metaBody','metaClose','fitBtn','status','readout',
+  'browse','explorer','crumbs','explorerList','showAll','streamPanel','dsFacts','netBig','netSub',
+  'levelLine','counters','opLog','resetStats','statsBtn','statsClose','zoomHint','tileSpin']
+  .reduce((o, k) => (o[k] = $(k), o), {});
+
+const EXTS = '.zgroup,.zattrs,.zmetadata';
+const DEFAULT_FILE = "s3://us-west-2.opendata.source.coop/mindearth/wsf/World_WSF_20160701-20260101.zarr";
+function storeRoot(p){
+  return p.replace(/\/(\.zgroup|\.zattrs|\.zmetadata|zarr\.json)$/, '');
+}
+
+const P = {
+  file:  () => storeRoot(fused.params.get('file') || fused.params.get('_file') || DEFAULT_FILE),
+  vr:    () => fused.params.get('var') || '',
+  index: () => fused.params.get('index') || '0',
+  cmap:  () => fused.params.get('cmap') || 'viridis',
+  stretch: () => fused.params.get('stretch') || '',
+  nofill:() => (fused.params.get('nofill') ?? '1') === '1',
+  stats: () => fused.params.get('stats') === '1',   // nerd panel, off by default
+  dir:   () => fused.params.get('dir') || P.file().replace(/\/[^/]*$/, '') || '~',
+  showAll:() => fused.params.get('showall') === '1',
+};
+const fmt = (x, d) => (x === null || x === undefined || !isFinite(x)) ? '—'
+  : Math.abs(x) >= 1000 ? Number(x).toLocaleString('en-US', {maximumFractionDigits: 0})
+  : Number(x).toFixed(d === undefined ? (Math.abs(x) >= 10 ? 1 : 3) : d);
+const human = n => n === null || n === undefined ? '—'
+  : n >= 1e12 ? (n/1e12).toFixed(2)+' TB' : n >= 1e9 ? (n/1e9).toFixed(2)+' GB'
+  : n >= 1e6 ? (n/1e6).toFixed(1)+' MB' : n >= 1e3 ? (n/1e3).toFixed(1)+' KB' : Math.round(n)+' B';
+function status(msg, err){ els.status.textContent = msg || ''; els.status.style.display = msg ? 'block' : 'none'; els.status.className = err ? 'err' : ''; }
+
+// ---------------- map ----------------
+const DARK = "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json";
+// deep-linkable view: ?ll=lon,lat&z=6 (written back on every move)
+const ll0 = (fused.params.get('ll') || '').split(',').map(Number);
+const z0 = parseFloat(fused.params.get('z'));
+const hadView = ll0.length === 2 && ll0.every(isFinite) && isFinite(z0);
+const map = new maplibregl.Map({ container: 'map', style: DARK,
+  center: hadView ? ll0 : [0, 25], zoom: hadView ? z0 : 1.4,
+  attributionControl: {compact: true}, fadeDuration: 80 });
+map.addControl(new maplibregl.NavigationControl({showCompass: false}), 'bottom-right');
+map.addControl(new maplibregl.ScaleControl({unit: 'metric'}), 'bottom-right');
+async function styleReady(){
+  map.resize();
+  for (let i = 0; i < 200 && !map.isStyleLoaded(); i++)
+    await new Promise(r => setTimeout(r, 50));
+  map.resize();
+}
+
+// ---------------- daemon + state ----------------
+let daemon = null, meta = null;
+
+async function ensureDaemon(){
+  if (daemon && daemon.port) return daemon;
+  status('Starting streaming daemon (first run installs zarr — may take a minute)…');
+  const r = await fused.runPython('./tile_server.py', {}).catch(() => null);
+  if (r && r.port) daemon = r;
+  return daemon;
+}
+const dURL = p => `http://127.0.0.1:${daemon.port}${p}`;
+
+function sliceQuery(){
+  return new URLSearchParams({ file: P.file(), var: P.vr(), index: P.index() });
+}
+function renderQuery(){
+  const q = sliceQuery();
+  q.set('cmap', P.cmap());
+  if (P.stretch()) q.set('stretch', P.stretch());
+  q.set('nofill', P.nofill() ? '1' : '0');
+  return q.toString();
+}
+
+function nativeZoom(){
+  if (!meta || !meta.levels || !meta.levels[0].res_deg) return 14;
+  return Math.ceil(Math.log2(360 / (256 * meta.levels[0].res_deg)));
+}
+function levelForZoom(z){
+  if (!meta) return null;
+  const dpp = 360 / (256 * Math.pow(2, z));
+  const cands = meta.levels.map((lv, i) => [i, lv.res_deg]).filter(t => t[1]);
+  const ok = cands.filter(t => t[1] <= dpp * 1.4);
+  if (ok.length) return ok.reduce((a, b) => (b[1] > a[1] ? b : a))[0];
+  return cands.reduce((a, b) => (b[1] < a[1] ? b : a))[0];
+}
+
+function setRasterTiles(){
+  const url = dURL(`/tile/{z}/{x}/{y}.png?${renderQuery()}`);
+  const src = map.getSource('raster');
+  if (src){ src.setTiles([url]); return; }
+  const lb = meta.lonlat_bounds;
+  map.addSource('raster', { type: 'raster', tiles: [url], tileSize: 256, minzoom: 0,
+    maxzoom: Math.min(nativeZoom(), 18), bounds: [lb.west, lb.south, lb.east, lb.north] });
+  map.addLayer({ id: 'raster', type: 'raster', source: 'raster',
+    paint: { 'raster-opacity': +els.opacity.value / 100, 'raster-fade-duration': 80,
+             'raster-resampling': 'nearest' } });
+}
+
+function fitToData(instant){
+  const lb = meta && meta.lonlat_bounds;
+  if (!lb) return;
+  map.fitBounds([[lb.west, lb.south], [lb.east, lb.north]],
+    {padding: 60, duration: instant === false ? 400 : 0, maxZoom: 10});
+}
+
+// ---------------- streaming panel ----------------
+let statsTimer = null, statsBusyUntil = 0;
+
+function renderFacts(){
+  if (!meta) return;
+  const sh = meta.shape || [];
+  const npx = sh.length >= 2 ? sh[sh.length-1] * sh[sh.length-2] : 0;
+  const parts = [];
+  parts.push(`<b>${human(meta.logical_bytes)}</b> logical · ${meta.dtype} · zarr v${meta.zarr_format}`);
+  parts.push(`${sh.map(x => fmt(x, 0)).join(' × ')} px (${(npx/1e12).toFixed(1)} Tpx)`);
+  let ck = `chunks ${(meta.chunks||[]).join('×')}`;
+  if (meta.inner_chunks) ck = `shards ${(meta.chunks||[]).join('×')} → chunks ${meta.inner_chunks.join('×')}`;
+  parts.push(`${ck} · ${(meta.codecs||[]).join('+') || 'raw'}`);
+  if ((meta.chunk_logical_bytes || 0) > 32e6)
+    parts.push(`<b>⚠ ${human(meta.chunk_logical_bytes)} per chunk</b> — every uncached slice read fetches whole chunks`);
+  parts.push(`${meta.n_levels} pyramid level${meta.n_levels>1?'s':''} · ${meta.source}`);
+  els.dsFacts.innerHTML = parts.map(p => `<div>${p}</div>`).join('');
+}
+
+function renderStats(s){
+  if (!meta || !s) return;
+  const frac = meta.logical_bytes ? s.net_bytes / meta.logical_bytes : 0;
+  els.netBig.textContent = human(s.net_bytes);
+  els.netSub.innerHTML = frac > 0
+    ? `streamed this session — <b style="color:#7ee787">${(frac*100).toPrecision(2)}%</b> of ${human(meta.logical_bytes)} (1 : ${fmt(1/Math.max(frac,1e-15),0)})`
+    : 'streamed this session';
+  const avg = s.requests ? s.net_ms / s.requests : 0;
+  els.counters.innerHTML = [
+    ['HTTP range requests', fmt(s.requests, 0)],
+    ['avg request', avg ? avg.toFixed(0) + ' ms' : '—'],
+    ['missing chunks (skipped)', fmt(s.missing, 0)],
+    ['cache hits', `${fmt(s.cache_hits, 0)} · saved ${human(s.cache_saved)}`],
+    ['cache in RAM', human(s.cache_bytes)],
+  ].map(([k, v]) => `<span class="k">${k}</span><span class="v">${v}</span>`).join('');
+  els.opLog.innerHTML = (s.ops || []).slice(0, 14).map(op => {
+    const what = op.kind === 'tile' ? `tile z${op.z} L${op.level}` :
+                 op.kind === 'tile-skipped' ? `skip z${op.z}` :
+                 op.kind === 'probe' ? 'probe L0' :
+                 op.kind === 'hist' ? `hist L${op.level}` : op.kind;
+    const win = op.window ? `${op.window[0]}×${op.window[1]}px` : (op.lonlat ? op.lonlat.join(',') : '');
+    const net = op.net_bytes !== undefined ? `${op.approx ? '≈' : ''}${human(op.net_bytes)} · ${op.requests} req` : (op.note || '');
+    const cch = op.cache_hits ? ` +${op.cache_hits}⚡` : '';
+    return `<div class="op"><span class="knd">${what}</span><span class="nm" style="flex:1">${win}</span>` +
+           `<span class="net">${net}</span><span class="cch">${cch}${op.ms !== undefined ? ' ' + op.ms + 'ms' : ''}</span></div>`;
+  }).join('');
+}
+
+async function pollStats(){
+  if (!daemon || !meta || !P.stats()) return;
+  try {
+    const r = await fetch(dURL('/stats?' + new URLSearchParams({file: P.file()})));
+    renderStats(await r.json());
+  } catch (e) {}
+}
+function statsActive(ms){
+  if (!P.stats()) return;
+  statsBusyUntil = Math.max(statsBusyUntil, performance.now() + (ms || 3000));
+  if (statsTimer) return;
+  statsTimer = setInterval(() => {
+    pollStats();
+    if (performance.now() > statsBusyUntil){ clearInterval(statsTimer); statsTimer = null; }
+  }, 800);
+}
+function syncStatsPanel(){
+  const on = P.stats();
+  els.streamPanel.style.display = on ? 'block' : 'none';
+  els.statsBtn.style.color = on ? '#7ee787' : '';
+  if (!on) return;
+  if (meta){ renderFacts(); renderLevelLine(); pollStats(); statsActive(2000); }
+  else els.dsFacts.textContent = 'waiting for the store to open…';
+}
+
+function zoomHintUpdate(){
+  // single-level giant stores can't stream a world view — say so
+  if (!meta || !meta.geographic || meta.n_levels > 1 || !meta.levels[0].res_deg){
+    els.zoomHint.style.display = 'none'; return;
+  }
+  const zmin = Math.ceil(Math.log2(360 / (meta.levels[0].res_deg * 2048)));
+  if (zmin > 0 && map.getZoom() < zmin - 0.2){
+    els.zoomHint.style.display = 'block';
+    els.zoomHint.innerHTML = `⚠ this store has no overview pyramid — a view this wide would stream ` +
+      `far too much data (hatched tiles are skipped).<br>Zoom in to about <b>z${zmin}</b> to start streaming native pixels.`;
+  } else els.zoomHint.style.display = 'none';
+}
+els.statsBtn.onclick = () => fused.params.set('stats', P.stats() ? '0' : '1');
+els.statsClose.onclick = () => fused.params.set('stats', '0');
+els.resetStats.onclick = async () => {
+  if (!daemon) return;
+  await fetch(dURL('/stats?' + new URLSearchParams({file: P.file(), reset: '1'})));
+  pollStats();
+};
+
+function renderLevelLine(){
+  if (!meta) return;
+  const z = map.getZoom();
+  const li = levelForZoom(z);
+  const lv = li !== null ? meta.levels[li] : null;
+  const m = lv && lv.res_deg ? lv.res_deg * 111320 : null;
+  els.levelLine.innerHTML = lv
+    ? `viewport reads <b>level ${lv.asset || li}</b> of ${meta.n_levels - 1} · ` +
+      `${lv.shape.map(x => fmt(x,0)).join('×')} px · ~${m < 1000 ? m.toFixed(0) + ' m' : (m/1000).toFixed(0) + ' km'}/px`
+    : '';
+}
+
+// ---------------- viewport hist (feeds auto-stretch) ----------------
+function viewportMercBbox(){
+  const b = map.getBounds();
+  const R = 6378137, l2m = (lon, lat) => [lon * Math.PI / 180 * R,
+    Math.log(Math.tan(Math.PI / 4 + Math.min(85, Math.max(-85, lat)) * Math.PI / 360)) * R];
+  const [w, s] = l2m(b.getWest(), b.getSouth()), [e, n] = l2m(b.getEast(), b.getNorth());
+  return [w, s, e, n];
+}
+els.stretchAuto.onclick = async () => {
+  if (!daemon || !meta) return;
+  const q = sliceQuery();
+  q.set('bbox', viewportMercBbox().join(','));
+  status('Sampling viewport…');
+  try {
+    const h = await (await fetch(dURL('/hist?' + q))).json();
+    if (h && h.p2 !== undefined && h.p98 > h.p2)
+      fused.params.set('stretch', `${h.p2},${h.p98}`);
+    else if (h && h.min !== undefined)
+      fused.params.set('stretch', `${h.min},${h.max + (h.max === h.min ? 1 : 0)}`);
+    statsActive();
+  } catch (e) {}
+  status('');
+};
+els.vLo.onchange = els.vHi.onchange = () => {
+  const lo = parseFloat(els.vLo.value), hi = parseFloat(els.vHi.value);
+  if (isFinite(lo) && isFinite(hi) && hi > lo) fused.params.set('stretch', `${lo},${hi}`);
+};
+
+// ---------------- click probe ----------------
+let probeTimer = null;
+map.on('dblclick', () => { clearTimeout(probeTimer); });
+map.on('click', e => {
+  clearTimeout(probeTimer);
+  probeTimer = setTimeout(() => runProbe(e), 300);   // let dblclick-zoom win
+});
+async function runProbe(e){
+  if (!daemon || !meta || !meta.geographic) return;
+  const q = sliceQuery();
+  q.set('lon', e.lngLat.lng); q.set('lat', e.lngLat.lat);
+  els.readout.innerHTML = 'probing native pixel…';
+  try {
+    const r = await (await fetch(dURL('/probe?' + q))).json();
+    if (!r.inside){ els.readout.innerHTML = 'outside dataset extent'; return; }
+    const c = r.cost || {};
+    els.readout.innerHTML =
+      `<b>${meta.selected}</b> = ${r.value === null ? 'fill / nodata' : fmt(r.value)}${r.units ? ' ' + r.units : ''} at native px ` +
+      `(row ${fmt(r.row,0)}, col ${fmt(r.col,0)})` +
+      (r.inner_chunk ? ` · shard [${r.shard}] chunk [${r.inner_chunk}]` : '') +
+      ` — <span class="cost">cost: ${c.requests || 0} req · ${human(c.net_bytes || 0)}` +
+      `${c.cache_hits ? ` (+${c.cache_hits} cached)` : ''} · ${c.ms} ms</span>`;
+    statsActive(1500);
+  } catch (err) { els.readout.innerHTML = 'probe failed'; }
+}
+
+// ---------------- metadata panel ----------------
+function renderMeta(){
+  if (!meta) return;
+  const rows = [
+    ['store', P.file().split('/').pop()],
+    ['source', meta.source],
+    ['variable', meta.selected],
+    ['dtype', meta.dtype], ['fill value', meta.fill_value],
+    ['logical size', human(meta.logical_bytes)],
+    ['zarr format', 'v' + meta.zarr_format],
+    ['codecs', (meta.codecs || []).join(', ')],
+  ];
+  if (meta.lonlat_bounds){
+    const lb = meta.lonlat_bounds;
+    rows.push(['extent', `${lb.west.toFixed(3)}, ${lb.south.toFixed(3)} → ${lb.east.toFixed(3)}, ${lb.north.toFixed(3)}`]);
+  }
+  for (const [k, v] of Object.entries(meta.attrs || {}).slice(0, 10)) rows.push(['attr: ' + k, String(v).slice(0, 200)]);
+  els.metaBody.innerHTML = '<table>' + rows.map(([k, v]) =>
+    `<tr><td>${k}</td><td>${v ?? '—'}</td></tr>`).join('') + '</table>' +
+    '<h2 style="margin-top:10px">Pyramid levels</h2><table>' +
+    (meta.levels || []).map((lv, i) => `<tr><td>level ${lv.asset || i}</td><td>${lv.shape.map(x => fmt(x,0)).join(' × ')}` +
+      `${lv.res_deg ? ' — ' + (lv.res_deg*111320 < 1000 ? (lv.res_deg*111320).toFixed(0)+' m' : (lv.res_deg*111.32).toFixed(0)+' km')+'/px' : ''}</td></tr>`).join('') + '</table>';
+}
+els.metaBtn.onclick = () => { els.metaPanel.style.display = els.metaPanel.style.display === 'block' ? 'none' : 'block'; };
+els.metaClose.onclick = () => els.metaPanel.style.display = 'none';
+els.fitBtn.onclick = () => fitToData(false);
+
+// ---------------- controls ----------------
+function syncControls(){
+  els.path.value = P.file();
+  els.cmap.value = P.cmap();
+  els.nofill.checked = P.nofill();
+  const st = P.stretch().split(',');
+  if (st.length === 2){ els.vLo.value = st[0]; els.vHi.value = st[1]; }
+  if (!meta) return;
+  els.var.innerHTML = (meta.vars || []).map(v =>
+    `<option value="${v}" ${v === meta.selected ? 'selected' : ''}>${v}</option>`).join('');
+  const ed = (meta.extra_dims || [])[0];
+  if (ed && ed.size > 1){
+    els.idxRow.style.display = '';
+    els.idxName.textContent = ed.name;
+    els.idxRange.max = ed.size - 1;
+    els.idxRange.value = meta.index;
+    els.idxLabel.textContent = `${meta.index} / ${ed.size - 1}`;
+  } else {
+    els.idxRow.style.display = 'none';
+  }
+}
+els.load.onclick = () => fused.params.set('file', els.path.value.trim());
+els.path.addEventListener('keydown', e => { if (e.key === 'Enter') els.load.click(); });
+els.var.onchange = () => { fused.params.set('var', els.var.value); fused.params.set('index', '0'); };
+let idxTimer = null;
+els.idxRange.oninput = () => {
+  els.idxLabel.textContent = `${els.idxRange.value} / ${els.idxRange.max}`;
+  clearTimeout(idxTimer);
+  idxTimer = setTimeout(() => fused.params.set('index', els.idxRange.value), 200);
+};
+els.cmap.onchange = () => fused.params.set('cmap', els.cmap.value);
+els.nofill.onchange = () => fused.params.set('nofill', els.nofill.checked ? '1' : '0');
+els.opacity.oninput = () => {
+  if (map.getLayer('raster')) map.setPaintProperty('raster', 'raster-opacity', +els.opacity.value / 100);
+};
+els.basemap.onchange = () => {
+  const show = els.basemap.checked ? 'visible' : 'none';
+  for (const l of map.getStyle().layers)
+    if (l.id !== 'raster') map.setLayoutProperty(l.id, 'visibility', show);
+};
+
+// ---------------- explorer ----------------
+els.browse.onclick = async () => {
+  const open = els.explorer.style.display === 'block';
+  els.explorer.style.display = open ? 'none' : 'block';
+  if (!open) refreshExplorer();
+};
+els.showAll.onchange = () => { fused.params.set('showall', els.showAll.checked ? '1' : ''); refreshExplorer(); };
+async function refreshExplorer(dir){
+  dir = dir || P.dir();
+  const r = await fused.runPython('./browse.py', { dir, exts: EXTS, show_all: P.showAll() ? 'true' : 'false' }).catch(() => null);
+  if (!r || r.error) return;
+  els.crumbs.innerHTML = r.crumbs.map(c =>
+    `<a data-p="${c.path}">${c.label || '/'}</a>`).join('<span style="color:#4b5058"> / </span>');
+  els.crumbs.querySelectorAll('a').forEach(a => a.onclick = () => refreshExplorer(a.dataset.p));
+  const entries = [...(r.dirs || []), ...(r.files || [])];
+  els.explorerList.innerHTML = entries.map(e =>
+    `<div class="row" data-p="${e.path}" data-d="${e.is_dir ? 1 : 0}">
+       <span class="ic">${e.is_dir ? (e.name.endsWith('.zarr') ? '🧊' : '📁') : '🌐'}</span><span class="nm">${e.name}</span>
+       <span class="sz">${e.size ? human(e.size) : ''}</span></div>`).join('') || '<div class="row" style="color:#6b7178">empty</div>';
+  els.explorerList.querySelectorAll('.row[data-p]').forEach(row => row.onclick = () => {
+    const p = row.dataset.p;
+    if (row.dataset.d === '1' && !p.endsWith('.zarr')) refreshExplorer(p);
+    else { fused.params.set('dir', p.replace(/\/[^/]*$/, '')); fused.params.set('var', ''); fused.params.set('index', '0');
+           fused.params.set('stretch', ''); fused.params.set('file', p); els.explorer.style.display = 'none'; }
+  });
+}
+
+// ---------------- load orchestration ----------------
+let loadedSlice = null, loadedQuery = null, loading = false, wantReload = false;
+
+async function loadSlice(){
+  if (loading){ wantReload = true; return; }   // never stampede the daemon
+  loading = true;
+  try { await loadSliceInner(); } finally {
+    loading = false;
+    if (wantReload){
+      wantReload = false;
+      if (sliceQuery().toString() !== loadedSlice) loadSlice();
+    }
+  }
+}
+
+async function loadSliceInner(){
+  if (!P.file()){ status('no store — use Browse or enter a path'); return; }
+  const sq = sliceQuery().toString();
+  status('Opening store — reads metadata + samples one chunk for stats (large chunks can take a minute)…');
+  await styleReady();
+  const d = await ensureDaemon();
+  if (!d || !d.port){ status('daemon failed to start', true); return; }
+  let m;
+  try {
+    m = await (await fetch(dURL('/meta?' + sq))).json();
+  } catch (e) { status('daemon unreachable', true); return; }
+  if (m.error){ status(m.error, true); return; }
+  const firstFile = !meta || meta.file !== m.file;
+  meta = m;
+  syncControls();
+  renderMeta();
+  if (m.geographic){
+    if (map.getLayer('raster') && firstFile){ map.removeLayer('raster'); map.removeSource('raster'); }
+    setRasterTiles();
+    if (firstFile && !hadView) fitToData();
+  } else {
+    status('store has no geo transform — switch to the classic Zarr template (mode picker)', true);
+  }
+  loadedSlice = sq;
+  loadedQuery = renderQuery();
+  if (m.geographic) status('');
+  syncStatsPanel();
+  zoomHintUpdate();
+  // warm the next time-chunk in the background so scrubbing forward is instant
+  if ((m.extra_dims || []).length) fetch(dURL('/prefetch?' + sq)).catch(() => {});
+}
+
+function onParamsChanged(){
+  syncStatsPanel();          // panel toggles instantly, even mid-load
+  const sq = sliceQuery().toString();
+  if (sq !== loadedSlice){ loadSlice(); return; }
+  syncControls();
+  const q = renderQuery();
+  if (q !== loadedQuery){
+    loadedQuery = q;
+    setRasterTiles();
+    statsActive();
+  }
+}
+fused.params.onChange(onParamsChanged);
+
+map.on('moveend', () => {
+  renderLevelLine(); zoomHintUpdate(); statsActive(2500);
+  const c = map.getCenter();
+  fused.params.set('ll', `${c.lng.toFixed(4)},${c.lat.toFixed(4)}`);
+  fused.params.set('z', map.getZoom().toFixed(2));
+});
+map.on('zoom', () => { renderLevelLine(); zoomHintUpdate(); });
+map.on('sourcedata', e => {
+  if (e.sourceId !== 'raster') return;
+  statsActive(1200);
+  map.triggerRepaint();     // background-tab loads can miss the first paint
+});
+
+// visible feedback while tiles stream — a cold chunk can take a minute and
+// MapLibre is otherwise silent about it
+let tilesBusySince = 0;
+const spinGlyphs = ['◐','◓','◑','◒'];
+setInterval(() => {
+  const busy = meta && map.getSource('raster') && !map.areTilesLoaded();
+  if (busy){
+    if (!tilesBusySince) tilesBusySince = performance.now();
+    const secs = (performance.now() - tilesBusySince) / 1000;
+    const g = spinGlyphs[Math.floor(secs * 2.5) % 4];
+    const chunky = (meta.chunk_logical_bytes || 0) > 32e6;
+    els.tileSpin.textContent = `${g} streaming tiles… ${secs.toFixed(0)}s` +
+      (chunky && secs > 2 ? ` — fetching a whole ${human(meta.chunk_logical_bytes)} chunk, hang tight` : '');
+    els.tileSpin.style.display = 'block';
+    statsActive(1500);
+  } else {
+    tilesBusySince = 0;
+    els.tileSpin.style.display = 'none';
+  }
+}, 400);
+
+loadSlice();
+</script>
+</body>
+</html>

--- a/fused_render/templates/zarr_aoi/tile_server.py
+++ b/fused_render/templates/zarr_aoi/tile_server.py
@@ -1,0 +1,976 @@
+"""Hosted-Zarr AOI streaming daemon.
+
+Preview a LARGE hosted Zarr store (terabytes, e.g. on Source Coop / S3)
+without downloading it: every map tile / histogram / pixel probe reads ONLY
+the chunk byte-ranges that intersect the requested AOI, via zarr-python 3
+(v2+v3 stores, sharding, zstd). All store I/O goes through a counting +
+caching wrapper so the UI can show exactly how many requests / bytes were
+streamed versus the logical size of the dataset.
+
+Same daemon architecture as zarr/grid_tile_server.py (the app runner costs
+~700ms per runPython call, so a long-lived localhost daemon serves MapLibre
+directly), but nothing is ever loaded fully into memory — the existing grid
+daemon loads one whole 2D slice, which is impossible here (WSF level 0 is
+1.5M x 4M px = 6 TB).
+
+Paths under ~/.fused-render/mounts/<name>/ are resolved back to their remote
+via mounts.json + rclone.conf and read DIRECTLY over S3/HTTP (not through the
+rclone FUSE mount) so byte counts are exact. Plain local stores and s3:// or
+https:// URLs also work.
+
+Endpoints (GET, CORS *):
+  /ping /quit
+  /meta?file=&var=&index=      -> source, levels, chunk/shard/codec layout,
+                                  logical size, bounds, sample stats
+  /tile/{z}/{x}/{y}.png?file=&var=&index=&cmap=&stretch=&nofill=
+  /hist?file=&var=&index=&bbox=w,s,e,n(3857)&bins=
+  /probe?file=&var=&index=&lon=&lat=   -> native-res pixel value + I/O cost
+  /stats?file=[&reset=1]       -> live counters + recent op log
+"""
+# /// script
+# dependencies = ["numpy", "zarr>=3.0.8", "s3fs", "crc32c"]
+# ///
+
+import hashlib
+import json
+import math
+import os
+import sys
+import threading
+import time
+
+STATE = os.path.expanduser("~/.cache/fused-render-zarraoi/daemon.json")
+DAEMON_VENV = os.path.expanduser("~/.cache/fused-render-zarraoi/venv")
+DAEMON_DEPS = ["numpy", "zarr>=3.0.8", "s3fs", "crc32c"]
+IDLE_EXIT_S = 30 * 60
+TILE = 256
+MERC_R = 6378137.0
+MERC_MAX = math.pi * MERC_R
+MAX_LAT = 85.05112878
+CACHE_CAP = 1024 * 1024 * 1024     # LRU byte-cache over store reads (chunky
+                                   # stores like CMIP6 have ~92 MB chunks)
+WINDOW_CAP = 2048 * 2048           # max cells fetched per tile/hist window
+
+SPATIAL_Y = {"lat", "latitude", "y", "yc", "rlat", "nav_lat"}
+SPATIAL_X = {"lon", "longitude", "x", "xc", "rlon", "nav_lon"}
+
+
+def _me():
+    if "__file__" in globals():
+        return os.path.abspath(__file__)
+    return os.path.join(os.path.abspath(sys.path[0]), "tile_server.py")
+
+
+def _daemon_python():
+    vp = os.path.join(DAEMON_VENV, "bin", "python")
+    if os.path.exists(vp):
+        return vp
+    import shutil
+    import subprocess
+    uv = shutil.which("uv") or os.path.expanduser("~/.local/bin/uv")
+    if os.path.exists(uv):
+        try:
+            os.makedirs(os.path.dirname(DAEMON_VENV), exist_ok=True)
+            subprocess.run([uv, "venv", "--python", "3.12", DAEMON_VENV],
+                           check=True, capture_output=True, timeout=120)
+            subprocess.run([uv, "pip", "install", "-p", vp] + DAEMON_DEPS,
+                           check=True, capture_output=True, timeout=600)
+            return vp
+        except Exception:
+            import shutil as _sh
+            _sh.rmtree(DAEMON_VENV, ignore_errors=True)
+    return sys.executable
+
+
+def _version():
+    try:
+        h = hashlib.sha256(open(_me(), "rb").read()).hexdigest()[:12]
+    except OSError:
+        h = "0"
+    return h + "|" + _daemon_python()
+
+
+def _alive(port, version):
+    import urllib.request
+    try:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/ping", timeout=2) as r:
+            d = json.load(r)
+        return d.get("ok") and d.get("version") == version
+    except Exception:
+        return False
+
+
+def main(action: str = "ensure"):
+    import subprocess
+    version = _version()
+    try:
+        with open(STATE) as f:
+            st = json.load(f)
+        if _alive(st.get("port"), version):
+            return {"port": st["port"], "reused": True}
+        try:
+            import urllib.request
+            urllib.request.urlopen(
+                f"http://127.0.0.1:{st.get('port')}/quit", timeout=1).read()
+        except Exception:
+            pass
+    except (OSError, ValueError):
+        pass
+    os.makedirs(os.path.dirname(STATE), exist_ok=True)
+    log = os.path.join(os.path.dirname(STATE), "daemon.log")
+    with open(log, "ab") as lf:
+        subprocess.Popen([_daemon_python(), _me(), "--serve"],
+                         stdout=lf, stderr=lf,
+                         start_new_session=True, cwd=os.path.dirname(_me()))
+    for _ in range(600):               # venv build on first run can take a while
+        time.sleep(0.1)
+        try:
+            with open(STATE) as f:
+                st = json.load(f)
+            if st.get("version") == version and _alive(st.get("port"), version):
+                return {"port": st["port"], "reused": False}
+        except (OSError, ValueError):
+            continue
+    return {"error": f"zarr AOI daemon did not start — see {log}"}
+
+
+try:
+    import fused as _fused
+    _udf_main = _fused.udf(main)
+except ImportError:
+    pass
+
+
+# ================================================================ daemon
+def _serve():
+    import numpy as np
+    import zarr
+    from collections import OrderedDict, deque
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    from urllib.parse import urlparse, parse_qs
+    from zarr.storage import WrapperStore
+
+    VERSION = _version()
+    last_hit = [time.time()]
+
+    # ---------------- counting + caching store ----------------
+    class MeterStore(WrapperStore):
+        """Counts every store read and serves repeats from an LRU byte cache,
+        so the UI can report exactly what was streamed from the network."""
+
+        def __init__(self, store, meter=None):
+            super().__init__(store)
+            self.meter = meter if meter is not None else new_meter()
+
+        def with_read_only(self, read_only=False):
+            # keep the SAME meter when zarr clones the store read-only
+            return MeterStore(self._store.with_read_only(read_only), self.meter)
+
+        def _cached(self, key, byte_range):
+            ck = (key, repr(byte_range))
+            m = self.meter
+            with m["lock"]:
+                hit = m["cache"].get(ck)
+                if hit is not None:
+                    m["cache"].move_to_end(ck)
+                    m["cache_hits"] += 1
+                    m["cache_saved"] += len(hit)
+            return ck, hit
+
+        def _cache_put(self, ck, data):
+            m = self.meter
+            with m["lock"]:
+                m["cache"][ck] = data
+                m["cache_bytes"] += len(data)
+                while m["cache_bytes"] > CACHE_CAP and m["cache"]:
+                    _, old = m["cache"].popitem(last=False)
+                    m["cache_bytes"] -= len(old)
+
+        async def get(self, key, prototype, byte_range=None):
+            ck, hit = self._cached(key, byte_range)
+            if hit is not None:
+                return prototype.buffer.from_bytes(hit)
+            m = self.meter
+            t0 = time.perf_counter()
+            out = await self._store_get(key, prototype, byte_range)
+            ms = (time.perf_counter() - t0) * 1000
+            n = len(out) if out is not None else 0
+            with m["lock"]:
+                m["requests"] += 1
+                m["net_bytes"] += n
+                m["net_ms"] += ms
+                if out is None:
+                    m["missing"] += 1
+            if out is not None:
+                self._cache_put(ck, out.to_bytes())
+            return out
+
+        async def _store_get(self, key, prototype, byte_range):
+            # big whole-chunk objects: fetch with parallel range requests —
+            # single-stream S3 GETs crawl, and chunky stores (e.g. CMIP6
+            # 90 MB chunks) make one slice read = one whole object
+            if byte_range is None:
+                try:
+                    import asyncio
+                    fs = getattr(self._store, "fs", None)
+                    root = getattr(self._store, "path", None)
+                    if fs is not None and root:
+                        full = f"{root}/{key}"
+                        size = int((await fs._info(full)).get("size") or 0)
+                        if size > 16 * 1024 * 1024:
+                            n = 8
+                            step = (size + n - 1) // n
+                            parts = await asyncio.gather(*(
+                                fs._cat_file(full, start=i * step,
+                                             end=min(size, (i + 1) * step))
+                                for i in range(n)))
+                            with self.meter["lock"]:
+                                self.meter["requests"] += n - 1
+                            return prototype.buffer.from_bytes(b"".join(parts))
+                except FileNotFoundError:
+                    return None
+                except Exception:
+                    pass    # fall through to the plain single GET
+            return await super().get(key, prototype, byte_range)
+
+        async def get_partial_values(self, prototype, key_ranges):
+            # route through .get so every range is counted + cached
+            import asyncio
+            return await asyncio.gather(
+                *(self.get(k, prototype, r) for k, r in key_ranges))
+
+        async def list_dir(self, prefix):
+            with self.meter["lock"]:
+                self.meter["lists"] += 1
+            async for k in super().list_dir(prefix):
+                yield k
+
+    def new_meter():
+        return {"lock": threading.Lock(), "requests": 0, "net_bytes": 0,
+                "net_ms": 0.0, "missing": 0, "lists": 0,
+                "cache": OrderedDict(), "cache_bytes": 0,
+                "cache_hits": 0, "cache_saved": 0,
+                "ops": deque(maxlen=40), "opened": time.time()}
+
+    # ---------------- source resolution ----------------
+    def rclone_conf():
+        out, sec = {}, None
+        for p in (os.path.expanduser("~/.config/rclone/rclone.conf"),):
+            try:
+                for ln in open(p):
+                    ln = ln.strip()
+                    if ln.startswith("[") and ln.endswith("]"):
+                        sec = ln[1:-1]
+                        out[sec] = {}
+                    elif "=" in ln and sec:
+                        k, _, v = ln.partition("=")
+                        out[sec][k.strip()] = v.strip()
+            except OSError:
+                pass
+        return out
+
+    def resolve_source(path):
+        """path -> dict(kind, url, storage_options, label)"""
+        # big parallel chunk fetches must not starve small metadata reads
+        S3_POOL = {"config_kwargs": {"max_pool_connections": 48}}
+        if path.startswith("s3://"):
+            return {"kind": "s3", "url": path,
+                    "storage_options": {"anon": True, **S3_POOL},
+                    "label": path + " (anonymous S3)"}
+        if path.startswith(("http://", "https://")):
+            return {"kind": "http", "url": path, "storage_options": {},
+                    "label": path}
+        path = os.path.abspath(os.path.expanduser(path))
+        mroot = os.path.expanduser("~/.fused-render/mounts") + os.sep
+        if path.startswith(mroot):
+            rel = path[len(mroot):]
+            name, _, rest = rel.partition(os.sep)
+            try:
+                mounts = json.load(open(os.path.expanduser(
+                    "~/.fused-render/mounts.json")))
+            except (OSError, ValueError):
+                mounts = []
+            ent = next((m for m in mounts if m.get("name") == name), None)
+            if ent and ":" in ent.get("remote", ""):
+                rname, _, rpath = ent["remote"].partition(":")
+                key = "/".join(s for s in (rpath.strip("/"), rest.replace(os.sep, "/"))
+                               if s)
+                cfg = rclone_conf().get(rname, {})
+                if cfg.get("type") == "s3":
+                    so = dict(S3_POOL)
+                    anon = cfg.get("env_auth", "false") != "true" and \
+                        not cfg.get("access_key_id")
+                    if anon:
+                        so["anon"] = True
+                    ck = {}
+                    if cfg.get("region"):
+                        ck["region_name"] = cfg["region"]
+                    if cfg.get("endpoint"):
+                        so["endpoint_url"] = cfg["endpoint"]
+                    if ck:
+                        so["client_kwargs"] = ck
+                    return {"kind": "s3", "url": "s3://" + key,
+                            "storage_options": so,
+                            "label": f"mount '{name}' → s3://{key}"
+                                     + (" (anonymous)" if anon else "")}
+        return {"kind": "local", "url": path, "label": path + " (local)"}
+
+    # ---------------- dataset open + discovery ----------------
+    datasets = {}
+    ds_lock = threading.Lock()
+
+    def dims_of(arr):
+        md = arr.metadata.to_dict()
+        d = md.get("dimension_names")
+        if not d:
+            d = dict(arr.attrs).get("_ARRAY_DIMENSIONS")
+        return [str(x) for x in d] if d else [f"dim{i}" for i in range(arr.ndim)]
+
+    def chunk_info(arr):
+        md = arr.metadata.to_dict()
+        info = {"chunks": None, "inner": None, "codecs": []}
+        if md.get("zarr_format") == 3:
+            info["chunks"] = list(md["chunk_grid"]["configuration"]["chunk_shape"])
+            for c in md.get("codecs", []):
+                if c.get("name") == "sharding_indexed":
+                    cfg = c["configuration"]
+                    info["inner"] = list(cfg["chunk_shape"])
+                    info["codecs"] += [cc.get("name") for cc in cfg.get("codecs", [])
+                                       if cc.get("name") != "bytes"]
+                elif c.get("name") != "bytes":
+                    info["codecs"].append(c.get("name"))
+        else:
+            info["chunks"] = list(md.get("chunks") or [])
+            comp = md.get("compressor")
+            if comp:
+                info["codecs"] = [comp.get("id", "?")]
+        return info
+
+    def open_dataset(path):
+        with ds_lock:
+            ds = datasets.get(path)
+        if ds is not None:
+            return ds
+        src = resolve_source(path)
+        meter = new_meter()
+        if src["kind"] == "local":
+            inner = zarr.storage.LocalStore(src["url"], read_only=True)
+        else:
+            inner = zarr.storage.FsspecStore.from_url(
+                src["url"], read_only=True,
+                storage_options=src["storage_options"])
+        store = MeterStore(inner, meter)
+        root = zarr.open_group(store=store, mode="r")
+        attrs = root.attrs.asdict()
+
+        levels = []      # fine -> coarse: {asset, res, transform, shape}
+        var_names = []
+        ms = attrs.get("multiscales")
+        if isinstance(ms, dict) and ms.get("layout"):
+            for ent in ms["layout"]:
+                tr = ent.get("spatial:transform")
+                sc = (ent.get("transform") or {}).get("scale", [1.0, 1.0])
+                if tr is None and levels and levels[0]["transform"]:
+                    t0, s0 = levels[0]["transform"], levels[0]["scale"]
+                    tr = [t0[0] * sc[1] / s0[1], 0.0, t0[2],
+                          0.0, t0[4] * sc[0] / s0[0], t0[5]]
+                levels.append({"asset": str(ent["asset"]),
+                               "shape": [int(s) for s in ent["spatial:shape"]],
+                               "transform": tr, "scale": sc})
+            g0 = root[levels[0]["asset"]]
+            g0_arrs = {k: a for k, a in g0.arrays() if a.ndim >= 2}
+            var_names = list(g0_arrs)
+            default_var = max(var_names, key=lambda n: (
+                g0_arrs[n].dtype.kind == "f", g0_arrs[n].ndim,
+                int(np.prod(g0_arrs[n].shape)))) if var_names else None
+        else:
+            arrs = {k: a for k, a in root.arrays()}
+            var_names = [k for k, a in arrs.items() if a.ndim >= 2
+                         and not k.lower().endswith(("_bnds", "_bounds", "bnds"))]
+            if var_names:
+                def score(n):
+                    v = arrs[n]
+                    return (v.dtype.kind == "f", v.ndim, int(np.prod(v.shape)))
+                main = default_var = max(var_names, key=score)
+                a = arrs[main]
+                dims = dims_of(a)
+                # keep only variables on the same spatial grid (drops aux arrays)
+                var_names = [n for n in var_names
+                             if dims_of(arrs[n])[-2:] == dims[-2:]]
+                H, W = a.shape[-2], a.shape[-1]
+                tr = None
+                ydim, xdim = dims[-2] if len(dims) >= 2 else None, \
+                    dims[-1] if dims else None
+                try:
+                    ya, xa = root[ydim], root[xdim]
+                    y0, y1 = float(ya[0]), float(ya[-1])
+                    x0, x1 = float(xa[0]), float(xa[-1])
+                    ry = (y1 - y0) / max(H - 1, 1)
+                    rx = (x1 - x0) / max(W - 1, 1)
+                    tr = [rx, 0.0, x0 - rx / 2, 0.0, ry, y0 - ry / 2]
+                    if not (-90.5 <= min(y0, y1) and max(y0, y1) <= 90.5
+                            and -360.5 <= min(x0, x1) and max(x0, x1) <= 360.5):
+                        tr = None
+                except (KeyError, TypeError, ValueError):
+                    tr = None
+                levels.append({"asset": "", "shape": [H, W],
+                               "transform": tr, "scale": [1.0, 1.0]})
+
+        if not levels or not var_names:
+            raise RuntimeError("no 2D+ arrays found in store")
+        geographic = bool(levels[0]["transform"])
+
+        ds = {"path": path, "src": src, "store": store, "root": root,
+              "meter": meter, "attrs": attrs, "levels": levels,
+              "vars": sorted(var_names), "default_var": default_var,
+              "arrays": {}, "stats": {},
+              "read_lock": threading.Lock(), "geographic": geographic}
+        with ds_lock:
+            datasets[path] = ds
+            while len(datasets) > 4:
+                datasets.pop(next(iter(datasets)))
+        return ds
+
+    def get_array(ds, level_i, var):
+        key = (level_i, var)
+        a = ds["arrays"].get(key)
+        if a is None:
+            asset = ds["levels"][level_i]["asset"]
+            a = ds["root"][f"{asset}/{var}" if asset else var]
+            ds["arrays"][key] = a
+        return a
+
+    # ---------------- metered reads + op log ----------------
+    def metered(ds, kind, fn, **log):
+        """Exact per-op counter deltas need serialized reads — but a cold
+        multi-second chunk fetch must not block cache-served tiles. If the
+        lock is busy, run anyway and mark the op's attribution approximate."""
+        m = ds["meter"]
+        got = ds["read_lock"].acquire(timeout=0.25)
+        try:
+            with m["lock"]:
+                r0, b0, h0 = m["requests"], m["net_bytes"], m["cache_hits"]
+            t0 = time.perf_counter()
+            out = fn()
+            ms = (time.perf_counter() - t0) * 1000
+            with m["lock"]:
+                ent = {"t": time.time(), "kind": kind, "ms": round(ms, 1),
+                       "requests": m["requests"] - r0,
+                       "net_bytes": m["net_bytes"] - b0,
+                       "cache_hits": m["cache_hits"] - h0, **log}
+                if not got:
+                    ent["approx"] = True     # ran concurrently with another op
+                m["ops"].appendleft(ent)
+        finally:
+            if got:
+                ds["read_lock"].release()
+        return out, ent
+
+    def read_window(ds, level_i, var, index, r0, r1, c0, c1):
+        a = get_array(ds, level_i, var)
+        nd = a.ndim
+        # the UI slider drives the FIRST extra dim; any further dims pin to 0
+        pre = tuple(min(max(int(index), 0), a.shape[k] - 1) if k == 0 else 0
+                    for k in range(nd - 2))
+        return np.asarray(a[pre + (slice(r0, r1), slice(c0, c1))])
+
+    def var_decode(ds, level_i, var):
+        """CF packing info: scale_factor / add_offset / fill value."""
+        key = ("dec", level_i, var)
+        c = ds["arrays"].get(key)
+        if c is None:
+            a = get_array(ds, level_i, var)
+            at = dict(a.attrs)
+            fv = a.fill_value
+            for k in ("_FillValue", "missing_value"):
+                if k in at:
+                    try:
+                        fv = float(np.asarray(at[k]).ravel()[0])
+                    except (TypeError, ValueError):
+                        pass
+
+            def num(k):
+                v = at.get(k)
+                if v is None:
+                    return None
+                try:
+                    return float(np.asarray(v).ravel()[0])
+                except (TypeError, ValueError):
+                    return None
+            c = {"sf": num("scale_factor"), "ao": num("add_offset"),
+                 "fill": None if fv is None or (isinstance(fv, float)
+                                                and math.isnan(fv))
+                 else float(fv),
+                 "units": str(at.get("units", ""))}
+            c["packed"] = c["sf"] is not None or c["ao"] is not None
+            ds["arrays"][key] = c
+        return c
+
+    def decode_vals(data, dec):
+        """-> (float64 vals with NaN fill if CF-packed, fill for alpha-mask)."""
+        if dec["packed"]:
+            v = data.astype("float64")
+            if dec["fill"] is not None:
+                v = np.where(v == dec["fill"], np.nan, v)
+            return v * (dec["sf"] or 1.0) + (dec["ao"] or 0.0), None
+        return data, dec["fill"]
+
+    # ---------------- geo helpers ----------------
+    def merc_to_lonlat(mx, my):
+        return (np.degrees(np.asarray(mx) / MERC_R),
+                np.degrees(2 * np.arctan(np.exp(np.asarray(my) / MERC_R)) - np.pi / 2))
+
+    def is_wrap360(lv):
+        a, _, west, _, _, _ = lv["transform"]
+        return west + lv["shape"][1] * a > 180.5
+
+    def norm_lon(lv, lon):
+        """Map lon(s) into the grid's own longitude frame (0-360 grids)."""
+        if is_wrap360(lv):
+            west = lv["transform"][2]
+            return np.mod(np.asarray(lon, dtype="float64") - west, 360.0) + west
+        return np.asarray(lon, dtype="float64")
+
+    def lonlat_bounds(lv):
+        a, _, west, _, e, north = lv["transform"]
+        H, W = lv["shape"]
+        south = north + H * e
+        east = west + W * a
+        if is_wrap360(lv):
+            west, east = -180.0, 180.0
+        return {"west": max(-180.0, west),
+                "south": max(-90.0, min(north, south)),
+                "east": min(180.0, east),
+                "north": min(90.0, max(north, south))}
+
+    def pick_level(ds, deg_per_px):
+        cands = [(i, abs(lv["transform"][0])) for i, lv in enumerate(ds["levels"])
+                 if lv["transform"]]
+        ok = [(i, r) for i, r in cands if r <= deg_per_px * 1.4]
+        if ok:
+            return max(ok, key=lambda t: t[1])[0]
+        return min(cands, key=lambda t: t[1])[0]
+
+    def window_of(lv, lon0, lat0, lon1, lat1, pad=1):
+        a, _, west, _, e, north = lv["transform"]
+        H, W = lv["shape"]
+        rows = sorted(((lat1 - north) / e, (lat0 - north) / e))
+        cols = sorted(((lon0 - west) / a, (lon1 - west) / a))
+        r0 = max(0, int(math.floor(rows[0])) - pad)
+        r1 = min(H, int(math.ceil(rows[1])) + pad)
+        c0 = max(0, int(math.floor(cols[0])) - pad)
+        c1 = min(W, int(math.ceil(cols[1])) + pad)
+        return r0, r1, c0, c1
+
+    # ---------------- stats sample ----------------
+    def sample_stats(ds, var, index):
+        # keyed by var only: one sample defines the stretch for ALL indexes —
+        # keeps colors comparable across time steps and avoids re-reading a
+        # whole (possibly huge) chunk on every slider move
+        key = var
+        s = ds["stats"].get(key)
+        if s is not None:
+            return s
+        coarse = len(ds["levels"]) - 1
+        lv = ds["levels"][coarse]
+        H, W = lv["shape"]
+        if H * W <= 2_500_000:
+            r0, r1, c0, c1 = 0, H, 0, W
+        else:                       # single-level giant store: central window
+            r0 = max(0, H // 2 - 512); r1 = min(H, H // 2 + 512)
+            c0 = max(0, W // 2 - 512); c1 = min(W, W // 2 + 512)
+        data, _ = metered(ds, "stats-sample",
+                          lambda: read_window(ds, coarse, var, index,
+                                              r0, r1, c0, c1),
+                          level=coarse, window=[r1 - r0, c1 - c0])
+        dec = var_decode(ds, coarse, var)
+        vals, fill = decode_vals(data, dec)
+        vals = vals.astype("float64")
+        if fill is not None:
+            vals = np.where(vals == fill, np.nan, vals)
+        fin = vals[np.isfinite(vals)]
+        s = {"count": int(fin.size), "fill_value": dec["fill"],
+             "packed": dec["packed"], "units": dec["units"],
+             "sampled_level": coarse}
+        if fin.size:
+            s.update({"min": float(fin.min()), "max": float(fin.max()),
+                      "mean": float(fin.mean()),
+                      "p2": float(np.percentile(fin, 2)),
+                      "p98": float(np.percentile(fin, 98))})
+        ds["stats"][key] = s
+        return s
+
+    # ---------------- colormaps + PNG ----------------
+    CMAPS = {
+        "viridis": ["440154", "472d7b", "3b528b", "2c728e", "21918c", "28ae80", "5ec962", "addc30", "fde725"],
+        "magma":   ["000004", "1c1044", "4f127b", "812581", "b5367a", "e55064", "fb8761", "fec287", "fcfdbf"],
+        "turbo":   ["30123b", "4145ab", "4675ed", "39a2fc", "1bcfd4", "24eca6", "61fc6c", "a4fc3b", "d1e834",
+                    "f3c63a", "fe9b2d", "f36315", "d93806", "b11901", "7a0402"],
+        "rdbu":    ["053061", "2166ac", "4393c3", "92c5de", "d1e5f0", "f7f7f7", "fddbc7", "f4a582", "d6604d",
+                    "b2182b", "67001f"],
+        "grays":   ["111111", "ffffff"],
+    }
+
+    def lut(name):
+        stops = np.array([[int(h[i:i + 2], 16) for i in (0, 2, 4)]
+                          for h in CMAPS.get(name, CMAPS["viridis"])], dtype="float64")
+        x = np.linspace(0, len(stops) - 1, 256)
+        i = np.clip(x.astype(int), 0, len(stops) - 2)
+        f = (x - i)[:, None]
+        return (stops[i] * (1 - f) + stops[i + 1] * f).round().astype("uint8")
+
+    def encode_png(rgba):
+        import struct
+        import zlib
+        h, w = rgba.shape[:2]
+        rows = np.zeros((h, 1 + w * 4), dtype=np.uint8)
+        rows[:, 1:] = rgba.reshape(h, w * 4)
+        comp = zlib.compress(rows.tobytes(), 1)
+
+        def chunk(tag, data):
+            return (struct.pack(">I", len(data)) + tag + data +
+                    struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+        ihdr = struct.pack(">IIBBBBB", w, h, 8, 6, 0, 0, 0)
+        return (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) +
+                chunk(b"IDAT", comp) + chunk(b"IEND", b""))
+
+    EMPTY_PNG = None
+    PLACEHOLDER_PNG = None
+
+    def empty_png():
+        nonlocal EMPTY_PNG
+        if EMPTY_PNG is None:
+            EMPTY_PNG = encode_png(np.zeros((TILE, TILE, 4), dtype=np.uint8))
+        return EMPTY_PNG
+
+    def placeholder_png():
+        nonlocal PLACEHOLDER_PNG
+        if PLACEHOLDER_PNG is None:
+            rgba = np.zeros((TILE, TILE, 4), dtype=np.uint8)
+            yy, xx = np.mgrid[0:TILE, 0:TILE]
+            band = ((yy + xx) // 10) % 2 == 0
+            rgba[band] = (255, 207, 112, 70)
+            PLACEHOLDER_PNG = encode_png(rgba)
+        return PLACEHOLDER_PNG
+
+    def colorize(q, ds, var, index, vals, fill):
+        s = sample_stats(ds, var, index)
+        st = q1(q, "stretch", "")
+        try:
+            lo, hi = [float(x) for x in st.split(",")]
+        except (ValueError, AttributeError):
+            lo, hi = s.get("p2", 0.0), s.get("p98", 1.0)
+        if hi <= lo:
+            lo = hi - 1.0     # single-valued data -> bright end of the cmap
+        L = lut(q1(q, "cmap", "viridis"))
+        v = vals.astype("float64")
+        alpha = np.isfinite(v)
+        if fill is not None and q1(q, "nofill", "1") == "1":
+            alpha &= (v != fill)
+        t = np.clip((v - lo) / (hi - lo), 0, 1)
+        ix = np.where(np.isfinite(t), t * 255, 0).astype("uint8")
+        rgba = np.zeros(v.shape + (4,), dtype="uint8")
+        rgba[:, :, :3] = L[ix]
+        rgba[:, :, 3] = np.where(alpha, 255, 0)
+        return rgba
+
+    # ---------------- endpoints ----------------
+    def q1(q, k, dflt=None):
+        v = q.get(k)
+        return v[0] if v else dflt
+
+    def ds_of(q):
+        ds = open_dataset(q1(q, "file"))
+        var = q1(q, "var") or ds["default_var"] or ds["vars"][0]
+        if var not in ds["vars"]:
+            var = ds["default_var"] or ds["vars"][0]
+        return ds, var, int(q1(q, "index", "0") or 0)
+
+    def tile_bbox(z, x, y):
+        n = 2 ** z
+        sz = 2 * MERC_MAX / n
+        return (-MERC_MAX + x * sz, MERC_MAX - (y + 1) * sz,
+                -MERC_MAX + (x + 1) * sz, MERC_MAX - y * sz)
+
+    def do_tile(q, z, x, y):
+        ds, var, index = ds_of(q)
+        if not ds["geographic"]:
+            return 404, b"not geographic", "text/plain"
+        mx0, my0, mx1, my1 = tile_bbox(z, x, y)
+        (lon0, lat0) = merc_to_lonlat(mx0, my0)
+        (lon1, lat1) = merc_to_lonlat(mx1, my1)
+        deg_per_px = (lon1 - lon0) / TILE
+        li = pick_level(ds, deg_per_px)
+        lv = ds["levels"][li]
+        # per-pixel lons in the grid's own frame (handles 0-360 grids)
+        px_lons = norm_lon(lv, np.linspace(lon0, lon1, TILE + 1)[:-1]
+                           + deg_per_px / 2)
+        r0, r1, c0, c1 = window_of(lv, float(px_lons.min()), lat0,
+                                   float(px_lons.max()), lat1)
+        if r1 <= r0 or c1 <= c0:
+            return 200, empty_png(), "image/png"
+        if (r1 - r0) * (c1 - c0) > WINDOW_CAP:
+            with ds["meter"]["lock"]:
+                ds["meter"]["ops"].appendleft(
+                    {"t": time.time(), "kind": "tile-skipped", "z": z,
+                     "level": li, "window": [r1 - r0, c1 - c0],
+                     "note": "window over cap — needs overviews or more zoom"})
+            return 200, placeholder_png(), "image/png"
+        data, _ = metered(ds, "tile", lambda: read_window(
+            ds, li, var, index, r0, r1, c0, c1),
+            z=z, level=li, window=[r1 - r0, c1 - c0])
+        data, fill = decode_vals(data, var_decode(ds, li, var))
+        # sample window onto the tile's mercator grid
+        a, _, west, _, e, north = lv["transform"]
+        my = np.linspace(my1, my0, TILE + 1)[:-1] - (my1 - my0) / (2 * TILE)
+        lats = merc_to_lonlat(0, my)[1]
+        iy = np.clip(((lats - north) / e).astype(int) - r0, -1, r1 - r0)
+        ix = np.clip(((px_lons - west) / a).astype(int) - c0, -1, c1 - c0)
+        yin = (iy >= 0) & (iy < r1 - r0)
+        xin = (ix >= 0) & (ix < c1 - c0)
+        out = data[np.ix_(np.clip(iy, 0, r1 - r0 - 1),
+                          np.clip(ix, 0, c1 - c0 - 1))].astype("float64")
+        out[~yin, :] = np.nan
+        out[:, ~xin] = np.nan
+        return 200, encode_png(np.ascontiguousarray(
+            colorize(q, ds, var, index, out, fill))), "image/png"
+
+    def do_meta(q):
+        ds, var, index = ds_of(q)
+        s = sample_stats(ds, var, index) if ds["geographic"] else {}
+        lv0 = ds["levels"][0]
+        a0 = get_array(ds, 0, var)
+        ci = chunk_info(a0)
+        itemsize = np.dtype(a0.dtype).itemsize
+        logical = sum(int(np.prod(get_array(ds, i, var).shape)) * itemsize
+                      for i in range(len(ds["levels"])))
+        extra = []
+        if a0.ndim > 2:
+            dims = dims_of(a0)
+            extra = [{"name": dims[k] if k < len(dims) else f"dim{k}",
+                      "size": int(a0.shape[k])} for k in range(a0.ndim - 2)]
+        out = {
+            "file": ds["path"], "source": ds["src"]["label"],
+            "kind": ds["src"]["kind"], "geographic": ds["geographic"],
+            "vars": ds["vars"], "selected": var, "index": index,
+            "extra_dims": extra, "dtype": str(a0.dtype),
+            "fill_value": s.get("fill_value"),
+            "shape": [int(x) for x in a0.shape],
+            "chunks": ci["chunks"], "inner_chunks": ci["inner"],
+            "chunk_logical_bytes": int(np.prod(ci["inner"] or ci["chunks"]
+                                               or [0])) * itemsize,
+            "codecs": ci["codecs"], "zarr_format":
+                a0.metadata.to_dict().get("zarr_format"),
+            "logical_bytes": logical,
+            "n_levels": len(ds["levels"]),
+            "levels": [{"asset": lv["asset"], "shape": lv["shape"],
+                        "res_deg": abs(lv["transform"][0]) if lv["transform"] else None}
+                       for lv in ds["levels"]],
+            "lonlat_bounds": lonlat_bounds(lv0) if ds["geographic"] else None,
+            "stats": s, "attrs": {str(k): str(v)[:400]
+                                  for k, v in ds["attrs"].items()
+                                  if k != "multiscales"},
+        }
+        return 200, json.dumps(out, default=str).encode(), "application/json"
+
+    def do_probe(q):
+        ds, var, index = ds_of(q)
+        if not ds["geographic"]:
+            return 404, b"{}", "application/json"
+        lon, lat = float(q1(q, "lon")), float(q1(q, "lat"))
+        lv = ds["levels"][0]
+        a, _, west, _, e, north = lv["transform"]
+        lon = float(norm_lon(lv, lon))
+        row, col = int((lat - north) / e), int((lon - west) / a)
+        H, W = lv["shape"]
+        if not (0 <= row < H and 0 <= col < W):
+            return 200, json.dumps({"value": None, "inside": False}).encode(), \
+                "application/json"
+        data, ent = metered(ds, "probe", lambda: read_window(
+            ds, 0, var, index, row, row + 1, col, col + 1),
+            lonlat=[round(lon, 5), round(lat, 5)])
+        arr = get_array(ds, 0, var)
+        ci = chunk_info(arr)
+        ch = ci["chunks"] or [1, 1]
+        inner = ci["inner"]
+        dec = var_decode(ds, 0, var)
+        v = float(decode_vals(data, dec)[0].ravel()[0])
+        out = {"value": None if math.isnan(v) else v,
+               "units": dec["units"], "inside": True,
+               "row": row, "col": col, "level": 0,
+               "shard": [row // ch[-2], col // ch[-1]],
+               "inner_chunk": ([row // inner[-2], col // inner[-1]]
+                               if inner else None),
+               "cost": {"requests": ent["requests"],
+                        "net_bytes": ent["net_bytes"],
+                        "cache_hits": ent["cache_hits"], "ms": ent["ms"]}}
+        return 200, json.dumps(out).encode(), "application/json"
+
+    def do_hist(q):
+        ds, var, index = ds_of(q)
+        if not (ds["geographic"] and q1(q, "bbox")):
+            return 200, json.dumps({"count": 0}).encode(), "application/json"
+        w, s_, e_, n_ = [float(v) for v in q1(q, "bbox").split(",")]
+        (lon0, lat0) = merc_to_lonlat(w, s_)
+        (lon1, lat1) = merc_to_lonlat(e_, n_)
+        li = pick_level(ds, max(lon1 - lon0, 1e-9) / 600)
+        lv = ds["levels"][li]
+        ln = norm_lon(lv, [lon0, lon1])
+        r0, r1, c0, c1 = window_of(lv, float(ln.min()), lat0,
+                                   float(ln.max()), lat1, pad=0)
+        if r1 <= r0 or c1 <= c0:
+            return 200, json.dumps({"count": 0}).encode(), "application/json"
+        if (r1 - r0) * (c1 - c0) > WINDOW_CAP:
+            return 200, json.dumps({"count": 0, "skipped": True}).encode(), \
+                "application/json"
+        data, _ = metered(ds, "hist", lambda: read_window(
+            ds, li, var, index, r0, r1, c0, c1),
+            level=li, window=[r1 - r0, c1 - c0])
+        vals, fill = decode_vals(data, var_decode(ds, li, var))
+        vals = vals.astype("float64")
+        if fill is not None:
+            vals = np.where(vals == fill, np.nan, vals)
+        fin = vals[np.isfinite(vals)]
+        bins = min(max(int(q1(q, "bins", "60")), 4), 200)
+        out = {"count": int(fin.size), "level": li,
+               "cells": int(vals.size),
+               "fill_frac": 1.0 - (fin.size / max(vals.size, 1))}
+        if fin.size:
+            c, edges = np.histogram(fin, bins=bins)
+            out.update({"counts": [int(x) for x in c],
+                        "edges": [float(x) for x in edges],
+                        "min": float(fin.min()), "max": float(fin.max()),
+                        "mean": float(fin.mean()),
+                        "p2": float(np.percentile(fin, 2)),
+                        "p98": float(np.percentile(fin, 98))})
+        return 200, json.dumps(out).encode(), "application/json"
+
+    prefetching = set()
+    pf_lock = threading.Lock()
+
+    def do_prefetch(q):
+        """Warm the NEXT time-chunk in the background (fire-and-forget from
+        the UI after a slider move) so scrubbing forward hits the cache.
+        Reads outside the per-dataset op lock — it must not block tiles."""
+        ds, var, index = ds_of(q)
+        a = get_array(ds, 0, var)
+        ci = chunk_info(a)
+        if a.ndim < 3 or not ci["chunks"]:
+            return 200, b'{"ok": false}', "application/json"
+        ct = max(int(ci["chunks"][0]), 1)
+        nxt = ((int(index) // ct) + 1) * ct
+        if nxt >= a.shape[0]:
+            return 200, b'{"ok": false}', "application/json"
+        key = (ds["path"], var, nxt // ct)
+        with pf_lock:
+            if key in prefetching:
+                return 200, b'{"ok": true, "already": true}', "application/json"
+            prefetching.add(key)
+        H, W = a.shape[-2], a.shape[-1]
+
+        def work():
+            t0 = time.perf_counter()
+            try:
+                read_window(ds, 0, var, nxt, H // 2, H // 2 + 1,
+                            W // 2, W // 2 + 1)
+                with ds["meter"]["lock"]:
+                    ds["meter"]["ops"].appendleft(
+                        {"t": time.time(), "kind": "prefetch",
+                         "note": f"warmed time chunk @ t={nxt}",
+                         "ms": round((time.perf_counter() - t0) * 1000, 1)})
+            except Exception:
+                pass
+            finally:
+                with pf_lock:
+                    prefetching.discard(key)
+        threading.Thread(target=work, daemon=True).start()
+        return 200, json.dumps({"ok": True, "next_index": nxt}).encode(), \
+            "application/json"
+
+    def do_stats(q):
+        ds, _, _ = ds_of(q)
+        m = ds["meter"]
+        with m["lock"]:
+            if q1(q, "reset") == "1":
+                m.update({"requests": 0, "net_bytes": 0, "net_ms": 0.0,
+                          "missing": 0, "lists": 0, "cache_hits": 0,
+                          "cache_saved": 0, "opened": time.time()})
+                m["ops"].clear()
+            out = {k: m[k] for k in ("requests", "net_bytes", "net_ms",
+                                     "missing", "lists", "cache_hits",
+                                     "cache_saved", "cache_bytes", "opened")}
+            out["ops"] = list(m["ops"])
+        return 200, json.dumps(out).encode(), "application/json"
+
+    # ---------------- HTTP ----------------
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            last_hit[0] = time.time()
+            u = urlparse(self.path)
+            q = parse_qs(u.query)
+            try:
+                if u.path == "/ping":
+                    code, body, ct = 200, json.dumps(
+                        {"ok": True, "version": VERSION}).encode(), "application/json"
+                elif u.path == "/quit":
+                    self._send(200, b"bye", "text/plain")
+                    threading.Thread(target=srv.shutdown, daemon=True).start()
+                    return
+                elif u.path.startswith("/tile/"):
+                    parts = u.path.split("/")
+                    z, x = int(parts[2]), int(parts[3])
+                    y = int(parts[4].split(".")[0])
+                    code, body, ct = do_tile(q, z, x, y)
+                elif u.path == "/meta":
+                    code, body, ct = do_meta(q)
+                elif u.path == "/probe":
+                    code, body, ct = do_probe(q)
+                elif u.path == "/hist":
+                    code, body, ct = do_hist(q)
+                elif u.path == "/stats":
+                    code, body, ct = do_stats(q)
+                elif u.path == "/prefetch":
+                    code, body, ct = do_prefetch(q)
+                else:
+                    code, body, ct = 404, b"not found", "text/plain"
+            except Exception as e:
+                import traceback
+                traceback.print_exc()
+                code, body, ct = 500, json.dumps(
+                    {"error": str(e)}).encode(), "application/json"
+            self._send(code, body, ct)
+
+        def _send(self, code, body, ct):
+            self.send_response(code)
+            self.send_header("Content-Type", ct)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            try:
+                self.wfile.write(body)
+            except BrokenPipeError:
+                pass
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    port = srv.server_address[1]
+    os.makedirs(os.path.dirname(STATE), exist_ok=True)
+    with open(STATE, "w") as fh:
+        json.dump({"port": port, "pid": os.getpid(), "version": VERSION}, fh)
+
+    def reaper():
+        while True:
+            time.sleep(60)
+            if time.time() - last_hit[0] > IDLE_EXIT_S:
+                srv.shutdown()
+                return
+    threading.Thread(target=reaper, daemon=True).start()
+    print(f"zarr AOI daemon on 127.0.0.1:{port} (v{VERSION})", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__" and "--serve" in sys.argv:
+    _serve()


### PR DESCRIPTION
## What

New `zarr_aoi` template, now the default mode for `.zarr/` (old `zarr` template stays as the second mode). It previews **terabyte-scale hosted Zarr stores** without downloading them: every tile / histogram / pixel probe reads only the chunk byte-ranges that intersect the viewport, and a collapsible **stats** panel reports exactly what was streamed.

## Why

The existing `zarr` template loads one full 2D slice into RAM and only reads v2 + blosc-lz4 natively — a 6 TB global v3/zstd/sharded store (or anything hosted) is out of reach. This template opens such stores in seconds: metadata + one sample chunk, then streams on demand.

## How

- `tile_server.py` daemon (same architecture as the geotiff/grid daemons) with its own uv venv (`zarr>=3`, `s3fs`, `crc32c`) — full v2+v3, sharding, zstd
- All store I/O goes through a counting + 1 GB LRU-caching wrapper → exact bytes/request metrics in the UI; >16 MB objects fetch via 8-way parallel ranged GETs
- Paths under `~/.fused-render/mounts/<name>/` resolve back to their rclone S3 remote and are read directly (metered), not through the FUSE mount; raw `s3://` URLs also accepted
- Multiscale pyramid support (zarr-conventions `multiscales`); no-pyramid stores get capped placeholder tiles + a zoom hint instead of accidental GB downloads
- Time/level slider (first extra dim) with background prefetch of the next time-chunk; CF `scale_factor`/`add_offset`/`units` decoding; 0–360° lon grids; `*_bnds` filtered from variables
- Shareable deep links: `?ll=lon,lat&z=6&index=…&stretch=lo,hi&cmap=turbo` (written back on move)

## Benchmarked against public stores

| Store | Result |
|---|---|
| WSF tracker (8 TB logical, v3 sharded, 13 levels) — `s3://us-west-2.opendata.source.coop/mindearth/wsf/World_WSF_20160701-20260101.zarr` | world → city-native session = **0.35 MB streamed (1 : 23.7M)**, native tile ≈ 3 req / 34 KB |
| MUR SST (3D, 4 vars, 6,443 daily steps) — `s3://mur-sst/zarr-v1` | pan/scrub within visited chunks ≈ 40 ms; cold region = 1 chunk (~33 MB) |
| CMIP6 ua (4D, 92 MB chunks) — `s3://cmip6-pds/CMIP6/CMIP/NCAR/CESM2/historical/r10i1p1f1/Amon/ua/gn/v20190313` | within-chunk time moves ≈ 80 ms; cross-chunk jump = one 92 MB fetch (60 s → 0.1 s when prefetch has run); parallel fetch cut cold chunks 210 s → 60 s |

Cold-jump cost is the publisher's chunk layout — the stats panel calls it out ("⚠ 92 MB per chunk") so the store's chunking is visible at a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface area (daemon + remote I/O) and a registry change that makes zarr_aoi the default for .zarr/ paths; behavior is additive with fallback to the classic zarr template, but first-run daemon/uv and anonymous S3 assumptions can affect user experience.
> 
> **Overview**
> Adds a new **`zarr_aoi`** Fused Render template and registers it as the **first/default** opener for **`.zarr/`** stores (classic **`zarr`** remains as the alternate mode).
> 
> The template previews **very large hosted Zarr** (local, `s3://`, mounts resolved to direct S3) by **streaming only chunk byte-ranges** for the current map viewport—tiles, histograms, and click probes—instead of loading a full 2D slice. A localhost **`tile_server.py`** daemon (zarr 3 via `uv` venv) wraps all I/O in a **metered 1 GB LRU cache**, exposes **parallel ranged fetches** for big objects, and serves MapLibre endpoints (`/meta`, `/tile`, `/hist`, `/probe`, `/stats`, `/prefetch`).
> 
> The **`template.html`** MapLibre UI adds variable/time controls, auto-stretch from viewport stats, native-pixel probes with per-read cost, optional **streaming stats** panel, pyramid level selection, zoom hints when overviews are missing (placeholder/skipped tiles), time-chunk prefetch, and shareable URL params (`ll`, `z`, `index`, `stretch`, `cmap`). **`browse.py`** supports picking `.zarr` stores in the file explorer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 558a57509dbca7ebc8bfd9c29a0b980179499d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->