### PR TITLE
Add page title support to recents and bookmarks

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -225,7 +225,7 @@ Header actions always include `Raw` (opens raw endpoint in new tab). Iframe fill
 Layout: `#app` becomes two-column flex — fixed sidebar (~220px, `--bg-alt`, right border) + existing content column (breadcrumb + content).
 
 - **Home entry:** icon + "Home"; click → `navigate(config.home)`. `/api/config` response gains `"home": os.path.expanduser("~")`.
-- **Bookmark capture:** "+ Bookmark" button right-aligned in the breadcrumb bar (present on every view); shows accent "starred" state when the current URL is already bookmarked. On click: `{id: crypto.randomUUID(), name: basename(currentFsPath), url: location.pathname + location.search, created_at: Date.now()}` appended to store; sidebar re-renders.
+- **Bookmark capture:** "+ Bookmark" button right-aligned in the breadcrumb bar (present on every view); shows accent "starred" state when the current URL is already bookmarked. On click: `{id: crypto.randomUUID(), name: renderedTitle || basename(currentFsPath), url: location.pathname + location.search, created_at: Date.now()}` appended to store; sidebar re-renders. `renderedTitle` is the previewed page's own `<title>` when known (StatView, threaded through `Breadcrumb`) — preferred over the file's basename so a page's authored title wins.
 - **Store (D75):** server-side `~/.fused-render/bookmarks.json`, JSON array (tree). Backend in `fused_render/shell/` — `storage.py` (home dir via `home_dir()`/`FUSED_RENDER_HOME`, atomic `read_json`/`write_json`) + `bookmarks.py` (`APIRouter`: `GET /api/bookmarks` → `{exists, bookmarks}`; `PUT` whole-tree, atomic, last-write-wins, `X-Fused` guard). Frontend `bookmarks.ts` keeps an in-memory cache (`loadBookmarks()`/`allBookmarks()` sync off it), hydrated once at boot by `hydrateBookmarks()`; each mutation clones → `await`s the PUT → advances the cache (no optimism/rollback — cache never holds unpersisted state). The one-time legacy `localStorage["fused.bookmarks"]` import (D75) has been removed (D104) — every pre-D75 install has long since migrated. A 30 s `setInterval` in `main.tsx` calls `refreshBookmarks()` (a `GET` through the same serial queue, re-rendering only on a real diff) so another tab's/window's edits converge (D77 — eventual ≤30 s, last-write-wins on simultaneous writes). Hydration, every mutation, and the poll all run through one `enqueue` chain, so no read/write ever interleaves (closes the hydration/mutation race Bugbot flagged). `shell/` is the seam for future shell-state backends, kept out of `server.py`'s fs/render internals (and acyclic — it never imports `server`).
 - **Bookmark row:** name ellipsized, rendered as a real `<a href="<url>">` (verbatim URL per D20; href kept for middle-click/copy-link). Plain click is intercepted: it **arms** the bookmark for update tracking and routes in-shell via `navigateUrl(url)` (pushState that preserves the query string, unlike `navigate()`). Hover shows a floating card beside the sidebar: decoded target path + saved params as a key/value grid ("no params" when none); card hides during rename/delete. Hover also reveals ✎ rename (inline `<input>`, Enter/blur commits, Escape cancels) and ✕ delete (no confirm). Active bookmark (url == current URL) is highlighted.
 - Order: creation time. Duplicates allowed.
