### PR TITLE
fix(mounts): stop rclone enumeration runaway that wedges NFS mounts

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -44,6 +44,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 from fastapi.staticfiles import StaticFiles
+from starlette.concurrency import iterate_in_threadpool, run_in_threadpool
 
 from fused_render import __version__
 from fused_render.account import router as account_router
@@ -155,6 +156,21 @@ S3_LIST_MAX_ENTRIES = 1_000
 # API storm. The walk truncates early and the existing `truncated` flag tells
 # the client search was bounded.
 WALK_MAX_ENTRIES_REMOTE = 2_000
+# Depth cap for a mount-backed walk, enforced INSIDE _walk_bfs so the generator
+# stops DESCENDING (stops enqueuing deeper dirs), not just the consumer. The
+# entry-count cap alone doesn't bound a deep, LOW-fan-out tree (e.g. NAIP
+# state/year/quad/tile): each level is one more remote LIST round-trip, and a
+# handful of children per level never trips the entry cap while the walk marches
+# arbitrarily deep. Kept generous enough for a real search (a few levels below a
+# bucket prefix) but finite so a search-as-you-type over a mount root can't kick
+# off an unbounded remote enumeration. Root is depth 0. Module-level so tests
+# can shrink it.
+WALK_MAX_DEPTH_REMOTE = 6
+# Depth cap for a LOCAL walk. Local listings are cheap kernel calls, so this is a
+# generous runaway guard (a symlink-free but pathologically deep tree) rather
+# than a budget — a normal project never approaches it. Module-level so tests can
+# shrink it.
+WALK_MAX_DEPTH_LOCAL = 40
 # Per-directory hard timeout for the rc listing of a mount-backed dir during a
 # walk (see _walk_bfs). Shorter than the interactive fs/list timeout: a walk
 # fans out across many directories, so a single slow/huge one is skipped (the
@@ -504,7 +520,7 @@ def _list_direct(path, cursor):
 _WALK_TRUNCATED = object()
 
 
-def _walk_bfs(path, include_hidden):
+def _walk_bfs(path, include_hidden, max_entries=None, max_depth=None):
     """Level-order walk of `path` yielding /api/fs/walk entry dicts.
 
     Breadth-first via a FIFO of pending directories: every entry at depth N is
@@ -524,6 +540,14 @@ def _walk_bfs(path, include_hidden):
     starts a nested repo with its own rules. Verdicts come from one streaming
     check-ignore co-process per repo (_IgnoreOracle), capped at
     WALK_MAX_ORACLES concurrently, all closed when the walk ends.
+
+    `max_entries`/`max_depth` bound the walk from INSIDE the generator, not just
+    the consumer: once `max_entries` entry dicts have been yielded the walk stops
+    (a low-fan-out subtree can't keep the consumer's cap from ever biting), and a
+    directory at `max_depth` is listed but its subdirs are never enqueued (a deep
+    chain can't march on forever below a mount root). Either bound, when it fires,
+    also emits a `_WALK_TRUNCATED` sentinel so the endpoint flags partial
+    coverage. `None` means unbounded on that axis.
     """
     from fused_render.shell import mounts as shell_mounts
 
@@ -545,9 +569,11 @@ def _walk_bfs(path, include_hidden):
         # I/O on the mount we're deliberately routing around.
         top = None if shell_mounts.is_mount_backed(path) else _repo_toplevel(path)
         top_rel = "" if top is None else os.path.relpath(path, top).replace(os.sep, "/")
-        queue = deque([(path, "", top, "" if top_rel == "." else top_rel)])
+        # 5th tuple element is depth (root = 0), used only for the max_depth cap.
+        queue = deque([(path, "", top, "" if top_rel == "." else top_rel, 0)])
+        emitted = 0  # entry dicts yielded so far (for the max_entries cap)
         while queue:
-            current, rel_base, repo, repo_rel_base = queue.popleft()
+            current, rel_base, repo, repo_rel_base, depth = queue.popleft()
             # Mount-backed dir: list it via the rcd rc API, off the kernel mount
             # (see rc_list_dir / the mur-sst incident). A dir that times out or
             # can't be listed is skipped and the walk moves on, rather than
@@ -642,6 +668,12 @@ def _walk_bfs(path, include_hidden):
                     files = [c for c in files if prefix + c.name not in ignored]
             dirs.sort(key=lambda e: e.name)
             files.sort(key=lambda e: e.name)
+            # Don't enqueue this dir's subdirs once we've hit the depth cap: a
+            # dir AT max_depth is still listed (its entries are yielded below),
+            # but the walk stops descending past it. Flagged so we emit one
+            # truncation sentinel per capped parent (not one per child).
+            can_descend = max_depth is None or depth < max_depth
+            depth_capped = False
             for child, is_dir in [(d, True) for d in dirs] + [(f, False) for f in files]:
                 try:
                     st = child.stat()
@@ -654,18 +686,32 @@ def _walk_bfs(path, include_hidden):
                     "size": None if is_dir else st.st_size,
                     "mtime": st.st_mtime,
                 }
+                # Entry-count cap enforced HERE, inside the generator, so the walk
+                # actually terminates early instead of the consumer draining a
+                # huge (or unbounded) tree. Flag partial coverage and stop.
+                emitted += 1
+                if max_entries is not None and emitted >= max_entries:
+                    yield _WALK_TRUNCATED
+                    return
                 if is_dir:
                     try:
                         is_link = child.is_symlink()
                     except OSError:
                         is_link = True  # can't tell — safer not to descend
                     if not is_link and not child.name.lower().endswith(WALK_LEAF_DIR_SUFFIXES):
+                        if not can_descend:
+                            depth_capped = True
+                            continue  # at the depth cap — don't enqueue deeper
                         repo_rel = (
                             (repo_rel_base + "/" + child.name if repo_rel_base else child.name)
                             if repo is not None
                             else ""
                         )
-                        queue.append((os.path.join(current, child.name), rel, repo, repo_rel))
+                        queue.append(
+                            (os.path.join(current, child.name), rel, repo, repo_rel, depth + 1)
+                        )
+            if depth_capped:
+                yield _WALK_TRUNCATED  # subtree(s) left unwalked at the depth cap
     finally:
         for oracle in oracles.values():
             oracle.close()
@@ -2812,8 +2858,16 @@ def create_app(start_dir: str) -> FastAPI:
         # deterministic tiebreak (same order for all three list routes).
         return _list_response(path, _sort_entries(entries), truncated, None)
 
+    # Poll request.is_disconnected() once every this many walked entries. The
+    # explorer search fires a fresh /api/fs/walk on each keystroke and abandons
+    # the previous one; without this the superseded walk would keep enumerating
+    # (over a mount, keep issuing remote LISTs) until it hit a cap. Checked
+    # between entries only — a single blocking directory listing can't be
+    # interrupted mid-call (same best-effort caveat as WALK_FLUSH_INTERVAL_S).
+    WALK_DISCONNECT_CHECK_EVERY = 64
+
     @app.get("/api/fs/walk")
-    def api_fs_walk(path: str, hidden: str = "0", stream: str = "0"):
+    async def api_fs_walk(request: Request, path: str, hidden: str = "0", stream: str = "0"):
         # Recursive listing of a directory subtree, for the explorer search
         # (flat, ranked client-side). Walks BREADTH-FIRST so shallow entries —
         # the ones a search almost always targets — are all emitted before any
@@ -2826,6 +2880,14 @@ def create_app(start_dir: str) -> FastAPI:
         # follows symlinks, and skips unreadable entries silently (matches
         # /api/fs/list). `rel` is posix-relative to `path`.
         #
+        # The walk is bounded on three axes so a search-as-you-type over a big
+        # (esp. mount) root can't kick off an unbounded enumeration: entry count
+        # and DEPTH (both enforced inside _walk_bfs — see its caps), and the HTTP
+        # request lifetime (if the client abandons this keystroke we stop pulling
+        # from the walk; see WALK_DISCONNECT_CHECK_EVERY). The blocking walk runs
+        # in a threadpool (iterate_in_threadpool) so this async route can poll for
+        # disconnect without stalling the event loop.
+        #
         # `hidden=1` (explicit intent: the user typed a dot-leading query)
         # includes dot-files and descends into dot-dirs. WALK_IGNORE_DIRS and
         # gitignore pruning apply regardless — those trees are noise, not
@@ -2836,9 +2898,8 @@ def create_app(start_dir: str) -> FastAPI:
         # lines (WALK_BATCH_SIZE each) followed by exactly one terminal
         # `{"done": true, "truncated": bool, "total": n}` line. The client
         # scores batches as they arrive, so first results paint while the walk
-        # is still running. Closing the connection cancels the walk (Starlette
-        # closes the generator on disconnect). Without `stream=1` the response
-        # is the original single-JSON shape, unchanged for old clients.
+        # is still running. Without `stream=1` the response is the original
+        # single-JSON shape, unchanged for old clients.
         include_hidden = hidden == "1"
         # Under a mount, os.path.isdir is itself a kernel GETATTR on the mount
         # we route around; _walk_bfs lists mount dirs via the rc API and simply
@@ -2846,22 +2907,28 @@ def create_app(start_dir: str) -> FastAPI:
         under_mount = shell_mounts.is_mount_backed(path)
         if not under_mount and not os.path.isdir(path):
             return _error(f"not a directory: {path}", status=400)
-        walker = _walk_bfs(path, include_hidden)
         # Remote-mount clamp: under a mount mountpoint every directory is a
-        # remote LIST round-trip, so the cap drops to WALK_MAX_ENTRIES_REMOTE
-        # (see the constant's comment).
+        # remote LIST round-trip, so both caps drop to their _REMOTE values (see
+        # the constants' comments). The caps are enforced INSIDE _walk_bfs so the
+        # walk terminates early instead of the consumer draining a huge tree.
         max_entries = WALK_MAX_ENTRIES_REMOTE if under_mount else WALK_MAX_ENTRIES
+        max_depth = WALK_MAX_DEPTH_REMOTE if under_mount else WALK_MAX_DEPTH_LOCAL
+        walker = _walk_bfs(path, include_hidden, max_entries=max_entries, max_depth=max_depth)
 
         # Force the ROOT listing eagerly (the first next() runs it) so a dead
         # mount / down rcd / timed-out or not-a-directory root fails with
         # fs/list's status codes instead of streaming a 200-empty body. Only the
         # ROOT raises out of _walk_bfs; deeper per-dir failures skip-and-continue
-        # (feeding the truncated flag via the _WALK_TRUNCATED sentinel).
+        # (feeding the truncated flag via the _WALK_TRUNCATED sentinel). Run in a
+        # threadpool: the root listing is blocking (a remote LIST under a mount).
+        def _pull_first():
+            try:
+                return next(walker), True
+            except StopIteration:
+                return None, False
+
         try:
-            first = next(walker)
-            have_first = True
-        except StopIteration:
-            first, have_first = None, False
+            first, have_first = await run_in_threadpool(_pull_first)
         except shell_mounts.RcListError as e:
             return _mount_list_error_response(path, e)
 
@@ -2873,7 +2940,11 @@ def create_app(start_dir: str) -> FastAPI:
         if stream != "1":
             entries = []
             truncated = False
-            for entry in _items():
+            seen = 0
+            async for entry in iterate_in_threadpool(_items()):
+                seen += 1
+                if seen % WALK_DISCONNECT_CHECK_EVERY == 0 and await request.is_disconnected():
+                    break  # client abandoned this keystroke — stop the walk
                 if entry is _WALK_TRUNCATED:
                     truncated = True  # a dir was cut / skipped (partial coverage)
                     continue
