### PR TITLE
Apply the Deploy dialog's caching choice on every redeploy, not just first deploy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -893,29 +893,20 @@ the product gains network access.
   caching differently (fused repo's spec/serve/fused-render.md § Caching /
   spec/serve/share-links.md §8): it travels in the export bundle's manifest
   (EX-9) for an AWS environment (read by `build_html_artifact`, so a later
-  `repoint`/redeploy can change it too — `deploy_page` sends it both ways
-  there, harmlessly redundant); for a managed `fused` environment the manifest
-  field is not read at all — only the explicit `--cache-max-age` on the
-  `share create` call is, as the mount's own `cache_settings` (a control-plane
-  concept independent of the bundle, `application` repo spec `021` §3.1). That
-  field is **fixed for the life of a token**: a `repoint` carries no cache
-  fields at all, and a revoked-token revive (`recreate --same-token`) preserves
-  it verbatim — so `deploy_page` deliberately withholds `--cache-max-age` on
-  those two calls (sending it would either be ignored or, on `repoint`,
-  rejected outright) and persists the setting that is **actually** live, not
-  the one requested (`_record_from`'s `effective_cache_max_age`), so the
-  deployment card never claims a setting the mount doesn't have. When the
-  modal detects the checkbox/duration no longer matches what's live on a
-  `fused`-backend redeploy, it shows this inline (naming the live value) with
-  a **"Deploy as new URL"** action (`deploy_page(..., force_new=True)`) — the
-  only way to actually change caching on that backend. It **replaces** the
-  deployment: skips token reuse, mints a fresh `share create` with the
-  requested setting at a new URL, repoints the page pointer to it, then
-  **best-effort revokes the superseded mount** (last, after the new URL is
-  live, so a create failure never takes the page down; a revoke failure is
-  non-fatal — the new URL stands and the old mount lingers, revocable from the
-  account page's deployments list). The pointer therefore tracks the new mount,
-  so the modal's Revoke targets the new URL — no orphaned URL to chase.
+  `repoint`/redeploy can change it too); for a managed `fused` environment the
+  manifest field is not read at all — only the explicit `--cache-max-age` flag
+  is, as the mount's own `cache_settings` (a control-plane concept independent
+  of the bundle, `application` repo spec `021` §3.1, amended). `deploy_page`
+  now sends `--cache-max-age` on every path — `create`, `repoint`, and the
+  follow-up `repoint` after a revoked-token `recreate --same-token` — so a
+  redeploy on either backend applies whatever the dialog's checkbox/duration
+  currently says, same token/URL, no "Deploy as new URL" workaround needed. A
+  `force_new=True` `deploy_page` call still exists as a general "mint an
+  entirely fresh URL and take the old one down" action (skip token reuse,
+  `share create` at a new token, repoint the page pointer to it, then
+  **best-effort revoke the superseded mount** last so a create failure never
+  takes the page down) — the modal just no longer needs to surface it as a
+  caching-change escape hatch.
 - **DP-18** **Clear cache** (`POST /api/deploy/clear-cache {"page"}` →
   `clear_cache_deployment` → `fused share cache-clear <token>`) forces every
   cached result for the deployment's mount to be recomputed on the next

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -973,35 +973,6 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </button>
           )}
         </div>
-        {env?.backend === "fused" &&
-          isRedeploy &&
-          cacheMaxAge !== (deployment?.cache_max_age ?? "0s") && (
-            <div className="deploy-note">
-              Managed Fused environments fix caching at first deploy — redeploying this URL
-              keeps its current setting (
-              {(deployment?.cache_max_age ?? "0s") === "0s"
-                ? "off"
-                : `on, ${deployment?.cache_max_age}`}
-              ), not the one just chosen above. Deploying as a new URL replaces this
-              deployment: it mints a fresh URL with the setting above and takes the old one
-              down.{" "}
-              <button
-                type="button"
-                className="btn btn-secondary"
-                onClick={() => onDeploy(true)}
-                disabled={
-                  busy !== null ||
-                  preview === null ||
-                  previewPending ||
-                  (preview?.errors.length ?? 0) > 0
-                }
-                title="Mint a fresh URL with the setting chosen above and switch this page to it — the old URL is taken down (existing links to it stop working)"
-              >
-                Deploy as new URL
-              </button>
-            </div>
-          )}
-
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
           <Select

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -396,16 +396,11 @@ def set_deployment(page: str, record: dict) -> None:
 def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
                  entrypoints: list[str], include: list[str], exclude: list[str],
                  cache_max_age: str, fallback: dict | None) -> dict:
