### PR TITLE
mounts: anonymous GCS remote, expired-credential errors, paginated GCS listing

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -136,17 +136,17 @@ KNOWN_SENTINELS = {"_render", "_listing"}
 # are all emitted long before the cap can bite. Module-level so tests can
 # shrink it.
 WALK_MAX_ENTRIES = 200_000
-# Flat cap on a single /api/fs/list response, across all three routes (S3-direct,
+# Flat cap on a single /api/fs/list response, across all three routes (direct,
 # rc, local). An unbounded listing of a directory with a million entries builds
 # and serializes a million-entry JSON response — slow to produce, slow to render.
-# The response's `truncated` flag (and, on the resumable S3-direct route, its
+# The response's `truncated` flag (and, on the resumable direct route, its
 # `cursor`) tells the client the listing is partial. Module-level so tests can
 # shrink it.
 LIST_MAX_ENTRIES = 10_000
-# Per-request cap for the RESUMABLE S3-direct listing route. Deliberately one
-# S3 page: each page runs seconds on a slow bucket (mur-sst ~2s), so a bigger
-# first paint just multiplies the wait, and unlike the local/rc routes the
-# client can always fetch the next 1000 via the cursor (Load more). Module-
+# Per-request cap for the RESUMABLE direct (S3/GCS) listing route. Deliberately
+# one store page: each page runs seconds on a slow bucket (mur-sst ~2s), so a
+# bigger first paint just multiplies the wait, and unlike the local/rc routes
+# the client can always fetch the next 1000 via the cursor (Load more). Module-
 # level so tests can shrink it.
 S3_LIST_MAX_ENTRIES = 1_000
 # Much smaller cap when the walked path sits under a mount mountpoint
@@ -161,8 +161,9 @@ WALK_MAX_ENTRIES_REMOTE = 2_000
 # walk moves on) rather than stalling the whole subtree — same "dead mount ->
 # skipped dir" safety, without failing the request.
 WALK_RC_LIST_TIMEOUT_S = 10.0
-# Overall wall-clock budget for accumulating S3 pages into ONE /api/fs/list
-# response. The per-page timeout (mounts.S3_LIST_TIMEOUT_S, 15s) bounds a single
+# Overall wall-clock budget for accumulating direct (S3/GCS) pages into ONE
+# /api/fs/list response. The per-page timeout (mounts.S3_LIST_TIMEOUT_S /
+# GCS_LIST_TIMEOUT_S, 15s) bounds a single
 # page, but page COUNT is unbounded — a prefix that returns few keys per page
 # could run many pages and stall a request for minutes. On budget exhaustion the
 # accumulator stops and returns what it has with the last continuation token, a
@@ -376,8 +377,9 @@ class _RcDirEntry:
 
 
 def _mount_list_item(de):
-    """Map one rc/S3 listing entry (Name/Size/IsDir/ModTime, the shared shape of
-    rc_list_dir and s3_list_page) to an /api/fs/list item. `ignored` is always
+    """Map one rc/direct listing entry (Name/Size/IsDir/ModTime, the shared shape
+    of rc_list_dir and the direct S3/GCS pagers) to an /api/fs/list item.
+    `ignored` is always
     False under a mount: there's no git repo there, and `git check-ignore`
     against a mount path is the very kernel I/O these routes avoid."""
     from fused_render.shell import mounts as shell_mounts
@@ -396,7 +398,7 @@ def _sort_entries(entries):
     """Sort /api/fs/list items in place and return them: dirs first, then
     case-insensitive by name with the exact name as a deterministic tiebreak so
     case-only variants get a stable order. The single sort key for all three
-    list routes (S3-direct, rc, local)."""
+    list routes (direct, rc, local)."""
     entries.sort(key=lambda e: (not e["is_dir"], e["name"].lower(), e["name"]))
     return entries
 
@@ -407,12 +409,13 @@ def _list_response(path, entries, truncated, cursor):
             "truncated": truncated, "cursor": cursor}
 
 
