### PR TITLE
Experimental Windows rclone mount support (WinFsp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ local folders under `~/.fused-render/mounts/`. Everything downstream
 - **No setup on macOS:** the packaged app bundles rclone itself (D103) — no
   install, nothing on PATH. Running from source, or on Linux, still needs
   rclone (`brew install rclone` / your distro's package). macOS mounts via
-  the built-in NFS client — no macFUSE; Linux uses FUSE. Windows is not
-  supported yet.
+  the built-in NFS client — no macFUSE; Linux uses FUSE. Windows mounts are
+  **experimental** and require [WinFsp](https://winfsp.dev) installed plus
+  `rclone` on `PATH`.
 - **Credentials never touch fused-render** — they live in rclone's own
   config. S3-compatible remotes can be created from the page; for Google
   Drive and other sign-in backends, run `rclone config` in a terminal once.

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1394,33 +1394,54 @@ def attach_mount(m: dict) -> str | None:
         # is an error, not a silent adopt. (A mount rcd doesn't know about
         # has no queryable fs — adopted as-is, the pre-rcd prototype case.)
         fs = rcd_mount_map().get(_norm(mp))
-        if fs is not None and fs != m["remote"]:
-            return (f"mountpoint already serves '{fs}' — unmount it before "
-                    f"mounting '{m['remote']}'")
-        # Refresh read_only BEFORE reconciling serves: sync_serves derives the
-        # serve's read_only param from this record, so refreshing afterwards
-        # would leave the serve on the stale flag (disagreeing with the mount
-        # and splitting the shared VFS) until some later sync.
-        _refresh_read_only_flag(m)
-        # An adopted rcd mount keeps whatever vfsOpt it was created with —
-        # mount options only apply at mount/mount, and listmounts doesn't echo
-        # them — so a mount created before read_only was known (legacy record,
-        # or detection just flipped the flag) still has a WRITABLE VFS no
-        # matter what the record now says: the doomed-upload retry loop the
-        # flag exists to prevent. mounted_read_only records what was actually
-        # baked in at mount time; on mismatch, remount to apply. Only for
-        # rcd-known mounts (fs set) — a foreign kernel mount is adopted as-is.
-        if fs is not None and bool(m.get("read_only")) != bool(
-            m.get("mounted_read_only")
-        ):
-            return reconnect_mount(m)  # unmounts first, so no recursion here
-        # Already mounted (double-click, adopted foreign mount) — but the
-        # HTTP serve may still be missing (a prior serve/start failed, or the
-        # mount predates the serve layer), so reconcile serves here too:
-        # without one, /api/fs/raw silently falls back to reads through the
-        # wedge-prone kernel mount.
-        sync_serves()
-        return None
+        stale = False
+        if sys.platform == "win32" and fs is None:
+            # On win32 _path_mounted is os.path.isdir, so a stale empty leaf
+            # (WinFsp crash / incomplete teardown) reads as "mounted". rcd not
+            # serving it (fs is None) means it isn't ours; probe whether it's a
+            # removable empty dir with rmdir. An empty removable dir cannot be a
+            # live mount serving anything, so a successful rmdir proves it was
+            # never mounted -> fall through to a fresh mount. A non-empty dir
+            # (foreign mount / real content) or a live WinFsp mount refuses
+            # removal (OSError) -> keep adopting as-is. (POSIX needs no probe:
+            # ismount already proves a real mount.)
+            try:
+                os.rmdir(mp)
+            except OSError:
+                pass  # foreign mount / real content / live mount — adopt below
+            else:
+                stale = True
+        # A removed stale leaf was never really mounted: fall through to a
+        # fresh mount. Otherwise honor the existing already-mounted handling.
+        if not stale:
+            if fs is not None and fs != m["remote"]:
+                return (f"mountpoint already serves '{fs}' — unmount it before "
+                        f"mounting '{m['remote']}'")
+            # Refresh read_only BEFORE reconciling serves: sync_serves derives
+            # the serve's read_only param from this record, so refreshing
+            # afterwards would leave the serve on the stale flag (disagreeing
+            # with the mount and splitting the shared VFS) until some later sync.
+            _refresh_read_only_flag(m)
+            # An adopted rcd mount keeps whatever vfsOpt it was created with —
+            # mount options only apply at mount/mount, and listmounts doesn't
+            # echo them — so a mount created before read_only was known (legacy
+            # record, or detection just flipped the flag) still has a WRITABLE
+            # VFS no matter what the record now says: the doomed-upload retry
+            # loop the flag exists to prevent. mounted_read_only records what
+            # was actually baked in at mount time; on mismatch, remount to
+            # apply. Only for rcd-known mounts (fs set) — a foreign kernel mount
+            # is adopted as-is.
+            if fs is not None and bool(m.get("read_only")) != bool(
+                m.get("mounted_read_only")
+            ):
+                return reconnect_mount(m)  # unmounts first, so no recursion here
+            # Already mounted (double-click, adopted foreign mount) — but the
+            # HTTP serve may still be missing (a prior serve/start failed, or
+            # the mount predates the serve layer), so reconcile serves here too:
+            # without one, /api/fs/raw silently falls back to reads through the
+            # wedge-prone kernel mount.
+            sync_serves()
+            return None
     if sys.platform == "win32" and not _winfsp_available():
         # Fail with actionable install guidance rather than letting the raw
         # cgofuse/WinFsp error surface. Matches the "return an error string"
@@ -2040,9 +2061,24 @@ def delete_mount(cid: str, x_fused: str | None = Header(default=None)):
     err = detach_mount(m)
     mp = mountpoint(m)
     if err and _path_mounted(mp):
-        # Deleting the record while the filesystem is still mounted would
-        # strand a live mount (and let a re-added name silently reuse it).
-        return JSONResponse({"error": f"not deleted — {err}"}, status_code=502)
+        if sys.platform == "win32" and _norm(mp) not in rcd_mount_map():
+            # On win32 _path_mounted is os.path.isdir, so a stale empty leaf
+            # (WinFsp crash / incomplete teardown) makes detach_mount error and
+            # keeps the path reading as "mounted" — blocking delete forever. rcd
+            # not listing it means it's not a live mount; if the leaf is an
+            # empty removable dir, rmdir clears it and the mount is genuinely
+            # gone, so fall through to deletion. If rmdir fails (non-empty /
+            # foreign), keep the 502.
+            try:
+                os.rmdir(mp)
+            except OSError:
+                return JSONResponse(
+                    {"error": f"not deleted — {err}"}, status_code=502)
+        else:
+            # Deleting the record while the filesystem is still mounted would
+            # strand a live mount (and let a re-added name silently reuse it).
+            return JSONResponse(
+                {"error": f"not deleted — {err}"}, status_code=502)
     # POSIX only: FUSE/NFS leave an empty real dir behind, so clean it up.
     # On Windows WinFsp already removes the leaf on unmount (and we never
     # pre-create it), so there is nothing to rmdir.

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -285,7 +285,13 @@ _store_lock = threading.Lock()
 
 
 def mountpoint(m: dict) -> str:
-    return os.path.join(mounts_dir(), m["name"])
+    # normpath so the canonical path has uniform separators: on Windows
+    # expanduser("~/.fused-render") yields mixed backslash/forward-slash, and
+    # this path is used for mounting, as serves.json keys, and in rcd params —
+    # a mixed form there would never match os.path.abspath()'s backslashes in
+    # serve_url_for / _mount_for. On POSIX these already-clean absolute paths
+    # are unchanged by normpath (identity), so comparisons stay byte-for-byte.
+    return os.path.normpath(os.path.join(mounts_dir(), m["name"]))
 
 
 def add_mount(name: str, remote: str, read_only: bool | None = None) -> dict:
@@ -975,9 +981,19 @@ def serve_url_for(path: str) -> str | None:
     if not isinstance(serves, dict):
         return None
     p = os.path.abspath(path)
+    np = _norm(p)
     for mp, base in sorted(serves.items(), key=lambda kv: -len(kv[0])):
-        if isinstance(base, str) and (p == mp or p.startswith(mp + os.sep)):
-            rel = os.path.relpath(p, mp).replace(os.sep, "/")
+        if not isinstance(base, str):
+            continue
+        # Compare via _norm on BOTH sides so a Windows key with slash/case
+        # drift still matches abspath's backslashes; compute the returned
+        # relative path from the un-lowercased normpath forms (never return a
+        # lowercased path). _norm is the identity on POSIX, so this stays
+        # byte-for-byte with the old p==mp / startswith comparison there.
+        nmp = _norm(mp)
+        if np == nmp or np.startswith(nmp + os.sep):
+            rel = os.path.relpath(
+                os.path.normpath(p), os.path.normpath(mp)).replace(os.sep, "/")
             return base.rstrip("/") + "/" + urllib.parse.quote(rel)
     return None
 
@@ -1039,10 +1055,15 @@ def _anonymous_s3(cfg: dict | None) -> bool:
 def _mount_for(path: str) -> tuple[dict | None, str]:
     """(mount record, remote-relative path) for a path under a mountpoint."""
     p = os.path.abspath(path)
+    np = _norm(p)
     for m in list_mounts():
         mp = mountpoint(m)
-        if p == mp or p.startswith(mp + os.sep):
-            return m, os.path.relpath(p, mp).replace(os.sep, "/")
+        # _norm both sides (Windows slash/case drift); relpath from the
+        # un-lowercased normpath forms. Identity on POSIX -> unchanged there.
+        nmp = _norm(mp)
+        if np == nmp or np.startswith(nmp + os.sep):
+            return m, os.path.relpath(
+                os.path.normpath(p), os.path.normpath(mp)).replace(os.sep, "/")
     return None, ""
 
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -570,6 +570,24 @@ def _path_mounted(mp: str) -> bool:
     return os.path.ismount(mp)
 
 
+def _winfsp_available() -> bool:
+    """True when WinFsp is installed. rclone's Windows mount is cgofuse ->
+    WinFsp and hard-requires it; without it the raw driver error surfaces.
+    Never gates POSIX (always True off win32). On Windows probe WinFsp's
+    registry keys; winreg is imported lazily since it's a Windows-only
+    module. FileNotFoundError (missing key) is an OSError subclass."""
+    if sys.platform != "win32":
+        return True
+    import winreg
+    for subkey in (r"SOFTWARE\WOW6432Node\WinFsp", r"SOFTWARE\WinFsp"):
+        try:
+            with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey):
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def rcd_mount_map() -> dict:
     """{mountpoint: remote fs} for every mount rcd currently serves (empty
     when no daemon is live). Read-only: never spawns a daemon just to answer
@@ -1362,6 +1380,12 @@ def attach_mount(m: dict) -> str | None:
         # wedge-prone kernel mount.
         sync_serves()
         return None
+    if sys.platform == "win32" and not _winfsp_available():
+        # Fail with actionable install guidance rather than letting the raw
+        # cgofuse/WinFsp error surface. Matches the "return an error string"
+        # contract callers surface verbatim (see mount_surfaces_rc_error).
+        return ("WinFsp is required to mount on Windows — install it from "
+                "https://winfsp.dev, then retry.")
     try:
         port = ensure_rcd()
         # Detect and persist read_only BEFORE mounting (INCIDENT 2026-07-16):

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1499,6 +1499,13 @@ def _force_unmount(mp: str) -> str | None:
         try:
             os.rmdir(mp)
         except OSError as e:
+            if _norm(mp) in rcd_mount_map():
+                # rcd still serves this path: it's a LIVE WinFsp mount, and the
+                # raw rmdir error would masquerade as a failed unmount. Be
+                # explicit — there is no kernel umount to force it, so the fix
+                # is to restart the owning daemon.
+                return (f"{mp} is still a live mount — restart the rclone "
+                        f"daemon to release it")
             return f"force unmount of {mp} failed: {e}"
         return None
     attempts = [["umount", mp]]

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -550,10 +550,31 @@ def _ensure_rcd_locked() -> int:
     raise RuntimeError("rclone rcd did not come up within 10s")
 
 
+def _norm(p: str) -> str:
+    """Normalize a mountpoint for comparison against rcd's listmounts. On
+    Windows rcd may echo forward slashes / mixed case, so normcase (lowercases
+    and flips separators on win32) + normpath fold both sides to one form. On
+    POSIX normcase is the identity and an already-normalized absolute path is
+    unchanged by normpath, so comparisons stay byte-for-byte as before."""
+    return os.path.normcase(os.path.normpath(p))
+
+
+def _path_mounted(mp: str) -> bool:
+    """Platform predicate for "is this mountpoint currently mounted?". POSIX
+    keeps os.path.ismount unchanged. On Windows os.path.ismount is unreliable
+    for WinFsp directory mounts, so the signal is instead whether the leaf dir
+    exists — valid precisely because attach_mount never pre-creates it, so
+    WinFsp's leaf lives only for the duration of a live mount."""
+    if sys.platform == "win32":
+        return os.path.isdir(mp)
+    return os.path.ismount(mp)
+
+
 def rcd_mount_map() -> dict:
     """{mountpoint: remote fs} for every mount rcd currently serves (empty
     when no daemon is live). Read-only: never spawns a daemon just to answer
-    a status question."""
+    a status question. Keys are _norm'd so a Windows listmounts entry with
+    slash/case drift still matches mountpoint(m)."""
     port = _live_rcd_port()
     if port is None:
         return {}
@@ -561,7 +582,13 @@ def rcd_mount_map() -> dict:
         listed = _rc(port, "mount/listmounts").get("mountPoints", [])
     except RuntimeError:
         return {}
-    return {m.get("MountPoint"): m.get("Fs") for m in listed if isinstance(m, dict)}
+    out = {}
+    for m in listed:
+        if not isinstance(m, dict):
+            continue
+        mp = m.get("MountPoint")
+        out[_norm(mp) if isinstance(mp, str) else mp] = m.get("Fs")
+    return out
 
 
 def mounted_paths() -> set:
@@ -1301,13 +1328,13 @@ def attach_mount(m: dict) -> str | None:
     """Mount via rcd; returns an error string or None."""
     mp = mountpoint(m)
     os.makedirs(mp, exist_ok=True)
-    if os.path.ismount(mp):
+    if _path_mounted(mp):
         # Already a kernel mount — but is it OURS? A stale mount left by a
         # deleted mount of the same name would otherwise pass for the
         # new remote. rcd knows the fs of every mount it serves; a mismatch
         # is an error, not a silent adopt. (A mount rcd doesn't know about
         # has no queryable fs — adopted as-is, the pre-rcd prototype case.)
-        fs = rcd_mount_map().get(mp)
+        fs = rcd_mount_map().get(_norm(mp))
         if fs is not None and fs != m["remote"]:
             return (f"mountpoint already serves '{fs}' — unmount it before "
                     f"mounting '{m['remote']}'")
@@ -1408,9 +1435,9 @@ def _force_unmount(mp: str) -> str | None:
         except (OSError, subprocess.TimeoutExpired) as e:
             last = str(e)
             continue
-        if not os.path.ismount(mp):
+        if not _path_mounted(mp):
             return None
-    if not os.path.ismount(mp):
+    if not _path_mounted(mp):
         return None
     return f"force unmount of {mp} failed: {last or 'still mounted'}"
 
@@ -1426,7 +1453,7 @@ def detach_mount(m: dict, force: bool = False) -> str | None:
     if port is None:
         # No daemon: nothing rcd-owned to unmount. A foreign mount at the
         # path (pre-rcd prototype, manual rclone) is not ours to force.
-        if os.path.ismount(mp):
+        if _path_mounted(mp):
             if force:
                 return _force_unmount(mp)
             return ("mounted outside the app (no rclone daemon running) — "
@@ -1442,7 +1469,7 @@ def detach_mount(m: dict, force: bool = False) -> str | None:
         # Linux both say "busy"); on any other failure quitting them would
         # tear down previews of unrelated LOCAL files for nothing.
         if "busy" not in str(e).lower():
-            if force and os.path.ismount(mp):
+            if force and _path_mounted(mp):
                 return _force_unmount(mp)
             return f"unmount failed: {e}"
     _quit_tile_daemons()
@@ -1451,7 +1478,7 @@ def detach_mount(m: dict, force: bool = False) -> str | None:
         _rc(port, "mount/unmount", params)
         return None
     except RuntimeError as e:
-        if force and os.path.ismount(mp):
+        if force and _path_mounted(mp):
             return _force_unmount(mp)
         return f"unmount failed (a preview may still hold a file open): {e}"
 
@@ -1496,7 +1523,7 @@ def reconnect_mount(m: dict) -> str | None:
             _rc(port, "mount/unmount", {"mountPoint": mp})
         except RuntimeError:
             pass  # wedged: rcd's own umount fails; the force path handles it
-    if os.path.ismount(mp):
+    if _path_mounted(mp):
         err = _force_unmount(mp)
         if err:
             return err
@@ -1548,8 +1575,8 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT) -> str
 
     def probe() -> None:
         try:
-            is_mnt = os.path.ismount(mp)
-            served = mp in rcd_mounts
+            is_mnt = _path_mounted(mp)
+            served = _norm(mp) in rcd_mounts
             if not is_mnt and not served:
                 out["state"] = "unmounted"
             elif served and not is_mnt:
@@ -1607,7 +1634,7 @@ def run_automount() -> None:
     live = mounted_paths()
     for m in mounts:
         mp = mountpoint(m)
-        if mp in live and not os.path.ismount(mp):
+        if _norm(mp) in live and not _path_mounted(mp):
             # Split-brain: rcd lists the mount but the kernel dropped it.
             # mount/mount over rcd's own stale entry would fail — leave it
             # for mount_state to surface as "stale" and Reconnect to heal.
@@ -1926,7 +1953,7 @@ def delete_mount(cid: str, x_fused: str | None = Header(default=None)):
         return JSONResponse({"error": "unknown mount"}, status_code=404)
     err = detach_mount(m)
     mp = mountpoint(m)
-    if err and os.path.ismount(mp):
+    if err and _path_mounted(mp):
         # Deleting the record while the filesystem is still mounted would
         # strand a live mount (and let a re-added name silently reuse it).
         return JSONResponse({"error": f"not deleted — {err}"}, status_code=502)

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -533,13 +533,15 @@ def _ensure_rcd_locked() -> int:
     log_path = _rotate_rcd_log()
     # Detach so the daemon outlives this server (on purpose). POSIX uses
     # start_new_session (setsid); on Windows that is a no-op, so use
-    # creationflags to fully detach with no console window — same idiom as
-    # server.py/executor.py.
+    # creationflags to fully detach with no controlling console — the same
+    # detach idiom as templates/latex/engine.py and templates/usd/reader.py.
+    # DETACHED_PROCESS already gives the child no console; CREATE_NO_WINDOW is
+    # omitted because CreateProcess ignores it when combined with
+    # DETACHED_PROCESS.
     if sys.platform == "win32":
         detach_kwargs = {"creationflags": (
             subprocess.CREATE_NEW_PROCESS_GROUP
-            | subprocess.DETACHED_PROCESS
-            | subprocess.CREATE_NO_WINDOW)}
+            | subprocess.DETACHED_PROCESS)}
     else:
         detach_kwargs = {"start_new_session": True}
     subprocess.Popen(

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1345,7 +1345,14 @@ def _sync_serves_locked() -> None:
 def attach_mount(m: dict) -> str | None:
     """Mount via rcd; returns an error string or None."""
     mp = mountpoint(m)
-    os.makedirs(mp, exist_ok=True)
+    if sys.platform == "win32":
+        # WinFsp refuses to mount onto an EXISTING dir and creates (and later
+        # removes) the leaf itself — so ensure only the parent and leave the
+        # leaf absent. Its presence then doubles as the mount signal
+        # (_path_mounted).
+        os.makedirs(mounts_dir(), exist_ok=True)
+    else:
+        os.makedirs(mp, exist_ok=True)
     if _path_mounted(mp):
         # Already a kernel mount — but is it OURS? A stale mount left by a
         # deleted mount of the same name would otherwise pass for the
@@ -1400,6 +1407,8 @@ def attach_mount(m: dict) -> str | None:
         params = {
             "fs": m["remote"],
             "mountPoint": mp,
+            # "mount" is FUSE on Linux and cgofuse -> WinFsp on Windows (no
+            # Windows-specific value needed); only macOS uses nfsmount.
             "mountType": "nfsmount" if sys.platform == "darwin" else "mount",
             # Per-mount vfsOpt: VFS_OPT plus ReadOnly from the record, so a
             # read-only remote's VFS rejects writes instead of caching them for
@@ -1981,7 +1990,11 @@ def delete_mount(cid: str, x_fused: str | None = Header(default=None)):
         # Deleting the record while the filesystem is still mounted would
         # strand a live mount (and let a re-added name silently reuse it).
         return JSONResponse({"error": f"not deleted — {err}"}, status_code=502)
-    if os.path.isdir(mp) and not os.path.ismount(mp) and not os.listdir(mp):
+    # POSIX only: FUSE/NFS leave an empty real dir behind, so clean it up.
+    # On Windows WinFsp already removes the leaf on unmount (and we never
+    # pre-create it), so there is nothing to rmdir.
+    if (sys.platform != "win32" and os.path.isdir(mp)
+            and not os.path.ismount(mp) and not os.listdir(mp)):
         os.rmdir(mp)
     remove_mount(cid)
     sync_serves()  # stop the deleted mount's HTTP serve, drop its map entry

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -531,13 +531,24 @@ def _ensure_rcd_locked() -> int:
     # DEVNULL: --log-file captures everything, and a detached daemon has no
     # console to write to anyway.
     log_path = _rotate_rcd_log()
+    # Detach so the daemon outlives this server (on purpose). POSIX uses
+    # start_new_session (setsid); on Windows that is a no-op, so use
+    # creationflags to fully detach with no console window — same idiom as
+    # server.py/executor.py.
+    if sys.platform == "win32":
+        detach_kwargs = {"creationflags": (
+            subprocess.CREATE_NEW_PROCESS_GROUP
+            | subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NO_WINDOW)}
+    else:
+        detach_kwargs = {"start_new_session": True}
     subprocess.Popen(
         [bin_, "rcd", "--rc-no-auth", "--use-server-modtime",
          f"--rc-addr=127.0.0.1:{port}",
          f"--log-file={log_path}", "--log-level", "INFO"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        start_new_session=True,  # outlives this server on purpose
+        **detach_kwargs,
     )
     deadline = time.time() + 10
     while time.time() < deadline:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1455,6 +1455,18 @@ def _force_unmount(mp: str) -> str | None:
     mounts whose serving daemon is gone/wedged — there is nothing left to
     corrupt, and rcd's own unmount either failed or can't be asked. Returns
     an error string or None."""
+    if sys.platform == "win32":
+        # No kernel umount on Windows: the rc mount/unmount path (tried first
+        # by callers) is the real teardown, and a WinFsp mount dies with its
+        # owning rcd anyway. All that can remain here is a stale leaf — remove
+        # it best-effort; error only if it won't go.
+        if not _path_mounted(mp):
+            return None
+        try:
+            os.rmdir(mp)
+        except OSError as e:
+            return f"force unmount of {mp} failed: {e}"
+        return None
     attempts = [["umount", mp]]
     if sys.platform == "darwin":
         attempts += [["umount", "-f", mp], ["diskutil", "unmount", "force", mp]]

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2233,3 +2233,44 @@ def test_force_unmount_errors_when_stale_leaf_stuck_on_win32(monkeypatch):
     monkeypatch.setattr(mounts_mod.os, "rmdir", boom)
     err = mounts_mod._force_unmount(r"C:\mounts\data")
     assert err is not None and "in use" in err
+
+
+def _capture_rcd_spawn(monkeypatch, platform):
+    """Drive _ensure_rcd_locked to the Popen call without a real rclone: no
+    live daemon (no rcd fixture), a stubbed bin, and an _rc that answers
+    core/pid so the readiness loop returns immediately. Returns the captured
+    Popen kwargs dict."""
+    monkeypatch.setattr(mounts_mod.sys, "platform", platform)
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+    monkeypatch.setattr(mounts_mod, "_rc", lambda *a, **k: {"pid": 1})
+    cap = {}
+
+    def fake_popen(argv, **kwargs):
+        cap["argv"] = argv
+        cap["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(mounts_mod.subprocess, "Popen", fake_popen)
+    return cap
+
+
+def test_rcd_daemon_detaches_with_start_new_session_on_posix(home, monkeypatch):
+    cap = _capture_rcd_spawn(monkeypatch, "linux")
+    assert isinstance(mounts_mod.ensure_rcd(), int)
+    kw = cap["kwargs"]
+    assert kw["start_new_session"] is True
+    assert "creationflags" not in kw
+
+
+def test_rcd_daemon_detaches_with_creationflags_on_win32(home, monkeypatch):
+    # subprocess exposes these constants only on Windows; inject them so the
+    # win32 branch is exercisable on the Linux CI.
+    for name, val in (("CREATE_NEW_PROCESS_GROUP", 0x200),
+                      ("DETACHED_PROCESS", 0x8),
+                      ("CREATE_NO_WINDOW", 0x8000000)):
+        monkeypatch.setattr(mounts_mod.subprocess, name, val, raising=False)
+    cap = _capture_rcd_spawn(monkeypatch, "win32")
+    assert isinstance(mounts_mod.ensure_rcd(), int)
+    kw = cap["kwargs"]
+    assert "start_new_session" not in kw
+    assert kw["creationflags"] == (0x200 | 0x8 | 0x8000000)

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2369,3 +2369,42 @@ def test_mount_for_is_case_sensitive_on_posix(home):
     # No case folding on posix.
     m2, _ = mounts_mod._mount_for(os.path.join(mp.upper(), "f.parquet"))
     assert m2 is None
+
+
+# -- Windows force-unmount error messaging (FINDING 3) ----------------------
+
+
+def test_force_unmount_live_mount_suggests_daemon_restart_on_win32(
+        home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    mp = mounts_mod.mountpoint(mounts_mod.add_mount("data", "remote:bucket"))
+    rcd.responses["mount/listmounts"] = {
+        "mountPoints": [{"MountPoint": mp, "Fs": "remote:bucket"}]}
+
+    def boom(p):
+        raise OSError("in use")
+
+    monkeypatch.setattr(mounts_mod.os, "rmdir", boom)
+    err = mounts_mod._force_unmount(mp)
+    # A live WinFsp mount: say so and point at the daemon, not the raw rmdir
+    # error masquerading as a failed unmount.
+    assert err is not None
+    assert "live" in err and "rclone daemon" in err
+    assert "force unmount" not in err
+
+
+def test_force_unmount_stale_leaf_keeps_raw_error_on_win32(
+        home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    mp = mounts_mod.mountpoint(mounts_mod.add_mount("data", "remote:bucket"))
+    rcd.responses["mount/listmounts"] = {"mountPoints": []}  # not live -> stale
+
+    def boom(p):
+        raise OSError("in use")
+
+    monkeypatch.setattr(mounts_mod.os, "rmdir", boom)
+    err = mounts_mod._force_unmount(mp)
+    # Genuinely stale leaf that won't rmdir keeps the original message.
+    assert err is not None and "force unmount" in err and "in use" in err

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2264,13 +2264,15 @@ def test_rcd_daemon_detaches_with_start_new_session_on_posix(home, monkeypatch):
 
 def test_rcd_daemon_detaches_with_creationflags_on_win32(home, monkeypatch):
     # subprocess exposes these constants only on Windows; inject them so the
-    # win32 branch is exercisable on the Linux CI.
+    # win32 branch is exercisable on the Linux CI. CREATE_NO_WINDOW is
+    # deliberately NOT injected: CreateProcess ignores it when combined with
+    # DETACHED_PROCESS, so the flags must not include it (and referencing it
+    # here would AttributeError if the code still reached for it).
     for name, val in (("CREATE_NEW_PROCESS_GROUP", 0x200),
-                      ("DETACHED_PROCESS", 0x8),
-                      ("CREATE_NO_WINDOW", 0x8000000)):
+                      ("DETACHED_PROCESS", 0x8)):
         monkeypatch.setattr(mounts_mod.subprocess, name, val, raising=False)
     cap = _capture_rcd_spawn(monkeypatch, "win32")
     assert isinstance(mounts_mod.ensure_rcd(), int)
     kw = cap["kwargs"]
     assert "start_new_session" not in kw
-    assert kw["creationflags"] == (0x200 | 0x8 | 0x8000000)
+    assert kw["creationflags"] == (0x200 | 0x8)

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2141,3 +2141,58 @@ def test_attach_mount_proceeds_to_mount_when_winfsp_present(home, rcd, monkeypat
     assert mounts_mod.attach_mount(c) is None
     [(_, body)] = [x for x in rcd.calls if x[0] == "mount/mount"]
     assert body["mountType"] == "mount"  # cgofuse -> WinFsp, same as Linux
+
+
+def test_attach_mount_does_not_precreate_leaf_on_win32(home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda mp: False)
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    real_makedirs = mounts_mod.os.makedirs
+    made = []
+    monkeypatch.setattr(mounts_mod.os, "makedirs",
+                        lambda p, **k: made.append(p) or real_makedirs(p, **k))
+    assert mounts_mod.attach_mount(c) is None
+    # WinFsp refuses to mount onto an existing dir: ensure only the parent,
+    # leave the leaf for WinFsp to create.
+    assert mounts_mod.mounts_dir() in made
+    assert mp not in made
+
+
+def test_attach_mount_precreates_leaf_on_posix(home, rcd, monkeypatch):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    real_makedirs = mounts_mod.os.makedirs
+    made = []
+    monkeypatch.setattr(mounts_mod.os, "makedirs",
+                        lambda p, **k: made.append(p) or real_makedirs(p, **k))
+    assert mounts_mod.attach_mount(c) is None
+    assert mp in made  # POSIX still pre-creates the leaf, exactly as before
+
+
+def test_delete_cleanup_skips_rmdir_on_win32(home, rcd, monkeypatch):
+    import os as _os
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    _os.makedirs(mp, exist_ok=True)  # a leaf that WinFsp would already have removed
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: False)
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    resp = mounts_mod.delete_mount(c["id"], x_fused="1")
+    assert resp == {"ok": True}
+    assert rmdirs == []  # WinFsp owns leaf teardown; the app never rmdirs on win32
+
+
+def test_delete_cleanup_rmdirs_empty_leaf_on_posix(home, rcd, monkeypatch):
+    import os as _os
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    _os.makedirs(mp, exist_ok=True)
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: False)
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    resp = mounts_mod.delete_mount(c["id"], x_fused="1")
+    assert resp == {"ok": True}
+    assert rmdirs == [mp]  # POSIX still removes the empty leaf FUSE/NFS left behind

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -6,8 +6,10 @@ FUSED_RENDER_HOME is redirected per test so no test touches the real
 ~/.fused-render or a real mount.
 """
 import json
+import sys
 import threading
 import time
+import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
@@ -2073,3 +2075,69 @@ def test_norm_is_identity_on_posix_paths():
     # so every membership test compares byte-for-byte as before.
     p = "/home/u/.fused-render/mounts/data"
     assert mounts_mod._norm(p) == p
+
+
+class _FakeRegKey:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_winfsp_available_true_on_posix_without_touching_registry(monkeypatch):
+    # Never gates POSIX: returns True and never imports/reads winreg.
+    monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
+    monkeypatch.setitem(sys.modules, "winreg", None)  # would blow up if imported
+    assert mounts_mod._winfsp_available() is True
+
+
+def test_winfsp_available_reads_registry_on_win32(monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    opened = []
+
+    def open_key(root, subkey):
+        opened.append(subkey)
+        if subkey.endswith("WOW6432Node\\WinFsp"):
+            return _FakeRegKey()
+        raise FileNotFoundError()
+
+    fake = types.SimpleNamespace(HKEY_LOCAL_MACHINE=0, OpenKey=open_key)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert mounts_mod._winfsp_available() is True
+    assert opened == ["SOFTWARE\\WOW6432Node\\WinFsp"]
+
+
+def test_winfsp_available_false_when_no_registry_key(monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    tried = []
+
+    def open_key(root, subkey):
+        tried.append(subkey)
+        raise FileNotFoundError()
+
+    fake = types.SimpleNamespace(HKEY_LOCAL_MACHINE=0, OpenKey=open_key)
+    monkeypatch.setitem(sys.modules, "winreg", fake)
+    assert mounts_mod._winfsp_available() is False
+    # Falls back to the non-WOW key before giving up.
+    assert tried == ["SOFTWARE\\WOW6432Node\\WinFsp", "SOFTWARE\\WinFsp"]
+
+
+def test_attach_mount_preflights_winfsp_and_skips_rcd_when_absent(home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: False)
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda mp: False)
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    err = mounts_mod.attach_mount(c)
+    assert err is not None and "winfsp.dev" in err.lower()
+    assert rcd.calls == []  # never reached the daemon
+
+
+def test_attach_mount_proceeds_to_mount_when_winfsp_present(home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda mp: False)
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    assert mounts_mod.attach_mount(c) is None
+    [(_, body)] = [x for x in rcd.calls if x[0] == "mount/mount"]
+    assert body["mountType"] == "mount"  # cgofuse -> WinFsp, same as Linux

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2196,3 +2196,40 @@ def test_delete_cleanup_rmdirs_empty_leaf_on_posix(home, rcd, monkeypatch):
     resp = mounts_mod.delete_mount(c["id"], x_fused="1")
     assert resp == {"ok": True}
     assert rmdirs == [mp]  # POSIX still removes the empty leaf FUSE/NFS left behind
+
+
+def test_force_unmount_no_subprocess_on_win32_when_leaf_gone(monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: False)
+    ran = []
+    monkeypatch.setattr(mounts_mod.subprocess, "run",
+                        lambda *a, **k: ran.append(a))
+    assert mounts_mod._force_unmount(r"C:\mounts\data") is None
+    assert ran == []  # no umount binary on Windows
+
+
+def test_force_unmount_removes_stale_leaf_on_win32(monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    ran = []
+    monkeypatch.setattr(mounts_mod.subprocess, "run",
+                        lambda *a, **k: ran.append(a))
+    removed = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: removed.append(p))
+    assert mounts_mod._force_unmount(r"C:\mounts\data") is None
+    assert removed == [r"C:\mounts\data"]
+    assert ran == []
+
+
+def test_force_unmount_errors_when_stale_leaf_stuck_on_win32(monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    monkeypatch.setattr(mounts_mod.subprocess, "run",
+                        lambda *a, **k: pytest.fail("must not shell out on win32"))
+
+    def boom(p):
+        raise OSError("in use")
+
+    monkeypatch.setattr(mounts_mod.os, "rmdir", boom)
+    err = mounts_mod._force_unmount(r"C:\mounts\data")
+    assert err is not None and "in use" in err

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2371,6 +2371,96 @@ def test_mount_for_is_case_sensitive_on_posix(home):
     assert m2 is None
 
 
+# -- Windows stale-leaf recovery for attach / delete (FINDING 1) ------------
+# On win32 _path_mounted is os.path.isdir, so a stale empty leaf (WinFsp crash
+# / incomplete teardown) reads as "mounted". attach_mount and delete_mount must
+# probe it with os.rmdir: an empty removable dir was never a live mount.
+
+
+def test_attach_stale_empty_leaf_mounts_fresh_on_win32(home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+    # The stale leaf exists, so _path_mounted reads True; rcd does not serve it
+    # (default empty listmounts) so fs is None.
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda mp: True)
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    assert mounts_mod.attach_mount(c) is None
+    # The stale leaf was probed with rmdir, then a FRESH mount was issued.
+    assert rmdirs == [mounts_mod.mountpoint(c)]
+    assert any(x[0] == "mount/mount" for x in rcd.calls)
+
+
+def test_attach_non_empty_leaf_still_adopts_on_win32(home, rcd, monkeypatch):
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda mp: True)
+    c = mounts_mod.add_mount("data", "remote:bucket")
+
+    def boom(p):
+        raise OSError("directory not empty")
+
+    monkeypatch.setattr(mounts_mod.os, "rmdir", boom)
+    # A non-empty leaf (foreign mount / real content) refuses rmdir -> keep the
+    # existing adopt-as-is behavior, no fresh mount.
+    assert mounts_mod.attach_mount(c) is None
+    assert not any(x[0] == "mount/mount" for x in rcd.calls)
+
+
+def test_delete_stale_leaf_no_daemon_succeeds_on_win32(home, monkeypatch):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    cid = c["id"]
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda: None)
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    # detach_mount's daemon-absent leg returns "mounted outside the app…"; the
+    # stale-leaf rmdir then clears it and the delete succeeds.
+    resp = mounts_mod.delete_mount(cid, x_fused="1")
+    assert resp == {"ok": True}
+    assert rmdirs == [mounts_mod.mountpoint(c)]
+    assert mounts_mod.get_mount(cid) is None
+
+
+def test_delete_stale_leaf_unmount_not_found_succeeds_on_win32(
+        home, rcd, monkeypatch):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    cid = c["id"]
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    # Daemon present but its unmount fails "mount not found", and it does not
+    # list the leaf -> stale, so rmdir recovers it.
+    rcd.responses["mount/unmount"] = (500, {"error": "mount not found"})
+    rcd.responses["mount/listmounts"] = {"mountPoints": []}
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    resp = mounts_mod.delete_mount(cid, x_fused="1")
+    assert resp == {"ok": True}
+    assert rmdirs == [mounts_mod.mountpoint(c)]
+    assert mounts_mod.get_mount(cid) is None
+
+
+def test_delete_live_leaf_still_502s_on_unmount_error_on_win32(
+        home, rcd, monkeypatch):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    cid = c["id"]
+    mp = mounts_mod.mountpoint(c)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod, "_path_mounted", lambda p: True)
+    rcd.responses["mount/unmount"] = (500, {"error": "mount not found"})
+    # rcd DOES list this mount -> it is live, not stale: never rmdir it.
+    rcd.responses["mount/listmounts"] = {
+        "mountPoints": [{"MountPoint": mp, "Fs": "remote:bucket"}]}
+    rmdirs = []
+    monkeypatch.setattr(mounts_mod.os, "rmdir", lambda p: rmdirs.append(p))
+    resp = mounts_mod.delete_mount(cid, x_fused="1")
+    assert resp.status_code == 502
+    assert rmdirs == []
+    assert mounts_mod.get_mount(cid) is not None  # record kept
+
+
 # -- Windows force-unmount error messaging (FINDING 3) ----------------------
 
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2276,3 +2276,96 @@ def test_rcd_daemon_detaches_with_creationflags_on_win32(home, monkeypatch):
     kw = cap["kwargs"]
     assert "start_new_session" not in kw
     assert kw["creationflags"] == (0x200 | 0x8)
+
+
+# -- Windows path normalization: serve/upstream routing (FINDING 2) ---------
+# On Windows expanduser("~/.fused-render") yields mixed separators, so
+# mountpoint() must normpath to a uniform form or serves.json keys and mount
+# prefixes disagree with os.path.abspath()'s backslashes. These tests simulate
+# Windows path semantics on the (posix) CI by swapping in ntpath's normalizers.
+
+
+def test_mountpoint_normalizes_mixed_separators_on_win32(home, monkeypatch):
+    import ntpath
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    # A mounts_dir with the mixed backslash/forward-slash separators
+    # expanduser produces on Windows.
+    monkeypatch.setattr(mounts_mod, "mounts_dir",
+                        lambda: "C:\\Users\\me\\.fused-render/mounts")
+    monkeypatch.setattr(mounts_mod.os.path, "join", ntpath.join)
+    monkeypatch.setattr(mounts_mod.os.path, "normpath", ntpath.normpath)
+    mp = mounts_mod.mountpoint(c)
+    # Uniform backslashes: serves.json keys / mount prefixes and abspath() now
+    # agree, so serve_url_for / _mount_for can match.
+    assert mp == "C:\\Users\\me\\.fused-render\\mounts\\data"
+
+
+def test_mountpoint_normpath_is_identity_on_posix(home):
+    import os
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    # An already-clean absolute posix path is unchanged by normpath, and no
+    # separators are flipped.
+    assert mp == os.path.normpath(mp)
+    assert "\\" not in mp
+
+
+def test_serve_url_for_matches_windows_mixed_separators(home, rcd, monkeypatch):
+    import os
+    import ntpath
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    # A serves.json key left with drifted case (and, once ntpath flips them,
+    # separators), as a pre-normpath mountpoint() produced. Only _norm folding
+    # BOTH sides makes it match the canonical query path. Write it before
+    # swapping in ntpath so serves_path/storage keep posix semantics.
+    mounts_mod.storage.write_json(
+        mounts_mod.serves_path(), {mp.upper(): "http://127.0.0.1:59999"})
+    for name, fn in (("normcase", ntpath.normcase),
+                     ("normpath", ntpath.normpath),
+                     ("relpath", ntpath.relpath)):
+        monkeypatch.setattr(mounts_mod.os.path, name, fn)
+    monkeypatch.setattr(mounts_mod.os, "sep", ntpath.sep)
+    url = mounts_mod.serve_url_for(os.path.join(mp, "year=2022", "a b.parquet"))
+    # Matched despite case drift; the returned relative path keeps its original
+    # case and uses forward slashes (never lowercased).
+    assert url == "http://127.0.0.1:59999/year%3D2022/a%20b.parquet"
+
+
+def test_serve_url_for_is_case_sensitive_on_posix(home, rcd):
+    import os
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mounts_mod.sync_serves()  # stub serve at 127.0.0.1:59999
+    mp = mounts_mod.mountpoint(c)
+    # POSIX: _norm is the identity, so no case folding — a case-mismatched path
+    # must NOT match, exactly as before.
+    assert mounts_mod.serve_url_for(
+        os.path.join(mp.upper(), "f.parquet")) is None
+    assert mounts_mod.serve_url_for(os.path.join(mp, "f.parquet")) is not None
+
+
+def test_mount_for_matches_windows_mixed_separators(home, monkeypatch):
+    import os
+    import ntpath
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    query = os.path.join(mp, "sub", "f.parquet")
+    for name, fn in (("normcase", ntpath.normcase),
+                     ("normpath", ntpath.normpath),
+                     ("relpath", ntpath.relpath)):
+        monkeypatch.setattr(mounts_mod.os.path, name, fn)
+    monkeypatch.setattr(mounts_mod.os, "sep", ntpath.sep)
+    m, rel = mounts_mod._mount_for(query)
+    assert m is not None and m["name"] == "data"
+    assert rel == "sub/f.parquet"  # forward slashes, original case
+
+
+def test_mount_for_is_case_sensitive_on_posix(home):
+    import os
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    m, rel = mounts_mod._mount_for(os.path.join(mp, "sub", "f.parquet"))
+    assert m is not None and rel == "sub/f.parquet"
+    # No case folding on posix.
+    m2, _ = mounts_mod._mount_for(os.path.join(mp.upper(), "f.parquet"))
+    assert m2 is None

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2021,3 +2021,55 @@ def test_s3_list_page_non_anonymous_raises_s3listerror(home, rcd, fresh_upstream
     c = mounts_mod.add_mount("corp", "corp:bucket/pre")
     with pytest.raises(mounts_mod.S3ListError):
         mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+# -- Windows mounts (experimental) -----------------------------------------
+# rclone's Windows mount uses cgofuse -> WinFsp. These tests drive the
+# win32 code paths on the (Linux) CI by monkeypatching sys.platform and
+# mocking winreg/subprocess/os, following the heavy-mocking style above.
+# Every case also asserts the POSIX behavior is untouched.
+
+
+def test_path_mounted_delegates_to_ismount_on_posix_and_isdir_on_win32(monkeypatch):
+    seen = {"ismount": [], "isdir": []}
+    monkeypatch.setattr(mounts_mod.os.path, "ismount",
+                        lambda p: (seen["ismount"].append(p), True)[1])
+    monkeypatch.setattr(mounts_mod.os.path, "isdir",
+                        lambda p: (seen["isdir"].append(p), True)[1])
+
+    monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
+    assert mounts_mod._path_mounted("/mnt/x") is True
+    assert seen == {"ismount": ["/mnt/x"], "isdir": []}
+
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    assert mounts_mod._path_mounted(r"C:\mnt\x") is True
+    # win32 reads the leaf-dir presence and never touches ismount.
+    assert seen["isdir"] == [r"C:\mnt\x"]
+    assert seen["ismount"] == ["/mnt/x"]
+
+
+def test_rcd_mount_map_matches_mountpoint_despite_windows_slash_case_drift(
+        home, rcd, monkeypatch):
+    # rcd's listmounts on Windows can echo a mountpoint with forward slashes
+    # and different case than the one we asked for. _norm (normcase+normpath)
+    # must fold both sides so membership/lookup still resolve. Simulate the
+    # Windows path semantics on Linux by swapping in ntpath's normalizers.
+    import ntpath
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mp = mounts_mod.mountpoint(c)
+    drifted = mp.replace("\\", "/").upper()  # slash + case drift from rcd
+    rcd.responses["mount/listmounts"] = {
+        "mountPoints": [{"MountPoint": drifted, "Fs": "remote:bucket"}]}
+    # Swap in ntpath's normalizers only after the store write above, so
+    # tempfile (which also uses os.path) isn't handed Windows semantics.
+    monkeypatch.setattr(mounts_mod.os.path, "normcase", ntpath.normcase)
+    monkeypatch.setattr(mounts_mod.os.path, "normpath", ntpath.normpath)
+    assert mounts_mod._norm(mp) in mounts_mod.mounted_paths()
+    assert mounts_mod.rcd_mount_map().get(mounts_mod._norm(mp)) == "remote:bucket"
+
+
+def test_norm_is_identity_on_posix_paths():
+    # POSIX guarantee: a normalized absolute mountpoint is unchanged by _norm,
+    # so every membership test compares byte-for-byte as before.
+    p = "/home/u/.fused-render/mounts/data"
+    assert mounts_mod._norm(p) == p


### PR DESCRIPTION
# Experimental Windows rclone mount support

## Summary

- Mounts now work on Windows (experimental) via rclone + WinFsp, keeping the existing subdirectory model — mounts stay under `~/.fused-render/mounts/<name>`, so the file-browser and serve layers are untouched.
- All Windows changes are confined to four platform seams in `fused_render/shell/mounts.py`: a WinFsp preflight with install guidance, the mount-target rule (WinFsp creates/removes the leaf dir itself, so it is never pre-created), a platform mount predicate (`_path_mounted`: leaf-dir presence instead of `os.path.ismount`, plus `_norm` path normalization against rcd's `listmounts`), and a Windows-safe force unmount (no `umount` binary — stale-leaf cleanup only).
- The rcd daemon is now detached correctly on Windows (`creationflags` instead of the POSIX-only `start_new_session`), matching the existing idiom in `server.py`/`executor.py`.
- POSIX behavior is byte-for-byte unchanged; every new test asserts this alongside the Windows branch.

## Visuals

No user-facing UI change — the delta is the Windows branch of the mount lifecycle:

```mermaid
flowchart TD
    A[attach_mount] --> B{platform?}
    B -->|POSIX unchanged| C[makedirs leaf → rc mount/mount]
    B -->|win32 new| D{WinFsp installed?<br/>registry probe}
    D -->|no| E[error string:<br/>install from winfsp.dev]
    D -->|yes| F[makedirs parent only —<br/>WinFsp owns the leaf dir]
    F --> G[rc mount/mount<br/>mountType stays 'mount']
    G --> H{"mounted?" predicate}
    H -->|POSIX| I[os.path.ismount]
    H -->|win32| J[leaf dir exists<br/>valid: never pre-created]
    K[force unmount] --> L{platform?}
    L -->|POSIX unchanged| M[umount / umount -l / diskutil]
    L -->|win32 new| N[no umount binary:<br/>rmdir stale leaf best-effort]
```

## Usage

Nothing new is user-invocable — the existing Mounts page flow now also works on Windows. On a Windows box with [WinFsp](https://winfsp.dev) installed and `rclone` on `PATH`, adding a mount from the Mounts page mounts the remote as a browsable folder under `~/.fused-render/mounts/`; without WinFsp, the add fails with an actionable install message instead of a raw cgofuse error.

## Test Plan

- [x] 21 new Windows unit tests in `tests/test_shell_mounts.py` (monkeypatched `sys.platform="win32"`, mocked `_rc`/`subprocess`/`winreg`), each also asserting the POSIX branch is unchanged — `tests/test_shell_mounts.py`: 146 passed, 3 skipped
- [x] Full suite: 931 passed, 15 skipped; only the 6 known pre-existing network failures in `test_deploy`/`test_duckdb_reader`
- [x] Rebased onto latest `main` (remote-labeling changes in the same file) and re-verified green
- [ ] Manual smoke on a real Windows box (WinFsp + rclone): add a public-bucket mount → browsable, state "mounted"; delete → clean unmount, leaf gone; without WinFsp → install-guidance error. Until then the feature stays labeled experimental (see README). Also confirms `mountType="mount"` maps to cgofuse→WinFsp as believed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
