### PR TITLE
fix(mounts+pyramid): keep the mount attached and rendering when opening/switching COGs

### DIFF
--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -80,16 +80,22 @@ def available() -> bool:
 
 def get_backend():
     # Lazy singleton: importing the backend pulls in the fused package tree,
-    # and constructing it is only needed once per server process. 30s matches
-    # the built-in executor's per-run timeout.
+    # and constructing it is only needed once per server process. 60s matches
+    # the built-in executor's per-run timeout (executor.DEFAULT_TIMEOUT) — a
+    # cold overview read of a large remote COG legitimately takes ~30-40s, so
+    # the two engines must agree or the cold pyramid analyze dies at 30s here.
     global _backend
     if _backend is None:
         from fused.agent_core.backends.local.python_compute import LocalPythonComputeBackend
 
+        from fused_render.executor import DEFAULT_TIMEOUT
+
         # cache_storage=None disables result caching explicitly (PY-9: fresh
         # execution every call). It is the upstream default today, but we may
         # track a nightly wheel — don't rely on a default staying put.
-        _backend = LocalPythonComputeBackend(timeout_seconds=30, cache_storage=None)
+        _backend = LocalPythonComputeBackend(
+            timeout_seconds=int(DEFAULT_TIMEOUT), cache_storage=None
+        )
     return _backend
 
 

--- a/fused_render/executor.py
+++ b/fused_render/executor.py
@@ -38,7 +38,11 @@ CHILD = os.path.join(os.path.dirname(__file__), "_child.py")
 # Built-in helpers run from the staged core-templates copy, not the bundle, so
 # the allowlist realpaths must point there too (see core_templates).
 _TEMPLATES_DIR = os.path.realpath(ensure_core_templates())
-DEFAULT_TIMEOUT = 30.0
+# 60s (not 30): a cold overview read of a large remote COG over the mount's HTTP
+# serve legitimately takes ~30-40s on first open (the pyramid analyze; the
+# template's own worker already allows 900s). 30s killed those mid-read. Still
+# well short of a runaway-guard — a genuinely hung script is caught, just later.
+DEFAULT_TIMEOUT = 60.0
 
 # Explicit allowlist of first-party helpers that run IN-PROCESS (D72): each is
 # bounded, self-contained, and never imports or executes user code — the

--- a/fused_render/executor.py
+++ b/fused_render/executor.py
@@ -182,6 +182,21 @@ def _run_python(path: str, params: dict, timeout: float) -> dict:
             capture_output=True,
             text=True,
             timeout=timeout,
+            # close_fds=False forces CPython to spawn via posix_spawn instead of
+            # fork()+exec (verified: the default close_fds=True takes the fork
+            # path on macOS/Linux). This is a native-crash fix, not an fd-policy
+            # choice. The server process has libproj resident with a live SQLite
+            # handle to proj.db in PROJ's SQLiteHandleCache (pyproj is pulled in
+            # transitively — e.g. via `fused`/geopandas). fork() runs every
+            # registered pthread_atfork *child* handler in the forked child
+            # before exec; PROJ's handler calls sqlite3_close/VFSClose on that
+            # inherited-but-now-invalid handle and segfaults (SIGSEGV) — so the
+            # child dies with code -11 before it can exec the worker, and the
+            # run surfaces as "worker exited with code -11 without producing a
+            # result". posix_spawn does NOT run atfork handlers, eliminating the
+            # crash path entirely. The worker is short-lived and inherits only
+            # the pipes it needs, so not closing inherited fds is harmless here.
+            close_fds=False,
             # a windowless server (Explorer-opener spawn) must not flash a
             # console window per run
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -824,11 +824,13 @@ def _is_file_mount_safe(path: str) -> bool:
     """os.path.isfile, but NEVER a kernel stat on a mount-backed path — a cold
     os.path.isfile there is the GETATTR that lists the whole parent prefix and
     wedges the mount (the /api/session + /api/recents open-flow wedge). Mount
-    paths answered via rc_kind_for; fail OPEN on an indeterminate rc probe so a
-    transient rcd hiccup never 404s a file the user just opened."""
+    paths answered via rc_kind_for; only a confirmed "file" passes (a "dir" is
+    not a file, matching os.path.isfile), while an "indeterminate" rc probe
+    fails OPEN so a transient rcd hiccup never 404s a file the user just
+    opened."""
     from fused_render.shell.mounts import is_mount_backed, rc_kind_for
     if is_mount_backed(path):
-        return rc_kind_for(path) != "missing"
+        return rc_kind_for(path) in ("file", "indeterminate")
     return os.path.isfile(path)
 
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -3199,13 +3199,27 @@ def create_app(start_dir: str) -> FastAPI:
                             return resp
                     return RedirectResponse(direct, status_code=307)
             # Not redirected (browser, warm read, or no direct URL): proxy the
-            # bytes. Guard non-files here — the cold redirect path above is the
-            # never-listed-object hot path and stays stat-free, but a directory
-            # proxied through rclone serve comes back as a 200 HTML listing, so
-            # stat before serving (warm getattr is cheap; a directory 404s).
-            st = await asyncio.to_thread(_stat_or_none, path)
-            if st is None:
-                return _error(f"no such file: {path}", status=404)
+            # bytes. Guard non-files here — a directory proxied through rclone
+            # serve comes back as a 200 HTML listing, so resolve shape before
+            # serving. But NOT with a kernel os.stat on a mount-backed path: this
+            # branch is reached once the prefetch has landed (is_done) or for a
+            # browser read, and a cold GETATTR on a never-listed object forces
+            # rclone to enumerate the whole parent prefix (~28s on a 44k-entry
+            # dir), past the NFS deadman -> the mount is dropped. Answer
+            # existence/shape through the rcd (_mount_probe) like the HEAD branch
+            # above; only a local path stats the kernel.
+            if shell_mounts.is_mount_backed(path):
+                try:
+                    pr = await asyncio.to_thread(_mount_probe, path)
+                except (shell_mounts.RcListUnavailable,
+                        shell_mounts.RcListTimeout) as e:
+                    return _mount_list_error_response(os.path.dirname(path), e)
+                if not pr.exists or pr.is_dir:
+                    return _error(f"no such file: {path}", status=404)
+            else:
+                st = await asyncio.to_thread(_stat_or_none, path)
+                if st is None:
+                    return _error(f"no such file: {path}", status=404)
             resp = await asyncio.to_thread(_proxy_raw, upstream, request)
             if resp is not None:
                 return resp  # upstream unreachable -> plain file read below

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -820,8 +820,20 @@ def _has_non_mode_param(search: str) -> bool:
     return any(k != "_mode" for k, _ in parse_qsl(search, keep_blank_values=True))
 
 
+def _is_file_mount_safe(path: str) -> bool:
+    """os.path.isfile, but NEVER a kernel stat on a mount-backed path — a cold
+    os.path.isfile there is the GETATTR that lists the whole parent prefix and
+    wedges the mount (the /api/session + /api/recents open-flow wedge). Mount
+    paths answered via rc_kind_for; fail OPEN on an indeterminate rc probe so a
+    transient rcd hiccup never 404s a file the user just opened."""
+    from fused_render.shell.mounts import is_mount_backed, rc_kind_for
+    if is_mount_backed(path):
+        return rc_kind_for(path) != "missing"
+    return os.path.isfile(path)
+
+
 def _session_get(path: str):
-    if not os.path.isfile(path):
+    if not _is_file_mount_safe(path):
         return _error(f"no such file: {path}", status=404)
     last = _read_sidecar(path).get("lastSession")
     return {"lastSession": last if isinstance(last, dict) else None}
@@ -835,7 +847,7 @@ def _session_put(body: dict, x_fused: str | None):
     search = body.get("search")
     if not path or not os.path.isabs(path):
         return _error("'path' must be an absolute filesystem path")
-    if not os.path.isfile(path):
+    if not _is_file_mount_safe(path):
         return _error(f"no such file: {path}", status=404)
     if not isinstance(search, str):
         return _error("'search' must be a string")

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -112,9 +112,16 @@ def _file_path_from_url(url: str) -> str | None:
     FILE right now (recents record files only, D22-style basename rows) —
     the gate for accepting a record and for the GET response filter."""
     fs_path = _decoded_fs_path(url)
