### PR TITLE
Run tests in parallel by default + add dev-env setup skill

### DIFF
--- a/.claude/skills/setting-up-dev-env/SKILL.md
+++ b/.claude/skills/setting-up-dev-env/SKILL.md
@@ -9,26 +9,31 @@ description: Use when setting up a fused-render checkout or git worktree for the
 
 Every fresh checkout/worktree needs a **3.12 venv** and a **built React shell** — both are gitignored, so they don't carry into a worktree. Without them, `pytest`/`python` silently run against the wrong interpreter or fail on missing deps, and every server test dies with `RuntimeError: React shell not built`.
 
-## Steps
-
-From the worktree root:
-
-```bash
-uv venv --python 3.12 .venv                                                  # 3.14 lacks duckdb/rasterio wheels
-uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]" pytest-xdist
-cd frontend && bun install && bun run build && cd ..                         # builds fused_render/static/shell-dist/
-```
-
-Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m pytest -q` (~1170 pass).
-
 ## Running the Dev Server
 
-Use `scripts/dev.sh` — never launch `python -m fused_render.cli` (or uvicorn) directly. It wires up the pieces a raw launch skips: `vite build --watch` for live frontend rebuilds, Python auto-reload, per-worktree port/state isolation, and reading templates straight from the repo. It also bootstraps a repo-local `.venv` (with `fused` + `bundled`) if one is missing.
+Use `scripts/dev.sh` — never launch `python -m fused_render.cli` (or uvicorn) directly. It does almost all the setup for you: bootstraps a repo-local `.venv` (with `[fused,bundled]`) if missing, `npm install`s the frontend, builds `shell-dist/`, then runs `vite build --watch` + the server with Python auto-reload and per-worktree port/state isolation.
 
 ```bash
 scripts/dev.sh                 # defaults
 scripts/dev.sh --port 9000     # extra args pass through to the server
 ```
+
+## Setup for Tests
+
+`dev.sh` covers the server, but its auto-venv has `[fused,bundled]` only — **not the `dev` extra** (pytest/xdist). And tests need a built `shell-dist/` or `create_app()` refuses to start. So the venv install is the one manual step:
+
+```bash
+uv venv --python 3.12 .venv                                         # 3.14 lacks duckdb/rasterio wheels
+uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]"  # dev extra now includes pytest-xdist
+```
+
+For `shell-dist/`: if you've run `scripts/dev.sh`, it's already built. If you'll *only* run tests and never start the server, build it once directly (repo uses npm, per `package-lock.json`):
+
+```bash
+cd frontend && npm install && npm run build && cd ..
+```
+
+Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m pytest -q` (~1170 pass).
 
 ## Reference
 

--- a/.claude/skills/setting-up-dev-env/SKILL.md
+++ b/.claude/skills/setting-up-dev-env/SKILL.md
@@ -19,7 +19,16 @@ uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]" pytest-xdist
 cd frontend && bun install && bun run build && cd ..                         # builds fused_render/static/shell-dist/
 ```
 
-Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m pytest -q` (~1150 pass).
+Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m pytest -q` (~1170 pass).
+
+## Running the Dev Server
+
+Use `scripts/dev.sh` — never launch `python -m fused_render.cli` (or uvicorn) directly. It wires up the pieces a raw launch skips: `vite build --watch` for live frontend rebuilds, Python auto-reload, per-worktree port/state isolation, and reading templates straight from the repo. It also bootstraps a repo-local `.venv` (with `fused` + `bundled`) if one is missing.
+
+```bash
+scripts/dev.sh                 # defaults
+scripts/dev.sh --port 9000     # extra args pass through to the server
+```
 
 ## Reference
 

--- a/.claude/skills/setting-up-dev-env/SKILL.md
+++ b/.claude/skills/setting-up-dev-env/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: setting-up-dev-env
+description: Use when setting up a fused-render checkout or git worktree for the first time — before running pytest, the dev server, or any daemon — so tests and the server actually work instead of silently failing on missing deps or an unbuilt React shell.
+---
+
+# Setting Up the Dev Env
+
+## Overview
+
+Every fresh checkout/worktree needs a **3.12 venv** and a **built React shell** — both are gitignored, so they don't carry into a worktree. Without them, `pytest`/`python` silently run against the wrong interpreter or fail on missing deps, and every server test dies with `RuntimeError: React shell not built`.
+
+## Steps
+
+From the worktree root:
+
+```bash
+uv venv --python 3.12 .venv                                                  # 3.14 lacks duckdb/rasterio wheels
+uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]" pytest-xdist
+cd frontend && bun install && bun run build && cd ..                         # builds fused_render/static/shell-dist/
+```
+
+Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m pytest -q` (~1150 pass).
+
+## Reference
+
+| Item | Why |
+|------|-----|
+| Python 3.12 | duckdb/rasterio have no 3.14 wheels; fused wheel needs ≥3.11 |
+| `dev` extra | pytest + httpx (backs TestClient) |
+| `bundled` extra | duckdb, rasterio, zarr, pandas, geopandas… (templates + daemons) |
+| `fused` extra | compute-engine wheel for `/api/run` |
+| frontend build | `create_app()` refuses to start without `shell-dist/` |
+| `ensurepip` | only for the Deploy one-click path, not the suite |
+
+Parallel tests: the suite is xdist-safe (process isolation), so `pytest -n auto` works (~4.5x faster). Process-based only — `os.chdir` + `importlib.reload` would race under a threaded runner.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ dev = [
     "pytest",
     # fastapi.testclient hard-requires httpx at import time.
     "httpx",
+    # Parallel test runs (see [tool.pytest.ini_options] addopts -n auto). The
+    # suite is xdist-safe via process isolation: conftest re-points
+    # FUSED_RENDER_HOME/DIR per worker, tests use tmp_path + monkeypatch, and
+    # servers bind 127.0.0.1:0. Process-based only — os.chdir / importlib.reload
+    # would race under a threaded runner.
+    "pytest-xdist",
 ]
 # Baked into the bundled CPython of the .app (SPEC DM-2): users of the packaged
 # app cannot pip install, so the interpreter ships with the popular data stack.
