### PR TITLE
Add fused.env runtime identity for environment branching

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -116,7 +116,17 @@ fused.params.get(name)
 fused.params.set(name, value)          // strings only; always replaceState
 fused.params.getAll()
 fused.params.onChange(callback)   // fires whenever params change; author re-runs Python here
+
+// Runtime identity — "local" here, "hosted" on a deployed artifact (§18, RH-10)
+fused.env
 ```
+
+- **RH-10** `fused.env` is the **runtime identity**: `"local"` in the fused-render app,
+  `"hosted"` on a deployed/exported artifact (set by the fused wheel's serve runtime,
+  §18). It lets a page branch on where it runs — e.g. use a local-only mechanism (a
+  spawned `runPython` daemon reachable at `127.0.0.1`) when `fused.env === "local"` and
+  degrade gracefully when `"hosted"`, where no such daemon exists. Both runtimes expose
+  it, so the check is a positive signal, not the absence of an API.
 
 ### 4.2 `runPython(path, params)`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -123,9 +123,8 @@ fused.env
 
 - **RH-10** `fused.env` is the **runtime identity**: `"local"` in the fused-render app,
   `"hosted"` on a deployed/exported artifact (set by the fused wheel's serve runtime,
-  §18). It lets a page branch on where it runs — e.g. use a local-only mechanism (a
-  spawned `runPython` daemon reachable at `127.0.0.1`) when `fused.env === "local"` and
-  degrade gracefully when `"hosted"`, where no such daemon exists. Both runtimes expose
+  §18). It lets a page branch on where it runs — gating any local-only behaviour when
+  `fused.env === "local"` and degrading gracefully when `"hosted"`. Both runtimes expose
   it, so the check is a positive signal, not the absence of an API.
 
 ### 4.2 `runPython(path, params)`

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -71,9 +71,15 @@ runtime API is portable:
 | `fused.rawUrl(path)` | ✅ | `path` is bundled as a read-only asset. |
 | `fused.readFile(path)` | ✅ | same bundling as `rawUrl`. |
 | `fused.params.*` | ✅ | pure client-side URL state — unchanged. |
+| `fused.env` | ✅ | runtime identity — `"local"` in the fused-render app, `"hosted"` here. Branch on it to skip local-only paths (e.g. a `127.0.0.1` daemon) when deployed. |
 | `fused.writeFile(...)` | ❌ | a hosted artifact is immutable. |
 | `fused.stat(...)` | ❌ | no filesystem to stat. |
 | SSE live-reload | ❌ | the artifact does not change under the page. |
+
+`fused.env` is the recommended way to tell the two environments apart: it is a
+**positive** signal present in both runtimes (`"local"` vs `"hosted"`), not the
+absence of a method — `writeFile`/`stat` exist in the hosted runtime too (they
+throw), so sniffing for them misidentifies a hosted page as local.
 
 ## Rules the exporter enforces
 

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -71,7 +71,7 @@ runtime API is portable:
 | `fused.rawUrl(path)` | ✅ | `path` is bundled as a read-only asset. |
 | `fused.readFile(path)` | ✅ | same bundling as `rawUrl`. |
 | `fused.params.*` | ✅ | pure client-side URL state — unchanged. |
-| `fused.env` | ✅ | runtime identity — `"local"` in the fused-render app, `"hosted"` here. Branch on it to skip local-only paths (e.g. a `127.0.0.1` daemon) when deployed. |
+| `fused.env` | ✅ | runtime identity — `"local"` in the fused-render app, `"hosted"` here. Branch on it to gate local-only paths when deployed. |
 | `fused.writeFile(...)` | ❌ | a hosted artifact is immutable. |
 | `fused.stat(...)` | ❌ | no filesystem to stat. |
 | SSE live-reload | ❌ | the artifact does not change under the page. |

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -8,8 +8,8 @@
  *   fused.params.get(key) / getAll() / set(key, value) / onChange(cb) -> unsubscribe
  *   fused.env -> "local" — the runtime identity. This is the local fused-render app;
  *                the hosted/exported runtime (fused wheel) sets "hosted" instead, so a
- *                page can branch on where it runs (e.g. skip a localhost daemon when
- *                deployed). See docs/EXPORT.md.
+ *                page can branch on where it runs and gate any local-only behaviour
+ *                when deployed. See docs/EXPORT.md.
  *
  * Same-origin iframe model: this script talks to an ancestor window's URL
  * directly (no postMessage bridge — see DECISIONS.md D3/D4). The param target

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -6,6 +6,10 @@
  *                   aborts the prior in-flight one (D113 — cancel stale scrubs).
  *     opts.signal — a caller AbortSignal; composes with the channel abort.
  *   fused.params.get(key) / getAll() / set(key, value) / onChange(cb) -> unsubscribe
+ *   fused.env -> "local" — the runtime identity. This is the local fused-render app;
+ *                the hosted/exported runtime (fused wheel) sets "hosted" instead, so a
+ *                page can branch on where it runs (e.g. skip a localhost daemon when
+ *                deployed). See docs/EXPORT.md.
  *
  * Same-origin iframe model: this script talks to an ancestor window's URL
  * directly (no postMessage bridge — see DECISIONS.md D3/D4). The param target
@@ -572,6 +576,9 @@
   }
 
   window.fused = {
+    // Runtime identity: "local" here (the fused-render app). The hosted/exported
+    // runtime sets "hosted", so a page can branch on where it runs (EXPORT.md).
+    env: "local",
     runPython,
     rawUrl,
     stat,

--- a/tests/test_runtime_cancellation.py
+++ b/tests/test_runtime_cancellation.py
@@ -20,6 +20,13 @@ SINE = (
 ).read_text(encoding="utf-8")
 
 
+def test_runtime_exposes_local_env_identity():
+    # fused.env is the runtime identity: "local" here, "hosted" on a deployed
+    # artifact (SPEC RH-10). A page branches on it to skip local-only paths
+    # (e.g. a 127.0.0.1 daemon) when served.
+    assert 'env: "local"' in RUNTIME
+
+
 def test_runtime_runpython_takes_opts():
     # runPython grew a third `opts` argument carrying key/signal.
     assert "function runPython(pyPath, params, opts)" in RUNTIME


### PR DESCRIPTION
## Summary
Introduces `fused.env`, a new runtime identity property that allows pages to detect whether they're running in the local fused-render app (`"local"`) or a deployed/exported artifact (`"hosted"`). This enables pages to gracefully branch behavior based on their execution environment.

## Key Changes
- **runtime.js**: Added `fused.env` property set to `"local"` in the local fused-render runtime, with documentation explaining that the hosted runtime sets it to `"hosted"`
- **SPEC.md**: Documented `fused.env` as part of the public API (§RH-10) with detailed explanation of its purpose and usage patterns
- **EXPORT.md**: Added `fused.env` to the API compatibility table and clarified it as the recommended way to distinguish environments (as a positive signal present in both runtimes, not by absence of methods)
- **test_runtime_cancellation.py**: Added test to verify `fused.env` is properly exposed in the runtime

## Implementation Details
- `fused.env` is a **positive signal** present in both runtimes, not a feature detection mechanism. This prevents misidentification of hosted pages as local when checking for method existence (e.g., `writeFile`/`stat` exist in hosted runtime but throw)
- The property enables use cases like skipping localhost-only mechanisms (e.g., a spawned `runPython` daemon at `127.0.0.1`) when deployed
- Both runtimes expose this property, making it a reliable way to branch behavior without relying on API absence

https://claude.ai/code/session_0123B1Pkj9cS6Lwtkx3KjgDe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation plus a read-only constant on the injected runtime; no auth, deploy, or execution-path changes.
> 
> **Overview**
> Adds **`fused.env`** as a public runtime API so renderable pages can tell whether they run in the fused-render app (`"local"`) or on a deployed/exported artifact (`"hosted"`).
> 
> The local injected runtime in `runtime.js` now exposes `env: "local"` on `window.fused`. **SPEC** documents **RH-10** and lists `fused.env` in the §4.1 API sketch; **EXPORT.md** adds it to the portable API table and recommends branching on this **positive** signal instead of inferring environment from missing or throwing methods (`writeFile`/`stat` exist on hosted too).
> 
> A string-contract test asserts the shipped runtime contains `env: "local"`. The hosted wheel runtime is expected to set `"hosted"` per docs (not changed in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 861cc6f3fd0aca71ccf1b3532c48c8fe5135487c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->