@@ -2883,12 +2954,16 @@ def create_app(start_dir: str) -> FastAPI:
                     break
             return {"path": path, "entries": entries, "truncated": truncated}
 
-        def ndjson():
+        async def ndjson():
             batch = []
             total = 0
             truncated = False
+            seen = 0
             last_flush = time.monotonic()
-            for entry in _items():
+            async for entry in iterate_in_threadpool(_items()):
+                seen += 1
+                if seen % WALK_DISCONNECT_CHECK_EVERY == 0 and await request.is_disconnected():
+                    return  # client abandoned this keystroke — stop the walk
                 if entry is _WALK_TRUNCATED:
                     truncated = True
                     continue

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1933,6 +1933,12 @@ def _fs_write(body: dict, x_fused: str | None):
 
 _LOCAL_POLL_S = 0.2   # local files: cheap os.stat, snappy reload
 _MOUNT_POLL_S = 5.0   # mount-backed files: rc stat, far less remote pressure
+# Mount-backed paths on a remote that is NOT direct_list_capable (e.g.
+# source.coop's custom S3 endpoint, not recognized as plain AWS S3): change
+# detection there costs a full rc_list_dir of the prefix, not a bounded unsigned
+# page. Poll such paths far less often to cut standing remote pressure, and skip
+# listing a mount ROOT entirely (see _mount_signal) — fs/events P1 #4.
+_MOUNT_SLOW_POLL_S = 60.0
 _STAT_TIMEOUT_S = 4.0  # a stat outliving this reports "unchanged" for this tick
 
 # Sentinel distinct from every real mtime signal (float, RFC3339 str, or None
@@ -1973,7 +1979,23 @@ class _WatchEntry:
 
         self.path = path
         self.is_mount = shell_mounts.is_mount_backed(path)
-        self.interval = _MOUNT_POLL_S if self.is_mount else _LOCAL_POLL_S
+        # Both flags below are pure path/config checks (no remote I/O): they fix
+        # the poll interval and the change-detection strategy once, at creation.
+        if self.is_mount:
+            # direct_list_capable: the remote can be enumerated by a cheap,
+            # bounded unsigned page (anonymous AWS S3 / GCS). When it CAN'T, a
+            # directory child-change signal would require a full rc_list_dir of
+            # the prefix — the standing enumeration we avoid (see _mount_signal).
+            self._direct_capable = shell_mounts.direct_list_capable(path)
+            # A mount ROOT lists the remote's top prefix (or the whole bucket):
+            # never poll-list it on a non-direct remote.
+            self._is_mount_root = shell_mounts.is_mount_root(path)
+            self.interval = (_MOUNT_POLL_S if self._direct_capable
+                             else _MOUNT_SLOW_POLL_S)
+        else:
+            self._direct_capable = False
+            self._is_mount_root = False
+            self.interval = _LOCAL_POLL_S
         self.subscribers: set = set()  # asyncio.Queue per socket
         self.last = _UNCHANGED  # primed by the first successful read
         self._inflight = None   # in-progress stat task; guards against pile-up
@@ -2015,6 +2037,21 @@ class _WatchEntry:
             which likewise falls back to operations/stat ModTime.
         Any failure/timeout -> _UNCHANGED (never an error storm)."""
         from fused_render.shell import mounts as shell_mounts
+
+        # A mount ROOT lists the remote's top prefix — or the whole bucket for a
+        # bucket-root mount — which on a world-scale remote is enormous. When the
+        # remote is NOT direct_list_capable (e.g. source.coop's custom S3
+        # endpoint, not recognized as plain AWS S3), the only way to hash its
+        # listing is an rc_list_dir of that entire prefix. Running that on every
+        # tick for the life of an open pane is a standing background enumeration
+        # (fs/events P1 #4), so we refuse it: change detection for such a root is
+        # best-effort (no live child-change events). Direct-capable roots keep
+        # their bounded single unsigned page below; non-root paths (which the
+        # widened _MOUNT_SLOW_POLL_S interval already de-pressurizes) are
+        # unaffected. self._direct_capable is the init-time classification; the
+        # branch below re-derives it live so tests can stub the backend check.
+        if self._is_mount_root and not self._direct_capable:
+            return _UNCHANGED
 
         try:
             if shell_mounts.direct_list_capable(self.path):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -34,6 +34,8 @@ import urllib.request
 from pathlib import Path
 from urllib.parse import parse_qsl, urlsplit
 
+import httpx
+
 from fastapi import Body, FastAPI, Header, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import (
     FileResponse,
@@ -1684,6 +1686,40 @@ def _proxy_raw(upstream: str, request: Request):
     return StreamingResponse(body(), status_code=r.status, headers=out)
 
 
+async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
+                            request: Request):
+    """Opt-in pooled proxy of a store's *signed* URL (TASK F). Same forwarded
+    header set (_PROXY_HEADERS) and status pass-through (206/416/404) as
+    _proxy_raw, but streams through a shared keep-alive httpx pool so a burst of
+    range reads reuses sockets to the store instead of paying urllib's fresh
+    TLS handshake + redirect round trip per block. Returns None only when the
+    store is unreachable at the connection level — the caller then falls back to
+    the 307 so the read still completes. Async (awaited on the event loop): the
+    pool is the point, and to_thread'ing a sync client would defeat it."""
+    headers = {}
+    rng = request.headers.get("range")
+    if rng:
+        headers["Range"] = rng
+    req = client.build_request(request.method, upstream, headers=headers)
+    try:
+        r = await client.send(req, stream=True)
+    except httpx.HTTPError:
+        return None
+    out = {k: v for k, v in r.headers.items() if k.lower() in _PROXY_HEADERS}
+    if request.method == "HEAD":
+        await r.aclose()
+        return Response(status_code=r.status_code, headers=out)
+
+    async def body():
+        try:
+            async for chunk in r.aiter_bytes(256 * 1024):
+                yield chunk
+        finally:
+            await r.aclose()
+
+    return StreamingResponse(body(), status_code=r.status_code, headers=out)
+
+
 def _stat_or_none(path: str) -> os.stat_result | None:
     """stat() for /api/fs/raw's 404 gate: None for missing paths and
     non-regular files alike (a directory has no raw bytes to serve)."""
@@ -2555,6 +2591,27 @@ def create_app(start_dir: str) -> FastAPI:
 
     app = FastAPI(title="fused-render")
 
+    # Shared keep-alive HTTP pool for the opt-in pooled /api/fs/raw proxy
+    # (TASK F). The pyramid/geotiff workers range-read a store's signed URL one
+    # ~64KB block at a time; a per-block urllib GET (and, before this, a 307
+    # they re-followed per block) pays a fresh TLS handshake every read — serial,
+    # multi-second cold. One AsyncClient with a connection pool lets those range
+    # reads reuse sockets to the store. Created at startup, closed at shutdown,
+    # stashed on app.state so api_fs_raw can await through it.
+    @app.on_event("startup")
+    async def _open_pooled_client():
+        app.state.pooled_client = httpx.AsyncClient(
+            timeout=httpx.Timeout(120.0),
+            limits=httpx.Limits(max_keepalive_connections=32,
+                                max_connections=64),
+        )
+
+    @app.on_event("shutdown")
+    async def _close_pooled_client():
+        client = getattr(app.state, "pooled_client", None)
+        if client is not None:
+            await client.aclose()
+
     @app.exception_handler(Exception)
     async def unhandled_exception(request, exc):
         # A bare "Internal Server Error" with an empty body is undebuggable on
@@ -3021,7 +3078,8 @@ def create_app(start_dir: str) -> FastAPI:
         return StreamingResponse(ndjson(), media_type="application/x-ndjson")
 
     @app.api_route("/api/fs/raw", methods=["GET", "HEAD"])
-    async def api_fs_raw(path: str, request: Request, base: str | None = None):
+    async def api_fs_raw(path: str, request: Request, base: str | None = None,
+                         pooled: str | None = None):
         # Page-relative resolution (SPEC RH-1): a *relative* `path` is resolved against
         # the directory of `base` — the page's own absolute path, sent by the runtime's
         # fused.rawUrl(), the same contract /api/run uses via `html` (see the resolve at
@@ -3114,6 +3172,22 @@ def create_app(start_dir: str) -> FastAPI:
                 direct = await asyncio.to_thread(
                     shell_mounts.upstream_url_for, path)
                 if direct:
