### PR TITLE
Add file selection UI to Deploy modal with include/exclude

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -585,15 +585,27 @@ nothing. Full detail: `docs/EXPORT.md`.
 
 ### 18.3 Static resolution & fail-loud
 
-- **EX-4** Every `runPython`/`rawUrl`/`readFile` path must be a **string literal**
-  resolvable at build time. A computed path, an unsupported API call, an absolute or
-  `..`-escaping path, or a missing target is a **blocking error** — export writes
-  nothing and reports all problems at once, rather than shipping a page whose calls
-  404 when hosted.
+- **EX-4** Blocking errors — export writes nothing and reports all problems at once,
+  rather than shipping a page whose calls 404 when hosted: a **computed `runPython`
+  path** (its served route name is derived from the literal, so it can't be routed),
+  an **unsupported API call** (`writeFile`/`stat`), an **absolute or `..`-escaping**
+  path (including a symlink resolving outside the page dir), or a **missing target**
+  (a referenced file, or an `include` file, not on disk).
+- **EX-4a** Warnings — advisory, never blocking: a **computed `rawUrl`/`readFile`
+  path** (the exporter can't resolve it, but the author can bundle its target via
+  `include` — EX-6 — and the served `_asset` route resolves it by key at request
+  time), and an **`exclude` that drops a literally-referenced file** (honored, but
+  that call 404s when hosted).
 - **EX-5** Route names derive from the `.py` stem (`sine.py` → `sine`), are prefixed
   `run-` when they'd collide with a reserved serve route (`data`, `health`, the
   `_`-prefixed control/shell/asset routes), and are suffixed `-2`, `-3`, … on
   duplicate stems — so the map is always valid and injective.
+- **EX-6** The auto-detected set can be adjusted by an optional selection on
+  `/api/export` (and the Deploy modal, §19): `include` — extra page-relative files
+  bundled as assets beyond the literal scan (for a computed-path target or data a
+  bundled `.py` reads at runtime), each validated like a scanned asset and deduped by
+  key; and `exclude` — files dropped from the final set by literal path or bundle
+  key. Both default empty (auto-only).
 
 ## 19. Deploy — Hosted Publish through the fused CLI (M11)
 
@@ -630,15 +642,27 @@ the product gains network access.
   to the current page; the **env-wide** deployment list (DP-13) lives on the
   Preferences page's Deployments section (PF-6), not in the modal.
 - **DP-2a** Before the click, the modal shows exactly what a deploy would
