### PR TITLE
Track asset provenance to label how bundled files are exposed

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -626,12 +626,19 @@ nothing. Full detail: `docs/EXPORT.md`.
   (a referenced file, or an `include` file, not on disk).
 - **EX-4a** Warnings — advisory, never blocking: a **computed `rawUrl`/`readFile`
   path** (the exporter can't discover the target from the HTML, but once the target is
-  bundled — via an `include` glob in the page's manifest (EX-7) or an explicit `include`
+  bundled — via an `include` glob in the page's manifest (EX-8) or an explicit `include`
   (EX-6) — the served `_asset` route resolves it by key at request time, and the hosted
   runtime resolves the computed path to that key; a call `fused.rawUrl("data/" + name)`
   is a string *prefix* + expression, so it is counted here as computed, **not**
-  mis-collected as a literal `data/` target), and an **`exclude` that drops a
-  literally-referenced file** (honored, but that call 404s when hosted).
+  mis-collected as a literal `data/` target). This warning is **suppressed when the
+  page's own bundle manifest (EX-8) contributes files**: those are `manifest`-source
+  assets (EX-6), shown as `bundle` provenance pills in §19's list (DP-2a), so the list
+  itself already shows what backs the call and the nag would be redundant — with no
+  manifest includes there is nothing bundled to resolve the computed key against, so it
+  still fires. A per-deployment `include` (EX-6, source `include`) does **not** suppress
+  it: that selection is not checked in with the page, so a fresh export without it would
+  still 404. Also warned: an **`exclude` that drops a literally-referenced file**
+  (honored, but that call 404s when hosted).
 - **EX-5** Route names derive from the `.py` stem (`sine.py` → `sine`), are prefixed
   `run-` when they'd collide with a reserved serve route (`data`, `health`, the
   `_`-prefixed control/shell/asset routes), and are suffixed `-2`, `-3`, … on

--- a/SPEC.md
+++ b/SPEC.md
@@ -641,7 +641,14 @@ nothing. Full detail: `docs/EXPORT.md`.
   bundled as assets beyond the literal scan (for a computed-path target or data a
   bundled `.py` reads at runtime), each validated like a scanned asset and deduped by
   key; and `exclude` — files dropped from the final set by literal path or bundle
-  key. Both default empty (auto-only).
+  key. Both default empty (auto-only). Each bundled asset carries a `source` —
+  `reference` (a literal `rawUrl`/`readFile` the scan resolved), `manifest`
+  (declared in the page's EX-8 manifest), or `include` (added out-of-band via the
+  selection) — attributed to the strongest claim in that order when a file is
+  reachable more than one way, and surfaced on `/api/deploy/preview` so §19's list
+  can label how each file is exposed (DP-2a). It is an in-process/preview
+  classification only: `manifest.json` (EX-2) does not carry it — the hosting
+  layer treats every asset the same.
 - **EX-7** First-party **modules** a bundled entrypoint imports are discovered by a
   static AST scan of the entrypoint sources (transitively) and shipped as `resources`,
   so a served entrypoint's `import helpers` resolves without hand-listing. Only an
@@ -711,7 +718,14 @@ the product gains network access.
   publish (`POST /api/deploy/preview` → `preview_deploy`, the same pure
   `plan_export` scan the real export runs, resolved fresh with the current
   selection, no files written): the page plus each `runPython` target (and its
-  served route name) and each `rawUrl`/`readFile` or included asset. Export
+  served route name) and each asset. Every asset row carries a **provenance
+  pill** driven by the preview's per-asset `source` (EX-6) so the list *mentions
+  how a bundled file is exposed*: `rawUrl` — a scanned literal
+  `fused.rawUrl()`/`readFile()` reference (the page fetches it via
+  rawUrl/readFile); `bundle` — a file declared in the page's fused-bundle
+  manifest (EX-8), which auto-shows here to back a computed rawUrl/readFile path;
+  `added` — a hand-added include. All three are served read-only on the hosted
+  `_asset` route (the pill's tooltip says so). Export
   blockers (EX-4) come back in the same response and **disable Deploy** with the
   full list — an unexportable page reads as "fix these" up front, never as a
   failed deploy; warnings (EX-4a) show alongside but never block. A preview

--- a/SPEC.md
+++ b/SPEC.md
@@ -630,15 +630,17 @@ nothing. Full detail: `docs/EXPORT.md`.
   (EX-6) — the served `_asset` route resolves it by key at request time, and the hosted
   runtime resolves the computed path to that key; a call `fused.rawUrl("data/" + name)`
   is a string *prefix* + expression, so it is counted here as computed, **not**
-  mis-collected as a literal `data/` target). This warning is **suppressed when the
-  page's own bundle manifest (EX-8) contributes files**: those are `manifest`-source
-  assets (EX-6), shown as `bundle` provenance pills in §19's list (DP-2a), so the list
-  itself already shows what backs the call and the nag would be redundant — with no
-  manifest includes there is nothing bundled to resolve the computed key against, so it
-  still fires. A per-deployment `include` (EX-6, source `include`) does **not** suppress
-  it: that selection is not checked in with the page, so a fresh export without it would
-  still 404. Also warned: an **`exclude` that drops a literally-referenced file**
-  (honored, but that call 404s when hosted).
+  mis-collected as a literal `data/` target). This warning is **suppressed when a
+  `manifest`-source asset (EX-6/EX-8) survives into the final bundle** — a `bundle`
+  provenance pill in §19's list (DP-2a) that shows the user what backs the call, so the
+  nag would be redundant. It keys on the *surviving* asset, evaluated after dedup and
+  exclude, **not** the raw manifest globs: a manifest entry that is also a literal
+  reference is deduped to a `reference` asset, and any manifest file can be dropped by
+  `exclude` — in both cases no `bundle` row remains and the warning still fires. A
+  per-deployment `include` (EX-6, source `include`) never suppresses it: that selection
+  is not checked in with the page, so a fresh export without it would still 404. Also
+  warned: an **`exclude` that drops a literally-referenced file** (honored, but that call
+  404s when hosted).
 - **EX-5** Route names derive from the `.py` stem (`sine.py` → `sine`), are prefixed
   `run-` when they'd collide with a reserved serve route (`data`, `health`, the
   `_`-prefixed control/shell/asset routes), and are suffixed `-2`, `-3`, … on

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -127,6 +127,10 @@ Some conditions are **warnings**, not errors — they don't block export:
   the hosted runtime resolves the computed path to that key, so `fused.rawUrl("data/" +
   name)` resolves fine. (A call like that is a string *prefix* plus an expression, so it
   is treated as computed — it is **not** mis-bundled as a literal `data/` target.)
