### PR TITLE
Sync perf improvements from examples into pdf_studio and latex templates

### DIFF
--- a/fused_render/templates/latex/engine.py
+++ b/fused_render/templates/latex/engine.py
@@ -209,7 +209,21 @@ def _dedup(diags):
     return out
 
 
-def _compile(main_path: str, synctex: bool = True):
+def _newest_source_mtime(root):
+    """Newest mtime under root (same exclusions as _tree). None means the dir
+    is too big to scan cheaply — treat as unknown and just compile."""
+    newest, seen = 0.0, 0
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in (".build", ".git", "__pycache__")]
+        for fn in filenames:
+            seen += 1
+            if seen > 2000:
+                return None
+            newest = max(newest, os.path.getmtime(os.path.join(dirpath, fn)))
+    return newest
+
+
+def _compile(main_path: str, synctex: bool = True, force: bool = False):
     main_path = os.path.abspath(main_path)
     if not os.path.exists(main_path):
         return {"ok": False, "error": f"no such file: {main_path}", "errors": []}
@@ -219,6 +233,20 @@ def _compile(main_path: str, synctex: bool = True):
                 "error": "Tectonic isn't installed — install it to compile."}
     os.makedirs(TECTONIC_CACHE, exist_ok=True)
     build = _build_dir_for(main_path)
+    # A compile costs ~10s (tectonic runs several passes), so skip it when the
+    # last PDF is newer than every file under the doc's directory — page
+    # reloads become instant. `force` (the Recompile button) always runs it.
+    if not force:
+        stem = os.path.splitext(os.path.basename(main_path))[0]
+        pdf = os.path.join(build, stem + ".pdf")
+        if os.path.exists(pdf):
+            newest = _newest_source_mtime(os.path.dirname(main_path))
+            if newest is not None and os.path.getmtime(pdf) > newest:
+                diags = _dedup(_parse_tex_log(os.path.join(build, stem + ".log")))
+                return {"ok": True, "pdf": pdf,
+                        "synctex": os.path.join(build, stem + ".synctex.gz"),
+                        "log_tail": "", "errors": diags, "seconds": 0.0,
+                        "cached": True}
     env = dict(os.environ, TECTONIC_CACHE_DIR=TECTONIC_CACHE)
     # We do NOT pass --only-cached: the Tectonic subprocess is server-side (not
     # the sandboxed browser iframe), so it may reach the package repo. A warm
@@ -232,9 +260,12 @@ def _compile(main_path: str, synctex: bool = True):
     t0 = time.time()
     try:
         # cwd = the .tex file's own directory, so relative \input/\includegraphics
-        # resolve the way the author expects.
+        # resolve the way the author expects. CREATE_NO_WINDOW: the server is
+        # windowless (pythonw), so a console subprocess would otherwise flash
+        # a terminal window per compile.
         p = subprocess.run(cmd, capture_output=True, text=True, env=env,
-                           cwd=os.path.dirname(main_path), timeout=28)
+                           cwd=os.path.dirname(main_path), timeout=28,
+                           creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0)
     except subprocess.TimeoutExpired:
         return {"ok": False, "error": "compile exceeded 28s (too complex, or a "
                 "cold package fetch) — simplify, or recompile once the fetch "
@@ -491,7 +522,7 @@ def _synctex_forward(synctex_gz: str, target_file: str, line: int):
 
 # -------------------------------------------------------------------- dispatcher
 def main(action: str = "tectonic_status", path: str = "", target: str = "",
-         line: int = 0, synctex: bool = True, name: str = ""):
+         line: int = 0, synctex: bool = True, name: str = "", force: int = 0):
     if action == "tectonic_status":
         return _tectonic_status()
 
