### PR TITLE
feat(mounts): credential-expiry recovery + Restart button + Mounts page overhaul

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -748,6 +748,14 @@ export interface Mount {
   // server re-creates on every startup — the API rejects deleting it, so the
   // Mounts view hides Delete for it too (unmount still works).
   builtin: boolean;
+  // Why restarting the rclone daemon would help this mount, else null:
+  //  - "params" = the mount is live but its running options no longer match the
+  //    record (e.g. read_only flipped) — a restart re-mounts to apply them.
+  //  - "credentials" = a disconnected env_auth mount whose credentials probe
+  //    valid again; the long-lived daemon still holds the stale keys, so only a
+  //    restart (not Reconnect) re-reads the refreshed ones.
+  // Both route the user to the single global Restart rclone button.
+  restart_reason?: "params" | "credentials" | null;
 }
 
 // A remote we can offer from credentials already present in the user's
@@ -801,6 +809,14 @@ export function detachMount(id: string, force = false): Promise<Mount> {
 // Repair a disconnected mount: force-clear the dead mountpoint, remount.
 export function reconnectMount(id: string): Promise<Mount> {
   return postJson<Mount>(`/api/mounts/${id}/reconnect`, {});
+}
+
+// Global recovery: restart the rcd daemon and re-mount everything. Briefly
+// disconnects ALL mounts, but is the only fix for a stale-credential daemon
+// (a fresh daemon re-reads refreshed keys) and for applying changed mount
+// params. Returns the same shape as getMounts so the caller refreshes at once.
+export function restartRclone(): Promise<MountsResult> {
+  return postJson<MountsResult>("/api/mounts/restart", {});
 }
 
 export function deleteMount(id: string): Promise<void> {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2788,10 +2788,107 @@ select.field-control:has(option[value=""]:checked) {
   flex-wrap: wrap;
 }
 
-/* rclone-not-found callout — a full-bordered card (no side stripe). */
+/* Paste-a-link fast path above the manual fields: a full-width input that
+   parses an S3/GCS URL and auto-fills Name/Remote/Path below. */
+.mount-paste {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.mount-paste :where(input, select) {
+  width: 100%;
+}
+
+.mount-paste-hint {
+  margin: 0;
+  font-size: 0.8em;
+}
+
+.mount-paste-hint.warn {
+  color: var(--warning);
+}
+
+/* Page header — title + one-line intro on the left, global actions on the
+   right. Wraps on a narrow pane so the action drops below the title. */
+.mounts-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.mounts-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.mounts-subtitle {
+  margin: 4px 0 0;
+  color: var(--fg-muted);
+  font-size: 12.5px;
+  line-height: 1.45;
+  max-width: 54ch;
+}
+
+.mounts-actions {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+/* Refresh glyph in the Restart button — sized independently of the label. */
+.mounts-restart-icon {
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* Callout card — the rclone-not-found notice and the recovery prompt share
+   one chassis; `.warn` tints it for the "needs a restart" case. */
+.mount-callout {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-alt);
+}
+
+.mount-callout.warn {
+  border-color: color-mix(in srgb, var(--warning) 50%, var(--border));
+  background: color-mix(in srgb, var(--warning) 9%, var(--bg-alt));
+}
+
 .mount-callout-title {
-  font-weight: 700;
-  margin-bottom: 4px;
+  font-weight: 600;
+  margin: 0;
+}
+
+/* Normal block flow (NOT flex) so the not-found callout's inline text + <code>
+   chips + link wrap as one paragraph; flex-column would stack each inline
+   child on its own line. The recovery callout's multiple <p> lines get their
+   own spacing via the adjacent-sibling margin below. */
+.mount-callout-body {
+  color: var(--fg-muted);
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+
+.mount-callout-body p {
+  margin: 0;
+}
+
+.mount-callout-body p + p {
+  margin-top: 3px;
+}
+
+.mount-callout-body code {
+  white-space: nowrap;
 }
 
 /* Mount cards — one bordered card per mounted/available mount. */
@@ -2809,12 +2906,66 @@ select.field-control:has(option[value=""]:checked) {
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--bg-alt);
+  transition: border-color 0.12s ease;
+}
+
+.mount-card:not(.mount-card--skeleton):hover {
+  border-color: var(--fg-muted);
+}
+
+/* Loading placeholder rows shown while getMounts() is in flight — a shimmer
+   sweep over an empty card, so the list area reserves its space instead of
+   the page jumping when data lands. */
+.mount-card--skeleton {
+  height: 60px;
+  position: relative;
+  overflow: hidden;
+}
+
+.mount-card--skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.04),
+    transparent
+  );
+  animation: mount-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes mount-shimmer {
+  to {
+    transform: translateX(100%);
+  }
 }
 
 .mount-card-main {
   display: flex;
   align-items: center;
   gap: 12px;
+  /* Wrap on a narrow pane: the name block (flex:1) keeps the first row and the
+     action buttons drop to a second row rather than crushing the name. */
+  flex-wrap: wrap;
+  row-gap: 10px;
+}
+
+/* The name/remote block is the flexible column; never let it shrink to zero
+   (which would collapse the ellipsised remote spec to nothing). */
+.mount-card-main > .mount-card-info {
+  flex: 1 1 200px;
+  min-width: 0;
+}
+
+/* Keep the action buttons together and pushed to the row's end; on wrap they
+   ride to the next line as a group. */
+.mount-card-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-left: auto;
 }
 
 .mount-card button {
@@ -2931,6 +3082,36 @@ select.field-control:has(option[value=""]:checked) {
 }
 .mount-link:hover {
   color: var(--fg);
+}
+
+/* Compact layout for narrow panes: tighten page padding, shrink the title, and
+   let the header action span the full width (so it doesn't get squeezed next to
+   a wrapping title). The mount-card / header flex-wrap rules handle the
+   in-between widths; this is the small-end polish. */
+@media (max-width: 560px) {
+  .prefs-page {
+    padding: 14px 14px 24px;
+    gap: 18px;
+  }
+
+  .mounts-title {
+    font-size: 16px;
+  }
+
+  .mounts-actions {
+    width: 100%;
+  }
+
+  .mounts-actions .mounts-restart {
+    width: 100%;
+    justify-content: center;
+  }
+
+  /* On a broken mount the Open/Reconnect + delete row wraps below the name;
+     stretch it full-width so the buttons aren't cramped against the edge. */
+  .mount-card-actions {
+    flex-wrap: wrap;
+  }
 }
 
 .prefs-radio {

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -167,15 +167,20 @@ export function parseStorageUrl(raw: string): ParsedLink | null {
   const qsPrefix = u.searchParams.get("prefix") ?? "";
 
   // AWS S3 console: …/s3/buckets/<bucket>?prefix=a/b/&region=…
+  // ONLY the S3 console is a storage link — require the "buckets/<bucket>"
+  // marker so an unrelated AWS console page (ec2, iam, …) isn't mistaken for a
+  // bucket and doesn't auto-fill a bogus path from its last URL segment.
   if (host.endsWith("console.aws.amazon.com")) {
     const bi = segs.indexOf("buckets");
-    const bucket = bi >= 0 ? segs[bi + 1] : segs[segs.length - 1];
+    const bucket = bi >= 0 ? segs[bi + 1] : "";
     return bucket ? { provider: "s3", path: joinPath(bucket, qsPrefix) } : null;
   }
-  // GCP console: …/storage/browser/<bucket>/<prefix>
+  // GCP console: …/storage/browser/<bucket>/<prefix> — likewise require the
+  // "browser/<bucket>" marker; other cloud-console pages are not storage links.
   if (host.endsWith("console.cloud.google.com")) {
     const bi = segs.indexOf("browser");
-    const rest = bi >= 0 ? segs.slice(bi + 1) : segs;
+    if (bi < 0) return null;
+    const rest = segs.slice(bi + 1);
     return rest.length ? { provider: "gcs", path: rest.join("/") } : null;
   }
   // GCS path-style data hosts.
@@ -569,7 +574,16 @@ export default function Mounts() {
   const [restartError, setRestartError] = useState<string | null>(null);
 
   const reload = () => {
-    getMounts().then(setState, (e: Error) => setLoadError(e.message));
+    getMounts().then(
+      (r) => {
+        setState(r);
+        // Clear any prior load error — otherwise a stale "Failed to load mounts"
+        // banner lingers over an up-to-date list after a recovered fetch (e.g.
+        // the reload() a failed doRestart fires, or a transient error healing).
+        setLoadError(null);
+      },
+      (e: Error) => setLoadError(e.message),
+    );
   };
   useEffect(reload, []);
 

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -166,14 +166,19 @@ export function parseStorageUrl(raw: string): ParsedLink | null {
   });
   const qsPrefix = u.searchParams.get("prefix") ?? "";
 
-  // AWS S3 console: …/s3/buckets/<bucket>?prefix=a/b/&region=…
-  // ONLY the S3 console is a storage link — require the "buckets/<bucket>"
-  // marker so an unrelated AWS console page (ec2, iam, …) isn't mistaken for a
-  // bucket and doesn't auto-fill a bogus path from its last URL segment.
+  // AWS S3 console link shapes: the bucket view …/s3/buckets/<bucket>?prefix=a/b/
+  // and the object view …/s3/object/<bucket>[/<key>]?prefix=<key>. Require one of
+  // those markers so an unrelated AWS console page (ec2, iam, …) isn't mistaken
+  // for a bucket and doesn't auto-fill a bogus path from its last URL segment.
   if (host.endsWith("console.aws.amazon.com")) {
     const bi = segs.indexOf("buckets");
-    const bucket = bi >= 0 ? segs[bi + 1] : "";
-    return bucket ? { provider: "s3", path: joinPath(bucket, qsPrefix) } : null;
+    const oi = segs.indexOf("object");
+    const bucket = bi >= 0 ? segs[bi + 1] : oi >= 0 ? segs[oi + 1] : "";
+    if (!bucket) return null;
+    // The object view may carry the key in the path after the bucket; both
+    // shapes may carry it in ?prefix=.
+    const inPath = oi >= 0 ? segs.slice(oi + 2).join("/") : "";
+    return { provider: "s3", path: joinPath(bucket, qsPrefix || inPath) };
   }
   // GCP console: …/storage/browser/<bucket>/<prefix> — likewise require the
   // "browser/<bucket>" marker; other cloud-console pages are not storage links.
@@ -204,26 +209,35 @@ export function parseStorageUrl(raw: string): ParsedLink | null {
   return null;
 }
 
-// A trailing path segment that looks like a file (has a short extension), e.g.
-// "TCI.tif", "part-0001.parquet" — used to tell a link-to-a-file from a
+// A trailing segment with a short extension (e.g. "TCI.tif", "part-0001.parquet")
+// — but NOT one whose extension names a directory this app browses as a folder
+// (.zarr, .gdb): those are prefixes, not objects, so a link ending in (or under)
+// one must keep the directory in the path. Used to tell a link-to-a-file from a
 // link-to-a-prefix.
-const FILE_TAIL = /\.[A-Za-z0-9]{1,8}$/;
+const FILE_EXT = /\.([A-Za-z0-9]{1,8})$/;
+const DIR_EXTS = new Set(["zarr", "gdb"]);
+function looksLikeFile(seg: string): boolean {
+  const m = FILE_EXT.exec(seg);
+  return !!m && !DIR_EXTS.has(m[1].toLowerCase());
+}
 
 // The path to actually mount for a pasted link. Pasting a deep link to a single
 // FILE — e.g. s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/QR/2025/8/…/TCI.tif —
 // should not mount that one scene folder (let alone the file); the useful mount
 // is the dataset root, bucket + first prefix segment
 // (sentinel-cogs/sentinel-s2-l2a-cogs), which you then browse. A link to a
-// PREFIX (no file tail — a bucket root, a trailing-slash prefix, a console
-// ?prefix=) is kept verbatim, since navigating there was deliberate. Either way
-// the Path field stays editable, so this is only the starting suggestion.
+// PREFIX (no file tail — a bucket root, a trailing-slash prefix, a .zarr/.gdb
+// directory, a console ?prefix=) is kept verbatim, since navigating there was
+// deliberate. Either way the Path field stays editable, so this is only the
+// starting suggestion.
 export function mountRootForLink(path: string): string {
   const segs = path.split("/").filter(Boolean);
-  if (!segs.length || !FILE_TAIL.test(segs[segs.length - 1])) return path;
+  if (!segs.length || !looksLikeFile(segs[segs.length - 1])) return path;
   const [bucket, ...key] = segs;
-  // First prefix segment is the dataset/collection; if the file sits directly
-  // under the bucket (or that first segment IS the file), fall back to the bucket.
-  return key[0] && !FILE_TAIL.test(key[0]) ? `${bucket}/${key[0]}` : bucket;
+  // key.length > 1 ⇒ there's a prefix directory before the file — keep it (even
+  // a dotted one like "data.zarr", which is a directory, not the object). A lone
+  // key segment IS the file (sits directly under the bucket) ⇒ just the bucket.
+  return key.length > 1 ? `${bucket}/${key[0]}` : bucket;
 }
 
 function AddMount({

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -64,7 +64,7 @@ function MountRow({
     <div className="mount-card">
       <div className="mount-card-main">
         <span className={`mount-dot ${conn.state}`} role="img" aria-label={dotLabel} title={dotLabel} />
-        <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="mount-card-info">
           <div style={{ fontWeight: 600 }}>
             {conn.name}
             {conn.read_only && (
@@ -87,7 +87,7 @@ function MountRow({
             {conn.remote}
           </div>
         </div>
-        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+        <div className="mount-card-actions">
           {conn.state === "mounted" ? (
             <button type="button" disabled={busy} onClick={() => navigate(conn.mountpoint)}>
               Open
@@ -125,6 +125,80 @@ function MountRow({
   );
 }
 
+// A storage location pasted as a URL, reduced to the rclone-relative form the
+// Path field wants: a provider ("s3" | "gcs") and a `bucket/prefix` string (the
+// key path an rclone S3/GCS remote is addressed by). null when the input isn't a
+// recognized storage link, so the caller leaves the manual fields untouched.
+type ParsedLink = { provider: "s3" | "gcs"; path: string };
+
+// Strip leading slashes and trailing whitespace; rclone paths are relative to
+// the remote and never start with "/".
+const stripLead = (p: string) => p.replace(/^\/+/, "").replace(/\s+$/, "");
+const joinPath = (bucket: string, rest: string) => {
+  const r = stripLead(rest);
+  return r ? `${bucket}/${r}` : bucket;
+};
+
+export function parseStorageUrl(raw: string): ParsedLink | null {
+  const s = raw.trim();
+  if (!s) return null;
+
+  // Scheme URIs: s3://bucket/prefix, gs://bucket/prefix (gcs:// tolerated too).
+  let m = /^s3:\/\/(.+)$/i.exec(s);
+  if (m) return { provider: "s3", path: stripLead(m[1]) };
+  m = /^gc?s:\/\/(.+)$/i.exec(s);
+  if (m) return { provider: "gcs", path: stripLead(m[1]) };
+
+  let u: URL;
+  try {
+    u = new URL(s);
+  } catch {
+    return null;
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+  const host = u.hostname.toLowerCase();
+  const segs = u.pathname.split("/").filter(Boolean).map((x) => {
+    try {
+      return decodeURIComponent(x);
+    } catch {
+      return x;
+    }
+  });
+  const qsPrefix = u.searchParams.get("prefix") ?? "";
+
+  // AWS S3 console: …/s3/buckets/<bucket>?prefix=a/b/&region=…
+  if (host.endsWith("console.aws.amazon.com")) {
+    const bi = segs.indexOf("buckets");
+    const bucket = bi >= 0 ? segs[bi + 1] : segs[segs.length - 1];
+    return bucket ? { provider: "s3", path: joinPath(bucket, qsPrefix) } : null;
+  }
+  // GCP console: …/storage/browser/<bucket>/<prefix>
+  if (host.endsWith("console.cloud.google.com")) {
+    const bi = segs.indexOf("browser");
+    const rest = bi >= 0 ? segs.slice(bi + 1) : segs;
+    return rest.length ? { provider: "gcs", path: rest.join("/") } : null;
+  }
+  // GCS path-style data hosts.
+  if (host === "storage.googleapis.com" || host === "storage.cloud.google.com") {
+    return segs.length ? { provider: "gcs", path: segs.join("/") } : null;
+  }
+  // GCS virtual-hosted: <bucket>.storage.googleapis.com/<prefix>
+  if (host.endsWith(".storage.googleapis.com")) {
+    const bucket = host.slice(0, -".storage.googleapis.com".length);
+    return { provider: "gcs", path: joinPath(bucket, segs.join("/")) };
+  }
+  if (host.endsWith(".amazonaws.com")) {
+    // Path-style: s3.amazonaws.com/<bucket>/… or s3.<region>.amazonaws.com/<bucket>/…
+    if (host === "s3.amazonaws.com" || /^s3[.-]/.test(host)) {
+      return segs.length ? { provider: "s3", path: segs.join("/") } : null;
+    }
+    // Virtual-hosted: <bucket>.s3.<region>.amazonaws.com/<prefix> (also s3-<region>).
+    const vm = /^(.+?)\.s3[.-]/.exec(host);
+    if (vm) return { provider: "s3", path: joinPath(vm[1], segs.join("/")) };
+  }
+  return null;
+}
+
 function AddMount({
   remotes,
   suggested,
@@ -159,6 +233,62 @@ function AddMount({
     }
   };
 
+  // A pasted S3/GCS link (see parseStorageUrl) that auto-fills the fields below.
+  const [link, setLink] = useState("");
+
+  // Classify an available remote/suggestion so a pasted link can pick a matching
+  // one: which cloud, and whether it's a public (no-credentials) remote. Names +
+  // labels are the only client-side signal (e.g. "aws:" + "AWS S3 — default
+  // profile", or "aws-open:" + "… public buckets (no credentials)").
+  const classify = (nameRaw: string, labelRaw: string) => {
+    const n = nameRaw.toLowerCase();
+    const l = labelRaw.toLowerCase();
+    const provider =
+      n.startsWith("gcs") || l.includes("google cloud")
+        ? "gcs"
+        : n.startsWith("aws") || l.includes("s3")
+          ? "s3"
+          : "other";
+    const isPublic =
+      n.includes("open") ||
+      l.includes("public") ||
+      l.includes("no credentials") ||
+      l.includes("anon");
+    return { provider, isPublic };
+  };
+
+  // The <option> value (a raw remote spec or "suggest:<id>") to select for a
+  // pasted link's provider: prefer a credentialed remote over a public one, so
+  // s3://…/a-private-bucket lands on the user's own creds by default. undefined
+  // when nothing matches — the link still fills Path/Name and the user picks.
+  const pickRemote = (provider: "s3" | "gcs"): string | undefined => {
+    const candidates = [
+      ...remotes.map((r) => ({ value: r.name, ...classify(r.name, r.label) })),
+      ...suggested.map((s) => ({
+        value: `suggest:${s.id}`,
+        ...classify(s.remote_name, s.label),
+        isPublic: s.kind === "public",
+      })),
+    ].filter((c) => c.provider === provider);
+    return (candidates.find((c) => !c.isPublic) ?? candidates[0])?.value;
+  };
+
+  const parsedLink = parseStorageUrl(link);
+
+  const applyLink = (raw: string) => {
+    setLink(raw);
+    const parsed = parseStorageUrl(raw);
+    if (!parsed) return;
+    const rv = pickRemote(parsed.provider);
+    if (rv) setRemote(rv);
+    setSubpath(parsed.path);
+    // Re-derive Name from the pasted path and let it keep tracking Path edits
+    // (the user hasn't hand-typed a name).
+    const seg = parsed.path.split("/").map((s) => s.trim()).filter(Boolean).pop() ?? "";
+    setName(folderSafe(seg));
+    setNameTouched(false);
+  };
+
   // The rclone spec the Add button will mount, previewed live so it matches
   // what the mounted card then shows. A "suggest:<id>" selection resolves to
   // its real remote name at submit; use the suggestion's name for the preview.
@@ -189,6 +319,7 @@ function AddMount({
       setName("");
       setSubpath("");
       setRemote("");
+      setLink("");
       setNameTouched(false);
       onChanged();
     } catch (e) {
@@ -202,10 +333,30 @@ function AddMount({
     <section className="prefs-section">
       <h2>Add mount</h2>
       <p className="deploy-muted">
-        Surface an rclone remote as a local folder. Pick a remote you created, one under{" "}
+        Surface a remote as a local folder. Pick a remote you created, one under{" "}
         <b>Detected credentials</b> (from your AWS / gcloud config — no keys stored), or{" "}
         <b>Public buckets</b> for anonymous access to open data (no credentials needed).
       </p>
+      <div className="mount-paste">
+        <Field label="Paste a link">
+          <TextInput
+            placeholder="s3://bucket/prefix, gs://bucket/prefix, or an S3/GCS console URL"
+            value={link}
+            onChange={(e) => applyLink(e.target.value)}
+          />
+        </Field>
+        {link.trim() &&
+          (parsedLink ? (
+            <p className="deploy-muted mount-paste-hint">
+              Recognized {parsedLink.provider.toUpperCase()} link — filled the fields below
+              {pickRemote(parsedLink.provider) ? "" : "; pick a remote"}. Review, then mount.
+            </p>
+          ) : (
+            <p className="deploy-muted mount-paste-hint warn">
+              Not a recognized S3/GCS link — fill the fields below manually.
+            </p>
+          ))}
+      </div>
       <form
         className="mount-form-row"
         onSubmit={(e) => {
@@ -411,7 +562,7 @@ export default function Mounts() {
   // Lifted from AddRemote so the modal can gate its Esc/backdrop/✕ close while a
   // create is in flight (previously the backdrop close was ungated).
   const [remoteBusy, setRemoteBusy] = useState(false);
-  // Global "Restart rclone": a confirm modal (it briefly disconnects ALL
+  // Global "Restart all mounts": a confirm modal (it briefly disconnects ALL
   // mounts) gating the multi-second daemon restart + re-mount.
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [restartBusy, setRestartBusy] = useState(false);
@@ -442,113 +593,109 @@ export default function Mounts() {
     }
   };
 
-  if (loadError) {
-    return <div className="status-message error">Failed to load mounts: {loadError}</div>;
-  }
-  if (!state) {
-    return <div className="status-message">Loading…</div>;
-  }
+  // Recovery prompt: some mounts signal that a restart would fix them (settings
+  // drifted, or credentials were refreshed under a still-stale connection).
+  const paramsMounts = state?.mounts.filter((m) => m.restart_reason === "params") ?? [];
+  const credMounts = state?.mounts.filter((m) => m.restart_reason === "credentials") ?? [];
+  const needsRestart = paramsMounts.length > 0 || credMounts.length > 0;
 
+  // The page chrome (heading, intro, actions) renders immediately; only the
+  // mount list itself waits on the async getMounts() — a blocking full-page
+  // "Loading…" made the whole page feel slow when just the list is pending.
   return (
-    <div className="prefs-page">
-      {!state.rclone.available && (
-        <div className="deploy-note mount-callout">
+    <div className="prefs-page mounts-page">
+      <header className="mounts-head">
+        <div>
+          <h1 className="mounts-title">Mounts</h1>
+          <p className="mounts-subtitle">
+            Browse remote storage as local folders. Large files are cached locally after the
+            first open.
+          </p>
+        </div>
+        {state?.rclone.available && (
+          <div className="mounts-actions">
+            <button
+              type="button"
+              className="btn btn-secondary mounts-restart"
+              disabled={restartBusy}
+              onClick={() => setConfirmRestart(true)}
+              title="Reconnect all mounts — recovers stuck mounts and picks up refreshed credentials"
+            >
+              <span className="mounts-restart-icon" aria-hidden="true">
+                ↻
+              </span>
+              {restartBusy ? "Restarting…" : "Restart all mounts"}
+            </button>
+          </div>
+        )}
+      </header>
+
+      {loadError && <ErrorBanner>Failed to load mounts: {loadError}</ErrorBanner>}
+
+      {!state && !loadError && (
+        <div className="mount-list" aria-busy="true" aria-label="Loading mounts">
+          <div className="mount-card mount-card--skeleton" />
+          <div className="mount-card mount-card--skeleton" />
+        </div>
+      )}
+
+      {state && !state.rclone.available && (
+        <div className="mount-callout">
           <div className="mount-callout-title">rclone not found</div>
-          <div style={{ fontSize: "0.9em" }}>
+          <div className="mount-callout-body">
             rclone must be installed and on your <code>PATH</code> for mounts to work. Install it
             with <code>brew install rclone</code> (macOS), <code>apt install rclone</code> /{" "}
             <code>dnf install rclone</code> (Linux), or the{" "}
             <a href="https://rclone.org/install/" target="_blank" rel="noreferrer">
               official installer
             </a>
-            , then reload this page. Distro packages can be outdated, so a recent rclone is
+            , then reload this page. Distro packages can be outdated, so a recent version is
             recommended.
           </div>
         </div>
       )}
-      <p className="deploy-muted" style={{ marginTop: 0 }}>
-        Remote storage mounted as local folders
-        {state.rclone.version ? ` (${state.rclone.version})` : ""}. The <b>first</b> open of a
-        large remote file downloads what it needs and can be slow; repeat opens are served from
-        a local cache and are fast. Mounts stay up automatically, including across restarts;
-        if one stops responding, use <b>Reconnect</b>.
-      </p>
-      {(() => {
-        // A restart is a daemon-wide recovery: re-reads refreshed credentials
-        // and applies changed mount params. Prompt when any mount signals it.
-        const paramsMounts = state.mounts.filter((m) => m.restart_reason === "params");
-        const credMounts = state.mounts.filter((m) => m.restart_reason === "credentials");
-        if (paramsMounts.length === 0 && credMounts.length === 0) return null;
-        // Explanatory callout only — the single Restart rclone button below is
-        // the one action, so we don't stack a second identical button here.
-        return (
-          <div className="deploy-note mount-callout">
-            <div className="mount-callout-title">Restart rclone to recover</div>
-            <div style={{ fontSize: "0.9em" }}>
-              {paramsMounts.length > 0 && (
-                <div>Mount params changed — restart rclone to apply them.</div>
-              )}
-              {credMounts.length > 0 && (
-                <div>
-                  Credentials look refreshed — restart rclone to reconnect{" "}
-                  {credMounts.map((m) => m.name).join(", ")}.
-                </div>
-              )}
-              <div style={{ marginTop: 4 }}>Use the Restart rclone button below.</div>
-            </div>
+
+      {state && needsRestart && (
+        <div className="mount-callout warn">
+          <div className="mount-callout-title">Some mounts need a restart</div>
+          <div className="mount-callout-body">
+            {paramsMounts.length > 0 && <p>Settings changed — restart to apply them.</p>}
+            {credMounts.length > 0 && (
+              <p>
+                Credentials were refreshed — restart to reconnect{" "}
+                {credMounts.map((m) => m.name).join(", ")}.
+              </p>
+            )}
           </div>
-        );
-      })()}
-      {state.rclone.available && (
-        <div style={{ marginBottom: 12 }}>
-          <button type="button" disabled={restartBusy} onClick={() => setConfirmRestart(true)}>
-            {restartBusy ? "Restarting…" : "Restart rclone"}
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={restartBusy}
+            onClick={() => setConfirmRestart(true)}
+          >
+            {restartBusy ? "Restarting…" : "Restart all mounts"}
           </button>
         </div>
       )}
+
       {restartError && <ErrorBanner>{restartError}</ErrorBanner>}
-      {confirmRestart && (
-        <Modal
-          title="Restart rclone?"
-          busy={restartBusy}
-          onClose={() => setConfirmRestart(false)}
-          footer={
-            <>
-              <button
-                type="button"
-                disabled={restartBusy}
-                onClick={() => setConfirmRestart(false)}
-              >
-                Cancel
-              </button>
-              <button type="button" disabled={restartBusy} onClick={doRestart}>
-                {restartBusy ? "Restarting…" : "Restart rclone"}
-              </button>
-            </>
-          }
-        >
-          <p>
-            This restarts the rclone daemon and re-mounts everything. <b>All</b>{" "}
-            mounts — including healthy ones — are briefly disconnected while it
-            happens, and files currently open from a mount may need to be
-            reopened.
-          </p>
-        </Modal>
-      )}
-      {state.mounts.length > 0 ? (
-        <div className="mount-list">
-          {state.mounts.map((c) => (
-            <MountRow key={c.id} conn={c} onChanged={reload} />
-          ))}
-        </div>
-      ) : (
-        state.rclone.available && (
-          <div className="mount-empty">
-            No mounts yet — add one below to browse remote storage as local folders.
+
+      {state &&
+        (state.mounts.length > 0 ? (
+          <div className="mount-list">
+            {state.mounts.map((c) => (
+              <MountRow key={c.id} conn={c} onChanged={reload} />
+            ))}
           </div>
-        )
-      )}
-      {state.rclone.available && (
+        ) : (
+          state.rclone.available && (
+            <div className="mount-empty">
+              No mounts yet — add one below to browse remote storage as local folders.
+            </div>
+          )
+        ))}
+
+      {state?.rclone.available && (
         <>
           <AddMount
             remotes={state.rclone.remotes}
@@ -574,6 +721,40 @@ export default function Mounts() {
             </Modal>
           )}
         </>
+      )}
+
+      {confirmRestart && (
+        <Modal
+          title="Restart all mounts?"
+          busy={restartBusy}
+          onClose={() => setConfirmRestart(false)}
+          footer={
+            <>
+              <button
+                type="button"
+                className="btn btn-secondary"
+                disabled={restartBusy}
+                onClick={() => setConfirmRestart(false)}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={restartBusy}
+                onClick={doRestart}
+              >
+                {restartBusy ? "Restarting…" : "Restart all mounts"}
+              </button>
+            </>
+          }
+        >
+          <p>
+            This reconnects every mount and re-reads storage credentials. <b>All</b> mounts —
+            including healthy ones — briefly disconnect while it happens, and files currently open
+            from a mount may need to be reopened.
+          </p>
+        </Modal>
       )}
     </div>
   );

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -204,6 +204,28 @@ export function parseStorageUrl(raw: string): ParsedLink | null {
   return null;
 }
 
+// A trailing path segment that looks like a file (has a short extension), e.g.
+// "TCI.tif", "part-0001.parquet" — used to tell a link-to-a-file from a
+// link-to-a-prefix.
+const FILE_TAIL = /\.[A-Za-z0-9]{1,8}$/;
+
+// The path to actually mount for a pasted link. Pasting a deep link to a single
+// FILE — e.g. s3://sentinel-cogs/sentinel-s2-l2a-cogs/32/T/QR/2025/8/…/TCI.tif —
+// should not mount that one scene folder (let alone the file); the useful mount
+// is the dataset root, bucket + first prefix segment
+// (sentinel-cogs/sentinel-s2-l2a-cogs), which you then browse. A link to a
+// PREFIX (no file tail — a bucket root, a trailing-slash prefix, a console
+// ?prefix=) is kept verbatim, since navigating there was deliberate. Either way
+// the Path field stays editable, so this is only the starting suggestion.
+export function mountRootForLink(path: string): string {
+  const segs = path.split("/").filter(Boolean);
+  if (!segs.length || !FILE_TAIL.test(segs[segs.length - 1])) return path;
+  const [bucket, ...key] = segs;
+  // First prefix segment is the dataset/collection; if the file sits directly
+  // under the bucket (or that first segment IS the file), fall back to the bucket.
+  return key[0] && !FILE_TAIL.test(key[0]) ? `${bucket}/${key[0]}` : bucket;
+}
+
 function AddMount({
   remotes,
   suggested,
@@ -263,9 +285,11 @@ function AddMount({
   };
 
   // The <option> value (a raw remote spec or "suggest:<id>") to select for a
-  // pasted link's provider: prefer a credentialed remote over a public one, so
-  // s3://…/a-private-bucket lands on the user's own creds by default. undefined
-  // when nothing matches — the link still fills Path/Name and the user picks.
+  // pasted link's provider: prefer a PUBLIC (anonymous) remote over a
+  // credentialed one — pasted links are usually to open/public data, and an
+  // anonymous request works even when creds are absent or expired; the user can
+  // switch to their own remote for a private bucket. undefined when nothing
+  // matches — the link still fills Path/Name and the user picks.
   const pickRemote = (provider: "s3" | "gcs"): string | undefined => {
     const candidates = [
       ...remotes.map((r) => ({ value: r.name, ...classify(r.name, r.label) })),
@@ -275,7 +299,7 @@ function AddMount({
         isPublic: s.kind === "public",
       })),
     ].filter((c) => c.provider === provider);
-    return (candidates.find((c) => !c.isPublic) ?? candidates[0])?.value;
+    return (candidates.find((c) => c.isPublic) ?? candidates[0])?.value;
   };
 
   const parsedLink = parseStorageUrl(link);
@@ -286,10 +310,12 @@ function AddMount({
     if (!parsed) return;
     const rv = pickRemote(parsed.provider);
     if (rv) setRemote(rv);
-    setSubpath(parsed.path);
-    // Re-derive Name from the pasted path and let it keep tracking Path edits
-    // (the user hasn't hand-typed a name).
-    const seg = parsed.path.split("/").map((s) => s.trim()).filter(Boolean).pop() ?? "";
+    const rooted = mountRootForLink(parsed.path);
+    setSubpath(rooted);
+    // Name from the MOUNTED root's last segment (the dataset/collection), not a
+    // deep scene or file name — and keep it tracking Path edits (no hand-typed
+    // name yet).
+    const seg = rooted.split("/").map((s) => s.trim()).filter(Boolean).pop() ?? "";
     setName(folderSafe(seg));
     setNameTouched(false);
   };
@@ -354,7 +380,10 @@ function AddMount({
           (parsedLink ? (
             <p className="deploy-muted mount-paste-hint">
               Recognized {parsedLink.provider.toUpperCase()} link — filled the fields below
-              {pickRemote(parsedLink.provider) ? "" : "; pick a remote"}. Review, then mount.
+              {pickRemote(parsedLink.provider) ? "" : "; pick a remote"}.
+              {mountRootForLink(parsedLink.path) !== parsedLink.path
+                ? " Trimmed to the dataset root — edit Path to mount deeper."
+                : " Review, then mount."}
             </p>
           ) : (
             <p className="deploy-muted mount-paste-hint warn">

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -13,6 +13,7 @@ import {
   deleteMount,
   getMounts,
   reconnectMount,
+  restartRclone,
 } from "../lib/api";
 import type { Mount, MountsResult, RcloneRemote, RemoteSuggestion } from "../lib/api";
 import { navigate } from "../lib/router";
@@ -410,11 +411,31 @@ export default function Mounts() {
   // Lifted from AddRemote so the modal can gate its Esc/backdrop/✕ close while a
   // create is in flight (previously the backdrop close was ungated).
   const [remoteBusy, setRemoteBusy] = useState(false);
+  // Global "Restart rclone": a confirm modal (it briefly disconnects ALL
+  // mounts) gating the multi-second daemon restart + re-mount.
+  const [confirmRestart, setConfirmRestart] = useState(false);
+  const [restartBusy, setRestartBusy] = useState(false);
+  const [restartError, setRestartError] = useState<string | null>(null);
 
   const reload = () => {
     getMounts().then(setState, (e: Error) => setLoadError(e.message));
   };
   useEffect(reload, []);
+
+  const doRestart = async () => {
+    setRestartBusy(true);
+    setRestartError(null);
+    try {
+      // Returns the fresh MountsResult, so swap state in directly rather than
+      // firing a second GET.
+      setState(await restartRclone());
+      setConfirmRestart(false);
+    } catch (e) {
+      setRestartError((e as Error).message);
+    } finally {
+      setRestartBusy(false);
+    }
+  };
 
   if (loadError) {
     return <div className="status-message error">Failed to load mounts: {loadError}</div>;
@@ -447,6 +468,73 @@ export default function Mounts() {
         a local cache and are fast. Mounts stay up automatically, including across restarts;
         if one stops responding, use <b>Reconnect</b>.
       </p>
+      {(() => {
+        // A restart is a daemon-wide recovery: re-reads refreshed credentials
+        // and applies changed mount params. Prompt when any mount signals it.
+        const paramsMounts = state.mounts.filter((m) => m.restart_reason === "params");
+        const credMounts = state.mounts.filter((m) => m.restart_reason === "credentials");
+        if (paramsMounts.length === 0 && credMounts.length === 0) return null;
+        return (
+          <div className="deploy-note mount-callout">
+            <div className="mount-callout-title">Restart rclone to recover</div>
+            <div style={{ fontSize: "0.9em" }}>
+              {paramsMounts.length > 0 && (
+                <div>Mount params changed — restart rclone to apply them.</div>
+              )}
+              {credMounts.length > 0 && (
+                <div>
+                  Credentials look refreshed — restart rclone to reconnect{" "}
+                  {credMounts.map((m) => m.name).join(", ")}.
+                </div>
+              )}
+              <button
+                type="button"
+                style={{ marginTop: 8 }}
+                disabled={restartBusy}
+                onClick={() => setConfirmRestart(true)}
+              >
+                {restartBusy ? "Restarting…" : "Restart rclone"}
+              </button>
+            </div>
+          </div>
+        );
+      })()}
+      {state.rclone.available && (
+        <div style={{ marginBottom: 12 }}>
+          <button type="button" disabled={restartBusy} onClick={() => setConfirmRestart(true)}>
+            {restartBusy ? "Restarting…" : "Restart rclone"}
+          </button>
+        </div>
+      )}
+      {restartError && <ErrorBanner>{restartError}</ErrorBanner>}
+      {confirmRestart && (
+        <Modal
+          title="Restart rclone?"
+          busy={restartBusy}
+          onClose={() => setConfirmRestart(false)}
+          footer={
+            <>
+              <button
+                type="button"
+                disabled={restartBusy}
+                onClick={() => setConfirmRestart(false)}
+              >
+                Cancel
+              </button>
+              <button type="button" disabled={restartBusy} onClick={doRestart}>
+                {restartBusy ? "Restarting…" : "Restart rclone"}
+              </button>
+            </>
+          }
+        >
+          <p>
+            This restarts the rclone daemon and re-mounts everything. <b>All</b>{" "}
+            mounts — including healthy ones — are briefly disconnected while it
+            happens, and files currently open from a mount may need to be
+            reopened.
+          </p>
+        </Modal>
+      )}
       {state.mounts.length > 0 ? (
         <div className="mount-list">
           {state.mounts.map((c) => (

--- a/frontend/src/views/Mounts.tsx
+++ b/frontend/src/views/Mounts.tsx
@@ -432,6 +432,11 @@ export default function Mounts() {
       setConfirmRestart(false);
     } catch (e) {
       setRestartError((e as Error).message);
+      // A failed restart isn't a no-op: the server may already have force-detached
+      // mounts (or killed the daemon) before failing, so the last MountsResult is
+      // stale. Re-fetch so the page shows the true post-attempt state instead of a
+      // healthy view that no longer matches reality.
+      reload();
     } finally {
       setRestartBusy(false);
     }
@@ -474,6 +479,8 @@ export default function Mounts() {
         const paramsMounts = state.mounts.filter((m) => m.restart_reason === "params");
         const credMounts = state.mounts.filter((m) => m.restart_reason === "credentials");
         if (paramsMounts.length === 0 && credMounts.length === 0) return null;
+        // Explanatory callout only — the single Restart rclone button below is
+        // the one action, so we don't stack a second identical button here.
         return (
           <div className="deploy-note mount-callout">
             <div className="mount-callout-title">Restart rclone to recover</div>
@@ -487,14 +494,7 @@ export default function Mounts() {
                   {credMounts.map((m) => m.name).join(", ")}.
                 </div>
               )}
-              <button
-                type="button"
-                style={{ marginTop: 8 }}
-                disabled={restartBusy}
-                onClick={() => setConfirmRestart(true)}
-              >
-                {restartBusy ? "Restarting…" : "Restart rclone"}
-              </button>
+              <div style={{ marginTop: 4 }}>Use the Restart rclone button below.</div>
             </div>
           </div>
         );

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -3154,6 +3154,23 @@ def reconnect_endpoint(cid: str, x_fused: str | None = Header(default=None)):
     return mount_view(m)
 
 
+@router.post("/api/mounts/restart")
+def restart_endpoint(x_fused: str | None = Header(default=None, alias="X-Fused")):
+    """Global recovery: restart the rcd daemon and re-mount everything. The one
+    tool that fixes a stale-credential daemon (a fresh daemon re-reads refreshed
+    keys) and applies changed mount params — see restart_rcd. Sync def so the
+    multi-second unmount+kill+spawn+remount runs in the threadpool, never the
+    event loop. Returns the same payload as GET /api/mounts."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    try:
+        restart_rcd()
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=500)
+    return get_mounts()
+
+
 @router.post("/api/mounts/{cid}/unmount")
 def unmount_endpoint(cid: str, force: str = "0",
                      x_fused: str | None = Header(default=None)):

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -819,6 +819,85 @@ def _ensure_rcd_locked() -> int:
     raise RuntimeError("rclone rcd did not come up within 10s")
 
 
+# How long _kill_current_rcd waits for a signalled daemon to actually exit
+# before escalating / giving up, mirroring the bounded poll ensure_rcd uses on
+# the way up.
+_KILL_TIMEOUT_S = 5.0
+
+
+def _kill_current_rcd() -> None:
+    """Terminate the recorded rcd daemon, if there is one to terminate.
+
+    Safety invariant (the single most important constraint here): only ever
+    signal a pid we can PROVE is our rclone rcd. Reuses the exact gates
+    reap_stale_rcd trusts — _pid_alive + _confirmed_our_rcd (which itself folds
+    in the rc core/pid check and _pid_looks_like_rcd). A recorded pid that is
+    alive but NOT confirmed ours raises rather than risk killing an unrelated
+    process that inherited a recycled pid.
+
+    No recorded daemon / a dead pid is a clean no-op: the caller's fresh spawn
+    just starts one. SIGTERM first (rcd unmounts cleanly on it), escalating to
+    SIGKILL only if it won't exit within _KILL_TIMEOUT_S; we poll until the
+    daemon's port stops answering AND the pid is gone."""
+    entry = storage.read_json(_rcd_state_path())
+    if not isinstance(entry, dict):
+        return  # no daemon on record — nothing to kill
+    pid = entry.get("pid") or 0
+    if not _pid_alive(pid):
+        return  # already gone; the stale rcd.json is harmless (spawn overwrites)
+    if not _confirmed_our_rcd(entry):
+        # Alive but unprovable: pids get recycled, so this could be anything.
+        # Fail loud instead of blind-killing (the critical safety invariant).
+        raise RuntimeError(
+            f"refusing to kill pid {pid}: not confirmed to be our rclone rcd"
+        )
+    for sig in (signal.SIGTERM, signal.SIGKILL):
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            return  # raced us and exited between the check and the signal
+        except OSError as e:
+            raise RuntimeError(f"failed to signal rcd pid {pid}: {e}") from e
+        deadline = time.time() + _KILL_TIMEOUT_S
+        while time.time() < deadline:
+            if _live_rcd_port() is None and not _pid_alive(pid):
+                return  # daemon gone
+            time.sleep(0.1)
+    raise RuntimeError(f"rcd pid {pid} did not exit after SIGKILL")
+
+
+def restart_rcd() -> None:
+    """Clean restart of the rcd daemon plus a full re-mount of everything.
+
+    Recovers wedged/disconnected mounts, applies changed mount params, and —
+    the credential-expiry fix — forces a brand-new daemon to re-read the static
+    credentials (e.g. ~/.aws/credentials): the long-lived rcd reads them ONCE at
+    fs instantiation and never again, so a refreshed SSO/STS token only reaches
+    a mount after the daemon itself is replaced (neither Reconnect nor a server
+    restart helps — the rcd survives both).
+
+    Sequence, serialized against ensure_rcd via _rcd_lock:
+      1. force-detach every kernel NFS mount FIRST, so killing rcd can't strand
+         a wedged mount (best-effort — a mount already gone is fine);
+      2. kill the current daemon (only if confirmed ours — see _kill_current_rcd);
+      3. spawn a fresh daemon via the already-locked body (we hold _rcd_lock, so
+         calling ensure_rcd() would deadlock the non-reentrant Lock).
+    run_automount() (which re-mounts every mount and rebuilds serves.json via
+    sync_serves) runs OUTSIDE _rcd_lock — it takes its own _serves_lock, and
+    holding both would invert the lock order. A spawn failure propagates: the
+    endpoint maps it to a 500 and mounts are left honestly unmounted."""
+    with _rcd_lock:
+        for m in list_mounts():
+            try:
+                detach_mount(m, force=True)
+            except Exception:
+                logger.warning("restart: detach of %r failed",
+                               m.get("name"), exc_info=True)
+        _kill_current_rcd()
+        _ensure_rcd_locked()
+    run_automount()
+
+
 def rcd_mount_map() -> dict:
     """{mountpoint: remote fs} for every mount rcd currently serves (empty
     when no daemon is live). Read-only: never spawns a daemon just to answer

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2535,13 +2535,13 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT) -> str
 
 
 # Sentinel: distinguishes "caller already ran the credential probe, here is its
-# result (possibly None = valid)" from "no probe result supplied, run one if the
-# credentials branch is reached". A plain None default couldn't tell them apart.
+# tri-state result" from "no result supplied, run the probe if the credentials
+# branch is reached". A plain None default couldn't tell them apart.
 _UNSET = object()
 
 
 def mount_restart_reason(m: dict, rcd_mounts: set | None = None,
-                         state: str | None = None, cred_err=_UNSET) -> str | None:
+                         state: str | None = None, cred_status=_UNSET) -> str | None:
     """Why restarting rclone would help this mount, or None. Surfaced on
     mount_view so the UI can prompt (both reasons route to the SAME global
     Restart button):
@@ -2552,41 +2552,46 @@ def mount_restart_reason(m: dict, rcd_mounts: set | None = None,
                       UI can change, and mounted_read_only records what was
                       actually baked into the live VFS (rcd never echoes vfsOpt
                       back — same signal attach_mount's adopt branch remounts on).
+                      A MISSING mounted_read_only (a legacy record adopted via
+                      listmounts that never went through attach_mount) is
+                      "unknown, assume no drift" — never a false prompt.
                       Broader vfsOpt/mountOpt diffing is deliberately deferred.
       "credentials" — a disconnected/stale mount on an env_auth remote whose
-                      credentials probe VALID again: the long-lived daemon still
-                      holds the pre-refresh keys, so Reconnect (and even a server
-                      restart) can't help — only replacing the daemon re-reads
-                      the refreshed creds (see restart_rcd / the module docstring).
+                      credentials probe POSITIVELY VALID again: the long-lived
+                      daemon still holds the pre-refresh keys, so Reconnect (and
+                      even a server restart) can't help — only replacing the
+                      daemon re-reads the refreshed creds (see restart_rcd).
+                      An inconclusive probe (timeout/network/AccessDenied) is NOT
+                      treated as valid, so a transient failure can't spam a false
+                      restart prompt.
 
-    `cred_err` lets a caller that already ran the credential probe (e.g.
-    broken_mount_error) thread its result in so we don't pay a second `rclone
-    lsd`; left unset, the credentials branch runs the probe itself."""
-    if rcd_mounts is None:
-        rcd_mounts = mounted_paths()
+    `cred_status` lets a caller that already ran the probe (e.g. get_mounts,
+    which threads it off the serial view-building path) pass the tri-state
+    result in so we don't pay a second `rclone lsd`; left unset, the credentials
+    branch runs the probe itself. `mounted_paths()` is only fetched when `state`
+    isn't supplied — the error path passes state and never needs the rc call."""
     if state is None:
+        if rcd_mounts is None:
+            rcd_mounts = mounted_paths()
         state = mount_state(m, rcd_mounts)
     if state == "mounted":
-        if bool(m.get("read_only")) != bool(m.get("mounted_read_only")):
+        baked = m.get("mounted_read_only")
+        # Only a KNOWN-and-differing baked flag is drift; a missing key is an
+        # adopted legacy mount whose live vfsOpt we can't compare — not a prompt.
+        if baked is not None and bool(m.get("read_only")) != bool(baked):
             return "params"
         return None
     if state in ("disconnected", "stale"):
-        # Only env_auth remotes expire this way; a non-cred remote disconnected
-        # is Reconnect's job, not a restart's (decision table). Check the stored
-        # config BEFORE probing so a non-env_auth remote never pays the lsd.
-        name = m["remote"].partition(":")[0]
-        cfg = _remote_config(name)
-        if not (isinstance(cfg, dict)
-                and str(cfg.get("env_auth", "")).lower() == "true"):
-            return None
-        if cred_err is _UNSET:
-            cred_err = _mount_credential_error(m)
-        # cred_err None == creds probe VALID now == daemon is holding stale keys.
-        return "credentials" if cred_err is None else None
+        if cred_status is _UNSET:
+            cred_status = _mount_credential_status(m)
+        # Only a POSITIVE "valid" means the daemon is holding stale-but-now-good
+        # keys; "bad"/"inconclusive"/"n/a" are Reconnect's or refresh's job.
+        return "credentials" if cred_status == "valid" else None
     return None
 
 
-def mount_view(m: dict, rcd_mounts: set | None = None, state: str | None = None) -> dict:
+def mount_view(m: dict, rcd_mounts: set | None = None, state: str | None = None,
+               cred_status=_UNSET) -> dict:
     mp = mountpoint(m)
     listed = mounted_paths() if rcd_mounts is None else rcd_mounts
     if state is None:
@@ -2608,8 +2613,10 @@ def mount_view(m: dict, rcd_mounts: set | None = None, state: str | None = None)
         # treat it differently from a user-created mount (e.g. hide delete).
         "builtin": bool(m.get("builtin")),
         # Why a Restart rclone would help (params drift / re-authed creds), or
-        # None. Reuses the state just computed so no extra probe (mount_state).
-        "restart_reason": mount_restart_reason(m, listed, state),
+        # None. Reuses the state just computed AND (on the get_mounts bulk path)
+        # a cred_status probed off the serial path, so building a view never
+        # blocks on a per-mount `rclone lsd`.
+        "restart_reason": mount_restart_reason(m, listed, state, cred_status),
     }
 
 
@@ -3123,15 +3130,16 @@ def broken_mount_error(path: str) -> str | None:
     # expired SSO token. When the remote probes credential-shaped, tell the
     # user to refresh their credentials instead of pointing them at reconnect.
     if state in ("disconnected", "stale"):
-        cred_err = _mount_credential_error(m)
-        if cred_err:
-            return f"mount '{name}' — {cred_err}"
-        # env_auth remote whose creds probe VALID now (cred_err is None): the
-        # user re-authed, but the long-lived daemon still holds the pre-refresh
-        # keys, so Reconnect (which reuses that daemon) can't help — only a
-        # daemon restart re-reads the refreshed credentials. Reuse the probe
-        # result just computed so mount_restart_reason doesn't run a second lsd.
-        if mount_restart_reason(m, state=state, cred_err=cred_err) == "credentials":
+        # One probe, three outcomes (see _credential_probe):
+        cred_status = _mount_credential_status(m)
+        if cred_status == "bad":
+            return f"mount '{name}' — {_CRED_EXPIRED_MSG}"
+        # "valid": the user re-authed, but the long-lived daemon still holds the
+        # pre-refresh keys, so Reconnect (which reuses that daemon) can't help —
+        # only a daemon restart re-reads them. "inconclusive"/"n/a" fall through
+        # to the generic reconnect message (a transient failure or a
+        # non-credential remote must NOT suggest a restart).
+        if cred_status == "valid":
             return (f"mount '{name}' — your credentials look refreshed; restart "
                     f"rclone from the Mounts page in the sidebar to pick up the "
                     f"new credentials")
@@ -3147,23 +3155,37 @@ def broken_mount_error(path: str) -> str | None:
 def get_mounts():
     live = mounted_paths()
     mounts = list_mounts()
-    # Probe states concurrently: each disconnected/wedged mount blocks its
-    # probe for the full PROBE_TIMEOUT, and serially those would stack.
+    bin_ = rclone_bin()
+    # Probe states — AND, for a broken mount, its credential status — concurrently:
+    # each disconnected/wedged mount blocks its state probe for the full
+    # PROBE_TIMEOUT, and the credential `rclone lsd` can take ~10s more. Serially
+    # (states threaded but the credential probe left to the mount_view loop) a
+    # few broken aws mounts would stall the polled Mounts page for tens of
+    # seconds — exactly when the user is polling to recover. So do BOTH in the
+    # per-mount worker and hand the results to mount_view, which never probes.
     states: list[str | None] = [None] * len(mounts)
+    cred_statuses: list[str] = ["n/a"] * len(mounts)
     threads = []
     for i, m in enumerate(mounts):
         def probe(i=i, m=m):
-            states[i] = mount_state(m, live)
+            st = mount_state(m, live)
+            states[i] = st
+            # Credentials only matter for a broken mount; a healthy/unmounted
+            # one never pays the lsd probe.
+            if st in ("disconnected", "stale"):
+                cred_statuses[i] = _mount_credential_status(m, bin_)
         t = threading.Thread(target=probe, daemon=True)
         t.start()
         threads.append(t)
     for t in threads:
-        t.join(PROBE_TIMEOUT + 1)
+        # Allow for the state probe PLUS the credential lsd (30s cap) so a slow
+        # probe still lands in this listing rather than defaulting to unknown.
+        t.join(PROBE_TIMEOUT + 31)
     return {
         "rclone": _rclone_state(),
         "mounts": [
-            mount_view(m, live, state=s or "disconnected")
-            for m, s in zip(mounts, states)
+            mount_view(m, live, state=s or "disconnected", cred_status=cs)
+            for m, s, cs in zip(mounts, states, cred_statuses)
         ],
     }
 
@@ -3336,6 +3358,43 @@ _BAD_CRED_MARKERS = (
 )
 
 
+_CRED_EXPIRED_MSG = (
+    "the detected credentials appear expired or invalid — refresh them "
+    "(e.g. `aws sso login` or `gcloud auth application-default login`) "
+    "and try again"
+)
+
+
+def _credential_probe(bin_: str, name: str) -> str:
+    """Tri-state result of a top-level `lsd` against an env_auth remote:
+
+      "valid"        — the listing succeeded (returncode 0): the credentials
+                       positively work right now.
+      "bad"          — a credential-shaped failure (_BAD_CRED_MARKERS): expired
+                       SSO/STS token, revoked key, missing default creds.
+      "inconclusive" — the probe couldn't decide: a timeout, network error, or a
+                       non-credential failure like AccessDenied (valid keys that
+                       merely lack ListBuckets). NOT proof the creds work.
+
+    The three-way split matters because "not bad" is not the same as "good":
+    only a POSITIVE success may drive the "credentials refreshed → Restart"
+    prompt, or a transient failure would spam a false restart suggestion."""
+    try:
+        r = subprocess.run(
+            [bin_, "lsd", f"{name}:", "--max-depth", "1",
+             "--contimeout", "5s", "--timeout", "10s",
+             "--retries", "1", "--low-level-retries", "2"],
+            capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return "inconclusive"
+    if r.returncode == 0:
+        return "valid"
+    err = ((r.stderr or "") + (r.stdout or "")).lower()
+    if any(m in err for m in _BAD_CRED_MARKERS):
+        return "bad"
+    return "inconclusive"
+
+
 def _detected_credential_error(bin_: str, name: str) -> str | None:
     """Probe a just-materialized env_auth remote with a top-level listing and
     return a user-facing message when the underlying credentials are expired
@@ -3346,41 +3405,38 @@ def _detected_credential_error(bin_: str, name: str) -> str | None:
     reject: AccessDenied (valid keys without ListBuckets permission) and
     transient/network errors pass — the check exists to catch stale keys
     early, not to demand list permission."""
-    try:
-        r = subprocess.run(
-            [bin_, "lsd", f"{name}:", "--max-depth", "1",
-             "--contimeout", "5s", "--timeout", "10s",
-             "--retries", "1", "--low-level-retries", "2"],
-            capture_output=True, text=True, timeout=30)
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if r.returncode == 0:
-        return None
-    err = ((r.stderr or "") + (r.stdout or "")).lower()
-    if any(m in err for m in _BAD_CRED_MARKERS):
-        return ("the detected credentials appear expired or invalid — "
-                "refresh them (e.g. `aws sso login` or `gcloud auth "
-                "application-default login`) and try again")
-    return None
+    return _CRED_EXPIRED_MSG if _credential_probe(bin_, name) == "bad" else None
 
 
-def _mount_credential_error(m: dict) -> str | None:
-    """For a broken mount whose remote is backed by detected (env_auth)
-    credentials, the 'refresh your credentials' message when a top-level
-    listing now fails credential-shaped — else None. broken_mount_error uses
-    this to distinguish an expired-credential mount (reconnect won't help;
-    the user must re-auth) from a merely dead daemon. Only env_auth remotes
-    are probed: anonymous/public and key-carrying remotes don't expire this
-    way, and the probe (an rclone `lsd`) is paid only on the already-broken
-    fs/list path, never on a healthy listing."""
-    bin_ = rclone_bin()
+def _mount_credential_status(m: dict, bin_: str | None = None) -> str:
+    """Tri-state credential health of a broken mount's remote, or "n/a":
+
+      "valid" / "bad" / "inconclusive" — the _credential_probe outcome, for an
+                       env_auth remote (see there).
+      "n/a"          — not an env_auth remote (anonymous/public or key-carrying
+                       remotes don't expire this way), or no rclone binary.
+
+    Only env_auth remotes are probed, and the probe (an rclone `lsd`) is paid
+    only on an already-broken mount, never on a healthy listing. Callers may
+    pass a resolved `bin_` to avoid re-resolving rclone per mount."""
+    if bin_ is None:
+        bin_ = rclone_bin()
     if not bin_:
-        return None
+        return "n/a"
     name = m["remote"].partition(":")[0]
     cfg = _remote_config(name)
     if not isinstance(cfg, dict) or str(cfg.get("env_auth", "")).lower() != "true":
-        return None
-    return _detected_credential_error(bin_, name)
+        return "n/a"
+    return _credential_probe(bin_, name)
+
+
+def _mount_credential_error(m: dict) -> str | None:
+    """For a broken mount backed by detected (env_auth) credentials, the
+    'refresh your credentials' message when a top-level listing fails
+    credential-shaped — else None. broken_mount_error uses this to distinguish
+    an expired-credential mount (reconnect won't help; the user must re-auth)
+    from a merely dead daemon."""
+    return _CRED_EXPIRED_MSG if _mount_credential_status(m) == "bad" else None
 
 
 @router.post("/api/mounts/remotes/detect")

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -3430,15 +3430,6 @@ def _mount_credential_status(m: dict, bin_: str | None = None) -> str:
     return _credential_probe(bin_, name)
 
 
-def _mount_credential_error(m: dict) -> str | None:
-    """For a broken mount backed by detected (env_auth) credentials, the
-    'refresh your credentials' message when a top-level listing fails
-    credential-shaped — else None. broken_mount_error uses this to distinguish
-    an expired-credential mount (reconnect won't help; the user must re-auth)
-    from a merely dead daemon."""
-    return _CRED_EXPIRED_MSG if _mount_credential_status(m) == "bad" else None
-
-
 @router.post("/api/mounts/remotes/detect")
 def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(default=None)):
     """Materialize a keyless rclone remote from an auto-detected credential

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2534,6 +2534,58 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT) -> str
     return out.get("state", "disconnected")  # no answer in time == wedged
 
 
+# Sentinel: distinguishes "caller already ran the credential probe, here is its
+# result (possibly None = valid)" from "no probe result supplied, run one if the
+# credentials branch is reached". A plain None default couldn't tell them apart.
+_UNSET = object()
+
+
+def mount_restart_reason(m: dict, rcd_mounts: set | None = None,
+                         state: str | None = None, cred_err=_UNSET) -> str | None:
+    """Why restarting rclone would help this mount, or None. Surfaced on
+    mount_view so the UI can prompt (both reasons route to the SAME global
+    Restart button):
+
+      "params"      — the mount is live but its RUNNING options differ from what
+                      the record now wants, so a restart is needed to apply them.
+                      Conservative subset: read_only is the one mount param the
+                      UI can change, and mounted_read_only records what was
+                      actually baked into the live VFS (rcd never echoes vfsOpt
+                      back — same signal attach_mount's adopt branch remounts on).
+                      Broader vfsOpt/mountOpt diffing is deliberately deferred.
+      "credentials" — a disconnected/stale mount on an env_auth remote whose
+                      credentials probe VALID again: the long-lived daemon still
+                      holds the pre-refresh keys, so Reconnect (and even a server
+                      restart) can't help — only replacing the daemon re-reads
+                      the refreshed creds (see restart_rcd / the module docstring).
+
+    `cred_err` lets a caller that already ran the credential probe (e.g.
+    broken_mount_error) thread its result in so we don't pay a second `rclone
+    lsd`; left unset, the credentials branch runs the probe itself."""
+    if rcd_mounts is None:
+        rcd_mounts = mounted_paths()
+    if state is None:
+        state = mount_state(m, rcd_mounts)
+    if state == "mounted":
+        if bool(m.get("read_only")) != bool(m.get("mounted_read_only")):
+            return "params"
+        return None
+    if state in ("disconnected", "stale"):
+        # Only env_auth remotes expire this way; a non-cred remote disconnected
+        # is Reconnect's job, not a restart's (decision table). Check the stored
+        # config BEFORE probing so a non-env_auth remote never pays the lsd.
+        name = m["remote"].partition(":")[0]
+        cfg = _remote_config(name)
+        if not (isinstance(cfg, dict)
+                and str(cfg.get("env_auth", "")).lower() == "true"):
+            return None
+        if cred_err is _UNSET:
+            cred_err = _mount_credential_error(m)
+        # cred_err None == creds probe VALID now == daemon is holding stale keys.
+        return "credentials" if cred_err is None else None
+    return None
+
+
 def mount_view(m: dict, rcd_mounts: set | None = None, state: str | None = None) -> dict:
     mp = mountpoint(m)
     listed = mounted_paths() if rcd_mounts is None else rcd_mounts
@@ -2555,6 +2607,9 @@ def mount_view(m: dict, rcd_mounts: set | None = None, state: str | None = None)
         # Shipped-with-the-app mount (see ensure_learn_mount); the UI can
         # treat it differently from a user-created mount (e.g. hide delete).
         "builtin": bool(m.get("builtin")),
+        # Why a Restart rclone would help (params drift / re-authed creds), or
+        # None. Reuses the state just computed so no extra probe (mount_state).
+        "restart_reason": mount_restart_reason(m, listed, state),
     }
 
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -3126,6 +3126,15 @@ def broken_mount_error(path: str) -> str | None:
         cred_err = _mount_credential_error(m)
         if cred_err:
             return f"mount '{name}' — {cred_err}"
+        # env_auth remote whose creds probe VALID now (cred_err is None): the
+        # user re-authed, but the long-lived daemon still holds the pre-refresh
+        # keys, so Reconnect (which reuses that daemon) can't help — only a
+        # daemon restart re-reads the refreshed credentials. Reuse the probe
+        # result just computed so mount_restart_reason doesn't run a second lsd.
+        if mount_restart_reason(m, state=state, cred_err=cred_err) == "credentials":
+            return (f"mount '{name}' — your credentials look refreshed; restart "
+                    f"rclone from the Mounts page in the sidebar to pick up the "
+                    f"new credentials")
     # "stale" (the INCIDENT split-brain) and "disconnected" both mean a mount
     # that was there and stopped flowing — same user-facing wording; only a
     # never-mounted mount reads as "not mounted".

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -3227,3 +3227,30 @@ def test_kill_current_rcd_signals_confirmed_pid(home, monkeypatch):
     mounts_mod._kill_current_rcd()
     # One SIGTERM was enough; no SIGKILL escalation.
     assert sigs == [(999, mounts_mod.signal.SIGTERM)]
+
+
+# -- POST /api/mounts/restart ----------------------------------------------
+
+
+def test_restart_endpoint_requires_fused_and_returns_mounts(client, rcd, monkeypatch):
+    # Write guard: no X-Fused -> 403, and restart_rcd is never invoked.
+    called = []
+    monkeypatch.setattr(mounts_mod, "restart_rcd", lambda: called.append(True))
+    assert client.post("/api/mounts/restart").status_code == 403
+    assert called == []
+
+    r = client.post("/api/mounts/restart", headers=FUSED)
+    assert r.status_code == 200
+    assert called == [True]
+    # Same payload as GET /api/mounts, so the client refreshes in one shot.
+    assert set(r.json()) == {"rclone", "mounts"}
+
+
+def test_restart_endpoint_500_on_failure(client, rcd, monkeypatch):
+    def boom():
+        raise RuntimeError("rclone rcd did not come up within 10s")
+
+    monkeypatch.setattr(mounts_mod, "restart_rcd", boom)
+    r = client.post("/api/mounts/restart", headers=FUSED)
+    assert r.status_code == 500
+    assert "did not come up" in r.json()["error"]

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -3093,3 +3093,137 @@ def test_probe_floor_never_exceeds_caller_timeout(home, rcd, fresh_upstream, dir
     assert kind == "indeterminate"
     assert elapsed < 0.19, (
         f"sub-floor budget still ran probes for {elapsed:.2f}s (floor granted, not bailed)")
+
+
+# -- restart_rcd / _kill_current_rcd: clean daemon restart -----------------
+#
+# The global "Restart rclone" recovery: tear down every kernel mount, kill the
+# confirmed daemon, spawn a fresh one (which re-reads ~/.aws/credentials — the
+# credential-expiry fix), then re-mount everything. _kill_current_rcd carries
+# the critical safety invariant: it must NEVER signal a pid it can't confirm is
+# our rcd.
+
+
+def test_restart_rcd_teardown_then_respawn_then_automount(home, rcd, monkeypatch):
+    mounts_mod.add_mount("a", "r:one")
+    mounts_mod.add_mount("b", "r:two")
+    events = []
+    monkeypatch.setattr(mounts_mod, "detach_mount",
+                        lambda m, force=False: events.append(("detach", m["name"], force)))
+    monkeypatch.setattr(mounts_mod, "_kill_current_rcd",
+                        lambda: events.append(("kill",)))
+    monkeypatch.setattr(mounts_mod, "_ensure_rcd_locked",
+                        lambda: events.append(("spawn",)))
+    monkeypatch.setattr(mounts_mod, "run_automount",
+                        lambda: events.append(("automount",)))
+
+    mounts_mod.restart_rcd()
+
+    # Every mount is force-detached FIRST, then kill, then spawn, then automount.
+    assert events == [
+        ("detach", "a", True),
+        ("detach", "b", True),
+        ("kill",),
+        ("spawn",),
+        ("automount",),
+    ]
+
+
+def test_restart_rcd_propagates_spawn_failure_after_teardown(home, rcd, monkeypatch):
+    mounts_mod.add_mount("a", "r:one")
+    events = []
+    monkeypatch.setattr(mounts_mod, "detach_mount",
+                        lambda m, force=False: events.append("detach"))
+    monkeypatch.setattr(mounts_mod, "_kill_current_rcd",
+                        lambda: events.append("kill"))
+
+    def boom():
+        events.append("spawn")
+        raise RuntimeError("rclone rcd did not come up within 10s")
+
+    monkeypatch.setattr(mounts_mod, "_ensure_rcd_locked", boom)
+    monkeypatch.setattr(mounts_mod, "run_automount",
+                        lambda: events.append("automount"))
+
+    with pytest.raises(RuntimeError, match="did not come up"):
+        mounts_mod.restart_rcd()
+    # Teardown + kill + failed spawn ran; automount did NOT (honest half-state).
+    assert events == ["detach", "kill", "spawn"]
+
+
+def test_restart_rcd_detach_failure_is_best_effort(home, rcd, monkeypatch):
+    # A wedged mount whose detach raises must not abort the restart — the whole
+    # point is to recover from wedged mounts.
+    mounts_mod.add_mount("a", "r:one")
+    events = []
+
+    def bad_detach(m, force=False):
+        raise OSError("wedged")
+
+    monkeypatch.setattr(mounts_mod, "detach_mount", bad_detach)
+    monkeypatch.setattr(mounts_mod, "_kill_current_rcd",
+                        lambda: events.append("kill"))
+    monkeypatch.setattr(mounts_mod, "_ensure_rcd_locked",
+                        lambda: events.append("spawn"))
+    monkeypatch.setattr(mounts_mod, "run_automount",
+                        lambda: events.append("automount"))
+
+    mounts_mod.restart_rcd()
+    assert events == ["kill", "spawn", "automount"]
+
+
+def test_kill_current_rcd_refuses_unconfirmed_pid(home, monkeypatch):
+    # THE safety invariant: an alive pid we can't confirm is our rcd is NEVER
+    # signalled — raise instead of murdering an unrelated process.
+    mounts_mod.write_rcd_state(12345, 999)
+    monkeypatch.setattr(mounts_mod, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(mounts_mod, "_confirmed_our_rcd", lambda e: False)
+    killed = []
+    monkeypatch.setattr(mounts_mod.os, "kill",
+                        lambda pid, sig: killed.append((pid, sig)))
+
+    with pytest.raises(RuntimeError):
+        mounts_mod._kill_current_rcd()
+    assert killed == []
+
+
+def test_kill_current_rcd_noops_without_state(home, monkeypatch):
+    # No rcd.json at all -> nothing to kill (the fresh spawn will just start one).
+    killed = []
+    monkeypatch.setattr(mounts_mod.os, "kill",
+                        lambda pid, sig: killed.append(pid))
+    mounts_mod._kill_current_rcd()
+    assert killed == []
+
+
+def test_kill_current_rcd_noops_when_pid_already_dead(home, monkeypatch):
+    # Dead pid short-circuits BEFORE the confirm check: already gone, drop it.
+    mounts_mod.write_rcd_state(12345, 999)
+    monkeypatch.setattr(mounts_mod, "_pid_alive", lambda pid: False)
+    confirmed = []
+    monkeypatch.setattr(mounts_mod, "_confirmed_our_rcd",
+                        lambda e: confirmed.append(e) or True)
+    killed = []
+    monkeypatch.setattr(mounts_mod.os, "kill",
+                        lambda pid, sig: killed.append(pid))
+    mounts_mod._kill_current_rcd()
+    assert killed == []
+    assert confirmed == []
+
+
+def test_kill_current_rcd_signals_confirmed_pid(home, monkeypatch):
+    mounts_mod.write_rcd_state(12345, 999)
+    alive = {"v": True}
+    monkeypatch.setattr(mounts_mod, "_pid_alive", lambda pid: alive["v"])
+    monkeypatch.setattr(mounts_mod, "_confirmed_our_rcd", lambda e: True)
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda: None)
+    sigs = []
+
+    def fake_kill(pid, sig):
+        sigs.append((pid, sig))
+        alive["v"] = False  # dies on the first (graceful) signal
+
+    monkeypatch.setattr(mounts_mod.os, "kill", fake_kill)
+    mounts_mod._kill_current_rcd()
+    # One SIGTERM was enough; no SIGKILL escalation.
+    assert sigs == [(999, mounts_mod.signal.SIGTERM)]

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1402,16 +1402,21 @@ def test_broken_mount_error_reports_expired_credentials(
     assert "reconnect" not in err.lower()
 
 
-def test_broken_mount_error_reconnect_when_creds_still_valid(
+def test_broken_mount_error_routes_reauthed_creds_to_restart(
         home, rcd, monkeypatch, fresh_upstream):
-    # env_auth remote, but the probe succeeds: the disconnection is a dead
-    # daemon, not stale creds — keep the generic "reconnect" guidance.
+    # env_auth remote, disconnected, but the creds probe SUCCEEDS: the user
+    # re-authed and the long-lived daemon is still holding the stale keys.
+    # Reconnect can't fix that — only a restart re-reads the refreshed creds.
+    # Regression guard for the exact credential-expiry bug being fixed.
     c, mp = _disconnected_mount(home, rcd, monkeypatch)
     rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
     _stub_lsd(monkeypatch, rc=0)
 
     err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
-    assert err is not None and "reconnect" in err.lower()
+    assert err is not None
+    assert "restart" in err.lower()
+    # Must NOT send the user to Reconnect — it hits the same stale daemon.
+    assert "reconnect" not in err.lower()
 
 
 def test_broken_mount_error_skips_cred_probe_for_non_env_auth(

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -731,7 +731,7 @@ def test_mount_view_has_no_automount_field(client, rcd):
     # automount is implicit for every mount now — the field is gone.
     assert "automount" not in m
     assert set(m) == {"id", "name", "remote", "mountpoint", "mounted", "state",
-                      "read_only", "builtin"}
+                      "read_only", "builtin", "restart_reason"}
 
 
 def test_delete_unmounts_and_removes(client, rcd):
@@ -3254,3 +3254,73 @@ def test_restart_endpoint_500_on_failure(client, rcd, monkeypatch):
     r = client.post("/api/mounts/restart", headers=FUSED)
     assert r.status_code == 500
     assert "did not come up" in r.json()["error"]
+
+
+# -- mount_restart_reason: params drift + credential-refresh ----------------
+#
+# A REASON STRING surfaced on mount_view so the UI can prompt a restart:
+#   "params"      — live+mounted but the running mount was baked with different
+#                   params than the record now wants (conservative subset:
+#                   read_only, the one param the UI changes).
+#   "credentials" — a disconnected/stale env_auth mount whose creds probe VALID
+#                   again: the daemon still holds the pre-refresh keys, so only
+#                   a restart re-reads them (Reconnect can't).
+
+
+def test_mount_restart_reason_params_on_read_only_drift(home, rcd):
+    m = {"id": "x", "name": "data", "remote": "r:bucket",
+         "read_only": True, "mounted_read_only": False}
+    # mounted + the live VFS was baked read_write but the record now wants
+    # read_only -> a restart is needed to apply it.
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="mounted") == "params"
+    # in agreement -> no drift
+    m["mounted_read_only"] = True
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="mounted") is None
+    # params drift is only meaningful for a live mount
+    m["mounted_read_only"] = False
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") is None
+
+
+def test_mount_restart_reason_credentials_when_reauthed(
+        home, rcd, monkeypatch, fresh_upstream):
+    m = mounts_mod.add_mount("data", "corp:bucket")
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=0)  # creds probe VALID again (user re-authed)
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") == "credentials"
+    # stale is healed the same way
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="stale") == "credentials"
+
+
+def test_mount_restart_reason_none_when_creds_still_expired(
+        home, rcd, monkeypatch, fresh_upstream):
+    m = mounts_mod.add_mount("data", "corp:bucket")
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=1, lsd_stderr="ExpiredToken")  # genuinely expired
+    # Genuinely-expired creds: a restart won't help, so no prompt.
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") is None
+
+
+def test_mount_restart_reason_none_for_non_env_auth(
+        home, rcd, monkeypatch, fresh_upstream):
+    m = mounts_mod.add_mount("data", "corp:bucket")
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "false",
+                                   "access_key_id": "AKIA"}
+    calls = []
+    _stub_lsd(monkeypatch, rc=0, record=calls)
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") is None
+    # A non-env_auth remote never gets the (latency-costing) lsd probe.
+    assert not any("lsd" in cmd for cmd in calls)
+
+
+def test_mount_view_includes_restart_reason(home, rcd):
+    c = mounts_mod.add_mount("data", "r:bucket")
+    view = mounts_mod.mount_view(c)
+    assert "restart_reason" in view
+    assert view["restart_reason"] is None  # healthy/unmounted -> nothing to prompt

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -3329,3 +3329,91 @@ def test_mount_view_includes_restart_reason(home, rcd):
     view = mounts_mod.mount_view(c)
     assert "restart_reason" in view
     assert view["restart_reason"] is None  # healthy/unmounted -> nothing to prompt
+
+
+# -- review fixes: tri-state credential probe, drift + perf guards ----------
+
+
+def test_mount_restart_reason_inconclusive_probe_is_not_credentials(
+        home, rcd, monkeypatch, fresh_upstream):
+    # A non-credential failure (AccessDenied = valid keys, no list perm) is
+    # INCONCLUSIVE, not proof the creds work — no false "credentials" prompt.
+    m = mounts_mod.add_mount("data", "corp:bucket")
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=1, lsd_stderr="AccessDenied: not authorized")
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") is None
+
+    # A timeout is likewise inconclusive (config/get is already memoized).
+    def timeout_run(cmd, **kw):
+        raise mounts_mod.subprocess.TimeoutExpired(cmd, 30)
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", timeout_run)
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="disconnected") is None
+
+
+def test_broken_mount_error_inconclusive_creds_falls_through_to_reconnect(
+        home, rcd, monkeypatch, fresh_upstream):
+    # env_auth + a transient/non-credential failure: neither "refresh" nor
+    # "restart" — fall through to the plain reconnect guidance.
+    c, mp = _disconnected_mount(home, rcd, monkeypatch)
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    _stub_lsd(monkeypatch, rc=1, lsd_stderr="AccessDenied: not authorized")
+    err = mounts_mod.broken_mount_error(_os.path.join(mp, "data"))
+    assert err is not None
+    assert "reconnect" in err.lower()
+    assert "restart" not in err.lower()
+    assert "refresh" not in err.lower()
+
+
+def test_mount_restart_reason_no_params_for_adopted_legacy_read_only(home, rcd):
+    # A read_only mount adopted via listmounts (no mounted_read_only key, so we
+    # can't know what the live VFS was baked with) must NOT show a false
+    # "params changed" prompt.
+    m = {"id": "x", "name": "data", "remote": "r:bucket", "read_only": True}
+    assert mounts_mod.mount_restart_reason(
+        m, rcd_mounts=set(), state="mounted") is None
+
+
+def test_mount_restart_reason_skips_mounted_paths_when_state_supplied(
+        home, monkeypatch):
+    # The error path passes state, so the rc round-trip mounted_paths() must be
+    # skipped entirely.
+    def boom():
+        raise AssertionError("mounted_paths() called on the state-supplied path")
+
+    monkeypatch.setattr(mounts_mod, "mounted_paths", boom)
+    m = {"id": "x", "name": "data", "remote": "r:bucket",
+         "read_only": False, "mounted_read_only": False}
+    assert mounts_mod.mount_restart_reason(m, state="mounted") is None
+
+
+def test_get_mounts_probes_credentials_off_serial_path(
+        client, rcd, home, monkeypatch):
+    # Several broken env_auth mounts must NOT stall the polled Mounts page: the
+    # credential probe runs once per mount, in PARALLEL with the state probes,
+    # off the serial view-building path.
+    mps = []
+    for i in range(4):
+        _c, mp = _make_mount(home, rcd, name=f"m{i}",
+                             remote=f"corp{i}:bucket", served=False)
+        mps.append(mp)
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p in mps)
+    calls = []
+
+    def slow_status(m, bin_=None):
+        calls.append(m["name"])
+        time.sleep(0.5)
+        return "valid"
+
+    monkeypatch.setattr(mounts_mod, "_mount_credential_status", slow_status)
+    t0 = time.monotonic()
+    data = client.get("/api/mounts").json()
+    elapsed = time.monotonic() - t0
+
+    # Exactly one probe per broken mount — no second probe from mount_view.
+    assert sorted(calls) == ["m0", "m1", "m2", "m3"]
+    # 4 x 0.5s SERIALLY would be >= 2s; parallel is ~0.5s.
+    assert elapsed < 1.3, f"credential probes ran serially ({elapsed:.2f}s)"
+    assert all(mv["restart_reason"] == "credentials" for mv in data["mounts"])


### PR DESCRIPTION
## Summary

Two related pieces of work on the Mounts feature:

**Backend — credential-expiry recovery + global restart**
- **Adds a global "Restart all mounts" action** (`restart_rcd` → `POST /api/mounts/restart`) that cleanly restarts the long-lived `rclone rcd` daemon and re-mounts everything — the one recovery path for stuck mounts and changed mount params.
- **Fixes the expired-credentials trap.** An `env_auth` remote (e.g. `aws:`) reads its static keys from `~/.aws/credentials` **once**, when the daemon instantiates the S3 backend, and never again. Since the rcd survives server restarts, a re-authed SSO/STS token never reaches a mount — neither Reconnect nor a server restart helps. Only replacing the daemon re-reads the fresh keys, which Restart now does.
- **Guides the user to the right action.** A disconnected `env_auth` mount whose credentials probe *valid again* now surfaces "credentials refreshed → Restart", not the dead-end "Reconnect". A live mount whose params drifted prompts the same way.
- **Safety-first teardown.** `_kill_current_rcd` only signals a pid it can *prove* is our rclone rcd (reusing `reap_stale_rcd`'s gates); an unconfirmed pid raises rather than risk killing a recycled pid.

**Frontend — Mounts page overhaul**
- **Non-blocking load:** the page chrome renders immediately; only the mount list waits on `getMounts()` (shimmer skeleton) instead of a full-page "Loading…".
- **Restyle + reduced copy:** a proper header (title + one-line intro), a restyled `↻ Restart all mounts` button (renamed from "Restart rclone" — rclone is an internal detail, now hidden from all user-facing copy), and a responsive layout (header/card rows wrap; a compact ≤560px breakpoint).
- **Paste-a-link add flow:** paste an `s3://`, `gs://`, virtual-hosted/path-style `https`, or AWS/GCS **console** URL and it auto-fills Name / Remote / Path. A link to a *file* collapses to the browsable dataset root (`bucket/first-prefix`); a link to a *prefix* is kept verbatim. Remote defaults to the **public** (anonymous) remote; Name follows the mounted root. Manual fields remain the fallback.

## Visuals

```mermaid
flowchart TD
    subgraph rec["Credential-expiry recovery"]
        A1[token expires → mount disconnected] --> A2{broken_mount_error /\nmount_restart_reason}
        A2 -->|env_auth + probe valid again| A3["prompt: Restart all mounts"]
        A3 --> C[POST /api/mounts/restart] --> D[restart_rcd]
        D --> D1["detach all (force)"] --> D2["_kill_current_rcd\n(confirmed-pid guard)"]
        D2 --> D3["_ensure_rcd_locked → fresh daemon"] --> D4["run_automount → re-mount + serves"]
        D4 --> E[fresh daemon re-reads keys ✅]
    end

    subgraph ui["Add-mount paste flow"]
        P1["paste s3:// · gs:// · https · console URL"] --> P2[parseStorageUrl]
        P2 -->|"file link"| P2a["collapse to dataset root\nbucket/first-prefix"]
        P2 -->|"prefix link"| P2b["keep verbatim"]
        P2a --> P3["auto-fill Name / Remote / Path\n(public remote, name = root)"]
        P2b --> P3
        P2 -->|unrecognized| P4["hint: fill fields manually"]
        P3 --> P5[Add & mount]
    end
```

## Usage

- **Restart:** Mounts page → **Restart all mounts** (header), or the prompt banner when a mount needs it. Confirm modal warns all mounts briefly disconnect. API: `POST /api/mounts/restart` (needs `X-Fused`), returns the same payload as `GET /api/mounts`.
- **Add by paste:** in *Add mount*, paste any of:
  - `s3://bucket/prefix` · `gs://bucket/prefix`
  - `https://bucket.s3.us-west-2.amazonaws.com/prefix` (virtual-hosted) · `https://s3.region.amazonaws.com/bucket/prefix` (path-style)
  - `https://s3.console.aws.amazon.com/s3/buckets/bucket?prefix=a/b/` · `https://console.cloud.google.com/storage/browser/bucket/prefix`
  - `https://storage.googleapis.com/bucket/prefix`
  - A deep link to a file — e.g. `https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/32/T/QR/2025/8/S2A_…/TCI.tif` — is trimmed to the dataset root `sentinel-cogs/sentinel-s2-l2a-cogs` (edit Path to go deeper).

## Test Plan

- [x] **Backend (+ tests in `tests/test_shell_mounts.py`):** restart_rcd call order; `_kill_current_rcd` refuses unconfirmed pid / no-ops without a daemon; spawn-failure propagation; `mount_restart_reason` params/credentials/none across states, env_auth, and tri-state probe outcomes; `broken_mount_error` routes re-authed→Restart, bad→refresh, inconclusive→reconnect; endpoint 403/200/500; `mount_view` includes `restart_reason`.
- [x] `tests/test_shell_mounts.py` → **208 passed**; full suite **1333 passed, 4 skipped, 2 failed** (the 2 failures are pre-existing `test_deploy.py` no-pip-in-venv cases, unrelated — `deploy.py` untouched).
- [x] **Frontend:** `tsc --noEmit` + `vite build` clean. No JS test runner in `frontend/`, so `parseStorageUrl` and the paste flow were verified live in the browser (s3/gs/virtual-hosted/console URLs fill correctly; ec2/compute console URLs and garbage are rejected with a hint).
- [ ] **Manual:** with an `aws:` mount, let the STS token expire → mount disconnects → re-run SSO login → confirm the "credentials refreshed → Restart" prompt appears, click it, confirm reads resume.

## Review

All Cursor Bugbot findings addressed and replied to on-thread:
- serial credential probes on `/api/mounts` → threaded off the serial view path;
- inconclusive probe treated as valid → tri-state `_credential_probe`, "credentials" only on positive valid;
- stale UI after failed restart → `doRestart` re-fetches; stale `loadError` → cleared on successful reload;
- console URLs false-recognized → require the `buckets/`·`browser/` marker;
- unused `_mount_credential_error` helper → removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
