### PR TITLE
Learn sidebar entry opens index.html when the mount has one

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -524,16 +524,17 @@ export default function Sidebar({ config }: SidebarProps) {
     const root = `${config.mounts_root.replace(/\/+$/, "")}/learn`;
     // Prefer the bundled index.html as the landing page when it exists;
     // fall back to the mount folder otherwise (older learn.zip builds).
+    // The stat can be slow (mount-backed read); if the user navigated
+    // elsewhere while it was in flight, don't yank them back.
+    const before = currentUrl();
+    let dest = root;
     try {
       const st = await statPath(`${root}/index.html`);
-      if (!st.is_dir) {
-        navigate(`${root}/index.html`);
-        return;
-      }
+      if (!st.is_dir) dest = `${root}/index.html`;
     } catch {
       // stat 404s (or the mount is briefly not attached) — open the folder.
     }
-    navigate(root);
+    if (currentUrl() === before) navigate(dest);
   };
 
   // --- bookmark row handlers -------------------------------------------------

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,7 +22,7 @@ import {
   setBookmarkIcon,
 } from "../lib/bookmarks";
 import { bookmarkSaveTarget } from "../lib/bookmark-file";
-import { exportBookmarkFile, getConfig } from "../lib/api";
+import { exportBookmarkFile, getConfig, statPath } from "../lib/api";
 import IconPicker from "./IconPicker";
 import { FolderIcon, LearnIcon } from "./FileIcons";
 import type { Bookmark, BookmarkFolder, BookmarkItem } from "../lib/bookmarks";
@@ -518,11 +518,22 @@ export default function Sidebar({ config }: SidebarProps) {
   // D123: the bundled learn.zip is mounted read-only at `${mounts_root}/learn`
   // (LEARN_MOUNT_NAME in shell/mounts.py — always "learn"), so no separate
   // /api/mounts round trip is needed, same as the Fused entry above.
-  const onLearnClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const onLearnClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (config && config.mounts_root) {
-      navigate(`${config.mounts_root.replace(/\/+$/, "")}/learn`);
+    if (!config || !config.mounts_root) return;
+    const root = `${config.mounts_root.replace(/\/+$/, "")}/learn`;
+    // Prefer the bundled index.html as the landing page when it exists;
+    // fall back to the mount folder otherwise (older learn.zip builds).
+    try {
+      const st = await statPath(`${root}/index.html`);
+      if (!st.is_dir) {
+        navigate(`${root}/index.html`);
+        return;
+      }
+    } catch {
+      // stat 404s (or the mount is briefly not attached) — open the folder.
     }
+    navigate(root);
   };
 
   // --- bookmark row handlers -------------------------------------------------


### PR DESCRIPTION
The sidebar's Learn entry now stats `<mounts_root>/learn/index.html` on click. If it exists, it opens directly; otherwise (older learn.zip without an index, or stat failure while the mount is briefly detached) it falls back to opening the mount folder as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single sidebar navigation path change with graceful fallback; no auth, data, or API contract changes beyond an existing stat call.
> 
> **Overview**
> The sidebar **Learn** click handler now **probes** `<mounts_root>/learn/index.html` via `statPath` before navigating. When that path exists as a **file**, navigation goes there instead of the mount folder; **404/stat errors** or missing index still open the folder (older learn bundles).
> 
> Because the stat can be **slow on mount-backed storage**, the handler is **async** and only calls `navigate` if `currentUrl()` is unchanged since the click, so a user who navigates away mid-request is not pulled back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0283aac08b0c66390b186aba11d3e472be680ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->