### PR TITLE
chore(skill): setting-up-dev-env uses Python 3.14

### DIFF
--- a/.claude/skills/setting-up-dev-env/SKILL.md
+++ b/.claude/skills/setting-up-dev-env/SKILL.md
@@ -7,7 +7,7 @@ description: Use when setting up a fused-render checkout or git worktree for the
 
 ## Overview
 
-Every fresh checkout/worktree needs a **3.12 venv** and a **built React shell** — both are gitignored, so they don't carry into a worktree. Without them, `pytest`/`python` silently run against the wrong interpreter or fail on missing deps, and every server test dies with `RuntimeError: React shell not built`.
+Every fresh checkout/worktree needs a **3.14 venv** and a **built React shell** — both are gitignored, so they don't carry into a worktree. Without them, `pytest`/`python` silently run against the wrong interpreter or fail on missing deps, and every server test dies with `RuntimeError: React shell not built`.
 
 ## Running the Dev Server
 
@@ -23,7 +23,7 @@ scripts/dev.sh --port 9000     # extra args pass through to the server
 `dev.sh` covers the server, but its auto-venv has `[fused,bundled]` only — **not the `dev` extra** (pytest/xdist). And tests need a built `shell-dist/` or `create_app()` refuses to start. So the venv install is the one manual step:
 
 ```bash
-uv venv --python 3.12 .venv                                         # 3.14 lacks duckdb/rasterio wheels
+uv venv --python 3.14 .venv                                         # 3.14 wheels now exist for the whole stack
 uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]"  # dev extra now includes pytest-xdist
 ```
 
@@ -39,7 +39,7 @@ Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m 
 
 | Item | Why |
 |------|-----|
-| Python 3.12 | duckdb/rasterio have no 3.14 wheels; fused wheel needs ≥3.11 |
+| Python 3.14 | whole stack (duckdb, rasterio, geopandas, shapely, zarr, scipy, pymupdf…) now ships 3.14 wheels; fused wheel is pure-python `py3-none-any` (marker needs ≥3.11). requires-python is ≥3.10, so 3.12/3.13 also work — 3.14 is just the current default |
 | `dev` extra | pytest + httpx (backs TestClient) |
 | `bundled` extra | duckdb, rasterio, zarr, pandas, geopandas… (templates + daemons) |
 | `fused` extra | compute-engine wheel for `/api/run` |


### PR DESCRIPTION
## What

Switch the `setting-up-dev-env` skill from forcing **Python 3.12** to **3.14**.

## Why

The 3.12 pin dated to when duckdb/rasterio shipped no 3.14 wheels. That's no longer true — verified the full `[dev,bundled,fused]` dependency set imports on 3.14:

> duckdb 1.5.4, rasterio 1.5.0, geopandas 1.1.4, shapely 2.1.2, zarr 3.2.1, scipy 1.18.0, pymupdf (fitz) 1.28.0, pikepdf 10.10.0, polars 1.42.1, matplotlib 3.11.1, pandas 2.3.3, numpy 2.5.1, pyproj 3.7.2, pillow 12.3.0, python-pptx, fpdf2, openpyxl, msgpack, drain3, pyarrow — and the `fused` wheel (pure-python `py3-none-any`, marker `python_version >= "3.11"`).

The full mount/template test suite passes on 3.14 in the main checkout.

## Changes

- Overview + manual venv step: `--python 3.12` → `--python 3.14`.
- Reference table row rewritten to explain the whole stack now ships 3.14 wheels; notes 3.12/3.13 still work (`requires-python >= 3.10`) — 3.14 is just the current default.
- `scripts/dev.sh` needs no change: its `uv venv` has no `--python` pin, so it was already version-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