+                    # OPT-IN pooled proxy (TASK F): the pyramid/geotiff workers
+                    # read this file with a plain per-block urllib GET and would
+                    # otherwise re-follow the 307 to the store on EVERY ~64KB
+                    # block — a fresh TLS handshake + redirect round trip per
+                    # read, serial, multi-second cold. When they set &pooled=1
+                    # we stream the same signed URL back through a shared
+                    # keep-alive httpx pool (sockets reused across range reads).
+                    # duckdb/parquet never set the flag, so they still get the
+                    # 307 and their own pooled parallel connections — no
+                    # regression. A pooled fetch that can't reach the store
+                    # returns None and falls through to the 307.
+                    if pooled:
+                        resp = await _proxy_raw_pooled(
+                            request.app.state.pooled_client, direct, request)
+                        if resp is not None:
+                            return resp
                     return RedirectResponse(direct, status_code=307)
             # Not redirected (browser, warm read, or no direct URL): proxy the
             # bytes. Guard non-files here — the cold redirect path above is the

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -656,26 +656,41 @@ def _rc_cancellable(port: int, method: str, params: dict | None = None,
     submit = _rc(port, method, p, timeout=min(timeout, 10))
     jobid = submit.get("jobid") if isinstance(submit, dict) else None
     if jobid is None:
-        # No jobid handed back (a command that doesn't honor _async, or an
-        # unexpected shape): fall back to a plain synchronous call on whatever
-        # budget remains, so behavior degrades to the old path rather than break.
+        # No jobid handed back. If the peer IGNORED _async and ran the command
+        # synchronously, `submit` already holds the full payload (operations/list
+        # -> {"list": [...]}, operations/stat -> {"item": ...}) — return it rather
+        # than re-issuing the same unbounded enumeration a second time. Only a
+        # truly empty/absent ack falls back to a fresh sync call on the remaining
+        # budget, so behavior still degrades to the old path when there's nothing
+        # to reuse.
+        if isinstance(submit, dict) and submit:
+            return submit
         remaining = deadline - time.monotonic()
         return _rc(port, method, params, timeout=max(remaining, 0.1))
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
-        status = _rc(port, "job/status", {"jobid": jobid},
-                     timeout=min(remaining, 10))
+        try:
+            status = _rc(port, "job/status", {"jobid": jobid},
+                         timeout=min(remaining, 10))
+        except RuntimeError:
+            # Polling itself failed — common near the deadline when the budget
+            # (min(remaining, 10)) is tiny, or when a busy rcd is slow to answer.
+            # Do NOT let it propagate uncancelled: break out and stop the job
+            # below so the in-flight enumeration can't outlive us (the INCIDENT).
+            logger.warning("rc job/status failed for job %s; cancelling",
+                           jobid, exc_info=True)
+            break
         if isinstance(status, dict) and status.get("finished"):
             if status.get("error"):
                 raise RuntimeError(status["error"])  # sync error path equivalent
             out = status.get("output")
             return out if isinstance(out, dict) else {}
         time.sleep(min(_RC_JOB_POLL_S, max(deadline - time.monotonic(), 0)))
-    # Deadline passed with the job still running: cancel it server-side so
-    # rclone stops enumerating (the whole point), then raise a timeout the
-    # callers recognize. job/stop failing is non-fatal — we still raise.
+    # Deadline passed (or polling failed) with the job still running: cancel it
+    # server-side so rclone stops enumerating (the whole point), then raise a
+    # timeout the callers recognize. job/stop failing is non-fatal — we still raise.
     try:
         _rc(port, "job/stop", {"jobid": jobid}, timeout=3)
     except RuntimeError:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -441,6 +441,75 @@ def _rc(port: int, method: str, params: dict | None = None, timeout: float = 30)
         raise RuntimeError(f"rclone rc {method}: {e}") from e
 
 
+# Poll cadence for a cancellable async job. A job/status round trip is cheap, so
+# a tight interval keeps the added latency of the async path (vs. a synchronous
+# _rc) down to one poll for a fast-finishing call — the list/stat hot path pays
+# ~this, not a full second.
+_RC_JOB_POLL_S = 0.05
+
+
+def _rc_cancellable(port: int, method: str, params: dict | None = None,
+                    timeout: float = 30):
+    """Like _rc, but runs `method` as a CANCELLABLE rclone job so a timed-out
+    call actually stops rclone's server-side work instead of orphaning it.
+
+    Why this exists (the 14h-runaway INCIDENT): operations/list and
+    operations/stat make rclone run an UNBOUNDED ListObjectsV2 over the whole
+    prefix (see rc_list_dir / _rc_stat_item). A plain urlopen socket timeout
+    only abandons the CLIENT socket — rclone KEEPS enumerating, and repeated
+    timed-out calls pile up orphaned walks that pinned a CPU for 14h. Submitting
+    with `_async=true` returns a {"jobid": N} immediately; we poll job/status
+    until the job finishes or the deadline passes, and on timeout call job/stop
+    so rclone's context cancellation propagates into the S3 lister and the walk
+    STOPS.
+
+    Returns the job's `output` dict — the SAME shape the synchronous _rc call
+    returns for this method (operations/list -> {"list": [...]}, operations/stat
+    -> {"item": ...}). Raises RuntimeError exactly where _rc would, so callers
+    keep their existing except handling:
+      - deadline exceeded -> raised FROM a TimeoutError, so _rc_timed_out()
+        recognizes it (rc_list_dir maps it to RcListTimeout; _rc_stat_item to
+        the indeterminate sentinel);
+      - a failed job      -> raised with rclone's own error message and NO
+        timeout cause (rc_list_dir maps it to RcListError, same as the sync
+        HTTPError path)."""
+    deadline = time.monotonic() + timeout
+    p = dict(params or {})
+    p["_async"] = True
+    # Submitting a job returns at once (only the enumeration is slow), so cap the
+    # submit round trip modestly rather than granting it the whole budget.
+    submit = _rc(port, method, p, timeout=min(timeout, 10))
+    jobid = submit.get("jobid") if isinstance(submit, dict) else None
+    if jobid is None:
+        # No jobid handed back (a command that doesn't honor _async, or an
+        # unexpected shape): fall back to a plain synchronous call on whatever
+        # budget remains, so behavior degrades to the old path rather than break.
+        remaining = deadline - time.monotonic()
+        return _rc(port, method, params, timeout=max(remaining, 0.1))
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        status = _rc(port, "job/status", {"jobid": jobid},
+                     timeout=min(remaining, 10))
+        if isinstance(status, dict) and status.get("finished"):
+            if status.get("error"):
+                raise RuntimeError(status["error"])  # sync error path equivalent
+            out = status.get("output")
+            return out if isinstance(out, dict) else {}
+        time.sleep(min(_RC_JOB_POLL_S, max(deadline - time.monotonic(), 0)))
+    # Deadline passed with the job still running: cancel it server-side so
+    # rclone stops enumerating (the whole point), then raise a timeout the
+    # callers recognize. job/stop failing is non-fatal — we still raise.
+    try:
+        _rc(port, "job/stop", {"jobid": jobid}, timeout=3)
+    except RuntimeError:
+        logger.warning("rc job/stop failed for job %s", jobid, exc_info=True)
+    raise RuntimeError(
+        f"rc {method} timed out after {timeout:g}s (job {jobid} cancelled)"
+    ) from TimeoutError()
+
+
 # A live-port probe (core/pid over the loopback rc port, timeout=3) runs on
 # EVERY rc-routed call — rc_list_dir, rc_mtime_for, _remote_config, the S3
 # capability check. A single fs/walk fans that probe out across every directory
@@ -838,8 +907,11 @@ def _rc_stat_item(path: str, *, timeout: float = RC_STAT_TIMEOUT_S):
     # rc_list_dir).
     remote = "" if rel == "." else rel
     try:
-        resp = _rc(port, "operations/stat",
-                   {"fs": m["remote"], "remote": remote}, timeout=timeout)
+        # Cancellable: operations/stat runs an UNBOUNDED ListObjectsV2 on a
+        # negative/dir probe, so a timed-out sync call would orphan that walk.
+        resp = _rc_cancellable(port, "operations/stat",
+                               {"fs": m["remote"], "remote": remote},
+                               timeout=timeout)
     except RuntimeError:
         return _STAT_INDETERMINATE
     if not isinstance(resp, dict) or "item" not in resp:
@@ -1060,9 +1132,11 @@ def rc_list_dir(path: str, timeout: float | None = None) -> list:
     # operations/stat has).
     remote = "" if rel == "." else rel
     try:
-        resp = _rc(port, "operations/list",
-                   {"fs": m["remote"], "remote": remote,
-                    "opt": {"noMimeType": True}}, timeout=timeout)
+        # Cancellable: operations/list enumerates the WHOLE prefix (the mur-sst
+        # runaway), so on timeout we job/stop it instead of orphaning the walk.
+        resp = _rc_cancellable(port, "operations/list",
+                               {"fs": m["remote"], "remote": remote,
+                                "opt": {"noMimeType": True}}, timeout=timeout)
     except RuntimeError as e:
         if _rc_timed_out(e):
             raise RcListTimeout(f"listing {path} timed out after {timeout:g}s") from e

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -826,6 +826,19 @@ def is_mounts_root(path: str) -> bool:
     return os.path.abspath(path) == os.path.abspath(mounts_dir())
 
 
+def is_mount_root(path: str) -> bool:
+    """True when `path` is the ROOT of an individual mount (its mountpoint), as
+    opposed to a subpath inside it. A single-level listing of a mount root is a
+    listing of the remote's top prefix — or the whole bucket for a bucket-root
+    mount — which on a world-scale remote is enormous. Callers use this to avoid
+    a standing periodic enumeration of such a prefix (fs/events P1 #4). The
+    mounts container itself counts as a root too. Pure string/abspath — no I/O."""
+    if is_mounts_root(path):
+        return True
+    m, rel = _mount_for(path)
+    return m is not None and rel == "."
+
+
 def rc_mtime_for(path: str) -> str | None:
     """ModTime of a mount-backed file, answered by the rclone rcd rc API
     (operations/stat) instead of the kernel NFS mount.

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -27,6 +27,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import socket
 import stat as stat_mod
 import subprocess
@@ -384,6 +385,145 @@ def _rcd_state_path() -> str:
     return os.path.join(storage.home_dir(), "rcd.json")
 
 
+def _rcd_registry_path() -> str:
+    """Path to the central registry of every rcd this machine has spawned,
+    one entry per home (state) dir.
+
+    Unlike rcd.json — which lives INSIDE home_dir() and so vanishes with the
+    dir when a pytest temp home is rmtree'd or a git worktree is deleted, taking
+    the only record of that daemon's pid with it — the registry lives at the
+    BASELINE home (never branch-nested). One registry is shared by the baseline
+    run and every per-branch/worktree run, so reap_stale_rcd() on any run can
+    still see, and reap, a daemon whose own (now-deleted) home would otherwise
+    leave no trace. This is the ONLY place we learn the pid of a daemon whose
+    home dir is already gone."""
+    base = os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
+    return os.path.join(base, "rcd-registry.json")
+
+
+def _register_rcd(pid: int, port: int) -> None:
+    """Record a freshly spawned daemon in the central registry, keyed by its
+    home dir (a new daemon for the same home replaces the old record). Purely
+    additive breadcrumb for reap_stale_rcd — a failure here must never fail a
+    mount, so it's swallowed."""
+    try:
+        home = storage.home_dir()
+        reg = storage.read_json(_rcd_registry_path())
+        entries = [e for e in reg if isinstance(e, dict)] if isinstance(reg, list) else []
+        entries = [e for e in entries if e.get("dir") != home]  # dedupe by home
+        entries.append({"pid": pid, "port": port, "dir": home})
+        storage.write_json(_rcd_registry_path(), entries)
+    except OSError:
+        logger.warning("rcd registry write failed", exc_info=True)
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if a process with `pid` currently exists. Signal 0 probes without
+    delivering anything; EPERM means it exists but is owned by someone else."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pid_looks_like_rcd(pid: int) -> bool:
+    """True only when pid's command line is recognisably an `rclone ... rcd`.
+
+    A conservative identity guard: the reaper must NEVER signal a process that
+    merely inherited a pid we once recorded (pids are recycled). Best-effort —
+    any ps failure is treated as 'not confirmed', so we fail closed (don't
+    kill on doubt)."""
+    if not pid or pid <= 0:
+        return False
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=3,
+        ).stdout.lower()
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return "rclone" in out and "rcd" in out
+
+
+def _confirmed_our_rcd(entry: dict) -> bool:
+    """Proof that entry's pid IS the rclone rcd we recorded, gating a kill.
+    Two independent checks, either suffices: (1) the recorded rc port still
+    answers core/pid with the recorded pid; (2) the pid's command line is an
+    rclone rcd. Both fail closed."""
+    pid = entry.get("pid") or 0
+    port = entry.get("port")
+    if port:
+        try:
+            if _rc(int(port), "core/pid", timeout=3).get("pid") == pid:
+                return True
+        except (RuntimeError, ValueError, TypeError):
+            pass
+    return _pid_looks_like_rcd(pid)
+
+
+def reap_stale_rcd() -> None:
+    """Kill rcd daemons that outlived the home/worktree that spawned them, and
+    prune dead entries from the registry. Best-effort and deliberately
+    CONSERVATIVE — the rcd is spawned detached and 'outlives the server on
+    purpose', so nothing else ever reaps it; days-old orphans from finished
+    pytest runs and deleted worktrees are the observed failure mode.
+
+    An entry is only ever killed when BOTH hold:
+      * its recorded home (state) dir no longer exists  -> orphaned, AND
+      * the pid is still alive AND provably our rclone rcd (_confirmed_our_rcd).
+    Then it gets a SIGTERM (rcd unmounts cleanly on SIGTERM) and its registry
+    entry is dropped.
+
+    Everything else is left as safe as possible:
+      * home dir still present            -> assumed in use, untouched (this is
+                                             also the daemon we're about to
+                                             reuse/spawn);
+      * pid already dead                  -> just drop the stale registry entry;
+      * orphaned but NOT provably ours    -> left in the registry, never
+                                             blind-killed, for a later run to
+                                             reconsider.
+
+    Wired into the (rare) spawn path of _ensure_rcd_locked, not a timer."""
+    reg = storage.read_json(_rcd_registry_path())
+    if not isinstance(reg, list):
+        return
+    kept: list = []
+    changed = False
+    for e in reg:
+        if not isinstance(e, dict):
+            changed = True
+            continue
+        pid = e.get("pid") or 0
+        home = e.get("dir")
+        home_present = isinstance(home, str) and os.path.isdir(home)
+        if home_present:
+            kept.append(e)  # dir present -> in use, leave alone
+            continue
+        # home dir is gone -> candidate orphan
+        if not _pid_alive(pid):
+            changed = True  # already dead: drop the stale record
+            continue
+        if _confirmed_our_rcd(e):
+            try:
+                os.kill(pid, signal.SIGTERM)
+                logger.info("reaped orphaned rcd pid=%s (home %s gone)", pid, home)
+            except OSError:
+                logger.warning("failed to signal orphaned rcd pid=%s", pid, exc_info=True)
+            changed = True  # drop after signalling
+        else:
+            kept.append(e)  # alive but unidentifiable -> never blind-kill
+    if changed:
+        try:
+            storage.write_json(_rcd_registry_path(), kept)
+        except OSError:
+            logger.warning("rcd registry prune failed", exc_info=True)
+
+
 def _rcd_log_path() -> str:
     return os.path.join(storage.home_dir(), "rcd.log")
 
