### PR TITLE
Pyramid template: overview-pyramid inspector/fixer as second .tif mode

### DIFF
--- a/fused_render/templates/geotiff/tile_server.py
+++ b/fused_render/templates/geotiff/tile_server.py
@@ -17,14 +17,17 @@ Endpoints (all GET, CORS *):
         &stretch=&vlo=&vhi=    -> PNG tile (transparent where no data)
   /hist?file=&bbox=w,s,e,n(3857)&bins=&band=&mode=  -> viewport stats+hist
   /value?file=&lon=&lat=&band= -> raw value under cursor
+  /ltile/{z}/{x}/{y}.png?file=&level=N -> PNG tile rendered ONLY from pyramid
+        level N (0 = full res) via rasterio — used by the pyramid template
 
-Only pure-decodable TIFFs (uncompressed/deflate) are served; /meta returns
-supported=false otherwise and the page falls back to tiff_reader.py.
+/tile tries the native pure-python engine first (uncompressed/deflate TIFFs);
+local files it can't read (BigTIFF, user-defined CRS, exotic compression)
+fall back to a rasterio WarpedVRT render instead of the runPython image path.
 Idle shutdown after 30 min. The state file embeds this file's mtime, so
 editing the module auto-respawns a fresh daemon on the next ensure().
 """
 # /// script
-# dependencies = ["numpy", "pyproj", "imagecodecs"]
+# dependencies = ["numpy", "pyproj", "imagecodecs", "rasterio"]
 # ///
 
 import json
@@ -113,7 +116,27 @@ def _version():
 
 
 DAEMON_VENV = os.path.expanduser("~/.cache/fused-render-geotiff-v2/venv")
-DAEMON_DEPS = ["numpy", "pyproj", "imagecodecs"]
+DAEMON_DEPS = ["numpy", "pyproj", "imagecodecs", "rasterio"]
+
+
+def _upgrade_deps(vp):
+    """Older venvs predate rasterio (needed by /ltile and the /tile fallback)
+    — install it in place instead of rebuilding the venv."""
+    import shutil
+    import subprocess
+    try:
+        subprocess.run([vp, "-c", "import rasterio"], check=True,
+                       capture_output=True, timeout=60)
+        return
+    except Exception:
+        pass
+    uv = shutil.which("uv") or os.path.expanduser("~/.local/bin/uv")
+    if os.path.exists(uv):
+        try:
+            subprocess.run([uv, "pip", "install", "-p", vp, "rasterio"],
+                           check=True, capture_output=True, timeout=300)
+        except Exception:
+            pass
 
 
 def _daemon_python():
@@ -172,9 +195,17 @@ def main(action: str = "ensure"):
 
     os.makedirs(os.path.dirname(STATE), exist_ok=True)
     log = os.path.join(os.path.dirname(STATE), "daemon.log")
+    dp = _daemon_python()
+    if dp != sys.executable:
+        _upgrade_deps(dp)
+    # scrub the app's interpreter env — inherited PYTHONPATH/PYTHONHOME makes
+    # the venv python import the APP BUNDLE's packages (mixed-install imports
+    # fail randomly under concurrency, e.g. bundle rasterio vs venv rasterio)
+    denv = {k: v for k, v in os.environ.items()
+            if k not in ("PYTHONPATH", "PYTHONHOME")}
     with open(log, "ab") as lf:
-        subprocess.Popen([_daemon_python(), _me(), "--serve"],
-                         stdout=lf, stderr=lf,
+        subprocess.Popen([dp, _me(), "--serve"],
+                         stdout=lf, stderr=lf, env=denv,
                          start_new_session=True, cwd=os.path.dirname(_me()))
     # wait for the state file to appear with a live port
     for _ in range(100):
@@ -671,9 +702,22 @@ def _serve():
         return get_stretch(f, idx, robust)
 
     def do_tile(q, z, x, y):
+        # native pure-python engine first; LOCAL files it can't read (BigTIFF,
+        # user-defined CRS, exotic compression) fall back to rasterio below.
+        # Mount-backed files keep the old 404 (rasterio can't range-read them
+        # through /api/fs/raw) so the page falls back to tiff_reader.py.
+        try:
+            return _tile_native(q, z, x, y)
+        except Exception:
+            f = os.path.abspath(os.path.expanduser(q1(q, "file") or ""))
+            if not os.path.exists(f):
+                return 404, b"unsupported", "text/plain"
+            return _tile_rio(q, z, x, y)
+
+    def _tile_native(q, z, x, y):
         f = open_file(q1(q, "file"), q1(q, "src"))
         if not f["supported"]:
-            return 404, b"unsupported", "text/plain"
+            raise ValueError("unsupported by native engine")
         want_rgb, idx = render_params(q, f)
         st = parse_stretch(q, f, idx, want_rgb)
         mx0, my0, mx1, my1 = tile_bbox(z, x, y)
@@ -872,6 +916,152 @@ def _serve():
                 for k in range(count)]
         return 200, json.dumps({"values": vals}).encode(), "application/json"
 
+    # ------------- forced-level tiles (rasterio — any compression) -------
+    # /ltile/{z}/{x}/{y}.png?file=&level=N renders ONLY from pyramid level N
+    # (0 = full res), reprojected to web mercator. Used by the overview-
+    # pyramid template to compare levels honestly on a basemap.
+    _lvl_cache = {}
+    _lvl_lock = threading.Lock()
+    # rasterio dataset handles are NOT thread-safe: concurrent vrt.read() from
+    # the threaded server corrupts libtiff state (TIFFReadEncodedTile failures,
+    # then a dead process). All reads through cached VRTs go through this lock.
+    _rio_read_lock = threading.Lock()
+
+    def _lvl_vrt(file, level):
+        import rasterio
+        from rasterio.enums import Resampling
+        from rasterio.vrt import WarpedVRT
+        key = (file, level, os.path.getmtime(file))
+        with _lvl_lock:
+            if key in _lvl_cache:
+                return _lvl_cache[key]
+            kw = {} if level <= 0 else {"overview_level": level - 1}
+            src = rasterio.open(file, **kw)
+            vrt = WarpedVRT(src, crs="EPSG:3857", resampling=Resampling.nearest)
+            _lvl_cache[key] = vrt
+            return vrt
+
+    def _render_level(file, level, z, x, y, stretch=None, cmap=None):
+        from rasterio.enums import Resampling
+        from rasterio.windows import Window
+        vrt = _lvl_vrt(file, level)
+        mx0, my0, mx1, my1 = tile_bbox(z, x, y)
+        rgba = np.zeros((TILE, TILE, 4), "uint8")
+        # nearest SOURCE pixel per output pixel, computed in source index
+        # space: pasting a fractionally-rounded resampled window instead puts
+        # pixel edges in different places per tile (non-square pixels when
+        # zoomed past the level's resolution)
+        T = vrt.transform
+        xs = mx0 + (np.arange(TILE) + 0.5) * (mx1 - mx0) / TILE
+        ys = my1 + (np.arange(TILE) + 0.5) * (my0 - my1) / TILE
+        cols = np.floor((xs - T.c) / T.a).astype("int64")
+        rows = np.floor((ys - T.f) / T.e).astype("int64")
+        okc = (cols >= 0) & (cols < vrt.width)
+        okr = (rows >= 0) & (rows < vrt.height)
+        if okc.any() and okr.any():
+            c0, c1 = int(cols[okc].min()), int(cols[okc].max()) + 1
+            r0, r1 = int(rows[okr].min()), int(rows[okr].max()) + 1
+            ow, oh = min(c1 - c0, TILE), min(r1 - r0, TILE)
+            win = Window(c0, r0, c1 - c0, r1 - r0)
+            n = min(3, vrt.count)
+            with _rio_read_lock:
+                data = vrt.read(indexes=list(range(1, n + 1)), window=win,
+                                out_shape=(n, oh, ow), resampling=Resampling.nearest)
+                msk = vrt.read_masks(1, window=win, out_shape=(oh, ow),
+                                     resampling=Resampling.nearest)
+            ci = np.clip((cols - c0) * ow // (c1 - c0), 0, ow - 1)
+            ri = np.clip((rows - r0) * oh // (r1 - r0), 0, oh - 1)
+            sub = data[:, ri[:, None], ci[None, :]]
+            m2 = msk[ri[:, None], ci[None, :]].copy()
+            m2[~okr, :] = 0
+            m2[:, ~okc] = 0
+            if n == 1 and cmap:
+                vals = sub[0].astype("float64")
+                lo, hi = stretch[0] if stretch else (
+                    np.percentile(vals[m2 > 0], [2, 98]) if (m2 > 0).any()
+                    else (0.0, 1.0))
+                lut = R._lut(cmap)
+                t = np.clip((vals - lo) / max(hi - lo, 1e-9), 0, 1)
+                rgba[:, :, :3] = lut[(t * 255).astype("uint8")]
+            else:
+                if sub.dtype != np.uint8:  # 2–98% stretch for non-8-bit
+                    d = sub.astype("float64")
+                    good = np.broadcast_to(m2 > 0, d.shape)
+                    for k in range(n):
+                        if stretch:
+                            lo, hi = stretch[k if k < len(stretch) else 0]
+                        else:
+                            g = d[k][good[k]]
+                            lo, hi = (np.percentile(g, [2, 98]) if g.size
+                                      else (0.0, 1.0))
+                        d[k] = np.clip((d[k] - lo) / max(hi - lo, 1e-9), 0, 1) * 255
+                    sub = d.astype("uint8")
+                px = np.transpose(sub, (1, 2, 0))
+                if n < 3:
+                    px = np.repeat(px[:, :, :1], 3, axis=2)
+                rgba[:, :, :3] = px
+            rgba[:, :, 3] = np.where(m2 > 0, 255, 0)
+        return 200, R.encode_png(np.ascontiguousarray(rgba)), "image/png"
+
+    def do_ltile(q, z, x, y):
+        file = os.path.abspath(os.path.expanduser(q1(q, "file")))
+        # global stretch (sampled once, coarsest level) — a per-tile stretch
+        # gives every tile its own contrast and the map shows seams
+        return _render_level(file, int(q1(q, "level", "0")), z, x, y,
+                             stretch=_rio_stretch(file))
+
+    def _rio_meta(file):
+        import rasterio
+        key = ("meta", file, os.path.getmtime(file))
+        with _lvl_lock:
+            if key in _lvl_cache:
+                return _lvl_cache[key]
+        with rasterio.open(file) as src:
+            factors = [1] + list(src.overviews(1))
+        meta = {"factors": factors, "res0": _lvl_vrt(file, 0).transform.a}
+        with _lvl_lock:
+            _lvl_cache[key] = meta
+        return meta
+
+    def _rio_stretch(file):
+        """Global 2–98% stretch sampled once from the coarsest level, so every
+        tile shares the same contrast (no per-tile seams)."""
+        key = ("stretch", file, os.path.getmtime(file))
+        with _lvl_lock:
+            if key in _lvl_cache:
+                return _lvl_cache[key]
+        m = _rio_meta(file)
+        vrt = _lvl_vrt(file, len(m["factors"]) - 1)
+        n = min(3, vrt.count)
+        oh, ow = max(1, min(512, vrt.height)), max(1, min(512, vrt.width))
+        with _rio_read_lock:
+            data = vrt.read(indexes=list(range(1, n + 1)), out_shape=(n, oh, ow))
+            msk = vrt.read_masks(1, out_shape=(oh, ow))
+        st = []
+        d = data.astype("float64")
+        for k in range(n):
+            g = d[k][msk > 0]
+            lo, hi = (np.percentile(g, [2, 98]) if g.size else (0.0, 1.0))
+            st.append((float(lo), float(hi if hi > lo else lo + 1)))
+        with _lvl_lock:
+            _lvl_cache[key] = st
+        return st
+
+    def _tile_rio(q, z, x, y):
+        """Rasterio fallback for local files the native engine can't read:
+        picks the overview level a COG reader would and renders through the
+        WarpedVRT."""
+        file = os.path.abspath(os.path.expanduser(q1(q, "file")))
+        m = _rio_meta(file)
+        mx0, my0, mx1, my1 = tile_bbox(z, x, y)
+        target = (mx1 - mx0) / TILE
+        level = 0
+        for i, fac in enumerate(m["factors"]):
+            if m["res0"] * fac <= target:
+                level = i
+        return _render_level(file, level, z, x, y, stretch=_rio_stretch(file),
+                             cmap=q1(q, "cmap", "viridis"))
+
     # ---------------- HTTP ----------------
     class H(BaseHTTPRequestHandler):
         def log_message(self, *a):
@@ -894,6 +1084,11 @@ def _serve():
                     z, x = int(parts[2]), int(parts[3])
                     y = int(parts[4].split(".")[0])
                     code, body, ct = do_tile(q, z, x, y)
+                elif u.path.startswith("/ltile/"):
+                    parts = u.path.split("/")   # '', 'ltile', z, x, 'y.png'
+                    z, x = int(parts[2]), int(parts[3])
+                    y = int(parts[4].split(".")[0])
+                    code, body, ct = do_ltile(q, z, x, y)
                 elif u.path == "/meta":
                     code, body, ct = do_meta(q)
                 elif u.path == "/hist":

--- a/fused_render/templates/pyramid/README.md
+++ b/fused_render/templates/pyramid/README.md
@@ -1,0 +1,38 @@
+# pyramid — overview-pyramid inspector & fixer for GeoTIFFs
+
+Second `.tif`/`.tiff` mode (after the default geotiff viewer). Makes a file's
+resolution pyramid tangible, and fixes files that don't have one.
+
+## What it shows
+
+- **3D pyramid** — every resolution level rendered as a real layer (true data,
+  not a mockup): dimensions, ground resolution, bytes on disk, internal tile
+  grid straight from the IFDs. Click a level to focus, click again to inspect
+  face-on, ↑/↓ to step levels, drag to orbit.
+- **Same-ground patch** — the same geographic window read from each level at
+  its native resolution, so you can *see* what each level throws away.
+- **On the map** — swipe any two levels against each other on a basemap at
+  their true resolutions (via the geotiff daemon's `/ltile` endpoint), plus an
+  "auto" mode that picks the level a COG reader would fetch at the current
+  zoom.
+- **COG health & fix** — rio-cogeo validation verdict; when the file has no
+  pyramid (or an invalid layout) a fix panel offers:
+  - *Add overviews in place* (gdaladdo-style append, keeps the file's codec)
+  - *Write a proper COG copy* (rio-cogeo `cog_translate` + validate), with
+    per-codec size predictions sampled from the file's real blocks
+  - long jobs run detached (runPython has a 30s budget) with a progress modal
+    polling a status file under `~/.cache/fused-render-compressbench/jobs/`.
+
+## Files
+
+| file | role |
+|---|---|
+| `template.html` | the view |
+| `overview_pyramid.py` | reader: analyze / predict / build / cogify / status |
+| `icon.svg` | mode-switcher icon |
+
+The reader manages its own uv venv (`~/.cache/fused-render-compressbench`,
+rasterio + rio-cogeo + tifffile + pillow) so it works from the app's bundled
+python. The map tab reuses the **geotiff template's tile daemon** via the
+relative path `../geotiff/tile_server.py` — one shared daemon, no respawn
+fights between the two modes.

--- a/fused_render/templates/pyramid/icon.svg
+++ b/fused_render/templates/pyramid/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linejoin="round">
+  <path d="M12 3l4 2.4-4 2.4-4-2.4z"/>
+  <path d="M12 9.5l6 3.4-6 3.4-6-3.4z" opacity=".75"/>
+  <path d="M12 16l8 4.4H4z" opacity=".5"/>
+</svg>

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -1,0 +1,462 @@
+"""COG overview pyramid — every resolution level of a GeoTIFF as real data:
+dimensions, ground resolution, bytes on disk, tile counts, plus two rendered
+previews per level (whole-image thumbnail + a fixed center crop at native
+pixels, so you can SEE the detail each level throws away).
+
+Uses rasterio + pillow + tifffile in the shared raster venv
+(~/.cache/fused-render-compressbench — same env as cog_doctor /
+compression playground, one install between the three tools).
+"""
+
+VENV_DIR_NAME = "fused-render-compressbench"
+VENV_DEPS = ["rasterio", "numpy", "pillow", "rio-cogeo", "tifffile"]
+
+WORKER = r'''
+import base64, io, json, math, os, sys
+import numpy as np
+import rasterio
+import tifffile
+from PIL import Image
+
+path = sys.argv[1]
+action = sys.argv[2] if len(sys.argv) > 2 else "analyze"
+opts = json.loads(sys.argv[3]) if len(sys.argv) > 3 else {}
+THUMB = 800          # max px for whole-image previews (small levels stay native)
+CROP_CAP = 512       # max stored px for the same-ground crops
+
+def emit(obj):
+    """Print the result AND (for detached build/cogify jobs) persist it to the
+    job status file the UI polls."""
+    sf = opts.get("status_file")
+    if sf:
+        tmp = sf + ".tmp"
+        with open(tmp, "w") as f:
+            json.dump(obj, f)
+        os.replace(tmp, sf)
+    print(json.dumps(obj))
+
+def fail(msg):
+    emit({"error": msg, "state": "error"})
+    sys.exit(0)
+
+def overview_factors(w, h):
+    """Halve until the largest dimension drops below one tile (512px)."""
+    factors, f = [], 2
+    while max(w, h) / f >= 512:
+        factors.append(f)
+        f *= 2
+    return factors or [2]
+
+def gdal_env_for(compression, dtype, bands):
+    """Overview-creation options matching the file's own codec."""
+    comp = (compression or "").upper().replace("ADOBE_DEFLATE", "DEFLATE")
+    env = {}
+    if comp and comp != "NONE":
+        env["COMPRESS_OVERVIEW"] = comp
+    if comp in ("DEFLATE", "LZW", "ZSTD"):
+        env["PREDICTOR_OVERVIEW"] = "3" if dtype.startswith("float") else "2"
+    if comp == "JPEG":
+        env["JPEG_QUALITY_OVERVIEW"] = "85"
+        if bands == 3:
+            env["PHOTOMETRIC_OVERVIEW"] = "YCBCR"
+            env["INTERLEAVE_OVERVIEW"] = "PIXEL"
+    return env
+
+# ---------- side actions (build / cogify / predict) ----------
+
+if action == "build":
+    # append internal overviews to the file IN PLACE (gdaladdo-style)
+    from rasterio.enums import Resampling
+    before = os.path.getsize(path)
+    with rasterio.open(path) as src:
+        if src.overviews(1):
+            fail("file already has overviews")
+        factors = overview_factors(src.width, src.height)
+        env = gdal_env_for(src.profile.get("compress"), src.dtypes[0], src.count)
+    rs = opts.get("resampling") or "average"
+    try:
+        with rasterio.Env(**env):
+            with rasterio.open(path, "r+") as ds:
+                ds.build_overviews(factors, Resampling[rs])
+    except Exception as e:
+        fail(f"build_overviews failed: {type(e).__name__}: {e}")
+    emit({"ok": True, "state": "done", "mode": "in-place", "factors": factors,
+          "resampling": rs, "before": before, "after": os.path.getsize(path)})
+    sys.exit(0)
+
+if action == "cogify":
+    # full rewrite to a sibling file with a proper COG layout, then validate
+    from rio_cogeo.cogeo import cog_translate, cog_validate
+    from rio_cogeo.profiles import cog_profiles
+    prof = opts.get("profile") or "deflate"
+    dst = opts.get("out") or os.path.splitext(path)[0] + "_cog.tif"
+    if os.path.abspath(dst) == os.path.abspath(path):
+        fail("output would overwrite the input — pick another name")
+    if os.path.exists(dst) and not opts.get("overwrite"):
+        fail(f"already exists: {dst}")
+    try:
+        p = cog_profiles.get(prof)
+        cog_translate(path, dst, p, quiet=True, web_optimized=False,
+                      overview_resampling=opts.get("resampling") or "average")
+        valid, errors, warnings = cog_validate(dst, quiet=True)
+    except Exception as e:
+        if os.path.exists(dst):
+            os.remove(dst)
+        fail(f"cog_translate failed: {type(e).__name__}: {e}")
+    emit({"ok": True, "state": "done", "mode": "cogify", "out": dst, "profile": prof,
+          "before": os.path.getsize(path), "after": os.path.getsize(dst),
+          "valid": bool(valid), "errors": list(errors), "warnings": list(warnings)})
+    sys.exit(0)
+
+if action == "predict":
+    # sample real blocks, recompress with candidate codecs, extrapolate sizes
+    from rasterio.io import MemoryFile
+    with rasterio.open(path) as src:
+        w, h, bands, dtype = src.width, src.height, src.count, src.dtypes[0]
+        raw_total = w * h * bands * np.dtype(dtype).itemsize
+        win = 1024
+        # 5×5 grid incl. edges — corner/edge windows catch nodata margins that
+        # compress to nothing; a center-heavy sample overestimates by ~30%
+        fracs = (0.02, 0.25, 0.5, 0.75, 0.98)
+        samples = []
+        for fy in fracs:
+            for fx in fracs:
+                cx = min(max(0, int(w * fx) - win // 2), max(0, w - win))
+                cy = min(max(0, int(h * fy) - win // 2), max(0, h - win))
+                samples.append(src.read(window=rasterio.windows.Window(
+                    cx, cy, min(win, w), min(win, h))))
+        nodata = src.nodata
+    # candidate codecs = the exact rio-cogeo profiles cogify would use, so the
+    # prediction measures what cog_translate will actually write
+    from rio_cogeo.profiles import cog_profiles
+    cands = ["deflate", "zstd", "lzw"]
+    if dtype == "uint8" and bands >= 3:
+        cands = ["jpeg", "webp"] + cands
+    rows = []
+    for comp in cands:
+        # pyramid = +1/3 pixels; resampled data compresses ~1.5× worse than the
+        # base under lossless codecs (measured on DEMs), same under jpeg/webp
+        ov_frac = (1 / 3) * (1.0 if comp in ("jpeg", "webp") else 1.5)
+        try:
+            base_prof = {k: v for k, v in dict(cog_profiles.get(comp)).items()
+                         if k not in ("driver", "interleave")}
+            cbytes = rbytes = 0
+            for arr in samples:
+                a = arr[:3] if comp in ("jpeg", "webp") else arr
+                prof = {"driver": "GTiff", "width": a.shape[2], "height": a.shape[1],
+                        "count": a.shape[0], "dtype": dtype, **base_prof}
+                with MemoryFile() as mem:
+                    with mem.open(**prof) as tmp:
+                        tmp.write(a)
+                    cbytes += len(mem.read())
+                rbytes += a.nbytes
+            ratio = cbytes / max(1, rbytes)
+            base = ratio * raw_total
+            rows.append({"profile": comp, "ratio": round(ratio, 4),
+                         "est_base": int(base),
+                         "est_total": int(base * (1 + ov_frac))})
+        except Exception:
+            continue  # codec unsupported in this build — drop the row
+    print(json.dumps({"ok": True, "raw_bytes": int(raw_total),
+                      "current_bytes": os.path.getsize(path), "rows": rows,
+                      "note": "sampled 25 windows with rio-cogeo's own profiles; "
+                              "overview overhead modeled as +33% pixels"}))
+    sys.exit(0)
+
+# ---------- default action: analyze ----------
+
+def png64(arr, cap=None):
+    """(bands, h, w) array -> base64 PNG. uint8 passes through as true color;
+    other dtypes get a per-band 2-98% stretch."""
+    raw = np.asarray(arr)
+    if raw.ndim == 2:
+        raw = raw[None]
+    raw = raw[:3] if raw.shape[0] >= 3 else raw[:1]
+    if raw.dtype == np.uint8:
+        img = np.transpose(raw, (1, 2, 0))
+        im = Image.fromarray(img[:, :, 0] if img.shape[2] == 1 else img)
+        if cap and max(im.size) > cap:
+            r = cap / max(im.size)
+            im = im.resize((max(1, round(im.size[0] * r)), max(1, round(im.size[1] * r))),
+                           Image.NEAREST)
+        buf = io.BytesIO()
+        im.save(buf, "PNG", optimize=True)
+        return base64.b64encode(buf.getvalue()).decode()
+    a = raw.astype("float64")
+    out = np.empty(a.shape, dtype="uint8")
+    for i, band in enumerate(a):
+        finite = band[np.isfinite(band)]
+        if finite.size == 0:
+            out[i] = 0
+            continue
+        lo, hi = np.percentile(finite, (2, 98))
+        if hi <= lo:
+            lo, hi = finite.min(), max(finite.max(), finite.min() + 1)
+        out[i] = np.clip((np.nan_to_num(band, nan=lo) - lo) / (hi - lo) * 255, 0, 255)
+    img = np.transpose(out, (1, 2, 0))
+    im = Image.fromarray(img[:, :, 0] if img.shape[2] == 1 else img)
+    if cap and max(im.size) > cap:
+        r = cap / max(im.size)
+        im = im.resize((max(1, round(im.size[0] * r)), max(1, round(im.size[1] * r))),
+                       Image.NEAREST)
+    buf = io.BytesIO()
+    im.save(buf, "PNG", optimize=True)
+    return base64.b64encode(buf.getvalue()).decode()
+
+try:
+    src0 = rasterio.open(path)
+except Exception as e:
+    fail(f"not a readable raster: {type(e).__name__}: {e}")
+
+with src0:
+    n_ov = len(src0.overviews(1))
+    crs = str(src0.crs) if src0.crs else None
+    crs_name = None
+    try:
+        if src0.crs:
+            from pyproj import CRS as _PC
+            _pc = _PC.from_wkt(src0.crs.to_wkt())
+            _epsg = _pc.to_epsg()
+            crs_name = f"EPSG:{_epsg}" if _epsg else (_pc.name or None)
+    except Exception:
+        pass
+    unit = None
+    try:
+        unit = src0.crs.linear_units if src0.crs and src0.crs.is_projected else (
+            "degree" if src0.crs else None)
+    except Exception:
+        pass
+    bounds = list(src0.bounds)
+    bounds4326 = None
+    try:
+        from rasterio.warp import transform_bounds
+        if src0.crs:
+            bounds4326 = list(transform_bounds(src0.crs, "EPSG:4326", *src0.bounds))
+    except Exception:
+        pass
+    dtype = str(src0.dtypes[0])
+    nbands = src0.count
+
+# ---- byte accounting per IFD via tifffile (no decode, tags only) ----
+ifds = []
+try:
+    with tifffile.TiffFile(path) as tf:
+        for pg in tf.pages:
+            try:
+                h, w = pg.imagelength, pg.imagewidth
+            except Exception:
+                continue
+            ifds.append({
+                "w": w, "h": h,
+                "bytes": int(sum(pg.databytecounts or [0])),
+                "offset": int(min(pg.dataoffsets)) if pg.dataoffsets else None,
+                "tiled": pg.is_tiled,
+                "tile": [pg.tilelength, pg.tilewidth] if pg.is_tiled else None,
+                "compression": str(pg.compression.name).lower(),
+                "reduced": bool(pg.is_reduced),
+            })
+except Exception as e:
+    fail(f"could not parse TIFF structure: {type(e).__name__}: {e}")
+
+def ifd_for(w, h):
+    for d in ifds:
+        if d["w"] == w and d["h"] == h:
+            return d
+    return None
+
+# ---- one entry per resolution level (level 0 = full res) ----
+# All crops cover the SAME center ground patch (a window `base` level-0 pixels
+# wide), each read at that level's own resolution — the quality comparison.
+levels = []
+file_size = os.path.getsize(path)
+w0 = h0 = base = None
+for lvl in range(-1, n_ov):
+    kw = {} if lvl < 0 else {"overview_level": lvl}
+    with rasterio.open(path, **kw) as src:
+        w, h = src.width, src.height
+        px = src.transform.a
+        if lvl < 0:
+            w0, h0 = w, h
+            base = min(max(256, w0 // 16), w0, h0)
+        tw = min(THUMB, w)
+        th = max(1, round(h * tw / w))
+        thumb = png64(src.read(out_shape=(src.count, th, tw)))
+        c = max(4, round(base * w / w0))
+        win = rasterio.windows.Window((w - c) // 2, (h - c) // 2, c, c)
+        crop = png64(src.read(window=win), cap=CROP_CAP)
+        d = ifd_for(w, h) or {}
+        blk = d.get("tile") or [src.block_shapes[0][0], src.block_shapes[0][1]]
+        levels.append({
+            "level": lvl + 1, "width": w, "height": h,
+            "pixel_size": abs(px), "unit": unit,
+            "bytes": d.get("bytes"), "offset": d.get("offset"),
+            "pct": round(100 * d["bytes"] / file_size, 2) if d.get("bytes") else None,
+            "compression": d.get("compression"),
+            "tiled": d.get("tiled"), "block": blk,
+            "n_blocks": math.ceil(w / blk[1]) * math.ceil(h / blk[0]),
+            "thumb": thumb, "crop": crop, "crop_px": c,
+            "crop_ground": base * abs(levels[0]["pixel_size"]) if levels else base * abs(px),
+        })
+
+masks = [d for d in ifds if not any(d["w"] == l["width"] and d["h"] == l["height"] for l in levels)]
+
+# ---- COG health + "what would fixing cost" estimate ----
+try:
+    from rio_cogeo.cogeo import cog_validate
+    _v, _e, _w = cog_validate(path, quiet=True)
+    cog = {"valid": bool(_v), "errors": list(_e), "warnings": list(_w)}
+except Exception as e:
+    cog = {"valid": None, "errors": [f"validator unavailable: {e}"], "warnings": []}
+fix = None
+if n_ov == 0:
+    factors = overview_factors(w0, h0)
+    ov_px = sum(math.ceil(w0 / f) * math.ceil(h0 / f) for f in factors)
+    l0d = ifd_for(w0, h0) or {}
+    bpp = (l0d.get("bytes") or file_size) / (w0 * h0)   # measured compressed bytes/px at L0
+    comp0 = (l0d.get("compression") or "").lower()
+    # resampled data packs ~1.5× worse under lossless codecs; jpeg/webp are
+    # unaffected and uncompressed bytes are exact (+33% pixels = +33% bytes)
+    penalty = 1.5 if comp0 not in ("jpeg", "webp", "none", "") else 1.0
+    fix = {"factors": factors, "n_new_levels": len(factors),
+           "ov_pixels_pct": round(100 * ov_px / (w0 * h0), 1),
+           "est_extra_bytes": int(ov_px * bpp * penalty),
+           "src_compression": l0d.get("compression"), "tiled": bool(l0d.get("tiled"))}
+
+print(json.dumps({
+    "file_size": file_size, "crs": crs, "crs_name": crs_name,
+    "dtype": dtype, "bands": nbands,
+    "bounds": bounds, "bounds4326": bounds4326,
+    "cog": cog, "fix": fix,
+    "n_overviews": n_ov, "levels": levels,
+    "extra_ifds": [{k: d[k] for k in ("w", "h", "bytes", "compression")} for d in masks],
+    "accounted": sum(l["bytes"] or 0 for l in levels) + sum(d["bytes"] for d in masks),
+}))
+'''
+
+
+def _venv_python():
+    import os
+    import shutil
+    import subprocess
+    cache = os.path.expanduser(f"~/.cache/{VENV_DIR_NAME}")
+    vpy = os.path.join(cache, "venv", "bin", "python")
+    marker = os.path.join(cache, "deps_ok_pyramid")
+    if os.path.exists(vpy) and os.path.exists(marker):
+        return vpy
+    uv = shutil.which("uv") or os.path.expanduser("~/.local/bin/uv")
+    if not os.path.exists(uv) and not shutil.which("uv"):
+        raise RuntimeError(
+            "The overview pyramid needs the 'uv' tool to set up rasterio. "
+            "Install it with: brew install uv — or: curl -LsSf https://astral.sh/uv/install.sh | sh")
+    os.makedirs(cache, exist_ok=True)
+    env = {k: v for k, v in os.environ.items() if k not in ("PYTHONHOME", "PYTHONPATH")}
+    if not os.path.exists(vpy):
+        subprocess.run([uv, "venv", "--python", "3.12", os.path.join(cache, "venv")],
+                       check=True, capture_output=True, env=env)
+    subprocess.run([uv, "pip", "install", "-p", vpy] + VENV_DEPS,
+                   check=True, capture_output=True, env=env)
+    open(marker, "w").write("ok")
+    return vpy
+
+
+def main(file: str = "", action: str = "analyze", resampling: str = "",
+         profile: str = "", out: str = "", overwrite: str = ""):
+    import json
+    import os
+    import subprocess
+    import tempfile
+
+    if not file:
+        return {"error": "no file selected — pass a .tif/.tiff path"}
+    file = os.path.abspath(os.path.expanduser(file))
+    if not os.path.isfile(file):
+        return {"error": f"not a file: {file}"}
+    if os.path.splitext(file)[1].lower() not in (".tif", ".tiff"):
+        return {"error": "the overview pyramid only reads .tif/.tiff files"}
+    if action not in ("analyze", "build", "cogify", "predict", "status"):
+        return {"error": f"unknown action: {action}"}
+    opts = {k: v for k, v in [("resampling", resampling), ("profile", profile),
+                              ("out", out), ("overwrite", overwrite)] if v}
+
+    def alive(pid):
+        try:
+            os.kill(pid, 0)
+            return True
+        except Exception:
+            return False
+
+    jobs = os.path.expanduser(f"~/.cache/{VENV_DIR_NAME}/jobs")
+    import hashlib
+    key = hashlib.md5(f"{file}|{action}|{opts.get('out', '')}".encode()).hexdigest()[:16]
+
+    if action == "status":
+        # poll a detached job: `out` carries the status_key returned by build/cogify
+        if not out or not out.isalnum():
+            return {"error": "status needs the job key in the 'out' param"}
+        sf = os.path.join(jobs, out + ".json")
+        if not os.path.exists(sf):
+            return {"error": "no such job"}
+        st = json.load(open(sf))
+        if st.get("state") == "running":
+            watch = st.get("watch") or file
+            st["cur_size"] = os.path.getsize(watch) if os.path.exists(watch) else 0
+            if st.get("pid") and not alive(st["pid"]):
+                st["state"] = "error"
+                st["error"] = "worker process died without reporting a result"
+        return st
+
+    try:
+        vpy = _venv_python()
+    except RuntimeError as e:
+        return {"error": str(e)}
+    except Exception as e:  # noqa: BLE001
+        return {"error": f"venv setup failed: {type(e).__name__}: {e}"}
+    env = {k: v for k, v in os.environ.items() if k not in ("PYTHONHOME", "PYTHONPATH")}
+
+    if action in ("build", "cogify"):
+        # too slow for the app's 30s runPython budget → detach and poll
+        import time
+        os.makedirs(jobs, exist_ok=True)
+        sf = os.path.join(jobs, key + ".json")
+        wfile = os.path.join(jobs, key + ".py")
+        watch = opts.get("out") or (os.path.splitext(file)[0] + "_cog.tif"
+                                    if action == "cogify" else file)
+        if os.path.exists(sf):
+            st = json.load(open(sf))
+            if st.get("state") == "running" and st.get("pid") and alive(st["pid"]):
+                return {"ok": True, "started": True, "already_running": True,
+                        "status_key": key, "watch": watch}
+        opts["status_file"] = sf
+        open(wfile, "w").write(WORKER)
+        st = {"state": "running", "pid": None, "action": action, "watch": watch,
+              "before": os.path.getsize(file), "started": time.time()}
+        json.dump(st, open(sf, "w"))
+        proc = subprocess.Popen([vpy, wfile, file, action, json.dumps(opts)],
+                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                                start_new_session=True, env=env)
+        st["pid"] = proc.pid
+        json.dump(st, open(sf, "w"))
+        return {"ok": True, "started": True, "status_key": key, "watch": watch,
+                "before": st["before"]}
+
+    with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as f:
+        f.write(WORKER)
+        wpath = f.name
+    try:
+        proc = subprocess.run([vpy, wpath, file, action, json.dumps(opts)],
+                              capture_output=True, text=True, timeout=900, env=env)
+        if proc.returncode != 0:
+            tail = (proc.stderr or "").strip().splitlines()
+            return {"error": "worker failed: " + (tail[-1] if tail else "unknown error")}
+        result = json.loads(proc.stdout)
+    finally:
+        os.remove(wpath)
+    result["file"] = file
+    return result
+
+
+try:
+    import fused as _fused
+    _udf_main = _fused.udf(main)
+except ImportError:
+    pass

--- a/fused_render/templates/pyramid/template.html
+++ b/fused_render/templates/pyramid/template.html
@@ -1,0 +1,994 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Overview pyramid</title>
+<link href="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.css" rel="stylesheet">
+<script src="https://unpkg.com/maplibre-gl@5.6.0/dist/maplibre-gl.js" crossorigin="anonymous"></script>
+<style>
+  :root {
+    --bg: #16181d; --panel: #1e2128; --border: #2c313a;
+    --text: #e6e9ef; --dim: #9aa3b2; --accent: #4a9eff; --good: #4caf7d; --warn: #e6b34a; --bad: #e66;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body { margin: 0; background: var(--bg); color: var(--text); display: flex; flex-direction: column;
+    font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  .topbar { display: flex; align-items: center; gap: 10px; padding: 10px 16px;
+    border-bottom: 1px solid var(--border); }
+  .topbar h1 { font-size: 15px; margin: 0; white-space: nowrap; }
+  #file-in { flex: 1; background: var(--panel); border: 1px solid var(--border); color: var(--text);
+    border-radius: 8px; padding: 7px 11px; font: 12px ui-monospace, Menlo, monospace; outline: none; }
+  #file-in:focus { border-color: var(--accent); }
+  button { background: var(--accent); color: #0c1016; border: none; border-radius: 8px;
+    padding: 7px 14px; font-weight: 600; cursor: pointer; font-size: 13px; }
+  #status { font-size: 12px; color: var(--dim); white-space: nowrap; }
+  #status.err { color: var(--bad); }
+  .main { flex: 1; display: grid; grid-template-columns: 430px 1fr; min-height: 0; }
+  .left { overflow: auto; border-right: 1px solid var(--border); padding: 12px;
+    display: flex; flex-direction: column; }
+  .left > * { flex: 0 0 auto; }
+  /* the ground-patch square absorbs whatever height is left → no scrolling */
+  #crop-flex { flex: 1 1 0; min-height: 150px; display: flex; justify-content: center;
+    align-items: flex-start; }
+  .chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 10px; }
+  .chip { background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    padding: 4px 10px; font-size: 12px; color: var(--dim); }
+  .chip b { color: var(--text); }
+  h2 { font-size: 12px; text-transform: uppercase; letter-spacing: .5px; color: var(--dim); margin: 12px 0 6px; }
+  .panel { background: var(--panel); border: 1px solid var(--border); border-radius: 8px; padding: 12px; }
+  .err-panel { border-color: #5c2a2a; color: var(--bad); white-space: pre-wrap; word-break: break-word; }
+  .hint { color: var(--dim); font-size: 11.5px; margin-top: 8px; }
+
+  /* patch-in-context: dimmed full level around the sharp dashed patch */
+  #crop-wrap { position: relative; aspect-ratio: 1; overflow: hidden; border-radius: 8px;
+    border: 1.5px solid var(--c, var(--border)); background: #000;
+    height: 100%; max-height: 100%; max-width: 100%; }
+  #crop-wrap .ctx { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%);
+    filter: brightness(.32) saturate(.7); image-rendering: pixelated; max-width: none; }
+  #crop-big { position: absolute; left: 15%; top: 15%; width: 70%; height: 70%;
+    image-rendering: pixelated; outline: 2px dashed #fff; box-shadow: 0 0 24px #000; }
+  #crop-cap { font-size: 12px; color: var(--dim); margin-top: 6px; }
+  #crop-cap b { color: var(--text); }
+
+  /* byte bars */
+  .sb { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; cursor: pointer; }
+  .sb .track { flex: 1; height: 17px; background: var(--panel); border: 1px solid var(--border);
+    border-radius: 6px; overflow: hidden; position: relative; }
+  .sb .fill { position: absolute; inset: 0 auto 0 0; background: var(--c); opacity: .85; border-radius: 5px 0 0 5px; }
+  .sb .txt { position: absolute; left: 8px; top: 0; line-height: 17px; font-size: 10.5px; color: #fff;
+    text-shadow: 0 1px 3px #000; white-space: nowrap; }
+  .sb .lv { width: 26px; font-size: 11.5px; font-weight: 700; color: var(--c); text-align: right; }
+  .sb.sel .track { border-color: var(--c); }
+
+  table.kv { border-collapse: collapse; width: 100%; font-size: 12.5px; }
+  table.kv td { padding: 3px 6px 3px 0; vertical-align: top; }
+  table.kv td:first-child { color: var(--dim); white-space: nowrap; width: 118px; }
+  #bar { position: relative; height: 26px; border: 1px solid var(--border); border-radius: 8px;
+    overflow: hidden; background: var(--panel); }
+  #bar .seg { position: absolute; top: 0; height: 100%; min-width: 2px; cursor: pointer; opacity: .8; }
+  #bar .seg.sel { opacity: 1; outline: 2px solid #fff; outline-offset: -2px; z-index: 2; }
+
+  /* ---- right pane + tabs ---- */
+  .right { position: relative; overflow: hidden; min-height: 0; }
+  #tabs { position: absolute; top: 12px; left: 14px; z-index: 20; display: flex; gap: 6px; }
+  .tab-btn { background: var(--panel); border: 1px solid var(--border); color: var(--dim);
+    padding: 5px 13px; font-size: 12.5px; border-radius: 8px; }
+  .tab-btn.sel { color: #0c1016; background: var(--accent); border-color: var(--accent); }
+  .pane { position: absolute; inset: 0; }
+
+  /* ---- 3D pyramid pane ---- */
+  #tab-pyr { cursor: grab; user-select: none;
+    background: radial-gradient(ellipse 75% 60% at 50% 45%, #1c2230 0%, var(--bg) 78%); }
+  #tab-pyr.dragging { cursor: grabbing; }
+  #scene { position: absolute; inset: 0; perspective: 1500px; }
+  #stack { position: absolute; left: 50%; top: 50%; width: 0; height: 0;
+    transform-style: preserve-3d; will-change: transform; }
+  .layer { position: absolute; transform-style: preserve-3d; cursor: pointer;
+    transition: opacity .45s, filter .15s; }
+  .layer img { display: block; width: 100%; height: 100%; border-radius: 4px;
+    border: 1.5px solid var(--c);
+    box-shadow: 0 0 20px 1px color-mix(in srgb, var(--c) 40%, transparent); background: #000; }
+  .layer img.px { image-rendering: pixelated; }
+  .layer .grid { position: absolute; inset: 0; opacity: 0; transition: opacity .4s;
+    pointer-events: none; border-radius: 4px;
+    box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--c) 90%, #fff);
+    background-image:
+      linear-gradient(to right, color-mix(in srgb, var(--c) 90%, #fff) 1.5px, transparent 1.5px),
+      linear-gradient(to bottom, color-mix(in srgb, var(--c) 90%, #fff) 1.5px, transparent 1.5px); }
+  .layer.zoomed .grid { opacity: .85; }
+  .layer .patch { position: absolute; opacity: 0; transition: opacity .4s; pointer-events: none;
+    border: 2px dashed #fff; box-shadow: 0 0 10px #000c, inset 0 0 10px #000c; }
+  .layer.zoomed .patch { opacity: .95; }
+  .layer.sel img { border-width: 2.5px;
+    box-shadow: 0 0 34px 5px color-mix(in srgb, var(--c) 70%, transparent); }
+  .layer:hover { filter: brightness(1.22); }
+  .layer.dim { opacity: .13; }                       /* focus mode: others stay clickable */
+  .layer.dim:hover { opacity: .45; filter: none; }
+  .layer.faded { opacity: .06; pointer-events: none; }  /* inspect mode: others inert */
+  .lbl { position: absolute; white-space: nowrap; font-size: 12px; color: var(--dim);
+    pointer-events: none; text-shadow: 0 1px 4px #000; transition: opacity .3s; z-index: 3; }
+  .lbl b { color: var(--text); font-size: 12.5px; }
+  .lbl .res { color: var(--c); font-weight: 600; }
+  .lbl::before { content: ""; position: absolute; right: 100%; top: 55%; width: 26px; height: 1px;
+    background: linear-gradient(to left, var(--dim), transparent); margin-right: 5px; opacity: .6; }
+  #scene-hint { position: absolute; left: 0; right: 0; bottom: 12px; text-align: center;
+    color: var(--dim); font-size: 12px; pointer-events: none; z-index: 4; }
+  #lvl-nav { position: absolute; top: 12px; left: 50%; transform: translateX(-50%);
+    display: flex; gap: 6px; z-index: 5; }
+  .lvl-chip { background: var(--panel); border: 1px solid var(--border); color: var(--dim);
+    padding: 4px 11px; font-size: 12px; border-radius: 8px; }
+  .lvl-chip.sel { color: #0c1016; background: var(--c); border-color: var(--c); }
+  #grid-cap { position: absolute; top: 46px; left: 50%; transform: translateX(-50%);
+    background: color-mix(in srgb, var(--panel) 88%, transparent); border: 1px solid var(--border);
+    border-radius: 8px; padding: 5px 12px; font-size: 12px; color: var(--dim);
+    display: none; z-index: 5; white-space: nowrap; }
+  #grid-cap b { color: var(--text); }
+  #zoom-btn, #reset-btn { position: absolute; right: 14px; bottom: 14px; z-index: 5; display: none;
+    background: var(--panel); color: var(--text); border: 1px solid var(--border); }
+
+  /* ---- map compare pane ---- */
+  #tab-map { display: none; }
+  #cmp { position: absolute; inset: 0; }
+  #mapA, #mapB { position: absolute; inset: 0; }
+  #mapB-wrap { position: absolute; inset: 0; pointer-events: none; }
+  #swipe { position: absolute; top: 0; bottom: 0; width: 26px; margin-left: -13px; z-index: 10;
+    cursor: ew-resize; }
+  #swipe::before { content: ""; position: absolute; left: 12px; top: 0; bottom: 0; width: 2px;
+    background: #fff; opacity: .85; box-shadow: 0 0 8px #000; }
+  #swipe::after { content: "⇔"; position: absolute; left: 50%; top: 50%; transform: translate(-50%,-50%);
+    background: #fff; color: #0c1016; border-radius: 50%; width: 30px; height: 30px;
+    line-height: 30px; text-align: center; font-size: 15px; font-weight: 700; box-shadow: 0 2px 8px #000a; }
+  .side-tag { position: absolute; top: 52px; z-index: 9; background: color-mix(in srgb, var(--panel) 90%, transparent);
+    border: 1px solid var(--border); border-radius: 8px; padding: 5px 11px; font-size: 12.5px; color: var(--dim); }
+  .side-tag b { color: var(--c); }
+  #map-ctl { position: absolute; left: 50%; transform: translateX(-50%); bottom: 14px; z-index: 11;
+    background: color-mix(in srgb, var(--panel) 94%, transparent); border: 1px solid var(--border);
+    border-radius: 10px; padding: 9px 13px; display: flex; flex-direction: column; gap: 7px; }
+  .ctl-row { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--dim); }
+  .ctl-row .who { width: 78px; text-align: right; }
+  .mchip { background: var(--bg); border: 1px solid var(--border); color: var(--dim);
+    padding: 3px 9px; font-size: 11.5px; border-radius: 7px; }
+  .mchip.sel { color: #0c1016; background: var(--c); border-color: var(--c); }
+  .mchip:disabled { opacity: .4; cursor: default; }
+  #hud { font-size: 11.5px; color: var(--dim); text-align: center; min-height: 15px; }
+  #hud b { color: var(--accent); }
+  #map-err { position: absolute; inset: 0; display: none; align-items: center; justify-content: center;
+    color: var(--dim); z-index: 12; }
+
+  /* ---- job modal (build / cogify progress) ---- */
+  #job-modal { position: fixed; inset: 0; z-index: 100; display: none;
+    align-items: center; justify-content: center; background: #000a;
+    backdrop-filter: blur(3px); }
+  #job-modal.on { display: flex; }
+  .jm-card { background: var(--panel); border: 1px solid var(--border); border-radius: 14px;
+    padding: 22px 26px; width: 440px; box-shadow: 0 14px 60px #000d; }
+  .jm-card h3 { margin: 0 0 3px; font-size: 15px; }
+  #jm-sub { color: var(--dim); font-size: 12.5px; margin-bottom: 16px;
+    font-family: ui-monospace, Menlo, monospace; }
+  .jm-track { height: 10px; border-radius: 6px; background: var(--bg);
+    border: 1px solid var(--border); overflow: hidden; }
+  #jm-fill { height: 100%; width: 0%; border-radius: 6px; transition: width .9s linear;
+    background: repeating-linear-gradient(-45deg, var(--accent) 0 12px, #6fb4ff 12px 24px);
+    background-size: 34px 100%; animation: jm-slide 1.2s linear infinite; }
+  @keyframes jm-slide { to { background-position: 34px 0; } }
+  #jm-txt { font-size: 12px; color: var(--text); margin-top: 9px; }
+  #jm-note { font-size: 11.5px; color: var(--dim); margin-top: 14px; }
+  #jm-hide { color: var(--accent); cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="topbar">
+  <h1>Overview pyramid</h1>
+  <input id="file-in" placeholder="/absolute/path/to/raster.tif (COG or plain GeoTIFF)" spellcheck="false">
+  <button id="an-btn">Analyze</button>
+  <span id="status"></span>
+</div>
+<div class="main">
+  <div class="left" id="left">
+    <div class="panel" style="color:var(--dim);font-size:13px">Every resolution level of a GeoTIFF.
+      <b>3D pyramid</b>: click a level to focus it (camera stays put), click again or hit the zoom
+      button to inspect it face-on; drag to orbit, scroll to zoom.
+      <b>On the map</b>: swipe two levels against each other at real resolution on a basemap.
+      First run installs rasterio (~1 min).</div>
+  </div>
+  <div class="right" id="right">
+    <div id="tabs">
+      <button class="tab-btn sel" data-t="pyr">3D pyramid</button>
+      <button class="tab-btn" data-t="map">On the map</button>
+    </div>
+
+    <div class="pane" id="tab-pyr">
+      <div id="scene-hint"></div>
+      <div id="lvl-nav"></div>
+      <div id="grid-cap"></div>
+      <div id="scene"><div id="stack"></div></div>
+      <button id="zoom-btn"></button>
+      <button id="reset-btn">↩ back to pyramid (Esc)</button>
+    </div>
+
+    <div class="pane" id="tab-map">
+      <div id="cmp">
+        <div id="mapA"></div>
+        <div id="mapB-wrap"><div id="mapB"></div></div>
+        <div id="swipe"></div>
+        <div class="side-tag" id="tag-a" style="left:14px"></div>
+        <div class="side-tag" id="tag-b" style="right:14px"></div>
+        <div id="map-ctl">
+          <div class="ctl-row"><span class="who">left of handle</span><span id="chips-a"></span>
+            <label style="margin-left:10px"><input type="checkbox" id="auto-a"> auto — pick like a COG reader</label></div>
+          <div class="ctl-row"><span class="who">right of handle</span><span id="chips-b"></span></div>
+          <div id="hud"></div>
+        </div>
+        <div id="map-err"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="job-modal"><div class="jm-card">
+  <h3 id="jm-title"></h3>
+  <div id="jm-sub"></div>
+  <div class="jm-track"><div id="jm-fill"></div></div>
+  <div id="jm-txt"></div>
+  <div id="jm-note">Runs in a detached local worker — leaving this page will <b>not</b> cancel it.
+    <span id="jm-hide">hide (keeps running)</span></div>
+</div></div>
+
+<script>
+window.addEventListener("error", (e) => {
+  const el = document.getElementById("status");
+  if (el) { el.textContent = "JS error: " + e.message + " @" + (e.lineno || "?"); el.className = "err"; }
+});
+const READER = "./overview_pyramid.py";
+// the sibling geotiff template's daemon — the SAME copy the .tif viewer
+// ensures, so the two modes share one daemon instead of respawning each
+// other's (relative py paths resolve against this template's folder)
+const TILE_SERVER = "../geotiff/tile_server.py";
+const DEMO = "";
+const $ = (id) => document.getElementById(id);
+const setStatus = (m, err) => { $("status").textContent = m; $("status").className = err ? "err" : ""; };
+const human = (n) => { if (n == null) return "?"; for (const u of ["B","KB","MB","GB"]) { if (n < 1024 || u === "GB") return u === "B" ? n + " B" : n.toFixed(1) + " " + u; n /= 1024; } };
+function esc(s) { const d = document.createElement("span"); d.textContent = s ?? "";
+  return d.innerHTML.replaceAll('"', "&quot;").replaceAll("'", "&#39;"); }
+function showError(msg) { setStatus("error", true);
+  $("left").innerHTML = `<div class="panel err-panel">${esc(msg)}</div>`;
+  $("stack").innerHTML = ""; $("scene-hint").textContent = ""; $("lvl-nav").innerHTML = ""; }
+const COLORS = ["#4a9eff", "#5ac8d8", "#4caf7d", "#e6b34a", "#e88a4a", "#e66", "#b07ce8", "#e88ab0"];
+let R = null, sel = 0;
+let focused = -1;          // highlighted level, camera keeps its tilt
+let zoomed = -1;           // face-on inspect mode
+let orbit = null;          // camera snapshot to restore when leaving inspect
+let layerGeom = [], homeTz = 0, stackFile = null;
+const HOME = { rx: 62, rz: 45, s: 1 };
+let view = { ...HOME, tz: 0 };
+
+function metersPerPx(l) {
+  if (!R.bounds4326) return null;
+  const lat = (R.bounds4326[1] + R.bounds4326[3]) / 2;
+  if (l.unit && l.unit.startsWith("met")) return l.pixel_size;
+  if (R.crs === "EPSG:4326" || (l.unit || "").startsWith("deg"))
+    return l.pixel_size * 111320 * Math.cos(lat * Math.PI / 180);
+  return l.unit ? l.pixel_size : null;
+}
+const fmtRes = (l) => {
+  const m = metersPerPx(l);
+  if (m == null) return l.pixel_size.toPrecision(3) + (l.unit ? " " + l.unit : " units") + "/px";
+  return m >= 1000 ? (m / 1000).toPrecision(3) + " km/px" : m.toPrecision(3) + " m/px";
+};
+const zoomEq = (l) => {
+  const m = metersPerPx(l);
+  if (m == null || !R.bounds4326) return null;
+  const lat = (R.bounds4326[1] + R.bounds4326[3]) / 2;
+  return Math.log2(156543.03 * Math.cos(lat * Math.PI / 180) / m);
+};
+const groundKm = () => {
+  const m = metersPerPx(R.levels[0]);
+  if (m == null) return null;
+  const km = R.levels[0].crop_ground / R.levels[0].pixel_size * m / 1000;
+  return km >= 1 ? km.toFixed(1) + " km" : Math.round(km * 1000) + " m";
+};
+
+async function analyze(file) {
+  if (!file) { setStatus("no file — paste a path above", true); return; }
+  setStatus("reading levels… (first run installs rasterio)");
+  let res;
+  try { res = await fused.runPython(READER, { file }); }
+  catch (e) { showError("reader failed: " + (e.message || e)); return; }
+  if (res.error) { showError(res.error); return; }
+  R = res; sel = 0;
+  cmp.inited = false;
+  // as a template mode the shell owns the file (_file param) — writing our own
+  // file param there would fight it and pin the demo path into the URL
+  if (!fused.params.get("_file")) fused.params.set("file", file);
+  $("file-in").value = file;
+  setStatus("");
+  buildScene();
+  renderLeft();
+  // debug/deep-link (read-only): ?tab=map | ?level=N (focus) | &inspect=1 (fly onto it)
+  // | ?rx/rz/s camera | ?click=N synthetic chip click
+  if (fused.params.get("tab") === "map") switchTab("map");
+  const pl = parseInt(fused.params.get("level"), 10);
+  if (!Number.isNaN(pl) && pl >= 0 && pl < R.levels.length) {
+    if (fused.params.get("inspect") === "1") zoomTo(pl);
+    else focusLayer(pl);
+  }
+  let dirty = false;
+  for (const k of ["rx", "rz", "s"]) {
+    const v = parseFloat(fused.params.get(k));
+    if (!Number.isNaN(v)) { view[k] = v; dirty = true; }
+  }
+  if (dirty) applyView(false);
+  const ck = parseInt(fused.params.get("click"), 10);
+  if (!Number.isNaN(ck)) setTimeout(() => {
+    const el = document.querySelector(`.lvl-chip[data-i="${ck}"]`);
+    if (el) el.click();
+  }, 800);
+  // headless debug only: ?fix=build|cog exercises the real button path once
+  const fx = fused.params.get("fix");
+  if (fx && !window.__fixClicked) {
+    window.__fixClicked = true;
+    setTimeout(() => $(fx === "cog" ? "fix-cog-toggle" : "fix-build")?.click(), 800);
+  }
+}
+
+/* ================= tabs ================= */
+
+let tab = "pyr";
+function switchTab(t) {
+  tab = t;
+  document.querySelectorAll(".tab-btn").forEach(b => b.classList.toggle("sel", b.dataset.t === t));
+  $("tab-pyr").style.display = t === "pyr" ? "block" : "none";
+  $("tab-map").style.display = t === "map" ? "block" : "none";
+  if (t === "map" && R) initCompare();
+}
+document.querySelectorAll(".tab-btn").forEach(b => b.addEventListener("click", () => switchTab(b.dataset.t)));
+
+/* ================= 3D pyramid ================= */
+
+function buildScene() {
+  const right = $("right");
+  const sw = right.clientWidth, sh = right.clientHeight;
+  const n = R.levels.length;
+  const W0 = Math.min(sw, sh) * 0.58;
+  const gap = Math.min(150, Math.max(70, (Math.min(sh, 760) * 0.62) / Math.max(1, n - 1)));
+  layerGeom = R.levels.map((l, i) => {
+    const scale = Math.pow(l.width / R.levels[0].width, 0.55);
+    const w = W0 * scale;
+    return { w, h: w * (l.height / l.width), z: i * gap };
+  });
+  homeTz = -(n - 1) * gap / 2;
+  if (stackFile !== R.file) {                 // new file → fresh state + camera
+    stackFile = R.file;
+    focused = -1; zoomed = -1; orbit = null;
+    view = { ...HOME, tz: homeTz };
+  } else if (zoomed >= 0) view = flyView(zoomed);
+  else view.tz = focused >= 0 ? -layerGeom[focused].z : homeTz;
+  if (!window.__urlCamDone)
+    for (const k of ["rx", "rz", "s"]) {
+      const v = parseFloat(fused.params.get(k));
+      if (!Number.isNaN(v)) view[k] = v;
+    }
+  $("scene-hint").innerHTML = `${esc(R.file.split("/").pop())} — click a level to focus · click again to zoom onto it · ↑/↓ to step levels · drag to orbit · scroll to zoom`;
+  $("lvl-nav").innerHTML = R.levels.map((l, i) =>
+    `<button class="lvl-chip" data-i="${i}" style="--c:${COLORS[i % COLORS.length]}">L${l.level}</button>`).join("");
+  $("lvl-nav").querySelectorAll(".lvl-chip").forEach(el =>
+    el.addEventListener("click", (e) => { e.stopPropagation(); focusLayer(+el.dataset.i); }));
+  $("stack").innerHTML = R.levels.map((l, i) => {
+    const g = layerGeom[i], c = COLORS[i % COLORS.length];
+    const N = Math.min(l.width, 800);
+    const Nh = N * (l.height / l.width);
+    const gx = N * l.block[1] / l.width, gy = Nh * l.block[0] / l.height;
+    return `
+      <div class="layer ${i === sel ? "sel" : ""}" data-i="${i}" style="--c:${c};width:${N}px;height:${Nh}px;
+        left:${-N / 2}px;top:${-Nh / 2}px;transform:translateZ(${g.z}px) scale(${g.w / N})">
+        <img class="${l.width <= 800 ? "px" : ""}" src="data:image/png;base64,${l.thumb}" alt="level ${l.level}" draggable="false">
+        ${l.tiled ? `<div class="grid" style="background-size:${gx}px ${gy}px"></div>` : ""}
+        <div class="patch" style="width:${N * l.crop_px / l.width}px;height:${Nh * l.crop_px / l.height}px;
+          left:${N * (1 - l.crop_px / l.width) / 2}px;top:${Nh * (1 - l.crop_px / l.height) / 2}px"></div>
+      </div>`;
+  }).join("");
+  document.querySelectorAll(".lbl").forEach(el => el.remove());
+  R.levels.forEach((l, i) => {
+    const el = document.createElement("div");
+    el.className = "lbl";
+    el.dataset.i = i;
+    el.style.setProperty("--c", COLORS[i % COLORS.length]);
+    el.innerHTML = `<b>L${l.level}</b> ${l.level === 0 ? "full res" : "overview"} · ${l.width.toLocaleString()}×${l.height.toLocaleString()}<br>
+      <span class="res">${fmtRes(l)}</span> · ${human(l.bytes)}${l.pct != null ? ` <span style="opacity:.7">(${l.pct}%)</span>` : ""}`;
+    $("tab-pyr").appendChild(el);
+  });
+  $("stack").querySelectorAll(".layer").forEach(el => {
+    el.addEventListener("click", (e) => {
+      e.stopPropagation();
+      if (justDragged) return;
+      const i = +el.dataset.i;
+      if (zoomed < 0 && focused === i) zoomTo(i);   // second click dives in
+      else focusLayer(i);
+    });
+  });
+  applyView(false);
+}
+
+function flyView(i) {
+  const right = $("right");
+  const g = layerGeom[i];
+  const fit = 0.74 * Math.min(right.clientWidth, right.clientHeight) / Math.max(g.w, g.h);
+  return { rx: 0, rz: 0, s: fit, tz: -g.z };
+}
+
+function updateGridCap(i) {
+  const l = R.levels[i];
+  const bw = l.block[1], bh = l.block[0];
+  const cols = Math.ceil(l.width / bw), rows = Math.ceil(l.height / bh);
+  const remW = l.width - (cols - 1) * bw, remH = l.height - (rows - 1) * bh;
+  const partial = (remW !== bw || remH !== bh)
+    ? ` · edge tiles are partial: only ${remW}×${remH} of their pixels are real` : "";
+  $("grid-cap").innerHTML = (l.tiled
+    ? `L${l.level} internal tiling (from the IFD): <b>${bw}×${bh}</b> px tiles →
+       <b>${cols}×${rows} = ${cols * rows}</b> tile${cols * rows === 1 ? "" : "s"}${partial}`
+    : `L${l.level} is stored as <b>strips</b>, not tiles`)
+    + ` · dashed square = the ${l.crop_px}×${l.crop_px}px patch at left`;
+  $("grid-cap").style.setProperty("--c", COLORS[i % COLORS.length]);
+}
+
+// focus: highlight a level WITHOUT moving the user's camera (only a gentle
+// slide along the stack axis so the focused level is centered)
+function focusLayer(i) {
+  select(i);
+  switchTab("pyr");
+  if (zoomed >= 0) {              // already inspecting → fly between levels
+    zoomed = i;
+    view = flyView(i);
+    applyView(true);
+    updateGridCap(i);
+    return;
+  }
+  focused = i;
+  view.tz = -layerGeom[i].z;
+  applyView(true);
+  updateGridCap(i);
+}
+
+function zoomTo(i) {
+  select(i);
+  if (zoomed < 0) orbit = { rx: view.rx, rz: view.rz, s: view.s };
+  focused = i;
+  zoomed = i;
+  view = flyView(i);
+  applyView(true);
+  updateGridCap(i);
+}
+
+function unzoom() {               // leave inspect → restore the orbit, keep focus
+  zoomed = -1;
+  const o = orbit || HOME;
+  view = { rx: o.rx, rz: o.rz, s: o.s, tz: focused >= 0 ? -layerGeom[focused].z : homeTz };
+  applyView(true);
+}
+
+function clearFocus() {
+  focused = -1;
+  view.tz = homeTz;
+  applyView(true);
+}
+
+function applyView(animate = true) {
+  const st = $("stack");
+  st.style.transition = animate ? "transform .6s cubic-bezier(.22,.85,.3,1)" : "none";
+  st.style.transform = `rotateX(${view.rx}deg) rotateZ(${view.rz}deg) scale(${view.s}) translateZ(${view.tz}px)`;
+  const hot = zoomed >= 0 ? zoomed : focused;
+  document.querySelectorAll(".layer").forEach(el => {
+    const i = +el.dataset.i;
+    el.classList.toggle("faded", zoomed >= 0 && i !== zoomed);
+    el.classList.toggle("dim", zoomed < 0 && focused >= 0 && i !== focused);
+    el.classList.toggle("zoomed", i === hot);
+  });
+  document.querySelectorAll(".lvl-chip").forEach(el =>
+    el.classList.toggle("sel", +el.dataset.i === hot));
+  $("grid-cap").style.display = hot >= 0 ? "block" : "none";
+  $("reset-btn").style.display = zoomed >= 0 ? "block" : "none";
+  const zb = $("zoom-btn");
+  zb.style.display = (zoomed < 0 && focused >= 0) ? "block" : "none";
+  if (focused >= 0) zb.textContent = `⤢ zoom into L${R.levels[focused].level}`;
+}
+
+let justDragged = false;
+{
+  const pane = $("tab-pyr");
+  let drag = null;
+  pane.addEventListener("pointerdown", (e) => {
+    if (e.button !== 0) return;
+    // do NOT capture here: with capture active, Chrome dispatches the click
+    // to the pane instead of the chip/layer under the cursor — capture only
+    // once an actual drag starts (below)
+    drag = { x: e.clientX, y: e.clientY, moved: false, id: e.pointerId };
+  });
+  pane.addEventListener("pointermove", (e) => {
+    if (!drag) return;
+    const dx = e.clientX - drag.x, dy = e.clientY - drag.y;
+    if (!drag.moved && Math.hypot(dx, dy) < 4) return;
+    if (!drag.moved) { try { pane.setPointerCapture(drag.id); } catch (_) {} }
+    drag.moved = true;
+    window.__urlCamDone = true;
+    pane.classList.add("dragging");
+    view.rz += dx * 0.35;
+    view.rx = Math.max(0, Math.min(88, view.rx - dy * 0.3));
+    drag.x = e.clientX; drag.y = e.clientY;
+    applyView(false);
+  });
+  const back = () => { if (zoomed >= 0) unzoom(); else if (focused >= 0) clearFocus(); };
+  const end = (e) => {
+    justDragged = !!(drag && drag.moved);
+    if (drag && !drag.moved && e.target === pane) back();
+    drag = null;
+    pane.classList.remove("dragging");
+    setTimeout(() => { justDragged = false; }, 0);
+  };
+  pane.addEventListener("pointerup", end);
+  pane.addEventListener("pointercancel", () => { drag = null; pane.classList.remove("dragging"); });
+  pane.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    window.__urlCamDone = true;
+    view.s = Math.max(0.3, Math.min(30, view.s * Math.exp(-e.deltaY * 0.0015)));
+    applyView(false);
+  }, { passive: false });
+  window.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") { back(); return; }
+    // ↑/↓ (or ←/→) step through the pyramid levels
+    if (!["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight"].includes(e.key)) return;
+    if (!R || tab !== "pyr") return;
+    if (e.target && /INPUT|SELECT|TEXTAREA/.test(e.target.tagName)) return;
+    e.preventDefault();
+    const dir = (e.key === "ArrowUp" || e.key === "ArrowRight") ? 1 : -1;
+    const cur = zoomed >= 0 ? zoomed : focused;
+    const start = cur >= 0 ? cur + dir : (dir > 0 ? 0 : R.levels.length - 1);
+    const nxt = Math.max(0, Math.min(R.levels.length - 1, start));
+    if (nxt !== cur) focusLayer(nxt);
+  });
+  $("reset-btn").addEventListener("click", unzoom);
+  $("zoom-btn").addEventListener("click", () => { if (focused >= 0) zoomTo(focused); });
+}
+
+(function labelLoop() {
+  if (R && tab === "pyr") {
+    const rr = $("tab-pyr").getBoundingClientRect();
+    document.querySelectorAll(".lbl").forEach(el => {
+      const i = +el.dataset.i;
+      const layer = document.querySelector(`.layer[data-i="${i}"]`);
+      if (!layer) { el.style.opacity = 0; return; }
+      const b = layer.getBoundingClientRect();
+      const show = zoomed >= 0 ? false : (focused >= 0 ? i === focused : true);
+      el.style.opacity = show ? 1 : 0;
+      el.style.left = Math.min(b.right - rr.left + 32, rr.width - 230) + "px";
+      el.style.top = Math.max(52, b.top - rr.top + b.height / 2 - 16) + "px";
+    });
+  }
+  requestAnimationFrame(labelLoop);
+})();
+
+/* ================= map compare ================= */
+
+const cmp = { inited: false, A: null, B: null, la: 0, lb: 0, auto: true, port: null };
+
+async function ensureTileDaemon() {
+  if (cmp.port !== null) return cmp.port;
+  cmp.port = 0;
+  if (TILE_SERVER) {
+    try {
+      const r = await fused.runPython(TILE_SERVER, { action: "ensure" });
+      if (r && r.port) cmp.port = r.port;
+    } catch (e) { /* fall back to thumbnails */ }
+  }
+  return cmp.port;
+}
+
+function ovlCoords() {
+  const b = R.bounds4326;
+  return [[b[0], b[3]], [b[2], b[3]], [b[2], b[1]], [b[0], b[1]]];
+}
+
+function setOverlay(map, idx) {
+  // real per-level tiles from the local daemon (honest resolution at any zoom);
+  // falls back to the ≤800px thumbnail overlay when the daemon is unavailable
+  const old = map.getSource("ovl");
+  if (cmp.port) {
+    const tiles = [`http://127.0.0.1:${cmp.port}/ltile/{z}/{x}/{y}.png?file=${encodeURIComponent(R.file)}&level=${idx}`];
+    if (old && old.setTiles) { old.setTiles(tiles); return; }
+    if (old) { map.removeLayer("ovl"); map.removeSource("ovl"); }
+    map.addSource("ovl", { type: "raster", tiles, tileSize: 256 });
+    map.addLayer({ id: "ovl", type: "raster", source: "ovl",
+      paint: { "raster-resampling": "nearest", "raster-fade-duration": 0 } });
+  } else {
+    const url = "data:image/png;base64," + R.levels[idx].thumb;
+    if (old && old.updateImage) { old.updateImage({ url, coordinates: ovlCoords() }); return; }
+    if (old) { map.removeLayer("ovl"); map.removeSource("ovl"); }
+    map.addSource("ovl", { type: "image", url, coordinates: ovlCoords() });
+    map.addLayer({ id: "ovl", type: "raster", source: "ovl",
+      paint: { "raster-resampling": "nearest", "raster-fade-duration": 0 } });
+  }
+}
+
+function sideTag(el, idx, autoNote) {
+  const l = R.levels[idx];
+  el.style.setProperty("--c", COLORS[idx % COLORS.length]);
+  el.innerHTML = `<b>L${l.level}</b> · ${l.width.toLocaleString()}×${l.height.toLocaleString()} · ${fmtRes(l)}${autoNote || ""}`;
+}
+
+function applySides() {
+  if (!cmp.A || !cmp.B) return;
+  setOverlay(cmp.A, cmp.la);
+  setOverlay(cmp.B, cmp.lb);
+  sideTag($("tag-a"), cmp.la, cmp.auto ? " (auto)" : "");
+  sideTag($("tag-b"), cmp.lb);
+  ["a", "b"].forEach(s => {
+    const cur = s === "a" ? cmp.la : cmp.lb;
+    $("chips-" + s).querySelectorAll(".mchip").forEach(el => {
+      el.classList.toggle("sel", +el.dataset.i === cur);
+      el.style.setProperty("--c", COLORS[+el.dataset.i % COLORS.length]);
+      if (s === "a") el.disabled = cmp.auto;
+    });
+  });
+}
+
+function autoPick() {
+  if (!cmp.auto || !cmp.A) return;
+  const z = cmp.A.getZoom();
+  let best = 0, bd = 1e9;
+  R.levels.forEach((l, i) => {
+    const ze = zoomEq(l);
+    if (ze == null) return;
+    const d = Math.abs(ze - z);
+    if (d < bd - 1e-9) { bd = d; best = i; }
+  });
+  const zeBest = zoomEq(R.levels[best]);
+  $("hud").innerHTML = `map is at z<b>${z.toFixed(1)}</b> → a COG reader fetches
+    <b style="color:${COLORS[best % COLORS.length]}">L${R.levels[best].level}</b>
+    (${fmtRes(R.levels[best])} ≈ z${zeBest.toFixed(0)}) — zoom in/out to watch it switch`;
+  if (best !== cmp.la) { cmp.la = best; applySides(); }
+}
+
+function initCompare() {
+  if (cmp.inited) { setTimeout(() => { cmp.A && cmp.A.resize(); cmp.B && cmp.B.resize(); }, 0); return; }
+  if (typeof maplibregl === "undefined") {
+    $("map-err").style.display = "flex";
+    $("map-err").textContent = "Map library unavailable (no network to unpkg.com).";
+    return;
+  }
+  if (!R.bounds4326) {
+    $("map-err").style.display = "flex";
+    $("map-err").textContent = "This file has no usable CRS — cannot place it on a map.";
+    return;
+  }
+  cmp.inited = true;
+  cmp.la = 0;
+  cmp.lb = R.levels.length - 1;
+  const pla = parseInt(fused.params.get("la"), 10);
+  const plb = parseInt(fused.params.get("lb"), 10);
+  if (pla >= 0 && pla < R.levels.length) cmp.la = pla;
+  if (plb >= 0 && plb < R.levels.length) cmp.lb = plb;
+  if (fused.params.get("auto") === "0") cmp.auto = false;
+  const style = "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json";
+  const b = R.bounds4326;
+  const opts = { style, bounds: [[b[0], b[1]], [b[2], b[3]]], fitBoundsOptions: { padding: 60 },
+                 attributionControl: false };
+  if (cmp.A) { cmp.A.remove(); cmp.B.remove(); cmp.A = cmp.B = null; }
+  try {
+    cmp.A = new maplibregl.Map({ container: "mapA", ...opts });
+    cmp.B = new maplibregl.Map({ container: "mapB", ...opts, interactive: false });
+  } catch (e) {
+    $("map-err").style.display = "flex";
+    $("map-err").textContent = "Map cannot start (WebGL unavailable): " + (e.message || e);
+    cmp.A = cmp.B = null;
+    return;
+  }
+  cmp.A.addControl(new maplibregl.NavigationControl({ showCompass: false }));
+  let ready = 0;
+  const onReady = () => {
+    if (++ready !== 2) return;
+    const mz = parseFloat(fused.params.get("mz"));
+    if (!Number.isNaN(mz)) cmp.A.jumpTo({ center: [(b[0] + b[2]) / 2, (b[1] + b[3]) / 2], zoom: mz });
+    applySides();      // thumbnails paint immediately…
+    autoPick();
+    ensureTileDaemon().then(p => { if (p) applySides(); });   // …then upgrade to real tiles
+  };
+  cmp.A.on("load", onReady);
+  cmp.B.on("load", onReady);
+  cmp.A.on("move", () => {
+    cmp.B.jumpTo({ center: cmp.A.getCenter(), zoom: cmp.A.getZoom(),
+                   bearing: cmp.A.getBearing(), pitch: cmp.A.getPitch() });
+    autoPick();
+  });
+  for (const s of ["a", "b"]) {
+    $("chips-" + s).innerHTML = R.levels.map((l, i) =>
+      `<button class="mchip" data-i="${i}">L${l.level}</button>`).join(" ");
+    $("chips-" + s).querySelectorAll(".mchip").forEach(el =>
+      el.addEventListener("click", () => {
+        if (s === "a") { cmp.la = +el.dataset.i; } else { cmp.lb = +el.dataset.i; }
+        applySides();
+      }));
+  }
+  $("auto-a").checked = cmp.auto;
+  $("auto-a").addEventListener("change", () => {
+    cmp.auto = $("auto-a").checked;
+    applySides();
+    autoPick();
+    if (!cmp.auto) $("hud").textContent = "";
+  });
+  const cmpEl = $("cmp"), sw = $("swipe"), wrap = $("mapB-wrap");
+  const setX = (frac) => {
+    const w = cmpEl.clientWidth;
+    const x = Math.max(40, Math.min(w - 40, frac * w));
+    sw.style.left = x + "px";
+    wrap.style.clipPath = `inset(0 0 0 ${x}px)`;
+    sw.dataset.frac = x / w;
+  };
+  setX(0.5);
+  let dragging = false;
+  sw.addEventListener("pointerdown", (e) => { dragging = true; sw.setPointerCapture(e.pointerId); });
+  window.addEventListener("pointermove", (e) => {
+    if (!dragging) return;
+    setX((e.clientX - cmpEl.getBoundingClientRect().left) / cmpEl.clientWidth);
+  });
+  window.addEventListener("pointerup", () => { dragging = false; });
+  window.addEventListener("resize", () => setX(parseFloat(sw.dataset.frac || "0.5")));
+}
+
+/* ================= build / cogify panel ================= */
+
+const RESAMPLINGS = ["average", "nearest", "bilinear", "cubic", "gauss", "mode"];
+const cogOut = () => R.file.replace(/\.tiff?$/i, "") + "_cog.tif";
+
+function cogSectionHtml() {
+  return `
+    <div id="fix-cog" style="display:none;margin-top:10px;border-top:1px solid var(--border);padding-top:10px">
+      <div class="hint" style="margin:0 0 8px">Full rewrite to <b>${esc(cogOut().split("/").pop())}</b>
+        with a proper COG layout — original untouched. The codec changes the size a lot:</div>
+      <div id="predict-out" class="hint" style="margin:0 0 8px">measuring real blocks…</div>
+      <div style="display:flex;gap:8px;align-items:center;font-size:12.5px;color:var(--dim)">
+        codec <select id="fix-prof"></select>
+        <button id="fix-run-cog">Create COG copy</button>
+      </div>
+    </div>
+    <div id="fix-prog" class="hint" style="margin-top:8px"></div>`;
+}
+
+function fixPanelHtml() {
+  if (R.fix) {
+    const mpx = (R.levels[0].width * R.levels[0].height / 1e6).toFixed(0);
+    return `
+    <div class="panel" id="fix-panel" style="border-color:#5c4a22;margin-bottom:14px">
+      <div style="font-weight:700;color:var(--warn);margin-bottom:4px">No overview pyramid</div>
+      <div class="hint" style="margin:0 0 8px">Every zoomed-out view has to chew through all
+        <b>${mpx} Mpx</b> of L0 — that's why this file feels slow on a map.</div>
+      <table class="kv">
+        <tr><td>would add</td><td><b>${R.fix.n_new_levels}</b> level${R.fix.n_new_levels === 1 ? "" : "s"} (÷${R.fix.factors.join(", ÷")})</td></tr>
+        <tr><td>estimated cost</td><td>≈ <b>+${human(R.fix.est_extra_bytes)}</b>
+          (${human(R.file_size)} → ~${human(R.file_size + R.fix.est_extra_bytes)})</td></tr>
+        <tr><td>resampling</td><td><select id="fix-rs">${RESAMPLINGS.map(r =>
+          `<option>${r}</option>`).join("")}</select></td></tr>
+      </table>
+      <div style="display:flex;gap:8px;margin-top:10px">
+        <button id="fix-build">⚒ Add overviews in place</button>
+        <button id="fix-cog-toggle" style="background:var(--bg);color:var(--text);border:1px solid var(--border)">COG copy…</button>
+      </div>
+      ${cogSectionHtml()}
+    </div>`;
+  }
+  if (R.cog && R.cog.valid === false) {
+    // pyramid exists (map + pyramid work fine locally) but the layout can't
+    // serve cheap HTTP range reads — typical after an in-place overview append
+    return `
+    <div class="panel" id="fix-panel" style="margin-bottom:14px">
+      <div style="font-weight:700;color:var(--warn);margin-bottom:4px">Pyramid ✓ — but not a valid COG layout</div>
+      <div class="hint" style="margin:0 0 8px">All levels are present, so local viewing is fast.
+        The layout just isn't ordered for cheap HTTP range reads (typical after an in-place
+        overview append) — only matters when serving from object storage.</div>
+      <details style="margin:0 0 10px">
+        <summary class="hint" style="cursor:pointer;margin:0">validator findings (${(R.cog.errors || []).length})</summary>
+        <div class="hint" style="margin:6px 0 0;color:var(--dim)">${
+          (R.cog.errors || []).map(e => `· ${esc(e)}`).join("<br>")}</div>
+      </details>
+      <button id="fix-cog-toggle" style="background:var(--bg);color:var(--text);border:1px solid var(--border)">Write a proper COG copy…</button>
+      ${cogSectionHtml()}
+    </div>`;
+  }
+  return "";
+}
+
+// progress modal — visible focus while a job runs, but never a real block:
+// the worker is detached, so hiding the modal or leaving the page is safe
+const jm = {
+  hidden: false,
+  open(title, sub) {
+    this.hidden = false;
+    $("jm-title").textContent = title;
+    $("jm-sub").textContent = sub;
+    $("jm-fill").style.width = "2%";
+    $("jm-txt").textContent = "starting…";
+    $("job-modal").classList.add("on");
+  },
+  progress(frac, txt) {
+    $("jm-fill").style.width = Math.min(98, Math.max(2, frac * 100)).toFixed(1) + "%";
+    $("jm-txt").textContent = txt;
+  },
+  close() { $("job-modal").classList.remove("on"); },
+};
+$("jm-hide").addEventListener("click", () => { jm.hidden = true; jm.close(); });
+
+// launch a detached reader job (build/cogify escape the app's 30s budget) and
+// poll its status file until it reports done
+async function runJob(params, onProgress) {
+  const r = await fused.runPython(READER, params);
+  if (r.error) throw new Error(r.error);
+  if (!r.started) return r;
+  for (;;) {
+    await new Promise(res => setTimeout(res, 2000));
+    const st = await fused.runPython(READER,
+      { file: params.file, action: "status", out: r.status_key });
+    if (st.state === "done") return st;
+    if (st.state === "error" || st.error) throw new Error(st.error || "job failed");
+    if (onProgress) onProgress(st.cur_size || 0, st.before || 0);
+  }
+}
+
+function wireFixPanel() {
+  const panel = $("fix-panel");
+  if (!panel) return;
+  const prog = (m, err) => { const el = $("fix-prog");
+    el.innerHTML = m; el.style.color = err ? "var(--bad)" : "var(--dim)"; };
+  const busy = (on) => panel.querySelectorAll("button, select").forEach(b => { b.disabled = on; });
+
+  if ($("fix-build")) $("fix-build").addEventListener("click", async () => {
+    const base = R.file_size, extra = R.fix.est_extra_bytes;
+    busy(true);
+    jm.open("Adding overviews in place",
+      `${R.file.split("/").pop()} · ${$("fix-rs").value} resampling · ≈ +${human(extra)}`);
+    try {
+      const res = await runJob({ file: R.file, action: "build", resampling: $("fix-rs").value },
+        (cur) => {
+          const done = Math.max(0, cur - base);
+          jm.progress(done / extra, `${human(done)} of ~${human(extra)} overview data written`);
+          prog(`building overviews in place… ${human(done)} of ~${human(extra)}`);
+        });
+      jm.close();
+      await analyze(R.file);
+      setStatus(`added ${res.factors.length} overview level${res.factors.length === 1 ? "" : "s"} in place: ${human(res.before)} → ${human(res.after)} (estimate was ~${human(base + extra)})`);
+    } catch (e) { jm.close(); busy(false); prog("build failed: " + esc(e.message || e), true); }
+  });
+
+  $("fix-cog-toggle").addEventListener("click", () => {
+    const box = $("fix-cog");
+    box.style.display = box.style.display === "none" ? "block" : "none";
+    if (box.style.display === "block" && !box.dataset.predicted) {
+      box.dataset.predicted = "1";
+      loadPredict();
+    }
+  });
+
+  async function loadPredict() {
+    try {
+      const p = await fused.runPython(READER, { file: R.file, action: "predict" });
+      if (p.error) throw new Error(p.error);
+      window.__predict = p;
+      $("predict-out").innerHTML = `<table class="kv">` + p.rows.map(row => `
+        <tr><td>${esc(row.profile)}</td><td><b>~${human(row.est_total)}</b>
+          <span style="opacity:.7">(${(row.est_total / R.file_size).toFixed(2)}× current, sampled from real blocks)</span></td></tr>`).join("")
+        + `</table><div style="margin-top:4px;opacity:.8">estimates ±20% — resampled overview data compresses worse than the base image</div>`;
+      $("fix-prof").innerHTML = p.rows.map(row => `<option>${esc(row.profile)}</option>`).join("");
+    } catch (e) { $("predict-out").textContent = "size prediction failed: " + (e.message || e); }
+  }
+
+  $("fix-run-cog").addEventListener("click", () => doCogify(false));
+  async function doCogify(overwrite) {
+    const profSel = $("fix-prof").value || "deflate";
+    const row = (window.__predict?.rows || []).find(r => r.profile === profSel);
+    busy(true);
+    try {
+      jm.open("Writing COG copy",
+        `${cogOut().split("/").pop()} · ${profSel}${row ? ` · ~${human(row.est_total)}` : ""}`);
+      const res = await runJob(
+        { file: R.file, action: "cogify", profile: profSel,
+          resampling: $("fix-rs") ? $("fix-rs").value : "average",
+          ...(overwrite ? { overwrite: "1" } : {}) },
+        (cur) => {
+          jm.progress(row ? cur / row.est_total : 0.5,
+            `${human(cur)}${row ? ` of ~${human(row.est_total)}` : ""} written`);
+          prog(`writing COG copy… ${human(cur)}${row ? ` of ~${human(row.est_total)}` : ""}`);
+        });
+      jm.close();
+      const orig = R.file;
+      await analyze(res.out);
+      setStatus(`wrote ${res.out.split("/").pop()}: ${human(res.before)} → ${human(res.after)} · ` +
+        (res.valid ? "valid COG ✓" : "validation FAILED") + ` · now viewing it (original ${orig.split("/").pop()} untouched)`);
+    } catch (e) {
+      jm.close();
+      busy(false);
+      const msg = String(e.message || e);
+      if (msg.includes("already exists")) {
+        prog(`${esc(msg)} — <a href="#" id="fix-ow" style="color:var(--accent)">overwrite it</a>`, true);
+        $("fix-ow").addEventListener("click", (ev) => { ev.preventDefault(); doCogify(true); });
+      } else prog("cogify failed: " + esc(msg), true);
+    }
+  }
+}
+
+/* ================= left panel ================= */
+
+function renderLeft() {
+  const l = R.levels[sel];
+  const c = COLORS[sel % COLORS.length];
+  const km = groundKm();
+  const maxBytes = Math.max(...R.levels.map(x => x.bytes || 0), 1);
+  $("left").innerHTML = `
+    <div class="chips">
+      <span class="chip"><b>${esc(R.file.split("/").pop())}</b> · ${human(R.file_size)}</span>
+      <span class="chip"><b>${R.bands}</b> × ${esc(R.dtype)}</span>
+      ${R.crs ? `<span class="chip" title="${esc(R.crs)}">${esc(R.crs_name || R.crs)}${
+        R.crs_name && !R.crs_name.startsWith("EPSG:") ? ' <span style="opacity:.65">· custom CRS</span>' : ""}</span>` : ""}
+      <span class="chip"><b>${R.n_overviews}</b> overview${R.n_overviews === 1 ? "" : "s"}${R.n_overviews === 0 ? ' <span style="color:var(--bad)">— no pyramid!</span>' : ""}</span>
+      ${R.cog ? `<span class="chip"
+        style="color:${R.cog.valid ? "var(--good)" : R.cog.valid === false ? "var(--warn)" : "var(--dim)"}">${
+        R.cog.valid ? "✓ valid COG" : R.cog.valid === false ? "✗ not a valid COG" : "COG validator n/a"}</span>` : ""}
+    </div>
+    ${fixPanelHtml()}
+
+    <h2>Bytes on disk per level <span style="text-transform:none;letter-spacing:0;opacity:.8">— click to select</span></h2>
+    ${R.levels.map((x, i) => [x, i]).reverse().map(([x, i]) => `
+      <div class="sb ${i === sel ? "sel" : ""}" data-i="${i}" style="--c:${COLORS[i % COLORS.length]}">
+        <span class="lv">L${x.level}</span>
+        <div class="track">
+          <div class="fill" style="width:${Math.max(1, 100 * (x.bytes || 0) / maxBytes)}%"></div>
+          <span class="txt">${human(x.bytes)}${x.pct != null ? ` · ${x.pct}% of file` : ""} · ${x.n_blocks.toLocaleString()} tile${x.n_blocks === 1 ? "" : "s"}</span>
+        </div>
+      </div>`).join("")}
+    <div class="hint" style="margin-top:4px">Each level has ¼ the pixels of the one below — the whole pyramid above
+      L0 costs only ~${(100 * R.levels.slice(1).reduce((a, x) => a + (x.bytes || 0), 0) / Math.max(1, R.levels[0].bytes || 1)).toFixed(0)}% extra.</div>
+
+    <h2>Same ${km ? km + " " : ""}ground patch — L${l.level} of ${R.levels.length - 1 ? "L0–L" + R.levels[R.levels.length - 1].level : "L0"}</h2>
+    <div id="crop-flex">
+      <div id="crop-wrap" style="--c:${c}">
+        <img class="ctx" src="data:image/png;base64,${l.thumb}"
+          style="width:${(70 * l.width / l.crop_px).toFixed(1)}%">
+        <img id="crop-big" src="data:image/png;base64,${l.crop}">
+      </div>
+    </div>
+    <div id="crop-cap"><b style="color:${c}">L${l.level}</b> stores this patch as
+      <b>${l.crop_px} × ${l.crop_px}</b> real pixels (${fmtRes(l)}${zoomEq(l) != null ? ` ≈ z${Math.round(zoomEq(l))}` : ""})${sel === 0 ? "" : ` — ${(R.levels[0].width / l.width).toFixed(0)}× fewer per side than L0`};
+      the dimmed surroundings are the rest of the level.<br>
+      <span style="opacity:.8">whole level: ${l.width.toLocaleString()} × ${l.height.toLocaleString()} px ·
+      ${l.tiled ? `tiled ${l.block[1]}×${l.block[0]}` : `<span style="color:var(--warn)">strips (not tiled)</span>`} ·
+      ${l.n_blocks.toLocaleString()} block${l.n_blocks === 1 ? "" : "s"} · ${esc(l.compression || "?")}</span></div>
+
+    <h2>Where each level lives in the file</h2>
+    <div id="bar"></div>
+    <div class="hint">A proper COG stores the coarse levels near the header for a cheap first paint.</div>`;
+  wireFixPanel();
+  $("left").querySelectorAll(".sb").forEach(el =>
+    el.addEventListener("click", () => focusLayer(+el.dataset.i)));
+  const bar = $("bar");
+  bar.innerHTML = R.levels.map((x, i) => x.offset == null ? "" :
+    `<div class="seg ${i === sel ? "sel" : ""}" data-i="${i}" title="L${x.level} — ${human(x.bytes)}"
+      style="left:${100 * x.offset / R.file_size}%;width:${100 * (x.bytes || 0) / R.file_size}%;
+      background:${COLORS[i % COLORS.length]}"></div>`).join("");
+  bar.querySelectorAll(".seg").forEach(el =>
+    el.addEventListener("click", () => focusLayer(+el.dataset.i)));
+}
+
+function select(i) {
+  sel = i;
+  document.querySelectorAll(".layer").forEach(el => el.classList.toggle("sel", +el.dataset.i === i));
+  renderLeft();
+}
+
+$("an-btn").addEventListener("click", () => analyze($("file-in").value.trim()));
+$("file-in").addEventListener("keydown", (e) => { if (e.key === "Enter") analyze($("file-in").value.trim()); });
+window.addEventListener("resize", () => { if (R && tab === "pyr") { buildScene(); applyView(false); } });
+// _file first: in template-mode views the shell owns it, and any file= param
+// alongside it is stale pollution from an older version of this tool
+const initial = fused.params.get("_file") || fused.params.get("file") || DEMO;
+$("file-in").value = initial;
+analyze(initial);
+</script>
+</body>
+</html>

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -353,10 +353,12 @@
   ],
   ".tif": [
     "geotiff",
+    "pyramid",
     "map"
   ],
   ".tiff": [
     "geotiff",
+    "pyramid",
     "map"
   ],
   ".nc": [


### PR DESCRIPTION
## What

Adds the **pyramid** template (overview-pyramid inspector & fixer) as a core template, registered as the **second** mode for `.tif`/`.tiff` — the geotiff map viewer stays the default:

```json
".tif":  ["geotiff", "pyramid", "map"],
".tiff": ["geotiff", "pyramid", "map"]
```

### The template (`fused_render/templates/pyramid/`)

- **3D pyramid** — every resolution level rendered as a real layer (true data): dimensions, ground res, bytes on disk, tile grid from the IFDs. Click to focus/inspect, ↑/↓ to step levels, drag to orbit.
- **Same-ground patch** — the same geographic window read from each level at native resolution.
- **On the map** — swipe any two levels against each other on a basemap at true resolution, plus an "auto" mode that picks the level a COG reader would fetch at the current zoom.
- **COG health & fix** — rio-cogeo validation verdict; files with no pyramid (or an invalid layout) get a fix panel: build overviews **in place** (keeps the codec) or write a **validated COG copy**, with per-codec size predictions sampled from the file's real blocks. Long jobs run detached (runPython's 30s budget) with a progress modal polling a status file.

The reader manages its own uv venv (`~/.cache/fused-render-compressbench`) so it works from the bundled python.

### geotiff `tile_server.py` (shared daemon, both modes)

- `/ltile/{z}/{x}/{y}.png?file=&level=N` — tiles rendered ONLY from pyramid level N; per-output-pixel source-index sampling (square pixels across tile borders) and a global 2–98% stretch (no per-tile contrast seams).
- `/tile` rasterio WarpedVRT fallback for **local** files the native engine can't read (BigTIFF, user-defined CRS, exotic compression). Mount-backed files keep the old 404 → `tiff_reader.py` fallback.
- Lock around all rasterio reads — dataset handles are not thread-safe; concurrent reads from the threaded server corrupt libtiff state and can kill the daemon.
- Daemon spawn env scrubs `PYTHONPATH`/`PYTHONHOME` (inherited values make the venv python import the app bundle's packages); older venvs get rasterio installed in place.

## Testing

- `tests/test_templates.py`: **59 passed** (registry names all resolve).
- Daemon smoke-tested standalone: `/tile` native + rio fallback + `/ltile` on JPEG-COG / BigTIFF-with-custom-CRS / uncompressed files — real payloads at correct extents; 16-way concurrent cold burst all 200s, daemon stays up.
- Template rendered end-to-end through a live app (`/render?path=…&file=…`): 3D tab and map tab both fully working via the relative `../geotiff/tile_server.py` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-place overview builds modify user GeoTIFFs; shared tile daemon changes affect both geotiff and pyramid map views under concurrency.
> 
> **Overview**
> Registers **`pyramid`** as the second viewer mode for `.tif`/`.tiff` (after **geotiff**). The new template is an overview-pyramid inspector and fixer: 3D stack of real per-level data, same-ground patch comparison, map swipe between levels, COG validation, and optional in-place overviews or a rio-cogeo COG copy (long jobs run detached with status polling).
> 
> **`overview_pyramid.py`** drives analyze/predict/build/cogify via a dedicated uv venv; **`template.html`** is the UI and calls the sibling **`../geotiff/tile_server.py`** daemon for map tiles.
> 
> **`tile_server.py`** changes: adds **rasterio** to the daemon venv (with in-place upgrade for older venvs), strips **`PYTHONPATH`/`PYTHONHOME`** on spawn, **`/ltile`** for forced pyramid-level Web Mercator tiles (global stretch, threaded read lock), and **`/tile`** tries the native engine first then **rasterio** for local files the native path cannot read (mount-backed files still 404 for the old fallback).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6593269ccb3f5c303b47e4af86b2f880932a5a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->