-def _accumulate_s3_pages(path, cursor, max_entries, *,
-                         page_timeout=None, overall_timeout=None):
-    """Accumulate raw S3 ListObjectsV2 entries (Name/Size/IsDir/ModTime dicts,
-    the shared rc/S3 shape) for a mount-backed dir on an anonymous S3 remote,
-    up to `max_entries`. The one page-accumulation loop shared by /api/fs/list
-    and the walk.
+def _accumulate_direct_pages(path, cursor, max_entries, *,
+                             page_timeout=None, overall_timeout=None):
+    """Accumulate raw direct-listing entries (Name/Size/IsDir/ModTime dicts, the
+    shared rc/direct shape) for a mount-backed dir on an anonymous S3 or GCS
+    remote, up to `max_entries`. The one page-accumulation loop shared by
+    /api/fs/list and the walk; the backend (S3 ListObjectsV2 vs GCS
+    objects.list) is picked per-path by shell_mounts.direct_list_page.
 
     Each page requests only min(1000, remaining) keys, so the accumulation never
     overshoots `max_entries` (a whole extra 1000-key page could otherwise push a
@@ -422,11 +425,11 @@ def _accumulate_s3_pages(path, cursor, max_entries, *,
     and returns the last token, a valid resume point.
 
     Returns (raw_entries, next_token). next_token is non-None exactly when more
-    entries remain (cap hit, budget hit with more pending, or S3 truncated) —
-    i.e. the listing is partial. Raises shell_mounts.S3ListError only when the
-    FIRST page fails (nothing fetched, so the rc fallback is worth trying); a
-    failure after at least one page returns what was accumulated with the
-    failed page's continuation token as the resume point — on a slow bucket
+    entries remain (cap hit, budget hit with more pending, or the listing was
+    truncated) — i.e. the listing is partial. Raises shell_mounts.DirectListError
+    only when the FIRST page fails (nothing fetched, so the rc fallback is worth
+    trying); a failure after at least one page returns what was accumulated with
+    the failed page's continuation token as the resume point — on a slow bucket
     the per-page timeout shrinks toward the budget's deadline and the last
     page routinely times out, and discarding thousands of fetched entries to
     re-list via rc (which can't paginate at all) would turn a partial success
@@ -444,21 +447,22 @@ def _accumulate_s3_pages(path, cursor, max_entries, *,
         # The first page always runs with the full page timeout (the progress
         # guarantee — even a zero budget returns one page). Later pages shrink
         # to the budget's remainder, and stop before it reaches zero: a
-        # non-positive timeout would hit urlopen as a ValueError, not an
-        # S3ListError (Bugbot), and token is already a valid resume point.
+        # non-positive timeout would hit urlopen as a ValueError, not a
+        # DirectListError (Bugbot), and token is already a valid resume point.
         if deadline is not None and entries:
             left = deadline - time.monotonic()
             if left <= 0:
                 break
             t = left if t is None else min(t, left)
         try:
-            page, next_token = shell_mounts.s3_list_page(
+            page, next_token = shell_mounts.direct_list_page(
                 path, max_keys=min(1000, remaining), continuation=token, timeout=t)
-        except shell_mounts.S3ListError:
+        except shell_mounts.DirectListError:
             if not entries:
                 raise
-            logger.warning("S3 page for %r failed mid-listing; returning %d "
-                           "accumulated entries as partial", path, len(entries))
+            logger.warning("direct-listing page for %r failed mid-listing; "
+                           "returning %d accumulated entries as partial",
+                           path, len(entries))
             return entries, token
         token = next_token
         entries.extend(page)
@@ -471,15 +475,15 @@ def _accumulate_s3_pages(path, cursor, max_entries, *,
     return entries, token
 
 
-def _list_s3_direct(path, cursor):
-    """Accumulate S3 ListObjectsV2 pages for a mount-backed dir on an anonymous
-    S3 remote into sorted /api/fs/list items, up to S3_LIST_MAX_ENTRIES within
-    an overall time budget — a deliberately small per-request cap, since this
-    route is resumable (Load more pages in the rest). Returns (entries,
-    next_token); a non-None token means the listing is partial and resumable.
-    Raises shell_mounts.S3ListError on any page failure so the caller can fall
-    back to the rc route."""
-    raw, token = _accumulate_s3_pages(
+def _list_direct(path, cursor):
+    """Accumulate direct-listing pages (S3 ListObjectsV2 / GCS objects.list) for
+    a mount-backed dir on an anonymous S3 or GCS remote into sorted /api/fs/list
+    items, up to S3_LIST_MAX_ENTRIES within an overall time budget — a
+    deliberately small per-request cap, since this route is resumable (Load more
+    pages in the rest). Returns (entries, next_token); a non-None token means the
+    listing is partial and resumable. Raises shell_mounts.DirectListError on any
+    page failure so the caller can fall back to the rc route."""
+    raw, token = _accumulate_direct_pages(
         path, cursor, S3_LIST_MAX_ENTRIES,
         overall_timeout=S3_LIST_OVERALL_TIMEOUT_S)
     # Sorted over what was fetched, not the whole directory — a truncated
@@ -489,9 +493,10 @@ def _list_s3_direct(path, cursor):
     return entries, token
 
 
-# Yielded by _walk_bfs when a directory's listing was cut short (S3 pages
-# stopped early, rc listing over the per-dir cap, or a per-dir rc/S3 failure
-# skipped it). The walk's `truncated` flag counts YIELDED entries, but dotfile /
+# Yielded by _walk_bfs when a directory's listing was cut short (direct S3/GCS
+# pages stopped early, rc listing over the per-dir cap, or a per-dir rc/direct
+# failure skipped it). The walk's `truncated` flag counts YIELDED entries, but
+# dotfile /
 # gitignore filtering means a dir cut at the per-dir cap can yield fewer than the
 # cap while thousands of keys went unlisted — so incompleteness is signalled
 # out-of-band with this sentinel rather than inferred from the entry count. The
@@ -552,19 +557,19 @@ def _walk_bfs(path, include_hidden):
                 is_root = current == path
                 listed = None
                 dir_cut = False  # this dir's listing stopped short (1.3)
-                # Anonymous S3 dir: page S3's own ListObjectsV2 (fast, non-
-                # timeout-prone) up to the remote walk cap instead of the rc
-                # listing rclone can't paginate. On any S3 failure, fall back to
-                # rc for THIS dir (same skip-on-failure semantics as below).
-                if shell_mounts.s3_direct_capable(current):
+                # Anonymous S3/GCS dir: page the store's own listing API (fast,
+                # non-timeout-prone) up to the remote walk cap instead of the rc
+                # listing rclone can't paginate. On any failure, fall back to rc
+                # for THIS dir (same skip-on-failure semantics as below).
+                if shell_mounts.direct_list_capable(current):
                     try:
-                        listed, s3_token = _accumulate_s3_pages(
+                        listed, direct_token = _accumulate_direct_pages(
                             current, None, WALK_MAX_ENTRIES_REMOTE,
                             page_timeout=WALK_RC_LIST_TIMEOUT_S,
                             overall_timeout=WALK_RC_LIST_TIMEOUT_S)
-                        if s3_token is not None:
+                        if direct_token is not None:
                             dir_cut = True  # more keys remained unlisted
-                    except shell_mounts.S3ListError:
+                    except shell_mounts.DirectListError:
                         listed = None  # fall back to the rc path for this dir
                 if listed is None:
                     try:
@@ -1514,17 +1519,18 @@ class _WatchEntry:
         """Change signal for a mount-backed watch, off the event loop.
 
         A DIRECTORY's rclone ModTime is a constant sentinel (2000-01-01) for
-        synthetic S3 dirs, so create/delete/rename of children never moves it —
-        the mount-dir auto-refresh (Listing LS-1) was silently dead. So for a
-        directory the signal is a hash of a BOUNDED shallow listing instead:
-        one s3_list_page (anonymous S3) or a short-timeout rc_list_dir. A FILE
-        (rc rejects the listing as not-a-directory) keeps using operations/stat
-        ModTime. Any failure/timeout -> _UNCHANGED (never an error storm)."""
+        synthetic S3/GCS dirs, so create/delete/rename of children never moves
+        it — the mount-dir auto-refresh (Listing LS-1) was silently dead. So for
+        a directory the signal is a hash of a BOUNDED shallow listing instead:
+        one direct_list_page (anonymous S3/GCS) or a short-timeout rc_list_dir.
+        A FILE (rc rejects the listing as not-a-directory) keeps using
+        operations/stat ModTime. Any failure/timeout -> _UNCHANGED (never an
+        error storm)."""
         from fused_render.shell import mounts as shell_mounts
 
         try:
-            if shell_mounts.s3_direct_capable(self.path):
-                page, _ = shell_mounts.s3_list_page(
+            if shell_mounts.direct_list_capable(self.path):
+                page, _ = shell_mounts.direct_list_page(
                     self.path, max_keys=1000, timeout=4)
                 return _hash_listing(page)
             listed = shell_mounts.rc_list_dir(self.path, timeout=4)
@@ -1536,7 +1542,7 @@ class _WatchEntry:
             m = shell_mounts.rc_mtime_for(self.path)
             return _UNCHANGED if m is None else m
         except Exception:
-            return _UNCHANGED  # S3ListError, etc.
+            return _UNCHANGED  # DirectListError, etc.
 
     async def _read(self):
         """One tick's read with a hard timeout and in-flight de-duplication.
@@ -2084,9 +2090,9 @@ def create_app(start_dir: str) -> FastAPI:
         # too-huge directory is a failed/partial request, never a wedged mount.
         #
         # Every response carries `truncated` (the listing is a partial page) and
-        # `cursor` (an opaque resume token, non-None only on the S3-direct route
-        # — rclone and a local scandir can't resume). Fallback ladder for a
-        # mount path: S3-direct -> rc -> 503.
+        # `cursor` (an opaque resume token, non-None only on the direct S3/GCS
+        # route — rclone and a local scandir can't resume). Fallback ladder for a
+        # mount path: direct -> rc -> 503.
         if shell_mounts.is_mounts_root(path):
             # The mounts container is a LOCAL directory whose children are the
             # mountpoints. is_mount_backed is true for it (so no kernel readdir
@@ -2102,15 +2108,15 @@ def create_app(start_dir: str) -> FastAPI:
             ])
             return _list_response(path, entries, False, None)
         if shell_mounts.is_mount_backed(path):
-            # S3-direct fast path: for anonymous plain AWS S3 — the backend that
-            # dominates our mounts — page S3's own ListObjectsV2 (rclone can't
-            # paginate its listing at any layer, so a million-key prefix times
-            # out on the rc route). On any page failure, log and fall through to
-            # the rc route below.
-            if shell_mounts.s3_direct_capable(path):
+            # Direct fast path: for anonymous plain AWS S3 / anonymous GCS — the
+            # backends that dominate our mounts — page the store's own listing
+            # API (rclone can't paginate its listing at any layer, so a
+            # million-key prefix times out on the rc route). On any page failure,
+            # log and fall through to the rc route below.
+            if shell_mounts.direct_list_capable(path):
                 try:
-                    entries, next_token = _list_s3_direct(path, cursor)
-                except shell_mounts.S3ListError:
+                    entries, next_token = _list_direct(path, cursor)
+                except shell_mounts.DirectListError:
                     # A cursored request can't fall through to rc: rc re-serves
                     # page 1 with cursor=None (the frontend dedupes it to zero
                     # rows and pagination dies) or 503s on a huge dir. Return a
@@ -2118,7 +2124,7 @@ def create_app(start_dir: str) -> FastAPI:
                     if cursor is not None:
                         return _error(
                             "listing continuation failed — retry", status=503)
-                    logger.warning("S3-direct listing of %s failed; falling "
+                    logger.warning("direct listing of %s failed; falling "
                                    "back to rc", path, exc_info=True)
                 else:
                     return _list_response(path, entries,

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1523,15 +1523,31 @@ class _WatchEntry:
         it — the mount-dir auto-refresh (Listing LS-1) was silently dead. So for
         a directory the signal is a hash of a BOUNDED shallow listing instead:
         one direct_list_page (anonymous S3/GCS) or a short-timeout rc_list_dir.
-        A FILE (rc rejects the listing as not-a-directory) keeps using
-        operations/stat ModTime. Any failure/timeout -> _UNCHANGED (never an
-        error storm)."""
+
+        A FILE reaches the ModTime path differently by branch:
+          - direct-listable (anonymous S3/GCS): direct_list_capable is a pure
+            path/config check that can't tell a file from a directory, and
+            direct_list_page on a file KEY returns an EMPTY page (the file's own
+            key != the "<key>/" listing prefix). An empty page is
+            indistinguishable from an empty directory, so we fall back to the
+            file's operations/stat ModTime — a real, changing signal for a file;
+            harmless for a genuinely empty directory, since the moment a child
+            appears the page is non-empty and the listing hash takes over.
+          - rc route: rc rejects listing a file as not-a-directory (RcListError),
+            which likewise falls back to operations/stat ModTime.
+        Any failure/timeout -> _UNCHANGED (never an error storm)."""
         from fused_render.shell import mounts as shell_mounts
 
         try:
             if shell_mounts.direct_list_capable(self.path):
                 page, _ = shell_mounts.direct_list_page(
                     self.path, max_keys=1000, timeout=4)
+                if not page:
+                    # Empty: a file (its key isn't under the "<key>/" prefix) or
+                    # an empty dir. Use the rc ModTime — moves for a file's
+                    # content, constant-but-harmless for an empty dir.
+                    m = shell_mounts.rc_mtime_for(self.path)
+                    return _UNCHANGED if m is None else m
                 return _hash_listing(page)
             listed = shell_mounts.rc_list_dir(self.path, timeout=4)
             return _hash_listing(listed)

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1074,11 +1074,17 @@ S3_LIST_TIMEOUT_S = 15.0
 _S3_XMLNS = "{http://s3.amazonaws.com/doc/2006-03-01/}"
 
 
-class S3ListError(Exception):
-    """A direct ListObjectsV2 page failed — an HTTP status (403 needs auth, 301
-    wrong region), a network error, or unparseable XML. The caller falls back
-    to rc_list_dir; kept distinct from the RcList* family so the fallback ladder
-    (S3-direct -> rc -> 503) reads cleanly."""
+class DirectListError(Exception):
+    """A direct (unsigned) S3/GCS listing page failed — an HTTP status (403
+    needs auth, 301 wrong region), a network error, or an unparseable body
+    (S3 XML / GCS JSON). The caller falls back to rc_list_dir; kept distinct
+    from the RcList* family so the fallback ladder (direct -> rc -> 503) reads
+    cleanly."""
+
+
+# Back-compat alias: the direct-listing path started S3-only. Kept so callers
+# (and tests) that still import S3ListError keep working.
+S3ListError = DirectListError
 
 
 def s3_direct_capable(path: str) -> bool:
@@ -1187,6 +1193,143 @@ def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
     if (root_el.findtext(f"{_S3_XMLNS}IsTruncated") or "").lower() == "true":
         next_token = root_el.findtext(f"{_S3_XMLNS}NextContinuationToken") or None
     return entries, next_token
+
+
+# ------------------------------------------------------ direct GCS pagination
+# The GCS analog of the S3-direct path above. rclone can't paginate a listing
+# at any layer either, so a flat GCS prefix with hundreds of thousands of
+# children times out on the rc route exactly as an S3 one does. But GCS's own
+# JSON API (objects.list) paginates fine, and anonymous GCS (the gcs-open
+# suggestion, _gcs_anonymous) serves it with a plain unsigned GET — so fetch a
+# single page at a time straight from GCS, unsigned. There is no dotted-bucket
+# / virtual-host rule here: the GCS JSON endpoint always carries the bucket in
+# the path, and there is no region.
+GCS_LIST_TIMEOUT_S = 15.0
+_GCS_LIST_URL = "https://storage.googleapis.com/storage/v1/b/{bucket}/o"
+
+
+def gcs_direct_capable(path: str) -> bool:
+    """True when `path` is mount-backed by an anonymous GCS remote — the one
+    GCS backend class gcs_list_page can enumerate unsigned. Mirrors
+    s3_direct_capable for the GCS side."""
+    m, _ = _mount_for(path)
+    if m is None:
+        return False
+    return _gcs_anonymous(_remote_config(m["remote"].partition(":")[0]) or {})
+
+
+def _gcs_bucket_prefix(fs: str) -> tuple[str, str] | None:
+    """(bucket, key prefix) for a GCS remote's fs string
+    (e.g. "gcs-open:mur-sst/zarr-v1" -> ("mur-sst", "zarr-v1")). The key prefix
+    is stripped of any trailing slash. None when the fs carries no bucket. The
+    GCS analog of _s3_bucket_prefix_region — no region (GCS has none)."""
+    _, _, root = fs.partition(":")
+    bucket, _, prefix = root.partition("/")
+    if not bucket:
+        return None
+    return bucket, prefix.rstrip("/")
+
+
+def gcs_list_page(path: str, *, max_keys: int, continuation: str | None = None,
+                  timeout: float | None = None) -> tuple[list, str | None]:
+    """One objects.list page for a mount-backed directory on an anonymous GCS
+    remote, fetched by a plain unsigned HTTPS GET against the GCS JSON API — no
+    kernel I/O on the mount, no rclone, no google SDK.
+
+    Returns (entries, next_token) in the identical shape to s3_list_page:
+    entries are Name/Size/IsDir/ModTime dicts (so downstream mapping is shared),
+    and next_token the GCS pageToken when the listing is truncated, else None.
+    `prefixes` become synthetic directories (Size/ModTime None); `items` become
+    files; the zero-byte placeholder object whose name IS the prefix (a GCS
+    "directory" marker) is skipped, exactly as s3_list_page skips the key ==
+    prefix.
+
+    Raises DirectListError on any HTTP/network/JSON failure so the caller can
+    fall back to rc_list_dir; a 403 (needs auth) raises too, never crashes."""
+    if timeout is None:
+        timeout = GCS_LIST_TIMEOUT_S
+    m, rel = _mount_for(path)
+    if m is None:
+        raise DirectListError(f"{path} is under no known mount")
+    fs = m["remote"]
+    cfg = _remote_config(fs.partition(":")[0])
+    if not _gcs_anonymous(cfg or {}):
+        raise DirectListError(f"{path}: remote {fs!r} is not anonymous GCS")
+    derived = _gcs_bucket_prefix(fs)
+    if derived is None:
+        raise DirectListError(f"{path}: remote {fs!r} carries no bucket")
+    bucket, store_prefix = derived
+    # _s3_listing_prefix is backend-agnostic (prefix/delimiter join) — reuse it.
+    prefix = _s3_listing_prefix(store_prefix, rel)
+    params = {"delimiter": "/", "prefix": prefix, "maxResults": str(max_keys)}
+    if continuation:
+        params["pageToken"] = continuation
+    query = urllib.parse.urlencode(params)
+    url = f"{_GCS_LIST_URL.format(bucket=bucket)}?{query}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        raise DirectListError(f"GCS list {path}: HTTP {e.code}") from e
+    except (urllib.error.URLError, OSError) as e:
+        raise DirectListError(f"GCS list {path}: {e}") from e
+    try:
+        doc = json.loads(body)
+    except (ValueError, TypeError) as e:
+        raise DirectListError(f"GCS list {path}: unparseable JSON") from e
+    entries: list = []
+    for p in doc.get("prefixes") or []:
+        name = str(p)[len(prefix):].rstrip("/")
+        if name:
+            entries.append({"Name": name, "Size": None, "IsDir": True,
+                            "ModTime": None})
+    for obj in doc.get("items") or []:
+        key = obj.get("name") or ""
+        # The zero-byte object whose name IS the prefix is the directory
+        # placeholder GCS consoles create — it's this directory, not an entry.
+        if key == prefix:
+            continue
+        name = key[len(prefix):]
+        if not name:
+            continue
+        size_txt = obj.get("size")
+        entries.append({
+            "Name": name,
+            "Size": int(size_txt) if isinstance(size_txt, str)
+            and size_txt.isdigit() else None,
+            "IsDir": False,
+            # RFC3339 already; the mapping site runs rc_modtime_epoch on it.
+            "ModTime": obj.get("updated"),
+        })
+    return entries, doc.get("nextPageToken") or None
+
+
+# ------------------------------------------- unified direct-listing dispatch
+# The server routes every listing through these two so a call site need not
+# know whether the mount is S3 or GCS. direct_list_page re-derives the backend
+# from `path`, so a continuation token always feeds back to the backend that
+# produced it (an S3 continuation-token and a GCS pageToken never cross).
+
+
+def direct_list_capable(path: str) -> bool:
+    """True when `path` is mount-backed by ANY backend the direct (unsigned)
+    pager can enumerate — anonymous plain AWS S3 or anonymous GCS."""
+    return s3_direct_capable(path) or gcs_direct_capable(path)
+
+
+def direct_list_page(path: str, *, max_keys: int, continuation: str | None = None,
+                     timeout: float | None = None) -> tuple[list, str | None]:
+    """One direct (unsigned) listing page for `path`, routed to the S3 or GCS
+    pager by the backend the path resolves to. Returns (entries, next_token) in
+    the shared rc/direct shape; raises DirectListError when the path is backed
+    by neither direct-listable backend (or the chosen pager fails)."""
+    if s3_direct_capable(path):
+        return s3_list_page(path, max_keys=max_keys,
+                            continuation=continuation, timeout=timeout)
+    if gcs_direct_capable(path):
+        return gcs_list_page(path, max_keys=max_keys,
+                            continuation=continuation, timeout=timeout)
+    raise DirectListError(f"{path}: no direct-listable backend")
 
 
 def upstream_url_for(path: str) -> str | None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1907,6 +1907,14 @@ def _credential_suggestions() -> list[dict]:
             "backend": "google cloud storage",
             "params": {"env_auth": "true"},
         })
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        out.append({
+            "id": "gcs-env",
+            "label": "Google Cloud Storage — environment credentials",
+            "remote_name": "gcs-env",
+            "backend": "google cloud storage",
+            "params": {"env_auth": "true"},
+        })
     return out
 
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2148,6 +2148,9 @@ def create_remote(body: dict = Body(...), x_fused: str | None = Header(default=N
 # network failure. Matched case-insensitively against rclone's output.
 _BAD_CRED_MARKERS = (
     "expiredtoken", "expired token", "token has expired", "token is expired",
+    # Google ADC/OAuth refresh failure: "Token has been expired or revoked."
+    # — matches neither "has expired" nor "is expired" above.
+    "has been expired or revoked",
     "invalidaccesskeyid", "invalidclienttokenid", "signaturedoesnotmatch",
     "no valid credential", "nocredentialproviders",
     "invalid_grant", "unauthenticated", "401 unauthorized",

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2211,7 +2211,8 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
     source (see _credential_suggestions). The spec comes from the server's own
     detection keyed by `id` — never from client-supplied rclone params — and
     env_auth=true means no keys are written. Idempotent: an already-created
-    remote is returned as-is."""
+    remote is returned as-is — but a detected (env_auth) one is re-probed
+    first, since its creds may have expired since creation."""
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
@@ -2223,8 +2224,21 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
     if sugg is None:
         return JSONResponse({"error": f"unknown credential source {sid!r}"}, status_code=404)
     name = sugg["remote_name"]
+    # Public (anonymous) remotes carry no credentials to go stale; only the
+    # detected, env_auth-backed ones get the validity probe (an rclone `lsd`).
+    detected = sugg.get("kind", "detected") == "detected"
     # remotes are {name,label} objects now — match on the bare rclone spec.
     if any(r["name"] == f"{name}:" for r in _rclone_state().get("remotes", [])):
+        # Idempotent re-entry: the remote already exists. Don't report it
+        # healthy on faith — a detected remote's creds may have expired since
+        # it was created, and returning {"ok": True} here would invite a doomed
+        # mount just as surely as a freshly created stale one. Re-probe (one
+        # `lsd`) so an expired detected remote is never reported ok; anonymous
+        # remotes carry nothing that expires and return quickly.
+        if detected:
+            cred_err = _detected_credential_error(bin_, name)
+            if cred_err:
+                return JSONResponse({"error": cred_err}, status_code=502)
         return {"ok": True, "name": name + ":"}
     cmd = [bin_, "config", "create", name, sugg["backend"]]
     for k, v in sugg["params"].items():
@@ -2235,17 +2249,25 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
         return JSONResponse({"error": "rclone config create timed out (30s)"}, status_code=502)
     if r.returncode != 0:
         return JSONResponse({"error": (r.stderr or r.stdout or "").strip()[-500:]}, status_code=502)
-    # Public (anonymous) remotes carry no credentials to go stale; only the
-    # detected, env_auth-backed ones get the validity probe. A remote whose
-    # creds turn out expired is rolled back so the broken thing doesn't
-    # linger under Remotes inviting doomed mounts.
-    if sugg.get("kind", "detected") == "detected":
+    # A detected remote whose creds turn out expired is rolled back so the
+    # broken thing doesn't linger under Remotes inviting doomed mounts.
+    if detected:
         cred_err = _detected_credential_error(bin_, name)
         if cred_err:
+            # Roll back the just-created remote. If the delete itself fails
+            # (non-zero exit or an OSError/timeout) the remote may still exist,
+            # so say so rather than returning the bare cred error as if cleanup
+            # succeeded — a silently-lingering remote would be reported ok on
+            # the next detect and re-invite the doomed mount.
             try:
-                subprocess.run([bin_, "config", "delete", name],
-                               capture_output=True, text=True, timeout=30)
+                d = subprocess.run([bin_, "config", "delete", name],
+                                   capture_output=True, text=True, timeout=30)
+                removed = d.returncode == 0
             except (OSError, subprocess.TimeoutExpired):
-                pass
+                removed = False
+            if not removed:
+                cred_err += (" (the half-created remote could not be removed "
+                             "automatically — delete it manually before "
+                             "retrying)")
             return JSONResponse({"error": cred_err}, status_code=502)
     return {"ok": True, "name": name + ":"}

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -656,12 +656,21 @@ def _s3_without_credentials(cfg: dict) -> bool:
                      or cfg.get("session_token")))
 
 
+def _gcs_anonymous(cfg: dict) -> bool:
+    """A GCS remote configured anonymous=true (the built-in gcs-open
+    suggestion) — rclone sends unauthenticated requests, which GCS accepts
+    for public-bucket reads only, so writes can never be accepted."""
+    return (cfg.get("type") == "google cloud storage"
+            and str(cfg.get("anonymous", "")).lower() == "true")
+
+
 def _detect_read_only(port: int, fs: str) -> bool | None:
     """Best-effort, NON-MUTATING read-onlyness probe for a remote. Never
     writes a probe object into the user's store; instead:
       - operations/fsinfo: a backend advertising no write feature at all
         (Put/PutStream/Copy — e.g. http) can never take a write.
-      - config/get: an anonymous S3 remote (see _s3_without_credentials).
+      - config/get: an anonymous S3 or GCS remote (see
+        _s3_without_credentials / _gcs_anonymous).
     Returns None when the probe is INCONCLUSIVE — an rc call failed, or the
     reply didn't carry the expected shape (absence of a Features map is
     version skew, not evidence of read-onlyness) — so the caller persists
@@ -683,7 +692,7 @@ def _detect_read_only(port: int, fs: str) -> bool | None:
         return None
     if not isinstance(cfg, dict):
         return None
-    return _s3_without_credentials(cfg)
+    return _s3_without_credentials(cfg) or _gcs_anonymous(cfg)
 
 
 def _refresh_read_only_flag(m: dict, port: int | None = None) -> None:
@@ -1677,11 +1686,12 @@ def _credential_suggestions() -> list[dict]:
     params) — the endpoint consumes these; the API view (below) exposes only
     id/label/remote_name/kind.
 
-    The first entry is always present: an anonymous S3 remote for public buckets
-    (AWS Open Data, etc.). It needs no credentials — env_auth=false with blank
-    keys makes rclone send unsigned requests — so it works even when the user
-    has no (or expired) AWS creds. region is just the endpoint rclone starts at;
-    it follows S3's region redirect to reach buckets in any region. The rest are
+    The first two entries are always present: anonymous S3 and anonymous GCS
+    remotes for public buckets (AWS Open Data, public GCS datasets, etc.).
+    They need no credentials — S3 via env_auth=false with blank keys (unsigned
+    requests), GCS via anonymous=true — so they work even when the user has no
+    (or expired) cloud creds. region is just the endpoint rclone starts at; it
+    follows S3's region redirect to reach buckets in any region. The rest are
     credential-backed (kind="detected", defaulted in _suggestions_view)."""
     out: list[dict] = [{
         "id": "aws-open-public",
@@ -1690,6 +1700,13 @@ def _credential_suggestions() -> list[dict]:
         "backend": "s3",
         "kind": "public",
         "params": {"provider": "AWS", "env_auth": "false", "region": "us-west-2"},
+    }, {
+        "id": "gcs-open-public",
+        "label": "Google Cloud Storage — public buckets (no credentials)",
+        "remote_name": "gcs-open",
+        "backend": "google cloud storage",
+        "kind": "public",
+        "params": {"anonymous": "true"},
     }]
     for prof in _aws_profiles():
         out.append({
@@ -1818,6 +1835,15 @@ def broken_mount_error(path: str) -> str | None:
     state = mount_state(m, mounted_paths())
     if state == "mounted":
         return None
+    # A mount backed by detected (env_auth) credentials that have since
+    # expired stops flowing with an opaque kernel I/O error — same
+    # "disconnected" symptom as a dead daemon, but "reconnect" can't fix an
+    # expired SSO token. When the remote probes credential-shaped, tell the
+    # user to refresh their credentials instead of pointing them at reconnect.
+    if state in ("disconnected", "stale"):
+        cred_err = _mount_credential_error(m)
+        if cred_err:
+            return f"mount '{name}' — {cred_err}"
     # "stale" (the INCIDENT split-brain) and "disconnected" both mean a mount
     # that was there and stopped flowing — same user-facing wording; only a
     # never-mounted mount reads as "not mounted".
@@ -1973,6 +1999,66 @@ def create_remote(body: dict = Body(...), x_fused: str | None = Header(default=N
     return {"ok": True, "name": name + ":"}
 
 
+# Errors that mean the credential material itself is bad — an expired STS/SSO
+# session, a revoked OAuth grant, a deleted access key — as opposed to valid
+# credentials that merely lack a permission (AccessDenied) or a transient
+# network failure. Matched case-insensitively against rclone's output.
+_BAD_CRED_MARKERS = (
+    "expiredtoken", "expired token", "token has expired", "token is expired",
+    "invalidaccesskeyid", "invalidclienttokenid", "signaturedoesnotmatch",
+    "no valid credential", "nocredentialproviders",
+    "invalid_grant", "unauthenticated", "401 unauthorized",
+    "could not find default credentials",
+)
+
+
+def _detected_credential_error(bin_: str, name: str) -> str | None:
+    """Probe a just-materialized env_auth remote with a top-level listing and
+    return a user-facing message when the underlying credentials are expired
+    or invalid, else None. Detection surfaces creds that merely EXIST in the
+    dotfiles — nothing proves they still work, and mounting with a stale SSO
+    token fails later with an opaque I/O error, so catch it here where the
+    fix is actionable. Only credential-shaped failures (_BAD_CRED_MARKERS)
+    reject: AccessDenied (valid keys without ListBuckets permission) and
+    transient/network errors pass — the check exists to catch stale keys
+    early, not to demand list permission."""
+    try:
+        r = subprocess.run(
+            [bin_, "lsd", f"{name}:", "--max-depth", "1",
+             "--contimeout", "5s", "--timeout", "10s",
+             "--retries", "1", "--low-level-retries", "2"],
+            capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if r.returncode == 0:
+        return None
+    err = ((r.stderr or "") + (r.stdout or "")).lower()
+    if any(m in err for m in _BAD_CRED_MARKERS):
+        return ("the detected credentials appear expired or invalid — "
+                "refresh them (e.g. `aws sso login` or `gcloud auth "
+                "application-default login`) and try again")
+    return None
+
+
+def _mount_credential_error(m: dict) -> str | None:
+    """For a broken mount whose remote is backed by detected (env_auth)
+    credentials, the 'refresh your credentials' message when a top-level
+    listing now fails credential-shaped — else None. broken_mount_error uses
+    this to distinguish an expired-credential mount (reconnect won't help;
+    the user must re-auth) from a merely dead daemon. Only env_auth remotes
+    are probed: anonymous/public and key-carrying remotes don't expire this
+    way, and the probe (an rclone `lsd`) is paid only on the already-broken
+    fs/list path, never on a healthy listing."""
+    bin_ = rclone_bin()
+    if not bin_:
+        return None
+    name = m["remote"].partition(":")[0]
+    cfg = _remote_config(name)
+    if not isinstance(cfg, dict) or str(cfg.get("env_auth", "")).lower() != "true":
+        return None
+    return _detected_credential_error(bin_, name)
+
+
 @router.post("/api/mounts/remotes/detect")
 def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(default=None)):
     """Materialize a keyless rclone remote from an auto-detected credential
@@ -2003,4 +2089,17 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
         return JSONResponse({"error": "rclone config create timed out (30s)"}, status_code=502)
     if r.returncode != 0:
         return JSONResponse({"error": (r.stderr or r.stdout or "").strip()[-500:]}, status_code=502)
+    # Public (anonymous) remotes carry no credentials to go stale; only the
+    # detected, env_auth-backed ones get the validity probe. A remote whose
+    # creds turn out expired is rolled back so the broken thing doesn't
+    # linger under Remotes inviting doomed mounts.
+    if sugg.get("kind", "detected") == "detected":
+        cred_err = _detected_credential_error(bin_, name)
+        if cred_err:
+            try:
+                subprocess.run([bin_, "config", "delete", name],
+                               capture_output=True, text=True, timeout=30)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+            return JSONResponse({"error": cred_err}, status_code=502)
     return {"ok": True, "name": name + ":"}

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -987,6 +987,15 @@ def _anonymous_s3(cfg: dict | None) -> bool:
             and not cfg.get("endpoint"))
 
 
+def _cannot_presign(cfg: dict | None) -> bool:
+    """True when the remote is anonymous S3 or anonymous GCS — the backend
+    classes that can never presign (S3's "unsupported signer type noAuth", and
+    anonymous GCS carrying no signing key at all) but reach their public
+    objects by a plain unsigned URL instead. Lets _upstream_url_for skip the
+    wasted publiclink rc call for either backend."""
+    return cfg is not None and (_anonymous_s3(cfg) or _gcs_anonymous(cfg))
+
+
 def _mount_for(path: str) -> tuple[dict | None, str]:
     """(mount record, remote-relative path) for a path under a mountpoint."""
     p = os.path.abspath(path)
@@ -1059,6 +1068,25 @@ def _public_object_url(fs: str, rel: str) -> str | None:
     key = (prefix + "/" if prefix else "") + rel
     # _s3_base_url applies the dotted-bucket path-style rule (see there).
     return _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
+
+
+def _gcs_public_object_url(fs: str, rel: str) -> str | None:
+    """Plain https URL for an object on an ANONYMOUS GCS remote — the GCS
+    analog of _public_object_url. GCS always path-addresses the bucket
+    (storage.googleapis.com/<bucket>/<key>), so there is no region and no
+    dotted-bucket rule. Credentialed or non-GCS remotes return None (their
+    objects aren't reachable unsigned). Pure string building once
+    _remote_config has memoized the config — no rc round trip per object."""
+    cfg = _remote_config(fs.partition(":")[0])
+    if not _gcs_anonymous(cfg or {}):
+        return None
+    derived = _gcs_bucket_prefix(fs)
+    if derived is None:
+        return None
+    bucket, prefix = derived
+    key = (prefix + "/" if prefix else "") + rel
+    # Match _public_object_url's key quoting (same default safe chars).
+    return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
 
 
 # ------------------------------------------------------- direct S3 pagination
@@ -1356,9 +1384,10 @@ def _upstream_url_for(path: str) -> str | None:
         mode = _upstream_mode.get(fs)
     if mode == "none":
         return None
-    if mode is None and _anonymous_s3(_remote_config(fs.partition(":")[0])):
-        # Anonymous S3 can never presign — don't burn an rc call per remote
-        # learning that from publiclink's "unsupported signer type" error.
+    if mode is None and _cannot_presign(_remote_config(fs.partition(":")[0])):
+        # Anonymous S3 or GCS can never presign — don't burn an rc call per
+        # remote learning that from publiclink's "unsupported signer type"
+        # error.
         mode = "public"
     url = None
     if mode in (None, "link"):
@@ -1378,7 +1407,9 @@ def _upstream_url_for(path: str) -> str | None:
         if url is not None:
             mode = "link"
     if url is None:
-        url = _public_object_url(fs, rel)
+        # Dispatch by backend, mirroring direct_list_page: whichever object-URL
+        # builder recognizes the remote returns a non-None URL, the rest None.
+        url = _public_object_url(fs, rel) or _gcs_public_object_url(fs, rel)
         mode = "public" if url else "none"
     with _upstream_lock:
         _upstream_mode[fs] = mode

--- a/fused_render/templates/zarr_aoi/tile_server.py
+++ b/fused_render/templates/zarr_aoi/tile_server.py
@@ -368,6 +368,14 @@ def _serve():
                             "storage_options": so,
                             "label": f"mount '{name}' → s3://{key}"
                                      + (" (anonymous)" if anon else "")}
+                elif cfg.get("type") == "google cloud storage":
+                    # GCS analog of the s3 branch: gcsfs takes token="anon" for
+                    # anonymous public buckets, and needs no region/endpoint.
+                    anon = cfg.get("anonymous") == "true"
+                    return {"kind": "gcs", "url": "gcs://" + key,
+                            "storage_options": {"token": "anon"} if anon else {},
+                            "label": f"mount '{name}' → gcs://{key}"
+                                     + (" (anonymous)" if anon else "")}
         return {"kind": "local", "url": path, "label": path + " (local)"}
 
     # ---------------- dataset open + discovery ----------------

--- a/fused_render/templates/zarr_aoi/tile_server.py
+++ b/fused_render/templates/zarr_aoi/tile_server.py
@@ -28,7 +28,7 @@ Endpoints (GET, CORS *):
   /stats?file=[&reset=1]       -> live counters + recent op log
 """
 # /// script
-# dependencies = ["numpy", "zarr>=3.0.8", "s3fs", "crc32c"]
+# dependencies = ["numpy", "zarr>=3.0.8", "s3fs", "gcsfs", "crc32c"]
 # ///
 
 import hashlib
@@ -41,7 +41,7 @@ import time
 
 STATE = os.path.expanduser("~/.cache/fused-render-zarraoi/daemon.json")
 DAEMON_VENV = os.path.expanduser("~/.cache/fused-render-zarraoi/venv")
-DAEMON_DEPS = ["numpy", "zarr>=3.0.8", "s3fs", "crc32c"]
+DAEMON_DEPS = ["numpy", "zarr>=3.0.8", "s3fs", "gcsfs", "crc32c"]
 IDLE_EXIT_S = 30 * 60
 TILE = 256
 MERC_R = 6378137.0

--- a/tests/test_server_fs_events.py
+++ b/tests/test_server_fs_events.py
@@ -192,6 +192,37 @@ def test_mount_file_signal_falls_back_to_modtime(home, monkeypatch):
     assert entry._mount_signal() == "2024-01-02T03:04:05Z"
 
 
+def test_mount_file_signal_direct_capable_empty_page_uses_modtime(home, monkeypatch):
+    # (3.2) A FILE under an anonymous S3/GCS mount is direct_list_capable (a pure
+    # path/config check that can't tell a file from a dir). direct_list_page on a
+    # file key returns an EMPTY page (its own key != the "<key>/" listing prefix),
+    # so a hash of that empty listing is CONSTANT and content changes go
+    # undetected. The empty page must fall back to the file's rc ModTime, which
+    # moves when the file content changes.
+    entry = server._WatchEntry(str(home / "mounts" / "open" / "f.parquet"))
+    monkeypatch.setattr(mounts_mod, "s3_direct_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "s3_list_page",
+                        lambda path, *, max_keys, continuation=None, timeout=None: ([], None))
+    mtimes = iter(["2024-01-02T03:04:05Z", "2024-01-02T09:09:09Z"])
+    monkeypatch.setattr(mounts_mod, "rc_mtime_for", lambda p: next(mtimes))
+
+    sig1 = entry._mount_signal()
+    assert sig1 == "2024-01-02T03:04:05Z"           # real ModTime, not empty-hash
+    assert not sig1.startswith("L")                 # not a listing hash
+    assert entry._mount_signal() == "2024-01-02T09:09:09Z"  # content change -> CHANGED
+
+
+def test_mount_file_signal_direct_capable_empty_page_none_modtime_unchanged(home, monkeypatch):
+    # (3.2) When the empty-page ModTime fallback returns None, report _UNCHANGED
+    # (matching the RcListError file arm) rather than a constant empty-hash.
+    entry = server._WatchEntry(str(home / "mounts" / "open" / "f.parquet"))
+    monkeypatch.setattr(mounts_mod, "s3_direct_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "s3_list_page",
+                        lambda path, *, max_keys, continuation=None, timeout=None: ([], None))
+    monkeypatch.setattr(mounts_mod, "rc_mtime_for", lambda p: None)
+    assert entry._mount_signal() is server._UNCHANGED
+
+
 def test_mount_dir_signal_unchanged_on_failure(home, monkeypatch):
     # (3.2) A down/timed-out listing returns _UNCHANGED — never an error storm.
     entry = server._WatchEntry(str(home / "mounts" / "s3demo" / "dir"))

--- a/tests/test_server_fs_list_mount.py
+++ b/tests/test_server_fs_list_mount.py
@@ -364,6 +364,32 @@ def test_list_s3_failure_falls_back_to_rc(home, rcd, tmp_path, monkeypatch, fres
     assert any(x[0] == "operations/list" for x in rcd.calls)
 
 
+ANON_GCS = {"type": "google cloud storage", "anonymous": "true"}
+
+
+def test_list_gcs_direct_routes_through_gcs_pager(home, rcd, tmp_path, monkeypatch, fresh_cfg_cache):
+    # An anonymous GCS mount takes the direct fast path exactly as anonymous S3
+    # does — the unified dispatcher routes it to the GCS pager, not rc.
+    rcd.responses["config/get"] = ANON_GCS
+    c = mounts_mod.add_mount("gopen", "gcs-open:mur-sst/zarr-v1")
+    got = {}
+
+    def fake(path, *, max_keys, continuation=None, timeout=None):
+        got["continuation"] = continuation
+        return ([_entry("x.txt", size=1)], None)
+
+    monkeypatch.setattr(mounts_mod, "gcs_list_page", fake)
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("rc used")))
+    data = _client(tmp_path).get(
+        "/api/fs/list",
+        params={"path": mounts_mod.mountpoint(c), "cursor": "RESUME"}).json()
+    assert got["continuation"] == "RESUME"
+    assert [e["name"] for e in data["entries"]] == ["x.txt"]
+    assert data["truncated"] is False
+    assert data["cursor"] is None
+
+
 # -- fs/walk on S3-capable mounts --------------------------------------------
 
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -697,6 +697,117 @@ def test_detect_materializes_public_anonymous_remote(client, monkeypatch):
     assert not any("secret" in str(x).lower() for x in cmd)
 
 
+def test_gcs_public_bucket_suggestion_always_present(monkeypatch):
+    """The anonymous GCS public-bucket remote is offered alongside aws-open,
+    even with no gcloud credentials — anonymous=true needs no key material."""
+    monkeypatch.setattr(mounts_mod, "_aws_profiles", lambda: [])
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setattr(mounts_mod.os.path, "exists", lambda p: False)
+
+    by_id = {s["id"]: s for s in mounts_mod._credential_suggestions()}
+    pub = by_id["gcs-open-public"]
+    assert pub["remote_name"] == "gcs-open"
+    assert pub["kind"] == "public"
+    assert pub["backend"] == "google cloud storage"
+    assert pub["params"] == {"anonymous": "true"}
+
+
+def test_detect_materializes_gcs_public_anonymous_remote(client, monkeypatch):
+    """Selecting the built-in GCS public option creates an anonymous GCS remote
+    — no key material, anonymous=true — reaching public buckets unsigned."""
+    created = []
+    _fake_rclone(monkeypatch, existing_remotes=(), record=created)
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "gcs-open-public"}, headers=FUSED)
+    assert r.status_code == 200
+    assert r.json()["name"] == "gcs-open:"
+    [cmd] = created
+    assert cmd[:5] == ["/usr/bin/rclone", "config", "create", "gcs-open",
+                       "google cloud storage"]
+    assert "anonymous" in cmd and "true" in cmd
+    assert not any("secret" in str(x).lower() for x in cmd)
+
+
+def test_gcs_anonymous_detected_read_only():
+    """anonymous=true GCS is the gcs-open shape — unauthenticated requests can
+    never take a write, so it must read-only detect like anonymous S3 does."""
+    assert mounts_mod._gcs_anonymous(
+        {"type": "google cloud storage", "anonymous": "true"})
+    assert not mounts_mod._gcs_anonymous({"type": "google cloud storage"})
+    assert not mounts_mod._gcs_anonymous(
+        {"type": "s3", "anonymous": "true"})
+
+
+_DETECTED_SUGG = {
+    "id": "aws-env", "label": "AWS S3 — environment credentials",
+    "remote_name": "aws-env", "backend": "s3",
+    "params": {"provider": "AWS", "env_auth": "true"},
+}
+
+
+def _fake_rclone_probe(monkeypatch, lsd_rc=0, lsd_stderr="", record=None):
+    """Like _fake_rclone but the `lsd` credential probe can be made to fail
+    with a given stderr; records EVERY argv (create, lsd, delete)."""
+    def fake_run(cmd, **kw):
+        if record is not None:
+            record.append(cmd)
+
+        class R:
+            returncode = lsd_rc if "lsd" in cmd else 0
+            stderr = lsd_stderr if "lsd" in cmd else ""
+            stdout = ("rclone v1.2\n" if "version" in cmd
+                      else "{}" if "dump" in cmd else "")
+        return R()
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+
+
+def test_detect_rejects_expired_credentials(client, monkeypatch):
+    """Materializing a detected credential source whose keys are stale (expired
+    STS/SSO token) fails with an actionable message and rolls the half-created
+    remote back — a broken remote must not linger inviting doomed mounts."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    calls = []
+    _fake_rclone_probe(
+        monkeypatch, lsd_rc=1, record=calls,
+        lsd_stderr="ERROR: ExpiredToken: The provided token has expired.")
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 502
+    assert "expired" in r.json()["error"].lower()
+    assert any(c[:3] == ["/usr/bin/rclone", "config", "delete"] for c in calls)
+
+
+def test_detect_accepts_access_denied_probe(client, monkeypatch):
+    """AccessDenied means valid keys without ListBuckets permission — the probe
+    must not reject those; only credential-shaped failures do."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    _fake_rclone_probe(monkeypatch, lsd_rc=1,
+                       lsd_stderr="ERROR: AccessDenied: Access Denied")
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 200
+    assert r.json()["name"] == "aws-env:"
+
+
+def test_detect_skips_probe_for_public_remotes(client, monkeypatch):
+    """Anonymous public remotes carry no credentials to go stale — no lsd
+    probe runs for them (it would only add latency and network flake)."""
+    calls = []
+    _fake_rclone_probe(monkeypatch, record=calls)
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-open-public"}, headers=FUSED)
+    assert r.status_code == 200
+    assert not any("lsd" in c for c in calls)
+
+
 def _fake_rclone(monkeypatch, existing_remotes=(), record=None, configs=None):
     """Stub rclone_bin + subprocess.run: version/listremotes/config-dump canned,
     every other argv appended to `record` and reported as success. `configs` is
@@ -908,6 +1019,95 @@ def test_state_disconnected_when_listing_hangs(home, rcd, monkeypatch):
 def test_state_unmounted_when_nothing_there(home, rcd):
     c, mp = _make_mount(home, rcd, served=False)
     assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "unmounted"
+
+
+# -- broken_mount_error: expired detected credentials ----------------------
+#
+# A mount backed by detected (env_auth) credentials keeps mounting fine, then
+# stops flowing when the SSO/STS token expires — the kernel raises an opaque
+# I/O error, so mount_state reads "disconnected" exactly like a dead daemon.
+# But "reconnect" can't fix an expired token: broken_mount_error probes the
+# remote and, when the failure is credential-shaped, tells the user to re-auth.
+
+
+def _stub_lsd(monkeypatch, rc=0, lsd_stderr="", record=None):
+    """Stub rclone_bin + subprocess.run so the credential probe's `lsd` returns
+    a chosen returncode/stderr; config/get still routes to the stub rcd."""
+    def fake_run(cmd, **kw):
+        if record is not None:
+            record.append(cmd)
+
+        class R:
+            returncode = rc
+            stderr = lsd_stderr
+            stdout = ""
+        return R()
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+
+
+def _disconnected_mount(home, rcd, monkeypatch, remote="corp:bucket"):
+    c, mp = _make_mount(home, rcd, remote=remote, served=False)
+    # ismount True + not served -> "disconnected" (kernel mount, daemon gone).
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    return c, mp
+
+
+def test_broken_mount_error_reports_expired_credentials(
+        home, rcd, monkeypatch, fresh_upstream):
+    c, mp = _disconnected_mount(home, rcd, monkeypatch)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=1,
+              lsd_stderr="ERROR: ExpiredToken: The provided token has expired.")
+
+    err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
+    assert err is not None
+    assert "expired" in err.lower() and "refresh" in err.lower()
+    # Must NOT send the user to the reconnect button — that won't re-auth.
+    assert "reconnect" not in err.lower()
+
+
+def test_broken_mount_error_reconnect_when_creds_still_valid(
+        home, rcd, monkeypatch, fresh_upstream):
+    # env_auth remote, but the probe succeeds: the disconnection is a dead
+    # daemon, not stale creds — keep the generic "reconnect" guidance.
+    c, mp = _disconnected_mount(home, rcd, monkeypatch)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=0)
+
+    err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
+    assert err is not None and "reconnect" in err.lower()
+
+
+def test_broken_mount_error_skips_cred_probe_for_non_env_auth(
+        home, rcd, monkeypatch, fresh_upstream):
+    # A remote that isn't env_auth-backed can't have detected creds expire —
+    # no lsd probe runs (it would only add latency), and the generic message
+    # stands.
+    c, mp = _disconnected_mount(home, rcd, monkeypatch)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "false",
+                                   "access_key_id": "AKIA"}
+    calls = []
+    _stub_lsd(monkeypatch, rc=1, lsd_stderr="ExpiredToken", record=calls)
+
+    err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
+    assert err is not None and "reconnect" in err.lower()
+    assert not any("lsd" in cmd for cmd in calls)
+
+
+def test_broken_mount_error_no_cred_probe_when_never_mounted(
+        home, rcd, monkeypatch, fresh_upstream):
+    # "unmounted" (never mounted / cleanly disconnected) is a user action, not
+    # a credential failure — the probe must not run for it.
+    c, mp = _make_mount(home, rcd, remote="corp:bucket", served=False)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    calls = []
+    _stub_lsd(monkeypatch, rc=1, lsd_stderr="ExpiredToken", record=calls)
+
+    err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
+    assert err is not None and "not mounted" in err.lower()
+    assert not any("lsd" in cmd for cmd in calls)
 
 
 def test_reconnect_force_unmounts_dead_mount_then_remounts(home, rcd, monkeypatch):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1860,6 +1860,53 @@ def test_upstream_url_public_s3_when_link_unsupported(home, rcd, fresh_upstream)
     assert len([x for x in rcd.calls if x[0] == "config/get"]) == 1
 
 
+def test_gcs_public_object_url_builds_unsigned_url(home, rcd, fresh_upstream):
+    # Anonymous GCS objects are reachable by a plain path-style storage URL —
+    # no region, no dotted-bucket rule. The key is percent-encoded exactly as
+    # the S3 builder encodes it.
+    mounts_mod._upstream_cfg["gcs-open"] = {
+        "type": "google cloud storage", "anonymous": "true"}
+    assert mounts_mod._gcs_public_object_url(
+        "gcs-open:bucket/pre fix", "k ey.parquet") == (
+        "https://storage.googleapis.com/bucket/pre%20fix/k%20ey.parquet")
+    # A non-anonymous GCS remote has no reachable unsigned URL.
+    mounts_mod._upstream_cfg["gcp"] = {"type": "google cloud storage"}
+    assert mounts_mod._gcs_public_object_url("gcp:bucket", "x.parquet") is None
+
+
+def test_upstream_url_public_gcs_when_anonymous(home, rcd, fresh_upstream):
+    import os
+
+    # Anonymous GCS remotes can never presign either — the config makes that
+    # knowable up front, so publiclink is never attempted and the plain public
+    # object URL is minted directly, config memoized for later objects.
+    rcd.responses["config/get"] = {
+        "type": "google cloud storage", "anonymous": "true"}
+    c = mounts_mod.add_mount("open", "gcs-open:bucket/pre fix")
+    f = os.path.join(mounts_mod.mountpoint(c), "k ey.parquet")
+    assert mounts_mod.upstream_url_for(f) == (
+        "https://storage.googleapis.com/bucket/pre%20fix/k%20ey.parquet")
+    f2 = os.path.join(mounts_mod.mountpoint(c), "other.parquet")
+    assert mounts_mod.upstream_url_for(f2) == (
+        "https://storage.googleapis.com/bucket/pre%20fix/other.parquet")
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+    assert len([x for x in rcd.calls if x[0] == "config/get"]) == 1
+
+
+def test_upstream_url_non_anonymous_gcs_gets_no_public_url(home, rcd, fresh_upstream):
+    import os
+
+    # A non-anonymous GCS remote whose publiclink fails has no reachable
+    # unsigned URL — the verdict is cached like the credentialed-S3 case.
+    rcd.responses["operations/publiclink"] = (500, {"error": "boom"})
+    rcd.responses["config/get"] = {"type": "google cloud storage"}
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "x.parquet")
+    assert mounts_mod.upstream_url_for(f) is None
+    assert mounts_mod.upstream_url_for(f) is None
+    assert len([x for x in rcd.calls if x[0] == "operations/publiclink"]) == 1
+
+
 def test_upstream_url_none_is_remembered(home, rcd, fresh_upstream):
     import os
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -782,6 +782,25 @@ def test_detect_rejects_expired_credentials(client, monkeypatch):
     assert any(c[:3] == ["/usr/bin/rclone", "config", "delete"] for c in calls)
 
 
+def test_detect_rejects_google_expired_or_revoked_token(client, monkeypatch):
+    """Google ADC/OAuth refresh failures surface as "Token has been expired or
+    revoked." — no invalid_grant, and it matches neither "has expired" nor "is
+    expired". _BAD_CRED_MARKERS must still classify it as expired creds, or
+    stale GCS creds slip through to the opaque reconnect path this replaces."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    calls = []
+    _fake_rclone_probe(
+        monkeypatch, lsd_rc=1, record=calls,
+        lsd_stderr="Token has been expired or revoked.")
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 502
+    assert "expired" in r.json()["error"].lower()
+    assert any(c[:3] == ["/usr/bin/rclone", "config", "delete"] for c in calls)
+
+
 def test_detect_accepts_access_denied_probe(client, monkeypatch):
     """AccessDenied means valid keys without ListBuckets permission — the probe
     must not reject those; only credential-shaped failures do."""

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -746,18 +746,25 @@ _DETECTED_SUGG = {
 }
 
 
-def _fake_rclone_probe(monkeypatch, lsd_rc=0, lsd_stderr="", record=None):
+def _fake_rclone_probe(monkeypatch, lsd_rc=0, lsd_stderr="", record=None,
+                       existing_remotes=(), delete_rc=0):
     """Like _fake_rclone but the `lsd` credential probe can be made to fail
-    with a given stderr; records EVERY argv (create, lsd, delete)."""
+    with a given stderr; records EVERY argv (create, lsd, delete). Pass
+    `existing_remotes` to make `listremotes` report already-created remotes
+    (exercises the idempotent re-entry path) and `delete_rc` to make the
+    rollback `config delete` exit non-zero."""
     def fake_run(cmd, **kw):
         if record is not None:
             record.append(cmd)
 
         class R:
-            returncode = lsd_rc if "lsd" in cmd else 0
+            returncode = (lsd_rc if "lsd" in cmd
+                          else delete_rc if "delete" in cmd else 0)
             stderr = lsd_stderr if "lsd" in cmd else ""
             stdout = ("rclone v1.2\n" if "version" in cmd
-                      else "{}" if "dump" in cmd else "")
+                      else "{}" if "dump" in cmd
+                      else "".join(f"{r}\n" for r in existing_remotes)
+                      if "listremotes" in cmd else "")
         return R()
 
     monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
@@ -825,6 +832,65 @@ def test_detect_skips_probe_for_public_remotes(client, monkeypatch):
                     json={"id": "aws-open-public"}, headers=FUSED)
     assert r.status_code == 200
     assert not any("lsd" in c for c in calls)
+
+
+def test_detect_reports_failed_rollback(client, monkeypatch):
+    """When creds are expired the half-created remote is rolled back — but if
+    the `config delete` itself fails (non-zero), the remote may still exist, so
+    the 502 must say so rather than returning the bare cred error as if cleanup
+    succeeded (a lingering remote would be reported ok on the next detect)."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    calls = []
+    _fake_rclone_probe(
+        monkeypatch, lsd_rc=1, record=calls, delete_rc=1,
+        lsd_stderr="ERROR: ExpiredToken: The provided token has expired.")
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 502
+    err = r.json()["error"].lower()
+    assert "expired" in err  # keep the cred-error wording
+    assert "could not be removed" in err or "manually" in err
+    assert any(c[:3] == ["/usr/bin/rclone", "config", "delete"] for c in calls)
+
+
+def test_detect_reprobes_existing_detected_remote_now_expired(client, monkeypatch):
+    """Idempotent re-entry must not report an already-existing detected remote
+    healthy on faith: if its creds have since expired, re-detect returns the
+    502 cred error, NOT {"ok": True} — otherwise the stale remote invites a
+    doomed mount just like a freshly created one would."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    calls = []
+    _fake_rclone_probe(
+        monkeypatch, lsd_rc=1, record=calls, existing_remotes=("aws-env:",),
+        lsd_stderr="ERROR: ExpiredToken: The provided token has expired.")
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 502
+    assert "expired" in r.json()["error"].lower()
+    # re-entry re-probed (lsd) but did NOT re-create or delete the remote
+    assert any("lsd" in c for c in calls)
+    assert not any("create" in c for c in calls)
+    assert not any("delete" in c for c in calls)
+
+
+def test_detect_existing_detected_remote_still_valid_returns_ok(client, monkeypatch):
+    """Regression: an already-existing detected remote whose creds are still
+    valid re-probes cleanly and returns {"ok": True} — the re-probe closes the
+    stale-cred hole without breaking the healthy idempotent path."""
+    monkeypatch.setattr(mounts_mod, "_credential_suggestions",
+                        lambda: [_DETECTED_SUGG])
+    calls = []
+    _fake_rclone_probe(monkeypatch, lsd_rc=0, record=calls,
+                       existing_remotes=("aws-env:",))
+
+    r = client.post("/api/mounts/remotes/detect",
+                    json={"id": "aws-env"}, headers=FUSED)
+    assert r.status_code == 200 and r.json()["name"] == "aws-env:"
+    assert not any("create" in c for c in calls)  # not re-created
 
 
 def _fake_rclone(monkeypatch, existing_remotes=(), record=None, configs=None):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -712,6 +712,27 @@ def test_gcs_public_bucket_suggestion_always_present(monkeypatch):
     assert pub["params"] == {"anonymous": "true"}
 
 
+def test_gcs_env_credentials_suggestion_detected(monkeypatch):
+    """GOOGLE_APPLICATION_CREDENTIALS (a service-account JSON path) is detected
+    symmetrically with AWS_ACCESS_KEY_ID → a keyless env_auth=true GCS
+    suggestion; absent, it isn't offered. No key material is copied."""
+    monkeypatch.setattr(mounts_mod, "_aws_profiles", lambda: [])
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.setattr(mounts_mod.os.path, "exists", lambda p: False)
+
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "/creds/sa.json")
+    by_id = {s["id"]: s for s in mounts_mod._credential_suggestions()}
+    sug = by_id["gcs-env"]
+    assert sug["remote_name"] == "gcs-env"
+    assert sug["backend"] == "google cloud storage"
+    assert sug["params"] == {"env_auth": "true"}
+    assert not any("secret" in k or "key" in k for k in sug["params"])
+
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    by_id = {s["id"]: s for s in mounts_mod._credential_suggestions()}
+    assert "gcs-env" not in by_id
+
+
 def test_detect_materializes_gcs_public_anonymous_remote(client, monkeypatch):
     """Selecting the built-in GCS public option creates an anonymous GCS remote
     — no key material, anonymous=true — reaching public buckets unsigned."""

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2221,3 +2221,195 @@ def test_s3_list_page_non_anonymous_raises_s3listerror(home, rcd, fresh_upstream
     c = mounts_mod.add_mount("corp", "corp:bucket/pre")
     with pytest.raises(mounts_mod.S3ListError):
         mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+# -- gcs_list_page / gcs_direct_capable -------------------------------------
+#
+# Anonymous GCS (the gcs-open shape) is the GCS analog of anonymous plain AWS
+# S3: rclone can't paginate a listing at any layer, so a flat prefix with
+# hundreds of thousands of children times out. For anonymous GCS a single page
+# is fetched straight from the GCS JSON API (objects.list) unsigned, off the
+# kernel mount. Real GCS is never hit: urllib.request.urlopen is monkeypatched
+# with canned JSON.
+
+_ANON_GCS_CFG = {"type": "google cloud storage", "anonymous": "true"}
+
+
+def _gcs_list_json(*, prefixes=(), items=(), next_token=None):
+    """A GCS objects.list response body. `items` are (name, size, updated);
+    `size` is emitted as a STRING, exactly as the JSON API returns it."""
+    body: dict = {}
+    if prefixes:
+        body["prefixes"] = list(prefixes)
+    if items:
+        body["items"] = [{"name": n, "size": str(sz), "updated": upd}
+                         for n, sz, upd in items]
+    if next_token:
+        body["nextPageToken"] = next_token
+    return json.dumps(body).encode()
+
+
+@pytest.fixture()
+def gcs_urlopen(monkeypatch):
+    """Capture the objects.list URL and hand back canned JSON. `box["body"]` is
+    the reply; set `box["raise"]` to an exception to fail the GET."""
+    calls = []
+    box = {"body": _gcs_list_json()}
+    real = mounts_mod.urllib.request.urlopen
+
+    def fake(url, timeout=None):
+        # rc calls (config/get etc.) go to the loopback stub rcd over http —
+        # only intercept the GCS objects.list GET, delegate the rest.
+        target = url if isinstance(url, str) else url.get_full_url()
+        if "storage.googleapis.com" not in target:
+            return real(url, timeout=timeout)
+        calls.append((target, timeout))
+        if box.get("raise") is not None:
+            raise box["raise"]
+        return _FakeS3Resp(box["body"])
+
+    monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", fake)
+    return calls, box
+
+
+def test_gcs_direct_capable_true_for_anonymous_gcs(home, rcd, fresh_upstream):
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/analysed_sst")
+
+
+def test_gcs_direct_capable_false_for_non_anonymous(home, rcd, fresh_upstream):
+    rcd.responses["config/get"] = {"type": "google cloud storage"}
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    assert not mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+
+
+def test_gcs_direct_capable_false_outside_mount(home, rcd, fresh_upstream):
+    assert not mounts_mod.gcs_direct_capable("/tmp/not/a/mount")
+
+
+def test_gcs_list_page_url_and_query_nested_dir(home, rcd, fresh_upstream, gcs_urlopen):
+    import urllib.parse as up
+
+    calls, _box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    mounts_mod.gcs_list_page(
+        mounts_mod.mountpoint(c) + "/analysed_sst", max_keys=1000)
+    [(url, timeout)] = calls
+    assert url.startswith(
+        "https://storage.googleapis.com/storage/v1/b/mur-sst/o?")
+    q = up.parse_qs(up.urlsplit(url).query)
+    assert q["delimiter"] == ["/"]
+    assert q["prefix"] == ["zarr-v1/analysed_sst/"]
+    assert q["maxResults"] == ["1000"]
+    assert "pageToken" not in q
+    assert timeout == mounts_mod.GCS_LIST_TIMEOUT_S
+
+
+def test_gcs_list_page_mountpoint_uses_store_prefix(home, rcd, fresh_upstream, gcs_urlopen):
+    import urllib.parse as up
+
+    calls, _box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=500)
+    q = up.parse_qs(up.urlsplit(calls[0][0]).query)
+    assert q["prefix"] == ["zarr-v1/"]
+
+
+def test_gcs_list_page_bucket_root_mountpoint_empty_prefix(home, rcd, fresh_upstream, gcs_urlopen):
+    import urllib.parse as up
+
+    calls, _box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst")
+    mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=500)
+    q = up.parse_qs(up.urlsplit(calls[0][0]).query, keep_blank_values=True)
+    assert q["prefix"] == [""]
+
+
+def test_gcs_list_page_continuation_token_urlencoded(home, rcd, fresh_upstream, gcs_urlopen):
+    import urllib.parse as up
+
+    calls, _box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000,
+                             continuation="a b/c+d=")
+    q = up.parse_qs(up.urlsplit(calls[0][0]).query)
+    assert q["pageToken"] == ["a b/c+d="]
+
+
+def test_gcs_list_page_parses_prefixes_files_and_token(home, rcd, fresh_upstream, gcs_urlopen):
+    calls, box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    box["body"] = _gcs_list_json(
+        prefixes=["zarr-v1/analysed_sst/2020/", "zarr-v1/analysed_sst/2021/"],
+        items=[
+            # placeholder object whose name IS the prefix -> skipped
+            ("zarr-v1/analysed_sst/", 0, "2000-01-01T00:00:00.000Z"),
+            ("zarr-v1/analysed_sst/.zattrs", 42, "2024-01-02T03:04:05.000Z"),
+        ],
+        next_token="TOKEN123")
+    entries, token = mounts_mod.gcs_list_page(
+        mounts_mod.mountpoint(c) + "/analysed_sst", max_keys=1000)
+    by = {e["Name"]: e for e in entries}
+    assert set(by) == {"2020", "2021", ".zattrs"}
+    assert by["2020"]["IsDir"] is True and by["2020"]["Size"] is None
+    assert by["2020"]["ModTime"] is None
+    assert by[".zattrs"]["IsDir"] is False and by[".zattrs"]["Size"] == 42
+    assert by[".zattrs"]["ModTime"] == "2024-01-02T03:04:05.000Z"
+    assert token == "TOKEN123"
+
+
+def test_gcs_list_page_not_truncated_returns_none_token(home, rcd, fresh_upstream, gcs_urlopen):
+    calls, box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    box["body"] = _gcs_list_json(items=[("zarr-v1/f.txt", 1, "2024-01-02T03:04:05Z")])
+    _entries, token = mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert token is None
+
+
+def test_gcs_list_page_http_403_raises_directlisterror(home, rcd, fresh_upstream, gcs_urlopen):
+    calls, box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    box["raise"] = mounts_mod.urllib.error.HTTPError(
+        "https://x", 403, "Forbidden", {}, None)
+    with pytest.raises(mounts_mod.DirectListError):
+        mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+def test_gcs_list_page_non_anonymous_raises_directlisterror(home, rcd, fresh_upstream, gcs_urlopen):
+    rcd.responses["config/get"] = {"type": "google cloud storage"}
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    with pytest.raises(mounts_mod.DirectListError):
+        mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+# -- unified direct-listing dispatchers (S3 + GCS) --------------------------
+
+
+def test_direct_list_capable_true_for_both_backends(home, rcd, fresh_upstream):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    c = mounts_mod.add_mount("s3open", "aws-open:mur-sst/zarr-v1")
+    assert mounts_mod.direct_list_capable(mounts_mod.mountpoint(c))
+    mounts_mod._upstream_cfg.clear()
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    g = mounts_mod.add_mount("gcsopen", "gcs-open:mur-sst/zarr-v1")
+    assert mounts_mod.direct_list_capable(mounts_mod.mountpoint(g))
+
+
+def test_direct_list_page_routes_gcs_to_googleapis(home, rcd, fresh_upstream, gcs_urlopen):
+    calls, _box = gcs_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    mounts_mod.direct_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert calls and "storage.googleapis.com" in calls[0][0]
+
+
+def test_s3listerror_is_directlisterror_alias():
+    assert mounts_mod.S3ListError is mounts_mod.DirectListError


### PR DESCRIPTION
## Summary

Related mount/credential improvements:

1. **Anonymous GCS public-bucket remote** — a built-in `gcs-open` remote (analogous to the existing `aws-open` anonymous S3 remote) so users can mount public GCS datasets with no credentials. It's an always-present suggestion (`anonymous=true`) and is treated read-only like anonymous S3.

2. **Clear "credentials expired" errors** — auto-detected credentials only prove keys *exist* in dotfiles, not that they still work. A stale SSO/STS token previously failed with an opaque I/O error. Now the user gets an actionable message telling them to re-auth, surfaced at both points where it matters:
   - **At materialization** (`/api/mounts/remotes/detect`): a detected (env_auth) remote is probed after creation; if creds are expired the half-created remote is rolled back and a 502 with the refresh-credentials message is returned. Public/anonymous remotes skip the probe.
   - **On mount use** (`broken_mount_error` → `/api/fs/list`): when credentials expire *after* a mount already exists, the mount stops flowing with the same "disconnected" symptom as a dead daemon — but "reconnect" can't re-auth an expired token. A disconnected/stale env_auth mount is probed and, when the failure is credential-shaped, the user is told to refresh their credentials instead.

3. **Paginated directory listing for anonymous GCS mounts** — the fast paginated-listing path (fetch one page straight from the store, off the kernel mount, so a flat prefix with hundreds of thousands of keys doesn't time out `rc_list_dir` or wedge the mount) previously existed only for anonymous S3. Adding `gcs-open` exposed the gap: large GCS chunk directories (e.g. ARCO-ERA5) fell back to unpaginated `operations/list` and timed out. This adds an anonymous-GCS analog via the GCS JSON API (`objects.list`, unsigned GET, `delimiter`+`prefix`+`maxResults`+`pageToken`), and unifies both backends behind `direct_list_capable` / `direct_list_page` so all four server listing sites (`_walk_bfs`, `api_fs_list`, `_mount_signal`, the page accumulator) route S3 or GCS transparently. Credentialed/signed listing remains out of scope (would need SigV4 / OAuth signing).

4. **Remaining S3-only gates generalized to anonymous GCS** — a codebase audit for backend-specific gates that should be mount-generic surfaced three more, now fixed symmetrically (mirroring the `direct_list_page` dispatch shape). Legitimately S3-only mechanics (virtual-host / dotted-bucket addressing, the region component, the user-supplied `s3://` scheme dispatch) were confirmed correct and left alone.
   - **Direct-store byte-read fast path** (`_public_object_url` / `_upstream_url_for`): the unsigned direct-object-URL path for raw ranged reads was gated on anonymous S3 only, so anonymous GCS mounts got no `307`-to-store fast path **and** burned one `operations/publiclink` rc call per remote (which can't sign for an anonymous remote) before falling back to the slow rclone-serve proxy. Added `_gcs_public_object_url` (`https://storage.googleapis.com/<bucket>/<quoted-key>`, via `_gcs_bucket_prefix`, no region/dotted-bucket rule), a unified `_cannot_presign(cfg) = _anonymous_s3 or _gcs_anonymous` short-circuit, and a backend-dispatching public-URL fallback. This is the hot path behind `/api/fs/raw` cold reads and prefetch warming — anonymous GCS now redirects straight to the store.
   - **`zarr_aoi` template transport** (`resolve_source`, under the opt-in `ZARRAOI_TRANSPORT=s3` A/B path): a GCS mount fell through the `type == "s3"` branch and was silently mis-resolved as a local path. Added a `google cloud storage` sibling branch returning a `gcs://` transport (`token="anon"` for anonymous). The default `raw` transport was already backend-agnostic; this fixes the legacy opt-in path.
   - **Credential discoverability** (`_credential_suggestions`): S3 detected both `~/.aws` profiles and `AWS_ACCESS_KEY_ID`, but GCS detected only the ADC file. Added `GOOGLE_APPLICATION_CREDENTIALS` env detection → a keyless `env_auth=true` GCS suggestion, symmetric with the AWS env block. (No `gcloud` multi-profile analog — no clean equivalent.)

## Details

- `_gcs_anonymous` / `_detect_read_only`: anonymous GCS is read-only, matching anonymous S3.
- `_BAD_CRED_MARKERS` + `_detected_credential_error`: only credential-shaped failures reject (expired/invalid tokens); `AccessDenied` (valid keys, no list permission) and transient/network errors pass. Markers cover Google's ADC/OAuth wording (`Token has been expired or revoked`) as well as AWS/STS phrasing.
- `create_detected_remote`: a failed rollback (`config delete`) is no longer swallowed — it's surfaced in the 502 — and the idempotent early-return re-probes an already-existing detected remote so an expired one is never reported healthy.
- `_mount_credential_error`: only env_auth remotes are probed, and only on the already-broken fs/list path — never on a healthy listing. `unmounted` (a user action) is never probed.
- `S3ListError` → `DirectListError` (with a back-compat alias); `gcs_list_page` returns the identical `{Name,Size,IsDir,ModTime}` entry shape as `s3_list_page`.
- `_public_object_url` / `_gcs_public_object_url` dispatch by backend behind the `_upstream_url_for` fallback; `_cannot_presign` unifies the "skip publiclink" short-circuit across anonymous S3 and GCS.
- No credential material is ever written to rclone config or the store; detected remotes use `env_auth=true`, anonymous remotes carry no keys. The direct-URL fast paths are anonymous/public only.
- Frontend needs no change.

## Review feedback addressed

Earlier `cursor[bot]` findings, fixed (commits `8a2a601`, `7b4c110`):
- **Google expiry phrase missed by markers** — `Token has been expired or revoked.` (Google ADC/OAuth, no `invalid_grant`) matched neither `has expired` nor `is expired`; added the `has been expired or revoked` marker so expired GCS creds no longer slip through to the opaque reconnect path.
- **Failed rollback left a remote behind** — the rollback `config delete` result was swallowed and the idempotent re-entry reported `{"ok": True}` without re-probing, so a lingering expired remote read as healthy. Now the delete result is checked (failure surfaced in the 502) and the early-return re-probes detected remotes.

Follow-up `cursor[bot]` findings on the generalization commits, fixed (commits `ffb5249`, `673b515`):
- **Dead file watches on anonymous S3/GCS mounts** — routing `_mount_signal` through `direct_list_capable`/`direct_list_page` meant a *file* watch (which the capability check can't distinguish from a directory) hashed an empty direct page — a constant signal — so file content changes never refreshed the pane; the `rc_list_dir` → `RcListError` → `rc_mtime_for` file fallback was unreachable once the direct branch was taken. Fix: when the direct page is empty, fall back to `rc_mtime_for(path)` (a file recovers its real changing ModTime; a genuinely empty directory gets the harmless constant sentinel, superseded by the listing hash the moment a child appears). Non-empty listings are unchanged.
- **GCS transport missing `gcsfs`** — the new `google cloud storage` branch in `resolve_source` returns a `gcs://` URL for `FsspecStore.from_url`, but the daemon venv installed only `s3fs`; added `gcsfs` to both the PEP-723 script header and `DAEMON_DEPS` so opening a GCS mount under `ZARRAOI_TRANSPORT=s3` works.

Two other findings in the latest bot pass were stale re-flags of the two already-fixed issues above (Google marker, failed rollback) — verified present in current code, no change needed.

## Self-review

Automated correctness review over the branch diff found **no correctness bugs**. The GCS paths are faithful mirrors of the proven S3 paths (listing routing/parsing, and now the byte-read direct-URL dispatch). Known non-blocking notes: the idempotent detect re-probe adds one blocking `lsd` to a previously-instant call (intended); `direct_list_page` re-derives capability per page (memoized, cheap); `gcs_list_page` treats a non-string `size` as `None` (GCS always sends a string — parity with S3). The `zarr_aoi` GCS transport branch has no unit test because `resolve_source` is a closure nested in `main()` (not importable) with no existing harness — verified by `py_compile` and by mirroring the adjacent S3 branch exactly.

## Testing

- Full suite: **973 passed, 1 skipped** (`.venv/bin/python -m pytest -q`).
- `tests/test_shell_mounts.py` + `tests/test_server_fs_list_mount.py`: **194 passed** — GCS suggestion/read-only; materialization-time rejection vs. AccessDenied/public skip; mount-use path (expired → re-auth message; valid → reconnect; non-env_auth/unmounted → no probe); Google expired-or-revoked wording; failed-rollback + re-probe-existing-detected-remote; the full anonymous-GCS listing mirror (direct_capable, URL/query, prefixes/items/token parsing, placeholder skip, 403 → DirectListError, dispatcher routing); the anonymous-GCS byte-read fast path (`_gcs_public_object_url` URL/encoding, non-anon → `None`, full `upstream_url_for` flow asserting `mode="public"` with zero `publiclink` calls); and the `GOOGLE_APPLICATION_CREDENTIALS` GCS suggestion.
- `tests/test_server_fs_events.py`: a file watch under an anonymous mount with an empty direct page recovers a changing-ModTime signal (not a constant empty-listing hash); `None` ModTime → `_UNCHANGED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