@@ -447,6 +587,10 @@ def write_rcd_state(port: int, pid: int, log_path: str | None = None) -> None:
         _rcd_state_path(),
         {"port": port, "pid": pid, "log": log_path or _rcd_log_path()},
     )
+    # Also record in the central registry so a future run can reap this daemon
+    # even after its home dir (and this rcd.json) is deleted (INCIDENT: leaked
+    # rcd daemons outliving pytest runs / deleted worktrees for days).
+    _register_rcd(pid, port)
 
 
 def _rc(port: int, method: str, params: dict | None = None, timeout: float = 30):
@@ -613,6 +757,13 @@ def _ensure_rcd_locked() -> int:
     port = _live_rcd_port()
     if port is not None:
         return port
+    # About to spawn a fresh daemon — a natural, rare moment to opportunistically
+    # reap any rcd that outlived a deleted home/worktree (best-effort, never
+    # blocks the spawn; NOT on a timer). The hot reuse path above skips this.
+    try:
+        reap_stale_rcd()
+    except Exception:
+        logger.warning("reap_stale_rcd failed", exc_info=True)
     bin_ = rclone_bin()
     if not bin_:
         raise RuntimeError("rclone is not installed")

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -165,7 +165,15 @@ SERVE_VFS_OPT = _serve_params(VFS_OPT)
 # forwards verbatim as `-o` flags to the macOS `mount` command (verified in
 # the rcd -vv log). nfsmount only — the Linux path uses FUSE `mount`, which
 # ignores these NFS options.
-NFS_MOUNT_OPT = {"ExtraOptions": ["timeo=600", "retrans=2"]}
+#
+# "nobrowse" is a standard macOS mount flag (`mount_nfs -o nobrowse`): it keeps
+# the volume out of Finder's sidebar/desktop and off Spotlight's auto-scan
+# radar. Without it, Finder browsing or Spotlight indexing walks the mount with
+# readdir, which on an S3-backed remote turns into a full prefix enumeration —
+# a latent mount-wedge trigger even when no app touches the mount. Harmless on
+# Linux (FUSE ignores it), but only ever passed on darwin anyway (see
+# _nfs_mount_opt / attach_mount).
+NFS_MOUNT_OPT = {"ExtraOptions": ["timeo=600", "retrans=2", "nobrowse"]}
 
 
 # INCIDENT (2026-07-16): a mount recorded read_only=true in mounts.json still
@@ -263,6 +271,29 @@ def _path() -> str:
 
 def mounts_dir() -> str:
     return os.path.join(storage.home_dir(), "mounts")
+
+
+def ensure_mounts_dir() -> str:
+    """Create the mounts root and mark it so macOS Spotlight never indexes it,
+    returning the path. A `.metadata_never_index` marker in a directory tells
+    mds (the Spotlight daemon) to skip the whole subtree — the simplest,
+    permission-safe, no-subprocess way to keep Spotlight from auto-walking the
+    S3-backed mounts with readdir (a prefix-enumeration mount-wedge trigger,
+    the browse-side companion to the "nobrowse" mount flag above). Dropped at
+    the root, not per-mount, so it covers mountpoints created later too. A
+    best-effort `mdutil -i off` would need privileges and often no-ops, so the
+    marker is the primary mechanism; we don't shell out. Idempotent."""
+    root = mounts_dir()
+    os.makedirs(root, exist_ok=True)
+    marker = os.path.join(root, ".metadata_never_index")
+    if not os.path.exists(marker):
+        try:
+            with open(marker, "w"):
+                pass
+        except OSError:
+            # Non-fatal: the mount still works, it just isn't Spotlight-excluded.
+            pass
+    return root
 
 
 def list_mounts() -> list:
@@ -1960,6 +1991,10 @@ def _sync_serves_locked() -> None:
 def attach_mount(m: dict) -> str | None:
     """Mount via rcd; returns an error string or None."""
     mp = mountpoint(m)
+    # Create the mounts root (with its Spotlight-exclusion marker) before the
+    # per-mount mountpoint, so the marker is in place the moment the mount goes
+    # live and Spotlight never gets a chance to scan it.
+    ensure_mounts_dir()
     os.makedirs(mp, exist_ok=True)
     if os.path.ismount(mp):
         # Already a kernel mount — but is it OURS? A stale mount left by a

