### PR TITLE
perf(prefetch): size-gate small files, bound the maps, async I/O model

### DIFF
--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -18,9 +18,21 @@ rclone's fingerprint check invalidates it if the object changes upstream.
 
 Triggered from the /api/fs/raw proxy (the one path every remote byte
 already flows through — templates stay mount-agnostic), so scheduling
-must be cheap, non-blocking, and never raise. Everything slow (the HEAD
-for the size gate, the download) happens on a daemon worker thread; a
-process-wide semaphore keeps at most one file prefetching at a time.
+must be cheap, non-blocking, and never raise. `schedule()` just records
+the job and submits a coroutine to a single dedicated prefetch event loop
+(one background thread for the whole process, not one thread per file —
+a zarr store's thousands of chunk reads would otherwise mint thousands of
+threads). The blocking urllib calls run via asyncio.to_thread on that
+loop's bounded shared executor.
+
+Two phases with very different cost profiles, kept separate:
+  1. Decide — a HEAD for the size gate. Cheap; runs immediately and
+     concurrently for every scheduled file, so a sub-MIN_BYTES chunk is
+     dismissed in one round trip without waiting behind anything.
+  2. Stream — the whole-file download. Expensive; serialized by an
+     asyncio semaphore (one file at a time: two big streams would evict
+     each other from the LRU serve cache) and delayed by START_DELAY_S so
+     the interactive read that triggered us wins its first cold seeks.
 
 The serve surfaces transient store errors as HTTP 500s mid-stream
 (observed on S3), so the worker fetches in ranged chunks and resumes with
@@ -29,6 +41,7 @@ costs nothing. A completed file is remembered for this server run only;
 re-prefetching after a restart re-streams from the local cache in
 seconds without touching the store.
 """
+import asyncio
 import logging
 import os
 import threading
@@ -60,7 +73,10 @@ MAX_TRACKED = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_TRACKED", 2048))
 ENABLED = os.environ.get("FUSED_RENDER_PREFETCH", "1") != "0"
 
 CHUNK_BYTES = 32 * 1024 * 1024
-# Let the interactive load that triggered us win the first cold seeks.
+# Applies to the DOWNLOAD phase only, not the size-gate HEAD: once a file
+# clears the gate, let the interactive load that triggered us win its
+# first cold seeks before the whole-file stream starts competing for the
+# store's bandwidth.
 START_DELAY_S = 5.0
 # Between chunks, hold off while the file is being read interactively —
 # but never indefinitely: prefetching IS the fix for those slow reads.
@@ -72,7 +88,15 @@ FAILED_RETRY_COOLDOWN_S = 60.0
 _lock = threading.Lock()
 _jobs: dict = {}     # path -> {"status", "size", "done", "at"}
 _touched: dict = {}  # path -> monotonic time of last interactive access
-_worker_slot = threading.Semaphore(1)
+
+# Single dedicated event loop for all prefetch work, spun up lazily on the
+# first schedule() and run on one daemon thread. Keeps schedule() a plain
+# sync call usable from anywhere (request handlers, tests) while the actual
+# I/O runs as coroutines off the caller's thread.
+_loop_lock = threading.Lock()
+_loop: "asyncio.AbstractEventLoop | None" = None
+# Serializes the download phase (created on the loop; see _acquire_slot).
+_download_slot: "asyncio.Semaphore | None" = None
 
 
 def status() -> dict:
@@ -109,6 +133,20 @@ def is_done(path: str) -> bool:
         return bool(job and job["status"] == "done")
 
 
+def _ensure_loop() -> "asyncio.AbstractEventLoop":
+    """Start (once) the background prefetch event loop and return it."""
+    global _loop
+    if _loop is not None:
+        return _loop
+    with _loop_lock:
+        if _loop is None:
+            loop = asyncio.new_event_loop()
+            threading.Thread(target=loop.run_forever, daemon=True,
+                             name="prefetch-loop").start()
+            _loop = loop
+    return _loop
+
+
 def schedule(path: str, url: str) -> None:
     """Note that `path` (served at `url`) is being read; start a background
     prefetch unless one already ran. Called on the raw-proxy hot path:
@@ -128,17 +166,9 @@ def schedule(path: str, url: str) -> None:
             _jobs[path] = {"status": "queued", "size": None, "done": 0,
                            "at": now}
             _evict_locked()
-        threading.Thread(target=_run, args=(path, url), daemon=True).start()
+        asyncio.run_coroutine_threadsafe(_prefetch(path, url), _ensure_loop())
     except Exception:                                  # pragma: no cover
         logger.warning("prefetch schedule failed for %r", path, exc_info=True)
-
-
-def _run(path: str, url: str) -> None:
-    try:
-        _prefetch(path, url)
-    except Exception:
-        logger.warning("prefetch of %r died", path, exc_info=True)
-        _finish(path, "failed")
 
 
 def _finish(path: str, status_: str) -> None:
@@ -168,21 +198,50 @@ def _head_size(url: str) -> int | None:
         return int(cl) if cl is not None else None
 
 
-def _wait_for_lull(path: str) -> None:
+def _fetch_chunk(url: str, off: int, end: int, path: str) -> int:
+    """Fetch bytes [off, end] through the serve and discard them (the point
+    is the serve's cache side effect); update the job's progress as bytes
+    land. Returns the new offset. Blocking — run via asyncio.to_thread."""
+    req = urllib.request.Request(url)
+    req.add_header("Range", f"bytes={off}-{end}")
+    with urllib.request.urlopen(req, timeout=120) as r:
+        while True:
+            b = r.read(1024 * 1024)
+            if not b:
+                break
+            off += len(b)
+            with _lock:
+                if path in _jobs:
+                    _jobs[path]["done"] = off
+    return off
+
+
+async def _acquire_slot() -> "asyncio.Semaphore":
+    """The download semaphore, created lazily on the loop thread (so it
+    binds to this loop). Runs single-threaded here, so no lock needed."""
+    global _download_slot
+    if _download_slot is None:
+        _download_slot = asyncio.Semaphore(1)
+    return _download_slot
+
+
+async def _wait_for_lull(path: str) -> None:
     start = time.monotonic()
     while time.monotonic() - start < MAX_IDLE_HOLD_S:
         with _lock:
             last = _touched.get(path, 0.0)
         if time.monotonic() - last >= IDLE_WAIT_S:
             return
-        time.sleep(0.5)
+        await asyncio.sleep(0.5)
 
 
-def _prefetch(path: str, url: str) -> None:
-    time.sleep(START_DELAY_S)
-    with _worker_slot:
+async def _prefetch(path: str, url: str) -> None:
+    try:
+        # Phase 1 — decide. No delay, no download slot: the HEAD is cheap
+        # and gates whether we bother at all, so it runs immediately and
+        # concurrently with every other scheduled file's HEAD.
         try:
-            size = _head_size(url)
+            size = await asyncio.to_thread(_head_size, url)
         except Exception as exc:
             _release(exc)
             _finish(path, "failed")
@@ -195,34 +254,33 @@ def _prefetch(path: str, url: str) -> None:
             if job is not None:
                 job.update(status="running", size=size)
 
