### PR TITLE
Skip read-only permission tests when running as root

### DIFF
--- a/tests/test_annotate_comments.py
+++ b/tests/test_annotate_comments.py
@@ -20,6 +20,11 @@ import os
 
 import pytest
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load_annotate():
     path = os.path.join("fused_render", "templates", "annotate", "annotate.py")
@@ -207,6 +212,7 @@ def test_status_writable_sidecar_dir(tmp_path):
     assert ann.main(action="status", file=str(target)) == {"writable": True}
 
 
+@skip_root
 def test_status_readonly_sidecar_file(tmp_path):
     ann = _load_annotate()
     target = tmp_path / "page.html"
@@ -220,6 +226,7 @@ def test_status_readonly_sidecar_file(tmp_path):
         os.chmod(sidecar, 0o644)
 
 
+@skip_root
 def test_status_readonly_parent_dir(tmp_path):
     ann = _load_annotate()
     target = tmp_path / "page.html"

--- a/tests/test_archive_preview_readonly.py
+++ b/tests/test_archive_preview_readonly.py
@@ -63,7 +63,13 @@ def _tar(tmp_path, content="hello"):
 
 ARCHIVES = [(zip_reader, _zip), (tar_reader, _tar)]
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
 
+
+@skip_root
 @pytest.mark.parametrize("reader,make", ARCHIVES, ids=["zip", "tar"])
 def test_preview_copy_is_read_only(tmp_path, reader, make):
     res = reader.main(make(tmp_path), "preview", "notes.txt")
@@ -73,6 +79,7 @@ def test_preview_copy_is_read_only(tmp_path, reader, make):
     assert not os.access(path, os.W_OK)
 
 
+@skip_root
 @pytest.mark.parametrize("reader,make", ARCHIVES, ids=["zip", "tar"])
 def test_preview_overwrites_stale_read_only_copy(tmp_path, reader, make):
     first = reader.main(make(tmp_path), "preview", "notes.txt")["path"]
@@ -92,6 +99,7 @@ def test_extract_output_stays_writable(tmp_path, reader, make):
     assert os.access(res["path"], os.W_OK)
 
 
+@skip_root
 @pytest.mark.parametrize("reader,make", ARCHIVES, ids=["zip", "tar"])
 def test_extract_refuses_write_protected_target(tmp_path, reader, make):
     # The preview chmod must NOT leak into deliberate extraction: a file the
@@ -117,6 +125,7 @@ def test_zip_extract_all_output_stays_writable(tmp_path):
     assert checked == 2
 
 
+@skip_root
 def test_tar_single_compressed_preview_is_read_only(tmp_path):
     p = tmp_path / "notes.json.gz"
     with gzip.open(p, "wt") as f:

--- a/tests/test_docs_readonly.py
+++ b/tests/test_docs_readonly.py
@@ -16,6 +16,11 @@ import os
 
 import pytest
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load_docs():
     path = os.path.join("fused_render", "templates", "docs", "docs.py")
@@ -39,6 +44,7 @@ def docx(tmp_path):
     os.chmod(str(f), 0o644)
 
 
+@skip_root
 def test_save_readonly_file_raises_permission_error(docs, docx):
     os.chmod(docx, 0o444)
     with pytest.raises(PermissionError):
@@ -55,6 +61,7 @@ def test_editability_writable(docs, docx):
     assert tooltip == ""
 
 
+@skip_root
 def test_editability_readonly(docs, docx):
     os.chmod(docx, 0o444)
     editable, message, tooltip = docs._editability(docx)

