### PR TITLE
Add result caching control and cache-busting to Deploy modal

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -887,13 +887,18 @@ the product gains network access.
   the current value verbatim when it isn't one of them — e.g. set by a direct
   `share create --cache-max-age` outside this dialog), seeded on open from the
   stored deployment record like `include`/`exclude` (DP-2c) and re-sent as
-  `cache_max_age` on every Deploy — there is no "leave it as it was". It travels
-  in the export bundle's manifest (EX-9), not a CLI flag, so it reaches either
-  backend the same way `include`/`exclude`-selected files do. On a managed
-  `fused` env the deploy still succeeds, but the control plane does not yet read
-  the field back out into caching behavior (fused repo's
-  spec/serve/fused-render.md § Limitations) — the modal says so inline rather
-  than implying the setting took effect.
+  `cache_max_age` on every Deploy — there is no "leave it as it was". It reaches
+  the two backends **differently**, because they model caching differently
+  (fused repo's spec/serve/fused-render.md § Caching / spec/serve/share-links.md
+  §8): it travels in the export bundle's manifest (EX-9) for an AWS environment
+  (read by `build_html_artifact`, so a later `repoint`/redeploy can change it
+  too — `deploy_page` sends it both ways there, harmlessly redundant); for a
+  managed `fused` environment the manifest field is not read at all — only the
+  explicit `--cache-max-age` on the `share create` call is, as the mount's own
+  `cache_settings` (a control-plane concept independent of the bundle). That
+  field is **fixed at create time**: a `repoint` (every redeploy after the
+  first) cannot change it, so the modal notes this inline on a redeploy to a
+  `fused` env rather than implying the checkbox took effect.
 - **DP-18** **Bust cache** (`POST /api/deploy/bust-cache {"page"}` →
   `bust_cache_deployment` → `fused share cache-clear <token>`) forces every
   cached result for the deployment's mount to be recomputed on the next

--- a/SPEC.md
+++ b/SPEC.md
@@ -692,7 +692,8 @@ nothing. Full detail: `docs/EXPORT.md`.
   `openfused.caching.parse_cache_max_age` accepts) — the Deploy modal's caching
   choice (DP-17), written fresh on every export so a redeploy always re-asserts
   the current setting. The hosting layer's `build_html_artifact` applies it
-  uniformly to every `runPython` route (never the shell or the asset route); see
+  **page-wide** — to every route uniformly (the shell, each `runPython` route,
+  and the asset route), matching the managed backend's mount-wide caching; see
   the fused repo's spec/serve/fused-render.md § Caching. A bundle exported before
   this field existed omits it, which the hosting layer reads as off.
 
@@ -882,32 +883,45 @@ the product gains network access.
   `share create` on AWS envs and lists the managed backend's inline-upload
   bundle classification as a follow-up. fused-render passes the CLI's own
   error through verbatim rather than second-guessing the installed version.
