### PR TITLE
fix(fs): mount-safe early gate in fs mutation handlers + /api/fs/raw HEAD/serve-loss

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1532,7 +1532,12 @@ def _fs_write(body: dict, x_fused: str | None):
             if not pr.exists:
                 return JSONResponse({"error": "conflict", "mtime": None},
                                     status_code=409)
-            if pr.mtime is None or abs(pr.mtime - expected_mtime) >= 1e-6:
+            # Cross-source compare: expected_mtime is a KERNEL /api/fs/stat
+            # st_mtime, but pr.mtime is the rclone rcd ModTime — the two round
+            # a mount's timestamp differently and disagree sub-second, so the
+            # 1e-6 tolerance the local branch uses would 409 every save on a
+            # writable mount. Tolerate < 1s here; a larger gap is a real change.
+            if pr.mtime is None or abs(pr.mtime - expected_mtime) >= 1.0:
                 return JSONResponse({"error": "conflict", "mtime": pr.mtime},
                                     status_code=409)
         # The write itself goes through the rclone VFS (acceptable — it is the

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2056,6 +2056,16 @@ def _fs_rename(body: dict, x_fused: str | None):
             return _error(f"parent directory does not exist: {dst_parent}")
         if dst_pr.exists and not overwrite:
             return JSONResponse({"error": "conflict"}, status_code=409)
+        # The mount read-only gate above only covers the mount side(s). A LOCAL
+        # side still needs the ordinary _writable check: a move deletes src and
+        # writes dst, so a chmod-protected local src or a non-writable local dst
+        # must 403 "readonly" (same contract as the all-local branch below).
+        # Never _writable a mount side — for a writable mount that kernel-probes
+        # W_OK on the mount, the exact stat this whole path exists to avoid.
+        if not shell_mounts.is_mount_backed(src) and not _writable(src):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        if not shell_mounts.is_mount_backed(dst) and not _writable(dst):
+            return JSONResponse({"error": "readonly"}, status_code=403)
         try:
             if dst_pr.exists:
                 os.remove(dst)  # single file (a dir dst was refused above)
@@ -2146,6 +2156,12 @@ def _fs_copy(body: dict, x_fused: str | None):
             return _error(f"parent directory does not exist: {dst_parent}")
         if dst_pr.exists and not overwrite:
             return JSONResponse({"error": "conflict"}, status_code=409)
+        # See _fs_rename: the mount read-only gate covers only the mount side. A
+        # copy writes dst (never src), so a LOCAL dst still needs _writable —
+        # matching the all-local branch, which checks dst only. Never _writable a
+        # mount side (it kernel-stats a writable mount).
+        if not shell_mounts.is_mount_backed(dst) and not _writable(dst):
+            return JSONResponse({"error": "readonly"}, status_code=403)
         try:
             if dst_pr.exists:
                 os.remove(dst)  # single file (a dir dst was refused above)

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1545,6 +1545,15 @@ def _fs_write(body: dict, x_fused: str | None):
         # temp-write + os.replace in the parent, same as the local path. No mode
         # preservation (a remote object has no unix mode, and reading it would
         # be an extra kernel getattr on the mount).
+        #
+        # RESIDUAL RISK: tempfile.mkstemp(dir=parent) + os.replace still do
+        # kernel negative LOOKUPs on the mount (as do os.mkdir/os.remove/
+        # shutil.move in the sibling handlers) — the rc probe above answers
+        # existence but does NOT warm the kernel dircache, so on a huge parent
+        # these lookups can still trigger the full-prefix enumeration this
+        # module exists to avoid. Follow-up: route the mutations themselves
+        # through rclone rc operations (uploadfile / deletefile / movefile),
+        # not the kernel VFS, so no mutation touches the mount through a LOOKUP.
         fd, tmp = tempfile.mkstemp(dir=parent)
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2683,16 +2683,32 @@ def create_app(start_dir: str) -> FastAPI:
             # the same rclone remote, so the sizes agree. In a thread — a
             # cold getattr would otherwise stall the event loop.
             if request.method == "HEAD":
-                st = await asyncio.to_thread(_stat_or_none, path)
-                if st is None:
-                    return _error(f"no such file: {path}", status=404)
+                if shell_mounts.is_mount_backed(path):
+                    # A missing-sidecar HEAD (.zmetadata, .ovr) is exactly the
+                    # cold-negative that a kernel os.stat would turn into a
+                    # full-prefix enumeration and a wedged mount — answer it
+                    # through the rclone rcd instead. Confirmed-missing/
+                    # non-regular -> 404; indeterminate (rcd down/timeout) ->
+                    # 503, never "missing".
+                    try:
+                        pr = await asyncio.to_thread(_mount_probe, path)
+                    except (shell_mounts.RcListUnavailable,
+                            shell_mounts.RcListTimeout) as e:
+                        return _mount_list_error_response(os.path.dirname(path), e)
+                    if not pr.exists or pr.is_dir:
+                        return _error(f"no such file: {path}", status=404)
+                    size, mtime = pr.size or 0, pr.mtime or 0.0
+                else:
+                    st = await asyncio.to_thread(_stat_or_none, path)
+                    if st is None:
+                        return _error(f"no such file: {path}", status=404)
+                    size, mtime = st.st_size, st.st_mtime
                 media_type, _ = mimetypes.guess_type(path)
                 return Response(status_code=200, headers={
-                    "content-length": str(st.st_size),
+                    "content-length": str(size),
                     "content-type": media_type or "application/octet-stream",
                     "accept-ranges": "bytes",
-                    "last-modified": email.utils.formatdate(
-                        st.st_mtime, usegmt=True),
+                    "last-modified": email.utils.formatdate(mtime, usegmt=True),
                 })
             # Cold reads go straight to the store: the serve's VFS layer
             # serializes concurrent uncached range reads of one file (an
@@ -2730,6 +2746,13 @@ def create_app(start_dir: str) -> FastAPI:
             resp = await asyncio.to_thread(_proxy_raw, upstream, request)
             if resp is not None:
                 return resp  # upstream unreachable -> plain file read below
+        # Reached when serve_url_for returned None (no live serve) or the
+        # proxied read failed. For a mount-backed path that means the rclone
+        # serve died or is respawning: reading through the kernel mount here is
+        # the wedge this whole module exists to avoid, so refuse with 503 rather
+        # than fall back to a local file read.
+        if shell_mounts.is_mount_backed(path):
+            return _error("mount serve unavailable", status=503)
         st = await asyncio.to_thread(_stat_or_none, path)
         if st is None:
             return _error(f"no such file: {path}", status=404)

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1319,7 +1319,11 @@ def _mount_probe(path: str) -> _MountProbe:
     parent = os.path.dirname(path)
     name = os.path.basename(path)
     if m.is_mounts_root(parent):
-        return _MountProbe(True, True, is_dir=True)  # `path` is a mountpoint
+        # A direct child of the container is a mountpoint only if a mount
+        # RECORD carries its name — an unknown/removed name is a phantom and
+        # must read as absent (mounts.json only, no I/O on any mount).
+        exists = any(rec.get("name") == name for rec in m.list_mounts())
+        return _MountProbe(True, exists, is_dir=exists)
     try:
         entries = m.rc_list_dir(parent)
     except (m.RcListUnavailable, m.RcListTimeout):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1270,6 +1270,126 @@ def _writable(path: str) -> bool:
     return os.access(os.path.dirname(path) or ".", os.W_OK)
 
 