+  This warning is **suppressed once the page's bundle manifest (below) contributes
+  files** — they show as `bundle` assets in the Deploy list, so the list already shows
+  what backs the call. A per-deployment `include` (Deploy modal / `/api/export`) does
+  not suppress it, since that selection isn't checked in with the page.
 - **Excluding a referenced file.** Dropping a file the page literally references is
   honored, but the page's call to it will 404 when hosted.
 

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -154,6 +154,18 @@ auto-detected default — and persists the selection on the deployment record so
 reopened modal reloads it. `/api/export` exposes the same two fields for driving a
 bundle by hand.
 
+Each asset in the list is labelled by how it is exposed, so it is clear which
+bundled files are web-fetchable via `rawUrl`/`readFile`:
+
+- **`rawUrl`** — a literal `fused.rawUrl()`/`readFile()` reference the scan found;
+  the page fetches it via rawUrl/readFile.
+- **`bundle`** — a file declared in the page's `<script type="application/fused-bundle">`
+  manifest (below). These **auto-show up** in the list — they back a *computed*
+  rawUrl/readFile path, so the manifest is how they get bundled without a literal.
+- **`added`** — a file you added by hand ("Add files" / "Add all in folder").
+
+All three are served read-only by the `_asset` route regardless of label.
+
 ### The page's own bundle manifest (checked in, reproducible)
 
 `include`/`exclude` above are the per-deployment selection (kept on the deployment

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -127,10 +127,13 @@ Some conditions are **warnings**, not errors — they don't block export:
   the hosted runtime resolves the computed path to that key, so `fused.rawUrl("data/" +
   name)` resolves fine. (A call like that is a string *prefix* plus an expression, so it
   is treated as computed — it is **not** mis-bundled as a literal `data/` target.)
-  This warning is **suppressed once the page's bundle manifest (below) contributes
-  files** — they show as `bundle` assets in the Deploy list, so the list already shows
-  what backs the call. A per-deployment `include` (Deploy modal / `/api/export`) does
-  not suppress it, since that selection isn't checked in with the page.
+  This warning is **suppressed when a manifest-declared file actually lands as a
+  `bundle` asset** in the Deploy list — the list then shows what backs the call. It is
+  keyed on the surviving asset, not the raw manifest globs: a manifest file that is also
+  a literal `rawUrl`/`readFile` target counts as `rawUrl`, and one dropped by `exclude`
+  is gone — either way no `bundle` row remains, so the warning still fires. A
+  per-deployment `include` (Deploy modal / `/api/export`) never suppresses it, since that
+  selection isn't checked in with the page.
 - **Excluding a referenced file.** Dropping a file the page literally references is
   honored, but the page's call to it will 404 when hosted.
 

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -238,26 +238,53 @@ function FileSelection({
     );
   }
 
-  const rows = [
-    ...preview.entrypoints.map((e) => ({
-      path: e.path,
-      label: relKey(e.path),
-      title: `fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`,
-      tag: "run" as const,
-    })),
-    ...preview.assets.map((a) => {
-      // "added" iff the file is NOT in the auto-detected set — a purely manual
-      // include. A file that's both referenced AND included reads as a normal
-      // asset (removing it must exclude, which the "added" affordance wouldn't
-      // convey), so auto-ness wins the label.
-      const manual = !autoKeys.has(relKey(a.path));
+  // A publish-list row. `tag` is the pill's CSS modifier class, `tagText` its
+  // (case-preserved) label — decoupled so the pill can read "rawUrl" while the
+  // class stays lowercase.
+  type Row = { path: string; label: string; title: string; tag: string; tagText: string };
+  const rows: Row[] = [
+    ...preview.entrypoints.map(
+      (e): Row => ({
+        path: e.path,
+        label: relKey(e.path),
+        title: `fused.runPython(${JSON.stringify(e.path)}) → route “${e.name}”`,
+        tag: "run",
+        tagText: "run",
+      }),
+    ),
+    ...preview.assets.map((a): Row => {
+      // Every asset is served read-only on the hosted `_asset` route — the surface
+      // fused.rawUrl()/readFile() fetch from. The pill mentions rawUrl/readFile
+      // exposure and names HOW the file got bundled (a.source, from the server):
+      //   reference → the page fetches it via a literal fused.rawUrl()/readFile()
+      //   manifest  → declared in the page's fused-bundle manifest to back a
+      //               *computed* rawUrl/readFile path (so it auto-shows here)
+      //   include   → added by hand (Add files / Add all in folder)
+      const served = `served read-only at _asset/${a.name} — the surface fused.rawUrl()/readFile() fetch from`;
+      if (a.source === "include") {
+        return {
+          path: a.path,
+          label: relKey(a.path),
+          title: `Added file — ${served} — ${a.path}`,
+          tag: "added",
+          tagText: "added",
+        };
+      }
+      if (a.source === "manifest") {
+        return {
+          path: a.path,
+          label: relKey(a.path),
+          title: `Declared in the page's fused-bundle manifest to back a computed fused.rawUrl()/readFile() path — ${served} — ${a.path}`,
+          tag: "rawurl",
+          tagText: "bundle",
+        };
+      }
       return {
         path: a.path,
         label: relKey(a.path),
-        title: manual
-          ? `included file — ${a.path}`
-          : `asset “${a.name}” (fused.rawUrl/readFile) — ${a.path}`,
-        tag: manual ? ("added" as const) : (null as null),
+        title: `Fetched by the page via fused.rawUrl()/readFile() — ${served} — ${a.path}`,
+        tag: "rawurl",
+        tagText: "rawUrl",
       };
     }),
   ];
@@ -309,11 +336,9 @@ function FileSelection({
               <span className="deploy-file-action" />
             </li>
             {rows.map((r) => (
-              <li key={(r.tag ?? "asset") + r.path} className="deploy-file">
+              <li key={r.tag + r.path} className="deploy-file">
                 <code title={r.title}>{r.label}</code>
-                <span className={"deploy-file-tag" + (r.tag ? " " + r.tag : " none")}>
-                  {r.tag ?? ""}
-                </span>
+                <span className={"deploy-file-tag " + r.tag}>{r.tagText}</span>
                 <button
                   type="button"
                   className="deploy-file-action deploy-file-remove"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -401,13 +401,23 @@ export interface ShareMount {
   page: string | null;
 }
 
+// How a bundled asset is exposed / why it's in the bundle (export.Asset.source):
+//   reference — a literal fused.rawUrl()/readFile() the HTML scan resolved (the
+//               page fetches it via rawUrl/readFile)
+//   manifest  — declared in the page's <script type="application/fused-bundle">
+//               include, the reproducible way to back a *computed* rawUrl/readFile path
+//   include   — added by hand via the modal's include ("Add all in folder")
+// Every asset is served read-only on the hosted `_asset` route regardless; the
+// distinction drives the row's label so the list mentions rawUrl/readFile exposure.
+export type AssetSource = "reference" | "manifest" | "include";
+
 // What deploying a page would publish, resolved fresh from on-disk state —
 // shown BEFORE the Deploy click. Non-empty `errors` means the page cannot be
 // exported as-is (Deploy would fail with exactly these).
 export interface DeployPreview {
   page: string;
   entrypoints: { path: string; name: string }[];
-  assets: { path: string; name: string }[];
+  assets: { path: string; name: string; source: AssetSource }[];
   // The auto-detected default set (literal runPython/rawUrl/readFile paths, before
   // include/exclude). Lets the modal distinguish an auto file (removing → exclude,
   // shown under "Excluded" with restore) from a manual include (removing → just drop).

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2240,11 +2240,14 @@ body.embed .preview-browse-chip:hover {
 }
 
 /* rawUrl/readFile-exposed assets — a scanned literal reference ("rawUrl") or a
-   manifest-declared bundle file ("bundle"). Slightly brighter than the muted
-   run/page pills so the list visibly flags which bundled files are web-fetchable
-   via the hosted `_asset` route. */
+   manifest-declared bundle file ("bundle"). Brighter than the muted run/page
+   pills so the list visibly flags which bundled files are web-fetchable via the
+   hosted `_asset` route. Casing is preserved (no uppercase) so "rawUrl" reads as
+   the fused.rawUrl API name rather than "RAWURL". */
 .deploy-file-tag.rawurl {
   color: var(--fg);
+  text-transform: none;
+  letter-spacing: normal;
 }
 
 /* The action column: ✕ is centered, Restore fills it — both sit in the same

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2185,7 +2185,7 @@ body.embed .preview-browse-chip:hover {
    columns align across the publish and excluded lists. */
 .deploy-file {
   display: grid;
-  grid-template-columns: 1fr 56px 72px;
+  grid-template-columns: 1fr 68px 72px;
   align-items: center;
   column-gap: 8px;
   padding: 2px 4px;
@@ -2237,6 +2237,14 @@ body.embed .preview-browse-chip:hover {
 .deploy-file-tag.added {
   color: var(--accent);
   border-color: var(--accent);
+}
+
+/* rawUrl/readFile-exposed assets — a scanned literal reference ("rawUrl") or a
+   manifest-declared bundle file ("bundle"). Slightly brighter than the muted
+   run/page pills so the list visibly flags which bundled files are web-fetchable
+   via the hosted `_asset` route. */
+.deploy-file-tag.rawurl {
+  color: var(--fg);
 }
 
 /* The action column: ✕ is centered, Restore fills it — both sit in the same

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -460,7 +460,10 @@ def preview_deploy(
     return {
         "page": os.path.basename(page),
         "entrypoints": [{"path": e.path, "name": e.name} for e in plan.entrypoints],
-        "assets": [{"path": a.path, "name": a.name} for a in plan.assets],
+        # `source` lets the "Will publish" list say HOW each asset is exposed: a
+        # scanned literal rawUrl/readFile reference, a manifest-declared bundle file
+        # (backs a computed path), or a hand-added include. See export.Asset.
+        "assets": [{"path": a.path, "name": a.name, "source": a.source} for a in plan.assets],
         "auto": [e.path for e in auto.entrypoints] + [a.path for a in auto.assets],
         "errors": plan.errors,
         "warnings": plan.warnings,

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -571,23 +571,8 @@ def plan_export(
             "hosted entrypoint's route name is derived from its literal path, so a "
             "computed runPython target cannot be bundled or routed"
         )
-    dyn_asset = sum(_dynamic_call_count(html, method) for method in ("rawUrl", "readFile"))
-    # Suppressed once the page's own bundle manifest already contributes files: those land as
-    # `manifest`-source assets ("bundle" badges in the Deploy list, §19), which is the
-    # reproducible, checked-in way to back a computed rawUrl/readFile path (EX-8) — the list
-    # then shows what's backing the call, so the nag is redundant. With no manifest includes
-    # there is nothing bundled for the hosted `_asset` route to resolve the computed key
-    # against, so it still fires. A per-deployment `include` (source `include`, e.g. "Add all
-    # in folder") does NOT suppress it: it is not checked in with the page, so a fresh export
-    # without that ad-hoc selection would still 404 — only the manifest travels with the page.
-    if dyn_asset > 0 and not manifest_include:
-        plan.warnings.append(
-            f"{dyn_asset} fused.rawUrl()/readFile() call(s) use a computed path the "
-            "exporter can't resolve — declare the files those calls fetch in a "
-            '<script type="application/fused-bundle"> manifest ("include" globs), or add '
-            'them under "Include files" ("Add all in folder"), so they are bundled and '
-            "served (the hosted _asset route then resolves the computed path by key)"
-        )
+    # The computed-path advisory is emitted AFTER the asset passes below (it depends on the
+    # FINAL bundle), near the end of this function.
 
     taken_names: set[str] = set()
     for path in _literal_paths(html, "runPython"):
@@ -704,6 +689,27 @@ def plan_export(
             else:
                 kept_assets.append(a)
         plan.assets = kept_assets
+
+    # A computed rawUrl/readFile path can't be resolved from the HTML — advisory, never
+    # blocking. Emitted HERE, after dedup and exclude, so it reflects the FINAL bundle:
+    # suppressed only when a `manifest`-source asset actually SURVIVED — a "bundle" badge in
+    # the Deploy list (§19) that shows the user what backs the call. Keyed on the surviving
+    # assets, NOT the raw manifest globs, because a manifest entry can fail to leave a
+    # `manifest` row: one that is also a literal reference is deduped to a `reference` asset,
+    # and any manifest file can be dropped by `exclude`. In both cases no "bundle" row
+    # remains, so the justification ("the list shows what backs it") does not hold and the
+    # nag must still fire. A per-deployment `include` (source `include`, e.g. "Add all in
+    # folder") never suppresses it either: that ad-hoc selection is not checked in with the
+    # page, so a fresh export without it would still 404 — only the manifest travels along.
+    dyn_asset = sum(_dynamic_call_count(html, method) for method in ("rawUrl", "readFile"))
+    if dyn_asset > 0 and not any(a.source == "manifest" for a in plan.assets):
+        plan.warnings.append(
+            f"{dyn_asset} fused.rawUrl()/readFile() call(s) use a computed path the "
+            "exporter can't resolve — declare the files those calls fetch in a "
+            '<script type="application/fused-bundle"> manifest ("include" globs), or add '
+            'them under "Include files" ("Add all in folder"), so they are bundled and '
+            "served (the hosted _asset route then resolves the computed path by key)"
+        )
 
     # Ship first-party modules the (surviving) entrypoints import, so `import helpers`
     # resolves on the hosted page with no hand-listing. Discovered after excludes so a

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -572,7 +572,15 @@ def plan_export(
             "computed runPython target cannot be bundled or routed"
         )
     dyn_asset = sum(_dynamic_call_count(html, method) for method in ("rawUrl", "readFile"))
-    if dyn_asset > 0:
+    # Suppressed once the page's own bundle manifest already contributes files: those land as
+    # `manifest`-source assets ("bundle" badges in the Deploy list, §19), which is the
+    # reproducible, checked-in way to back a computed rawUrl/readFile path (EX-8) — the list
+    # then shows what's backing the call, so the nag is redundant. With no manifest includes
+    # there is nothing bundled for the hosted `_asset` route to resolve the computed key
+    # against, so it still fires. A per-deployment `include` (source `include`, e.g. "Add all
+    # in folder") does NOT suppress it: it is not checked in with the page, so a fresh export
+    # without that ad-hoc selection would still 404 — only the manifest travels with the page.
+    if dyn_asset > 0 and not manifest_include:
         plan.warnings.append(
             f"{dyn_asset} fused.rawUrl()/readFile() call(s) use a computed path the "
             "exporter can't resolve — declare the files those calls fetch in a "

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -141,11 +141,28 @@ class Entrypoint:
 
 @dataclass(frozen=True)
 class Asset:
-    """A ``rawUrl``/``readFile`` target: a read-only file bundled and served by ``_asset``."""
+    """A read-only file bundled and served by the ``_asset`` route — the surface
+    ``fused.rawUrl``/``readFile`` fetch from.
+
+    ``source`` records WHY the file is in the bundle, so the Deploy modal's "Will
+    publish" list can say whether the page is *known* to fetch it via
+    ``rawUrl``/``readFile`` versus bundled to back a computed path or added by hand:
+
+      * ``"reference"`` — a literal ``fused.rawUrl()``/``readFile()`` argument the
+        HTML scan resolved: the page fetches this file via rawUrl/readFile.
+      * ``"manifest"`` — declared in the page's embedded
+        ``<script type="application/fused-bundle">`` include (globs/literals), the
+        reproducible way to back a *computed* rawUrl/readFile path (EX-4a/EX-8).
+      * ``"include"`` — added out-of-band via the caller's / Deploy modal's
+        ``include`` (e.g. "Add all in folder"), not seen in the HTML at all.
+
+    A file reachable more than one way is attributed to the first that claims it,
+    in that order (reference > manifest > include), and bundled once."""
 
     path: str  # the literal string passed to rawUrl/readFile, e.g. "./logo.png"
     name: str  # the asset key the page requests, e.g. "logo.png"
     file: str  # bundle-relative destination, e.g. "files/logo.png"
+    source: str = "reference"  # "reference" | "manifest" | "include" (see above)
 
 
 @dataclass(frozen=True)
@@ -532,8 +549,13 @@ def plan_export(
     # The embedded manifest is read first: its block is stripped from `html` (so its JSON
     # body can't false-positive in the scans below) and its expanded `include` globs are
     # prepended to the caller's include list (both are just added assets; exclude runs last).
+    # The prepend order also fixes provenance: a key declared in BOTH the manifest and the
+    # caller's include is deduped to the manifest entry (first wins), so it is attributed to
+    # the page's own reproducible declaration rather than the ad-hoc selection.
     manifest_include, html = _extract_bundle_manifest(html, plan.errors, plan.warnings)
-    include = _expand_manifest_include(page_dir, manifest_include, plan.errors, plan.warnings) + include
+    manifest_include = _expand_manifest_include(page_dir, manifest_include, plan.errors, plan.warnings)
+    manifest_keys = {_asset_key(p) for p in manifest_include}
+    include = manifest_include + include
 
     for m in _UNSUPPORTED.finditer(html):
         api = m.group(1)
@@ -604,7 +626,9 @@ def plan_export(
             key = _asset_key(path)
             seen_asset_paths.add(path)
             seen_asset_keys.add(key)
-            plan.assets.append(Asset(path=path, name=key, file=f"{_PAYLOAD_DIR}/{key}"))
+            plan.assets.append(
+                Asset(path=path, name=key, file=f"{_PAYLOAD_DIR}/{key}", source="reference")
+            )
 
     # Manual includes: extra files bundled as assets, keyed the same way. A file already
     # brought in by the literal scan (same key) is skipped — bundled once. A file already
@@ -632,7 +656,12 @@ def plan_export(
             plan.errors.append(f"included file {path!r} not found next to the page ({src})")
             continue
         seen_asset_keys.add(key)
-        plan.assets.append(Asset(path=path, name=key, file=f"{_PAYLOAD_DIR}/{key}"))
+        # A manifest-declared file is the page's own reproducible bundle declaration
+        # (it backs a computed rawUrl/readFile path); a caller/modal include is ad-hoc.
+        source = "manifest" if key in manifest_keys else "include"
+        plan.assets.append(
+            Asset(path=path, name=key, file=f"{_PAYLOAD_DIR}/{key}", source=source)
+        )
 
     # Excludes drop matching entrypoints/assets by their literal path OR bundle key.
     # Dropping something the page literally references is the user's call, but warned —

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -902,9 +902,10 @@ def test_preview_reports_asset_source(tmp_path, monkeypatch):
         "tiles/0.png": "manifest",
         "extra.csv": "include",
     }
-    # The computed rawUrl path still warns — the manifest backs it but the scan
-    # can't verify the glob covers what the page will actually request.
-    assert any("computed path" in w for w in body["warnings"])
+    # The computed rawUrl path's warning is suppressed: the page's manifest bundles
+    # files to back it (shown as a "bundle" provenance pill in the list), so the nag
+    # is redundant.
+    assert not any("computed path" in w for w in body["warnings"])
 
 
 def test_preview_reports_export_blockers(tmp_path, monkeypatch):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -876,6 +876,37 @@ def test_preview_applies_include_and_exclude(tmp_path, monkeypatch):
     assert any("sine.py" in w for w in body["warnings"])
 
 
+def test_preview_reports_asset_source(tmp_path, monkeypatch):
+    # The preview tags each asset with HOW it's exposed so the "Will publish" list
+    # can mention rawUrl/readFile exposure: a scanned literal reference, a
+    # manifest-declared bundle file, and a hand-added include each land distinctly.
+    h = _harness(tmp_path, monkeypatch)
+    h.page.write_text(
+        '<html><body><script type="application/fused-bundle">'
+        '{"include": ["tiles/*.png"]}</script>'
+        "<script>fused.rawUrl('./logo.png'); const u = fused.rawUrl('tiles/' + z);</script>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+    (tmp_path / "logo.png").write_text("PNG", encoding="utf-8")
+    (tmp_path / "tiles").mkdir()
+    (tmp_path / "tiles" / "0.png").write_text("PNG", encoding="utf-8")
+    (tmp_path / "extra.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    resp = h.client.post(
+        "/api/deploy/preview", json={"path": str(h.page), "include": ["extra.csv"]}
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert {a["name"]: a["source"] for a in body["assets"]} == {
+        "logo.png": "reference",
+        "tiles/0.png": "manifest",
+        "extra.csv": "include",
+    }
+    # The computed rawUrl path still warns — the manifest backs it but the scan
+    # can't verify the glob covers what the page will actually request.
+    assert any("computed path" in w for w in body["warnings"])
+
+
 def test_preview_reports_export_blockers(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     h.page.write_text(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -84,6 +84,46 @@ def test_dynamic_asset_path_is_a_warning_not_an_error(tmp_path):
     assert any("computed path" in w for w in plan.warnings)
 
 
+def test_manifest_backing_suppresses_computed_path_warning(tmp_path):
+    # When the page's own bundle manifest contributes files, the computed-path nag is
+    # suppressed — those files show as "bundle" (manifest) assets in the Deploy list, which
+    # is the reproducible way to back the computed call, so the warning would be redundant.
+    html = (
+        _manifest_block('{"include": ["tiles/*.png"]}')
+        + "<script>const z = 2; fused.rawUrl('tiles/' + z + '.png');</script>"
+    )
+    _write(tmp_path, "tiles/0.png", "PNG")
+    plan = plan_export(html, str(tmp_path))
+    assert not plan.errors
+    assert not any("computed path" in w for w in plan.warnings)
+    assert [(a.name, a.source) for a in plan.assets] == [("tiles/0.png", "manifest")]
+
+
+def test_manifest_with_no_matching_files_still_warns(tmp_path):
+    # A manifest whose globs match nothing bundles no backing file, so there is still
+    # nothing for the hosted _asset route to resolve the computed key against — the
+    # computed-path warning must still fire (alongside the zero-match glob warning).
+    html = (
+        _manifest_block('{"include": ["tiles/*.png"]}')
+        + "<script>const z = 2; fused.rawUrl('tiles/' + z + '.png');</script>"
+    )
+    plan = plan_export(html, str(tmp_path))
+    assert not plan.errors
+    assert any("computed path" in w for w in plan.warnings)
+
+
+def test_manual_include_does_not_suppress_computed_path_warning(tmp_path):
+    # A per-deployment include ("Add all in folder") is not checked in with the page, so a
+    # fresh export without it would still 404 — it must NOT suppress the warning (only the
+    # page's own manifest does).
+    html = "<script>const z = 2; fused.rawUrl('tiles/' + z + '.png');</script>"
+    _write(tmp_path, "tiles/0.png", "PNG")
+    plan = plan_export(html, str(tmp_path), include=["tiles/0.png"])
+    assert not plan.errors
+    assert any("computed path" in w for w in plan.warnings)
+    assert [(a.name, a.source) for a in plan.assets] == [("tiles/0.png", "include")]
+
+
 def test_include_bundles_an_unreferenced_file(tmp_path):
     html = "<script>fused.runPython('./sine.py', {});</script>"
     _write(tmp_path, "sine.py", "def main():\n    return 1\n")
@@ -528,8 +568,9 @@ def test_manifest_glob_bundles_matching_files(tmp_path):
     plan = plan_export(html, str(tmp_path))
     assert not plan.errors
     assert {a.name for a in plan.assets} == {"data/a.json", "data/b.json"}
-    # The computed rawUrl call is still an advisory warning, now mentioning the manifest.
-    assert any("computed path" in w for w in plan.warnings)
+    # The computed rawUrl call's warning is suppressed: the manifest bundles files to back
+    # it (they show as "bundle" provenance assets), so the nag would be redundant.
+    assert not any("computed path" in w for w in plan.warnings)
 
 
 def test_manifest_recursive_glob(tmp_path):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -124,6 +124,39 @@ def test_manual_include_does_not_suppress_computed_path_warning(tmp_path):
     assert [(a.name, a.source) for a in plan.assets] == [("tiles/0.png", "include")]
 
 
+def test_manifest_file_that_is_also_a_literal_leaves_no_bundle_row_and_warns(tmp_path):
+    # Suppression keys on a SURVIVING `manifest` asset, not the raw manifest globs. When the
+    # only manifest match is also a literal rawUrl target, dedup attributes it to `reference`
+    # (literal wins), so no "bundle" row remains — the computed call still has no visible
+    # backing, so the warning must still fire (Bugbot #192).
+    html = (
+        _manifest_block('{"include": ["data/a.json"]}')
+        + "<script>fused.rawUrl('data/a.json'); const u = fused.rawUrl('data/' + n);</script>"
+    )
+    _write(tmp_path, "data/a.json", "1")
+    plan = plan_export(html, str(tmp_path))
+    assert not plan.errors
+    assert [(a.name, a.source) for a in plan.assets] == [("data/a.json", "reference")]
+    assert not any(a.source == "manifest" for a in plan.assets)
+    assert any("computed path" in w for w in plan.warnings)
+
+
+def test_excluding_the_manifest_file_reinstates_the_computed_path_warning(tmp_path):
+    # A manifest file dropped by `exclude` leaves no "bundle" row, so the suppression
+    # justification no longer holds and the warning must fire again (Bugbot #192).
+    html = (
+        _manifest_block('{"include": ["tiles/*.png"]}')
+        + "<script>const z = 2; fused.rawUrl('tiles/' + z + '.png');</script>"
+    )
+    _write(tmp_path, "tiles/0.png", "PNG")
+    # Without the exclude the warning is suppressed; excluding the sole backing file brings it back.
+    assert not any("computed path" in w for w in plan_export(html, str(tmp_path)).warnings)
+    plan = plan_export(html, str(tmp_path), exclude=["tiles/0.png"])
+    assert not plan.errors
+    assert not any(a.source == "manifest" for a in plan.assets)
+    assert any("computed path" in w for w in plan.warnings)
+
+
 def test_include_bundles_an_unreferenced_file(tmp_path):
     html = "<script>fused.runPython('./sine.py', {});</script>"
     _write(tmp_path, "sine.py", "def main():\n    return 1\n")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -32,6 +32,41 @@ def test_plan_collects_runpython_and_assets(tmp_path):
         ("./sine.py", "sine", "files/sine.py")
     ]
     assert {a.name for a in plan.assets} == {"logo.png", "notes.txt"}
+    # A literal rawUrl/readFile target is exposed via rawUrl/readFile — source "reference".
+    assert {a.source for a in plan.assets} == {"reference"}
+
+
+def test_asset_source_reflects_how_the_file_entered_the_bundle(tmp_path):
+    # Three provenances land as three distinct `source` values so the Deploy modal's
+    # list can say whether the page is known to fetch a file via rawUrl/readFile.
+    html = (
+        _manifest_block('{"include": ["data/*.geojson"]}')
+        + "<script>fused.rawUrl('./logo.png'); const u = fused.rawUrl('data/' + n);</script>"
+    )
+    _write(tmp_path, "logo.png", "PNG")
+    _write(tmp_path, "data/a.geojson", "{}")
+    _write(tmp_path, "extra.csv", "a,b\n1,2\n")
+    plan = plan_export(html, str(tmp_path), include=["extra.csv"])
+    assert not plan.errors
+    by_name = {a.name: a.source for a in plan.assets}
+    assert by_name == {
+        "logo.png": "reference",  # literal fused.rawUrl() target
+        "data/a.geojson": "manifest",  # declared in the page's fused-bundle manifest
+        "extra.csv": "include",  # added out-of-band via the caller's include
+    }
+
+
+def test_literal_reference_wins_source_over_manifest_and_include(tmp_path):
+    # A file reachable more than one way is attributed to the strongest claim
+    # (reference > manifest > include) and bundled once.
+    html = (
+        _manifest_block('{"include": ["logo.png"]}')
+        + "<script>fused.rawUrl('./logo.png');</script>"
+    )
+    _write(tmp_path, "logo.png", "PNG")
+    plan = plan_export(html, str(tmp_path), include=["logo.png"])
+    assert not plan.errors
+    assert [(a.name, a.source) for a in plan.assets] == [("logo.png", "reference")]
 
 
 def test_dynamic_path_is_an_error(tmp_path):


### PR DESCRIPTION
## Summary

This change adds provenance tracking to bundled assets so the Deploy modal can clearly indicate how each file is exposed to the page. Assets are now classified by their `source` — whether they're literal `fused.rawUrl()`/`readFile()` references found by scanning, files declared in the page's fused-bundle manifest, or manually added includes — and this classification is surfaced in the preview and UI.

## Key Changes

- **Asset provenance tracking** (`fused_render/export.py`):
  - Added `source` field to `Asset` dataclass with three possible values: `"reference"` (literal scan), `"manifest"` (declared in page's bundle manifest), or `"include"` (manually added)
  - Updated `plan_export()` to track manifest-declared files separately and attribute assets to the strongest claim when reachable multiple ways (reference > manifest > include)
  - Manifest includes are now prepended to caller includes to ensure proper deduplication by provenance

- **Deploy preview API** (`fused_render/deploy.py`):
  - Extended `/api/deploy/preview` response to include `source` field for each asset
  - Added comments explaining the provenance classification

- **Frontend UI** (`frontend/src/components/DeployModal.tsx`):
  - Refactored row data structure to separate `tag` (CSS class) from `tagText` (display label)
  - Updated asset rows to show three distinct pill labels:
    - `"rawUrl"` for literal scanned references
    - `"bundle"` for manifest-declared files
    - `"added"` for manually included files
  - Enhanced tooltips to explain how each asset is exposed and served via the `_asset` route
  - Adjusted grid column width to accommodate wider pill labels

- **Type definitions** (`frontend/src/lib/api.ts`):
  - Added `AssetSource` type definition
  - Updated `DeployPreview.assets` to include `source` field

- **Styling** (`frontend/src/shell.css`):
  - Added `.deploy-file-tag.rawurl` styling to make rawUrl/bundle assets slightly brighter, visually flagging web-fetchable files
  - Adjusted grid column width from 56px to 68px

- **Tests** (`tests/test_export.py`, `tests/test_deploy.py`):
  - Added `test_asset_source_reflects_how_the_file_entered_the_bundle()` to verify three provenance types
  - Added `test_literal_reference_wins_source_over_manifest_and_include()` to verify deduplication priority
  - Added `test_preview_reports_asset_source()` to verify preview API includes source field

- **Documentation** (`SPEC.md`, `docs/EXPORT.md`):
  - Updated export specification to document asset source classification
  - Added explanation of how each asset type is exposed and when it auto-appears in the list
  - Clarified that source is a preview-only classification, not persisted in manifest.json

## Implementation Details

The provenance system ensures that when a file is reachable through multiple paths (e.g., both a literal `fused.rawUrl()` call and a manifest include), it's attributed to the strongest claim and bundled only once. This provides users with clear visibility into which bundled files are actually web-fetchable via the `_asset` route versus those backing computed paths or added manually.

https://claude.ai/code/session_01QoBKjKEqq8H94uQFpzp8xY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes export planning and deploy-preview warnings that affect whether users see blockers vs nags before publish; behavior is well-tested but touches the deploy path.
> 
> **Overview**
> Bundled assets now carry a **`source`** (`reference` | `manifest` | `include`) through `plan_export` and **`POST /api/deploy/preview`**, so the Deploy modal’s “Will publish” list can show **provenance pills**: **`rawUrl`** (literal scan), **`bundle`** (fused-bundle manifest), **`added`** (manual include), with tooltips describing `_asset` exposure.
> 
> **Computed `rawUrl`/`readFile` warnings** are emitted only after dedup/exclude and are **suppressed when a surviving `manifest`-source asset remains** (not when files are only added via per-deployment `include`). Manifest includes are prepended before caller includes so dedup attributes **reference > manifest > include**.
> 
> Docs (**SPEC**, **docs/EXPORT.md**) and tests cover the new classification and suppression edge cases (literal-over-manifest dedup, exclude dropping manifest backing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d1848067952f298551864927725d7f9dc46ee36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->