### PR TITLE
dev: per-branch port isolation + fail loud on port collision

### DIFF
--- a/fused_render/_branch.py
+++ b/fused_render/_branch.py
@@ -89,6 +89,23 @@ def branch_suffix(ref: str | None = None) -> str:
     return f"-{r}" if r else ""
 
 
+# Per-branch data dirs nest under this segment so they don't clutter ``base``'s
+# top level alongside baseline state (``~/.fused-render/branches/foo`` rather
+# than ``~/.fused-render/foo``).
+_BRANCHES_SUBDIR = "branches"
+
+
+def branch_dir(base: str, ref: str | None = None) -> str:
+    """Return the data dir under ``base`` for the active (or given) branch ref.
+
+    Baseline (no ref) is ``base`` itself, unchanged. A ref nests two levels
+    deep under ``base/branches/<ref>`` — the ``branches/`` container keeps
+    per-branch dirs from mixing with baseline files at ``base``'s top level.
+    """
+    r = branch_ref(ref)
+    return os.path.join(base, _BRANCHES_SUBDIR, r) if r else base
+
+
 if __name__ == "__main__":
     field = sys.argv[1]
     if field == "ref":

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -23,7 +23,7 @@ import webbrowser
 
 import uvicorn
 
-from fused_render._branch import branch_port, branch_ref
+from fused_render._branch import branch_dir, branch_port
 from fused_render.logs import log_path, setup_logging
 from fused_render.server import create_app
 from fused_render.shell.seed import ensure_fused_dir
@@ -31,9 +31,7 @@ from fused_render.shell.seed import ensure_fused_dir
 logger = logging.getLogger("fused_render")
 
 _APP_SUPPORT_BASE = os.path.expanduser("~/Library/Application Support/fused-render")
-APP_SUPPORT_DIR = (
-    _APP_SUPPORT_BASE if not branch_ref() else os.path.join(_APP_SUPPORT_BASE, branch_ref())
-)
+APP_SUPPORT_DIR = branch_dir(_APP_SUPPORT_BASE)
 PIDFILE = os.path.join(APP_SUPPORT_DIR, "server.pid")
 PORTFILE = os.path.join(APP_SUPPORT_DIR, "server.port")
 

--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -58,14 +58,18 @@ _HOST = "127.0.0.1"
 
 
 def _port_free(port: int) -> bool:
-    """True if we can bind ``port`` on the loopback right now.
+    """True if uvicorn could bind ``port`` on the loopback right now.
 
-    A plain bind (no SO_REUSEADDR) reflects real availability against an active
-    listener: if a stale dev server holds the port it fails, which is what we
-    want. uvicorn binds with SO_REUSEADDR (more permissive, only affects
-    TIME_WAIT sockets), so any port this probe accepts uvicorn will too.
+    Mirror uvicorn's own bind by setting SO_REUSEADDR so the probe agrees with
+    it in both directions: an active listener (a stale server) still makes bind
+    fail — SO_REUSEADDR does not permit two live binds to the same address, that
+    needs SO_REUSEPORT — so a real collision is still caught, while a port merely
+    lingering in TIME_WAIT after a clean shutdown reads as free (uvicorn, which
+    also sets SO_REUSEADDR, would bind it). A plain bind here would reject those
+    TIME_WAIT ports and wrongly block an immediate dev.sh restart.
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         try:
             s.bind((_HOST, port))
             return True

--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -12,6 +12,7 @@ CLI subcommand — it needs no separate offline step.
 import argparse
 import logging
 import os
+import socket
 import sys
 import threading
 import webbrowser
@@ -41,12 +42,51 @@ def _build_parser() -> argparse.ArgumentParser:
         "The whole filesystem remains browsable.",
     )
     serve.add_argument(
-        "--port", type=int, default=DEFAULT_PORT, help=f"port to bind (default: {DEFAULT_PORT})"
+        "--port",
+        type=int,
+        default=None,
+        help=f"port to bind (default: {DEFAULT_PORT}; startup fails if the port is "
+        "already in use rather than silently picking another)",
     )
     serve.add_argument(
         "--no-browser", action="store_true", help="do not open a browser tab on startup"
     )
     return parser
