### PR TITLE
Fix NetCDF4/HDF5 open on NFS-mounted buckets (ENOLCK)

### DIFF
--- a/fused_render/templates/netcdf/grid_tile_server.py
+++ b/fused_render/templates/netcdf/grid_tile_server.py
@@ -402,6 +402,12 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
         if not py:
             raise Z.Unsupported(f"needs a system Python with {module} (set GEO_PYTHON)")
         env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
+        # NetCDF4/HDF5 opens request a POSIX file lock. Mounted buckets are
+        # served over NFS (see shell/mounts.py), which grants no locks, so HDF5
+        # aborts with "errno = 77, No locks available" (ENOLCK). The mounts are
+        # read-only, so disabling locking is safe. setdefault leaves an explicit
+        # host override intact.
+        env.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
         r = subprocess.run([py, "-c", code], input=json.dumps(params),
                            capture_output=True, text=True, timeout=180, env=env)
         if r.returncode != 0:


### PR DESCRIPTION
## Problem
Opening a NetCDF4/HDF5 `.nc` file from a **mounted bucket** fails:
```
OSError: [Errno 77] Unable to synchronously open file
(unable to lock file, errno = 77, error message = 'No locks available')
```
A local `.nc` (on APFS) opens fine — so it's not the data or the file.

## Cause
HDF5 requests a POSIX file lock on every open. Mounted buckets are served over **NFS** (`shell/mounts.py`), which grants no locks → HDF5 aborts with ENOLCK. It's the mount transport, not GCS/S3.

## Fix
Set `HDF5_USE_FILE_LOCKING=FALSE` in the NetCDF/HDF5 worker subprocess env only (`grid_tile_server.py:run_worker`). Mounts are read-only, so skipping locks is safe. `setdefault` leaves an explicit host override intact.

## Verification
Against a real NFS-mounted GCS ERA5 file, with the var unset in the daemon env (so only the patch supplies it):
- **Before:** worker fails with the exact ENOLCK error above.
- **After:** `/meta` returns full metadata (`t2m`, 24×721×1440), and `/tile/0/0/0.png` renders a valid 256×256 PNG (HTTP 200).
- Local NetCDF path unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single env default in the existing worker subprocess for read-only NFS mounts; no auth, data writes, or API surface changes.
> 
> **Overview**
> Fixes **NetCDF4/HDF5** preview failures when `.nc` files live on **rclone NFS mounts** (bucket paths). HDF5 tries to take a POSIX lock on open; NFS returns **ENOLCK** (“No locks available”), so the xarray worker subprocess dies before `/meta` or tiles can load.
> 
> In `grid_tile_server.py` **`run_worker`**, the worker subprocess env now sets **`HDF5_USE_FILE_LOCKING=FALSE`** via `setdefault`, so an explicit host value still wins. Mounts are **read-only**, so skipping locks is considered safe. **NetCDF3/scipy** and local APFS paths are unchanged; only the system **xarray** (and shared zarr) worker path picks up the env.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7a2d269a9addb5fef1b1e0d5d087719e40a063a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->