### PR TITLE
fix(deeplink): stop Finder file-opens misrouting to clone flow

### DIFF
--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -67,6 +67,25 @@ def clone_url_path(raw_url: str) -> str:
     return "/clone?src=" + quote(raw_url, safe="")
 
 
+def openurls_target_path(raw_url: str) -> str:
+    """Shell URL path for an `application:openURLs:` event (SPEC §26, D110).
+
+    AppKit delivers both `fused-render://` deep links AND plain document
+    opens (e.g. a Finder double-click on a registered `.bookmark` file, as
+    a `file://` URL) through this one selector — unlike `openFiles:`, which
+    only ever gets plain paths. Only a `fused-render:` URL is a deep link;
+    anything else is a file open and must resolve the same way
+    `application_openFiles_` does, via `view_url_path`. Module-level (not a
+    closure) so it is testable without AppKit.
+    """
+    if raw_url.lower().startswith("fused-render:"):
+        return clone_url_path(raw_url)
+
+    from urllib.parse import unquote, urlparse
+
+    return view_url_path(unquote(urlparse(raw_url).path))
+
+
 def _is_process_alive(pid: int) -> bool:
     try:
         os.kill(pid, 0)
@@ -225,17 +244,23 @@ def main() -> None:
     # to application:openURLs:. Same delegate-patch mechanism as openFiles
     # above; the /clone confirm page does all parsing and asks before any
     # clone, so this handler only ferries the raw URL to the server.
+    #
+    # AppKit also routes plain document opens (Finder double-click on a
+    # registered file type, e.g. .bookmark) through this same selector as a
+    # file:// URL on some launches, not through application:openFiles:.
+    # openurls_target_path tells the two apart (mirrors the scheme check in
+    # winopen.py's _open()).
     def application_openURLs_(self, _app, urls):
         raws = [str(u.absoluteString()) for u in urls]
         logger.info("deep-link open-URLs event: %s", raws)
         state["docs"] = True  # a deep-link launch shouldn't also open the home tab
         for raw in raws:
-            target = f"http://127.0.0.1:{port}" + clone_url_path(raw)
+            target = f"http://127.0.0.1:{port}" + openurls_target_path(raw)
             if state["ready"]:
-                logger.info("opening clone page: %s", target)
+                logger.info("opening open-URLs target: %s", target)
                 webbrowser.open(target)
             else:
-                logger.info("queuing clone page until server is ready: %s", target)
+                logger.info("queuing open-URLs target until server is ready: %s", target)
                 state["pending"].append(target)
 
     rumps.rumps.NSApp.application_openURLs_ = application_openURLs_

--- a/tests/test_deeplink.py
+++ b/tests/test_deeplink.py
@@ -121,6 +121,28 @@ def test_winopen_clone_url():
     )
 
 
+def test_openurls_target_path_routes_deeplink_to_clone():
+    from fused_render.app import clone_url_path, openurls_target_path
+
+    assert openurls_target_path(DEEPLINK) == clone_url_path(DEEPLINK)
+
+
+def test_openurls_target_path_routes_bookmark_file_to_view():
+    # Finder can deliver a double-clicked .bookmark through the same
+    # application:openURLs: selector as a file:// URL, not openFiles:.
+    from fused_render.app import openurls_target_path, view_url_path
+
+    raw = "file:///Users/vasu/Desktop/My%20Note.bookmark"
+    assert openurls_target_path(raw) == view_url_path("/Users/vasu/Desktop/My Note.bookmark")
+
+
+def test_openurls_target_path_routes_plain_file_to_view():
+    from fused_render.app import openurls_target_path, view_url_path
+
+    raw = "file:///Users/vasu/Desktop/notes.txt"
+    assert openurls_target_path(raw) == view_url_path("/Users/vasu/Desktop/notes.txt")
+
+
 # ---- clone / pull ------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- `application:openURLs:` (added in #144 for `fused-render://` deep links) can also receive plain document opens — AppKit routes a Finder double-click on a registered file type (e.g. `.bookmark`) through this same selector as a `file://` URL, not through `application:openFiles:`.
- It had no scheme guard, so **every** open-URLs event — deep link or plain file — was sent to `/clone?src=...`, breaking Finder-opened files (`.bookmark` and otherwise).
- Added `openurls_target_path()`: routes `fused-render:` URLs to the clone flow, everything else to `view_url_path` (same resolution `application_openFiles_` already uses). Mirrors the scheme check already present in `winopen.py`'s `_open()` on Windows, which was unaffected.

## Test plan
- [x] `openurls_target_path` unit tests added in `tests/test_deeplink.py` (deep link → clone, `.bookmark` file:// → view, plain file:// → view) — pass.
- [x] Full `tests/test_deeplink.py` + `tests/test_app_view_url.py` run; only pre-existing unrelated failures remain (React shell not built in this environment).
- [ ] Manual: double-click a `.bookmark` file in Finder on macOS and confirm it opens the view, not the clone confirm page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to macOS launch URL routing with unit tests; no auth, data, or server API changes.
> 
> **Overview**
> Fixes macOS **Finder double-clicks** (and other document opens) that arrive via `application:openURLs:` as `file://` URLs being sent to `/clone?src=...` instead of the normal file view flow.
> 
> Adds **`openurls_target_path()`** so only `fused-render:` URLs go to the clone confirm page; everything else is parsed like `application:openFiles:` via **`view_url_path`**. The **`application_openURLs_`** handler now uses that helper (aligned with the scheme check in **`winopen.py`** on Windows). Unit tests cover deep links, `.bookmark` files, and plain files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b67d8614f00fd2c38f48dc042b89385e2b50834c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->