### PR TITLE
dev.sh: Python auto-reload via watchfiles

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -183,17 +183,28 @@ if [[ "$RELOAD" -eq 1 ]]; then
   # One-shot opener: wait for the port to accept a connection, then open the tab.
   if [[ "$NO_BROWSER" -eq 0 && -n "$PORT" ]]; then
     (
+      ready=0
       for _ in $(seq 1 120); do
         if "$PY" -c "import socket,sys; s=socket.socket(); s.settimeout(0.5); sys.exit(0 if s.connect_ex(('127.0.0.1', $PORT))==0 else 1)" 2>/dev/null; then
+          ready=1
           break
         fi
         sleep 0.5
       done
-      URL="http://127.0.0.1:$PORT/"
-      # Open via Python's webbrowser (cross-platform, matches cli.py); a shell
-      # open/xdg-open/start chain misses Windows/git-bash (start is a cmd
-      # builtin, not a binary on PATH).
-      "$PY" -c "import webbrowser; webbrowser.open('$URL')" >/dev/null 2>&1 || true
+      # Only open if the server actually came up — otherwise (e.g. the port
+      # guard SystemExited on a stale server) we'd pop a dead tab after timeout.
+      if [[ "$ready" -eq 1 ]]; then
+        # Match cli.py's first-run onboarding: open the seeded showcase landing
+        # page on a brand-new install, else the root. ensure_fused_dir_and_landing
+        # is idempotent (cli.py calls it too) and returns (fused_dir, landing);
+        # landing is a "/view/…" path on first run, else None → fall back to root.
+        LANDING="$("$PY" -c 'from fused_render.shell.seed import ensure_fused_dir_and_landing; _, l = ensure_fused_dir_and_landing(); print(l or "")' 2>/dev/null || true)"
+        if [[ -n "$LANDING" ]]; then URL="http://127.0.0.1:$PORT$LANDING"; else URL="http://127.0.0.1:$PORT/"; fi
+        # Open via Python's webbrowser (cross-platform, matches cli.py); a shell
+        # open/xdg-open/start chain misses Windows/git-bash (start is a cmd
+        # builtin, not a binary on PATH).
+        "$PY" -c "import webbrowser; webbrowser.open('$URL')" >/dev/null 2>&1 || true
+      fi
     ) &
     OPENER_PID=$!
   fi
@@ -205,8 +216,14 @@ if [[ "$RELOAD" -eq 1 ]]; then
   # fused_render/templates/ — those *.py are per-request UDF code, not imported
   # into the server process, so editing them shouldn't restart it (watchfiles
   # resolves ignore paths to absolute; comma-separate to add more).
-  CMD="$(printf '%q' "$PY") -m fused_render.cli --no-browser"
+  #
+  # --no-browser goes AFTER the passthrough args: cli.py's main() injects a
+  # default `serve` only when argv[0] isn't already a subcommand, so a leading
+  # `serve` (e.g. `dev.sh serve --port N`) must stay argv[0]. Prepending
+  # --no-browser would shift it and trigger a duplicate-`serve` parse error.
+  CMD="$(printf '%q' "$PY") -m fused_render.cli"
   for a in "$@"; do CMD+=" $(printf '%q' "$a")"; done
+  CMD+=" --no-browser"
   "$PY" -m watchfiles --filter python --ignore-paths "$REPO_ROOT/fused_render/templates" "$CMD" "$REPO_ROOT/fused_render"
 else
   # Original single-launch behavior: the server opens its own browser tab.

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -211,11 +211,12 @@ if [[ "$RELOAD" -eq 1 ]]; then
 
   # watchfiles wants the target as a single shell-command string, then the watch
   # paths. printf %q quotes $PY and each passthrough arg so paths/args with
-  # spaces survive. --filter python watches only *.py, so vite's shell-dist
-  # output (.html/.js/.css) never triggers a restart. --ignore-paths excludes
-  # fused_render/templates/ — those *.py are per-request UDF code, not imported
-  # into the server process, so editing them shouldn't restart it (watchfiles
-  # resolves ignore paths to absolute; comma-separate to add more).
+  # spaces survive. --filter python watches only *.py under the whole
+  # fused_render/ tree, so vite's shell-dist output (.html/.js/.css) never
+  # triggers a restart. Editing a template UDF (fused_render/templates/**/*.py)
+  # triggers a harmless extra server restart; we don't exclude templates/
+  # because watchfiles' --ignore-paths matches by bare prefix (filters.py:
+  # startswith), so it would also hide the imported sibling templates_api.py.
   #
   # --no-browser goes AFTER the passthrough args: cli.py's main() injects a
   # default `serve` only when argv[0] isn't already a subcommand, so a leading
