### PR TITLE
geotiff: auto stretch off by default

### DIFF
--- a/fused_render/templates/geotiff/template.html
+++ b/fused_render/templates/geotiff/template.html
@@ -128,7 +128,9 @@ const P = {
   b:     () => fused.params.get('b') || '3',
   cmap:  () => fused.params.get('cmap') || 'viridis',
   stretch: () => fused.params.get('stretch') || '',
-  autoStretch: () => (fused.params.get('autostretch') ?? '1') === '1',
+  // off by default: re-stretching to every viewport shifts colors on each
+  // pan/zoom, which reads as flicker; opt in via the checkbox / autostretch=1
+  autoStretch: () => fused.params.get('autostretch') === '1',
   vlo:   () => fused.params.get('vlo') || '',
   vhi:   () => fused.params.get('vhi') || '',
   dir:   () => fused.params.get('dir') || P.file().replace(/\/[^/]*$/, '') || '~',


### PR DESCRIPTION
## What

The geotiff viewer's **auto stretch** (re-stretch colors to the current viewport's 2–98th percentile after every pan/zoom) was on by default. This flips the default to **off** — the colormap stays pinned to the file's global stretch unless the user opts in.

Why: with auto stretch on, colors shift on every pan/zoom, which reads as flicker and makes the same value render as a different color depending on where you're looking.

One-line behavior change in `P.autoStretch()`: unset → off, `?autostretch=1` (or ticking the checkbox) → on. The manual "stretch → viewport" button and "reset stretch" are unchanged, and existing URLs that carry `autostretch=1` keep their behavior.

## Testing

Rendered the template end-to-end through a live app (`/render?path=…&file=<float32 DEM>`): checkbox starts unchecked, map renders with the global stretch, histogram/manual stretch buttons intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default flip in the geotiff template’s URL param parsing; no auth, data, or server changes.
> 
> **Overview**
> **Auto stretch** in the GeoTIFF viewer now defaults to **off** instead of on when `autostretch` is not set in the URL.
> 
> `P.autoStretch()` only returns true when `autostretch=1` (or the histogram checkbox is checked), so colormap stretch stays on the file’s global stretch during pan/zoom unless the user opts in. Links that already include `?autostretch=1` behave the same; manual **stretch → viewport** and **reset stretch** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31f86e261f52cd693822da6e5a1b0206844e4400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->