### PR TITLE
fix(list): list the mounts root by enumerating mount records, not rc

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2079,6 +2079,20 @@ def create_app(start_dir: str) -> FastAPI:
         # `cursor` (an opaque resume token, non-None only on the S3-direct route
         # — rclone and a local scandir can't resume). Fallback ladder for a
         # mount path: S3-direct -> rc -> 503.
+        if shell_mounts.is_mounts_root(path):
+            # The mounts container is a LOCAL directory whose children are the
+            # mountpoints. is_mount_backed is true for it (so no kernel readdir
+            # touches it), yet it sits under no single mount record, so the
+            # rc/S3 routes below have nothing to list and 503 ("cannot list
+            # directory"). Enumerate the mount records directly instead — the
+            # authoritative mount list, with zero kernel or remote I/O and no
+            # sidecar files (mounts.json, per-mount *.json) leaking in.
+            entries = _sort_entries([
+                {"name": m["name"], "is_dir": True, "size": None,
+                 "mtime": None, "ignored": False}
+                for m in shell_mounts.list_mounts() if m.get("name")
+            ])
+            return _list_response(path, entries, False, None)
         if shell_mounts.is_mount_backed(path):
             # S3-direct fast path: for anonymous plain AWS S3 — the backend that
             # dominates our mounts — page S3's own ListObjectsV2 (rclone can't

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -734,6 +734,17 @@ def is_mount_backed(path: str) -> bool:
     return rp == real_root or rp.startswith(real_root + os.sep)
 
 
