### PR TITLE
duckdb grid: prune row groups on first-page reads + prioritize footer/head in prefetch

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2063,6 +2063,14 @@ def create_app(start_dir: str) -> FastAPI:
         # Deferred condition.py evaluation (SPEC CT-12): stat marks gated
         # templates `conditional`; this resolves them while the client already
         # renders the first unconditional template.
+        #
+        # This does NOT gate first paint, on either side. Server-side it's a
+        # sync `def`, so FastAPI runs it in the threadpool — its cold os.stat
+        # over the mount (~1.6s) never blocks the event loop or other requests.
+        # Client-side the frontend fetches it from a background useEffect
+        # (Preview.tsx `useConditions`) and renders every unconditional
+        # template while the verdict is still `null` — the gated ones just show
+        # a spinner until it lands. So no change on the render path is needed.
         return _conditions_payload(path)
 
     @app.get("/api/fs/list")

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -232,16 +232,22 @@ def _prioritized_chunks(size: int) -> "list[tuple[int, int]]":
             + _split(head_end, tail_start))
 
 
-def _fetch_chunk(url: str, off: int, end: int, path: str) -> int:
-    """Fetch bytes [off, end] through the serve and discard them (the point
-    is the serve's cache side effect); add the bytes that land to the job's
-    progress. Returns the new offset. Blocking — run via asyncio.to_thread.
+def _fetch_chunk(url: str, start: int, end: int, path: str,
+                 committed: int) -> None:
+    """Fetch bytes [start, end] through the serve and discard them (the point
+    is the serve's cache side effect); report progress as the bytes land.
+    Blocking — run via asyncio.to_thread.
 
-    Progress is accumulated (not set to the absolute offset) because chunks
-    stream out of file order — head, then tail, then middle — so `done` tracks
-    total bytes fetched, still reaching `size` when every chunk is in."""
+    Progress is `committed + (off - start)` — the bytes banked by fully
+    finished chunks plus this chunk's own intra-chunk offset. That is
+    idempotent across retries: a retried chunk re-requests from `start`, so a
+    failed partial attempt's bytes are simply re-counted from the chunk base
+    rather than added a second time — `done` can never overshoot `size`.
+    Chunks also stream out of file order (head, tail, middle), so the base is
+    `committed` (finished-chunk bytes), not the absolute file offset."""
     req = urllib.request.Request(url)
-    req.add_header("Range", f"bytes={off}-{end}")
+    req.add_header("Range", f"bytes={start}-{end}")
+    off = start
     with urllib.request.urlopen(req, timeout=120) as r:
         while True:
             b = r.read(1024 * 1024)
@@ -250,8 +256,7 @@ def _fetch_chunk(url: str, off: int, end: int, path: str) -> int:
             off += len(b)
             with _lock:
                 if path in _jobs:
-                    _jobs[path]["done"] += len(b)
-    return off
+                    _jobs[path]["done"] = committed + (off - start)
 
 
 async def _acquire_slot() -> "asyncio.Semaphore":
@@ -296,30 +301,34 @@ async def _prefetch(path: str, url: str) -> None:
         # after START_DELAY_S so the triggering interactive read gets ahead.
         await asyncio.sleep(START_DELAY_S)
         async with await _acquire_slot():
-            errors = 0
+            errors, committed = 0, 0
             # Head, then footer tail, then the middle bulk (see
             # _prioritized_chunks) so a first-page read racing us warms fast.
+            # `committed` banks the bytes of finished chunks; a chunk is
+            # re-requested whole on failure, so nothing partial is committed.
             for start, end in _prioritized_chunks(size):
-                off = start
-                while off <= end:
+                while True:
                     await _wait_for_lull(path)
                     try:
-                        off = await asyncio.to_thread(
-                            _fetch_chunk, url, off, end, path)
-                        errors = 0
+                        await asyncio.to_thread(
+                            _fetch_chunk, url, start, end, path, committed)
+                        break
                     except Exception as exc:
                         _release(exc)
                         errors += 1
                         if errors > MAX_CONSECUTIVE_ERRORS:
                             logger.warning(
                                 "prefetch of %r gave up at %d/%d bytes",
-                                path, off, size)
+                                path, committed, size)
                             _finish(path, "failed")
                             return
-                        # Resume at `off`: everything fetched so far is already
-                        # in the serve's cache, so re-requesting it replays
-                        # locally.
+                        # Re-request the whole chunk from `start`: bytes already
+                        # fetched are in the serve's cache and replay locally,
+                        # and progress resets to `committed` so the retry can't
+                        # push `done` past `size`.
                         await asyncio.sleep(min(2.0 * errors, 30.0))