+# ---------------------------------------------------------------------------
+# Mount-safe existence/shape probes for the fs mutation handlers + /api/fs/raw.
+#
+# An rclone-backed NFS mount has no cheap point lookup: a cold NEGATIVE kernel
+# probe (os.stat / os.path.exists / os.path.isdir / os.listdir) forces rclone
+# to enumerate the ENTIRE parent S3 prefix (measured: 44k entries, ~64s), which
+# blows the macOS NFS deadman and DROPS the mount — server threads then block
+# uninterruptibly. So a mutation handler must never touch a mount-backed path
+# through the kernel to decide whether it exists or what shape it is. These
+# helpers answer that via the rclone rcd (operations/list, bounded by a hard
+# timeout: a too-huge directory becomes a failed request, never a dead mount).
+
+
+class _MountProbe:
+    """Result of a mount-safe existence/shape probe. `parent_is_dir` is whether
+    the path's parent is a listable directory (a mount-safe stand-in for
+    os.path.isdir(parent)); `exists`/`is_dir`/`size`/`mtime` describe the path
+    itself. Size/mtime come from the rc listing entry (None when absent)."""
+
+    __slots__ = ("parent_is_dir", "exists", "is_dir", "size", "mtime")
+
+    def __init__(self, parent_is_dir, exists, is_dir=False, size=None, mtime=None):
+        self.parent_is_dir = parent_is_dir
+        self.exists = exists
+        self.is_dir = is_dir
+        self.size = size
+        self.mtime = mtime
+
+
+def _mount_probe(path: str) -> _MountProbe:
+    """Existence + shape of a MOUNT-BACKED path, answered by the rclone rcd
+    (rc_list_dir of the parent + membership match), doing ZERO kernel FS I/O on
+    the mount. The parent listing is bounded by rc_list_dir's hard timeout, so a
+    huge remote directory raises RcListTimeout rather than wedging the mount.
+
+    Returns a _MountProbe. Raises RcListUnavailable (rcd down / broken mount) or
+    RcListTimeout (directory too large to enumerate) when existence is
+    INDETERMINATE — the caller maps those to 503 (via _mount_list_error_response),
+    never to "missing"."""
+    from fused_render.shell import mounts as m
+
+    # The mounts container and each individual mountpoint are LOCAL directories
+    # the shell created to host mounts; they always exist as directories and
+    # their own parent has no single mount record to list. Answer directly.
+    if m.is_mounts_root(path):
+        return _MountProbe(True, True, is_dir=True)
+    parent = os.path.dirname(path)
+    name = os.path.basename(path)
+    if m.is_mounts_root(parent):
+        return _MountProbe(True, True, is_dir=True)  # `path` is a mountpoint
+    try:
+        entries = m.rc_list_dir(parent)
+    except (m.RcListUnavailable, m.RcListTimeout):
+        raise  # indeterminate -> caller returns 503
+    except m.RcListError:
+        # The rcd rejected the listing: the parent is a file or is missing, so
+        # the child cannot exist. Mount-safe equivalent of a False os.path.isdir.
+        return _MountProbe(False, False)
+    for ent in entries:
+        if ent.get("Name") == name:
+            return _MountProbe(True, True, is_dir=bool(ent.get("IsDir")),
+                               size=ent.get("Size"),
+                               mtime=m.rc_modtime_epoch(ent.get("ModTime")))
+    return _MountProbe(True, False)  # parent listable, child absent
+
+
+def _mount_stat_payload(path: str, is_dir: bool, size, mtime) -> dict:
+    """The /api/fs/stat payload for a MOUNT-BACKED path, built from an rc probe
+    (size/mtime) with NO kernel os.stat/os.access on the mount. `writable` is
+    True by construction — the caller only reaches this after clearing the
+    read-only gate (mount_read_only False)."""
+    templates, template_error = _templates_for(path, is_dir)
+    payload = {
+        "path": path,
+        "name": os.path.basename(path) or path,
+        "is_dir": is_dir,
+        "size": None if is_dir else size,
+        "mtime": mtime,
+        "writable": True,
+        "remote": True,
+        "templates": templates,
+    }
+    if template_error:
+        payload["template_error"] = template_error
+    return payload
+
+
+def _probe_path(path: str) -> _MountProbe:
+    """Existence + shape of `path`, mount-safe: a mount-backed path is answered
+    through the rclone rcd (_mount_probe, zero kernel I/O), a local path with a
+    plain kernel stat. Used by _fs_rename/_fs_copy, which may mix a local and a
+    mount-backed side. Raises RcListUnavailable/RcListTimeout for an
+    indeterminate mount probe (caller maps to 503)."""
+    from fused_render.shell import mounts as m
+
+    if m.is_mount_backed(path):
+        return _mount_probe(path)
+    parent_is_dir = os.path.isdir(os.path.dirname(path) or ".")
+    if not os.path.exists(path):
+        return _MountProbe(parent_is_dir, False)
+    return _MountProbe(parent_is_dir, True, is_dir=os.path.isdir(path))
+
+
+def _mutation_result_payload(path: str, is_dir: bool) -> dict:
+    """The /api/fs/stat payload returned after a successful mutation, mount-safe:
+    a mount-backed path is described from a fresh rc probe (no kernel os.stat),
+    a local path via the ordinary _stat_payload."""
+    from fused_render.shell import mounts as m
+
+    if not m.is_mount_backed(path):
+        return _stat_payload(path, is_dir)
+    try:
+        pr = _mount_probe(path)
+    except (m.RcListUnavailable, m.RcListTimeout):
+        pr = None
+    size = pr.size if pr and pr.exists else None
+    mtime = pr.mtime if pr and pr.exists else None
+    return _mount_stat_payload(path, is_dir, size, mtime)
+
+
 # Response headers forwarded from the rclone serve on a proxied /api/fs/raw.
 # Content-Length/-Range/Accept-Ranges make ranged readers (duckdb httpfs)
 # work; Last-Modified/ETag let their caches revalidate.
@@ -1383,9 +1503,64 @@ def _fs_write(body: dict, x_fused: str | None):
         return _error("'path' must be an absolute filesystem path")
     if not isinstance(content, str):
         return _error("'content' must be a string")
+    parent = os.path.dirname(path)
+
+    # Mount-backed target: gate on read-only-ness and answer existence/shape via
+    # the rclone rcd BEFORE any kernel probe — a cold negative os.stat here is
+    # the exact enumerate-the-whole-prefix call that wedges the mount.
+    from fused_render.shell import mounts as shell_mounts
+    if shell_mounts.is_mount_backed(path):
+        # Read-only mount: refuse first, before touching anything (the same
+        # "readonly" wire contract as the local guard below).
+        if shell_mounts.mount_read_only(path):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        try:
+            pr = _mount_probe(path)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout) as e:
+            return _mount_list_error_response(parent, e)  # indeterminate -> 503
+        if pr.exists and pr.is_dir:
+            return _error(f"path is a directory: {path}")
+        if not pr.parent_is_dir:
+            return _error(f"parent directory does not exist: {parent}", status=404)
+        if create and pr.exists:
+            return JSONResponse({"error": "conflict"}, status_code=409)
+        if expected_mtime is not None:
+            if not pr.exists:
+                return JSONResponse({"error": "conflict", "mtime": None},
+                                    status_code=409)
+            if pr.mtime is None or abs(pr.mtime - expected_mtime) >= 1e-6:
+                return JSONResponse({"error": "conflict", "mtime": pr.mtime},
+                                    status_code=409)
+        # The write itself goes through the rclone VFS (acceptable — it is the
+        # negative/list probes, not the mutation, that wedge the mount): atomic
+        # temp-write + os.replace in the parent, same as the local path. No mode
+        # preservation (a remote object has no unix mode, and reading it would
+        # be an extra kernel getattr on the mount).
+        fd, tmp = tempfile.mkstemp(dir=parent)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(content)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, path)
+        except OSError as e:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            return _error(f"cannot write {path}: {e}", status=400)
+        # Re-arm the client's optimistic lock from a fresh rc probe; fall back to
+        # the written length if the rcd can't answer (never kernel-stat).
+        try:
+            after = _mount_probe(path)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout):
+            after = None
+        size = after.size if after and after.exists else len(content.encode("utf-8"))
+        mtime = after.mtime if after and after.exists else None
+        return _mount_stat_payload(path, False, size, mtime)
+
     if os.path.isdir(path):
         return _error(f"path is a directory: {path}")
-    parent = os.path.dirname(path)
     if not os.path.isdir(parent):
         return _error(f"parent directory does not exist: {parent}", status=404)
 
@@ -1656,6 +1831,27 @@ def _fs_mkdir(body: dict, x_fused: str | None):
     if not path or not os.path.isabs(path):
         return _error("'path' must be an absolute filesystem path")
     parent = os.path.dirname(path)
+
+    # Mount-backed target: read-only refusal first, then existence/shape via the
+    # rclone rcd — never a kernel probe (see _fs_write's mount branch).
+    from fused_render.shell import mounts as shell_mounts
+    if shell_mounts.is_mount_backed(path):
+        if shell_mounts.mount_read_only(path):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        try:
+            pr = _mount_probe(path)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout) as e:
+            return _mount_list_error_response(parent, e)  # indeterminate -> 503
+        if not pr.parent_is_dir:
+            return _error(f"parent directory does not exist: {parent}")
+        if pr.exists:
+            return JSONResponse({"error": "conflict"}, status_code=409)
+        try:
+            os.mkdir(path)  # through the rclone VFS
+        except OSError as e:
+            return _error(f"cannot create directory {path}: {e}")
+        return _mount_stat_payload(path, True, None, None)
+
     if not os.path.isdir(parent):
         return _error(f"parent directory does not exist: {parent}")
     if os.path.exists(path):
