### PR TITLE
fix(fs): mount-safe recents checks + rc-routed condition gates & fs/stat

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -884,6 +884,15 @@ def _condition_file(template_path: str):
     return condition_file if os.path.isfile(condition_file) else None
 
 
+# Per-gate probe budget (SPEC CT-12 fail-closed). One condition gate evaluation
+# shares this wall-clock deadline across ALL its mount probes. On a
+# non-direct-capable mount each operations/stat can burn the full rc timeout
+# resolving a miss (rclone lists the whole parent prefix), so a gate's serialized
+# probes would otherwise stack to N * that timeout. 5s bounds a whole gate to
+# roughly one slow probe; direct-capable mounts probe in ~1s and rarely reach it.
+GATE_PROBE_BUDGET_S = 5.0
+
+
 def _mount_gate_builtins(target_path: str):
     """Custom `__builtins__` for a condition gate whose target is MOUNT-backed,
     so the gate's own filesystem primitives route through the rclone rc API
@@ -920,25 +929,47 @@ def _mount_gate_builtins(target_path: str):
 
     real_os = os
 
+    # The gate's probes run SERIALLY in this one thread; give them ONE shared
+    # deadline (GATE_PROBE_BUDGET_S from now). Each probe is bounded to the budget
+    # REMAINING, and once it is spent every further probe fails closed instantly
+    # (isfile/isdir/exists -> False, stat -> OSError) instead of issuing another
+    # slow rc call — so a hung/slow backend can't stack timeouts across a gate.
+    deadline = time.monotonic() + GATE_PROBE_BUDGET_S
+
+    def _probe_budget():
+        return deadline - time.monotonic()
+
     def _isfile(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isfile(p)
-        return mounts.rc_kind_for(p) == "file"
+        left = _probe_budget()
+        if left <= 0:
+            return False  # budget spent -> fail closed
+        return mounts.rc_kind_for(p, timeout=left) == "file"
 
     def _isdir(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isdir(p)
-        return mounts.rc_kind_for(p) == "dir"
+        left = _probe_budget()
+        if left <= 0:
+            return False
+        return mounts.rc_kind_for(p, timeout=left) == "dir"
 
     def _exists(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.exists(p)
-        return mounts.rc_kind_for(p) in ("file", "dir")
+        left = _probe_budget()
+        if left <= 0:
+            return False
+        return mounts.rc_kind_for(p, timeout=left) in ("file", "dir")
 
     def _stat(p, *a, **k):
         if not mounts.is_mount_backed(p):
             return real_os.stat(p, *a, **k)
-        return mounts.rc_stat_result(p)
+        left = _probe_budget()
+        if left <= 0:
+            raise OSError(f"probe budget exhausted for {p}")
+        return mounts.rc_stat_result(p, timeout=left)
 
     def _listdir(p="."):
         # A kernel listing over a mount is the mur-sst wedge; the gate is
@@ -1125,11 +1156,14 @@ def _conditions_payload(path: str):
     if is_mount_backed(path):
         # A mount is_dir probe off the kernel (a kernel os.stat here is a
         # GETATTR that can force an S3 re-list and wedge the mount). "missing" is
-        # a trustworthy 404; "indeterminate" (rcd down / rc error) must NOT 404 a
-        # path the user just opened — proceed treating it as a dir, and the gates
-        # then fail closed on their own indeterminate rc calls, so the endpoint
-        # still returns 200 with all-False conditions rather than a spurious 404.
-        kind = rc_kind_for(path)
+        # a trustworthy 404; "indeterminate" (rcd down / rc error / probe budget
+        # exhausted) must NOT 404 a path the user just opened — proceed treating
+        # it as a dir, and the gates then fail closed on their own indeterminate
+        # probes, so the endpoint still returns 200 with all-False conditions
+        # rather than a spurious 404. The probe is bounded by GATE_PROBE_BUDGET_S
+        # so a stalled non-direct-capable backend can't hang this endpoint before
+        # the gates (each also budgeted) even start.
+        kind = rc_kind_for(path, timeout=GATE_PROBE_BUDGET_S)
         if kind == "missing":
             return _error(f"no such file or directory: {path}", status=404)
         is_dir = kind != "file"

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -976,10 +976,24 @@ def _mount_gate_builtins(target_path: str):
     real_import = builtins.__import__
     real_open = open
 
-    def _import(name, *args, **kwargs):
+    def _import(name, globals=None, locals=None, fromlist=(), level=0):
+        # Route every import form of `os`/`os.path` to the shim. __import__'s
+        # return-value contract differs by form: `import os` / `import os as o`
+        # (name "os") and `import os.path` (name "os.path", empty fromlist) bind
+        # the TOP package, then the import machinery walks .path off it via
+        # getattr — so return os_shim. `from os import ...` (name "os", non-empty
+        # fromlist) also wants the top package. Only `from os.path import x`
+        # (name "os.path", non-empty fromlist) wants the SUBMODULE — return the
+        # shim's path object so the names bind to shimmed functions.
+        # NOTE: this covers os / os.path only. A gate reaching the mount through
+        # a different stdlib module (pathlib, io, glob, ...) would still hit the
+        # kernel — a known, deliberately out-of-scope escape (low likelihood;
+        # the builtin gates use os).
         if name == "os":
             return os_shim
-        return real_import(name, *args, **kwargs)
+        if name == "os.path":
+            return os_shim.path if fromlist else os_shim
+        return real_import(name, globals, locals, fromlist, level)
 
     def _open(file, *args, **kwargs):
         if isinstance(file, str) and mounts.is_mount_backed(file):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -884,6 +884,121 @@ def _condition_file(template_path: str):
     return condition_file if os.path.isfile(condition_file) else None
 
 
+def _mount_gate_builtins(target_path: str):
+    """Custom `__builtins__` for a condition gate whose target is MOUNT-backed,
+    so the gate's own filesystem primitives route through the rclone rc API
+    instead of the kernel NFS mount.
+
+    Kernel NFS is the enemy: a cold NEGATIVE os.path.isfile over an rclone-NFS
+    mount is a kernel LOOKUP miss that forces rclone to LIST the whole parent S3
+    prefix to resolve it (~18-24s on a world-scale store), tripping the macOS NFS
+    deadman so the mount is declared dead. This is the same "route via rc, never
+    the kernel" hardening api_fs_list / rc_list_dir already carry; the gate path
+    never got it because gates run raw os.path against the mount.
+
+    The gate is exec'd stdlib-only and calls os.path directly (we can't ask
+    arbitrary gate code to call an rc helper), so we intercept at the os / open
+    layer. `import os` inside the gate resolves through __import__, so a fake
+    `os` injected into the module globals would just be overwritten by the real
+    one — instead we override __import__ (and open) in the gate module's OWN
+    __builtins__. That dict is built per _run_condition call on a fresh module,
+    so this is thread-safe under the concurrent ThreadPoolExecutor fan-out
+    (_evaluate_conditions) — NEVER a global monkeypatch of os.path.*, which would
+    race across threads and the rest of the server.
+
+    Fail-closed (SPEC CT-12): any rc error / timeout / unreachable rcd makes the
+    routed call behave as the kernel exception would today (isfile/isdir/exists
+    -> False, os.stat -> OSError, open -> OSError), so the gate returns False
+    quietly. A mount path NEVER falls back to the kernel os.* — that reintroduces
+    the wedge. Non-mount paths a gate might also touch pass straight through to
+    the real os / open.
+    """
+    import builtins
+    import io
+
+    from fused_render.shell import mounts
+
+    real_os = os
+
+    def _isfile(p):
+        if not mounts.is_mount_backed(p):
+            return real_os.path.isfile(p)
+        return mounts.rc_kind_for(p) == "file"
+
+    def _isdir(p):
+        if not mounts.is_mount_backed(p):
+            return real_os.path.isdir(p)
+        return mounts.rc_kind_for(p) == "dir"
+
+    def _exists(p):
+        if not mounts.is_mount_backed(p):
+            return real_os.path.exists(p)
+        return mounts.rc_kind_for(p) in ("file", "dir")
+
+    def _stat(p, *a, **k):
+        if not mounts.is_mount_backed(p):
+            return real_os.stat(p, *a, **k)
+        return mounts.rc_stat_result(p)
+
+    def _listdir(p="."):
+        # A kernel listing over a mount is the mur-sst wedge; the gate is
+        # forbidden from enumerating anyway (constant-time by design), so fail
+        # closed rather than route a listing it should never issue.
+        if mounts.is_mount_backed(p):
+            raise OSError(f"listing not permitted for mount path {p} in a gate")
+        return real_os.listdir(p)
+
+    def _scandir(p="."):
+        if mounts.is_mount_backed(p):
+            raise OSError(f"scandir not permitted for mount path {p} in a gate")
+        return real_os.scandir(p)
+
+    class _OsPathShim:
+        # Instance attrs win over __getattr__, so only these three route via rc;
+        # join / basename / everything else delegate to the real os.path.
+        isfile = staticmethod(_isfile)
+        isdir = staticmethod(_isdir)
+        exists = staticmethod(_exists)
+
+        def __getattr__(self, name):
+            return getattr(real_os.path, name)
+
+    class _OsShim:
+        path = _OsPathShim()
+        stat = staticmethod(_stat)
+        listdir = staticmethod(_listdir)
+        scandir = staticmethod(_scandir)
+
+        def __getattr__(self, name):
+            return getattr(real_os, name)
+
+    os_shim = _OsShim()
+    real_import = builtins.__import__
+    real_open = open
+
+    def _import(name, *args, **kwargs):
+        if name == "os":
+            return os_shim
+        return real_import(name, *args, **kwargs)
+
+    def _open(file, *args, **kwargs):
+        if isinstance(file, str) and mounts.is_mount_backed(file):
+            # The one bounded gate read (zarr.json node_type). Ranged HTTP read
+            # over the mount's serve — never a kernel open. OSError -> the gate's
+            # own except -> fail closed.
+            data = mounts.rc_read_bounded(file)
+            mode = args[0] if args else kwargs.get("mode", "r")
+            if "b" in mode:
+                return io.BytesIO(data)
+            return io.StringIO(data.decode(kwargs.get("encoding") or "utf-8"))
+        return real_open(file, *args, **kwargs)
+
+    b = dict(vars(builtins))
+    b["__import__"] = _import
+    b["open"] = _open
+    return b
+
+
 def _run_condition(condition_file: str, target_path: str):
     """Load+exec a `condition.py` and call `main(target_path)`. Returns
     (allowed: bool, error: str|None).
@@ -896,6 +1011,12 @@ def _run_condition(condition_file: str, target_path: str):
     template and surfaces the reason as `template_error`, mirroring how an
     unresolvable name is dropped (SPEC CT-6): a template gated by code that
     can't decide is not silently shown.
+
+    For a MOUNT-backed target the gate runs under a per-call, thread-safe shim
+    (_mount_gate_builtins) that routes its os.path / os.stat / open off the
+    kernel NFS mount and onto the rclone rc API — a cold negative os.path.isfile
+    over a mount otherwise lists the whole S3 prefix and wedges the mount.
+    Templates stay mount-agnostic; all mount-awareness lives here.
     """
     import importlib.util
 
@@ -904,6 +1025,11 @@ def _run_condition(condition_file: str, target_path: str):
             "__fused_condition__", condition_file
         )
         mod = importlib.util.module_from_spec(spec)
+        # Local import keeps shell ↛ server acyclic; resolves the attr at call
+        # time so the mount routing is monkeypatchable in tests.
+        from fused_render.shell.mounts import is_mount_backed
+        if is_mount_backed(target_path):
+            mod.__dict__["__builtins__"] = _mount_gate_builtins(target_path)
         spec.loader.exec_module(mod)
         fn = getattr(mod, "main", None)
         if not callable(fn):
@@ -980,11 +1106,26 @@ def _conditions_payload(path: str):
     carries the first gate error in list order (a broken gate reports False —
     fail closed — with the reason), matching stat's `template_error` posture.
     """
-    try:
-        st = os.stat(path)
-    except OSError:
-        return _error(f"no such file or directory: {path}", status=404)
-    entries, _ = _templates_for(path, stat_mod.S_ISDIR(st.st_mode))
+    from fused_render.shell.mounts import is_mount_backed, rc_kind_for
+
+    if is_mount_backed(path):
+        # A mount is_dir probe off the kernel (a kernel os.stat here is a
+        # GETATTR that can force an S3 re-list and wedge the mount). "missing" is
+        # a trustworthy 404; "indeterminate" (rcd down / rc error) must NOT 404 a
+        # path the user just opened — proceed treating it as a dir, and the gates
+        # then fail closed on their own indeterminate rc calls, so the endpoint
+        # still returns 200 with all-False conditions rather than a spurious 404.
+        kind = rc_kind_for(path)
+        if kind == "missing":
+            return _error(f"no such file or directory: {path}", status=404)
+        is_dir = kind != "file"
+    else:
+        try:
+            st = os.stat(path)
+        except OSError:
+            return _error(f"no such file or directory: {path}", status=404)
+        is_dir = stat_mod.S_ISDIR(st.st_mode)
+    entries, _ = _templates_for(path, is_dir)
 
     gated = []  # [(mode, condition_file)] — mode keys are unique per list
     for entry in entries:
@@ -1261,10 +1402,18 @@ def _writable(path: str) -> bool:
     cache and only fails at the async upload, so W_OK is a lie there."""
     # Local import, like _stat_payload's: server -> shell.mounts only,
     # keeping shell ↛ server acyclic.
-    from fused_render.shell.mounts import mount_read_only
+    from fused_render.shell.mounts import is_mount_backed, mount_read_only
 
     if mount_read_only(path):
         return False
+    if is_mount_backed(path):
+        # A writable (not read-only) mount: the rclone VFS (CacheMode=full) takes
+        # writes into its local cache, so a path under it is writable regardless
+        # of kernel permission bits. Return True WITHOUT a kernel
+        # os.path.exists/os.access — a cold negative lookup over the mount lists
+        # the whole S3 prefix and wedges it, the same trap fs/stat's os.stat is
+        # routed off the kernel to avoid (mount_read_only reads mounts.json only).
+        return True
     if os.path.exists(path):
         return os.access(path, os.W_OK)
     return os.access(os.path.dirname(path) or ".", os.W_OK)
@@ -1331,12 +1480,13 @@ def _stat_payload(path: str, is_dir: bool, st: os.stat_result | None = None) -> 
     """The /api/fs/stat shape. /api/fs/write returns it too, so the editor can
     re-arm its optimistic lock from a save response. Pass a pre-fetched `st` to
     avoid a redundant stat() — one remote round-trip under a mount."""
-    if st is None:
-        st = os.stat(path)
-    templates, template_error = _templates_for(path, is_dir)
     # Local import, like api_fs_walk's: server -> shell.mounts only, keeping
     # shell ↛ server acyclic.
     from fused_render.shell.mounts import is_mount_backed
+
+    if st is None:
+        st = _mount_safe_stat(path)
+    templates, template_error = _templates_for(path, is_dir)
 
     payload = {
         "path": path,
@@ -1355,12 +1505,30 @@ def _stat_payload(path: str, is_dir: bool, st: os.stat_result | None = None) -> 
     return payload
 
 
+def _mount_safe_stat(path: str) -> os.stat_result:
+    """os.stat for a path that may be mount-backed, off the kernel for mounts.
+
+    A kernel os.stat on a mount is a GETATTR that can force an S3 re-list and
+    wedge the mount (the stat-storm / deadman incident); route mount paths
+    through the rclone rc API (rc_stat_result) instead. It raises OSError /
+    FileNotFoundError exactly like the kernel os.stat it replaces, so callers'
+    existing OSError->404 handling holds — and it NEVER falls back to that kernel
+    GETATTR, which is the call that killed the mount."""
+    from fused_render.shell.mounts import is_mount_backed, rc_stat_result
+
+    if is_mount_backed(path):
+        return rc_stat_result(path)
+    return os.stat(path)
+
+
 def _fs_stat(path: str):
     # One stat, not the exists()+isdir()+stat() trio: over a remote mount each
     # is a round-trip, so a plain metadata fetch cost 3 LISTs. os.path.exists()
-    # returns False for any OSError, so mirror that -> 404.
+    # returns False for any OSError, so mirror that -> 404. _mount_safe_stat keeps
+    # a mount stat off the kernel (rc API), raising OSError like os.stat on any
+    # unreachable/missing so this 404 path is unchanged.
     try:
-        st = os.stat(path)
+        st = _mount_safe_stat(path)
     except OSError:
         return _error(f"no such file or directory: {path}", status=404)
     return _stat_payload(path, stat_mod.S_ISDIR(st.st_mode), st)

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1537,13 +1537,27 @@ def _mount_safe_stat(path: str) -> os.stat_result:
 
 def _fs_stat(path: str):
     # One stat, not the exists()+isdir()+stat() trio: over a remote mount each
-    # is a round-trip, so a plain metadata fetch cost 3 LISTs. os.path.exists()
-    # returns False for any OSError, so mirror that -> 404. _mount_safe_stat keeps
-    # a mount stat off the kernel (rc API), raising OSError like os.stat on any
-    # unreachable/missing so this 404 path is unchanged.
+    # is a round-trip, so a plain metadata fetch cost 3 LISTs. _mount_safe_stat
+    # keeps a mount stat off the kernel (rc API / direct probe).
+    #
+    # 404 vs 503: FileNotFoundError is a CONFIRMED miss (kernel ENOENT, or a
+    # healthy backend's trustworthy negative) -> 404, matching os.path.exists()'s
+    # OSError->False for a local path. A bare OSError on a MOUNT path is
+    # rc_stat_result's "indeterminate" (rcd unreachable, rc timeout, mount slow /
+    # unresponsive) — NOT proof the path is gone. Mapping it to 404 tells the
+    # client a path it just opened has vanished; surface it as a retryable 503
+    # instead. A non-mount OSError keeps the historical exists()->False -> 404.
+    from fused_render.shell.mounts import is_mount_backed
+
     try:
         st = _mount_safe_stat(path)
+    except FileNotFoundError:
+        return _error(f"no such file or directory: {path}", status=404)
     except OSError:
+        if is_mount_backed(path):
+            return _error(
+                f"mount is slow or unresponsive, could not stat {path}",
+                status=503)
         return _error(f"no such file or directory: {path}", status=404)
     return _stat_payload(path, stat_mod.S_ISDIR(st.st_mode), st)
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -804,6 +804,15 @@ _STAT_INDETERMINATE = object()
 # mounts skip this path entirely (see _stat_item -> direct_head/direct_is_dir).
 RC_STAT_TIMEOUT_S = 10.0
 
+# A direct stat may run TWO probes back-to-back (a HeadObject, then a max-keys=1
+# list) and, on a direct miss, fall back to operations/stat. All of them share
+# the caller's SINGLE `timeout` via one deadline (see _stat_item), so a slow
+# first probe can't hand the next one a fresh full budget — which is how one
+# logical stat used to burn up to 2x the cap. This floor is the smallest slice
+# worth spending on a follow-on probe: below it there is no plausible round trip
+# left, so we stop and report indeterminate rather than overrun the deadline.
+_DIRECT_PROBE_MIN_S = 0.5
+
 
 def _rc_stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
     """The raw operations/stat `item` for a mount-backed path, off the kernel:
@@ -863,12 +872,17 @@ def _stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
     same direct-first path and agree on what each outcome means. rc_mtime_for
     stays on _rc_stat_item directly (its raw-ModTime-string contract predates
     this and no world-scale caller relies on it)."""
+    deadline = time.monotonic() + timeout
     if direct_list_capable(path):
         try:
-            return _direct_stat_item(path, timeout=timeout)
+            return _direct_stat_item(path, deadline=deadline)
         except DirectProbeError:
-            pass  # fall through to the slow rc route
-    item = _rc_stat_item(path, timeout=timeout)
+            pass  # fall through to the slow rc route, on the SAME deadline
+    # The rc fallback shares the direct probes' deadline so an indeterminate
+    # direct outcome can't add a fresh full timeout on top; when the budget is
+    # already spent it gets only the floor and fails open to indeterminate.
+    item = _rc_stat_item(path, timeout=max(_DIRECT_PROBE_MIN_S,
+                                           deadline - time.monotonic()))
     if not isinstance(item, dict):
         return item  # None (missing) or _STAT_INDETERMINATE pass straight through
     return {"IsDir": bool(item.get("IsDir")), "Size": item.get("Size"),
@@ -1596,16 +1610,25 @@ def direct_is_dir(path: str, *, timeout: float = _HEAD_TIMEOUT_S) -> bool:
     raise DirectProbeError(f"{path}: no direct-probe backend")
 
 
-def _direct_stat_item(path: str, *, timeout: float):
+def _direct_stat_item(path: str, *, deadline: float):
     """The _stat_item dict|None outcome via direct probes: a HeadObject decides
     FILE, else a max-keys=1 list decides DIR, else confirmed missing (None). Any
     probe raising DirectProbeError propagates so _stat_item falls back to rc.
-    Two round trips at worst (dir/miss); one for the common file hit."""
-    head = direct_head(path, timeout=timeout)
+    Two round trips at worst (dir/miss); one for the common file hit.
+
+    Both probes share the caller's single `deadline` (monotonic seconds): the
+    head gets the whole remaining budget, the dir list only what the head left,
+    so one logical stat never spends up to 2x the timeout. If the head consumed
+    the budget the dir probe can't fit -> raise so _stat_item treats it as
+    indeterminate (and its own rc fallback is bounded by the same deadline)."""
+    head = direct_head(path, timeout=max(_DIRECT_PROBE_MIN_S,
+                                         deadline - time.monotonic()))
     if head.exists:
         return {"IsDir": False, "Size": head.size,
                 "MtimeEpoch": rc_modtime_epoch(head.mtime)}