--- a/tests/test_duckdb_reader.py
+++ b/tests/test_duckdb_reader.py
@@ -12,6 +12,11 @@ import pytest
 pytest.importorskip("duckdb")
 import duckdb  # noqa: E402
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load(name):
     path = os.path.join(os.path.dirname(__file__), "..", "fused_render",
@@ -766,6 +771,7 @@ def readonly_parquet(parquet_file):
     os.chmod(parquet_file, 0o644)  # so tmp_path cleanup works
 
 
+@skip_root
 def test_reader_readonly_file_not_editable(readonly_parquet):
     out = reader.main(readonly_parquet)
     assert out["editable"] is False
@@ -774,6 +780,7 @@ def test_reader_readonly_file_not_editable(readonly_parquet):
     assert out["readonly_tooltip"]
 
 
+@skip_root
 def test_writer_refuses_readonly_file(readonly_parquet):
     before = os.stat(readonly_parquet).st_size
     with pytest.raises(PermissionError):

--- a/tests/test_excel_readonly.py
+++ b/tests/test_excel_readonly.py
@@ -22,6 +22,11 @@ import stat
 
 import pytest
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load_reader():
     path = os.path.join("fused_render", "templates", "excel", "reader.py")
@@ -44,6 +49,7 @@ def _small_payload():
     return [{"name": "data", "big": False, "rows": [["x", "y"], ["9", "8"]]}]
 
 
+@skip_root
 def test_save_readonly_csv_raises_and_leaves_bytes_untouched(tmp_path):
     rd = _load_reader()
     f = _csv(tmp_path)
@@ -78,6 +84,7 @@ def test_load_writable_csv_is_editable(tmp_path):
     assert res["readonly_tooltip"] == ""
 
 
+@skip_root
 def test_load_readonly_csv_reports_readonly_verdict(tmp_path):
     rd = _load_reader()
     f = _csv(tmp_path)

--- a/tests/test_pdf_studio_readonly.py
+++ b/tests/test_pdf_studio_readonly.py
@@ -21,6 +21,11 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 PDF_PY = os.path.join(HERE, os.pardir, "fused_render", "templates",
                       "pdf_studio", "pdf.py")
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load_pdf(tmp_path, monkeypatch):
     spec = importlib.util.spec_from_file_location("pdf_studio_target", PDF_PY)
@@ -46,6 +51,7 @@ def _original(tmp_path, content=b"%PDF-original"):
     return f
 
 
+@skip_root
 def test_save_readonly_original_raises_and_leaves_file(tmp_path, monkeypatch):
     mod = _load_pdf(tmp_path, monkeypatch)
     f = _original(tmp_path)
@@ -68,6 +74,7 @@ def test_save_readonly_original_raises_and_leaves_file(tmp_path, monkeypatch):
         os.chmod(src, 0o644)
 
 
+@skip_root
 def test_save_readonly_beats_conflict_force(tmp_path, monkeypatch):
     # Even force=1 (the conflict dialog's override) can't write a read-only
     # file — the gate sits before the conflict check.
@@ -90,6 +97,7 @@ def test_save_readonly_beats_conflict_force(tmp_path, monkeypatch):
         os.chmod(src, 0o644)
 
 
+@skip_root
 def test_rename_doc_readonly_raises_and_keeps_name(tmp_path, monkeypatch):
     mod = _load_pdf(tmp_path, monkeypatch)
     f = _original(tmp_path)

--- a/tests/test_server_fs_mount_safe.py
+++ b/tests/test_server_fs_mount_safe.py
@@ -28,6 +28,7 @@ redirected per test.
 import json
 import os
 
+import pytest
 from fastapi.responses import JSONResponse
 
 import fused_render.shell.mounts as mounts_mod
@@ -44,6 +45,11 @@ from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
     _no_kernel_on_mount,
     home,
 )
+
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
 
 
 # --------------------------------------------------------------------------- helpers
@@ -386,6 +392,7 @@ def test_mounts_root_known_mount_name_still_exists_mkdir_409(home, monkeypatch):
 # The mount side is NEVER _writable-probed (that kernel-stats a writable mount).
 # ===========================================================================
 
+@skip_root
 def test_rename_local_readonly_src_refused_with_mount_dst(home, monkeypatch, tmp_path):
     mp = _mount("rw", read_only=False, on_disk=True)
     _no_kernel_on_mount(monkeypatch, mp)