-  publish (`GET /api/deploy/preview` → `preview_deploy`, the same pure
-  `plan_export` scan the real export runs, resolved fresh, no files written):
-  the page plus each `runPython` target (and its served route name) and each
-  `rawUrl`/`readFile` asset. Export blockers come back in the same response
-  and **disable Deploy** with the full list — an unexportable page reads as
-  "fix these" up front, never as a failed deploy. A preview *fetch* failure
-  (unexportable type, file deleted since the header rendered) degrades to a
-  blocker entry the same way — the dialog still renders its form; it never
-  dead-ends on the preview call.
+  publish (`POST /api/deploy/preview` → `preview_deploy`, the same pure
+  `plan_export` scan the real export runs, resolved fresh with the current
+  selection, no files written): the page plus each `runPython` target (and its
+  served route name) and each `rawUrl`/`readFile` or included asset. Export
+  blockers (EX-4) come back in the same response and **disable Deploy** with the
+  full list — an unexportable page reads as "fix these" up front, never as a
+  failed deploy; warnings (EX-4a) show alongside but never block. A preview
+  *fetch* failure (unexportable type, file deleted since the header rendered)
+  degrades to a blocker entry the same way — the dialog still renders its form; it
+  never dead-ends on the preview call. (Preview is `POST`, not `GET`: it carries
+  the include/exclude selection, which doesn't fit a query string; it stays
+  read-only and unguarded.)
+- **DP-2c** The "will publish" list is **editable** — the user layers a file
+  selection (EX-6) on the auto-detected set: remove a listed file (× → `exclude`),
+  restore an excluded one, add extra files via a picker over the page's folder
+  (`walkDir`, gitignore-aware), "Add all in folder", or "Reset to default"
+  (clear both lists). The selection is sent on Deploy and **persisted on the
+  deployment record** (`include`/`exclude`, beside `entrypoints` — no separate
+  sidecar), so a reopened modal reloads exactly what was last published. This is
+  how a page whose data is fetched by a computed path deploys at all (EX-4a): the
+  author bundles those files explicitly.
 - **DP-2b** Login guidance, before and after the click.
   `GET /api/deploy/config` carries `fused_logged_in` — presence of the fused
   CLI's own control-plane credentials file

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -20,12 +20,16 @@ the minted URL. Manual export remains the path for driving the hosting layer
 yourself.
 
 `page` and `out` must both be absolute filesystem paths (same convention as
-every other endpoint). On success the response is
-`{"out", "entrypoints": [...], "assets": [...]}` — the same shape written into
-`manifest.json` below, plus the resolved `out` directory. On a blocking export
-problem (see "Rules the exporter enforces" below) the response is a `400`
-`{"error": "..."}`; the `X-Fused` header is required on every call, like any
-other mutating endpoint (a missing/invalid header is a `403`).
+every other endpoint). Two optional fields tune the file set (see "Choosing which
+files are bundled" below): `include` (extra page-relative files to bundle as
+assets) and `exclude` (files to drop from the bundle) — both arrays of relative
+paths, defaulting to empty. On success the response is
+`{"out", "entrypoints": [...], "assets": [...], "warnings": [...]}` — the same
+shape written into `manifest.json` below, plus the resolved `out` directory and
+any advisory warnings. On a blocking export problem (see "Rules the exporter
+enforces" below) the response is a `400` `{"error": "..."}`; the `X-Fused` header
+is required on every call, like any other mutating endpoint (a missing/invalid
+header is a `403`).
 
 ## What a bundle contains
 
@@ -76,14 +80,43 @@ runtime API is portable:
 Export **fails loudly** (nothing is written) when a page cannot be hosted
 faithfully, rather than shipping a page whose data calls 404 at request time:
 
-- **String-literal paths only.** Every `runPython`/`rawUrl`/`readFile` path must be
-  a quoted literal. A computed path (a variable, a template string) cannot be
-  resolved at build time and is an error.
+- **Literal `runPython` paths only.** A `runPython` path must be a quoted literal:
+  a hosted entrypoint's served route name is derived from that literal, so a
+  computed target (a variable, a template string) cannot be routed and is an error.
 - **No unsupported API.** `writeFile`/`stat` in the page are errors.
 - **In-bundle paths only.** Absolute paths and paths escaping the page directory
   (`..`) are rejected — a hosted page can only reach files inside its bundle.
-- **Targets must exist.** A referenced `.py`/asset that isn't on disk is an error.
+- **Targets must exist.** A referenced `.py`/asset (or an `include` file) that
+  isn't on disk is an error.
+
+Some conditions are **warnings**, not errors — they don't block export:
+
+- **Computed `rawUrl`/`readFile` paths.** The exporter can't discover the target,
+  but you can bundle it yourself via `include` (below); the served `_asset` route
+  looks the file up by its bundle key, so a runtime-computed path resolves fine.
+- **Excluding a referenced file.** Dropping a file the page literally references is
+  honored, but the page's call to it will 404 when hosted.
 
 Route names are derived from the `.py` filename stem (`sine.py` → `sine`),
 prefixed with `run-` if they would collide with a reserved serve route (`data`,
 `health`, …) and suffixed `-2`, `-3`, … on duplicate stems.
+
+## Choosing which files are bundled
+
+By default the bundle is exactly the auto-detected set — the page plus every file
+reached by a literal `runPython`/`rawUrl`/`readFile` call. `include` and `exclude`
+layer a user selection on top:
+
+- **`include`** — extra page-relative files bundled as read-only assets, beyond the
+  scan. Use it for files reached by a computed path, or data a bundled `.py` reads
+  at runtime, which the HTML scan can't see. An included file that duplicates an
+  auto-detected asset is bundled once.
+- **`exclude`** — page-relative paths (or their bundle key) dropped from the final
+  set. Dropping an auto-detected target warns (its call 404s when hosted); dropping
+  a file you only added via `include` is silent.
+
+The Deploy modal (SPEC §19) drives these from its editable "Will publish" list —
+add files from the page's folder, add everything, remove a file, or reset to the
+auto-detected default — and persists the selection on the deployment record so a
+reopened modal reloads it. `/api/export` exposes the same two fields for driving a
+bundle by hand.

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -120,3 +120,25 @@ add files from the page's folder, add everything, remove a file, or reset to the
 auto-detected default — and persists the selection on the deployment record so a
 reopened modal reloads it. `/api/export` exposes the same two fields for driving a
 bundle by hand.
+
+### Reading a bundled file from a `runPython` entrypoint
+
+Included data is not placed beside your `.py` at the top level of the served
+runtime — the hosting layer materializes every bundled asset under an `assets/`
+prefix in the entrypoint's working directory (keyed by the manifest `name`, the
+same key `fused.rawUrl`/`readFile` use). So from entrypoint Python, a bare
+`open("data.csv")` will **not** find it. Read it via the injected `openfused`
+helper, which anchors an absolute path at the runtime's project root:
+
+```python
+import openfused
+
+def main():
+    return open(openfused.asset_path("data.csv")).read()   # <root>/assets/data.csv
+    # a nested include works the same: openfused.asset_path("tiles", "0.png")
+```
+
+`open("assets/data.csv")` (relative to the working directory) also resolves, but
+`asset_path(...)` is the stable form and matches how the `_asset` route serves the
+same bytes to the browser. This `assets/` location is set by the hosting layer's
+resource scheme, not by where the bundle physically stores the file.

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -86,6 +86,7 @@ function FileSelection({
   setExclude: (v: string[]) => void;
 }) {
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [collapsed, setCollapsed] = useState(false);
   const [dirFiles, setDirFiles] = useState<WalkEntry[] | null>(null);
   const [dirTruncated, setDirTruncated] = useState(false);
   const [walkBusy, setWalkBusy] = useState(false);
@@ -102,12 +103,20 @@ function FileSelection({
     [preview],
   );
 
-  // × on a row → add to exclude. Exclude is applied last server-side and drops a
-  // file by key whether it was auto-detected OR manually included, so this always
-  // takes the file out of the bundle; "Restore" (remove from exclude) brings an
-  // auto/included file back. include is left untouched so a restore is lossless.
+  // × on a row. A manually-added file (in `include`) is simply dropped from
+  // `include` — it was never part of the default set, so it just goes away with
+  // no "Excluded" tombstone. An auto-detected file (a runPython entrypoint or a
+  // literally-referenced asset — the default publish set) is instead moved to
+  // `exclude`, which suppresses it AND surfaces it under "Excluded" with a
+  // Restore. So "Excluded" only ever lists files the page would publish by
+  // default, never the noise of add-all extras the user then removed.
   const removeRow = (path: string) => {
-    if (!exclude.some((e) => relKey(e) === relKey(path))) setExclude([...exclude, path]);
+    const key = relKey(path);
+    if (includeKeys.has(key)) {
+      setInclude(include.filter((i) => relKey(i) !== key));
+    } else if (!exclude.some((e) => relKey(e) === key)) {
+      setExclude([...exclude, path]);
+    }
   };
   const restore = (path: string) => setExclude(exclude.filter((e) => relKey(e) !== relKey(path)));
   // Adding files (picker / add-all): append to include and clear any exclusion of
@@ -180,7 +189,7 @@ function FileSelection({
       path: e.path,
       label: relKey(e.path),
       title: `fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`,
-      kind: "run" as const,
+      tag: "run" as const,
     })),
     ...preview.assets.map((a) => ({
       path: a.path,
@@ -188,108 +197,139 @@ function FileSelection({
       title: includeKeys.has(relKey(a.path))
         ? `included file — ${a.path}`
         : `asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`,
-      kind: includeKeys.has(relKey(a.path)) ? ("added" as const) : ("asset" as const),
+      tag: includeKeys.has(relKey(a.path)) ? ("added" as const) : (null as null),
     })),
   ];
 
-  return (
-    <div className="deploy-preview">
-      <div className="deploy-preview-head">
-        <span className="deploy-muted">Will publish:</span>
-        <div className="deploy-preview-actions">
-          <button type="button" onClick={openPicker} disabled={disabled}>
-            Add files…
-          </button>
-          <button type="button" onClick={() => void addAllInFolder()} disabled={disabled || walkBusy}>
-            {walkBusy ? "Scanning…" : "Add all in folder"}
-          </button>
-          {(include.length > 0 || exclude.length > 0) && (
-            <button type="button" onClick={reset} disabled={disabled}>
-              Reset to default
-            </button>
-          )}
-        </div>
-      </div>
+  const publishCount = rows.length + 1; // + the page itself
+  const summary =
+    `${publishCount} file${publishCount === 1 ? "" : "s"}` +
+    (exclude.length ? ` · ${exclude.length} excluded` : "");
 
-      <ul className="deploy-file-list">
-        <li className="deploy-file page">
-          <code title={preview.page}>{relKey(preview.page)}</code>
-          <span className="deploy-file-tag">page</span>
-        </li>
-        {rows.map((r) => (
-          <li key={r.kind + r.path} className="deploy-file">
-            <code title={r.title}>{r.label}</code>
-            {r.kind === "run" && <span className="deploy-file-tag">run</span>}
-            {r.kind === "added" && <span className="deploy-file-tag added">added</span>}
+  return (
+    <div className="deploy-files">
+      <button
+        type="button"
+        className="deploy-files-head"
+        aria-expanded={!collapsed}
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <span className="deploy-files-chevron" aria-hidden="true">
+          {collapsed ? "▸" : "▾"}
+        </span>
+        <span className="deploy-files-title">Will publish</span>
+        <span className="deploy-files-count">{summary}</span>
+      </button>
+
+      {!collapsed && (
+        <div className="deploy-files-body">
+          <div className="deploy-preview-actions">
+            <button type="button" onClick={openPicker} disabled={disabled}>
+              Add files…
+            </button>
             <button
               type="button"
-              className="deploy-file-remove"
-              title="Remove from the bundle"
-              onClick={() => removeRow(r.path)}
-              disabled={disabled}
+              onClick={() => void addAllInFolder()}
+              disabled={disabled || walkBusy}
             >
-              ✕
+              {walkBusy ? "Scanning…" : "Add all in folder"}
             </button>
-          </li>
-        ))}
-        {rows.length === 0 && (
-          <li className="deploy-muted">(the page only — no runPython/rawUrl targets)</li>
-        )}
-      </ul>
+            {(include.length > 0 || exclude.length > 0) && (
+              <button type="button" onClick={reset} disabled={disabled}>
+                Reset to default
+              </button>
+            )}
+          </div>
 
-      {exclude.length > 0 && (
-        <div className="deploy-excluded">
-          <span className="deploy-muted">Excluded (won't be bundled):</span>
           <ul className="deploy-file-list">
-            {exclude.map((p) => (
-              <li key={p} className="deploy-file excluded">
-                <code title={p}>{relKey(p)}</code>
+            <li className="deploy-file">
+              <code title={preview.page}>{relKey(preview.page)}</code>
+              <span className="deploy-file-tag">page</span>
+              <span className="deploy-file-action" />
+            </li>
+            {rows.map((r) => (
+              <li key={(r.tag ?? "asset") + r.path} className="deploy-file">
+                <code title={r.title}>{r.label}</code>
+                <span className={"deploy-file-tag" + (r.tag ? " " + r.tag : " none")}>
+                  {r.tag ?? ""}
+                </span>
                 <button
                   type="button"
-                  className="deploy-file-restore"
-                  title="Add back to the bundle"
-                  onClick={() => restore(p)}
+                  className="deploy-file-action deploy-file-remove"
+                  title="Remove from the bundle"
+                  onClick={() => removeRow(r.path)}
                   disabled={disabled}
                 >
-                  Restore
+                  ✕
                 </button>
               </li>
             ))}
+            {rows.length === 0 && (
+              <li className="deploy-muted deploy-file-empty">
+                (the page only — no runPython/rawUrl targets)
+              </li>
+            )}
           </ul>
-        </div>
-      )}
 
-      {pickerOpen && (
-        <div className="deploy-picker">
-          <div className="deploy-picker-head">
-            <span className="deploy-muted">Add files from this page's folder</span>
-            <button type="button" onClick={() => setPickerOpen(false)}>
-              Done
-            </button>
-          </div>
-          {walkBusy && <div className="deploy-muted">Scanning folder…</div>}
-          {walkError && <div className="deploy-error">{walkError}</div>}
-          {dirTruncated && (
-            <div className="deploy-note deploy-muted">
-              This folder is large — some files were omitted from the scan.
+          {exclude.length > 0 && (
+            <div className="deploy-excluded">
+              <span className="deploy-muted">Excluded (won't be bundled):</span>
+              <ul className="deploy-file-list">
+                {exclude.map((p) => (
+                  <li key={p} className="deploy-file excluded">
+                    <code title={p}>{relKey(p)}</code>
+                    <span className="deploy-file-tag none" />
+                    <button
+                      type="button"
+                      className="deploy-file-action deploy-file-restore"
+                      title="Add back to the bundle"
+                      onClick={() => restore(p)}
+                      disabled={disabled}
+                    >
+                      Restore
+                    </button>
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
-          {dirFiles !== null && !walkBusy && available.length === 0 && (
-            <div className="deploy-muted">
-              No other files to add — everything in the folder is already listed.
+
+          {pickerOpen && (
+            <div className="deploy-picker">
+              <div className="deploy-picker-head">
+                <span className="deploy-muted">Add files from this page's folder</span>
+                <button type="button" onClick={() => setPickerOpen(false)}>
+                  Done
+                </button>
+              </div>
+              {walkBusy && <div className="deploy-muted">Scanning folder…</div>}
+              {walkError && <div className="deploy-error">{walkError}</div>}
+              {dirTruncated && (
+                <div className="deploy-note deploy-muted">
+                  This folder is large — some files were omitted from the scan.
+                </div>
+              )}
+              {dirFiles !== null && !walkBusy && available.length === 0 && (
+                <div className="deploy-muted">
+                  No other files to add — everything in the folder is already listed.
+                </div>
+              )}
+              {available.length > 0 && (
+                <ul className="deploy-picker-list">
+                  {available.map((f) => (
+                    <li key={f.rel}>
+                      <button type="button" onClick={() => addFiles([f.rel])} disabled={disabled}>
+                        <span className="deploy-picker-add" aria-hidden="true">
+                          +
+                        </span>
+                        <code>{f.rel}</code>
+                        <span className="deploy-muted">{formatSize(f.size)}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
             </div>
-          )}
-          {available.length > 0 && (
-            <ul className="deploy-picker-list">
-              {available.map((f) => (
-                <li key={f.rel}>
-                  <button type="button" onClick={() => addFiles([f.rel])} disabled={disabled}>
-                    + <code>{f.rel}</code>
-                    <span className="deploy-muted">{formatSize(f.size)}</span>
-                  </button>
-                </li>
-              ))}
-            </ul>
           )}
         </div>
       )}
@@ -699,11 +739,17 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             type="button"
             className="deploy-primary"
             onClick={onDeploy}
-            disabled={busy !== null || env === null || (preview !== null && preview.errors.length > 0)}
+            // preview === null: the "will publish" resolution is still in flight
+            // (or was just cleared on a page switch), so we don't yet know the
+            // file set or whether there are export blockers — block Deploy until
+            // it lands rather than shipping blind.
+            disabled={busy !== null || env === null || preview === null || preview.errors.length > 0}
             title={
-              preview !== null && preview.errors.length > 0
-                ? "Fix the export problems listed above first"
-                : undefined
+              preview === null
+                ? "Preparing the publish preview…"
+                : preview.errors.length > 0
+                  ? "Fix the export problems listed above first"
+                  : undefined
             }
           >
             {busy === "deploy" && <span className="deploy-spinner" />}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -367,6 +367,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // sent back on Deploy. Both empty = the auto-detected default.
   const [include, setInclude] = useState<string[]>([]);
   const [exclude, setExclude] = useState<string[]>([]);
+  // True while a preview fetch is in flight — the shown "Will publish" list may
+  // not yet reflect the latest include/exclude edit, so Deploy is held until it
+  // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
+  const [previewPending, setPreviewPending] = useState(true);
 
   // The modal can be closed while an action is still running (#12): guard the
   // modal's own post-action setState so a deploy/revoke/install that resolves
@@ -401,6 +405,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const previewSeq = useRef(0);
   const refreshPreview = async (inc: string[], exc: string[]) => {
     const seq = ++previewSeq.current;
+    if (alive.current) setPreviewPending(true);
     const prev = await getDeployPreview(fsPath, inc, exc).catch(
       (e): DeployPreview => ({
         page: basename(fsPath),
@@ -410,7 +415,13 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         warnings: [],
       }),
     );
-    if (seq === previewSeq.current && alive.current) setPreview(prev);
+    // Only the latest request settles the view: a superseded fetch leaves both
+    // `preview` and `previewPending` for the newer one to resolve, so Deploy
+    // stays held until what's shown matches the current selection.
+    if (seq === previewSeq.current && alive.current) {
+      setPreview(prev);
+      setPreviewPending(false);
+    }
   };
 
   const load = async (background = false) => {
@@ -739,13 +750,20 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             type="button"
             className="deploy-primary"
             onClick={onDeploy}
-            // preview === null: the "will publish" resolution is still in flight
-            // (or was just cleared on a page switch), so we don't yet know the
-            // file set or whether there are export blockers — block Deploy until
-            // it lands rather than shipping blind.
-            disabled={busy !== null || env === null || preview === null || preview.errors.length > 0}
+            // Hold Deploy until the shown "Will publish" list matches the current
+            // selection: preview === null (still resolving, or cleared on a page
+            // switch) or previewPending (a refresh is in flight after an edit) both
+            // mean the list on screen may not reflect what a click would ship, so
+            // we don't deploy blind; preview.errors are hard export blockers.
+            disabled={
+              busy !== null ||
+              env === null ||
+              preview === null ||
+              previewPending ||
+              preview.errors.length > 0
+            }
             title={
-              preview === null
+              preview === null || previewPending
                 ? "Preparing the publish preview…"
                 : preview.errors.length > 0
                   ? "Fix the export problems listed above first"

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -21,9 +21,15 @@ import {
   getDeployStatus,
   installFused,
   revokeDeployment,
+  walkDir,
 } from "../lib/api";
-import type { DeployConfig, DeployPreview, Deployment } from "../lib/api";
-import { basename } from "../lib/format";
+import type { DeployConfig, DeployPreview, Deployment, WalkEntry } from "../lib/api";
+import { basename, dirname, formatSize } from "../lib/format";
+
+// A path's bundle key: what dedup/exclude match on. Mirrors the server's
+// _asset_key (export.py) for the common case — strip a leading "./"; the exact
+// literal is preserved elsewhere for display/tooltips.
+const relKey = (p: string) => p.replace(/^\.\//, "");
 
 interface DeployModalProps {
   fsPath: string;
@@ -56,11 +62,109 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-// What deploying would publish, resolved fresh from the page's on-disk state
-// (GET /api/deploy/preview) — shown BEFORE the click, and export blockers
-// disable Deploy with the exact list instead of a post-click failure.
-function PreviewSection({ preview }: { preview: DeployPreview }) {
+// What deploying would publish, resolved fresh from on-disk state
+// (POST /api/deploy/preview) with the user's include/exclude selection applied —
+// shown BEFORE the click. Export blockers disable Deploy with the exact list;
+// warnings are advisory. The list is editable: drop a file (× → exclude),
+// restore it, add extra files (a folder picker), add everything, or reset to the
+// auto-detected default.
+function FileSelection({
+  fsPath,
+  preview,
+  include,
+  exclude,
+  disabled,
+  setInclude,
+  setExclude,
+}: {
+  fsPath: string;
+  preview: DeployPreview;
+  include: string[];
+  exclude: string[];
+  disabled: boolean;
+  setInclude: (v: string[]) => void;
+  setExclude: (v: string[]) => void;
+}) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [dirFiles, setDirFiles] = useState<WalkEntry[] | null>(null);
+  const [dirTruncated, setDirTruncated] = useState(false);
+  const [walkBusy, setWalkBusy] = useState(false);
+  const [walkError, setWalkError] = useState<string | null>(null);
+
+  const pageBase = basename(fsPath);
+  const includeKeys = useMemo(() => new Set(include.map(relKey)), [include]);
+  const publishedKeys = useMemo(
+    () =>
+      new Set([
+        ...preview.entrypoints.map((e) => relKey(e.path)),
+        ...preview.assets.map((a) => relKey(a.path)),
+      ]),
+    [preview],
+  );
+
+  // × on a row → add to exclude. Exclude is applied last server-side and drops a
+  // file by key whether it was auto-detected OR manually included, so this always
+  // takes the file out of the bundle; "Restore" (remove from exclude) brings an
+  // auto/included file back. include is left untouched so a restore is lossless.
+  const removeRow = (path: string) => {
+    if (!exclude.some((e) => relKey(e) === relKey(path))) setExclude([...exclude, path]);
+  };
+  const restore = (path: string) => setExclude(exclude.filter((e) => relKey(e) !== relKey(path)));
+  // Adding files (picker / add-all): append to include and clear any exclusion of
+  // the same paths, so a previously-dropped file comes back.
+  const addFiles = (paths: string[]) => {
+    const fresh = paths.filter((p) => !includeKeys.has(relKey(p)));
+    if (fresh.length) setInclude([...include, ...fresh]);
+    const addedKeys = new Set(paths.map(relKey));
+    if (paths.some((p) => exclude.some((e) => relKey(e) === relKey(p))))
+      setExclude(exclude.filter((e) => !addedKeys.has(relKey(e))));
+  };
+  const reset = () => {
+    setInclude([]);
+    setExclude([]);
+  };
+
+  const loadDir = async (): Promise<WalkEntry[]> => {
+    setWalkBusy(true);
+    setWalkError(null);
+    try {
+      const r = await walkDir(dirname(fsPath));
+      const files = r.entries.filter((e) => !e.is_dir);
+      setDirFiles(files);
+      setDirTruncated(r.truncated);
+      return files;
+    } catch (e) {
+      setWalkError((e as Error).message);
+      return [];
+    } finally {
+      setWalkBusy(false);
+    }
+  };
+
+  const openPicker = () => {
+    setPickerOpen(true);
+    if (dirFiles === null) void loadDir();
+  };
+  const addAllInFolder = async () => {
+    const files = dirFiles ?? (await loadDir());
+    addFiles(
+      files
+        .map((f) => f.rel)
+        .filter((rel) => rel !== pageBase && !publishedKeys.has(relKey(rel))),
+    );
+  };
+
+  // Files on disk that aren't already published and aren't excluded — the picker's
+  // candidates. Excluded files live in their own "Excluded" list (with Restore).
+  const excludeKeys = useMemo(() => new Set(exclude.map(relKey)), [exclude]);
+  const available = (dirFiles ?? []).filter(
+    (f) =>
+      f.rel !== pageBase && !publishedKeys.has(relKey(f.rel)) && !excludeKeys.has(relKey(f.rel)),
+  );
+
   if (preview.errors.length > 0) {
+    // Blocking problems: no editable list — show the fix-it list. (The selection
+    // controls stay hidden until the page exports cleanly.)
     return (
       <div className="deploy-error">
         This page can't be deployed yet:
@@ -70,28 +174,134 @@ function PreviewSection({ preview }: { preview: DeployPreview }) {
       </div>
     );
   }
-  // Display each file as a plain relative name. The backend gives the page as a
-  // bare basename but entrypoints/assets as their literal fused.runPython/rawUrl
-  // argument, which usually carries a leading "./" — so the list mixed "sine.html"
-  // with "./sine.py". Strip a leading "./" for the shown text (one consistent root);
-  // the exact literal stays in the title tooltip so nothing is lost.
-  const rel = (p: string) => p.replace(/^\.\//, "");
+
+  const rows = [
+    ...preview.entrypoints.map((e) => ({
+      path: e.path,
+      label: relKey(e.path),
+      title: `fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`,
+      kind: "run" as const,
+    })),
+    ...preview.assets.map((a) => ({
+      path: a.path,
+      label: relKey(a.path),
+      title: includeKeys.has(relKey(a.path))
+        ? `included file — ${a.path}`
+        : `asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`,
+      kind: includeKeys.has(relKey(a.path)) ? ("added" as const) : ("asset" as const),
+    })),
+  ];
+
   return (
     <div className="deploy-preview">
-      <span className="deploy-muted">Will publish:</span>
-      <code>{rel(preview.page)}</code>
-      {preview.entrypoints.map((e) => (
-        <code key={"e" + e.path} title={`fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`}>
-          {rel(e.path)}
-        </code>
-      ))}
-      {preview.assets.map((a) => (
-        <code key={"a" + a.path} title={`asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`}>
-          {rel(a.path)}
-        </code>
-      ))}
-      {preview.entrypoints.length === 0 && preview.assets.length === 0 && (
-        <span className="deploy-muted">(the page only — no runPython/rawUrl targets)</span>
+      <div className="deploy-preview-head">
+        <span className="deploy-muted">Will publish:</span>
+        <div className="deploy-preview-actions">
+          <button type="button" onClick={openPicker} disabled={disabled}>
+            Add files…
+          </button>
+          <button type="button" onClick={() => void addAllInFolder()} disabled={disabled || walkBusy}>
+            {walkBusy ? "Scanning…" : "Add all in folder"}
+          </button>
+          {(include.length > 0 || exclude.length > 0) && (
+            <button type="button" onClick={reset} disabled={disabled}>
+              Reset to default
+            </button>
+          )}
+        </div>
+      </div>
+
+      <ul className="deploy-file-list">
+        <li className="deploy-file page">
+          <code title={preview.page}>{relKey(preview.page)}</code>
+          <span className="deploy-file-tag">page</span>
+        </li>
+        {rows.map((r) => (
+          <li key={r.kind + r.path} className="deploy-file">
+            <code title={r.title}>{r.label}</code>
+            {r.kind === "run" && <span className="deploy-file-tag">run</span>}
+            {r.kind === "added" && <span className="deploy-file-tag added">added</span>}
+            <button
+              type="button"
+              className="deploy-file-remove"
+              title="Remove from the bundle"
+              onClick={() => removeRow(r.path)}
+              disabled={disabled}
+            >
+              ✕
+            </button>
+          </li>
+        ))}
+        {rows.length === 0 && (
+          <li className="deploy-muted">(the page only — no runPython/rawUrl targets)</li>
+        )}
+      </ul>
+
+      {exclude.length > 0 && (
+        <div className="deploy-excluded">
+          <span className="deploy-muted">Excluded (won't be bundled):</span>
+          <ul className="deploy-file-list">
+            {exclude.map((p) => (
+              <li key={p} className="deploy-file excluded">
+                <code title={p}>{relKey(p)}</code>
+                <button
+                  type="button"
+                  className="deploy-file-restore"
+                  title="Add back to the bundle"
+                  onClick={() => restore(p)}
+                  disabled={disabled}
+                >
+                  Restore
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {pickerOpen && (
+        <div className="deploy-picker">
+          <div className="deploy-picker-head">
+            <span className="deploy-muted">Add files from this page's folder</span>
+            <button type="button" onClick={() => setPickerOpen(false)}>
+              Done
+            </button>
+          </div>
+          {walkBusy && <div className="deploy-muted">Scanning folder…</div>}
+          {walkError && <div className="deploy-error">{walkError}</div>}
+          {dirTruncated && (
+            <div className="deploy-note deploy-muted">
+              This folder is large — some files were omitted from the scan.
+            </div>
+          )}
+          {dirFiles !== null && !walkBusy && available.length === 0 && (
+            <div className="deploy-muted">
+              No other files to add — everything in the folder is already listed.
+            </div>
+          )}
+          {available.length > 0 && (
+            <ul className="deploy-picker-list">
+              {available.map((f) => (
+                <li key={f.rel}>
+                  <button type="button" onClick={() => addFiles([f.rel])} disabled={disabled}>
+                    + <code>{f.rel}</code>
+                    <span className="deploy-muted">{formatSize(f.size)}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {preview.warnings.length > 0 && (
+        <div className="deploy-warnings">
+          {preview.warnings.map((w, i) => (
+            <div key={i} className="deploy-warning">
+              ⚠ {w}
+            </div>
+          ))}
+        </div>
       )}
     </div>
   );
@@ -111,6 +321,12 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
   const [busy, setBusy] = useState<"deploy" | "revoke" | "install" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
+  // The user's file selection, layered on the auto-detected set: `include` adds
+  // extra files (as assets), `exclude` drops files. Seeded on open from the
+  // stored deployment record (so it reloads the last-published selection) and
+  // sent back on Deploy. Both empty = the auto-detected default.
+  const [include, setInclude] = useState<string[]>([]);
+  const [exclude, setExclude] = useState<string[]>([]);
 
   // The modal can be closed while an action is still running (#12): guard the
   // modal's own post-action setState so a deploy/revoke/install that resolves
@@ -137,6 +353,26 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // failure, leaves the current view intact instead of replacing it with an
   // error. The initial mount load (background=false) still shows "Loading…"
   // and surfaces a load error, since there is nothing to preserve yet.
+  // Preview (the "will publish" set) is a function of the page's on-disk state
+  // AND the current include/exclude — so it lives in its own seq-guarded fetch,
+  // re-run whenever fsPath or the selection changes (effect below) and on a
+  // background reconcile (to pick up on-disk edits). A fetch failure degrades to
+  // an export blocker so the form still renders with Deploy disabled.
+  const previewSeq = useRef(0);
+  const refreshPreview = async (inc: string[], exc: string[]) => {
+    const seq = ++previewSeq.current;
+    const prev = await getDeployPreview(fsPath, inc, exc).catch(
+      (e): DeployPreview => ({
+        page: basename(fsPath),
+        entrypoints: [],
+        assets: [],
+        errors: [(e as Error).message],
+        warnings: [],
+      }),
+    );
+    if (seq === previewSeq.current && alive.current) setPreview(prev);
+  };
+
   const load = async (background = false) => {
     const seq = ++loadSeq.current;
     if (!background) {
@@ -144,29 +380,27 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       setConfig(null);
     }
     try {
-      const [cfg, status, prev] = await Promise.all([
+      const [cfg, status] = await Promise.all([
         getDeployConfig(),
         getDeployStatus(fsPath, true),
-        // A preview failure (unexportable file type, file deleted since the
-        // header rendered, …) must not kill the whole dialog — degrade it to
-        // an export blocker: the form renders, the reason shows in the
-        // blocker list, and Deploy stays disabled.
-        getDeployPreview(fsPath).catch(
-          (e): DeployPreview => ({
-            page: basename(fsPath),
-            entrypoints: [],
-            assets: [],
-            errors: [(e as Error).message],
-          }),
-        ),
       ]);
       if (seq !== loadSeq.current) return;
       setLoadError(null);
       setConfig(cfg);
-      setPreview(prev);
       applyDeployment(status.deployment);
       setReconciled(status.reconciled);
       setLive(status.live ?? null);
+      // Seed the selection from the stored record on a fresh open (never on a
+      // background refresh — that would clobber the user's in-progress edits).
+      // Setting the state triggers the preview effect; a background load instead
+      // refreshes the preview explicitly (its inputs didn't change but the page
+      // on disk may have).
+      if (!background) {
+        setInclude(status.deployment?.include ?? []);
+        setExclude(status.deployment?.exclude ?? []);
+      } else {
+        void refreshPreview(include, exclude);
+      }
       // Preselect the deployment's env (or the default) — but only if it is
       // actually in the picker; an env removed from envs.json since deploy
       // must fall back to a selectable one, or the <select> renders blank
@@ -190,6 +424,13 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fsPath]);
+
+  // Re-resolve the "will publish" preview whenever the page or the selection
+  // changes (covers the initial seed from load, and every include/exclude edit).
+  useEffect(() => {
+    void refreshPreview(include, exclude);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [fsPath, include, exclude]);
 
   // Latest-ref pattern: `load` and `busy` are captured fresh every render, so
   // the focus effect below (which subscribes once) always calls the current
@@ -247,11 +488,15 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     setBusy("deploy");
     setActionError(null);
     try {
-      const record = await deployPage(fsPath, env.name);
+      const record = await deployPage(fsPath, env.name, include, exclude);
       applyDeployment(record);
       if (!alive.current) return;
       setReconciled(true);
       setLive("active");
+      // Re-seed from what was actually persisted, so the list reflects the
+      // stored record (e.g. server-side dedup) rather than the raw local lists.
+      setInclude(record.include ?? include);
+      setExclude(record.exclude ?? exclude);
     } catch (e) {
       // A deploy can fail AFTER the server mutated the pointer — the
       // failed-revive compensation path (deploy.py) persists status active or
@@ -418,7 +663,17 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
           </div>
         )}
 
-        {preview && <PreviewSection preview={preview} />}
+        {preview && (
+          <FileSelection
+            fsPath={fsPath}
+            preview={preview}
+            include={include}
+            exclude={exclude}
+            disabled={busy !== null}
+            setInclude={setInclude}
+            setExclude={setExclude}
+          />
+        )}
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
           <select

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -378,6 +378,13 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     if (!background) {
       setLoadError(null);
       setConfig(null);
+      // Drop the previous page's preview too (not just config): a fresh open —
+      // including an fsPath switch with the modal still mounted — must not leave
+      // last page's "Will publish" list on screen while the new fetch is in
+      // flight. FileSelection only renders when BOTH config and preview are set,
+      // so clearing preview keeps it hidden until the new page's preview lands —
+      // no stale rows, and no × / restore edit that could target the wrong page.
+      setPreview(null);
     }
     try {
       const [cfg, status] = await Promise.all([

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -183,9 +183,13 @@ function FileSelection({
     ) : null;
 
   if (preview.errors.length > 0) {
-    // Blocking problems: no editable list — show the fix-it list, plus any
-    // advisory warnings beneath it. (The selection controls stay hidden until the
-    // page exports cleanly.)
+    // Blocking problems: show the fix-it list. The full editable preview is
+    // unavailable (the scan failed), but a bad selection can BE the cause — a
+    // persisted `include` for a file that no longer exists fails the preview
+    // even when the page is fine. So still offer a recovery path: list the
+    // manually-included files with a remove, plus Reset — otherwise the modal
+    // traps the user with no way to clear the offending selection. (Only
+    // `include` can error; `exclude` just filters, so it's not shown here.)
     return (
       <>
         <div className="deploy-error">
@@ -194,6 +198,37 @@ function FileSelection({
             <div key={i}>• {e}</div>
           ))}
         </div>
+        {include.length > 0 && (
+          <div className="deploy-files">
+            <div className="deploy-files-body">
+              <span className="deploy-muted">
+                Files you added (remove one that no longer exists, or reset):
+              </span>
+              <ul className="deploy-file-list">
+                {include.map((p) => (
+                  <li key={p} className="deploy-file">
+                    <code title={p}>{relKey(p)}</code>
+                    <span className="deploy-file-tag added">added</span>
+                    <button
+                      type="button"
+                      className="deploy-file-action deploy-file-remove"
+                      title="Remove from the bundle"
+                      onClick={() => removeRow(p)}
+                      disabled={disabled}
+                    >
+                      ✕
+                    </button>
+                  </li>
+                ))}
+              </ul>
+              <div className="deploy-preview-actions">
+                <button type="button" onClick={reset} disabled={disabled}>
+                  Reset to default
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         {warningsBlock}
       </>
     );

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -380,6 +380,12 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // not yet reflect the latest include/exclude edit, so Deploy is held until it
   // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
   const [previewPending, setPreviewPending] = useState(true);
+  // False until `load` has seeded include/exclude from the deployment record on
+  // open. The preview effect is gated on this so we NEVER issue a preview for the
+  // initial empty selection (which would race the seeded request and could commit
+  // the default bundle after state already holds the persisted selection). The
+  // first — and only correct — preview request fires once the selection is known.
+  const [selectionReady, setSelectionReady] = useState(false);
   // Latest-ref mirrors of the selection. A background reconcile (load(true)) is
   // async: it must refresh the preview with the selection current at COMPLETION,
   // not the value captured when its closure was created — otherwise a focus/
@@ -447,6 +453,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     if (!background) {
       setLoadError(null);
       setConfig(null);
+      // Re-gate the preview until this load seeds the selection, so an fsPath
+      // switch can't issue/commit a preview for the old-or-empty selection.
+      setSelectionReady(false);
       // Drop the previous page's preview too (not just config): a fresh open —
       // including an fsPath switch with the modal still mounted — must not leave
       // last page's "Will publish" list on screen while the new fetch is in
@@ -474,6 +483,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       if (!background) {
         setInclude(status.deployment?.include ?? []);
         setExclude(status.deployment?.exclude ?? []);
+        // Selection is now known — open the gate; this (with the seeded include/
+        // exclude) triggers the effect to fetch the first, correct preview.
+        setSelectionReady(true);
       } else {
         // Refs, not the closure's include/exclude: this runs after the await, so
         // read the selection as it stands now (an edit may have landed meanwhile).
@@ -503,12 +515,14 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fsPath]);
 
-  // Re-resolve the "will publish" preview whenever the page or the selection
-  // changes (covers the initial seed from load, and every include/exclude edit).
+  // Re-resolve the "will publish" preview whenever the selection changes — but
+  // only once `load` has seeded it (selectionReady), so the initial empty
+  // selection never issues a preview that could race the seeded one.
   useEffect(() => {
+    if (!selectionReady) return;
     void refreshPreview(include, exclude);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fsPath, include, exclude]);
+  }, [fsPath, include, exclude, selectionReady]);
 
   // Latest-ref pattern: `load` and `busy` are captured fresh every render, so
   // the focus effect below (which subscribes once) always calls the current

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -171,16 +171,33 @@ function FileSelection({
       f.rel !== pageBase && !publishedKeys.has(relKey(f.rel)) && !excludeKeys.has(relKey(f.rel)),
   );
 
-  if (preview.errors.length > 0) {
-    // Blocking problems: no editable list — show the fix-it list. (The selection
-    // controls stay hidden until the page exports cleanly.)
-    return (
-      <div className="deploy-error">
-        This page can't be deployed yet:
-        {preview.errors.map((e, i) => (
-          <div key={i}>• {e}</div>
+  // Advisory (non-blocking) notes — shown whether or not there are blockers, since
+  // the backend can return both at once (SPEC DP-2a: warnings appear alongside).
+  const warningsBlock =
+    preview.warnings.length > 0 ? (
+      <div className="deploy-warnings">
+        {preview.warnings.map((w, i) => (
+          <div key={i} className="deploy-warning">
+            ⚠ {w}
+          </div>
         ))}
       </div>
+    ) : null;
+
+  if (preview.errors.length > 0) {
+    // Blocking problems: no editable list — show the fix-it list, plus any
+    // advisory warnings beneath it. (The selection controls stay hidden until the
+    // page exports cleanly.)
+    return (
+      <>
+        <div className="deploy-error">
+          This page can't be deployed yet:
+          {preview.errors.map((e, i) => (
+            <div key={i}>• {e}</div>
+          ))}
+        </div>
+        {warningsBlock}
+      </>
     );
   }
 
@@ -334,15 +351,7 @@ function FileSelection({
         </div>
       )}
 
-      {preview.warnings.length > 0 && (
-        <div className="deploy-warnings">
-          {preview.warnings.map((w, i) => (
-            <div key={i} className="deploy-warning">
-              ⚠ {w}
-            </div>
-          ))}
-        </div>
-      )}
+      {warningsBlock}
     </div>
   );
 }

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -371,6 +371,15 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // not yet reflect the latest include/exclude edit, so Deploy is held until it
   // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
   const [previewPending, setPreviewPending] = useState(true);
+  // Latest-ref mirrors of the selection. A background reconcile (load(true)) is
+  // async: it must refresh the preview with the selection current at COMPLETION,
+  // not the value captured when its closure was created — otherwise a focus/
+  // visibility reconcile finishing after an edit overwrites the list (and, being
+  // the newest fetch, wins the seq race) with a preview for the stale selection.
+  const includeRef = useRef(include);
+  includeRef.current = include;
+  const excludeRef = useRef(exclude);
+  excludeRef.current = exclude;
 
   // The modal can be closed while an action is still running (#12): guard the
   // modal's own post-action setState so a deploy/revoke/install that resolves
@@ -457,7 +466,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         setInclude(status.deployment?.include ?? []);
         setExclude(status.deployment?.exclude ?? []);
       } else {
-        void refreshPreview(include, exclude);
+        // Refs, not the closure's include/exclude: this runs after the await, so
+        // read the selection as it stands now (an edit may have landed meanwhile).
+        void refreshPreview(includeRef.current, excludeRef.current);
       }
       // Preselect the deployment's env (or the default) — but only if it is
       // actually in the picker; an env removed from envs.json since deploy

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -94,39 +94,36 @@ function FileSelection({
 
   const pageBase = basename(fsPath);
   const includeKeys = useMemo(() => new Set(include.map(relKey)), [include]);
-  const publishedKeys = useMemo(
-    () =>
-      new Set([
-        ...preview.entrypoints.map((e) => relKey(e.path)),
-        ...preview.assets.map((a) => relKey(a.path)),
-      ]),
-    [preview],
-  );
+  const excludeKeys = useMemo(() => new Set(exclude.map(relKey)), [exclude]);
+  // The page's default publish set (runPython/rawUrl/readFile literals), from the
+  // server — the authority on whether a file is auto-detected vs a manual include.
+  const autoKeys = useMemo(() => new Set(preview.auto.map(relKey)), [preview.auto]);
 
-  // × on a row. A manually-added file (in `include`) is simply dropped from
-  // `include` — it was never part of the default set, so it just goes away with
-  // no "Excluded" tombstone. An auto-detected file (a runPython entrypoint or a
-  // literally-referenced asset — the default publish set) is instead moved to
-  // `exclude`, which suppresses it AND surfaces it under "Excluded" with a
-  // Restore. So "Excluded" only ever lists files the page would publish by
-  // default, never the noise of add-all extras the user then removed.
+  // × on a row. Branch on whether the file is auto-detected (in the default set):
+  //  - auto → move to `exclude` (suppresses it even if it's ALSO in `include`, and
+  //    surfaces it under "Excluded" with a Restore); drop any stale include entry
+  //    so the lists stay clean. Excluding is the only way to remove an auto file,
+  //    since the page still references it.
+  //  - purely manual (in include, not auto) → just drop it from `include`; it was
+  //    never a default, so no "Excluded" tombstone.
   const removeRow = (path: string) => {
     const key = relKey(path);
-    if (includeKeys.has(key)) {
+    if (autoKeys.has(key)) {
+      if (includeKeys.has(key)) setInclude(include.filter((i) => relKey(i) !== key));
+      if (!excludeKeys.has(key)) setExclude([...exclude, path]);
+    } else {
       setInclude(include.filter((i) => relKey(i) !== key));
-    } else if (!exclude.some((e) => relKey(e) === key)) {
-      setExclude([...exclude, path]);
     }
   };
   const restore = (path: string) => setExclude(exclude.filter((e) => relKey(e) !== relKey(path)));
-  // Adding files (picker / add-all): append to include and clear any exclusion of
-  // the same paths, so a previously-dropped file comes back.
+  // Adding files (picker / add-all): append to `include` only. It never touches
+  // `exclude` — a deliberate exclusion must not be silently cleared by an add — so
+  // re-including an excluded file goes through Restore. Callers only ever pass
+  // candidates that are neither auto, already included, nor excluded (see
+  // `available`), so there's nothing to un-exclude here anyway.
   const addFiles = (paths: string[]) => {
     const fresh = paths.filter((p) => !includeKeys.has(relKey(p)));
     if (fresh.length) setInclude([...include, ...fresh]);
-    const addedKeys = new Set(paths.map(relKey));
-    if (paths.some((p) => exclude.some((e) => relKey(e) === relKey(p))))
-      setExclude(exclude.filter((e) => !addedKeys.has(relKey(e))));
   };
   const reset = () => {
     setInclude([]);
@@ -150,26 +147,27 @@ function FileSelection({
     }
   };
 
+  // A file on disk is a candidate to add when it isn't the page, isn't already in
+  // the default set, isn't already manually included, and isn't excluded (excluded
+  // files live in the "Excluded" list with Restore). Shared by the picker and
+  // "Add all in folder", so the two never re-add or un-exclude the same files.
+  const isCandidate = (rel: string) => {
+    const key = relKey(rel);
+    return (
+      rel !== pageBase && !autoKeys.has(key) && !includeKeys.has(key) && !excludeKeys.has(key)
+    );
+  };
+
   const openPicker = () => {
     setPickerOpen(true);
     if (dirFiles === null) void loadDir();
   };
   const addAllInFolder = async () => {
     const files = dirFiles ?? (await loadDir());
-    addFiles(
-      files
-        .map((f) => f.rel)
-        .filter((rel) => rel !== pageBase && !publishedKeys.has(relKey(rel))),
-    );
+    addFiles(files.map((f) => f.rel).filter(isCandidate));
   };
 
-  // Files on disk that aren't already published and aren't excluded — the picker's
-  // candidates. Excluded files live in their own "Excluded" list (with Restore).
-  const excludeKeys = useMemo(() => new Set(exclude.map(relKey)), [exclude]);
-  const available = (dirFiles ?? []).filter(
-    (f) =>
-      f.rel !== pageBase && !publishedKeys.has(relKey(f.rel)) && !excludeKeys.has(relKey(f.rel)),
-  );
+  const available = (dirFiles ?? []).filter((f) => isCandidate(f.rel));
 
   // Advisory (non-blocking) notes — shown whether or not there are blockers, since
   // the backend can return both at once (SPEC DP-2a: warnings appear alongside).
@@ -208,14 +206,21 @@ function FileSelection({
       title: `fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`,
       tag: "run" as const,
     })),
-    ...preview.assets.map((a) => ({
-      path: a.path,
-      label: relKey(a.path),
-      title: includeKeys.has(relKey(a.path))
-        ? `included file — ${a.path}`
-        : `asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`,
-      tag: includeKeys.has(relKey(a.path)) ? ("added" as const) : (null as null),
-    })),
+    ...preview.assets.map((a) => {
+      // "added" iff the file is NOT in the auto-detected set — a purely manual
+      // include. A file that's both referenced AND included reads as a normal
+      // asset (removing it must exclude, which the "added" affordance wouldn't
+      // convey), so auto-ness wins the label.
+      const manual = !autoKeys.has(relKey(a.path));
+      return {
+        path: a.path,
+        label: relKey(a.path),
+        title: manual
+          ? `included file — ${a.path}`
+          : `asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`,
+        tag: manual ? ("added" as const) : (null as null),
+      };
+    }),
   ];
 
   const publishCount = rows.length + 1; // + the page itself
@@ -435,6 +440,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         page: basename(fsPath),
         entrypoints: [],
         assets: [],
+        auto: [],
         errors: [(e as Error).message],
         warnings: [],
       }),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -317,6 +317,12 @@ export interface Deployment {
   url: string | null;
   status: "active" | "revoked";
   entrypoints: string[];
+  // The file selection this deployment was published with (persisted on the
+  // record, not a sidecar): extra files bundled beyond the auto-scan, and files
+  // dropped from it. Reopening the modal reloads these so the selection sticks.
+  // Optional — records written before this feature omit them (read as []).
+  include?: string[];
+  exclude?: string[];
   updated_at: string;
 }
 
@@ -352,6 +358,10 @@ export interface DeployPreview {
   entrypoints: { path: string; name: string }[];
   assets: { path: string; name: string }[];
   errors: string[];
+  // Advisory, non-blocking: a computed rawUrl/readFile path (bundle its target
+  // via include), or an exclude that drops a file the page references. Distinct
+  // from `errors`, which disable Deploy.
+  warnings: string[];
 }
 
 export interface SharesResult {
@@ -369,12 +379,23 @@ export function getDeployStatus(fsPath: string, reconcile: boolean): Promise<Dep
   return getJson<DeployStatusResult>(url);
 }
 
-export function getDeployPreview(fsPath: string): Promise<DeployPreview> {
-  return getJson<DeployPreview>("/api/deploy/preview?path=" + encodeURIComponent(fsPath));
+export function getDeployPreview(
+  fsPath: string,
+  include: string[],
+  exclude: string[],
+): Promise<DeployPreview> {
+  // POST (not GET) so the include/exclude selection travels in the body — arrays
+  // don't fit a query string cleanly. Read-only server-side (no files written).
+  return postJson<DeployPreview>("/api/deploy/preview", { path: fsPath, include, exclude });
 }
 
-export function deployPage(fsPath: string, env: string): Promise<Deployment> {
-  return postJson<Deployment>("/api/deploy", { page: fsPath, env });
+export function deployPage(
+  fsPath: string,
+  env: string,
+  include: string[],
+  exclude: string[],
+): Promise<Deployment> {
+  return postJson<Deployment>("/api/deploy", { page: fsPath, env, include, exclude });
 }
 
 export function revokeDeployment(fsPath: string): Promise<Deployment> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -357,6 +357,10 @@ export interface DeployPreview {
   page: string;
   entrypoints: { path: string; name: string }[];
   assets: { path: string; name: string }[];
+  // The auto-detected default set (literal runPython/rawUrl/readFile paths, before
+  // include/exclude). Lets the modal distinguish an auto file (removing → exclude,
+  // shown under "Excluded" with restore) from a manual include (removing → just drop).
+  auto: string[];
   errors: string[];
   // Advisory, non-blocking: a computed rawUrl/readFile path (bundle its target
   // via include), or an exclude that drops a file the page references. Distinct

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -22,3 +22,9 @@ export function basename(fsPath: string): string {
   const parts = fsPath.split("/").filter((s) => s.length > 0);
   return parts.length ? parts[parts.length - 1] : "/";
 }
+
+export function dirname(fsPath: string): string {
+  const idx = fsPath.replace(/\/+$/, "").lastIndexOf("/");
+  if (idx <= 0) return idx === 0 ? "/" : "";
+  return fsPath.slice(0, idx);
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1745,13 +1745,171 @@ body.embed .preview-browse-chip:hover {
   }
 }
 
-/* "Will publish:" preview — the page + each bundled runPython/rawUrl target
-   as compact chips. */
+/* "Will publish:" preview — the page + each bundled runPython/rawUrl target,
+   plus the user's include/exclude edits (add files, remove, restore, reset). */
 .deploy-preview {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.deploy-preview-head {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   flex-wrap: wrap;
+}
+
+.deploy-preview-actions {
+  display: flex;
   gap: 6px;
+  flex-wrap: wrap;
+}
+
+.deploy-preview-actions button {
+  font-size: 12px;
+  padding: 3px 8px;
+}
+
+.deploy-file-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.deploy-file {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 6px;
+  border-radius: 6px;
+}
+
+.deploy-file:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.deploy-file code {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deploy-file.excluded code {
+  text-decoration: line-through;
+  color: var(--fg-muted);
+}
+
+.deploy-file-tag {
+  flex: 0 0 auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0 6px;
+}
+
+.deploy-file-tag.added {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.deploy-file-remove,
+.deploy-file-restore {
+  flex: 0 0 auto;
+  font-size: 12px;
+  padding: 2px 6px;
+}
+
+.deploy-file-remove {
+  color: var(--fg-muted);
+}
+
+.deploy-file-remove:hover:not(:disabled) {
+  color: var(--error);
+}
+
+.deploy-excluded {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.deploy-picker {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.deploy-picker-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.deploy-picker-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.deploy-picker-list button {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  font: inherit;
+  background: none;
+  border: none;
+  color: var(--fg);
+  cursor: pointer;
+  padding: 3px 6px;
+  border-radius: 6px;
+}
+
+.deploy-picker-list button:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.deploy-picker-list code {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.deploy-warnings {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.deploy-warning {
+  color: var(--warning, #d9a441);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 /* ---- Preferences page (SPEC §20) ------------------------------------------ */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1794,7 +1794,7 @@ body.embed .preview-browse-chip:hover {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 0 12px 12px;
+  padding: 4px 12px 12px;
 }
 
 .deploy-preview-actions {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1745,20 +1745,56 @@ body.embed .preview-browse-chip:hover {
   }
 }
 
-/* "Will publish:" preview — the page + each bundled runPython/rawUrl target,
-   plus the user's include/exclude edits (add files, remove, restore, reset). */
-.deploy-preview {
+/* "Will publish" — a bordered, collapsible card holding the page + each bundled
+   runPython/rawUrl target plus the user's include/exclude edits (add files,
+   remove, restore, reset). Every row shares one 3-column grid — filename |
+   tag | action — so tags and the ✕/Restore buttons line up in fixed columns
+   regardless of which cells a given row fills. */
+.deploy-files {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Collapse toggle: a full-width header that reads as a section label, not a
+   button (no chrome), with the chevron + count inline. */
+.deploy-files-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  font: inherit;
+  color: var(--fg);
+  cursor: pointer;
+  text-align: left;
+}
+
+.deploy-files-chevron {
+  flex: 0 0 auto;
+  width: 12px;
+  color: var(--fg-muted);
+  font-size: 10px;
+}
+
+.deploy-files-title {
+  font-weight: 600;
+}
+
+.deploy-files-count {
+  margin-left: auto;
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.deploy-files-body {
   display: flex;
   flex-direction: column;
   gap: 8px;
-}
-
-.deploy-preview-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  flex-wrap: wrap;
+  padding: 0 12px 12px;
 }
 
 .deploy-preview-actions {
@@ -1779,15 +1815,18 @@ body.embed .preview-browse-chip:hover {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  max-height: 200px;
+  max-height: 220px;
   overflow-y: auto;
 }
 
+/* filename (flex-fills) | tag (fixed) | action (fixed) — shared by every row so
+   columns align across the publish and excluded lists. */
 .deploy-file {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 56px 72px;
   align-items: center;
-  gap: 8px;
-  padding: 3px 6px;
+  column-gap: 8px;
+  padding: 2px 4px;
   border-radius: 6px;
 }
 
@@ -1796,27 +1835,41 @@ body.embed .preview-browse-chip:hover {
 }
 
 .deploy-file code {
-  flex: 1 1 auto;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 8px;
 }
 
 .deploy-file.excluded code {
   text-decoration: line-through;
   color: var(--fg-muted);
+  background: none;
+}
+
+.deploy-file-empty {
+  padding: 4px;
 }
 
 .deploy-file-tag {
-  flex: 0 0 auto;
+  justify-self: center;
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--fg-muted);
   border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 0 6px;
+  padding: 1px 8px;
+}
+
+/* An empty tag cell keeps the column width without drawing a pill. */
+.deploy-file-tag.none {
+  border-color: transparent;
+  padding: 0;
 }
 
 .deploy-file-tag.added {
@@ -1824,11 +1877,13 @@ body.embed .preview-browse-chip:hover {
   border-color: var(--accent);
 }
 
-.deploy-file-remove,
-.deploy-file-restore {
-  flex: 0 0 auto;
+/* The action column: ✕ is centered, Restore fills it — both sit in the same
+   fixed column so they align down the list. */
+.deploy-file-action {
+  justify-self: stretch;
   font-size: 12px;
-  padding: 2px 6px;
+  padding: 3px 6px;
+  min-height: 24px;
 }
 
 .deploy-file-remove {
@@ -1837,6 +1892,7 @@ body.embed .preview-browse-chip:hover {
 
 .deploy-file-remove:hover:not(:disabled) {
   color: var(--error);
+  border-color: var(--error);
 }
 
 .deploy-excluded {
@@ -1889,6 +1945,12 @@ body.embed .preview-browse-chip:hover {
 
 .deploy-picker-list button:hover:not(:disabled) {
   background: rgba(255, 255, 255, 0.06);
+}
+
+.deploy-picker-add {
+  flex: 0 0 auto;
+  color: var(--accent);
+  font-weight: 600;
 }
 
 .deploy-picker-list code {

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -101,6 +101,19 @@ def _error(message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"error": message}, status_code=status)
 
 
+def _str_list(body: dict, key: str) -> list[str] | None:
+    """A JSON body field that must be a list of strings (absent/None -> []).
+
+    Returns None when the field is present but malformed (not a list, or holds a
+    non-string) so the caller can 400 rather than pass junk to the exporter."""
+    value = body.get(key)
+    if value is None:
+        return []
+    if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
+        return None
+    return value
+
+
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -520,7 +533,8 @@ def set_deployment(page: str, record: dict) -> None:
 
 
 def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
-                 entrypoints: list[str], fallback: dict | None) -> dict:
+                 entrypoints: list[str], include: list[str], exclude: list[str],
+                 fallback: dict | None) -> dict:
     token = raw.get("token") or raw.get("id") or (fallback or {}).get("token")
     if not isinstance(token, str) or not token:
         raise DeployError("the fused CLI did not return a mount token")
@@ -542,18 +556,28 @@ def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
         "url": url if isinstance(url, str) else None,
         "status": "active",
         "entrypoints": entrypoints,
+        # The file-selection the user deployed with, persisted here (not a separate
+        # sidecar) so reopening the modal reloads exactly what was published: extra
+        # files bundled beyond the auto-scan, and files dropped from it.
+        "include": include,
+        "exclude": exclude,
         "updated_at": _now_iso(),
     }
 
 
-def preview_deploy(page: str) -> dict:
+def preview_deploy(
+    page: str,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> dict:
     """What a deploy of `page` would publish, resolved fresh — no files written.
 
     The modal shows this BEFORE the Deploy click (the flow app's
     DeployPreview precedent): the page itself, each runPython target and the
-    route it becomes, each rawUrl/readFile asset — and any export blockers,
-    so an unexportable page reads as "fix these" up front instead of a failed
-    deploy. Same scan the real export runs (export.plan_export).
+    route it becomes, each rawUrl/readFile asset (plus the user's `include`,
+    minus `exclude`) — plus any export blockers and advisory warnings, so an
+    unexportable page reads as "fix these" up front instead of a failed deploy.
+    Same scan the real export runs (export.plan_export), with the same selection.
     """
     if not os.path.isfile(page):
         raise DeployError(f"no such file: {page}")
@@ -564,18 +588,30 @@ def preview_deploy(page: str) -> dict:
             html = f.read()
     except OSError as e:
         raise DeployError(f"cannot read {page}: {e}") from None
-    plan = plan_export(html, os.path.dirname(os.path.abspath(page)))
+    plan = plan_export(
+        html, os.path.dirname(os.path.abspath(page)), include=include, exclude=exclude
+    )
     return {
         "page": os.path.basename(page),
         "entrypoints": [{"path": e.path, "name": e.name} for e in plan.entrypoints],
         "assets": [{"path": a.path, "name": a.name} for a in plan.assets],
         "errors": plan.errors,
+        "warnings": plan.warnings,
     }
 
 
-def deploy_page(page: str, env_name: str) -> dict:
+def deploy_page(
+    page: str,
+    env_name: str,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> dict:
     """Export `page` to a temp bundle and publish it on `env_name`; returns the
     stored deployment record (token, URL when the backend returned one).
+
+    `include`/`exclude` are the user's file selection (see export.plan_export):
+    extra files bundled beyond the auto-scan, and files dropped from it. They are
+    persisted on the record so a reopened modal reloads the same selection.
 
     First deploy (or a pointer on a different env): `share create --public` —
     a fresh opaque capability URL. Redeploy on the same env keeps the URL:
@@ -583,6 +619,8 @@ def deploy_page(page: str, env_name: str) -> dict:
     recreate --same-token` then repoint (same URL comes back); token absent
     from `share list` entirely -> fresh create (nothing left to revive).
     """
+    include = include or []
+    exclude = exclude or []
     # Canonicalize up front so the direct locked store.get below, the record's
     # `page` field, and set_deployment all key on the same path as get_deployment
     # / deployment_status (all via _page_key) — one file, one pointer.
@@ -617,7 +655,7 @@ def deploy_page(page: str, env_name: str) -> dict:
 
     bundle = tempfile.mkdtemp(prefix="fused-render-deploy-")
     try:
-        plan = export_page(page, bundle)
+        plan = export_page(page, bundle, include=include, exclude=exclude)
         entrypoints = [e.name for e in plan.entrypoints]
 
         same_env = pointer if pointer and pointer.get("env") == env_name else None
@@ -666,7 +704,7 @@ def deploy_page(page: str, env_name: str) -> dict:
 
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
-            entrypoints=entrypoints, fallback=same_env,
+            entrypoints=entrypoints, include=include, exclude=exclude, fallback=same_env,
         )
         set_deployment(page, record)
         return record
@@ -863,12 +901,20 @@ def api_deploy_status(path: str, reconcile: str = "0"):
     return deployment_status(path, reconcile == "1")
 
 
-@router.get("/api/deploy/preview")
-def api_deploy_preview(path: str):
-    if not os.path.isabs(path):
+@router.post("/api/deploy/preview")
+def api_deploy_preview(body: dict = Body(...)):
+    # POST (not GET) because it carries the include/exclude selection — arrays
+    # don't fit a query string cleanly. Read-only (no files written), so no
+    # X-Fused guard, matching the former GET.
+    path = body.get("path")
+    if not isinstance(path, str) or not path or not os.path.isabs(path):
         return _error("'path' must be an absolute filesystem path")
+    include = _str_list(body, "include")
+    exclude = _str_list(body, "exclude")
+    if include is None or exclude is None:
+        return _error("'include'/'exclude' must be arrays of relative file paths")
     try:
-        return preview_deploy(path)
+        return preview_deploy(path, include, exclude)
     except DeployError as e:
         return _error(str(e))
 
@@ -894,8 +940,12 @@ def api_deploy(body: dict = Body(...), x_fused: str | None = Header(default=None
         return _error("'page' must be an absolute path to the .html page")
     if not env_name or not isinstance(env_name, str):
         return _error("'env' must name a hosted environment")
+    include = _str_list(body, "include")
+    exclude = _str_list(body, "exclude")
+    if include is None or exclude is None:
+        return _error("'include'/'exclude' must be arrays of relative file paths")
     try:
-        return deploy_page(page, env_name)
+        return deploy_page(page, env_name, include, exclude)
     except ExportError as e:
         return _error(str(e))
     except DeployError as e:

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -588,13 +588,19 @@ def preview_deploy(
             html = f.read()
     except OSError as e:
         raise DeployError(f"cannot read {page}: {e}") from None
-    plan = plan_export(
-        html, os.path.dirname(os.path.abspath(page)), include=include, exclude=exclude
-    )
+    page_dir = os.path.dirname(os.path.abspath(page))
+    plan = plan_export(html, page_dir, include=include, exclude=exclude)
+    # The auto-detected set (the literal runPython/rawUrl/readFile scan, before any
+    # include/exclude) — what the page publishes by DEFAULT. The modal uses it to
+    # tell an auto-detected file (removing it means excluding it, and it belongs in
+    # "Excluded" with a restore) from a purely manual include (removing it just
+    # drops it). Cheap: a second pure regex scan over the same HTML.
+    auto = plan_export(html, page_dir)
     return {
         "page": os.path.basename(page),
         "entrypoints": [{"path": e.path, "name": e.name} for e in plan.entrypoints],
         "assets": [{"path": a.path, "name": a.name} for a in plan.assets],
+        "auto": [e.path for e in auto.entrypoints] + [a.path for a in auto.assets],
         "errors": plan.errors,
         "warnings": plan.warnings,
     }

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -103,11 +103,19 @@ class Asset:
 
 @dataclass
 class ExportPlan:
-    """What an export will bundle, plus any blocking problems found while scanning."""
+    """What an export will bundle, plus any problems found while scanning.
+
+    ``errors`` are blocking (``export_page`` raises; Deploy is disabled). ``warnings``
+    are advisory and never block — a computed ``rawUrl``/``readFile`` path (whose target
+    the user can bundle via an explicit include) or an ``exclude`` that drops a
+    literally-referenced file (which will 404 when hosted). The user chose to ship it;
+    the note explains the consequence.
+    """
 
     entrypoints: list[Entrypoint] = field(default_factory=list)
     assets: list[Asset] = field(default_factory=list)
     errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
 
 def _slugify(stem: str) -> str:
@@ -140,6 +148,17 @@ def _route_name(rel_path: str, taken: set[str]) -> str:
         n += 1
     taken.add(name)
     return name
+
+
+def _asset_key(path: str) -> str:
+    """The bundle-relative asset key for a page-relative ``path``.
+
+    ``removeprefix``, NOT ``lstrip``: ``lstrip("./")`` strips any leading run of
+    ``.``/``/`` chars, mangling dotfiles (``./.env`` -> ``env``). ``normpath`` already
+    collapses ``./x`` to ``x``; this only guards a residual ``./``. Shared by the
+    ``rawUrl``/``readFile`` scan and the manual-include loop so a file reachable both
+    ways lands on the same key (and is bundled once)."""
+    return os.path.normpath(path).replace(os.sep, "/").removeprefix("./")
 
 
 def _literal_paths(html: str, method: str) -> list[str]:
@@ -192,14 +211,39 @@ def _within_page_dir(page_dir: str, target: str) -> bool:
     return real == root or real.startswith(root + os.sep)
 
 
-def plan_export(html: str, page_dir: str) -> ExportPlan:
+def plan_export(
+    html: str,
+    page_dir: str,
+    *,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> ExportPlan:
     """Scan a page's HTML and build an :class:`ExportPlan` (pure — no files written).
 
     Resolves each literal ``runPython``/``rawUrl``/``readFile`` path against ``page_dir``,
-    recording blocking problems (dynamic paths, unsupported API, unsafe/missing files) in
-    ``plan.errors`` rather than raising — so a caller can report them all at once.
+    recording blocking problems (dynamic ``runPython`` paths, unsupported API,
+    unsafe/missing files) in ``plan.errors`` rather than raising — so a caller can report
+    them all at once.
+
+    The auto-detected set is then adjusted by the user's selection:
+
+      * ``include`` — extra page-relative files to bundle as read-only assets (beyond
+        the literal ``rawUrl``/``readFile`` scan). Each goes through the same safety
+        gauntlet as a scanned asset; a bad one is a blocking error. This is how a file
+        reached by a *computed* path (a warning, below) or read at runtime by a bundled
+        ``.py`` actually gets into the bundle.
+      * ``exclude`` — page-relative paths (or their bundle key) to drop from the final
+        set. Dropping a literally-referenced target is honored but warned (that call
+        404s when hosted).
+
+    A computed (non-literal) ``rawUrl``/``readFile`` path is a **warning**, not an error:
+    the exporter can't discover the target, but the user can bundle it via ``include``.
+    A computed ``runPython`` path stays a hard error (its served route name is derived
+    from the literal path — there is nothing to route a computed call to).
     """
     plan = ExportPlan()
+    include = include or []
+    exclude = exclude or []
 
     for m in _UNSUPPORTED.finditer(html):
         api = m.group(1)
@@ -208,13 +252,20 @@ def plan_export(html: str, page_dir: str) -> ExportPlan:
             "immutable and has no filesystem); remove it before exporting"
         )
 
-    for method in ("runPython", "rawUrl", "readFile"):
-        dyn = _dynamic_call_count(html, method)
-        if dyn > 0:
-            plan.errors.append(
-                f"{dyn} fused.{method}() call(s) use a non-literal (computed) path; the "
-                "exporter can only bundle string-literal paths known at build time"
-            )
+    dyn_run = _dynamic_call_count(html, "runPython")
+    if dyn_run > 0:
+        plan.errors.append(
+            f"{dyn_run} fused.runPython() call(s) use a non-literal (computed) path; a "
+            "hosted entrypoint's route name is derived from its literal path, so a "
+            "computed runPython target cannot be bundled or routed"
+        )
+    dyn_asset = sum(_dynamic_call_count(html, method) for method in ("rawUrl", "readFile"))
+    if dyn_asset > 0:
+        plan.warnings.append(
+            f"{dyn_asset} fused.rawUrl()/readFile() call(s) use a computed path the "
+            "exporter can't resolve — add the files those calls fetch under \"Include "
+            "files\" (or \"Add all in folder\") so they are bundled and served"
+        )
 
     taken_names: set[str] = set()
     for path in _literal_paths(html, "runPython"):
@@ -241,6 +292,7 @@ def plan_export(html: str, page_dir: str) -> ExportPlan:
     # runtime — which looks up by the exact string the page passed — never 404s. They
     # share one key/file, so the bundle stores the bytes once.
     seen_asset_paths: set[str] = set()
+    seen_asset_keys: set[str] = set()
     for method in ("rawUrl", "readFile"):
         for path in _literal_paths(html, method):
             if path in seen_asset_paths:
@@ -257,12 +309,66 @@ def plan_export(html: str, page_dir: str) -> ExportPlan:
             if not os.path.isfile(src):
                 plan.errors.append(f"{method} target {path!r} not found next to the page ({src})")
                 continue
-            # removeprefix, NOT lstrip: lstrip("./") strips any leading run of
-            # '.'/'/' chars, mangling dotfiles ("./.env" -> "env"). normpath
-            # already collapses "./x" to "x"; this only guards a residual "./".
-            key = os.path.normpath(path).replace(os.sep, "/").removeprefix("./")
+            key = _asset_key(path)
             seen_asset_paths.add(path)
+            seen_asset_keys.add(key)
             plan.assets.append(Asset(path=path, name=key, file=f"assets/{key}"))
+
+    # Manual includes: extra files bundled as assets, keyed the same way. A file already
+    # brought in by the literal scan (same key) is skipped — bundled once. An unsafe or
+    # missing include is a blocking error, like a scanned asset that doesn't exist.
+    for path in include:
+        key = _asset_key(path)
+        if key in seen_asset_keys:
+            continue
+        if not _reject_unsafe_rel(path, "included file", plan.errors):
+            continue
+        src = os.path.join(page_dir, path)
+        if not _within_page_dir(page_dir, src):
+            plan.errors.append(
+                f"included file {path!r} resolves outside the page directory "
+                "(a symlink escaping the bundle); only files under the page can be bundled"
+            )
+            continue
+        if not os.path.isfile(src):
+            plan.errors.append(f"included file {path!r} not found next to the page ({src})")
+            continue
+        seen_asset_keys.add(key)
+        plan.assets.append(Asset(path=path, name=key, file=f"assets/{key}"))
+
+    # Excludes drop matching entrypoints/assets by their literal path OR bundle key.
+    # Dropping something the page literally references is the user's call, but warned —
+    # the served page's call to it will 404. Manually-included files (not referenced)
+    # drop silently.
+    if exclude:
+        drop_keys = {_asset_key(p) for p in exclude}
+        drop_raw = set(exclude)
+
+        def _excluded(path: str) -> bool:
+            return path in drop_raw or _asset_key(path) in drop_keys
+
+        kept_entrypoints = []
+        for e in plan.entrypoints:
+            if _excluded(e.path):
+                plan.warnings.append(
+                    f"excluding {e.path!r}, which the page runs via fused.runPython() — "
+                    "that call will fail on the hosted page"
+                )
+            else:
+                kept_entrypoints.append(e)
+        plan.entrypoints = kept_entrypoints
+
+        kept_assets = []
+        for a in plan.assets:
+            if _excluded(a.path):
+                if a.path in seen_asset_paths:  # a literally-referenced asset, not just an include
+                    plan.warnings.append(
+                        f"excluding {a.path!r}, which the page fetches via "
+                        "fused.rawUrl()/readFile() — that fetch will 404 on the hosted page"
+                    )
+            else:
+                kept_assets.append(a)
+        plan.assets = kept_assets
 
     return plan
 
@@ -285,13 +391,21 @@ def _manifest(plan: ExportPlan, page_file: str) -> dict:
     }
 
 
-def export_page(html_path: str, out_dir: str) -> ExportPlan:
+def export_page(
+    html_path: str,
+    out_dir: str,
+    *,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> ExportPlan:
     """Export the page at ``html_path`` into a portable bundle at ``out_dir``.
 
     Writes ``page.html``, ``manifest.json``, ``code/<name>.py`` per ``runPython`` target,
-    and ``assets/<key>`` per ``rawUrl``/``readFile`` target. Raises :class:`ExportError`
-    on any blocking problem (dynamic path, unsupported API, unsafe/missing file) with all
-    problems listed at once. Returns the realized :class:`ExportPlan` on success.
+    and ``assets/<key>`` per ``rawUrl``/``readFile`` target (plus any ``include`` files,
+    minus any ``exclude`` — see :func:`plan_export`). Raises :class:`ExportError` on any
+    blocking problem (dynamic runPython path, unsupported API, unsafe/missing file) with
+    all problems listed at once; advisory ``plan.warnings`` never block. Returns the
+    realized :class:`ExportPlan` on success.
     """
     import json
 
@@ -306,7 +420,7 @@ def export_page(html_path: str, out_dir: str) -> ExportPlan:
         html = f.read()
     page_dir = os.path.dirname(html_path)
 
-    plan = plan_export(html, page_dir)
+    plan = plan_export(html, page_dir, include=include, exclude=exclude)
     if plan.errors:
         raise ExportError(
             "cannot export "

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -315,11 +315,15 @@ def plan_export(
             plan.assets.append(Asset(path=path, name=key, file=f"assets/{key}"))
 
     # Manual includes: extra files bundled as assets, keyed the same way. A file already
-    # brought in by the literal scan (same key) is skipped — bundled once. An unsafe or
-    # missing include is a blocking error, like a scanned asset that doesn't exist.
+    # brought in by the literal scan (same key) is skipped — bundled once. A file already
+    # bundled as a runPython ENTRYPOINT is skipped too (compare by asset key): it is
+    # served as a route from code/<name>.py, so also copying it under assets/ would ship
+    # the bytes twice and list it as both an entrypoint and an asset. An unsafe or missing
+    # include is a blocking error, like a scanned asset that doesn't exist.
+    entrypoint_keys = {_asset_key(e.path) for e in plan.entrypoints}
     for path in include:
         key = _asset_key(path)
-        if key in seen_asset_keys:
+        if key in seen_asset_keys or key in entrypoint_keys:
             continue
         if not _reject_unsafe_rel(path, "included file", plan.errors):
             continue

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1684,8 +1684,16 @@ def create_app(start_dir: str) -> FastAPI:
         if not out or not os.path.isabs(out):
             return _error("'out' must be an absolute path to the output directory")
 
+        # Optional file selection (same as the Deploy modal): extra files to bundle
+        # beyond the literal-call scan, and files to drop from it. Absent -> auto-only.
+        include = body.get("include") or []
+        exclude = body.get("exclude") or []
+        for name, value in (("include", include), ("exclude", exclude)):
+            if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
+                return _error(f"'{name}' must be an array of relative file paths")
+
         try:
-            plan = export_page(page, out)
+            plan = export_page(page, out, include=include, exclude=exclude)
         except ExportError as e:
             return _error(str(e))
 
@@ -1693,6 +1701,7 @@ def create_app(start_dir: str) -> FastAPI:
             "out": os.path.abspath(out),
             "entrypoints": [{"path": e.path, "name": e.name, "file": e.file} for e in plan.entrypoints],
             "assets": [{"path": a.path, "name": a.name, "file": a.file} for a in plan.assets],
+            "warnings": plan.warnings,
         }
 
     return app

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -38,8 +38,18 @@ command -v npm >/dev/null || { echo "npm not found — the dev loop needs Node 2
   exit 1
 }
 
+# Install deps when they're missing OR stale. `node_modules/.package-lock.json`
+# is npm's own record of the last install; if the real package-lock.json is
+# newer than it (a dependency bump, or a branch switch that changed the lock),
+# node_modules no longer matches the manifest and the build fails on a missing
+# module — reinstall to reconcile. `-nt` also fires when the marker is absent
+# entirely (never installed, or a non-npm install left no marker), so a
+# markerless node_modules self-heals on the next run.
 if [[ ! -d "$FRONTEND/node_modules" ]]; then
   echo "==> npm install (first run)"
+  (cd "$FRONTEND" && npm install --no-audit --no-fund)
+elif [[ "$FRONTEND/package-lock.json" -nt "$FRONTEND/node_modules/.package-lock.json" ]]; then
+  echo "==> npm install (package-lock.json changed since last install)"
   (cd "$FRONTEND" && npm install --no-audit --no-fund)
 fi
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -381,6 +381,30 @@ def test_deploy_creates_public_share_and_stores_pointer(tmp_path, monkeypatch):
     assert h.pointer()["token"] == "abc123"
 
 
+def test_deploy_bundles_included_file_and_persists_selection(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    (tmp_path / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "include": ["data.csv"], "exclude": []},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    record = resp.json()
+    # The selection is persisted on the record itself (no sidecar), so a reopened
+    # modal reloads it.
+    assert record["include"] == ["data.csv"]
+    assert record["exclude"] == []
+    assert h.pointer()["include"] == ["data.csv"]
+
+    # The included file was actually bundled as an asset alongside the auto scan.
+    (call,) = h.calls()
+    assert call["bundle_files"] == ["assets", "code", "manifest.json", "page.html"]
+
+
 def test_redeploy_active_mount_repoints_same_token(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
@@ -807,14 +831,32 @@ def test_shares_urls_stay_null_with_no_recorded_link_to_derive_from(tmp_path, mo
 
 def test_preview_lists_what_would_be_published(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    resp = h.client.get("/api/deploy/preview", params={"path": str(h.page)})
+    resp = h.client.post("/api/deploy/preview", json={"path": str(h.page)})
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["page"] == "view.html"
     assert body["entrypoints"] == [{"path": "./sine.py", "name": "sine"}]
     assert body["assets"] == []
     assert body["errors"] == []
+    assert body["warnings"] == []
     assert h.calls() == []  # a preview is a pure local scan — no CLI, no files
+
+
+def test_preview_applies_include_and_exclude(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    (tmp_path / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    # Include a file the scan can't see; exclude the auto-detected entrypoint.
+    resp = h.client.post(
+        "/api/deploy/preview",
+        json={"path": str(h.page), "include": ["data.csv"], "exclude": ["./sine.py"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["entrypoints"] == []  # sine.py excluded
+    assert [a["path"] for a in body["assets"]] == ["data.csv"]  # include added
+    assert body["errors"] == []
+    # excluding a literally-referenced target warns (its call will fail when hosted)
+    assert any("sine.py" in w for w in body["warnings"])
 
 
 def test_preview_reports_export_blockers(tmp_path, monkeypatch):
@@ -823,14 +865,14 @@ def test_preview_reports_export_blockers(tmp_path, monkeypatch):
         "<html><body><script>fused.writeFile('/x', 'y');</script></body></html>",
         encoding="utf-8",
     )
-    body = h.client.get("/api/deploy/preview", params={"path": str(h.page)}).json()
+    body = h.client.post("/api/deploy/preview", json={"path": str(h.page)}).json()
     assert len(body["errors"]) == 1
     assert "writeFile" in body["errors"][0]
 
 
 def test_preview_rejects_non_html(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    resp = h.client.get("/api/deploy/preview", params={"path": str(tmp_path / "sine.py")})
+    resp = h.client.post("/api/deploy/preview", json={"path": str(tmp_path / "sine.py")})
     assert resp.status_code == 400
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -837,6 +837,7 @@ def test_preview_lists_what_would_be_published(tmp_path, monkeypatch):
     assert body["page"] == "view.html"
     assert body["entrypoints"] == [{"path": "./sine.py", "name": "sine"}]
     assert body["assets"] == []
+    assert body["auto"] == ["./sine.py"]  # the default set, before any selection
     assert body["errors"] == []
     assert body["warnings"] == []
     assert h.calls() == []  # a preview is a pure local scan — no CLI, no files
@@ -854,6 +855,9 @@ def test_preview_applies_include_and_exclude(tmp_path, monkeypatch):
     body = resp.json()
     assert body["entrypoints"] == []  # sine.py excluded
     assert [a["path"] for a in body["assets"]] == ["data.csv"]  # include added
+    # `auto` is the default set and ignores the selection — sine.py stays listed
+    # so the UI knows excluding it (not data.csv) belongs in "Excluded".
+    assert body["auto"] == ["./sine.py"]
     assert body["errors"] == []
     # excluding a literally-referenced target warns (its call will fail when hosted)
     assert any("sine.py" in w for w in body["warnings"])

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -39,6 +39,69 @@ def test_dynamic_path_is_an_error(tmp_path):
     assert any("non-literal" in e for e in plan.errors)
 
 
+def test_dynamic_asset_path_is_a_warning_not_an_error(tmp_path):
+    # A computed rawUrl/readFile path can't be resolved, but the user can bundle
+    # its target via include — so it warns rather than blocking the deploy.
+    html = "<script>const z = 2; fused.rawUrl(`./tiles/${z}.png`); fused.readFile(u);</script>"
+    plan = plan_export(html, str(tmp_path))
+    assert not plan.errors
+    assert any("computed path" in w for w in plan.warnings)
+
+
+def test_include_bundles_an_unreferenced_file(tmp_path):
+    html = "<script>fused.runPython('./sine.py', {});</script>"
+    _write(tmp_path, "sine.py", "def main():\n    return 1\n")
+    _write(tmp_path, "data/points.csv", "a,b\n1,2\n")
+    plan = plan_export(html, str(tmp_path), include=["data/points.csv"])
+    assert not plan.errors
+    assert [(a.path, a.name, a.file) for a in plan.assets] == [
+        ("data/points.csv", "data/points.csv", "assets/data/points.csv")
+    ]
+
+
+def test_include_missing_or_unsafe_file_is_an_error(tmp_path):
+    plan = plan_export("<html></html>", str(tmp_path), include=["nope.csv", "/etc/passwd"])
+    assert any("not found" in e for e in plan.errors)
+    assert any("absolute" in e for e in plan.errors)
+
+
+def test_include_of_referenced_file_dedups(tmp_path):
+    html = "<script>fused.rawUrl('./logo.png');</script>"
+    _write(tmp_path, "logo.png", "PNG")
+    # Same file reached by both the scan and an include (spelled without "./").
+    plan = plan_export(html, str(tmp_path), include=["logo.png"])
+    assert not plan.errors
+    assert [a.name for a in plan.assets] == ["logo.png"]  # bundled once
+
+
+def test_exclude_drops_asset_and_warns_when_referenced(tmp_path):
+    html = "<script>fused.rawUrl('./logo.png'); fused.rawUrl('./keep.png');</script>"
+    _write(tmp_path, "logo.png", "PNG")
+    _write(tmp_path, "keep.png", "PNG")
+    plan = plan_export(html, str(tmp_path), exclude=["./logo.png"])
+    assert not plan.errors
+    assert [a.name for a in plan.assets] == ["keep.png"]
+    assert any("logo.png" in w for w in plan.warnings)
+
+
+def test_exclude_drops_entrypoint_and_warns(tmp_path):
+    html = "<script>fused.runPython('./sine.py', {});</script>"
+    _write(tmp_path, "sine.py", "def main():\n    return 1\n")
+    plan = plan_export(html, str(tmp_path), exclude=["./sine.py"])
+    assert plan.entrypoints == []
+    assert any("sine.py" in w and "runPython" in w for w in plan.warnings)
+
+
+def test_exclude_drops_manual_include_silently(tmp_path):
+    _write(tmp_path, "data.csv", "a,b\n1,2\n")
+    plan = plan_export(
+        "<html></html>", str(tmp_path), include=["data.csv"], exclude=["data.csv"]
+    )
+    assert not plan.errors
+    assert plan.assets == []
+    assert plan.warnings == []  # dropping an unreferenced include is not warned
+
+
 def test_unsupported_api_is_an_error(tmp_path):
     html = "<script>fused.writeFile('./x.txt', 'hi'); fused.stat('./y');</script>"
     plan = plan_export(html, str(tmp_path))
@@ -201,8 +264,6 @@ def test_dotfile_asset_key_not_mangled(tmp_path):
 
 
 def test_symlink_escaping_page_dir_rejected(tmp_path):
-    import os
-
     outside = tmp_path / "outside"
     outside.mkdir()
     (outside / "secret.py").write_text("def main():\n    return 'leak'\n")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -65,6 +65,17 @@ def test_include_missing_or_unsafe_file_is_an_error(tmp_path):
     assert any("absolute" in e for e in plan.errors)
 
 
+def test_include_of_runpython_target_is_not_duplicated(tmp_path):
+    # A persisted include that names a file the page ALSO runs via runPython must
+    # not bundle it twice (once as code/<name>.py, once as assets/<key>).
+    html = "<script>fused.runPython('./sine.py', {});</script>"
+    _write(tmp_path, "sine.py", "def main():\n    return 1\n")
+    plan = plan_export(html, str(tmp_path), include=["sine.py"])
+    assert not plan.errors
+    assert [e.path for e in plan.entrypoints] == ["./sine.py"]
+    assert plan.assets == []  # not also added as an asset
+
+
 def test_include_of_referenced_file_dedups(tmp_path):
     html = "<script>fused.rawUrl('./logo.png');</script>"
     _write(tmp_path, "logo.png", "PNG")

--- a/tests/test_server_export.py
+++ b/tests/test_server_export.py
@@ -57,8 +57,47 @@ def test_export_success(tmp_path):
     data = resp.json()
     assert data["out"] == os.path.abspath(str(out_dir))
     assert [e["path"] for e in data["entrypoints"]] == ["./sine.py"]
+    assert data["warnings"] == []
     assert (out_dir / "page.html").is_file()
     assert (out_dir / "manifest.json").is_file()
+
+
+def test_export_honors_include_and_exclude(tmp_path):
+    html = "<script>fused.runPython('./sine.py', {});</script>"
+    _write(tmp_path, "page.html", html)
+    _write(tmp_path, "sine.py", "def main():\n    return 1\n")
+    _write(tmp_path, "data.csv", "a,b\n1,2\n")
+    out_dir = tmp_path / "bundle"
+
+    client = _client(tmp_path)
+    resp = client.post(
+        "/api/export",
+        json={
+            "page": str(tmp_path / "page.html"),
+            "out": str(out_dir),
+            "include": ["data.csv"],
+            "exclude": ["./sine.py"],
+        },
+        headers={"X-Fused": "1"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["entrypoints"] == []  # sine.py excluded
+    assert [a["path"] for a in data["assets"]] == ["data.csv"]  # include bundled
+    assert (out_dir / "assets" / "data.csv").is_file()
+    assert any("sine.py" in w for w in data["warnings"])
+
+
+def test_export_rejects_bad_include_type(tmp_path):
+    _write(tmp_path, "page.html", "<html></html>")
+    client = _client(tmp_path)
+    resp = client.post(
+        "/api/export",
+        json={"page": str(tmp_path / "page.html"), "out": str(tmp_path / "out"), "include": "x"},
+        headers={"X-Fused": "1"},
+    )
+    assert resp.status_code == 400
+    assert "include" in resp.json()["error"]
 
 
 def test_export_error_is_400(tmp_path):


### PR DESCRIPTION
## Summary

This PR adds user-controlled file selection to the Deploy modal, allowing users to manually include extra files and exclude files from the bundle beyond what the auto-detection scan discovers. The feature includes a visual file picker, restore/remove buttons, and persists the selection on deployment records.

## Key Changes

**Frontend (DeployModal & FileSelection)**
- Renamed `PreviewSection` to `FileSelection` and significantly expanded it with interactive controls
- Added "Add files…" button that opens a folder picker (via new `walkDir` API)
- Added "Add all in folder" button to bulk-include available files
- Added "Reset to default" button to clear manual selections
- Each published file now has a remove (×) button; excluded files show in a separate list with restore buttons
- File list displays tags (page/run/added) and file sizes in the picker
- Integrated `include` and `exclude` state management, seeded from stored deployment records on modal open
- Added visual distinction for excluded files (strikethrough) and added files (accent color tag)

**Backend Export Logic (export.py)**
- Added `include` and `exclude` parameters to `plan_export()` function
- Implemented `_asset_key()` helper to normalize paths consistently (strips leading `./`)
- Manual includes are validated like scanned assets (safety checks, existence verification)
- Deduplication by key ensures files reached both ways are bundled once
- Changed computed `rawUrl`/`readFile` paths from errors to **warnings** (not blocking)
- Computed `runPython` paths remain hard errors (route names can't be derived)
- Added warnings for excluded files that are literally referenced (will 404 when hosted)

**Deploy API (deploy.py)**
- Updated `preview_deploy()` to accept and apply `include`/`exclude` parameters
- Updated `deploy_page()` to accept and persist file selection on deployment records
- Added `_str_list()` helper for safe JSON list parsing
- Selection is stored on the deployment record itself (not a sidecar) so reopening the modal reloads the exact published set

**API Types & Endpoints**
- Added `WalkEntry` type for directory listing results
- Extended `DeployPreview` interface with `warnings` field
- Extended `Deployment` interface with optional `include`/`exclude` fields
- Changed `/api/deploy/preview` from GET to POST to accept body parameters
- Added `/api/walk` endpoint for directory traversal (with truncation for large folders)

**Styling (shell.css)**
- New `.deploy-file-list` with scrollable container and hover states
- File tags (page/run/added) with distinct styling
- Remove/restore buttons with appropriate colors and hover effects
- File picker modal with its own list and "Done" button
- Warnings section for advisory messages

**Tests**
- Added comprehensive tests for include/exclude behavior (dedup, validation, warnings)
- Updated preview tests to verify warnings field
- Added deploy test verifying selection persistence on records
- Added export endpoint tests for include/exclude with validation

## Notable Implementation Details

- **Path normalization**: Uses `_asset_key()` to strip leading `./` consistently across frontend and backend, enabling proper deduplication
- **Lossless restore**: Exclude is applied last server-side, so removing from exclude brings back both auto-detected and manually-included files
- **Graceful degradation**: Preview fetch failures degrade to export blockers rather than crashing the modal
- **Selection persistence**: Stored on deployment records so the modal reloads the exact published set when reopened
- **Warnings vs. errors**: Computed asset paths are warnings (user can bundle via include), while computed runPython paths remain errors (can't be routed)

https://claude.ai/code/session_01WB8V9EvHGYJurY7AbbRPuP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deploy/export bundle composition and API contracts (preview GET→POST); wrong selection can ship pages that 404 at runtime, though blockers and warnings mitigate that.
> 
> **Overview**
> Adds **include/exclude** layering on top of the auto-detected export set so deploy and manual export can bundle extra page-relative files and drop others, with the choice **persisted on the deployment record** and reloaded when the modal reopens.
> 
> **Export (`plan_export` / `/api/export`)** splits rules: computed **`runPython`** paths stay blocking errors; computed **`rawUrl`/`readFile`** become **warnings** (bundle targets via `include`). **`_asset_key`** normalizes paths for dedup; excludes warn when they drop literally referenced files. Responses add **`warnings`**.
> 
> **Deploy API** threads selection through **`POST /api/deploy/preview`** (was GET), **`POST /api/deploy`**, and **`preview_deploy`/`deploy_page`**; preview returns **`auto`** (default scan) plus **`warnings`**.
> 
> **Deploy modal** replaces the static preview with an editable **“Will publish”** panel: folder picker via **`walkDir`**, add-all, remove/restore, reset, and **Deploy** gated until preview matches the current selection (no blind deploy).
> 
> Docs (**SPEC**, **EXPORT.md**) and tests cover the new behavior; **`scripts/dev.sh`** reinstalls npm deps when **`package-lock.json`** is newer than the install marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb9b0a84c128ca7e3a3e995fd4e5a7ef27256c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->