### PR TITLE
zarr v3 + raw-transport zarr_aoi: multiscale grid daemons, cold-read fast path

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -13,6 +13,7 @@ at startup if missing) to opt in to the local compute backend (`engine.py`).
 """
 import asyncio
 import codecs
+import email.utils
 import json
 import logging
 from collections import deque
@@ -1453,7 +1454,11 @@ def create_app(start_dir: str) -> FastAPI:
 
     @app.api_route("/api/fs/raw", methods=["GET", "HEAD"])
     async def api_fs_raw(path: str, request: Request):
-        if not os.path.isfile(path):
+        try:
+            st = os.stat(path)
+        except OSError:
+            st = None
+        if st is None or not stat_mod.S_ISREG(st.st_mode):
             return _error(f"no such file: {path}", status=404)
         # Mount-backed file with a live HTTP serve: proxy the bytes from
         # rclone instead of reading through the kernel mount. Concurrent
@@ -1469,6 +1474,20 @@ def create_app(start_dir: str) -> FastAPI:
             # touch) its background whole-file prefetch. Cheap no-op after
             # the first call; templates stay mount-agnostic (prefetch.py).
             shell_prefetch.schedule(path, upstream)
+            # HEAD answered from the stat this route already took: ranged
+            # clients (duckdb httpfs, fsspec/zarr, geotiff) probe the length
+            # before reading, and proxying that probe is a full remote round
+            # trip (~1s cold) for headers the VFS getattr already knows. The
+            # serve reads the same rclone remote, so the sizes agree.
+            if request.method == "HEAD":
+                media_type, _ = mimetypes.guess_type(path)
+                return Response(status_code=200, headers={
+                    "content-length": str(st.st_size),
+                    "content-type": media_type or "application/octet-stream",
+                    "accept-ranges": "bytes",
+                    "last-modified": email.utils.formatdate(
+                        st.st_mtime, usegmt=True),
+                })
             # Cold ranged reads go straight to the store: the serve's VFS
             # layer serializes concurrent uncached range reads of one file
             # (an analytical scan pays ~0.25s per seek), while the store

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1038,6 +1038,16 @@ def _proxy_raw(upstream: str, request: Request):
     return StreamingResponse(body(), status_code=r.status, headers=out)
 
 
+def _stat_or_none(path: str) -> os.stat_result | None:
+    """stat() for /api/fs/raw's 404 gate: None for missing paths and
+    non-regular files alike (a directory has no raw bytes to serve)."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return st if stat_mod.S_ISREG(st.st_mode) else None
+
+
 def _stat_payload(path: str, is_dir: bool, st: os.stat_result | None = None) -> dict:
     """The /api/fs/stat shape. /api/fs/write returns it too, so the editor can
     re-arm its optimistic lock from a save response. Pass a pre-fetched `st` to
@@ -1454,12 +1464,6 @@ def create_app(start_dir: str) -> FastAPI:
 
     @app.api_route("/api/fs/raw", methods=["GET", "HEAD"])
     async def api_fs_raw(path: str, request: Request):
-        try:
-            st = os.stat(path)
-        except OSError:
-            st = None
-        if st is None or not stat_mod.S_ISREG(st.st_mode):
-            return _error(f"no such file: {path}", status=404)
         # Mount-backed file with a live HTTP serve: proxy the bytes from
         # rclone instead of reading through the kernel mount. Concurrent
         # ranged reads (duckdb's httpfs) through the NFS mount stall its 1s
@@ -1467,6 +1471,14 @@ def create_app(start_dir: str) -> FastAPI:
         # over HTTP are merely slow. Explicit HEAD support matters: httpfs
         # HEADs for the length first, and Starlette's implicit HEAD-on-GET
         # would run the full upstream GET just to drop the body.
+        #
+        # No stat() before a serve-backed GET: on a mount that's a VFS
+        # getattr — a full remote round trip (~1s cold), paid serially
+        # before the read even starts, per never-listed object. The serve
+        # and the store both 404 a missing object themselves (_proxy_raw
+        # passes error statuses through), so existence falls out of the
+        # read. Only HEAD (answered from st_size) and the local-file
+        # fallback below still stat.
         upstream = shell_mounts.serve_url_for(path)
         if upstream is not None:
             # Every remote read flows through here, so this is where the
@@ -1474,12 +1486,16 @@ def create_app(start_dir: str) -> FastAPI:
             # touch) its background whole-file prefetch. Cheap no-op after
             # the first call; templates stay mount-agnostic (prefetch.py).
             shell_prefetch.schedule(path, upstream)
-            # HEAD answered from the stat this route already took: ranged
+            # HEAD answered from a VFS getattr rather than proxied: ranged
             # clients (duckdb httpfs, fsspec/zarr, geotiff) probe the length
             # before reading, and proxying that probe is a full remote round
-            # trip (~1s cold) for headers the VFS getattr already knows. The
-            # serve reads the same rclone remote, so the sizes agree.
+            # trip for headers the getattr already knows. The serve reads
+            # the same rclone remote, so the sizes agree. In a thread — a
+            # cold getattr would otherwise stall the event loop.
             if request.method == "HEAD":
+                st = await asyncio.to_thread(_stat_or_none, path)
+                if st is None:
+                    return _error(f"no such file: {path}", status=404)
                 media_type, _ = mimetypes.guess_type(path)
                 return Response(status_code=200, headers={
                     "content-length": str(st.st_size),
@@ -1488,25 +1504,26 @@ def create_app(start_dir: str) -> FastAPI:
                     "last-modified": email.utils.formatdate(
                         st.st_mtime, usegmt=True),
                 })
-            # Cold ranged reads go straight to the store: the serve's VFS
-            # layer serializes concurrent uncached range reads of one file
-            # (an analytical scan pays ~0.25s per seek), while the store
-            # answers the same GETs in parallel. Once the prefetch has
-            # landed the whole file in the serve cache, the serve replays
-            # ranges from local disk and wins again. A 307 rather than a
-            # proxied fetch: the client (duckdb httpfs) re-issues each
-            # ranged GET against the store itself with its own pooled
-            # parallel connections — proxying here paid a fresh TLS
+            # Cold reads go straight to the store: the serve's VFS layer
+            # serializes concurrent uncached range reads of one file (an
+            # analytical scan pays ~0.25s per seek) and its per-file open
+            # ceremony dwarfs a small metadata fetch (zarr.json), while the
+            # store answers the same GETs in parallel. Once the prefetch
+            # has landed the whole file in the serve cache, the serve
+            # replays ranges from local disk and wins again. A 307 rather
+            # than a proxied fetch: the client (duckdb httpfs, fsspec)
+            # re-issues each GET against the store itself with its own
+            # pooled parallel connections — proxying here paid a fresh TLS
             # handshake per range read (measured 2x on the point-read
             # phase) and streamed every byte through this process twice.
-            # GET+Range only: presigned links are minted for GET (a HEAD
-            # fails their signature), and a whole-file GET through the
-            # serve is effectively the prefetch itself. Native clients
-            # only: a browser fetch would follow the redirect cross-origin
-            # and die on CORS — browsers always send Sec-Fetch-Mode,
-            # duckdb's httpfs never does, so its absence is the gate.
-            if (request.method == "GET" and request.headers.get("range")
-                    and "sec-fetch-mode" not in request.headers
+            # Whole-file GETs redirect too (zarr stores read many tiny
+            # metadata files whole; schedule() above warms the serve cache
+            # regardless). GET only: presigned links are minted for GET (a
+            # HEAD fails their signature). Native clients only: a browser
+            # fetch would follow the redirect cross-origin and die on CORS
+            # — browsers always send Sec-Fetch-Mode, duckdb's httpfs never
+            # does, so its absence is the gate.
+            if ("sec-fetch-mode" not in request.headers
                     and not shell_prefetch.is_done(path)):
                 direct = await asyncio.to_thread(
                     shell_mounts.upstream_url_for, path)
@@ -1515,6 +1532,9 @@ def create_app(start_dir: str) -> FastAPI:
             resp = await asyncio.to_thread(_proxy_raw, upstream, request)
             if resp is not None:
                 return resp  # upstream unreachable -> plain file read below
+        st = await asyncio.to_thread(_stat_or_none, path)
+        if st is None:
+            return _error(f"no such file: {path}", status=404)
         media_type, _ = mimetypes.guess_type(path)
         return FileResponse(path, media_type=media_type or "application/octet-stream")
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1479,7 +1479,7 @@ def create_app(start_dir: str) -> FastAPI:
         # passes error statuses through), so existence falls out of the
         # read. Only HEAD (answered from st_size) and the local-file
         # fallback below still stat.
-        upstream = shell_mounts.serve_url_for(path)
+        upstream = await asyncio.to_thread(shell_mounts.serve_url_for, path)
         if upstream is not None:
             # Every remote read flows through here, so this is where the
             # shell learns a mounted file is in use: kick off (or just
@@ -1529,6 +1529,14 @@ def create_app(start_dir: str) -> FastAPI:
                     shell_mounts.upstream_url_for, path)
                 if direct:
                     return RedirectResponse(direct, status_code=307)
+            # Not redirected (browser, warm read, or no direct URL): proxy the
+            # bytes. Guard non-files here — the cold redirect path above is the
+            # never-listed-object hot path and stays stat-free, but a directory
+            # proxied through rclone serve comes back as a 200 HTML listing, so
+            # stat before serving (warm getattr is cheap; a directory 404s).
+            st = await asyncio.to_thread(_stat_or_none, path)
+            if st is None:
+                return _error(f"no such file: {path}", status=404)
             resp = await asyncio.to_thread(_proxy_raw, upstream, request)
             if resp is not None:
                 return resp  # upstream unreachable -> plain file read below

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -592,6 +592,24 @@ def _mount_for(path: str) -> tuple[dict | None, str]:
     return None, ""
 
 
+def _fix_dotted_bucket_url(url: str) -> str | None:
+    """Virtual-hosted S3 URLs put the bucket in the TLS hostname, and
+    *.s3.<region>.amazonaws.com can't match a bucket with dots in its name
+    (e.g. us-west-2.opendata.source.coop) — every client fails the handshake.
+    Rewrite an unsigned dotted-bucket URL to path-style; a SIGNED one can't be
+    rewritten (SigV4 covers the Host header), so drop it — the caller then
+    stays on the serve proxy, which is slow but works."""
+    p = urllib.parse.urlsplit(url)
+    m = re.match(r"^(.+)\.s3[.-]([a-z0-9-]+)\.amazonaws\.com$",
+                 p.hostname or "")
+    if not m or "." not in m.group(1):
+        return url
+    if p.query:
+        return None
+    bucket, region = m.group(1), m.group(2)
+    return f"https://s3.{region}.amazonaws.com/{bucket}{p.path}"
+
+
 def _public_object_url(fs: str, rel: str) -> str | None:
     """Plain https URL for an object on an ANONYMOUS AWS S3 remote — the one
     backend class that can't presign but doesn't need to. Credentialed or