--- a/fused_render/templates/geotiff/tile_server.py
+++ b/fused_render/templates/geotiff/tile_server.py
@@ -301,7 +301,15 @@ def _serve():
         I/O — so it's safe to call under files_lock. The caller closes the
         returned old buffer outside the lock and spawns _prefetch_overviews
         once f is visible to other threads."""
-        f["reader"] = _RangeReader(_server_url(src, "/api/fs/raw", path))
+        # &pooled=1: this reader does one Range GET per ~64KB block over the
+        # server's /api/fs/raw. On a cold mount that endpoint 307-redirects to
+        # the store's signed URL, and urllib would re-follow it (fresh TLS) on
+        # every block. The flag opts this read into the server's pooled proxy
+        # so those range reads share keep-alive sockets to the store. Just a
+        # query param on the endpoint we already use — the template stays
+        # mount-agnostic.
+        f["reader"] = _RangeReader(
+            _server_url(src, "/api/fs/raw", path) + "&pooled=1")
         old, f["buf"] = f["buf"], None
         return old
 

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -621,7 +621,13 @@ def main(file: str = "", action: str = "analyze", resampling: str = "",
         # here) + size, so every rasterio/tifffile open goes over HTTP range
         # reads. Never a kernel open/mmap of a file the server called remote.
         opts["remote"] = True
-        opts["raw_url"] = _server_url(src, "/api/fs/raw", file)
+        # &pooled=1: the worker's _HttpRangeFile does one Range GET per ~64KB
+        # block. On a cold mount /api/fs/raw 307-redirects to the store's signed
+        # URL and urllib re-follows it (fresh TLS) every block. The flag opts
+        # this read into the server's pooled proxy so the range reads share
+        # keep-alive sockets to the store — just a query param on the endpoint
+        # the template already uses (stays mount-agnostic).
+        opts["raw_url"] = _server_url(src, "/api/fs/raw", file) + "&pooled=1"
         if remote_size is not None:
             opts["size"] = remote_size
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,10 @@ never use. The dirs we create are removed at process exit.
 import atexit
 import os
 import shutil
+import signal
 import tempfile
+
+import pytest
 
 for _var, _prefix in (("FUSED_RENDER_HOME", "fused-render-tests-"),
                        ("FUSED_RENDER_DIR", "fused-render-tests-dir-")):
@@ -25,3 +28,49 @@ for _var, _prefix in (("FUSED_RENDER_HOME", "fused-render-tests-"),
         _tmp = tempfile.mkdtemp(prefix=_prefix)
         os.environ[_var] = _tmp
         atexit.register(shutil.rmtree, _tmp, ignore_errors=True)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _reap_test_rcd_daemons():
+    """Kill any REAL rclone rcd daemon a test spawned, on session teardown.
+
+    The rcd daemon is spawned detached and "outlives the server on purpose"
+    (mounts.ensure_rcd) — nothing in the app kills it. A test that drives a real
+    spawn (not the StubRcd stand-in) therefore leaks a daemon that survives the
+    pytest process, which is exactly how days-old orphaned rcd daemons pile up.
+
+    We wrap mounts.write_rcd_state — the one call every spawn makes to record its
+    {port, pid} — to track every (pid, home) recorded during the session, then
+    on teardown SIGTERM the ones that are ALL of:
+      (a) recorded under a throwaway temp home (never a user's real
+          ~/.fused-render daemon — that's the strict provenance guard), AND
+      (b) still alive, AND
+      (c) provably an rclone rcd (mounts._pid_looks_like_rcd).
+    The StubRcd fixture records a FAKE pid (4242); guard (c) means we never
+    signal it, nor whatever unrelated process happens to hold a recycled pid."""
+    import fused_render.shell.mounts as mounts
+
+    tracked = []  # (pid, home) recorded this session
+    original = mounts.write_rcd_state
+
+    def _tracking_write_rcd_state(port, pid, log_path=None):
+        original(port, pid, log_path)
+        try:
+            tracked.append((pid, mounts.storage.home_dir()))
+        except Exception:
+            pass
+
+    mounts.write_rcd_state = _tracking_write_rcd_state
+    try:
+        yield
+    finally:
+        mounts.write_rcd_state = original
+        tmp_root = os.path.realpath(tempfile.gettempdir())
+        for pid, home in tracked:
+            try:
+                if not os.path.realpath(str(home)).startswith(tmp_root):
+                    continue  # provenance guard: only temp-home test daemons
+                if mounts._pid_alive(pid) and mounts._pid_looks_like_rcd(pid):
+                    os.kill(pid, signal.SIGTERM)
+            except Exception:
+                pass

--- a/tests/test_daemon_reaper.py
+++ b/tests/test_daemon_reaper.py
@@ -1,0 +1,169 @@
+"""Tests for the rcd daemon reaper (shell/mounts.reap_stale_rcd) and the
+guard primitives the pytest session-teardown fixture (tests/conftest.py
+_reap_test_rcd_daemons) relies on.
+
+The rcd daemon is spawned detached and outlives the server on purpose, with no
+reaper — so finished pytest runs and deleted worktrees leave orphaned daemons
+alive for days. These tests exercise reaping WITHOUT touching real system
+processes: the only process we ever signal is a short-lived subprocess we spawn
+ourselves, and the rclone-identity guard is monkeypatched for it.
+"""
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    """Redirect FUSED_RENDER_HOME (and hence the registry path) into tmp."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    monkeypatch.delenv("FUSED_RENDER_BRANCH", raising=False)
+    return home
+
+
+def _spawn_sleeper():
+    """A real, harmless child process to stand in for a leaked rcd — so a
+    SIGTERM lands on something we own, never a system process."""
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+
+
+def _wait_dead(proc, timeout=5.0):
+    try:
+        proc.wait(timeout=timeout)
+        return True
+    except subprocess.TimeoutExpired:
+        return False
+
+
+def test_reap_kills_orphan_with_gone_dir_and_keeps_live(home, tmp_path, monkeypatch):
+    # A daemon whose home dir is gone (orphan) alongside one whose home dir
+    # still exists (in use). Only the orphan may be killed.
+    orphan = _spawn_sleeper()
+    try:
+        gone_home = str(tmp_path / "gone")  # never created -> dir is absent
+        live_home = str(tmp_path / "live")
+        os.makedirs(live_home)
+
+        # The orphan's rc port is dead, so _confirmed_our_rcd must fall through
+        # to the (monkeypatched) command-line identity check.
+        monkeypatch.setattr(
+            mounts_mod, "_pid_looks_like_rcd",
+            lambda pid: pid == orphan.pid,
+        )
+
+        registry = [
+            {"pid": orphan.pid, "port": 0, "dir": gone_home},
+            {"pid": os.getpid(), "port": 0, "dir": live_home},  # this test proc
+        ]
+        mounts_mod.storage.write_json(mounts_mod._rcd_registry_path(), registry)
+
+        mounts_mod.reap_stale_rcd()
+
+        # Orphan was signalled and actually terminated.
+        assert _wait_dead(orphan), "orphaned daemon should have been SIGTERM'd"
+
+        # Registry now holds only the live entry; orphan entry was pruned.
+        remaining = mounts_mod.storage.read_json(mounts_mod._rcd_registry_path())
+        assert remaining == [{"pid": os.getpid(), "port": 0, "dir": live_home}]
+    finally:
+        if orphan.poll() is None:
+            orphan.kill()
+            orphan.wait()
+
+
+def test_reap_leaves_orphan_it_cannot_identify(home, tmp_path, monkeypatch):
+    # Home dir gone AND pid alive, but NOT provably our rclone rcd -> must NOT
+    # be killed, and its entry must be retained for a later run.
+    survivor = _spawn_sleeper()
+    try:
+        gone_home = str(tmp_path / "gone")
+        monkeypatch.setattr(mounts_mod, "_pid_looks_like_rcd", lambda pid: False)
+        entry = {"pid": survivor.pid, "port": 0, "dir": gone_home}
+        mounts_mod.storage.write_json(mounts_mod._rcd_registry_path(), [entry])
+
+        mounts_mod.reap_stale_rcd()
+
+        assert survivor.poll() is None, "unidentifiable process must not be killed"
+        remaining = mounts_mod.storage.read_json(mounts_mod._rcd_registry_path())
+        assert remaining == [entry]
+    finally:
+        survivor.kill()
+        survivor.wait()
+
+
+def test_reap_drops_dead_pid_entry_without_killing(home, tmp_path):
+    # Home dir gone and pid already dead -> just clean the stale registry entry.
+    dead = _spawn_sleeper()
+    dead.kill()
+    dead.wait()
+    gone_home = str(tmp_path / "gone")
+    mounts_mod.storage.write_json(
+        mounts_mod._rcd_registry_path(),
+        [{"pid": dead.pid, "port": 0, "dir": gone_home}],
+    )
+
+    mounts_mod.reap_stale_rcd()
+
+    assert mounts_mod.storage.read_json(mounts_mod._rcd_registry_path()) == []
+
+
+def test_write_rcd_state_registers_daemon(home):
+    # write_rcd_state must record the daemon in the central registry keyed by
+    # home, so the reaper can find it after the home dir is gone.
+    mounts_mod.write_rcd_state(12345, 999, log_path=str(home / "rcd.log"))
+    reg = mounts_mod.storage.read_json(mounts_mod._rcd_registry_path())
+    assert reg == [{"pid": 999, "port": 12345, "dir": str(home)}]
+
+    # A re-spawn for the same home replaces (not duplicates) the entry.
+    mounts_mod.write_rcd_state(23456, 1001, log_path=str(home / "rcd.log"))
+    reg = mounts_mod.storage.read_json(mounts_mod._rcd_registry_path())
+    assert reg == [{"pid": 1001, "port": 23456, "dir": str(home)}]
+
+
+def test_pid_alive_and_identity_guard(home, monkeypatch):
+    # The primitives the conftest teardown fixture gates every kill on.
+    proc = _spawn_sleeper()
+    try:
+        assert mounts_mod._pid_alive(proc.pid) is True
+        assert mounts_mod._pid_alive(0) is False
+    finally:
+        proc.kill()
+        proc.wait()
+    assert mounts_mod._pid_alive(proc.pid) is False
+
+
+def test_conftest_teardown_guard_terminates_tracked_pid(tmp_path, monkeypatch):
+    # Mirror the conftest fixture's teardown decision: a tracked pid recorded
+    # under a temp home, still alive, provably rcd -> SIGTERM. Verifies the
+    # exact guard logic terminates a real (self-spawned) tracked process.
+    import signal
+    import tempfile
+
+    proc = _spawn_sleeper()
+    try:
+        monkeypatch.setattr(
+            mounts_mod, "_pid_looks_like_rcd", lambda pid: pid == proc.pid
+        )
+        # home under the system temp root, as every test home is.
+        home = tempfile.mkdtemp(dir=tempfile.gettempdir())
+        tracked = [(proc.pid, home)]
+
+        tmp_root = os.path.realpath(tempfile.gettempdir())
+        for pid, h in tracked:
+            if not os.path.realpath(str(h)).startswith(tmp_root):
+                continue
+            if mounts_mod._pid_alive(pid) and mounts_mod._pid_looks_like_rcd(pid):
+                os.kill(pid, signal.SIGTERM)
+
+        assert _wait_dead(proc), "tracked test daemon should be terminated"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()

--- a/tests/test_fs_raw_pooled_proxy.py
+++ b/tests/test_fs_raw_pooled_proxy.py
@@ -1,0 +1,157 @@
+"""Opt-in pooled proxy on /api/fs/raw (TASK F, fused_render/server.py).
+
+For a COLD mount-backed read, /api/fs/raw 307-redirects native clients to the
+store's signed URL (duckdb/fsspec re-issue GETs with their own pooled parallel
+connections — proxying there paid a fresh TLS handshake per range read). But the
+pyramid/geotiff workers read block-by-block with a plain urllib GET and would
+re-follow that 307 on EVERY block. So those workers now tack `&pooled=1` onto the
+raw URL, opting that read into a server-side proxy that streams the same signed
+URL back through a shared keep-alive httpx pool (sockets reused across ranges).
+
+These tests pin the endpoint contract:
+  * `/api/fs/raw?...&pooled=1` on a cold mount path returns 200/206 with the
+    bytes and NO 307 (the opt-in proxy fired);
+  * WITHOUT the flag the same request still 307s to the store (no regression for
+    duckdb/parquet).
+
+A threaded localhost server stands in for the signed store URL; upstream_url_for
+is stubbed to point at it, and a serve is armed so the serve-backed branch is
+entered. prefetch is stubbed so the read stays "cold" (redirect-eligible) and no
+background reader touches the file.
+
+Shared fixtures/helpers (home, _mount, _no_kernel_on_mount) live in
+_mount_safe_helpers, mirroring test_server_fs_raw_mount_safe.
+"""
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import create_app
+from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
+    _mount,
+    home,
+)
+
+
+class _FakeStore:
+    """Stands in for the store's signed S3 URL: serves a fixed blob and honours
+    Range with a 206 (200 whole-body otherwise). Records how many GETs it saw,
+    so a test can confirm the proxy actually fetched from it."""
+
+    def __init__(self, blob: bytes):
+        self.blob = blob
+        self.gets = 0
+        store = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                store.gets += 1
+                rng = self.headers.get("Range")
+                if rng and rng.startswith("bytes="):
+                    s, _, e = rng[6:].partition("-")
+                    s = int(s)
+                    e = int(e) if e else len(store.blob) - 1
+                    chunk = store.blob[s:e + 1]
+                    self.send_response(206)
+                    self.send_header("Content-Range",
+                                     f"bytes {s}-{e}/{len(store.blob)}")
+                    self.send_header("Content-Length", str(len(chunk)))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(chunk)
+                else:
+                    self.send_response(200)
+                    self.send_header("Content-Length", str(len(store.blob)))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(store.blob)
+
+        self._srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.port = self._srv.server_address[1]
+        self._t = threading.Thread(target=self._srv.serve_forever, daemon=True)
+        self._t.start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}/signed/object.tif"
+
+    def close(self):
+        self._srv.shutdown()
+
+
+@pytest.fixture()
+def cold_raw(home, monkeypatch):
+    """A TestClient over a cold mount-backed file: a serve is armed (so the
+    serve-backed branch is entered), prefetch is stubbed so the read stays cold
+    (redirect-eligible) and touches nothing, and a _FakeStore stands in for the
+    signed URL. Yields (client, mountpoint, file_path, store)."""
+    import fused_render.shell.prefetch as prefetch
+    monkeypatch.setattr(prefetch, "schedule", lambda *a, **k: None)
+    # Cold: not yet prefetched -> the handler is in its redirect-to-store phase.
+    monkeypatch.setattr(prefetch, "is_done", lambda *a, **k: False)
+
+    store = _FakeStore(b"PYRAMID-COG-BYTES-" + bytes(range(64)) * 8)
+
+    mp = _mount("rw", read_only=False)
+    # Arm a live serve for the mount so serve_url_for(path) is non-None (its
+    # base need not be reachable: the pooled/redirect branch fires before any
+    # proxy to the serve).
+    from fused_render.shell import storage
+    storage.write_json(mounts_mod.serves_path(), {mp: "http://127.0.0.1:1"})
+    # The store's signed URL for any path under the mount.
+    monkeypatch.setattr(mounts_mod, "upstream_url_for", lambda p: store.url)
+
+    file_path = os.path.join(mp, "cog.tif")
+    try:
+        # Context-manager form so Starlette runs the app's startup event and
+        # creates app.state.pooled_client (the pool the opt-in proxy awaits
+        # through); a bare TestClient(...) skips lifespan.
+        with TestClient(create_app(start_dir=str(home))) as client:
+            yield client, mp, file_path, store
+    finally:
+        store.close()
+
+
+def test_pooled_flag_proxies_bytes_no_redirect(cold_raw):
+    client, mp, file_path, store = cold_raw
+    # Full-body GET with the opt-in flag: the proxy streams the store's bytes
+    # back (200), never a 307. follow_redirects=False so a stray 307 would show.
+    r = client.get("/api/fs/raw",
+                   params={"path": file_path, "pooled": "1"},
+                   follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == store.blob
+    assert store.gets == 1  # the proxy fetched from the store itself
+
+
+def test_pooled_flag_forwards_range_206(cold_raw):
+    client, mp, file_path, store = cold_raw
+    # A ranged read (what _HttpRangeFile issues per block) comes back as a 206
+    # window through the pool, not a redirect.
+    r = client.get("/api/fs/raw",
+                   params={"path": file_path, "pooled": "1"},
+                   headers={"Range": "bytes=4-11"},
+                   follow_redirects=False)
+    assert r.status_code == 206
+    assert r.content == store.blob[4:12]
+    assert r.headers["content-range"] == f"bytes 4-11/{len(store.blob)}"
+
+
+def test_no_flag_still_redirects_to_store(cold_raw):
+    client, mp, file_path, store = cold_raw
+    # WITHOUT the flag the cold read still 307s to the signed store URL — the
+    # untouched duckdb/parquet path. The proxy never runs (store sees no GET).
+    r = client.get("/api/fs/raw",
+                   params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 307
+    assert r.headers["location"] == store.url
+    assert store.gets == 0

--- a/tests/test_fs_walk_bound.py
+++ b/tests/test_fs_walk_bound.py
@@ -1,0 +1,115 @@
+"""Tests that the recursive /api/fs/walk enumeration is BOUNDED — depth cap,
+entry-count cap enforced inside the generator, and abort on client disconnect —
+so a search-as-you-type over a big (esp. mount) root can't kick off an
+unbounded, uncancelled walk. Companion to test_server_walk.py (behaviour)."""
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from fused_render import server
+from fused_render.server import _WALK_TRUNCATED, _walk_bfs, create_app
+
+
+def _client(tmp_path):
+    app = create_app(start_dir=str(tmp_path))
+    return TestClient(app)
+
+
+def _make_deep_chain(root, depth):
+    """root/d0/d1/.../d{depth-1}, each level holding a marker file."""
+    cur = root
+    for i in range(depth):
+        cur = cur / f"d{i}"
+        cur.mkdir()
+        (cur / f"file{i}.txt").write_text("x", encoding="utf-8")
+    return cur
+
+
+# --- (a) depth cap: the walk stops DESCENDING -------------------------------
+
+
+def test_walk_stops_at_depth_cap(tmp_path, monkeypatch):
+    # A deep, low-fan-out chain (the NAIP state/year/quad/tile shape) never
+    # trips the entry-count cap, so only the depth cap bounds it.
+    _make_deep_chain(tmp_path, 8)
+    monkeypatch.setattr(server, "WALK_MAX_DEPTH_LOCAL", 2)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    assert data["truncated"] is True  # depth cap flags partial coverage
+    rels = {e["rel"] for e in data["entries"]}
+    # rel slash-count == entry depth; a cap of 2 yields depths 0,1,2 and no more.
+    assert rels  # something came back
+    assert max(r.count("/") for r in rels) == 2
+    assert "d0" in rels and "d0/d1" in rels and "d0/d1/d2" in rels
+    assert not any(r.count("/") > 2 for r in rels)  # never descended past the cap
+
+
+def test_walk_bfs_depth_cap_direct(tmp_path):
+    # Same, exercised directly on the generator (bypasses the main-checkout
+    # import caveat for the wiring, pins the sentinel contract).
+    _make_deep_chain(tmp_path, 6)
+    items = list(_walk_bfs(str(tmp_path), include_hidden=False, max_entries=None, max_depth=1))
+    entries = [e for e in items if e is not _WALK_TRUNCATED]
+    rels = {e["rel"] for e in entries}
+    assert max(r.count("/") for r in rels) == 1  # depths 0 and 1 only
+    assert any(e is _WALK_TRUNCATED for e in items)  # partial-coverage signalled
+
+
+# --- (b) entry-count cap: the generator stops early, un-exhausted -----------
+
+
+def test_walk_bfs_entry_cap_stops_generator(tmp_path):
+    # 100 top-level files plus a subtree that BFS reaches only after them. With
+    # a cap of 5 the generator must yield exactly 5 entries then a truncation
+    # sentinel and STOP — never descending into (or listing) the later subtree.
+    for i in range(100):
+        (tmp_path / f"f{i:03d}.txt").write_text("x", encoding="utf-8")
+    deep = tmp_path / "zzz_deep"
+    deep.mkdir()
+    for i in range(100):
+        (deep / f"g{i:03d}.txt").write_text("x", encoding="utf-8")
+
+    gen = _walk_bfs(str(tmp_path), include_hidden=False, max_entries=5, max_depth=None)
+    collected = list(gen)  # generator terminates on its own — no manual break
+    entries = [e for e in collected if e is not _WALK_TRUNCATED]
+    assert len(entries) == 5  # stopped at the cap, did NOT drain 200+ entries
+    assert collected[-1] is _WALK_TRUNCATED  # cap emits the truncation sentinel
+    # Proof it never exhausted the tree: nothing from the later subtree leaked.
+    assert not any(e["rel"].startswith("zzz_deep/") for e in entries)
+
+
+def test_walk_entry_cap_via_endpoint(tmp_path, monkeypatch):
+    for i in range(20):
+        (tmp_path / f"f{i}.txt").write_text("x", encoding="utf-8")
+    monkeypatch.setattr(server, "WALK_MAX_ENTRIES", 4)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    assert data["truncated"] is True
+    assert len(data["entries"]) == 4
+
+
+# --- (c) client disconnect aborts the walk ----------------------------------
+
+
+class _DisconnectedRequest:
+    """Minimal stand-in for a Starlette Request whose client has gone away."""
+
+    async def is_disconnected(self):
+        return True
+
+
+def _walk_endpoint(app):
+    return next(r.endpoint for r in app.routes if getattr(r, "path", "") == "/api/fs/walk")
+
+
+def test_walk_aborts_on_disconnect(tmp_path):
+    # Enough entries that the disconnect poll (every 64) fires before the tree
+    # is drained; a disconnected request must break out with a partial result
+    # rather than enumerating all 200.
+    for i in range(200):
+        (tmp_path / f"f{i:03d}.txt").write_text("x", encoding="utf-8")
+    app = create_app(start_dir=str(tmp_path))
+    endpoint = _walk_endpoint(app)
+    result = asyncio.run(
+        endpoint(request=_DisconnectedRequest(), path=str(tmp_path), hidden="0", stream="0")
+    )
+    # Stopped at the first disconnect check (seen==64) instead of returning 200.
+    assert len(result["entries"]) < 200

--- a/tests/test_fs_walk_bound.py
+++ b/tests/test_fs_walk_bound.py
@@ -7,7 +7,7 @@ import asyncio
 from fastapi.testclient import TestClient
 
 from fused_render import server
-from fused_render.server import _WALK_TRUNCATED, _walk_bfs, create_app
+from fused_render.server import _walk_bfs, create_app
 
 
 def _client(tmp_path):
@@ -48,10 +48,17 @@ def test_walk_bfs_depth_cap_direct(tmp_path):
     # import caveat for the wiring, pins the sentinel contract).
     _make_deep_chain(tmp_path, 6)
     items = list(_walk_bfs(str(tmp_path), include_hidden=False, max_entries=None, max_depth=1))
-    entries = [e for e in items if e is not _WALK_TRUNCATED]
+    # Identify entries vs the truncation sentinel STRUCTURALLY (real entries are
+    # dicts; the sentinel is not), never by `is _WALK_TRUNCATED`: an
+    # importlib.reload of fused_render.server elsewhere in the suite
+    # (test_branch_runtime's autouse teardown) rebinds the module-level
+    # _WALK_TRUNCATED to a fresh object(), so the sentinel the reloaded generator
+    # yields is no longer the object THIS module imported — an identity filter
+    # would then fail to drop it (the CI-only failure this test file had).
+    entries = [e for e in items if isinstance(e, dict)]
     rels = {e["rel"] for e in entries}
     assert max(r.count("/") for r in rels) == 1  # depths 0 and 1 only
-    assert any(e is _WALK_TRUNCATED for e in items)  # partial-coverage signalled
+    assert any(not isinstance(e, dict) for e in items)  # partial-coverage signalled
 
 
 # --- (b) entry-count cap: the generator stops early, un-exhausted -----------
@@ -70,9 +77,18 @@ def test_walk_bfs_entry_cap_stops_generator(tmp_path):
 
     gen = _walk_bfs(str(tmp_path), include_hidden=False, max_entries=5, max_depth=None)
     collected = list(gen)  # generator terminates on its own — no manual break
-    entries = [e for e in collected if e is not _WALK_TRUNCATED]
+    # Real entries are dicts; the truncation sentinel is the sole non-dict.
+    # Filter STRUCTURALLY, not by `is _WALK_TRUNCATED`: an importlib.reload of
+    # fused_render.server elsewhere in the suite (test_branch_runtime's autouse
+    # teardown) rebinds the module-level _WALK_TRUNCATED to a fresh object(), so
+    # the sentinel the reloaded generator yields is no longer the object THIS
+    # module imported — an identity `is not` filter then leaves it in `entries`,
+    # which is exactly why this assertion counted 6 instead of 5 on CI.
+    entries = [e for e in collected if isinstance(e, dict)]
+    sentinels = [e for e in collected if not isinstance(e, dict)]
     assert len(entries) == 5  # stopped at the cap, did NOT drain 200+ entries
-    assert collected[-1] is _WALK_TRUNCATED  # cap emits the truncation sentinel
+    assert len(sentinels) == 1  # exactly one truncation signal, no double-yield
+    assert collected[-1] is sentinels[0]  # and it's the FINAL item emitted
     # Proof it never exhausted the tree: nothing from the later subtree leaked.
     assert not any(e["rel"].startswith("zzz_deep/") for e in entries)
 

--- a/tests/test_mount_nobrowse.py
+++ b/tests/test_mount_nobrowse.py
@@ -1,0 +1,53 @@
+"""Tests for the macOS Finder/Spotlight enumeration guards on the NFS mounts
+(shell/mounts.py): the "nobrowse" NFS mount flag and the
+`.metadata_never_index` Spotlight-exclusion marker.
+
+Both exist to stop macOS from autonomously walking an S3-backed mount with
+readdir (a prefix-enumeration mount-wedge trigger). No real mount is ever
+created and mdutil is never invoked — FUSED_RENDER_HOME is redirected so the
+marker lands under a tmp dir, and the mount flag is asserted on the option list
+directly.
+"""
+import os
+
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    return home
+
+
+def test_nfs_mount_opt_includes_nobrowse():
+    # "nobrowse" keeps the mount out of Finder and off Spotlight's auto-scan;
+    # without it, browsing/indexing readdir's the S3-backed mount into a full
+    # prefix enumeration. It rides the same ExtraOptions list as timeo/retrans
+    # that rclone forwards verbatim to the macOS mount command.
+    assert "nobrowse" in mounts_mod.NFS_MOUNT_OPT["ExtraOptions"]
+    # Still carried through the per-mount option builder (alongside rdonly for
+    # read-only mounts), which is what attach_mount actually passes to rcd.
+    assert "nobrowse" in mounts_mod._nfs_mount_opt({"read_only": False})["ExtraOptions"]
+    assert "nobrowse" in mounts_mod._nfs_mount_opt({"read_only": True})["ExtraOptions"]
+
+
+def test_ensure_mounts_dir_drops_spotlight_marker(home):
+    # Creating the mounts root must drop the `.metadata_never_index` marker so
+    # Spotlight (mds) skips the whole subtree — the browse-side companion to the
+    # nobrowse mount flag.
+    root = mounts_mod.ensure_mounts_dir()
+    assert root == mounts_mod.mounts_dir()
+    assert os.path.isdir(root)
+    assert os.path.isfile(os.path.join(root, ".metadata_never_index"))
+
+
+def test_ensure_mounts_dir_is_idempotent(home):
+    # Called on every attach; a second call must not raise or clobber.
+    mounts_mod.ensure_mounts_dir()
+    mounts_mod.ensure_mounts_dir()
+    assert os.path.isfile(
+        os.path.join(mounts_mod.mounts_dir(), ".metadata_never_index")
+    )

--- a/tests/test_pyramid_mount.py
+++ b/tests/test_pyramid_mount.py
@@ -290,7 +290,10 @@ def test_main_remote_analyze_passes_raw_url_to_worker(fs, monkeypatch):
     opts = json.loads(captured["argv"][4])
     assert opts.get("remote") is True
     assert opts.get("size") == len(s.blob)
-    assert opts["raw_url"].endswith("/api/fs/raw?path=/mnt/x.tif")
+    # The worker's raw_url opts into the server's pooled proxy (&pooled=1) so a
+    # cold COG range-read streams through one keep-alive pool instead of a fresh
+    # TLS handshake per block.
+    assert opts["raw_url"].endswith("/api/fs/raw?path=/mnt/x.tif&pooled=1")
     assert "/api/fs/raw" in opts["raw_url"]
 
 

--- a/tests/test_rc_cancellation.py
+++ b/tests/test_rc_cancellation.py
@@ -1,0 +1,123 @@
+"""Tests for the CANCELLABLE rc path (shell/mounts._rc_cancellable).
+
+The mount-runaway P0: a plain urlopen socket timeout on operations/list /
+operations/stat abandons only the CLIENT socket while rclone keeps running its
+unbounded ListObjectsV2 server-side — repeated timed-out calls piled up orphaned
+walks and pinned a CPU for 14h. The fix submits these commands with
+`_async=true` and, on timeout, calls job/stop so rclone actually cancels the
+in-flight enumeration. These tests assert that stop-on-timeout contract against
+the async-aware StubRcd (real rclone is never invoked).
+"""
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+# Reuse the async-aware stub + fixtures from the main mounts test module.
+from tests.test_shell_mounts import StubRcd, home, rcd  # noqa: F401
+
+
+def test_list_timeout_stops_the_job_and_raises_rc_list_timeout(home, rcd):
+    # A directory too large to enumerate: the async job never finishes. On the
+    # client deadline we must job/stop the SAME jobid (so rclone stops walking)
+    # and still raise RcListTimeout for the caller.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    rcd.responses["operations/list"] = {"list": []}
+    rcd.delay["operations/list"] = float("inf")  # job never becomes ready
+
+    with pytest.raises(mounts_mod.RcListTimeout):
+        mounts_mod.rc_list_dir(mounts_mod.mountpoint(c) + "/huge", timeout=0.2)
+
+    # The submit went out with _async, a jobid came back, and we cancelled it.
+    submit = [b for (m, b) in rcd.calls if m == "operations/list"]
+    assert submit and submit[0].get("_async") is not True  # _async stripped on record
+    stops = [b for (m, b) in rcd.calls if m == "job/stop"]
+    assert len(stops) == 1
+    jobid = stops[0]["jobid"]
+    # The cancelled job is the one the stub handed out (jobid 1 here).
+    assert jobid in rcd.jobs
+    assert rcd.jobs[jobid]["stopped"] is True
+
+
+def test_stat_timeout_stops_the_job_and_reports_indeterminate(home, rcd):
+    # operations/stat on a flat prefix also runs the unbounded lister. On
+    # timeout the stat path must cancel the job and fail open to indeterminate
+    # (never fall back to a kernel os.stat).
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    rcd.responses["operations/stat"] = {"item": {"Size": 1}}
+    rcd.delay["operations/stat"] = float("inf")
+
+    # timeout must clear _DIRECT_PROBE_MIN_S (else _stat_item bails to
+    # indeterminate before ever issuing the rc call we want to cancel).
+    assert mounts_mod.rc_stat_for(
+        mounts_mod.mountpoint(c) + "/f", timeout=1.0) == "indeterminate"
+
+    stops = [b for (m, b) in rcd.calls if m == "job/stop"]
+    assert len(stops) == 1
+    assert rcd.jobs[stops[0]["jobid"]]["stopped"] is True
+
+
+def test_list_fast_success_returns_normally_without_stopping(home, rcd):
+    # The hot path: a job that finishes at once returns the SAME shape the old
+    # synchronous call did, and never touches job/stop.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    rcd.responses["operations/list"] = {"list": [
+        {"Name": "a", "IsDir": True, "Size": -1},
+        {"Name": "b.txt", "IsDir": False, "Size": 7},
+    ]}
+
+    entries = mounts_mod.rc_list_dir(mounts_mod.mountpoint(c) + "/sub", timeout=5)
+    assert [e["Name"] for e in entries] == ["a", "b.txt"]
+    assert not any(m == "job/stop" for (m, _) in rcd.calls)
+
+
+def test_failed_job_maps_to_rc_list_error_not_timeout(home, rcd):
+    # A job that finishes with an error (the remote path is a file, not a dir)
+    # must surface as RcListError — same as the synchronous HTTPError path —
+    # and NOT as a timeout, so the caller answers 400 not 503.
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    rcd.responses["operations/list"] = (500, {"error": "not a directory"})
+
+    with pytest.raises(mounts_mod.RcListError) as exc:
+        mounts_mod.rc_list_dir(mounts_mod.mountpoint(c) + "/file.parquet", timeout=5)
+    assert not isinstance(exc.value, mounts_mod.RcListTimeout)
+    assert not any(m == "job/stop" for (m, _) in rcd.calls)
+
+
+def test_rc_cancellable_falls_back_when_no_jobid(home, monkeypatch):
+    # A command that doesn't honor _async (no jobid in the reply) must degrade
+    # to a plain synchronous _rc rather than break. Stub _rc to always answer
+    # without a jobid and record the second (fallback) call has no _async.
+    import threading
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+    import json as _json
+
+    seen = []
+
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length") or 0)
+            body = _json.loads(self.rfile.read(n) or b"{}")
+            seen.append(body)
+            raw = _json.dumps({"list": [{"Name": "x"}]}).encode()  # never a jobid
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(raw)))
+            self.end_headers()
+            self.wfile.write(raw)
+
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+    port = srv.server_address[1]
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    try:
+        out = mounts_mod._rc_cancellable(port, "operations/list", {"fs": "r:"},
+                                         timeout=2)
+    finally:
+        srv.shutdown()
+
+    assert out == {"list": [{"Name": "x"}]}
+    # First call carried _async (the submit attempt); the fallback retry did not.
+    assert seen[0].get("_async") is True
+    assert "_async" not in seen[1]

