### PR TITLE
Bump pinned fused wheel to 2.9.3.post6

### DIFF
--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -137,7 +137,7 @@ def _now_iso() -> str:
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
 PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post5-py3-none-any.whl"
+    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post6-py3-none-any.whl"
 )
 # The wheel's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ app = [
 # The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post5-py3-none-any.whl ; python_version >= "3.11"',
+    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post6-py3-none-any.whl ; python_version >= "3.11"',
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

Bumps the pinned `fused` wheel from `2.9.3.post5` (current `main`, merged in #183) → `2.9.3.post6`.

fused-render has no lockfile, so both pins that a test keeps in lockstep are updated:

- `pyproject.toml` — the `[fused]` optional dependency
- `fused_render/deploy.py` — `PINNED_FUSED_REQUIREMENT` (the Deploy modal's one-click install)

## Verification

- `tests/test_deploy.py::test_pinned_requirement_matches_pyproject_extra` passes — confirms the two pins match at `post6`.
- The `post6` wheel returns 200 from S3.

Note: `test_install_invokes_pip_with_the_pinned_requirement` fails in a bare checkout because the gitignored React `shell-dist/` build artifact is absent (the harness can't start the app) — environmental, unrelated to the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013HfZzakAQiFiKYBXPKcoSw

---
_Generated by [Claude Code](https://claude.ai/code/session_013HfZzakAQiFiKYBXPKcoSw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only URL change with no logic changes; risk is limited to the new wheel’s behavior if post6 differs from post5.
> 
> **Overview**
> Bumps the pinned **`fused`** wheel from **`2.9.3.post5`** → **`2.9.3.post6`** so local execution, hosted pages, and one-click Deploy install stay on one build.
> 
> Both lockstep pins are updated: **`fused_render/deploy.py`** (`PINNED_FUSED_REQUIREMENT` for `POST /api/deploy/install`) and **`pyproject.toml`** (`[project.optional-dependencies]` **`fused`** extra). **`tests/test_deploy.py::test_pinned_requirement_matches_pyproject_extra`** is what keeps the two URLs aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 952f72880b10685a26a69cab1515dffc046ddb05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->