@@ -224,7 +225,7 @@ if [[ "$RELOAD" -eq 1 ]]; then
   CMD="$(printf '%q' "$PY") -m fused_render.cli"
   for a in "$@"; do CMD+=" $(printf '%q' "$a")"; done
   CMD+=" --no-browser"
-  "$PY" -m watchfiles --filter python --ignore-paths "$REPO_ROOT/fused_render/templates" "$CMD" "$REPO_ROOT/fused_render"
+  "$PY" -m watchfiles --filter python "$CMD" "$REPO_ROOT/fused_render"
 else
   # Original single-launch behavior: the server opens its own browser tab.
   "$PY" -m fused_render.cli "$@"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -190,10 +190,10 @@ if [[ "$RELOAD" -eq 1 ]]; then
         sleep 0.5
       done
       URL="http://127.0.0.1:$PORT/"
-      if command -v open >/dev/null 2>&1; then open "$URL"
-      elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
-      elif command -v start >/dev/null 2>&1; then start "$URL"
-      fi >/dev/null 2>&1 || true
+      # Open via Python's webbrowser (cross-platform, matches cli.py); a shell
+      # open/xdg-open/start chain misses Windows/git-bash (start is a cmd
+      # builtin, not a binary on PATH).
+      "$PY" -c "import webbrowser; webbrowser.open('$URL')" >/dev/null 2>&1 || true
     ) &
     OPENER_PID=$!
   fi
@@ -201,10 +201,13 @@ if [[ "$RELOAD" -eq 1 ]]; then
   # watchfiles wants the target as a single shell-command string, then the watch
   # paths. printf %q quotes $PY and each passthrough arg so paths/args with
   # spaces survive. --filter python watches only *.py, so vite's shell-dist
-  # output (.html/.js/.css) never triggers a restart.
+  # output (.html/.js/.css) never triggers a restart. --ignore-paths excludes
+  # fused_render/templates/ — those *.py are per-request UDF code, not imported
+  # into the server process, so editing them shouldn't restart it (watchfiles
+  # resolves ignore paths to absolute; comma-separate to add more).
   CMD="$(printf '%q' "$PY") -m fused_render.cli --no-browser"
   for a in "$@"; do CMD+=" $(printf '%q' "$a")"; done
-  "$PY" -m watchfiles --filter python "$CMD" "$REPO_ROOT/fused_render"
+  "$PY" -m watchfiles --filter python --ignore-paths "$REPO_ROOT/fused_render/templates" "$CMD" "$REPO_ROOT/fused_render"
 else
   # Original single-launch behavior: the server opens its own browser tab.
   "$PY" -m fused_render.cli "$@"

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,13 +5,31 @@
 #
 # Pipeline: npm install (if needed) -> one gated build (tsc + vite, so type
 # errors surface before anything starts) -> `vite build --watch` in the
-# background -> fused-render server in the foreground. Ctrl-C stops both.
+# background -> fused-render server in the foreground, supervised by
+# watchfiles for Python auto-reload. Ctrl-C stops everything.
 #
-# The watch rebuilds into fused_render/static/shell-dist/ on every shell
-# edit; the server reads files per-request with Cache-Control: no-cache, so
-# a browser refresh picks up the new bundle — no server restart needed.
-# (Note: the watch skips the tsc gate for speed; run `npm run typecheck` or
-# a full `npm run build` before committing.)
+# Two independent reload paths:
+#   * Frontend: `vite build --watch` rebuilds into fused_render/static/
+#     shell-dist/ on every shell edit; the server reads files per-request with
+#     Cache-Control: no-cache, so a browser refresh picks up the new bundle —
+#     no server restart needed. (The watch skips the tsc gate for speed; run
+#     `npm run typecheck` or a full `npm run build` before committing.)
+#   * Python: edits to fused_render/**/*.py restart the server automatically.
+#     watchfiles supervises `python -m fused_render.cli`, watching only *.py
+#     under fused_render/ (the vite shell-dist output is .html/.js/.css and is
+#     ignored, so frontend rebuilds never restart the server). On each restart
+#     watchfiles gracefully stops the old process (SIGINT + wait for exit)
+#     before relaunching, so the port guard in cli.py is respected.
+#
+# Under the reloader the server runs with --no-browser (so a save doesn't spawn
+# a new tab); dev.sh opens the browser once, after the port comes up.
+#
+# Knobs:
+#   * --no-browser (passed through): dev.sh won't open a tab either.
+#   * FUSED_RENDER_NO_RELOAD=1: disable Python auto-reload; run the server once
+#     exactly as before (server opens its own browser tab).
+# watchfiles is auto-installed into the venv if missing; if the install fails,
+# dev.sh falls back to the original single-launch behavior.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -107,7 +125,10 @@ rm -f "$DIST_INDEX"
 echo "==> starting vite watch + fused-render server (Ctrl-C stops both)"
 (cd "$FRONTEND" && npm run watch) &
 WATCH_PID=$!