+def is_mounts_root(path: str) -> bool:
+    """True when `path` IS the mounts container itself — the local parent that
+    holds each mountpoint as a subdir — as opposed to a path under an individual
+    mount. is_mount_backed is true for the root too (its `ap == root` clause), so
+    the root is kept off the kernel like any remote path; but the root is under
+    no single mount record, so the rc/S3 listing routes have nothing to list.
+    Callers list the root by enumerating mount records instead (no kernel or
+    remote I/O)."""
+    return os.path.abspath(path) == os.path.abspath(mounts_dir())
+
+
 def rc_mtime_for(path: str) -> str | None:
     """ModTime of a mount-backed file, answered by the rclone rcd rc API
     (operations/stat) instead of the kernel NFS mount.

--- a/tests/test_server_fs_list_mount.py
+++ b/tests/test_server_fs_list_mount.py
@@ -103,6 +103,34 @@ def test_list_mount_root_normalizes_rel_to_empty(home, rcd, tmp_path):
     assert body["remote"] == ""  # "." normalized to the fs root
 
 
+def test_list_mounts_root_enumerates_records_not_rc(home, tmp_path, monkeypatch):
+    # The mounts CONTAINER (the parent that holds every mountpoint as a subdir)
+    # is is_mount_backed too — is_mount_backed's `ap == root` clause keeps it off
+    # the kernel — but it sits under no single mount record, so the rc/S3 routes
+    # would 503 ("cannot list directory") on it. It must instead be listed by
+    # enumerating the mount records directly: 200, each mount as a dir entry,
+    # sorted, with zero rc I/O and no sidecar files (mounts.json, per-mount
+    # *.json) leaking in from a raw readdir. No rcd needed — the record
+    # enumeration precedes any remote call.
+    mounts_mod.add_mount("zebra", "remote:z")
+    mounts_mod.add_mount("alpha", "remote:a")
+    root = mounts_mod.mounts_dir()
+    # A stray sidecar file in the container must NOT appear in the listing.
+    with open(os.path.join(root, "alpha.json"), "w", encoding="utf-8") as f:
+        f.write("{}")
+    called = []
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: called.append(1) or [])
+    resp = _client(tmp_path).get("/api/fs/list", params={"path": root})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [e["name"] for e in data["entries"]] == ["alpha", "zebra"]  # sorted
+    assert all(e["is_dir"] is True and e["size"] is None
+               for e in data["entries"])
+    assert data["truncated"] is False and data["cursor"] is None
+    assert called == []  # never fell through to the rc listing route
+
+
 def test_list_mount_file_is_not_a_directory(home, rcd, tmp_path, monkeypatch):
     # The mount is HEALTHY but operations/list errors on a file remote (stub
     # 404s the unset method) -> 400, the mount-safe stand-in for os.path.isdir.


### PR DESCRIPTION
## Summary

- **Fixes the `mounts/` container 503'ing on `/api/fs/list`.** Opening `/view/.../.fused-render/mounts` rendered an empty listing with `{"error":"cannot list directory ...}` — the folder that holds every mount was itself un-listable.
- **Root cause:** `is_mount_backed()` classifies the mounts *root* as mount-backed (its `ap == root` clause), so the listing is kept off the kernel and routed to the rc/S3 fallback ladder — but the root sits under no single mount record, so `_mount_for()` returns `None`, `rc_list_dir` raises `RcListUnavailable`, and the handler returns 503.
- **Fix:** special-case the mounts root in `api_fs_list` — enumerate `list_mounts()` records as directory entries with zero kernel or remote I/O. Sidecar files (`mounts.json`, per-mount `*.json`) are excluded because it lists records, not raw filenames.
- Adds `is_mounts_root()` to distinguish the container from paths under an individual mount. No behavior change for sub-mounts or local dirs.

## Visuals

Routing delta for `GET /api/fs/list` on the mounts root — a new guard short-circuits before the rc/S3 ladder that had no record to list:

```mermaid
flowchart TD
    R["GET /api/fs/list?path=…/mounts"] --> A{is_mounts_root?}
    A -->|"yes (NEW)"| E["enumerate list_mounts()\n→ 200, mounts as dir entries"]
    A -->|no| B{is_mount_backed?}
    B -->|yes| S["S3-direct → rc → 503"]
    B -->|no| K["kernel os.scandir → 200"]
    S -. "was: root fell here →\n_mount_for None →\nRcListUnavailable → 503" .-> X["503 cannot list directory"]
    style E fill:#dcffe4,stroke:#2da44e,color:#000
    style X fill:#ffe3e3,stroke:#cf222e,color:#000
```

**Screenshot (verified locally):** drove the running dev server to `/view/.../.fused-render/mounts` and confirmed the folder now lists all 7 mounts (fused-asset, mindearth, ookla, overturemaps-address, sentinel, sentinel-cogs, zarr-v1) as folders, sorted, with no sidecar `.json` files. PNG captured at `cmux-assets/fix-mounts-root-listing/browser/…/mounts-listing.png` (not embedded — private repo, and the automated uploader was blocked; drag it into the PR from the web UI to attach).

## Usage

No new user-invocable surface. The existing Mounts view (`/view/<home>/.fused-render/mounts`, or clicking into the mounts folder) now populates instead of erroring:

```bash
curl "http://127.0.0.1:1777/api/fs/list?path=%2FUsers%2F<you>%2F.fused-render%2Fmounts"
# → 200 {"entries":[{"name":"fused-asset","is_dir":true,...}, ...], "truncated":false, "cursor":null}
```

## Test Plan

- [x] **Added** `test_list_mounts_root_enumerates_records_not_rc` in `tests/test_server_fs_list_mount.py` — asserts 200, mounts listed as sorted dir entries, sidecar `*.json` excluded, and `rc_list_dir` never called (zero remote I/O).
- [x] `tests/test_server_fs_list_mount.py` — 29 passed.
- [x] Related suites green: `test_shell_mounts.py`, `test_server_list_sort.py`, `test_server_fs_meta.py`, `test_server_walk.py` — 162 passed, 1 skipped.
- [x] **Manual (live server):** mounts root → 200 (was 503); sub-mount `.../mounts/sentinel` → 200; local dir `Documents/Fused` → 200; trailing-slash root → 200. UI listing verified via screenshot above.