-        off, errors = 0, 0
-        while off < size:
-            _wait_for_lull(path)
-            end = min(off + CHUNK_BYTES, size) - 1
-            try:
-                req = urllib.request.Request(url)
-                req.add_header("Range", f"bytes={off}-{end}")
-                with urllib.request.urlopen(req, timeout=120) as r:
-                    while True:
-                        b = r.read(1024 * 1024)
-                        if not b:
-                            break
-                        off += len(b)
-                        with _lock:
-                            if path in _jobs:
-                                _jobs[path]["done"] = off
-                errors = 0
-            except Exception as exc:
-                _release(exc)
-                errors += 1
-                if errors > MAX_CONSECUTIVE_ERRORS:
-                    logger.warning("prefetch of %r gave up at %d/%d bytes",
-                                   path, off, size)
-                    _finish(path, "failed")
-                    return
-                # Resume at `off`: everything fetched so far is already in
-                # the serve's cache, so a re-request of it replays locally.
-                time.sleep(min(2.0 * errors, 30.0))
-        _finish(path, "done")
-        logger.info("prefetched %r (%d bytes) into the serve cache",
-                    path, size)
+        # Phase 2 — stream. Expensive, so one file at a time, and only
+        # after START_DELAY_S so the triggering interactive read gets ahead.
+        await asyncio.sleep(START_DELAY_S)
+        async with await _acquire_slot():
+            off, errors = 0, 0
+            while off < size:
+                await _wait_for_lull(path)
+                end = min(off + CHUNK_BYTES, size) - 1
+                try:
+                    off = await asyncio.to_thread(
+                        _fetch_chunk, url, off, end, path)
+                    errors = 0
+                except Exception as exc:
+                    _release(exc)
+                    errors += 1
+                    if errors > MAX_CONSECUTIVE_ERRORS:
+                        logger.warning("prefetch of %r gave up at %d/%d bytes",
+                                       path, off, size)
+                        _finish(path, "failed")
+                        return
+                    # Resume at `off`: everything fetched so far is already
+                    # in the serve's cache, so re-requesting it replays
+                    # locally.
+                    await asyncio.sleep(min(2.0 * errors, 30.0))
+            _finish(path, "done")
+            logger.info("prefetched %r (%d bytes) into the serve cache",
+                        path, size)
+    except Exception:
+        logger.warning("prefetch of %r died", path, exc_info=True)
+        _finish(path, "failed")

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -43,6 +43,20 @@ logger = logging.getLogger(__name__)
 # the cap the on-demand path still works exactly as before.
 MAX_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_BYTES",
                                1024 * 1024 * 1024))
+# Skip files smaller than this. Prefetch only pays off for large,
+# latency-bound files whose scattered reads dominate (see the module
+# docstring): a zarr chunk or a tiny metadata object is read once, whole,
+# and fast on-demand — streaming it through the serve to warm a cache the
+# redirected client never reads back is pure waste, and one tracked job
+# per chunk is how the maps below blow up on a store with thousands of
+# them. Below the floor the on-demand path is already quick.
+MIN_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MIN_BYTES",
+                               16 * 1024 * 1024))
+# Bound the in-memory maps: a store with thousands of tiny objects would
+# otherwise mint a permanent entry per object for the life of the process.
+# Only terminal jobs are evicted (oldest first); the MIN_BYTES floor keeps
+# most chunk churn out of the maps entirely, so this is a backstop.
+MAX_TRACKED = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_TRACKED", 2048))
 ENABLED = os.environ.get("FUSED_RENDER_PREFETCH", "1") != "0"
 
 CHUNK_BYTES = 32 * 1024 * 1024
@@ -65,6 +79,24 @@ def status() -> dict:
     """Snapshot of all jobs (introspection/tests)."""
     with _lock:
         return {p: dict(j) for p, j in _jobs.items()}
+
+
+def _evict_locked() -> None:
+    """Drop oldest terminal jobs (and their touch times) once the maps
+    exceed MAX_TRACKED. Caller must hold `_lock`. Queued/running jobs are
+    never evicted — losing one would strand an in-flight download's
+    status; a completed job only means a slightly slower next read (it
+    re-prefetches from the local cache in seconds, see docstring)."""
+    if len(_jobs) <= MAX_TRACKED:
+        return
+    terminal = sorted(
+        (j["at"], p) for p, j in _jobs.items()
+        if j["status"] in ("done", "skipped", "failed"))
+    for _, p in terminal:
+        if len(_jobs) <= MAX_TRACKED:
+            break
+        _jobs.pop(p, None)
+        _touched.pop(p, None)
 
 
 def is_done(path: str) -> bool:
@@ -95,6 +127,7 @@ def schedule(path: str, url: str) -> None:
                     return
             _jobs[path] = {"status": "queued", "size": None, "done": 0,
                            "at": now}
+            _evict_locked()
         threading.Thread(target=_run, args=(path, url), daemon=True).start()
     except Exception:                                  # pragma: no cover
         logger.warning("prefetch schedule failed for %r", path, exc_info=True)
@@ -154,7 +187,7 @@ def _prefetch(path: str, url: str) -> None:
             _release(exc)
             _finish(path, "failed")
             return
-        if size is None or size > MAX_BYTES:
+        if size is None or not (MIN_BYTES <= size <= MAX_BYTES):
             _finish(path, "skipped")
             return
         with _lock:

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -106,15 +106,21 @@ def status() -> dict:
 
 
 def _evict_locked() -> None:
-    """Drop oldest terminal jobs (and their touch times) once the maps
-    exceed MAX_TRACKED. Caller must hold `_lock`. Queued/running jobs are
-    never evicted — losing one would strand an in-flight download's
-    status; a completed job only means a slightly slower next read (it
-    re-prefetches from the local cache in seconds, see docstring)."""
+    """Evict terminal jobs least-recently-*read* once the maps exceed
+    MAX_TRACKED. Caller must hold `_lock`. Queued/running jobs are never
+    evicted — losing one would strand an in-flight download's status.
+
+    Ordered by `_touched` (last interactive access), NOT completion time:
+    `schedule` refreshes `_touched` on every read, so a `done` file still
+    being read stays warm and keeps its `is_done` routing. Evicting a hot
+    `done` entry would flip `is_done` false for a file still in use, send
+    its next read back down the cold redirect path, and re-trigger a
+    whole-file prefetch. A genuinely stale entry only costs a slightly
+    slower next read (it re-prefetches from the local cache in seconds)."""
     if len(_jobs) <= MAX_TRACKED:
         return
     terminal = sorted(
-        (j["at"], p) for p, j in _jobs.items()
+        (_touched.get(p, j["at"]), p) for p, j in _jobs.items()
         if j["status"] in ("done", "skipped", "failed"))
     for _, p in terminal:
         if len(_jobs) <= MAX_TRACKED:

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -51,7 +51,7 @@ MAX_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_BYTES",
 # per chunk is how the maps below blow up on a store with thousands of
 # them. Below the floor the on-demand path is already quick.
 MIN_BYTES = int(os.environ.get("FUSED_RENDER_PREFETCH_MIN_BYTES",
-                               16 * 1024 * 1024))
+                               8 * 1024 * 1024))
 # Bound the in-memory maps: a store with thousands of tiny objects would
 # otherwise mint a permanent entry per object for the life of the process.
 # Only terminal jobs are evicted (oldest first); the MIN_BYTES floor keeps

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -153,6 +153,28 @@ def test_evicts_oldest_terminal_jobs_over_cap(fast, monkeypatch):
         stub.close()
 
 