@@ -1737,6 +1933,37 @@ def _fs_delete(body: dict, x_fused: str | None):
     trash = bool(body.get("trash", False))
     if not path or not os.path.isabs(path):
         return _error("'path' must be an absolute filesystem path")
+
+    # Mount-backed target: read-only refusal first; then answer shape via the
+    # rclone rcd. A DIRECTORY delete (the non-recursive os.listdir emptiness
+    # check or a recursive shutil.rmtree) would kernel-enumerate/walk the remote
+    # tree — refused, out of scope. A single-file delete goes through the VFS.
+    from fused_render.shell import mounts as shell_mounts
+    if shell_mounts.is_mount_backed(path):
+        if shell_mounts.mount_read_only(path):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        try:
+            pr = _mount_probe(path)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout) as e:
+            return _mount_list_error_response(os.path.dirname(path), e)  # 503
+        if not pr.exists:
+            return _error(f"no such file or directory: {path}", status=404)
+        if pr.is_dir:
+            return _error(
+                "cannot delete a directory on a remote mount: directory-tree "
+                "operations are not supported over mounts", status=400)
+        if trash:
+            # Move-to-Trash lifts the file OFF the mount, which reads the whole
+            # file through the kernel; report it unsupported so the client
+            # falls back to the confirm-then-hard-delete flow (same 501 signal
+            # a non-darwin platform returns).
+            return JSONResponse({"error": "trash unsupported"}, status_code=501)
+        try:
+            os.remove(path)  # single VFS unlink
+        except OSError as e:
+            return _error(f"cannot delete {path}: {e}")
+        return {"deleted": path, "trashed": False}
+
     if not os.path.exists(path):
         return _error(f"no such file or directory: {path}", status=404)
     if not _writable(path):
@@ -1796,11 +2023,47 @@ def _fs_rename(body: dict, x_fused: str | None):
         return _error("'src' must be an absolute filesystem path")
     if not dst or not os.path.isabs(dst):
         return _error("'dst' must be an absolute filesystem path")
+    dst_parent = os.path.dirname(dst)
+
+    # A mount is involved on either side: gate mount-safely BEFORE any kernel
+    # probe. A move deletes src and writes dst, so a read-only mount on EITHER
+    # side refuses (readonly first, as the mount contract). Existence/shape is
+    # answered through the rclone rcd; a DIRECTORY on a mount side is refused
+    # (a rmtree/copytree-style walk of a remote tree is out of scope).
+    from fused_render.shell import mounts as shell_mounts
+    if shell_mounts.is_mount_backed(src) or shell_mounts.is_mount_backed(dst):
+        if shell_mounts.mount_read_only(src) or shell_mounts.mount_read_only(dst):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        try:
+            src_pr = _probe_path(src)
+            dst_pr = _probe_path(dst)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout) as e:
+            return _mount_list_error_response(
+                os.path.dirname(src) if shell_mounts.is_mount_backed(src)
+                else dst_parent, e)
+        if not src_pr.exists:
+            return _error(f"no such file or directory: {src}", status=404)
+        if src_pr.is_dir or (dst_pr.exists and dst_pr.is_dir):
+            return _error(
+                "cannot move a directory to or from a remote mount: "
+                "directory-tree operations are not supported over mounts",
+                status=400)
+        if not dst_pr.parent_is_dir:
+            return _error(f"parent directory does not exist: {dst_parent}")
+        if dst_pr.exists and not overwrite:
+            return JSONResponse({"error": "conflict"}, status_code=409)
+        try:
+            if dst_pr.exists:
+                os.remove(dst)  # single file (a dir dst was refused above)
+            shutil.move(src, dst)
+        except OSError as e:
+            return _error(f"cannot rename {src} -> {dst}: {e}")
+        return _mutation_result_payload(dst, False)
+
     # dst's parent must already exist — a rename never creates intermediate
     # dirs. Without this, a missing parent falls through to _writable (which
     # walks up to the nearest existing ancestor) and surfaces a misleading
     # "readonly" 403; a 400 is the honest error, same as _fs_write/_fs_mkdir.
-    dst_parent = os.path.dirname(dst)
     if not os.path.isdir(dst_parent):
         return _error(f"parent directory does not exist: {dst_parent}")
     if not os.path.exists(src):
@@ -1850,11 +2113,47 @@ def _fs_copy(body: dict, x_fused: str | None):
         return _error("'src' must be an absolute filesystem path")
     if not dst or not os.path.isabs(dst):
         return _error("'dst' must be an absolute filesystem path")
+    dst_parent = os.path.dirname(dst)
+
+    # A mount is involved on either side: gate mount-safely BEFORE any kernel
+    # probe. A copy writes dst (only the dst mount must be writable — readonly
+    # first, as the mount contract) and never modifies src. A DIRECTORY on a
+    # mount side is refused (a copytree walk of a remote tree is out of scope);
+    # a single-file copy proceeds (its sequential read/write is slow, not fatal).
+    from fused_render.shell import mounts as shell_mounts
+    if shell_mounts.is_mount_backed(src) or shell_mounts.is_mount_backed(dst):
+        if shell_mounts.mount_read_only(dst):
+            return JSONResponse({"error": "readonly"}, status_code=403)
+        try:
+            src_pr = _probe_path(src)
+            dst_pr = _probe_path(dst)
+        except (shell_mounts.RcListUnavailable, shell_mounts.RcListTimeout) as e:
+            return _mount_list_error_response(
+                os.path.dirname(src) if shell_mounts.is_mount_backed(src)
+                else dst_parent, e)
+        if not src_pr.exists:
+            return _error(f"no such file or directory: {src}", status=404)
+        if src_pr.is_dir or (dst_pr.exists and dst_pr.is_dir):
+            return _error(
+                "cannot copy a directory to or from a remote mount: "
+                "directory-tree operations are not supported over mounts",
+                status=400)
+        if not dst_pr.parent_is_dir:
+            return _error(f"parent directory does not exist: {dst_parent}")
+        if dst_pr.exists and not overwrite:
+            return JSONResponse({"error": "conflict"}, status_code=409)
+        try:
+            if dst_pr.exists:
+                os.remove(dst)  # single file (a dir dst was refused above)
+            shutil.copy2(src, dst)
+        except OSError as e:
+            return _error(f"cannot copy {src} -> {dst}: {e}")
+        return _mutation_result_payload(dst, False)
+
     # dst's parent must already exist — a copy never creates intermediate dirs.
     # Without this, a missing parent falls through to _writable (which walks up
     # to the nearest existing ancestor) and surfaces a misleading "readonly"
     # 403; a 400 is the honest error, same as _fs_write/_fs_mkdir.
-    dst_parent = os.path.dirname(dst)
     if not os.path.isdir(dst_parent):
         return _error(f"parent directory does not exist: {dst_parent}")
     if not os.path.exists(src):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2717,7 +2717,11 @@ def create_app(start_dir: str) -> FastAPI:
                         return _mount_list_error_response(os.path.dirname(path), e)
                     if not pr.exists or pr.is_dir:
                         return _error(f"no such file: {path}", status=404)
-                    size, mtime = pr.size or 0, pr.mtime or 0.0
+                    # rclone reports Size:-1 for an object of unknown length;
+                    # `-1 or 0` is -1, which is an invalid content-length. Clamp
+                    # a missing/negative size to 0 (keep the mtime fallback).
+                    size = pr.size if pr.size is not None and pr.size >= 0 else 0
+                    mtime = pr.mtime or 0.0
                 else:
                     st = await asyncio.to_thread(_stat_or_none, path)
                     if st is None:

