### PR TITLE
Use authored title from _render iframe for document tab title

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -154,7 +154,14 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   // Sidebar "Recents": record the open, then keep the entry's url live as
   // params change (same confirmed-file gate as session tracking).
   useRecentsTracking(fsPath, isDir);
-  useDocumentTitle(fsPath === "/" ? null : basename(fsPath));
+  // A "_render" preview (the file's own HTML, no template) reports its
+  // authored <title> here (Preview -> TemplatePreview); everything else
+  // (templates, listings, fallback cards) has no better name than the
+  // file's own, so this stays null and the basename wins below. Local state
+  // is safe to reset only on remount (StatView is keyed by fsPath in App),
+  // not on a `_mode` switch within the same file — TemplatePreview owns that.
+  const [renderedTitle, setRenderedTitle] = useState<string | null>(null);
+  useDocumentTitle(fsPath === "/" ? null : renderedTitle || basename(fsPath));
   let content = null;
   if (stat.status === "error") {
     content = (
@@ -181,7 +188,7 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
       // synchronously (useSessionRestore), so no flash on those paths.
       content = <div className="status-message">Loading…</div>;
     } else {
-      content = <Preview fsPath={fsPath} stat={s} />;
+      content = <Preview fsPath={fsPath} stat={s} onRenderedTitle={setRenderedTitle} />;
     }
   }
   return (

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -436,9 +436,14 @@ function TemplatePreview({
   // that set it; the "_render" branch overwrites it once its iframe loads.
   // Same-origin iframe (D3/D4 — /render always serves same-origin), so a
   // direct contentDocument read is safe and needs no postMessage round trip.
+  const titleObserverRef = useRef<MutationObserver | null>(null);
   useEffect(() => {
     onRenderedTitle?.(null);
-    return () => onRenderedTitle?.(null);
+    return () => {
+      titleObserverRef.current?.disconnect();
+      titleObserverRef.current = null;
+      onRenderedTitle?.(null);
+    };
   }, [mode, onRenderedTitle]);
   const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
     if (entry.mode !== "_render") return;
@@ -446,9 +451,25 @@ function TemplatePreview({
     // it: React already detached this exact node (key={mode} swaps it out),
     // so a late event here is stale regardless of what entry.mode's closure
     // says — isConnected is checked at call time, not closure-capture time.
-    if (!e.currentTarget.isConnected) return;
-    const title = e.currentTarget.contentDocument?.title.trim();
-    onRenderedTitle?.(title || null);
+    const frame = e.currentTarget;
+    if (!frame.isConnected) return;
+    const doc = frame.contentDocument;
+    const report = () => {
+      if (!frame.isConnected) return;
+      onRenderedTitle?.(doc?.title.trim() || null);
+    };
+    report();
+    // The authored title can change after load (e.g. a page updates
+    // document.title once async data arrives) — watch <head> (not just the
+    // <title> node) so both a text edit on an existing <title> and a
+    // <title> element added after load are caught; the isConnected guard in
+    // `report` covers the same stale-after-unmount race as above.
+    titleObserverRef.current?.disconnect();
+    if (doc?.head) {
+      const observer = new MutationObserver(report);
+      observer.observe(doc.head, { childList: true, subtree: true, characterData: true });
+      titleObserverRef.current = observer;
+    }
   };
 
   // One switch at a time: the flush below is async, and a second click landing

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -395,11 +395,13 @@ function TemplatePreview({
   stat,
   templates,
   conditions,
+  onRenderedTitle,
 }: {
   fsPath: string;
   stat: StatResult;
   templates: TemplateEntry[];
   conditions: Record<string, boolean> | null;
+  onRenderedTitle?: (title: string | null) => void;
 }) {
   // Caller only renders this when `templates` (already sentinel-filtered by
   // Preview's dispatch, SPEC PT-12) is non-empty. Entries whose condition.py
@@ -422,6 +424,24 @@ function TemplatePreview({
   // single `_listing` mode), so the preview header is uniform across files and
   // dirs.
   const isListing = entry.mode === "_listing";
+
+  // Tab title (App's StatView owns the actual document.title write): only a
+  // "_render" entry is the file's OWN html, so only it can carry an authored
+  // <title> worth showing over the filename — a template's title is a fixed
+  // generic string ("CSV preview") that's strictly worse than the filename
+  // StatView already falls back to. Reset on every mode change (covers
+  // switching away from "_render") so a stale title never survives a switch;
+  // the "_render" branch overwrites it once its iframe loads. Same-origin
+  // iframe (D3/D4 — /render always serves same-origin), so a direct
+  // contentDocument read is safe and needs no postMessage round trip.
+  useEffect(() => {
+    onRenderedTitle?.(null);
+  }, [mode, onRenderedTitle]);
+  const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
+    if (entry.mode !== "_render") return;
+    const title = e.currentTarget.contentDocument?.title.trim();
+    onRenderedTitle?.(title || null);
+  };
 
   // One switch at a time: the flush below is async, and a second click landing
   // mid-flight could resolve in either order, desyncing iframe key / local
@@ -548,7 +568,7 @@ function TemplatePreview({
           <Listing fsPath={fsPath} />
         ) : (
           /* key: switching mode replaces the iframe (fresh document per switch). */
-          <iframe key={mode} src={src as string} />
+          <iframe key={mode} src={src as string} onLoad={onRenderFrameLoad} />
         )}
         {toggleListing && (
           <button type="button" className="preview-browse-chip" onClick={toggleListing}>
@@ -598,9 +618,13 @@ function FallbackPreview({ fsPath, stat }: { fsPath: string; stat: StatResult })
 interface PreviewProps {
   fsPath: string;
   stat: StatResult;
+  // Reports the "_render" iframe's own authored <title>, so callers wanting a
+  // better tab title than the filename can use it (App's StatView). Undefined
+  // for every dispatch branch that isn't the "_render"-carrying TemplatePreview.
+  onRenderedTitle?: (title: string | null) => void;
 }
 
-export default function Preview({ fsPath, stat }: PreviewProps) {
+export default function Preview({ fsPath, stat, onRenderedTitle }: PreviewProps) {
   // Defensive filter (SPEC PT-12): an entry with path===null whose mode isn't
   // a recognized sentinel (`_render`, `_listing`) is dropped. Filtering here
   // keeps the non-empty dispatch check honest (an all-unknown list falls back
@@ -628,6 +652,14 @@ export default function Preview({ fsPath, stat }: PreviewProps) {
     );
   }
   if (visible.length > 0)
-    return <TemplatePreview fsPath={fsPath} stat={stat} templates={visible} conditions={conditions} />;
+    return (
+      <TemplatePreview
+        fsPath={fsPath}
+        stat={stat}
+        templates={visible}
+        conditions={conditions}
+        onRenderedTitle={onRenderedTitle}
+      />
+    );
   return <FallbackPreview fsPath={fsPath} stat={stat} />;
 }

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -429,16 +429,24 @@ function TemplatePreview({
   // "_render" entry is the file's OWN html, so only it can carry an authored
   // <title> worth showing over the filename — a template's title is a fixed
   // generic string ("CSV preview") that's strictly worse than the filename
-  // StatView already falls back to. Reset on every mode change (covers
-  // switching away from "_render") so a stale title never survives a switch;
-  // the "_render" branch overwrites it once its iframe loads. Same-origin
-  // iframe (D3/D4 — /render always serves same-origin), so a direct
-  // contentDocument read is safe and needs no postMessage round trip.
+  // StatView already falls back to. Reset on mode change AND on unmount (the
+  // cleanup covers TemplatePreview being swapped out entirely — the resolving
+  // spinner, FallbackPreview, a re-stat that errors — cases the mode-keyed
+  // effect alone never observes) so a stale title never outlives the preview
+  // that set it; the "_render" branch overwrites it once its iframe loads.
+  // Same-origin iframe (D3/D4 — /render always serves same-origin), so a
+  // direct contentDocument read is safe and needs no postMessage round trip.
   useEffect(() => {
     onRenderedTitle?.(null);
+    return () => onRenderedTitle?.(null);
   }, [mode, onRenderedTitle]);
   const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
     if (entry.mode !== "_render") return;
+    // Guards a slow "_render" iframe's load firing AFTER a switch away from
+    // it: React already detached this exact node (key={mode} swaps it out),
+    // so a late event here is stale regardless of what entry.mode's closure
+    // says — isConnected is checked at call time, not closure-capture time.
+    if (!e.currentTarget.isConnected) return;
     const title = e.currentTarget.contentDocument?.title.trim();
     onRenderedTitle?.(title || null);
   };


### PR DESCRIPTION
## Summary
This PR improves the document tab title by extracting and using the authored `<title>` from the "_render" preview iframe (when viewing a file's own HTML) instead of always falling back to the filename.

## Key Changes
- **TemplatePreview**: Added `onRenderedTitle` callback prop to report the iframe's authored title to parent components
  - Extracts the `<title>` from the "_render" iframe's `contentDocument` on load
  - Resets the title to `null` when switching preview modes to prevent stale titles
  - Only processes titles from "_render" mode (ignores template previews which have generic titles like "CSV preview")

- **Preview**: Added `onRenderedTitle` prop to pass through to TemplatePreview with documentation explaining its purpose

- **StatView (App.tsx)**: 
  - Added local state to track the rendered title from the preview
  - Updated `useDocumentTitle` to prefer the rendered title when available, falling back to the filename
  - Passes `setRenderedTitle` callback to the Preview component

## Implementation Details
- The iframe title extraction is safe because the "_render" endpoint always serves same-origin content (D3/D4), allowing direct `contentDocument` access without postMessage
- Title reset on mode changes ensures stale titles don't persist when switching away from "_render" mode
- The solution respects the component hierarchy: StatView owns the actual `document.title` write, while TemplatePreview only reports what it finds

https://claude.ai/code/session_0128Q7nZKkWVWCsdRjbfDSH1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to document.title with existing same-origin iframe access; no auth, data, or API surface changes.
> 
> **Overview**
> **Browser tab titles** for file previews now prefer the HTML document’s authored `<title>` when the active mode is **`_render`** (the file’s own page), instead of always showing the filename.
> 
> `StatView` holds `renderedTitle` and passes a callback into `Preview` → `TemplatePreview`. On **`_render`** iframe load, the preview reads `contentDocument.title` (same-origin `/render`) and reports it upward; `useDocumentTitle` uses that value when set, otherwise keeps the basename fallback. Generic template titles are ignored on purpose.
> 
> Mode switches and unmount clear the reported title; a `MutationObserver` on the iframe `<head>` picks up late `document.title` updates. **`isConnected`** checks avoid applying titles from slow loads after the iframe was torn down or the user switched modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c31cf0681375669d54ddcc93a53b000d4b2f930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->