### PR TITLE
fix(win): suppress console window flash on git subprocess spawns

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -184,6 +184,7 @@ def _empty_git_dir():
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
+                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
             _EMPTY_GIT_DIR = os.path.join(root, ".git")
         except (OSError, subprocess.SubprocessError):
@@ -234,6 +235,7 @@ class _IgnoreOracle:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 env=env,
+                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
         except OSError:
             self.proc = None
@@ -301,6 +303,7 @@ def _repo_toplevel(path):
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=5,
+            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
     except (OSError, subprocess.TimeoutExpired):
         return None
@@ -453,6 +456,7 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=5,
+            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
     except (OSError, subprocess.SubprocessError):
         return set()


### PR DESCRIPTION
## Problem

On Windows, navigating between folders in the viewer (`/view/...`) flashes a console window on every navigation.

## Cause

Every `GET /api/fs/list` (once per folder opened) calls `_git_ignored()`, which shells out to `git check-ignore` to dim `.gitignore`d entries in the listing. The gitignore helpers spawn `git` in four places (`git init`, the `_IgnoreOracle` streaming `check-ignore`, `rev-parse --show-toplevel`, and the per-listing `check-ignore`), none of which set `creationflags`.

The server runs **windowless** — `winopen._spawn` launches it via `pythonw.exe` with `CREATE_NO_WINDOW`. When a process with no console spawns a console child (`git.exe`) without `CREATE_NO_WINDOW`, Windows allocates a brand-new console window for it, which pops up and vanishes when git exits — the flicker. POSIX has no console-window concept, so this is Windows-only and purely cosmetic (git behavior is unchanged; it's an optional display hint).

## Fix

Pass `creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0` on the four `git` spawns in `server.py`, matching the existing idiom in `executor.py`. No behavior change off Windows, and `git check-ignore` output is unchanged.

## Verification

- `_git_ignored()` / `_repo_toplevel()` still return correct results with the flag (e.g. `.venv` and `.git` correctly reported ignored).
- Syntax/compile check passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Windows-only subprocess flag with no logic changes; gitignore dimming and walk pruning behavior stay the same.
> 
> **Overview**
> On Windows, folder navigation in the viewer was flashing a brief console window because each directory listing runs `git check-ignore` (and related helpers) without hiding the child process console.
> 
> This adds `creationflags=subprocess.CREATE_NO_WINDOW` on **win32 only** to all four `git` spawns in `server.py` (`git init` for the empty-git dir, `_IgnoreOracle` streaming `check-ignore`, `rev-parse --show-toplevel`, and per-listing `_git_ignored`), using the same pattern already used in `executor.py`. **Git behavior and ignore/dimming logic are unchanged**; non-Windows paths pass `creationflags=0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5976bf437e3c74e2093deeeb4f32e8a34c0687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->