--- a/tests/_mount_safe_helpers.py
+++ b/tests/_mount_safe_helpers.py
@@ -1,0 +1,83 @@
+"""Shared fixtures + helpers for the mount-safety tests
+(test_server_fs_mount_safe, test_server_fs_raw_mount_safe).
+
+Kept in a non-test module (not a test_* file) so both suites import from a
+neutral home instead of one test module reaching into another. The `home`
+fixture is imported into each suite's namespace and used like a local fixture.
+
+Real rclone is never invoked: rc_list_dir is monkeypatched directly and
+FUSED_RENDER_HOME is redirected per test.
+"""
+import os
+
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / "mounts").mkdir(parents=True)
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
+    # add_mount before create_app would otherwise spawn the automount thread.
+    monkeypatch.setattr(mounts_mod, "startup", lambda: None)
+    return h
+
+
+def _mount(name, read_only=False, on_disk=False):
+    """Create a mount record and return its mountpoint. on_disk makes the
+    mountpoint a real local directory (so a VFS-style write can land) — the
+    mount is fake, there is no real NFS underneath."""
+    c = mounts_mod.add_mount(name, f"{name}-remote:bucket", read_only=read_only)
+    mp = mounts_mod.mountpoint(c)
+    if on_disk:
+        os.makedirs(mp, exist_ok=True)
+    return mp
+
+
+def _entry(name, is_dir=False, size=0, mtime="2024-01-02T03:04:05Z"):
+    return {"Name": name, "IsDir": is_dir,
+            "Size": -1 if is_dir else size, "ModTime": mtime}
+
+
+def _no_kernel_on_mount(monkeypatch, mp):
+    """Make any kernel FS probe under `mp` raise AssertionError. Proves the
+    handler answered existence/shape via the rclone rcd, never the kernel.
+
+    The `mount-probe-*` background thread is exempt: broken_mount_error (in
+    mounts.py, off-limits here) spawns it to kernel-probe the mountpoint OFF the
+    request path when mapping an indeterminate listing to 503 — that is not the
+    synchronous decision probe these tests police."""
+    import threading
+
+    real_os = {n: getattr(os, n) for n in ("stat", "lstat", "listdir", "scandir")}
+    real_path = {n: getattr(os.path, n) for n in ("exists", "isdir", "islink")}
+
+    def _wrap(fn, name):
+        def guarded(path, *a, **k):
+            try:
+                p = os.fspath(path)
+            except TypeError:
+                p = path
+            if (isinstance(p, str) and (p == mp or p.startswith(mp + os.sep))
+                    and not threading.current_thread().name.startswith("mount-probe")):
+                raise AssertionError(f"kernel {name}({p}) touched the mount")
+            return fn(path, *a, **k)
+        return guarded
+
+    for n, fn in real_os.items():
+        monkeypatch.setattr(os, n, _wrap(fn, "os." + n))
+    for n, fn in real_path.items():
+        monkeypatch.setattr(os.path, n, _wrap(fn, "os.path." + n))
+
+
+def _list_returns(monkeypatch, entries):
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: list(entries))
+
+
+def _list_raises(monkeypatch, exc):
+    def boom(p, timeout=None):
+        raise exc
+    monkeypatch.setattr(mounts_mod, "rc_list_dir", boom)

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -172,6 +172,34 @@ def test_write_writable_mount_create_conflict_409_via_rc(home, monkeypatch):
     assert _data(resp)["error"] == "conflict"
 
 