-    if fs_path is None or not os.path.isfile(fs_path):
+    if fs_path is None:
         return None
-    return fs_path
+    # NEVER a raw os.path.isfile on a mount-backed path: a cold GETATTR there
+    # lists the whole parent prefix and wedges the mount (the open-flow wedge —
+    # POST /api/recents/open resolves the just-opened file through here). Route
+    # mounts via the rc API (_mount_exists), locals via the kernel (_local_exists).
+    from fused_render.shell import mounts as shell_mounts
+    exists = (_mount_exists(fs_path) if shell_mounts.is_mount_backed(fs_path)
+              else _local_exists(fs_path))
+    return fs_path if exists else None
 
 
 def _local_exists(fs_path: str) -> bool:

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -135,20 +135,21 @@ def _local_exists(fs_path: str) -> bool:
 
 
 def _mount_exists(fs_path: str) -> bool:
-    """Existence of a MOUNT-BACKED path, answered by the rclone rc API
-    (mounts.rc_stat_for) — NEVER os.path.isfile. A raw os.stat/isfile on a hung
-    NFS mount is the exact GETATTR that wedges it (see rc_stat_for/rc_mtime_for
-    in mounts.py); the rc route keeps the kernel out of the loop entirely.
+    """Whether a MOUNT-BACKED path is an existing FILE, answered by the rclone
+    rc API (mounts.rc_kind_for) — NEVER os.path.isfile. A raw os.stat/isfile on
+    a hung NFS mount is the exact GETATTR that wedges it (see rc_kind_for/
+    rc_mtime_for in mounts.py); the rc route keeps the kernel out of the loop
+    entirely.
 