+def test_eviction_is_lru_by_access_not_completion(fast, monkeypatch):
+    # A done file still being read must survive; the least-recently-read
+    # one is dropped first. Otherwise is_done routing flaps and an in-use
+    # file gets re-prefetched.
+    monkeypatch.setattr(prefetch_mod, "MAX_TRACKED", 2)
+    stub = StubServe(b"a" * 50)
+    try:
+        for p in ("/m/old.bin", "/m/mid.bin"):
+            prefetch_mod.schedule(p, stub.url)
+            wait_status(p, "done")
+        # Re-read old.bin: touches it even though it completed first.
+        prefetch_mod.schedule("/m/old.bin", stub.url)   # done -> touch only
+        # New file trips the cap; least-recently-read (mid.bin) is evicted.
+        prefetch_mod.schedule("/m/new.bin", stub.url)
+        wait_status("/m/new.bin", "done")
+        st = prefetch_mod.status()
+        assert "/m/old.bin" in st       # recently re-read -> survives
+        assert "/m/mid.bin" not in st   # least-recently-read -> evicted
+    finally:
+        stub.close()
+
+
 def test_schedule_is_idempotent(fast):
     stub = StubServe(b"y" * 500)
     try:

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -68,7 +68,6 @@ def fast(monkeypatch):
     in milliseconds; shrink the chunk so multi-chunk paths are exercised."""
     monkeypatch.setattr(prefetch_mod, "_jobs", {})
     monkeypatch.setattr(prefetch_mod, "_touched", {})
-    monkeypatch.setattr(prefetch_mod, "_worker_slot", threading.Semaphore(1))
     monkeypatch.setattr(prefetch_mod, "START_DELAY_S", 0.0)
     monkeypatch.setattr(prefetch_mod, "IDLE_WAIT_S", 0.0)
     monkeypatch.setattr(prefetch_mod, "MAX_IDLE_HOLD_S", 0.0)
@@ -120,6 +119,21 @@ def test_size_gate_skips_small_files(fast, monkeypatch):
     try:
         prefetch_mod.schedule("/m/chunk.bin", stub.url)
         wait_status("/m/chunk.bin", "skipped")
+        assert not any(r[0] == "GET" for r in stub.requests)
+    finally:
+        stub.close()
+
+
+def test_size_gate_decides_without_start_delay(fast, monkeypatch):
+    # The gate HEAD runs before START_DELAY (delay applies to the download
+    # phase only), so a sub-floor file is dismissed immediately even with a
+    # long delay configured — no 5s wait to decide not to prefetch.
+    monkeypatch.setattr(prefetch_mod, "START_DELAY_S", 30.0)
+    monkeypatch.setattr(prefetch_mod, "MIN_BYTES", 1000)
+    stub = StubServe(b"x" * 100)
+    try:
+        prefetch_mod.schedule("/m/chunk.bin", stub.url)
+        wait_status("/m/chunk.bin", "skipped", timeout=5.0)   # << 30s delay
         assert not any(r[0] == "GET" for r in stub.requests)
     finally:
         stub.close()

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -73,6 +73,8 @@ def fast(monkeypatch):
     monkeypatch.setattr(prefetch_mod, "IDLE_WAIT_S", 0.0)
     monkeypatch.setattr(prefetch_mod, "MAX_IDLE_HOLD_S", 0.0)
     monkeypatch.setattr(prefetch_mod, "CHUNK_BYTES", 1024)
+    # Tests use tiny payloads; drop the size floor so they aren't skipped.
+    monkeypatch.setattr(prefetch_mod, "MIN_BYTES", 0)
     monkeypatch.setattr(prefetch_mod, "ENABLED", True)
 
 
@@ -107,6 +109,32 @@ def test_size_gate_skips_large_files(fast, monkeypatch):
         prefetch_mod.schedule("/m/big.bin", stub.url)
         wait_status("/m/big.bin", "skipped")
         assert not any(r[0] == "GET" for r in stub.requests)
+    finally:
+        stub.close()
+
+
+def test_size_gate_skips_small_files(fast, monkeypatch):
+    # A zarr chunk / tiny metadata object: below the floor, never streamed.
+    monkeypatch.setattr(prefetch_mod, "MIN_BYTES", 1000)
+    stub = StubServe(b"x" * 100)
+    try:
+        prefetch_mod.schedule("/m/chunk.bin", stub.url)
+        wait_status("/m/chunk.bin", "skipped")
+        assert not any(r[0] == "GET" for r in stub.requests)
+    finally:
+        stub.close()
+
+
+def test_evicts_oldest_terminal_jobs_over_cap(fast, monkeypatch):
+    # Thousands of chunks would otherwise mint a permanent entry each; the
+    # map stays bounded by evicting oldest terminal jobs.
+    monkeypatch.setattr(prefetch_mod, "MAX_TRACKED", 2)
+    stub = StubServe(b"a" * 50)
+    try:
+        for i in range(5):
+            prefetch_mod.schedule(f"/m/f{i}.bin", stub.url)
+            wait_status(f"/m/f{i}.bin", "done")
+        assert len(prefetch_mod.status()) <= 2
     finally:
         stub.close()
 


### PR DESCRIPTION
Follow-up to #149 review findings (prefetch double-read + unbounded map growth), plus an async restructure of the worker.

## Problem
`shell/prefetch.py` streams a whole file through the rclone serve in the background so future scattered reads replay from the local VFS cache — a big win for large, latency-bound files (a cold sort on a 644MB parquet drops from ~30s to disk-speed). But #149 made whole-file GETs 307-redirect to the store, and costs surfaced for zarr/netcdf stores made of **thousands of tiny chunk objects**:

1. **Double-read waste** — the redirected client reads each chunk from the store directly, then the background worker re-streams the same chunk through the serve to warm a cache the client never reads back.
2. **Unbounded growth** — every distinct chunk path minted a permanent `_jobs`/`_touched` entry (no eviction), leaking memory for the life of the process.
3. **Thread + latency storm** — `schedule()` spawned one daemon thread per distinct path, and the size-gate HEAD sat behind a 5s delay *and* the single download semaphore, so thousands of chunks meant thousands of threads each sleeping 5s then serializing a pointless HEAD.

## Fix
- **`MIN_BYTES` floor (8Mi, `FUSED_RENDER_PREFETCH_MIN_BYTES`)**: skip files too small to benefit. **Size — not redirect-vs-proxy — is the correct discriminator**: cold reads of a big parquet always hit the redirect path first, so gating on the redirect branch would disable prefetch entirely.
- **`MAX_TRACKED` cap** (2048, `FUSED_RENDER_PREFETCH_MAX_TRACKED`): evict terminal jobs so the maps stay bounded; queued/running jobs are never dropped. Eviction is **LRU by last access** (`_touched`), not completion time — since `schedule()` refreshes `_touched` on every read, a `done` file still in use stays warm and keeps its `is_done` routing.
- **Async I/O model**: replace thread-per-path with a single dedicated `asyncio` loop; blocking `urllib` runs via `asyncio.to_thread` on its bounded shared executor. Thousands of chunk reads are now cheap coroutines on one loop thread instead of thousands of daemon threads. **Zero new dependencies** (stdlib `urllib` kept).
- **Phase split**: the size-gate HEAD (cheap) runs immediately and concurrently — off the download semaphore, no `START_DELAY`. A sub-floor chunk is dismissed in one round trip instead of sleeping 5s and queueing behind the download slot. Only the whole-file *stream* (expensive) stays serialized and delayed.

`schedule()` remains a plain sync call (submits via `run_coroutine_threadsafe`); public API and behavior unchanged.

## Tests
Added `test_size_gate_skips_small_files`, `test_evicts_oldest_terminal_jobs_over_cap`, `test_size_gate_decides_without_start_delay`, and `test_eviction_is_lru_by_access_not_completion`. Full suite: 762 passed, 3 skipped.

## Review
Cursor Bugbot flagged "Done eviction breaks active warm routing" — fixed in ae83ea0 by ordering eviction by `_touched` (LRU) rather than completion `at`.

## Not addressed here
Each distinct chunk path still incurs one HEAD on its first read before the floor skips it (now cheap and concurrent, no longer thread-backed or serialized). Eliminating the HEAD entirely would need a size source that avoids a round trip (e.g. piggybacking a listing the daemon already did), which reopens the stat-free-redirect tradeoff from #149 — deliberately out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)