@@ -235,24 +235,26 @@ Layout: `#app` becomes two-column flex — fixed sidebar (~220px, `--bg-alt`, ri
 
 Sidebar section listing the last 3 files opened, each with the params they last
 had. Backend `shell/recents.py` (beside bookmarks/prefs): `~/.fused-render/recents.json`
-holds `{collapsed, entries: [{url, openedAt}]}` — urls verbatim incl. query
+holds `{collapsed, entries: [{url, openedAt, title?}]}` — urls verbatim incl. query
 (D20 posture), newest first, deduped by target fs path, capped at 20; `GET
 /api/recents` filters entries whose file no longer exists (without deleting
-them), `POST /api/recents/open {url}` records (file-view `/view/` urls only —
+them), `POST /api/recents/open {url, title?}` records (file-view `/view/` urls only —
 directories and `_`-sentinels no-op), `PUT /api/recents/collapsed` persists the
 fold with the data (D44 posture). Frontend `lib/recents.ts` mirrors
 `bookmarks.ts` (sync cache, serial queue, `notifyRecentsChanged` signal); its
-`useRecentsTracking(fsPath, isDir)` is mounted in `App.tsx`'s StatView beside
-the session hooks — records the open once the stat confirms a file, then
-re-records the current url on every `fused:urlchange`/`popstate` (500 ms
-debounce), so the entry tracks live param changes. Display order is
+`useRecentsTracking(fsPath, isDir, title)` is mounted in `App.tsx`'s StatView
+beside the session hooks — records the open once the stat confirms a file,
+then re-records the current url (and the page's own `<title>`, once known)
+on every `fused:urlchange`/`popstate` (500 ms debounce) or title change, so
+the entry tracks live param and title changes. Display order is
 **stable-slot**, not raw MRU (RC-11): `displayRecents()` keeps session-scoped
 slots — a displayed file's row updates in place (rows keyed by fs path; the
 store notifies on visible changes only, urls included so hrefs stay fresh,
 and param churn moves nothing); only a not-displayed file entering at
 the top shifts rows, and a vanished file's slot fills from the bottom.
-Sidebar rows are basename
-labels (D22); click = `navigateUrl` (query-preserving), arms nothing; the
+Sidebar rows prefer the recorded
+`title` (the page's own `<title>`) and fall back to the basename otherwise
+(D22, extended); click = `navigateUrl` (query-preserving), arms nothing; the
 heading toggles the fold (count pill as the collapsed signal, no chevron — D44
 visual language); the section is hidden while empty.
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -151,9 +151,6 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   // already on the shell URL (no param flash from defaults -> restored).
   const ready = useSessionRestore(fsPath, isDir);
   useSessionTracking(fsPath, isDir);
-  // Sidebar "Recents": record the open, then keep the entry's url live as
-  // params change (same confirmed-file gate as session tracking).
-  useRecentsTracking(fsPath, isDir);
   // A "_render" preview (the file's own HTML, no template) reports its
   // authored <title> here (Preview -> TemplatePreview); everything else
   // (templates, listings, fallback cards) has no better name than the
@@ -162,6 +159,10 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   // not on a `_mode` switch within the same file — TemplatePreview owns that.
   const [renderedTitle, setRenderedTitle] = useState<string | null>(null);
   useDocumentTitle(fsPath === "/" ? null : renderedTitle || basename(fsPath));
+  // Sidebar "Recents": record the open, then keep the entry's url (and its
+  // title, once known) live as params/title change — same confirmed-file
+  // gate as session tracking.
+  useRecentsTracking(fsPath, isDir, renderedTitle);
   let content = null;
   if (stat.status === "error") {
     content = (
@@ -194,7 +195,7 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   return (
     <>
       <div id="breadcrumb">
-        <Breadcrumb fsPath={fsPath} home={home} />
+        <Breadcrumb fsPath={fsPath} home={home} renderedTitle={renderedTitle} />
       </div>
       <div id="content">{content}</div>
     </>

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -190,7 +190,18 @@ function navigatePreservingMode(target: string): void {
   else navigate(target);
 }
 
-export function Breadcrumb({ fsPath, home }: { fsPath: string; home?: string }) {
+export function Breadcrumb({
+  fsPath,
+  home,
+  renderedTitle,
+}: {
+  fsPath: string;
+  home?: string;
+  // The previewed page's own <title>, when known (see StatView) — preferred
+  // over the file's basename for the default bookmark name (and, via
+  // Recents, for its sidebar row) so "My DB app" beats "index.html".
+  renderedTitle?: string | null;
+}) {
   // Strictly below home only — home itself shows its full path, not a lone "~".
   const underHome = home !== undefined && fsPath.startsWith(home + "/");
   const rest = underHome ? fsPath.slice(home.length) : fsPath;
@@ -251,7 +262,7 @@ export function Breadcrumb({ fsPath, home }: { fsPath: string; home?: string }) 
         {pieces}
         <RevealButton fsPath={fsPath} />
       </div>
-      <CrumbActions name={basename(fsPath)} onSplit={(dir) => enterPanel(fsPath, dir)} />
+      <CrumbActions name={renderedTitle || basename(fsPath)} onSplit={(dir) => enterPanel(fsPath, dir)} />
     </>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -914,7 +914,7 @@ export default function Sidebar({ config }: SidebarProps) {
                       <path d="M8 4.8V8l2.3 1.6" />
                     </svg>
                   </span>
-                  <span className="bookmark-name">{basename(fsPath)}</span>
+                  <span className="bookmark-name">{r.title || basename(fsPath)}</span>
                 </a>
               );
             })}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -302,6 +302,9 @@ export function putSession(fsPath: string, search: string): Promise<void> {
 export interface RecentEntry {
   url: string;
   openedAt: string;
+  // The page's own <title>, when one was known at record time — preferred
+  // over the file's basename for the sidebar row (see Sidebar.tsx).
+  title?: string;
 }
 
 export interface RecentsResult {
@@ -315,8 +318,11 @@ export function getRecents(): Promise<RecentsResult> {
 
 // Server no-ops (recorded: false) for directory/sentinel/missing-file urls,
 // so callers need not pre-classify the target.
-export function postRecentOpen(url: string): Promise<{ recorded: boolean }> {
-  return postJson<{ recorded: boolean }>("/api/recents/open", { url });
+export function postRecentOpen(url: string, title?: string | null): Promise<{ recorded: boolean }> {
+  return postJson<{ recorded: boolean }>(
+    "/api/recents/open",
+    title ? { url, title } : { url }
+  );
 }
 
 export function putRecentsCollapsed(collapsed: boolean): Promise<void> {

--- a/frontend/src/lib/recents.ts
+++ b/frontend/src/lib/recents.ts
@@ -88,13 +88,23 @@ function enqueue<T>(op: () => Promise<T>): Promise<T> {
 }
 
 // What the sidebar actually renders from this store: the collapse flag plus
-// each displayed slot's (path, latest url). Urls are INCLUDED — a stale href
-// is a real bug (middle-click/copy-link navigates to outdated params, RC-3);
-// with stable slots + path-keyed rows a url-only notify re-renders the anchor
-// attributes in place with zero movement and zero remounts.
+// each displayed slot's (path, latest url, latest title). Urls are INCLUDED —
+// a stale href is a real bug (middle-click/copy-link navigates to outdated
+// params, RC-3); with stable slots + path-keyed rows a url-only notify
+// re-renders the anchor attributes in place with zero movement and zero
+// remounts. Title is included for the same reason: the open-record and the
+// title-report re-record that follows it share the same url (only the title
+// differs), so a url-only signature would miss that change entirely and the
+// row would keep showing the basename after the cache already has the title.
 function displaySignature(slots: string[], entries: RecentEntry[], collapsed: boolean): string {
   const byPath = new Map(entries.map((e) => [recentFsPath(e.url), e]));
-  return JSON.stringify([collapsed, slots.map((p) => [p, byPath.get(p)?.url])]);
+  return JSON.stringify([
+    collapsed,
+    slots.map((p) => {
+      const e = byPath.get(p);
+      return [p, e?.url, e?.title];
+    }),
+  ]);
 }
 
 async function refresh(): Promise<void> {

--- a/frontend/src/lib/recents.ts
+++ b/frontend/src/lib/recents.ts
@@ -119,11 +119,13 @@ export function hydrateRecents(): Promise<void> {
 // server dedupes by target fs path — a re-record of an already-listed file
 // moves it to the top and replaces its url — and no-ops for anything that is
 // not an existing file's /view/ url, so the caller stays dumb about the
-// target's kind.
-export function recordRecentOpen(url: string): Promise<void> {
+// target's kind. `title`, when known (the page's own <title>, see App.tsx's
+// StatView), is stored alongside the url so the sidebar row can prefer it
+// over the file's basename — same posture as bookmark naming.
+export function recordRecentOpen(url: string, title?: string | null): Promise<void> {
   return enqueue(async () => {
     try {
-      await postRecentOpen(url);
+      await postRecentOpen(url, title);
       await refresh();
     } catch (e) {
       console.error("[fused] failed to record recent open:", e);
@@ -150,7 +152,11 @@ export function setRecentsCollapsed(collapsed: boolean): Promise<void> {
 // with a 500 ms debounce against slider-style param churn. Embed panes,
 // directories, and not-yet-stat'd opens (isDir null) opt out, mirroring
 // session tracking; the server rejects non-file urls anyway.
-export function useRecentsTracking(fsPath: string, isDir: boolean | null): void {
+// `title` is the previewed page's own <title>, when known — it arrives async
+// (after the iframe loads), so it is also a dependency: once it resolves, the
+// effect re-runs and re-records the current url with the now-known title,
+// same as a live param update would.
+export function useRecentsTracking(fsPath: string, isDir: boolean | null, title: string | null): void {
   const timer = useRef<number | undefined>(undefined);
   useEffect(() => {
     if (IS_EMBED || isDir !== false) return;
@@ -162,13 +168,13 @@ export function useRecentsTracking(fsPath: string, isDir: boolean | null): void 
     const flush = () => {
       window.clearTimeout(timer.current);
       if (pending !== null) {
-        void recordRecentOpen(pending);
+        void recordRecentOpen(pending, title);
         pending = null;
       }
     };
     // The open itself (session restore's replaceState re-records with the
     // restored params). Guarded against a same-tick navigation race.
-    if (fsPathFromLocation() === fsPath) void recordRecentOpen(currentUrl());
+    if (fsPathFromLocation() === fsPath) void recordRecentOpen(currentUrl(), title);
     const onUrlChange = () => {
       if (fsPathFromLocation() !== fsPath) return; // navigated away — not ours
       pending = currentUrl();
@@ -184,7 +190,8 @@ export function useRecentsTracking(fsPath: string, isDir: boolean | null): void 
       // param state — flush the captured url instead of dropping it.
       flush();
     };
-    // fsPath + isDir identify the open, like useSessionTracking.
+    // fsPath + isDir identify the open, like useSessionTracking; title is
+    // included so its late arrival triggers a re-record.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fsPath, isDir]);
+  }, [fsPath, isDir, title]);
 }

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -425,26 +425,31 @@ function TemplatePreview({
   // dirs.
   const isListing = entry.mode === "_listing";
 
-  // Tab title (App's StatView owns the actual document.title write): only a
-  // "_render" entry is the file's OWN html, so only it can carry an authored
-  // <title> worth showing over the filename — a template's title is a fixed
-  // generic string ("CSV preview") that's strictly worse than the filename
-  // StatView already falls back to. Reset on mode change AND on unmount (the
-  // cleanup covers TemplatePreview being swapped out entirely — the resolving
-  // spinner, FallbackPreview, a re-stat that errors — cases the mode-keyed
-  // effect alone never observes) so a stale title never outlives the preview
-  // that set it; the "_render" branch overwrites it once its iframe loads.
-  // Same-origin iframe (D3/D4 — /render always serves same-origin), so a
-  // direct contentDocument read is safe and needs no postMessage round trip.
+  // Tab title (App's StatView owns the actual document.title write, and it
+  // also feeds the default bookmark name and the Recents row — see
+  // Breadcrumb.tsx / recents.ts): only a "_render" entry is the file's OWN
+  // html, so only it can carry an authored <title> worth showing over the
+  // filename — a template's title is a fixed generic string ("CSV preview")
+  // that's strictly worse than the filename StatView falls back to. So a
+  // known title must OUTLIVE a mode switch away from "_render": switching
+  // modes is local state on this same TemplatePreview instance (`mode`),
+  // not a remount, and the filename is often undescriptive ("index.html") —
+  // clearing a real title back to that on every switch would be a strict
+  // downgrade. Only reset on true unmount (TemplatePreview swapped out
+  // entirely — the resolving spinner, FallbackPreview, a re-stat that
+  // errors), so a title never outlives the file whose page set it; the
+  // "_render" branch overwrites it (to a fresh value, or null if genuinely
+  // absent) once its iframe loads. Same-origin iframe (D3/D4 — /render
+  // always serves same-origin), so a direct contentDocument read is safe and
+  // needs no postMessage round trip.
   const titleObserverRef = useRef<MutationObserver | null>(null);
   useEffect(() => {
-    onRenderedTitle?.(null);
     return () => {
       titleObserverRef.current?.disconnect();
       titleObserverRef.current = null;
       onRenderedTitle?.(null);
     };
-  }, [mode, onRenderedTitle]);
+  }, [onRenderedTitle]);
   const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
     if (entry.mode !== "_render") return;
     // Guards a slow "_render" iframe's load firing AFTER a switch away from

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -7,7 +7,9 @@ sentinel routes (`_panel`, `_prefs`, any `_`-prefixed view) are never recorded.
 
 File shape:
 
-    {"collapsed": false, "entries": [{"url": "/view/...?...", "openedAt": iso}]}
+    {"collapsed": false, "entries": [
+        {"url": "/view/...?...", "openedAt": iso, "title": "optional page title"}
+    ]}
 
 Entries are newest-first, deduped by target fs path, capped at ENTRY_CAP (a
 buffer so the UI's top 3 survive missing-file filtering). URLs are stored
@@ -214,6 +216,11 @@ def post_recent_open(
         # Directory / sentinel / missing-file url -> benign no-op, same
         # posture as POST /api/bookmarks/history for non-file urls.
         return {"recorded": False}
+    # The rendered page's own <title> (frontend lib/recents.ts), preferred
+    # over the file's basename by the sidebar row — same posture as bookmark
+    # naming. Optional: absent until the preview iframe reports one.
+    title_raw = payload.get("title")
+    title = title_raw.strip() if isinstance(title_raw, str) and title_raw.strip() else None
     data = _read()
     # Dedupe by DECODED target fs path — existence-blind, so a dead entry for
     # the same path (file deleted and recreated since) is replaced rather than
@@ -223,6 +230,8 @@ def post_recent_open(
         if not (isinstance(e.get("url"), str) and _decoded_fs_path(e["url"]) == fs_path)
     ]
     entry = {"url": url, "openedAt": datetime.now(timezone.utc).isoformat()}
+    if title is not None:
+        entry["title"] = title
     data["entries"] = [entry, *kept][:ENTRY_CAP]
     storage.write_json(_path(), data)
     return {"recorded": True}

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -224,14 +224,25 @@ def post_recent_open(
     data = _read()
     # Dedupe by DECODED target fs path — existence-blind, so a dead entry for
     # the same path (file deleted and recreated since) is replaced rather than
-    # left wasting a cap slot beside the fresh one.
-    kept = [
-        e for e in data["entries"]
-        if not (isinstance(e.get("url"), str) and _decoded_fs_path(e["url"]) == fs_path)
-    ]
+    # left wasting a cap slot beside the fresh one. A title-less record (the
+    # synchronous open-record always fires before the async title arrives;
+    # some modes never report one at all) must not erase a title learned on a
+    # PREVIOUS open — carry the old one forward when this record doesn't
+    # supply a fresher one, so a known title only ever improves, never regresses.
+    existing_title = None
+    kept = []
+    for e in data["entries"]:
+        if isinstance(e.get("url"), str) and _decoded_fs_path(e["url"]) == fs_path:
+            t = e.get("title")
+            if existing_title is None and isinstance(t, str) and t:
+                existing_title = t
+            continue
+        kept.append(e)
     entry = {"url": url, "openedAt": datetime.now(timezone.utc).isoformat()}
     if title is not None:
         entry["title"] = title
+    elif existing_title is not None:
+        entry["title"] = existing_title
     data["entries"] = [entry, *kept][:ENTRY_CAP]
     storage.write_json(_path(), data)
     return {"recorded": True}

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -147,6 +147,40 @@ def test_open_re_record_updates_title(tmp_path, monkeypatch):
     assert saved["entries"][0]["title"] == "My DB app"
 
 
+def test_open_title_persists_across_titleless_re_record(tmp_path, monkeypatch):
+    # The initial open-record always fires before the async <title> arrives
+    # (and opening straight into a mode other than "_render" never reports
+    # one at all) — a later title-less re-record of the same fs path (a param
+    # update, or just reopening the file) must not erase a title already
+    # learned, so recents never regresses back to the filename once it knows
+    # better.
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    client.post(
+        "/api/recents/open",
+        json={"url": _view_url(f), "title": "My DB app"},
+        headers=FUSED,
+    )
+    client.post("/api/recents/open", json={"url": _view_url(f, "?x=1")}, headers=FUSED)
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert len(saved["entries"]) == 1
+    assert saved["entries"][0]["title"] == "My DB app"
+    assert saved["entries"][0]["url"] == _view_url(f, "?x=1")
+
+
+def test_open_new_title_overrides_old_one(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    client.post(
+        "/api/recents/open", json={"url": _view_url(f), "title": "Old title"}, headers=FUSED
+    )
+    client.post(
+        "/api/recents/open", json={"url": _view_url(f), "title": "New title"}, headers=FUSED
+    )
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert saved["entries"][0]["title"] == "New title"
+
+
 def test_get_hides_missing_files_without_deleting_them(tmp_path, monkeypatch):
     client, home = _client(tmp_path, monkeypatch)
     keep = _make_file(tmp_path, "keep.csv")

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -96,6 +96,57 @@ def test_open_requires_url(tmp_path, monkeypatch):
     assert client.post("/api/recents/open", json={}, headers=FUSED).status_code == 400
 
 
+def test_open_stores_title_when_given(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    url = _view_url(f)
+    resp = client.post(
+        "/api/recents/open", json={"url": url, "title": "My DB app"}, headers=FUSED
+    )
+    assert resp.status_code == 200
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert saved["entries"][0]["title"] == "My DB app"
+    assert client.get("/api/recents").json()["entries"][0]["title"] == "My DB app"
+
+
+def test_open_without_title_omits_the_field(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    client.post("/api/recents/open", json={"url": _view_url(f)}, headers=FUSED)
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert "title" not in saved["entries"][0]
+
+
+def test_open_ignores_blank_or_non_string_title(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    client.post(
+        "/api/recents/open", json={"url": _view_url(f), "title": "   "}, headers=FUSED
+    )
+    client.post(
+        "/api/recents/open", json={"url": _view_url(f), "title": 42}, headers=FUSED
+    )
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert "title" not in saved["entries"][0]
+
+
+def test_open_re_record_updates_title(tmp_path, monkeypatch):
+    # A re-record of the same fs path (e.g. once the iframe's <title> resolves
+    # after the initial open) replaces the entry, so the title lands even
+    # though the first record predates it.
+    client, home = _client(tmp_path, monkeypatch)
+    f = _make_file(tmp_path)
+    client.post("/api/recents/open", json={"url": _view_url(f)}, headers=FUSED)
+    client.post(
+        "/api/recents/open",
+        json={"url": _view_url(f), "title": "My DB app"},
+        headers=FUSED,
+    )
+    saved = json.loads((home / "recents.json").read_text(encoding="utf-8"))
+    assert len(saved["entries"]) == 1
+    assert saved["entries"][0]["title"] == "My DB app"
+
+
 def test_get_hides_missing_files_without_deleting_them(tmp_path, monkeypatch):
     client, home = _client(tmp_path, monkeypatch)
     keep = _make_file(tmp_path, "keep.csv")


### PR DESCRIPTION
## Summary
This change extends the recents and bookmarks features to capture and display the previewed page's own `<title>` element, providing more descriptive names than file basenames (e.g., "My DB app" instead of "index.html").

## Key Changes

- **Backend (recents.py):** Extended `POST /api/recents/open` to accept an optional `title` parameter. The title is validated (must be a non-empty string) and stored in the recents entry only when provided.

- **Frontend API (api.ts):** Updated `postRecentOpen()` to accept an optional title parameter and include it in the request payload only when present.

- **Recents tracking (recents.ts):** Modified `useRecentsTracking()` to accept a `title` parameter and re-record the current URL whenever the title changes. This ensures that once the preview iframe loads and reports its `<title>`, the recents entry is updated with that information.

- **Preview rendering (Preview.tsx):** Adjusted the title observer effect to only reset on unmount (not on mode changes), allowing a discovered page title to persist across template mode switches within the same file.

- **Breadcrumb (Breadcrumb.tsx):** Added `renderedTitle` prop to use the page's own title for the default bookmark name, preferring it over the file's basename.

- **Sidebar (Sidebar.tsx):** Updated recents row display to show the stored `title` when available, falling back to the file's basename.

- **App.tsx (StatView):** Threaded the `renderedTitle` state through to both `Breadcrumb` and `useRecentsTracking()`, ensuring the title is captured and propagated throughout the UI.

- **Documentation (ARCHITECTURE.md):** Updated to reflect that recents entries now include an optional title field and that sidebar rows prefer the page's authored title over the basename.

## Implementation Details

- The title is captured asynchronously (after the preview iframe loads) and triggers a re-record of the recents entry via the dependency array in `useRecentsTracking()`.
- Blank or non-string titles are filtered out server-side, keeping the JSON clean.
- Re-recording the same file path with a newly discovered title replaces the entry (deduped by fs path), so the title is added even if the initial record predated it.
- The same title-preference pattern is applied to both recents sidebar rows and bookmark naming, maintaining consistency across the UI.

https://claude.ai/code/session_018pDDbXs1ab8nYXpLpKPwT1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized shell UX and optional recents JSON field with backward-compatible omission; no auth or critical path changes.
> 
> **Overview**
> **Recents and bookmarks** now use the previewed page's own `<title>` when available (e.g. "My DB app" instead of `index.html`), aligned across the document tab, sidebar recents rows, and the default **+ Bookmark** name.
> 
> **Backend:** `POST /api/recents/open` accepts optional `title` (non-empty string only). On re-record, a title-less update keeps a title learned on a prior open; a new title overwrites the old one.
> 
> **Frontend:** `StatView` threads `renderedTitle` from `Preview` into `useRecentsTracking` and `Breadcrumb`. Recents tracking re-records when the title arrives async; the sidebar display signature includes `title` so rows refresh when only the title changes. **`Preview`:** the authored title is no longer cleared on template `_mode` switches—only on unmount—so bookmark/recents naming stays stable when switching away from `_render`.
> 
> Docs (`ARCHITECTURE.md`) and shell recents tests cover the new field and merge behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17379396b284d6ed668f6ed5282ca26eca657b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->