-    # `cache_max_age` here must be the setting actually now in effect on the live
-    # mount — NOT necessarily what the caller requested. On a managed Fused env, a
-    # repoint/recreate-revive reuses the existing mount's `cache_settings` verbatim
-    # (fixed at first `create`, `application` repo spec 021 §3.1); the CLI already
-    # withholds `--cache-max-age` on those calls (see deploy_page) precisely because
-    # sending it would either be ignored or (on `repoint`) rejected outright. The
-    # caller (deploy_page) resolves the effective value before calling this, so a
-    # reused-token redeploy that requested a different duration still shows the
-    # duration that is really running — the deployment card must never claim a
-    # setting the mount doesn't have.
+    # `cache_max_age` here is simply what the caller requested this deploy — every
+    # branch in deploy_page (create, repoint, recreate+repoint) now actually applies
+    # it (`application` repo spec 021 §3.1, amended: a managed Fused mount's
+    # cache_settings is changeable in place via repoint, not just fixed at first
+    # create), so the record's stored value and the live mount agree on every path.
     token = raw.get("token") or raw.get("id") or (fallback or {}).get("token")
     if not isinstance(token, str) or not token:
         raise DeployError("the fused CLI did not return a mount token")
@@ -503,31 +498,28 @@ def deploy_page(
     `cache_max_age` (`"0s"` off by default, e.g. `"5m"`/`"1h"`) is the Deploy
     dialog's caching choice: how long a page's result may be served from cache
     instead of re-executed. It rides the export bundle's own manifest
-    (`export.export_page`) AND is passed explicitly as `share create
-    --cache-max-age` — the two backends read it from different places (`fused`
-    repo's spec/serve/fused-render.md § Caching): an AWS environment's
-    `build_html_artifact` reads the manifest field (so either source works,
-    including on a later `repoint`); a managed Fused environment reads it only
-    on `create`, as its own mount-level `cache_settings` field (`application`
-    repo spec `021` §3.1), wholly independent of the bundle. On a managed
-    environment `cache_settings` is fixed for the life of a token — `repoint`
-    carries no cache fields at all (the control plane rejects one), and a
-    revoked-token revive (`recreate --same-token`) preserves the existing
-    setting verbatim — so a redeploy that reuses the token can request a
-    different `cache_max_age` all it wants, it never takes effect. This
-    function does not pretend otherwise: on that reuse path the stored record
-    keeps reporting the setting that is actually live, not the one requested
-    (see `_record_from`). `force_new=True` is the only way to actually change
-    it on a managed environment: it **replaces** the deployment — mints a fresh
-    `share create` (a new token, new URL) with the requested `cache_max_age`,
-    repoints this page's pointer to it, then **best-effort revokes the old
-    mount** so the page is never left with two live URLs. The revoke is
-    deliberately last (after the new mount is live) so a create failure never
-    takes the page down, and best-effort (a revoke failure doesn't fail the
-    deploy — the new URL is live and correct; the superseded mount lingers and
-    is revocable from the Fused account page's deployments list). Because the
-    pointer now tracks the new mount, the modal's Revoke button targets the new
-    URL, as expected — there is no orphaned URL the user must chase separately.
+    (`export.export_page`) AND is passed explicitly as `--cache-max-age` on
+    every `share create`/`repoint` call — the two backends read it from
+    different places (`fused` repo's spec/serve/fused-render.md § Caching): an
+    AWS environment's `build_html_artifact` reads the manifest field (so either
+    source works, including on a later `repoint`); a managed Fused environment
+    reads it only from the explicit flag, as its own mount-level
+    `cache_settings` field (`application` repo spec `021` §3.1), wholly
+    independent of the bundle. `cache_settings` is no longer pinned for the
+    life of a token — `repoint` (and a revoked-token revive's follow-up
+    `repoint`) now carries `--cache-max-age` too, so a redeploy that reuses the
+    token applies whatever `cache_max_age` this call requested, same as a fresh
+    `create`. `force_new=True` still replaces the deployment outright — mints a
+    fresh `share create` (a new token, new URL) with the requested
+    `cache_max_age`, repoints this page's pointer to it, then **best-effort
+    revokes the old mount** so the page is never left with two live URLs. The
+    revoke is deliberately last (after the new mount is live) so a create
+    failure never takes the page down, and best-effort (a revoke failure
+    doesn't fail the deploy — the new URL is live and correct; the superseded
+    mount lingers and is revocable from the Fused account page's deployments
+    list). Because the pointer now tracks the new mount, the modal's Revoke
+    button targets the new URL, as expected — there is no orphaned URL the user
+    must chase separately.
 
     First deploy (or a pointer on a different env, or `force_new=True`):
     `share create --public` — a fresh opaque capability URL. Otherwise, redeploy
@@ -591,35 +583,28 @@ def deploy_page(
             if force_new and pointer and pointer.get("env") == env_name
             else None
         )
-        # What the mount will ACTUALLY be caching after this call — defaults to
-        # the requested value (true for AWS always, and for fused on any branch
-        # that runs `create`); overridden below on a fused-backend token-reuse
-        # branch, where the request never reaches the control plane.
-        effective_cache_max_age = cache_max_age
-
         if not token:
             raw = _run_share(
                 env_name, ["create", bundle, "--public", "--cache-max-age", cache_max_age]
             )
         else:
             live = _classify_mount(_list_mounts(env_name), token)
-            # A repoint/recreate-revive (the "active"/"revoked" branches just
-            # below) reuses the mount's own cache_settings on a managed Fused env
-            # (spec 021 §3.1) — the request never reaches the control plane on
-            # those two calls (see docstring), so the record must keep reporting
-            # whatever was already live, not this request. The "absent" branch
-            # below is a genuine fresh `create`, so it's excluded here — the
-            # requested value really does take effect there. AWS is unaffected
-            # either way: build_html_artifact re-reads the bundle's own manifest
-            # on every repoint, so the request DOES take effect there too.
-            if backend == "fused" and live in ("active", "revoked"):
-                effective_cache_max_age = (same_env or {}).get("cache_max_age", "0s")
+            # `--cache-max-age` on every branch below: AWS re-reads the bundle's own
+            # manifest on every repoint anyway (so this is a no-op-equivalent
+            # restatement of the same value), and on a managed Fused env `repoint`
+            # now updates the mount's own `cache_settings` in place too
+            # (`application` repo spec 021 §3.1, amended) — no fresh mount required
+            # to change caching on a redeploy that reuses the token.
             if live == "active":
-                raw = _run_share(env_name, ["repoint", token, bundle])
+                raw = _run_share(
+                    env_name, ["repoint", token, bundle, "--cache-max-age", cache_max_age]
+                )
             elif live == "revoked":
                 _run_share(env_name, ["recreate", token, "--same-token"])
                 try:
-                    raw = _run_share(env_name, ["repoint", token, bundle])
+                    raw = _run_share(
+                        env_name, ["repoint", token, bundle, "--cache-max-age", cache_max_age]
+                    )
                 except DeployError as repoint_err:
                     # The revive (recreate) succeeded but the republish
                     # (repoint) failed — so the mount is live again with its
@@ -656,7 +641,7 @@ def deploy_page(
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
             entrypoints=entrypoints, include=include, exclude=exclude,
-            cache_max_age=effective_cache_max_age, fallback=same_env,
+            cache_max_age=cache_max_age, fallback=same_env,
         )
         set_deployment(page, record)
         # force_new replace: the new mount is live and the pointer now tracks it,

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -137,7 +137,7 @@ def _now_iso() -> str:
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
 PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post7-py3-none-any.whl"
+    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post9-py3-none-any.whl"
 )
 # The wheel's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ app = [
 # The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post7-py3-none-any.whl ; python_version >= "3.11"',
+    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post9-py3-none-any.whl ; python_version >= "3.11"',
 ]
 
 [project.scripts]

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -460,11 +460,11 @@ def test_deploy_rejects_invalid_cache_max_age(tmp_path, monkeypatch):
     assert h.calls() == []  # rejected before any CLI shellout
 
 
-def test_repoint_on_fused_backend_keeps_previous_cache_max_age(tmp_path, monkeypatch):
-    # A managed Fused mount's cache_settings are fixed at `create` (021 §3.1) —
-    # `repoint` carries no cache fields at all, so a redeploy requesting a
-    # DIFFERENT duration must not claim it took effect: the record has to keep
-    # reporting the value that's actually live.
+def test_repoint_on_fused_backend_applies_the_new_cache_max_age(tmp_path, monkeypatch):
+    # 021 §3.1, amended: a managed Fused mount's cache_settings is changeable in
+    # place via repoint, not just fixed at create — a redeploy requesting a
+    # DIFFERENT duration on the same token now actually takes effect, and the
+    # record reports the value that's actually live.
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
@@ -487,16 +487,17 @@ def test_repoint_on_fused_backend_keeps_previous_cache_max_age(tmp_path, monkeyp
         headers=FUSED,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["cache_max_age"] == "5m"
-    assert h.pointer()["cache_max_age"] == "5m"
+    assert resp.json()["cache_max_age"] == "1h"
+    assert h.pointer()["cache_max_age"] == "1h"
     repoint_call = h.calls()[-1]
     assert repoint_call["argv"][1] == "repoint"
-    assert "--cache-max-age" not in repoint_call["argv"]
+    assert repoint_call["argv"][-2:] == ["--cache-max-age", "1h"]
 
 
-def test_recreate_revive_on_fused_backend_keeps_previous_cache_max_age(tmp_path, monkeypatch):
-    # Same guarantee on the revoked-tombstone revive path (recreate --same-token
-    # + repoint): neither call can change cache_settings on a managed env.
+def test_recreate_revive_on_fused_backend_applies_the_new_cache_max_age(tmp_path, monkeypatch):
+    # Same on the revoked-tombstone revive path (recreate --same-token + repoint):
+    # the follow-up repoint now carries --cache-max-age too, so reviving with a
+    # different duration actually changes it, same as the plain-repoint case above.
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
@@ -520,15 +521,17 @@ def test_recreate_revive_on_fused_backend_keeps_previous_cache_max_age(tmp_path,
         headers=FUSED,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["cache_max_age"] == "5m"
+    assert resp.json()["cache_max_age"] == "1h"
     verbs_and_flags = [(c["argv"][1], "--cache-max-age" in c["argv"]) for c in h.calls()[-2:]]
-    assert verbs_and_flags == [("recreate", False), ("repoint", False)]
+    assert verbs_and_flags == [("recreate", False), ("repoint", True)]
 
 
 def test_repoint_on_aws_backend_applies_the_new_cache_max_age(tmp_path, monkeypatch):
-    # AWS is unaffected by the fused-backend carve-out above: build_html_artifact
-    # re-reads the bundle's own manifest on every repoint, so a redeploy's request
-    # really does take effect there.
+    # AWS applies a redeploy's cache_max_age two ways: build_html_artifact re-reads
+    # the bundle's own manifest on every repoint, AND deploy_page now also passes
+    # --cache-max-age explicitly on the repoint call (same as the managed backend) —
+    # a no-op-equivalent restatement of the same value there, but it means a
+    # redeploy's request really does take effect either way.
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario({"create": {"token": "abc123", "status": "active"}})
     h.client.post(
@@ -550,12 +553,15 @@ def test_repoint_on_aws_backend_applies_the_new_cache_max_age(tmp_path, monkeypa
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["cache_max_age"] == "1h"
+    repoint_call = h.calls()[-1]
+    assert repoint_call["argv"][-2:] == ["--cache-max-age", "1h"]
 
 
 def test_force_new_replaces_the_deployment_and_revokes_the_old_mount(tmp_path, monkeypatch):
-    # The only way to actually change caching on a managed Fused mount: skip token
-    # reuse and mint a brand-new mount via `create`, then take the OLD mount down so
-    # the page isn't left serving at two URLs the pointer can't both track.
+    # force_new skips token reuse and mints a brand-new mount via `create`, then
+    # takes the OLD mount down so the page isn't left serving at two URLs the
+    # pointer can't both track — used when the user wants a fresh URL outright,
+    # not merely to change caching (repoint can do that in place now).
     h = _harness(tmp_path, monkeypatch)
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}


### PR DESCRIPTION
## Summary

Companion to changes in `fusedio/fused` and `fusedlabs/application` (same branch name) that let a managed Fused mount's caching change in place via `repoint`, instead of being fixed at first deploy.

- `deploy_page` now passes `--cache-max-age` on every `repoint` call (both the plain active-mount repoint and the follow-up repoint after a revoked-token `recreate --same-token` revive), instead of withholding it because the control plane used to ignore/reject it on that path.
- Removed the now-dead `effective_cache_max_age` override in `deploy_page`/`_record_from` — every branch (`create`, `repoint`, `recreate`+`repoint`) now actually applies the requested `cache_max_age`, so the stored record and the live mount always agree.
- Removed the Deploy dialog's stale "Managed Fused environments fix caching at first deploy…" warning and its "Deploy as new URL" caching-change escape hatch (`DeployModal.tsx`) — an ordinary Redeploy now applies whatever the checkbox/duration currently says, same token/URL, on both backends. (`force_new`/`deployPage(..., force_new)` itself is untouched — it's still there as a general "mint an entirely fresh URL" action, just no longer surfaced as a caching workaround.)
- Updated `SPEC.md` DP-17 to match; rewrote the two tests that asserted the old "keeps previous cache_max_age" behavior into "applies the new cache_max_age" tests, and updated the AWS-repoint test's comment/assertion.

## Test plan

- [x] `.venv/bin/python -m pytest -q` — 1249 passed, 47 skipped, 1 pre-existing unrelated failure (`test_create_remote_rejects_bad_name`, untouched by this change)
- [x] `npx tsc --noEmit` (frontend) — clean
- [ ] Manual click-through of the Deploy dialog against a live managed Fused environment (not done in this sandbox — no network access to a real control plane)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LyoFZEEVv9E98mTQLiEUgQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live deploy CLI orchestration for managed Fused mounts (caching on repoint), though behavior is covered by updated tests and depends on the matching fused/application releases.
> 
> **Overview**
> **Managed Fused redeploys** can now change page caching on the **same URL/token**: `deploy_page` always forwards the dialog’s `cache_max_age` as `--cache-max-age` on `share create`, active-mount `repoint`, and the post-`recreate --same-token` `repoint` (companion to upstream control-plane/CLI changes). The old **`effective_cache_max_age`** path that stored the live mount setting while withholding the flag on repoint is gone — deployment records now match what was requested.
> 
> The **Deploy modal** drops the inline note and **“Deploy as new URL”** button that existed because caching was fixed at first deploy on managed backends; ordinary **Redeploy** applies the checkbox/duration. **`force_new`** remains in the API for minting a fresh URL but is no longer surfaced as a caching escape hatch.
> 
> **SPEC.md** DP-17 is updated; deploy tests flip from “keeps previous cache” to “applies new cache” and assert `--cache-max-age` on repoint. The pinned **`fused`** wheel moves **2.9.3.post7 → post9** in `deploy.py` and `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7a998965d9c746bb1bd1f60b914ededd6ca7f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->