### PR TITLE
Add GitHub Actions CI workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,13 @@ name: test
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: ["*"]
+  pull_request: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  # PR number is unique repo-wide, unlike head_ref — two fork PRs that happen
+  # to share a branch name (e.g. "patch-1") must not land in the same group
+  # and cancel each other's runs.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -65,7 +67,7 @@ jobs:
 
   test-python:
     needs: [detect-changes, frontend]
-    if: needs.detect-changes.outputs.app == 'true'
+    if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     strategy:
       fail-fast: false
       matrix:
@@ -105,13 +107,19 @@ jobs:
     steps:
       - name: Check test status
         run: |
+          if [[ "${{ needs.detect-changes.result }}" != "success" ]]; then
+            echo "detect-changes did not succeed (${{ needs.detect-changes.result }})"
+            exit 1
+          fi
           if [[ "${{ needs.detect-changes.outputs.app }}" != "true" ]]; then
             echo "No relevant changes; skipped."
             exit 0
           fi
-          if [[ "${{ needs.frontend.result }}" == "failure" || "${{ needs.test-python.result }}" == "failure" ]]; then
-            echo "Job failed"
-            exit 1
-          fi
+          for result in "${{ needs.frontend.result }}" "${{ needs.test-python.result }}"; do
+            if [[ "$result" != "success" ]]; then
+              echo "Job did not succeed: $result"
+              exit 1
+            fi
+          done
           echo "Tests passed"
           exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,117 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: ["*"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read # for dorny/paths-filter on pull_request
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'fused_render/**'
+              - 'tests/**'
+              - 'frontend/**'
+              - 'examples/**'
+              - 'scripts/hatch_build.py'
+              - 'pyproject.toml'
+              - '.github/workflows/test.yml'
+
+  # The React shell (frontend/) is built once here and shared with every
+  # python-version job below — fused_render/server.py refuses to start
+  # (RuntimeError) until fused_render/static/shell-dist/ exists (D52/D54),
+  # and the output is never committed, so tests always need a fresh build.
+  frontend:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm install --no-audit --no-fund
+
+      - name: Typecheck + build shell (tsc --noEmit && vite build)
+        working-directory: frontend
+        run: npm run build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: shell-dist
+          path: fused_render/static/shell-dist/
+          retention-days: 1
+
+  test-python:
+    needs: [detect-changes, frontend]
+    if: needs.detect-changes.outputs.app == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: shell-dist
+          path: fused_render/static/shell-dist
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install fused-render (dev extra)
+        run: pip install -e ".[dev]"
+
+      # shell/mounts.py shells out to rclone (D102/D103); not bundled outside
+      # the packaged macOS app, so CI installs the real binary like a dev
+      # machine would (README's "Remote storage (mounts)" section).
+      - name: Install rclone
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone
+
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
+  test-status:
+    name: Test Status
+    runs-on: ubuntu-latest
+    needs: [detect-changes, frontend, test-python]
+    if: always()
+    steps:
+      - name: Check test status
+        run: |
+          if [[ "${{ needs.detect-changes.outputs.app }}" != "true" ]]; then
+            echo "No relevant changes; skipped."
+            exit 0
+          fi
+          if [[ "${{ needs.frontend.result }}" == "failure" || "${{ needs.test-python.result }}" == "failure" ]]; then
+            echo "Job failed"
+            exit 1
+          fi
+          echo "Tests passed"
+          exit 0

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -100,11 +100,15 @@ def script_requirements(text: str) -> list[str]:
     ValueError with the parse error so the caller can surface it to the page
     instead of 500ing.
     """
-    import tomllib  # 3.11+; the engine is only reachable when fused imports, which needs 3.11+
-
     for match in _PEP723_BLOCK.finditer(text):
         if match.group("type") != "script":
             continue
+        # Imported here, not at function top: tomllib is 3.11+, but this
+        # function must still return [] on 3.10 for the (overwhelmingly
+        # common) case of a script with no PEP 723 block at all — run_python
+        # calls this unconditionally, regardless of which engine is active.
+        import tomllib
+
         content = "".join(
             line[2:] if line.startswith("# ") else line[1:]
             for line in match.group("content").splitlines(keepends=True)

--- a/fused_render/templates/canvas/condition.py
+++ b/fused_render/templates/canvas/condition.py
@@ -15,7 +15,6 @@ or anything that fails to parse → False, so the `canvas` mode never shows for
 ordinary toml.
 """
 import os
-import tomllib
 
 # Content sniff only opens files small enough to be a real canvas definition —
 # a canvas.toml is node/edge metadata, never megabytes. Anything larger is not
@@ -32,6 +31,10 @@ def main(target_path) -> bool:
         # Size guard before opening — a pathological file must not be parsed.
         if os.path.getsize(target_path) > MAX_BYTES:
             return False
+        # tomllib is 3.11+; imported here (not at module level) so a 3.10
+        # server still imports this module — the except below then fails
+        # closed on ImportError exactly like any other parse failure.
+        import tomllib
         with open(target_path, "rb") as f:
             data = tomllib.load(f)
     except Exception:

--- a/tests/test_canvas_template.py
+++ b/tests/test_canvas_template.py
@@ -14,6 +14,7 @@ Two surfaces:
 """
 import importlib.util
 import os
+import sys
 
 import pytest
 
@@ -21,6 +22,13 @@ from fused_render import server
 
 
 TEMPLATES_DIR = server.TEMPLATES_DIR
+
+# tomllib is 3.11+; the condition gate fails closed (returns False) without
+# it, same as for malformed TOML, so only the genuine-canvas assertions
+# (which need a real parse to come back True) can't run on 3.10.
+requires_tomllib = pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="canvas.toml parsing needs tomllib (Python 3.11+)"
+)
 
 
 def modes(path, is_dir=False):
@@ -96,6 +104,7 @@ def _write_canvas(dir_path, name="canvas.toml", body=CANVAS_TOML):
 
 # ------------------------------------------------------- condition gate (CT-12)
 
+@requires_tomllib
 def test_canvas_toml_gets_canvas_mode_first(tmp_path):
     p = _write_canvas(tmp_path / "cv")
     m, error = modes(str(p))
@@ -160,6 +169,7 @@ def test_oversized_canvas_toml_skipped(tmp_path):
     assert allowed is False
 
 
+@requires_tomllib
 def test_condition_module_main_directly(tmp_path):
     # The condition runs in the server process (plain module, stdlib) — exercise
     # `main` (the CT-12 entrypoint) directly to prove it never raises on odd input.

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -13,6 +13,7 @@ nothing touches the real stores.
 import json
 import sys
 
+import pytest
 from fastapi.testclient import TestClient
 
 import fused_render.deploy as deploy_mod
@@ -21,6 +22,13 @@ from fused_render.server import create_app
 
 
 FUSED = {"X-Fused": "1"}  # D3 guard header required on writes
+
+# The one-click install path (deploy.py's `install_fused`/`_availability`)
+# refuses outright on Python <3.11 (the fused package itself needs 3.11+) —
+# these tests exercise the 3.11+ "installable" behavior, not that refusal.
+requires_py311 = pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="one-click fused install needs Python 3.11+"
+)
 
 # Answers each `fused share <verb>` from the FUSED_STUB_SCENARIO json file and
 # appends {argv, env, bundle_files} to FUSED_STUB_LOG. A verb missing from the
@@ -144,6 +152,7 @@ def test_config_default_honors_ambient_openfused_env(tmp_path, monkeypatch):
     assert h.client.get("/api/deploy/config").json()["default_env"] == "prod"
 
 
+@requires_py311
 def test_config_reports_missing_cli_as_installable(tmp_path, monkeypatch):
     # The pin is a code constant (never package metadata, which is absent on
     # source runs and stale on pre-extra editable installs), so a missing CLI
@@ -157,6 +166,7 @@ def test_config_reports_missing_cli_as_installable(tmp_path, monkeypatch):
     assert "fused-render[fused]" in cli["install_hint"]
 
 
+@requires_py311
 def test_config_missing_cli_without_pip_names_the_workaround(tmp_path, monkeypatch):
     # An embedded/packaged interpreter (no pip) can't install into itself —
     # the reason must route the user to FUSED_RENDER_FUSED_BIN instead.
@@ -303,6 +313,7 @@ def test_pointer_store_key_is_canonicalized(tmp_path, monkeypatch):
     assert "sub" not in " ".join(store)
 
 
+@requires_py311
 def test_install_invokes_pip_with_the_pinned_requirement(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     ran: list[list[str]] = []

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -790,6 +790,25 @@ def test_writer_refuses_readonly_file(readonly_parquet):
 # mounts — just "bytes are also available here".
 
 
+def _require_httpfs():
+    """Skip the calling test when the httpfs extension can't be loaded (e.g.
+    no network access to extensions.duckdb.org from this CI environment).
+
+    reader.main() itself never raises on a missing httpfs — it's designed to
+    fall back to a plain local read (see reader.py's `_http_connection`
+    docstring) — so probing it directly here, instead of wrapping the
+    reader.main() call in try/except, is what actually catches this case
+    rather than silently exercising the fallback path and failing later on
+    the "reader never hit the URL" assertion."""
+    con = duckdb.connect(":memory:")
+    try:
+        con.execute("LOAD httpfs")
+    except duckdb.Error:
+        pytest.skip("duckdb httpfs extension unavailable")
+    finally:
+        con.close()
+
+
 def _serve_dir(directory):
     """A local HTTP server over `directory` that records request paths."""
     import functools
@@ -817,13 +836,11 @@ def _serve_dir(directory):
 
 
 def test_source_url_reads_over_http(parquet_file):
+    _require_httpfs()
     srv, hits = _serve_dir(os.path.dirname(parquet_file))
     try:
         url = f"http://127.0.0.1:{srv.server_address[1]}/s.parquet"
-        try:
-            out = reader.main(parquet_file, limit=5, source_url=url)
-        except Exception:
-            pytest.skip("duckdb httpfs extension unavailable")
+        out = reader.main(parquet_file, limit=5, source_url=url)
         assert [r["id"] for r in out["rows"]] == [0, 1, 2, 3, 4]
         assert any("s.parquet" in h for h in hits), "reader never hit the URL"
     finally:
@@ -835,13 +852,11 @@ def test_http_connection_persists_across_reads(parquet_file):
     # single reader run; with parquet_metadata_cache=true set once at build,
     # the SECOND open in a server session reuses the parsed footer instead of
     # re-downloading/re-parsing it (the ~7s cold DESCRIBE is paid only once).
+    _require_httpfs()
     srv, hits = _serve_dir(os.path.dirname(parquet_file))
     try:
         url = f"http://127.0.0.1:{srv.server_address[1]}/s.parquet"
-        try:
-            reader.main(parquet_file, limit=5, source_url=url)
-        except Exception:
-            pytest.skip("duckdb httpfs extension unavailable")
+        reader.main(parquet_file, limit=5, source_url=url)
         con1 = getattr(duckdb, "_fused_render_http_con_v3", None)
         assert con1 is not None                   # stashed for reuse
         reader.main(parquet_file, limit=5, source_url=url)
@@ -874,13 +889,11 @@ def test_source_url_reads_csv_over_http(csv_file):
     # scanned over the serve where hammering the NFS mount with the scan risks
     # dropping the whole mount. Reading the whole file over HTTP is slow-but-
     # safe (and the serve's shared VFS cache makes the repeat reads cheap).
+    _require_httpfs()
     srv, hits = _serve_dir(os.path.dirname(csv_file))
     try:
         url = f"http://127.0.0.1:{srv.server_address[1]}/s.csv"
-        try:
-            out = reader.main(csv_file, limit=3, source_url=url)
-        except Exception:
-            pytest.skip("duckdb httpfs extension unavailable")
+        out = reader.main(csv_file, limit=3, source_url=url)
         assert out["rows"][0]["zip"] == "00000"   # all-varchar preserved
         assert any("s.csv" in h for h in hits), "reader never hit the URL"
     finally:
@@ -888,15 +901,13 @@ def test_source_url_reads_csv_over_http(csv_file):
 
 
 def test_source_url_reads_json_over_http(tmp_path):
+    _require_httpfs()
     p = _make(tmp_path, "s.json",
               "SELECT range AS id, 'n'||range AS name FROM range(5)")
     srv, hits = _serve_dir(os.path.dirname(p))
     try:
         url = f"http://127.0.0.1:{srv.server_address[1]}/s.json"
-        try:
-            out = reader.main(p, limit=3, source_url=url)
-        except Exception:
-            pytest.skip("duckdb httpfs extension unavailable")
+        out = reader.main(p, limit=3, source_url=url)
         assert [r["id"] for r in out["rows"]] == [0, 1, 2]
         assert out["editable"] is False           # JSON stays view-only
         assert any("s.json" in h for h in hits), "reader never hit the URL"

--- a/tests/test_inspector.py
+++ b/tests/test_inspector.py
@@ -1,6 +1,7 @@
 """Tests for the api/template.html inspector (static AST parsing only)."""
 import importlib.util
 import os
+import sys
 
 import pytest
 
@@ -62,6 +63,9 @@ def test_no_entrypoint_at_all(tmp_path):
     assert info["static_result"] is False
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="PEP 723 dependency parsing needs tomllib (Python 3.11+)"
+)
 def test_fused_engine_reports_pep723_dependencies(tmp_path):
     src = (
         "# /// script\n"


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive GitHub Actions CI workflow to automatically test the fused_render project on every push to main and pull request.

## Key Changes
- **New CI workflow** (`.github/workflows/test.yml`):
  - Detects relevant code changes using path filtering to avoid unnecessary runs
  - Builds the React frontend (shell) once and shares the output across test jobs
  - Runs Python tests across multiple Python versions (3.10, 3.11, 3.12, 3.13)
  - Installs rclone binary for remote storage mount testing
  - Includes a final status check job that reports overall test results

## Implementation Details
- Uses `dorny/paths-filter` to skip CI runs when only unrelated files are modified
- Frontend build is a separate job that runs once, with output cached via artifacts for efficiency
- Python test matrix runs in parallel across supported versions with `fail-fast: false` to see all failures
- Concurrency controls prevent duplicate runs for the same branch
- Status check job handles conditional logic to properly report results even when jobs are skipped

https://claude.ai/code/session_014aAeMc8GXBw32VZD1YU9dv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are CI wiring and test/3.10 compatibility around stdlib `tomllib`; no auth, data, or deploy runtime behavior changes in production paths.
> 
> **Overview**
> Introduces **`.github/workflows/test.yml`**, running on push to `main` and on PRs with path filtering, PR-scoped concurrency, a one-time **frontend** build uploaded as `shell-dist`, a **pytest** matrix on Python **3.10–3.13** (with **rclone** installed), and a **`test-status`** gate that passes when no app paths changed.
> 
> **Python 3.10 support:** **`script_requirements`** in `engine.py` and the canvas **`condition.py`** gate move **`tomllib`** imports inside the parse path so modules load on 3.10 and scripts without PEP 723 blocks still return `[]` / fail closed like other parse errors.
> 
> **Tests:** **`requires_tomllib`** / **`requires_py311`** skip 3.11-only assertions (canvas gate positives, deploy install/config, PEP 723 inspector); DuckDB HTTP **`source_url`** tests use **`_require_httpfs()`** up front so missing **httpfs** skips instead of exercising the local fallback and failing on URL-hit assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559263981a652c720ceaa743d7524b206a26fd50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->