--- a/tests/test_rc_cancellation.py
+++ b/tests/test_rc_cancellation.py
@@ -83,10 +83,9 @@ def test_failed_job_maps_to_rc_list_error_not_timeout(home, rcd):
     assert not any(m == "job/stop" for (m, _) in rcd.calls)
 
 
-def test_rc_cancellable_falls_back_when_no_jobid(home, monkeypatch):
-    # A command that doesn't honor _async (no jobid in the reply) must degrade
-    # to a plain synchronous _rc rather than break. Stub _rc to always answer
-    # without a jobid and record the second (fallback) call has no _async.
+def _one_shot_server(reply_for):
+    """Spin a localhost HTTP server that answers each POST with reply_for(body),
+    recording the request bodies it saw. Returns (port, seen, shutdown)."""
     import threading
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
     import json as _json
@@ -100,9 +99,10 @@ def test_rc_cancellable_falls_back_when_no_jobid(home, monkeypatch):
         def do_POST(self):
             n = int(self.headers.get("Content-Length") or 0)
             body = _json.loads(self.rfile.read(n) or b"{}")
-            seen.append(body)
-            raw = _json.dumps({"list": [{"Name": "x"}]}).encode()  # never a jobid
-            self.send_response(200)
+            seen.append((self.path.lstrip("/"), body))
+            code, payload = reply_for(self.path.lstrip("/"), body)
+            raw = _json.dumps(payload).encode()
+            self.send_response(code)
             self.send_header("Content-Type", "application/json")
             self.send_header("Content-Length", str(len(raw)))
             self.end_headers()
