### PR TITLE
app: silent-launch mode for flow-v2 background boot

### DIFF
--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -305,7 +305,7 @@ def main() -> None:
         for target in pending:
             webbrowser.open(target)
         # Home tab only when this launch wasn't a document double-click.
-        if not state["docs"]:
+        if not state["docs"] and not os.environ.get("FUSED_RENDER_NO_BROWSER"):
             webbrowser.open(url)
 
     class FusedRenderStatusApp(rumps.App):


### PR DESCRIPTION
## Summary
- flow-v2 launches FusedRender.app in the background via `open --env FUSED_RENDER_NO_BROWSER=1 -b io.fused.render`; gate the automatic home-tab browser open on a fresh boot behind that env var so it doesn't pop a tab.
- Only the automatic "home tab, not a doc/deep-link open" path in `_bootstrap_server` is gated. All user-initiated opens (deep link, pin, explicit "open in browser", file-association double-click, and the "reuse an already-running instance" path) still fire unconditionally.

## Test plan
- [ ] `FUSED_RENDER_NO_BROWSER=1 python3 -m fused_render.app` boots the server without opening a browser tab
- [ ] unset `FUSED_RENDER_NO_BROWSER`, same command opens the home tab as before
- [ ] Finder double-click / deep link / pin still open a browser tab regardless of the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional on an env var for one automatic browser open; no auth, data, or API behavior changes.
> 
> **Overview**
> Adds a **silent-launch** path for background boots (e.g. flow-v2 via `open --env FUSED_RENDER_NO_BROWSER=1`): when the server finishes starting, the automatic home-tab `webbrowser.open` in `_bootstrap_server` now runs only if **`FUSED_RENDER_NO_BROWSER` is unset** and the launch had no document/deep-link events (`state["docs"]`).
> 
> User-driven opens are unchanged—queued pending URLs, Finder/deep-link handlers, Dock reopen, menu “Open in browser”, and the “reuse existing server” path still open tabs regardless of the env var.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7090915d4ae54993116e0a9624a45a4a656ee995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->