@@ -612,6 +630,13 @@ def _public_object_url(fs: str, rel: str) -> str | None:
         return None
     key = (prefix.rstrip("/") + "/" if prefix else "") + rel
     region = cfg.get("region") or "us-east-1"
+    # Path-style for dotted buckets: virtual-hosted style puts the bucket in
+    # the TLS hostname, and *.s3.<region>.amazonaws.com can't match the extra
+    # dots (e.g. us-west-2.opendata.source.coop) — every client fails the
+    # handshake on the redirect.
+    if "." in bucket:
+        return (f"https://s3.{region}.amazonaws.com/{bucket}/"
+                + urllib.parse.quote(key))
     return f"https://{bucket}.s3.{region}.amazonaws.com/" + urllib.parse.quote(key)
 
 
@@ -650,6 +675,8 @@ def _upstream_url_for(path: str) -> str | None:
                       timeout=10).get("url") or None
         except RuntimeError:
             url = None
+        if url is not None:
+            url = _fix_dotted_bucket_url(url)
         if url is None and mode == "link":
             return None  # transient failure on a known-linkable remote
         if url is not None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -580,6 +580,39 @@ _LINK_TTL_S = 30 * 60.0
 _upstream_lock = threading.Lock()
 _upstream_links: dict = {}  # (fs, rel) -> (url, monotonic expiry)
 _upstream_mode: dict = {}   # fs -> "link" | "public" | "none"
+_upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
+
+
+def _remote_config(name: str) -> dict | None:
+    """config/get for a remote, memoized. Public-URL minting consults the
+    config per OBJECT (a zarr store touches thousands), and remote configs
+    only change through this process (add_remote restarts nothing that would
+    invalidate them) — so one rc round trip per remote, then pure lookups.
+    Failures aren't cached: rcd may simply not be up yet."""
+    with _upstream_lock:
+        cfg = _upstream_cfg.get(name)
+    if cfg is not None:
+        return cfg
+    port = _live_rcd_port()
+    if port is None:
+        return None
+    try:
+        cfg = _rc(port, "config/get", {"name": name}, timeout=10)
+    except RuntimeError:
+        return None
+    if not isinstance(cfg, dict):
+        return None
+    with _upstream_lock:
+        _upstream_cfg[name] = cfg
+    return cfg
+
+
+def _anonymous_s3(cfg: dict | None) -> bool:
+    """True when the remote is plain AWS S3 with no credentials — the one
+    backend class whose objects are reachable by unsigned public URL and
+    which can never presign ("unsupported signer type noAuth")."""
+    return (cfg is not None and _s3_without_credentials(cfg)
+            and not cfg.get("endpoint"))
 
 
 def _mount_for(path: str) -> tuple[dict | None, str]:
@@ -613,18 +646,14 @@ def _fix_dotted_bucket_url(url: str) -> str | None:
 def _public_object_url(fs: str, rel: str) -> str | None:
     """Plain https URL for an object on an ANONYMOUS AWS S3 remote — the one
     backend class that can't presign but doesn't need to. Credentialed or
-    non-AWS remotes return None (their objects aren't reachable unsigned)."""
+    non-AWS remotes return None (their objects aren't reachable unsigned).
+    Pure string building once _remote_config has memoized the config — no rc
+    round trip per object."""
     name, _, root = fs.partition(":")
-    port = _live_rcd_port()
-    if port is None:
+    cfg = _remote_config(name)
+    if not _anonymous_s3(cfg):
         return None
-    try:
-        cfg = _rc(port, "config/get", {"name": name}, timeout=10)
-    except RuntimeError:
-        return None
-    if (not isinstance(cfg, dict) or not _s3_without_credentials(cfg)
-            or cfg.get("endpoint")):
-        return None
+    assert cfg is not None
     bucket, _, prefix = root.partition("/")
     if not bucket:
         return None
@@ -664,6 +693,10 @@ def _upstream_url_for(path: str) -> str | None:
         mode = _upstream_mode.get(fs)
     if mode == "none":
         return None
+    if mode is None and _anonymous_s3(_remote_config(fs.partition(":")[0])):
+        # Anonymous S3 can never presign — don't burn an rc call per remote
+        # learning that from publiclink's "unsupported signer type" error.
+        mode = "public"
     url = None
     if mode in (None, "link"):
         port = _live_rcd_port()

--- a/fused_render/templates/netcdf/_zarr_core.py
+++ b/fused_render/templates/netcdf/_zarr_core.py
@@ -187,12 +187,16 @@ def _chunk_stats(store, name, za):
 
 
 def _store_summary(store):
-    """Total bytes + file count on disk (capped walk so huge stores stay fast)."""
+    """Total bytes + file count on disk (walk capped by count AND wall time:
+    on a remote mount every listing/stat is a network round-trip, so a large
+    store would otherwise stall for minutes long before any file-count cap)."""
+    import time
     size = files = 0
+    deadline = time.time() + 2.0
     for dirpath, _, names in os.walk(store):
         for n in names:
             files += 1
-            if files > 50000:
+            if files > 50000 or time.time() > deadline:
                 return {"size": size, "files": files, "approx": True}
             try:
                 size += os.path.getsize(os.path.join(dirpath, n))
@@ -292,9 +296,20 @@ def _read_pure(store, var, index, bins, max_cells):
 
     def kind(n):
         return np.dtype(arrays[n]["zarray"]["dtype"]).kind
-    chosen = var if var in band_names else max(
-        band_names, key=lambda n: (kind(n) == "f", len(arrays[n]["zarray"]["shape"]),
-                                   int(np.prod(arrays[n]["zarray"]["shape"]))))
+
+    def slice_cells(n):
+        shp = arrays[n]["zarray"]["shape"]
+        return int(np.prod(shp[-2:] if len(shp) >= 2 else shp))
+    if var in band_names:
+        chosen = var
+    else:
+        fit = [n for n in band_names if slice_cells(n) <= 32_000_000]
+        chosen = max(fit, key=lambda n: (kind(n) == "f", len(arrays[n]["zarray"]["shape"]),
+                                         int(np.prod(arrays[n]["zarray"]["shape"])))) \
+            if fit else min(band_names, key=slice_cells)
+    if slice_cells(chosen) > 256_000_000:
+        return {"error": f"slice of '{chosen}' is {slice_cells(chosen) // 1000000}M "
+                         "cells - too large to load; pick a smaller variable"}
 
     info = arrays[chosen]
     za = info["zarray"]
@@ -408,6 +423,9 @@ def _system_python():
     cands = []
     if os.environ.get("GEO_PYTHON"):
         cands.append(os.environ["GEO_PYTHON"])
+    # when running inside the grid daemon its venv ships zarr (DAEMON_DEPS),
+    # so the current interpreter is normally the one found here
+    cands.append(sys.executable)
     home = os.path.expanduser("~")
     cands += [os.path.join(home, p) for p in
               ("miniforge3/bin/python", "miniconda3/bin/python", "anaconda3/bin/python")]
@@ -418,14 +436,17 @@ def _system_python():
     env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
     seen = set()
     for c in cands:
+        # dedup on the resolved target but RUN the original path: a venv's
+        # bin/python is a symlink to the base interpreter, and resolving it
+        # before exec would escape the venv (losing its site-packages)
         rc = os.path.realpath(c)
         if rc in seen or not os.path.exists(rc):
             continue
         seen.add(rc)
         try:
-            r = subprocess.run([rc, "-c", "import zarr"], capture_output=True, timeout=15, env=env)
+            r = subprocess.run([c, "-c", "import zarr"], capture_output=True, timeout=15, env=env)
             if r.returncode == 0:
-                return rc
+                return c
         except Exception:
             continue
     return None
@@ -439,6 +460,27 @@ import _grid_common as G
 
 p = json.loads(sys.stdin.read())
 root = zarr.open(p["store"], mode="r")
+BUDGET = 32_000_000     # target cells for an auto-picked 2D slice
+HARD_CAP = 256_000_000  # refuse (error, don't OOM) above this
+# Multiscale stores: pick the finest pyramid level that fits the budget from
+# the root attrs alone and walk ONLY that subgroup — walking every level costs
+# a metadata round-trip per node (slow on remote mounts) and pick-by-size
+# would grab the native-resolution level (can be trillions of cells).
+asset = None
+ms = dict(getattr(root, "attrs", {})).get("multiscales")
+if isinstance(ms, dict) and isinstance(ms.get("layout"), list):
+    levels = []
+    for e in ms["layout"]:
+        sh = e.get("spatial:shape") or []
+        if isinstance(e.get("asset"), str) and len(sh) == 2:
+            levels.append((str(e["asset"]), int(sh[0]) * int(sh[1])))
+    if levels:
+        want = p["var"].split("/", 1)[0] if p["var"] else None
+        if any(nm == want for nm, _ in levels):
+            asset = want
+        else:
+            fit = [t for t in levels if t[1] <= BUDGET]
+            asset = max(fit, key=lambda t: t[1])[0] if fit else min(levels, key=lambda t: t[1])[0]
 arrays = {}
 def walk(node, prefix=""):
     try:
@@ -446,15 +488,31 @@ def walk(node, prefix=""):
         for k, v in node.groups(): walk(v, prefix + k + "/")
     except AttributeError:
         arrays[prefix.rstrip("/") or node.basename or "array"] = node
-walk(root)
+if asset is not None: walk(root[asset], asset + "/")
+else: walk(root)
 SY={"lat","latitude","y"}; SX={"lon","longitude","x"}
-def dims_of(a): return list(a.attrs.get("_ARRAY_DIMENSIONS", [f"dim{i}" for i in range(a.ndim)]))
+def dims_of(a):
+    d = a.attrs.get("_ARRAY_DIMENSIONS")
+    if not d:
+        d = getattr(getattr(a, "metadata", None), "dimension_names", None)
+        if d and not all(d): d = None
+    return list(d) if d else [f"dim{i}" for i in range(a.ndim)]
 dim_sizes={}
 for n,a in arrays.items():
     for d,s in zip(dims_of(a), a.shape): dim_sizes[d]=int(s)
 coord_names=[n for n,a in arrays.items() if (n in dim_sizes or n.split("/")[-1] in dim_sizes) and a.ndim<=1]
 band_names=[n for n in arrays if n not in coord_names] or list(arrays)
-chosen = p["var"] if p["var"] in band_names else max(band_names, key=lambda n:(arrays[n].dtype.kind=="f", arrays[n].ndim, arrays[n].size))
+def slice_cells(n):
+    a = arrays[n]
+    return int(np.prod(a.shape[-2:])) if a.ndim >= 2 else int(np.prod(a.shape))
+if p["var"] in band_names:
+    chosen = p["var"]
+else:
+    fit = [n for n in band_names if slice_cells(n) <= BUDGET]
+    chosen = max(fit, key=lambda n:(arrays[n].dtype.kind=="f", arrays[n].ndim, arrays[n].size)) \
+        if fit else min(band_names, key=slice_cells)
+if slice_cells(chosen) > HARD_CAP:
+    print(json.dumps({"error": "slice of '%s' is %dM cells - too large to load; pick a coarser overview level or smaller variable" % (chosen, slice_cells(chosen) // 1000000)})); sys.exit(0)
 a=arrays[chosen]; dims=dims_of(a)
 ydim=next((d for d in dims if d.split("/")[-1].lower() in SY), None)
 xdim=next((d for d in dims if d.split("/")[-1].lower() in SX), None)
@@ -474,10 +532,17 @@ for d in extra:
     ca=coord_for(d); vals=None
     if ca and arrays[ca].size<=200: vals=[G.clean(x) for x in arrays[ca][:]]
     extra_dims.append({"name":d,"size":int(size),"values":vals,"index": idx if d==extra[0] else 0})
-arr=np.asarray(a[tuple(sl)], dtype="float64")
+# data + coords live in separate files: overlap the reads (remote mounts pay
+# a network round-trip per file, so serial reads add up)
+from concurrent.futures import ThreadPoolExecutor
+def _coordvals(dim):
+    ca = coord_for(dim)
+    return [G.clean(x) for x in arrays[ca][:]] if ca else None
+with ThreadPoolExecutor(3) as _ex:
+    _fd = _ex.submit(lambda: np.asarray(a[tuple(sl)], dtype="float64"))
+    _fy = _ex.submit(_coordvals, ydim); _fx = _ex.submit(_coordvals, xdim)
+    arr = _fd.result(); lats = _fy.result(); lons = _fx.result()
 if ypos>xpos: arr=arr.T
-lats=[G.clean(x) for x in arrays[coord_for(ydim)][:]] if coord_for(ydim) else None
-lons=[G.clean(x) for x in arrays[coord_for(xdim)][:]] if coord_for(xdim) else None
 payload=G.present(arr, lats, lons, p["bins"], p["max_cells"])
 coords_meta=[]
 for n in coord_names:
@@ -487,16 +552,39 @@ for n in coord_names:
         "max":G.clean(np.nanmax(v)) if v is not None and v.size else None,
         "values":[G.clean(x) for x in v] if (v is not None and v.size<=200) else None,
         "attrs":{k:G.clean(vv) for k,vv in dict(c.attrs).items() if k!="_ARRAY_DIMENSIONS"}})
+# zarr-python 3: Array.compressor RAISES for v3 arrays (use .compressors),
+# filters codecs have no codec_id, and nchunks_initialized lists the whole
+# store (deadly over a remote mount) — read all of these defensively.
+def _codec_name(c):
+    return str(getattr(c, "codec_id", None) or type(c).__name__)
+def _comp_of(a):
+    try:
+        cs = getattr(a, "compressors", None)
+        if cs: return ",".join(_codec_name(c) for c in cs)
+        c = a.compressor
+        return _codec_name(c) if c else "none"
+    except Exception:
+        return "unknown"
+def _filt_of(a):
+    try:
+        return [_codec_name(f) for f in (a.filters or [])]
+    except Exception:
+        return []
+def _stored_of(a):
+    try:
+        return int(a.nchunks_initialized) if int(a.nchunks) <= 1024 else -1
+    except Exception:
+        return -1
 vars_meta=[{"name":n,"dims":dims_of(arrays[n]),"shape":[int(s) for s in arrays[n].shape],
     "dtype":str(arrays[n].dtype),
     "attrs":{k:G.clean(vv) for k,vv in dict(arrays[n].attrs).items() if k!="_ARRAY_DIMENSIONS"},
-    "compressor": (arrays[n].compressor.codec_id if arrays[n].compressor else "none"),
+    "compressor": _comp_of(arrays[n]),
     "chunks": [int(c) for c in (arrays[n].chunks or [])],
-    "chunks_stored": int(getattr(arrays[n], "nchunks_initialized", 0)),
+    "chunks_stored": _stored_of(arrays[n]),
     "chunks_total": int(getattr(arrays[n], "nchunks", 0)),
     "fill_value": G.clean(arrays[n].fill_value),
     "order": str(getattr(arrays[n], "order", "C")),
-    "filters": [f.codec_id for f in (arrays[n].filters or [])]} for n in band_names]
+    "filters": _filt_of(arrays[n])} for n in band_names]
 def mm(v):
     vv=[x for x in (v or []) if x is not None]
     return (min(vv),max(vv)) if vv else (None,None)

--- a/fused_render/templates/netcdf/_zarr_core.py
+++ b/fused_render/templates/netcdf/_zarr_core.py
@@ -560,7 +560,11 @@ def _codec_name(c):
 def _comp_of(a):
     try:
         cs = getattr(a, "compressors", None)
-        if cs: return ",".join(_codec_name(c) for c in cs)
+        # v3 exposes .compressors (an empty tuple means uncompressed, not
+        # "unknown"); only fall back to the v2 .compressor when the attr is
+        # absent, since reading .compressor RAISES on a v3 array.
+        if cs is not None:
+            return ",".join(_codec_name(c) for c in cs) if cs else "none"
         c = a.compressor
         return _codec_name(c) if c else "none"
     except Exception:

--- a/fused_render/templates/netcdf/grid_tile_server.py
+++ b/fused_render/templates/netcdf/grid_tile_server.py
@@ -798,13 +798,18 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
                 total, files, capped = 0, 0, False
                 for dp, _, fs in os.walk(path):
                     for f in fs:
+                        files += 1
+                        # Check per file, not per directory: a flat store can
+                        # hold all its chunks in one dir, and a per-dir check
+                        # would stat every one before the cap could fire.
+                        if time.time() > deadline or files > 20000:
+                            capped = True
+                            break
                         try:
                             total += os.path.getsize(os.path.join(dp, f))
                         except OSError:
                             pass
-                        files += 1
-                    if time.time() > deadline or files > 20000:
-                        capped = True
+                    if capped:
                         break
                 dir_sizes[path] = None if capped else total
                 out["file_size"] = dir_sizes[path]

--- a/fused_render/templates/netcdf/grid_tile_server.py
+++ b/fused_render/templates/netcdf/grid_tile_server.py
@@ -28,7 +28,7 @@ This file is kept BYTE-IDENTICAL in netcdf/ and zarr/ (the daemon
 version is a content hash, so both copies share one daemon).
 """
 # /// script
-# dependencies = ["numpy", "scipy"]
+# dependencies = ["numpy", "scipy", "zarr"]
 # ///
 
 import hashlib
@@ -40,8 +40,12 @@ import threading
 import time
 
 STATE = os.path.expanduser("~/.cache/fused-render-gridv2/daemon.json")
-DAEMON_VENV = os.path.expanduser("~/.cache/fused-render-gridv2/venv")
-DAEMON_DEPS = ["numpy", "scipy"]
+DAEMON_DEPS = ["numpy", "scipy", "zarr"]
+# venv dir is keyed by the dep set: growing DAEMON_DEPS must provision a fresh
+# venv, not reuse an existing one that lacks the new package
+DAEMON_VENV = os.path.expanduser(
+    "~/.cache/fused-render-gridv2/venv-"
+    + hashlib.sha256(",".join(DAEMON_DEPS).encode()).hexdigest()[:8])
 IDLE_EXIT_S = 30 * 60
 TILE = 256
 MERC_R = 6378137.0
@@ -200,6 +204,9 @@ def _serve():
         cands = []
         if os.environ.get("GEO_PYTHON"):
             cands.append(os.environ["GEO_PYTHON"])
+        # the daemon venv itself ships zarr (DAEMON_DEPS), so it is normally
+        # the interpreter found here — no host python needed
+        cands.append(sys.executable)
         home = os.path.expanduser("~")
         cands += [os.path.join(home, p) for p in
                   ("miniforge3/bin/python", "miniconda3/bin/python", "anaconda3/bin/python")]
@@ -210,15 +217,18 @@ def _serve():
         env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
         seen = set()
         for c in cands:
+            # dedup on the resolved target but RUN the original path: a venv's
+            # bin/python is a symlink to the base interpreter, and resolving it
+            # before exec would escape the venv (losing its site-packages)
             rc = os.path.realpath(c)
             if rc in seen or not os.path.exists(rc):
                 continue
             seen.add(rc)
             try:
-                r = subprocess.run([rc, "-c", f"import {module}"],
+                r = subprocess.run([c, "-c", f"import {module}"],
                                    capture_output=True, timeout=15, env=env)
                 if r.returncode == 0:
-                    return rc
+                    return c
             except Exception:
                 continue
         return None
@@ -282,13 +292,39 @@ p = json.loads(sys.stdin.read())
 SY = {"lat","latitude","y","yc","rlat","nav_lat"}
 SX = {"lon","longitude","x","xc","rlon","nav_lon"}
 g = zarr.open_group(p["file"], mode="r")
+BUDGET = 32_000_000     # target cells for an auto-picked 2D slice
+HARD_CAP = 256_000_000  # refuse (error, don't OOM) above this
+# Multiscale stores (zarr-conventions "multiscales"): the root attrs list every
+# pyramid level with its shape, so pick the finest level that fits the budget
+# up front and walk ONLY that subgroup — walking all levels costs a metadata
+# round-trip per node (slow on remote mounts) and auto-pick-by-size would grab
+# the native-resolution level (trillions of cells).
+asset = None
+ms = dict(g.attrs).get("multiscales")
+if isinstance(ms, dict) and isinstance(ms.get("layout"), list):
+    levels = []
+    for e in ms["layout"]:
+        sh = e.get("spatial:shape") or []
+        if isinstance(e.get("asset"), str) and len(sh) == 2:
+            levels.append((str(e["asset"]), int(sh[0]) * int(sh[1])))
+    if levels:
+        want = p["var"].split("/", 1)[0] if p["var"] else None
+        if any(nm == want for nm, _ in levels):
+            asset = want
+        else:
+            fit = [t for t in levels if t[1] <= BUDGET]
+            asset = max(fit, key=lambda t: t[1])[0] if fit else min(levels, key=lambda t: t[1])[0]
 arrays = {}
 def walk(node, prefix=""):
     for k, v in node.arrays(): arrays[prefix + k] = v
     for k, v in node.groups(): walk(v, prefix + k + "/")
-walk(g)
+if asset is not None: walk(g[asset], asset + "/")
+else: walk(g)
 def dims_of(a, n):
     d = a.attrs.get("_ARRAY_DIMENSIONS")
+    if not d:
+        d = getattr(getattr(a, "metadata", None), "dimension_names", None)
+        if d and not all(d): d = None
     return list(d) if d else [f"dim{i}" for i in range(a.ndim)]
 dimnames = set()
 for n, a in arrays.items():
@@ -300,9 +336,18 @@ for n, a in arrays.items():
         coords.append(n)
     else: bands.append(n)
 if not bands: bands = list(arrays)
+def slice_cells(n):
+    a = arrays[n]
+    return int(np.prod(a.shape[-2:])) if a.ndim >= 2 else int(np.prod(a.shape))
 def score(n):
     a = arrays[n]; return (a.dtype.kind == "f", a.ndim, int(np.prod(a.shape)))
-chosen = p["var"] if p["var"] in bands else max(bands, key=score)
+if p["var"] in bands:
+    chosen = p["var"]
+else:
+    fit = [n for n in bands if slice_cells(n) <= BUDGET]
+    chosen = max(fit, key=score) if fit else min(bands, key=slice_cells)
+if slice_cells(chosen) > HARD_CAP:
+    print(json.dumps({"error": "slice of '%s' is %dM cells - too large to load; pick a coarser overview level or smaller variable" % (chosen, slice_cells(chosen) // 1000000)})); sys.exit(0)
 a = arrays[chosen]; dims = dims_of(a, chosen)
 ydim = next((d for d in dims if d.split("/")[-1].lower() in SY), None)
 xdim = next((d for d in dims if d.split("/")[-1].lower() in SX), None)
@@ -321,16 +366,21 @@ for i, d in enumerate(extra):
     ca = coord_arr(d); vals = None
     if ca is not None and ca.size <= 500: vals = [str(x) for x in np.asarray(ca[:]).ravel()]
     extra_dims.append({"name": d, "size": int(n0), "values": vals})
-data = np.squeeze(np.asarray(a[tuple(sl)], dtype="float64"))
-if data.ndim != 2: data = np.atleast_2d(data)
-ypos, xpos = dims.index(ydim), dims.index(xdim)
-if ypos > xpos: data = data.T
 def cvals(d):
     ca = coord_arr(d)
     if ca is not None and np.issubdtype(ca.dtype, np.number):
         return np.asarray(ca[:], dtype="float64").ravel()
     return None
-lats = cvals(ydim); lons = cvals(xdim)
+# data + coords live in separate files: overlap the reads (remote mounts pay
+# a network round-trip per file, so serial reads add up)
+from concurrent.futures import ThreadPoolExecutor
+with ThreadPoolExecutor(3) as _ex:
+    _fd = _ex.submit(lambda: np.asarray(a[tuple(sl)], dtype="float64"))
+    _fy = _ex.submit(cvals, ydim); _fx = _ex.submit(cvals, xdim)
+    data = np.squeeze(_fd.result()); lats = _fy.result(); lons = _fx.result()
+if data.ndim != 2: data = np.atleast_2d(data)
+ypos, xpos = dims.index(ydim), dims.index(xdim)
+if ypos > xpos: data = data.T
 tmp = tempfile.NamedTemporaryFile(suffix=".npz", delete=False)
 np.savez(tmp.name, vals=data,
          lats=(lats if lats is not None else np.zeros(0)),
@@ -473,10 +523,21 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
 
         def kind(n):
             return np.dtype(arrays[n]["zarray"]["dtype"]).kind
-        chosen = var if var in band_names else max(
-            band_names, key=lambda n: (kind(n) == "f",
-                                       len(arrays[n]["zarray"]["shape"]),
-                                       int(np.prod(arrays[n]["zarray"]["shape"]))))
+
+        def slice_cells(n):
+            shape = arrays[n]["zarray"]["shape"]
+            return int(np.prod(shape[-2:] if len(shape) >= 2 else shape))
+        if var in band_names:
+            chosen = var
+        else:
+            fit = [n for n in band_names if slice_cells(n) <= 32_000_000]
+            chosen = max(fit, key=lambda n: (kind(n) == "f",
+                                             len(arrays[n]["zarray"]["shape"]),
+                                             int(np.prod(arrays[n]["zarray"]["shape"])))) \
+                if fit else min(band_names, key=slice_cells)
+        if slice_cells(chosen) > 256_000_000:
+            raise RuntimeError(f"slice of '{chosen}' is {slice_cells(chosen) // 1000000}M "
+                               "cells - too large to load; pick a smaller variable")
         info = arrays[chosen]
         za = info["zarray"]
         dims = Z._dims_of(chosen, info)
@@ -709,6 +770,8 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
         vals = sample_bbox(s, mx0, my0, mx1, my1, TILE, TILE)
         return 200, encode_png(np.ascontiguousarray(colorize(q, s, vals))), "image/png"
 
+    dir_sizes = {}     # store path -> capped-walk size (None when capped)
+
     def do_meta(q):
         path = os.path.abspath(os.path.expanduser(q1(q, "file")))
         s = slice_of(q)
@@ -722,9 +785,29 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
                "shape": [rows, cols],
                "lonlat_bounds": (g["bounds"] if g else None)}
         try:
-            out["file_size"] = (os.path.getsize(path) if os.path.isfile(path)
-                                else sum(os.path.getsize(os.path.join(dp, f))
-                                         for dp, _, fs in os.walk(path) for f in fs))
+            if os.path.isfile(path):
+                out["file_size"] = os.path.getsize(path)
+            elif path in dir_sizes:
+                out["file_size"] = dir_sizes[path]
+            else:
+                # capped walk: a store can hold millions of chunk files and on
+                # a remote mount every listing/stat is a network round-trip —
+                # give up after a short deadline instead of stalling /meta,
+                # and cache the answer so only the first /meta per store pays
+                deadline = time.time() + 2.0
+                total, files, capped = 0, 0, False
+                for dp, _, fs in os.walk(path):
+                    for f in fs:
+                        try:
+                            total += os.path.getsize(os.path.join(dp, f))
+                        except OSError:
+                            pass
+                        files += 1
+                    if time.time() > deadline or files > 20000:
+                        capped = True
+                        break
+                dir_sizes[path] = None if capped else total
+                out["file_size"] = dir_sizes[path]
         except OSError:
             out["file_size"] = None
         return 200, json.dumps(out, default=str).encode(), "application/json"

--- a/fused_render/templates/zarr/_zarr_core.py
+++ b/fused_render/templates/zarr/_zarr_core.py
@@ -187,12 +187,16 @@ def _chunk_stats(store, name, za):
 
 
 def _store_summary(store):
-    """Total bytes + file count on disk (capped walk so huge stores stay fast)."""
+    """Total bytes + file count on disk (walk capped by count AND wall time:
+    on a remote mount every listing/stat is a network round-trip, so a large
+    store would otherwise stall for minutes long before any file-count cap)."""
+    import time
     size = files = 0
+    deadline = time.time() + 2.0
     for dirpath, _, names in os.walk(store):
         for n in names:
             files += 1
-            if files > 50000:
+            if files > 50000 or time.time() > deadline:
                 return {"size": size, "files": files, "approx": True}
             try:
                 size += os.path.getsize(os.path.join(dirpath, n))
@@ -292,9 +296,20 @@ def _read_pure(store, var, index, bins, max_cells):
 
     def kind(n):
         return np.dtype(arrays[n]["zarray"]["dtype"]).kind
-    chosen = var if var in band_names else max(
-        band_names, key=lambda n: (kind(n) == "f", len(arrays[n]["zarray"]["shape"]),
-                                   int(np.prod(arrays[n]["zarray"]["shape"]))))
+
+    def slice_cells(n):
+        shp = arrays[n]["zarray"]["shape"]
+        return int(np.prod(shp[-2:] if len(shp) >= 2 else shp))
+    if var in band_names:
+        chosen = var
+    else:
+        fit = [n for n in band_names if slice_cells(n) <= 32_000_000]
+        chosen = max(fit, key=lambda n: (kind(n) == "f", len(arrays[n]["zarray"]["shape"]),
+                                         int(np.prod(arrays[n]["zarray"]["shape"])))) \
+            if fit else min(band_names, key=slice_cells)
+    if slice_cells(chosen) > 256_000_000:
+        return {"error": f"slice of '{chosen}' is {slice_cells(chosen) // 1000000}M "
+                         "cells - too large to load; pick a smaller variable"}
 
     info = arrays[chosen]
     za = info["zarray"]
@@ -408,6 +423,9 @@ def _system_python():
     cands = []
     if os.environ.get("GEO_PYTHON"):
         cands.append(os.environ["GEO_PYTHON"])
+    # when running inside the grid daemon its venv ships zarr (DAEMON_DEPS),
+    # so the current interpreter is normally the one found here
+    cands.append(sys.executable)
     home = os.path.expanduser("~")
     cands += [os.path.join(home, p) for p in
               ("miniforge3/bin/python", "miniconda3/bin/python", "anaconda3/bin/python")]
@@ -418,14 +436,17 @@ def _system_python():
     env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
     seen = set()
     for c in cands:
+        # dedup on the resolved target but RUN the original path: a venv's
+        # bin/python is a symlink to the base interpreter, and resolving it
+        # before exec would escape the venv (losing its site-packages)
         rc = os.path.realpath(c)
         if rc in seen or not os.path.exists(rc):
             continue
         seen.add(rc)
         try:
-            r = subprocess.run([rc, "-c", "import zarr"], capture_output=True, timeout=15, env=env)
+            r = subprocess.run([c, "-c", "import zarr"], capture_output=True, timeout=15, env=env)
             if r.returncode == 0:
-                return rc
+                return c
         except Exception:
             continue
     return None
@@ -439,6 +460,27 @@ import _grid_common as G
 
 p = json.loads(sys.stdin.read())
 root = zarr.open(p["store"], mode="r")
+BUDGET = 32_000_000     # target cells for an auto-picked 2D slice
+HARD_CAP = 256_000_000  # refuse (error, don't OOM) above this
+# Multiscale stores: pick the finest pyramid level that fits the budget from
+# the root attrs alone and walk ONLY that subgroup — walking every level costs
+# a metadata round-trip per node (slow on remote mounts) and pick-by-size
+# would grab the native-resolution level (can be trillions of cells).
+asset = None
+ms = dict(getattr(root, "attrs", {})).get("multiscales")
+if isinstance(ms, dict) and isinstance(ms.get("layout"), list):
+    levels = []
+    for e in ms["layout"]:
+        sh = e.get("spatial:shape") or []
+        if isinstance(e.get("asset"), str) and len(sh) == 2:
+            levels.append((str(e["asset"]), int(sh[0]) * int(sh[1])))
+    if levels:
+        want = p["var"].split("/", 1)[0] if p["var"] else None
+        if any(nm == want for nm, _ in levels):
+            asset = want
+        else:
+            fit = [t for t in levels if t[1] <= BUDGET]
+            asset = max(fit, key=lambda t: t[1])[0] if fit else min(levels, key=lambda t: t[1])[0]
 arrays = {}
 def walk(node, prefix=""):
     try:
@@ -446,15 +488,31 @@ def walk(node, prefix=""):
         for k, v in node.groups(): walk(v, prefix + k + "/")
     except AttributeError:
         arrays[prefix.rstrip("/") or node.basename or "array"] = node
-walk(root)
+if asset is not None: walk(root[asset], asset + "/")
+else: walk(root)
 SY={"lat","latitude","y"}; SX={"lon","longitude","x"}
-def dims_of(a): return list(a.attrs.get("_ARRAY_DIMENSIONS", [f"dim{i}" for i in range(a.ndim)]))
+def dims_of(a):
+    d = a.attrs.get("_ARRAY_DIMENSIONS")
+    if not d:
+        d = getattr(getattr(a, "metadata", None), "dimension_names", None)
+        if d and not all(d): d = None
+    return list(d) if d else [f"dim{i}" for i in range(a.ndim)]
 dim_sizes={}
 for n,a in arrays.items():
     for d,s in zip(dims_of(a), a.shape): dim_sizes[d]=int(s)
 coord_names=[n for n,a in arrays.items() if (n in dim_sizes or n.split("/")[-1] in dim_sizes) and a.ndim<=1]
 band_names=[n for n in arrays if n not in coord_names] or list(arrays)
-chosen = p["var"] if p["var"] in band_names else max(band_names, key=lambda n:(arrays[n].dtype.kind=="f", arrays[n].ndim, arrays[n].size))
+def slice_cells(n):
+    a = arrays[n]
+    return int(np.prod(a.shape[-2:])) if a.ndim >= 2 else int(np.prod(a.shape))
+if p["var"] in band_names:
+    chosen = p["var"]
+else:
+    fit = [n for n in band_names if slice_cells(n) <= BUDGET]
+    chosen = max(fit, key=lambda n:(arrays[n].dtype.kind=="f", arrays[n].ndim, arrays[n].size)) \
+        if fit else min(band_names, key=slice_cells)
+if slice_cells(chosen) > HARD_CAP:
+    print(json.dumps({"error": "slice of '%s' is %dM cells - too large to load; pick a coarser overview level or smaller variable" % (chosen, slice_cells(chosen) // 1000000)})); sys.exit(0)
 a=arrays[chosen]; dims=dims_of(a)
 ydim=next((d for d in dims if d.split("/")[-1].lower() in SY), None)
 xdim=next((d for d in dims if d.split("/")[-1].lower() in SX), None)
@@ -474,10 +532,17 @@ for d in extra:
     ca=coord_for(d); vals=None
     if ca and arrays[ca].size<=200: vals=[G.clean(x) for x in arrays[ca][:]]
     extra_dims.append({"name":d,"size":int(size),"values":vals,"index": idx if d==extra[0] else 0})
-arr=np.asarray(a[tuple(sl)], dtype="float64")
+# data + coords live in separate files: overlap the reads (remote mounts pay
+# a network round-trip per file, so serial reads add up)
+from concurrent.futures import ThreadPoolExecutor
+def _coordvals(dim):
+    ca = coord_for(dim)
+    return [G.clean(x) for x in arrays[ca][:]] if ca else None
+with ThreadPoolExecutor(3) as _ex:
+    _fd = _ex.submit(lambda: np.asarray(a[tuple(sl)], dtype="float64"))
+    _fy = _ex.submit(_coordvals, ydim); _fx = _ex.submit(_coordvals, xdim)
+    arr = _fd.result(); lats = _fy.result(); lons = _fx.result()
 if ypos>xpos: arr=arr.T
-lats=[G.clean(x) for x in arrays[coord_for(ydim)][:]] if coord_for(ydim) else None
-lons=[G.clean(x) for x in arrays[coord_for(xdim)][:]] if coord_for(xdim) else None
 payload=G.present(arr, lats, lons, p["bins"], p["max_cells"])
 coords_meta=[]
 for n in coord_names:
@@ -487,16 +552,39 @@ for n in coord_names:
         "max":G.clean(np.nanmax(v)) if v is not None and v.size else None,
         "values":[G.clean(x) for x in v] if (v is not None and v.size<=200) else None,
         "attrs":{k:G.clean(vv) for k,vv in dict(c.attrs).items() if k!="_ARRAY_DIMENSIONS"}})
+# zarr-python 3: Array.compressor RAISES for v3 arrays (use .compressors),
+# filters codecs have no codec_id, and nchunks_initialized lists the whole
+# store (deadly over a remote mount) — read all of these defensively.
+def _codec_name(c):
+    return str(getattr(c, "codec_id", None) or type(c).__name__)
+def _comp_of(a):
+    try:
+        cs = getattr(a, "compressors", None)
+        if cs: return ",".join(_codec_name(c) for c in cs)
+        c = a.compressor
+        return _codec_name(c) if c else "none"
+    except Exception:
+        return "unknown"
+def _filt_of(a):
+    try:
+        return [_codec_name(f) for f in (a.filters or [])]
+    except Exception:
+        return []
+def _stored_of(a):
+    try:
+        return int(a.nchunks_initialized) if int(a.nchunks) <= 1024 else -1
+    except Exception:
+        return -1
 vars_meta=[{"name":n,"dims":dims_of(arrays[n]),"shape":[int(s) for s in arrays[n].shape],
     "dtype":str(arrays[n].dtype),
     "attrs":{k:G.clean(vv) for k,vv in dict(arrays[n].attrs).items() if k!="_ARRAY_DIMENSIONS"},
-    "compressor": (arrays[n].compressor.codec_id if arrays[n].compressor else "none"),
+    "compressor": _comp_of(arrays[n]),
     "chunks": [int(c) for c in (arrays[n].chunks or [])],
-    "chunks_stored": int(getattr(arrays[n], "nchunks_initialized", 0)),
+    "chunks_stored": _stored_of(arrays[n]),
     "chunks_total": int(getattr(arrays[n], "nchunks", 0)),
     "fill_value": G.clean(arrays[n].fill_value),
     "order": str(getattr(arrays[n], "order", "C")),
-    "filters": [f.codec_id for f in (arrays[n].filters or [])]} for n in band_names]
+    "filters": _filt_of(arrays[n])} for n in band_names]
 def mm(v):
     vv=[x for x in (v or []) if x is not None]
     return (min(vv),max(vv)) if vv else (None,None)

--- a/fused_render/templates/zarr/_zarr_core.py
+++ b/fused_render/templates/zarr/_zarr_core.py
@@ -560,7 +560,11 @@ def _codec_name(c):
 def _comp_of(a):
     try:
         cs = getattr(a, "compressors", None)
-        if cs: return ",".join(_codec_name(c) for c in cs)
+        # v3 exposes .compressors (an empty tuple means uncompressed, not
+        # "unknown"); only fall back to the v2 .compressor when the attr is
+        # absent, since reading .compressor RAISES on a v3 array.
+        if cs is not None:
+            return ",".join(_codec_name(c) for c in cs) if cs else "none"
         c = a.compressor
         return _codec_name(c) if c else "none"
     except Exception:

--- a/fused_render/templates/zarr/grid_tile_server.py
+++ b/fused_render/templates/zarr/grid_tile_server.py
@@ -798,13 +798,18 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
                 total, files, capped = 0, 0, False
                 for dp, _, fs in os.walk(path):
                     for f in fs:
+                        files += 1
+                        # Check per file, not per directory: a flat store can
+                        # hold all its chunks in one dir, and a per-dir check
+                        # would stat every one before the cap could fire.
+                        if time.time() > deadline or files > 20000:
+                            capped = True
+                            break
                         try:
                             total += os.path.getsize(os.path.join(dp, f))
                         except OSError:
                             pass
-                        files += 1
-                    if time.time() > deadline or files > 20000:
-                        capped = True
+                    if capped:
                         break
                 dir_sizes[path] = None if capped else total
                 out["file_size"] = dir_sizes[path]

--- a/fused_render/templates/zarr/grid_tile_server.py
+++ b/fused_render/templates/zarr/grid_tile_server.py
@@ -28,7 +28,7 @@ This file is kept BYTE-IDENTICAL in netcdf/ and zarr/ (the daemon
 version is a content hash, so both copies share one daemon).
 """
 # /// script
-# dependencies = ["numpy", "scipy"]
+# dependencies = ["numpy", "scipy", "zarr"]
 # ///
 
 import hashlib
@@ -40,8 +40,12 @@ import threading
 import time
 
 STATE = os.path.expanduser("~/.cache/fused-render-gridv2/daemon.json")
-DAEMON_VENV = os.path.expanduser("~/.cache/fused-render-gridv2/venv")
-DAEMON_DEPS = ["numpy", "scipy"]
+DAEMON_DEPS = ["numpy", "scipy", "zarr"]
+# venv dir is keyed by the dep set: growing DAEMON_DEPS must provision a fresh
+# venv, not reuse an existing one that lacks the new package
+DAEMON_VENV = os.path.expanduser(
+    "~/.cache/fused-render-gridv2/venv-"
+    + hashlib.sha256(",".join(DAEMON_DEPS).encode()).hexdigest()[:8])
 IDLE_EXIT_S = 30 * 60
 TILE = 256
 MERC_R = 6378137.0
@@ -200,6 +204,9 @@ def _serve():
         cands = []
         if os.environ.get("GEO_PYTHON"):
             cands.append(os.environ["GEO_PYTHON"])
+        # the daemon venv itself ships zarr (DAEMON_DEPS), so it is normally
+        # the interpreter found here — no host python needed
+        cands.append(sys.executable)
         home = os.path.expanduser("~")
         cands += [os.path.join(home, p) for p in
                   ("miniforge3/bin/python", "miniconda3/bin/python", "anaconda3/bin/python")]
@@ -210,15 +217,18 @@ def _serve():
         env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
         seen = set()
         for c in cands:
+            # dedup on the resolved target but RUN the original path: a venv's
+            # bin/python is a symlink to the base interpreter, and resolving it
+            # before exec would escape the venv (losing its site-packages)
             rc = os.path.realpath(c)
             if rc in seen or not os.path.exists(rc):
                 continue
             seen.add(rc)
             try:
-                r = subprocess.run([rc, "-c", f"import {module}"],
+                r = subprocess.run([c, "-c", f"import {module}"],
                                    capture_output=True, timeout=15, env=env)
                 if r.returncode == 0:
-                    return rc
+                    return c
             except Exception:
                 continue
         return None
@@ -282,13 +292,39 @@ p = json.loads(sys.stdin.read())
 SY = {"lat","latitude","y","yc","rlat","nav_lat"}
 SX = {"lon","longitude","x","xc","rlon","nav_lon"}
 g = zarr.open_group(p["file"], mode="r")
+BUDGET = 32_000_000     # target cells for an auto-picked 2D slice
+HARD_CAP = 256_000_000  # refuse (error, don't OOM) above this
+# Multiscale stores (zarr-conventions "multiscales"): the root attrs list every
+# pyramid level with its shape, so pick the finest level that fits the budget
+# up front and walk ONLY that subgroup — walking all levels costs a metadata
+# round-trip per node (slow on remote mounts) and auto-pick-by-size would grab
+# the native-resolution level (trillions of cells).
+asset = None
+ms = dict(g.attrs).get("multiscales")
+if isinstance(ms, dict) and isinstance(ms.get("layout"), list):
+    levels = []
+    for e in ms["layout"]:
+        sh = e.get("spatial:shape") or []
+        if isinstance(e.get("asset"), str) and len(sh) == 2:
+            levels.append((str(e["asset"]), int(sh[0]) * int(sh[1])))
+    if levels:
+        want = p["var"].split("/", 1)[0] if p["var"] else None
+        if any(nm == want for nm, _ in levels):
+            asset = want
+        else:
+            fit = [t for t in levels if t[1] <= BUDGET]
+            asset = max(fit, key=lambda t: t[1])[0] if fit else min(levels, key=lambda t: t[1])[0]
 arrays = {}
 def walk(node, prefix=""):
     for k, v in node.arrays(): arrays[prefix + k] = v
     for k, v in node.groups(): walk(v, prefix + k + "/")
-walk(g)
+if asset is not None: walk(g[asset], asset + "/")
+else: walk(g)
 def dims_of(a, n):
     d = a.attrs.get("_ARRAY_DIMENSIONS")
+    if not d:
+        d = getattr(getattr(a, "metadata", None), "dimension_names", None)
+        if d and not all(d): d = None
     return list(d) if d else [f"dim{i}" for i in range(a.ndim)]
 dimnames = set()
 for n, a in arrays.items():
@@ -300,9 +336,18 @@ for n, a in arrays.items():
         coords.append(n)
     else: bands.append(n)
 if not bands: bands = list(arrays)
+def slice_cells(n):
+    a = arrays[n]
+    return int(np.prod(a.shape[-2:])) if a.ndim >= 2 else int(np.prod(a.shape))
 def score(n):
     a = arrays[n]; return (a.dtype.kind == "f", a.ndim, int(np.prod(a.shape)))
-chosen = p["var"] if p["var"] in bands else max(bands, key=score)
+if p["var"] in bands:
+    chosen = p["var"]
+else:
+    fit = [n for n in bands if slice_cells(n) <= BUDGET]
+    chosen = max(fit, key=score) if fit else min(bands, key=slice_cells)
+if slice_cells(chosen) > HARD_CAP:
+    print(json.dumps({"error": "slice of '%s' is %dM cells - too large to load; pick a coarser overview level or smaller variable" % (chosen, slice_cells(chosen) // 1000000)})); sys.exit(0)
 a = arrays[chosen]; dims = dims_of(a, chosen)
 ydim = next((d for d in dims if d.split("/")[-1].lower() in SY), None)
 xdim = next((d for d in dims if d.split("/")[-1].lower() in SX), None)
@@ -321,16 +366,21 @@ for i, d in enumerate(extra):
     ca = coord_arr(d); vals = None
     if ca is not None and ca.size <= 500: vals = [str(x) for x in np.asarray(ca[:]).ravel()]
     extra_dims.append({"name": d, "size": int(n0), "values": vals})
-data = np.squeeze(np.asarray(a[tuple(sl)], dtype="float64"))
-if data.ndim != 2: data = np.atleast_2d(data)
-ypos, xpos = dims.index(ydim), dims.index(xdim)
-if ypos > xpos: data = data.T
 def cvals(d):
     ca = coord_arr(d)
     if ca is not None and np.issubdtype(ca.dtype, np.number):
         return np.asarray(ca[:], dtype="float64").ravel()
     return None
-lats = cvals(ydim); lons = cvals(xdim)
+# data + coords live in separate files: overlap the reads (remote mounts pay
+# a network round-trip per file, so serial reads add up)
+from concurrent.futures import ThreadPoolExecutor
+with ThreadPoolExecutor(3) as _ex:
+    _fd = _ex.submit(lambda: np.asarray(a[tuple(sl)], dtype="float64"))
+    _fy = _ex.submit(cvals, ydim); _fx = _ex.submit(cvals, xdim)
+    data = np.squeeze(_fd.result()); lats = _fy.result(); lons = _fx.result()
+if data.ndim != 2: data = np.atleast_2d(data)
+ypos, xpos = dims.index(ydim), dims.index(xdim)
+if ypos > xpos: data = data.T
 tmp = tempfile.NamedTemporaryFile(suffix=".npz", delete=False)
 np.savez(tmp.name, vals=data,
          lats=(lats if lats is not None else np.zeros(0)),
@@ -473,10 +523,21 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
 
         def kind(n):
             return np.dtype(arrays[n]["zarray"]["dtype"]).kind
-        chosen = var if var in band_names else max(
-            band_names, key=lambda n: (kind(n) == "f",
-                                       len(arrays[n]["zarray"]["shape"]),
-                                       int(np.prod(arrays[n]["zarray"]["shape"]))))
+
+        def slice_cells(n):
+            shape = arrays[n]["zarray"]["shape"]
+            return int(np.prod(shape[-2:] if len(shape) >= 2 else shape))
+        if var in band_names:
+            chosen = var
+        else:
+            fit = [n for n in band_names if slice_cells(n) <= 32_000_000]
+            chosen = max(fit, key=lambda n: (kind(n) == "f",
+                                             len(arrays[n]["zarray"]["shape"]),
+                                             int(np.prod(arrays[n]["zarray"]["shape"])))) \
+                if fit else min(band_names, key=slice_cells)
+        if slice_cells(chosen) > 256_000_000:
+            raise RuntimeError(f"slice of '{chosen}' is {slice_cells(chosen) // 1000000}M "
+                               "cells - too large to load; pick a smaller variable")
         info = arrays[chosen]
         za = info["zarray"]
         dims = Z._dims_of(chosen, info)
@@ -709,6 +770,8 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
         vals = sample_bbox(s, mx0, my0, mx1, my1, TILE, TILE)
         return 200, encode_png(np.ascontiguousarray(colorize(q, s, vals))), "image/png"
 
+    dir_sizes = {}     # store path -> capped-walk size (None when capped)
+
     def do_meta(q):
         path = os.path.abspath(os.path.expanduser(q1(q, "file")))
         s = slice_of(q)
@@ -722,9 +785,29 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
                "shape": [rows, cols],
                "lonlat_bounds": (g["bounds"] if g else None)}
         try:
-            out["file_size"] = (os.path.getsize(path) if os.path.isfile(path)
-                                else sum(os.path.getsize(os.path.join(dp, f))
-                                         for dp, _, fs in os.walk(path) for f in fs))
+            if os.path.isfile(path):
+                out["file_size"] = os.path.getsize(path)
+            elif path in dir_sizes:
+                out["file_size"] = dir_sizes[path]
+            else:
+                # capped walk: a store can hold millions of chunk files and on
+                # a remote mount every listing/stat is a network round-trip —
+                # give up after a short deadline instead of stalling /meta,
+                # and cache the answer so only the first /meta per store pays
+                deadline = time.time() + 2.0
+                total, files, capped = 0, 0, False
+                for dp, _, fs in os.walk(path):
+                    for f in fs:
+                        try:
+                            total += os.path.getsize(os.path.join(dp, f))
+                        except OSError:
+                            pass
+                        files += 1
+                    if time.time() > deadline or files > 20000:
+                        capped = True
+                        break
+                dir_sizes[path] = None if capped else total
+                out["file_size"] = dir_sizes[path]
         except OSError:
             out["file_size"] = None
         return 200, json.dumps(out, default=str).encode(), "application/json"

--- a/fused_render/templates/zarr_aoi/tile_server.py
+++ b/fused_render/templates/zarr_aoi/tile_server.py
@@ -118,9 +118,22 @@ def main(action: str = "ensure"):
         pass
     os.makedirs(os.path.dirname(STATE), exist_ok=True)
     log = os.path.join(os.path.dirname(STATE), "daemon.log")
+    env = dict(os.environ)
+    if "FUSED_RENDER_ORIGIN" not in env:
+        # The daemon reads store bytes through the server's /api/fs/raw
+        # (resolve_source), so it needs the server's origin. main() runs
+        # inside the server, where the port module is importable; the
+        # daemon's own venv has no fused_render, so pass it via env. The
+        # 1777 fallback matches _branch._BASE_PORT (baseline, no branch
+        # isolation).
+        try:
+            from fused_render._branch import branch_port
+            env["FUSED_RENDER_ORIGIN"] = f"http://127.0.0.1:{branch_port()}"
+        except ImportError:
+            pass
     with open(log, "ab") as lf:
         subprocess.Popen([_daemon_python(), _me(), "--serve"],
-                         stdout=lf, stderr=lf,
+                         stdout=lf, stderr=lf, env=env,
                          start_new_session=True, cwd=os.path.dirname(_me()))
     for _ in range(600):               # venv build on first run can take a while
         time.sleep(0.1)
@@ -231,6 +244,33 @@ def _serve():
                     return None
                 except Exception:
                     pass    # fall through to the plain single GET
+            # suffix reads (shard indexes) on an http store: fsspec's
+            # HTTPFileSystem emulates "last N bytes" with a HEAD size probe
+            # first — one extra remote round trip per shard object. HTTP
+            # servers (/api/fs/raw, S3 behind its redirect) accept the native
+            # `Range: bytes=-N` form, so send it directly.
+            try:
+                from zarr.abc.store import SuffixByteRequest
+                fs = getattr(self._store, "fs", None)
+                root = getattr(self._store, "path", None)
+                proto = getattr(fs, "protocol", None)
+                proto = proto if isinstance(proto, (tuple, list)) else (proto,)
+                if (isinstance(byte_range, SuffixByteRequest) and root
+                        and "http" in proto):
+                    n = int(byte_range.suffix)
+                    session = await fs.set_session()
+                    async with session.get(
+                            f"{root}/{key}",
+                            headers={"Range": f"bytes=-{n}"}) as r:
+                        if r.status == 404:
+                            return None
+                        r.raise_for_status()
+                        data = await r.read()
+                    if len(data) > n:   # server ignored the Range header
+                        data = data[-n:]
+                    return prototype.buffer.from_bytes(data)
+            except Exception:
+                pass    # fall through to fsspec's emulated suffix read
             return await super().get(key, prototype, byte_range)
 
         async def get_partial_values(self, prototype, key_ranges):
@@ -283,6 +323,21 @@ def _serve():
         path = os.path.abspath(os.path.expanduser(path))
         mroot = os.path.expanduser("~/.fused-render/mounts") + os.sep
         if path.startswith(mroot):
+            # Default transport: the server's own ranged-read API. The server
+            # decides how the bytes move (rclone-serve proxy, presigned 307,
+            # local file) and holds the credentials, so private buckets work
+            # and this template never has to know what a mount is.
+            # ZARRAOI_TRANSPORT=s3 keeps the old rclone.conf back-resolution
+            # (anonymous buckets only) for A/B comparison.
+            if os.environ.get("ZARRAOI_TRANSPORT", "raw") != "s3":
+                from urllib.parse import quote
+                origin = os.environ.get("FUSED_RENDER_ORIGIN",
+                                        "http://127.0.0.1:1777")
+                return {"kind": "http",
+                        "url": origin + "/api/fs/raw?path="
+                        + quote(path, safe="/"),
+                        "storage_options": {},
+                        "label": path + " (server raw API)"}
             rel = path[len(mroot):]
             name, _, rest = rel.partition(os.sep)
             try:
@@ -742,8 +797,12 @@ def _serve():
         a0 = get_array(ds, 0, var)
         ci = chunk_info(a0)
         itemsize = np.dtype(a0.dtype).itemsize
-        logical = sum(int(np.prod(get_array(ds, i, var).shape)) * itemsize
-                      for i in range(len(ds["levels"])))
+        # spatial shapes come from the multiscales attrs — opening every
+        # level's array instead costs 2 serial GETs per level on stores
+        # without consolidated metadata
+        extra_cells = int(np.prod(a0.shape[:-2])) if a0.ndim > 2 else 1
+        logical = sum(int(np.prod(lv["shape"])) * extra_cells * itemsize
+                      for lv in ds["levels"])
         extra = []
         if a0.ndim > 2:
             dims = dims_of(a0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ bundled = [
     "usd-core>=24.5",
     "msgpack>=1.0",
     "rasterio",
+    "zarr",
     "pymupdf>=1.25",
     "pikepdf>=9",
     "drain3>=0.9.11",

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1016,13 +1016,15 @@ def test_fs_raw_proxy_error_keeps_range_headers(client, home):
 
 @pytest.fixture()
 def fresh_upstream():
-    """The bypass memoizes per-remote capability and per-object links in
-    module globals; clear around each test so results don't leak."""
+    """The bypass memoizes per-remote capability, config and per-object
+    links in module globals; clear around each test so results don't leak."""
     mounts_mod._upstream_links.clear()
     mounts_mod._upstream_mode.clear()
+    mounts_mod._upstream_cfg.clear()
     yield
     mounts_mod._upstream_links.clear()
     mounts_mod._upstream_mode.clear()
+    mounts_mod._upstream_cfg.clear()
 
 
 def test_upstream_url_prefers_presigned_link(home, rcd, fresh_upstream):
@@ -1043,7 +1045,10 @@ def test_upstream_url_public_s3_when_link_unsupported(home, rcd, fresh_upstream)
     import os
 
     # Anonymous S3 remotes can't presign ("unsupported signer type noAuth")
-    # but don't need to — the plain public object URL works.
+    # but don't need to — the plain public object URL works. The config makes
+    # that knowable up front, so publiclink is never even attempted, and the
+    # config is memoized: minting URLs for later objects on the same remote
+    # (a zarr store touches thousands) is pure string building, no rc call.
     rcd.responses["operations/publiclink"] = (
         500, {"error": 'unsupported signer type "smithy.api#noAuth"'})
     rcd.responses["config/get"] = {
@@ -1053,6 +1058,11 @@ def test_upstream_url_public_s3_when_link_unsupported(home, rcd, fresh_upstream)
     f = os.path.join(mounts_mod.mountpoint(c), "k ey.parquet")
     assert mounts_mod.upstream_url_for(f) == (
         "https://bucket.s3.us-west-2.amazonaws.com/pre%20fix/k%20ey.parquet")
+    f2 = os.path.join(mounts_mod.mountpoint(c), "other.parquet")
+    assert mounts_mod.upstream_url_for(f2) == (
+        "https://bucket.s3.us-west-2.amazonaws.com/pre%20fix/other.parquet")
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+    assert len([x for x in rcd.calls if x[0] == "config/get"]) == 1
 
 
 def test_upstream_url_none_is_remembered(home, rcd, fresh_upstream):
@@ -1074,10 +1084,13 @@ def test_upstream_url_none_outside_mounts(home, rcd, fresh_upstream):
 
 
 def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstream):
-    """A ranged GET from a native client (no Sec-Fetch-Mode) on a cold
-    mount-backed file 307s to the store's direct URL; browser requests and
-    HEADs keep today's serve proxy (a redirect would die on CORS / fail a
-    GET-signed link)."""
+    """A GET from a native client (no Sec-Fetch-Mode) on a cold mount-backed
+    file 307s to the store's direct URL — ranged or whole-file alike (zarr
+    reads its many tiny metadata files whole); browser requests and HEADs
+    keep today's serve proxy (a redirect would die on CORS / fail a
+    GET-signed link). No stat gates the redirect: a getattr on a never-listed
+    mount object is a full remote round trip, and the store 404s a missing
+    object itself."""
     import os
 
     import fused_render.shell.storage as storage
@@ -1097,12 +1110,26 @@ def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstr
     assert r.status_code == 307
     assert r.headers["location"] == "https://signed.example/x"
 
+    # Whole-file native GET: redirected too, and without any local stat —
+    # a path that doesn't exist under the (fake) mount still redirects, so
+    # the daemon's read never pays the VFS getattr round trip.
+    r = client.get("/api/fs/raw", params={"path": f}, follow_redirects=False)
+    assert r.status_code == 307
+    ghost = os.path.join(mp, "not-listed-yet.bin")
+    r = client.get("/api/fs/raw", params={"path": ghost},
+                   follow_redirects=False)
+    assert r.status_code == 307
+
     r = client.get("/api/fs/raw", params={"path": f},
                    headers={"Range": "bytes=0-3", "Sec-Fetch-Mode": "cors"},
                    follow_redirects=False)
     assert r.status_code != 307
     r = client.head("/api/fs/raw", params={"path": f}, follow_redirects=False)
     assert r.status_code != 307
+    # HEAD still answers from the stat: missing files 404 locally.
+    r = client.head("/api/fs/raw", params={"path": ghost},
+                    follow_redirects=False)
+    assert r.status_code == 404
 
 
 def test_api_run_rewrites_raw_source_url_to_direct(

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -909,8 +909,13 @@ def test_stat_marks_mount_backed_files_remote(client, home):
 
 
 def test_fs_raw_proxies_range_from_mount_serve(client, home):
-    """/api/fs/raw for a mount-backed path streams from the mount's HTTP
-    serve (Range and HEAD forwarded), not from the local filesystem."""
+    """/api/fs/raw for a mount-backed path streams GETs from the mount's
+    HTTP serve, not from the local filesystem. HEAD is the exception: it is
+    answered from the mount's own stat — ranged clients (duckdb httpfs,
+    fsspec/zarr) probe the length before every read, and proxying that probe
+    costs a full remote round trip for headers the VFS getattr already
+    knows; on a real mount the stat and the serve read the same remote, so
+    the sizes agree (here they intentionally differ to prove the source)."""
     import functools
     import http.server
     import os
@@ -942,7 +947,9 @@ def test_fs_raw_proxies_range_from_mount_serve(client, home):
         assert r.status_code == 200 and r.content == b"REMOTE-BYTES"
         r = client.head("/api/fs/raw", params={"path": f})
         assert r.status_code == 200
-        assert r.headers["content-length"] == str(len(b"REMOTE-BYTES"))
+        assert r.headers["content-length"] == str(len(b"LOCAL-BYTES"))
+        assert r.headers["accept-ranges"] == "bytes"
+        assert "last-modified" in r.headers
         assert r.content == b""
     finally:
         srv.shutdown()
@@ -1259,3 +1266,22 @@ def test_mount_view_exposes_read_only(home):
     assert mounts_mod.mount_view(m, rcd_mounts=set())["read_only"] is True
     m2 = mounts_mod.add_mount("data", "aws:bucket")
     assert mounts_mod.mount_view(m2, rcd_mounts=set())["read_only"] is False
+
+
+def test_fix_dotted_bucket_url():
+    fix = mounts_mod._fix_dotted_bucket_url
+    # dotted bucket in the TLS hostname can never pass the wildcard cert:
+    # unsigned URLs are rewritten to path-style
+    assert fix("https://us-west-2.opendata.source.coop.s3.us-west-2"
+               ".amazonaws.com/mindearth/a%20b/zarr.json") == \
+        ("https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop"
+         "/mindearth/a%20b/zarr.json")
+    # a signed one can't be (SigV4 covers Host) — dropped, caller stays on
+    # the serve proxy
+    assert fix("https://buck.et.s3.us-east-1.amazonaws.com/k"
+               "?X-Amz-Signature=abc") is None
+    # dot-free buckets and non-AWS hosts pass through untouched
+    for u in ("https://plain.s3.us-west-2.amazonaws.com/key",
+              "https://plain.s3.us-west-2.amazonaws.com/key?X-Amz-Sig=x",
+              "https://minio.example.com/bucket/key"):
+        assert fix(u) == u

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -955,6 +955,46 @@ def test_fs_raw_proxies_range_from_mount_serve(client, home):
         srv.shutdown()
 
 
+def test_fs_raw_directory_404s_not_listing(client, home):
+    """A directory path under a served mount 404s on GET and HEAD. The serve
+    (like rclone serve http) answers a directory with a 200 HTML listing, so
+    without a guard the proxy would hand that listing back as raw bytes; a
+    directory has no bytes to serve, so both verbs must 404."""
+    import functools
+    import http.server
+    import os
+    import threading
+
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    os.makedirs(mp)
+    d = os.path.join(mp, "subdir")
+    os.makedirs(d)
+    open(os.path.join(d, "x.bin"), "wb").write(b"CHUNK")
+
+    class H(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+    srv = http.server.ThreadingHTTPServer(
+        ("127.0.0.1", 0), functools.partial(H, directory=str(mp)))
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        import fused_render.shell.storage as storage
+        storage.write_json(mounts_mod.serves_path(),
+                           {mp: f"http://127.0.0.1:{srv.server_address[1]}"})
+        # Browser-style request (Sec-Fetch-Mode present) skips the redirect
+        # branch and reaches the proxy path, which is where a directory would
+        # otherwise leak a 200 listing.
+        h = {"sec-fetch-mode": "navigate"}
+        r = client.get("/api/fs/raw", params={"path": d}, headers=h)
+        assert r.status_code == 404
+        r = client.head("/api/fs/raw", params={"path": d}, headers=h)
+        assert r.status_code == 404
+    finally:
+        srv.shutdown()
+
+
 def test_fs_raw_falls_back_to_file_when_serve_dead(client, home):
     import os
     import socket

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -99,9 +99,10 @@ def test_duckdb_database_files_route_to_duckdb():
 
 
 def test_builtin_zarr_directory_key():
-    # zarr dir carries the map preview plus the raw member listing as a peer
-    # mode (D81 — replaces the old `?listing=1` escape hatch)
-    assert modes("/x/store.zarr", is_dir=True) == (["zarr", "_listing"], None)
+    # zarr dir carries the AOI streamer, the map preview, and the raw member
+    # listing as peer modes (D81 — replaces the old `?listing=1` escape hatch)
+    assert modes("/x/store.zarr", is_dir=True) == (
+        ["zarr_aoi", "zarr", "_listing"], None)
     # a *file* named .zarr does not match the directory key
     assert modes("/x/store.zarr", is_dir=False) == ([], None)
 


### PR DESCRIPTION
## What

Three related pieces, proven out against the WSF multiscale store (`s3://us-west-2.opendata.source.coop/mindearth/wsf/`, 6.2T-cell native level, zarr v3 sharded):

### 1. zarr v3 + multiscale support in the zarr/netcdf grid daemons
- Daemon venv keyed by its dependency list (`venv-<sha8>`), ships `zarr`; changing deps provisions a fresh venv automatically.
- Multiscale stores (zarr-conventions `multiscales` root attr) are never walked level-by-level; workers pick the finest level ≤ 32M slice cells from root attrs alone, 256M hard cap errors instead of OOMing.
- `/meta` file-size walk is deadline-capped and cached (a walk over a remote mount is a network call per entry; the WSF store has ~93k shard files).

### 2. `/api/fs/raw` cold-read fast path
- **HEAD answered from the mount stat** the route already had, instead of proxying a full remote round trip for headers the VFS getattr already knows.
- **No stat before serve-backed GETs**: the VFS getattr was a ~1s serial round trip per never-listed object, paid before the read even started. The serve and the store 404 missing objects themselves. (HEAD and the local-file fallback still stat, now off the event loop.)
- **Cold 307-to-store redirect covers whole-file native GETs** too, not just ranged ones — zarr reads many tiny metadata files whole, and the serve VFS's per-file open ceremony dwarfs those fetches. Background prefetch still warms the serve cache for later replays.
- **Per-remote config cache** in `upstream_url_for`; anonymous S3 skips the doomed `publiclink` rc call (it can never presign), so public URL minting is pure string building after first touch.
- **Dotted-bucket 307 URLs fixed**: rclone publiclink mints virtual-hosted URLs, and `*.s3.<region>.amazonaws.com` can't TLS-match a bucket with dots (`us-west-2.opendata.source.coop`); unsigned URLs are rewritten path-style, signed ones stay on the proxy.

### 3. zarr_aoi template rides the raw transport
- `resolve_source()` defaults to the server's `/api/fs/raw` instead of rclone.conf S3 back-resolution: the server decides how bytes move and holds the credentials, so **private buckets work** and the template stays mount-agnostic. `ZARRAOI_TRANSPORT=s3` keeps the old path for A/B.
- `MeterStore` sends native suffix `Range` headers for shard indexes — fsspec's HEAD-size-probe emulation cost an extra serial round trip per shard object (~3× on cold sharded reads).
- `/meta` logical size from multiscales attrs (2 serial GETs per level saved on unconsolidated stores).
- The spawned daemon learns the server's true origin (branch-isolated ports) via `FUSED_RENDER_ORIGIN`.

## Numbers (WSF store, fresh daemon, identical 24-request read pattern)

| transport | /meta cold | tiles |
|---|---|---|
| direct anonymous s3fs (old default) | 4.35s | 1.4–1.7s |
| raw transport, before this PR's cold-path fixes | 6.0s | 2.6s |
| **raw transport, after** | **2.2s** | ~parity cold, **0.01s** once the serve cache is warm |

Also includes a fix for `test_builtin_zarr_directory_key`, stale on main since #143 added `zarr_aoi` to the built-in `.zarr/` registry key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)