@@ -401,6 +408,7 @@ def test_rename_local_readonly_src_refused_with_mount_dst(home, monkeypatch, tmp
         os.chmod(src, 0o600)
 
 
+@skip_root
 def test_copy_local_readonly_dst_refused_with_mount_src(home, monkeypatch, tmp_path):
     mp = _mount("rw", read_only=False)
     _no_kernel_on_mount(monkeypatch, mp)

--- a/tests/test_server_fs_mutate.py
+++ b/tests/test_server_fs_mutate.py
@@ -21,6 +21,11 @@ from fused_render.server import _fs_delete as DELETE
 from fused_render.server import _fs_mkdir as MKDIR
 from fused_render.server import _fs_rename as RENAME
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _status(resp) -> int:
     return resp.status_code if isinstance(resp, JSONResponse) else 200
@@ -76,6 +81,7 @@ def test_mkdir_existing_path_409(tmp_path):
     assert _data(resp)["error"] == "conflict"
 
 
+@skip_root
 def test_mkdir_readonly_parent_403(tmp_path):
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IXUSR)
     try:
@@ -142,6 +148,7 @@ def test_delete_symlink_to_dir_removes_link_not_target(tmp_path):
     assert (target / "keep.txt").read_text() == "x"  # contents intact
 
 
+@skip_root
 def test_delete_readonly_file_403(tmp_path):
     f = tmp_path / "ro.txt"
     f.write_text("x")
@@ -286,6 +293,7 @@ def test_rename_dir_into_itself_400(tmp_path):
     assert (d / "sub").is_dir()  # tree untouched
 
 
+@skip_root
 def test_rename_readonly_src_403(tmp_path):
     # A move deletes the source, so a readonly source must refuse the same way
     # delete does — otherwise rename lifts entries off a read-only location.

--- a/tests/test_server_fs_write.py
+++ b/tests/test_server_fs_write.py
@@ -21,6 +21,11 @@ from fastapi.responses import JSONResponse
 from fused_render.server import _fs_stat as STAT
 from fused_render.server import _fs_write as WRITE
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _status(resp) -> int:
     return resp.status_code if isinstance(resp, JSONResponse) else 200
@@ -58,11 +63,13 @@ def test_stat_writable_true_for_writable_file(target):
     assert out["writable"] is True
 
 
+@skip_root
 def test_stat_writable_false_for_readonly_file(readonly):
     out = _data(STAT(str(readonly)))
     assert out["writable"] is False
 
 
+@skip_root
 def test_stat_writable_on_directory(tmp_path):
     assert _data(STAT(str(tmp_path)))["writable"] is True
     os.chmod(tmp_path, stat.S_IRUSR | stat.S_IXUSR)
@@ -74,6 +81,7 @@ def test_stat_writable_on_directory(tmp_path):
 
 # --------------------------------------------------------- write guard (403)
 
+@skip_root
 def test_write_refuses_readonly_target(readonly):
     resp = _write(readonly, "clobbered")
     assert _status(resp) == 403

