### PR TITLE
Skip bookmark/session sidecar writes on read-only remote mounts

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -786,6 +786,15 @@ def _session_put(body: dict, x_fused: str | None):
         return _error(f"no such file: {path}", status=404)
     if not isinstance(search, str):
         return _error("'search' must be a string")
+    # A file browsed inside a read-only remote mount can never take the
+    # sidecar write: with CacheMode=full the doomed PutObject lands in the VFS
+    # cache and 403-loops forever (the sidecar-write incident). Skip before
+    # even reading the sidecar (that read is a network stat too) — reopening
+    # the file just restores the default view. Same "skipped" shape as the
+    # LSN-3 gate below.
+    from fused_render.shell.mounts import mount_read_only
+    if mount_read_only(path):
+        return {"ok": True, "skipped": True}
     # Read-merge-write the whole dict so claudeSessions / bookmarkHistory
     # survive alongside lastSession (see _read_sidecar comment).
     data = _read_sidecar(path)

--- a/fused_render/shell/bookmarks.py
+++ b/fused_render/shell/bookmarks.py
@@ -17,7 +17,7 @@ from urllib.parse import unquote, urlsplit
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
 
-from fused_render.shell import storage
+from fused_render.shell import mounts, storage
 
 router = APIRouter()
 
@@ -304,6 +304,12 @@ def post_bookmark_history(
     fs_path = _fs_path_from_url(url)
     if fs_path is None:
         # Sentinel / directory-that-vanished / non-file url -> nothing to record.
+        return {"recorded": False}
+    # The bookmark itself already lives in the global tree (bookmarks.json);
+    # this sidecar mirror can't be written when fs_path is inside a read-only
+    # remote mount (CacheMode=full would 403-loop the doomed PutObject — the
+    # sidecar-write incident). Skip the mirror; the bookmark still works.
+    if mounts.mount_read_only(fs_path):
         return {"recorded": False}
     # Store only the portable query string, NOT the incoming url: the sidecar
     # lives next to fs_path, so the target file is implicit (it is the sidecar's

--- a/fused_render/static/shell-dist
+++ b/fused_render/static/shell-dist
@@ -1,0 +1,1 @@
+/home/iamsdas/Work/fused-render/fused_render/static/shell-dist

--- a/fused_render/static/shell-dist
+++ b/fused_render/static/shell-dist
@@ -1,1 +1,0 @@
-/home/iamsdas/Work/fused-render/fused_render/static/shell-dist

--- a/fused_render/templates/annotate/annotate.py
+++ b/fused_render/templates/annotate/annotate.py
@@ -19,7 +19,10 @@ own (claudeSessions, bookmarkHistory, lastSession, ...) is preserved through a
 read-merge-write — a later claude turn round-trips them instead of clobbering
 them off disk.
 
-Stdlib only (runs in a subprocess; cannot import fused_render.shell).
+Stdlib only, save for one guarded lazy import: _sidecar_writable consults the
+shell's mount read_only flag (fused_render.shell.mounts) to detect a read-only
+remote mount, degrading to pure os.access when fused_render isn't importable
+(a standalone copy of this template). See _sidecar_writable.
 
 Actions:
   main(action="record", file=..., comments=[...], deleted_ids=[...])
@@ -157,8 +160,24 @@ def _sidecar_writable(file: str) -> bool:
     """True iff _save_sidecar would succeed: an existing sidecar needs W_OK on
     itself (the os.replace above would otherwise bypass its read-only bit via
     the directory), a fresh one needs W_OK on the directory (mkstemp+replace
-    both land there)."""
-    path = _sidecar_path(os.path.abspath(file))
+    both land there).
+
+    False under a read-only remote mount, where os.access(W_OK) LIES: with
+    CacheMode=full a write lands in the local VFS cache and only 403s at the
+    async upload (the sidecar-write incident), so os.access would wave the
+    doomed write through. Only the shell's persisted read_only flag can answer
+    this, so this reaches for a fused_render internal via a guarded lazy import
+    (cf. templates/zarr_aoi/tile_server.py) — a standalone copy of this
+    template with no fused_render on the path keeps the pure os.access
+    behavior."""
+    file = os.path.abspath(file)
+    try:
+        from fused_render.shell.mounts import mount_read_only
+        if mount_read_only(file):
+            return False
+    except Exception:
+        pass
+    path = _sidecar_path(file)
     if os.path.exists(path):
         return os.access(path, os.W_OK)
     return os.access(os.path.dirname(path), os.W_OK)

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -69,6 +69,24 @@ def _sidecar_path(file: str) -> str:
     return file + ".json"
 
 
+def _mount_read_only(file: str) -> bool:
+    """True when `file` sits under a read-only remote mount, where the sidecar
+    write can never be accepted — with CacheMode=full the doomed upload lands
+    in the VFS cache and 403-loops forever (the sidecar-write incident).
+
+    Guarded lazy import: in the app this reads the mount store; a standalone
+    copy of this template (no fused_render on the path) degrades to False, the
+    pre-guard behavior. Deliberately not the stdlib-only rule the rest of this
+    file follows (cf. templates/zarr_aoi/tile_server.py, which also reaches for
+    a fused_render internal) — os.access(W_OK) can't see a remote's read-only
+    -ness, so only the shell's flag can answer this."""
+    try:
+        from fused_render.shell.mounts import mount_read_only
+        return mount_read_only(file)
+    except Exception:
+        return False
+
+
 def _load_sidecar(file: str) -> dict:
     # Preserve every key we don't own (bookmarkHistory, lastSession, ...) so a
     # claude turn round-trips them instead of clobbering them off disk. Only the