+
+
+_HOST = "127.0.0.1"
+
+
+def _port_free(port: int) -> bool:
+    """True if we can bind ``port`` on the loopback right now.
+
+    A plain bind (no SO_REUSEADDR) reflects real availability against an active
+    listener: if a stale dev server holds the port it fails, which is what we
+    want. uvicorn binds with SO_REUSEADDR (more permissive, only affects
+    TIME_WAIT sockets), so any port this probe accepts uvicorn will too.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((_HOST, port))
+            return True
+        except OSError:
+            return False
+
+
+def _check_port_free(port: int) -> None:
+    """Fail loudly if ``port`` is already taken.
+
+    Probing before uvicorn binds keeps the browser tab (opened a beat later)
+    from landing on a leftover server: with per-branch ports (see
+    fused_render._branch) a collision means a stale server for this same branch
+    is already running, so we stop with a clear message rather than silently
+    drifting to another port the tab wouldn't point at.
+    """
+    if not _port_free(port):
+        raise SystemExit(
+            f"port {port} is already in use — a server (likely a stale dev instance "
+            "for this branch) is running there. Stop it, or pass a different --port."
+        )
 
 
 def _run_serve(args: argparse.Namespace) -> None:
@@ -61,7 +101,10 @@ def _run_serve(args: argparse.Namespace) -> None:
     start_dir = os.path.abspath(os.path.expanduser(args.start_dir))
     app = create_app(start_dir=start_dir)
 
-    url = f"http://127.0.0.1:{args.port}/"
+    port = args.port if args.port is not None else DEFAULT_PORT
+    _check_port_free(port)
+
+    url = f"http://{_HOST}:{port}/"
     branch_note = f" (branch {branch_ref()})" if branch_ref() else ""
     print(f"fused-render serving at {url}{branch_note}")
     print(f"start dir: {start_dir}")
@@ -73,7 +116,7 @@ def _run_serve(args: argparse.Namespace) -> None:
     if not args.no_browser:
         threading.Timer(1.0, lambda: webbrowser.open(url)).start()
 
-    uvicorn.run(app, host="127.0.0.1", port=args.port)
+    uvicorn.run(app, host=_HOST, port=port)
 
 
 def main() -> None:

--- a/fused_render/shell/storage.py
+++ b/fused_render/shell/storage.py
@@ -19,14 +19,13 @@ def home_dir() -> str:
     ~/.fused-render — tests set it so they never touch the real home dir.
 
     When a branch ref is set (FUSED_RENDER_BRANCH, see fused_render._branch),
-    all shell state (templates, bookmarks, prefs) nests under a per-branch
-    subdir so parallel branches don't collide; baseline (no ref) is the
-    unnested dir, byte-identical to today."""
-    from fused_render._branch import branch_ref
+    all shell state (templates, bookmarks, prefs) nests under
+    ~/.fused-render/branches/<ref>/ so parallel branches don't collide; baseline
+    (no ref) is the unnested dir, byte-identical to today."""
+    from fused_render._branch import branch_dir
 
     base = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
-    ref = branch_ref()
-    return os.path.join(base, ref) if ref else base
+    return branch_dir(base)
 
 
 def read_json(path: str):

--- a/fused_render/winopen.py
+++ b/fused_render/winopen.py
@@ -22,7 +22,7 @@ import webbrowser
 from contextlib import contextmanager
 from urllib.parse import quote
 
-from fused_render._branch import branch_port, branch_ref, branch_suffix
+from fused_render._branch import branch_dir, branch_port, branch_suffix
 from fused_render.logs import setup_logging
 
 logger = logging.getLogger("fused_render")
@@ -82,9 +82,7 @@ _ICON_VARIANT_FOR_TOKEN = {
 
 _LOCALAPPDATA = os.environ.get("LOCALAPPDATA") or os.path.expanduser(r"~\AppData\Local")
 _APP_SUPPORT_BASE = os.path.join(_LOCALAPPDATA, "fused-render")
-APP_SUPPORT_DIR = (
-    _APP_SUPPORT_BASE if not branch_ref() else os.path.join(_APP_SUPPORT_BASE, branch_ref())
-)
+APP_SUPPORT_DIR = branch_dir(_APP_SUPPORT_BASE)
 PIDFILE = os.path.join(APP_SUPPORT_DIR, "server.pid")
 PORTFILE = os.path.join(APP_SUPPORT_DIR, "server.port")
 SERVER_LOG = os.path.join(APP_SUPPORT_DIR, "server.out.log")

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -23,6 +23,18 @@ FRONTEND="$REPO_ROOT/frontend"
 # or a manual wipe. Respect an already-set value so the caller can override.
 export FUSED_RENDER_CORE_TEMPLATES="${FUSED_RENDER_CORE_TEMPLATES:-$REPO_ROOT/fused_render/templates}"
 
+# Isolate each branch/worktree onto its own port + state dir. Without this every
+# dev.sh run (main checkout and every worktree) defaults to the baseline port
+# 1777 and clobbers the same ~/.fused-render state, so a server left running in
+# one worktree collides with — or gets served stale to — another. Deriving the
+# ref from the current branch gives each branch a deterministic port of its own
+# (see fused_render/_branch.py). main/master and detached HEAD sanitize to the
+# baseline, so this is a no-op there. Respect an already-set value so the caller
+# can override (including to "" to force baseline).
+if [[ -z "${FUSED_RENDER_BRANCH+x}" ]]; then
+  export FUSED_RENDER_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+
 # Python: active venv first, then the repo-local .venv, then PATH.
 if [[ -n "${VIRTUAL_ENV:-}" ]]; then
   PY="$VIRTUAL_ENV/bin/python"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -31,6 +31,13 @@ export FUSED_RENDER_CORE_TEMPLATES="${FUSED_RENDER_CORE_TEMPLATES:-$REPO_ROOT/fu
 # (see fused_render/_branch.py). main/master and detached HEAD sanitize to the
 # baseline, so this is a no-op there. Respect an already-set value so the caller
 # can override (including to "" to force baseline).
+#
+# NOTE: on main/master this mirrors baseline (port 1777 + the shared
+# ~/.fused-render state), which is exactly what the installed macOS desktop app
+# uses. Running dev.sh on main alongside the installed app therefore collides:
+# the port bind fails loudly (see cli.py _check_port_free) and, more subtly,
+# both read/write the same baseline state dir. Work on a feature branch (or pass
+# FUSED_RENDER_BRANCH / --port) to run dev fully isolated from the desktop app.
 if [[ -z "${FUSED_RENDER_BRANCH+x}" ]]; then
   export FUSED_RENDER_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -35,18 +35,36 @@ if [[ -z "${FUSED_RENDER_BRANCH+x}" ]]; then
   export FUSED_RENDER_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
 fi
 
-# Python: active venv first, then the repo-local .venv, then PATH.
+# Python: active venv first, then the repo-local .venv. With neither, bootstrap
+# a repo-local .venv (with the `fused` + `bundled` extras) so a fresh worktree is
+# self-contained. Without this the fallback was bare `python3` on PATH, whose
+# fused_render resolves to whatever global/editable install happens to be there
+# (often the main checkout's) and whose site-packages lack the sci deps the
+# map/geotiff/zarr daemons need — a fresh worktree would silently run the wrong
+# code or fail at daemon spawn. `-e` keeps the install pointed at this worktree's
+# source. Uses uv when present (fast, no ensurepip dance), else stdlib venv+pip.
 if [[ -n "${VIRTUAL_ENV:-}" ]]; then
   PY="$VIRTUAL_ENV/bin/python"
 elif [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
   PY="$REPO_ROOT/.venv/bin/python"
 else
-  PY="$(command -v python3)"
+  echo "==> no venv found — creating $REPO_ROOT/.venv with the [fused,bundled] extras"
+  # Run the install from REPO_ROOT with the `.[extras]` form: uv rejects an
+  # absolute path carrying extras (parses it as a PEP508 requirement).
+  if command -v uv >/dev/null 2>&1; then
+    uv venv "$REPO_ROOT/.venv"
+    (cd "$REPO_ROOT" && uv pip install --python "$REPO_ROOT/.venv/bin/python" -e ".[fused,bundled]")
+  else
+    python3 -m venv "$REPO_ROOT/.venv"
+    "$REPO_ROOT/.venv/bin/python" -m pip install --upgrade pip
+    (cd "$REPO_ROOT" && "$REPO_ROOT/.venv/bin/python" -m pip install -e ".[fused,bundled]")
+  fi
+  PY="$REPO_ROOT/.venv/bin/python"
 fi
 
 command -v npm >/dev/null || { echo "npm not found — the dev loop needs Node 22"; exit 1; }
 "$PY" -c "import fused_render" 2>/dev/null || {
-  echo "fused_render not importable from $PY — run: pip install -e ."
+  echo "fused_render not importable from $PY — run: pip install -e \".[fused,bundled]\""
   exit 1
 }
 

--- a/tests/test_branch_runtime.py
+++ b/tests/test_branch_runtime.py
@@ -60,12 +60,12 @@ def test_branch_ref_foo(monkeypatch):
     server, app, cli = _reload_with_ref("foo")
     import fused_render.shell.storage as storage
 
-    # Ref "foo": the whole shell home nests under foo/ (templates, bookmarks,
-    # prefs all follow home_dir), and App Support + port shift too.
+    # Ref "foo": the whole shell home nests under branches/foo/ (templates,
+    # bookmarks, prefs all follow home_dir), and App Support + port shift too.
     base = os.environ["FUSED_RENDER_HOME"]
-    assert storage.home_dir() == os.path.join(base, "foo")
-    assert server.USER_TEMPLATES_DIR == os.path.join(base, "foo", "templates")
-    assert app.APP_SUPPORT_DIR.endswith("Application Support/fused-render/foo")
+    assert storage.home_dir() == os.path.join(base, "branches", "foo")
+    assert server.USER_TEMPLATES_DIR == os.path.join(base, "branches", "foo", "templates")
+    assert app.APP_SUPPORT_DIR.endswith("Application Support/fused-render/branches/foo")
     assert app.DEFAULT_PORT == _branch.branch_port("foo")
     assert app.MAX_PORT == app.DEFAULT_PORT + 10
     assert cli.DEFAULT_PORT == app.DEFAULT_PORT


### PR DESCRIPTION
## Summary

Makes `scripts/dev.sh` self-isolating and self-bootstrapping so parallel worktrees/branches don't step on each other or on the installed desktop app.

- **Per-branch dev-server isolation.** `dev.sh` derives `FUSED_RENDER_BRANCH` from the current git branch, so each branch/worktree gets its own deterministic port and state dir (`fused_render/_branch.py`). Previously every run defaulted to the shared baseline port **1777** and clobbered the same `~/.fused-render` state. `main`/`master`/detached HEAD stay baseline.
- **Fail loud on port collision.** `cli.py` probes the port before uvicorn binds and exits with a clear message if it's taken — instead of scheduling the browser tab (which would open onto a leftover server) and then failing the bind. The probe uses `SO_REUSEADDR` to mirror uvicorn, so a port in `TIME_WAIT` after a clean shutdown doesn't wrongly block an immediate restart.
- **Auto-bootstrap a venv.** With no active/repo-local venv, `dev.sh` now creates `$REPO_ROOT/.venv` and installs `-e ".[fused,bundled]"` (uv when present, else stdlib venv+pip), so a fresh worktree is self-contained and runs its own source instead of silently falling back to a global install lacking the sci deps.
- **Cleaner state layout.** Per-branch state now nests under `~/.fused-render/branches/<ref>/` (via `branch_dir()`) instead of directly at the top level next to baseline files.
- **Documented** that `dev.sh` on `main` intentionally mirrors baseline and therefore collides with the installed macOS app (use a feature branch / `--port` to isolate).

## Visuals

```mermaid
flowchart TD
    A[scripts/dev.sh] --> V{active or repo-local .venv?}
    V -->|no| VB["create .venv + install -e '.[fused,bundled]'"]
    V -->|yes| B
    VB --> B{FUSED_RENDER_BRANCH set?}
    B -->|no| C["export FUSED_RENDER_BRANCH=$(git rev-parse --abbrev-ref HEAD)"]
    B -->|yes| D[respect caller value]
    C --> E[python -m fused_render.cli serve]
    D --> E
    E --> F["port = branch_port(ref)<br/>main → 1777, branch → deterministic"]
    F --> G{"_check_port_free(port)<br/>(SO_REUSEADDR probe)"}
    G -->|taken| H["SystemExit: port already in use"]
    G -->|free| I[open browser at resolved port] --> J["uvicorn.run(host, port)"]

    subgraph state["state dir (branch_dir)"]
      K["baseline → ~/.fused-render/"]
      L["branch foo → ~/.fused-render/branches/foo/"]
    end
```

## Usage

```bash
./scripts/dev.sh            # branch 'foo' → own port + ~/.fused-render/branches/foo/
                            # (first run auto-creates .venv with [fused,bundled])
./scripts/dev.sh --port N   # explicit override
FUSED_RENDER_BRANCH="" ./scripts/dev.sh   # force baseline (port 1777)
```

Port already in use now stops startup with:

```
port 2389 is already in use — a server (likely a stale dev instance for this
branch) is running there. Stop it, or pass a different --port.
```

## Test Plan

- [x] `pytest tests/test_branch.py tests/test_branch_runtime.py` — 17 passed (branch/port resolution + new `branches/` nesting)
- [x] Manual: `./scripts/dev.sh` on `worktree-cuddly-seeking-rose` → bound branch port **2389**, state under `~/.fused-render/branches/worktree-cud/`
- [x] Manual: second launch on the occupied port → fail-loud message (not a stale-server tab)
- [x] Manual: fresh worktree with no `.venv` → auto-created `.venv` (uv, py3.14) with `fused`+`bundled` extras; `import fused_render` resolves to the worktree source
- [x] Verified `_port_free` sets `SO_REUSEADDR` so `TIME_WAIT` doesn't block restart (PR review fix)