-    if direct_is_dir(path, timeout=timeout):
+    if deadline - time.monotonic() < _DIRECT_PROBE_MIN_S:
+        raise DirectProbeError(f"{path}: budget spent before dir probe")
+    if direct_is_dir(path, timeout=deadline - time.monotonic()):
         # S3/GCS have no real directories; a present prefix (or marker) is a dir.
         return {"IsDir": True, "Size": None, "MtimeEpoch": None}
     return None  # no object, no children -> a trustworthy miss

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -777,12 +777,40 @@ def rc_mtime_for(path: str) -> str | None:
     (path not under a mount, rcd unreachable, rc error/timeout, or missing
     item). Callers MUST treat None as "unchanged" and MUST NOT fall back to
     os.stat — that fallback is the exact GETATTR that killed the mount."""
+    item = _rc_stat_item(path)
+    # Both "missing" (None) and "indeterminate" (the sentinel) collapse to None
+    # here — this preserves rc_mtime_for's documented contract. A caller that
+    # must distinguish a confirmed deletion from a transient failure uses
+    # rc_stat_for instead.
+    if not isinstance(item, dict):
+        return None
+    return item.get("ModTime") or None
+
+
+# Sentinel returned by _rc_stat_item when operations/stat could not be answered
+# at all (no mount record, no live rcd, rc error/timeout, malformed response) —
+# as opposed to None, which is a healthy rcd's TRUSTWORTHY "the item is gone".
+_STAT_INDETERMINATE = object()
+
+
+def _rc_stat_item(path: str):
+    """The raw operations/stat `item` for a mount-backed path, off the kernel:
+      - a dict          -> the item exists (its ModTime may or may not be set);
+      - None            -> a healthy rcd answered {"item": null}: the file is
+                           GONE (a trustworthy negative);
+      - _STAT_INDETERMINATE -> the stat could not be taken (path under no mount,
+                           no live rcd port, rc RuntimeError/timeout, or a
+                           malformed response). Callers MUST fail open on this
+                           and MUST NOT fall back to os.stat — that GETATTR is
+                           the exact call that wedged the mount.
+    Shared by rc_mtime_for and rc_stat_for so both speak to the rcd once and
+    agree on what each outcome means."""
     m, rel = _mount_for(path)
     if m is None:
-        return None
+        return _STAT_INDETERMINATE
     port = _live_rcd_port()
     if port is None:
-        return None
+        return _STAT_INDETERMINATE
     # _mount_for returns "." for the mountpoint itself; operations/stat wants ""
     # for the fs root (remote "." returns {"item": null}, so the mount-ROOT
     # watch would never prime — same quirk operations/list has, normalized in
@@ -792,11 +820,31 @@ def rc_mtime_for(path: str) -> str | None:
         resp = _rc(port, "operations/stat",
                    {"fs": m["remote"], "remote": remote}, timeout=10)
     except RuntimeError:
-        return None
-    item = resp.get("item") if isinstance(resp, dict) else None
+        return _STAT_INDETERMINATE
+    if not isinstance(resp, dict) or "item" not in resp:
+        return _STAT_INDETERMINATE  # malformed answer -> fail open
+    item = resp["item"]
+    if item is None:
+        return None  # healthy rcd: file confirmed gone
     if not isinstance(item, dict):
-        return None
-    return item.get("ModTime") or None
+        return _STAT_INDETERMINATE
+    return item
+
+
+def rc_stat_for(path: str) -> str:
+    """Tri-state existence of a mount-backed path via the rclone rc API, never
+    the kernel: "exists", "missing", or "indeterminate".
+
+    Splits apart what rc_mtime_for collapses into None, so a caller can filter a
+    genuinely-deleted mount file (a healthy rcd's {"item": null}) while still
+    failing open on any transient failure. "missing" is the ONLY outcome that
+    proves absence; treat "indeterminate" as "keep / unchanged"."""
+    item = _rc_stat_item(path)
+    if item is _STAT_INDETERMINATE:
+        return "indeterminate"
+    if item is None:
+        return "missing"
+    return "exists"
 
 
 # operations/list can't be paginated at any rclone layer (verified: `rclone lsf

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -26,6 +26,7 @@ import os
 import re
 import shutil
 import socket
+import stat as stat_mod
 import subprocess
 import sys
 import threading
@@ -845,6 +846,81 @@ def rc_stat_for(path: str) -> str:
     if item is None:
         return "missing"
     return "exists"
+
+
+def rc_kind_for(path: str) -> str:
+    """Four-state kind of a mount-backed path via the rclone rc API, never the
+    kernel: "dir", "file", "missing", or "indeterminate".
+
+    Extends rc_stat_for's present/absent with the IsDir bit operations/stat
+    already carries, so a caller can tell os.path.isfile from os.path.isdir
+    without a kernel LOOKUP. That LOOKUP is the whole point: a cold NEGATIVE
+    os.path.isfile over an rclone-NFS mount forces rclone to LIST the entire
+    parent S3 prefix to resolve the miss (~18-24s on a world-scale store), which
+    trips the macOS NFS deadman and the mount is declared dead. Same "kernel NFS
+    is the enemy, route via rc" hardening rc_list_dir / api_fs_list got.
+
+    "file"/"dir" prove presence; "missing" is the ONLY outcome that proves
+    absence (a healthy rcd's {"item": null}); "indeterminate" (rcd down / rc
+    error / no mount / malformed answer) must be treated as "don't know" and
+    MUST NOT fall back to the kernel."""
+    item = _rc_stat_item(path)
+    if item is _STAT_INDETERMINATE:
+        return "indeterminate"
+    if item is None:
+        return "missing"
+    return "dir" if item.get("IsDir") else "file"
+
+
+def rc_stat_result(path: str) -> os.stat_result:
+    """A synthesized os.stat_result for a mount-backed path, from operations/stat
+    instead of a kernel GETATTR (the stat-storm/deadman class — see rc_mtime_for).
+
+    Only the fields callers actually read are meaningful — st_mode's dir/file
+    bit, st_size, and st_mtime; the rest are zero-filled. Raises
+    FileNotFoundError when the rcd confirms the item is gone and OSError when the
+    stat is indeterminate (rcd down / rc error / no mount / malformed answer), so
+    a mount stat fails EXACTLY like the kernel os.stat it replaces and callers'
+    existing OSError->404 handling holds — and it NEVER falls back to that kernel
+    GETATTR, which is the call that wedged the mount."""
+    item = _rc_stat_item(path)
+    if item is _STAT_INDETERMINATE:
+        raise OSError(f"rc stat unavailable for {path}")
+    if item is None:
+        raise FileNotFoundError(path)
+    size = item.get("Size")
+    # rclone reports -1 for a directory / unknown size; clamp to 0.
+    size = int(size) if isinstance(size, (int, float)) and size >= 0 else 0
+    mtime = rc_modtime_epoch(item.get("ModTime")) or 0.0
+    mode = (stat_mod.S_IFDIR | 0o755) if item.get("IsDir") else (stat_mod.S_IFREG | 0o644)
+    # (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime)
+    return os.stat_result((mode, 0, 0, 1, 0, 0, size, mtime, mtime, mtime))
+
+
+# A shim'd condition gate reads exactly one small known file (the zarr.json
+# node_type probe). Cap it so a surprise huge file can't stream unbounded
+# through the serve — a store's zarr.json is a few KB; 1 MiB is generous.
+_GATE_READ_CAP = 1 << 20
+
+
+def rc_read_bounded(path: str, cap: int = _GATE_READ_CAP, timeout: float = 10) -> bytes:
+    """Up to `cap` bytes of a mount-backed file, fetched over the mount's
+    localhost HTTP serve (serve_url_for) instead of a kernel open()/read.
+
+    The condition-gate shim uses this for the one bounded zarr.json read: a
+    kernel open of a mount file is the same GETATTR/READ class that wedges the
+    mount, while a ranged GET over the serve is at worst slow, never fatal.
+    Raises OSError on no live serve / transport error / timeout so the gate fails
+    closed (urllib.error.URLError and socket timeouts are already OSError)."""
+    url = serve_url_for(path)
+    if url is None:
+        raise OSError(f"no HTTP serve for {path}")
+    req = urllib.request.Request(url, headers={"Range": f"bytes=0-{cap - 1}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return r.read(cap)
+    except OSError as e:  # URLError/HTTPError/socket timeout are all OSError
+        raise OSError(f"serve read failed for {path}: {e}") from e
 
 
 # operations/list can't be paginated at any rclone layer (verified: `rclone lsf

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -19,7 +19,9 @@ instead of orphaning them. Unmount is an explicit user action.
 Store: home_dir()/mounts.json, whole-file last-write-wins like
 shell/bookmarks.py. Same acyclic-router + X-Fused-guard conventions.
 """
+import collections
 import configparser
+import email.utils
 import json
 import logging
 import os
@@ -793,8 +795,17 @@ def rc_mtime_for(path: str) -> str | None:
 # as opposed to None, which is a healthy rcd's TRUSTWORTHY "the item is gone".
 _STAT_INDETERMINATE = object()
 
+# Default per-call ceiling for a single rc operations/stat. operations/stat has
+# NO S3 point lookup — rclone answers a negative or a directory probe with an
+# UNBOUNDED ListObjectsV2 of the whole parent prefix, so on a flat world-scale
+# prefix (source.coop/earthgenome/...) every probe burns this full timeout. The
+# ceiling caps ONE probe; the per-gate budget (_mount_gate_builtins) shrinks it
+# further so a gate's serialized probes can't stack to N*ceiling. Direct-capable
+# mounts skip this path entirely (see _stat_item -> direct_head/direct_is_dir).
+RC_STAT_TIMEOUT_S = 10.0
 
-def _rc_stat_item(path: str):
+
+def _rc_stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
     """The raw operations/stat `item` for a mount-backed path, off the kernel:
       - a dict          -> the item exists (its ModTime may or may not be set);
       - None            -> a healthy rcd answered {"item": null}: the file is
@@ -819,7 +830,7 @@ def _rc_stat_item(path: str):
     remote = "" if rel == "." else rel
     try:
         resp = _rc(port, "operations/stat",
-                   {"fs": m["remote"], "remote": remote}, timeout=10)
+                   {"fs": m["remote"], "remote": remote}, timeout=timeout)
     except RuntimeError:
         return _STAT_INDETERMINATE
     if not isinstance(resp, dict) or "item" not in resp:
@@ -832,15 +843,48 @@ def _rc_stat_item(path: str):
     return item
 
 
-def rc_stat_for(path: str) -> str:
-    """Tri-state existence of a mount-backed path via the rclone rc API, never
-    the kernel: "exists", "missing", or "indeterminate".
+def _stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
+    """Normalized stat outcome for a mount-backed path, DIRECT-PROBE-FIRST:
+      - a dict {"IsDir", "Size", "MtimeEpoch"} -> the path exists;
+      - None                                   -> confirmed missing;
+      - _STAT_INDETERMINATE                    -> could not be determined.
+
+    operations/stat has no S3 point lookup: a negative file probe or a directory
+    probe makes rclone run an UNBOUNDED ListObjectsV2 of the whole parent prefix,
+    so on a flat world-scale prefix every probe burns the full rc timeout. But
+    S3/GCS expose true point lookups — HeadObject answers exists/size/mtime in
+    one round trip and a max-keys=1 list answers dir-ness in another — so for the
+    anonymous backends we already list unsigned (direct_list_capable) we probe
+    the store DIRECTLY and never touch operations/stat. Any direct failure
+    (403/301/network — DirectProbeError) falls back to the rc path so a
+    misconfigured remote still degrades to the slow-but-correct route.
+
+    Shared by rc_stat_for / rc_kind_for / rc_stat_result so all three speak the
+    same direct-first path and agree on what each outcome means. rc_mtime_for
+    stays on _rc_stat_item directly (its raw-ModTime-string contract predates
+    this and no world-scale caller relies on it)."""
+    if direct_list_capable(path):
+        try:
+            return _direct_stat_item(path, timeout=timeout)
+        except DirectProbeError:
+            pass  # fall through to the slow rc route
+    item = _rc_stat_item(path, timeout=timeout)
+    if not isinstance(item, dict):
+        return item  # None (missing) or _STAT_INDETERMINATE pass straight through
+    return {"IsDir": bool(item.get("IsDir")), "Size": item.get("Size"),
+            "MtimeEpoch": rc_modtime_epoch(item.get("ModTime"))}
+
+
+def rc_stat_for(path: str, *, timeout: float = RC_STAT_TIMEOUT_S) -> str:
+    """Tri-state existence of a mount-backed path, never the kernel: "exists",
+    "missing", or "indeterminate".
 
     Splits apart what rc_mtime_for collapses into None, so a caller can filter a
     genuinely-deleted mount file (a healthy rcd's {"item": null}) while still
     failing open on any transient failure. "missing" is the ONLY outcome that
-    proves absence; treat "indeterminate" as "keep / unchanged"."""
-    item = _rc_stat_item(path)
+    proves absence; treat "indeterminate" as "keep / unchanged". Answered by a
+    direct point probe where the backend supports it, else operations/stat."""
+    item = _stat_item(path, timeout=timeout)
     if item is _STAT_INDETERMINATE:
         return "indeterminate"
     if item is None:
@@ -848,51 +892,50 @@ def rc_stat_for(path: str) -> str:
     return "exists"
 
 
-def rc_kind_for(path: str) -> str:
-    """Four-state kind of a mount-backed path via the rclone rc API, never the
-    kernel: "dir", "file", "missing", or "indeterminate".
+def rc_kind_for(path: str, *, timeout: float = RC_STAT_TIMEOUT_S) -> str:
+    """Four-state kind of a mount-backed path, never the kernel: "dir", "file",
+    "missing", or "indeterminate".
 
-    Extends rc_stat_for's present/absent with the IsDir bit operations/stat
-    already carries, so a caller can tell os.path.isfile from os.path.isdir
-    without a kernel LOOKUP. That LOOKUP is the whole point: a cold NEGATIVE
-    os.path.isfile over an rclone-NFS mount forces rclone to LIST the entire
-    parent S3 prefix to resolve the miss (~18-24s on a world-scale store), which
-    trips the macOS NFS deadman and the mount is declared dead. Same "kernel NFS
-    is the enemy, route via rc" hardening rc_list_dir / api_fs_list got.
+    Extends rc_stat_for's present/absent with the IsDir bit, so a caller can tell
+    os.path.isfile from os.path.isdir without a kernel LOOKUP. That LOOKUP is the
+    whole point: a cold NEGATIVE os.path.isfile over an rclone-NFS mount forces
+    rclone to LIST the entire parent S3 prefix to resolve the miss (~18-24s on a
+    world-scale store), which trips the macOS NFS deadman and the mount is
+    declared dead. Same "kernel NFS is the enemy, route via a bounded probe"
+    hardening rc_list_dir / api_fs_list got.
 
     "file"/"dir" prove presence; "missing" is the ONLY outcome that proves
-    absence (a healthy rcd's {"item": null}); "indeterminate" (rcd down / rc
-    error / no mount / malformed answer) must be treated as "don't know" and
-    MUST NOT fall back to the kernel."""
-    item = _rc_stat_item(path)
+    absence; "indeterminate" (backend unreachable / no mount / malformed answer)
+    must be treated as "don't know" and MUST NOT fall back to the kernel."""
+    item = _stat_item(path, timeout=timeout)
     if item is _STAT_INDETERMINATE:
         return "indeterminate"
     if item is None:
         return "missing"
-    return "dir" if item.get("IsDir") else "file"
+    return "dir" if item["IsDir"] else "file"
 
 
-def rc_stat_result(path: str) -> os.stat_result:
-    """A synthesized os.stat_result for a mount-backed path, from operations/stat
-    instead of a kernel GETATTR (the stat-storm/deadman class — see rc_mtime_for).
+def rc_stat_result(path: str, *, timeout: float = RC_STAT_TIMEOUT_S) -> os.stat_result:
+    """A synthesized os.stat_result for a mount-backed path, off the kernel
+    GETATTR (the stat-storm/deadman class — see rc_mtime_for).
 
     Only the fields callers actually read are meaningful — st_mode's dir/file
     bit, st_size, and st_mtime; the rest are zero-filled. Raises
-    FileNotFoundError when the rcd confirms the item is gone and OSError when the
-    stat is indeterminate (rcd down / rc error / no mount / malformed answer), so
-    a mount stat fails EXACTLY like the kernel os.stat it replaces and callers'
-    existing OSError->404 handling holds — and it NEVER falls back to that kernel
-    GETATTR, which is the call that wedged the mount."""
-    item = _rc_stat_item(path)
+    FileNotFoundError when the backend confirms the item is gone and OSError when
+    the stat is indeterminate, so a mount stat fails EXACTLY like the kernel
+    os.stat it replaces and callers' existing OSError->404 handling holds — and
+    it NEVER falls back to that kernel GETATTR, which is the call that wedged the
+    mount."""
+    item = _stat_item(path, timeout=timeout)
     if item is _STAT_INDETERMINATE:
         raise OSError(f"rc stat unavailable for {path}")
     if item is None:
         raise FileNotFoundError(path)
-    size = item.get("Size")
+    size = item["Size"]
     # rclone reports -1 for a directory / unknown size; clamp to 0.
     size = int(size) if isinstance(size, (int, float)) and size >= 0 else 0
-    mtime = rc_modtime_epoch(item.get("ModTime")) or 0.0
-    mode = (stat_mod.S_IFDIR | 0o755) if item.get("IsDir") else (stat_mod.S_IFREG | 0o644)
+    mtime = item["MtimeEpoch"] or 0.0
+    mode = (stat_mod.S_IFDIR | 0o755) if item["IsDir"] else (stat_mod.S_IFREG | 0o644)
     # (mode, ino, dev, nlink, uid, gid, size, atime, mtime, ctime)
     return os.stat_result((mode, 0, 0, 1, 0, 0, size, mtime, mtime, mtime))
 
@@ -1482,6 +1525,200 @@ def direct_list_page(path: str, *, max_keys: int, continuation: str | None = Non
         return gcs_list_page(path, max_keys=max_keys,
                             continuation=continuation, timeout=timeout)
     raise DirectListError(f"{path}: no direct-listable backend")
+
+
+# ------------------------------------------------- direct point probes (stat)
+# The stat analog of the direct-listing path above. operations/stat has no S3
+# point lookup — rclone resolves a negative file probe or a directory probe by
+# an UNBOUNDED ListObjectsV2 of the whole parent prefix, so on a flat
+# world-scale prefix (source.coop/earthgenome/sentinel2-temporal-mosaics) every
+# probe burns the full rc timeout, and an existing directory even 404s after the
+# timeout expires. But S3/GCS expose real point lookups: HeadObject answers
+# exists/size/mtime, and a max-keys=1 list answers dir-ness — each in ~one round
+# trip. For the anonymous backends we already list unsigned, probe those
+# directly and never touch the rc path. Path-style S3 URLs come from the shared
+# _s3_base_url (its dotted-bucket rule; see there) via _public_object_url.
+_HEAD_TIMEOUT_S = 5.0
+# objects.get (metadata) is the GCS analog of S3 HeadObject; the list endpoint
+# (_GCS_LIST_URL) answers dir-ness. Both carry the bucket in the path (no region).
+_GCS_OBJ_URL = "https://storage.googleapis.com/storage/v1/b/{bucket}/o/{key}"
+
+# (exists, size, mtime) for one object; mtime is RFC3339 (rc_modtime_epoch parses
+# it) so a direct head and an rc item feed rc_modtime_epoch identically.
+DirectHead = collections.namedtuple("DirectHead", ["exists", "size", "mtime"])
+
+
+class DirectProbeError(Exception):
+    """A direct (unsigned) S3/GCS point probe could not decide — an HTTP status
+    other than 404 (403 needs auth, 301 wrong region), a network error, or an
+    unparseable body. Distinct from a 404, which is a TRUSTWORTHY "the object is
+    not there". The caller falls back to operations/stat; kept separate from
+    DirectListError so the two fallback ladders read independently."""
+
+
+def _http_date_epoch(value: str | None) -> str | None:
+    """An HTTP-date Last-Modified header ("Wed, 21 Oct 2015 07:28:00 GMT") ->
+    RFC3339, so a direct S3 head yields the same ModTime shape rc_modtime_epoch
+    already parses off an rc item. None when absent/unparseable."""
+    if not value:
+        return None
+    try:
+        return email.utils.parsedate_to_datetime(value).isoformat()
+    except (TypeError, ValueError):
+        return None
+
+
+def direct_head(path: str, *, timeout: float = _HEAD_TIMEOUT_S) -> DirectHead:
+    """Point existence+metadata probe for a mount-backed FILE via an unsigned
+    S3 HeadObject / GCS objects.get — the fast alternative to operations/stat's
+    parent-prefix list. Returns DirectHead(exists, size, mtime): exists=False on
+    a definitive 404 (the object is not there). The mountpoint itself (rel ".")
+    is never an object -> exists=False. Raises DirectProbeError on any
+    indeterminate outcome (non-404 HTTP, network, unparseable) so the caller can
+    fall back to rc, and when `path` is under no direct-probe-capable backend."""
+    if s3_direct_capable(path):
+        return _s3_head(path, timeout)
+    if gcs_direct_capable(path):
+        return _gcs_head(path, timeout)
+    raise DirectProbeError(f"{path}: no direct-probe backend")
+
+
+def direct_is_dir(path: str, *, timeout: float = _HEAD_TIMEOUT_S) -> bool:
+    """Whether any key lives under `path`'s prefix — the point dir-ness probe, a
+    max-keys=1 S3 ListObjectsV2 / GCS objects.list. True even when only the
+    zero-byte directory-marker object exists (that marker IS the directory).
+    Raises DirectProbeError on any indeterminate outcome (so the caller falls
+    back to rc) and when the backend is not direct-probe-capable."""
+    if s3_direct_capable(path):
+        return _s3_has_children(path, timeout)
+    if gcs_direct_capable(path):
+        return _gcs_has_children(path, timeout)
+    raise DirectProbeError(f"{path}: no direct-probe backend")
+
+
+def _direct_stat_item(path: str, *, timeout: float):
+    """The _stat_item dict|None outcome via direct probes: a HeadObject decides
+    FILE, else a max-keys=1 list decides DIR, else confirmed missing (None). Any
+    probe raising DirectProbeError propagates so _stat_item falls back to rc.
+    Two round trips at worst (dir/miss); one for the common file hit."""
+    head = direct_head(path, timeout=timeout)
+    if head.exists:
+        return {"IsDir": False, "Size": head.size,
+                "MtimeEpoch": rc_modtime_epoch(head.mtime)}
+    if direct_is_dir(path, timeout=timeout):
+        # S3/GCS have no real directories; a present prefix (or marker) is a dir.
+        return {"IsDir": True, "Size": None, "MtimeEpoch": None}
+    return None  # no object, no children -> a trustworthy miss
+
+
+def _s3_head(path: str, timeout: float) -> DirectHead:
+    m, rel = _mount_for(path)
+    if rel == ".":
+        return DirectHead(False, None, None)  # the mountpoint is not an object
+    url = _public_object_url(m["remote"], rel)
+    if url is None:  # not anonymous S3 after all — let the caller fall back
+        raise DirectProbeError(f"{path}: no unsigned S3 object URL")
+    req = urllib.request.Request(url, method="HEAD")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            size = resp.headers.get("Content-Length")
+            return DirectHead(
+                True,
+                int(size) if size and size.isdigit() else None,
+                _http_date_epoch(resp.headers.get("Last-Modified")))
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return DirectHead(False, None, None)  # trustworthy negative
+        raise DirectProbeError(f"S3 head {path}: HTTP {e.code}") from e
+    except (urllib.error.URLError, OSError) as e:
+        raise DirectProbeError(f"S3 head {path}: {e}") from e
+
+
+def _gcs_head(path: str, timeout: float) -> DirectHead:
+    m, rel = _mount_for(path)
+    if rel == ".":
+        return DirectHead(False, None, None)  # the mountpoint is not an object
+    fs = m["remote"]
+    derived = _gcs_bucket_prefix(fs)
+    if derived is None:
+        raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
+    bucket, store_prefix = derived
+    key = (store_prefix + "/" if store_prefix else "") + rel
+    url = _GCS_OBJ_URL.format(bucket=bucket,
+                              key=urllib.parse.quote(key, safe=""))
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return DirectHead(False, None, None)  # trustworthy negative
+        raise DirectProbeError(f"GCS head {path}: HTTP {e.code}") from e
+    except (urllib.error.URLError, OSError) as e:
+        raise DirectProbeError(f"GCS head {path}: {e}") from e
+    try:
+        doc = json.loads(body)
+    except (ValueError, TypeError) as e:
+        raise DirectProbeError(f"GCS head {path}: unparseable JSON") from e
+    size = doc.get("size")
+    return DirectHead(
+        True,
+        int(size) if isinstance(size, str) and size.isdigit() else None,
+        doc.get("updated"))  # RFC3339 already
+
+
+def _s3_has_children(path: str, timeout: float) -> bool:
+    m, rel = _mount_for(path)
+    fs = m["remote"]
+    cfg = _remote_config(fs.partition(":")[0])
+    derived = _s3_bucket_prefix_region(fs, cfg or {})
+    if derived is None:
+        raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
+    bucket, store_prefix, region = derived
+    prefix = _s3_listing_prefix(store_prefix, rel)
+    # NO delimiter and max-keys=1: cheapest "does anything live here" — one key
+    # (the marker included) proves the directory. delimiter would only add
+    # CommonPrefixes work we don't need for a boolean.
+    params = {"list-type": "2", "prefix": prefix, "max-keys": "1"}
+    query = urllib.parse.urlencode(params)
+    base = _s3_base_url(bucket, region)
+    url = f"{base}?{query}" if "." in bucket else f"{base}/?{query}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        raise DirectProbeError(f"S3 list {path}: HTTP {e.code}") from e
+    except (urllib.error.URLError, OSError) as e:
+        raise DirectProbeError(f"S3 list {path}: {e}") from e
+    try:
+        root_el = ElementTree.fromstring(body)
+    except ElementTree.ParseError as e:
+        raise DirectProbeError(f"S3 list {path}: unparseable XML") from e
+    return root_el.find(f"{_S3_XMLNS}Contents") is not None
+
+
+def _gcs_has_children(path: str, timeout: float) -> bool:
+    m, rel = _mount_for(path)
+    fs = m["remote"]
+    derived = _gcs_bucket_prefix(fs)
+    if derived is None:
+        raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
+    bucket, store_prefix = derived
+    prefix = _s3_listing_prefix(store_prefix, rel)  # backend-agnostic join
+    params = {"prefix": prefix, "maxResults": "1"}
+    query = urllib.parse.urlencode(params)
+    url = f"{_GCS_LIST_URL.format(bucket=bucket)}?{query}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        raise DirectProbeError(f"GCS list {path}: HTTP {e.code}") from e
+    except (urllib.error.URLError, OSError) as e:
+        raise DirectProbeError(f"GCS list {path}: {e}") from e
+    try:
+        doc = json.loads(body)
+    except (ValueError, TypeError) as e:
+        raise DirectProbeError(f"GCS list {path}: unparseable JSON") from e
+    return bool(doc.get("items") or doc.get("prefixes"))
 
 
 def upstream_url_for(path: str) -> str | None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -879,10 +879,14 @@ def _stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
         except DirectProbeError:
             pass  # fall through to the slow rc route, on the SAME deadline
     # The rc fallback shares the direct probes' deadline so an indeterminate
-    # direct outcome can't add a fresh full timeout on top; when the budget is
-    # already spent it gets only the floor and fails open to indeterminate.
-    item = _rc_stat_item(path, timeout=max(_DIRECT_PROBE_MIN_S,
-                                           deadline - time.monotonic()))
+    # direct outcome can't add a fresh full timeout on top; below the floor
+    # there is no plausible round trip left, so fail open to indeterminate
+    # rather than overrun the caller's timeout (the floor is a bail-out
+    # threshold, never a grant).
+    remaining = deadline - time.monotonic()
+    if remaining < _DIRECT_PROBE_MIN_S:
+        return _STAT_INDETERMINATE
+    item = _rc_stat_item(path, timeout=remaining)
     if not isinstance(item, dict):
         return item  # None (missing) or _STAT_INDETERMINATE pass straight through
     return {"IsDir": bool(item.get("IsDir")), "Size": item.get("Size"),
@@ -1621,8 +1625,10 @@ def _direct_stat_item(path: str, *, deadline: float):
     so one logical stat never spends up to 2x the timeout. If the head consumed
     the budget the dir probe can't fit -> raise so _stat_item treats it as
     indeterminate (and its own rc fallback is bounded by the same deadline)."""
-    head = direct_head(path, timeout=max(_DIRECT_PROBE_MIN_S,
-                                         deadline - time.monotonic()))
+    remaining = deadline - time.monotonic()
+    if remaining < _DIRECT_PROBE_MIN_S:
+        raise DirectProbeError(f"{path}: budget spent before head probe")
+    head = direct_head(path, timeout=remaining)
     if head.exists:
         return {"IsDir": False, "Size": head.size,
                 "MtimeEpoch": rc_modtime_epoch(head.mtime)}

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -127,22 +127,21 @@ def _local_exists(fs_path: str) -> bool:
 
 def _mount_exists(fs_path: str) -> bool:
     """Existence of a MOUNT-BACKED path, answered by the rclone rc API
-    (mounts.rc_mtime_for) — NEVER os.path.isfile. A raw os.stat/isfile on a hung
-    NFS mount is the exact GETATTR that wedges it (see rc_mtime_for's docstring
-    in mounts.py); rc_mtime_for keeps the kernel out of the loop entirely.
+    (mounts.rc_stat_for) — NEVER os.path.isfile. A raw os.stat/isfile on a hung
+    NFS mount is the exact GETATTR that wedges it (see rc_stat_for/rc_mtime_for
+    in mounts.py); the rc route keeps the kernel out of the loop entirely.
 
-    A present ModTime proves the file exists. None is INDETERMINATE — rc can't
-    tell "rcd down / timed out" from "genuinely missing" — so we fail open and
-    KEEP the entry (True) rather than risk hiding a live recent on a transient
+    The only outcome that filters the entry is a healthy rcd's confirmed
+    "missing" (operations/stat returned {"item": null}). "exists" keeps it, and
+    "indeterminate" (rcd down / timed out / errored — rc can't prove absence)
+    also keeps it: we fail open rather than hide a live recent on a transient
     rc hiccup."""
     from fused_render.shell import mounts as shell_mounts
 
     try:
-        if shell_mounts.rc_mtime_for(fs_path) is not None:
-            return True
+        return shell_mounts.rc_stat_for(fs_path) != "missing"
     except Exception:
-        pass
-    return True  # indeterminate -> fail open, keep the entry
+        return True  # unexpected error -> fail open, keep the entry
 
 
 async def _keep_entry(url: str) -> bool:

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -17,7 +17,9 @@ persisted folder collapse. Entries whose file has since been deleted are
 hidden from the GET response but never deleted from disk — the file may come
 back (a mount reconnect, an undeleted trash item).
 """
+import asyncio
 import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
 from urllib.parse import unquote, urlsplit
 
@@ -33,6 +35,25 @@ VIEW_PREFIX = "/view/"
 # Cap well above the UI's 3 visible rows so enough valid entries remain after
 # missing-file filtering.
 ENTRY_CAP = 20
+
+# Total wall-clock budget for ALL of a GET /api/recents' existence checks. The
+# checks fan out concurrently (on _CHECK_POOL below) and share this one deadline
+# — so the endpoint stays bounded no matter how many entries sit on a slow or hung
+# mount. An entry whose check outlives the budget is KEPT, not dropped (fail
+# open): a possibly-dead sidebar row beats a multi-second stall. Sized like the
+# fs/events watch ticker's per-stat _STAT_TIMEOUT_S (server.py, 4.0s) but tighter
+# — this is the whole sidebar section, not one background poll.
+CHECK_BUDGET_S = 1.5
+
+# Existence checks run on a DEDICATED pool, not asyncio's default loop executor:
+# a check that outlives CHECK_BUDGET_S keeps running in its thread (a blocking
+# os.stat/rc call can't be cancelled mid-flight), and parking those on the
+# shared default executor makes the request wait for them at loop teardown.
+# ENTRY_CAP-wide so every entry's check can run at once (true fan-out); slots
+# free themselves as the local isfile / bounded rc_mtime_for calls return.
+_CHECK_POOL = ThreadPoolExecutor(
+    max_workers=ENTRY_CAP, thread_name_prefix="recents-exists"
+)
 
 
 def _require_fused(x_fused: str | None) -> JSONResponse | None:
@@ -94,6 +115,54 @@ def _file_path_from_url(url: str) -> str | None:
     return fs_path
 
 
+def _local_exists(fs_path: str) -> bool:
+    """Existence of a LOCAL (non-mount-backed) path. A plain os.path.isfile is
+    safe and cheap here — the mount-wedging GETATTR concern only applies under a
+    managed mount, which _keep_entry routes away from this call."""
+    try:
+        return os.path.isfile(fs_path)
+    except OSError:
+        return False
+
+
+def _mount_exists(fs_path: str) -> bool:
+    """Existence of a MOUNT-BACKED path, answered by the rclone rc API
+    (mounts.rc_mtime_for) — NEVER os.path.isfile. A raw os.stat/isfile on a hung
+    NFS mount is the exact GETATTR that wedges it (see rc_mtime_for's docstring
+    in mounts.py); rc_mtime_for keeps the kernel out of the loop entirely.
+
+    A present ModTime proves the file exists. None is INDETERMINATE — rc can't
+    tell "rcd down / timed out" from "genuinely missing" — so we fail open and
+    KEEP the entry (True) rather than risk hiding a live recent on a transient
+    rc hiccup."""
+    from fused_render.shell import mounts as shell_mounts
+
+    try:
+        if shell_mounts.rc_mtime_for(fs_path) is not None:
+            return True
+    except Exception:
+        pass
+    return True  # indeterminate -> fail open, keep the entry
+
+
+async def _keep_entry(url: str) -> bool:
+    """Whether a recents entry should appear in the GET response: True to keep,
+    False to filter (file confirmed gone). Runs the existence check off the
+    event loop and routes mount-backed paths through the rc API. Only a check
+    that COMPLETES False filters; anything indeterminate keeps (fail open)."""
+    fs_path = _decoded_fs_path(url)
+    if fs_path is None:
+        return False  # not a file-naming url (sentinel / non-/view/) -> filtered
+    from fused_render.shell import mounts as shell_mounts
+
+    check = _mount_exists if shell_mounts.is_mount_backed(fs_path) else _local_exists
+    loop = asyncio.get_running_loop()
+    try:
+        return await loop.run_in_executor(_CHECK_POOL, check, fs_path)
+    except Exception:
+        return True  # fail open on any unexpected error
+
+
 def _read() -> dict:
     data = storage.read_json(_path())
     if not isinstance(data, dict):
@@ -106,15 +175,28 @@ def _read() -> dict:
 
 
 @router.get("/api/recents")
-def get_recents():
+async def get_recents():
     """The collapsed flag + entries whose target file still exists. Missing
     files are filtered from the response, NOT deleted from disk (read-only
-    GET, like bookmarks; the file may reappear)."""
+    GET, like bookmarks; the file may reappear).
+
+    Existence checks fan out concurrently under a single CHECK_BUDGET_S deadline
+    and are mount-safe (mount-backed paths route through the rclone rc API, not
+    a kernel os.stat). An entry whose check outlives the budget is KEPT (fail
+    open) — a possibly-dead row beats a stalled sidebar."""
     data = _read()
-    entries = [
-        e for e in data["entries"]
-        if isinstance(e.get("url"), str) and _file_path_from_url(e["url"]) is not None
-    ]
+    raw = [e for e in data["entries"] if isinstance(e.get("url"), str)]
+    keeps = [True] * len(raw)  # default keep (fail open on timeout/cancel)
+    if raw:
+        tasks = [asyncio.ensure_future(_keep_entry(e["url"])) for e in raw]
+        done, pending = await asyncio.wait(tasks, timeout=CHECK_BUDGET_S)
+        for i, t in enumerate(tasks):
+            if t in done:
+                # _keep_entry never raises, but stay defensive: keep on error.
+                keeps[i] = t.result() if not t.cancelled() else True
+        for t in pending:
+            t.cancel()  # deadline hit; underlying thread finishes on its own
+    entries = [e for e, keep in zip(raw, keeps) if keep]
     return {"collapsed": data["collapsed"], "entries": entries}
 
 

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -1,0 +1,212 @@
+"""The condition-gate mount shim (server._run_condition + _conditions_payload +
+_fs_stat).
+
+`/api/fs/conditions` runs template condition gates (`condition.py`) whose plain
+`os.path.isfile`/`isdir`/`os.stat`/`open` hit the kernel NFS mount. A cold
+NEGATIVE `os.path.isfile` on a mount forces rclone to LIST the whole parent S3
+prefix (~18-24s) and trips the macOS NFS deadman -> the mount is dropped. For a
+mount-backed target the gate runs under a per-call, thread-safe shim that routes
+those primitives through the rclone rc API instead of the kernel (Solution A).
+
+These tests drive the shim through the server surface with the rc helpers
+monkeypatched (the helpers themselves are tested against a real stub rcd in
+tests/test_shell_mounts.py), and GUARD the real kernel os.* so any leak fails
+loudly — the mount-safety property is the whole point.
+"""
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render import server
+
+MOUNT_PREFIX = "/fake-mounts/"
+STORE = "/fake-mounts/s3demo/store"
+ZARR_CONDITION = os.path.join(server.TEMPLATES_DIR, "zarr_aoi", "condition.py")
+
+
+@pytest.fixture()
+def guard_kernel(monkeypatch):
+    """Make every kernel os call on a mount-backed path explode, so a shim leak
+    fails loudly. Non-mount paths (template files, tmp fixtures) pass through."""
+    real = {
+        "isfile": os.path.isfile,
+        "isdir": os.path.isdir,
+        "exists": os.path.exists,
+        "stat": os.stat,
+        "listdir": os.listdir,
+        "scandir": os.scandir,
+    }
+
+    def _guard(name, fn):
+        def wrapped(p, *a, **k):
+            if isinstance(p, str) and p.startswith(MOUNT_PREFIX):
+                raise AssertionError(f"kernel os.{name} on mount path {p!r}")
+            return fn(p, *a, **k)
+        return wrapped
+
+    for name in ("isfile", "isdir", "exists"):
+        monkeypatch.setattr(os.path, name, _guard(name, real[name]))
+    for name in ("stat", "listdir", "scandir"):
+        monkeypatch.setattr(os, name, _guard(name, real[name]))
+    return real
+
+
+def _mount(monkeypatch, kind_map, read_bytes=None):
+    """Route the mount prefix through fake rc helpers. `kind_map` maps an exact
+    path (or the string "*") to a rc_kind_for verdict; `read_bytes` is what
+    rc_read_bounded returns for the zarr.json probe."""
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p):
+        return kind_map.get(p, kind_map.get("*", "missing"))
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+
+    def _read(p, *a, **k):
+        if read_bytes is None:
+            raise OSError("no serve")
+        return read_bytes
+
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded", _read)
+
+
+# ----------------------------------------------------------- _run_condition shim
+
+
+def test_shimmed_gate_group_true_with_zero_kernel_os_calls(monkeypatch, guard_kernel):
+    # A v3 group root on a mount: isdir(dir) hits, .zmetadata misses, zarr.json
+    # hits, its node_type=="group" -> True. Every probe routes via rc; the kernel
+    # guard proves not one os.* call touched the mount.
+    _mount(
+        monkeypatch,
+        {STORE: "dir", STORE + "/zarr.json": "file"},
+        read_bytes=b'{"node_type": "group"}',
+    )
+    allowed, err = server._run_condition(ZARR_CONDITION, STORE)
+    assert allowed is True and err is None
+
+
+def test_shimmed_gate_bare_array_is_false(monkeypatch, guard_kernel):
+    # v3 bare-array root: zarr.json present but node_type=="array" -> not a group
+    # -> False (fail-closed correctness preserved over the shim).
+    _mount(
+        monkeypatch,
+        {STORE: "dir", STORE + "/zarr.json": "file"},
+        read_bytes=b'{"node_type": "array"}',
+    )
+    allowed, err = server._run_condition(ZARR_CONDITION, STORE)
+    assert allowed is False and err is None
+
+
+def test_shimmed_gate_plain_dir_is_false(monkeypatch, guard_kernel):
+    # A directory with no store markers: isdir hits, all three isfile probes miss
+    # -> False, all off the kernel.
+    _mount(monkeypatch, {STORE: "dir", "*": "missing"})
+    allowed, err = server._run_condition(ZARR_CONDITION, STORE)
+    assert allowed is False and err is None
+
+
+def test_shimmed_gate_named_zarr_fast_path_true(monkeypatch, guard_kernel):
+    # The zero-I/O `.zarr` name fast path returns True without any rc call at all.
+    named = "/fake-mounts/s3demo/world.zarr"
+    _mount(monkeypatch, {})  # every rc_kind_for would be "missing" if consulted
+    allowed, err = server._run_condition(ZARR_CONDITION, named)
+    assert allowed is True and err is None
+
+
+def test_shimmed_gate_fail_closed_on_indeterminate(monkeypatch, guard_kernel):
+    # rcd down / rc error / timeout -> every routed probe is "indeterminate",
+    # which the shim maps to False (isdir False) so the gate fails closed exactly
+    # like a kernel exception. NEVER a fall back to kernel os.* (the guard proves).
+    _mount(monkeypatch, {"*": "indeterminate"})
+    allowed, err = server._run_condition(ZARR_CONDITION, STORE)
+    assert allowed is False and err is None
+
+
+def test_shimmed_gate_fail_closed_when_read_unavailable(monkeypatch, guard_kernel):
+    # zarr.json exists but the bounded serve read fails (no serve / transport
+    # error) -> OSError inside the gate -> fail closed, not a group.
+    _mount(
+        monkeypatch,
+        {STORE: "dir", STORE + "/zarr.json": "file"},
+        read_bytes=None,  # rc_read_bounded raises OSError
+    )
+    allowed, err = server._run_condition(ZARR_CONDITION, STORE)
+    assert allowed is False and err is None
+
+
+def test_local_path_gate_uses_kernel_unaffected(tmp_path, guard_kernel):
+    # Regression: a NON-mount target keeps the exact current behavior — the gate
+    # runs against the real kernel os (the guard only fires for mount paths).
+    store = tmp_path / "m"
+    store.mkdir()
+    (store / ".zgroup").write_text("{}")
+    allowed, err = server._run_condition(ZARR_CONDITION, str(store))
+    assert allowed is True and err is None
+    assert server._run_condition(ZARR_CONDITION, str(tmp_path))[0] is False
+
+
+# ------------------------------------------------- /api/fs/conditions + /api/fs/stat
+
+
+def _client():
+    return TestClient(server.create_app(start_dir="/"))
+
+
+def test_conditions_endpoint_true_on_mount_group(monkeypatch, guard_kernel):
+    _mount(
+        monkeypatch,
+        {STORE: "dir", STORE + "/zarr.json": "file"},
+        read_bytes=b'{"node_type": "group"}',
+    )
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+
+
+def test_conditions_endpoint_200_fail_closed_when_rc_indeterminate(monkeypatch, guard_kernel):
+    # rcd unreachable: the endpoint must NOT 404 a path the user just opened —
+    # it stays 200 with the gate fail-closed to False.
+    _mount(monkeypatch, {"*": "indeterminate"})
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is False
+
+
+def test_conditions_endpoint_404_on_confirmed_missing_mount(monkeypatch, guard_kernel):
+    # A healthy rcd confirming the target is gone -> a real 404 (trustworthy
+    # negative), never the kernel os.stat.
+    _mount(monkeypatch, {"*": "missing"})
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 404
+
+
+def test_fs_stat_mount_routes_via_rc_not_kernel(monkeypatch, guard_kernel):
+    # /api/fs/stat on a mount path synthesizes its stat from rc, never a kernel
+    # GETATTR, and reports remote=True.
+    _mount(monkeypatch, {STORE: "dir"})
+
+    def _stat_result(p):
+        import stat as _s
+        return os.stat_result((_s.S_IFDIR | 0o755, 0, 0, 1, 0, 0, 0, 0, 0.0, 0.0))
+
+    monkeypatch.setattr(mounts_mod, "rc_stat_result", _stat_result)
+    r = _client().get("/api/fs/stat", params={"path": STORE})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["is_dir"] is True and body["remote"] is True
+
+
+def test_fs_stat_local_unaffected(tmp_path, guard_kernel):
+    # Regression: a local path still stats through the kernel and reports
+    # remote=False.
+    f = tmp_path / "a.bin"
+    f.write_bytes(b"xyz")
+    r = _client().get("/api/fs/stat", params={"path": str(f)})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["is_dir"] is False and body["remote"] is False and body["size"] == 3

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -61,7 +61,7 @@ def _mount(monkeypatch, kind_map, read_bytes=None):
     monkeypatch.setattr(mounts_mod, "is_mount_backed",
                         lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
 
-    def _kind(p):
+    def _kind(p, **k):  # shim now passes a per-probe `timeout=` (budget backstop)
         return kind_map.get(p, kind_map.get("*", "missing"))
 
     monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
@@ -195,7 +195,7 @@ def test_from_os_import_stat_routed(monkeypatch, guard_kernel, tmp_path):
     _mount(monkeypatch, {STORE: "dir"})
     monkeypatch.setattr(
         mounts_mod, "rc_stat_result",
-        lambda p: os.stat_result((_s.S_IFDIR | 0o755, 0, 0, 1, 0, 0, 0, 0, 0.0, 0.0)))
+        lambda p, **k: os.stat_result((_s.S_IFDIR | 0o755, 0, 0, 1, 0, 0, 0, 0, 0.0, 0.0)))
     cf = _gate(tmp_path, "from os import stat\n"
                          "def main(path):\n"
                          "    import stat as s\n"
@@ -277,3 +277,31 @@ def test_fs_stat_local_unaffected(tmp_path, guard_kernel):
     assert r.status_code == 200
     body = r.json()
     assert body["is_dir"] is False and body["remote"] is False and body["size"] == 3
+
+
+def test_fs_stat_mount_indeterminate_is_503_not_404(monkeypatch, guard_kernel):
+    # BUG FIX: an rc stat that could not be TAKEN (rcd hung past its deadline /
+    # rc timeout / mount slow) raises a bare OSError — the "indeterminate"
+    # outcome, NOT proof the path is gone. /api/fs/stat must surface a retryable
+    # 503; mapping it to 404 tells the client a path it just opened has vanished.
+    _mount(monkeypatch, {STORE: "dir"})
+
+    def _indeterminate(p, **k):
+        raise OSError(f"rc stat unavailable for {p}")
+
+    monkeypatch.setattr(mounts_mod, "rc_stat_result", _indeterminate)
+    r = _client().get("/api/fs/stat", params={"path": STORE})
+    assert r.status_code == 503
+
+
+def test_fs_stat_mount_confirmed_missing_is_404(monkeypatch, guard_kernel):
+    # A backend confirming the item is gone (FileNotFoundError) is a trustworthy
+    # negative -> a real 404, distinct from the indeterminate 503 above.
+    _mount(monkeypatch, {STORE: "missing"})
+
+    def _gone(p, **k):
+        raise FileNotFoundError(p)
+
+    monkeypatch.setattr(mounts_mod, "rc_stat_result", _gone)
+    r = _client().get("/api/fs/stat", params={"path": STORE})
+    assert r.status_code == 404

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -150,6 +150,73 @@ def test_local_path_gate_uses_kernel_unaffected(tmp_path, guard_kernel):
     assert server._run_condition(ZARR_CONDITION, str(tmp_path))[0] is False
 
 
+# --------------------------------------------------- import-form coverage
+#
+# The shim routes the gate's `os` off the kernel by overriding __import__ in the
+# gate module's builtins. Every idiomatic import form a gate (builtin or
+# user-authored) might use must resolve to the shim — `import os`, `import os as
+# o`, `from os import path/stat`, and the DOTTED forms `import os.path` /
+# `from os.path import isfile`, which call __import__("os.path", ...) and would
+# otherwise fall through to the real kernel os.path.
+
+
+def _gate(tmp_path, body):
+    p = tmp_path / "condition.py"
+    p.write_text(body)
+    return str(p)
+
+
+def test_import_os_path_dotted_routed(monkeypatch, guard_kernel, tmp_path):
+    # `import os.path` -> __import__("os.path") must yield the shim, not real os.
+    _mount(monkeypatch, {STORE: "file"})
+    cf = _gate(tmp_path, "import os.path\n"
+                         "def main(path):\n    return os.path.isfile(path)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
+def test_from_os_path_import_isfile_routed(monkeypatch, guard_kernel, tmp_path):
+    # `from os.path import isfile` -> __import__("os.path", fromlist=("isfile",))
+    # must return the shim's path submodule so isfile binds the shimmed function.
+    _mount(monkeypatch, {STORE: "file"})
+    cf = _gate(tmp_path, "from os.path import isfile\n"
+                         "def main(path):\n    return isfile(path)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
+def test_from_os_path_import_isdir_exists_routed(monkeypatch, guard_kernel, tmp_path):
+    _mount(monkeypatch, {STORE: "dir"})
+    cf = _gate(tmp_path, "from os.path import isdir, exists\n"
+                         "def main(path):\n    return isdir(path) and exists(path)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
+def test_from_os_import_stat_routed(monkeypatch, guard_kernel, tmp_path):
+    import stat as _s
+    _mount(monkeypatch, {STORE: "dir"})
+    monkeypatch.setattr(
+        mounts_mod, "rc_stat_result",
+        lambda p: os.stat_result((_s.S_IFDIR | 0o755, 0, 0, 1, 0, 0, 0, 0, 0.0, 0.0)))
+    cf = _gate(tmp_path, "from os import stat\n"
+                         "def main(path):\n"
+                         "    import stat as s\n"
+                         "    return s.S_ISDIR(stat(path).st_mode)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
+def test_import_os_aliased_routed(monkeypatch, guard_kernel, tmp_path):
+    _mount(monkeypatch, {STORE: "file"})
+    cf = _gate(tmp_path, "import os as o\n"
+                         "def main(path):\n    return o.path.isfile(path)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
+def test_from_os_import_path_aliased_routed(monkeypatch, guard_kernel, tmp_path):
+    _mount(monkeypatch, {STORE: "file"})
+    cf = _gate(tmp_path, "from os import path as p\n"
+                         "def main(path):\n    return p.isfile(path)\n")
+    assert server._run_condition(cf, STORE) == (True, None)
+
+
 # ------------------------------------------------- /api/fs/conditions + /api/fs/stat
 
 

--- a/tests/test_condition_probe_budget.py
+++ b/tests/test_condition_probe_budget.py
@@ -1,0 +1,99 @@
+"""Per-gate probe budget backstop (server._mount_gate_builtins / _run_condition
+and the /api/fs/conditions endpoint).
+
+operations/stat has NO S3 point lookup: on a non-direct-capable mount each probe
+makes rclone list the whole parent prefix, burning the full rc timeout. A
+condition gate runs its probes SERIALLY, so three of them would stack to ~3x the
+timeout (20-30s on source.coop). One gate evaluation shares a single wall-clock
+deadline (GATE_PROBE_BUDGET_S): each probe is bounded to the budget remaining and
+once it is spent the rest fail closed instantly (SPEC CT-12), so the gate — and
+the endpoint — completes within the budget rather than stacking timeouts.
+
+These drive the REAL rc path against a hanging stub rcd (the socket-timeout
+cutoff is the mechanism under test, so it must be exercised for real), mirroring
+the CHECK_BUDGET_S pattern in tests/test_shell_recents.py. Real rclone is never
+invoked; FUSED_RENDER_HOME is redirected per test.
+"""
+import os
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.server as server
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import create_app
+from test_shell_mounts import StubRcd
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / "mounts").mkdir(parents=True)
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
+    # A mount is added BEFORE create_app; skip the automount startup thread so it
+    # can't outlive the test and corrupt the next test's home.
+    monkeypatch.setattr(mounts_mod, "startup", lambda: None)
+    return h
+
+
+@pytest.fixture()
+def rcd(home):
+    stub = StubRcd()
+    mounts_mod.write_rcd_state(stub.port, 4242)
+    yield stub
+    stub.close()
+
+
+@pytest.fixture(autouse=True)
+def fresh_cfg():
+    # _remote_config memoizes per remote in a module global; clear so a
+    # credentialed config from one test doesn't leak into the next.
+    mounts_mod._upstream_cfg.clear()
+    yield
+    mounts_mod._upstream_cfg.clear()
+
+
+def _hanging_noncapable_mount(rcd, monkeypatch, budget=1.0):
+    """A mount whose stat backend HANGS: credentialed S3 (not direct-capable, so
+    the rc route is taken) with operations/stat delayed far past the budget."""
+    monkeypatch.setattr(server, "GATE_PROBE_BUDGET_S", budget)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    rcd.delay["operations/stat"] = 10.0  # every rc probe would burn 10s
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    return os.path.join(mounts_mod.mountpoint(c), "store")
+
+
+def test_gate_probe_budget_caps_serialized_hanging_probes(home, rcd, tmp_path, monkeypatch):
+    store = _hanging_noncapable_mount(rcd, monkeypatch, budget=1.0)
+    gate = tmp_path / "condition.py"
+    gate.write_text(
+        "import os\n"
+        "def main(path):\n"
+        "    a = os.path.isfile(path + '/a')\n"
+        "    b = os.path.isfile(path + '/b')\n"
+        "    c = os.path.isfile(path + '/c')\n"
+        "    return a or b or c\n")
+
+    start = time.monotonic()
+    allowed, err = server._run_condition(str(gate), store)
+    elapsed = time.monotonic() - start
+
+    # Fail closed, and within roughly one budget — NOT 3 * 10s of stacked probes.
+    assert allowed is False and err is None
+    assert elapsed < 3.0, f"gate took {elapsed:.1f}s — budget not enforced"
+
+
+def test_fs_conditions_bounded_when_stat_backend_stalls(home, rcd, tmp_path, monkeypatch):
+    store = _hanging_noncapable_mount(rcd, monkeypatch, budget=1.0)
+
+    client = TestClient(create_app(start_dir="/"))
+    start = time.monotonic()
+    r = client.get("/api/fs/conditions", params={"path": store})
+    elapsed = time.monotonic() - start
+
+    # Fail-closed 200 (never a spurious 404 or a hang): the endpoint dir probe
+    # and every gate are budget-bounded, so all conditions resolve False fast.
+    assert r.status_code == 200
+    assert all(v is False for v in r.json()["conditions"].values())
+    assert elapsed < 6.0, f"/api/fs/conditions took {elapsed:.1f}s — not bounded"

--- a/tests/test_server_fs_write.py
+++ b/tests/test_server_fs_write.py
@@ -120,9 +120,18 @@ def test_write_create_ok_for_new_file(tmp_path):
 @pytest.fixture
 def mounted(tmp_path, monkeypatch):
     """A real file sitting under a fake mountpoint inside a redirected
-    FUSED_RENDER_HOME. Returns a factory: mounted(read_only=...) -> file path."""
+    FUSED_RENDER_HOME. Returns a factory: mounted(read_only=...) -> file path.
+
+    fs/stat routes a mount-backed stat through the rclone rc API instead of the
+    kernel (a kernel GETATTR over a mount can wedge it), so a live stub rcd must
+    answer operations/stat for the mounted file."""
     monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
     import fused_render.shell.mounts as mounts
+    from test_shell_mounts import StubRcd
+
+    stub = StubRcd()
+    stub.responses["operations/stat"] = {"item": {"Size": len(b"original")}}
+    mounts.write_rcd_state(stub.port, 4242)
 
     def make(name, read_only):
         m = mounts.add_mount(name, f"{name}-remote:bucket", read_only=read_only)
@@ -133,7 +142,8 @@ def mounted(tmp_path, monkeypatch):
             fh.write("original")
         return f
 
-    return make
+    yield make
+    stub.close()
 
 
 def test_stat_not_writable_under_read_only_mount(mounted):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -336,6 +336,110 @@ def test_rc_mtime_for_and_rc_stat_for_share_one_rc_call_semantics(home, rcd):
     assert mounts_mod.rc_stat_for(path) == "missing"
 
 
+def test_rc_kind_for_four_state(home, rcd):
+    # rc_kind_for extends rc_stat_for with the IsDir bit operations/stat already
+    # carries, so a condition-gate shim can tell os.path.isfile from isdir over a
+    # mount WITHOUT the cold negative kernel LOOKUP that lists the whole S3 prefix
+    # and wedges the mount.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/store"
+
+    rcd.responses["operations/stat"] = {"item": {"IsDir": True}}
+    assert mounts_mod.rc_kind_for(path) == "dir"
+    rcd.responses["operations/stat"] = {"item": {"IsDir": False, "Size": 12}}
+    assert mounts_mod.rc_kind_for(path) == "file"
+    rcd.responses["operations/stat"] = {"item": {"Size": 12}}  # IsDir absent -> file
+    assert mounts_mod.rc_kind_for(path) == "file"
+    rcd.responses["operations/stat"] = {"item": None}  # healthy rcd: gone
+    assert mounts_mod.rc_kind_for(path) == "missing"
+    rcd.responses["operations/stat"] = {"nope": 1}  # malformed -> indeterminate
+    assert mounts_mod.rc_kind_for(path) == "indeterminate"
+
+
+def test_rc_kind_for_indeterminate_on_error_or_no_rcd_or_no_mount(home, rcd):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/store"
+    # rc error (stub 404s unset methods) and a path under no mount -> indeterminate.
+    assert mounts_mod.rc_kind_for(path) == "indeterminate"
+    assert mounts_mod.rc_kind_for("/tmp/not/a/mount/store") == "indeterminate"
+
+
+def test_rc_stat_result_synthesizes_from_operations_stat(home, rcd):
+    # A mount stat is answered off the kernel: st_mode's dir/file bit, st_size,
+    # and st_mtime come from operations/stat, never a kernel GETATTR.
+    import stat as _stat
+
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/store"
+
+    rcd.responses["operations/stat"] = {
+        "item": {"IsDir": True, "ModTime": "2024-01-02T03:04:05Z"}}
+    st = mounts_mod.rc_stat_result(path)
+    assert _stat.S_ISDIR(st.st_mode)
+    assert st.st_mtime == mounts_mod.rc_modtime_epoch("2024-01-02T03:04:05Z")
+
+    rcd.responses["operations/stat"] = {
+        "item": {"IsDir": False, "Size": 99, "ModTime": "2024-01-02T03:04:05Z"}}
+    st = mounts_mod.rc_stat_result(path)
+    assert _stat.S_ISREG(st.st_mode)
+    assert st.st_size == 99
+
+
+def test_rc_stat_result_raises_like_kernel_on_missing_and_indeterminate(home, rcd):
+    # Fail exactly like the kernel os.stat it replaces so callers' 404 handling
+    # holds: FileNotFoundError when the rcd confirms the item gone, OSError on any
+    # indeterminate outcome — and NEVER fall back to a kernel GETATTR.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/store"
+
+    rcd.responses["operations/stat"] = {"item": None}
+    with pytest.raises(FileNotFoundError):
+        mounts_mod.rc_stat_result(path)
+
+    rcd.responses["operations/stat"] = {"nope": 1}  # malformed -> indeterminate
+    with pytest.raises(OSError):
+        mounts_mod.rc_stat_result(path)
+
+
+def test_rc_read_bounded_reads_over_http_serve(home, monkeypatch):
+    # The condition-gate shim's open() reads the one bounded zarr.json over the
+    # mount's localhost HTTP serve (serve_url_for), never a kernel open/read.
+    import io as _io
+
+    calls = []
+
+    def _fake_serve_url_for(p):
+        return "http://127.0.0.1:59999/store/zarr.json"
+
+    def _fake_urlopen(req, timeout=None):
+        calls.append((req.full_url, dict(req.headers), timeout))
+        return _io.BytesIO(b'{"node_type": "group"}')
+
+    monkeypatch.setattr(mounts_mod, "serve_url_for", _fake_serve_url_for)
+    monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", _fake_urlopen)
+
+    data = mounts_mod.rc_read_bounded("/mnt/store/zarr.json")
+    assert data == b'{"node_type": "group"}'
+    # Bounded: a Range header caps the read.
+    assert "Range" in calls[0][1] or "range" in {k.lower() for k in calls[0][1]}
+
+
+def test_rc_read_bounded_raises_oserror_without_serve_or_on_transport_error(home, monkeypatch):
+    # No live serve, or any transport failure -> OSError so the gate fails closed.
+    monkeypatch.setattr(mounts_mod, "serve_url_for", lambda p: None)
+    with pytest.raises(OSError):
+        mounts_mod.rc_read_bounded("/mnt/store/zarr.json")
+
+    monkeypatch.setattr(mounts_mod, "serve_url_for", lambda p: "http://127.0.0.1:1/x")
+
+    def _boom(req, timeout=None):
+        raise mounts_mod.urllib.error.URLError("refused")
+
+    monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", _boom)
+    with pytest.raises(OSError):
+        mounts_mod.rc_read_bounded("/mnt/store/zarr.json")
+
+
 def test_is_mount_backed_follows_symlink_into_mounts(home, tmp_path):
     # A symlink whose target is inside the mounts dir must classify as
     # mount-backed (else it lands on the kernel os.stat ticker — the GETATTR

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2960,3 +2960,23 @@ def test_rc_stat_result_falls_back_to_rc_when_direct_errors(home, rcd, fresh_ups
     st = mounts_mod.rc_stat_result(mounts_mod.mountpoint(c) + "/d")
     assert stat.S_ISDIR(st.st_mode)
     assert any(x[0] == "operations/stat" for x in rcd.calls)
+
+
+def test_probe_floor_never_exceeds_caller_timeout(home, rcd, fresh_upstream, direct_stub):
+    # _DIRECT_PROBE_MIN_S is a bail-out threshold, NOT a grant: when the
+    # caller's remaining budget is already below the floor, the stat must
+    # report indeterminate immediately — a max(floor, remaining) clamp would
+    # instead hand a 0.5s head probe PLUS a 0.5s rc fallback to a caller who
+    # asked for 0.2s, stacking one logical stat past the gate budget (the
+    # "probe floor exceeds caller timeout" bug).
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.head = (404, {})
+    direct_stub.listing = (200, _s3_list_xml())
+    direct_stub.delay = {"HEAD": 2.0, "GET": 2.0}  # any granted probe shows up as wall time
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    t0 = time.monotonic()
+    kind = mounts_mod.rc_kind_for(mounts_mod.mountpoint(c) + "/x", timeout=0.2)
+    elapsed = time.monotonic() - t0
+    assert kind == "indeterminate"
+    assert elapsed < 0.19, (
+        f"sub-floor budget still ran probes for {elapsed:.2f}s (floor granted, not bailed)")

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1827,10 +1827,15 @@ def test_serve_url_for_maps_and_quotes(home, rcd):
     assert mounts_mod.serve_url_for("/somewhere/else.parquet") is None
 
 
-def test_stat_marks_mount_backed_files_remote(client, home):
+def test_stat_marks_mount_backed_files_remote(client, home, rcd):
     import os
 
-    mp = os.path.join(mounts_mod.mounts_dir(), "data")
+    # fs/stat routes a mount stat through the rc API, so the stub rcd answers
+    # operations/stat for the mount-backed file (the local path still stats via
+    # the kernel).
+    rcd.responses["operations/stat"] = {"item": {"Size": 2}}
+    c = mounts_mod.add_mount("data", "remote:bucket")  # a real record for _mount_for
+    mp = mounts_mod.mountpoint(c)
     os.makedirs(mp)
     f = os.path.join(mp, "x.parquet")
     open(f, "wb").write(b"pq")

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2747,6 +2747,7 @@ class DirectObjStub:
 
     def __init__(self):
         self.calls = []  # (method, path, query)
+        self.delay = {}  # method -> seconds to sleep before responding (timeouts)
         # (status, headers-or-body). 200 head -> send those headers, no body.
         self.head = (200, {"Content-Length": "123",
                            "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT"})
@@ -2761,6 +2762,8 @@ class DirectObjStub:
             def _record(self):
                 p, _, q = self.path.partition("?")
                 stub.calls.append((self.command, p, q))
+                if self.command in stub.delay:
+                    time.sleep(stub.delay[self.command])
 
             def do_HEAD(self):
                 self._record()
@@ -2922,6 +2925,27 @@ def test_rc_kind_for_direct_dir_then_missing(home, rcd, fresh_upstream, direct_s
     direct_stub.listing = (200, _s3_list_xml())
     assert mounts_mod.rc_kind_for(base + "/gone") == "missing"
     assert not any(x[0] == "operations/stat" for x in rcd.calls)
+
+
+def test_direct_stat_pair_shares_one_timeout_budget(home, rcd, fresh_upstream, direct_stub):
+    # A dir/miss resolution runs direct_head THEN direct_is_dir back-to-back. If
+    # each got a fresh full `timeout`, one logical rc_kind_for could burn up to
+    # 2x the caller's budget (the "direct stat doubles probe timeout" bug). The
+    # two probes must SHARE one deadline, so a slow head leaves the list only the
+    # remaining budget — a single stat never exceeds ~timeout.
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    # Both point probes are slow (0.8s); together they'd be ~1.6s if unbounded.
+    direct_stub.head = (404, {})                 # HEAD -> not a file (proceeds to dir probe)
+    direct_stub.listing = (200, _s3_list_xml())  # empty prefix
+    direct_stub.delay = {"HEAD": 0.8, "GET": 0.8}
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    t0 = time.monotonic()
+    mounts_mod.rc_kind_for(mounts_mod.mountpoint(c) + "/slow", timeout=1.0)
+    elapsed = time.monotonic() - t0
+    # With the shared budget the head eats most of the 1.0s and the list gets no
+    # meaningful budget, so the whole call stays well under 2x. Without the fix
+    # this is ~1.6s.
+    assert elapsed < 1.3, f"one stat took {elapsed:.2f}s, ~2x the 1.0s budget"
 
 
 def test_rc_stat_result_falls_back_to_rc_when_direct_errors(home, rcd, fresh_upstream, direct_stub):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -284,6 +284,58 @@ def test_rc_mtime_for_none_outside_any_mount(home, rcd):
     assert mounts_mod.rc_mtime_for("/tmp/not/a/mount/f.parquet") is None
 
 
+def test_rc_stat_for_tri_state(home, rcd):
+    # rc_stat_for distinguishes the three outcomes rc_mtime_for collapses to
+    # None, so a caller can filter a genuinely-deleted mount file while still
+    # failing open on anything indeterminate.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/f.parquet"
+
+    # Healthy rcd, item is a dict -> file exists (ModTime irrelevant to stat).
+    rcd.responses["operations/stat"] = {"item": {"ModTime": "2024-01-02T03:04:05Z"}}
+    assert mounts_mod.rc_stat_for(path) == "exists"
+    rcd.responses["operations/stat"] = {"item": {"Size": 1}}  # exists, no ModTime
+    assert mounts_mod.rc_stat_for(path) == "exists"
+
+    # Healthy rcd, item is null -> a TRUSTWORTHY "the file is gone".
+    rcd.responses["operations/stat"] = {"item": None}
+    assert mounts_mod.rc_stat_for(path) == "missing"
+
+    # Malformed answer (missing 'item' key, non-dict resp) -> indeterminate.
+    rcd.responses["operations/stat"] = {"nope": 1}
+    assert mounts_mod.rc_stat_for(path) == "indeterminate"
+
+
+def test_rc_stat_for_indeterminate_on_error_or_no_rcd_or_no_mount(home, rcd):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/f.parquet"
+    # rc error (stub 404s unset methods) -> indeterminate, NOT missing.
+    assert mounts_mod.rc_stat_for(path) == "indeterminate"
+    # Path under no mount record -> indeterminate.
+    assert mounts_mod.rc_stat_for("/tmp/not/a/mount/f.parquet") == "indeterminate"
+
+
+def test_rc_stat_for_indeterminate_when_rcd_down(home):
+    # No live rcd port at all -> indeterminate (fail open), never "missing".
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/f.parquet"
+    assert mounts_mod.rc_stat_for(path) == "indeterminate"
+
+
+def test_rc_mtime_for_and_rc_stat_for_share_one_rc_call_semantics(home, rcd):
+    # rc_mtime_for's documented None contract is preserved after being
+    # reimplemented on the shared stat: exists-but-no-ModTime and item-null
+    # both still yield None.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    path = mounts_mod.mountpoint(c) + "/f.parquet"
+    rcd.responses["operations/stat"] = {"item": {"Size": 1}}
+    assert mounts_mod.rc_mtime_for(path) is None
+    assert mounts_mod.rc_stat_for(path) == "exists"
+    rcd.responses["operations/stat"] = {"item": None}
+    assert mounts_mod.rc_mtime_for(path) is None
+    assert mounts_mod.rc_stat_for(path) == "missing"
+
+
 def test_is_mount_backed_follows_symlink_into_mounts(home, tmp_path):
     # A symlink whose target is inside the mounts dir must classify as
     # mount-backed (else it lands on the kernel os.stat ticker — the GETATTR

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -6,6 +6,7 @@ FUSED_RENDER_HOME is redirected per test so no test touches the real
 ~/.fused-render or a real mount.
 """
 import json
+import stat
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -2727,3 +2728,211 @@ def test_direct_list_page_routes_gcs_to_googleapis(home, rcd, fresh_upstream, gc
 
 def test_s3listerror_is_directlisterror_alias():
     assert mounts_mod.S3ListError is mounts_mod.DirectListError
+
+
+# -- direct_head / direct_is_dir (point probes) -----------------------------
+#
+# operations/stat has no S3 point lookup — rclone answers a negative or a dir
+# probe with an UNBOUNDED ListObjectsV2 of the whole parent prefix, so on a flat
+# world-scale prefix every probe burns the full rc timeout. HeadObject and a
+# max-keys=1 list are the true point lookups. These drive direct_head /
+# direct_is_dir against a LOCAL stub HTTP server (real HTTP HEAD/GET, real 404 ->
+# HTTPError, real header parsing); a urlopen redirector rewrites the object-store
+# host to the stub so the real path-style URL building still runs.
+
+
+class DirectObjStub:
+    """A stand-in for anonymous S3 / GCS object endpoints. `head` drives the
+    HEAD (or GCS objects.get GET) reply; `listing` drives the GET list reply."""
+
+    def __init__(self):
+        self.calls = []  # (method, path, query)
+        # (status, headers-or-body). 200 head -> send those headers, no body.
+        self.head = (200, {"Content-Length": "123",
+                           "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT"})
+        self.head_body = b'{"size": "123", "updated": "2015-10-21T07:28:00Z"}'
+        self.listing = (200, b"")  # GET list/objects.get body
+        stub = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def _record(self):
+                p, _, q = self.path.partition("?")
+                stub.calls.append((self.command, p, q))
+
+            def do_HEAD(self):
+                self._record()
+                status, headers = stub.head
+                if status != 200:
+                    self.send_error(status)
+                    return
+                self.send_response(200)
+                for k, v in headers.items():
+                    self.send_header(k, v)
+                self.end_headers()
+
+            def do_GET(self):
+                self._record()
+                # GCS objects.get lands here too (path has no query); the
+                # objects.list has a query. Both use the `listing`/`head_body`.
+                p = self.path
+                if "/storage/v1/b/" in p and "?" not in p:
+                    status, body = 200, stub.head_body  # objects.get metadata
+                    if stub.head[0] != 200:
+                        self.send_error(stub.head[0])
+                        return
+                else:
+                    status, body = stub.listing
+                if status != 200:
+                    self.send_error(status)
+                    return
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.port = self.server.server_address[1]
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self.server.shutdown()
+
+
+@pytest.fixture()
+def direct_stub(monkeypatch):
+    """A live object-store stub + a urlopen redirector: object-store URLs
+    (amazonaws / googleapis) are rewritten to the local stub host, preserving
+    path/query/method; rc calls (loopback rcd) delegate to the real urlopen."""
+    import urllib.parse as _up
+
+    stub = DirectObjStub()
+    real = mounts_mod.urllib.request.urlopen
+
+    def fake(req, timeout=None):
+        url = req if isinstance(req, str) else req.get_full_url()
+        parts = _up.urlsplit(url)
+        if ("amazonaws.com" not in (parts.hostname or "")
+                and "googleapis.com" not in (parts.hostname or "")):
+            return real(req, timeout=timeout)
+        local = _up.urlunsplit(("http", f"127.0.0.1:{stub.port}",
+                               parts.path, parts.query, ""))
+        method = "GET" if isinstance(req, str) else req.get_method()
+        return real(mounts_mod.urllib.request.Request(local, method=method),
+                    timeout=timeout)
+
+    monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", fake)
+    yield stub
+    stub.close()
+
+
+def test_direct_head_s3_exists_returns_size_and_mtime(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    got = mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/analysed_sst/zarr.json")
+    assert got.exists is True and got.size == 123
+    assert got.mtime.startswith("2015-10-21T07:28:00")
+    # A HEAD, not a prefix list — one point round trip.
+    assert direct_stub.calls and direct_stub.calls[-1][0] == "HEAD"
+
+
+def test_direct_head_s3_missing_is_definitive_not_error(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.head = (404, {})
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    got = mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/nope.json")
+    assert got.exists is False  # a 404 is a trustworthy negative, not a raise
+
+
+def test_direct_head_s3_http_error_raises(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.head = (403, {})  # needs auth -> indeterminate
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    with pytest.raises(mounts_mod.DirectProbeError):
+        mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/x.json")
+
+
+def test_direct_head_not_capable_raises(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}  # credentialed
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    with pytest.raises(mounts_mod.DirectProbeError):
+        mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/x.json")
+
+
+def test_direct_is_dir_s3_true_when_children(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.listing = (200, _s3_list_xml(contents=[("zarr-v1/analysed_sst/x", 1, "2024-01-01T00:00:00Z")]))
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/analysed_sst") is True
+    # max-keys=1 list against the prefix, off the kernel.
+    assert any(q for _m, _p, q in direct_stub.calls if "max-keys=1" in q)
+
+
+def test_direct_is_dir_s3_false_when_empty(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.listing = (200, _s3_list_xml())  # no Contents
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/ghost") is False
+
+
+def test_direct_is_dir_s3_http_error_raises(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.listing = (500, b"")
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    with pytest.raises(mounts_mod.DirectProbeError):
+        mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/x")
+
+
+def test_direct_head_gcs_exists_and_dir(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    c = mounts_mod.add_mount("open", "gcs-open:mur-sst/zarr-v1")
+    got = mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/analysed_sst/zarr.json")
+    assert got.exists is True and got.size == 123
+    assert got.mtime == "2015-10-21T07:28:00Z"
+    direct_stub.listing = (200, _gcs_list_json(items=[("zarr-v1/analysed_sst/x", 1, "2024-01-01T00:00:00Z")]))
+    assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/analysed_sst") is True
+
+
+# -- rc stat helpers route direct-first (no operations/stat when capable) ----
+
+
+def test_rc_kind_for_uses_direct_probe_not_operations_stat(home, rcd, fresh_upstream, direct_stub):
+    # A direct-capable mount must answer rc_kind_for via HeadObject, NEVER via
+    # operations/stat (which lists the whole prefix). The stub rcd would fail the
+    # test if operations/stat were called.
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    rcd.responses["operations/stat"] = (500, {"error": "must not be called"})
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    kind = mounts_mod.rc_kind_for(mounts_mod.mountpoint(c) + "/analysed_sst/zarr.json")
+    assert kind == "file"
+    assert not any(x[0] == "operations/stat" for x in rcd.calls)
+
+
+def test_rc_kind_for_direct_dir_then_missing(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    base = mounts_mod.mountpoint(c)
+    # HEAD 404 + a non-empty prefix list -> "dir".
+    direct_stub.head = (404, {})
+    direct_stub.listing = (200, _s3_list_xml(contents=[("zarr-v1/d/x", 1, "2024-01-01T00:00:00Z")]))
+    assert mounts_mod.rc_kind_for(base + "/d") == "dir"
+    # HEAD 404 + empty prefix list -> "missing" (trustworthy negative).
+    direct_stub.listing = (200, _s3_list_xml())
+    assert mounts_mod.rc_kind_for(base + "/gone") == "missing"
+    assert not any(x[0] == "operations/stat" for x in rcd.calls)
+
+
+def test_rc_stat_result_falls_back_to_rc_when_direct_errors(home, rcd, fresh_upstream, direct_stub):
+    # Direct probe indeterminate (403) -> fall back to operations/stat, which
+    # here reports a healthy directory item. Proves the ladder direct -> rc.
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    direct_stub.head = (403, {})       # HEAD indeterminate
+    direct_stub.listing = (403, b"")   # is_dir indeterminate too
+    rcd.responses["operations/stat"] = {"item": {"IsDir": True, "Size": -1,
+                                                 "ModTime": "2024-01-02T03:04:05Z"}}
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    st = mounts_mod.rc_stat_result(mounts_mod.mountpoint(c) + "/d")
+    assert stat.S_ISDIR(st.st_mode)
+    assert any(x[0] == "operations/stat" for x in rcd.calls)

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -4,11 +4,13 @@ recently-opened-files store at ~/.fused-render/recents.json.
 FUSED_RENDER_HOME is redirected to a tmp dir so no test touches the real home.
 """
 import json
+import time
 from urllib.parse import quote
 
 from fastapi.testclient import TestClient
 
 from fused_render.server import create_app
+from fused_render.shell import recents as recents_mod
 
 
 FUSED = {"X-Fused": "1"}  # D3 guard header required on writes
@@ -165,6 +167,76 @@ def test_writes_without_fused_header_are_rejected(tmp_path, monkeypatch):
     assert client.post("/api/recents/open", json={"url": _view_url(f)}).status_code == 403
     assert client.put("/api/recents/collapsed", json={"collapsed": True}).status_code == 403
     assert not (home / "recents.json").exists()
+
+
+def test_get_is_bounded_when_existence_check_hangs(tmp_path, monkeypatch):
+    # A stale entry sitting on a slow/hung mount must never stall the sidebar.
+    # With the existence check hung for 10s each, a serial GET would take
+    # 30s+; the bounded, fan-out GET must return well under the hang duration
+    # AND keep the entries (fail open: a possibly-dead row beats a stalled
+    # sidebar — only a check that COMPLETES False may filter).
+    client, _ = _client(tmp_path, monkeypatch)
+    urls = []
+    for i in range(3):
+        f = _make_file(tmp_path, f"hang{i}.parquet")
+        url = _view_url(f)
+        urls.append(url)
+        client.post("/api/recents/open", json={"url": url}, headers=FUSED)
+
+    def _hang(path):
+        time.sleep(10)
+        return False  # would filter if it ever completed within budget
+
+    monkeypatch.setattr(recents_mod.os.path, "isfile", _hang)
+
+    start = time.monotonic()
+    resp = client.get("/api/recents")
+    elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200
+    assert elapsed < 3.0, f"GET /api/recents took {elapsed:.1f}s — not bounded"
+    # Fail open: every hung entry is still present.
+    got = {e["url"] for e in resp.json()["entries"]}
+    assert got == set(urls)
+
+
+def test_get_checks_run_concurrently_not_serially(tmp_path, monkeypatch):
+    # N entries each with a ~0.5s existence check must complete in ~one sleep
+    # (concurrent fan-out), not N sleeps (serial). Five serial checks = 2.5s;
+    # concurrent + shared budget stays well under that.
+    client, _ = _client(tmp_path, monkeypatch)
+    for i in range(5):
+        f = _make_file(tmp_path, f"slow{i}.parquet")
+        client.post("/api/recents/open", json={"url": _view_url(f)}, headers=FUSED)
+
+    def _slow(path):
+        time.sleep(0.5)
+        return True
+
+    monkeypatch.setattr(recents_mod.os.path, "isfile", _slow)
+
+    start = time.monotonic()
+    resp = client.get("/api/recents")
+    elapsed = time.monotonic() - start
+
+    assert resp.status_code == 200
+    assert len(resp.json()["entries"]) == 5
+    assert elapsed < 1.5, f"GET took {elapsed:.1f}s — checks not concurrent"
+
+
+def test_get_completed_false_filters_completed_true_shows(tmp_path, monkeypatch):
+    # Fast-path regression: a check that COMPLETES False filters the entry; one
+    # that completes True keeps it. (The completed-False path is what the
+    # fail-open timeout path must NOT reach.)
+    client, _ = _client(tmp_path, monkeypatch)
+    keep = _make_file(tmp_path, "present.csv")
+    gone = _make_file(tmp_path, "vanished.csv")
+    client.post("/api/recents/open", json={"url": _view_url(gone)}, headers=FUSED)
+    client.post("/api/recents/open", json={"url": _view_url(keep)}, headers=FUSED)
+    gone.unlink()
+
+    entries = client.get("/api/recents").json()["entries"]
+    assert [e["url"] for e in entries] == [_view_url(keep)]
 
 
 def test_corrupt_file_reads_as_defaults(tmp_path, monkeypatch):

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -242,14 +242,18 @@ def test_get_completed_false_filters_completed_true_shows(tmp_path, monkeypatch)
 
 def test_get_mount_backed_paths_route_through_rc_not_isfile(tmp_path, monkeypatch):
     # Mount safety: a mount-backed recents path must be checked via the rclone
-    # rc API (rc_mtime_for), NEVER a kernel os.path.isfile — a raw GETATTR on a
-    # hung NFS mount is the exact call that wedges it. A present ModTime keeps
-    # the entry; a None (indeterminate) also keeps it (fail open).
+    # rc API (rc_stat_for), NEVER a kernel os.path.isfile — a raw GETATTR on a
+    # hung NFS mount is the exact call that wedges it. The tri-state result
+    # governs filtering: only a healthy-rcd-confirmed "missing" filters an
+    # entry; "exists" keeps it, and "indeterminate" (rcd down / timeout / error)
+    # keeps it too (fail open).
     client, _ = _client(tmp_path, monkeypatch)
     live = _make_file(tmp_path, "live_mount.parquet")
     indet = _make_file(tmp_path, "indet_mount.parquet")
+    gone = _make_file(tmp_path, "gone_mount.parquet")
     client.post("/api/recents/open", json={"url": _view_url(live)}, headers=FUSED)
     client.post("/api/recents/open", json={"url": _view_url(indet)}, headers=FUSED)
+    client.post("/api/recents/open", json={"url": _view_url(gone)}, headers=FUSED)
 
     monkeypatch.setattr(mounts_mod, "is_mount_backed", lambda p: True)
 
@@ -258,15 +262,19 @@ def test_get_mount_backed_paths_route_through_rc_not_isfile(tmp_path, monkeypatc
 
     monkeypatch.setattr(recents_mod.os.path, "isfile", _no_isfile)
 
-    # live -> ModTime present (exists), indet -> None (rc can't tell): both kept.
-    def _rc(path):
-        return "2026-01-01T00:00:00Z" if path.endswith("live_mount.parquet") else None
+    def _stat(path):
+        if path.endswith("live_mount.parquet"):
+            return "exists"
+        if path.endswith("gone_mount.parquet"):
+            return "missing"  # healthy rcd, item null -> trustworthy negative
+        return "indeterminate"  # rcd down / timeout / error
 
-    monkeypatch.setattr(mounts_mod, "rc_mtime_for", _rc)
+    monkeypatch.setattr(mounts_mod, "rc_stat_for", _stat)
 
     resp = client.get("/api/recents")
     assert resp.status_code == 200
     got = {e["url"] for e in resp.json()["entries"]}
+    # exists + indeterminate kept; only the confirmed-missing entry filtered.
     assert got == {_view_url(live), _view_url(indet)}
 
 

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -10,6 +10,7 @@ from urllib.parse import quote
 from fastapi.testclient import TestClient
 
 from fused_render.server import create_app
+from fused_render.shell import mounts as mounts_mod
 from fused_render.shell import recents as recents_mod
 
 
@@ -237,6 +238,36 @@ def test_get_completed_false_filters_completed_true_shows(tmp_path, monkeypatch)
 
     entries = client.get("/api/recents").json()["entries"]
     assert [e["url"] for e in entries] == [_view_url(keep)]
+
+
+def test_get_mount_backed_paths_route_through_rc_not_isfile(tmp_path, monkeypatch):
+    # Mount safety: a mount-backed recents path must be checked via the rclone
+    # rc API (rc_mtime_for), NEVER a kernel os.path.isfile — a raw GETATTR on a
+    # hung NFS mount is the exact call that wedges it. A present ModTime keeps
+    # the entry; a None (indeterminate) also keeps it (fail open).
+    client, _ = _client(tmp_path, monkeypatch)
+    live = _make_file(tmp_path, "live_mount.parquet")
+    indet = _make_file(tmp_path, "indet_mount.parquet")
+    client.post("/api/recents/open", json={"url": _view_url(live)}, headers=FUSED)
+    client.post("/api/recents/open", json={"url": _view_url(indet)}, headers=FUSED)
+
+    monkeypatch.setattr(mounts_mod, "is_mount_backed", lambda p: True)
+
+    def _no_isfile(path):
+        raise AssertionError("os.path.isfile called on a mount-backed path")
+
+    monkeypatch.setattr(recents_mod.os.path, "isfile", _no_isfile)
+
+    # live -> ModTime present (exists), indet -> None (rc can't tell): both kept.
+    def _rc(path):
+        return "2026-01-01T00:00:00Z" if path.endswith("live_mount.parquet") else None
+
+    monkeypatch.setattr(mounts_mod, "rc_mtime_for", _rc)
+
+    resp = client.get("/api/recents")
+    assert resp.status_code == 200
+    got = {e["url"] for e in resp.json()["entries"]}
+    assert got == {_view_url(live), _view_url(indet)}
 
 
 def test_corrupt_file_reads_as_defaults(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

This PR removes the two remaining ways the file explorer could stall for 10–30s (and wedge the rclone-NFS mount) on remote folders: unbounded recents existence checks, and kernel filesystem I/O in `fs/stat` + template condition gates.

**Recents (first two commits)**

- `GET /api/recents` could take 10+ seconds on some remote mount folders: it checked up to 20 stored entries **serially** with a raw `os.path.isfile` each — a kernel GETATTR per entry over NFS, with no deadline. Checks now **fan out concurrently** on a dedicated thread pool under a single **1.5s budget** (`CHECK_BUDGET_S`); endpoint latency no longer scales with entry count.
- **Fail open**: only a check that completes and returns False filters an entry; timeouts/errors keep it. Mount-backed paths route through the rclone rc API (`rc_stat_for` tri-state: exists / missing / indeterminate) — never the kernel NFS client.

**Condition gates + fs/stat (last two commits)**

- A cold **negative** `os.path.isfile` on a mount forces rclone to list the entire parent S3 prefix (measured 18–24s) and trips the macOS NFS deadman — the mount drops. The `zarr_aoi` gate probes for `.zmetadata`/`zarr.json`/`.zgroup` on **every directory open**, so `/api/fs/conditions` took 21–25s on cold mount dirs and `/api/fs/stat` 18s+.
- New kernel-free rc helpers in `mounts.py`: `rc_kind_for` (dir/file/missing/indeterminate via `operations/stat` + `IsDir`), `rc_stat_result` (synthesized `os.stat_result`, raises like kernel `os.stat`), `rc_read_bounded` (capped ranged GET via the mount's HTTP serve).
- `_run_condition` now execs gate modules for mount-backed targets with a per-call `__builtins__` whose `__import__` returns an **rc-routed fake `os`/`os.path`** and whose `open()` uses `rc_read_bounded` — thread-safe under the concurrent gate executor, no global monkeypatch, and it fixes the whole class (builtin **and** user-authored gates). Templates stay mount-agnostic.
- `fs/stat`, `_conditions_payload`, and `_writable` route mount paths via rc too — zero kernel READDIR/GETATTR on mounts. Fail-closed preserved (SPEC CT-12): rc error/timeout → gate returns False; indeterminate rcd → 200 with gates fail-closed, never a spurious 404.

**Direct point probes + probe budget (last three commits)**

- rclone has **no point lookup at any layer**: `operations/stat` on a path whose parent holds tens of thousands of keys runs an unbounded `ListObjectsV2` of the whole parent (measured: 44,361 siblings under `source.coop/.../sentinel2-temporal-mosaics`, 45 serial pages, ~64s) — past the 10s rc timeout, so `fs/stat` returned a **false 404 for an existing directory** and `fs/conditions` stacked 10s probe timeouts into 20–30s responses.
- New `direct_head` / `direct_is_dir` in `mounts.py`: point probes straight against the object store (S3 `HeadObject` + `list-type=2&max-keys=1&prefix=`, path-style URLs; GCS equivalents) answering in <1s with **zero parent enumeration**. `rc_kind_for` / `rc_stat_for` / `rc_stat_result` now try the direct probe first and fall back to rc only when the backend isn't direct-capable or the probe is indeterminate — recents, condition gates, and `fs/stat` all get the fast path with no call-site changes.
- `_fs_stat` now distinguishes a confirmed miss (`FileNotFoundError` → 404) from an indeterminate mount stat (bare `OSError` → retryable **503**) — an rc timeout can no longer tell the client an existing path vanished.
- Backstop for non-direct-capable backends: one condition-gate evaluation shares a **5s wall-clock probe budget** (`GATE_PROBE_BUDGET_S`); once spent, remaining probes fail closed instantly instead of stacking 10s rc timeouts, and the `fs/conditions` endpoint dir-probe is bounded by the same budget.

## Visuals

```mermaid
flowchart LR
    A["GET /api/recents"] --> P{"is_mount_backed?"}
    P -->|yes| M["rc_stat_for via rclone rc"]
    P -->|no| L["os.path.isfile in _CHECK_POOL"]
    M --> W["asyncio.wait(timeout=1.5s)"]
    L --> W
    W -->|"completed missing"| F[filter entry]
    W -->|"exists / timeout / error"| K["keep entry (fail open)"]

    B["GET /api/fs/conditions | /api/fs/stat"] --> Q{"is_mount_backed?"}
    Q -->|no| KOS["kernel os.stat / gate os.path (unchanged)"]
    Q -->|yes| S["exec gate with rc-routed __builtins__ shim"]
    S --> S1["isfile/isdir/exists → rc_kind_for"]
    S --> S2["os.stat → rc_stat_result"]
    S --> S3["open() → rc_read_bounded (HTTP serve)"]
    S1 & S2 & S3 -->|"rc error/timeout"| FC["fail closed (gate → False)"]
```

## Usage

No new user-invocable surface. The sidebar's Recents section populates within ~1.5s worst case, and opening remote mount directories no longer stalls `fs/stat`/`fs/conditions` for 18–25s or drops the mount ("Server connections interrupted").

## Test Plan

- [x] Recents: 4 tests in `tests/test_shell_recents.py`, written RED first — bounded latency under hanging checks, concurrency, filter/keep semantics, mount paths routed via rc.
- [x] Shim: 18 tests in new `tests/test_condition_mount_shim.py` — includes a kernel-`os.*` guard proving **zero kernel calls** on mount paths; every import form a gate can use (`import os`, `import os as o`, `import os.path`, `from os import path/stat`, `from os.path import isfile/isdir/exists`); real `.zarr` group → True, bare array / plain dir → False; indeterminate / read-unavailable fail closed; endpoint 200/404 semantics; fs/stat rc-routing; local-path regressions.
- [x] rc helpers: 6 tests in `tests/test_shell_mounts.py` against a stub rcd (kind/stat/bounded read, timeout and error paths).
- [x] Direct probes: 11 new tests in `tests/test_shell_mounts.py` — real HTTP HEAD/GET against a local object-store stub (path-style URL building exercised end to end), 404-as-definitive-miss, network errors → indeterminate → rc fallback.
- [x] Probe budget + 503: `tests/test_condition_probe_budget.py` — endpoint-level latency regression against a hanging stub rcd (mirrors the recents CHECK_BUDGET pattern), and the fs/stat 404→503 regression.
- [x] Full suite: **1071 passed, 13 skipped, 0 failures** (verified independently after the final commit).
- [ ] Manual: reconnect a mount cold, open a large remote dir — `fs/conditions` returns in seconds, mount stays alive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