+def test_write_mount_subsecond_mtime_gap_does_not_conflict(home, monkeypatch):
+    # The client's expected_mtime is a kernel /api/fs/stat st_mtime; the mount
+    # conflict check compares it against the rc ModTime. The two sources
+    # disagree sub-second, so the MOUNT branch tolerates < 1s and must NOT 409.
+    mp = _mount("rw", read_only=False, on_disk=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    modtime = "2024-01-02T03:04:05Z"
+    _list_returns(monkeypatch, [_entry("notes.txt", size=3, mtime=modtime)])
+    epoch = mounts_mod.rc_modtime_epoch(modtime)
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x",
+                  "expected_mtime": epoch + 0.4}, x_fused="1")
+    assert _status(resp) == 200
+
+
+def test_write_mount_large_mtime_gap_still_conflicts(home, monkeypatch):
+    # A gap beyond the cross-source tolerance is a genuine concurrent change:
+    # still a 409, so the widened tolerance can't mask a real conflict.
+    mp = _mount("rw", read_only=False, on_disk=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    modtime = "2024-01-02T03:04:05Z"
+    _list_returns(monkeypatch, [_entry("notes.txt", size=3, mtime=modtime)])
+    epoch = mounts_mod.rc_modtime_epoch(modtime)
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x",
+                  "expected_mtime": epoch + 5.0}, x_fused="1")
+    assert _status(resp) == 409
+    assert _data(resp)["error"] == "conflict"
+
+
 def test_write_writable_mount_new_file_succeeds_via_vfs(home, monkeypatch):
     mp = _mount("rw", read_only=False, on_disk=True)
     _no_kernel_on_mount(monkeypatch, mp)

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -1,0 +1,376 @@
+"""Mount-safety of the fs mutation handlers and /api/fs/raw
+(fused_render/server.py).
+
+An rclone-backed NFS mount has no cheap point lookup: a cold negative kernel
+probe (os.stat / os.path.exists / os.path.isdir / os.listdir) forces rclone to
+enumerate the ENTIRE parent S3 prefix, blows past the macOS NFS deadman, and
+DROPS the mount — server threads then block uninterruptibly. So no kernel FS
+call may ever touch a mount-backed path in these handlers.
+
+These tests pin:
+  * the five fs mutation handlers (_fs_write/_fs_mkdir/_fs_delete/_fs_rename/
+    _fs_copy) gate a mount path on read-only-ness BEFORE any kernel probe, and
+    route existence/shape probes for a writable mount through the rclone rcd
+    (rc_list_dir), never the kernel;
+  * directory-tree operations on a mount (delete of a mount dir, rename/copy
+    where a mount side is a directory) are refused rather than kernel-walked.
+
+/api/fs/raw's HEAD + serve-loss mount-safety lives in test_server_fs_raw_mount_safe.
+
+Every "must not touch the mount through the kernel" assertion is enforced with
+a guard that makes any kernel FS probe under the mountpoint raise
+AssertionError — a sneaked-in kernel call fails the test loudly.
+
+Real rclone is never invoked: the StubRcd from test_shell_mounts answers the rc
+calls (or rc_list_dir is monkeypatched directly), and FUSED_RENDER_HOME is
+redirected per test.
+"""
+import json
+import os
+
+import pytest
+from fastapi.responses import JSONResponse
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import _fs_copy as COPY
+from fused_render.server import _fs_delete as DELETE
+from fused_render.server import _fs_mkdir as MKDIR
+from fused_render.server import _fs_rename as RENAME
+from fused_render.server import _fs_write as WRITE
+
+
+# --------------------------------------------------------------------------- helpers
+
+def _status(resp) -> int:
+    return resp.status_code if isinstance(resp, JSONResponse) else 200
+
+
+def _data(resp) -> dict:
+    if isinstance(resp, JSONResponse):
+        return json.loads(bytes(resp.body))
+    return resp
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    h = tmp_path / "home"
+    (h / "mounts").mkdir(parents=True)
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
+    # add_mount before create_app would otherwise spawn the automount thread.
+    monkeypatch.setattr(mounts_mod, "startup", lambda: None)
+    return h
+
+
+def _mount(name, read_only=False, on_disk=False):
+    """Create a mount record and return its mountpoint. on_disk makes the
+    mountpoint a real local directory (so a VFS-style write can land) — the
+    mount is fake, there is no real NFS underneath."""
+    c = mounts_mod.add_mount(name, f"{name}-remote:bucket", read_only=read_only)
+    mp = mounts_mod.mountpoint(c)
+    if on_disk:
+        os.makedirs(mp, exist_ok=True)
+    return mp
+
+
+def _entry(name, is_dir=False, size=0, mtime="2024-01-02T03:04:05Z"):
+    return {"Name": name, "IsDir": is_dir,
+            "Size": -1 if is_dir else size, "ModTime": mtime}
+
+
+def _no_kernel_on_mount(monkeypatch, mp):
+    """Make any kernel FS probe under `mp` raise AssertionError. Proves the
+    handler answered existence/shape via the rclone rcd, never the kernel.
+
+    The `mount-probe-*` background thread is exempt: broken_mount_error (in
+    mounts.py, off-limits here) spawns it to kernel-probe the mountpoint OFF the
+    request path when mapping an indeterminate listing to 503 — that is not the
+    synchronous decision probe these tests police."""
+    import threading
+
+    real_os = {n: getattr(os, n) for n in ("stat", "lstat", "listdir", "scandir")}
+    real_path = {n: getattr(os.path, n) for n in ("exists", "isdir", "islink")}
+
+    def _wrap(fn, name):
+        def guarded(path, *a, **k):
+            try:
+                p = os.fspath(path)
+            except TypeError:
+                p = path
+            if (isinstance(p, str) and (p == mp or p.startswith(mp + os.sep))
+                    and not threading.current_thread().name.startswith("mount-probe")):
+                raise AssertionError(f"kernel {name}({p}) touched the mount")
+            return fn(path, *a, **k)
+        return guarded
+
+    for n, fn in real_os.items():
+        monkeypatch.setattr(os, n, _wrap(fn, "os." + n))
+    for n, fn in real_path.items():
+        monkeypatch.setattr(os.path, n, _wrap(fn, "os.path." + n))
+
+
+def _list_returns(monkeypatch, entries):
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: list(entries))
+
+
+def _list_raises(monkeypatch, exc):
+    def boom(p, timeout=None):
+        raise exc
+    monkeypatch.setattr(mounts_mod, "rc_list_dir", boom)
+
+
+# ===========================================================================
+# Task 1 — early mount gate in the fs mutation handlers
+# ===========================================================================
+
+# -- _fs_write --------------------------------------------------------------
+
+def test_write_read_only_mount_refused_before_any_kernel_probe(home, monkeypatch):
+    mp = _mount("ro", read_only=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # rc_list_dir must NOT be consulted either — readonly settles it first.
+    _list_raises(monkeypatch, AssertionError("rc_list_dir called before readonly gate"))
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x"}, x_fused="1")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+
+
+def test_write_writable_mount_missing_parent_404_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # Parent is not a listable directory (rc rejects the listing).
+    _list_raises(monkeypatch, mounts_mod.RcListError("not a directory"))
+    resp = WRITE({"path": os.path.join(mp, "sub", "notes.txt"), "content": "x"},
+                 x_fused="1")
+    assert _status(resp) == 404
+
+
+def test_write_writable_mount_target_is_dir_400_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("notes.txt", is_dir=True)])
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x"}, x_fused="1")
+    assert _status(resp) == 400
+    assert "directory" in _data(resp)["error"]
+
+
+def test_write_writable_mount_indeterminate_is_503_not_missing(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, mounts_mod.RcListUnavailable("rcd down"))
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x"}, x_fused="1")
+    assert _status(resp) == 503
+
+
+def test_write_writable_mount_create_conflict_409_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("notes.txt", size=3)])
+    resp = WRITE({"path": os.path.join(mp, "notes.txt"), "content": "x", "create": True},
+                 x_fused="1")
+    assert _status(resp) == 409
+    assert _data(resp)["error"] == "conflict"
+
+
+def test_write_writable_mount_new_file_succeeds_via_vfs(home, monkeypatch):
+    mp = _mount("rw", read_only=False, on_disk=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [])  # parent listable, target absent
+    target = os.path.join(mp, "notes.txt")
+    resp = WRITE({"path": target, "content": "hello"}, x_fused="1")
+    assert _status(resp) == 200
+    out = _data(resp)
+    assert out["writable"] is True and out["remote"] is True and out["is_dir"] is False
+    # The bytes actually landed (the mutation goes through the VFS).
+    with open(target) as fh:
+        assert fh.read() == "hello"
+
+
+# -- _fs_mkdir --------------------------------------------------------------
+
+def test_mkdir_read_only_mount_refused_before_probe(home, monkeypatch):
+    mp = _mount("ro", read_only=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, AssertionError("rc_list_dir called before readonly gate"))
+    resp = MKDIR({"path": os.path.join(mp, "newdir")}, x_fused="1")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+
+
+def test_mkdir_writable_mount_conflict_409_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("newdir", is_dir=True)])
+    resp = MKDIR({"path": os.path.join(mp, "newdir")}, x_fused="1")
+    assert _status(resp) == 409
+    assert _data(resp)["error"] == "conflict"
+
+
+def test_mkdir_writable_mount_indeterminate_503(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, mounts_mod.RcListTimeout("too many entries"))
+    resp = MKDIR({"path": os.path.join(mp, "newdir")}, x_fused="1")
+    assert _status(resp) == 503
+
+
+def test_mkdir_writable_mount_success_via_vfs(home, monkeypatch):
+    # The DECISION phase (readonly gate + existence probe) is proven kernel-free
+    # by the refusal/missing/indeterminate tests; here the guard is off so the
+    # VFS mutation itself (os.mkdir) can land, per the task's "mutation is OK".
+    mp = _mount("rw", read_only=False, on_disk=True)
+    _list_returns(monkeypatch, [])  # parent listable, target absent
+    target = os.path.join(mp, "newdir")
+    resp = MKDIR({"path": target}, x_fused="1")
+    assert _status(resp) == 200
+    out = _data(resp)
+    assert out["is_dir"] is True and out["writable"] is True and out["remote"] is True
+    assert os.path.isdir(target)
+
+
+# -- _fs_delete -------------------------------------------------------------
+
+def test_delete_read_only_mount_refused_before_probe(home, monkeypatch):
+    mp = _mount("ro", read_only=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, AssertionError("rc_list_dir called before readonly gate"))
+    resp = DELETE({"path": os.path.join(mp, "notes.txt")}, x_fused="1")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+
+
+def test_delete_mount_directory_refused_not_kernel_walked(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # rc reports the target is a directory; a real delete would os.listdir /
+    # shutil.rmtree over the remote tree — refuse instead.
+    _list_returns(monkeypatch, [_entry("adir", is_dir=True)])
+    resp = DELETE({"path": os.path.join(mp, "adir")}, x_fused="1")
+    assert _status(resp) == 400
+    assert "director" in _data(resp)["error"].lower()
+
+
+def test_delete_mount_directory_recursive_still_refused(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("adir", is_dir=True)])
+    resp = DELETE({"path": os.path.join(mp, "adir"), "recursive": True}, x_fused="1")
+    assert _status(resp) == 400
+
+
+def test_delete_mount_missing_404_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("other.txt")])  # target absent
+    resp = DELETE({"path": os.path.join(mp, "gone.txt")}, x_fused="1")
+    assert _status(resp) == 404
+
+
+def test_delete_mount_indeterminate_503(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, mounts_mod.RcListUnavailable("rcd down"))
+    resp = DELETE({"path": os.path.join(mp, "notes.txt")}, x_fused="1")
+    assert _status(resp) == 503
+
+
+def test_delete_mount_single_file_succeeds_via_vfs(home, monkeypatch):
+    # Guard off: the decision phase is pinned kernel-free elsewhere; here the
+    # VFS unlink (os.remove) must be free to run.
+    mp = _mount("rw", read_only=False, on_disk=True)
+    target = os.path.join(mp, "notes.txt")
+    with open(target, "w") as fh:
+        fh.write("bytes")
+    _list_returns(monkeypatch, [_entry("notes.txt", size=5)])
+    resp = DELETE({"path": target}, x_fused="1")
+    assert _status(resp) == 200
+    assert _data(resp)["deleted"] == target
+    assert not os.path.exists(target)
+
+
+# -- _fs_rename -------------------------------------------------------------
+
+def test_rename_read_only_mount_src_refused(home, monkeypatch):
+    mp = _mount("ro", read_only=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, AssertionError("probed before readonly gate"))
+    resp = RENAME({"src": os.path.join(mp, "a.txt"),
+                   "dst": os.path.join(mp, "b.txt")}, x_fused="1")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+
+
+def test_rename_mount_directory_src_refused(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("adir", is_dir=True), _entry("b", is_dir=True)])
+    resp = RENAME({"src": os.path.join(mp, "adir"),
+                   "dst": os.path.join(mp, "b", "adir")}, x_fused="1")
+    assert _status(resp) == 400
+    assert "director" in _data(resp)["error"].lower()
+
+
+def test_rename_mount_missing_src_404_via_rc(home, monkeypatch):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("other.txt")])  # src absent
+    resp = RENAME({"src": os.path.join(mp, "gone.txt"),
+                   "dst": os.path.join(mp, "b.txt")}, x_fused="1")
+    assert _status(resp) == 404
+
+
+def test_rename_mount_single_file_succeeds(home, monkeypatch):
+    # Guard off: the decision phase is pinned kernel-free elsewhere; here the
+    # VFS move (shutil.move, which probes/writes dst) must be free to run.
+    mp = _mount("rw", read_only=False, on_disk=True)
+    src = os.path.join(mp, "a.txt")
+    with open(src, "w") as fh:
+        fh.write("data")
+    _list_returns(monkeypatch, [_entry("a.txt", size=4)])
+    dst = os.path.join(mp, "b.txt")
+    resp = RENAME({"src": src, "dst": dst}, x_fused="1")
+    assert _status(resp) == 200
+    assert os.path.exists(dst) and not os.path.exists(src)
+
+
+# -- _fs_copy ---------------------------------------------------------------
+
+def test_copy_read_only_mount_dst_refused(home, monkeypatch, tmp_path):
+    mp = _mount("ro", read_only=True)
+    local_src = tmp_path / "src.txt"
+    local_src.write_text("x")
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, AssertionError("probed before readonly gate"))
+    resp = COPY({"src": str(local_src), "dst": os.path.join(mp, "dst.txt")},
+                x_fused="1")
+    assert _status(resp) == 403
+    assert _data(resp)["error"] == "readonly"
+
+
+def test_copy_mount_directory_src_refused(home, monkeypatch, tmp_path):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("adir", is_dir=True)])
+    resp = COPY({"src": os.path.join(mp, "adir"), "dst": str(tmp_path / "out")},
+                x_fused="1")
+    assert _status(resp) == 400
+    assert "director" in _data(resp)["error"].lower()
+
+
+def test_copy_mount_missing_src_404_via_rc(home, monkeypatch, tmp_path):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("other.txt")])
+    resp = COPY({"src": os.path.join(mp, "gone.txt"), "dst": str(tmp_path / "out.txt")},
+                x_fused="1")
+    assert _status(resp) == 404
+
+
+def test_copy_mount_indeterminate_503(home, monkeypatch, tmp_path):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, mounts_mod.RcListTimeout("too big"))
+    resp = COPY({"src": os.path.join(mp, "a.txt"), "dst": str(tmp_path / "out.txt")},
+                x_fused="1")
+    assert _status(resp) == 503
+

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -410,3 +410,42 @@ def test_mounts_root_known_mount_name_still_exists_mkdir_409(home, monkeypatch):
     assert _status(resp) == 409
     assert _data(resp)["error"] == "conflict"
 