-trap 'kill "$WATCH_PID" 2>/dev/null || true' EXIT INT TERM
+# OPENER_PID is the one-shot browser opener (set below, reload path only). The
+# trap references it lazily so it's harmless while still unset.
+OPENER_PID=""
+trap 'kill "$WATCH_PID" 2>/dev/null || true; [[ -n "$OPENER_PID" ]] && kill "$OPENER_PID" 2>/dev/null || true' EXIT INT TERM
 
 echo "==> waiting for the vite watch to emit the shell bundle"
 for _ in $(seq 1 60); do
@@ -116,4 +137,75 @@ for _ in $(seq 1 60); do
 done
 [[ -f "$DIST_INDEX" ]] || { echo "shell bundle never appeared at $DIST_INDEX — check the vite watch output above"; exit 1; }
 
-"$PY" -m fused_render.cli "$@"
+# Python auto-reload via watchfiles (opt out with FUSED_RENDER_NO_RELOAD).
+# Restarts the server on any fused_render/**/*.py edit. watchfiles stops the old
+# process (SIGINT + wait) before relaunching, so cli.py's port guard is honored.
+RELOAD=1
+[[ -n "${FUSED_RENDER_NO_RELOAD:-}" ]] && RELOAD=0
+
+if [[ "$RELOAD" -eq 1 ]]; then
+  # Ensure watchfiles is importable from this venv; install it if not. Match the
+  # venv-bootstrap style above (uv when present, else pip). Any failure is
+  # non-fatal — we fall back to the plain single launch below.
+  if ! "$PY" -c 'import watchfiles' 2>/dev/null; then
+    echo "==> installing watchfiles into the venv (for Python auto-reload)"
+    if command -v uv >/dev/null 2>&1; then
+      uv pip install --python "$PY" watchfiles || true
+    else
+      "$PY" -m pip install watchfiles || true
+    fi
+  fi
+  if ! "$PY" -c 'import watchfiles' 2>/dev/null; then
+    echo "==> WARNING: watchfiles unavailable — falling back to a single launch (no Python auto-reload)"
+    RELOAD=0
+  fi
+fi
+
+if [[ "$RELOAD" -eq 1 ]]; then
+  # Decide whether to open a browser tab, and on which port. The server runs
+  # with --no-browser under the reloader, so dev.sh opens the tab exactly once.
+  NO_BROWSER=0
+  PORT=""
+  want_port=0
+  for a in "$@"; do
+    if [[ "$want_port" -eq 1 ]]; then PORT="$a"; want_port=0; continue; fi
+    case "$a" in
+      --no-browser) NO_BROWSER=1 ;;
+      --port=*)     PORT="${a#--port=}" ;;
+      --port)       want_port=1 ;;
+    esac
+  done
+  # No explicit --port: fall back to the per-branch default the server derives.
+  if [[ -z "$PORT" ]]; then
+    PORT="$("$PY" -c 'from fused_render._branch import branch_port; print(branch_port())' 2>/dev/null || true)"
+  fi
+
+  # One-shot opener: wait for the port to accept a connection, then open the tab.
+  if [[ "$NO_BROWSER" -eq 0 && -n "$PORT" ]]; then
+    (
+      for _ in $(seq 1 120); do
+        if "$PY" -c "import socket,sys; s=socket.socket(); s.settimeout(0.5); sys.exit(0 if s.connect_ex(('127.0.0.1', $PORT))==0 else 1)" 2>/dev/null; then
+          break
+        fi
+        sleep 0.5
+      done
+      URL="http://127.0.0.1:$PORT/"
+      if command -v open >/dev/null 2>&1; then open "$URL"
+      elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
+      elif command -v start >/dev/null 2>&1; then start "$URL"
+      fi >/dev/null 2>&1 || true
+    ) &
+    OPENER_PID=$!
+  fi
+
+  # watchfiles wants the target as a single shell-command string, then the watch
+  # paths. printf %q quotes $PY and each passthrough arg so paths/args with
+  # spaces survive. --filter python watches only *.py, so vite's shell-dist
+  # output (.html/.js/.css) never triggers a restart.
+  CMD="$(printf '%q' "$PY") -m fused_render.cli --no-browser"
+  for a in "$@"; do CMD+=" $(printf '%q' "$a")"; done
+  "$PY" -m watchfiles --filter python "$CMD" "$REPO_ROOT/fused_render"
+else
+  # Original single-launch behavior: the server opens its own browser tab.
+  "$PY" -m fused_render.cli "$@"
+fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -202,8 +202,10 @@ if [[ "$RELOAD" -eq 1 ]]; then
         if [[ -n "$LANDING" ]]; then URL="http://127.0.0.1:$PORT$LANDING"; else URL="http://127.0.0.1:$PORT/"; fi
         # Open via Python's webbrowser (cross-platform, matches cli.py); a shell
         # open/xdg-open/start chain misses Windows/git-bash (start is a cmd
