### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fused-render"
-version = "0.3.3"
+version = "0.3.4"
 description = "Local file explorer with Python-powered renderable HTML previews"
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
Bumps `pyproject.toml` version 0.3.3 → 0.3.4 ahead of the `v0.3.4` release tag.

The release build derives artifact versions from `pyproject.toml` (`build_dmg.sh:35`), not the git tag, so this must land before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)