### PR TITLE
mounts: show remotes by their friendly label in the add-mount dropdown

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -702,11 +702,19 @@ export interface RemoteSuggestion {
   kind: "public" | "detected";
 }
 
+// An existing rclone remote. `name` is the verbatim rclone spec (incl trailing
+// ':') used unchanged as the mount base; `label` is the friendly name to show —
+// the same one its suggestion used, or the bare `name` for a custom remote.
+export interface RcloneRemote {
+  name: string;
+  label: string;
+}
+
 export interface MountsResult {
   rclone: {
     available: boolean;
     version: string | null;
-    remotes: string[];
+    remotes: RcloneRemote[];
     suggested: RemoteSuggestion[];
   };
   mounts: Mount[];

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -14,7 +14,7 @@ import {
   getMounts,
   reconnectMount,
 } from "../lib/api";
-import type { Mount, MountsResult, RemoteSuggestion } from "../lib/api";
+import type { Mount, MountsResult, RcloneRemote, RemoteSuggestion } from "../lib/api";
 import { navigate } from "../lib/router";
 
 // Lightweight modal reusing the Deploy modal's overlay/dialog chrome
@@ -196,7 +196,7 @@ function AddMount({
   suggested,
   onChanged,
 }: {
-  remotes: string[];
+  remotes: RcloneRemote[];
   suggested: RemoteSuggestion[];
   onChanged: () => void;
 }) {
@@ -289,8 +289,10 @@ function AddMount({
             {remotes.length > 0 && (
               <optgroup label="Remotes">
                 {remotes.map((r) => (
-                  <option key={r} value={r}>
-                    {r}
+                  // value is the raw rclone spec (add() and the live preview
+                  // mount against r.name); only the shown text is the label.
+                  <option key={r.name} value={r.name}>
+                    {r.label}
                   </option>
                 ))}
               </optgroup>

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1719,20 +1719,40 @@ def _credential_suggestions() -> list[dict]:
     return out
 
 
-def _remote_label(remote: str, suggestions: list[dict] | None = None) -> str:
+def _rclone_config_dump(bin_: str) -> dict:
+    """Every remote's stored config as {bare_name: {"type": …, …params}} via
+    `rclone config dump` — a plain subprocess, no rcd daemon required (keeps
+    _rclone_state callable before any mount exists). {} on any failure, so
+    _remote_label just degrades to bare names rather than raising."""
+    try:
+        out = subprocess.run(
+            [bin_, "config", "dump"], capture_output=True, text=True, timeout=10
+        ).stdout
+        cfg = json.loads(out) if out.strip() else {}
+        return cfg if isinstance(cfg, dict) else {}
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return {}
+
+
+def _remote_label(remote: str, suggestions: list[dict], configs: dict) -> str:
     """Friendly label for a materialized rclone remote, so it presents under the
     SAME human name the suggestion used across its whole lifecycle (e.g. the
     built-in public option shows as "AWS S3 — public buckets…", not the cryptic
     "aws-open:" it materializes into). Match against the FULL suggestion set —
-    including ones already materialized, which _suggestions_view drops. remotes
-    carry a trailing ':', suggestion remote_name does not. No match (a custom
-    remote like "myminio:") falls back to the bare rclone string.
+    including ones already materialized, which _suggestions_view drops.
 
-    Pass a precomputed `suggestions` when labeling many remotes at once —
-    _credential_suggestions() re-reads the AWS dotfiles on every call, so
-    computing it once and reusing it avoids O(N) redundant disk I/O."""
-    for s in suggestions if suggestions is not None else _credential_suggestions():
-        if f'{s["remote_name"]}:' == remote:
+    Matching is by PROVENANCE, not name alone: the remote's stored config (from
+    `rclone config dump`, keyed by bare name) must match the suggestion's backend
+    and every param it was created with. A user's own remote that merely happens
+    to be named `aws`/`gcs` therefore keeps its bare name instead of inheriting a
+    credential-source label it never came from. Values compare case-insensitively
+    (rclone normalizes booleans). No match (e.g. "myminio:") → the bare string."""
+    cfg = configs.get(remote.rstrip(":"), {})
+    for s in suggestions:
+        if (f'{s["remote_name"]}:' == remote
+                and str(cfg.get("type", "")).lower() == s["backend"].lower()
+                and all(str(cfg.get(k, "")).lower() == str(v).lower()
+                        for k, v in s["params"].items())):
             return s["label"]
     return remote
 
@@ -1767,10 +1787,12 @@ def _rclone_state() -> dict:
     # Each remote carries its verbatim rclone spec (`name`, incl trailing ':',
     # used unchanged as the mount base) plus a friendly `label` for display —
     # so a remote reads under one stable human name whatever its lifecycle stage.
-    # Compute the suggestion set once and reuse it across every remote (it reads
-    # the AWS dotfiles per call, so a per-remote call would be O(N) disk I/O).
+    # Compute the suggestion set and the config dump once, then label every
+    # remote against them (both do I/O, so a per-remote call would be O(N)).
     suggestions = _credential_suggestions()
-    remotes = [{"name": n, "label": _remote_label(n, suggestions)} for n in names]
+    configs = _rclone_config_dump(bin_)
+    remotes = [{"name": n, "label": _remote_label(n, suggestions, configs)}
+               for n in names]
     return {"available": True, "version": version, "remotes": remotes,
             "suggested": _suggestions_view(names)}
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1719,15 +1719,19 @@ def _credential_suggestions() -> list[dict]:
     return out
 
 
-def _remote_label(remote: str) -> str:
+def _remote_label(remote: str, suggestions: list[dict] | None = None) -> str:
     """Friendly label for a materialized rclone remote, so it presents under the
     SAME human name the suggestion used across its whole lifecycle (e.g. the
     built-in public option shows as "AWS S3 — public buckets…", not the cryptic
     "aws-open:" it materializes into). Match against the FULL suggestion set —
     including ones already materialized, which _suggestions_view drops. remotes
     carry a trailing ':', suggestion remote_name does not. No match (a custom
-    remote like "myminio:") falls back to the bare rclone string."""
-    for s in _credential_suggestions():
+    remote like "myminio:") falls back to the bare rclone string.
+
+    Pass a precomputed `suggestions` when labeling many remotes at once —
+    _credential_suggestions() re-reads the AWS dotfiles on every call, so
+    computing it once and reusing it avoids O(N) redundant disk I/O."""
+    for s in suggestions if suggestions is not None else _credential_suggestions():
         if f'{s["remote_name"]}:' == remote:
             return s["label"]
     return remote
@@ -1763,7 +1767,10 @@ def _rclone_state() -> dict:
     # Each remote carries its verbatim rclone spec (`name`, incl trailing ':',
     # used unchanged as the mount base) plus a friendly `label` for display —
     # so a remote reads under one stable human name whatever its lifecycle stage.
-    remotes = [{"name": n, "label": _remote_label(n)} for n in names]
+    # Compute the suggestion set once and reuse it across every remote (it reads
+    # the AWS dotfiles per call, so a per-remote call would be O(N) disk I/O).
+    suggestions = _credential_suggestions()
+    remotes = [{"name": n, "label": _remote_label(n, suggestions)} for n in names]
     return {"available": True, "version": version, "remotes": remotes,
             "suggested": _suggestions_view(names)}
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1962,7 +1962,8 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
     if sugg is None:
         return JSONResponse({"error": f"unknown credential source {sid!r}"}, status_code=404)
     name = sugg["remote_name"]
-    if f"{name}:" in _rclone_state().get("remotes", []):
+    # remotes are {name,label} objects now — match on the bare rclone spec.
+    if any(r["name"] == f"{name}:" for r in _rclone_state().get("remotes", [])):
         return {"ok": True, "name": name + ":"}
     cmd = [bin_, "config", "create", name, sugg["backend"]]
     for k, v in sugg["params"].items():

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1719,6 +1719,20 @@ def _credential_suggestions() -> list[dict]:
     return out
 
 
+def _remote_label(remote: str) -> str:
+    """Friendly label for a materialized rclone remote, so it presents under the
+    SAME human name the suggestion used across its whole lifecycle (e.g. the
+    built-in public option shows as "AWS S3 — public buckets…", not the cryptic
+    "aws-open:" it materializes into). Match against the FULL suggestion set —
+    including ones already materialized, which _suggestions_view drops. remotes
+    carry a trailing ':', suggestion remote_name does not. No match (a custom
+    remote like "myminio:") falls back to the bare rclone string."""
+    for s in _credential_suggestions():
+        if f'{s["remote_name"]}:' == remote:
+            return s["label"]
+    return remote
+
+
 def _suggestions_view(remotes: list[str]) -> list[dict]:
     """Public shape, minus any suggestion already materialized as a remote (so
     the built-in aws-open drops out of the suggestions once created and shows
@@ -1743,11 +1757,15 @@ def _rclone_state() -> dict:
         remotes_out = subprocess.run(
             [bin_, "listremotes"], capture_output=True, text=True, timeout=10
         ).stdout
-        remotes = [r.strip() for r in remotes_out.splitlines() if r.strip()]
+        names = [r.strip() for r in remotes_out.splitlines() if r.strip()]
     except (OSError, subprocess.TimeoutExpired, IndexError):
         return {"available": False, "version": None, "remotes": [], "suggested": []}
+    # Each remote carries its verbatim rclone spec (`name`, incl trailing ':',
+    # used unchanged as the mount base) plus a friendly `label` for display —
+    # so a remote reads under one stable human name whatever its lifecycle stage.
+    remotes = [{"name": n, "label": _remote_label(n)} for n in names]
     return {"available": True, "version": version, "remotes": remotes,
-            "suggested": _suggestions_view(remotes)}
+            "suggested": _suggestions_view(names)}
 
 
 def broken_mount_error(path: str) -> str | None:

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -626,6 +626,47 @@ def test_public_suggestion_hidden_once_materialized(monkeypatch):
                    for s in mounts_mod._suggestions_view(["aws-open:"]))
 
 
+def test_remote_label_matches_suggestion(monkeypatch):
+    """A materialized remote whose name matches a known suggestion reuses that
+    suggestion's friendly label — one stable human name across its lifecycle."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [
+        {"id": "aws-open-public",
+         "label": "AWS S3 — public buckets (no credentials)",
+         "remote_name": "aws-open", "backend": "s3", "kind": "public",
+         "params": {"provider": "AWS", "env_auth": "false"}},
+    ])
+    assert (mounts_mod._remote_label("aws-open:")
+            == "AWS S3 — public buckets (no credentials)")
+
+
+def test_remote_label_falls_back_to_bare_name(monkeypatch):
+    """An unknown/custom remote (no matching suggestion) keeps its bare rclone
+    name as the label."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [])
+    assert mounts_mod._remote_label("myminio:") == "myminio:"
+
+
+def test_rclone_state_labels_materialized_remote(monkeypatch):
+    """_rclone_state exposes remotes as {name,label}: a materialized suggestion
+    (aws-open:) carries its friendly label, a custom remote (myminio:) its bare
+    name. The name stays the verbatim rclone spec used as the mount base."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [
+        {"id": "aws-open-public",
+         "label": "AWS S3 — public buckets (no credentials)",
+         "remote_name": "aws-open", "backend": "s3", "kind": "public",
+         "params": {"provider": "AWS", "env_auth": "false"}},
+    ])
+    _fake_rclone(monkeypatch, existing_remotes=("aws-open:", "myminio:"))
+
+    state = mounts_mod._rclone_state()
+    assert state["remotes"] == [
+        {"name": "aws-open:", "label": "AWS S3 — public buckets (no credentials)"},
+        {"name": "myminio:", "label": "myminio:"},
+    ]
+    # the materialized aws-open drops out of the suggestions (shown under Remotes)
+    assert not any(s["id"] == "aws-open-public" for s in state["suggested"])
+
+
 def test_detect_materializes_public_anonymous_remote(client, monkeypatch):
     """Selecting the built-in public option creates an anonymous S3 remote —
     no secret material, env_auth=false — so unsigned requests reach open data."""

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -626,37 +626,51 @@ def test_public_suggestion_hidden_once_materialized(monkeypatch):
                    for s in mounts_mod._suggestions_view(["aws-open:"]))
 
 