-    The only outcome that filters the entry is a healthy rcd's confirmed
-    "missing" (operations/stat returned {"item": null}). "exists" keeps it, and
-    "indeterminate" (rcd down / timed out / errored — rc can't prove absence)
-    also keeps it: we fail open rather than hide a live recent on a transient
-    rc hiccup."""
+    Files only, matching recents' D22 files-only contract (and _local_exists'
+    os.path.isfile): a confirmed "dir" filters the entry just like a "missing"
+    would. Only a "file" or an "indeterminate" probe (rcd down / timed out /
+    errored — rc can't prove anything) keeps it: we fail open rather than hide a
+    live recent on a transient rc hiccup."""
     from fused_render.shell import mounts as shell_mounts
 
     try:
-        return shell_mounts.rc_stat_for(fs_path) != "missing"
+        return shell_mounts.rc_kind_for(fs_path) in ("file", "indeterminate")
     except Exception:
         return True  # unexpected error -> fail open, keep the entry
 

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -98,6 +98,12 @@ class _HttpRangeFile(_io.RawIOBase):
         self._block = int(block)
         self._cache = {}
         self._order = []
+        # LRU bounded by BYTES, not block count: the block size is now 4MiB (was
+        # 64KiB), so a fixed 64-block cap would balloon to 256MiB per handle.
+        # Cap the resident set at ~32MiB instead — enough blocks to keep the
+        # scattered IFD/tile-index reads collapsing into a few Range GETs, while
+        # the memory bound stays flat regardless of the block size.
+        self._max_blocks = max(4, (32 << 20) // self._block)
 
     def readable(self):
         return True
@@ -130,7 +136,7 @@ class _HttpRangeFile(_io.RawIOBase):
         blk = self._r.read(off, n)
         self._cache[bi] = blk
         self._order.append(bi)
-        if len(self._order) > 64:  # tiny LRU — keep memory bounded
+        if len(self._order) > self._max_blocks:  # LRU — byte-bounded (~32MiB)
             self._cache.pop(self._order.pop(0), None)
         return blk
 

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -91,7 +91,7 @@ class _HttpRangeFile(_io.RawIOBase):
     one round-trip per read. `size` comes from /api/fs/stat, so we never kernel-
     stat the mount to learn the length."""
 
-    def __init__(self, url, size, block=65536):
+    def __init__(self, url, size, block=4 << 20):
         self._r = _RangeReader(url)
         self._size = int(size)
         self._pos = 0

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -98,12 +98,17 @@ class _HttpRangeFile(_io.RawIOBase):
         self._block = int(block)
         self._cache = {}
         self._order = []
-        # LRU bounded by BYTES, not block count: the block size is now 4MiB (was
-        # 64KiB), so a fixed 64-block cap would balloon to 256MiB per handle.
-        # Cap the resident set at ~32MiB instead — enough blocks to keep the
-        # scattered IFD/tile-index reads collapsing into a few Range GETs, while
-        # the memory bound stays flat regardless of the block size.
-        self._max_blocks = max(4, (32 << 20) // self._block)
+        # LRU bounded by BYTES, not a raw block count, so the cap tracks the
+        # block size instead of silently scaling with it. The budget is large
+        # (256MiB) ON PURPOSE: tifffile/GDAL walk tile-offset tables scattered
+        # across the WHOLE file, and at 4MiB granularity each tiny scattered
+        # read pulls a full block, so the working set for a ~150-230MiB COG is
+        # itself ~150-250MiB. A smaller cap thrashes catastrophically —
+        # measured: a 32MiB budget turned a 42MiB COG's cold analyze from
+        # seconds into a >180s timeout (evict-then-refetch storm). The budget
+        # is transient: one bounded analyze in a short-lived worker, freed on
+        # exit. For 4MiB blocks this yields the proven-working 64-block set.
+        self._max_blocks = max(4, (256 << 20) // self._block)
 
     def readable(self):
         return True
@@ -136,7 +141,7 @@ class _HttpRangeFile(_io.RawIOBase):
         blk = self._r.read(off, n)
         self._cache[bi] = blk
         self._order.append(bi)
-        if len(self._order) > self._max_blocks:  # LRU — byte-bounded (~32MiB)
+        if len(self._order) > self._max_blocks:  # LRU — byte-bounded (~256MiB)
             self._cache.pop(self._order.pop(0), None)
         return blk
 

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -695,10 +695,23 @@ def main(file: str = "", action: str = "analyze", resampling: str = "",
         st = {"state": "running", "pid": None, "action": action, "watch": watch,
               "before": os.path.getsize(file), "started": time.time()}
         json.dump(st, open(sf, "w"))
-        proc = subprocess.Popen([vpy, wfile, file, action, json.dumps(opts)],
-                                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                                start_new_session=True, env=env)
-        st["pid"] = proc.pid
+        # posix_spawn, NOT Popen's fork()+exec, for the same reason as the
+        # analyze branch below: this process has libproj resident with a live
+        # proj.db SQLite handle, and fork() would run PROJ's pthread_atfork
+        # child handler in the forked child and segfault before exec. setsid=True
+        # detaches this long-running build job into its own session (what
+        # start_new_session did) so it survives the parent; stdout/stderr are
+        # sent to /dev/null via file_actions. posix_spawn runs no atfork handlers.
+        _null = os.open(os.devnull, os.O_WRONLY)
+        try:
+            pid = os.posix_spawn(
+                vpy, [vpy, wfile, file, action, json.dumps(opts)], env,
+                file_actions=[(os.POSIX_SPAWN_DUP2, _null, 1),
+                              (os.POSIX_SPAWN_DUP2, _null, 2)],
+                setsid=True)
+        finally:
+            os.close(_null)
+        st["pid"] = pid
         json.dump(st, open(sf, "w"))
         return {"ok": True, "started": True, "status_key": key, "watch": watch,
                 "before": st["before"]}
@@ -707,8 +720,18 @@ def main(file: str = "", action: str = "analyze", resampling: str = "",
         f.write(_worker_source())
         wpath = f.name
     try:
+        # close_fds=False makes CPython spawn the worker via posix_spawn rather
+        # than fork()+exec. This process (the executor's _child.py running
+        # main()) has libproj resident with a live proj.db SQLite handle in
+        # PROJ's SQLiteHandleCache (pulled in transitively, e.g. via the
+        # module-level `import fused` below). On a fork() the child runs PROJ's
+        # registered pthread_atfork child handler, which sqlite3_close()es that
+        # now-invalid handle and segfaults (SIGSEGV, code -11) before it can
+        # exec the worker. posix_spawn runs no atfork handlers, so the crash
+        # path is gone. The worker is short-lived and needs no inherited fds.
         proc = subprocess.run([vpy, wpath, file, action, json.dumps(opts)],
-                              capture_output=True, text=True, timeout=900, env=env)
+                              capture_output=True, text=True, timeout=900,
+                              env=env, close_fds=False)
         if proc.returncode != 0:
             tail = (proc.stderr or "").strip().splitlines()
             return {"error": "worker failed: " + (tail[-1] if tail else "unknown error")}

--- a/tests/test_fs_raw_warm_read_mount_safe.py
+++ b/tests/test_fs_raw_warm_read_mount_safe.py
@@ -1,0 +1,171 @@
+"""Mount-safety of the WARM-READ fallthrough on /api/fs/raw (server.py).
+
+Regression for the fsraw-mount-stat wedge: once a mount-backed file's background
+prefetch has completed (prefetch.is_done True) — or for a browser read — the
+redirect/pooled block is skipped and the handler falls through to its "not
+redirected, proxy the bytes" branch. That branch used to guard directories with a
+raw kernel os.stat(path). On a mount-backed file whose parent prefix isn't
+VFS-cached that cold GETATTR forces rclone to enumerate the whole S3 prefix (~28s
+on a 44k-entry dir), blows past the macOS NFS deadman, and drops the mount.
+
+The fix mirrors the HEAD branch: a mount-backed path resolves existence/shape
+through the rclone rcd (_mount_probe), never the kernel. These tests pin that:
+
+  * a present mount-backed file on the warm-read path proxies (200) WITHOUT any
+    kernel os.stat / _stat_or_none of the mount (existence came from the rc probe);
+  * a mount-backed directory still 404s (answered via the rc probe);
+  * an indeterminate rc probe (rcd down/timeout) maps to 503, never "missing";
+  * a local (non-mount) read is unchanged (still a kernel-backed FileResponse).
+
+Shared fixtures/helpers live in _mount_safe_helpers.
+"""
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.server as server_mod
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import create_app
+from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
+    _entry,
+    _list_raises,
+    _list_returns,
+    _mount,
+    _no_kernel_on_mount,
+    home,
+)
+
+
+class _FakeServe:
+    """Stands in for a mount's localhost rclone serve: answers any GET with a
+    fixed blob so the warm-read proxy branch returns 200 without touching the
+    kernel mount."""
+
+    def __init__(self, blob: bytes):
+        self.blob = blob
+        serve = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(serve.blob)))
+                self.send_header("Accept-Ranges", "bytes")
+                self.end_headers()
+                self.wfile.write(serve.blob)
+
+        self._srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.port = self._srv.server_address[1]
+        self._t = threading.Thread(target=self._srv.serve_forever, daemon=True)
+        self._t.start()
+
+    @property
+    def base(self):
+        return f"http://127.0.0.1:{self.port}"
+
+    def close(self):
+        self._srv.shutdown()
+
+
+@pytest.fixture()
+def warm_raw(home, monkeypatch):
+    """A TestClient on the WARM-READ path: prefetch.is_done True (so the
+    redirect/pooled block is skipped and execution reaches the proxy
+    fallthrough), plus a factory that arms a reachable serve for a mountpoint and
+    a spy that makes any _stat_or_none call fail loudly (proves the mount path
+    resolved existence via the rc probe, never the kernel)."""
+    import fused_render.shell.prefetch as prefetch
+    monkeypatch.setattr(prefetch, "schedule", lambda *a, **k: None)
+    # Warm: prefetch already landed -> the handler is past its redirect phase and
+    # falls through to the proxy branch (the one that used to kernel-stat).
+    monkeypatch.setattr(prefetch, "is_done", lambda *a, **k: True)
+
+    serve = _FakeServe(b"WARM-MOUNT-FILE-BYTES")
+
+    def arm_serve(mp):
+        from fused_render.shell import storage
+        storage.write_json(mounts_mod.serves_path(), {mp: serve.base})
+
+    client = TestClient(create_app(start_dir=str(home)))
+    try:
+        yield client, arm_serve, serve
+    finally:
+        serve.close()
+
+
+def test_warm_present_file_proxies_200_without_kernel_stat(warm_raw, monkeypatch):
+    client, arm_serve, serve = warm_raw
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # A kernel _stat_or_none of the mount is the wedge — make it fail loudly so a
+    # silent regression to the old code path can't pass this test.
+    def _boom_stat(path):
+        raise AssertionError(f"_stat_or_none({path}) touched the mount")
+    monkeypatch.setattr(server_mod, "_stat_or_none", _boom_stat)
+    # Parent lists the store; the file is present and a regular object.
+    _list_returns(monkeypatch, [_entry("cog.tif", size=len(serve.blob))])
+
+    r = client.get("/api/fs/raw",
+                   params={"path": os.path.join(mp, "cog.tif")},
+                   follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == serve.blob
+
+
+def test_warm_directory_still_404s_via_rc(warm_raw, monkeypatch):
+    client, arm_serve, serve = warm_raw
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # A directory proxied through the serve would come back as a 200 HTML
+    # listing; the rc probe reports IsDir -> 404, answered without a kernel stat.
+    _list_returns(monkeypatch, [_entry("subdir", is_dir=True)])
+    r = client.get("/api/fs/raw",
+                   params={"path": os.path.join(mp, "subdir")},
+                   follow_redirects=False)
+    assert r.status_code == 404
+
+
+def test_warm_missing_file_404s_via_rc(warm_raw, monkeypatch):
+    client, arm_serve, serve = warm_raw
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # Parent listable, child absent -> 404 via the rc probe, no kernel stat.
+    _list_returns(monkeypatch, [_entry("other.tif", size=1)])
+    r = client.get("/api/fs/raw",
+                   params={"path": os.path.join(mp, "cog.tif")},
+                   follow_redirects=False)
+    assert r.status_code == 404
+
+
+def test_warm_indeterminate_probe_is_503(warm_raw, monkeypatch):
+    client, arm_serve, serve = warm_raw
+    mp = _mount("rw", read_only=False)
+    arm_serve(mp)
+    _no_kernel_on_mount(monkeypatch, mp)
+    # rcd down/timeout -> existence is INDETERMINATE; the handler must 503, never
+    # fall back to a kernel read or report "missing".
+    _list_raises(monkeypatch, mounts_mod.RcListUnavailable("rcd down"))
+    r = client.get("/api/fs/raw",
+                   params={"path": os.path.join(mp, "cog.tif")},
+                   follow_redirects=False)
+    assert r.status_code == 503
+
+
+def test_warm_local_path_unchanged(warm_raw, home, monkeypatch):
+    client, _arm, _serve = warm_raw
+    # A local (non-mount) file has no serve, so serve_url_for is None and the
+    # handler serves it with an ordinary kernel-backed FileResponse — unchanged
+    # by the mount guard.
+    local = home / "local.txt"
+    local.write_text("hello-local")
+    r = client.get("/api/fs/raw", params={"path": str(local)})
+    assert r.status_code == 200
+    assert r.content == b"hello-local"

--- a/tests/test_pyramid_mount.py
+++ b/tests/test_pyramid_mount.py
@@ -217,20 +217,22 @@ def test_http_range_file_default_block_is_4mib(fs):
 
 
 @pytest.mark.parametrize("block,expected", [
-    (4 << 20, 8),        # 4MiB blocks -> 8 resident (32MiB budget)
-    (1 << 20, 32),       # 1MiB blocks -> 32 resident
-    (64 << 20, 4),       # block larger than the budget -> floor of 4
+    (4 << 20, 64),        # 4MiB blocks -> 64 resident (256MiB budget)
+    (1 << 20, 256),       # 1MiB blocks -> 256 resident
+    (512 << 20, 4),       # block larger than the budget -> floor of 4
 ])
 def test_http_range_file_cache_is_byte_bounded(fs, block, expected):
-    # The LRU is bounded by BYTES (~32MiB), not a fixed block count: with 4MiB
-    # blocks a 64-block cap (the old constant) would balloon to 256MiB/handle.
+    # The LRU is bounded by BYTES (256MiB), not a fixed block count, so the cap
+    # tracks the block size rather than silently scaling with it. The budget is
+    # deliberately large: a COG's scattered tile-offset reads span the whole
+    # file at block granularity, so a too-small cap thrashes (evict/re-fetch).
     # max_blocks scales inversely with block size, with a floor of 4.
     s = fs(blob=b"x")
     f = op._HttpRangeFile(op._server_url(s.src, "/api/fs/raw", "/x.tif"), 1,
                           block=block)
     assert f._max_blocks == expected
     # Memory bound holds except where the floor dominates (huge blocks).
-    assert f._max_blocks * f._block <= (32 << 20) or f._max_blocks == 4
+    assert f._max_blocks * f._block <= (256 << 20) or f._max_blocks == 4
 
 
 def test_http_range_file_evicts_beyond_max_blocks(fs):

--- a/tests/test_pyramid_mount.py
+++ b/tests/test_pyramid_mount.py
@@ -207,6 +207,45 @@ def test_http_range_file_seek_and_partial_reads(fs):
     assert f.read() == blob[-10:]
 
 
+def test_http_range_file_default_block_is_4mib(fs):
+    # Perf: the default block grew 64KiB -> 4MiB so a cold remote-COG analyze
+    # collapses hundreds of scattered IFD/tile reads into a few Range GETs
+    # (measured ~195s -> ~31s). Pin the default so it can't silently regress.
+    s = fs(blob=b"x")
+    f = op._HttpRangeFile(op._server_url(s.src, "/api/fs/raw", "/x.tif"), 1)
+    assert f._block == 4 << 20
+
+
+@pytest.mark.parametrize("block,expected", [
+    (4 << 20, 8),        # 4MiB blocks -> 8 resident (32MiB budget)
+    (1 << 20, 32),       # 1MiB blocks -> 32 resident
+    (64 << 20, 4),       # block larger than the budget -> floor of 4
+])
+def test_http_range_file_cache_is_byte_bounded(fs, block, expected):
+    # The LRU is bounded by BYTES (~32MiB), not a fixed block count: with 4MiB
+    # blocks a 64-block cap (the old constant) would balloon to 256MiB/handle.
+    # max_blocks scales inversely with block size, with a floor of 4.
+    s = fs(blob=b"x")
+    f = op._HttpRangeFile(op._server_url(s.src, "/api/fs/raw", "/x.tif"), 1,
+                          block=block)
+    assert f._max_blocks == expected
+    # Memory bound holds except where the floor dominates (huge blocks).
+    assert f._max_blocks * f._block <= (32 << 20) or f._max_blocks == 4
+
+
+def test_http_range_file_evicts_beyond_max_blocks(fs):
+    # The eviction loop honors _max_blocks: reading across more blocks than the
+    # cap keeps only the cap-many most-recent, and the bytes are still correct.
+    blob = bytes((i * 13) % 256 for i in range(5000))
+    s = fs(blob=blob)
+    f = op._HttpRangeFile(op._server_url(s.src, "/api/fs/raw", "/x.tif"),
+                          len(blob), block=512)  # 10 blocks over the blob
+    f._max_blocks = 3  # force eviction with a tiny cap
+    assert f.read() == blob  # sequential read touches all 10 blocks
+    assert len(f._cache) <= 3
+    assert len(f._order) == len(f._cache)  # order list stays in lockstep
+
+
 # --------------------------------------------------------------------------
 # main() remote gating
 # --------------------------------------------------------------------------

--- a/tests/test_server_session.py
+++ b/tests/test_server_session.py
@@ -169,3 +169,54 @@ def test_put_skips_under_read_only_mount(ro_mount):
     assert not os.path.exists(ro_mount + ".json")
     # And GET reports no session for it.
     assert GET(path=ro_mount)["lastSession"] is None
+
+
+# --- mount-safe existence gate (_is_file_mount_safe) ----------------------
+# GET/PUT gate on _is_file_mount_safe. On a mount-backed path it MUST answer
+# via the rclone rc API (rc_kind_for), NEVER a kernel os.path.isfile — a cold
+# GETATTR there enumerates the whole parent S3 prefix and wedges the mount.
+# The gate is files-only, matching os.path.isfile: "file" passes, "dir" and
+# "missing" 404, and an "indeterminate" rc probe fails OPEN (never 404s a file
+# the user just opened on a transient rcd hiccup).
+
+@pytest.fixture
+def mount_gate(monkeypatch):
+    """Force every path mount-backed, make any kernel os.path.isfile on it fail
+    loudly, and let each test dictate rc_kind_for's answer. Returns a setter."""
+    import fused_render.shell.mounts as mounts
+
+    monkeypatch.setattr(mounts, "is_mount_backed", lambda p: True)
+
+    def _no_isfile(path):
+        raise AssertionError(f"kernel os.path.isfile({path}) touched the mount")
+
+    monkeypatch.setattr(os.path, "isfile", _no_isfile)
+
+    def _set(kind):
+        monkeypatch.setattr(mounts, "rc_kind_for", lambda path, **kw: kind)
+
+    return _set
+
+
+@pytest.mark.parametrize("kind,ok", [
+    ("file", True),           # a real file -> gate passes
+    ("indeterminate", True),  # rcd down/timeout -> fail open, gate passes
+    ("dir", False),           # a directory is not a file -> 404
+    ("missing", False),       # confirmed absent -> 404
+])
+def test_get_gate_is_files_only_via_rc(mount_gate, kind, ok):
+    mount_gate(kind)
+    resp = GET(path="/mnt/pub/big-prefix/cog.tif")
+    if ok:
+        assert _status(resp) == 200
+        assert resp == {"lastSession": None}
+    else:
+        assert _status(resp) == 404
+
+
+def test_put_gate_rejects_mount_directory_via_rc(mount_gate):
+    # A mount-backed DIRECTORY must 404 at the existence gate before any write,
+    # answered by rc_kind_for — regression for the gate accepting dirs.
+    mount_gate("dir")
+    resp = PUT(body={"path": "/mnt/pub/big-prefix", "search": "a=1"}, x_fused="1")
+    assert _status(resp) == 404

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2017,7 +2017,7 @@ def test_fs_raw_serve_dead_returns_503_never_kernel_reads_mount(client, home):
     assert r.status_code == 503
 
 
-def test_fs_raw_proxy_error_keeps_range_headers(client, home):
+def test_fs_raw_proxy_error_keeps_range_headers(client, home, monkeypatch):
     """An HTTP error from a live serve passes through WITH its protocol
     headers — a 416's `Content-Range: bytes */<size>` is how a range client
     (DuckDB httpfs) learns the file length."""
@@ -2030,6 +2030,13 @@ def test_fs_raw_proxy_error_keeps_range_headers(client, home):
     os.makedirs(mp)
     f = os.path.join(mp, "x.bin")
     open(f, "wb").write(b"LOCAL-BYTES")
+    # The warm-read fallthrough resolves a mount-backed path's shape through the
+    # rcd (_mount_probe), never a kernel stat — stub the parent listing so the
+    # file reads as a present regular object and the proxy is reached.
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: [{"Name": "x.bin", "IsDir": False,
+                                                  "Size": 11,
+                                                  "ModTime": "2024-01-02T03:04:05Z"}])
 
     class H(http.server.BaseHTTPRequestHandler):
         def do_GET(self):

--- a/tests/test_shell_prefetch.py
+++ b/tests/test_shell_prefetch.py
@@ -357,6 +357,14 @@ def test_fs_raw_schedules_prefetch_for_mount_backed_file(
     (home / "serves.json").write_text(json.dumps(
         {str(mp): stub.url.rsplit("/", 1)[0]}))
 
+    # The warm-read fallthrough resolves a mount-backed path's shape through the
+    # rcd (_mount_probe), never a kernel stat — stub the parent listing so the
+    # file reads as a present regular object and the proxy is reached.
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: [{"Name": "table.parquet",
+                                                  "IsDir": False, "Size": 23,
+                                                  "ModTime": "2024-01-02T03:04:05Z"}])
+
     scheduled = []
     monkeypatch.setattr(prefetch_mod, "schedule",
                         lambda path, url: scheduled.append((path, url)))

--- a/tests/test_shell_recents.py
+++ b/tests/test_shell_recents.py
@@ -327,18 +327,18 @@ def test_get_completed_false_filters_completed_true_shows(tmp_path, monkeypatch)
 
 def test_get_mount_backed_paths_route_through_rc_not_isfile(tmp_path, monkeypatch):
     # Mount safety: a mount-backed recents path must be checked via the rclone
-    # rc API (rc_stat_for), NEVER a kernel os.path.isfile — a raw GETATTR on a
-    # hung NFS mount is the exact call that wedges it. The tri-state result
-    # governs filtering: only a healthy-rcd-confirmed "missing" filters an
-    # entry; "exists" keeps it, and "indeterminate" (rcd down / timeout / error)
-    # keeps it too (fail open).
+    # rc API (rc_kind_for), NEVER a kernel os.path.isfile — a raw GETATTR on a
+    # hung NFS mount is the exact call that wedges it. The four-state result
+    # governs filtering, files-only (D22): a confirmed "file" keeps the entry;
+    # "missing" AND "dir" both filter it (recents record files, not dirs); only
+    # an "indeterminate" (rcd down / timeout / error) keeps it (fail open).
     client, _ = _client(tmp_path, monkeypatch)
     live = _make_file(tmp_path, "live_mount.parquet")
+    adir = _make_file(tmp_path, "dir_mount.parquet")
     indet = _make_file(tmp_path, "indet_mount.parquet")
     gone = _make_file(tmp_path, "gone_mount.parquet")
-    client.post("/api/recents/open", json={"url": _view_url(live)}, headers=FUSED)
-    client.post("/api/recents/open", json={"url": _view_url(indet)}, headers=FUSED)
-    client.post("/api/recents/open", json={"url": _view_url(gone)}, headers=FUSED)
+    for f in (live, adir, indet, gone):
+        client.post("/api/recents/open", json={"url": _view_url(f)}, headers=FUSED)
 
     monkeypatch.setattr(mounts_mod, "is_mount_backed", lambda p: True)
 
@@ -347,20 +347,43 @@ def test_get_mount_backed_paths_route_through_rc_not_isfile(tmp_path, monkeypatc
 
     monkeypatch.setattr(recents_mod.os.path, "isfile", _no_isfile)
 
-    def _stat(path):
+    def _kind(path, **kw):
         if path.endswith("live_mount.parquet"):
-            return "exists"
+            return "file"
+        if path.endswith("dir_mount.parquet"):
+            return "dir"  # a dir is not a file -> filtered (files-only contract)
         if path.endswith("gone_mount.parquet"):
             return "missing"  # healthy rcd, item null -> trustworthy negative
         return "indeterminate"  # rcd down / timeout / error
 
-    monkeypatch.setattr(mounts_mod, "rc_stat_for", _stat)
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
 
     resp = client.get("/api/recents")
     assert resp.status_code == 200
     got = {e["url"] for e in resp.json()["entries"]}
-    # exists + indeterminate kept; only the confirmed-missing entry filtered.
+    # file + indeterminate kept; confirmed-missing AND confirmed-dir filtered.
     assert got == {_view_url(live), _view_url(indet)}
+
+
+def test_open_rejects_mount_backed_directory(tmp_path, monkeypatch):
+    # POST /api/recents/open resolves the just-opened target through
+    # _file_path_from_url, which is files-only. A mount-backed DIRECTORY url must
+    # not be recorded (rc_kind_for "dir"), mirroring the local os.path.isfile
+    # gate — and never via a kernel probe that would wedge the mount.
+    client, _ = _client(tmp_path, monkeypatch)
+    d = _make_file(tmp_path, "a_directory")
+    monkeypatch.setattr(mounts_mod, "is_mount_backed", lambda p: True)
+
+    def _no_isfile(path):
+        raise AssertionError("os.path.isfile called on a mount-backed path")
+
+    monkeypatch.setattr(recents_mod.os.path, "isfile", _no_isfile)
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", lambda path, **kw: "dir")
+
+    resp = client.post("/api/recents/open", json={"url": _view_url(d)}, headers=FUSED)
+    assert resp.status_code == 200
+    assert resp.json() == {"recorded": False}  # a dir is not a recordable file
+    assert client.get("/api/recents").json()["entries"] == []
 
 
 def test_corrupt_file_reads_as_defaults(tmp_path, monkeypatch):

--- a/tests/test_worker_forksafe.py
+++ b/tests/test_worker_forksafe.py
@@ -70,10 +70,21 @@ def test_executor_spawn_runs_no_atfork_child_handler(tmp_path, monkeypatch):
     NOT run on posix_spawn (the fix). This test FAILS before the fix."""
     import ctypes
 
+    libc = ctypes.CDLL(None)
+    # pthread_atfork is a plain exported symbol on macOS libSystem, but on glibc
+    # it is a static-only wrapper around __register_atfork and is NOT resolvable
+    # through CDLL(None) ("undefined symbol: pthread_atfork"). Where we can't
+    # register a probe handler, skip — the close_fds=False assertion in
+    # test_executor_child_spawn_disables_fork already covers the fix portably,
+    # and the crash this behavioral guard mirrors is macOS-specific anyway.
+    try:
+        register_atfork = libc.pthread_atfork
+    except AttributeError:
+        pytest.skip("pthread_atfork not dynamically resolvable here (e.g. glibc)")
+
     marker = tmp_path / "atfork_child_ran"
     monkeypatch.setenv("FR_ATFORK_MARKER", str(marker))
 
-    libc = ctypes.CDLL(None)
     HANDLER = ctypes.CFUNCTYPE(None)
 
     def _child_handler():
@@ -92,7 +103,7 @@ def test_executor_spawn_runs_no_atfork_child_handler(tmp_path, monkeypatch):
     _cb = HANDLER(_child_handler)
     # keep a ref alive for the life of the process (handler is never unregistered)
     globals().setdefault("_atfork_cbs", []).append(_cb)
-    libc.pthread_atfork(None, None, _cb)
+    register_atfork(None, None, _cb)
 
     script = tmp_path / "trivial.py"
     script.write_text("def main():\n    return {'ok': 1}\n")

--- a/tests/test_worker_forksafe.py
+++ b/tests/test_worker_forksafe.py
@@ -1,0 +1,174 @@
+"""Fork-safety of the worker/child spawns (native-SIGSEGV regression).
+
+Opening the pyramid view of a large mount-backed COG could crash the whole run
+with `worker exited with code -11 without producing a result` (-11 = SIGSEGV).
+The faulting thread was always a PROJ pthread_atfork *child* handler:
+
+    subprocess_fork_exec -> fork -> _pthread_atfork_child_handlers
+      -> osgeo::proj::io::SQLiteHandleCache::getHandle(...)::$_2
+      -> ...Cache::clear() -> sqlite3Close -> osgeo::proj::VFSClose
+      -> EXC_BAD_ACCESS (SIGSEGV)
+
+The forking process (the server thread running executor.run_python, and the
+executor's _child.py running the pyramid main()) has libproj resident with a
+live proj.db SQLite handle in PROJ's handle cache (pyproj is pulled in
+transitively, e.g. via `fused`/geopandas). `fork()` runs every registered
+pthread_atfork child handler in the forked child before exec; PROJ's handler
+sqlite3_close()es that now-invalid handle and segfaults before the worker can
+even exec.
+
+The fix makes every worker spawn use `posix_spawn` instead of `fork()+exec`
+(via `close_fds=False`, or `os.posix_spawn` directly for the detached build
+job). posix_spawn runs NO atfork handlers, so the crash path is gone. These
+tests lock that in: the spawns must not take the fork path.
+"""
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from fused_render import executor
+from fused_render.templates.pyramid import overview_pyramid as op
+
+_POSIX = os.name == "posix"
+
+
+# --------------------------------------------------------------------------
+# executor._child.py spawn — the site in the crash report (server thread)
+# --------------------------------------------------------------------------
+
+def test_executor_child_spawn_disables_fork(tmp_path, monkeypatch):
+    """run_python must spawn _child.py with close_fds=False, which is what
+    forces CPython onto the posix_spawn path (no atfork handlers) instead of
+    fork()+exec. A regression that drops this reopens the PROJ atfork SIGSEGV."""
+    script = tmp_path / "trivial.py"
+    script.write_text("def main():\n    return {'ok': 1}\n")
+
+    captured = {}
+
+    real_run = subprocess.run
+
+    def fake_run(argv, **kw):
+        captured.update(kw)
+        return real_run(argv, **kw)
+
+    monkeypatch.setattr(executor.subprocess, "run", fake_run)
+    executor.run_python(str(script), {})
+    assert captured.get("close_fds") is False, (
+        "executor must pass close_fds=False so the child is spawned via "
+        "posix_spawn, not fork() (which runs PROJ's crashing atfork handler)"
+    )
+
+
+@pytest.mark.skipif(not _POSIX, reason="pthread_atfork is POSIX-only")
+def test_executor_spawn_runs_no_atfork_child_handler(tmp_path, monkeypatch):
+    """Behavioral guard: register a C-level pthread_atfork CHILD handler (the
+    same layer PROJ's crashing handler lives at) and prove it does NOT run when
+    the executor spawns the child. It runs on fork() (the buggy path) and does
+    NOT run on posix_spawn (the fix). This test FAILS before the fix."""
+    import ctypes
+
+    marker = tmp_path / "atfork_child_ran"
+    monkeypatch.setenv("FR_ATFORK_MARKER", str(marker))
+
+    libc = ctypes.CDLL(None)
+    HANDLER = ctypes.CFUNCTYPE(None)
+
+    def _child_handler():
+        # gated on the env var so this process-global handler stays inert for
+        # the rest of the session once the test clears the var
+        p = os.environ.get("FR_ATFORK_MARKER")
+        if not p:
+            return
+        try:
+            fd = os.open(p, os.O_CREAT | os.O_WRONLY, 0o644)
+            os.write(fd, b"x")
+            os.close(fd)
+        except Exception:
+            pass
+
+    _cb = HANDLER(_child_handler)
+    # keep a ref alive for the life of the process (handler is never unregistered)
+    globals().setdefault("_atfork_cbs", []).append(_cb)
+    libc.pthread_atfork(None, None, _cb)
+
+    script = tmp_path / "trivial.py"
+    script.write_text("def main():\n    return {'ok': 1}\n")
+
+    res = executor.run_python(str(script), {})
+    assert res.get("ok"), res
+    assert not marker.exists(), (
+        "a pthread_atfork child handler ran during the child spawn -> the "
+        "executor took the fork() path; PROJ's atfork handler would SIGSEGV here"
+    )
+
+
+# --------------------------------------------------------------------------
+# pyramid template worker spawns (_child.py running main() forks the worker)
+# --------------------------------------------------------------------------
+
+def test_pyramid_analyze_worker_spawn_disables_fork(monkeypatch):
+    """The analyze/predict worker spawn (subprocess.run) must pass
+    close_fds=False -> posix_spawn, not fork()+exec."""
+    captured = {}
+
+    class _Proc:
+        returncode = 0
+        stdout = json.dumps({"ok": True, "levels": []})
+        stderr = ""
+
+    def fake_run(argv, **kw):
+        captured.update(kw)
+        return _Proc()
+
+    monkeypatch.setattr(op, "_venv_python", lambda: "/fake/python")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # local file, no src -> analyze spawns the worker straight away
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+    op.main(file="/tmp/x.tif", action="analyze")
+    assert captured.get("close_fds") is False
+
+
+@pytest.mark.skipif(not _POSIX, reason="posix_spawn is POSIX-only")
+def test_pyramid_build_worker_uses_posix_spawn(tmp_path, monkeypatch):
+    """The detached build/cogify spawn must go through os.posix_spawn with
+    setsid=True (session detachment, no atfork handlers), NOT subprocess.Popen
+    (fork()+exec)."""
+    tif = tmp_path / "x.tif"
+    tif.write_bytes(b"II*\x00" + b"0" * 100)
+
+    # redirect ~/.cache job dir into tmp so the test writes nothing under $HOME
+    real_expand = os.path.expanduser
+
+    def fake_expand(p):
+        if p.startswith("~"):
+            return str(tmp_path / "home") + p[1:]
+        return real_expand(p)
+
+    monkeypatch.setattr(os.path, "expanduser", fake_expand)
+    monkeypatch.setattr(op, "_venv_python", lambda: "/fake/python")
+    # build is local-only; no src -> local kernel isfile probe
+    monkeypatch.setattr(os.path, "isfile", lambda p: True)
+
+    captured = {}
+
+    def fake_spawn(path, argv, env, **kw):
+        captured["path"] = path
+        captured["kw"] = kw
+        return 424242
+
+    # Popen must NOT be used for this spawn; blow up if it is.
+    def boom_popen(*a, **k):
+        raise AssertionError("build spawn used subprocess.Popen (fork), not posix_spawn")
+
+    monkeypatch.setattr(os, "posix_spawn", fake_spawn)
+    monkeypatch.setattr(subprocess, "Popen", boom_popen)
+
+    res = op.main(file=str(tif), action="build")
+    assert res.get("started") is True
+    assert res.get("status_key")
+    assert captured["kw"].get("setsid") is True
+    assert captured["path"] == "/fake/python"


### PR DESCRIPTION
## Summary

Opening — and especially **switching between** — `.tif` files inside an rclone-backed mount (e.g. the 44k-entry `source.coop/.../sentinel2-temporal-mosaics`) could **disconnect the mount** ("source.coop unresponsive") and/or **crash the pyramid render** with `worker exited with code -11`. This PR fixes both failure classes and the cold-render performance that sat on top of them:

- **No kernel FS probe ever touches a mount path.** A cold `os.stat`/`isfile`/`listdir` on an rclone-NFS mount forces rclone to enumerate the *entire* parent S3 prefix, trips the macOS NFS deadman, and drops the mount. Three open-flow handlers still did this — the `/api/fs/raw` warm-read fallthrough, `/api/session` GET/PUT, and `/api/recents` — now all route existence/shape through the rclone rc API (`rc_kind_for`/`_mount_probe`), never the kernel. Files-only gates reject a mount **directory** (a `"dir"` is not a file) while failing **open** on an indeterminate rc probe.
- **Cold remote-COG analyze fits the run budget.** Range reads use a 4 MiB block (was 64 KiB: ~195s → ~31s), the built-in *and* fused engines share a single 60s timeout, and the range cache is byte-bounded to a working-set-sized 256 MiB (a too-small cap thrashes: a 42 MiB COG went 23s → >180s timeout).
- **Fixed a native `fork()`-after-PROJ SIGSEGV.** The process spawning the reader worker has `libproj` resident with a live `proj.db` SQLite handle; `subprocess`'s `fork()+exec` ran PROJ's `pthread_atfork` child handler in the fork child, which segfaulted before `exec`. Workers now spawn via `posix_spawn` (no atfork handlers).

## Visuals

Where each fix sits in the open-a-mounted-COG flow — the removed kernel probes (✗) and the fork hazard are the delta:

```mermaid
flowchart TD
    Open["Open /view/&lt;mount&gt;/B0x.tif?_mode=pyramid"] --> Session["/api/session GET/PUT"]
    Open --> Recents["/api/recents/open"]
    Open --> Raw["/api/fs/raw warm-read fallthrough"]

    Session -->|"was: kernel os.path.isfile ✗"| GateS{"_is_file_mount_safe"}
    Recents -->|"was: kernel os.path.isfile ✗"| GateR{"_mount_exists"}
    Raw -->|"was: kernel os.stat ✗"| GateW{"_mount_probe"}

    GateS -->|rc_kind_for| RC[("rclone rcd operations/stat")]
    GateR -->|rc_kind_for| RC
    GateW -->|rc list| RC
    RC -->|"file to ok / dir,missing to 404 / indeterminate fail-open"| Analyze

    Analyze["/api/run to executor to _child.py to main()"] --> Spawn["spawn reader worker"]
    Spawn -->|"was: fork()+exec to PROJ atfork to SIGSEGV -11"| PosixSpawn["posix_spawn (no atfork handlers)"]
    PosixSpawn --> Worker["worker: 4 MiB blocks / 256 MiB cache / 60s budget"]
    Worker --> Render["pyramid renders / mount stays attached"]
```

## Usage

No API or config change — the behavior is transparent. To exercise it: open a large `.tif` inside a managed mount in the pyramid view and switch between several files, e.g.

```
http://127.0.0.1:1777/view/Users/<you>/.fused-render/mounts/source.coop/earthgenome/sentinel2-temporal-mosaics/01KAU_2023-01-01_2024-01-01/B02.tif?_mode=pyramid
```

The mount stays attached across switches and each COG renders its full overview pyramid on a cold cache.

## Test Plan

- [x] **Automated — new/updated:**
  - `test_fs_raw_warm_read_mount_safe.py` — warm-read fallthrough resolves via rc, never a kernel stat.
  - `test_server_session.py` — parametrized `_is_file_mount_safe` gate (file/indeterminate pass, dir/missing 404) with a loud kernel-`isfile` guard; PUT dir-rejection.
  - `test_shell_recents.py` — recents existence on `rc_kind_for` (four states), dir filtered, open-time dir rejection.
  - `test_pyramid_mount.py` — 4 MiB default block, byte-bounded LRU derivation + eviction.
  - `test_worker_forksafe.py` — worker spawns take the `posix_spawn` path (no fork); behavioral `pthread_atfork` guard (skips where the symbol isn't dynamically resolvable, e.g. glibc).
  - `test_shell_mounts.py` / `test_shell_prefetch.py` — stub `rc_list_dir` for the warm paths.
- [x] **Suite green** locally: pyramid + prefetch + fork-safe + session + recents + mount-safety → **122 passed, 3 skipped**. CI reddened only on the atfork probe's glibc symbol resolution — fixed in `877a244`.
- [x] **Manual (live mount, `source.coop`):** switched across B08 → TCI → B03 → B05 → B06 → B02 (40–232 MB) — mount never disconnected; B02 (158 MB), the reliable `-11` crasher, renders the full pyramid **with concurrent prefetch running** and **0 new PROJ-atfork crash reports** across 25+ analyzes.

### Known separate issues (pre-existing, out of scope here)
- A distinct worker-side `SIGABRT` (uncaught GDAL `std::length_error`) on some files under concurrent prefetch — surfaces as a clean "worker failed", does **not** wedge the mount.
- TCI.tif (232 MB) occasionally exceeds the 60s cold-read budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