-        # builtin, not a binary on PATH).
-        "$PY" -c "import webbrowser; webbrowser.open('$URL')" >/dev/null 2>&1 || true
+        # builtin, not a binary on PATH). Pass the URL through argv, not
+        # interpolated into the -c source: a landing path with an apostrophe
+        # (e.g. a home dir containing ') would otherwise break the string literal.
+        "$PY" -c "import sys, webbrowser; webbrowser.open(sys.argv[1])" "$URL" >/dev/null 2>&1 || true
       fi
     ) &
     OPENER_PID=$!


### PR DESCRIPTION
## Summary

- **`scripts/dev.sh` now auto-restarts the Python server on `fused_render/**/*.py` edits.** Previously only the frontend hot-reloaded (via `vite build --watch` + browser refresh); a Python change required a manual Ctrl-C and re-run.
- Uses the **`watchfiles` CLI as a supervisor**, which gracefully stops the old process (SIGINT + wait-for-exit) *before* relaunching — so `cli.py`'s hard `_check_port_free` guard is never tripped by a not-yet-released port.
- Watches **only `*.py`** (`--filter python`), so the independent vite watch and its `shell-dist` output (`.html/.js/.css`) never trigger a server restart — avoiding the `create_app` "shell-dist missing" crash-loop.
- **No new browser tabs on every save**: the reloaded server runs `--no-browser`; dev.sh opens the tab exactly once, after the port comes up.
- **Robust + reversible**: `watchfiles` is auto-installed into the venv if missing; install failure falls back to the original single-launch behavior; `FUSED_RENDER_NO_RELOAD=1` opts out entirely (exact prior behavior).
- Daemons (rclone `rcd`, per-page tile daemons) are unaffected — they're detached and spawn-or-reuse via state files, so restarts reconnect rather than leak.

## Visuals

```mermaid
flowchart TD
    subgraph before["Before"]
        A1[edit *.py] -->|manual| A2[Ctrl-C + re-run dev.sh]
    end

    subgraph after["After"]
        B0[dev.sh] --> B1[vite build --watch]
        B0 --> B2{FUSED_RENDER_NO_RELOAD?<br/>watchfiles available?}
        B2 -->|reload| B3["watchfiles --filter python<br/>fused_render/"]
        B2 -->|fallback / opt-out| B7["single launch<br/>(server opens own tab)"]
        B3 --> B4["python -m fused_render.cli --no-browser"]
        B5[edit *.py] -->|SIGINT + wait| B3
        B3 -->|relaunch| B4
        B0 --> B6["one-shot opener:<br/>wait for port -> open tab once"]
        B1 -.->|edit shell src<br/>browser refresh only| B1
    end
```

## Usage

Nothing changes in how you invoke it:

```bash
scripts/dev.sh                 # auto-reload on (default)
scripts/dev.sh --port 9000     # honored for the browser-open URL too
scripts/dev.sh --no-browser    # server runs, dev.sh opens no tab
FUSED_RENDER_NO_RELOAD=1 scripts/dev.sh   # disable auto-reload (old behavior)
```

Edit any file under `fused_render/` — the server restarts on its own within ~a second. Edit frontend source — vite rebuilds and a browser refresh picks it up (unchanged).

## Test Plan

- [x] `bash -n scripts/dev.sh` passes (syntax).
- [x] `watchfiles --help` confirms CLI form `watchfiles [--filter python] '<command>' [PATHS...]` (command string first, then watch paths).
- [x] Live smoke test: watchfiles runs the quoted command, and on SIGINT stops the child and waits for exit before relaunch (respects the port guard).
- [x] Port parsing verified for `--port N`, `--port=N`, and absent (falls back to `branch_port()`).
- [ ] Manual: run `scripts/dev.sh` on a feature branch, edit a `.py` file, confirm the server restarts once and no extra browser tab opens.
- [ ] Manual: `FUSED_RENDER_NO_RELOAD=1 scripts/dev.sh` restores single-launch + server-opened tab.
- Note: no automated suite covers `dev.sh`; this is a shell-script-only change touching zero Python, so the Python test suite is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