--- a/tests/test_sqlite_edit.py
+++ b/tests/test_sqlite_edit.py
@@ -6,6 +6,11 @@ import sqlite3
 
 import pytest
 
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
+
 
 def _load(name):
     path = os.path.join(os.path.dirname(__file__), "..", "fused_render",
@@ -186,6 +191,7 @@ def readonly_db(db):
     os.chmod(db, 0o644)  # so tmp_path cleanup works
 
 
+@skip_root
 def test_reader_readonly_file_not_editable(readonly_db):
     out = reader.main(readonly_db, table="people")
     assert out["editable"] is False
@@ -195,6 +201,7 @@ def test_reader_readonly_file_not_editable(readonly_db):
     assert out["readonly_tooltip"]
 
 
+@skip_root
 def test_writer_refuses_readonly_file(readonly_db):
     with pytest.raises(PermissionError):
         writer.main(readonly_db, table="people",

--- a/tests/test_usd_readonly.py
+++ b/tests/test_usd_readonly.py
@@ -17,9 +17,16 @@ nothing can touch the real home.
 import importlib.util
 import os
 
+import pytest
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 READER_PY = os.path.join(HERE, os.pardir, "fused_render", "templates",
                          "usd", "reader.py")
+
+# os.access always says yes for root, so the chmod-based gates can't trip.
+skip_root = pytest.mark.skipif(
+    hasattr(os, "geteuid") and os.geteuid() == 0,
+    reason="read-only bits are ignored when running as root")
 
 
 def _load_reader(tmp_path, monkeypatch):
@@ -44,6 +51,7 @@ def test_sidecar_writable_no_sidecar_writable_dir(tmp_path, monkeypatch):
     assert mod._sidecar_writable(str(f)) is True
 
 
+@skip_root
 def test_sidecar_writable_existing_readonly_sidecar(tmp_path, monkeypatch):
     mod = _load_reader(tmp_path, monkeypatch)
     f = _asset(tmp_path)
@@ -56,6 +64,7 @@ def test_sidecar_writable_existing_readonly_sidecar(tmp_path, monkeypatch):
         os.chmod(sidecar, 0o644)
 
 
+@skip_root
 def test_sidecar_writable_readonly_parent_no_sidecar(tmp_path, monkeypatch):
     mod = _load_reader(tmp_path, monkeypatch)
     d = tmp_path / "locked"
@@ -79,6 +88,7 @@ def test_inspect_reports_sidecar_writable_true(tmp_path, monkeypatch):
     assert out["sidecar_writable"] is True
 
 
+@skip_root
 def test_inspect_reports_sidecar_writable_false(tmp_path, monkeypatch):
     mod = _load_reader(tmp_path, monkeypatch)
     f = _asset(tmp_path)


### PR DESCRIPTION
## Summary
Add a `skip_root` pytest marker to all test files that verify read-only file permission behavior. This prevents false test failures when running the test suite as root, since `os.access()` always returns `True` for the root user regardless of actual file permissions.

## Changes
- Added `skip_root` pytest marker definition to 11 test files:
  - `test_usd_readonly.py`
  - `test_archive_preview_readonly.py`
  - `test_pdf_studio_readonly.py`
  - `test_server_fs_mount_safe.py`
  - `test_server_fs_mutate.py`
  - `test_server_fs_write.py`
  - `test_annotate_comments.py`
  - `test_docs_readonly.py`
  - `test_duckdb_reader.py`
  - `test_excel_readonly.py`
  - `test_sqlite_edit.py`

- Applied `@skip_root` decorator to 27 test functions that verify read-only permission checks

## Implementation Details
The `skip_root` marker checks if the test is running as root using `os.geteuid()` (Unix-like systems only) and skips the test with the reason "read-only bits are ignored when running as root". This allows the test suite to run successfully in containerized or CI environments where tests may execute as root, while still validating permission behavior in normal user contexts.

https://claude.ai/code/session_01UAMft1RSSFkDj9DeipNGFN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no application or API behavior is modified.
> 
> **Overview**
> Adds a shared **`skip_root`** pytest marker across eleven read-only / permission test modules so the suite stays green in root CI and containers.
> 
> Root ignores file mode bits, so **`os.access(..., W_OK)`** stays true after **`chmod`** and those assertions fail spuriously. The marker skips when **`os.geteuid() == 0`** (Unix only) with a short reason comment.
> 
> **`@skip_root`** is applied only to tests that depend on chmod or **`os.access`** for read-only behavior (roughly 27 cases)—server FS handlers, template writers/readers, archive preview copies, and similar. Writable-path and mount **`read_only`** flag tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a54b894f0c28094c670c812c3e484a7e9965397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->