+
+# ===========================================================================
+# Local side of a mixed local+mount rename/copy still gets the _writable check
+# (Bugbot 3615342580 "Local writable checks skipped"). The mount read-only gate
+# only covers the mount side; a chmod-protected LOCAL src (rename) or a
+# non-writable LOCAL dst must still 403 "readonly", same as the all-local branch.
+# The mount side is NEVER _writable-probed (that kernel-stats a writable mount).
+# ===========================================================================
+
+def test_rename_local_readonly_src_refused_with_mount_dst(home, monkeypatch, tmp_path):
+    mp = _mount("rw", read_only=False, on_disk=True)
+    _no_kernel_on_mount(monkeypatch, mp)
+    src = tmp_path / "src.txt"
+    src.write_text("data")
+    os.chmod(src, 0o400)  # read-only local file: a move (delete+write) must 403
+    _list_returns(monkeypatch, [])  # mount dst parent listable, dst absent
+    try:
+        resp = RENAME({"src": str(src), "dst": os.path.join(mp, "b.txt")}, x_fused="1")
+        assert _status(resp) == 403
+        assert _data(resp)["error"] == "readonly"
+    finally:
+        os.chmod(src, 0o600)
+
+
+def test_copy_local_readonly_dst_refused_with_mount_src(home, monkeypatch, tmp_path):
+    mp = _mount("rw", read_only=False)
+    _no_kernel_on_mount(monkeypatch, mp)
+    ro_dir = tmp_path / "roout"
+    ro_dir.mkdir()
+    os.chmod(ro_dir, 0o500)  # non-writable local dst parent -> new file refused
+    _list_returns(monkeypatch, [_entry("a.txt", size=4)])  # mount src is a file
+    try:
+        resp = COPY({"src": os.path.join(mp, "a.txt"), "dst": str(ro_dir / "b.txt")},
+                    x_fused="1")
+        assert _status(resp) == 403
+        assert _data(resp)["error"] == "readonly"
+    finally:
+        os.chmod(ro_dir, 0o700)
+

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -374,3 +374,39 @@ def test_copy_mount_indeterminate_503(home, monkeypatch, tmp_path):
                 x_fused="1")
     assert _status(resp) == 503
 
+
+# ===========================================================================
+# Mounts-root children exist only when a mount RECORD carries the name
+# (Bugbot 3615342568 "Mount root children always exist"). A direct child of the
+# mounts container is a mountpoint iff mounts.json lists its name — an unknown/
+# removed name is a phantom that must read as ABSENT, settled from mounts.json
+# with no rc_list_dir / no I/O on any mount.
+# ===========================================================================
+
+def test_mounts_root_unknown_child_reads_as_absent_delete_404(home, monkeypatch):
+    # An unknown name directly under the mounts container has no mount record:
+    # DELETE must 404 (absent), NOT treat it as an existing mountpoint dir. The
+    # rc listing must never be consulted — mounts.json settles it.
+    _list_raises(monkeypatch, AssertionError("rc_list_dir consulted for a mounts-root child"))
+    resp = DELETE({"path": os.path.join(mounts_mod.mounts_dir(), "phantom")}, x_fused="1")
+    assert _status(resp) == 404
+
+
+def test_mounts_root_unknown_child_mkdir_not_conflict(home, monkeypatch):
+    # MKDIR of an unknown mounts-root name must NOT 409: before the fix every
+    # basename read as "already exists". With the phantom absent, the create
+    # proceeds (200).
+    _list_raises(monkeypatch, AssertionError("rc_list_dir consulted for a mounts-root child"))
+    resp = MKDIR({"path": os.path.join(mounts_mod.mounts_dir(), "phantom")}, x_fused="1")
+    assert _status(resp) != 409
+
+
+def test_mounts_root_known_mount_name_still_exists_mkdir_409(home, monkeypatch):
+    # A name carried by a real mount record still reads as an existing dir, so
+    # MKDIR over it is a 409 conflict (the fix must not regress this direction).
+    mp = _mount("real", read_only=False)
+    _list_raises(monkeypatch, AssertionError("rc_list_dir consulted for a mounts-root child"))
+    resp = MKDIR({"path": mp}, x_fused="1")
+    assert _status(resp) == 409
+    assert _data(resp)["error"] == "conflict"
+

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -28,7 +28,6 @@ redirected per test.
 import json
 import os
 
-import pytest
 from fastapi.responses import JSONResponse
 
 import fused_render.shell.mounts as mounts_mod
@@ -37,6 +36,14 @@ from fused_render.server import _fs_delete as DELETE
 from fused_render.server import _fs_mkdir as MKDIR
 from fused_render.server import _fs_rename as RENAME
 from fused_render.server import _fs_write as WRITE
+from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
+    _entry,
+    _list_raises,
+    _list_returns,
+    _mount,
+    _no_kernel_on_mount,
+    home,
+)
 
 
 # --------------------------------------------------------------------------- helpers
@@ -49,74 +56,6 @@ def _data(resp) -> dict:
     if isinstance(resp, JSONResponse):
         return json.loads(bytes(resp.body))
     return resp