@@ -112,7 +130,15 @@ def _record_session(file: str, session_id: str, message: str,
     old entry's id in place (keeping created_at/preview) so one conversation
     stays one row. `cwd` tracks where the transcript lives so a moved file
     can migrate it (see _migrate_session); refreshed every turn.
+
+    No-op when `file` is inside a read-only remote mount: the sidecar write
+    can't be accepted there (the sidecar-write incident). The chat and its
+    transcript (~/.claude/projects) are unaffected — only this file's session
+    list stays empty, so past conversations won't be listed/resumable from the
+    template UI for a mounted file.
     """
+    if _mount_read_only(file):
+        return
     data = _load_sidecar(file)
     now = time.time()
     cwd = os.path.dirname(file)

--- a/tests/test_annotate_comments.py
+++ b/tests/test_annotate_comments.py
@@ -18,6 +18,8 @@ import importlib.util
 import json
 import os
 
+import pytest
+
 
 def _load_annotate():
     path = os.path.join("fused_render", "templates", "annotate", "annotate.py")
@@ -227,3 +229,40 @@ def test_status_readonly_parent_dir(tmp_path):
         assert ann.main(action="status", file=str(target)) == {"writable": False}
     finally:
         os.chmod(tmp_path, 0o755)
+
+
+# ------------------------------------------------- read-only remote mounts
+# os.access(W_OK) lies under a read-only S3 mount (CacheMode=full: a write
+# lands in the VFS cache and only 403s at the async upload — the sidecar-write
+# incident). _sidecar_writable must consult the mount's read_only flag so the
+# template shows its "history not saved" badge instead of looping the doomed
+# upload. Commenting itself still works — the URL is the live store.
+
+@pytest.fixture
+def ro_mount(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    import fused_render.shell.mounts as mounts
+
+    m = mounts.add_mount("pub", "pub-remote:bucket", read_only=True)
+    mp = mounts.mountpoint(m)
+    os.makedirs(mp)
+    f = os.path.join(mp, "page.html")
+    with open(f, "w") as fh:
+        fh.write("<html></html>")
+    return f
+
+
+def test_status_not_writable_under_read_only_mount(ro_mount):
+    ann = _load_annotate()
+    assert ann.main(action="status", file=ro_mount) == {"writable": False}
+
+
+def test_record_refuses_under_read_only_mount(ro_mount):
+    ann = _load_annotate()
+    with pytest.raises(PermissionError):
+        ann._record(ro_mount, [
+            {"id": "c1", "content": "hi", "createdAt": 1720000000000,
+             "view": "_render"},
+        ], [])
+    # Nothing written next to the mounted file.
+    assert not os.path.exists(ro_mount + ".json")

--- a/tests/test_claude_agent_sidecar.py
+++ b/tests/test_claude_agent_sidecar.py
@@ -53,3 +53,25 @@ def test_bookmark_history_survives_load_save_roundtrip(tmp_path):
     agent._save_sidecar(str(f), loaded)
     data = json.loads((tmp_path / "sample.html.json").read_text())
     assert data["bookmarkHistory"] == history
+
+
+def test_record_session_skipped_under_read_only_mount(tmp_path, monkeypatch):
+    # Chatting about a file inside a read-only S3 mount must not write a
+    # claudeSessions sidecar next to it — the mount can't take the write
+    # (CacheMode=full loops the doomed upload, the sidecar-write incident).
+    # The chat + its transcript (~/.claude/projects) still work; only the
+    # sidecar session list is skipped.
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    import fused_render.shell.mounts as mounts
+
+    m = mounts.add_mount("pub", "pub-remote:bucket", read_only=True)
+    mp = mounts.mountpoint(m)
+    os.makedirs(mp)
+    f = os.path.join(mp, "sample.html")
+    with open(f, "w") as fh:
+        fh.write("<html></html>")
+
+    agent = _load_agent()
+    agent._record_session(f, "sid-1", "hello there", "")
+    assert not os.path.exists(f + ".json")
+    assert agent._sessions(f)["sessions"] == []

--- a/tests/test_server_session.py
+++ b/tests/test_server_session.py
@@ -9,7 +9,9 @@ module importable in venvs where TestClient's httpx dependency is missing, and
 sidesteps create_app's built-shell requirement).
 """
 import json
+import os
 
+import pytest
 from fastapi.responses import JSONResponse
 
 from fused_render.server import _session_get as GET
@@ -133,3 +135,37 @@ def test_empty_query_does_not_clobber_existing_session(tmp_path):
     PUT(body={"path": str(f), "search": "city=oslo"}, x_fused="1")
     assert PUT(body={"path": str(f), "search": ""}, x_fused="1")["skipped"] is True
     assert GET(path=str(f))["lastSession"]["search"] == "city=oslo"
+
+
+# ------------------------------------------------- read-only remote mounts
+# A file browsed inside a read-only S3 mount must not get a lastSession
+# sidecar: os.access(W_OK) lies under CacheMode=full (the write lands in the
+# VFS cache and only 403s at the async upload — the sidecar-write incident),
+# so _session_put must consult the mount's read_only flag and skip the write
+# entirely rather than loop the doomed PutObject.
+
+@pytest.fixture
+def ro_mount(tmp_path, monkeypatch):
+    """A real file under a fake read-only mountpoint inside a redirected
+    FUSED_RENDER_HOME. Returns the absolute file path."""
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    import fused_render.shell.mounts as mounts
+
+    m = mounts.add_mount("pub", "pub-remote:bucket", read_only=True)
+    mp = mounts.mountpoint(m)
+    os.makedirs(mp)
+    f = os.path.join(mp, "cog.tif")
+    with open(f, "w") as fh:
+        fh.write("x")
+    return f
+
+
+def test_put_skips_under_read_only_mount(ro_mount):
+    # A qualifying (non-_mode) query would normally start a session.
+    resp = PUT(body={"path": ro_mount, "search": "_mode=geotiff&stretch=2,1471"},
+               x_fused="1")
+    assert resp == {"ok": True, "skipped": True}
+    # No sidecar written next to the mounted file.
+    assert not os.path.exists(ro_mount + ".json")
+    # And GET reports no session for it.
+    assert GET(path=ro_mount)["lastSession"] is None

--- a/tests/test_shell_bookmark_history.py
+++ b/tests/test_shell_bookmark_history.py
@@ -8,6 +8,9 @@ keeps the module importable in venvs where starlette's TestClient is missing
 its httpx dependency.
 """
 import json
+import os
+
+import pytest
 
 from fused_render.shell import bookmarks
 
@@ -162,3 +165,30 @@ def test_embed_prefix_handled(tmp_path):
     resp = _post({"id": "bk-1", "url": "/embed" + str(f)})
     assert resp == {"recorded": True}
     assert (tmp_path / "sample.html.json").exists()
+
+
+# ------------------------------------------------- read-only remote mounts
+# Bookmarking a file inside a read-only S3 mount still stores the bookmark in
+# the global tree (bookmarks.json), but the per-file bookmarkHistory sidecar
+# mirror must be skipped: the mount can't take the write (CacheMode=full loops
+# the doomed PutObject — the sidecar-write incident).
+
+@pytest.fixture
+def ro_mount(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    import fused_render.shell.mounts as mounts
+
+    m = mounts.add_mount("pub", "pub-remote:bucket", read_only=True)
+    mp = mounts.mountpoint(m)
+    os.makedirs(mp)
+    f = os.path.join(mp, "cog.tif")
+    with open(f, "w") as fh:
+        fh.write("x")
+    return f
+
+
+def test_history_skipped_under_read_only_mount(ro_mount):
+    resp = _post({"id": "bk-1", "name": "cog.tif",
+                  "url": "/view" + ro_mount + "?stretch=2,1471"})
+    assert resp == {"recorded": False}
+    assert not os.path.exists(ro_mount + ".json")


### PR DESCRIPTION
## Summary

- Fixes the sidecar-write incident (ITEM-11984): browsing/bookmarking/annotating a file inside a **read-only S3 rclone mount** made the app write a `<file>.json` sidecar next to the item. The bucket rejects the anonymous write, so under `CacheMode=full` it lands in rclone's VFS cache and the doomed `PutObject` **403-loops forever** (665 retries over ~4 days observed).
- Root cause: `os.access(W_OK)` can't see a remote's read-onlyness — the kernel write "succeeds" into the VFS cache and only fails at the async upload. So the writers happily attempted a write that could never land.
- Fix: all **four** sidecar writers now consult the mount's authoritative `read_only` flag (`mount_read_only`, the same guard `/api/fs/write` already uses) and **skip the write** on a read-only mount. No sidecar state is relocated; local-file behavior is unchanged.
- No stray writes into read-only buckets means no VFS-cache retry loop, no network churn, and no cache entries that never expire.

## Visuals

Backend-only change — no new user-facing surface (annotate's "History not saved" badge already existed; this just makes it fire correctly). Diagram of the delta: every sidecar write now passes through the read-only-mount guard first.

```mermaid
flowchart TD
    subgraph writers[Four sidecar writers]
        A["lastSession<br/>server._session_put"]
        B["bookmarkHistory<br/>bookmarks.post_bookmark_history"]
        C["claudeSessions<br/>agent._record_session"]
        D["comments<br/>annotate._sidecar_writable"]
    end
    A --> G{"mount_read_only(path)?"}
    B --> G
    C --> G
    D --> G
    G -->|"yes (NEW)"| S["skip the write<br/>· session: {ok, skipped}<br/>· history: {recorded: false}<br/>· claude: silent no-op<br/>· annotate: refuse → 'History not saved' badge"]
    G -->|no| W["write &lt;file&gt;.json next to target<br/>(unchanged)"]
```

## Usage

Not directly user-invocable — the guard is transparent. Behavior for a file inside a read-only mount:

- **Bookmarking** still works (the bookmark lives in the global `~/.fused-render/bookmarks.json` tree); only the per-file history *mirror* is skipped.
- **Claude chat** still works and its transcript is preserved under `~/.claude/projects`; only the sidecar session list stays empty, so past sessions aren't listed/resumable from the template UI for that file.
- **Annotate** shows the existing "History not saved" badge instead of silently looping a doomed write — commenting still works (the URL is the live store).
- **View-state restore** (last mode/stretch) is not remembered for mounted files; they open with the default view.

The two stdlib-only templates (`agent.py`, `annotate.py`) reach `mount_read_only` via a **guarded lazy import** (cf. `templates/zarr_aoi/tile_server.py`), degrading to the prior `os.access` behavior when `fused_render` isn't importable (a standalone copy of the template).

## Test Plan

- [x] **Automated (5 new tests)**, one per writer, using the established read-only-mount fixture (`mounts.add_mount(..., read_only=True)` under a redirected `FUSED_RENDER_HOME`):
  - `test_server_session.py::test_put_skips_under_read_only_mount`
  - `test_shell_bookmark_history.py::test_history_skipped_under_read_only_mount`
  - `test_claude_agent_sidecar.py::test_record_session_skipped_under_read_only_mount`
  - `test_annotate_comments.py::test_status_not_writable_under_read_only_mount`
  - `test_annotate_comments.py::test_record_refuses_under_read_only_mount`
- [x] TDD: confirmed the 5 tests fail before the change (red) and pass after (green).
- [x] **Full suite: 923 passed**, 15 skipped. The only 6 failures (`test_deploy.py` pip/CLI, `test_duckdb_reader.py` HTTP-over-network) are pre-existing and environmental — verified they fail identically on the clean base, so no regression.
- [ ] Manual (reviewer, on macOS with a mounted public bucket): browse a COG in a read-only mount, adjust stretch / bookmark it / annotate it → `POST /core/stats` on the rclone rc API shows `errors` no longer incrementing; no new `<path>.json` in `~/Library/Caches/rclone/vfs/aws-open/`.

## Out of scope

Other ITEM-11984 findings not addressed here: rc API credential exposure (no rc auth on `/config/dump`), double-mounting, and the `.bookmark` "Save to disk" export (a user-chosen destination, not an automatic sidecar).
