### PR TITLE
Upgrade pinned fused dependency to 2.9.3.post2

### DIFF
--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -163,7 +163,7 @@ def fused_cli() -> FusedCli | None:
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
 PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post1-py3-none-any.whl"
+    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post2-py3-none-any.whl"
 )
 # The wheel's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ app = [
 # The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post1-py3-none-any.whl ; python_version >= "3.11"',
+    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post2-py3-none-any.whl ; python_version >= "3.11"',
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
Updates the pinned version of the `fused` package from 2.9.3.post1 to 2.9.3.post2 across the codebase.

## Key Changes
- Updated `PINNED_FUSED_REQUIREMENT` in `fused_render/deploy.py` to reference the new wheel version
- Updated the corresponding dependency specification in `pyproject.toml` to match the pinned requirement

## Implementation Details
Both the deploy modal's one-click install requirement and the project's optional dependency specification have been synchronized to use the same wheel version (2.9.3.post2), maintaining consistency between the two locations as enforced by existing tests.

https://claude.ai/code/session_01MfVK8SrU8cT2Mpe7XLFi5P

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only dependency pin with no application logic changes; misaligned pins would be caught by tests.
> 
> **Overview**
> Bumps the pinned **`fused`** wheel from **2.9.3.post1** to **2.9.3.post2** so deploy one-click install, optional `[fused]` installs, and hosted execution stay on the same build.
> 
> **`PINNED_FUSED_REQUIREMENT`** in `deploy.py` (used by `POST /api/deploy/install`) and the **`[project.optional-dependencies].fused`** URL in `pyproject.toml` are updated together; existing tests still require those two strings to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42a1c430f5c981d51824ff93404491cb91cd010e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->