@@ -563,7 +594,7 @@ def main(action: str = "tectonic_status", path: str = "", target: str = "",
     if action == "compile":
         if not path:
             return {"ok": False, "error": "compile needs path", "errors": []}
-        return _compile(path, synctex=synctex)
+        return _compile(path, synctex=synctex, force=bool(force))
 
     if action == "outline":
         if not path or not os.path.exists(path):

--- a/fused_render/templates/latex/template.html
+++ b/fused_render/templates/latex/template.html
@@ -434,7 +434,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
       CM.autocompletion({ override: [latexCompletions] }),
       CM.keymap.of([
         { key: "Mod-s", preventDefault: true, run: () => { saveNow(); return true; } },
-        { key: "Mod-Enter", preventDefault: true, run: () => { compile(); return true; } },
+        { key: "Mod-Enter", preventDefault: true, run: () => { compile(true); return true; } },
         ...CM.closeBracketsKeymap, ...CM.defaultKeymap, ...CM.historyKeymap,
         ...CM.searchKeymap, ...CM.completionKeymap, ...CM.foldKeymap, CM.indentWithTab,
       ]),
@@ -507,18 +507,18 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
     $("drawer").classList.toggle("collapsed", collapsed);
     fused.params.set("drawer", collapsed ? "collapsed" : "open");
   }