-def test_remote_label_matches_suggestion(monkeypatch):
-    """A materialized remote whose name matches a known suggestion reuses that
-    suggestion's friendly label — one stable human name across its lifecycle."""
-    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [
-        {"id": "aws-open-public",
-         "label": "AWS S3 — public buckets (no credentials)",
-         "remote_name": "aws-open", "backend": "s3", "kind": "public",
-         "params": {"provider": "AWS", "env_auth": "false"}},
-    ])
-    assert (mounts_mod._remote_label("aws-open:")
+_AWS_OPEN_SUGG = {
+    "id": "aws-open-public",
+    "label": "AWS S3 — public buckets (no credentials)",
+    "remote_name": "aws-open", "backend": "s3", "kind": "public",
+    "params": {"provider": "AWS", "env_auth": "false"},
+}
+
+
+def test_remote_label_matches_suggestion():
+    """A remote whose stored config matches a suggestion's backend+params reuses
+    that suggestion's friendly label — one stable human name across its lifecycle."""
+    configs = {"aws-open": {"type": "s3", "provider": "AWS", "env_auth": "false"}}
+    assert (mounts_mod._remote_label("aws-open:", [_AWS_OPEN_SUGG], configs)
             == "AWS S3 — public buckets (no credentials)")
 
 
-def test_remote_label_falls_back_to_bare_name(monkeypatch):
+def test_remote_label_falls_back_to_bare_name():
     """An unknown/custom remote (no matching suggestion) keeps its bare rclone
     name as the label."""
-    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [])
-    assert mounts_mod._remote_label("myminio:") == "myminio:"
+    assert mounts_mod._remote_label("myminio:", [], {}) == "myminio:"
+
+
+def test_remote_label_ignores_name_collision():
+    """Provenance, not name: a user's own remote merely named `aws` whose config
+    differs from the default-profile suggestion must NOT inherit that label —
+    the dropdown would otherwise claim the wrong credential source for the mount."""
+    sugg = {"id": "aws-profile:default", "label": "AWS S3 — default profile",
+            "remote_name": "aws", "backend": "s3",
+            "params": {"provider": "AWS", "env_auth": "true", "profile": "default"}}
+    # a custom MinIO remote that just happens to be named "aws"
+    configs = {"aws": {"type": "s3", "provider": "Minio",
+                       "endpoint": "http://localhost:9000"}}
+    assert mounts_mod._remote_label("aws:", [sugg], configs) == "aws:"
 
 
 def test_rclone_state_labels_materialized_remote(monkeypatch):
     """_rclone_state exposes remotes as {name,label}: a materialized suggestion
-    (aws-open:) carries its friendly label, a custom remote (myminio:) its bare
-    name. The name stays the verbatim rclone spec used as the mount base."""
-    monkeypatch.setattr(mounts_mod, "_credential_suggestions", lambda: [
-        {"id": "aws-open-public",
-         "label": "AWS S3 — public buckets (no credentials)",
-         "remote_name": "aws-open", "backend": "s3", "kind": "public",
-         "params": {"provider": "AWS", "env_auth": "false"}},
-    ])
-    _fake_rclone(monkeypatch, existing_remotes=("aws-open:", "myminio:"))
+    (aws-open:, config matches) carries its friendly label, a custom remote
+    (myminio:) its bare name. The name stays the verbatim rclone mount base."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_AWS_OPEN_SUGG])
+    _fake_rclone(monkeypatch, existing_remotes=("aws-open:", "myminio:"),
+                 configs={"aws-open": {"type": "s3", "provider": "AWS",
+                                       "env_auth": "false"},
+                          "myminio": {"type": "s3", "provider": "Minio"}})
 
     state = mounts_mod._rclone_state()
     assert state["remotes"] == [
@@ -683,9 +697,10 @@ def test_detect_materializes_public_anonymous_remote(client, monkeypatch):
     assert not any("secret" in str(x).lower() for x in cmd)
 
 
-def _fake_rclone(monkeypatch, existing_remotes=(), record=None):
-    """Stub rclone_bin + subprocess.run: version/listremotes canned, every
-    other argv appended to `record` and reported as success."""
+def _fake_rclone(monkeypatch, existing_remotes=(), record=None, configs=None):
+    """Stub rclone_bin + subprocess.run: version/listremotes/config-dump canned,
+    every other argv appended to `record` and reported as success. `configs` is
+    the {bare_name: cfg} map `rclone config dump` returns (JSON-encoded)."""
     def fake_run(cmd, **kw):
         if record is not None and "create" in cmd:
             record.append(cmd)
@@ -694,6 +709,7 @@ def _fake_rclone(monkeypatch, existing_remotes=(), record=None):
             returncode = 0
             stderr = ""
             stdout = ("rclone v1.2\n" if "version" in cmd
+                      else json.dumps(configs or {}) if "dump" in cmd
                       else "".join(f"{r}\n" for r in existing_remotes)
                       if "listremotes" in cmd else "")
         return R()


### PR DESCRIPTION
## Summary

- Fixes an inconsistency in the "Add a new mount" **Remote** dropdown: existing rclone remotes rendered as bare specs (`aws-open:`, `aws:`, `gcs:`) while credential/public-bucket suggestions rendered as friendly labels. The jarring case — you pick *"AWS S3 — public buckets (no credentials)"*, mount it, and it reappears under **Remotes** as the cryptic `aws-open:`, a name you never chose.
- A remote now presents under the **same friendly label its suggestion used, across its whole lifecycle** (suggestion → materialized → listed under Remotes). Unknown/custom remotes (e.g. an R2/MinIO remote) fall back to their bare rclone name.
- Backend-driven so the frontend stays a dumb renderer: the dropdown shows `label`, and still mounts against the raw `name` — the actual rclone spec is unchanged.

## Visuals

**Before → After** (the "Remotes" group of the dropdown, after the public-bucket option has been mounted):

```
Before                          After
──────────────────────         ─────────────────────────────────────────
Remotes                         Remotes
  aws-open:                       AWS S3 — public buckets (no credentials)
  aws:                            AWS S3 — default profile
  myminio:                        myminio:              ← custom, unchanged
```

No live screenshot: populating this dropdown requires a running server with `rclone` remotes actually configured on the host, which isn't reproducible in this environment. The change is purely the displayed text of `<option>` elements in the "Remotes" `<optgroup>` (`Mounts.tsx`); `value` (the rclone spec) is untouched.

Data-shape delta (the only structural change):

```mermaid
classDiagram
    class MountsResult_before {
      remotes: string[]
    }
    class MountsResult_after {
      remotes: RcloneRemote[]
    }
    class RcloneRemote {
      name: string  «verbatim rclone spec, the mount base»
      label: string «friendly name, or bare name if custom»
    }
    MountsResult_after --> RcloneRemote
```

## Usage

No new user action. On the Mounts page, the **Remote** dropdown's "Remotes" group now reads with the same human labels as the suggestion groups. Selecting an entry and mounting behaves exactly as before (mounts against the raw rclone spec).

## Test Plan

- [x] Automated (`tests/test_shell_mounts.py`, added): `test_remote_label_matches_suggestion` (materialized `aws-open:` → friendly label), `test_remote_label_falls_back_to_bare_name` (unknown `myminio:` → bare name), `test_rclone_state_labels_materialized_remote` (`_rclone_state` returns `{name,label}` objects and drops the materialized suggestion from `suggested`).
- [x] `python -m pytest tests/test_shell_mounts.py -q` → 128 passed, 3 skipped.
- [x] `cd frontend && bun run typecheck` → clean (new `RcloneRemote` type threaded through `MountsResult`, `AddMount` prop, and the optgroup).
- [x] Backend consumer swept in lockstep: the `/api/mounts/remotes/detect` idempotency check updated for the new `{name,label}` shape.
- [ ] Manual: on a host with rclone remotes, create a mount from the "AWS S3 — public buckets" suggestion, confirm it then shows under **Remotes** with that same label (not `aws-open:`), and that mounting still works.

Note: full `pytest -q` has 7 pre-existing failures in `test_deploy.py` (pip) and `test_duckdb_reader.py` (network), unrelated to this change and failing identically on the base commit.
