### PR TITLE
Publish release artifacts to fused-render bucket via CloudFront

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,11 @@ jobs:
       KEYCHAIN_PATH: ${{ github.workspace }}/ci-signing.keychain-db
       NOTARY_PROFILE: ci-notary
       AWS_DEFAULT_REGION: us-west-2
+      S3_BUCKET: fused-render
+      # CloudFront distribution fronting the fused-render bucket
+      # (application/terraform/main, aws_cloudfront_distribution.fused_render).
+      CDN_DOMAIN: d2ic19jpchjovp.cloudfront.net
+      CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
     steps:
       - uses: actions/checkout@v4
         with:
@@ -101,11 +106,18 @@ jobs:
           echo "DMG_PATH=$DMG_PATH" >> "$GITHUB_ENV"
           echo "DMG_SHA256=$DMG_SHA256" >> "$GITHUB_ENV"
           echo "WHL_PATH=$WHL_PATH" >> "$GITHUB_ENV"
-          # Bucket is public read; plain https S3 URL works with no signing.
-          echo "DMG_URL=https://fused-magic.s3.us-west-2.amazonaws.com/fused-render-dmgs/$(basename "$DMG_PATH")" >> "$GITHUB_ENV"
-          echo "WHL_URL=https://fused-magic.s3.us-west-2.amazonaws.com/fused-render-wheels/$(basename "$WHL_PATH")" >> "$GITHUB_ENV"
-          aws s3 cp "$DMG_PATH" "s3://fused-magic/fused-render-dmgs/$(basename "$DMG_PATH")"
-          aws s3 cp "$WHL_PATH" "s3://fused-magic/fused-render-wheels/$(basename "$WHL_PATH")"
+          # Served via CloudFront (public bucket behind the CDN).
+          echo "DMG_URL=https://${CDN_DOMAIN}/fused-render-dmgs/$(basename "$DMG_PATH")" >> "$GITHUB_ENV"
+          echo "WHL_URL=https://${CDN_DOMAIN}/fused-render-wheels/$(basename "$WHL_PATH")" >> "$GITHUB_ENV"
+          aws s3 cp "$DMG_PATH" "s3://${S3_BUCKET}/fused-render-dmgs/$(basename "$DMG_PATH")"
+          aws s3 cp "$WHL_PATH" "s3://${S3_BUCKET}/fused-render-wheels/$(basename "$WHL_PATH")"
+
+      - name: Invalidate CloudFront
+        run: |
+          set -euo pipefail
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths "/fused-render-dmgs/*" "/fused-render-wheels/*"
 
       - name: Find previous tag
         id: prev_tag


### PR DESCRIPTION
## What

Switches the release workflow from the shared `fused-magic` bucket to the dedicated **`fused-render`** bucket fronted by **CloudFront**, and invalidates the CDN after each publish.

Depends on the infra PR that creates the bucket/distribution/IAM: fusedlabs/application#7867 (already applied — distribution `E393B7TS7Y3EDS`, `d2ic19jpchjovp.cloudfront.net`).

## Changes (`.github/workflows/release.yml`)

- Upload DMG/wheel to `s3://fused-render/` instead of `s3://fused-magic/` (same `fused-render-dmgs/` + `fused-render-wheels/` prefixes).
- Release-notes download URLs now point at the CloudFront domain.
- New **Invalidate CloudFront** step after upload (`--paths /fused-render-dmgs/* /fused-render-wheels/*`) so new artifacts aren't served stale.
- Added `S3_BUCKET`, `CDN_DOMAIN`, `CLOUDFRONT_DISTRIBUTION_ID` job env vars.

AWS auth (OIDC role `github_fused_render_role`, us-west-2) is unchanged; that role's policy gains the new bucket + invalidation permissions in the companion infra PR.

## Verification

Merge, then push a `v*` tag: confirm upload lands in `s3://fused-render/`, the invalidation succeeds (`aws cloudfront list-invalidations --distribution-id E393B7TS7Y3EDS`), and the Release notes link resolves via `https://d2ic19jpchjovp.cloudfront.net/...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release delivery path and public download URLs; a failed upload or missing IAM/infra would break releases or leave stale CDN content until invalidation succeeds.
> 
> **Overview**
> Release DMG and wheel uploads move from **`fused-magic`** to the dedicated **`fused-render`** S3 bucket (same `fused-render-dmgs/` and `fused-render-wheels/` key prefixes). GitHub Release download links now use the **CloudFront** domain instead of direct S3 URLs.
> 
> Job env adds **`S3_BUCKET`**, **`CDN_DOMAIN`**, and **`CLOUDFRONT_DISTRIBUTION_ID`**. A new **Invalidate CloudFront** step runs after upload so CDN paths for those prefixes are refreshed on each release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3518e8618c826b9ae802a826590abd78a509425. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->