-
-
-@pytest.fixture()
-def home(tmp_path, monkeypatch):
-    h = tmp_path / "home"
-    (h / "mounts").mkdir(parents=True)
-    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
-    # add_mount before create_app would otherwise spawn the automount thread.
-    monkeypatch.setattr(mounts_mod, "startup", lambda: None)
-    return h
-
-
-def _mount(name, read_only=False, on_disk=False):
-    """Create a mount record and return its mountpoint. on_disk makes the
-    mountpoint a real local directory (so a VFS-style write can land) — the
-    mount is fake, there is no real NFS underneath."""
-    c = mounts_mod.add_mount(name, f"{name}-remote:bucket", read_only=read_only)
-    mp = mounts_mod.mountpoint(c)
-    if on_disk:
-        os.makedirs(mp, exist_ok=True)
-    return mp
-
-
-def _entry(name, is_dir=False, size=0, mtime="2024-01-02T03:04:05Z"):
-    return {"Name": name, "IsDir": is_dir,
-            "Size": -1 if is_dir else size, "ModTime": mtime}
-
-
-def _no_kernel_on_mount(monkeypatch, mp):
-    """Make any kernel FS probe under `mp` raise AssertionError. Proves the
-    handler answered existence/shape via the rclone rcd, never the kernel.
-
-    The `mount-probe-*` background thread is exempt: broken_mount_error (in
-    mounts.py, off-limits here) spawns it to kernel-probe the mountpoint OFF the
-    request path when mapping an indeterminate listing to 503 — that is not the
-    synchronous decision probe these tests police."""
-    import threading
-
-    real_os = {n: getattr(os, n) for n in ("stat", "lstat", "listdir", "scandir")}
-    real_path = {n: getattr(os.path, n) for n in ("exists", "isdir", "islink")}
-
-    def _wrap(fn, name):
-        def guarded(path, *a, **k):
-            try:
-                p = os.fspath(path)
-            except TypeError:
-                p = path
-            if (isinstance(p, str) and (p == mp or p.startswith(mp + os.sep))
-                    and not threading.current_thread().name.startswith("mount-probe")):
-                raise AssertionError(f"kernel {name}({p}) touched the mount")
-            return fn(path, *a, **k)
-        return guarded
-
-    for n, fn in real_os.items():
-        monkeypatch.setattr(os, n, _wrap(fn, "os." + n))
-    for n, fn in real_path.items():
-        monkeypatch.setattr(os.path, n, _wrap(fn, "os.path." + n))
-
-
-def _list_returns(monkeypatch, entries):
-    monkeypatch.setattr(mounts_mod, "rc_list_dir",
-                        lambda p, timeout=None: list(entries))
-
-
-def _list_raises(monkeypatch, exc):
-    def boom(p, timeout=None):
-        raise exc
-    monkeypatch.setattr(mounts_mod, "rc_list_dir", boom)
 
 
 # ===========================================================================

--- a/tests/test_server_fs_raw_mount_safe.py
+++ b/tests/test_server_fs_raw_mount_safe.py
@@ -10,7 +10,7 @@
     rather than falling through to a local-file kernel read of the mount.
 
 Shared fixtures/helpers (home, _mount, _entry, _no_kernel_on_mount,
-_list_returns, _list_raises) are reused from test_server_fs_mount_safe.
+_list_returns, _list_raises) live in _mount_safe_helpers.
 """
 import os
 
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 
 import fused_render.shell.mounts as mounts_mod
 from fused_render.server import create_app
-from test_server_fs_mount_safe import (  # noqa: F401 — `home` is a reused fixture
+from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
     _entry,
     _list_raises,
     _list_returns,

--- a/tests/test_server_fs_raw_mount_safe.py
+++ b/tests/test_server_fs_raw_mount_safe.py
@@ -1,0 +1,89 @@
+"""Mount-safety of /api/fs/raw (fused_render/server.py) — Task 2.
+
+  * HEAD for a serve-backed mount path is answered through the rclone rcd
+    (rc_list_dir), never a kernel os.stat: a missing-sidecar HEAD (.zmetadata,
+    .ovr) is exactly the cold-negative probe that would enumerate the whole
+    remote prefix and wedge the mount. Confirmed-missing/non-regular -> 404,
+    indeterminate (rcd down/timeout) -> 503.
+  * When serve_url_for returns None (or the proxied read fails) but the path IS
+    mount-backed, the rclone serve is down/respawning — the handler returns 503
+    rather than falling through to a local-file kernel read of the mount.
+
+Shared fixtures/helpers (home, _mount, _entry, _no_kernel_on_mount,
+_list_returns, _list_raises) are reused from test_server_fs_mount_safe.
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import create_app
+from test_server_fs_mount_safe import (  # noqa: F401 — `home` is a reused fixture
+    _entry,
+    _list_raises,
+    _list_returns,
+    _mount,
+    _no_kernel_on_mount,
+    home,
+)
+
+
+@pytest.fixture()
+def raw_client(home, monkeypatch):
+    """A TestClient plus a factory that arms a live serve for a mountpoint and
+    stubs prefetch (whose background reader would otherwise touch the file)."""
+    import fused_render.shell.prefetch as prefetch
+    monkeypatch.setattr(prefetch, "schedule", lambda *a, **k: None)
+    monkeypatch.setattr(prefetch, "is_done", lambda *a, **k: True)
+    client = TestClient(create_app(start_dir=str(home)))
+
+    def arm_serve(mp):
+        from fused_render.shell import storage
+        storage.write_json(mounts_mod.serves_path(), {mp: "http://127.0.0.1:1"})
+
+    return client, arm_serve
+
+
+def test_raw_head_missing_sidecar_404_via_rc(raw_client, home, monkeypatch):
+    client, arm_serve = raw_client
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # Parent lists the store, but the .zmetadata sidecar is absent -> 404,
+    # answered without a kernel os.stat (the cold-negative wedge).
+    _list_returns(monkeypatch, [_entry("zarr.json", size=10)])
+    r = client.head("/api/fs/raw", params={"path": os.path.join(mp, ".zmetadata")})
+    assert r.status_code == 404
+
+
+def test_raw_head_present_file_200_via_rc(raw_client, home, monkeypatch):
+    client, arm_serve = raw_client
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_returns(monkeypatch, [_entry("zarr.json", size=42)])
+    r = client.head("/api/fs/raw", params={"path": os.path.join(mp, "zarr.json")})
+    assert r.status_code == 200
+    assert r.headers["content-length"] == "42"
+
+
+def test_raw_head_indeterminate_is_503(raw_client, home, monkeypatch):
+    client, arm_serve = raw_client
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    _list_raises(monkeypatch, mounts_mod.RcListUnavailable("rcd down"))
+    r = client.head("/api/fs/raw", params={"path": os.path.join(mp, ".zmetadata")})
+    assert r.status_code == 503
+
+
+def test_raw_serve_lost_but_mount_backed_returns_503_not_kernel_read(
+        raw_client, home, monkeypatch):
+    client, _ = raw_client
+    mp = _mount("rw", read_only=False)
+    # No serve armed -> serve_url_for returns None; the path IS mount-backed,
+    # so the handler must 503 rather than fall through to a kernel file read.
+    _no_kernel_on_mount(monkeypatch, mp)
+    r = client.get("/api/fs/raw", params={"path": os.path.join(mp, "data.parquet")})
+    assert r.status_code == 503

--- a/tests/test_server_fs_raw_mount_safe.py
+++ b/tests/test_server_fs_raw_mount_safe.py
@@ -68,6 +68,20 @@ def test_raw_head_present_file_200_via_rc(raw_client, home, monkeypatch):
     assert r.headers["content-length"] == "42"
 
 
+def test_raw_head_unknown_size_reports_zero_not_negative(raw_client, home, monkeypatch):
+    client, arm_serve = raw_client
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # rclone reports Size:-1 for an object of unknown length; `-1 or 0` is -1,
+    # which would emit an invalid content-length: -1. It must clamp to 0.
+    _list_returns(monkeypatch, [{"Name": "blob.bin", "IsDir": False, "Size": -1,
+                                 "ModTime": "2024-01-02T03:04:05Z"}])
+    r = client.head("/api/fs/raw", params={"path": os.path.join(mp, "blob.bin")})
+    assert r.status_code == 200
+    assert r.headers["content-length"] == "0"
+
+
 def test_raw_head_indeterminate_is_503(raw_client, home, monkeypatch):
     client, arm_serve = raw_client
     mp = _mount("rw", read_only=False)

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1684,14 +1684,13 @@ def test_stat_marks_mount_backed_files_remote(client, home):
     assert client.get("/api/fs/stat", params={"path": plain}).json()["remote"] is False
 
 