@@ -111,13 +111,74 @@ def test_rc_cancellable_falls_back_when_no_jobid(home, monkeypatch):
     srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
     port = srv.server_address[1]
     threading.Thread(target=srv.serve_forever, daemon=True).start()
+    return port, seen, srv.shutdown
+
+
+def test_rc_cancellable_reuses_sync_payload_when_no_jobid(home):
+    # Peer IGNORED _async and ran the command synchronously, handing back the
+    # full payload with no jobid. _rc_cancellable must RETURN that result — not
+    # re-issue the same unbounded enumeration a second time (Bugbot: "fallback
+    # re-lists after sync result").
+    def reply(method, body):
+        return 200, {"list": [{"Name": "x"}]}  # never a jobid
+
+    port, seen, shutdown = _one_shot_server(reply)
     try:
         out = mounts_mod._rc_cancellable(port, "operations/list", {"fs": "r:"},
                                          timeout=2)
     finally:
-        srv.shutdown()
+        shutdown()
 
     assert out == {"list": [{"Name": "x"}]}
-    # First call carried _async (the submit attempt); the fallback retry did not.
-    assert seen[0].get("_async") is True
-    assert "_async" not in seen[1]
+    # Exactly ONE call — the submit result was reused, not thrown away + redone.
+    assert len(seen) == 1
+    assert seen[0][1].get("_async") is True
+
+
+def test_rc_cancellable_falls_back_on_empty_ack(home):
+    # A truly empty/absent ack (no jobid, nothing to reuse) still degrades to a
+    # plain synchronous _rc so behavior doesn't break.
+    replies = iter([(200, {}), (200, {"list": [{"Name": "y"}]})])
+
+    def reply(method, body):
+        return next(replies)
+
+    port, seen, shutdown = _one_shot_server(reply)
+    try:
+        out = mounts_mod._rc_cancellable(port, "operations/list", {"fs": "r:"},
+                                         timeout=2)
+    finally:
+        shutdown()
+
+    assert out == {"list": [{"Name": "y"}]}
+    # Submit (with _async) returned empty -> a second, plain sync call was made.
+    assert len(seen) == 2
+    assert seen[0][1].get("_async") is True
+    assert "_async" not in seen[1][1]
+
+
+def test_rc_cancellable_stops_job_when_polling_fails(home):
+    # If job/status itself raises (a busy/slow rcd near the deadline), the job
+    # must STILL be cancelled server-side rather than left enumerating — the
+    # exact runaway this path exists to prevent (Bugbot: "poll failure skips job
+    # cancellation"). The raised error must read as a timeout to callers.
+    def reply(method, body):
+        if method == "job/status":
+            return 500, {"error": "server busy"}   # _rc -> RuntimeError
+        if method == "job/stop":
+            return 200, {}
+        return 200, {"jobid": 1}                    # the async submit
+
+    port, seen, shutdown = _one_shot_server(reply)
+    try:
+        with pytest.raises(RuntimeError) as exc:
+            mounts_mod._rc_cancellable(port, "operations/list", {"fs": "r:"},
+                                       timeout=2)
+    finally:
+        shutdown()
+
+    # job/stop was issued for the submitted job despite the poll failure...
+    stops = [b for (m, b) in seen if m == "job/stop"]
+    assert stops and stops[0]["jobid"] == 1
+    # ...and the surfaced error reads as a timeout (so rc_list_dir -> RcListTimeout).
+    assert mounts_mod._rc_timed_out(exc.value)

--- a/tests/test_server_fs_events.py
+++ b/tests/test_server_fs_events.py
@@ -134,16 +134,67 @@ def test_duplicate_watchers_share_one_stat_stream(home, tmp_path, monkeypatch):
     assert 1 <= count["n"] <= 5
 
 