+                errors = 0
+                committed += end - start + 1
             _finish(path, "done")
             logger.info("prefetched %r (%d bytes) into the serve cache",
                         path, size)

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -257,6 +257,15 @@ def _fetch_chunk(url: str, start: int, end: int, path: str,
             with _lock:
                 if path in _jobs:
                     _jobs[path]["done"] = committed + (off - start)
+    # A connection-close-delimited (or otherwise unframed) response can reach a
+    # clean EOF with the body truncated — read() just returns empty, no
+    # exception. Verify we actually consumed the whole [start, end] range; if
+    # not, raise so the caller re-requests the chunk instead of committing bytes
+    # that never landed and finishing the job with data missing.
+    if off != end + 1:
+        raise OSError(
+            f"short read: got {off - start} of {end - start + 1} bytes "
+            f"for range [{start}, {end}]")
 
 
 async def _acquire_slot() -> "asyncio.Semaphore":

--- a/fused_render/shell/prefetch.py
+++ b/fused_render/shell/prefetch.py
@@ -73,6 +73,15 @@ MAX_TRACKED = int(os.environ.get("FUSED_RENDER_PREFETCH_MAX_TRACKED", 2048))
 ENABLED = os.environ.get("FUSED_RENDER_PREFETCH", "1") != "0"
 
 CHUNK_BYTES = 32 * 1024 * 1024
+# Two regions a cold first-page read touches before anything else, fetched
+# ahead of the bulk so an interactive read racing this background stream finds
+# them already warm in the serve cache: the parquet footer/metadata lives in
+# the file *tail* (the ~7s cold DESCRIBE parses it), and row group 0 — what an
+# unsorted first page reads — lives in the *head*. Streaming strictly 0->end
+# would warm the head early but leave the footer cold until the very end, so a
+# first open midway through the stream still pays the cold footer parse.
+HEAD_BYTES = 8 * 1024 * 1024
+FOOTER_BYTES = 1 * 1024 * 1024
 # Applies to the DOWNLOAD phase only, not the size-gate HEAD: once a file
 # clears the gate, let the interactive load that triggered us win its
 # first cold seeks before the whole-file stream starts competing for the
@@ -204,10 +213,33 @@ def _head_size(url: str) -> int | None:
         return int(cl) if cl is not None else None
 
 
+def _prioritized_chunks(size: int) -> "list[tuple[int, int]]":
+    """The whole file as [start, end] chunks (end inclusive), ordered so the
+    two latency-critical regions stream first: the head (row group 0) then the
+    footer tail, then the middle bulk. Every byte of [0, size) is covered
+    exactly once. On a file at or below HEAD_BYTES the head already spans the
+    whole file, so this degrades to a plain sequential 0->end plan (the tail
+    and middle ranges are empty) — preserving the small-file behaviour."""
+    head_end = min(HEAD_BYTES, size)
+    tail_start = max(head_end, size - FOOTER_BYTES)
+
+    def _split(lo: int, hi: int) -> "list[tuple[int, int]]":
+        return [(o, min(o + CHUNK_BYTES, hi) - 1)
+                for o in range(lo, hi, CHUNK_BYTES)]
+
+    # head (row group 0), then footer tail, then the middle bulk.
+    return (_split(0, head_end) + _split(tail_start, size)
+            + _split(head_end, tail_start))
+
+
 def _fetch_chunk(url: str, off: int, end: int, path: str) -> int:
     """Fetch bytes [off, end] through the serve and discard them (the point
-    is the serve's cache side effect); update the job's progress as bytes
-    land. Returns the new offset. Blocking — run via asyncio.to_thread."""
+    is the serve's cache side effect); add the bytes that land to the job's
+    progress. Returns the new offset. Blocking — run via asyncio.to_thread.
+
+    Progress is accumulated (not set to the absolute offset) because chunks
+    stream out of file order — head, then tail, then middle — so `done` tracks
+    total bytes fetched, still reaching `size` when every chunk is in."""
     req = urllib.request.Request(url)
     req.add_header("Range", f"bytes={off}-{end}")
     with urllib.request.urlopen(req, timeout=120) as r:
@@ -218,7 +250,7 @@ def _fetch_chunk(url: str, off: int, end: int, path: str) -> int:
             off += len(b)
             with _lock:
                 if path in _jobs:
-                    _jobs[path]["done"] = off
+                    _jobs[path]["done"] += len(b)
     return off
 
 
@@ -264,26 +296,30 @@ async def _prefetch(path: str, url: str) -> None:
         # after START_DELAY_S so the triggering interactive read gets ahead.
         await asyncio.sleep(START_DELAY_S)
         async with await _acquire_slot():
-            off, errors = 0, 0
-            while off < size:
-                await _wait_for_lull(path)
-                end = min(off + CHUNK_BYTES, size) - 1
-                try:
-                    off = await asyncio.to_thread(
-                        _fetch_chunk, url, off, end, path)
-                    errors = 0
-                except Exception as exc:
-                    _release(exc)
-                    errors += 1
-                    if errors > MAX_CONSECUTIVE_ERRORS:
-                        logger.warning("prefetch of %r gave up at %d/%d bytes",
-                                       path, off, size)
-                        _finish(path, "failed")
-                        return
-                    # Resume at `off`: everything fetched so far is already
-                    # in the serve's cache, so re-requesting it replays
-                    # locally.
-                    await asyncio.sleep(min(2.0 * errors, 30.0))
+            errors = 0
+            # Head, then footer tail, then the middle bulk (see
+            # _prioritized_chunks) so a first-page read racing us warms fast.
+            for start, end in _prioritized_chunks(size):
+                off = start
+                while off <= end:
+                    await _wait_for_lull(path)
+                    try:
+                        off = await asyncio.to_thread(
+                            _fetch_chunk, url, off, end, path)
+                        errors = 0
+                    except Exception as exc:
+                        _release(exc)
+                        errors += 1
+                        if errors > MAX_CONSECUTIVE_ERRORS:
+                            logger.warning(
+                                "prefetch of %r gave up at %d/%d bytes",
+                                path, off, size)
+                            _finish(path, "failed")
+                            return
+                        # Resume at `off`: everything fetched so far is already
+                        # in the serve's cache, so re-requesting it replays
+                        # locally.
+                        await asyncio.sleep(min(2.0 * errors, 30.0))
             _finish(path, "done")
             logger.info("prefetched %r (%d bytes) into the serve cache",
                         path, size)

--- a/fused_render/templates/duckdb/reader.py
+++ b/fused_render/templates/duckdb/reader.py
@@ -600,11 +600,15 @@ def _read_flat(file: str, scan: str, con, ext: str, offset: int, limit: int,
         in_list = ",".join(str(int(p)) for p in positions[:MAX_LIMIT]) or "-1"
         cur = con.execute(f"SELECT file_row_number AS {_POS}, {proj} "
                           f"FROM {rel} WHERE file_row_number IN ({in_list})")
-    elif ext == ".parquet" and not where and not order:
+    elif _logical_ext(scan) == ".parquet" and not where and not order:
         # Unsorted, unfiltered parquet page: _page_sql bakes the window into a
         # file_row_number range predicate (see its docstring) so DuckDB prunes
         # to the covering row groups. The window is in the SQL, not bound —
         # wbinds is empty here (no filter), so there are no ? to fill.
+        # Key on the SCAN's ext, not `ext` (the file's): _page_sql branches on
+        # _logical_ext(scan), and if the two diverge (a source_url without a
+        # splitext-visible .parquet) the branch and the emitted SQL must still
+        # agree, else the no-bind path meets a LIMIT ? OFFSET ? query.
         cur = con.execute(_page_sql(scan, relation, where, order, projection,
                                     offset=offset, limit=limit), wbinds)
     else:

--- a/fused_render/templates/duckdb/reader.py
+++ b/fused_render/templates/duckdb/reader.py
@@ -256,6 +256,17 @@ def _http_connection():
         # converge to the slowest column (measured: 32 threads -> the light
         # columns land in ~5s while an 18MB column takes 13s; default pool ->
         # everything takes 13s). IO-bound, so way past core count is fine.
+        #
+        # threads=32 used to also *drive* an over-read on many-small-row-group
+        # files: a LIMIT/OFFSET page let the parallel scan speculatively open
+        # ~threads row groups before the LIMIT halted it (measured ~32 groups /
+        # ~12s cold when only row group 0 was needed). That is fixed at the
+        # source now — the unsorted, unfiltered page prunes to its row-group
+        # range via a file_row_number predicate (see _page_sql), so DuckDB never
+        # schedules groups outside the window regardless of thread count. So
+        # threads=32 stays: it helps the single-big-row-group file (which must
+        # read whole column chunks and parallelizes to the bucket ceiling)
+        # without hurting the many-small-group file any more.
         con.execute("SET threads=32")
         setattr(duckdb, key, con)
     return con.cursor()
@@ -285,7 +296,8 @@ def relation_for(file: str, file_row_number: bool = False) -> str:
 
 
 def _page_sql(scan: str, relation: str, where: str, order: str,
-              projection: str = "*") -> str:
+              projection: str = "*", offset: int = 0,
+              limit: int = MAX_LIMIT) -> str:
     """The paging SELECT, which must also yield each row's physical file position
     as `_POS` (the writer's edit key) even after WHERE/ORDER reshuffle the page.
     `scan` is whatever relation_for reads — the file path, or the http URL on
@@ -304,6 +316,19 @@ def _page_sql(scan: str, relation: str, where: str, order: str,
     match. CSV/JSON have no such pseudo-column and can't prune anyway, so they
     keep the streaming window (LIMIT still pushes through it).
 
+    The common first-page case — an unsorted, unfiltered parquet page — gets
+    row-group pruning up front: file position IS the page order, so the window
+    [offset, offset+limit) is expressed as a `file_row_number` range predicate
+    instead of LIMIT/OFFSET. LIMIT/OFFSET alone are *reactive* — DuckDB's
+    parallel scan (threads=32 here) speculatively reads ~threads row groups
+    before the LIMIT halts it (measured: ~32 groups / ~12s cold when only row
+    group 0 / ~2MB was needed). The range predicate prunes to just the groups
+    spanning the window, so only their bytes move. Sound only unsorted +
+    unfiltered, where physical position and logical page order coincide; a sort
+    or filter keeps the LIMIT/OFFSET window (position no longer tracks order).
+    offset/limit are int-clamped in main, so interpolating them as literals is
+    safe and matches _rowgroup_prune / the positions IN-list path.
+
     A user sort always gets the physical position appended as a tiebreaker.
     Without it, ties at a page boundary make the LIMIT/OFFSET window itself
     nondeterministic under parallel execution — and the grid's per-column
@@ -314,6 +339,10 @@ def _page_sql(scan: str, relation: str, where: str, order: str,
     if _logical_ext(scan) == ".parquet":
         rel = relation_for(scan, file_row_number=True)
         proj = "* EXCLUDE (file_row_number)" if projection == "*" else projection
+        if not where and not order:
+            return (f"SELECT file_row_number AS {_POS}, {proj} FROM {rel} "
+                    f"WHERE file_row_number >= {offset} "
+                    f"AND file_row_number < {offset + limit}")
         tie = f"{order}, file_row_number" if order else ""
         return (f"SELECT file_row_number AS {_POS}, {proj} "
                 f"FROM {rel}{where}{tie} LIMIT ? OFFSET ?")
@@ -571,6 +600,13 @@ def _read_flat(file: str, scan: str, con, ext: str, offset: int, limit: int,
         in_list = ",".join(str(int(p)) for p in positions[:MAX_LIMIT]) or "-1"
         cur = con.execute(f"SELECT file_row_number AS {_POS}, {proj} "
                           f"FROM {rel} WHERE file_row_number IN ({in_list})")
+    elif ext == ".parquet" and not where and not order:
+        # Unsorted, unfiltered parquet page: _page_sql bakes the window into a
+        # file_row_number range predicate (see its docstring) so DuckDB prunes
+        # to the covering row groups. The window is in the SQL, not bound —
+        # wbinds is empty here (no filter), so there are no ? to fill.
+        cur = con.execute(_page_sql(scan, relation, where, order, projection,
+                                    offset=offset, limit=limit), wbinds)
     else:
         cur = con.execute(_page_sql(scan, relation, where, order, projection),
                           wbinds + [limit, offset])

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -269,6 +269,30 @@ def test_pruned_page_matches_limit_offset_scan(grouped_parquet):
         assert [r["seq"] for r in out["rows"]] == expected, offset
 
 
+def test_pruned_page_over_http_preserves_file_order(grouped_parquet):
+    # The pruned first page has no ORDER BY — it relies on
+    # preserve_insertion_order to return rows in file_row_number order. Prove
+    # that holds on the remote path this fix actually targets: the shared
+    # _http_connection runs SET threads=32, where an unordered parallel scan
+    # could otherwise interleave row groups. Windows straddling the 2048-row
+    # group boundary exercise the multi-group case.
+    srv, hits = _serve_dir(os.path.dirname(grouped_parquet))
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/g.parquet"
+        try:
+            reader.main(grouped_parquet, mode="page", limit=1, source_url=url)
+        except Exception:
+            pytest.skip("duckdb httpfs extension unavailable")
+        for offset in (0, 2000, 2048, 4096, 6000):
+            out = reader.main(grouped_parquet, mode="page", offset=offset,
+                              limit=100, source_url=url)
+            expected = list(range(offset, offset + 100))
+            assert out["ids"] == expected, offset
+            assert [r["seq"] for r in out["rows"]] == expected, offset
+    finally:
+        srv.shutdown()
+
+
 def test_pruned_page_projection_matches_scan(grouped_parquet):
     # A narrow projection on the pruned path still keys rows by physical
     # position and returns exactly the window's rows.

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -206,6 +206,58 @@ def test_parquet_page_sql_uses_file_row_number(parquet_file):
     assert "row_number() OVER" not in sql
 
 
+def test_parquet_unsorted_page_sql_prunes_by_file_row_number_range(parquet_file):
+    # The common first-page case (no sort, no filter) expresses its window as a
+    # file_row_number range predicate so DuckDB prunes to the covering row
+    # groups instead of reading ~threads groups ahead before LIMIT halts it.
+    rel = reader.relation_for(parquet_file)
+    sql = reader._page_sql(parquet_file, rel, "", "", offset=100, limit=50)
+    assert "file_row_number >= 100 AND file_row_number < 150" in sql
+    assert "LIMIT ? OFFSET ?" not in sql          # window is the predicate now
+    # A sort or filter must NOT prune by physical position (it no longer tracks
+    # logical page order) — those keep the LIMIT/OFFSET window.
+    sorted_sql = reader._page_sql(parquet_file, rel, "", ' ORDER BY "id" ASC',
+                                  offset=100, limit=50)
+    assert "file_row_number >= 100" not in sorted_sql
+    assert "LIMIT ? OFFSET ?" in sorted_sql
+    filtered_sql = reader._page_sql(parquet_file, rel, ' WHERE "id" > 5', "",
+                                    offset=100, limit=50)
+    assert "file_row_number >= 100" not in filtered_sql
+    assert "LIMIT ? OFFSET ?" in filtered_sql
+
+
+def _direct_page_positions(path, offset, limit):
+    """Reference window: the plain LIMIT/OFFSET natural-order scan the pruning
+    path replaces. Its rows/positions must match exactly."""
+    con = duckdb.connect()
+    rows = con.execute(
+        f"SELECT file_row_number FROM read_parquet('{path}', "
+        f"file_row_number=true) LIMIT {limit} OFFSET {offset}").fetchall()
+    con.close()
+    return [r[0] for r in rows]
+
+
+def test_pruned_page_matches_limit_offset_scan(grouped_parquet):
+    # Offsets landing in the first, a middle, and the last row group, plus one
+    # past EOF (empty). Each pruned page must return exactly the rows/positions
+    # the LIMIT/OFFSET scan would.
+    for offset in (0, 100, 5000, 9950, 10000, 12000):
+        out = reader.main(grouped_parquet, mode="page", offset=offset, limit=50)
+        expected = _direct_page_positions(grouped_parquet, offset, 50)
+        assert out["ids"] == expected, offset
+        assert [r["seq"] for r in out["rows"]] == expected, offset
+
+
+def test_pruned_page_projection_matches_scan(grouped_parquet):
+    # A narrow projection on the pruned path still keys rows by physical
+    # position and returns exactly the window's rows.
+    out = reader.main(grouped_parquet, mode="page", columns=["seq"],
+                      offset=4096, limit=10)
+    assert out["columns"] == ["seq"]
+    assert out["ids"] == list(range(4096, 4106))
+    assert [r["seq"] for r in out["rows"]] == list(range(4096, 4106))
+
+
 def test_csv_page_sql_keeps_window(csv_file):
     # CSV/JSON can't prune, and have no file_row_number, so they keep the
     # streaming row_number() window.

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -226,6 +226,27 @@ def test_parquet_unsorted_page_sql_prunes_by_file_row_number_range(parquet_file)
     assert "LIMIT ? OFFSET ?" in filtered_sql
 
 
+def test_page_branch_keys_on_scan_ext_not_file_ext(tmp_path):
+    # The natural-order pruning branch must be chosen by the SCAN's logical ext
+    # (what _page_sql itself branches on), not the file's. They can diverge — a
+    # source_url whose splitext-visible extension isn't .parquet while the local
+    # file is. If the branch keyed on the file ext it would take the no-bind
+    # range path while _page_sql emits a LIMIT ? OFFSET ? query -> a bind-count
+    # error. Here scan is a real .json (non-parquet ext) with the file ext
+    # forced to .parquet: the robust LIMIT/OFFSET path must run and read it.
+    jp = _make(tmp_path, "s.json",
+               "SELECT range AS id, 'n'||range AS name FROM range(5)")
+    con = duckdb.connect(":memory:")
+    con.execute("PRAGMA enable_object_cache=true")
+    try:
+        out = reader._read_flat(jp, jp, con, ".parquet", 0, 3,
+                                None, None, "page")
+    finally:
+        con.close()
+    assert out["ids"] == [0, 1, 2]
+    assert [r["id"] for r in out["rows"]] == [0, 1, 2]
+
+
 def _direct_page_positions(path, offset, limit):
     """Reference window: the plain LIMIT/OFFSET natural-order scan the pruning
     path replaces. Its rows/positions must match exactly."""

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -785,6 +785,27 @@ def test_source_url_reads_over_http(parquet_file):
         srv.shutdown()
 
 
+def test_http_connection_persists_across_reads(parquet_file):
+    # The shared connection is stashed on the duckdb module so it outlives a
+    # single reader run; with parquet_metadata_cache=true set once at build,
+    # the SECOND open in a server session reuses the parsed footer instead of
+    # re-downloading/re-parsing it (the ~7s cold DESCRIBE is paid only once).
+    srv, hits = _serve_dir(os.path.dirname(parquet_file))
+    try:
+        url = f"http://127.0.0.1:{srv.server_address[1]}/s.parquet"
+        try:
+            reader.main(parquet_file, limit=5, source_url=url)
+        except Exception:
+            pytest.skip("duckdb httpfs extension unavailable")
+        con1 = getattr(duckdb, "_fused_render_http_con_v3", None)
+        assert con1 is not None                   # stashed for reuse
+        reader.main(parquet_file, limit=5, source_url=url)
+        con2 = getattr(duckdb, "_fused_render_http_con_v3", None)
+        assert con2 is con1                        # same connection -> warm cache
+    finally:
+        srv.shutdown()
+
+
 def test_source_url_falls_back_when_dead(parquet_file):
     import socket
 

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -21,11 +21,12 @@ class StubServe:
     then the connection drops)."""
 
     def __init__(self, data: bytes, fail_first_gets: int = 0,
-                 partial_first_gets: int = 0):
+                 partial_first_gets: int = 0, short_clean_first_gets: int = 0):
         self.data = data
         self.requests = []          # (method, range_header)
         self.fail_remaining = fail_first_gets
         self.partial_remaining = partial_first_gets
+        self.short_clean_remaining = short_clean_first_gets
         stub = self
 
         class H(BaseHTTPRequestHandler):
@@ -70,6 +71,21 @@ class StubServe:
                     self.wfile.write(b"HTTP/1.1 %d x\r\n" % status)
                     self.wfile.write(b"Transfer-Encoding: chunked\r\n\r\n")
                     self.wfile.write(b"%x\r\n%s\r\n" % (len(half), half))
+                    self.wfile.flush()
+                    self.close_connection = True
+                    return
+                if stub.short_clean_remaining > 0:
+                    stub.short_clean_remaining -= 1
+                    # Deliver half the body under HTTP/1.0 with NO Content-Length
+                    # and NO chunked framing, then close. The body is delimited
+                    # by connection close, so the client returns the partial
+                    # bytes and sees a *clean* EOF — no IncompleteRead, no
+                    # exception. This is the silent short read: the fetch returns
+                    # "successfully" with a truncated body, so the missing bytes
+                    # must be caught by an explicit full-range check.
+                    half = body[: max(1, len(body) // 2)]
+                    self.wfile.write(b"HTTP/1.0 %d x\r\n\r\n" % status)
+                    self.wfile.write(half)
                     self.wfile.flush()
                     self.close_connection = True
                     return
@@ -263,6 +279,28 @@ def test_progress_stays_exact_across_midchunk_retry(fast, monkeypatch):
         prefetch_mod.schedule("/m/f.bin", stub.url)
         job = wait_status("/m/f.bin", "done", timeout=15.0)
         assert job["done"] == job["size"] == 3 * mb    # exact, never > size
+    finally:
+        stub.close()
+
+
+def test_short_clean_read_is_retried_not_committed(fast, monkeypatch):
+    # A truncated body under a connection-close-delimited response yields a
+    # *clean* EOF: _fetch_chunk's read loop ends without an exception even
+    # though only half the range arrived. Treating that as a full chunk would
+    # commit bytes that never landed and finish the job as "done" with data
+    # missing. _fetch_chunk must verify it consumed the whole [start, end]
+    # range and raise otherwise, so the retry loop re-requests the chunk.
+    mb = 1024 * 1024
+    monkeypatch.setattr(prefetch_mod, "CHUNK_BYTES", 8 * mb)   # one chunk
+    monkeypatch.setattr(prefetch_mod, "HEAD_BYTES", 8 * mb)
+    stub = StubServe(os.urandom(3 * mb), short_clean_first_gets=1)
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        job = wait_status("/m/f.bin", "done", timeout=15.0)
+        assert job["done"] == job["size"] == 3 * mb
+        # The short read forced a retry: the chunk was requested twice.
+        gets = [r for r in stub.requests if r[0] == "GET"]
+        assert len(gets) >= 2
     finally:
         stub.close()
 

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -101,6 +101,31 @@ def test_streams_whole_file_in_sequential_chunks(fast):
         stub.close()
 
 
+def test_prioritizes_head_then_footer_before_middle(fast, monkeypatch):
+    # A file larger than the head region: the head (row group 0) streams first,
+    # then the footer tail, and only then the middle bulk — so an interactive
+    # first-page read racing the stream finds footer + row group 0 warm early.
+    monkeypatch.setattr(prefetch_mod, "HEAD_BYTES", 1024)
+    monkeypatch.setattr(prefetch_mod, "FOOTER_BYTES", 1024)
+    stub = StubServe(os.urandom(5000))          # CHUNK_BYTES=1024 -> 5 chunks
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        job = wait_status("/m/f.bin", "done")
+        assert job["done"] == job["size"] == 5000
+        gets = [r[1] for r in stub.requests if r[0] == "GET"]
+        # head first, footer tail second, middle after.
+        assert gets == ["bytes=0-1023", "bytes=3976-4999",
+                        "bytes=1024-2047", "bytes=2048-3071", "bytes=3072-3975"]
+        # every byte covered exactly once (no gap, no overlap).
+        covered = []
+        for g in gets:
+            lo, hi = g.removeprefix("bytes=").split("-")
+            covered.extend(range(int(lo), int(hi) + 1))
+        assert sorted(covered) == list(range(5000))
+    finally:
+        stub.close()
+
+
 def test_size_gate_skips_large_files(fast, monkeypatch):
     monkeypatch.setattr(prefetch_mod, "MAX_BYTES", 100)
     stub = StubServe(b"x" * 3000)

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -15,12 +15,17 @@ import fused_render.shell.prefetch as prefetch_mod
 class StubServe:
     """Range-capable HTTP stand-in for an rclone serve. Serves `data` at
     every path, records requests, and can fail the first N GETs with a 500
-    (the transient store errors the real serve surfaces mid-stream)."""
+    (the transient store errors the real serve surfaces mid-stream) or, with
+    `partial_first_gets`, send a truncated body under a full Content-Length so
+    the client hits an IncompleteRead *mid-chunk* (partial bytes delivered,
+    then the connection drops)."""
 
-    def __init__(self, data: bytes, fail_first_gets: int = 0):
+    def __init__(self, data: bytes, fail_first_gets: int = 0,
+                 partial_first_gets: int = 0):
         self.data = data
         self.requests = []          # (method, range_header)
         self.fail_remaining = fail_first_gets
+        self.partial_remaining = partial_first_gets
         stub = self
 
         class H(BaseHTTPRequestHandler):
@@ -34,6 +39,12 @@ class StubServe:
                 self.send_header("Accept-Ranges", "bytes")
                 self.end_headers()
 
+            def _body(self, rng):
+                if rng:
+                    lo, hi = rng.removeprefix("bytes=").split("-")
+                    return stub.data[int(lo):int(hi) + 1], 206
+                return stub.data, 200
+
             def do_GET(self):
                 rng = self.headers.get("Range")
                 stub.requests.append(("GET", rng))
@@ -43,12 +54,25 @@ class StubServe:
                     self.send_header("Content-Length", "0")
                     self.end_headers()
                     return
-                body = stub.data
-                status = 200
-                if rng:
-                    lo, hi = rng.removeprefix("bytes=").split("-")
-                    body = stub.data[int(lo):int(hi) + 1]
-                    status = 206
+                body, status = self._body(rng)
+                if stub.partial_remaining > 0:
+                    stub.partial_remaining -= 1
+                    # Deliver half the body as one complete chunked frame, then
+                    # close WITHOUT the terminating 0-length chunk. The client
+                    # cleanly receives (and returns to the reader) the partial
+                    # bytes, then raises IncompleteRead on the missing
+                    # terminator — a genuine mid-chunk failure with partial
+                    # bytes already counted, which is what the retry accounting
+                    # must survive. (A clean short EOF or an RST would either be
+                    # tolerated as a short read or discard the buffered bytes,
+                    # neither of which exercises the double-count path.)
+                    half = body[: max(1, len(body) // 2)]
+                    self.wfile.write(b"HTTP/1.1 %d x\r\n" % status)
+                    self.wfile.write(b"Transfer-Encoding: chunked\r\n\r\n")
+                    self.wfile.write(b"%x\r\n%s\r\n" % (len(half), half))
+                    self.wfile.flush()
+                    self.close_connection = True
+                    return
                 self.send_response(status)
                 self.send_header("Content-Length", str(len(body)))
                 self.end_headers()
@@ -219,6 +243,26 @@ def test_resumes_after_transient_errors(fast):
         prefetch_mod.schedule("/m/f.bin", stub.url)
         job = wait_status("/m/f.bin", "done", timeout=15.0)
         assert job["done"] == 2500
+    finally:
+        stub.close()
+
+
+def test_progress_stays_exact_across_midchunk_retry(fast, monkeypatch):
+    # A mid-chunk failure that delivers real bytes before raising (partial
+    # bytes counted, then IncompleteRead) must not double-count on retry: the
+    # retry re-requests the whole chunk from its start, so progress resets to
+    # the committed base rather than adding the failed attempt's partial bytes
+    # again. done must land exactly on size, never past it. MB-scale so the
+    # partial delivery clears _fetch_chunk's 1MB read block and is genuinely
+    # counted before the stream drops (the buggy `+= len(b)` overshoots here).
+    mb = 1024 * 1024
+    monkeypatch.setattr(prefetch_mod, "CHUNK_BYTES", 8 * mb)   # one chunk
+    monkeypatch.setattr(prefetch_mod, "HEAD_BYTES", 8 * mb)
+    stub = StubServe(os.urandom(3 * mb), partial_first_gets=1)  # ~2MB then drops
+    try:
+        prefetch_mod.schedule("/m/f.bin", stub.url)
+        job = wait_status("/m/f.bin", "done", timeout=15.0)
+        assert job["done"] == job["size"] == 3 * mb    # exact, never > size
     finally:
         stub.close()
 


### PR DESCRIPTION
## Summary

Cold-load latency fixes for the DuckDB parquet grid, targeting the two file shapes that dominate slow opens:

- **Row-group pruning on the first page (primary fix).** An unsorted, unfiltered parquet page now expresses its window `[offset, offset+limit)` as a `file_row_number` range predicate instead of `LIMIT/OFFSET`. `LIMIT/OFFSET` is *reactive* — DuckDB's parallel scan (`threads=32`) speculatively opens ~`threads` row groups before the `LIMIT` halts it (measured ~32 groups / ~12s cold on a 256-row-group file when only row group 0 / ~2 MB was actually needed). The range predicate prunes to just the covering groups, so only their bytes move.
- **`threads=32` retained safely.** With the over-read killed at the source, high thread count keeps helping the single-big-row-group file (ookla — must read whole column chunks, parallelizes to the S3 bucket ceiling) without hurting the many-small-group file. Documented in `_http_connection`.
- **Prefetch warms the footer and head first.** The whole-file background prefetch now streams **head (row group 0) → footer tail (metadata) → middle bulk** instead of strictly `0→end`. A cold `DESCRIBE` parses the footer (~7s), which lives in the file tail; a plain forward stream left it cold until the very end, so an interactive open racing the prefetch still paid the cold footer parse.
- **`/api/fs/conditions` confirmed non-blocking** (comment only): sync `def` route → FastAPI threadpool (event loop never blocks on the ~1.6s cold `os.stat`), and the frontend fetches it from a background `useEffect`, rendering unconditional templates while the verdict resolves.

Scope guard: the pruning is applied **only** to the unsorted + unfiltered page, where physical file position and logical page order coincide. Any sort or filter keeps the `LIMIT/OFFSET` window (plus the existing physical-position tiebreaker), and CSV/JSON are unchanged.

## Visuals

No user-facing UI change — the grid renders identically, it just loads faster cold. This is a control-flow change, so the delta:

**First-page read path (reader.py `_page_sql`):**

```mermaid
flowchart TD
    A[first-page query] --> B{parquet, unsorted, unfiltered?}
    B -->|no: sort/filter, or csv/json| C["LIMIT ? OFFSET ?<br/>(unchanged; tiebreaker on sort)"]
    B -->|yes| D["WHERE file_row_number >= offset<br/>AND < offset+limit"]
    C --> E[DuckDB parallel scan]
    D --> E
    E --> F{how many row groups read?}
    F -->|LIMIT/OFFSET| G["~threads groups speculatively<br/>(over-read: ~32 groups / ~12s)"]
    F -->|range predicate| H["only covering groups<br/>(row group 0 / ~2MB)"]
```

**Prefetch stream order (prefetch.py `_prioritized_chunks`):**

```mermaid
flowchart LR
    subgraph before["before: strict 0 to end"]
        B1[head] --> B2[bulk...] --> B3[footer LAST]
    end
    subgraph after["after: latency-critical first"]
        A1["head (row group 0)"] --> A2["footer tail (metadata)"] --> A3[middle bulk]
    end
```

## Usage

Not user-invocable — behavior is automatic. Opening any parquet in the grid view exercises it:

- Fast path (pruned): open a multi-row-group parquet and view the first page unsorted/unfiltered → DuckDB reads only the covering row groups.
- Sorted/filtered pages fall back to the windowed query exactly as before.
- Prefetch prioritization applies to any mount-backed file that clears the size gate (`FUSED_RENDER_PREFETCH=1`, default on).

## Test Plan

- [x] **Automated — new tests, all green.** `tests/test_duckdb_reader.py` (+3 pruning tests incl. `test_http_connection_persists_across_reads` for footer reuse) and `tests/test_shell_prefetch.py` (+prioritized-chunk ordering / accumulated-progress tests).
- [x] **Full suite: 918 passed, 13 skipped, 0 failed** (Python 3.12 venv with `[dev]` + `[bundled]`, frontend built). The 2 `test_deploy.py` failures seen with a pip-less venv are environmental (uv venv lacks `pip`) and clear once `pip` is present — not related to this diff.
- [x] **Pruning mechanism validated** via `EXPLAIN ANALYZE` scan cardinality: `LIMIT 100 OFFSET 40000` decodes 20 row groups (over-read); the `file_row_number` range predicate decodes only the covering group. Aligns with the codebase's existing `_rowgroup_prune` / positions IN-list assumption that `file_row_number` predicates prune.
- [ ] **Manual (reviewer):** cold-open a multi-row-group parquet (e.g. `overturemaps-address`) and a single-big-row-group parquet (e.g. `ookla`) via the grid; confirm first paint is faster on the former and unchanged/parallel on the latter, and that sorting/filtering a column still returns correct pages.

## Notes for review

- `offset`/`limit` are int-clamped in `main` before reaching `_page_sql`, so interpolating them as SQL literals (rather than binds) is safe and matches the existing `_rowgroup_prune` and positions IN-list paths. The pruned branch in `_read_flat` passes empty binds (no `?` in the emitted SQL).