-def test_fs_raw_proxies_range_from_mount_serve(client, home):
+def test_fs_raw_proxies_range_from_mount_serve(client, home, rcd):
     """/api/fs/raw for a mount-backed path streams GETs from the mount's
-    HTTP serve, not from the local filesystem. HEAD is the exception: it is
-    answered from the mount's own stat — ranged clients (duckdb httpfs,
-    fsspec/zarr) probe the length before every read, and proxying that probe
-    costs a full remote round trip for headers the VFS getattr already
-    knows; on a real mount the stat and the serve read the same remote, so
-    the sizes agree (here they intentionally differ to prove the source)."""
+    HTTP serve, not from the local filesystem. HEAD is answered from the
+    rclone rcd (operations/list), NOT a kernel os.stat: a missing-sidecar HEAD
+    is the cold-negative probe that would enumerate the whole remote prefix and
+    wedge the mount. Here the rc size (77) intentionally differs from both the
+    local file (11) and the serve body (12) to prove HEAD is rc-sourced."""
     import functools
     import http.server
     import os
@@ -1701,6 +1700,9 @@ def test_fs_raw_proxies_range_from_mount_serve(client, home):
     os.makedirs(mp)
     f = os.path.join(mp, "x.bin")
     open(f, "wb").write(b"LOCAL-BYTES")  # what a (dead-mount) local read would see
+    rcd.responses["operations/list"] = {"list": [
+        {"Name": "x.bin", "IsDir": False, "Size": 77,
+         "ModTime": "2024-01-02T03:04:05Z"}]}
 
     served = home / "served"
     served.mkdir()
@@ -1723,7 +1725,7 @@ def test_fs_raw_proxies_range_from_mount_serve(client, home):
         assert r.status_code == 200 and r.content == b"REMOTE-BYTES"
         r = client.head("/api/fs/raw", params={"path": f})
         assert r.status_code == 200
-        assert r.headers["content-length"] == str(len(b"LOCAL-BYTES"))
+        assert r.headers["content-length"] == "77"  # from the rcd, not kernel
         assert r.headers["accept-ranges"] == "bytes"
         assert "last-modified" in r.headers
         assert r.content == b""
@@ -1731,11 +1733,13 @@ def test_fs_raw_proxies_range_from_mount_serve(client, home):
         srv.shutdown()
 
 
-def test_fs_raw_directory_404s_not_listing(client, home):
+def test_fs_raw_directory_404s_not_listing(client, home, rcd):
     """A directory path under a served mount 404s on GET and HEAD. The serve
     (like rclone serve http) answers a directory with a 200 HTML listing, so
     without a guard the proxy would hand that listing back as raw bytes; a
-    directory has no bytes to serve, so both verbs must 404."""
+    directory has no bytes to serve, so both verbs must 404. GET's guard is the
+    proxy-path stat; HEAD detects the directory via the rclone rcd (IsDir), the
+    mount-safe replacement for the kernel os.stat."""
     import functools
     import http.server
     import os
@@ -1747,6 +1751,11 @@ def test_fs_raw_directory_404s_not_listing(client, home):
     d = os.path.join(mp, "subdir")
     os.makedirs(d)
     open(os.path.join(d, "x.bin"), "wb").write(b"CHUNK")
+    # rcd reports `subdir` as a directory, so the HEAD probe 404s without a
+    # kernel stat.
+    rcd.responses["operations/list"] = {"list": [
+        {"Name": "subdir", "IsDir": True, "Size": -1,
+         "ModTime": "2024-01-02T03:04:05Z"}]}
 
     class H(http.server.SimpleHTTPRequestHandler):
         def log_message(self, *a):
@@ -1771,7 +1780,11 @@ def test_fs_raw_directory_404s_not_listing(client, home):
         srv.shutdown()
 
 
-def test_fs_raw_falls_back_to_file_when_serve_dead(client, home):
+def test_fs_raw_serve_dead_returns_503_never_kernel_reads_mount(client, home):
+    """When the mount's HTTP serve is unreachable, /api/fs/raw must 503 rather
+    than fall back to a local-file kernel read: reading through the kernel NFS
+    mount is the wedge this whole subsystem exists to avoid, so even a file that
+    happens to be cached locally is refused while the serve is down/respawning."""
     import os
     import socket
 
@@ -1786,7 +1799,7 @@ def test_fs_raw_falls_back_to_file_when_serve_dead(client, home):
     import fused_render.shell.storage as storage
     storage.write_json(mounts_mod.serves_path(), {mp: f"http://127.0.0.1:{dead}"})
     r = client.get("/api/fs/raw", params={"path": f})
-    assert r.status_code == 200 and r.content == b"LOCAL-BYTES"
+    assert r.status_code == 503
 
 
 def test_fs_raw_proxy_error_keeps_range_headers(client, home):


### PR DESCRIPTION
## Summary

- The five fs mutation handlers (`/api/fs/write|mkdir|delete|rename|copy`) ran raw kernel probes (`os.path.isdir`, `os.path.exists`, `os.stat`, delete's `os.listdir`) **before** any mount awareness. On an rclone-NFS mount a cold **negative** probe forces rclone to enumerate the entire parent S3 prefix (measured 44,361 siblings ≈ 64s), trips the macOS NFS deadman, and drops the mount — so "New File" in a mount folder, or a drag-move whose destination is on a mount, could kill the mount before the read-only refusal was ever reached.
- Mount-backed paths now take an **early gate**: read-only refusal (`{"error":"readonly"}` 403) before any probe; existence/shape via a new `_mount_probe` (rclone rc `operations/list` of the parent + membership match — zero kernel I/O, hard-timeout bounded); indeterminate rc answers map to a retryable **503**, never a false "missing". The local code path and its 400→404→409→403 error ordering are byte-for-byte untouched — the mount branch returns before reaching it.
- Remote **tree** operations are refused up front (400) instead of kernel-enumerating a remote subtree: delete of a mount directory (`shutil.rmtree`/emptiness `os.listdir`), rename/copy where a mount side is a directory. Single-file operations on writable mounts proceed through the VFS as before (the wedge is the negative/list probe, not the mutation). Trash of a mount file returns 501, routing the client to the hard-delete fallback rather than reading the whole file off the mount.
- `/api/fs/raw`: HEAD on a mount-backed path now answers via `_mount_probe` instead of a kernel `os.stat` (a HEAD for a **missing** sidecar — `.zmetadata`, `.ovr` — was exactly the cold-negative wedge, and httpfs/fsspec probe those constantly); and when the rclone HTTP serve is down, a mount-backed GET returns 503 "mount serve unavailable" instead of silently falling back to a kernel read through NFS.

Note for reviewers: this branch is cut from `main` and deliberately does not touch `shell/mounts.py` (PR #199 is rewriting probe internals there). Once #199 lands, `_mount_probe` should be routed through its sub-second direct S3/GCS point probes as a follow-up — today it is bounded-but-slower on huge parents (rc list timeout → 503).

## Visuals

```mermaid
flowchart LR
    A["POST /api/fs/write|mkdir|delete|rename|copy"] --> G{"is_mount_backed?"}
    G -->|no| L["local path: kernel probes,<br/>400→404→409→403 (unchanged)"]
    G -->|yes| RO{"mount_read_only?"}
    RO -->|yes| R403["403 readonly<br/>(before ANY probe)"]
    RO -->|no| P["_mount_probe: rc list parent,<br/>membership match — no kernel I/O"]
    P -->|"rc timeout / unavailable"| R503["503 retryable"]
    P -->|"dir-tree op on mount"| R400["400 refused"]
    P -->|"single-file op ok"| VFS["mutation via VFS (unchanged)"]

    H["HEAD /api/fs/raw (mount path)"] --> P2["_mount_probe"]
    P2 -->|missing/non-regular| N404[404]
    P2 -->|indeterminate| N503[503]
    S["GET /api/fs/raw, serve down"] --> S503["503 mount serve unavailable<br/>(was: kernel read fallback)"]
```

## Usage

No new user-invocable surface. Creating/renaming/deleting files in a mounted folder now fails fast with an honest 403/400/503 instead of stalling 10–60s and risking a mount drop; ranged readers probing missing sidecars over `/api/fs/raw` get an instant 404/503 off the kernel.

## Test Plan

- [x] `tests/test_server_fs_mount_safe.py` — 24 new tests (red-first): per-handler early readonly refusal, rc-routed existence/shape, indeterminate→503, mount-dir tree-op refusals, trash→501, local-path contract untouched — with a kernel guard fixture that raises `AssertionError` if any `os.stat/exists/isdir/listdir/lstat/scandir` touches the mount during the decision phase.
- [x] `tests/test_server_fs_raw_mount_safe.py` — 4 new tests: mount HEAD via probe (404/503), serve-loss GET → 503, same kernel guard.
- [x] Updated 3 tests in `tests/test_shell_mounts.py` that pinned the superseded contract (HEAD-from-kernel-stat; serve-dead → local read).
- [x] Full suite: **1062 passed, 13 skipped, 0 failures** (verified independently after the final commit; baseline on main was 1034 passed).
- [ ] Manual: on a mounted read-only folder, try New File / rename / delete from the explorer — instant readonly error, mount stays attached; `curl -I /api/fs/raw?path=<mount>/missing.ovr` returns fast 404 with no rclone parent enumeration in rcd.log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
