### PR TITLE
perf(fs): speed up conditions + folder-open navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@
 // which is the React equivalent of the vanilla shell rebuilding the view DOM
 // on each route() call (fresh iframes, fresh fetches, dropped local state).
 import { useEffect, useState } from "react";
-import { IS_EMBED, fsPathFromLocation, urlForFsPath } from "./lib/router";
+import { IS_EMBED, fsPathFromLocation, urlForFsPath, navHintIsDir } from "./lib/router";
 import { useSessionRestore, useSessionTracking } from "./lib/session";
 import { useRecentsTracking } from "./lib/recents";
 import { statPath, getMounts, reconnectMount, type Config, type Mount, type StatResult } from "./lib/api";
@@ -134,12 +134,50 @@ function StatErrorView({
   );
 }
 
+// First paint while `stat` is still in flight (~1.6s on a cold remote mount),
+// so a navigation shows a populated scaffold instead of a blank screen. The
+// breadcrumb is already rendered by StatView; here the preview header shows the
+// folder/file name (from the URL) with a spinner where the template
+// ModeSwitcher will land once stat resolves. When the nav hint says this is a
+// directory, the real Listing mounts NOW — its /api/fs/list runs in parallel
+// with stat rather than serialized behind it, and the same fetch is reused
+// (api.prefetchListDir) when stat resolves and the preview remounts the
+// listing. Without a directory hint we can't safely show a listing (a file's
+// list would 404), so only the header + a neutral loading body paint.
+function LoadingScaffold({ fsPath, isDir }: { fsPath: string; isDir: boolean }) {
+  return (
+    <>
+      <div className="preview-header">
+        <h1 title={fsPath}>{basename(fsPath)}</h1>
+        <div className="preview-actions">
+          <span className="mode-icon-spinner" aria-label="Loading" />
+        </div>
+      </div>
+      <div className="preview-body">
+        {isDir ? (
+          <Listing fsPath={fsPath} />
+        ) : (
+          <div className="preview-resolving">
+            <span className="mode-icon-spinner" />
+            Loading…
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
 // Stat-backed views (listing/preview): breadcrumb + content under one hook
 // component so useStat only runs when the pathname is a real fs path, not a
 // sentinel.
 function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home: string }) {
   // Bumped by StatErrorView to re-stat in place after reconnecting a mount.
   const [reloadKey, setReloadKey] = useState(0);
+  // Directory hint from the navigation that mounted this view (see router
+  // navHintIsDir). Captured ONCE at mount — StatView is keyed by epoch+fsPath
+  // so it remounts per navigation, and reading it live would be clobbered by
+  // the listing's own sort/search replaceState (which pass null state).
+  const [navIsDir] = useState<boolean | null>(() => navHintIsDir());
   const stat = useStat(fsPath, epoch, reloadKey);
   // null until the stat resolves — the session hooks opt out for anything that
   // is not a confirmed file, so a directory never gets a restore/track before
@@ -164,7 +202,11 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   // gate as session tracking.
   useRecentsTracking(fsPath, isDir, renderedTitle);
   let content = null;
-  if (stat.status === "error") {
+  if (stat.status === "loading") {
+    // Not a blank screen: paint the scaffold immediately (Fix #1). A directory
+    // nav also starts its listing fetch now, parallel with stat (Fix #2).
+    content = <LoadingScaffold fsPath={fsPath} isDir={navIsDir === true} />;
+  } else if (stat.status === "error") {
     content = (
       <StatErrorView
         fsPath={fsPath}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -175,8 +175,10 @@ function StatView({ fsPath, epoch, home }: { fsPath: string; epoch: number; home
   const [reloadKey, setReloadKey] = useState(0);
   // Directory hint from the navigation that mounted this view (see router
   // navHintIsDir). Captured ONCE at mount — StatView is keyed by epoch+fsPath
-  // so it remounts per navigation, and reading it live would be clobbered by
-  // the listing's own sort/search replaceState (which pass null state).
+  // so it remounts per navigation. In-place param syncs go through
+  // router.replaceSearch, which preserves history.state, so the hint survives
+  // for Back/Forward; capturing once here is belt-and-braces (and correct even
+  // if some future caller forgets to preserve it).
   const [navIsDir] = useState<boolean | null>(() => navHintIsDir());
   const stat = useStat(fsPath, epoch, reloadKey);
   // null until the stat resolves — the session hooks opt out for anything that

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -155,7 +155,10 @@ function LoadingScaffold({ fsPath, isDir }: { fsPath: string; isDir: boolean }) 
       </div>
       <div className="preview-body">
         {isDir ? (
-          <Listing fsPath={fsPath} />
+          // provisional: the hint could be stale (file, not dir). Suppress
+          // Listing's hard "Failed to list" error while stat resolves — a 404
+          // here just means the hint was wrong; stat will paint the file view.
+          <Listing fsPath={fsPath} provisional />
         ) : (
           <div className="preview-resolving">
             <span className="mode-icon-spinner" />

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -187,7 +187,7 @@ function enterPanel(fsPath: string, dir: "row" | "col"): void {
 function navigatePreservingMode(target: string): void {
   const mode = new URLSearchParams(location.search).get("_mode");
   if (mode) navigateUrl(urlForFsPath(target, "?_mode=" + encodeURIComponent(mode)));
-  else navigate(target);
+  else navigate(target, { isDir: true }); // breadcrumb targets are always dirs
 }
 
 export function Breadcrumb({

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -512,7 +512,7 @@ export default function Sidebar({ config }: SidebarProps) {
 
   const onFusedClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault();
-    if (config && config.fused_dir) navigate(config.fused_dir);
+    if (config && config.fused_dir) navigate(config.fused_dir, { isDir: true });
   };
 
   // D123: the bundled learn.zip is mounted read-only at `${mounts_root}/learn`
@@ -528,13 +528,17 @@ export default function Sidebar({ config }: SidebarProps) {
     // elsewhere while it was in flight, don't yank them back.
     const before = currentUrl();
     let dest = root;
+    let destIsDir = true;
     try {
       const st = await statPath(`${root}/index.html`);
-      if (!st.is_dir) dest = `${root}/index.html`;
+      if (!st.is_dir) {
+        dest = `${root}/index.html`;
+        destIsDir = false;
+      }
     } catch {
       // stat 404s (or the mount is briefly not attached) — open the folder.
     }
-    if (currentUrl() === before) navigate(dest);
+    if (currentUrl() === before) navigate(dest, { isDir: destIsDir });
   };
 
   // --- bookmark row handlers -------------------------------------------------

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -130,6 +130,32 @@ export function listDir(fsPath: string, cursor?: string | null): Promise<ListRes
   return getJson<ListResult>(url);
 }
 
+// Brief cross-mount dedupe for a directory's FIRST listing page. On navigation
+// the app paints a listing scaffold whose Listing kicks off /api/fs/list in
+// parallel with the slow /api/fs/stat; when stat resolves, the real preview
+// mounts a fresh Listing for the SAME path. Without this cache that second
+// mount would re-issue the identical request and throw the parallel fetch away.
+// So the initial (non-cursor, un-refreshed) listing goes through here: a call
+// within the short TTL of an earlier one for the same path reuses its promise.
+// A rejected promise evicts at once (errors never stick); the TTL keeps the
+// window small so a later navigation back to the same dir always re-reads,
+// matching stat's freshness posture (the dir-watch socket refresh bypasses this
+// entirely — it must see live data).
+const LIST_PREFETCH_TTL_MS = 5000;
+const listPrefetch = new Map<string, { promise: Promise<ListResult>; ts: number }>();
+
+export function prefetchListDir(fsPath: string): Promise<ListResult> {
+  const hit = listPrefetch.get(fsPath);
+  if (hit && Date.now() - hit.ts < LIST_PREFETCH_TTL_MS) return hit.promise;
+  const promise = listDir(fsPath);
+  listPrefetch.set(fsPath, { promise, ts: Date.now() });
+  promise.catch(() => {
+    // Evict only if still the same entry (a newer prefetch may have replaced it).
+    if (listPrefetch.get(fsPath)?.promise === promise) listPrefetch.delete(fsPath);
+  });
+  return promise;
+}
+
 export function walkDir(fsPath: string, opts?: { hidden?: boolean }): Promise<WalkResult> {
   let url = "/api/fs/walk?path=" + encodeURIComponent(fsPath);
   if (opts?.hidden) url += "&hidden=1";

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -73,12 +73,25 @@ export function navigate(fsPath: string, opts?: { isDir?: boolean }): void {
 
 // The directory hint carried by the navigation that landed on the current URL
 // (see navigate). null = unknown: a fresh page load, a typed URL, or a caller
-// that didn't pass one. Read once at the destination view's mount — later
-// param-sync replaceState calls (sort/search) pass null state and would wipe
-// it, so callers must not re-read it after mount.
+// that didn't pass one. Read once at the destination view's mount (StatView),
+// which is why in-place param syncs must go through replaceSearch below — a
+// raw history.replaceState(null, …) would wipe the hint off the current entry
+// and Back/Forward to it would lose the scaffold.
 export function navHintIsDir(): boolean | null {
   const s = history.state as { fsDir?: boolean } | null;
   return s && typeof s.fsDir === "boolean" ? s.fsDir : null;
+}
+
+// In-place view-param sync (sort/search/_mode/session replay) on the CURRENT
+// history entry. Unlike navigate(), this MUST NOT create a history entry and
+// MUST preserve the existing state — nulling it (a plain
+// history.replaceState(null, …)) drops the { fsDir } hint navigate() stashed,
+// so a later Back/Forward to this entry loses its directory scaffold and paints
+// a blank/header-only view. Passing history.state through keeps the hint intact.
+// Still routes through the main.tsx-wrapped replaceState, so fused:urlchange
+// (bookmark buttons, hooks) fires exactly as before.
+export function replaceSearch(url: string): void {
+  history.replaceState(history.state, "", url);
 }
 
 export function navigateUrl(url: string): void {

--- a/frontend/src/lib/router.ts
+++ b/frontend/src/lib/router.ts
@@ -57,10 +57,28 @@ export function urlForFsPath(fsPath: string, search?: string): string {
   return PREFIX + encoded + (search || "");
 }
 
-export function navigate(fsPath: string): void {
+export function navigate(fsPath: string, opts?: { isDir?: boolean }): void {
   // Navigating between files/dirs drops old view params (fresh query string).
-  history.pushState(null, "", urlForFsPath(fsPath));
+  // `opts.isDir` is a nav hint (the clicked listing row / breadcrumb already
+  // knows whether the target is a directory): it rides in history.state so the
+  // destination view can paint the right scaffold — a directory's listing plus
+  // a template-strip spinner — BEFORE the ~1.6s stat resolves, instead of a
+  // blank screen. Restored on back/forward (popstate carries the state), and
+  // simply absent (null) for callers that don't know, which falls back to a
+  // plain header scaffold. See navHintIsDir below.
+  const state = opts && typeof opts.isDir === "boolean" ? { fsDir: opts.isDir } : null;
+  history.pushState(state, "", urlForFsPath(fsPath));
   notifyNavigate();
+}
+
+// The directory hint carried by the navigation that landed on the current URL
+// (see navigate). null = unknown: a fresh page load, a typed URL, or a caller
+// that didn't pass one. Read once at the destination view's mount — later
+// param-sync replaceState calls (sort/search) pass null state and would wipe
+// it, so callers must not re-read it after mount.
+export function navHintIsDir(): boolean | null {
+  const s = history.state as { fsDir?: boolean } | null;
+  return s && typeof s.fsDir === "boolean" ? s.fsDir : null;
 }
 
 export function navigateUrl(url: string): void {

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -4,7 +4,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import { getSession, putSession } from "./api";
-import { IS_EMBED } from "./router";
+import { IS_EMBED, replaceSearch } from "./router";
 
 function stripQ(): string {
   return location.search.replace(/^\?/, "");
@@ -32,7 +32,7 @@ export function useSessionRestore(fsPath: string, isDir: boolean | null): boolea
       (r) => {
         if (!alive) return;
         const s = r.lastSession?.search;
-        if (s) history.replaceState(null, "", location.pathname + "?" + s);
+        if (s) replaceSearch(location.pathname + "?" + s);
         setRestored(true);
       },
       () => {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -9,7 +9,7 @@
 // on first focus (or a URL-seeded query) and is cached until the dir watch
 // fires.
 import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { navigate, navigateUrl, urlForFsPath } from "../lib/router";
+import { navigate, navigateUrl, urlForFsPath, replaceSearch } from "../lib/router";
 import {
   listDir,
   prefetchListDir,
@@ -273,7 +273,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     const params = new URLSearchParams(location.search);
     params.set("sort", s.get("sort") || "name");
     params.set("order", s.get("order") === "desc" ? "desc" : "asc");
-    history.replaceState(null, "", location.pathname + "?" + params.toString());
+    replaceSearch(location.pathname + "?" + params.toString());
   }, [fsPath]);
   const [refresh, setRefresh] = useState(0); // bumped by the dir watch socket
   // loadMore captures the refresh generation it started in; a dir-watch refresh
@@ -658,7 +658,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
       if (value) params.set("q", value);
       else params.delete("q");
       const qs = params.toString();
-      history.replaceState(null, "", location.pathname + (qs ? "?" + qs : ""));
+      replaceSearch(location.pathname + (qs ? "?" + qs : ""));
     }, URL_SYNC_MS);
   };
 
@@ -670,7 +670,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     const params = new URLSearchParams(location.search);
     params.set("sort", next.sort);
     params.set("order", next.order);
-    history.replaceState(null, "", location.pathname + "?" + params.toString());
+    replaceSearch(location.pathname + "?" + params.toString());
     setSortState(next);
     // Remember this folder's choice so returning to it later restores this sort.
     // Only sort/order are persisted — the in-folder search `q` stays transient.

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -12,6 +12,7 @@ import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState
 import { navigate, navigateUrl, urlForFsPath } from "../lib/router";
 import {
   listDir,
+  prefetchListDir,
   walkDirStream,
   revealPath,
   writeFile,
@@ -332,6 +333,10 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const navRowsRef = useRef<string[]>([]);
   const selectedPathRef = useRef<string | null>(null);
   selectedPathRef.current = selectedPath;
+  // Path -> RowCtx for the rendered rows, read by the once-registered keydown
+  // handler so Enter can pass the row's is_dir as a nav hint (see rowCtxByPath
+  // below, which assigns this each render).
+  const rowCtxByPathRef = useRef<Map<string, RowCtx>>(new Map());
   // True while a context menu or a modal dialog is open. The document-level nav
   // and shortcut handlers (registered once, reading refs) hard-guard on this so
   // an open overlay owns the keyboard — a stray Enter can't navigate a row and
@@ -407,7 +412,8 @@ export default function Listing({ fsPath }: { fsPath: string }) {
         if (!rows.length) return;
         const idx = rows.indexOf(selectedPathRef.current ?? "");
         e.preventDefault();
-        navigate(idx === -1 ? rows[0] : rows[idx]);
+        const target = idx === -1 ? rows[0] : rows[idx];
+        navigate(target, { isDir: rowCtxByPathRef.current.get(target)?.isDir });
         return;
       }
       // Start typing → focus the search box so the character lands there. Only
@@ -440,7 +446,11 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     // A fresh fetch (navigation or dir-watch refresh) resets any accumulated
     // Load more pages: the new listing replaces the array wholesale.
     setLoadingMore(false);
-    listDir(fsPath).then(
+    // Initial mount goes through the prefetch cache so a listing kicked off by
+    // the loading scaffold (in parallel with stat) is reused when the real
+    // preview remounts this component for the same path — no duplicate request.
+    // A dir-watch refresh (refresh > 0) must see live data, so it bypasses.
+    (refresh === 0 ? prefetchListDir(fsPath) : listDir(fsPath)).then(
       (data) =>
         alive &&
         setState({
@@ -863,6 +873,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
     }
     return m;
   }, [searching, visibleHits, sortedEntries, base]);
+  rowCtxByPathRef.current = rowCtxByPath;
 
   const refetch = () => setRefresh((n) => n + 1);
 
@@ -1088,7 +1099,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
   const rowMenu = (row: RowCtx): MenuEntry[] => {
     const dir = targetDirOf(row);
     return [
-      { label: isAppEntry(row.name, row.isDir) ? "Open App" : "Open", icon: MenuIcons.open, onClick: () => navigate(row.path) },
+      { label: isAppEntry(row.name, row.isDir) ? "Open App" : "Open", icon: MenuIcons.open, onClick: () => navigate(row.path, { isDir: row.isDir }) },
       { label: "Open With", icon: MenuIcons.openWith, submenu: loadOpenWith(row.path) },
       "separator",
       { label: "Move to Bin", icon: MenuIcons.trash, onClick: () => doTrash(row) },
@@ -1212,7 +1223,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
                     (childPath === selectedPath ? " selected" : "") +
                     (childPath === cutPath ? " cut" : "")
                   }
-                  onClick={() => navigate(childPath)}
+                  onClick={() => navigate(childPath, { isDir: entry.is_dir })}
                   onContextMenu={(e) =>
                     openRowMenu(e, {
                       path: childPath,
@@ -1296,7 +1307,7 @@ export default function Listing({ fsPath }: { fsPath: string }) {
             (childPath === selectedPath ? " selected" : "") +
             (childPath === cutPath ? " cut" : "")
           }
-          onClick={() => navigate(childPath)}
+          onClick={() => navigate(childPath, { isDir: entry.is_dir })}
           onContextMenu={(e) =>
             openRowMenu(e, {
               path: childPath,

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -253,7 +253,15 @@ type WalkState =
 
 const IDLE_WALK: WalkState = { status: "idle" };
 
-export default function Listing({ fsPath }: { fsPath: string }) {
+// `provisional`: this Listing is rendering inside the pre-stat loading scaffold
+// (App LoadingScaffold), mounted off a directory NAV HINT rather than a
+// confirmed stat. The hint is authoritative in practice but can be stale — if
+// the path is actually a file, /api/fs/list 404s. In that provisional phase a
+// failed listing must NOT paint the hard "Failed to list" error: stat is still
+// resolving and will drive the correct final view (a file <Preview>) a beat
+// later, so we show the neutral loading body and let stat commit the real view.
+// Absent/false (the committed post-stat render), errors show normally.
+export default function Listing({ fsPath, provisional = false }: { fsPath: string; provisional?: boolean }) {
   const [state, setState] = useState<ListingState>({ status: "loading" });
   // Sort lives in the URL; mirror it in state so clicks re-render without a
   // navigation (vanilla re-ran renderListing after its replaceState).
@@ -1289,7 +1297,18 @@ export default function Listing({ fsPath }: { fsPath: string }) {
       </tr>
     );
   } else if (state.status === "error") {
-    body = (
+    // In the provisional scaffold phase a list failure is most likely a stale
+    // dir hint pointing at a file (its /api/fs/list 404s); suppress the hard
+    // error and show neutral loading — stat is still resolving and will replace
+    // this scaffold with the correct file view. Post-stat (committed render),
+    // a genuine list failure surfaces normally.
+    body = provisional ? (
+      <tr>
+        <td colSpan={3} className="status-message">
+          Loading…
+        </td>
+      </tr>
+    ) : (
       <tr>
         <td colSpan={3} className="status-message error">
           Failed to list {fsPath}: {state.message}

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -88,7 +88,7 @@ function MountRow({
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
           {conn.state === "mounted" ? (
-            <button type="button" disabled={busy} onClick={() => navigate(conn.mountpoint)}>
+            <button type="button" disabled={busy} onClick={() => navigate(conn.mountpoint, { isDir: true })}>
               Open
             </button>
           ) : (

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -140,7 +140,7 @@ function usePreviewFileMenu(
         deleteEntry(fsPath, stat.is_dir).then(
           () => {
             clearClipboardIfDeleted(fsPath);
-            navigate(parent); // the open file is gone — leave for the parent listing
+            navigate(parent, { isDir: true }); // the open file is gone — leave for the parent listing
           },
           (e: Error) => setToast({ msg: friendlyFsError(e, { verb: "delete", name: stat.name }), tone: "error" })
         );
@@ -151,7 +151,7 @@ function usePreviewFileMenu(
     trashEntry(fsPath, stat.is_dir).then((r) => {
       if (r.status === "trashed") {
         clearClipboardIfDeleted(fsPath);
-        navigate(parent);
+        navigate(parent, { isDir: true });
       } else if (r.status === "unsupported") {
         startDelete();
       } else {

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -15,7 +15,7 @@ import {
   deleteEntry,
 } from "../lib/api";
 import type { Deployment, StatResult, TemplateEntry } from "../lib/api";
-import { navigate, navigateUrl, urlForFsPath } from "../lib/router";
+import { navigate, navigateUrl, urlForFsPath, replaceSearch } from "../lib/router";
 import { formatSize, formatMtime, basename } from "../lib/format";
 import { useRefreshOnReturn } from "../lib/hooks";
 import {
@@ -527,7 +527,7 @@ function TemplatePreview({
     if (next === defaultEntry.mode) params.delete("_mode");
     else params.set("_mode", next);
     const search = params.toString();
-    history.replaceState(null, "", location.pathname + (search ? "?" + search : ""));
+    replaceSearch(location.pathname + (search ? "?" + search : ""));
     setModeState(next);
   };
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -955,7 +955,28 @@ def _condition_file(template_path: str):
 GATE_PROBE_BUDGET_S = 5.0
 
 
-def _mount_gate_builtins(target_path: str):
+class _GateSeed:
+    """What `_conditions_payload` already knows about the target dir, threaded
+    into the gate shim so it answers isdir/isfile locally instead of reprobing.
+
+    - `kinds`: exact path -> "dir"|"file"|"missing" (a verdict already taken by
+      the endpoint's rc is_dir probe; consulted before any rc call).
+    - `dir_path`: the normalized (rstrip("/")) dir the listing describes.
+    - `file_children`: set of immediate FILE basenames from a COMPLETE listing,
+      or None when no complete listing is available.
+    - `listing_complete`: True only when the listing was NOT truncated, so an
+      absent marker is provably absent (a truncated listing can't prove that).
+    """
+
+    def __init__(self, kinds=None, dir_path=None, file_children=None,
+                 listing_complete=False):
+        self.kinds = kinds or {}
+        self.dir_path = dir_path
+        self.file_children = file_children
+        self.listing_complete = listing_complete
+
+
+def _mount_gate_builtins(target_path: str, seed=None):
     """Custom `__builtins__` for a condition gate whose target is MOUNT-backed,
     so the gate's own filesystem primitives route through the rclone rc API
     instead of the kernel NFS mount.
@@ -1004,6 +1025,9 @@ def _mount_gate_builtins(target_path: str):
     def _isfile(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isfile(p)
+        # A verdict the endpoint already took for this exact path (fix #2).
+        if seed is not None and p in seed.kinds:
+            return seed.kinds[p] == "file"
         left = _probe_budget()
         if left <= 0:
             return False  # budget spent -> fail closed
@@ -1012,6 +1036,8 @@ def _mount_gate_builtins(target_path: str):
     def _isdir(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isdir(p)
+        if seed is not None and p in seed.kinds:
+            return seed.kinds[p] == "dir"  # no reprobe of the target (fix #2)
         left = _probe_budget()
         if left <= 0:
             return False
@@ -1020,6 +1046,8 @@ def _mount_gate_builtins(target_path: str):
     def _exists(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.exists(p)
+        if seed is not None and p in seed.kinds:
+            return seed.kinds[p] in ("file", "dir")
         left = _probe_budget()
         if left <= 0:
             return False
@@ -1106,7 +1134,7 @@ def _mount_gate_builtins(target_path: str):
     return b
 
 
-def _run_condition(condition_file: str, target_path: str):
+def _run_condition(condition_file: str, target_path: str, seed=None):
     """Load+exec a `condition.py` and call `main(target_path)`. Returns
     (allowed: bool, error: str|None).
 
@@ -1136,7 +1164,7 @@ def _run_condition(condition_file: str, target_path: str):
         # time so the mount routing is monkeypatchable in tests.
         from fused_render.shell.mounts import is_mount_backed
         if is_mount_backed(target_path):
-            mod.__dict__["__builtins__"] = _mount_gate_builtins(target_path)
+            mod.__dict__["__builtins__"] = _mount_gate_builtins(target_path, seed)
         spec.loader.exec_module(mod)
         fn = getattr(mod, "main", None)
         if not callable(fn):
@@ -1164,7 +1192,7 @@ def _mark_conditions(entries: list):
             entry["conditional"] = True
 
 
-def _evaluate_conditions(gated: list, target_path: str):
+def _evaluate_conditions(gated: list, target_path: str, seed=None):
     """Evaluate `condition.py` gates: `gated` is [(key, condition_file)];
     returns {key: (allowed: bool, error: str|None)}.
 
@@ -1177,7 +1205,7 @@ def _evaluate_conditions(gated: list, target_path: str):
 
     def _serial():
         for k, cf in gated:
-            results[k] = _run_condition(cf, target_path)
+            results[k] = _run_condition(cf, target_path, seed)
 
     if len(gated) == 1:
         _serial()
@@ -1193,7 +1221,7 @@ def _evaluate_conditions(gated: list, target_path: str):
             from concurrent.futures import ThreadPoolExecutor
 
             with ThreadPoolExecutor(max_workers=len(gated)) as pool:
-                futures = {pool.submit(_run_condition, cf, target_path): k for k, cf in gated}
+                futures = {pool.submit(_run_condition, cf, target_path, seed): k for k, cf in gated}
                 for fut, k in futures.items():
                     results[k] = fut.result()
         except BaseException:
@@ -1215,6 +1243,7 @@ def _conditions_payload(path: str):
     """
     from fused_render.shell.mounts import is_mount_backed, rc_kind_for
 
+    seed = None
     if is_mount_backed(path):
         # A mount is_dir probe off the kernel (a kernel os.stat here is a
         # GETATTR that can force an S3 re-list and wedge the mount). "missing" is
@@ -1229,6 +1258,11 @@ def _conditions_payload(path: str):
         if kind == "missing":
             return _error(f"no such file or directory: {path}", status=404)
         is_dir = kind != "file"
+        # Feed the verdict we just took to the gate shim so the gate answers its
+        # own isdir(path) with no rc call instead of reprobing this exact path
+        # (fix #2). Fail-open: the seed is purely additive — an empty seed just
+        # falls through to the existing rc probe path.
+        seed = _GateSeed(kinds={path: kind})
     else:
         try:
             st = os.stat(path)
@@ -1244,7 +1278,7 @@ def _conditions_payload(path: str):
             if cf is not None:
                 gated.append((entry["mode"], cf))
 
-    results = _evaluate_conditions(gated, path)
+    results = _evaluate_conditions(gated, path, seed)
     conditions, error = {}, None
     for mode, _cf in gated:
         allowed, err = results[mode]

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -746,6 +746,21 @@ _STAT_TTL_S = 60.0
 _STAT_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monotonic, payload)
 
 
+def _invalidate_stat_cache(*paths: object) -> None:
+    # Drop cached /api/fs/stat entries for paths a mutation just touched, plus
+    # their parent directories (creating/deleting a child moves the parent's
+    # mtime on many backends). The editor re-stats a path right after
+    # write/rename/copy/mkdir to re-arm its optimistic lock, so a stale hit here
+    # would be a real clobber bug — invalidation is the correctness backbone of
+    # this cache, not an optimization. Popping a key that was never cached (or a
+    # non-string/None body field) is a harmless no-op, so callers can pass raw
+    # body values and invalidate unconditionally without inspecting the result.
+    for p in paths:
+        if isinstance(p, str) and p:
+            _STAT_CACHE.pop(p, None)
+            _STAT_CACHE.pop(os.path.dirname(p), None)
+
+
 def _mount_list_error_response(path, exc):
     """Map an RcList* failure to the same HTTP response /api/fs/list returns, so
     fs/walk surfaces a failed ROOT listing identically (timeout/down rcd/broken
@@ -3474,25 +3489,49 @@ def create_app(start_dir: str) -> FastAPI:
         subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return JSONResponse({"ok": True})
 
+    # Every mutation endpoint invalidates the /api/fs/stat cache for the paths it
+    # touches (and their parents, via _invalidate_stat_cache) so the editor's
+    # immediate post-mutation stat re-reads fresh metadata. Invalidation runs
+    # unconditionally after the handler — a no-op on error/409 costs nothing, and
+    # doing it here (not inside each _fs_* helper's many return branches) keeps
+    # the contract in one obvious place per route.
+    #
+    # RESIDUAL: a RECURSIVE delete / overwriting rename of a directory does not
+    # walk the (now-gone) subtree to evict individually-cached child stats. Those
+    # entries simply age out within _STAT_TTL_S — the same bounded staleness the
+    # cache accepts for out-of-band changes — and the editor navigates top-down,
+    # so it re-lists the parent (fresh) before it would re-stat a vanished child.
     @app.post("/api/fs/write")
     def api_fs_write(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        return _fs_write(body, x_fused)
+        result = _fs_write(body, x_fused)
+        _invalidate_stat_cache(body.get("path"))
+        return result
 
     @app.post("/api/fs/mkdir")
     def api_fs_mkdir(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        return _fs_mkdir(body, x_fused)
+        result = _fs_mkdir(body, x_fused)
+        _invalidate_stat_cache(body.get("path"))
+        return result
 
     @app.post("/api/fs/delete")
     def api_fs_delete(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        return _fs_delete(body, x_fused)
+        result = _fs_delete(body, x_fused)
+        _invalidate_stat_cache(body.get("path"))
+        return result
 
     @app.post("/api/fs/rename")
     def api_fs_rename(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        return _fs_rename(body, x_fused)
+        result = _fs_rename(body, x_fused)
+        # A move changes both ends: src disappears, dst appears.
+        _invalidate_stat_cache(body.get("src"), body.get("dst"))
+        return result
 
     @app.post("/api/fs/copy")
     def api_fs_copy(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-        return _fs_copy(body, x_fused)
+        result = _fs_copy(body, x_fused)
+        # A copy only writes dst; src is untouched, so its cached stat stays valid.
+        _invalidate_stat_cache(body.get("dst"))
+        return result
 
     @app.get("/render")
     def render(path: str):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1042,15 +1042,19 @@ def _mount_gate_builtins(target_path: str, seed=None):
     def _isfile(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isfile(p)
-        # A COMPLETE listing of the dir answers every marker isfile with no
-        # network call: for a child of the listed dir, an absent basename is
-        # PROVABLY absent (fix #3/#4). A truncated listing can't prove absence,
-        # so listing_complete gates this branch and we fall through to the rc
-        # probe below. real_os.path is the real (captured) os.path.
-        if (seed is not None and seed.listing_complete
-                and seed.file_children is not None
+        # A listing of the dir answers marker isfile with no network call
+        # (fix #3/#4). PRESENCE in the page is conclusive even if the page was
+        # TRUNCATED (the marker demonstrably exists); ABSENCE is only provable
+        # from a COMPLETE (untruncated) page. So a truncated page that captured
+        # the marker still short-circuits True, and only a truncated-and-absent
+        # marker falls through to the rc probe below. real_os.path is the real
+        # (captured) os.path.
+        if (seed is not None and seed.file_children is not None
                 and real_os.path.dirname(p) == seed.dir_path):
-            return real_os.path.basename(p) in seed.file_children
+            if real_os.path.basename(p) in seed.file_children:
+                return True
+            if seed.listing_complete:
+                return False
         # Else a verdict the endpoint already took for this exact path (fix #2).
         if seed is not None and p in seed.kinds:
             return seed.kinds[p] == "file"
@@ -1289,28 +1293,16 @@ def _conditions_payload(path: str):
         if kind == "missing":
             return _error(f"no such file or directory: {path}", status=404)
         is_dir = kind != "file"
-        # Feed the verdict we just took to the gate shim so the gate answers its
-        # own isdir(path) with no rc call instead of reprobing this exact path
-        # (fix #2). Fail-open: the seed is purely additive — an empty seed just
-        # falls through to the existing rc probe path.
-        seed = _GateSeed(kinds={path: kind})
-        # For a direct-list-capable mount (anonymous S3/GCS), one bounded
-        # unsigned listing of the dir's immediate children answers all three
-        # marker isfile probes locally (fix #3/#4) — the markers are always
-        # immediate children, so a COMPLETE page proves each present/absent
-        # without a per-marker rc probe. Fail-open: any error (not capable,
-        # transport, truncation is handled by listing_complete) leaves the seed
-        # marker-less and the gate falls back to today's per-marker probes.
-        if is_dir and direct_list_capable(path):
-            try:
-                entries, next_token = direct_list_page(
-                    path, max_keys=_GATE_LIST_MAX_KEYS, timeout=GATE_PROBE_BUDGET_S)
-                seed.file_children = {
-                    e["Name"] for e in entries if not e.get("IsDir")}
-                seed.listing_complete = next_token is None
-            except Exception:
-                pass  # never break the endpoint on a listing failure
-            seed.dir_path = path.rstrip("/")
+        # Feed a DEFINITIVE verdict to the gate shim so the gate answers its own
+        # isdir(path) with no rc call instead of reprobing this exact path
+        # (fix #2). An "indeterminate" kind (rcd blip / budget exhausted) is NOT
+        # seeded: seeding it would make the gate's isdir return False without a
+        # probe and pin a spurious all-False verdict (and the TTL cache would
+        # hold it). Leaving seed=None lets the gate do its OWN probe, which may
+        # recover, and otherwise fail closed on its own budget — the posture the
+        # is_dir comment above describes.
+        if kind in ("dir", "file"):
+            seed = _GateSeed(kinds={path: kind})
     else:
         try:
             st = os.stat(path)
@@ -1325,6 +1317,25 @@ def _conditions_payload(path: str):
             cf = _condition_file(entry["path"])
             if cf is not None:
                 gated.append((entry["mode"], cf))
+
+    # Only now that we know a gate will actually consume it is the bounded
+    # listing worth its network cost. For a direct-list-capable mount (anonymous
+    # S3/GCS), one unsigned listing of the dir's immediate children answers all
+    # three marker isfile probes locally (fix #3/#4) — the markers are always
+    # immediate children, so a COMPLETE page proves each present/absent without
+    # a per-marker rc probe. Fail-open: any error leaves the seed marker-less and
+    # the gate falls back to today's per-marker probes (logged, not silent).
+    if gated and seed is not None and is_dir and direct_list_capable(path):
+        try:
+            listing, next_token = direct_list_page(
+                path, max_keys=_GATE_LIST_MAX_KEYS, timeout=GATE_PROBE_BUDGET_S)
+            seed.file_children = {
+                e["Name"] for e in listing if not e.get("IsDir")}
+            seed.listing_complete = next_token is None
+        except Exception:
+            logger.debug("gate seed listing failed for %s; falling back to "
+                         "per-marker probes", path, exc_info=True)
+        seed.dir_path = path.rstrip("/")
 
     results = _evaluate_conditions(gated, path, seed)
     conditions, error = {}, None

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -954,6 +954,13 @@ def _condition_file(template_path: str):
 # roughly one slow probe; direct-capable mounts probe in ~1s and rarely reach it.
 GATE_PROBE_BUDGET_S = 5.0
 
+# One bounded direct-listing page fed to the gate seed (fix #3/#4). All zarr
+# group-root markers are immediate children of the store dir, so a COMPLETE
+# (untruncated) page of the dir's children answers all three marker isfile
+# probes with zero extra network calls; 1000 keys comfortably covers a store
+# root's immediate children in one unsigned request.
+_GATE_LIST_MAX_KEYS = 1000
+
 
 class _GateSeed:
     """What `_conditions_payload` already knows about the target dir, threaded
@@ -1025,7 +1032,16 @@ def _mount_gate_builtins(target_path: str, seed=None):
     def _isfile(p):
         if not mounts.is_mount_backed(p):
             return real_os.path.isfile(p)
-        # A verdict the endpoint already took for this exact path (fix #2).
+        # A COMPLETE listing of the dir answers every marker isfile with no
+        # network call: for a child of the listed dir, an absent basename is
+        # PROVABLY absent (fix #3/#4). A truncated listing can't prove absence,
+        # so listing_complete gates this branch and we fall through to the rc
+        # probe below. real_os.path is the real (captured) os.path.
+        if (seed is not None and seed.listing_complete
+                and seed.file_children is not None
+                and real_os.path.dirname(p) == seed.dir_path):
+            return real_os.path.basename(p) in seed.file_children
+        # Else a verdict the endpoint already took for this exact path (fix #2).
         if seed is not None and p in seed.kinds:
             return seed.kinds[p] == "file"
         left = _probe_budget()
@@ -1241,7 +1257,12 @@ def _conditions_payload(path: str):
     carries the first gate error in list order (a broken gate reports False —
     fail closed — with the reason), matching stat's `template_error` posture.
     """
-    from fused_render.shell.mounts import is_mount_backed, rc_kind_for
+    from fused_render.shell.mounts import (
+        direct_list_capable,
+        direct_list_page,
+        is_mount_backed,
+        rc_kind_for,
+    )
 
     seed = None
     if is_mount_backed(path):
@@ -1263,6 +1284,23 @@ def _conditions_payload(path: str):
         # (fix #2). Fail-open: the seed is purely additive — an empty seed just
         # falls through to the existing rc probe path.
         seed = _GateSeed(kinds={path: kind})
+        # For a direct-list-capable mount (anonymous S3/GCS), one bounded
+        # unsigned listing of the dir's immediate children answers all three
+        # marker isfile probes locally (fix #3/#4) — the markers are always
+        # immediate children, so a COMPLETE page proves each present/absent
+        # without a per-marker rc probe. Fail-open: any error (not capable,
+        # transport, truncation is handled by listing_complete) leaves the seed
+        # marker-less and the gate falls back to today's per-marker probes.
+        if is_dir and direct_list_capable(path):
+            try:
+                entries, next_token = direct_list_page(
+                    path, max_keys=_GATE_LIST_MAX_KEYS, timeout=GATE_PROBE_BUDGET_S)
+                seed.file_children = {
+                    e["Name"] for e in entries if not e.get("IsDir")}
+                seed.listing_complete = next_token is None
+            except Exception:
+                pass  # never break the endpoint on a listing failure
+            seed.dir_path = path.rstrip("/")
     else:
         try:
             st = os.stat(path)

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -744,6 +744,14 @@ _CONDITIONS_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monot
 # can override it.
 _STAT_TTL_S = 60.0
 _STAT_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monotonic, payload)
+# Monotonic invalidation counter for the TOCTOU guard in api_fs_stat. Every
+# _invalidate_stat_cache bump happens-before the post-compute check in a stat
+# that reads the generation first, so any mutation that completes while a slow
+# _fs_stat is in flight is observed and blocks that stale result from refilling
+# the cache. A single global counter is deliberately conservative: a concurrent
+# mutation to ANY path just skips caching this one in-flight stat (rare and
+# harmless) rather than requiring per-path bookkeeping.
+_STAT_CACHE_GEN = 0
 
 
 def _invalidate_stat_cache(*paths: object) -> None:
@@ -755,6 +763,13 @@ def _invalidate_stat_cache(*paths: object) -> None:
     # this cache, not an optimization. Popping a key that was never cached (or a
     # non-string/None body field) is a harmless no-op, so callers can pass raw
     # body values and invalidate unconditionally without inspecting the result.
+    #
+    # Bump the generation UNCONDITIONALLY (even for a no-op pop): a stat for a
+    # not-yet-cached path may be mid-flight, and the bump is what tells its
+    # post-compute check that a mutation raced it so it must not cache a
+    # pre-mutation payload. See api_fs_stat for the guard.
+    global _STAT_CACHE_GEN
+    _STAT_CACHE_GEN += 1
     for p in paths:
         if isinstance(p, str) and p:
             _STAT_CACHE.pop(p, None)
@@ -2958,8 +2973,19 @@ def create_app(start_dir: str) -> FastAPI:
         cached = _STAT_CACHE.get(path)
         if cached is not None and time.monotonic() - cached[0] < _STAT_TTL_S:
             return cached[1]
+        # Snapshot the invalidation generation BEFORE the (slow) stat. _fs_stat
+        # releases the GIL on its cold mount LIST, so a concurrent mutation can
+        # complete _invalidate_stat_cache — popping this key AND bumping the
+        # generation — while we're in flight. Caching unconditionally here would
+        # write our now-stale payload back, undoing that invalidation and
+        # handing the editor's post-write optimistic-lock re-stat pre-mutation
+        # metadata (a real clobber bug). So only cache if the generation is
+        # UNCHANGED: the bump happens-before this check for any invalidation
+        # that finished before our write, closing the TOCTOU window. If it
+        # moved, return the fresh result WITHOUT caching it.
+        gen = _STAT_CACHE_GEN
         result = _fs_stat(path)
-        if isinstance(result, dict) and is_mount_backed(path):
+        if isinstance(result, dict) and is_mount_backed(path) and _STAT_CACHE_GEN == gen:
             _STAT_CACHE[path] = (time.monotonic(), result)
         return result
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -723,6 +723,16 @@ def _error(message: str, status: int = 400) -> JSONResponse:
     return JSONResponse({"error": message}, status_code=status)
 
 
+# /api/fs/conditions evaluates template condition.py gates, which over a remote
+# mount costs ~6.8s and was recomputed on every call. A small check-on-read TTL
+# cache lets re-navigation to the same directory reuse the verdict. Only success
+# payloads (plain dicts) are cached; error/404 responses are JSONResponse and are
+# never stored. No background eviction — a stale entry is overwritten on the next
+# miss. _CONDITIONS_TTL_S is a module attribute so tests can monkeypatch it.
+_CONDITIONS_TTL_S = 60.0
+_CONDITIONS_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monotonic, payload)
+
+
 def _mount_list_error_response(path, exc):
     """Map an RcList* failure to the same HTTP response /api/fs/list returns, so
     fs/walk surfaces a failed ROOT listing identically (timeout/down rcd/broken
@@ -2835,7 +2845,18 @@ def create_app(start_dir: str) -> FastAPI:
         # (Preview.tsx `useConditions`) and renders every unconditional
         # template while the verdict is still `null` — the gated ones just show
         # a spinner until it lands. So no change on the render path is needed.
-        return _conditions_payload(path)
+        #
+        # Re-navigating to the same directory would otherwise re-pay the full
+        # gate-evaluation cost, so a short check-on-read TTL cache serves a
+        # recent verdict. Only success payloads (plain dicts) are cached; error
+        # responses (_error -> JSONResponse) are always recomputed.
+        cached = _CONDITIONS_CACHE.get(path)
+        if cached is not None and time.monotonic() - cached[0] < _CONDITIONS_TTL_S:
+            return cached[1]
+        result = _conditions_payload(path)
+        if isinstance(result, dict):
+            _CONDITIONS_CACHE[path] = (time.monotonic(), result)
+        return result
 
     @app.get("/api/fs/list")
     def api_fs_list(path: str, cursor: str | None = None):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -733,6 +733,19 @@ _CONDITIONS_TTL_S = 60.0
 _CONDITIONS_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monotonic, payload)
 
 
+# /api/fs/stat on a MOUNT path goes _mount_safe_stat -> _mount_probe ->
+# rc_list_dir(parent), a full cold LIST of the parent prefix over rclone/S3
+# (~1.6s) just to describe one child; opening a folder fires it, and
+# re-navigating to a sibling repaid it uncached. A short check-on-read TTL cache
+# (same shape as _CONDITIONS_CACHE) serves a recent stat instead. Only
+# MOUNT-backed success payloads are cached — see api_fs_stat for the scope
+# rationale and mutation-invalidation contract. Separate TTL from conditions so
+# each can be tuned/monkeypatched on its own; kept a module attribute so tests
+# can override it.
+_STAT_TTL_S = 60.0
+_STAT_CACHE: dict[str, tuple[float, dict]] = {}  # path -> (inserted_monotonic, payload)
+
+
 def _mount_list_error_response(path, exc):
     """Map an RcList* failure to the same HTTP response /api/fs/list returns, so
     fs/walk surfaces a failed ROOT listing identically (timeout/down rcd/broken
@@ -2913,7 +2926,27 @@ def create_app(start_dir: str) -> FastAPI:
 
     @app.get("/api/fs/stat")
     def api_fs_stat(path: str):
-        return _fs_stat(path)
+        # Short check-on-read TTL cache (mirrors api_fs_conditions) to avoid
+        # re-paying the ~1.6s cold parent-prefix LIST that a mount stat costs
+        # (see _STAT_CACHE). Only MOUNT-backed paths are cached: a local stat is
+        # a cheap kernel call, and a local file can be mutated out-of-band (git,
+        # another editor) with no hook for us to invalidate — caching those
+        # would risk handing back a stale mtime the editor's optimistic lock
+        # trusts, for no latency win. Mount paths are mutated only through this
+        # server's fs/write|rename|copy|delete|mkdir handlers, which call
+        # _invalidate_stat_cache, so their only staleness is the same bounded
+        # external-change window the conditions cache already accepts. Only
+        # success payloads (plain dicts) are stored; _fs_stat's 404/503 branches
+        # return _error -> JSONResponse and are always recomputed.
+        from fused_render.shell.mounts import is_mount_backed
+
+        cached = _STAT_CACHE.get(path)
+        if cached is not None and time.monotonic() - cached[0] < _STAT_TTL_S:
+            return cached[1]
+        result = _fs_stat(path)
+        if isinstance(result, dict) and is_mount_backed(path):
+            _STAT_CACHE[path] = (time.monotonic(), result)
+        return result
 
     @app.get("/api/fs/conditions")
     def api_fs_conditions(path: str):

--- a/tests/test_condition_gate_seed.py
+++ b/tests/test_condition_gate_seed.py
@@ -28,6 +28,16 @@ STORE = "/fake-mounts/s3demo/store"
 ZARR_CONDITION = os.path.join(server.TEMPLATES_DIR, "zarr_aoi", "condition.py")
 
 
+@pytest.fixture(autouse=True)
+def _clear_conditions_cache():
+    # /api/fs/conditions caches success payloads by path for a short TTL. These
+    # tests reuse a single STORE path across differing listing/mount states and
+    # expect each call to recompute, so drop the cache between tests.
+    server._CONDITIONS_CACHE.clear()
+    yield
+    server._CONDITIONS_CACHE.clear()
+
+
 @pytest.fixture()
 def guard_kernel(monkeypatch):
     """Make every kernel os call on a mount-backed path explode, so a shim leak

--- a/tests/test_condition_gate_seed.py
+++ b/tests/test_condition_gate_seed.py
@@ -248,3 +248,98 @@ def test_v3_group_via_listing(monkeypatch, guard_kernel):
     r = _client().get("/api/fs/conditions", params={"path": STORE})
     assert r.status_code == 200
     assert r.json()["conditions"].get("zarr_aoi") is True
+
+
+# --------------------------------------------- Bugbot: indeterminate not seeded
+
+
+def test_indeterminate_kind_not_seeded_gate_reprobes(monkeypatch, guard_kernel):
+    # The endpoint's own is_dir probe can come back "indeterminate" (rcd blip /
+    # budget exhausted). That verdict must NOT be seeded: seeding it would make
+    # the gate's isdir(STORE) return False immediately and pin a spurious
+    # all-False verdict (worse: cached 60s). Instead the gate must do its OWN
+    # probe, which here recovers to "dir" and, with .zmetadata present, -> True.
+    calls = {"n": 0}
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            calls["n"] += 1
+            # 1st call is the endpoint probe (indeterminate); the gate's own
+            # reprobe recovers to "dir".
+            return "indeterminate" if calls["n"] == 1 else "dir"
+        if p == STORE + "/.zmetadata":
+            return "file"
+        return "missing"
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    # No direct listing: force the pure rc probe path so the gate reprobe shows.
+    _direct_list(monkeypatch, capable=False)
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+    assert calls["n"] >= 2, "gate must do its own probe when endpoint was indeterminate"
+
+
+# ------------------------------------------- Bugbot: present marker conclusive
+
+
+def test_truncated_listing_with_present_marker_true(monkeypatch, guard_kernel):
+    # A TRUNCATED listing (next_token set) that CONTAINS .zgroup is conclusive
+    # for .zgroup: presence proves it exists even though absence can't be proven
+    # from a partial page. So .zgroup is answered locally and must NEVER be rc
+    # probed (proven by _kind raising on it) — even though rc probing it would
+    # "miss" (returns missing). Earlier markers (.zmetadata, zarr.json), absent
+    # from the partial page, DO fall through to rc probes and come back missing.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            return "dir"
+        if p == STORE + "/.zgroup":
+            raise AssertionError("present marker .zgroup was rc probed")
+        return "missing"  # .zmetadata / zarr.json legitimately probe -> missing
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    _direct_list(monkeypatch,
+                 result=([{"Name": ".zgroup", "IsDir": False}], "next-tok"))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+
+
+# ----------------------------------------- efficiency: no gates -> no listing
+
+
+def test_no_gated_templates_skips_listing(monkeypatch, guard_kernel):
+    # The bounded listing is only worth its network cost if a gate will consume
+    # it. When the dir has no conditional template, direct_list_page must never
+    # be called.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", lambda p, **k: "dir")
+    monkeypatch.setattr(server, "_templates_for", lambda path, is_dir: ([], None))
+
+    # Count calls rather than raise: a raised AssertionError would be swallowed
+    # by the listing's fail-open except and mask the wasted call.
+    calls = {"n": 0}
+
+    def _count(*a, **k):
+        calls["n"] += 1
+        return ([], None)
+
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "direct_list_page", _count)
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"] == {}
+    assert calls["n"] == 0, "listing must be skipped when no gated templates exist"

--- a/tests/test_condition_gate_seed.py
+++ b/tests/test_condition_gate_seed.py
@@ -1,0 +1,240 @@
+"""Gate-seed fast path for /api/fs/conditions (fixes #2, #3, #4).
+
+`_conditions_payload` already does ONE rc is_dir probe of the target; the
+zarr_aoi gate then RE-probed the same dir (`os.path.isdir`) plus three serial
+`os.path.isfile(join(path, marker))` misses. On the anonymous-S3 ookla mount
+that's ~10 sequential round trips (~6.8s) for the common non-zarr directory.
+
+The seed threads what the endpoint already knows (the dir kind) AND, for a
+direct-list-capable mount, ONE bounded complete listing of the dir's immediate
+children into the gate shim, so the gate answers isdir + all three marker
+isfile probes locally with ZERO extra network calls. A truncated / failed
+listing transparently falls back to today's per-marker rc probe path.
+
+These mirror tests/test_condition_mount_shim.py: the guard_kernel fixture
+proves no kernel os.* ever touches a mount path, and the rc helpers are
+monkeypatched (they are tested against a real stub rcd elsewhere).
+"""
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render import server
+
+MOUNT_PREFIX = "/fake-mounts/"
+STORE = "/fake-mounts/s3demo/store"
+ZARR_CONDITION = os.path.join(server.TEMPLATES_DIR, "zarr_aoi", "condition.py")
+
+
+@pytest.fixture()
+def guard_kernel(monkeypatch):
+    """Make every kernel os call on a mount-backed path explode, so a shim leak
+    fails loudly. Non-mount paths (template files, tmp fixtures) pass through."""
+    real = {
+        "isfile": os.path.isfile,
+        "isdir": os.path.isdir,
+        "exists": os.path.exists,
+        "stat": os.stat,
+        "listdir": os.listdir,
+        "scandir": os.scandir,
+    }
+
+    def _guard(name, fn):
+        def wrapped(p, *a, **k):
+            if isinstance(p, str) and p.startswith(MOUNT_PREFIX):
+                raise AssertionError(f"kernel os.{name} on mount path {p!r}")
+            return fn(p, *a, **k)
+        return wrapped
+
+    for name in ("isfile", "isdir", "exists"):
+        monkeypatch.setattr(os.path, name, _guard(name, real[name]))
+    for name in ("stat", "listdir", "scandir"):
+        monkeypatch.setattr(os, name, _guard(name, real[name]))
+    return real
+
+
+def _mount(monkeypatch, kind_map, read_bytes=None):
+    """Route the mount prefix through fake rc helpers. `kind_map` maps an exact
+    path (or "*") to a rc_kind_for verdict; `read_bytes` is what rc_read_bounded
+    returns for the zarr.json probe."""
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        return kind_map.get(p, kind_map.get("*", "missing"))
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+
+    def _read(p, *a, **k):
+        if read_bytes is None:
+            raise OSError("no serve")
+        return read_bytes
+
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded", _read)
+
+
+def _direct_list(monkeypatch, *, capable=True, result=None, raises=None):
+    """Monkeypatch the direct (unsigned) pager. `result` is (entries, next_token);
+    `raises` is an exception instance the pager raises instead."""
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: capable)
+
+    def _page(p, *, max_keys, continuation=None, timeout=None):
+        if raises is not None:
+            raise raises
+        return result
+
+    monkeypatch.setattr(mounts_mod, "direct_list_page", _page)
+
+
+def _client():
+    return TestClient(server.create_app(start_dir="/"))
+
+
+# ----------------------------------------------------------------------- fix #2
+
+
+def test_seed_skips_target_reprobe(monkeypatch, guard_kernel):
+    # A seed carrying {STORE: "dir"} lets the gate answer its own isdir(STORE)
+    # with no rc call. rc_kind_for raising for STORE proves it was never
+    # reprobed; markers return "missing" so the plain dir is False.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            raise AssertionError(f"target reprobed: {p}")
+        return "missing"
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+
+    allowed, err = server._run_condition(
+        ZARR_CONDITION, STORE, seed=server._GateSeed(kinds={STORE: "dir"}))
+    assert allowed is False and err is None
+
+
+# ------------------------------------------------------------------- fix #3 + #4
+
+
+def test_complete_listing_no_markers_false(monkeypatch, guard_kernel):
+    # A complete listing (next_token None) with no marker among the children
+    # answers all three isfile probes locally -> False, and rc_kind_for RAISES
+    # for any marker path, proving not one marker was probed.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            return "dir"
+        raise AssertionError(f"marker probed despite complete listing: {p}")
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    _direct_list(monkeypatch,
+                 result=([{"Name": "part-0.parquet", "IsDir": False}], None))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is False
+
+
+def test_complete_listing_with_zgroup_true(monkeypatch, guard_kernel):
+    # A complete listing containing .zgroup -> True with NO marker probe.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            return "dir"
+        raise AssertionError(f"marker probed despite complete listing: {p}")
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    _direct_list(monkeypatch, result=([{"Name": ".zgroup", "IsDir": False}], None))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+
+
+def test_truncated_listing_falls_back_to_probes(monkeypatch, guard_kernel):
+    # A truncated listing (next_token not None) can't prove a marker absent, so
+    # the gate must fall back to per-marker rc probes. .zmetadata -> "file"
+    # decides True, and we assert a marker WAS probed.
+    probed = []
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p != STORE:
+            probed.append(p)
+        if p == STORE:
+            return "dir"
+        if p == STORE + "/.zmetadata":
+            return "file"
+        return "missing"
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    _direct_list(monkeypatch,
+                 result=([{"Name": "a", "IsDir": False}], "next-tok"))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+    assert probed, "expected a marker probe fallback on a truncated listing"
+
+
+def test_listing_failure_falls_back_to_probes(monkeypatch, guard_kernel):
+    # The pager raising (DirectListError) must fail-open to the per-marker rc
+    # probe path; provide marker kinds so the verdict is still correct.
+    probed = []
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p != STORE:
+            probed.append(p)
+        if p == STORE:
+            return "dir"
+        if p == STORE + "/.zmetadata":
+            return "file"
+        return "missing"
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("no serve")))
+    _direct_list(monkeypatch, raises=mounts_mod.DirectListError("boom"))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True
+    assert probed, "expected a marker probe fallback on a listing failure"
+
+
+def test_v3_group_via_listing(monkeypatch, guard_kernel):
+    # A complete listing containing zarr.json answers isfile locally; the
+    # node_type read still runs via rc_read_bounded and node_type=="group"
+    # -> True. rc_kind_for RAISES for any marker, proving no marker probe.
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: isinstance(p, str) and p.startswith(MOUNT_PREFIX))
+
+    def _kind(p, **k):
+        if p == STORE:
+            return "dir"
+        raise AssertionError(f"marker probed despite complete listing: {p}")
+
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", _kind)
+    monkeypatch.setattr(mounts_mod, "rc_read_bounded",
+                        lambda *a, **k: b'{"node_type": "group"}')
+    _direct_list(monkeypatch, result=([{"Name": "zarr.json", "IsDir": False}], None))
+
+    r = _client().get("/api/fs/conditions", params={"path": STORE})
+    assert r.status_code == 200
+    assert r.json()["conditions"].get("zarr_aoi") is True

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -29,12 +29,16 @@ ZARR_CONDITION = os.path.join(server.TEMPLATES_DIR, "zarr_aoi", "condition.py")
 
 @pytest.fixture(autouse=True)
 def _clear_conditions_cache():
-    # /api/fs/conditions now caches success payloads by path for a short TTL.
-    # These tests reuse a single STORE path across differing mount states and
-    # expect each call to recompute, so drop the cache between tests.
+    # /api/fs/conditions and /api/fs/stat now cache success payloads by path for
+    # a short TTL. These tests reuse a single STORE path across differing mount
+    # states and expect each call to recompute, so drop both caches between
+    # tests (a success stat cached under one mount state would otherwise mask the
+    # 503/404 a later state expects).
     server._CONDITIONS_CACHE.clear()
+    server._STAT_CACHE.clear()
     yield
     server._CONDITIONS_CACHE.clear()
+    server._STAT_CACHE.clear()
 
 
 @pytest.fixture()

--- a/tests/test_condition_mount_shim.py
+++ b/tests/test_condition_mount_shim.py
@@ -27,6 +27,16 @@ STORE = "/fake-mounts/s3demo/store"
 ZARR_CONDITION = os.path.join(server.TEMPLATES_DIR, "zarr_aoi", "condition.py")
 
 
+@pytest.fixture(autouse=True)
+def _clear_conditions_cache():
+    # /api/fs/conditions now caches success payloads by path for a short TTL.
+    # These tests reuse a single STORE path across differing mount states and
+    # expect each call to recompute, so drop the cache between tests.
+    server._CONDITIONS_CACHE.clear()
+    yield
+    server._CONDITIONS_CACHE.clear()
+
+
 @pytest.fixture()
 def guard_kernel(monkeypatch):
     """Make every kernel os call on a mount-backed path explode, so a shim leak

--- a/tests/test_conditions_cache.py
+++ b/tests/test_conditions_cache.py
@@ -1,0 +1,92 @@
+"""Tests for the /api/fs/conditions TTL cache.
+
+Evaluating template condition.py gates over a remote mount is slow (~6.8s) and
+was recomputed on every call. api_fs_conditions now caches success payloads for
+a short TTL. These tests monkeypatch server._conditions_payload with a
+call-counting stub so cache hits vs recomputes can be asserted directly.
+"""
+
+from fastapi.testclient import TestClient
+
+from fused_render import server
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _clear_conditions_cache():
+    server._CONDITIONS_CACHE.clear()
+    yield
+    server._CONDITIONS_CACHE.clear()
+
+
+@pytest.fixture
+def client():
+    return TestClient(server.create_app(start_dir="/"))
+
+
+def test_cache_hit_within_ttl(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "conditions": {}}
+
+    monkeypatch.setattr(server, "_conditions_payload", stub)
+
+    r1 = client.get("/api/fs/conditions", params={"path": "/some/dir"})
+    r2 = client.get("/api/fs/conditions", params={"path": "/some/dir"})
+
+    assert calls["n"] == 1
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json() == r2.json()
+
+
+def test_distinct_paths_cached_separately(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "conditions": {}}
+
+    monkeypatch.setattr(server, "_conditions_payload", stub)
+
+    client.get("/api/fs/conditions", params={"path": "/dir/a"})
+    client.get("/api/fs/conditions", params={"path": "/dir/b"})
+
+    assert calls["n"] == 2
+
+
+def test_stale_ttl_recomputes(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "conditions": {}}
+
+    monkeypatch.setattr(server, "_conditions_payload", stub)
+    monkeypatch.setattr(server, "_CONDITIONS_TTL_S", 0.0)
+
+    client.get("/api/fs/conditions", params={"path": "/some/dir"})
+    client.get("/api/fs/conditions", params={"path": "/some/dir"})
+
+    assert calls["n"] == 2
+
+
+def test_errors_are_not_cached(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return server._error("no such file", status=404)
+
+    monkeypatch.setattr(server, "_conditions_payload", stub)
+
+    r1 = client.get("/api/fs/conditions", params={"path": "/missing"})
+    r2 = client.get("/api/fs/conditions", params={"path": "/missing"})
+
+    assert calls["n"] == 2
+    assert r1.status_code == 404
+    assert r2.status_code == 404

--- a/tests/test_stat_cache.py
+++ b/tests/test_stat_cache.py
@@ -151,6 +151,35 @@ def test_write_invalidates_cache(client, monkeypatch):
     assert calls["n"] == 2
 
 
+def test_midflight_invalidation_is_not_refilled(client, monkeypatch):
+    # TOCTOU race guard: a slow _fs_stat (cold mount LIST, GIL released during
+    # I/O) can start BEFORE a concurrent mutation, then finish AFTER that
+    # mutation's _invalidate_stat_cache popped the key. Without a generation
+    # guard, api_fs_stat would unconditionally write its pre-mutation payload
+    # back, undoing the invalidation and serving stale metadata to the editor's
+    # post-write optimistic-lock re-stat. We reproduce it deterministically with
+    # no real threads: the stub invalidates DURING its own call (as a mutation
+    # completing mid-flight would), then returns a stale payload.
+    path = "/mnt/proj/main.py"
+    calls = {"n": 0}
+
+    def racing_stub(p):
+        calls["n"] += 1
+        # A mutation lands and invalidates while this stat is "in flight".
+        server._invalidate_stat_cache(p)
+        return {"path": p, "is_dir": False, "mtime": float(calls["n"])}
+
+    monkeypatch.setattr(server, "_fs_stat", racing_stub)
+
+    r = client.get("/api/fs/stat", params={"path": path})
+    assert r.status_code == 200
+    # The raced result must NOT be cached — the invalidation wins.
+    assert path not in server._STAT_CACHE
+    # And a subsequent stat recomputes rather than serving a stale hit.
+    client.get("/api/fs/stat", params={"path": path})
+    assert calls["n"] == 2
+
+
 def test_rename_invalidates_src_and_dst(client, monkeypatch):
     src = "/mnt/proj/old.py"
     dst = "/mnt/proj/new.py"

--- a/tests/test_stat_cache.py
+++ b/tests/test_stat_cache.py
@@ -1,0 +1,121 @@
+"""Tests for the /api/fs/stat TTL cache.
+
+Stat'ing a path on a remote mount goes _fs_stat -> _mount_safe_stat ->
+_mount_probe -> rc_list_dir(parent) — a full cold LIST of the parent prefix over
+rclone/S3 (~1.6s) just to describe one child. Re-navigating to a sibling repaid
+it every time. api_fs_stat now caches success payloads for MOUNT-backed paths
+for a short TTL. These tests monkeypatch server._fs_stat with a call-counting
+stub (and force is_mount_backed True) so cache hits vs recomputes can be
+asserted directly, mirroring tests/test_conditions_cache.py.
+"""
+
+from fastapi.testclient import TestClient
+
+import pytest
+
+from fused_render import server
+from fused_render.shell import mounts
+
+
+@pytest.fixture(autouse=True)
+def _clear_stat_cache():
+    server._STAT_CACHE.clear()
+    yield
+    server._STAT_CACHE.clear()
+
+
+@pytest.fixture(autouse=True)
+def _force_mount_backed(monkeypatch):
+    # Only mount-backed paths are cached; make the test paths look mount-backed
+    # so the cache engages (api_fs_stat imports is_mount_backed from this module
+    # at call time, so patching the module attribute is picked up).
+    monkeypatch.setattr(mounts, "is_mount_backed", lambda path: True)
+
+
+@pytest.fixture
+def client():
+    return TestClient(server.create_app(start_dir="/"))
+
+
+def test_cache_hit_within_ttl(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "is_dir": True, "mtime": 1.0}
+
+    monkeypatch.setattr(server, "_fs_stat", stub)
+
+    r1 = client.get("/api/fs/stat", params={"path": "/mnt/some/dir"})
+    r2 = client.get("/api/fs/stat", params={"path": "/mnt/some/dir"})
+
+    assert calls["n"] == 1
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    assert r1.json() == r2.json()
+
+
+def test_distinct_paths_cached_separately(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "is_dir": True, "mtime": 1.0}
+
+    monkeypatch.setattr(server, "_fs_stat", stub)
+
+    client.get("/api/fs/stat", params={"path": "/mnt/dir/a"})
+    client.get("/api/fs/stat", params={"path": "/mnt/dir/b"})
+
+    assert calls["n"] == 2
+
+
+def test_stale_ttl_recomputes(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "is_dir": True, "mtime": 1.0}
+
+    monkeypatch.setattr(server, "_fs_stat", stub)
+    monkeypatch.setattr(server, "_STAT_TTL_S", 0.0)
+
+    client.get("/api/fs/stat", params={"path": "/mnt/some/dir"})
+    client.get("/api/fs/stat", params={"path": "/mnt/some/dir"})
+
+    assert calls["n"] == 2
+
+
+def test_errors_are_not_cached(client, monkeypatch):
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return server._error("no such file", status=404)
+
+    monkeypatch.setattr(server, "_fs_stat", stub)
+
+    r1 = client.get("/api/fs/stat", params={"path": "/mnt/missing"})
+    r2 = client.get("/api/fs/stat", params={"path": "/mnt/missing"})
+
+    assert calls["n"] == 2
+    assert r1.status_code == 404
+    assert r2.status_code == 404
+
+
+def test_non_mount_paths_not_cached(client, monkeypatch):
+    # Local paths are cheap kernel stats and can be mutated out-of-band, so they
+    # are deliberately never cached — recompute every call.
+    calls = {"n": 0}
+
+    def stub(path):
+        calls["n"] += 1
+        return {"path": path, "is_dir": True, "mtime": 1.0}
+
+    monkeypatch.setattr(server, "_fs_stat", stub)
+    monkeypatch.setattr(mounts, "is_mount_backed", lambda path: False)
+
+    client.get("/api/fs/stat", params={"path": "/local/dir"})
+    client.get("/api/fs/stat", params={"path": "/local/dir"})
+
+    assert calls["n"] == 2

--- a/tests/test_stat_cache.py
+++ b/tests/test_stat_cache.py
@@ -119,3 +119,57 @@ def test_non_mount_paths_not_cached(client, monkeypatch):
     client.get("/api/fs/stat", params={"path": "/local/dir"})
 
     assert calls["n"] == 2
+
+
+def test_write_invalidates_cache(client, monkeypatch):
+    path = "/mnt/proj/main.py"
+    calls = {"n": 0}
+
+    def stat_stub(p):
+        calls["n"] += 1
+        return {"path": p, "is_dir": False, "mtime": float(calls["n"])}
+
+    monkeypatch.setattr(server, "_fs_stat", stat_stub)
+
+    # Prime the cache.
+    client.get("/api/fs/stat", params={"path": path})
+    assert calls["n"] == 1
+    assert path in server._STAT_CACHE
+
+    # A write must drop the entry so the editor's post-write stat re-reads the
+    # fresh mtime instead of the stale cached one. Monkeypatching _fs_write
+    # bypasses the auth guard and the actual filesystem mutation.
+    monkeypatch.setattr(
+        server, "_fs_write", lambda body, x_fused: {"path": body["path"], "mtime": 99.0}
+    )
+    r = client.post("/api/fs/write", json={"path": path, "content": "x"})
+    assert r.status_code == 200
+    assert path not in server._STAT_CACHE
+
+    # Subsequent stat recomputes.
+    client.get("/api/fs/stat", params={"path": path})
+    assert calls["n"] == 2
+
+
+def test_rename_invalidates_src_and_dst(client, monkeypatch):
+    src = "/mnt/proj/old.py"
+    dst = "/mnt/proj/new.py"
+
+    def stat_stub(p):
+        return {"path": p, "is_dir": False, "mtime": 1.0}
+
+    monkeypatch.setattr(server, "_fs_stat", stat_stub)
+
+    # Prime both.
+    client.get("/api/fs/stat", params={"path": src})
+    client.get("/api/fs/stat", params={"path": dst})
+    assert src in server._STAT_CACHE
+    assert dst in server._STAT_CACHE
+
+    monkeypatch.setattr(
+        server, "_fs_rename", lambda body, x_fused: {"path": body["dst"], "mtime": 5.0}
+    )
+    r = client.post("/api/fs/rename", json={"src": src, "dst": dst})
+    assert r.status_code == 200
+    assert src not in server._STAT_CACHE
+    assert dst not in server._STAT_CACHE


### PR DESCRIPTION
## Summary

- Opening a directory view fired `GET /api/fs/conditions`, which evaluated the `zarr_aoi` gate over the mount and took **~6.8s** — long enough that the mode switcher spun before the view was fully usable. On a non-zarr directory (the common case, e.g. an Ookla parquet partition on an anonymous-S3 mount) the gate hit its worst path: a redundant `is_dir` re-probe plus three serial marker `isfile` misses, ≈10 sequential S3 round trips.
- **No cache (#1):** re-navigating to the same directory now reuses a recent verdict via a short (60s) check-on-read TTL cache on the endpoint. Only success payloads are cached; `404`/error responses are always recomputed. Warm re-open drops from ~6.8s to instant.
- **Redundant probe removed (#2):** the endpoint already takes one `rc_kind_for` `is_dir` probe; that verdict is now threaded into the gate shim so the gate no longer re-probes the same path.
- **Marker probes consolidated (#3/#4):** for a direct-list-capable (anonymous S3/GCS) mount, one bounded unsigned listing of the directory's immediate children answers all three zarr marker `isfile` probes locally (the markers are always immediate children, so a *complete* page proves each present/absent). A truncated or failed listing transparently falls back to today's per-marker rc probes.
- Net cold cost on the reported ookla path: ≈**10 round trips → ≈3** (one `is_dir` probe + one listing), warm ≈**0**. All existing mount-safety invariants preserved: no kernel `os.*` ever touches a mount path, gates still fail closed, and the `404`-on-missing / `200`-on-indeterminate endpoint semantics are unchanged.

## Visuals

Gate evaluation for a mount-backed directory. The delta is the TTL cache + the `_GateSeed` (one is_dir probe and one bounded listing replacing the redundant re-probe and three serial marker probes).

**Before — ~6.8s, every call:**

```mermaid
flowchart TB
    A1[GET /api/fs/conditions] --> A2[rc is_dir probe]
    A2 --> A3["gate: os.path.isdir(path)<br/>REDUNDANT re-probe"]
    A3 --> A4["isfile .zmetadata (rc)"]
    A4 --> A5["isfile zarr.json (rc)"]
    A5 --> A6["isfile .zgroup (rc)"]
    A6 --> A7[verdict]
```

**After — ≈3 round trips cold, ≈0 warm:**

```mermaid
flowchart TB
    B1[GET /api/fs/conditions] --> B2{fresh in TTL cache?}
    B2 -->|hit| B9[cached verdict ~0ms]
    B2 -->|miss| B3[rc is_dir probe] --> B4[one bounded direct listing]
    B4 --> B5["_GateSeed: kinds + file_children"]
    B5 --> B6["gate: isdir -> seed.kinds (no probe)"]
    B6 --> B7["3x isfile -> seed.file_children (no probe)"]
    B7 --> B8[verdict] --> B10[store in cache]
    B4 -. truncated / not direct-capable .-> B11[fall back to per-marker rc probes]
    B11 --> B8
```

No UI change — the frontend already fetches this endpoint from a background effect and renders unconditional templates immediately; this PR only makes the verdict land faster.

## Usage

Not directly user-invocable — it's the existing `GET /api/fs/conditions?path=<dir>` endpoint, now faster. To observe:

```bash
# Cold (first open of a directory)
curl -s -o /dev/null -w '%{time_total}\n' \
  "http://127.0.0.1:1777/api/fs/conditions?path=<url-encoded-mount-dir>"
# Warm (within 60s) — served from the TTL cache, ~0s
curl -s -o /dev/null -w '%{time_total}\n' \
  "http://127.0.0.1:1777/api/fs/conditions?path=<same-dir>"
```

Tunable: `server._CONDITIONS_TTL_S` (default `60.0`) and `server._GATE_LIST_MAX_KEYS` (default `1000`).

## Test Plan

- [x] **Automated — new `tests/test_conditions_cache.py`** (4): cache hit within TTL, distinct paths cached separately, stale-TTL recompute, error/404 responses not cached.
- [x] **Automated — new `tests/test_condition_gate_seed.py`** (6): seed skips target re-probe; complete listing with no markers → False with no marker probes; complete listing with `.zgroup` → True; truncated listing falls back to probes; listing failure falls back to probes; v3 group via listing (`zarr.json` from listing, `node_type` read still runs). All under the `guard_kernel` fixture that fails loudly on any kernel `os.*` against a mount path.
- [x] **Regression** — existing `tests/test_condition_mount_shim.py`, `tests/test_zarr_aoi_mount.py`, `tests/test_templates.py` pass unchanged (all `seed` params default to `None`; behavior is byte-for-byte identical when unseeded). Added a shared cache-clearing fixture to the two endpoint test files so the module-level cache doesn't leak verdicts across tests.
- [x] **Full suite** — `python -m pytest -o addopts="" -q` passes (exit 0).
- [ ] **Manual** — open a mount-backed directory in the app; confirm the mode switcher resolves quickly, re-opening the same dir is instant, and a real `.zarr` store still offers the AOI streamer.

---

## Follow-up: the folder-open navigation pause

With `conditions` no longer the bottleneck, opening a folder still showed a **~1s blank screen** before the template list + a "loading" listing appeared. A network waterfall pinned it: **`/api/fs/stat` (~1.6s cold)** sat on the critical path — the frontend rendered nothing until it resolved — and `/api/fs/list` + `/api/fs/conditions` were **serialized behind it** rather than overlapping. `stat` is slow because a mount stat LISTs the parent prefix over rclone/S3 just to describe one child.

**Three fixes (backend + frontend):**

- **BE — `/api/fs/stat` TTL cache:** a 60s check-on-read cache (mirrors the conditions cache) so re-navigation / the stat that follows a listing is instant. Only **mount-backed success** payloads are cached (local stats are cheap and can change out-of-band); every mutation route (`write`/`mkdir`/`delete`/`rename`/`copy`) invalidates the touched paths + parents, so the editor's post-write stat always re-reads fresh.
- **FE #1 — don't gate first paint on `stat`:** navigation now paints a scaffold immediately (breadcrumb + folder name + a template-strip spinner + the real listing) instead of blanking. A directory hint rides in `history.state` so the destination knows to show a listing before `stat` resolves.
- **FE #2 — parallelize:** the scaffold's listing fires `/api/fs/list` in parallel with the in-flight `stat` (a 5s `prefetchListDir` dedupe means the remount into the resolved preview reuses that same request). `conditions` stays non-blocking as before.

**Net effect:** the blank screen is gone (instant scaffold); the listing renders as soon as `list` returns (~800ms) instead of after `stat`+`list` in series; warm re-navigation is instant (stat cache).

```mermaid
flowchart TB
    subgraph B["Before — serialized behind stat"]
      direction TB
      N1[click folder] --> N2["BLANK screen"]
      N2 --> N3["stat ~1.6s (blocks paint)"]
      N3 --> N4["then list ~0.8s → 'loading'"]
      N4 --> N5[then conditions]
      N5 --> N6[usable]
    end
```

```mermaid
flowchart TB
    subgraph A["After — scaffold + parallel"]
      direction TB
      M1[click folder] --> M2["scaffold paints NOW<br/>breadcrumb + listing skeleton"]
      M2 --> M3["stat, list, conditions in parallel"]
      M3 --> M4["list ~0.8s → rows render"]
      M3 --> M5["stat fills templates/metadata<br/>(cached & instant when warm)"]
      M3 --> M6[conditions gates AOI spinner]
    end
```

### Test Plan (follow-up)

- [x] **Automated — new `tests/test_stat_cache.py`** (7): cache hit within TTL, distinct paths, stale-TTL recompute, errors not cached, non-mount paths not cached, write invalidates, rename invalidates src+dst.
- [x] **Regression** — `tests/test_condition_mount_shim.py` fixture extended to clear `_STAT_CACHE` between cases; full suite **1336 passed, 4 skipped**.
- [x] **Frontend** — `tsc --noEmit` clean, `vite build` succeeds (no FE unit-test harness exists in this repo).
- [ ] **Manual** — open a mount-backed folder: confirm no blank screen (instant scaffold), listing appears without waiting on stat, re-opening a sibling is instant, and a wrong-hint edge (dir that's actually a file) resolves cleanly into the file preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