-  async function compile() {
+  async function compile(force) {
     if (S.compiling) { S.pendingCompile = true; return; }   // coalesce: one in flight
     S.compiling = true; setStatus("busy", "compiling…");
     try {
       if (S.dirty) await saveNow();
-      const r = await py({ action: "compile", path: S.mainAbs });
+      const r = await py({ action: "compile", path: S.mainAbs, force: force ? 1 : 0 });
       if (r.missing_tectonic) { setStatus("err", "no compiler"); renderMissingTectonic(); return; }
       if (r.error) { setStatus("err", "error"); renderDiags([{ severity:"error", message:r.error, line:0, file:"" }], ""); return; }
       renderDiags(r.errors || [], r.log_tail || "");
       const hardErrors = (r.errors || []).filter(e => e.severity === "error");
       if (r.ok && r.pdf) {
-        setStatus("ok", `✓ ${r.seconds}s`);
+        setStatus("ok", r.cached ? "✓ up to date" : `✓ ${r.seconds}s`);
         await renderPdf(r.pdf);
         S.lastPdf = r.pdf;
         refreshIndex();                    // outline + bib may have changed
@@ -930,7 +930,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = "/template-assets/pdfjs.worker.bundle.mjs"
     if (S.lastPdf) setTimeout(() => renderPdf(S.lastPdf), 60);   // reflow at new width
   }
   $("modeSeg").querySelectorAll("button").forEach(b => b.addEventListener("click", () => setMode(b.dataset.mode)));
-  $("compileBtn").addEventListener("click", () => compile());
+  $("compileBtn").addEventListener("click", () => compile(true));
   $("zoomIn").addEventListener("click", () => setZoom(S.scale + 0.15));
   $("zoomOut").addEventListener("click", () => setZoom(S.scale - 0.15));
   $("addFileBtn").addEventListener("click", openFileBrowser);

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -4,6 +4,8 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>PDF Studio</title>
+<link rel="modulepreload" href="/template-assets/pdfjs.bundle.mjs">
+<link rel="modulepreload" href="/template-assets/pdfjs.worker.bundle.mjs">
 <style>
   /* ---- Light Airtable-flavored design system (shared with latex/docs) ---- */
   :root {
@@ -532,88 +534,104 @@ function pageWidth() {
   return Math.min(860, Math.max(320, avail)) * state.zoom / 100;
 }
 
+// Bumped per render so stale in-flight page/thumb loops cancel themselves.
+let renderGen = 0;
+
+async function renderPage(pdf, n, gen) {
+  const page = await pdf.getPage(n);
+  const base = page.getViewport({ scale: 1 });
+  const scale = pageWidth() / base.width;
+  const vp = page.getViewport({ scale });
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  if (gen !== renderGen) return;
+  const wrap = document.createElement("div");
+  wrap.className = "pdf-page";
+  wrap.id = `__fr_page_${n}`;
+  wrap.dataset.page = n;
+  wrap.dataset.scale = scale;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.floor(vp.width * dpr);
+  canvas.height = Math.floor(vp.height * dpr);
+  canvas.style.width = vp.width + "px";
+  canvas.style.height = vp.height + "px";
+  wrap.appendChild(canvas);
+  wrap.style.setProperty("--scale-factor", scale);
+  const textLayer = document.createElement("div");
+  textLayer.className = "textLayer";
+  wrap.appendChild(textLayer);
+  const overlay = document.createElement("div");
+  overlay.className = "overlay";
+  wrap.appendChild(overlay);
+  wrap.insertAdjacentHTML("beforeend", `<div class="qa">
+    <button title="Rotate left" data-qa="rotL">${icoRotL}</button>
+    <button title="Rotate right" data-qa="rotR">${icoRotR}</button>
+    <button title="Extract this page" data-qa="extract">${icoExtract}</button>
+    <button title="Delete page" data-qa="del" class="danger">${icoTrash}</button>
+  </div>`);
+  $("pages").appendChild(wrap);
+  pageWatcher.observe(wrap);
+  await page.render({
+    canvasContext: canvas.getContext("2d"), viewport: vp,
+    transform: dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined,
+  }).promise;
+  await new pdfjs.TextLayer({
+    textContentSource: page.streamTextContent(), container: textLayer, viewport: vp,
+  }).render();
+}
+
+async function renderThumb(pdf, n, gen) {
+  const page = await pdf.getPage(n);
+  const base = page.getViewport({ scale: 1 });
+  const vp = page.getViewport({ scale: 132 / base.width });
+  if (gen !== renderGen) return;
+  const div = document.createElement("div");
+  div.className = "thumb" + (n === state.curPage ? " on" : "");
+  div.dataset.page = n;
+  const canvas = document.createElement("canvas");
+  canvas.width = Math.floor(vp.width);
+  canvas.height = Math.floor(vp.height);
+  div.appendChild(canvas);
+  div.insertAdjacentHTML("beforeend", `<span class="pn">${n}</span><div class="qa">
+    <button title="Rotate left" data-qa="rotL">${icoRotL}</button>
+    <button title="Rotate right" data-qa="rotR">${icoRotR}</button>
+    <button title="Delete page" data-qa="del" class="danger">${icoTrash}</button>
+  </div>`);
+  $("thumbs").appendChild(div);
+  await page.render({ canvasContext: canvas.getContext("2d"), viewport: vp }).promise;
+}
+
+// Resolves once page 1 is on screen; the remaining pages and the thumbnail
+// rail keep rendering in the background.
 async function renderAll() {
   cancelEdit();
   state.spans = {};
+  const gen = ++renderGen;
   if (state.pdf) { state.pdf.destroy(); state.pdf = null; }
   const data = await loadPdfBytes();
-  state.pdf = await pdfjs.getDocument({ data }).promise;
-  const shown = Math.min(state.pdf.numPages, MAX_PAGES);
+  const pdf = await pdfjs.getDocument({ data }).promise;
+  if (gen !== renderGen) { pdf.destroy(); return; }
+  state.pdf = pdf;
+  const shown = Math.min(pdf.numPages, MAX_PAGES);
   const note = $("pagesNote");
-  note.classList.toggle("hidden", state.pdf.numPages <= MAX_PAGES);
-  if (state.pdf.numPages > MAX_PAGES)
-    note.textContent = `Showing ${shown} of ${state.pdf.numPages} pages`;
-  $("docPages").textContent = `${state.pdf.numPages} ${state.pdf.numPages === 1 ? "page" : "pages"}`;
-
-  const pagesEl = $("pages");
-  pagesEl.innerHTML = "";
-  const dpr = Math.min(window.devicePixelRatio || 1, 2);
-  const cssW = pageWidth();
-  for (let n = 1; n <= shown; n++) {
-    const page = await state.pdf.getPage(n);
-    const base = page.getViewport({ scale: 1 });
-    const scale = cssW / base.width;
-    const vp = page.getViewport({ scale });
-    const wrap = document.createElement("div");
-    wrap.className = "pdf-page";
-    wrap.id = `__fr_page_${n}`;
-    wrap.dataset.page = n;
-    wrap.dataset.scale = scale;
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.floor(vp.width * dpr);
-    canvas.height = Math.floor(vp.height * dpr);
-    canvas.style.width = vp.width + "px";
-    canvas.style.height = vp.height + "px";
-    wrap.appendChild(canvas);
-    wrap.style.setProperty("--scale-factor", scale);
-    const textLayer = document.createElement("div");
-    textLayer.className = "textLayer";
-    wrap.appendChild(textLayer);
-    const overlay = document.createElement("div");
-    overlay.className = "overlay";
-    wrap.appendChild(overlay);
-    wrap.insertAdjacentHTML("beforeend", `<div class="qa">
-      <button title="Rotate left" data-qa="rotL">${icoRotL}</button>
-      <button title="Rotate right" data-qa="rotR">${icoRotR}</button>
-      <button title="Extract this page" data-qa="extract">${icoExtract}</button>
-      <button title="Delete page" data-qa="del" class="danger">${icoTrash}</button>
-    </div>`);
-    pagesEl.appendChild(wrap);
-    await page.render({
-      canvasContext: canvas.getContext("2d"), viewport: vp,
-      transform: dpr !== 1 ? [dpr, 0, 0, dpr, 0, 0] : undefined,
-    }).promise;
-    await new pdfjs.TextLayer({
-      textContentSource: page.streamTextContent(), container: textLayer, viewport: vp,
-    }).render();
-  }
-  renderThumbs(shown);
+  note.classList.toggle("hidden", pdf.numPages <= MAX_PAGES);
+  if (pdf.numPages > MAX_PAGES)
+    note.textContent = `Showing ${shown} of ${pdf.numPages} pages`;
+  $("docPages").textContent = `${pdf.numPages} ${pdf.numPages === 1 ? "page" : "pages"}`;
+  $("pages").innerHTML = "";
+  $("thumbs").innerHTML = "";
   watchPages();
+  await renderPage(pdf, 1, gen);
   if (document.body.classList.contains("mode-edit")) primeOverlays();
-}
-
-async function renderThumbs(shown) {
-  const rail = $("thumbs");
-  rail.innerHTML = "";
-  for (let n = 1; n <= shown; n++) {
-    const page = await state.pdf.getPage(n);
-    const base = page.getViewport({ scale: 1 });
-    const vp = page.getViewport({ scale: 132 / base.width });
-    const div = document.createElement("div");
-    div.className = "thumb" + (n === state.curPage ? " on" : "");
-    div.dataset.page = n;
-    const canvas = document.createElement("canvas");
-    canvas.width = Math.floor(vp.width);
-    canvas.height = Math.floor(vp.height);
-    div.appendChild(canvas);
-    div.insertAdjacentHTML("beforeend", `<span class="pn">${n}</span><div class="qa">
-      <button title="Rotate left" data-qa="rotL">${icoRotL}</button>
-      <button title="Rotate right" data-qa="rotR">${icoRotR}</button>
-      <button title="Delete page" data-qa="del" class="danger">${icoTrash}</button>
-    </div>`);
-    rail.appendChild(div);
-    await page.render({ canvasContext: canvas.getContext("2d"), viewport: vp }).promise;
-  }
+  (async () => {
+    for (let n = 2; n <= shown; n++) {
+      if (gen !== renderGen) return;
+      await renderPage(pdf, n, gen);
+    }
+    for (let n = 1; n <= shown; n++) {
+      if (gen !== renderGen) return;
+      await renderThumb(pdf, n, gen);
+    }
+  })().catch((err) => { if (gen === renderGen) toast(err?.message || String(err), true); });
 }
 
 let pageWatcher = null;
@@ -799,6 +817,7 @@ async function openDoc(path) {
 
 function clearOpenDoc() {
   cancelEdit();
+  renderGen++;
   state.doc = ""; state.pdf?.destroy(); state.pdf = null;
   $("pages").innerHTML = ""; $("thumbs").innerHTML = "";
   $("docName").textContent = ""; $("docPages").textContent = "";
@@ -1267,17 +1286,21 @@ document.addEventListener("keydown", (e) => {
 
 // ---------- boot ----------
 async function bootDoc(path) {
-  await py({ action: "add_to_library", src: path });
-  await refreshLib();
+  if (!state.docs.some((d) => d.path === path)) {
+    await py({ action: "add_to_library", src: path });
+    await refreshLib();
+  }
   await openDoc(path);
 }
 
 async function boot() {
   try {
+    const libP = refreshLib();
     let health;
     try { health = await py({ action: "health" }); }
     catch { health = await py({ action: "health" }); }   // one retry: engine warm-up
     if (!health.ok) {
+      libP.catch(() => {});
       $("boot").innerHTML = "";
       const msg = document.createElement("div");
       msg.innerHTML = `<b>PDF Studio needs its Python engines.</b><br>
@@ -1289,22 +1312,22 @@ async function boot() {
     }
     state.zoom = +(fused.params.get("zoom") || 100) || 100;
     if (fused.params.get("panel") === "0") document.body.classList.add("panel-off");
-    await refreshLib();
-    const wanted = fused.params.get("doc") || fused.params.get("_file") || "";
-    let opened = false;
-    if (wanted && wanted.toLowerCase().endsWith(".pdf")) {
-      try { await bootDoc(wanted); opened = true; }
-      catch (err) { console.error(err); toast(`Could not open ${wanted.split("/").pop()}: ${err?.message || err}`, true); }
-    }
-    if (!opened && state.docs.length) {
-      try { await openDoc(state.docs[0].path); }
-      catch (err) { console.error(err); }
-    }
+    await libP;
     setMode(fused.params.get("mode") === "edit" ? "edit" : "view");
     $("boot").remove();
   } catch (err) {
     console.error(err);
     $("boot").textContent = `PDF Studio failed to start: ${err?.message || err}`;
+    return;
+  }
+  const wanted = fused.params.get("doc") || fused.params.get("_file") || "";
+  if (wanted && wanted.toLowerCase().endsWith(".pdf")) {
+    try { await bootDoc(wanted); return; }
+    catch (err) { console.error(err); toast(`Could not open ${wanted.split("/").pop()}: ${err?.message || err}`, true); }
+  }
+  if (state.docs.length) {
+    try { await openDoc(state.docs[0].path); }
+    catch (err) { console.error(err); }
   }
 }
 boot();


### PR DESCRIPTION
## Summary
- **pdf_studio**: progressive PDF rendering — page 1 renders immediately, remaining pages/thumbnails stream in afterward with a cancellation token so navigating away mid-render is clean; adds pdfjs modulepreload hints and dedupes/parallelizes boot()'s library refresh.
- **latex**: compile caching — a plain reload skips the ~10s tectonic invocation when the existing PDF is newer than every source file; Recompile / Cmd+Ctrl+Enter always force a real rebuild. Also sets `CREATE_NO_WINDOW` on Windows so the pythonw server doesn't flash a console per compile.

Both templates' example counterparts (`examples/pdf_studio`, `examples/latex_studio`) have continued to evolve independently as untracked local dev copies. This PR ports the genuinely new work from each into the built-in templates while deliberately preserving template-only features that the examples don't have (pdf_studio's read-only-file gating, latex's tectonic auto-installer flow) — verified via diff that nothing else regressed.

More template syncs may follow in later commits on this branch.

## Test plan
- [ ] Smoke-test pdf_studio: open a multi-page PDF, confirm page 1 appears quickly and remaining pages/thumbnails fill in; navigate away while rendering to confirm no console errors
- [ ] Smoke-test latex: compile a doc, reload the page and confirm status shows "up to date" without recompiling; edit a file and confirm it recompiles; hit Recompile/Cmd+Enter and confirm it always rebuilds
- [x] JS parses cleanly (checked via Node vm SourceTextModule) and engine.py parses cleanly (ast.parse)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and compile-path optimizations only; no auth, persistence, or security-sensitive logic. Stale-PDF risk on cache skip is bounded by mtime comparison and explicit force rebuild.
> 
> **Overview**
> Ports performance work from the example studios into the built-in **latex** and **pdf_studio** templates.
> 
> **LaTeX:** `_compile` can skip invoking Tectonic when the cached PDF under the build dir is newer than every file in the document directory (mtime scan capped at 2000 files). Reloads return the existing PDF with `cached: true` and status **"✓ up to date"**. **Recompile** and **Mod+Enter** pass `force` so a full rebuild always runs. On Windows, Tectonic is started with `CREATE_NO_WINDOW` to avoid a console flash under `pythonw`.
> 
> **PDF Studio:** Adds pdf.js **modulepreload** hints, then refactors rendering so **page 1** paints first while other pages and the thumbnail rail stream in behind a **`renderGen`** cancellation token (navigation/clear mid-render aborts stale work). **Boot** overlaps library refresh with the health check, avoids re-adding a PDF already in the library, and opens the requested document only after the shell is ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 448cfba645ecbcf0e32b67e315492e1e79fc114e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->