### PR TITLE
Bump pinned fused wheel to 2.9.3.post3

### DIFF
--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -137,7 +137,7 @@ def _now_iso() -> str:
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
 PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post2-py3-none-any.whl"
+    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post3-py3-none-any.whl"
 )
 # The wheel's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ app = [
 # The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post2-py3-none-any.whl ; python_version >= "3.11"',
+    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post3-py3-none-any.whl ; python_version >= "3.11"',
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Bumps the pinned `fused` wheel from `2.9.3.post2` → `2.9.3.post3`.

fused-render has no lockfile, so both pins that a test keeps in lockstep are updated:

- `pyproject.toml` — the `[fused]` optional dependency
- `fused_render/deploy.py` — `PINNED_FUSED_REQUIREMENT` (the Deploy modal's one-click install)

## Verification

- `tests/test_deploy.py::test_pinned_requirement_matches_pyproject_extra` passes — confirms the two pins match at `post3`.
- The `post3` wheel URL returns 200 from S3.

Note: `test_install_invokes_pip_with_the_pinned_requirement` fails in a bare checkout because the gitignored React `shell-dist/` build artifact is absent (the test harness can't start the app). This is environmental and unrelated to the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HfZzakAQiFiKYBXPKcoSw

---
_Generated by [Claude Code](https://claude.ai/code/session_013HfZzakAQiFiKYBXPKcoSw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only pin updates with no logic changes; risk is limited to whether the new wheel behaves identically for deploy and `/api/run`.
> 
> **Overview**
> Updates the locked **`fused`** wheel from **`2.9.3.post2`** to **`2.9.3.post3`** on the same S3 URL pattern so deploy one-click install and optional local execution stay on one build.
> 
> Both pins that must match are changed: **`PINNED_FUSED_REQUIREMENT`** in `deploy.py` (Deploy modal `POST /api/deploy/install`) and the **`[fused]`** extra in `pyproject.toml` (Python 3.11+ marker unchanged). Existing tests keep the two in lockstep.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4ffb0a802fb03bf771f1d6d7046f8d42188336d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->