### PR TITLE
Templates UI: remove Reveal, always-visible row actions

### DIFF
--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -3332,7 +3332,7 @@ body.embed .preview-browse-chip:hover {
   margin-left: 6px;
 }
 
-/* Row-hover-only ghost action buttons. */
+/* Ghost action buttons. */
 .templates-ghost-btn {
   font: inherit;
   font-size: 12px;
@@ -3342,12 +3342,6 @@ body.embed .preview-browse-chip:hover {
   background: none;
   color: var(--fg-muted);
   cursor: pointer;
-  opacity: 0;
-}
-
-.templates-inv-table tr:hover .templates-ghost-btn,
-.templates-ghost-btn:focus-visible {
-  opacity: 1;
 }
 
 .templates-ghost-btn.danger:hover {

--- a/frontend/src/views/templates/InventoryPanel.tsx
+++ b/frontend/src/views/templates/InventoryPanel.tsx
@@ -4,7 +4,6 @@ import {
   downloadTemplatesExport,
   openTemplateInClaude,
   rawUrl,
-  revealPath,
 } from "../../lib/api";
 import type { InventoryTemplate, TemplateInventory } from "../../lib/api";
 import { navigate } from "../../lib/router";
@@ -37,18 +36,10 @@ export function InventoryPanel({
       return next;
     });
 
-  // Reveal/Open target the template's absolute folder path from the inventory
+  // Open targets the template's absolute folder path from the inventory
   // (works for core under .core-templates AND user), NOT a dir derived from the
   // user registry. Open reuses the file explorer's navigate() (Listing.tsx),
   // which stats the path and shows the directory listing.
-  const reveal = async (path: string) => {
-    setError(null);
-    try {
-      await revealPath(path);
-    } catch (e) {
-      setError((e as Error).message);
-    }
-  };
   const open = (path: string) => {
     navigate(path);
   };
@@ -174,7 +165,6 @@ export function InventoryPanel({
                     checked={selected.has(t.name)}
                     onToggle={() => toggle(t.name)}
                     onExport={() => runExport([t.name])}
-                    onReveal={() => reveal(t.path)}
                     onOpen={() => open(t.path)}
                     onOpenInClaude={g.source.editable ? () => openClaude(t.name) : undefined}
                     onDelete={g.source.editable ? () => setDeleting(t) : undefined}
@@ -350,7 +340,6 @@ function InventoryRow({
   checked,
   onToggle,
   onExport,
-  onReveal,
   onOpen,
   onOpenInClaude,
   onDelete,
@@ -359,7 +348,6 @@ function InventoryRow({
   checked: boolean;
   onToggle: () => void;
   onExport: () => void;
-  onReveal: () => void;
   onOpen: () => void;
   onOpenInClaude?: () => void; // only for editable (user) sources; core is read-only
   onDelete?: () => void; // only for editable (user) sources; core is undeletable
@@ -400,9 +388,6 @@ function InventoryRow({
       <td className="templates-inv-actions">
         <button type="button" className="templates-ghost-btn" onClick={onExport} title="Export this template as a zip">
           Export
-        </button>
-        <button type="button" className="templates-ghost-btn" onClick={onReveal} title="Reveal in Finder">
-          Reveal
         </button>
         <button type="button" className="templates-ghost-btn" onClick={onOpen} title="Open the folder in the file explorer">
           Open


### PR DESCRIPTION
## Summary
- Remove **Reveal** action from the template inventory panel (button, callback plumbing, unused helper/import). The `/api/fs/reveal` endpoint and `revealPath()` API stay — Preview, Listing, Preferences, and Breadcrumb still use them.
- Template row action buttons (**Open, Export, Delete**) are now always visible instead of only on row hover (dropped `opacity: 0` default and the `tr:hover` reveal rule on `.templates-ghost-btn`).

## Verification
- `npm run typecheck` clean
- `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Templates UI-only changes; no API or auth impact, and reveal remains elsewhere in the app.
> 
> **Overview**
> **Templates inventory** drops the **Reveal** action (Finder) on each row and the related `revealPath` wiring in `InventoryPanel`; **Open** remains for in-app navigation to the template folder. The shared `revealPath` API and `/api/fs/reveal` are unchanged for other surfaces.
> 
> **Row actions** (`Export`, `Open`, `Delete`, etc.) on `.templates-ghost-btn` are **always visible** instead of hidden until row hover or keyboard focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1886224d893b613d997769fa2c42e73d4acabea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->