-- **DP-17** The modal carries a **caching control**: a checkbox ("Cache
-  runPython results") plus a duration select (1m/5m/15m/1h/6h/1d presets, plus
-  the current value verbatim when it isn't one of them — e.g. set by a direct
-  `share create --cache-max-age` outside this dialog), seeded on open from the
-  stored deployment record like `include`/`exclude` (DP-2c) and re-sent as
-  `cache_max_age` on every Deploy — there is no "leave it as it was". It reaches
-  the two backends **differently**, because they model caching differently
-  (fused repo's spec/serve/fused-render.md § Caching / spec/serve/share-links.md
-  §8): it travels in the export bundle's manifest (EX-9) for an AWS environment
-  (read by `build_html_artifact`, so a later `repoint`/redeploy can change it
-  too — `deploy_page` sends it both ways there, harmlessly redundant); for a
-  managed `fused` environment the manifest field is not read at all — only the
-  explicit `--cache-max-age` on the `share create` call is, as the mount's own
-  `cache_settings` (a control-plane concept independent of the bundle). That
-  field is **fixed at create time**: a `repoint` (every redeploy after the
-  first) cannot change it, so the modal notes this inline on a redeploy to a
-  `fused` env rather than implying the checkbox took effect.
+- **DP-17** The modal carries a **caching control**: a checkbox ("Cache page
+  results") plus a duration select (1m/5m/15m/1h/6h/1d presets, default **1h**,
+  plus the current value verbatim when it isn't one of them — e.g. set by a
+  direct `share create --cache-max-age` outside this dialog), seeded on open
+  from the stored deployment record like `include`/`exclude` (DP-2c) and
+  re-sent as `cache_max_age` on every Deploy — there is no "leave it as it
+  was". It reaches the two backends **differently**, because they model
+  caching differently (fused repo's spec/serve/fused-render.md § Caching /
+  spec/serve/share-links.md §8): it travels in the export bundle's manifest
+  (EX-9) for an AWS environment (read by `build_html_artifact`, so a later
+  `repoint`/redeploy can change it too — `deploy_page` sends it both ways
+  there, harmlessly redundant); for a managed `fused` environment the manifest
+  field is not read at all — only the explicit `--cache-max-age` on the
+  `share create` call is, as the mount's own `cache_settings` (a control-plane
+  concept independent of the bundle, `application` repo spec `021` §3.1). That
+  field is **fixed for the life of a token**: a `repoint` carries no cache
+  fields at all, and a revoked-token revive (`recreate --same-token`) preserves
+  it verbatim — so `deploy_page` deliberately withholds `--cache-max-age` on
+  those two calls (sending it would either be ignored or, on `repoint`,
+  rejected outright) and persists the setting that is **actually** live, not
+  the one requested (`_record_from`'s `effective_cache_max_age`), so the
+  deployment card never claims a setting the mount doesn't have. When the
+  modal detects the checkbox/duration no longer matches what's live on a
+  `fused`-backend redeploy, it shows this inline (naming the live value) with
+  a **"Deploy as new URL"** action (`deploy_page(..., force_new=True)`) — the
+  only way to actually change caching on that backend: it skips token reuse
+  and mints a fresh `share create` with the requested setting, at a new URL.
+  The previous URL is left running; the caller revokes it separately (Revoke)
+  if it should stop serving.
 - **DP-18** **Bust cache** (`POST /api/deploy/bust-cache {"page"}` →
   `bust_cache_deployment` → `fused share cache-clear <token>`) forces every
   cached result for the deployment's mount to be recomputed on the next
   request, without touching its status, URL, or caching setting — for "the
   underlying data changed, not the code" (a redeploy dedupes to the same
   content address and would otherwise keep serving the old cached result until
-  `cache_max_age` expires). Shown alongside Revoke whenever the deployment is
-  active; its result (`{deleted, scope}`) renders as a one-line status
-  ("Cleared N cached results…" / "Nothing was cached…").
+  `cache_max_age` expires). Shown in the caching row (next to the duration
+  control) whenever the deployment is active; its result (`{deleted, scope}`)
+  renders as a one-line status ("Cleared N cached results…" / "Nothing was
+  cached…").
 
 ### 19.5 State & truth
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -687,6 +687,14 @@ nothing. Full detail: `docs/EXPORT.md`.
   (kept on the deployment record, off the artifact). This is what collapses a
   hand-maintained `RAW_URLS`-style table (or a fake `_bundle*()` scanner-bait function)
   down to `fused.rawUrl("data/" + name)` against a `data/*.json` glob.
+- **EX-9** `manifest.json` carries a top-level **`cache_max_age`** (`"0s"` off by
+  default; a duration like `"5m"`/`"1h"` — the same format the fused repo's
+  `openfused.caching.parse_cache_max_age` accepts) — the Deploy modal's caching
+  choice (DP-17), written fresh on every export so a redeploy always re-asserts
+  the current setting. The hosting layer's `build_html_artifact` applies it
+  uniformly to every `runPython` route (never the shell or the asset route); see
+  the fused repo's spec/serve/fused-render.md § Caching. A bundle exported before
+  this field existed omits it, which the hosting layer reads as off.
 
 ## 19. Deploy — Hosted Publish through the fused CLI (M11)
 
@@ -874,12 +882,34 @@ the product gains network access.
   `share create` on AWS envs and lists the managed backend's inline-upload
   bundle classification as a follow-up. fused-render passes the CLI's own
   error through verbatim rather than second-guessing the installed version.
+- **DP-17** The modal carries a **caching control**: a checkbox ("Cache
+  runPython results") plus a duration select (1m/5m/15m/1h/6h/1d presets, plus
+  the current value verbatim when it isn't one of them — e.g. set by a direct
+  `share create --cache-max-age` outside this dialog), seeded on open from the
+  stored deployment record like `include`/`exclude` (DP-2c) and re-sent as
+  `cache_max_age` on every Deploy — there is no "leave it as it was". It travels
+  in the export bundle's manifest (EX-9), not a CLI flag, so it reaches either
+  backend the same way `include`/`exclude`-selected files do. On a managed
+  `fused` env the deploy still succeeds, but the control plane does not yet read
+  the field back out into caching behavior (fused repo's
+  spec/serve/fused-render.md § Limitations) — the modal says so inline rather
+  than implying the setting took effect.
+- **DP-18** **Bust cache** (`POST /api/deploy/bust-cache {"page"}` →
+  `bust_cache_deployment` → `fused share cache-clear <token>`) forces every
+  cached result for the deployment's mount to be recomputed on the next
+  request, without touching its status, URL, or caching setting — for "the
+  underlying data changed, not the code" (a redeploy dedupes to the same
+  content address and would otherwise keep serving the old cached result until
+  `cache_max_age` expires). Shown alongside Revoke whenever the deployment is
+  active; its result (`{deleted, scope}`) renders as a one-line status
+  ("Cleared N cached results…" / "Nothing was cached…").
 
 ### 19.5 State & truth
 
 - **DP-12** A thin per-page pointer at `~/.fused-render/deployments.json`
   (shell/storage; keyed by absolute page path — env, backend, token, url,
-  status, entrypoints, updated_at) lets the shell mark deployed files, re-show
+  status, entrypoints, `cache_max_age` (DP-17), updated_at) lets the shell mark
+  deployed files, re-show
   the URL (`create` returns it exactly once; `share list` never carries one),
   and redeploy to the same token. **`share list` on the env stays the
   authority**: the modal reconciles status against it on open (`--all`, so an
@@ -931,7 +961,8 @@ the product gains network access.
 - **DP-14** Endpoints (`fused_render/deploy.py`, an APIRouter like
   shell/bookmarks): `GET /api/deploy/config`, `GET /api/deploy/status`,
   `GET /api/deploy/preview`, `GET /api/deploy/shares`, `POST /api/deploy`,
-  `POST /api/deploy/revoke`, `POST /api/deploy/install`; the POSTs carry the
+  `POST /api/deploy/revoke`, `POST /api/deploy/bust-cache` (DP-18),
+  `POST /api/deploy/install`; the POSTs carry the
   `X-Fused` guard (D36). CLI failures surface their last stderr line verbatim
   (click's `Error: ` prefix stripped) — the fused CLI's messages already name
   the fix (`fused cloud login`, `fused infra serve`, …).

--- a/SPEC.md
+++ b/SPEC.md
@@ -908,10 +908,14 @@ the product gains network access.
   modal detects the checkbox/duration no longer matches what's live on a
   `fused`-backend redeploy, it shows this inline (naming the live value) with
   a **"Deploy as new URL"** action (`deploy_page(..., force_new=True)`) — the
-  only way to actually change caching on that backend: it skips token reuse
-  and mints a fresh `share create` with the requested setting, at a new URL.
-  The previous URL is left running; the caller revokes it separately (Revoke)
-  if it should stop serving.
+  only way to actually change caching on that backend. It **replaces** the
+  deployment: skips token reuse, mints a fresh `share create` with the
+  requested setting at a new URL, repoints the page pointer to it, then
+  **best-effort revokes the superseded mount** (last, after the new URL is
+  live, so a create failure never takes the page down; a revoke failure is
+  non-fatal — the new URL stands and the old mount lingers, revocable from the
+  account page's deployments list). The pointer therefore tracks the new mount,
+  so the modal's Revoke targets the new URL — no orphaned URL to chase.
 - **DP-18** **Clear cache** (`POST /api/deploy/clear-cache {"page"}` →
   `clear_cache_deployment` → `fused share cache-clear <token>`) forces every
   cached result for the deployment's mount to be recomputed on the next

--- a/SPEC.md
+++ b/SPEC.md
@@ -912,8 +912,8 @@ the product gains network access.
   and mints a fresh `share create` with the requested setting, at a new URL.
   The previous URL is left running; the caller revokes it separately (Revoke)
   if it should stop serving.
-- **DP-18** **Bust cache** (`POST /api/deploy/bust-cache {"page"}` →
-  `bust_cache_deployment` → `fused share cache-clear <token>`) forces every
+- **DP-18** **Clear cache** (`POST /api/deploy/clear-cache {"page"}` →
+  `clear_cache_deployment` → `fused share cache-clear <token>`) forces every
   cached result for the deployment's mount to be recomputed on the next
   request, without touching its status, URL, or caching setting — for "the
   underlying data changed, not the code" (a redeploy dedupes to the same
@@ -980,7 +980,7 @@ the product gains network access.
 - **DP-14** Endpoints (`fused_render/deploy.py`, an APIRouter like
   shell/bookmarks): `GET /api/deploy/config`, `GET /api/deploy/status`,
   `GET /api/deploy/preview`, `GET /api/deploy/shares`, `POST /api/deploy`,
-  `POST /api/deploy/revoke`, `POST /api/deploy/bust-cache` (DP-18),
+  `POST /api/deploy/revoke`, `POST /api/deploy/clear-cache` (DP-18),
   `POST /api/deploy/install`; the POSTs carry the
   `X-Fused` guard (D36). CLI failures surface their last stderr line verbatim
   (click's `Error: ` prefix stripped) — the fused CLI's messages already name

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -22,11 +22,12 @@ yourself.
 `page` and `out` must both be absolute filesystem paths (same convention as
 every other endpoint). Export is **non-destructive** — it never deletes an existing
 file — so `out` must be **empty** (or not yet exist); a non-empty `out` is rejected.
-Re-export to a fresh directory (the Deploy flow always uses a new temp dir). Two
-optional fields tune the file set (see "Choosing which
-files are bundled" below): `include` (extra page-relative files to bundle as
-assets) and `exclude` (files to drop from the bundle) — both arrays of relative
-paths, defaulting to empty. On success the response is
+Re-export to a fresh directory (the Deploy flow always uses a new temp dir). Three
+optional fields tune the bundle: `include` (extra page-relative files to bundle as
+assets) and `exclude` (files to drop from the bundle) — see "Choosing which files
+are bundled" below, both arrays of relative paths defaulting to empty — and
+`cache_max_age` (a string, default `"0s"`; see "Caching" below). On success the
+response is
 `{"out", "entrypoints": [...], "assets": [...], "warnings": [...]}` — the same
 shape written into `manifest.json` below, plus the resolved `out` directory and
 any advisory warnings. On a blocking export problem (see "Rules the exporter
@@ -58,7 +59,8 @@ bundle/
   "page": "page.html",
   "entrypoints": [{ "path": "./sine.py", "name": "sine", "key": "sine.py" }],
   "assets": [{ "path": "./logo.png", "name": "logo.png" }],
-  "resources": [{ "key": "helpers.py" }]
+  "resources": [{ "key": "helpers.py" }],
+  "cache_max_age": "0s"
 }
 ```
 
@@ -83,6 +85,21 @@ is no separate `file` field. (The hosting layer also still reads legacy **v1** b
 
 The hosting layer uses the manifest to wire the served page's runtime — which
 literal path posts to which route — without re-parsing the HTML.
+
+## Caching
+
+`cache_max_age` is the deploy-time choice for how long a `runPython` route's result
+may be served from cache instead of re-executed — `"0s"` (off, the default) or a
+duration like `"5m"`/`"1h"`/`"1d"` (a non-negative integer + `s`/`m`/`h`/`d` unit).
+It applies uniformly to every `runPython` route in the bundle — never the page shell
+or the `_asset` route, which the hosting layer always keeps uncached. The Deploy
+modal (SPEC §19, DP-17) exposes it as a checkbox + duration picker and re-exports on
+every deploy so the manifest always carries the current choice; a direct
+`POST /api/export` caller sets it the same way. See the fused repo's
+spec/serve/fused-render.md § Caching and spec/caching/serve.md for how the hosting
+layer honors it (result caching, cache-key scoping, the `X-Openfused-Cache`
+hit/miss header) and `fused share cache-clear <token>` / the Deploy modal's "Bust
+cache" action (DP-18) for forcing a recompute without changing this setting.
 
 ## The portable subset of `window.fused`
 

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -95,11 +95,23 @@ It applies uniformly to every `runPython` route in the bundle — never the page
 or the `_asset` route, which the hosting layer always keeps uncached. The Deploy
 modal (SPEC §19, DP-17) exposes it as a checkbox + duration picker and re-exports on
 every deploy so the manifest always carries the current choice; a direct
-`POST /api/export` caller sets it the same way. See the fused repo's
-spec/serve/fused-render.md § Caching and spec/caching/serve.md for how the hosting
-layer honors it (result caching, cache-key scoping, the `X-Openfused-Cache`
-hit/miss header) and `fused share cache-clear <token>` / the Deploy modal's "Bust
-cache" action (DP-18) for forcing a recompute without changing this setting.
+`POST /api/export` caller sets it the same way.
+
+The manifest field is only **one** of the two ways this choice reaches a hosting
+layer — see the fused repo's spec/serve/fused-render.md § Caching for the full
+picture. An **AWS** environment's `build_html_artifact` reads this manifest field
+directly, so it works on both a fresh `share create` and a later `share repoint`
+(redeploy). A managed **Fused** environment does not read the manifest field for
+caching at all — it is a mount-level control-plane setting, sent as an explicit
+`share create --cache-max-age` (the Deploy modal's `deploy_page` sends both, so
+either backend gets it correctly) — and it is fixed at that first create; a
+`repoint` cannot change it, so redeploying an already-cached page to a managed
+environment cannot toggle or retune caching there.
+
+See spec/caching/serve.md for how the AWS dispatcher honors it (result caching,
+cache-key scoping, the `X-Openfused-Cache` hit/miss header) and
+`fused share cache-clear <token>` / the Deploy modal's "Bust cache" action (DP-18)
+for forcing a recompute on either backend without changing this setting.
 
 ## The portable subset of `window.fused`
 

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -117,7 +117,7 @@ setting at a new URL.
 
 See spec/caching/serve.md for how the AWS dispatcher honors it (result caching,
 cache-key scoping, the `X-Openfused-Cache` hit/miss header) and
-`fused share cache-clear <token>` / the Deploy modal's "Bust cache" action (DP-18)
+`fused share cache-clear <token>` / the Deploy modal's "Clear cache" action (DP-18)
 for forcing a recompute on either backend without changing this setting.
 
 ## The portable subset of `window.fused`

--- a/docs/EXPORT.md
+++ b/docs/EXPORT.md
@@ -88,12 +88,16 @@ literal path posts to which route — without re-parsing the HTML.
 
 ## Caching
 
-`cache_max_age` is the deploy-time choice for how long a `runPython` route's result
-may be served from cache instead of re-executed — `"0s"` (off, the default) or a
+`cache_max_age` is the deploy-time choice for how long the page's result may be
+served from cache instead of re-executed — `"0s"` (off, the default) or a
 duration like `"5m"`/`"1h"`/`"1d"` (a non-negative integer + `s`/`m`/`h`/`d` unit).
-It applies uniformly to every `runPython` route in the bundle — never the page shell
-or the `_asset` route, which the hosting layer always keeps uncached. The Deploy
-modal (SPEC §19, DP-17) exposes it as a checkbox + duration picker and re-exports on
+It applies **page-wide** — to every served route uniformly (the page shell, each
+`runPython` route, and the `_asset` route), matching the managed backend's
+mount-wide caching. This is safe against a redeploy serving stale content: the
+hosting layer folds the full bundle into each route's cache key, so any content
+change re-hashes it (and the `_asset` route's HTTP Range reads cache correctly
+because the `Range` header is part of that key). The Deploy modal (SPEC §19,
+DP-17) exposes it as a checkbox + duration picker (default 1h) and re-exports on
 every deploy so the manifest always carries the current choice; a direct
 `POST /api/export` caller sets it the same way.
 
@@ -104,9 +108,12 @@ directly, so it works on both a fresh `share create` and a later `share repoint`
 (redeploy). A managed **Fused** environment does not read the manifest field for
 caching at all — it is a mount-level control-plane setting, sent as an explicit
 `share create --cache-max-age` (the Deploy modal's `deploy_page` sends both, so
-either backend gets it correctly) — and it is fixed at that first create; a
-`repoint` cannot change it, so redeploying an already-cached page to a managed
-environment cannot toggle or retune caching there.
+either backend gets it correctly) — and it is fixed for the life of a mount
+token; a `repoint` cannot change it, so `deploy_page` withholds the flag on
+redeploys there and persists the setting that is actually live. To actually
+change caching on a managed environment, the Deploy modal offers a "Deploy as
+new URL" action (`force_new`) that mints a fresh `share create` with the new
+setting at a new URL.
 
 See spec/caching/serve.md for how the AWS dispatcher honors it (result caching,
 cache-key scoping, the `X-Openfused-Cache` hit/miss header) and

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -16,7 +16,7 @@
 // modal is scoped to the current page.
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
-  bustCacheDeployment,
+  clearCacheDeployment,
   deployPage,
   getDeployConfig,
   getDeployPreview,
@@ -26,7 +26,7 @@ import {
   walkDir,
 } from "../lib/api";
 import type {
-  CacheBustResult,
+  CacheClearResult,
   DeployConfig,
   DeployPreview,
   Deployment,
@@ -469,7 +469,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const [live, setLive] = useState<"active" | "revoked" | "absent" | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
-  const [busy, setBusy] = useState<"deploy" | "revoke" | "install" | "bust-cache" | null>(null);
+  const [busy, setBusy] = useState<"deploy" | "revoke" | "install" | "clear-cache" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   // The user's file selection, layered on the auto-detected set: `include` adds
   // extra files (as assets), `exclude` drops files. Seeded on open from the
@@ -481,9 +481,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // fused's cache_max_age. Seeded on open from the stored record (like include/
   // exclude) and sent back on every Deploy; there is no "leave it as it was".
   const [cacheMaxAge, setCacheMaxAge] = useState<string>("0s");
-  // The result of the last "Bust cache" click (deleted/scope), shown as a status
+  // The result of the last "Clear cache" click (deleted/scope), shown as a status
   // line until the next load/action clears it.
-  const [bustCacheResult, setBustCacheResult] = useState<CacheBustResult | null>(null);
+  const [clearCacheResult, setClearCacheResult] = useState<CacheClearResult | null>(null);
   // True while a preview fetch is in flight — the shown "Will publish" list may
   // not yet reflect the latest include/exclude edit, so Deploy is held until it
   // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
@@ -573,7 +573,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // no stale rows, and no × / restore edit that could target the wrong page.
       setPreview(null);
       // A stale "N cleared" note from the previous page must not linger.
-      setBustCacheResult(null);
+      setClearCacheResult(null);
     }
     try {
       const [cfg, status] = await Promise.all([
@@ -679,7 +679,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     if (!env) return;
     setBusy("deploy");
     setActionError(null);
-    setBustCacheResult(null); // a stale "N cleared" note must not survive a redeploy
+    setClearCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
       const record = await deployPage(fsPath, env.name, include, exclude, cacheMaxAge, forceNew);
       applyDeployment(record);
@@ -726,17 +726,17 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   };
 
   // Forces cached results to be recomputed on next request, without touching the
-  // mount's status/URL/caching setting (deploy.py's bust_cache_deployment) — for
+  // mount's status/URL/caching setting (deploy.py's clear_cache_deployment) — for
   // "I changed the underlying data, not the code" (a redeploy dedupes to the same
   // content-address and would otherwise keep serving the old cached result until
   // cache_max_age expires).
-  const onBustCache = async () => {
-    setBusy("bust-cache");
+  const onClearCache = async () => {
+    setBusy("clear-cache");
     setActionError(null);
-    setBustCacheResult(null);
+    setClearCacheResult(null);
     try {
-      const result = await bustCacheDeployment(fsPath);
-      if (alive.current) setBustCacheResult(result);
+      const result = await clearCacheDeployment(fsPath);
+      if (alive.current) setClearCacheResult(result);
     } catch (e) {
       if (alive.current) setActionError((e as Error).message);
     } finally {
@@ -965,11 +965,11 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             <button
               type="button"
               className="btn btn-secondary"
-              onClick={onBustCache}
+              onClick={onClearCache}
               disabled={busy !== null}
               title="Force cached results to be recomputed on the next request, without redeploying or changing the URL"
             >
-              {busy === "bust-cache" ? "Busting cache…" : "Bust cache"}
+              {busy === "clear-cache" ? "Clearing cache…" : "Clear cache"}
             </button>
           )}
         </div>
@@ -1056,10 +1056,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         {/* One status line for the same-env case — the URL nuance that used to
             live in the button label / a stack of notes. */}
         {deployStatus && <div className="deploy-muted">{deployStatus}</div>}
-        {bustCacheResult && (
+        {clearCacheResult && (
           <div className="deploy-muted">
-            {bustCacheResult.deleted > 0
-              ? `Cleared ${bustCacheResult.deleted} cached result${bustCacheResult.deleted === 1 ? "" : "s"} — the next request recomputes.`
+            {clearCacheResult.deleted > 0
+              ? `Cleared ${clearCacheResult.deleted} cached result${clearCacheResult.deleted === 1 ? "" : "s"} — the next request recomputes.`
               : "Nothing was cached — nothing to clear."}
           </div>
         )}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -56,7 +56,7 @@ const CACHE_DURATION_PRESETS: { value: string; label: string }[] = [
   { value: "6h", label: "6 hours" },
   { value: "1d", label: "1 day" },
 ];
-const DEFAULT_CACHE_DURATION = "5m";
+const DEFAULT_CACHE_DURATION = "1h";
 
 // The preset list, plus the current value as its own option when it isn't a preset
 // (e.g. a duration set via `share create --cache-max-age` outside this dialog) — so
@@ -675,13 +675,13 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // Each handler applies its result (onChange always propagates to the header
   // dot), then guards the modal's OWN setState on `alive` — the dialog may
   // have been closed mid-action (#12).
-  const onDeploy = async () => {
+  const onDeploy = async (forceNew = false) => {
     if (!env) return;
     setBusy("deploy");
     setActionError(null);
     setBustCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
-      const record = await deployPage(fsPath, env.name, include, exclude, cacheMaxAge);
+      const record = await deployPage(fsPath, env.name, include, exclude, cacheMaxAge, forceNew);
       applyDeployment(record);
       if (!alive.current) return;
       setReconciled(true);
@@ -945,7 +945,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                 setCacheMaxAge(e.target.checked ? DEFAULT_CACHE_DURATION : "0s")
               }
             />
-            Cache runPython results
+            Cache page results
           </label>
           {cacheMaxAge !== "0s" && (
             <Select
@@ -961,13 +961,44 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               ))}
             </Select>
           )}
+          {deployment?.status === "active" && (
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={onBustCache}
+              disabled={busy !== null}
+              title="Force cached results to be recomputed on the next request, without redeploying or changing the URL"
+            >
+              {busy === "bust-cache" ? "Busting cache…" : "Bust cache"}
+            </button>
+          )}
         </div>
-        {env?.backend === "fused" && isRedeploy && (
-          <div className="deploy-note">
-            Managed Fused environments fix caching at first deploy — redeploying can't
-            change it here. Revoke and deploy fresh if you need a different setting.
-          </div>
-        )}
+        {env?.backend === "fused" &&
+          isRedeploy &&
+          cacheMaxAge !== (deployment?.cache_max_age ?? "0s") && (
+            <div className="deploy-note">
+              Managed Fused environments fix caching at first deploy — redeploying this URL
+              keeps its current setting (
+              {(deployment?.cache_max_age ?? "0s") === "0s"
+                ? "off"
+                : `on, ${deployment?.cache_max_age}`}
+              ), not the one just chosen above.{" "}
+              <button
+                type="button"
+                className="btn btn-secondary"
+                onClick={() => onDeploy(true)}
+                disabled={
+                  busy !== null ||
+                  preview === null ||
+                  previewPending ||
+                  (preview?.errors.length ?? 0) > 0
+                }
+                title="Publish this page at a brand-new URL with the setting chosen above — the current URL keeps serving until you revoke it separately"
+              >
+                Deploy as new URL
+              </button>
+            </div>
+          )}
 
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
@@ -986,7 +1017,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
           <button
             type="button"
             className="btn btn-primary"
-            onClick={onDeploy}
+            onClick={() => onDeploy()}
             // Hold Deploy until the shown "Will publish" list matches the current
             // selection: preview === null (still resolving, or cleared on a page
             // switch) or previewPending (a refresh is in flight after an edit) both
@@ -1019,16 +1050,6 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               title="Take the URL down (the link stops working until you deploy again)"
             >
               {busy === "revoke" ? "Revoking…" : "Revoke"}
-            </button>
-          )}
-          {deployment?.status === "active" && (
-            <button
-              type="button"
-              onClick={onBustCache}
-              disabled={busy !== null}
-              title="Force cached results to be recomputed on the next request, without redeploying or changing the URL"
-            >
-              {busy === "bust-cache" ? "Busting cache…" : "Bust cache"}
             </button>
           )}
         </div>

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -16,6 +16,7 @@
 // modal is scoped to the current page.
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
+  bustCacheDeployment,
   deployPage,
   getDeployConfig,
   getDeployPreview,
@@ -24,7 +25,13 @@ import {
   revokeDeployment,
   walkDir,
 } from "../lib/api";
-import type { DeployConfig, DeployPreview, Deployment, WalkEntry } from "../lib/api";
+import type {
+  CacheBustResult,
+  DeployConfig,
+  DeployPreview,
+  Deployment,
+  WalkEntry,
+} from "../lib/api";
 import { useFusedLogin } from "../lib/account";
 import { basename, dirname, formatSize } from "../lib/format";
 import { useRefreshOnReturn } from "../lib/hooks";
@@ -37,6 +44,28 @@ import { Select } from "./field/fields";
 // _asset_key (export.py) for the common case — strip a leading "./"; the exact
 // literal is preserved elsewhere for display/tooltips.
 const relKey = (p: string) => p.replace(/^\.\//, "");
+
+// Caching duration presets (fused's cache_max_age format — a non-negative integer +
+// s/m/h/d unit; see fused/agent_core/caching.py's parse_cache_max_age). "0s" is off
+// and not itself an option here — the checkbox controls that axis.
+const CACHE_DURATION_PRESETS: { value: string; label: string }[] = [
+  { value: "1m", label: "1 minute" },
+  { value: "5m", label: "5 minutes" },
+  { value: "15m", label: "15 minutes" },
+  { value: "1h", label: "1 hour" },
+  { value: "6h", label: "6 hours" },
+  { value: "1d", label: "1 day" },
+];
+const DEFAULT_CACHE_DURATION = "5m";
+
+// The preset list, plus the current value as its own option when it isn't a preset
+// (e.g. a duration set via `share create --cache-max-age` outside this dialog) — so
+// the <select> always shows the TRUE value rather than silently falling back to
+// the first preset while a redeploy would still send the real, unlisted one.
+function cacheDurationOptions(current: string) {
+  if (CACHE_DURATION_PRESETS.some((o) => o.value === current)) return CACHE_DURATION_PRESETS;
+  return [{ value: current, label: current }, ...CACHE_DURATION_PRESETS];
+}
 
 interface DeployModalProps {
   fsPath: string;
@@ -440,7 +469,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const [live, setLive] = useState<"active" | "revoked" | "absent" | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [selectedEnv, setSelectedEnv] = useState<string | null>(null);
-  const [busy, setBusy] = useState<"deploy" | "revoke" | "install" | null>(null);
+  const [busy, setBusy] = useState<"deploy" | "revoke" | "install" | "bust-cache" | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
   // The user's file selection, layered on the auto-detected set: `include` adds
   // extra files (as assets), `exclude` drops files. Seeded on open from the
@@ -448,6 +477,13 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // sent back on Deploy. Both empty = the auto-detected default.
   const [include, setInclude] = useState<string[]>([]);
   const [exclude, setExclude] = useState<string[]>([]);
+  // The caching choice: "0s" (off, the default) or a duration like "5m"/"1h" —
+  // fused's cache_max_age. Seeded on open from the stored record (like include/
+  // exclude) and sent back on every Deploy; there is no "leave it as it was".
+  const [cacheMaxAge, setCacheMaxAge] = useState<string>("0s");
+  // The result of the last "Bust cache" click (deleted/scope), shown as a status
+  // line until the next load/action clears it.
+  const [bustCacheResult, setBustCacheResult] = useState<CacheBustResult | null>(null);
   // True while a preview fetch is in flight — the shown "Will publish" list may
   // not yet reflect the latest include/exclude edit, so Deploy is held until it
   // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
@@ -536,6 +572,8 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // so clearing preview keeps it hidden until the new page's preview lands —
       // no stale rows, and no × / restore edit that could target the wrong page.
       setPreview(null);
+      // A stale "N cleared" note from the previous page must not linger.
+      setBustCacheResult(null);
     }
     try {
       const [cfg, status] = await Promise.all([
@@ -556,6 +594,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       if (!background) {
         setInclude(status.deployment?.include ?? []);
         setExclude(status.deployment?.exclude ?? []);
+        setCacheMaxAge(status.deployment?.cache_max_age ?? "0s");
         // Selection is now known — open the gate; this (with the seeded include/
         // exclude) triggers the effect to fetch the first, correct preview.
         setSelectionReady(true);
@@ -640,8 +679,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     if (!env) return;
     setBusy("deploy");
     setActionError(null);
+    setBustCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
-      const record = await deployPage(fsPath, env.name, include, exclude);
+      const record = await deployPage(fsPath, env.name, include, exclude, cacheMaxAge);
       applyDeployment(record);
       if (!alive.current) return;
       setReconciled(true);
@@ -650,6 +690,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // stored record (e.g. server-side dedup) rather than the raw local lists.
       setInclude(record.include ?? include);
       setExclude(record.exclude ?? exclude);
+      setCacheMaxAge(record.cache_max_age ?? cacheMaxAge);
     } catch (e) {
       // A deploy can fail AFTER the server mutated the pointer — the
       // failed-revive compensation path (deploy.py) persists status active or
@@ -679,6 +720,25 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         setActionError((e as Error).message);
         void load(true);
       }
+    } finally {
+      if (alive.current) setBusy(null);
+    }
+  };
+
+  // Forces cached results to be recomputed on next request, without touching the
+  // mount's status/URL/caching setting (deploy.py's bust_cache_deployment) — for
+  // "I changed the underlying data, not the code" (a redeploy dedupes to the same
+  // content-address and would otherwise keep serving the old cached result until
+  // cache_max_age expires).
+  const onBustCache = async () => {
+    setBusy("bust-cache");
+    setActionError(null);
+    setBustCacheResult(null);
+    try {
+      const result = await bustCacheDeployment(fsPath);
+      if (alive.current) setBustCacheResult(result);
+    } catch (e) {
+      if (alive.current) setActionError((e as Error).message);
     } finally {
       if (alive.current) setBusy(null);
     }
@@ -854,6 +914,12 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                 absolute URL; it is served under your environment's serving-plane base URL.
               </div>
             )}
+            <div className="deploy-muted">
+              Caching:{" "}
+              {(deployment.cache_max_age ?? "0s") === "0s"
+                ? "off"
+                : `on, ${deployment.cache_max_age}`}
+            </div>
           </div>
         )}
 
@@ -868,6 +934,42 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             setExclude={setExclude}
           />
         )}
+
+        <div className="deploy-form-row">
+          <label className="deploy-cache-toggle">
+            <input
+              type="checkbox"
+              checked={cacheMaxAge !== "0s"}
+              disabled={busy !== null}
+              onChange={(e) =>
+                setCacheMaxAge(e.target.checked ? DEFAULT_CACHE_DURATION : "0s")
+              }
+            />
+            Cache runPython results
+          </label>
+          {cacheMaxAge !== "0s" && (
+            <Select
+              aria-label="Cache duration"
+              value={cacheMaxAge}
+              onChange={(e) => setCacheMaxAge(e.target.value)}
+              disabled={busy !== null}
+            >
+              {cacheDurationOptions(cacheMaxAge).map((d) => (
+                <option key={d.value} value={d.value}>
+                  for {d.label}
+                </option>
+              ))}
+            </Select>
+          )}
+        </div>
+        {cacheMaxAge !== "0s" && env?.backend === "fused" && (
+          <div className="deploy-note">
+            Caching isn't supported yet on managed Fused environments — this page will
+            deploy, but results won't be cached until that lands. Use an AWS environment
+            to cache results today.
+          </div>
+        )}
+
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
           <Select
@@ -920,10 +1022,27 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               {busy === "revoke" ? "Revoking…" : "Revoke"}
             </button>
           )}
+          {deployment?.status === "active" && (
+            <button
+              type="button"
+              onClick={onBustCache}
+              disabled={busy !== null}
+              title="Force cached results to be recomputed on the next request, without redeploying or changing the URL"
+            >
+              {busy === "bust-cache" ? "Busting cache…" : "Bust cache"}
+            </button>
+          )}
         </div>
         {/* One status line for the same-env case — the URL nuance that used to
             live in the button label / a stack of notes. */}
         {deployStatus && <div className="deploy-muted">{deployStatus}</div>}
+        {bustCacheResult && (
+          <div className="deploy-muted">
+            {bustCacheResult.deleted > 0
+              ? `Cleared ${bustCacheResult.deleted} cached result${bustCacheResult.deleted === 1 ? "" : "s"} — the next request recomputes.`
+              : "Nothing was cached — nothing to clear."}
+          </div>
+        )}
         {/* One context-derived note for the cross-env cases (recorded env still
             configured vs. removed) — mutually exclusive, collapsed into one. */}
         {deployment && selectedEnv !== null && deployment.env !== selectedEnv && (

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -962,11 +962,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </Select>
           )}
         </div>
-        {cacheMaxAge !== "0s" && env?.backend === "fused" && (
+        {env?.backend === "fused" && isRedeploy && (
           <div className="deploy-note">
-            Caching isn't supported yet on managed Fused environments — this page will
-            deploy, but results won't be cached until that lands. Use an AWS environment
-            to cache results today.
+            Managed Fused environments fix caching at first deploy — redeploying can't
+            change it here. Revoke and deploy fresh if you need a different setting.
           </div>
         )}
 

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -982,7 +982,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               {(deployment?.cache_max_age ?? "0s") === "0s"
                 ? "off"
                 : `on, ${deployment?.cache_max_age}`}
-              ), not the one just chosen above.{" "}
+              ), not the one just chosen above. Deploying as a new URL replaces this
+              deployment: it mints a fresh URL with the setting above and takes the old one
+              down.{" "}
               <button
                 type="button"
                 className="btn btn-secondary"
@@ -993,7 +995,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                   previewPending ||
                   (preview?.errors.length ?? 0) > 0
                 }
-                title="Publish this page at a brand-new URL with the setting chosen above — the current URL keeps serving until you revoke it separately"
+                title="Mint a fresh URL with the setting chosen above and switch this page to it — the old URL is taken down (existing links to it stop working)"
               >
                 Deploy as new URL
               </button>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -382,9 +382,9 @@ export interface Deployment {
   updated_at: string;
 }
 
-// `POST /api/deploy/bust-cache`'s result — the fused CLI's `share cache-clear`
-// output verbatim (see deploy.py's bust_cache_deployment).
-export interface CacheBustResult {
+// `POST /api/deploy/clear-cache`'s result — the fused CLI's `share cache-clear`
+// output verbatim (see deploy.py's clear_cache_deployment).
+export interface CacheClearResult {
   token: string;
   deleted: number;
   scope: string;
@@ -490,12 +490,12 @@ export function revokeDeployment(fsPath: string): Promise<Deployment> {
   return postJson<Deployment>("/api/deploy/revoke", { page: fsPath });
 }
 
-// Busts every cached result for the page's deployed mount (`fused share
+// Clears every cached result for the page's deployed mount (`fused share
 // cache-clear <token>`) — forces the next request to recompute instead of
 // waiting out cache_max_age. Doesn't change the deployment's status/URL/caching
 // setting.
-export function bustCacheDeployment(fsPath: string): Promise<CacheBustResult> {
-  return postJson<CacheBustResult>("/api/deploy/bust-cache", { page: fsPath });
+export function clearCacheDeployment(fsPath: string): Promise<CacheClearResult> {
+  return postJson<CacheClearResult>("/api/deploy/clear-cache", { page: fsPath });
 }
 
 export function installFused(): Promise<void> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -474,6 +474,7 @@ export function deployPage(
   include: string[],
   exclude: string[],
   cacheMaxAge: string,
+  forceNew?: boolean,
 ): Promise<Deployment> {
   return postJson<Deployment>("/api/deploy", {
     page: fsPath,
@@ -481,6 +482,7 @@ export function deployPage(
     include,
     exclude,
     cache_max_age: cacheMaxAge,
+    force_new: forceNew ?? false,
   });
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -374,7 +374,21 @@ export interface Deployment {
   // Optional — records written before this feature omit them (read as []).
   include?: string[];
   exclude?: string[];
+  // The caching choice this deployment was published with — "0s" (off) or a
+  // duration like "5m"/"1h" (fused/agent_core/caching.py's cache_max_age format).
+  // Reopening the modal reloads it, same as include/exclude. Optional — records
+  // written before this feature omit it (read as "0s").
+  cache_max_age?: string;
   updated_at: string;
+}
+
+// `POST /api/deploy/bust-cache`'s result — the fused CLI's `share cache-clear`
+// output verbatim (see deploy.py's bust_cache_deployment).
+export interface CacheBustResult {
+  token: string;
+  deleted: number;
+  scope: string;
+  prefix?: string;
 }
 
 export interface DeployStatusResult {
@@ -459,12 +473,27 @@ export function deployPage(
   env: string,
   include: string[],
   exclude: string[],
+  cacheMaxAge: string,
 ): Promise<Deployment> {
-  return postJson<Deployment>("/api/deploy", { page: fsPath, env, include, exclude });
+  return postJson<Deployment>("/api/deploy", {
+    page: fsPath,
+    env,
+    include,
+    exclude,
+    cache_max_age: cacheMaxAge,
+  });
 }
 
 export function revokeDeployment(fsPath: string): Promise<Deployment> {
   return postJson<Deployment>("/api/deploy/revoke", { page: fsPath });
+}
+
+// Busts every cached result for the page's deployed mount (`fused share
+// cache-clear <token>`) — forces the next request to recompute instead of
+// waiting out cache_max_age. Doesn't change the deployment's status/URL/caching
+// setting.
+export function bustCacheDeployment(fsPath: string): Promise<CacheBustResult> {
+  return postJson<CacheBustResult>("/api/deploy/bust-cache", { page: fsPath });
 }
 
 export function installFused(): Promise<void> {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2194,6 +2194,12 @@ select.field-control:has(option[value=""]:checked) {
   color: var(--fg-muted);
 }
 
+.deploy-cache-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
 /* Safety net for unmigrated selects only (e.g. Account's workspace picker) —
    .field-control selects carry their own canonical skin + custom chevron. */
 .deploy-form-row select:not(.field-control) {

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -395,7 +395,7 @@ def set_deployment(page: str, record: dict) -> None:
 
 def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
                  entrypoints: list[str], include: list[str], exclude: list[str],
-                 fallback: dict | None) -> dict:
+                 cache_max_age: str, fallback: dict | None) -> dict:
     token = raw.get("token") or raw.get("id") or (fallback or {}).get("token")
     if not isinstance(token, str) or not token:
         raise DeployError("the fused CLI did not return a mount token")
@@ -422,6 +422,11 @@ def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
         # files bundled beyond the auto-scan, and files dropped from it.
         "include": include,
         "exclude": exclude,
+        # The caching choice deployed with (see deploy_page) — persisted the same way
+        # as include/exclude so reopening the modal shows the current setting, and a
+        # redeploy that doesn't touch it re-sends the same value (the fused CLI has no
+        # "preserve on omit" for this — every deploy is an explicit, full statement).
+        "cache_max_age": cache_max_age,
         "updated_at": _now_iso(),
     }
 
@@ -475,6 +480,7 @@ def deploy_page(
     env_name: str,
     include: list[str] | None = None,
     exclude: list[str] | None = None,
+    cache_max_age: str = "0s",
 ) -> dict:
     """Export `page` to a temp bundle and publish it on `env_name`; returns the
     stored deployment record (token, URL when the backend returned one).
@@ -482,6 +488,16 @@ def deploy_page(
     `include`/`exclude` are the user's file selection (see export.plan_export):
     extra files bundled beyond the auto-scan, and files dropped from it. They are
     persisted on the record so a reopened modal reloads the same selection.
+
+    `cache_max_age` (`"0s"` off by default, e.g. `"5m"`/`"1h"`) is the Deploy
+    dialog's caching choice: how long a `runPython` route's result may be served
+    from cache instead of re-executed. It rides the export bundle's own manifest
+    (`export.export_page`), so the hosting layer (`fused` repo's
+    `build_html_artifact`) applies it with no extra deploy-time plumbing — see
+    spec/serve/fused-render.md § Caching in the fused repo. Every deploy re-sends
+    it explicitly, like `include`/`exclude`; there is no "leave it as it was"
+    (see `bust_cache_deployment` to force-refresh already-cached results without
+    changing this setting).
 
     First deploy (or a pointer on a different env): `share create --public` —
     a fresh opaque capability URL. Redeploy on the same env keeps the URL:
@@ -525,7 +541,7 @@ def deploy_page(
 
     bundle = tempfile.mkdtemp(prefix="fused-render-deploy-")
     try:
-        plan = export_page(page, bundle, include=include, exclude=exclude)
+        plan = export_page(page, bundle, include=include, exclude=exclude, cache_max_age=cache_max_age)
         entrypoints = [e.name for e in plan.entrypoints]
 
         same_env = pointer if pointer and pointer.get("env") == env_name else None
@@ -574,7 +590,8 @@ def deploy_page(
 
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
-            entrypoints=entrypoints, include=include, exclude=exclude, fallback=same_env,
+            entrypoints=entrypoints, include=include, exclude=exclude,
+            cache_max_age=cache_max_age, fallback=same_env,
         )
         set_deployment(page, record)
         return record
@@ -592,6 +609,22 @@ def revoke_deployment(page: str) -> dict:
     record = {**pointer, "status": "revoked", "updated_at": _now_iso()}
     set_deployment(page, record)
     return record
+
+
+def bust_cache_deployment(page: str) -> dict:
+    """Bust every cached result for the page's deployed mount (`fused share
+    cache-clear <token>`) — forces the next request to recompute instead of
+    waiting out `cache_max_age`.
+
+    Doesn't touch the mount record, its URL, or the deployment pointer: this is
+    orthogonal to caching being on or off (it's a no-op cost if it was already
+    off — nothing was cached). Returns the CLI's result verbatim
+    (`{token, deleted, scope, prefix}`) so the modal can show what was cleared.
+    """
+    pointer = get_deployment(page)
+    if pointer is None or not pointer.get("token") or not pointer.get("env"):
+        raise DeployError("this page has no recorded deployment to bust the cache of")
+    return _run_share(pointer["env"], ["cache-clear", pointer["token"]])
 
 
 def revoke_mount(env_name: str, token: str) -> dict:
@@ -793,8 +826,11 @@ def api_deploy(body: dict = Body(...), x_fused: str | None = Header(default=None
     exclude = _str_list(body, "exclude")
     if include is None or exclude is None:
         return _error("'include'/'exclude' must be arrays of relative file paths")
+    cache_max_age = body.get("cache_max_age", "0s")
+    if not isinstance(cache_max_age, str):
+        return _error("'cache_max_age' must be a string, e.g. '0s'/'5m'/'1h'")
     try:
-        return deploy_page(page, env_name, include, exclude)
+        return deploy_page(page, env_name, include, exclude, cache_max_age=cache_max_age)
     except ExportError as e:
         return _error(str(e))
     except DeployError as e:
@@ -820,6 +856,20 @@ def api_deploy_revoke(body: dict = Body(...), x_fused: str | None = Header(defau
         return _error("provide 'page' (absolute path) or 'env' + 'token'")
     try:
         return revoke_deployment(page)
+    except DeployError as e:
+        return _error(str(e))
+
+
+@router.post("/api/deploy/bust-cache")
+def api_deploy_bust_cache(body: dict = Body(...), x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    page = body.get("page")
+    if not isinstance(page, str) or not page or not os.path.isabs(page):
+        return _error("'page' must be an absolute path to the .html page")
+    try:
+        return bust_cache_deployment(page)
     except DeployError as e:
         return _error(str(e))
 

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -137,7 +137,7 @@ def _now_iso() -> str:
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
 PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post6-py3-none-any.whl"
+    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post7-py3-none-any.whl"
 )
 # The wheel's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -518,12 +518,16 @@ def deploy_page(
     function does not pretend otherwise: on that reuse path the stored record
     keeps reporting the setting that is actually live, not the one requested
     (see `_record_from`). `force_new=True` is the only way to actually change
-    it on a managed environment: it skips token reuse entirely and always
-    mints a fresh `share create` (a new token, new URL) with the requested
-    `cache_max_age`, matching what a genuinely fresh deploy would get. The
-    caller is responsible for revoking the old token first if it should stop
-    serving (see `revoke_deployment`); `force_new` does not do that itself, so
-    the old and new mounts can briefly coexist if that is what's wanted.
+    it on a managed environment: it **replaces** the deployment — mints a fresh
+    `share create` (a new token, new URL) with the requested `cache_max_age`,
+    repoints this page's pointer to it, then **best-effort revokes the old
+    mount** so the page is never left with two live URLs. The revoke is
+    deliberately last (after the new mount is live) so a create failure never
+    takes the page down, and best-effort (a revoke failure doesn't fail the
+    deploy — the new URL is live and correct; the superseded mount lingers and
+    is revocable from the Fused account page's deployments list). Because the
+    pointer now tracks the new mount, the modal's Revoke button targets the new
+    URL, as expected — there is no orphaned URL the user must chase separately.
 
     First deploy (or a pointer on a different env, or `force_new=True`):
     `share create --public` — a fresh opaque capability URL. Otherwise, redeploy
@@ -578,6 +582,15 @@ def deploy_page(
             None if force_new else (pointer if pointer and pointer.get("env") == env_name else None)
         )
         token = same_env.get("token") if same_env else None
+        # On a force_new replace, the mount we're superseding (same page + env) —
+        # revoked best-effort AFTER the new one is live, so the page never ends up
+        # with two URLs the pointer can't both track. None unless force_new found a
+        # prior same-env token.
+        superseded_token = (
+            pointer.get("token")
+            if force_new and pointer and pointer.get("env") == env_name
+            else None
+        )
         # What the mount will ACTUALLY be caching after this call — defaults to
         # the requested value (true for AWS always, and for fused on any branch
         # that runs `create`); overridden below on a fused-backend token-reuse
@@ -646,6 +659,21 @@ def deploy_page(
             cache_max_age=effective_cache_max_age, fallback=same_env,
         )
         set_deployment(page, record)
+        # force_new replace: the new mount is live and the pointer now tracks it,
+        # so take the superseded mount down — otherwise the page would serve at two
+        # URLs while the pointer (and the modal's Revoke) tracks only the new one,
+        # leaving the old one orphaned. Best-effort and LAST: the new URL is already
+        # live and persisted, so a revoke failure must not fail the deploy — the
+        # superseded mount just lingers and is revocable from the account page's
+        # deployments list. Skip if the token didn't actually change (defensive: a
+        # create that somehow returned the same token needs no self-revoke).
+        if superseded_token and superseded_token != record["token"]:
+            try:
+                _run_share(env_name, ["revoke", superseded_token])
+            except DeployError:
+                # New deployment stands; the old mount outlives it until manually
+                # revoked (account page / `fused share revoke <token>`). Not fatal.
+                pass
         return record
     finally:
         shutil.rmtree(bundle, ignore_errors=True)

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -663,8 +663,8 @@ def revoke_deployment(page: str) -> dict:
     return record
 
 
-def bust_cache_deployment(page: str) -> dict:
-    """Bust every cached result for the page's deployed mount (`fused share
+def clear_cache_deployment(page: str) -> dict:
+    """Clear every cached result for the page's deployed mount (`fused share
     cache-clear <token>`) — forces the next request to recompute instead of
     waiting out `cache_max_age`.
 
@@ -675,7 +675,7 @@ def bust_cache_deployment(page: str) -> dict:
     """
     pointer = get_deployment(page)
     if pointer is None or not pointer.get("token") or not pointer.get("env"):
-        raise DeployError("this page has no recorded deployment to bust the cache of")
+        raise DeployError("this page has no recorded deployment to clear the cache of")
     return _run_share(pointer["env"], ["cache-clear", pointer["token"]])
 
 
@@ -917,8 +917,8 @@ def api_deploy_revoke(body: dict = Body(...), x_fused: str | None = Header(defau
         return _error(str(e))
 
 
-@router.post("/api/deploy/bust-cache")
-def api_deploy_bust_cache(body: dict = Body(...), x_fused: str | None = Header(default=None)):
+@router.post("/api/deploy/clear-cache")
+def api_deploy_clear_cache(body: dict = Body(...), x_fused: str | None = Header(default=None)):
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
@@ -926,7 +926,7 @@ def api_deploy_bust_cache(body: dict = Body(...), x_fused: str | None = Header(d
     if not isinstance(page, str) or not page or not os.path.isabs(page):
         return _error("'page' must be an absolute path to the .html page")
     try:
-        return bust_cache_deployment(page)
+        return clear_cache_deployment(page)
     except DeployError as e:
         return _error(str(e))
 

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -492,12 +492,19 @@ def deploy_page(
     `cache_max_age` (`"0s"` off by default, e.g. `"5m"`/`"1h"`) is the Deploy
     dialog's caching choice: how long a `runPython` route's result may be served
     from cache instead of re-executed. It rides the export bundle's own manifest
-    (`export.export_page`), so the hosting layer (`fused` repo's
-    `build_html_artifact`) applies it with no extra deploy-time plumbing — see
-    spec/serve/fused-render.md § Caching in the fused repo. Every deploy re-sends
-    it explicitly, like `include`/`exclude`; there is no "leave it as it was"
-    (see `bust_cache_deployment` to force-refresh already-cached results without
-    changing this setting).
+    (`export.export_page`) AND is passed explicitly as `share create
+    --cache-max-age` — the two backends read it from different places (`fused`
+    repo's spec/serve/fused-render.md § Caching): an AWS environment's
+    `build_html_artifact` reads the manifest field (so either source works,
+    including on a later `repoint`); a managed Fused environment reads only the
+    explicit `--cache-max-age` on `create`, as its own mount-level
+    `cache_settings` field, wholly independent of the bundle. Every deploy
+    re-sends it explicitly, like `include`/`exclude`; there is no "leave it as
+    it was" (see `bust_cache_deployment` to force-refresh already-cached results
+    without changing this setting). On a managed environment this setting is
+    fixed at first deploy — a `repoint` (every redeploy after that) cannot
+    change it, so toggling caching on an already-deployed page there has no
+    effect until it is revoked and redeployed fresh.
 
     First deploy (or a pointer on a different env): `share create --public` —
     a fresh opaque capability URL. Redeploy on the same env keeps the URL:
@@ -548,7 +555,9 @@ def deploy_page(
         token = same_env.get("token") if same_env else None
 
         if not token:
-            raw = _run_share(env_name, ["create", bundle, "--public"])
+            raw = _run_share(
+                env_name, ["create", bundle, "--public", "--cache-max-age", cache_max_age]
+            )
         else:
             live = _classify_mount(_list_mounts(env_name), token)
             if live == "active":
@@ -586,7 +595,9 @@ def deploy_page(
                     )
                     raise
             else:  # absent — e.g. after an infra teardown; nothing to revive
-                raw = _run_share(env_name, ["create", bundle, "--public"])
+                raw = _run_share(
+                    env_name, ["create", bundle, "--public", "--cache-max-age", cache_max_age]
+                )
 
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -396,6 +396,16 @@ def set_deployment(page: str, record: dict) -> None:
 def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
                  entrypoints: list[str], include: list[str], exclude: list[str],
                  cache_max_age: str, fallback: dict | None) -> dict:
+    # `cache_max_age` here must be the setting actually now in effect on the live
+    # mount — NOT necessarily what the caller requested. On a managed Fused env, a
+    # repoint/recreate-revive reuses the existing mount's `cache_settings` verbatim
+    # (fixed at first `create`, `application` repo spec 021 §3.1); the CLI already
+    # withholds `--cache-max-age` on those calls (see deploy_page) precisely because
+    # sending it would either be ignored or (on `repoint`) rejected outright. The
+    # caller (deploy_page) resolves the effective value before calling this, so a
+    # reused-token redeploy that requested a different duration still shows the
+    # duration that is really running — the deployment card must never claim a
+    # setting the mount doesn't have.
     token = raw.get("token") or raw.get("id") or (fallback or {}).get("token")
     if not isinstance(token, str) or not token:
         raise DeployError("the fused CLI did not return a mount token")
@@ -481,6 +491,7 @@ def deploy_page(
     include: list[str] | None = None,
     exclude: list[str] | None = None,
     cache_max_age: str = "0s",
+    force_new: bool = False,
 ) -> dict:
     """Export `page` to a temp bundle and publish it on `env_name`; returns the
     stored deployment record (token, URL when the backend returned one).
@@ -490,27 +501,36 @@ def deploy_page(
     persisted on the record so a reopened modal reloads the same selection.
 
     `cache_max_age` (`"0s"` off by default, e.g. `"5m"`/`"1h"`) is the Deploy
-    dialog's caching choice: how long a `runPython` route's result may be served
-    from cache instead of re-executed. It rides the export bundle's own manifest
+    dialog's caching choice: how long a page's result may be served from cache
+    instead of re-executed. It rides the export bundle's own manifest
     (`export.export_page`) AND is passed explicitly as `share create
     --cache-max-age` — the two backends read it from different places (`fused`
     repo's spec/serve/fused-render.md § Caching): an AWS environment's
     `build_html_artifact` reads the manifest field (so either source works,
-    including on a later `repoint`); a managed Fused environment reads only the
-    explicit `--cache-max-age` on `create`, as its own mount-level
-    `cache_settings` field, wholly independent of the bundle. Every deploy
-    re-sends it explicitly, like `include`/`exclude`; there is no "leave it as
-    it was" (see `bust_cache_deployment` to force-refresh already-cached results
-    without changing this setting). On a managed environment this setting is
-    fixed at first deploy — a `repoint` (every redeploy after that) cannot
-    change it, so toggling caching on an already-deployed page there has no
-    effect until it is revoked and redeployed fresh.
+    including on a later `repoint`); a managed Fused environment reads it only
+    on `create`, as its own mount-level `cache_settings` field (`application`
+    repo spec `021` §3.1), wholly independent of the bundle. On a managed
+    environment `cache_settings` is fixed for the life of a token — `repoint`
+    carries no cache fields at all (the control plane rejects one), and a
+    revoked-token revive (`recreate --same-token`) preserves the existing
+    setting verbatim — so a redeploy that reuses the token can request a
+    different `cache_max_age` all it wants, it never takes effect. This
+    function does not pretend otherwise: on that reuse path the stored record
+    keeps reporting the setting that is actually live, not the one requested
+    (see `_record_from`). `force_new=True` is the only way to actually change
+    it on a managed environment: it skips token reuse entirely and always
+    mints a fresh `share create` (a new token, new URL) with the requested
+    `cache_max_age`, matching what a genuinely fresh deploy would get. The
+    caller is responsible for revoking the old token first if it should stop
+    serving (see `revoke_deployment`); `force_new` does not do that itself, so
+    the old and new mounts can briefly coexist if that is what's wanted.
 
-    First deploy (or a pointer on a different env): `share create --public` —
-    a fresh opaque capability URL. Redeploy on the same env keeps the URL:
-    active mount -> `share repoint <token>`; revoked tombstone -> `share
-    recreate --same-token` then repoint (same URL comes back); token absent
-    from `share list` entirely -> fresh create (nothing left to revive).
+    First deploy (or a pointer on a different env, or `force_new=True`):
+    `share create --public` — a fresh opaque capability URL. Otherwise, redeploy
+    on the same env keeps the URL: active mount -> `share repoint <token>`;
+    revoked tombstone -> `share recreate --same-token` then repoint (same URL
+    comes back); token absent from `share list` entirely -> fresh create
+    (nothing left to revive).
     """
     include = include or []
     exclude = exclude or []
@@ -551,8 +571,18 @@ def deploy_page(
         plan = export_page(page, bundle, include=include, exclude=exclude, cache_max_age=cache_max_age)
         entrypoints = [e.name for e in plan.entrypoints]
 
-        same_env = pointer if pointer and pointer.get("env") == env_name else None
+        # force_new deliberately treats any existing pointer as absent — never
+        # reused for token lookup below — so the branch that follows always
+        # takes the fresh-create path and mints a new token (see docstring).
+        same_env = (
+            None if force_new else (pointer if pointer and pointer.get("env") == env_name else None)
+        )
         token = same_env.get("token") if same_env else None
+        # What the mount will ACTUALLY be caching after this call — defaults to
+        # the requested value (true for AWS always, and for fused on any branch
+        # that runs `create`); overridden below on a fused-backend token-reuse
+        # branch, where the request never reaches the control plane.
+        effective_cache_max_age = cache_max_age
 
         if not token:
             raw = _run_share(
@@ -560,6 +590,17 @@ def deploy_page(
             )
         else:
             live = _classify_mount(_list_mounts(env_name), token)
+            # A repoint/recreate-revive (the "active"/"revoked" branches just
+            # below) reuses the mount's own cache_settings on a managed Fused env
+            # (spec 021 §3.1) — the request never reaches the control plane on
+            # those two calls (see docstring), so the record must keep reporting
+            # whatever was already live, not this request. The "absent" branch
+            # below is a genuine fresh `create`, so it's excluded here — the
+            # requested value really does take effect there. AWS is unaffected
+            # either way: build_html_artifact re-reads the bundle's own manifest
+            # on every repoint, so the request DOES take effect there too.
+            if backend == "fused" and live in ("active", "revoked"):
+                effective_cache_max_age = (same_env or {}).get("cache_max_age", "0s")
             if live == "active":
                 raw = _run_share(env_name, ["repoint", token, bundle])
             elif live == "revoked":
@@ -602,7 +643,7 @@ def deploy_page(
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
             entrypoints=entrypoints, include=include, exclude=exclude,
-            cache_max_age=cache_max_age, fallback=same_env,
+            cache_max_age=effective_cache_max_age, fallback=same_env,
         )
         set_deployment(page, record)
         return record
@@ -840,8 +881,13 @@ def api_deploy(body: dict = Body(...), x_fused: str | None = Header(default=None
     cache_max_age = body.get("cache_max_age", "0s")
     if not isinstance(cache_max_age, str):
         return _error("'cache_max_age' must be a string, e.g. '0s'/'5m'/'1h'")
+    force_new = body.get("force_new", False)
+    if not isinstance(force_new, bool):
+        return _error("'force_new' must be a boolean")
     try:
-        return deploy_page(page, env_name, include, exclude, cache_max_age=cache_max_age)
+        return deploy_page(
+            page, env_name, include, exclude, cache_max_age=cache_max_age, force_new=force_new
+        )
     except ExportError as e:
         return _error(str(e))
     except DeployError as e:

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -792,8 +792,9 @@ def export_page(
     ``include`` files, minus any ``exclude`` — see :func:`plan_export`), and each first-party
     module a bundled entrypoint imports, all at their real page-relative path. ``cache_max_age``
     (``"0s"`` off by default, e.g. ``"5m"``) is the deploy-time result-caching choice, written
-    into the manifest and applied by the hosting layer to every ``runPython`` route (never the
-    shell or an asset route) — see spec/serve/fused-render.md § Caching in the fused repo.
+    into the manifest and applied by the hosting layer **page-wide** — to every served route
+    uniformly (the shell, each ``runPython`` route, and the asset route) — see
+    spec/serve/fused-render.md § Caching in the fused repo.
     Raises :class:`ExportError` on any blocking problem (dynamic runPython path, unsupported
     API, unsafe/missing file, malformed ``cache_max_age``) with all problems listed at once;
     advisory ``plan.warnings`` never block. Returns the realized :class:`ExportPlan` on success.

--- a/fused_render/export.py
+++ b/fused_render/export.py
@@ -723,7 +723,7 @@ def plan_export(
     return plan
 
 
-def _manifest(plan: ExportPlan, page_key: str) -> dict:
+def _manifest(plan: ExportPlan, page_key: str, cache_max_age: str) -> dict:
     """The bundle's ``manifest.json`` (v2) — the contract the hosting layer reads.
 
     v2 lays every bundled file under a single ``root`` payload dir at its real page-relative
@@ -739,6 +739,10 @@ def _manifest(plan: ExportPlan, page_key: str) -> dict:
       the payload-relative key (also the ``_asset`` allow-list entry). Two distinct literals
       may share a key — both appear so the runtime's exact-string lookup never misses.
     - ``resources`` — imported modules: ``key`` is the payload-relative path (never web-served).
+    - ``cache_max_age`` — the deploy-time result-caching choice (``"0s"`` off by default),
+      e.g. ``"5m"``/``"1h"``. Applied uniformly to every ``runPython`` route by the hosting
+      layer's ``build_html_artifact`` (never the shell or asset routes); see
+      spec/serve/fused-render.md § Caching in the fused repo.
     """
     return {
         "fused_render_bundle": 2,
@@ -750,7 +754,27 @@ def _manifest(plan: ExportPlan, page_key: str) -> dict:
         ],
         "assets": [{"path": a.path, "name": a.name} for a in plan.assets],
         "resources": [{"key": r.key} for r in plan.resources],
+        "cache_max_age": cache_max_age,
     }
+
+
+_CACHE_MAX_AGE_RE = re.compile(r"^(\d+)([smhd])$")
+
+
+def _validate_cache_max_age(value: str) -> None:
+    """Reject a malformed ``cache_max_age`` before it lands in a manifest.
+
+    Mirrors the hosting layer's own parser (the ``fused`` wheel's
+    ``openfused.caching.parse_cache_max_age`` — not imported here, since ``fused`` is an
+    optional extra export must work without): a non-negative integer + unit (``s``/``m``/
+    ``h``/``d``), ``"0s"`` the off sentinel. Validating at export time (not deferred to
+    `share create`) means a bad value fails the local, no-network step, not a later publish.
+    """
+    if not isinstance(value, str) or not _CACHE_MAX_AGE_RE.match(value):
+        raise ExportError(
+            f"invalid cache_max_age {value!r}: expected a non-negative integer with a unit "
+            "(s/m/h/d), e.g. '0s', '90s', '15m', '24h', '7d'."
+        )
 
 
 def export_page(
@@ -759,17 +783,22 @@ def export_page(
     *,
     include: list[str] | None = None,
     exclude: list[str] | None = None,
+    cache_max_age: str = "0s",
 ) -> ExportPlan:
     """Export the page at ``html_path`` into a portable bundle at ``out_dir`` (bundle v2).
 
     Writes ``manifest.json`` and a single ``files/`` payload dir mirroring the page's folder:
     the page, each ``runPython`` target, each ``rawUrl``/``readFile`` target (plus any
     ``include`` files, minus any ``exclude`` — see :func:`plan_export`), and each first-party
-    module a bundled entrypoint imports, all at their real page-relative path. Raises
-    :class:`ExportError` on any blocking problem (dynamic runPython path, unsupported API,
-    unsafe/missing file) with all problems listed at once; advisory ``plan.warnings`` never
-    block. Returns the realized :class:`ExportPlan` on success.
+    module a bundled entrypoint imports, all at their real page-relative path. ``cache_max_age``
+    (``"0s"`` off by default, e.g. ``"5m"``) is the deploy-time result-caching choice, written
+    into the manifest and applied by the hosting layer to every ``runPython`` route (never the
+    shell or an asset route) — see spec/serve/fused-render.md § Caching in the fused repo.
+    Raises :class:`ExportError` on any blocking problem (dynamic runPython path, unsupported
+    API, unsafe/missing file, malformed ``cache_max_age``) with all problems listed at once;
+    advisory ``plan.warnings`` never block. Returns the realized :class:`ExportPlan` on success.
     """
+    _validate_cache_max_age(cache_max_age)
     html_path = os.path.abspath(html_path)
     if not os.path.isfile(html_path):
         raise ExportError(f"no such file: {html_path}")
@@ -830,7 +859,7 @@ def export_page(
             _copy_into(stage, os.path.join(page_dir, r.key), r.file)
 
         with open(os.path.join(stage, "manifest.json"), "w", encoding="utf-8") as f:
-            json.dump(_manifest(plan, page_key), f, indent=2, sort_keys=True)
+            json.dump(_manifest(plan, page_key, cache_max_age), f, indent=2, sort_keys=True)
             f.write("\n")
 
         # Atomic handoff: drop the (empty) out_dir if it exists so the rename can take the

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -3240,8 +3240,12 @@ def create_app(start_dir: str) -> FastAPI:
             if not isinstance(value, list) or any(not isinstance(v, str) for v in value):
                 return _error(f"'{name}' must be an array of relative file paths")
 
+        cache_max_age = body.get("cache_max_age") or "0s"
+
         try:
-            plan = export_page(page, out, include=include, exclude=exclude)
+            plan = export_page(
+                page, out, include=include, exclude=exclude, cache_max_age=cache_max_age
+            )
         except ExportError as e:
             return _error(str(e))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ app = [
 # The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post6-py3-none-any.whl ; python_version >= "3.11"',
+    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post7-py3-none-any.whl ; python_version >= "3.11"',
 ]
 
 [project.scripts]

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -460,6 +460,150 @@ def test_deploy_rejects_invalid_cache_max_age(tmp_path, monkeypatch):
     assert h.calls() == []  # rejected before any CLI shellout
 
 
+def test_repoint_on_fused_backend_keeps_previous_cache_max_age(tmp_path, monkeypatch):
+    # A managed Fused mount's cache_settings are fixed at `create` (021 §3.1) —
+    # `repoint` carries no cache fields at all, so a redeploy requesting a
+    # DIFFERENT duration must not claim it took effect: the record has to keep
+    # reporting the value that's actually live.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "repoint": {"token": "abc123", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "1h"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cache_max_age"] == "5m"
+    assert h.pointer()["cache_max_age"] == "5m"
+    repoint_call = h.calls()[-1]
+    assert repoint_call["argv"][1] == "repoint"
+    assert "--cache-max-age" not in repoint_call["argv"]
+
+
+def test_recreate_revive_on_fused_backend_keeps_previous_cache_max_age(tmp_path, monkeypatch):
+    # Same guarantee on the revoked-tombstone revive path (recreate --same-token
+    # + repoint): neither call can change cache_settings on a managed env.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "revoked"}],
+            "recreate": {"token": "abc123", "status": "active"},
+            "repoint": {"token": "abc123", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "1h"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cache_max_age"] == "5m"
+    verbs_and_flags = [(c["argv"][1], "--cache-max-age" in c["argv"]) for c in h.calls()[-2:]]
+    assert verbs_and_flags == [("recreate", False), ("repoint", False)]
+
+
+def test_repoint_on_aws_backend_applies_the_new_cache_max_age(tmp_path, monkeypatch):
+    # AWS is unaffected by the fused-backend carve-out above: build_html_artifact
+    # re-reads the bundle's own manifest on every repoint, so a redeploy's request
+    # really does take effect there.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario({"create": {"token": "abc123", "status": "active"}})
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "prod", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "repoint": {"token": "abc123", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "prod", "cache_max_age": "1h"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cache_max_age"] == "1h"
+
+
+def test_force_new_mints_a_fresh_token_on_fused_backend_with_the_new_setting(tmp_path, monkeypatch):
+    # The only way to actually change caching on a managed Fused mount: skip
+    # token reuse entirely and mint a brand-new mount via `create`.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+
+    # The old token is still very much live in `share list` — force_new must
+    # not even look it up (no repoint/recreate call at all).
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "create": {"token": "new789", "url": "https://serve.example/new789", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={
+            "page": str(h.page),
+            "env": "cloud",
+            "cache_max_age": "1h",
+            "force_new": True,
+        },
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["token"] == "new789"
+    assert body["cache_max_age"] == "1h"
+    assert body["url"] == "https://serve.example/new789"
+    verbs = [c["argv"][1] for c in h.calls()]
+    assert verbs == ["create", "create"]  # never repoint/recreate/list
+    assert h.calls()[-1]["argv"][-2:] == ["--cache-max-age", "1h"]
+
+
+def test_force_new_rejects_non_bool(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "force_new": "yes"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert "force_new" in resp.json()["error"]
+
+
 def test_redeploy_active_mount_repoints_same_token(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -552,9 +552,10 @@ def test_repoint_on_aws_backend_applies_the_new_cache_max_age(tmp_path, monkeypa
     assert resp.json()["cache_max_age"] == "1h"
 
 
-def test_force_new_mints_a_fresh_token_on_fused_backend_with_the_new_setting(tmp_path, monkeypatch):
-    # The only way to actually change caching on a managed Fused mount: skip
-    # token reuse entirely and mint a brand-new mount via `create`.
+def test_force_new_replaces_the_deployment_and_revokes_the_old_mount(tmp_path, monkeypatch):
+    # The only way to actually change caching on a managed Fused mount: skip token
+    # reuse and mint a brand-new mount via `create`, then take the OLD mount down so
+    # the page isn't left serving at two URLs the pointer can't both track.
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
@@ -565,12 +566,10 @@ def test_force_new_mints_a_fresh_token_on_fused_backend_with_the_new_setting(tmp
         headers=FUSED,
     )
 
-    # The old token is still very much live in `share list` — force_new must
-    # not even look it up (no repoint/recreate call at all).
     h.set_scenario(
         {
-            "list": [{"token": "abc123", "status": "active"}],
             "create": {"token": "new789", "url": "https://serve.example/new789", "status": "active"},
+            "revoke": {"token": "abc123", "status": "revoked"},
         }
     )
     resp = h.client.post(
@@ -588,9 +587,44 @@ def test_force_new_mints_a_fresh_token_on_fused_backend_with_the_new_setting(tmp
     assert body["token"] == "new789"
     assert body["cache_max_age"] == "1h"
     assert body["url"] == "https://serve.example/new789"
-    verbs = [c["argv"][1] for c in h.calls()]
-    assert verbs == ["create", "create"]  # never repoint/recreate/list
-    assert h.calls()[-1]["argv"][-2:] == ["--cache-max-age", "1h"]
+    # The pointer tracks the NEW mount (so the modal's Revoke targets it, not the old).
+    assert h.pointer()["token"] == "new789"
+    # A fresh create (never repoint/recreate reuse), then the OLD token is revoked.
+    calls = h.calls()
+    assert [c["argv"][1] for c in calls] == ["create", "create", "revoke"]
+    create_call = calls[1]
+    assert create_call["argv"][-2:] == ["--cache-max-age", "1h"]
+    revoke_call = calls[2]
+    assert revoke_call["argv"][1:3] == ["revoke", "abc123"]  # the superseded mount
+
+
+def test_force_new_revoke_of_old_mount_is_best_effort(tmp_path, monkeypatch):
+    # If revoking the superseded mount fails, the deploy still succeeds — the new URL
+    # is already live and persisted; the old mount just lingers (revocable elsewhere).
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+
+    # No "revoke" answer in the scenario → the stub exits 1, so the revoke raises
+    # DeployError, which deploy_page swallows (best-effort).
+    h.set_scenario(
+        {"create": {"token": "new789", "url": "https://serve.example/new789", "status": "active"}}
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "1h", "force_new": True},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token"] == "new789"
+    assert h.pointer()["token"] == "new789"  # new deployment stands despite the revoke failure
+    assert [c["argv"][1] for c in h.calls()] == ["create", "create", "revoke"]
 
 
 def test_force_new_rejects_non_bool(tmp_path, monkeypatch):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -431,6 +431,11 @@ def test_deploy_persists_cache_max_age(tmp_path, monkeypatch):
     assert resp.status_code == 200, resp.text
     assert resp.json()["cache_max_age"] == "5m"
     assert h.pointer()["cache_max_age"] == "5m"
+    # Explicit --cache-max-age on the CLI create call too — not just the export
+    # manifest — since a managed Fused environment reads only the flag (021
+    # spec's mount-level cache_settings, independent of the bundle).
+    (call,) = h.calls()
+    assert call["argv"][-2:] == ["--cache-max-age", "5m"]
 
 
 def test_deploy_defaults_cache_max_age_off(tmp_path, monkeypatch):
@@ -576,10 +581,17 @@ def test_redeploy_absent_mount_falls_back_to_fresh_create(tmp_path, monkeypatch)
             "create": {"token": "new456", "url": "https://serve.example/new456", "status": "active"},
         }
     )
-    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "1h"},
+        headers=FUSED,
+    )
     assert resp.status_code == 200, resp.text
     assert resp.json()["token"] == "new456"
     assert h.pointer()["url"] == "https://serve.example/new456"
+    # The fresh-create fallback also carries the explicit CLI flag (not just the
+    # export manifest), same as the first-deploy path.
+    assert h.calls()[-1]["argv"][-2:] == ["--cache-max-age", "1h"]
 
 
 def test_fresh_create_with_new_token_never_keeps_the_old_url(tmp_path, monkeypatch):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -418,6 +418,43 @@ def test_deploy_bundles_included_file_and_persists_selection(tmp_path, monkeypat
     assert call["bundle_files"] == ["files", "manifest.json"]
 
 
+def test_deploy_persists_cache_max_age(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "5m"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cache_max_age"] == "5m"
+    assert h.pointer()["cache_max_age"] == "5m"
+
+
+def test_deploy_defaults_cache_max_age_off(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["cache_max_age"] == "0s"
+
+
+def test_deploy_rejects_invalid_cache_max_age(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "cache_max_age": "bogus"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert "cache_max_age" in resp.json()["error"]
+    assert h.calls() == []  # rejected before any CLI shellout
+
+
 def test_redeploy_active_mount_repoints_same_token(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
@@ -739,6 +776,34 @@ def test_revoke_without_deployment_is_400(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     resp = h.client.post("/api/deploy/revoke", json={"page": str(h.page)}, headers=FUSED)
     assert resp.status_code == 400
+
+
+def test_bust_cache_calls_cache_clear_and_returns_result(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+
+    h.set_scenario({"cache-clear": {"token": "abc123", "deleted": 3, "scope": "route:abc123"}})
+    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"token": "abc123", "deleted": 3, "scope": "route:abc123"}
+    assert h.calls()[-1]["argv"][1:3] == ["cache-clear", "abc123"]
+    # Busting the cache doesn't touch the deployment pointer (still active).
+    assert h.pointer()["status"] == "active"
+
+
+def test_bust_cache_without_deployment_is_400(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)}, headers=FUSED)
+    assert resp.status_code == 400
+
+
+def test_bust_cache_requires_fused_header(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)})
+    assert resp.status_code == 403
 
 
 def test_revoke_by_token_covers_untracked_mounts(tmp_path, monkeypatch):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -934,7 +934,7 @@ def test_revoke_without_deployment_is_400(tmp_path, monkeypatch):
     assert resp.status_code == 400
 
 
-def test_bust_cache_calls_cache_clear_and_returns_result(tmp_path, monkeypatch):
+def test_clear_cache_calls_cache_clear_and_returns_result(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
@@ -942,23 +942,23 @@ def test_bust_cache_calls_cache_clear_and_returns_result(tmp_path, monkeypatch):
     h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
 
     h.set_scenario({"cache-clear": {"token": "abc123", "deleted": 3, "scope": "route:abc123"}})
-    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)}, headers=FUSED)
+    resp = h.client.post("/api/deploy/clear-cache", json={"page": str(h.page)}, headers=FUSED)
     assert resp.status_code == 200, resp.text
     assert resp.json() == {"token": "abc123", "deleted": 3, "scope": "route:abc123"}
     assert h.calls()[-1]["argv"][1:3] == ["cache-clear", "abc123"]
-    # Busting the cache doesn't touch the deployment pointer (still active).
+    # Clearing the cache doesn't touch the deployment pointer (still active).
     assert h.pointer()["status"] == "active"
 
 
-def test_bust_cache_without_deployment_is_400(tmp_path, monkeypatch):
+def test_clear_cache_without_deployment_is_400(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)}, headers=FUSED)
+    resp = h.client.post("/api/deploy/clear-cache", json={"page": str(h.page)}, headers=FUSED)
     assert resp.status_code == 400
 
 
-def test_bust_cache_requires_fused_header(tmp_path, monkeypatch):
+def test_clear_cache_requires_fused_header(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    resp = h.client.post("/api/deploy/bust-cache", json={"page": str(h.page)})
+    resp = h.client.post("/api/deploy/clear-cache", json={"page": str(h.page)})
     assert resp.status_code == 403
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -317,6 +317,23 @@ def test_export_page_writes_bundle(tmp_path):
     assert manifest["page"] == "page.html"
     assert manifest["entrypoints"][0] == {"path": "./sine.py", "name": "sine", "key": "sine.py"}
     assert manifest["assets"][0] == {"path": "./data/logo.png", "name": "data/logo.png"}
+    assert manifest["cache_max_age"] == "0s"  # default: off
+
+
+def test_export_page_writes_cache_max_age(tmp_path):
+    _write(tmp_path, "src/page.html", "<script>fused.runPython('./sine.py', {});</script>")
+    _write(tmp_path, "src/sine.py", "def main():\n    return 1\n")
+    out = tmp_path / "bundle"
+    export_page(str(tmp_path / "src" / "page.html"), str(out), cache_max_age="5m")
+    manifest = json.loads((out / "manifest.json").read_text())
+    assert manifest["cache_max_age"] == "5m"
+
+
+def test_export_page_rejects_invalid_cache_max_age(tmp_path):
+    _write(tmp_path, "page.html", "<html></html>")
+    with pytest.raises(ExportError, match="cache_max_age"):
+        export_page(str(tmp_path / "page.html"), str(tmp_path / "out"), cache_max_age="bogus")
+    assert not (tmp_path / "out").exists()
 
 
 def test_export_page_raises_on_error(tmp_path):

--- a/tests/test_server_export.py
+++ b/tests/test_server_export.py
@@ -100,6 +100,45 @@ def test_export_rejects_bad_include_type(tmp_path):
     assert "include" in resp.json()["error"]
 
 
+def test_export_forwards_cache_max_age_to_manifest(tmp_path):
+    html = "<script>fused.runPython('./sine.py', {});</script>"
+    _write(tmp_path, "page.html", html)
+    _write(tmp_path, "sine.py", "def main():\n    return 1\n")
+    out_dir = tmp_path / "bundle"
+
+    client = _client(tmp_path)
+    resp = client.post(
+        "/api/export",
+        json={
+            "page": str(tmp_path / "page.html"),
+            "out": str(out_dir),
+            "cache_max_age": "15m",
+        },
+        headers={"X-Fused": "1"},
+    )
+    assert resp.status_code == 200, resp.text
+    import json
+
+    manifest = json.loads((out_dir / "manifest.json").read_text())
+    assert manifest["cache_max_age"] == "15m"
+
+
+def test_export_rejects_bad_cache_max_age(tmp_path):
+    _write(tmp_path, "page.html", "<html></html>")
+    client = _client(tmp_path)
+    resp = client.post(
+        "/api/export",
+        json={
+            "page": str(tmp_path / "page.html"),
+            "out": str(tmp_path / "out"),
+            "cache_max_age": "5x",
+        },
+        headers={"X-Fused": "1"},
+    )
+    assert resp.status_code == 400
+    assert "cache_max_age" in resp.json()["error"]
+
+
 def test_export_error_is_400(tmp_path):
     html = "<script>const p = './x.py'; fused.runPython(p, {});</script>"
     _write(tmp_path, "page.html", html)


### PR DESCRIPTION
## Summary

This PR adds result caching functionality to the Deploy modal, allowing users to control how long `runPython` route results are cached (0s/off by default, or durations like 5m/1h/1d). It also adds a "Bust cache" action to force recomputation of cached results without redeploying.

## Key Changes

**Frontend (Deploy Modal)**
- Added caching control UI: checkbox to enable/disable caching + duration select with presets (1m/5m/15m/1h/6h/1d)
- Caching choice is persisted on the deployment record and reloaded when reopening the modal (like include/exclude)
- Added "Bust cache" button that appears when a deployment is active
- Displays cache bust results ("Cleared N cached results…" or "Nothing was cached…") as a status line
- Added inline warning for managed Fused environments where caching isn't yet supported
- Displays current caching setting in the deployment info section

**Backend (Deploy API)**
- `deploy_page()` now accepts `cache_max_age` parameter (default "0s") and persists it on the deployment record
- Added `bust_cache_deployment()` function that calls `fused share cache-clear <token>` to force cache invalidation
- Added `POST /api/deploy/bust-cache` endpoint with Fused auth guard
- Validates `cache_max_age` format (non-negative integer + s/m/h/d unit) at export time
- Returns cache-clear result (`{token, deleted, scope}`) to the frontend

**Export Bundle**
- `export_page()` now accepts and validates `cache_max_age` parameter
- Added `_validate_cache_max_age()` to reject malformed values before they reach the manifest
- `manifest.json` now includes top-level `cache_max_age` field (applied uniformly to all `runPython` routes by the hosting layer)
- Validation mirrors the hosting layer's parser to catch errors locally

**Tests**
- Added tests for cache_max_age persistence across deploys
- Added tests for default (off) behavior
- Added tests for invalid cache_max_age rejection
- Added tests for bust-cache endpoint (success, missing deployment, auth guard)
- Added tests for export validation and manifest inclusion

**Documentation**
- Updated SPEC.md with DP-17 (caching control) and DP-18 (bust cache) requirements
- Updated EXPORT.md with caching section explaining the feature and format
- Added JSDoc comments explaining the caching choice and its persistence

## Implementation Details

- The caching setting is stored in the deployment pointer (like include/exclude) so reopening the modal shows the current setting
- Every deploy re-sends the caching choice explicitly (no "leave it as it was" behavior) — this ensures the manifest always reflects the current choice
- Cache busting is orthogonal to the caching setting: it works whether caching is on or off, and doesn't change the deployment's status/URL
- The feature gracefully handles pre-existing deployments that lack the `cache_max_age` field (reads as "0s"/off)
- Managed Fused environments show an inline warning that caching isn't yet supported there, but the deploy still succeeds

https://claude.ai/code/session_017iGKn3RiQ97RqDwarGP4G1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy orchestration and hosted caching semantics differ by backend (Fused token reuse vs AWS manifest), and force_new revokes superseded mounts best-effort; mistakes could misreport live cache settings or leave an extra live URL.
> 
> **Overview**
> Adds **deploy-time result caching** end-to-end: bundles carry **`cache_max_age`** in `manifest.json` (validated at export), deploy/export APIs accept it, and the deployment pointer stores it so the Deploy modal can seed and re-send the choice on every publish.
> 
> The modal gets a **“Cache page results”** toggle with duration presets (default **1h** when on), shows the live setting on the deployment card, and **`POST /api/deploy/clear-cache`** (CLI `share cache-clear`) to invalidate cached results without redeploying.
> 
> **Backend-specific behavior** is wired in `deploy_page`: **`share create`** passes `--cache-max-age`; on managed **Fused**, **repoint/recreate** cannot change mount caching, so the stored record reports **`effective_cache_max_age`** (not the requested value). When the user changes caching on a Fused redeploy, the UI offers **“Deploy as new URL”** (`force_new`) — fresh create, pointer update, then best-effort revoke of the old mount. AWS repoints still pick up the new manifest value.
> 
> Also bumps the pinned **`fused`** wheel to **2.9.3.post7**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4d75d24edc648b50122e591029c7bc1e00ddcc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->