### PR TITLE
Consolidate table row actions into overflow menus

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1728,8 +1728,13 @@ provisioning stays a documented terminal flow.
   --org --env` connects the existing environment; nothing is created) and
   as create-your-workspace when it has none: workspace picker when >1
   org/env, the single workspace shown read-only when exactly one (the
-  user must see WHICH environment will be connected), prefilled editable
-  env name, live progress log; prominent while no managed env exists, else collapsed
+  user must see WHICH environment will be connected). The CONNECT path is
+  a one-click import of the discovered environment — the primary button
+  names it ("Connect <org> / <env>") and the local env name (a nickname
+  for this machine's store, prefilled by convention) is demoted behind an
+  "Edit name" reveal so the common path needs no typing; the create path
+  (no workspace) shows the editable name up front, since naming is the
+  point there. Live progress log; prominent while no managed env exists, else collapsed
   behind an "Add managed environment" toggle. The deep probe is CACHED:
   focus/visibility refreshes re-read only the cheap presence status and
   keep the orgs view they have, re-probing only when it is missing (initial

--- a/SPEC.md
+++ b/SPEC.md
@@ -1721,7 +1721,9 @@ provisioning stays a documented terminal flow.
   started elsewhere — Deploy modal, another tab — is adopted read-only with
   its own Cancel); signed in → account summary (probe orgs/roles table,
   not-admitted note), the environments management table (default marker,
-  make-default, forget-with-confirm), and the setup panel — presented
+  with make-default and forget-with-confirm behind a per-row overflow
+  ("⋯") menu — one quiet control per row instead of a button pair), and
+  the setup panel — presented
   as CONNECT when the account already has a workspace (`cloud setup
   --org --env` connects the existing environment; nothing is created) and
   as create-your-workspace when it has none: workspace picker when >1
@@ -1740,7 +1742,11 @@ provisioning stays a documented terminal flow.
 - **AC-11** The page also hosts the **Deployments** section — the env-wide
   `fused share list` view with per-mount Revoke that PF-6 previously placed
   on Preferences (semantics unchanged: `/api/deploy/shares` joined to local
-  pages, revoke by env+token via `deploy.revoke_mount`). Environments and
+  pages, revoke by env+token via `deploy.revoke_mount`). Each row's actions
+  (Open ↗ / Copy link, and the destructive Revoke behind a separator) live in
+  the same per-row overflow ("⋯") menu as the environments table, so the
+  section shows one control per row rather than an Open link + Revoke button
+  pair; a row with no link and nothing to revoke shows a muted "—". Environments and
   Deployments render in BOTH auth states: the env store and an AWS env's
   share list need the CLI, not a managed-Fused sign-in — an AWS-only user
   must not pass through an irrelevant sign-in to revoke a link. Only the

--- a/frontend/src/components/DeploymentsList.tsx
+++ b/frontend/src/components/DeploymentsList.tsx
@@ -9,6 +9,8 @@ import { useEffect, useRef, useState } from "react";
 import { getDeployConfig, listShares, revokeMount } from "../lib/api";
 import type { DeployConfig, ShareMount } from "../lib/api";
 import { basename } from "../lib/format";
+import RowActionsMenu from "./RowActionsMenu";
+import type { MenuEntry } from "./ContextMenu";
 
 export default function DeploymentsList() {
   const [config, setConfig] = useState<DeployConfig | null>(null);
@@ -111,46 +113,62 @@ export default function DeploymentsList() {
       {mounts && mounts.length > 0 && (
         <table className="deploy-shares-table">
           <tbody>
-            {mounts.map((m) => (
-              <tr key={m.token}>
-                <td className="share-page" title={m.page ?? "Deployed by the CLI, another app, or another machine"}>
-                  {m.page ? basename(m.page) : <span className="deploy-muted">not from this app</span>}
-                </td>
-                <td className="share-token" title={m.token}>
-                  {m.token}
-                </td>
-                <td>
-                  <span className={"share-status " + m.status}>{m.status}</span>
-                </td>
-                <td>
-                  {m.url ? (
-                    <a href={m.url} target="_blank" rel="noreferrer">
-                      Open ↗
-                    </a>
-                  ) : (
-                    <span
-                      className="deploy-muted"
-                      title="`fused share list` doesn't report URLs; a link shows once this app has recorded (or can derive) one for this environment"
-                    >
-                      —
-                    </span>
-                  )}
-                </td>
-                <td>
-                  {m.status !== "revoked" && (
-                    <button
-                      type="button"
-                      className="deploy-danger"
-                      onClick={() => onRevoke(m.token)}
-                      disabled={revoking !== null || loading}
-                      title="Take this link down"
-                    >
-                      {revoking === m.token ? "Revoking…" : "Revoke"}
-                    </button>
-                  )}
-                </td>
-              </tr>
-            ))}
+            {mounts.map((m) => {
+              // One "⋯" per row instead of a separate Open link and Revoke
+              // button: Open/Copy first, the destructive Revoke tucked behind a
+              // separator. A revoked row with no URL has no entries, so the menu
+              // renders a muted "—" (nothing to do).
+              const url = m.url;
+              const items: MenuEntry[] = [];
+              if (url) {
+                items.push({
+                  label: "Open ↗",
+                  onClick: () => window.open(url, "_blank", "noopener,noreferrer"),
+                });
+                items.push({
+                  label: "Copy link",
+                  onClick: () => {
+                    void navigator.clipboard?.writeText(url);
+                  },
+                });
+              } else {
+                // Preserves the old "—" tooltip's explanation, now inside the menu.
+                items.push({ label: "No link reported yet", disabled: true });
+              }
+              if (m.status !== "revoked") {
+                items.push("separator");
+                items.push({
+                  label: "Revoke",
+                  danger: true,
+                  onClick: () => void onRevoke(m.token),
+                });
+              }
+              const rowLabel = m.page ? basename(m.page) : m.token;
+              return (
+                <tr key={m.token}>
+                  <td className="share-page" title={m.page ?? "Deployed by the CLI, another app, or another machine"}>
+                    {m.page ? basename(m.page) : <span className="deploy-muted">not from this app</span>}
+                  </td>
+                  <td className="share-token" title={m.token}>
+                    {m.token}
+                  </td>
+                  <td>
+                    <span className={"share-status " + m.status}>{m.status}</span>
+                  </td>
+                  <td className="row-actions-cell">
+                    {revoking === m.token ? (
+                      <span className="deploy-muted">Revoking…</span>
+                    ) : (
+                      <RowActionsMenu
+                        items={items}
+                        disabled={revoking !== null || loading}
+                        label={`Actions for ${rowLabel}`}
+                      />
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       )}

--- a/frontend/src/components/DeploymentsList.tsx
+++ b/frontend/src/components/DeploymentsList.tsx
@@ -140,6 +140,11 @@ export default function DeploymentsList() {
                 items.push({
                   label: "Revoke",
                   danger: true,
+                  // Gate ONLY the destructive action while the list reloads or
+                  // another row is being revoked — Open ↗ / Copy link are
+                  // read-only and stay available (they were always clickable
+                  // before this moved into the menu).
+                  disabled: revoking !== null || loading,
                   onClick: () => void onRevoke(m.token),
                 });
               }
@@ -159,11 +164,7 @@ export default function DeploymentsList() {
                     {revoking === m.token ? (
                       <span className="deploy-muted">Revoking…</span>
                     ) : (
-                      <RowActionsMenu
-                        items={items}
-                        disabled={revoking !== null || loading}
-                        label={`Actions for ${rowLabel}`}
-                      />
+                      <RowActionsMenu items={items} label={`Actions for ${rowLabel}`} />
                     )}
                   </td>
                 </tr>

--- a/frontend/src/components/RowActionsMenu.tsx
+++ b/frontend/src/components/RowActionsMenu.tsx
@@ -1,0 +1,56 @@
+// A single "⋯" overflow trigger that opens the app's Finder-style ContextMenu
+// (components/ContextMenu) anchored just under it. It lets a table row expose
+// ONE quiet control instead of a pair of always-visible action buttons — the
+// row's actions (open/copy, and the destructive revoke/forget) live behind an
+// intentional click. Used by the Environments and Deployments tables on the
+// Fused account page to cut the number of buttons on screen at once.
+//
+// Positioning and dismissal (viewport clamp, outside-pointerdown, Escape,
+// scroll, resize, blur) are all inherited from ContextMenu — this only decides
+// the open point (the button's bottom-left; ContextMenu clamps it back in when
+// the row sits near a viewport edge). A row with no actionable entries renders
+// a muted "—" so the actions column still lines up.
+import { useRef, useState } from "react";
+import ContextMenu, { type MenuEntry } from "./ContextMenu";
+
+export default function RowActionsMenu({
+  items,
+  disabled = false,
+  label = "Row actions",
+}: {
+  items: MenuEntry[];
+  disabled?: boolean;
+  label?: string;
+}) {
+  const btnRef = useRef<HTMLButtonElement | null>(null);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+
+  const hasActions = items.some((it) => it !== "separator" && !it.disabled);
+  if (!hasActions) return <span className="deploy-muted">—</span>;
+
+  const open = () => {
+    const r = btnRef.current?.getBoundingClientRect();
+    if (!r) return;
+    setMenu({ x: r.left, y: r.bottom + 4 });
+  };
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        type="button"
+        className="row-actions-btn"
+        aria-label={label}
+        aria-haspopup="menu"
+        disabled={disabled}
+        // Re-clicking while open lands after ContextMenu's outside-pointerdown
+        // has already closed it, so it just reopens at the same point — a
+        // no-op-feel that never leaves a stale menu behind.
+        onClick={open}
+      >
+        ⋯
+      </button>
+      {menu && <ContextMenu x={menu.x} y={menu.y} items={items} onClose={() => setMenu(null)} />}
+    </>
+  );
+}

--- a/frontend/src/components/RowActionsMenu.tsx
+++ b/frontend/src/components/RowActionsMenu.tsx
@@ -10,7 +10,7 @@
 // the open point (the button's bottom-left; ContextMenu clamps it back in when
 // the row sits near a viewport edge). A row with no actionable entries renders
 // a muted "—" so the actions column still lines up.
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ContextMenu, { type MenuEntry } from "./ContextMenu";
 
 export default function RowActionsMenu({
@@ -24,6 +24,13 @@ export default function RowActionsMenu({
 }) {
   const btnRef = useRef<HTMLButtonElement | null>(null);
   const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+
+  // A disabled trigger must not leave an already-open menu interactive: if the
+  // trigger disables while the menu is open (e.g. another row's action starts),
+  // close it so its actions can't still be run from the open menu.
+  useEffect(() => {
+    if (disabled) setMenu(null);
+  }, [disabled]);
 
   const hasActions = items.some((it) => it !== "separator" && !it.disabled);
   if (!hasActions) return <span className="deploy-muted">—</span>;

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2053,6 +2053,26 @@ body.embed .preview-browse-chip:hover {
   cursor: default;
 }
 
+/* Inline text-link button (e.g. the setup panel's "Edit name") — no button
+   chrome, accent underline on hover. Scoped under .prefs-section to override
+   the generic `.prefs-section button` box styling. */
+.prefs-section .link-button {
+  font: inherit;
+  display: inline;
+  padding: 0;
+  border: none;
+  border-radius: 0;
+  background: none;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.prefs-section .link-button:hover:not(:disabled) {
+  background: none;
+  border: none;
+  text-decoration: underline;
+}
+
 .deploy-close:disabled {
   opacity: 0.4;
   cursor: default;

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1485,6 +1485,9 @@ body.embed .preview-browse-chip:hover {
   display: flex;
   flex-direction: column;
   gap: 1px;
+  /* Own its text alignment so it never inherits `text-align` from the element
+     it's mounted under (e.g. the right-aligned .row-actions-cell). */
+  text-align: left;
   min-width: 220px;
   padding: 5px;
   background: var(--bg-alt);
@@ -2012,6 +2015,42 @@ body.embed .preview-browse-chip:hover {
 
 .deploy-shares-table a:hover {
   text-decoration: underline;
+}
+
+/* Row overflow ("⋯") trigger and its cell — one quiet control per table row
+   that opens the shared ContextMenu with that row's actions, replacing the
+   always-visible per-row button pairs on the Fused account page. Right-aligned
+   so the triggers line up in a single narrow column. Scoped under
+   .prefs-section to win over the generic `.prefs-section button` rules. */
+.row-actions-cell {
+  text-align: right;
+  white-space: nowrap;
+  width: 1%;
+}
+
+.prefs-section .row-actions-btn {
+  font: inherit;
+  line-height: 1;
+  font-size: 18px;
+  letter-spacing: 0.06em;
+  padding: 0 8px;
+  min-height: 24px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.prefs-section .row-actions-btn:hover:not(:disabled) {
+  background: var(--bg-alt);
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.prefs-section .row-actions-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .deploy-close:disabled {

--- a/frontend/src/views/Account.tsx
+++ b/frontend/src/views/Account.tsx
@@ -29,6 +29,8 @@ import type { AccountSetupStatus, AccountStatus } from "../lib/api";
 import { notifyAccountChanged, useFusedLogin } from "../lib/account";
 import { useRefreshOnReturn } from "../lib/hooks";
 import DeploymentsList from "../components/DeploymentsList";
+import RowActionsMenu from "../components/RowActionsMenu";
+import type { MenuEntry } from "../components/ContextMenu";
 
 // The managed-env setup panel: pick the workspace (when the account has more
 // than one), name the env, run `fused cloud setup` as a tracked server job,
@@ -532,40 +534,47 @@ export default function Account() {
                   </tr>
                 </thead>
                 <tbody>
-                  {status.store.envs.map((e) => (
-                    <tr key={e.name}>
-                      <td>{e.name}</td>
-                      <td>
-                        {e.backend === "fused" ? "fused — managed" : e.backend}
-                        {!e.hosted && <span className="deploy-muted"> (not a deploy target)</span>}
-                      </td>
-                      <td className="deploy-muted">
-                        {e.name === status.store.default ? "default" : ""}
-                      </td>
-                      <td>
-                        {e.name !== status.store.default && (
-                          <button
-                            type="button"
-                            className="deploy-muted"
-                            onClick={() => void onMakeDefault(e.name)}
-                            disabled={envBusy !== null}
-                            title="Make this the fused CLI's default environment"
-                          >
-                            {envBusy === "default:" + e.name ? "Setting…" : "Make default"}
-                          </button>
-                        )}{" "}
-                        <button
-                          type="button"
-                          className="deploy-danger"
-                          onClick={() => onDeleteEnv(e.name)}
-                          disabled={envBusy !== null}
-                          title="Remove the local entry only — cloud resources are not touched"
-                        >
-                          {envBusy === "delete:" + e.name ? "Forgetting…" : "Forget"}
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
+                  {status.store.envs.map((e) => {
+                    // Collapse Make default + Forget into one "⋯" per row —
+                    // fewer buttons on screen, destructive Forget behind an
+                    // intentional click (it still shows its own confirm).
+                    const isDefault = e.name === status.store.default;
+                    const items: MenuEntry[] = [];
+                    if (!isDefault) {
+                      items.push({
+                        label: "Make default",
+                        onClick: () => void onMakeDefault(e.name),
+                      });
+                    }
+                    items.push({
+                      label: "Forget…",
+                      danger: true,
+                      onClick: () => onDeleteEnv(e.name),
+                    });
+                    return (
+                      <tr key={e.name}>
+                        <td>{e.name}</td>
+                        <td>
+                          {e.backend === "fused" ? "fused — managed" : e.backend}
+                          {!e.hosted && <span className="deploy-muted"> (not a deploy target)</span>}
+                        </td>
+                        <td className="deploy-muted">{isDefault ? "default" : ""}</td>
+                        <td className="row-actions-cell">
+                          {envBusy === "default:" + e.name ? (
+                            <span className="deploy-muted">Setting…</span>
+                          ) : envBusy === "delete:" + e.name ? (
+                            <span className="deploy-muted">Forgetting…</span>
+                          ) : (
+                            <RowActionsMenu
+                              items={items}
+                              disabled={envBusy !== null}
+                              label={`Actions for ${e.name}`}
+                            />
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </>

--- a/frontend/src/views/Account.tsx
+++ b/frontend/src/views/Account.tsx
@@ -59,6 +59,10 @@ function SetupPanel({
   const [progress, setProgress] = useState<AccountSetupStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [doneName, setDoneName] = useState<string | null>(null);
+  // The local name is a nickname for this machine's env store, not something
+  // the user must know — so it stays hidden behind "Edit name" and the common
+  // path (import the discovered env under its default name) needs zero typing.
+  const [editingName, setEditingName] = useState(false);
 
   const chosen = orgs.length > 0 ? orgs[Math.min(pick, orgs.length - 1)] : null;
   // Mirror the server's default-name rule (flow's convention) so the field
@@ -167,16 +171,18 @@ function SetupPanel({
 
   // An account that already has a workspace doesn't get anything "created" —
   // `cloud setup --org --env` CONNECTS the existing environment (mints its
-  // access key, registers it locally). Say so, and show WHICH one, even when
-  // there is exactly one and no picker is needed.
+  // access key, registers it locally). Lead with WHICH environment that is
+  // (discovered from the server via `cloud orgs`) and make importing it one
+  // click; the local name is a nickname with a working default, so it hides
+  // behind "Edit name" rather than reading as required knowledge.
   const hasWorkspace = chosen !== null;
   return (
     <>
       <p className="deploy-muted">
         {hasWorkspace
-          ? "Your account already has a hosted environment — connecting stores its access " +
-            "key with the fused CLI on this machine and registers it as a deploy target. " +
-            "Nothing new is created."
+          ? "Your account already has a hosted environment. Connecting imports it to this " +
+            "machine — it stores the environment's access key with the fused CLI and " +
+            "registers it as a deploy target. Nothing new is created."
           : "One-time setup: creates the managed Fused environment, stores its access key " +
             "with the fused CLI, and registers it as a deploy target."}
         {orgs.length === 0 &&
@@ -186,10 +192,16 @@ function SetupPanel({
           (!probe || !probe.ok) &&
           " (Workspace discovery failed — setup will discover it itself.)"}
       </p>
-      <div className="deploy-form-row">
-        {orgs.length > 1 ? (
+      {/* The discovered environment(s): a picker when the account can target
+          more than one, else the single one shown read-only. Either way the
+          user never types the org/env — it comes from the server. */}
+      {orgs.length > 1 ? (
+        <div className="deploy-form-row">
+          <label htmlFor="account-workspace-select" className="deploy-muted">
+            Environment
+          </label>
           <select
-            aria-label="Workspace"
+            id="account-workspace-select"
             value={pick}
             onChange={(e) => {
               setPick(Number(e.target.value));
@@ -205,29 +217,54 @@ function SetupPanel({
               </option>
             ))}
           </select>
-        ) : chosen ? (
+        </div>
+      ) : chosen ? (
+        <div className="deploy-form-row">
+          <span className="deploy-muted">Environment</span>
+          <code>
+            {chosen.org} / {chosen.env}
+          </code>
+          {chosen.provision_state && chosen.provision_state !== "ready" && (
+            <span className="deploy-muted">({chosen.provision_state})</span>
+          )}
+        </div>
+      ) : null}
+      {/* Local nickname — demoted: a plain line + "Edit name", so the default
+          import path needs no typing. Shown up front only when there's no
+          workspace to import (a create, where naming is the point). */}
+      <div className="deploy-form-row">
+        {editingName || !hasWorkspace ? (
+          <>
+            <label htmlFor="account-env-name" className="deploy-muted">
+              Local name
+            </label>
+            <input
+              id="account-env-name"
+              type="text"
+              value={envName}
+              onChange={(e) => setNameOverride(e.target.value)}
+              size={14}
+            />
+          </>
+        ) : (
           <span className="deploy-muted">
-            Workspace:{" "}
-            <code>
-              {chosen.org} / {chosen.env}
-            </code>
+            Saved on this machine as <code>{envName}</code>.{" "}
+            <button
+              type="button"
+              className="link-button"
+              onClick={() => setEditingName(true)}
+            >
+              Edit name
+            </button>
           </span>
-        ) : null}
-        <label htmlFor="account-env-name" className="deploy-muted">
-          Environment name
-        </label>
-        <input
-          id="account-env-name"
-          type="text"
-          value={envName}
-          onChange={(e) => setNameOverride(e.target.value)}
-          size={14}
-        />
+        )}
+      </div>
+      <div className="deploy-form-row">
         <button type="button" className="deploy-primary" onClick={begin} disabled={starting}>
           {starting
             ? "Starting…"
-            : hasWorkspace
-              ? "Connect environment"
+            : hasWorkspace && chosen
+              ? `Connect ${chosen.org} / ${chosen.env}`
               : "Set up hosted environment"}
         </button>
       </div>


### PR DESCRIPTION
Replace per-row action buttons with a single "⋯" overflow menu trigger in the Environments and Deployments tables on the account page, reducing visual clutter while keeping destructive actions behind an intentional click.

## Summary
This change introduces a new `RowActionsMenu` component that consolidates multiple action buttons per table row into a single quiet control. The menu opens a `ContextMenu` with all available actions for that row, including separators to visually distinguish destructive operations.

## Key Changes
- **New `RowActionsMenu` component** (`frontend/src/components/RowActionsMenu.tsx`): A reusable button that opens a context menu anchored below it, displaying row-specific actions. Renders a muted "—" when no actionable items are available.

- **Deployments table refactor** (`DeploymentsList.tsx`):
  - Replaced separate "Open ↗" link and "Revoke" button with a single menu
  - Menu includes: "Open ↗", "Copy link" (new), and "Revoke" (behind a separator)
  - Rows with no URL show "No link reported yet" (disabled) instead of a dash
  - Revoked rows with no URL render a muted "—"

- **Environments table refactor** (`Account.tsx`):
  - Replaced "Make default" and "Forget" buttons with a single menu per row
  - "Make default" only appears for non-default environments
  - "Forget…" is always available and marked as destructive
  - Loading states display inline text instead of button text changes

- **Styling** (`shell.css`):
  - Added `.row-actions-cell` for right-aligned, narrow action columns
  - Added `.row-actions-btn` styling: subtle appearance with hover/disabled states
  - Ensured `ContextMenu` respects `text-align: left` regardless of parent alignment

- **Documentation** (`SPEC.md`): Updated to reflect the new overflow menu pattern for both tables

## Implementation Details
- The menu positioning is handled entirely by `ContextMenu` (viewport clamping, dismissal on outside click/Escape/scroll/resize/blur)
- `RowActionsMenu` only calculates the open point (button's bottom-left corner)
- Disabled state is passed through to prevent interaction during async operations
- The "Copy link" action uses the Clipboard API with optional chaining for safety

https://claude.ai/code/session_019U3G4gM6SyafL3k4XQWHR8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only refactor on the account page using existing ContextMenu and the same API calls; no auth, deploy, or data-model changes.
> 
> **Overview**
> The Fused account page **Environments** and **Deployments** tables no longer show multiple buttons per row. Each row uses a single **⋯** control via new **`RowActionsMenu`**, which opens the existing **`ContextMenu`** for that row’s actions.
> 
> **Deployments:** Inline **Open ↗** and **Revoke** are replaced by a menu with **Open ↗**, **Copy link**, and **Revoke** (destructive, after a separator). Rows with no URL show a disabled “No link reported yet” item; rows with nothing to do show **—**.
> 
> **Environments:** **Make default** and **Forget** move into the same overflow pattern (**Forget…** as destructive).
> 
> **Setup panel:** When connecting an existing workspace, the primary action is **`Connect <org> / <env>`**; the local env nickname is hidden behind **Edit name** (link-style control) instead of always showing an editable field. Create-without-workspace still shows the name field up front.
> 
> **SPEC.md** is updated for AC-8/AC-11. **shell.css** adds row-action and link-button styles plus left-aligned context menu text when opened from a right-aligned cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaf642edb6500095b6d3eedde95592e55b789fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->