@@ -85,6 +91,12 @@ fused-render-app = "fused_render.app:main"
 # exe because the Open With dialog displays a pythonw.exe command as "Python".
 [project.gui-scripts]
 fused-render-open = "fused_render.winopen:main"
+
+# Run the suite in parallel by default (needs pytest-xdist, in the dev extra).
+# -n auto spawns one worker per CPU; the suite is xdist-safe (see the dev-extra
+# comment). To debug a single test serially, override: `pytest -n0 -x path::test`.
+[tool.pytest.ini_options]
+addopts = "-n auto"
 
 # Single source of truth for the version: fused_render/__init__.py's
 # __version__. Bump it there only — hatchling reads it at build time for the


### PR DESCRIPTION
## Summary

- **Tests run in parallel by default.** Adds `pytest-xdist` to the `dev` extra and sets `addopts = "-n auto"`, so a bare `pytest` fans out across all cores. On a 10-core machine this cut a clean full-suite run from **~149s to ~33s (~4.5x)** with an identical pass count — the suite is already xdist-safe (per-worker tmp `FUSED_RENDER_HOME`/`DIR`, `tmp_path` + `monkeypatch`, servers bound to `127.0.0.1:0`).
- **New `setting-up-dev-env` project skill.** Documents the one-time setup every fresh checkout/worktree needs — a Python 3.12 venv, the `[dev,bundled,fused]` extras, and the frontend build — so `pytest`/the dev server stop silently failing on missing deps or an unbuilt React shell.

## Visuals

```mermaid
flowchart LR
    subgraph before[Before]
        A[pytest] --> B[1 process<br/>~149s]
    end
    subgraph after[After]
        C[pytest] --> D{addopts = -n auto}
        D --> W1[worker 1]
        D --> W2[worker 2]
        D --> Wn[worker N<br/>= CPU count]
        W1 & W2 & Wn --> E[~33s]
    end
```

## Usage

```bash
# Parallel by default now — no flags needed:
pytest

# Debug a single test serially (override xdist):
pytest -n0 -x tests/test_foo.py::test_bar
```

New worktree setup (also captured in the `setting-up-dev-env` skill):

```bash
uv venv --python 3.12 .venv
uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]"
cd frontend && bun install && bun run build && cd ..
```

## Test Plan

- [x] Full suite passes with the new `-n auto` default (bare `pytest`): **1171 passed, 4 skipped in 29.8s** (3.12 venv, 10 cores)
- [x] Confirmed `-n auto` is active from a flagless invocation ("bringing up nodes..." + ~4.5x wall-clock drop)
- [x] Serial (`-n0`) and parallel runs produce identical pass/skip counts — no ordering-dependent failures introduced
- [ ] Reviewer: `pip install -e ".[dev]"` then `pytest` — should auto-parallelize