-def test_mount_paths_tick_slowly_local_paths_tick_fast(home, tmp_path):
-    # (d) Classification fixes the poll interval once: mount-backed paths poll
-    # every 5s (rc API, low remote pressure), local paths every 200ms.
-    mount_entry = server._WatchEntry(str(home / "mounts" / "m" / "f.parquet"))
+def test_mount_paths_tick_slowly_local_paths_tick_fast(home, tmp_path, monkeypatch):
+    # (d) Classification fixes the poll interval once. A direct_list_capable
+    # mount (bounded unsigned page) polls every 5s; a non-direct-capable mount
+    # (change detection needs a full rc_list_dir) polls far more rarely to cut
+    # standing remote pressure (P1 #4); local paths every 200ms.
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    direct_entry = server._WatchEntry(str(home / "mounts" / "open" / "f.parquet"))
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+    slow_entry = server._WatchEntry(str(home / "mounts" / "m" / "f.parquet"))
     local_entry = server._WatchEntry(str(tmp_path / "local.html"))
 
-    assert mount_entry.is_mount is True
-    assert mount_entry.interval == server._MOUNT_POLL_S == 5.0
+    assert direct_entry.is_mount is True
+    assert direct_entry.interval == server._MOUNT_POLL_S == 5.0
+    assert slow_entry.is_mount is True
+    assert slow_entry.interval == server._MOUNT_SLOW_POLL_S == 60.0
     assert local_entry.is_mount is False
     assert local_entry.interval == server._LOCAL_POLL_S == 0.2
+
+
+def test_non_direct_mount_root_never_lists(home, monkeypatch):
+    # (P1 #4) The mount ROOT of a non-direct-capable remote (e.g. source.coop's
+    # custom S3 endpoint) must NOT be periodically enumerated: an rc_list_dir of
+    # the whole top prefix every tick, for the life of an open pane, is the
+    # standing background listing this fix removes. _mount_signal returns
+    # _UNCHANGED (best-effort: no live child-change events for the root) and
+    # never touches rc_list_dir / direct_list_page.
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+    monkeypatch.setattr(mounts_mod, "is_mount_root", lambda p: True)
+    entry = server._WatchEntry(str(home / "mounts" / "sourcecoop"))
+    assert entry.is_mount is True
+    assert entry._is_mount_root is True
+    assert entry._direct_capable is False
+
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            AssertionError("rc_list_dir called on a mount root")))
+    monkeypatch.setattr(mounts_mod, "direct_list_page",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            AssertionError("direct_list_page called on a mount root")))
+    assert entry._mount_signal() is server._UNCHANGED
+
+
+def test_direct_mount_root_still_lists_one_bounded_page(home, monkeypatch):
+    # (P1 #4) A direct_list_capable mount ROOT is cheaply listable (ONE bounded
+    # unsigned page), so it keeps its change signal — the fix only suppresses the
+    # expensive rc_list_dir enumeration, never the cheap direct page.
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "is_mount_root", lambda p: True)
+    entry = server._WatchEntry(str(home / "mounts" / "openbucket"))
+    assert entry._is_mount_root is True and entry._direct_capable is True
+
+    calls = []
+
+    def fake_page(path, *, max_keys, continuation=None, timeout=None):
+        calls.append(max_keys)
+        return ([{"Name": "x", "Size": 1, "ModTime": "t"}], None)
+
+    monkeypatch.setattr(mounts_mod, "s3_direct_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "s3_list_page", fake_page)
+    sig = entry._mount_signal()
+    assert sig.startswith("L") and calls == [1000]  # one bounded page, still signalled
 
 
 def test_mount_dir_signal_hashes_listing_and_detects_change(home, monkeypatch):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -31,6 +31,8 @@ class StubRcd:
     def __init__(self):
         self.calls = []
         self.delay = {}  # method -> seconds to sleep before responding (timeouts)
+        self.jobs = {}   # jobid -> job dict (for the _async / job/* path)
+        self._next_jobid = 1
         self.responses = {
             "core/pid": {"pid": 4242},
             "mount/mount": {},
@@ -46,28 +48,78 @@ class StubRcd:
             def log_message(self, *a):
                 pass
 
-            def do_POST(self):
-                length = int(self.headers.get("Content-Length") or 0)
-                body = json.loads(self.rfile.read(length) or b"{}")
-                method = self.path.lstrip("/")
-                stub.calls.append((method, body))
-                if method in stub.delay:
-                    time.sleep(stub.delay[method])
+            def _resolve(self, method):
+                """The (code, payload) this stub would answer `method` with,
+                from the canned per-method responses."""
                 resp = stub.responses.get(method)
                 if isinstance(resp, list):  # per-call sequence; last repeats
                     resp = resp.pop(0) if len(resp) > 1 else resp[0]
                 if resp is None:
-                    payload, code = {"error": f"unknown method {method}"}, 404
-                elif isinstance(resp, tuple):
-                    code, payload = resp
-                else:
-                    payload, code = resp, 200
+                    return 404, {"error": f"unknown method {method}"}
+                if isinstance(resp, tuple):
+                    return resp
+                return 200, resp
+
+            def _reply(self, code, payload):
                 raw = json.dumps(payload).encode()
                 self.send_response(code)
                 self.send_header("Content-Type", "application/json")
                 self.send_header("Content-Length", str(len(raw)))
                 self.end_headers()
                 self.wfile.write(raw)
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length") or 0)
+                body = json.loads(self.rfile.read(length) or b"{}")
+                method = self.path.lstrip("/")
+
+                # job/status and job/stop drive the _async cancellation path.
+                if method == "job/status":
+                    stub.calls.append((method, body))
+                    job = stub.jobs.get(body.get("jobid"))
+                    if job is None:
+                        return self._reply(500, {"error": "job not found"})
+                    finished = (job["ready_at"] is not None
+                                and time.monotonic() >= job["ready_at"])
+                    out = {"id": body["jobid"], "finished": finished,
+                           "success": finished and not job["error"],
+                           "error": job["error"] if finished else ""}
+                    if finished and not job["error"]:
+                        out["output"] = job["output"]
+                    return self._reply(200, out)
+                if method == "job/stop":
+                    stub.calls.append((method, body))
+                    job = stub.jobs.get(body.get("jobid"))
+                    if job is None:
+                        return self._reply(500, {"error": "job not found"})
+                    job["stopped"] = True
+                    return self._reply(200, {})
+
+                # Async submit: record the logical call (minus the _async control
+                # key), stash the eventual result as a job keyed by delay, and
+                # hand back a jobid immediately — exactly like rclone rcd.
+                if body.pop("_async", None):
+                    stub.calls.append((method, body))
+                    code, payload = self._resolve(method)
+                    jobid = stub._next_jobid
+                    stub._next_jobid += 1
+                    # A never-ending job: delay is None => ready_at never arrives.
+                    d = stub.delay.get(method)
+                    stub.jobs[jobid] = {
+                        "ready_at": (None if d == float("inf")
+                                     else time.monotonic() + (d or 0)),
+                        "output": payload if code == 200 else {},
+                        "error": "" if code == 200 else str(payload.get("error", "err")),
+                        "stopped": False,
+                    }
+                    return self._reply(200, {"jobid": jobid})
+
+                # Synchronous path (core/pid, mount/*, and any non-async caller).
+                stub.calls.append((method, body))
+                if method in stub.delay:
+                    time.sleep(stub.delay[method])
+                code, payload = self._resolve(method)
+                self._reply(code, payload)
 
         self.server = ThreadingHTTPServer(("127.0.0.1", 0), H)
         self.port = self.server.server_address[1]


### PR DESCRIPTION
## Problem

A single search-as-you-type or folder browse over a large/flat S3-backed rclone NFS mount could pin `rclone` at ~150% CPU for hours and eventually drop the mount, wedging the server. Root causes, confirmed against a live runaway (`listed: 4.1M+` keys and climbing on a bucket-root mount):

1. **Non-cancelling rc timeout** — `_rc` used a urllib socket timeout that does *not* stop rclone's server-side `ListObjectsV2`. When a client gave up, rclone kept enumerating the whole prefix. **This is the actual CPU-runaway cause.**
2. **Unbounded `/api/fs/walk`** — `_walk_bfs` had no depth cap and enforced its entry cap only in the *consumer*, so the generator kept walking/enqueuing a deep or flat tree.
3. **Standing fs/events re-list** — the watcher issued a 5s single-level `operations/list` on mount roots, so an idle preview pane periodically re-enumerated a huge top prefix.
4. **macOS auto-enumerators** — Finder/Spotlight walk NFS mounts unprompted.
5. **Leaked `rcd` daemons** — the "outlives the server" design had no reaper; pytest/worktree runs left daemons for days.

## Changes (one commit per isolated fix)

| Area | Fix |
|------|-----|
| **rc cancellation** (`mounts.py`) | New `_rc_cancellable`: submits `operations/list`/`operations/stat` with `_async:true`, polls `job/status` at 50ms, and on timeout calls **`job/stop`** so rclone cancels the in-flight enumeration server-side. Exceptions/return shapes preserved exactly; cheap calls stay on the sync fast path. |
| **bounded walk** (`server.py`) | `WALK_MAX_DEPTH_REMOTE=6` / `_LOCAL=40` enforced *inside* `_walk_bfs` (depth carried in the queue); entry cap moved into the generator (emits `_WALK_TRUNCATED` and returns). `api_fs_walk` is now `async` + iterates via `iterate_in_threadpool`, polling `request.is_disconnected()` every 64 entries to abort abandoned keystrokes. |
| **fs/events** (`server.py`, `mounts.py`) | New pure-config `is_mount_root`. `_WatchEntry` classifies each watch once: non-direct-capable mounts poll at 60s (was 5s), and `_mount_signal` returns `_UNCHANGED` immediately for a non-direct-capable mount **root** — never lists the top prefix. |
| **macOS mount opts** (`mounts.py`) | `nobrowse` added to the NFS mount options (darwin-only path); `ensure_mounts_dir()` drops a `.metadata_never_index` marker so Spotlight skips the whole subtree. |
| **daemon reaper** (`mounts.py`, `conftest.py`) | Central `rcd-registry.json` at the baseline home (survives temp-home/worktree deletion). `reap_stale_rcd()` kills only when the recorded home is gone, the pid is alive, AND it's provably our rclone rcd (`core/pid` match or `ps` shows `rclone … rcd`). Wired into the rare spawn path; pytest teardown reaps only tracked temp-home pids. |
| **pooled proxy** (`server.py` + pyramid/geotiff workers) | Opt-in `&pooled=1` on `/api/fs/raw` streams the signed store URL through a shared `httpx.AsyncClient` keep-alive pool (fixes the pyramid cold-load: dozens of serial per-block TLS handshakes). The **307-to-store redirect is kept** for duckdb/parquet and as the fallback when the pool can't reach the store. |

## Tests

Red-first per fix: `test_rc_cancellation.py`, `test_fs_walk_bound.py`, `test_server_fs_events.py` (updated), `test_mount_nobrowse.py`, `test_daemon_reaper.py`, `test_fs_raw_pooled_proxy.py`. **223 passed** in the main-checkout venv (authoritative, not a worktree).

## Notes

- The six fixes were developed in isolated worktrees and cherry-picked onto fresh `origin/main` (one trivial auto-merge in `mounts.py`).
- FastAPI startup/shutdown for the pooled client uses `@app.on_event` (functional; emits a deprecation warning in this FastAPI version — kept for a tight diff).
- Pre-existing, out of scope: the PROJ fork-safety SIGSEGV in the zarr_aoi daemon spawn path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
