### PR TITLE
S3 private-bucket fast paths: local SigV4 presign, signed direct listing, cache hygiene

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -427,72 +427,6 @@ def _list_response(path, entries, truncated, cursor):
             "truncated": truncated, "cursor": cursor}
 
 
-def _accumulate_direct_pages(path, cursor, max_entries, *,
-                             page_timeout=None, overall_timeout=None):
-    """Accumulate raw direct-listing entries (Name/Size/IsDir/ModTime dicts, the
-    shared rc/direct shape) for a mount-backed dir on an anonymous S3 or GCS
-    remote, up to `max_entries`. The one page-accumulation loop shared by
-    /api/fs/list and the walk; the backend (S3 ListObjectsV2 vs GCS
-    objects.list) is picked per-path by shell_mounts.direct_list_page.
-
-    Each page requests only min(1000, remaining) keys, so the accumulation never
-    overshoots `max_entries` (a whole extra 1000-key page could otherwise push a
-    LIST_MAX_ENTRIES=10k cap to 10,999) while the returned continuation token
-    still resumes cleanly. `overall_timeout` bounds total wall time across pages
-    (page count is otherwise unbounded); on exhaustion the loop stops mid-listing
-    and returns the last token, a valid resume point.
-
-    Returns (raw_entries, next_token). next_token is non-None exactly when more
-    entries remain (cap hit, budget hit with more pending, or the listing was
-    truncated) — i.e. the listing is partial. Raises shell_mounts.DirectListError
-    only when the FIRST page fails (nothing fetched, so the rc fallback is worth
-    trying); a failure after at least one page returns what was accumulated with
-    the failed page's continuation token as the resume point — on a slow bucket
-    the per-page timeout shrinks toward the budget's deadline and the last
-    page routinely times out, and discarding thousands of fetched entries to
-    re-list via rc (which can't paginate at all) would turn a partial success
-    into a guaranteed 503."""
-    from fused_render.shell import mounts as shell_mounts
-
-    entries: list = []
-    token = cursor or None
-    deadline = None if overall_timeout is None else time.monotonic() + overall_timeout
-    while True:
-        remaining = max_entries - len(entries)
-        if remaining <= 0:
-            break
-        t = page_timeout
-        # The first page always runs with the full page timeout (the progress
-        # guarantee — even a zero budget returns one page). Later pages shrink
-        # to the budget's remainder, and stop before it reaches zero: a
-        # non-positive timeout would hit urlopen as a ValueError, not a
-        # DirectListError (Bugbot), and token is already a valid resume point.
-        if deadline is not None and entries:
-            left = deadline - time.monotonic()
-            if left <= 0:
-                break
-            t = left if t is None else min(t, left)
-        try:
-            page, next_token = shell_mounts.direct_list_page(
-                path, max_keys=min(1000, remaining), continuation=token, timeout=t)
-        except shell_mounts.DirectListError:
-            if not entries:
-                raise
-            logger.warning("direct-listing page for %r failed mid-listing; "
-                           "returning %d accumulated entries as partial",
-                           path, len(entries))
-            return entries, token
-        token = next_token
-        entries.extend(page)
-        if token is None:
-            break
-        # Budget checked AFTER a page so the loop always makes progress; the
-        # token from the last fetched page is a valid resume point.
-        if deadline is not None and time.monotonic() >= deadline:
-            break
-    return entries, token
-
-
 def _list_direct(path, cursor):
     """Accumulate direct-listing pages (S3 ListObjectsV2 / GCS objects.list) for
     a mount-backed dir on an anonymous S3 or GCS remote into sorted /api/fs/list
@@ -561,6 +495,7 @@ def _walk_bfs(path, include_hidden, max_entries=None, max_depth=None):
     coverage. `None` means unbounded on that axis.
     """
     from fused_render.shell import mounts as shell_mounts
+    from fused_render.shell import pathops
 
     oracles = {}  # repo root -> _IgnoreOracle, insertion order = LRU
 
@@ -592,36 +527,34 @@ def _walk_bfs(path, include_hidden, max_entries=None, max_depth=None):
             mount_backed = shell_mounts.is_mount_backed(current)
             if mount_backed:
                 is_root = current == path
-                listed = None
                 dir_cut = False  # this dir's listing stopped short (1.3)
-                # Anonymous S3/GCS dir: page the store's own listing API (fast,
-                # non-timeout-prone) up to the remote walk cap instead of the rc
-                # listing rclone can't paginate. On any failure, fall back to rc
-                # for THIS dir (same skip-on-failure semantics as below).
-                if shell_mounts.direct_list_capable(current):
-                    try:
-                        listed, direct_token = _accumulate_direct_pages(
-                            current, None, WALK_MAX_ENTRIES_REMOTE,
-                            page_timeout=WALK_RC_LIST_TIMEOUT_S,
-                            overall_timeout=WALK_RC_LIST_TIMEOUT_S)
-                        if direct_token is not None:
-                            dir_cut = True  # more keys remained unlisted
-                    except shell_mounts.DirectListError:
-                        listed = None  # fall back to the rc path for this dir
-                if listed is None:
-                    try:
-                        listed = shell_mounts.rc_list_dir(
-                            current, timeout=WALK_RC_LIST_TIMEOUT_S)
-                    except shell_mounts.RcListError:
-                        # The ROOT listing failing is fatal — surface it with the
-                        # same status codes fs/list uses (see api_fs_walk, which
-                        # pulls the first item eagerly to catch this). A non-root
-                        # dir keeps skip-and-continue, but marks the walk
-                        # truncated so the client knows coverage is partial.
-                        if is_root:
-                            raise
-                        yield _WALK_TRUNCATED
-                        continue
+                # Mount-backed dir: the direct→rc ladder (anonymous S3/GCS page
+                # the store's own listing API up to the remote walk cap; else, or
+                # on a direct page failure, the rc listing rclone can't paginate),
+                # single-sourced in pathops.list_mount_dir.
+                try:
+                    listing = pathops.list_mount_dir(
+                        current, max_entries=WALK_MAX_ENTRIES_REMOTE,
+                        page_timeout=WALK_RC_LIST_TIMEOUT_S,
+                        overall_timeout=WALK_RC_LIST_TIMEOUT_S,
+                        rc_timeout=WALK_RC_LIST_TIMEOUT_S)
+                except shell_mounts.RcListError:
+                    # rc route rejected the listing (a file / missing / broken —
+                    # RcListTimeout and RcListUnavailable subclass RcListError).
+                    # The ROOT listing failing is fatal — surface it with the same
+                    # status codes fs/list uses (see api_fs_walk, which pulls the
+                    # first item eagerly to catch this). A non-root dir keeps
+                    # skip-and-continue, but marks the walk truncated so the
+                    # client knows coverage is partial.
+                    if is_root:
+                        raise
+                    yield _WALK_TRUNCATED
+                    continue
+                listed = listing.entries
+                if listing.direct:
+                    if listing.token is not None:
+                        dir_cut = True  # more keys remained unlisted
+                else:
                     # rclone can't paginate, so a huge dir comes back whole: cap
                     # it at the per-dir remote budget and flag the cut.
                     if len(listed) > WALK_MAX_ENTRIES_REMOTE:

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -770,10 +770,8 @@ def _is_file_mount_safe(path: str) -> bool:
     not a file, matching os.path.isfile), while an "indeterminate" rc probe
     fails OPEN so a transient rcd hiccup never 404s a file the user just
     opened."""
-    from fused_render.shell.mounts import is_mount_backed, rc_kind_for
-    if is_mount_backed(path):
-        return rc_kind_for(path) in ("file", "indeterminate")
-    return os.path.isfile(path)
+    from fused_render.shell import pathops
+    return pathops.is_file(path)
 
 
 def _session_get(path: str):

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -500,15 +500,24 @@ def _list_direct(path, cursor):
     deliberately small per-request cap, since this route is resumable (Load more
     pages in the rest). Returns (entries, next_token); a non-None token means the
     listing is partial and resumable. Raises shell_mounts.DirectListError on any
-    page failure so the caller can fall back to the rc route."""
-    raw, token = _accumulate_direct_pages(
-        path, cursor, S3_LIST_MAX_ENTRIES,
-        overall_timeout=S3_LIST_OVERALL_TIMEOUT_S)
+    page failure so the caller can fall back to the rc route.
+
+    The direct→rc ladder itself lives in pathops.list_mount_dir (single-sourced
+    with the fs/walk); here we drive its DIRECT route only (allow_rc_fallback
+    False) so api_fs_list keeps its own rc handling — the warning and the
+    cursor-specific 503 are HTTP response shaping. This route is reached only
+    after the caller has confirmed direct_list_capable(path)."""
+    from fused_render.shell import pathops
+
+    listing = pathops.list_mount_dir(
+        path, cursor=cursor, max_entries=S3_LIST_MAX_ENTRIES,
+        overall_timeout=S3_LIST_OVERALL_TIMEOUT_S, allow_rc_fallback=False)
     # Sorted over what was fetched, not the whole directory — a truncated
     # listing is honestly partial (see the endpoint's sort caveat). Skip any
     # entry missing a Name (a malformed page must not 500 the request).
-    entries = _sort_entries([_mount_list_item(de) for de in raw if de.get("Name")])
-    return entries, token
+    entries = _sort_entries(
+        [_mount_list_item(de) for de in listing.entries if de.get("Name")])
+    return entries, listing.token
 
 
 # Yielded by _walk_bfs when a directory's listing was cut short (direct S3/GCS

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1776,17 +1776,19 @@ def _signing_region(fs: str, cfg: dict | None) -> str | None:
 
 def _adopt_region_on_301(fs: str, code: int, headers,
                          signed_region: str | None) -> bool:
-    """A wrong-region S3 response (301/400) carries the bucket's true region in
-    x-amz-bucket-region. When it does, adopt it into the shared map (under
-    _upstream_lock) so later requests sign for the right region, and report
-    whether THIS request should retry — which it must whenever the hint differs
-    from the region it actually signed with (`signed_region`), NOT whether the
-    shared map already holds the correction. Keying the retry off the shared map
-    would let a concurrent request that still signed with the stale region see a
-    sibling's correction already applied and skip its own needed re-sign/retry,
-    failing it into the slow rc path. Mirrors _validate_and_sign's rule so
-    signed listings/probes region-correct exactly as signed raw reads do."""
-    if code not in (301, 400):
+    """A wrong-region S3 response (301/307/400) carries the bucket's true region
+    in x-amz-bucket-region (307 Temporary Redirect is what S3 returns for a
+    newly created bucket whose region hasn't propagated). When it does, adopt it
+    into the shared map (under _upstream_lock) so later requests sign for the
+    right region, and report whether THIS request should retry — which it must
+    whenever the hint differs from the region it actually signed with
+    (`signed_region`), NOT whether the shared map already holds the correction.
+    Keying the retry off the shared map would let a concurrent request that still
+    signed with the stale region see a sibling's correction already applied and
+    skip its own needed re-sign/retry, failing it into the slow rc path. Mirrors
+    _validate_and_sign's rule so signed listings/probes region-correct exactly
+    as signed raw reads do."""
+    if code not in (301, 307, 400):
         return False
     corrected = headers.get("x-amz-bucket-region") if headers else None
     if not corrected:
@@ -1807,7 +1809,7 @@ def _s3_get_direct(fs: str, rel: str, *, query: dict | None = None,
     followed exactly as before).
 
     SIGNABLE remote: the presigned URL fetched through the NON-redirect opener
-    so a wrong/unset-region 301/400 is observable (the default opener would
+    so a wrong/unset-region 301/307/400 is observable (the default opener would
     chase it to a host the SigV4 signature — which covers Host — doesn't match,
     turning a correctable region hint into an opaque 403). On such a response
     carrying x-amz-bucket-region, adopt the region, re-sign and retry ONCE.
@@ -1933,7 +1935,7 @@ def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
     # _s3_get_direct builds the unsigned URL (anonymous — byte-identical to the
     # old base?query with the dotted-bucket path-style rule) or the presigned
     # URL (signable — the list params ride through the presigner), and for a
-    # signable remote self-corrects the region on a wrong-region 301/400.
+    # signable remote self-corrects the region on a wrong-region 301/307/400.
     try:
         body = _s3_get_direct(fs, rel, query=params, timeout=timeout)
     except urllib.error.HTTPError as e:
@@ -2214,7 +2216,7 @@ def _s3_head(path: str, timeout: float) -> DirectHead:
     # Anonymous: plain urlopen on the unsigned URL, byte-identical to before.
     # Signable: presigned HEAD (signed explicitly — a presigned GET rejects a
     # HEAD) through the non-redirect opener, self-correcting the region once on
-    # a wrong-region 301/400 so a probe doesn't wedge on an unset/wrong region.
+    # a wrong-region 301/307/400 so a probe doesn't wedge on an unset/wrong region.
     cfg = _remote_config(fs.partition(":")[0])
     anonymous = _anonymous_s3(cfg)
     for attempt in (1, 2):
@@ -2365,15 +2367,16 @@ def _validate_and_sign(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
       - (url, "ok")            S3 accepted the signature (200/206/404/416 — a
                                404 means accepted, object merely absent);
       - (None, "reject")       S3 definitively rejected it (403, or an
-                               uncorrectable 301/400) — sign mode can't serve
-                               this remote; the caller settles on publiclink;
+                               uncorrectable 301/307/400) — sign mode can't
+                               serve this remote; caller settles on publiclink;
       - (None, "inconclusive") network error / 5xx — transient; the caller must
                                NOT pin a mode so sign is re-attempted later.
     The trial region is passed via region_override and NEVER published to
     _upstream_region until the signature is accepted — so a losing racer can't
-    erase a winner's adopted region. Self-corrects the region ONCE on a 301/400
-    carrying x-amz-bucket-region and re-signs; on success writes
-    _upstream_region[fs] exactly once."""
+    erase a winner's adopted region. Self-corrects the region ONCE on a
+    301/307/400 carrying x-amz-bucket-region and re-signs (307 is S3's
+    newly-created-bucket redirect); on success writes _upstream_region[fs]
+    exactly once."""
     derived = _s3_bucket_prefix_region(fs, cfg)
     if derived is None:
         return None, "reject"
@@ -2389,11 +2392,11 @@ def _validate_and_sign(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
             with _upstream_lock:
                 _upstream_region[fs] = region  # publish once, on success only
             return url, "ok"
-        if (attempt == 1 and status in (301, 400)
+        if (attempt == 1 and status in (301, 307, 400)
                 and corrected and corrected != region):
             region = corrected
             continue
-        # 403 / uncorrectable 301/400 (< 500) is a definite reject; a network
+        # 403 / uncorrectable 301/307/400 (< 500) is a definite reject; a network
         # error (status 0) or 5xx is inconclusive — don't let a transient blip
         # permanently pin the remote to the slow link path (finding 7).
         verdict = "reject" if 0 < status < 500 else "inconclusive"

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -44,7 +44,7 @@ from datetime import datetime
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
 
-from fused_render.shell import storage
+from fused_render.shell import s3sign, storage
 
 logger = logging.getLogger(__name__)
 
@@ -1435,10 +1435,32 @@ def serve_url_for(path: str) -> str | None:
 # Presigned links default to a 1h expiry; reuse them for well under that so
 # a link handed to a proxied read is never near expiry.
 _LINK_TTL_S = 30 * 60.0
+# Sign-mode presign lifetime. A signed link is handed to the 307 client and
+# consumed at once, so this only bounds the window a leaked link is replayable;
+# creds are re-resolved every _CRED_TTL_S regardless.
+_SIGN_EXPIRY_S = 15 * 60
+_SIGN_VALIDATE_TIMEOUT_S = 5.0
+_CRED_TTL_S = 60.0  # re-read env / ~/.aws so a rotated key / STS refresh lands
+_UPSTREAM_LINKS_CAP = 4096  # bound the publiclink cache (sign mode never inserts)
 _upstream_lock = threading.Lock()
 _upstream_links: dict = {}  # (fs, rel) -> (url, monotonic expiry)
-_upstream_mode: dict = {}   # fs -> "link" | "public" | "none"
+_upstream_mode: dict = {}   # fs -> "link" | "public" | "none" | "sign"
 _upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
+_upstream_region: dict = {}  # fs -> region (self-corrected from x-amz-bucket-region)
+_cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry)
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Redirect handler that never follows: sign-mode validation must observe
+    a wrong-region 301/307 itself (with its x-amz-bucket-region header) rather
+    than have urllib chase it to a host the signature — which covers Host —
+    doesn't match, turning a correctable region hint into an opaque 403."""
+
+    def redirect_request(self, *args, **kwargs):
+        return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirect)
 
 
 def _remote_config(name: str) -> dict | None:
@@ -1480,6 +1502,20 @@ def _cannot_presign(cfg: dict | None) -> bool:
     objects by a plain unsigned URL instead. Lets _upstream_url_for skip the
     wasted publiclink rc call for either backend."""
     return cfg is not None and (_anonymous_s3(cfg) or _gcs_anonymous(cfg))
+
+
+def _s3_signable(cfg: dict | None) -> bool:
+    """True when the remote is plain AWS S3 (no custom endpoint) whose
+    credentials resolve locally — the class we can presign in-process instead
+    of round-tripping publiclink per object. NOT anonymous S3 (that carries no
+    creds and is handled first by _anonymous_s3/_cannot_presign), and NOT
+    custom-endpoint S3 (R2/MinIO/source.coop mirrors): endpoint addressing and
+    region conventions vary per provider, so those keep the publiclink path.
+    Callers must check _anonymous_s3 FIRST so an anonymous remote never reaches
+    the resolver."""
+    if cfg is None or cfg.get("type") != "s3" or cfg.get("endpoint"):
+        return False
+    return s3sign.resolve_credentials(cfg) is not None
 
 
 def _mount_for(path: str) -> tuple[dict | None, str]:
@@ -1573,6 +1609,72 @@ def _gcs_public_object_url(fs: str, rel: str) -> str | None:
     key = (prefix + "/" if prefix else "") + rel
     # Match _public_object_url's key quoting (same default safe chars).
     return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
+
+
+def _signable_credentials(name: str, cfg: dict | None):
+    """resolve_credentials for a remote, cached per name for _CRED_TTL_S so a
+    rotated ~/.aws/credentials or an STS refresh is picked up without a
+    restart, but the env/file reads aren't paid per object on the sign hot
+    path. None (also cached) when nothing resolves."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = _cred_cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+    creds = s3sign.resolve_credentials(cfg)
+    with _upstream_lock:
+        _cred_cache[name] = (creds, now + _CRED_TTL_S)
+    return creds
+
+
+def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
+                    query: dict | None = None) -> str | None:
+    """The direct S3 URL for one request against a mount's remote — the single
+    dispatch the raw-read, listing and probe sites share so they can't diverge
+    on how a URL is built or signed:
+      - anonymous remote  -> the EXISTING unsigned builders, verbatim
+        (_public_object_url for an object; the same base?query build the pager
+        used for a listing) — byte-identical to today, resolver never consulted;
+      - signable remote   -> a locally presigned URL for `method`;
+      - neither           -> None (caller falls back to rc).
+    `query` present means a ListObjectsV2 request against the bucket root (its
+    params are signed through the presigner, canonicalized in one place);
+    absent means an object request keyed by `rel`."""
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
+    if cfg is None:
+        return None
+    # Anonymous FIRST: an anonymous remote never resolves credentials, never
+    # signs — its URLs are the exact unsigned ones today's code produces.
+    if _anonymous_s3(cfg):
+        if query is None:
+            return _public_object_url(fs, rel)
+        derived = _s3_bucket_prefix_region(fs, cfg)
+        if derived is None:
+            return None
+        bucket, _prefix, region = derived
+        base = _s3_base_url(bucket, region)
+        qs = urllib.parse.urlencode(query)
+        return f"{base}?{qs}" if "." in bucket else f"{base}/?{qs}"
+    if not _s3_signable(cfg):
+        return None
+    creds = _signable_credentials(name, cfg)
+    derived = _s3_bucket_prefix_region(fs, cfg)
+    if creds is None or derived is None:
+        return None
+    bucket, prefix, cfg_region = derived
+    with _upstream_lock:
+        region = _upstream_region.get(fs, cfg_region)  # adopted region wins
+    if query is None:
+        key = (prefix + "/" if prefix else "") + rel
+        url = _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
+        return s3sign.presign_url(url, method=method, region=region,
+                                  credentials=creds, expires=_SIGN_EXPIRY_S)
+    base = _s3_base_url(bucket, region)
+    root = base if "." in bucket else base + "/"
+    return s3sign.presign_url(root, method=method, region=region,
+                              credentials=creds, extra_query=query,
+                              expires=_SIGN_EXPIRY_S)
 
 
 # ------------------------------------------------------- direct S3 pagination
@@ -2062,6 +2164,63 @@ def upstream_url_for(path: str) -> str | None:
         return None
 
 
+def _remember_region(fs: str, region: str) -> None:
+    with _upstream_lock:
+        _upstream_region[fs] = region
+
+
+def _forget_region(fs: str) -> None:
+    with _upstream_lock:
+        _upstream_region.pop(fs, None)
+
+
+def _sign_validation_status(url: str) -> tuple[int, str | None]:
+    """Sign mode's one validation probe: a Range: bytes=0-0 GET against a
+    presigned URL, redirects NOT followed (see _NoRedirect). Returns (HTTP
+    status, x-amz-bucket-region header) — (0, None) on a network error. Only
+    the status/region is surfaced; the presigned URL is never logged."""
+    req = urllib.request.Request(url, method="GET",
+                                 headers={"Range": "bytes=0-0"})
+    try:
+        with _NO_REDIRECT_OPENER.open(
+                req, timeout=_SIGN_VALIDATE_TIMEOUT_S) as resp:
+            return resp.status, resp.headers.get("x-amz-bucket-region")
+    except urllib.error.HTTPError as e:
+        return e.code, e.headers.get("x-amz-bucket-region")
+    except (urllib.error.URLError, OSError):
+        return 0, None
+
+
+def _validate_and_sign(fs: str, rel: str, cfg: dict) -> str | None:
+    """One-time sign-mode validation for a remote: presign a ranged GET for
+    `rel` and issue it once. Returns that presigned URL when S3 accepts the
+    signature (200/206/404/416 — a 404 means the signature was accepted and the
+    object is merely absent), self-correcting the region ONCE on a 301/400 that
+    carries x-amz-bucket-region (common for wrong-region private-bucket configs)
+    and re-signing. Returns None on 403 / network failure so the caller keeps
+    today's publiclink path — behavior identical to today for anything sign mode
+    can't serve."""
+    derived = _s3_bucket_prefix_region(fs, cfg)
+    if derived is None:
+        return None
+    region = derived[2]
+    for attempt in (1, 2):
+        _remember_region(fs, region)  # _s3_request_url reads the adopted region
+        url = _s3_request_url(fs, rel, method="GET")
+        if url is None:
+            break
+        status, corrected = _sign_validation_status(url)
+        if status in (200, 206, 404, 416):
+            return url
+        if (attempt == 1 and status in (301, 400)
+                and corrected and corrected != region):
+            region = corrected
+            continue
+        break
+    _forget_region(fs)  # don't leave a guessed/wrong region cached on failure
+    return None
+
+
 def _upstream_url_for(path: str) -> str | None:
     m, rel = _mount_for(path)
     if m is None:
@@ -2075,12 +2234,31 @@ def _upstream_url_for(path: str) -> str | None:
         mode = _upstream_mode.get(fs)
     if mode == "none":
         return None
-    if mode is None and _cannot_presign(_remote_config(fs.partition(":")[0])):
-        # Anonymous S3 or GCS can never presign — don't burn an rc call per
-        # remote learning that from publiclink's "unsupported signer type"
-        # error.
-        mode = "public"
+    if mode == "sign":
+        # In-process signing is microseconds and creds rotate, so sign mode
+        # mints per object and never caches a link. None means creds stopped
+        # resolving (a rotated-away key) — the caller falls back to the serve
+        # until a remote change (Task 4 invalidation) resets the mode.
+        return _s3_request_url(fs, rel, method="GET")
     url = None
+    if mode is None:
+        cfg = _remote_config(fs.partition(":")[0])
+        if _cannot_presign(cfg):
+            # Anonymous S3 or GCS can never presign — don't burn an rc call per
+            # remote learning that from publiclink's "unsupported signer type"
+            # error. CHECKED FIRST: an anonymous remote never resolves creds,
+            # never signs, never issues the validation GET; its mode is "public".
+            mode = "public"
+        elif _s3_signable(cfg):
+            # Credentialed plain-AWS S3: presign locally instead of a publiclink
+            # rc call per object. Validate the signature once per fs before
+            # committing; on 403/network fall through to publiclink below.
+            signed = _validate_and_sign(fs, rel, cfg)
+            if signed is not None:
+                with _upstream_lock:
+                    _upstream_mode[fs] = "sign"
+                return signed
+            # validation inconclusive -> mode stays None, publiclink handles it
     if mode in (None, "link"):
         port = _live_rcd_port()
         if port is None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1635,6 +1635,26 @@ def _s3_bucket_prefix_region(fs: str, cfg: dict) -> tuple[str, str, str] | None:
     return bucket, prefix.rstrip("/"), cfg.get("region") or "us-east-1"
 
 
+def _s3_object_url(bucket: str, prefix: str, rel: str, region: str) -> str:
+    """One S3 object URL: prefix-join then percent-quote the key, applying the
+    dotted-bucket path-style rule via _s3_base_url. The single builder both the
+    anonymous (unsigned) and signable (presigned-input) branches of
+    _s3_request_url join their key through, so the two can't diverge on the
+    prefix-join or the quoting."""
+    key = (prefix + "/" if prefix else "") + rel
+    return _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
+
+
+def _s3_list_root(bucket: str, region: str) -> str:
+    """The bucket-root URL a ListObjectsV2 query hangs off, applying the
+    dotted-bucket rule once: a dotted bucket is already path-style (root has no
+    trailing slash — "s3.<r>.amazonaws.com/<bucket>?..."), a virtual-hosted one
+    needs the "/" before the "?". Shared by the anonymous (base?query) and
+    signable (presigned) branches so the dotted-bucket handling can't diverge."""
+    base = _s3_base_url(bucket, region)
+    return base if "." in bucket else base + "/"
+
+
 def _public_object_url(fs: str, rel: str) -> str | None:
     """Plain https URL for an object on an ANONYMOUS AWS S3 remote — the one
     backend class that can't presign but doesn't need to. Credentialed or
@@ -1649,9 +1669,7 @@ def _public_object_url(fs: str, rel: str) -> str | None:
     if derived is None:
         return None
     bucket, prefix, region = derived
-    key = (prefix + "/" if prefix else "") + rel
-    # _s3_base_url applies the dotted-bucket path-style rule (see there).
-    return _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
+    return _s3_object_url(bucket, prefix, rel, region)
 
 
 def _gcs_public_object_url(fs: str, rel: str) -> str | None:
@@ -1719,9 +1737,7 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
         if derived is None:
             return None
         bucket, _prefix, region = derived
-        base = _s3_base_url(bucket, region)
-        qs = urllib.parse.urlencode(query)
-        return f"{base}?{qs}" if "." in bucket else f"{base}/?{qs}"
+        return f"{_s3_list_root(bucket, region)}?{urllib.parse.urlencode(query)}"
     # Cheap uncached shape gate, then ONE cached credential resolution (the
     # single source of the sign/no-sign decision on this path — no separate
     # uncached pre-gate that could disagree with it within the TTL window).
@@ -1738,15 +1754,12 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
         with _upstream_lock:
             region = _upstream_region.get(fs, cfg_region)  # adopted region wins
     if query is None:
-        key = (prefix + "/" if prefix else "") + rel
-        url = _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
+        url = _s3_object_url(bucket, prefix, rel, region)
         return s3sign.presign_url(url, method=method, region=region,
                                   credentials=creds, expires=_SIGN_EXPIRY_S)
-    base = _s3_base_url(bucket, region)
-    root = base if "." in bucket else base + "/"
-    return s3sign.presign_url(root, method=method, region=region,
-                              credentials=creds, extra_query=query,
-                              expires=_SIGN_EXPIRY_S)
+    return s3sign.presign_url(_s3_list_root(bucket, region), method=method,
+                              region=region, credentials=creds,
+                              extra_query=query, expires=_SIGN_EXPIRY_S)
 
 
 def _adopt_region_on_301(fs: str, code: int, headers) -> bool:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1704,13 +1704,16 @@ S3ListError = DirectListError
 
 
 def s3_direct_capable(path: str) -> bool:
-    """True when `path` is mount-backed by an anonymous plain-AWS-S3 remote —
-    the one backend class s3_list_page can enumerate unsigned. Lets the server
-    pick the fast path without re-deriving the _anonymous_s3 test."""
+    """True when `path` is mount-backed by a plain-AWS-S3 remote s3_list_page
+    can enumerate directly — anonymous (unsigned) OR signable (locally
+    presigned). Lets the server pick the fast path without re-deriving the
+    predicates. _anonymous_s3 is tested first, so an anonymous remote never
+    reaches the credential resolver."""
     m, _ = _mount_for(path)
     if m is None:
         return False
-    return _anonymous_s3(_remote_config(m["remote"].partition(":")[0]))
+    cfg = _remote_config(m["remote"].partition(":")[0])
+    return _anonymous_s3(cfg) or _s3_signable(cfg)
 
 
 def _s3_listing_prefix(store_prefix: str, rel: str) -> str:
@@ -1731,9 +1734,9 @@ def _s3_listing_prefix(store_prefix: str, rel: str) -> str:
 
 def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
                  timeout: float | None = None) -> tuple[list, str | None]:
-    """One ListObjectsV2 page for a mount-backed directory on an anonymous AWS
-    S3 remote, fetched by a plain unsigned HTTPS GET — no kernel I/O on the
-    mount, no rclone, no boto3.
+    """One ListObjectsV2 page for a mount-backed directory on a direct-listable
+    AWS S3 remote — anonymous (plain unsigned GET) or signable (locally
+    presigned GET) — off the kernel mount, no rclone, no boto3.
 
     Returns (entries, next_token): entries shaped exactly like rc_list_dir
     output (Name/Size/IsDir/ModTime dicts) so downstream mapping is shared, and
@@ -1752,24 +1755,25 @@ def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
         raise S3ListError(f"{path} is under no known mount")
     fs = m["remote"]
     cfg = _remote_config(fs.partition(":")[0])
-    if not _anonymous_s3(cfg):
-        raise S3ListError(f"{path}: remote {fs!r} is not anonymous AWS S3")
+    if not (_anonymous_s3(cfg) or _s3_signable(cfg)):
+        raise S3ListError(f"{path}: remote {fs!r} is not direct-listable S3")
     assert cfg is not None
     derived = _s3_bucket_prefix_region(fs, cfg)
     if derived is None:
         raise S3ListError(f"{path}: remote {fs!r} carries no bucket")
-    bucket, store_prefix, region = derived
+    _bucket, store_prefix, _region = derived
     prefix = _s3_listing_prefix(store_prefix, rel)
     params = {"list-type": "2", "delimiter": "/", "prefix": prefix,
               "max-keys": str(max_keys)}
     if continuation:
         params["continuation-token"] = continuation
-    query = urllib.parse.urlencode(params)
-    # _s3_base_url applies the dotted-bucket path-style rule. Path-style
-    # addresses the bucket in the path already; virtual-hosted style needs the
-    # root "/" before the query string.
-    base = _s3_base_url(bucket, region)
-    url = f"{base}?{query}" if "." in bucket else f"{base}/?{query}"
+    # _s3_request_url builds the unsigned URL (anonymous — byte-identical to the
+    # old base?query with the dotted-bucket path-style rule) or the presigned
+    # URL (signable — the list params ride through the presigner). None is
+    # unreachable here (the remote is anonymous-or-signable per the gate above).
+    url = _s3_request_url(fs, rel, method="GET", query=params)
+    if url is None:
+        raise S3ListError(f"{path}: remote {fs!r} has no direct list URL")
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             body = resp.read()
@@ -2047,9 +2051,11 @@ def _s3_head(path: str, timeout: float) -> DirectHead:
     m, rel = _mount_for(path)
     if rel == ".":
         return DirectHead(False, None, None)  # the mountpoint is not an object
-    url = _public_object_url(m["remote"], rel)
-    if url is None:  # not anonymous S3 after all — let the caller fall back
-        raise DirectProbeError(f"{path}: no unsigned S3 object URL")
+    # Unsigned public URL for anonymous, presigned HEAD URL for signable. HEAD
+    # is signed explicitly: a presigned GET rejects a HEAD request.
+    url = _s3_request_url(m["remote"], rel, method="HEAD")
+    if url is None:  # neither anonymous nor signable — let the caller fall back
+        raise DirectProbeError(f"{path}: no direct S3 object URL")
     req = urllib.request.Request(url, method="HEAD")
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
@@ -2101,19 +2107,21 @@ def _gcs_head(path: str, timeout: float) -> DirectHead:
 def _s3_has_children(path: str, timeout: float) -> bool:
     m, rel = _mount_for(path)
     fs = m["remote"]
-    cfg = _remote_config(fs.partition(":")[0])
-    derived = _s3_bucket_prefix_region(fs, cfg or {})
+    derived = _s3_bucket_prefix_region(
+        fs, _remote_config(fs.partition(":")[0]) or {})
     if derived is None:
         raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
-    bucket, store_prefix, region = derived
+    _bucket, store_prefix, _region = derived
     prefix = _s3_listing_prefix(store_prefix, rel)
     # NO delimiter and max-keys=1: cheapest "does anything live here" — one key
     # (the marker included) proves the directory. delimiter would only add
     # CommonPrefixes work we don't need for a boolean.
     params = {"list-type": "2", "prefix": prefix, "max-keys": "1"}
-    query = urllib.parse.urlencode(params)
-    base = _s3_base_url(bucket, region)
-    url = f"{base}?{query}" if "." in bucket else f"{base}/?{query}"
+    # Unsigned for anonymous (byte-identical to the old base?query), presigned
+    # for signable — routed through the same helper the pager uses.
+    url = _s3_request_url(fs, rel, method="GET", query=params)
+    if url is None:
+        raise DirectProbeError(f"{path}: no direct S3 list URL")
     try:
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             body = resp.read()

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1762,22 +1762,39 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
                               extra_query=query, expires=_SIGN_EXPIRY_S)
 
 
-def _adopt_region_on_301(fs: str, code: int, headers) -> bool:
+def _signing_region(fs: str, cfg: dict | None) -> str | None:
+    """The region _s3_request_url would presign `fs` for right now: the adopted
+    (self-corrected) region if one exists, else the config default. A caller
+    captures this just before it signs so it can tell _adopt_region_on_301 what
+    region THIS request actually used (see that function)."""
+    derived = _s3_bucket_prefix_region(fs, cfg or {})
+    if derived is None:
+        return None
+    with _upstream_lock:
+        return _upstream_region.get(fs, derived[2])
+
+
+def _adopt_region_on_301(fs: str, code: int, headers,
+                         signed_region: str | None) -> bool:
     """A wrong-region S3 response (301/400) carries the bucket's true region in
-    x-amz-bucket-region. When it does and it differs from what we signed with,
-    adopt it (under _upstream_lock) so a re-sign targets the right region, and
-    report True so the caller retries once. Mirrors _validate_and_sign's rule
-    so signed listings/probes region-correct exactly as signed raw reads do."""
+    x-amz-bucket-region. When it does, adopt it into the shared map (under
+    _upstream_lock) so later requests sign for the right region, and report
+    whether THIS request should retry — which it must whenever the hint differs
+    from the region it actually signed with (`signed_region`), NOT whether the
+    shared map already holds the correction. Keying the retry off the shared map
+    would let a concurrent request that still signed with the stale region see a
+    sibling's correction already applied and skip its own needed re-sign/retry,
+    failing it into the slow rc path. Mirrors _validate_and_sign's rule so
+    signed listings/probes region-correct exactly as signed raw reads do."""
     if code not in (301, 400):
         return False
     corrected = headers.get("x-amz-bucket-region") if headers else None
     if not corrected:
         return False
     with _upstream_lock:
-        if _upstream_region.get(fs) == corrected:
-            return False
-        _upstream_region[fs] = corrected
-    return True
+        if _upstream_region.get(fs) != corrected:
+            _upstream_region[fs] = corrected
+    return corrected != signed_region
 
 
 def _s3_get_direct(fs: str, rel: str, *, query: dict | None = None,
@@ -1805,6 +1822,7 @@ def _s3_get_direct(fs: str, rel: str, *, query: dict | None = None,
         with urllib.request.urlopen(url, timeout=timeout) as resp:
             return resp.read()
     for attempt in (1, 2):
+        signed_region = _signing_region(fs, cfg)
         url = _s3_request_url(fs, rel, method=method, query=query)
         if url is None:
             raise urllib.error.URLError(f"{fs}: no direct S3 URL")
@@ -1813,7 +1831,8 @@ def _s3_get_direct(fs: str, rel: str, *, query: dict | None = None,
             with _NO_REDIRECT_OPENER.open(req, timeout=timeout) as resp:
                 return resp.read()
         except urllib.error.HTTPError as e:
-            if attempt == 1 and _adopt_region_on_301(fs, e.code, e.headers):
+            if attempt == 1 and _adopt_region_on_301(
+                    fs, e.code, e.headers, signed_region):
                 continue
             raise
     raise urllib.error.URLError(f"{fs}: no direct S3 URL")  # unreachable
@@ -2196,8 +2215,10 @@ def _s3_head(path: str, timeout: float) -> DirectHead:
     # Signable: presigned HEAD (signed explicitly — a presigned GET rejects a
     # HEAD) through the non-redirect opener, self-correcting the region once on
     # a wrong-region 301/400 so a probe doesn't wedge on an unset/wrong region.
-    anonymous = _anonymous_s3(_remote_config(fs.partition(":")[0]))
+    cfg = _remote_config(fs.partition(":")[0])
+    anonymous = _anonymous_s3(cfg)
     for attempt in (1, 2):
+        signed_region = None if anonymous else _signing_region(fs, cfg)
         url = _s3_request_url(fs, rel, method="HEAD")
         if url is None:  # neither anonymous nor signable — caller falls back
             raise DirectProbeError(f"{path}: no direct S3 object URL")
@@ -2215,7 +2236,8 @@ def _s3_head(path: str, timeout: float) -> DirectHead:
             if e.code == 404:
                 return DirectHead(False, None, None)  # trustworthy negative
             if (not anonymous and attempt == 1
-                    and _adopt_region_on_301(fs, e.code, e.headers)):
+                    and _adopt_region_on_301(
+                        fs, e.code, e.headers, signed_region)):
                 continue
             raise DirectProbeError(f"S3 head {path}: HTTP {e.code}") from e
         except (urllib.error.URLError, OSError) as e:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1530,9 +1530,20 @@ def _store_upstream_link(key, url: str, expiry: float, now: float) -> None:
 
 def _link_ttl(fs: str) -> float:
     """publiclink cache TTL for `fs`: the short session-token clamp when the
-    remote carries an STS session_token, else _LINK_TTL_S. Must be called
-    WITHOUT _upstream_lock held (_remote_config takes it)."""
-    if (_remote_config(fs.partition(":")[0]) or {}).get("session_token"):
+    remote's credentials carry an STS session token, else _LINK_TTL_S. The token
+    can arrive three ways and all three must clamp so a dying token isn't
+    replayable for the full half hour: a config `session_token`, or — via
+    resolve_credentials — `AWS_SESSION_TOKEN` in the env or `aws_session_token`
+    in ~/.aws/credentials on an env_auth/profile remote (e.g. a non-signable
+    custom-endpoint S3). Rides the cached _signable_credentials so this adds no
+    per-call env/file parsing on the link path. Must be called WITHOUT
+    _upstream_lock held (_remote_config / _signable_credentials take it)."""
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
+    if (cfg or {}).get("session_token"):
+        return _SESSION_TOKEN_LINK_TTL_S
+    creds = _signable_credentials(name, cfg)
+    if creds is not None and creds.session_token:
         return _SESSION_TOKEN_LINK_TTL_S
     return _LINK_TTL_S
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1441,6 +1441,11 @@ _LINK_TTL_S = 30 * 60.0
 _SIGN_EXPIRY_S = 15 * 60
 _SIGN_VALIDATE_TIMEOUT_S = 5.0
 _CRED_TTL_S = 60.0  # re-read env / ~/.aws so a rotated key / STS refresh lands
+# When sign-mode validation fails while no fallback can be committed (rcd down,
+# so publiclink can't cache a "link" mode either), negative-cache the failed
+# validation per fs for this window so every raw read doesn't re-run the 1-2
+# blocking 5s validation GETs. Short so a transient failure self-heals.
+_SIGN_NEG_TTL_S = 45.0
 _UPSTREAM_LINKS_CAP = 4096  # bound the publiclink cache (sign mode never inserts)
 # A publiclink URL minted under a dying STS token shouldn't stay replayable for
 # the full half hour, so a session-token remote gets a shorter link TTL.
@@ -1451,6 +1456,8 @@ _upstream_mode: dict = {}   # fs -> "link" | "public" | "none" | "sign"
 _upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
 _upstream_region: dict = {}  # fs -> region (self-corrected from x-amz-bucket-region)
 _cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry)
+_sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
+_validation_locks: dict = {}  # fs -> Lock: per-fs single-flight for validation
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -1504,6 +1511,8 @@ def _invalidate_upstream_caches() -> None:
         _upstream_region.clear()
         _cred_cache.clear()
         _upstream_links.clear()
+        _sign_neg_cache.clear()
+        _validation_locks.clear()
 
 
 def _store_upstream_link(key, url: str, expiry: float, now: float) -> None:
@@ -1545,18 +1554,30 @@ def _cannot_presign(cfg: dict | None) -> bool:
     return cfg is not None and (_anonymous_s3(cfg) or _gcs_anonymous(cfg))
 
 
-def _s3_signable(cfg: dict | None) -> bool:
+def _s3_signable_shape(cfg: dict | None) -> bool:
+    """Cheap, UNCACHED config-shape gate for the sign path: plain AWS S3 with no
+    custom endpoint. NOT custom-endpoint S3 (R2/MinIO/source.coop mirrors):
+    endpoint addressing and region conventions vary per provider, so those keep
+    the publiclink path. Says nothing about credentials — that is resolved
+    separately through the CACHED _signable_credentials, so the hot path never
+    re-reads env / ~/.aws per object (anonymous S3 also matches this shape but
+    resolves no creds, and callers check _anonymous_s3 first regardless)."""
+    return cfg is not None and cfg.get("type") == "s3" and not cfg.get("endpoint")
+
+
+def _s3_signable(name: str, cfg: dict | None) -> bool:
     """True when the remote is plain AWS S3 (no custom endpoint) whose
     credentials resolve locally — the class we can presign in-process instead
     of round-tripping publiclink per object. NOT anonymous S3 (that carries no
     creds and is handled first by _anonymous_s3/_cannot_presign), and NOT
-    custom-endpoint S3 (R2/MinIO/source.coop mirrors): endpoint addressing and
-    region conventions vary per provider, so those keep the publiclink path.
-    Callers must check _anonymous_s3 FIRST so an anonymous remote never reaches
-    the resolver."""
-    if cfg is None or cfg.get("type") != "s3" or cfg.get("endpoint"):
+    custom-endpoint S3. Credential resolution rides the cached
+    _signable_credentials so the predicate itself is hot-path safe and can't
+    disagree with the URL builder within a _CRED_TTL_S window. Callers must
+    check _anonymous_s3 FIRST so an anonymous remote never reaches the
+    resolver (its creds resolve to None, so this would return False anyway)."""
+    if not _s3_signable_shape(cfg):
         return False
-    return s3sign.resolve_credentials(cfg) is not None
+    return _signable_credentials(name, cfg) is not None
 
 
 def _mount_for(path: str) -> tuple[dict | None, str]:
@@ -1669,7 +1690,8 @@ def _signable_credentials(name: str, cfg: dict | None):
 
 
 def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
-                    query: dict | None = None) -> str | None:
+                    query: dict | None = None,
+                    region_override: str | None = None) -> str | None:
     """The direct S3 URL for one request against a mount's remote — the single
     dispatch the raw-read, listing and probe sites share so they can't diverge
     on how a URL is built or signed:
@@ -1680,7 +1702,10 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
       - neither           -> None (caller falls back to rc).
     `query` present means a ListObjectsV2 request against the bucket root (its
     params are signed through the presigner, canonicalized in one place);
-    absent means an object request keyed by `rel`."""
+    absent means an object request keyed by `rel`. `region_override` presigns
+    for a specific region WITHOUT publishing it to _upstream_region — used by
+    validation to try a trial region before it's been confirmed; absent, the
+    adopted (self-corrected) region wins over the config default."""
     name = fs.partition(":")[0]
     cfg = _remote_config(name)
     if cfg is None:
@@ -1697,15 +1722,21 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
         base = _s3_base_url(bucket, region)
         qs = urllib.parse.urlencode(query)
         return f"{base}?{qs}" if "." in bucket else f"{base}/?{qs}"
-    if not _s3_signable(cfg):
+    # Cheap uncached shape gate, then ONE cached credential resolution (the
+    # single source of the sign/no-sign decision on this path — no separate
+    # uncached pre-gate that could disagree with it within the TTL window).
+    if not _s3_signable_shape(cfg):
         return None
     creds = _signable_credentials(name, cfg)
     derived = _s3_bucket_prefix_region(fs, cfg)
     if creds is None or derived is None:
         return None
     bucket, prefix, cfg_region = derived
-    with _upstream_lock:
-        region = _upstream_region.get(fs, cfg_region)  # adopted region wins
+    if region_override is not None:
+        region = region_override
+    else:
+        with _upstream_lock:
+            region = _upstream_region.get(fs, cfg_region)  # adopted region wins
     if query is None:
         key = (prefix + "/" if prefix else "") + rel
         url = _s3_base_url(bucket, region) + "/" + urllib.parse.quote(key)
@@ -1716,6 +1747,63 @@ def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
     return s3sign.presign_url(root, method=method, region=region,
                               credentials=creds, extra_query=query,
                               expires=_SIGN_EXPIRY_S)
+
+
+def _adopt_region_on_301(fs: str, code: int, headers) -> bool:
+    """A wrong-region S3 response (301/400) carries the bucket's true region in
+    x-amz-bucket-region. When it does and it differs from what we signed with,
+    adopt it (under _upstream_lock) so a re-sign targets the right region, and
+    report True so the caller retries once. Mirrors _validate_and_sign's rule
+    so signed listings/probes region-correct exactly as signed raw reads do."""
+    if code not in (301, 400):
+        return False
+    corrected = headers.get("x-amz-bucket-region") if headers else None
+    if not corrected:
+        return False
+    with _upstream_lock:
+        if _upstream_region.get(fs) == corrected:
+            return False
+        _upstream_region[fs] = corrected
+    return True
+
+
+def _s3_get_direct(fs: str, rel: str, *, query: dict | None = None,
+                   method: str = "GET", timeout: float) -> bytes:
+    """Body bytes of a direct S3 listing/probe request, shared by s3_list_page
+    and _s3_has_children so they can't diverge on transport.
+
+    ANONYMOUS remote: a plain urlopen on the unsigned URL — byte-identical to
+    the pre-existing code (the resolver is never consulted, redirects are
+    followed exactly as before).
+
+    SIGNABLE remote: the presigned URL fetched through the NON-redirect opener
+    so a wrong/unset-region 301/400 is observable (the default opener would
+    chase it to a host the SigV4 signature — which covers Host — doesn't match,
+    turning a correctable region hint into an opaque 403). On such a response
+    carrying x-amz-bucket-region, adopt the region, re-sign and retry ONCE.
+
+    Propagates HTTPError/URLError/OSError to the caller's error mapping; a
+    missing direct URL surfaces as URLError (both callers map it)."""
+    cfg = _remote_config(fs.partition(":")[0])
+    if _anonymous_s3(cfg):
+        url = _s3_request_url(fs, rel, method=method, query=query)
+        if url is None:
+            raise urllib.error.URLError(f"{fs}: no direct S3 URL")
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.read()
+    for attempt in (1, 2):
+        url = _s3_request_url(fs, rel, method=method, query=query)
+        if url is None:
+            raise urllib.error.URLError(f"{fs}: no direct S3 URL")
+        req = urllib.request.Request(url, method=method)
+        try:
+            with _NO_REDIRECT_OPENER.open(req, timeout=timeout) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            if attempt == 1 and _adopt_region_on_301(fs, e.code, e.headers):
+                continue
+            raise
+    raise urllib.error.URLError(f"{fs}: no direct S3 URL")  # unreachable
 
 
 # ------------------------------------------------------- direct S3 pagination
@@ -1753,8 +1841,9 @@ def s3_direct_capable(path: str) -> bool:
     m, _ = _mount_for(path)
     if m is None:
         return False
-    cfg = _remote_config(m["remote"].partition(":")[0])
-    return _anonymous_s3(cfg) or _s3_signable(cfg)
+    name = m["remote"].partition(":")[0]
+    cfg = _remote_config(name)
+    return _anonymous_s3(cfg) or _s3_signable(name, cfg)
 
 
 def _s3_listing_prefix(store_prefix: str, rel: str) -> str:
@@ -1795,8 +1884,9 @@ def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
     if m is None:
         raise S3ListError(f"{path} is under no known mount")
     fs = m["remote"]
-    cfg = _remote_config(fs.partition(":")[0])
-    if not (_anonymous_s3(cfg) or _s3_signable(cfg)):
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
+    if not (_anonymous_s3(cfg) or _s3_signable(name, cfg)):
         raise S3ListError(f"{path}: remote {fs!r} is not direct-listable S3")
     assert cfg is not None
     derived = _s3_bucket_prefix_region(fs, cfg)
@@ -1808,16 +1898,12 @@ def s3_list_page(path: str, *, max_keys: int, continuation: str | None = None,
               "max-keys": str(max_keys)}
     if continuation:
         params["continuation-token"] = continuation
-    # _s3_request_url builds the unsigned URL (anonymous — byte-identical to the
+    # _s3_get_direct builds the unsigned URL (anonymous — byte-identical to the
     # old base?query with the dotted-bucket path-style rule) or the presigned
-    # URL (signable — the list params ride through the presigner). None is
-    # unreachable here (the remote is anonymous-or-signable per the gate above).
-    url = _s3_request_url(fs, rel, method="GET", query=params)
-    if url is None:
-        raise S3ListError(f"{path}: remote {fs!r} has no direct list URL")
+    # URL (signable — the list params ride through the presigner), and for a
+    # signable remote self-corrects the region on a wrong-region 301/400.
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
+        body = _s3_get_direct(fs, rel, query=params, timeout=timeout)
     except urllib.error.HTTPError as e:
         raise S3ListError(f"S3 list {path}: HTTP {e.code}") from e
     except (urllib.error.URLError, OSError) as e:
@@ -2092,25 +2178,36 @@ def _s3_head(path: str, timeout: float) -> DirectHead:
     m, rel = _mount_for(path)
     if rel == ".":
         return DirectHead(False, None, None)  # the mountpoint is not an object
-    # Unsigned public URL for anonymous, presigned HEAD URL for signable. HEAD
-    # is signed explicitly: a presigned GET rejects a HEAD request.
-    url = _s3_request_url(m["remote"], rel, method="HEAD")
-    if url is None:  # neither anonymous nor signable — let the caller fall back
-        raise DirectProbeError(f"{path}: no direct S3 object URL")
-    req = urllib.request.Request(url, method="HEAD")
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            size = resp.headers.get("Content-Length")
-            return DirectHead(
-                True,
-                int(size) if size and size.isdigit() else None,
-                _http_date_epoch(resp.headers.get("Last-Modified")))
-    except urllib.error.HTTPError as e:
-        if e.code == 404:
-            return DirectHead(False, None, None)  # trustworthy negative
-        raise DirectProbeError(f"S3 head {path}: HTTP {e.code}") from e
-    except (urllib.error.URLError, OSError) as e:
-        raise DirectProbeError(f"S3 head {path}: {e}") from e
+    fs = m["remote"]
+    # Anonymous: plain urlopen on the unsigned URL, byte-identical to before.
+    # Signable: presigned HEAD (signed explicitly — a presigned GET rejects a
+    # HEAD) through the non-redirect opener, self-correcting the region once on
+    # a wrong-region 301/400 so a probe doesn't wedge on an unset/wrong region.
+    anonymous = _anonymous_s3(_remote_config(fs.partition(":")[0]))
+    for attempt in (1, 2):
+        url = _s3_request_url(fs, rel, method="HEAD")
+        if url is None:  # neither anonymous nor signable — caller falls back
+            raise DirectProbeError(f"{path}: no direct S3 object URL")
+        req = urllib.request.Request(url, method="HEAD")
+        opener = (urllib.request.urlopen if anonymous
+                  else _NO_REDIRECT_OPENER.open)
+        try:
+            with opener(req, timeout=timeout) as resp:
+                size = resp.headers.get("Content-Length")
+                return DirectHead(
+                    True,
+                    int(size) if size and size.isdigit() else None,
+                    _http_date_epoch(resp.headers.get("Last-Modified")))
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return DirectHead(False, None, None)  # trustworthy negative
+            if (not anonymous and attempt == 1
+                    and _adopt_region_on_301(fs, e.code, e.headers)):
+                continue
+            raise DirectProbeError(f"S3 head {path}: HTTP {e.code}") from e
+        except (urllib.error.URLError, OSError) as e:
+            raise DirectProbeError(f"S3 head {path}: {e}") from e
+    raise DirectProbeError(f"S3 head {path}: region-correction retry exhausted")
 
 
 def _gcs_head(path: str, timeout: float) -> DirectHead:
@@ -2159,13 +2256,10 @@ def _s3_has_children(path: str, timeout: float) -> bool:
     # CommonPrefixes work we don't need for a boolean.
     params = {"list-type": "2", "prefix": prefix, "max-keys": "1"}
     # Unsigned for anonymous (byte-identical to the old base?query), presigned
-    # for signable — routed through the same helper the pager uses.
-    url = _s3_request_url(fs, rel, method="GET", query=params)
-    if url is None:
-        raise DirectProbeError(f"{path}: no direct S3 list URL")
+    # for signable (with region self-correction) — the same transport the pager
+    # uses via _s3_get_direct.
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
+        body = _s3_get_direct(fs, rel, query=params, timeout=timeout)
     except urllib.error.HTTPError as e:
         raise DirectProbeError(f"S3 list {path}: HTTP {e.code}") from e
     except (urllib.error.URLError, OSError) as e:
@@ -2213,16 +2307,6 @@ def upstream_url_for(path: str) -> str | None:
         return None
 
 
-def _remember_region(fs: str, region: str) -> None:
-    with _upstream_lock:
-        _upstream_region[fs] = region
-
-
-def _forget_region(fs: str) -> None:
-    with _upstream_lock:
-        _upstream_region.pop(fs, None)
-
-
 def _sign_validation_status(url: str) -> tuple[int, str | None]:
     """Sign mode's one validation probe: a Range: bytes=0-0 GET against a
     presigned URL, redirects NOT followed (see _NoRedirect). Returns (HTTP
@@ -2240,34 +2324,99 @@ def _sign_validation_status(url: str) -> tuple[int, str | None]:
         return 0, None
 
 
-def _validate_and_sign(fs: str, rel: str, cfg: dict) -> str | None:
+def _validate_and_sign(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
     """One-time sign-mode validation for a remote: presign a ranged GET for
-    `rel` and issue it once. Returns that presigned URL when S3 accepts the
-    signature (200/206/404/416 — a 404 means the signature was accepted and the
-    object is merely absent), self-correcting the region ONCE on a 301/400 that
-    carries x-amz-bucket-region (common for wrong-region private-bucket configs)
-    and re-signing. Returns None on 403 / network failure so the caller keeps
-    today's publiclink path — behavior identical to today for anything sign mode
-    can't serve."""
+    `rel` and issue it once, returning (url, verdict):
+      - (url, "ok")            S3 accepted the signature (200/206/404/416 — a
+                               404 means accepted, object merely absent);
+      - (None, "reject")       S3 definitively rejected it (403, or an
+                               uncorrectable 301/400) — sign mode can't serve
+                               this remote; the caller settles on publiclink;
+      - (None, "inconclusive") network error / 5xx — transient; the caller must
+                               NOT pin a mode so sign is re-attempted later.
+    The trial region is passed via region_override and NEVER published to
+    _upstream_region until the signature is accepted — so a losing racer can't
+    erase a winner's adopted region. Self-corrects the region ONCE on a 301/400
+    carrying x-amz-bucket-region and re-signs; on success writes
+    _upstream_region[fs] exactly once."""
     derived = _s3_bucket_prefix_region(fs, cfg)
     if derived is None:
-        return None
-    region = derived[2]
+        return None, "reject"
+    with _upstream_lock:
+        region = _upstream_region.get(fs, derived[2])  # a prior correction wins
+    verdict = "inconclusive"
     for attempt in (1, 2):
-        _remember_region(fs, region)  # _s3_request_url reads the adopted region
-        url = _s3_request_url(fs, rel, method="GET")
+        url = _s3_request_url(fs, rel, method="GET", region_override=region)
         if url is None:
-            break
+            return None, "reject"
         status, corrected = _sign_validation_status(url)
         if status in (200, 206, 404, 416):
-            return url
+            with _upstream_lock:
+                _upstream_region[fs] = region  # publish once, on success only
+            return url, "ok"
         if (attempt == 1 and status in (301, 400)
                 and corrected and corrected != region):
             region = corrected
             continue
+        # 403 / uncorrectable 301/400 (< 500) is a definite reject; a network
+        # error (status 0) or 5xx is inconclusive — don't let a transient blip
+        # permanently pin the remote to the slow link path (finding 7).
+        verdict = "reject" if 0 < status < 500 else "inconclusive"
         break
-    _forget_region(fs)  # don't leave a guessed/wrong region cached on failure
-    return None
+    return None, verdict
+
+
+def _sign_mode_url(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
+    """Resolve/serve sign mode for one request with per-fs single-flight, so N
+    concurrent first reads issue ONE validation GET instead of N. Returns
+    (url, disposition):
+      - (url, "sign")  sign mode active/just-validated -> use this presigned URL
+                       (url may be None if creds rotated away mid-flight — the
+                       caller then demotes and falls through, finding 4);
+      - (None, "link") validated as a definite reject, OR another thread owns
+                       validation -> use the publiclink ladder for this request;
+                       it's safe to cache mode="link";
+      - (None, "retry") validation inconclusive or negative-cached -> use the
+                       publiclink ladder for THIS request but DON'T pin a mode,
+                       so sign is re-attempted once the window lapses (findings
+                       5 and 7)."""
+    now = time.monotonic()
+    with _upstream_lock:
+        if _upstream_mode.get(fs) == "sign":
+            active = True
+        else:
+            active = False
+            if _sign_neg_cache.get(fs, 0.0) > now:
+                return None, "retry"  # recently failed -> skip validation window
+        lock = _validation_locks.setdefault(fs, threading.Lock())
+    if active:
+        return _s3_request_url(fs, rel, method="GET"), "sign"
+    if not lock.acquire(blocking=False):
+        return None, "retry"  # another thread is validating; don't pile on
+    try:
+        with _upstream_lock:
+            if _upstream_mode.get(fs) == "sign":
+                won = False
+            elif _sign_neg_cache.get(fs, 0.0) > time.monotonic():
+                return None, "retry"
+            else:
+                won = True
+        if not won:  # a racer finished validating while we took the lock
+            return _s3_request_url(fs, rel, method="GET"), "sign"
+        url, verdict = _validate_and_sign(fs, rel, cfg)
+        if verdict == "ok":
+            with _upstream_lock:
+                _upstream_mode[fs] = "sign"
+                _sign_neg_cache.pop(fs, None)
+            return url, "sign"
+        # Failed: negative-cache so we don't re-run the blocking validation GETs
+        # on every request while no fallback is committed (rcd down); a definite
+        # reject settles on "link", an inconclusive one leaves the mode open.
+        with _upstream_lock:
+            _sign_neg_cache[fs] = time.monotonic() + _SIGN_NEG_TTL_S
+        return None, ("link" if verdict == "reject" else "retry")
+    finally:
+        lock.release()
 
 
 def _upstream_url_for(path: str) -> str | None:
@@ -2283,31 +2432,51 @@ def _upstream_url_for(path: str) -> str | None:
         mode = _upstream_mode.get(fs)
     if mode == "none":
         return None
+    name = fs.partition(":")[0]
+    # cache_mode stays True unless a sign validation was INCONCLUSIVE (transient)
+    # — then we serve this request via publiclink but don't pin a mode, so sign
+    # is retried after the negative-cache window (findings 5, 7).
+    cache_mode = True
     if mode == "sign":
         # In-process signing is microseconds and creds rotate, so sign mode
-        # mints per object and never caches a link. None means creds stopped
-        # resolving (a rotated-away key) — the caller falls back to the serve
-        # until a remote change (Task 4 invalidation) resets the mode.
-        return _s3_request_url(fs, rel, method="GET")
+        # mints per object and never caches a link.
+        signed = _s3_request_url(fs, rel, method="GET")
+        if signed is not None:
+            return signed
+        # None means creds stopped resolving (a rotated-away key). Demote to the
+        # link ladder for this and future requests rather than returning None
+        # per-request forever (finding 4); a remote change (invalidation) or a
+        # cred refresh re-derives the mode from scratch. (No live 403 detection
+        # of an expired-but-present token — out of scope.)
+        with _upstream_lock:
+            if _upstream_mode.get(fs) == "sign":
+                _upstream_mode[fs] = "link"
+        mode = "link"
     url = None
     if mode is None:
-        cfg = _remote_config(fs.partition(":")[0])
+        cfg = _remote_config(name)
         if _cannot_presign(cfg):
             # Anonymous S3 or GCS can never presign — don't burn an rc call per
             # remote learning that from publiclink's "unsupported signer type"
             # error. CHECKED FIRST: an anonymous remote never resolves creds,
             # never signs, never issues the validation GET; its mode is "public".
             mode = "public"
-        elif _s3_signable(cfg):
+        elif _s3_signable(name, cfg):
             # Credentialed plain-AWS S3: presign locally instead of a publiclink
-            # rc call per object. Validate the signature once per fs before
-            # committing; on 403/network fall through to publiclink below.
-            signed = _validate_and_sign(fs, rel, cfg)
-            if signed is not None:
-                with _upstream_lock:
-                    _upstream_mode[fs] = "sign"
+            # rc call per object. Single-flight validation the first time; on a
+            # definite reject fall to publiclink ("link"), on a transient
+            # failure fall to publiclink for this request but keep retrying sign.
+            signed, disp = _sign_mode_url(fs, rel, cfg)
+            if disp == "sign" and signed is not None:
                 return signed
-            # validation inconclusive -> mode stays None, publiclink handles it
+            if disp == "sign":  # active but creds vanished -> demote (finding 4)
+                with _upstream_lock:
+                    if _upstream_mode.get(fs) == "sign":
+                        _upstream_mode[fs] = "link"
+                mode = "link"
+            elif disp == "retry":
+                cache_mode = False
+            # disp == "link": mode stays None; publiclink below caches "link"
     if mode in (None, "link"):
         port = _live_rcd_port()
         if port is None:
@@ -2332,7 +2501,8 @@ def _upstream_url_for(path: str) -> str | None:
     # _link_ttl reads config (takes _upstream_lock), so resolve it first.
     ttl = (_link_ttl(fs) if mode == "link" else 3600.0) if url is not None else 0.0
     with _upstream_lock:
-        _upstream_mode[fs] = mode
+        if cache_mode:
+            _upstream_mode[fs] = mode
         if url is not None:
             _store_upstream_link((fs, rel), url, now + ttl, now)
     return url

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1442,6 +1442,9 @@ _SIGN_EXPIRY_S = 15 * 60
 _SIGN_VALIDATE_TIMEOUT_S = 5.0
 _CRED_TTL_S = 60.0  # re-read env / ~/.aws so a rotated key / STS refresh lands
 _UPSTREAM_LINKS_CAP = 4096  # bound the publiclink cache (sign mode never inserts)
+# A publiclink URL minted under a dying STS token shouldn't stay replayable for
+# the full half hour, so a session-token remote gets a shorter link TTL.
+_SESSION_TOKEN_LINK_TTL_S = 5 * 60.0
 _upstream_lock = threading.Lock()
 _upstream_links: dict = {}  # (fs, rel) -> (url, monotonic expiry)
 _upstream_mode: dict = {}   # fs -> "link" | "public" | "none" | "sign"
@@ -1485,6 +1488,44 @@ def _remote_config(name: str) -> dict | None:
     with _upstream_lock:
         _upstream_cfg[name] = cfg
     return cfg
+
+
+def _invalidate_upstream_caches() -> None:
+    """Drop every memoized upstream fact — config, resolved mode/region,
+    credentials, and per-object links. Called on remote create/delete: those
+    change a remote's config or credentials out from under the memoization
+    (config/get is otherwise cached for the process lifetime), and a changed
+    key must be picked up without a restart. Wholesale, not per-name — these
+    are rare, user-initiated events, and for anonymous remotes it only forces a
+    cheap re-derivation of the public mode."""
+    with _upstream_lock:
+        _upstream_cfg.clear()
+        _upstream_mode.clear()
+        _upstream_region.clear()
+        _cred_cache.clear()
+        _upstream_links.clear()
+
+
+def _store_upstream_link(key, url: str, expiry: float, now: float) -> None:
+    """Insert into the bounded publiclink cache (caller holds _upstream_lock).
+    At the cap, evict expired entries first, then the oldest by expiry. Sign
+    mode never inserts, so this only guards the publiclink path."""
+    if key not in _upstream_links and len(_upstream_links) >= _UPSTREAM_LINKS_CAP:
+        for k in [k for k, (_u, exp) in _upstream_links.items() if exp <= now]:
+            del _upstream_links[k]
+        while len(_upstream_links) >= _UPSTREAM_LINKS_CAP:
+            del _upstream_links[min(_upstream_links,
+                                    key=lambda k: _upstream_links[k][1])]
+    _upstream_links[key] = (url, expiry)
+
+
+def _link_ttl(fs: str) -> float:
+    """publiclink cache TTL for `fs`: the short session-token clamp when the
+    remote carries an STS session_token, else _LINK_TTL_S. Must be called
+    WITHOUT _upstream_lock held (_remote_config takes it)."""
+    if (_remote_config(fs.partition(":")[0]) or {}).get("session_token"):
+        return _SESSION_TOKEN_LINK_TTL_S
+    return _LINK_TTL_S
 
 
 def _anonymous_s3(cfg: dict | None) -> bool:
@@ -2288,11 +2329,12 @@ def _upstream_url_for(path: str) -> str | None:
         # builder recognizes the remote returns a non-None URL, the rest None.
         url = _public_object_url(fs, rel) or _gcs_public_object_url(fs, rel)
         mode = "public" if url else "none"
+    # _link_ttl reads config (takes _upstream_lock), so resolve it first.
+    ttl = (_link_ttl(fs) if mode == "link" else 3600.0) if url is not None else 0.0
     with _upstream_lock:
         _upstream_mode[fs] = mode
         if url is not None:
-            ttl = _LINK_TTL_S if mode == "link" else 3600.0
-            _upstream_links[(fs, rel)] = (url, now + ttl)
+            _store_upstream_link((fs, rel), url, now + ttl, now)
     return url
 
 
@@ -3307,6 +3349,7 @@ def delete_mount(cid: str, x_fused: str | None = Header(default=None)):
         os.rmdir(mp)
     remove_mount(cid)
     sync_serves()  # stop the deleted mount's HTTP serve, drop its map entry
+    _invalidate_upstream_caches()  # the gone remote's memoized facts mustn't linger
     return {"ok": True}
 
 
@@ -3343,6 +3386,7 @@ def create_remote(body: dict = Body(...), x_fused: str | None = Header(default=N
         return JSONResponse({"error": "rclone config create timed out (30s)"}, status_code=502)
     if r.returncode != 0:
         return JSONResponse({"error": (r.stderr or r.stdout or "").strip()[-500:]}, status_code=502)
+    _invalidate_upstream_caches()  # new/changed keys must be picked up without restart
     return {"ok": True, "name": name + ":"}
 
 
@@ -3474,4 +3518,5 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
                              "automatically — delete it manually before "
                              "retrying)")
             return JSONResponse({"error": cred_err}, status_code=502)
+    _invalidate_upstream_caches()  # new/changed keys must be picked up without restart
     return {"ok": True, "name": name + ":"}

--- a/fused_render/shell/pathops.py
+++ b/fused_render/shell/pathops.py
@@ -135,9 +135,12 @@ def list_mount_dir(path, *, cursor=None, max_entries, page_timeout=None,
 
     Returns a MountListing. Does ZERO kernel I/O on `path`. Raises exactly what
     the underlying primitives raise, for the caller to map:
-      * mounts.DirectListError — only when the direct route fails AND
-        allow_rc_fallback is False (a cursored /api/fs/list request that must not
-        silently re-list page 1 via rc);
+      * mounts.DirectListError — when allow_rc_fallback is False and the direct
+        route is unavailable, i.e. either a direct page failed OR the path is not
+        direct_list_capable (it can flip between the caller's gate and this call).
+        allow_rc_fallback=False means rc is unreachable, period: a cursored
+        /api/fs/list request must never silently re-list page 1 via rc, and an rc
+        error must not escape the caller's `except DirectListError`;
       * mounts.RcListTimeout / RcListUnavailable / RcListError — from the rc
         route (the caller maps these to 503 / 400 as it already did).
 
@@ -157,6 +160,15 @@ def list_mount_dir(path, *, cursor=None, max_entries, page_timeout=None,
             if not allow_rc_fallback:
                 raise
             # fall through to the rc route on the same request
+    elif not allow_rc_fallback:
+        # Not direct-capable and the caller forbade rc: the direct route this
+        # call is meant to drive is simply unavailable (capability can flip
+        # between the caller's direct_list_capable gate and here). Raising
+        # keeps rc unreachable when allow_rc_fallback is False — a silent rc
+        # result would skip the caller's cap / broken-mount handling and an rc
+        # error would escape its `except DirectListError`.
+        raise mounts.DirectListError(
+            f"not direct-list-capable and rc fallback disabled: {path}")
     listed = mounts.rc_list_dir(path, timeout=rc_timeout)
     return MountListing(listed, None, direct=False)
 

--- a/fused_render/shell/pathops.py
+++ b/fused_render/shell/pathops.py
@@ -1,0 +1,205 @@
+"""pathops — mount-aware path operations facade.
+
+The one place that knows the mount-vs-local branching for the two operations
+that were, before this module, re-implemented across server.py: listing a
+directory (the direct→rc ladder) and probing whether a path is an existing file
+(the tri-state, fail-open kernel-free probe). Predicates and the low-level rc /
+direct primitives still live in mounts.py; this module only composes them so the
+composition can't drift between call sites.
+
+Layering: pathops imports ONLY mounts.py (never server). The shell↛server
+acyclic rule (see shell/bookmarks.py) holds — server depends on pathops, not the
+other way around.
+
+The mount-wedge invariant is load-bearing: on a mount-backed path these helpers
+NEVER issue a kernel os.scandir/os.stat/os.path.* — not even on an error path. A
+cold kernel READDIR/GETATTR over an rclone NFS mount forces rclone to enumerate
+the whole remote prefix, which trips the macOS NFS deadman and kills the mount
+(the mur-sst / stat-storm incidents documented in mounts.py). Every mount branch
+here routes through the rcd rc API or the direct S3/GCS pager instead.
+
+The mounts-module functions are looked up as ATTRIBUTES at call time (never bound
+at import), so tests that monkeypatch e.g. mounts.rc_list_dir / rc_kind_for —
+often via late imports — take effect here too.
+"""
+import logging
+import os
+import time
+
+from fused_render.shell import mounts
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------- directory listing
+
+
+def _accumulate_direct_pages(path, cursor, max_entries, *,
+                             page_timeout=None, overall_timeout=None):
+    """Accumulate raw direct-listing entries (Name/Size/IsDir/ModTime dicts, the
+    shared rc/direct shape) for a mount-backed dir on an anonymous S3 or GCS
+    remote, up to `max_entries`. The one page-accumulation loop shared by
+    /api/fs/list and the walk; the backend (S3 ListObjectsV2 vs GCS
+    objects.list) is picked per-path by mounts.direct_list_page.
+
+    Each page requests only min(1000, remaining) keys, so the accumulation never
+    overshoots `max_entries` (a whole extra 1000-key page could otherwise push a
+    LIST_MAX_ENTRIES=10k cap to 10,999) while the returned continuation token
+    still resumes cleanly. `overall_timeout` bounds total wall time across pages
+    so a slow bucket can't stall a request unboundedly; the FIRST page always
+    gets the full `page_timeout` (progress guarantee), later pages shrink toward
+    the deadline.
+
+    Returns (entries, next_token); a non-None token means the listing is partial
+    (either the cap bit or the budget expired) and is resumable. Raises
+    mounts.DirectListError only when the FIRST page fails (nothing to return); a
+    mid-listing page failure logs and returns what was accumulated as a partial
+    with the last good token, since discarding thousands of fetched entries to
+    re-list via rc (which can't paginate at all) would turn a partial success
+    into a guaranteed failure."""
+    entries: list = []
+    token = cursor or None
+    deadline = None if overall_timeout is None else time.monotonic() + overall_timeout
+    while True:
+        remaining = max_entries - len(entries)
+        if remaining <= 0:
+            break
+        t = page_timeout
+        # The first page always runs with the full page timeout (the progress
+        # guarantee — even a zero budget returns one page). Later pages shrink
+        # to the budget's remainder, and stop before it reaches zero: a
+        # non-positive timeout would hit urlopen as a ValueError, not a
+        # DirectListError (Bugbot), and token is already a valid resume point.
+        if deadline is not None and entries:
+            left = deadline - time.monotonic()
+            if left <= 0:
+                break
+            t = left if t is None else min(t, left)
+        try:
+            page, next_token = mounts.direct_list_page(
+                path, max_keys=min(1000, remaining), continuation=token, timeout=t)
+        except mounts.DirectListError:
+            if not entries:
+                raise
+            logger.warning("direct-listing page for %r failed mid-listing; "
+                           "returning %d accumulated entries as partial",
+                           path, len(entries))
+            return entries, token
+        token = next_token
+        entries.extend(page)
+        if token is None:
+            break
+        # Budget checked AFTER a page so the loop always makes progress; the
+        # token from the last fetched page is a valid resume point.
+        if deadline is not None and time.monotonic() >= deadline:
+            break
+    return entries, token
+
+
+class MountListing:
+    """The raw result of listing a mount-backed directory through the direct→rc
+    ladder, before any caller-specific shaping (sort / cap / entry adaptation /
+    error→HTTP mapping — those stay with the caller).
+
+      * entries — the operations/list-shape dicts (Name/Size/IsDir/ModTime), from
+        either the direct S3/GCS pager or the rcd rc listing;
+      * token   — a resume cursor for the DIRECT route (non-None ⇒ the listing is
+        partial and resumable); always None on the rc route (rclone can't
+        paginate a listing at any layer);
+      * direct  — True when the direct pager produced this, False for the rc
+        route. Callers shape the two differently (the direct route is resumable
+        and pre-capped at max_entries; the rc route returns the whole listing and
+        the caller sorts-then-caps), so they need to know which one ran.
+    """
+
+    __slots__ = ("entries", "token", "direct")
+
+    def __init__(self, entries, token, direct):
+        self.entries = entries
+        self.token = token
+        self.direct = direct
+
+
+def list_mount_dir(path, *, cursor=None, max_entries, page_timeout=None,
+                   overall_timeout=None, rc_timeout=None, allow_rc_fallback=True):
+    """List a MOUNT-BACKED directory via the direct→rc ladder, off the kernel.
+
+    The ladder, single-sourced here so /api/fs/list and the fs/walk can't drift:
+      1. direct_list_capable (anonymous plain AWS S3 / anonymous GCS): page the
+         store's own listing API — rclone can't paginate its listing, so a
+         million-key prefix would time out on the rc route. Accumulate up to
+         `max_entries` within the `page_timeout`/`overall_timeout` budget.
+      2. otherwise, or (when `allow_rc_fallback`) after a direct page failure:
+         the rcd rc listing (operations/list), bounded by `rc_timeout`
+         (rc_list_dir's own default when None).
+
+    Returns a MountListing. Does ZERO kernel I/O on `path`. Raises exactly what
+    the underlying primitives raise, for the caller to map:
+      * mounts.DirectListError — only when the direct route fails AND
+        allow_rc_fallback is False (a cursored /api/fs/list request that must not
+        silently re-list page 1 via rc);
+      * mounts.RcListTimeout / RcListUnavailable / RcListError — from the rc
+        route (the caller maps these to 503 / 400 as it already did).
+
+    `path` is assumed mount-backed (the caller gates on is_mount_backed); this
+    function does not re-check, and the mounts_root special case and the local
+    scandir route stay with the caller (they diverge per call site — see the
+    server rewires). `allow_rc_fallback=True` is the fs/walk's full-ladder use;
+    /api/fs/list drives the direct route with allow_rc_fallback=False and keeps
+    its own warning / cursor-503 / rc handling as HTTP response shaping."""
+    if mounts.direct_list_capable(path):
+        try:
+            entries, token = _accumulate_direct_pages(
+                path, cursor, max_entries,
+                page_timeout=page_timeout, overall_timeout=overall_timeout)
+            return MountListing(entries, token, direct=True)
+        except mounts.DirectListError:
+            if not allow_rc_fallback:
+                raise
+            # fall through to the rc route on the same request
+    listed = mounts.rc_list_dir(path, timeout=rc_timeout)
+    return MountListing(listed, None, direct=False)
+
+
+# ----------------------------------------------------------- file existence probe
+
+# rc_kind_for outcomes that count as "this is a file". "indeterminate" is
+# included deliberately — the probe FAILS OPEN: an rcd hiccup / timeout must not
+# 404 a file the user just opened. Only a confirmed "dir" or "missing" is a
+# negative. Single-sourced here so _is_file_mount_safe and recents' _mount_exists
+# can't drift on the fail-open contract.
+_MOUNT_FILE_OK = ("file", "indeterminate")
+
+
+def mount_is_file(path) -> bool:
+    """os.path.isfile for a KNOWN mount-backed path, answered by the rcd rc API
+    (mounts.rc_kind_for) and NEVER a kernel stat — a cold GETATTR over the mount
+    is the call that lists the whole parent prefix and wedges it. Fails OPEN on
+    an indeterminate probe (see _MOUNT_FILE_OK). For callers that have already
+    established the path is mount-backed (they must not pay a second gate)."""
+    return mounts.rc_kind_for(path) in _MOUNT_FILE_OK
+
+
+def local_is_file(path) -> bool:
+    """os.path.isfile for a LOCAL (non-mount-backed) path. A plain kernel stat is
+    safe and cheap here — the mount-wedging GETATTR concern only applies under a
+    managed mount. The OSError guard mirrors the callers it replaces; os.path
+    already swallows OSError, so this changes nothing observable."""
+    try:
+        return os.path.isfile(path)
+    except OSError:
+        return False
+
+
+def is_file(path) -> bool:
+    """Mount-safe os.path.isfile: dispatches on is_mount_backed, then answers a
+    mount-backed path through the rc API (never the kernel — the wedge class) and
+    a local path through the kernel. Fails OPEN on an indeterminate mount probe.
+
+    The single gate+dispatch; callers that already know the side (recents
+    pre-gates to pick an executor) use mount_is_file / local_is_file directly so
+    a local path never pays a second is_mount_backed (whose symlink re-check is a
+    kernel realpath)."""
+    if mounts.is_mount_backed(path):
+        return mount_is_file(path)
+    return local_is_file(path)

--- a/fused_render/shell/recents.py
+++ b/fused_render/shell/recents.py
@@ -127,11 +127,12 @@ def _file_path_from_url(url: str) -> str | None:
 def _local_exists(fs_path: str) -> bool:
     """Existence of a LOCAL (non-mount-backed) path. A plain os.path.isfile is
     safe and cheap here — the mount-wedging GETATTR concern only applies under a
-    managed mount, which _keep_entry routes away from this call."""
-    try:
-        return os.path.isfile(fs_path)
-    except OSError:
-        return False
+    managed mount, which _keep_entry routes away from this call. Delegates to the
+    shared local leaf (pathops.local_is_file) so the local existence check is
+    single-sourced with server._is_file_mount_safe."""
+    from fused_render.shell import pathops
+
+    return pathops.local_is_file(fs_path)
 
 
 def _mount_exists(fs_path: str) -> bool:
@@ -145,11 +146,13 @@ def _mount_exists(fs_path: str) -> bool:
     os.path.isfile): a confirmed "dir" filters the entry just like a "missing"
     would. Only a "file" or an "indeterminate" probe (rcd down / timed out /
     errored — rc can't prove anything) keeps it: we fail open rather than hide a
-    live recent on a transient rc hiccup."""
-    from fused_render.shell import mounts as shell_mounts
+    live recent on a transient rc hiccup. The rc_kind_for probe and its
+    file/indeterminate fail-open contract are single-sourced in
+    pathops.mount_is_file (shared with server._is_file_mount_safe)."""
+    from fused_render.shell import pathops
 
     try:
-        return shell_mounts.rc_kind_for(fs_path) in ("file", "indeterminate")
+        return pathops.mount_is_file(fs_path)
     except Exception:
         return True  # unexpected error -> fail open, keep the entry
 

--- a/fused_render/shell/s3sign.py
+++ b/fused_render/shell/s3sign.py
@@ -1,0 +1,179 @@
+"""Stdlib AWS SigV4 query presigner + local S3 credential resolver.
+
+Private-bucket S3 mounts get the same fast direct reads and paginated
+listings the anonymous/public ones already have, by signing the store's own
+URLs locally instead of round-tripping rcd's operations/publiclink per object.
+SigV4 query presigning is a well-specified ~80-line HMAC computation with
+published test vectors, so it lives here in pure stdlib (hmac/hashlib/
+urllib.parse) — no botocore/boto3 dependency to bundle into the DMG.
+
+Two concerns, kept separate:
+  - presign_url: given a URL + credentials + region, return the same URL with
+    the X-Amz-* query parameters that make S3 accept it unauthenticated for
+    the URL's expiry window. Method-aware (a presigned GET rejects a HEAD, so
+    probes must sign HEAD explicitly); session-token aware; UNSIGNED-PAYLOAD
+    with host the only signed header. The timestamp is a parameter so the
+    output is reproducible under test.
+  - resolve_credentials: the three cheap credential sources (remote config
+    keys, environment, shared credentials file). SSO/IMDS/credential_process
+    return None — the caller keeps its existing publiclink path for those.
+
+This module is PURE: no caching, no rc calls, no logging of URLs. Caching and
+the one-time signature validation live in shell/mounts.py, which composes the
+store URL (path-style via _s3_base_url) and hands it here to sign.
+"""
+import configparser
+import datetime
+import hashlib
+import hmac
+import os
+import urllib.parse
+from collections import namedtuple
+
+_ALGORITHM = "AWS4-HMAC-SHA256"
+# S3 accepts a signature computed over the literal "UNSIGNED-PAYLOAD" for a
+# presigned URL — the body is never hashed, which is what lets us sign without
+# reading the object.
+_UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
+_SERVICE = "s3"
+
+# Static AWS credentials. session_token is None unless the source carries an
+# STS token (env / shared-file / config session_token) — when present it must
+# ride along as X-Amz-Security-Token or S3 rejects the signature.
+Credentials = namedtuple("Credentials", ["access_key", "secret_key",
+                                          "session_token"])
+
+
+def _uri_encode(value: str) -> str:
+    """RFC3986 percent-encoding for a query key/value: only the unreserved set
+    A-Za-z0-9-_.~ stays literal (so '/' in X-Amz-Credential becomes %2F and a
+    space becomes %20, never '+') — exactly what SigV4 canonicalization and the
+    final query string both require."""
+    return urllib.parse.quote(str(value), safe="-_.~")
+
+
+def _sign(key: bytes, msg: str) -> bytes:
+    return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
+
+
+def _signing_key(secret: str, date_stamp: str, region: str) -> bytes:
+    k_date = _sign(("AWS4" + secret).encode("utf-8"), date_stamp)
+    k_region = _sign(k_date, region)
+    k_service = _sign(k_region, _SERVICE)
+    return _sign(k_service, "aws4_request")
+
+
+def presign_url(url: str, *, method: str, region: str,
+                credentials: Credentials, expires: int = 900,
+                extra_query: dict | None = None,
+                timestamp: datetime.datetime | None = None) -> str:
+    """Return `url` with the SigV4 query parameters that authorize `method` on
+    it for `expires` seconds. The host is taken from `url` verbatim, so the
+    caller controls virtual-hosted vs path-style addressing (private dotted
+    buckets go path-style via _s3_base_url, which SigV4 handles because only
+    the Host header — not the bucket-in-path — is signed).
+
+    `extra_query` (e.g. ListObjectsV2's list-type/prefix/delimiter/max-keys)
+    is merged in and signed, so those parameters are canonicalized in this one
+    place. The path in `url` is used as the canonical URI unchanged: S3 signs a
+    single-encoded key, and callers pass keys already quoted with '/' kept."""
+    if timestamp is None:
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
+    amz_date = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = timestamp.strftime("%Y%m%d")
+
+    parts = urllib.parse.urlsplit(url)
+    host = parts.netloc
+    canonical_uri = parts.path or "/"
+    scope = f"{date_stamp}/{region}/{_SERVICE}/aws4_request"
+
+    # Every query parameter is part of the signature except the signature
+    # itself. Start from any params already on the URL, then the caller's
+    # extras, then the fixed X-Amz-* set.
+    query: dict = dict(urllib.parse.parse_qsl(parts.query,
+                                              keep_blank_values=True))
+    if extra_query:
+        query.update(extra_query)
+    query["X-Amz-Algorithm"] = _ALGORITHM
+    query["X-Amz-Credential"] = f"{credentials.access_key}/{scope}"
+    query["X-Amz-Date"] = amz_date
+    query["X-Amz-Expires"] = str(int(expires))
+    query["X-Amz-SignedHeaders"] = "host"
+    if credentials.session_token:
+        query["X-Amz-Security-Token"] = credentials.session_token
+
+    canonical_qs = "&".join(f"{_uri_encode(k)}={_uri_encode(v)}"
+                            for k, v in sorted(query.items()))
+    canonical_headers = f"host:{host}\n"
+    canonical_request = "\n".join([
+        method.upper(), canonical_uri, canonical_qs,
+        canonical_headers, "host", _UNSIGNED_PAYLOAD])
+    string_to_sign = "\n".join([
+        _ALGORITHM, amz_date, scope,
+        hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()])
+    signature = hmac.new(_signing_key(credentials.secret_key, date_stamp,
+                                      region),
+                         string_to_sign.encode("utf-8"),
+                         hashlib.sha256).hexdigest()
+    query["X-Amz-Signature"] = signature
+
+    final_qs = "&".join(f"{_uri_encode(k)}={_uri_encode(v)}"
+                        for k, v in sorted(query.items()))
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, canonical_uri, final_qs, ""))
+
+
+def _from_shared_file(cfg: dict) -> Credentials | None:
+    """Static keys from an AWS shared-credentials file. Path: cfg's
+    shared_credentials_file, else AWS_SHARED_CREDENTIALS_FILE, else
+    ~/.aws/credentials. Profile: cfg's profile, else AWS_PROFILE, else
+    'default'. None when the file/section/keys are absent."""
+    path = (cfg.get("shared_credentials_file")
+            or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+            or os.path.expanduser("~/.aws/credentials"))
+    if not os.path.isfile(path):
+        return None
+    parser = configparser.ConfigParser()
+    try:
+        parser.read(path)
+    except configparser.Error:
+        return None
+    profile = cfg.get("profile") or os.environ.get("AWS_PROFILE") or "default"
+    if not parser.has_section(profile):
+        return None
+    section = parser[profile]
+    access = section.get("aws_access_key_id")
+    secret = section.get("aws_secret_access_key")
+    if access and secret:
+        return Credentials(access, secret,
+                           section.get("aws_session_token") or None)
+    return None
+
+
+def resolve_credentials(cfg: dict | None) -> Credentials | None:
+    """Resolve static AWS credentials for an S3 remote config, cheapest source
+    first, or None when only out-of-scope sources exist (SSO / IMDS /
+    credential_process) — then the caller keeps today's publiclink path:
+      1. explicit access_key_id/secret_access_key in the remote config
+         (rclone's config/get returns the plaintext secret on the pinned
+         version, so no config-dump fallback is needed);
+      2. environment (AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN) when env_auth;
+      3. the shared credentials file when env_auth or a profile /
+         shared_credentials_file is configured.
+    Non-S3 or empty configs return None."""
+    if not isinstance(cfg, dict) or cfg.get("type") != "s3":
+        return None
+    access = cfg.get("access_key_id")
+    secret = cfg.get("secret_access_key")
+    if access and secret:
+        return Credentials(access, secret, cfg.get("session_token") or None)
+    env_auth = str(cfg.get("env_auth", "")).lower() == "true"
+    if env_auth:
+        access = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+        if access and secret:
+            return Credentials(access, secret,
+                               os.environ.get("AWS_SESSION_TOKEN") or None)
+    if env_auth or cfg.get("profile") or cfg.get("shared_credentials_file"):
+        return _from_shared_file(cfg)
+    return None

--- a/fused_render/shell/s3sign.py
+++ b/fused_render/shell/s3sign.py
@@ -128,9 +128,10 @@ def _from_shared_file(cfg: dict) -> Credentials | None:
     shared_credentials_file, else AWS_SHARED_CREDENTIALS_FILE, else
     ~/.aws/credentials. Profile: cfg's profile, else AWS_PROFILE, else
     'default'. None when the file/section/keys are absent."""
-    path = (cfg.get("shared_credentials_file")
-            or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
-            or os.path.expanduser("~/.aws/credentials"))
+    path = os.path.expanduser(
+        cfg.get("shared_credentials_file")
+        or os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+        or "~/.aws/credentials")
     if not os.path.isfile(path):
         return None
     parser = configparser.ConfigParser()

--- a/tests/test_s3_sign.py
+++ b/tests/test_s3_sign.py
@@ -187,3 +187,26 @@ def test_resolver_env_auth_missing_env_falls_to_none(tmp_path, monkeypatch):
     monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "absent"))
     assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) is None
+
+
+def test_resolver_expands_tilde_in_shared_credentials_file(tmp_path, monkeypatch):
+    # A ~-relative shared_credentials_file must be expanded, matching botocore
+    # and mounts._aws_profiles — a verbatim "~/..." path never resolves.
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    (home / "creds").write_text(
+        "[default]\naws_access_key_id = AKIATILDE\n"
+        "aws_secret_access_key = TILDESEC\n", encoding="utf-8")
+    # cfg-supplied ~ path expands.
+    assert s3sign.resolve_credentials(
+        {"type": "s3", "shared_credentials_file": "~/creds"}) == \
+        s3sign.Credentials("AKIATILDE", "TILDESEC", None)
+    # env-supplied ~ path expands too.
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "~/creds")
+    assert s3sign.resolve_credentials(
+        {"type": "s3", "env_auth": "true"}) == \
+        s3sign.Credentials("AKIATILDE", "TILDESEC", None)

--- a/tests/test_s3_sign.py
+++ b/tests/test_s3_sign.py
@@ -1,0 +1,189 @@
+"""Unit tests for the stdlib SigV4 query presigner and the local S3
+credential resolver (shell/s3sign.py). Pure — no network, no rclone.
+
+The presigner is checked against AWS's own published SigV4 test vector for a
+GET presigned S3 URL (docs.aws.amazon.com/AmazonS3/.../sigv4-query-string-auth):
+a fixed key pair, region, timestamp and expiry yield one exact signature hex.
+The resolver is checked with monkeypatched env vars and tmp credentials files.
+"""
+import datetime
+
+import pytest
+
+import fused_render.shell.s3sign as s3sign
+
+# AWS's published example (SigV4 query-string auth, "GET Object"):
+#   key    AKIAIOSFODNN7EXAMPLE / wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+#   region us-east-1, service s3, expires 86400
+#   time   20130524T000000Z, host examplebucket.s3.amazonaws.com, key test.txt
+_AWS_ACCESS = "AKIAIOSFODNN7EXAMPLE"
+_AWS_SECRET = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+_AWS_TS = datetime.datetime(2013, 5, 24, 0, 0, 0, tzinfo=datetime.timezone.utc)
+_AWS_EXPECTED_SIG = (
+    "aeeed9bbccd4d02ee5c0109b86d86835f995330da4c265957d157751f604d404")
+
+
+def _sig_of(url):
+    import urllib.parse
+    q = dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
+    return q["X-Amz-Signature"]
+
+
+# ------------------------------------------------------------------- presigner
+
+
+def test_presign_matches_aws_published_get_vector():
+    creds = s3sign.Credentials(_AWS_ACCESS, _AWS_SECRET, None)
+    url = s3sign.presign_url(
+        "https://examplebucket.s3.amazonaws.com/test.txt",
+        method="GET", region="us-east-1", credentials=creds,
+        expires=86400, timestamp=_AWS_TS)
+    assert _sig_of(url) == _AWS_EXPECTED_SIG
+    # The query carries the full SigV4 parameter set.
+    for p in ("X-Amz-Algorithm", "X-Amz-Credential", "X-Amz-Date",
+              "X-Amz-Expires", "X-Amz-SignedHeaders", "X-Amz-Signature"):
+        assert p in url
+    assert "X-Amz-SignedHeaders=host" in url
+    assert "X-Amz-Security-Token" not in url  # no session token given
+
+
+def test_presign_head_differs_from_get():
+    # HEAD must be signed as HEAD (a presigned GET rejects a HEAD request), so
+    # the method is part of the canonical request and the signatures differ.
+    creds = s3sign.Credentials(_AWS_ACCESS, _AWS_SECRET, None)
+    common = dict(region="us-east-1", credentials=creds, expires=86400,
+                  timestamp=_AWS_TS)
+    get = s3sign.presign_url("https://examplebucket.s3.amazonaws.com/test.txt",
+                             method="GET", **common)
+    head = s3sign.presign_url("https://examplebucket.s3.amazonaws.com/test.txt",
+                              method="HEAD", **common)
+    assert _sig_of(get) != _sig_of(head)
+
+
+def test_presign_includes_session_token_when_present():
+    creds = s3sign.Credentials(_AWS_ACCESS, _AWS_SECRET, "FQoGZXIvYXdzEXAMPLE//")
+    url = s3sign.presign_url(
+        "https://examplebucket.s3.amazonaws.com/test.txt",
+        method="GET", region="us-east-1", credentials=creds,
+        expires=900, timestamp=_AWS_TS)
+    # Token is a signed query parameter — present and URL-encoded (no raw /).
+    assert "X-Amz-Security-Token=FQoGZXIvYXdzEXAMPLE%2F%2F" in url
+
+
+def test_presign_path_style_dotted_bucket_host_is_signed():
+    # A dotted bucket must go path-style (the caller uses _s3_base_url); the
+    # host in the signature is then the regional s3 endpoint, path carries the
+    # bucket. Just assert a signature is produced over that host/path shape.
+    creds = s3sign.Credentials(_AWS_ACCESS, _AWS_SECRET, None)
+    url = s3sign.presign_url(
+        "https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/a/b",
+        method="GET", region="us-west-2", credentials=creds,
+        expires=900, timestamp=_AWS_TS)
+    assert "X-Amz-Signature=" in url
+    assert url.startswith(
+        "https://s3.us-west-2.amazonaws.com/us-west-2.opendata.source.coop/a/b?")
+
+
+def test_presign_extra_query_is_signed_and_canonicalized():
+    # ListObjectsV2 params flow through the presigner so they're canonicalized
+    # once. They must appear in the output and be part of the signature.
+    creds = s3sign.Credentials(_AWS_ACCESS, _AWS_SECRET, None)
+    q = {"list-type": "2", "delimiter": "/", "prefix": "a/b c/",
+         "max-keys": "1000"}
+    with_q = s3sign.presign_url(
+        "https://examplebucket.s3.amazonaws.com/", method="GET",
+        region="us-east-1", credentials=creds, expires=900,
+        timestamp=_AWS_TS, extra_query=q)
+    without_q = s3sign.presign_url(
+        "https://examplebucket.s3.amazonaws.com/", method="GET",
+        region="us-east-1", credentials=creds, expires=900, timestamp=_AWS_TS)
+    assert "list-type=2" in with_q
+    assert "prefix=a%2Fb%20c%2F" in with_q  # space is %20, slash %2F
+    assert _sig_of(with_q) != _sig_of(without_q)  # query is signed
+
+
+# -------------------------------------------------------------------- resolver
+
+
+def test_resolver_prefers_config_keys():
+    cfg = {"type": "s3", "access_key_id": "AKIACFG", "secret_access_key": "SEC"}
+    creds = s3sign.resolve_credentials(cfg)
+    assert creds == s3sign.Credentials("AKIACFG", "SEC", None)
+
+
+def test_resolver_config_keys_carry_session_token():
+    cfg = {"type": "s3", "access_key_id": "AKIACFG",
+           "secret_access_key": "SEC", "session_token": "TOK"}
+    assert s3sign.resolve_credentials(cfg).session_token == "TOK"
+
+
+def test_resolver_env_auth_reads_environment(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENVSEC")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "ENVTOK")
+    creds = s3sign.resolve_credentials({"type": "s3", "env_auth": "true"})
+    assert creds == s3sign.Credentials("AKIAENV", "ENVSEC", "ENVTOK")
+
+
+def test_resolver_shared_credentials_file_and_profile(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_PROFILE", raising=False)
+    cred = tmp_path / "credentials"
+    cred.write_text(
+        "[default]\n"
+        "aws_access_key_id = AKIADEFAULT\n"
+        "aws_secret_access_key = DEFSEC\n\n"
+        "[work]\n"
+        "aws_access_key_id = AKIAWORK\n"
+        "aws_secret_access_key = WORKSEC\n"
+        "aws_session_token = WORKTOK\n",
+        encoding="utf-8")
+    # profile from cfg selects the [work] section.
+    creds = s3sign.resolve_credentials(
+        {"type": "s3", "env_auth": "true", "profile": "work",
+         "shared_credentials_file": str(cred)})
+    assert creds == s3sign.Credentials("AKIAWORK", "WORKSEC", "WORKTOK")
+    # No cfg profile -> AWS_PROFILE env; here unset -> default section.
+    creds2 = s3sign.resolve_credentials(
+        {"type": "s3", "env_auth": "true",
+         "shared_credentials_file": str(cred)})
+    assert creds2 == s3sign.Credentials("AKIADEFAULT", "DEFSEC", None)
+
+
+def test_resolver_profile_from_aws_profile_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    cred = tmp_path / "credentials"
+    cred.write_text(
+        "[team]\naws_access_key_id = AKIATEAM\n"
+        "aws_secret_access_key = TEAMSEC\n", encoding="utf-8")
+    monkeypatch.setenv("AWS_PROFILE", "team")
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred))
+    creds = s3sign.resolve_credentials({"type": "s3", "env_auth": "true"})
+    assert creds == s3sign.Credentials("AKIATEAM", "TEAMSEC", None)
+
+
+def test_resolver_none_for_sso_shaped_config(tmp_path, monkeypatch):
+    # SSO / credential_process configs carry no static keys, no env, no file
+    # entry -> out of scope -> None (caller keeps the publiclink path).
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "none"))
+    cfg = {"type": "s3", "sso_start_url": "https://x.awsapps.com/start",
+           "sso_account_id": "123456789012"}
+    assert s3sign.resolve_credentials(cfg) is None
+
+
+def test_resolver_none_for_empty_or_non_s3():
+    assert s3sign.resolve_credentials({}) is None
+    assert s3sign.resolve_credentials(None) is None
+    assert s3sign.resolve_credentials(
+        {"type": "google cloud storage"}) is None
+
+
+def test_resolver_env_auth_missing_env_falls_to_none(tmp_path, monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "absent"))
+    assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) is None

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2384,6 +2384,99 @@ def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_ups
     assert mounts_mod._upstream_mode["aws-open:bucket/pre fix"] == "public"
 
 
+# -- upstream cache hygiene (Task 4) -----------------------------------------
+
+
+def test_create_remote_invalidates_upstream_caches(client, fresh_upstream, monkeypatch):
+    # The stale-_upstream_cfg bug: a changed key must be picked up without a
+    # restart. Creating a remote clears every memoized upstream fact.
+    mounts_mod._upstream_cfg["mys3"] = {"type": "s3", "stale": True}
+    mounts_mod._upstream_mode["mys3:bucket"] = "link"
+    mounts_mod._upstream_links[("mys3:bucket", "x")] = ("u", 9e18)
+    mounts_mod._cred_cache["mys3"] = (None, 9e18)
+    mounts_mod._upstream_region["mys3:bucket"] = "us-east-1"
+
+    class _R:
+        returncode, stdout, stderr = 0, "", ""
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", lambda cmd, **kw: _R())
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+    r = client.post("/api/mounts/remotes", json={
+        "name": "mys3",
+        "params": {"access_key_id": "AK", "secret_access_key": "SK"}},
+        headers=FUSED)
+    assert r.status_code == 200
+    assert mounts_mod._upstream_cfg == {}
+    assert mounts_mod._upstream_mode == {}
+    assert mounts_mod._upstream_links == {}
+    assert mounts_mod._cred_cache == {}
+    assert mounts_mod._upstream_region == {}
+
+
+def test_delete_mount_invalidates_upstream_caches(client, rcd, fresh_upstream, monkeypatch):
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    mounts_mod._upstream_cfg["remote"] = {"type": "s3"}
+    mounts_mod._upstream_mode["remote:bucket"] = "link"
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: False)
+    r = client.delete(f"/api/mounts/{c['id']}", headers=FUSED)
+    assert r.status_code == 200
+    assert mounts_mod._upstream_cfg == {}
+    assert mounts_mod._upstream_mode == {}
+
+
+def test_link_cache_cap_holds_under_many_inserts(home, fresh_upstream):
+    now = time.monotonic()
+    with mounts_mod._upstream_lock:
+        for i in range(5000):
+            mounts_mod._store_upstream_link((f"fs{i}", "r"), f"u{i}",
+                                            now + 1800, now)
+    assert len(mounts_mod._upstream_links) <= mounts_mod._UPSTREAM_LINKS_CAP
+
+
+def test_link_cache_evicts_expired_before_oldest(home, fresh_upstream):
+    now = time.monotonic()
+    cap = mounts_mod._UPSTREAM_LINKS_CAP
+    with mounts_mod._upstream_lock:
+        for i in range(cap):  # fill to the cap with already-expired entries
+            mounts_mod._store_upstream_link((f"old{i}", "r"), "u", now - 1, now)
+        # One insert past the cap drops the expired ones, keeping the fresh one.
+        mounts_mod._store_upstream_link(("fresh", "r"), "keep", now + 1800, now)
+    assert ("fresh", "r") in mounts_mod._upstream_links
+    assert len(mounts_mod._upstream_links) < cap
+
+
+def test_session_token_remote_gets_short_link_ttl(home, rcd, fresh_upstream):
+    import os
+
+    # A custom-endpoint S3 remote carrying an STS session_token: not signable
+    # (endpoint excluded), so it takes the publiclink path — and its link is
+    # cached for the 5-minute clamp, not the 30-minute default.
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "false",
+                                   "endpoint": "https://r2.example.com",
+                                   "session_token": "TOK"}
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    before = time.monotonic()
+    assert mounts_mod.upstream_url_for(f) == "https://signed.example/x?sig=1"
+    _url, expiry = mounts_mod._upstream_links[("corp:bucket", "a.parquet")]
+    # Clamped to ~5 min, far below the 30-min default (small slack: `before` is
+    # captured just before the function's own monotonic `now`).
+    assert 240 < expiry - before < mounts_mod._SESSION_TOKEN_LINK_TTL_S + 60
+
+
+def test_no_session_token_remote_keeps_default_link_ttl(home, rcd, fresh_upstream):
+    import os
+
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    c = mounts_mod.add_mount("data", "remote:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    before = time.monotonic()
+    mounts_mod.upstream_url_for(f)
+    _url, expiry = mounts_mod._upstream_links[("remote:bucket", "a.parquet")]
+    assert expiry - before > mounts_mod._SESSION_TOKEN_LINK_TTL_S
+
+
 def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstream):
     """A GET from a native client (no Sec-Fetch-Mode) on a cold mount-backed
     file 307s to the store's direct URL — ranged or whole-file alike (zarr

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2599,6 +2599,27 @@ def test_session_token_remote_gets_short_link_ttl(home, rcd, fresh_upstream):
     assert 240 < expiry - before < mounts_mod._SESSION_TOKEN_LINK_TTL_S + 60
 
 
+def test_env_session_token_remote_gets_short_link_ttl(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    # An STS token arriving via AWS_SESSION_TOKEN (not a config session_token)
+    # on a non-signable custom-endpoint remote must clamp the link TTL too — the
+    # resolved credentials carry the token even though the config doesn't.
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAIOSFODNN7EXAMPLE")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY",
+                       "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "FQoGZ//envtoken")
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true",
+                                   "endpoint": "https://r2.example.com"}
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    before = time.monotonic()
+    assert mounts_mod.upstream_url_for(f) == "https://signed.example/x?sig=1"
+    _url, expiry = mounts_mod._upstream_links[("corp:bucket", "a.parquet")]
+    assert 240 < expiry - before < mounts_mod._SESSION_TOKEN_LINK_TTL_S + 60
+
+
 def test_no_session_token_remote_keeps_default_link_ttl(home, rcd, fresh_upstream):
     import os
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2814,6 +2814,71 @@ def test_s3_list_page_non_anonymous_raises_s3listerror(home, rcd, fresh_upstream
         mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
 
 
+# -- signable S3: direct listing for credentialed remotes -------------------
+
+
+def test_s3_direct_capable_true_for_signable(home, rcd, fresh_upstream):
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    assert mounts_mod.s3_direct_capable(mounts_mod.mountpoint(c) + "/x")
+
+
+def test_s3_list_page_signable_presigns(home, rcd, fresh_upstream, s3_urlopen):
+    import urllib.parse as up
+
+    calls, box = s3_urlopen
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-west-2"}
+    box["body"] = _s3_list_xml(
+        contents=[("pre/f.txt", 5, "2024-01-02T03:04:05Z")])
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    entries, token = mounts_mod.s3_list_page(
+        mounts_mod.mountpoint(c), max_keys=1000)
+    [(url, _t)] = calls
+    q = up.parse_qs(up.urlsplit(url).query)
+    # ListObjectsV2 params AND the SigV4 signature are both present — the list
+    # params ride through the presigner, canonicalized in one place.
+    assert q["list-type"] == ["2"] and q["prefix"] == ["pre/"]
+    assert q["max-keys"] == ["1000"] and q["delimiter"] == ["/"]
+    assert q["X-Amz-Algorithm"] == ["AWS4-HMAC-SHA256"]
+    assert "X-Amz-Signature" in q
+    assert url.startswith("https://bucket.s3.us-west-2.amazonaws.com/?")
+    assert [e["Name"] for e in entries] == ["f.txt"]
+    assert token is None
+
+
+def test_s3_list_page_signable_continuation_roundtrips(home, rcd, fresh_upstream, s3_urlopen):
+    import urllib.parse as up
+
+    calls, _box = s3_urlopen
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000,
+                            continuation="a b/c+d=")
+    q = up.parse_qs(up.urlsplit(calls[0][0]).query)
+    assert q["continuation-token"] == ["a b/c+d="]
+    assert "X-Amz-Signature" in q
+
+
+def test_s3_list_page_signable_403_raises(home, rcd, fresh_upstream, s3_urlopen):
+    _calls, box = s3_urlopen
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    box["raise"] = mounts_mod.urllib.error.HTTPError(
+        "https://x", 403, "Forbidden", {}, None)
+    with pytest.raises(mounts_mod.S3ListError):
+        mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+def test_s3_list_page_anonymous_url_has_no_xamz(home, rcd, fresh_upstream, s3_urlopen):
+    # INVARIANT: an anonymous listing URL is byte-identical to today — no
+    # X-Amz-* parameters, resolver never consulted (only _anonymous_s3 matches).
+    calls, _box = s3_urlopen
+    rcd.responses["config/get"] = _ANON_S3_CFG
+    c = mounts_mod.add_mount("open", "aws-open:mur-sst/zarr-v1")
+    mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert "X-Amz" not in calls[0][0]
+
+
 # -- gcs_list_page / gcs_direct_capable -------------------------------------
 #
 # Anonymous GCS (the gcs-open shape) is the GCS analog of anonymous plain AWS
@@ -3172,6 +3237,38 @@ def test_direct_head_gcs_exists_and_dir(home, rcd, fresh_upstream, direct_stub):
     assert got.mtime == "2015-10-21T07:28:00Z"
     direct_stub.listing = (200, _gcs_list_json(items=[("zarr-v1/analysed_sst/x", 1, "2024-01-01T00:00:00Z")]))
     assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/analysed_sst") is True
+
+
+def test_direct_head_signable_signs_head_method(home, rcd, fresh_upstream, direct_stub):
+    # A signable (credentialed) remote probes via a presigned HEAD — signed as
+    # HEAD, not GET (a presigned GET rejects a HEAD request).
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    direct_stub.head = (200, {"Content-Length": "10",
+                              "Last-Modified": "Wed, 21 Oct 2015 07:28:00 GMT"})
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    got = mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/x.json")
+    assert got.exists is True and got.size == 10
+    method, _p, query = direct_stub.calls[-1]
+    assert method == "HEAD"
+    assert "X-Amz-Signature" in query
+
+
+def test_direct_head_signable_404_is_definitive(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    direct_stub.head = (404, {})
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    assert mounts_mod.direct_head(
+        mounts_mod.mountpoint(c) + "/nope.json").exists is False
+
+
+def test_direct_is_dir_signable_presigns_list(home, rcd, fresh_upstream, direct_stub):
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    direct_stub.listing = (200, _s3_list_xml(
+        contents=[("pre/sub/x", 1, "2024-01-01T00:00:00Z")]))
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/sub") is True
+    _method, _p, query = direct_stub.calls[-1]
+    assert "max-keys=1" in query and "X-Amz-Signature" in query
 
 
 # -- rc stat helpers route direct-first (no operations/stat when capable) ----

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -23,6 +23,20 @@ def home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_aws_creds(tmp_path, monkeypatch):
+    """Sign mode's credential resolver reads AWS_* env vars and
+    ~/.aws/credentials; neutralize both so a developer's real AWS credentials
+    can't make an env_auth remote resolve as signable and perturb these tests.
+    Tests that exercise sign mode put explicit keys in the remote config."""
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE",
+                       str(tmp_path / "no-aws-credentials"))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-aws-config"))
+
+
 class StubRcd:
     """Minimal rclone rcd stand-in: answers the rc methods the module uses
     and records every call. Responses are per-method canned JSON that a test
@@ -2112,10 +2126,14 @@ def fresh_upstream():
     mounts_mod._upstream_links.clear()
     mounts_mod._upstream_mode.clear()
     mounts_mod._upstream_cfg.clear()
+    mounts_mod._upstream_region.clear()
+    mounts_mod._cred_cache.clear()
     yield
     mounts_mod._upstream_links.clear()
     mounts_mod._upstream_mode.clear()
     mounts_mod._upstream_cfg.clear()
+    mounts_mod._upstream_region.clear()
+    mounts_mod._cred_cache.clear()
 
 
 def test_upstream_url_prefers_presigned_link(home, rcd, fresh_upstream):
@@ -2219,6 +2237,151 @@ def test_upstream_url_none_is_remembered(home, rcd, fresh_upstream):
 
 def test_upstream_url_none_outside_mounts(home, rcd, fresh_upstream):
     assert mounts_mod.upstream_url_for("/somewhere/else.parquet") is None
+
+
+# -- sign mode: locally presigned URLs for credentialed plain-AWS S3 ---------
+
+_CRED_S3_CFG = {"type": "s3", "provider": "AWS",
+                "access_key_id": "AKIAIOSFODNN7EXAMPLE",
+                "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+                "region": "us-east-1"}
+
+
+def _query_of(url):
+    import urllib.parse as up
+    return dict(up.parse_qsl(up.urlsplit(url).query))
+
+
+def test_upstream_sign_mode_presigns_credentialed_s3(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (206, None))
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a", "b.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    q = _query_of(url)
+    assert url.startswith(
+        "https://bucket.s3.us-east-1.amazonaws.com/pre/a/b.parquet?")
+    assert q["X-Amz-Algorithm"] == "AWS4-HMAC-SHA256"
+    assert "X-Amz-Signature" in q and "X-Amz-Expires" in q
+    # publiclink is never consulted, and sign mode caches no per-object link.
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+    assert mounts_mod._upstream_mode["corp:bucket/pre"] == "sign"
+    assert mounts_mod._upstream_links == {}
+    # Validation is one-time per fs: a second object does not re-validate.
+    seen = []
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: seen.append(url) or (206, None))
+    mounts_mod.upstream_url_for(
+        os.path.join(mounts_mod.mountpoint(c), "c.parquet"))
+    assert seen == []
+
+
+def test_upstream_sign_dotted_bucket_is_path_style_and_signed(home, rcd, fresh_upstream, monkeypatch):
+    # The regression for the dropped-URL gap: a dotted bucket can't be
+    # virtual-hosted, and a SIGNED publiclink URL can't be rewritten path-style
+    # (SigV4 covers Host) so today it's dropped. Sign mode builds path-style
+    # from the start, so the signature is valid.
+    import os
+
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-west-2"}
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (200, None))
+    c = mounts_mod.add_mount("corp", "corp:us-west-2.opendata.source.coop/foo")
+    f = os.path.join(mounts_mod.mountpoint(c), "z.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    assert url.startswith(
+        "https://s3.us-west-2.amazonaws.com/"
+        "us-west-2.opendata.source.coop/foo/z.parquet?")
+    assert "X-Amz-Signature" in url
+
+
+def test_upstream_sign_falls_back_to_publiclink_on_403(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (403, None))
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) == "https://signed.example/x?sig=1"
+    assert mounts_mod._upstream_mode["corp:bucket/pre"] == "link"
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"]
+    # A wrong/guessed region isn't left cached after a failed validation.
+    assert "corp:bucket/pre" not in mounts_mod._upstream_region
+
+
+def test_upstream_custom_endpoint_never_signs(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "endpoint": "https://r2.example.com"}
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    validated = []
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: validated.append(url) or (200, None))
+    c = mounts_mod.add_mount("r2", "r2:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) == "https://signed.example/x?sig=1"
+    assert validated == []  # never entered sign mode, so never validated
+    assert mounts_mod._upstream_mode["r2:bucket"] == "link"
+
+
+def test_upstream_sign_includes_session_token(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "session_token": "FQoTOK//"}
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (200, None))
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    assert "X-Amz-Security-Token=FQoTOK%2F%2F" in url
+
+
+def test_upstream_sign_region_self_corrects(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-east-1"}
+    seq = [(301, "eu-west-1"), (206, None)]
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: seq.pop(0))
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    assert url.startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
+    assert mounts_mod._upstream_region["corp:bucket"] == "eu-west-1"
+    assert seq == []  # exactly two probes: initial + one retry after correction
+    # Later objects reuse the corrected region without re-validating.
+    url2 = mounts_mod.upstream_url_for(
+        os.path.join(mounts_mod.mountpoint(c), "b.parquet"))
+    assert url2.startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
+
+
+def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_upstream, monkeypatch):
+    # INVARIANT: an anonymous S3 mount is byte-identical to today — the
+    # resolver is never called, no validation GET is issued, the URL carries no
+    # X-Amz-* params, and the mode is "public".
+    import os
+
+    rcd.responses["config/get"] = {**_ANON_S3_CFG, "region": "us-west-2"}
+    resolver_calls = []
+    monkeypatch.setattr(mounts_mod.s3sign, "resolve_credentials",
+                        lambda cfg: resolver_calls.append(cfg) or None)
+    validated = []
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: validated.append(url) or (200, None))
+    c = mounts_mod.add_mount("open", "aws-open:bucket/pre fix")
+    f = os.path.join(mounts_mod.mountpoint(c), "k ey.parquet")
+    got = mounts_mod.upstream_url_for(f)
+    assert got == (
+        "https://bucket.s3.us-west-2.amazonaws.com/pre%20fix/k%20ey.parquet")
+    assert "X-Amz" not in got
+    assert resolver_calls == []
+    assert validated == []
+    assert mounts_mod._upstream_mode["aws-open:bucket/pre fix"] == "public"
 
 
 def test_fs_raw_redirects_cold_native_range_reads(client, home, rcd, fresh_upstream):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2128,12 +2128,16 @@ def fresh_upstream():
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._sign_neg_cache.clear()
+    mounts_mod._validation_locks.clear()
     yield
     mounts_mod._upstream_links.clear()
     mounts_mod._upstream_mode.clear()
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._sign_neg_cache.clear()
+    mounts_mod._validation_locks.clear()
 
 
 def test_upstream_url_prefers_presigned_link(home, rcd, fresh_upstream):
@@ -2382,6 +2386,91 @@ def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_ups
     assert resolver_calls == []
     assert validated == []
     assert mounts_mod._upstream_mode["aws-open:bucket/pre fix"] == "public"
+
+
+def test_upstream_sign_demotes_to_link_when_creds_vanish(home, rcd, fresh_upstream, monkeypatch):
+    # Finding 4: once sign mode is active, if creds stop resolving (rotated-away
+    # key) the request must fall through to the publiclink ladder AND the mode
+    # demote to "link" — not return None per-request forever.
+    import os
+
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    rcd.responses["operations/publiclink"] = {"url": "https://signed.example/x?sig=1"}
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (206, None))
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    first = mounts_mod.upstream_url_for(
+        os.path.join(mounts_mod.mountpoint(c), "a.parquet"))
+    assert first.startswith("https://bucket.s3.")  # presigned
+    assert mounts_mod._upstream_mode["corp:bucket/pre"] == "sign"
+    # Creds rotate away: the resolver now returns None and the cache expires.
+    monkeypatch.setattr(mounts_mod.s3sign, "resolve_credentials", lambda cfg: None)
+    mounts_mod._cred_cache.clear()
+    got = mounts_mod.upstream_url_for(
+        os.path.join(mounts_mod.mountpoint(c), "b.parquet"))
+    assert got == "https://signed.example/x?sig=1"  # fell back to publiclink
+    assert mounts_mod._upstream_mode["corp:bucket/pre"] == "link"
+
+
+def test_upstream_sign_negative_cache_skips_revalidation(home, rcd, fresh_upstream, monkeypatch):
+    # Finding 5: when validation fails and no fallback can commit (publiclink
+    # also failing), the failed validation is negative-cached so a second read
+    # in the window doesn't re-run the blocking validation GET.
+    import os
+
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    rcd.responses["operations/publiclink"] = (500, {"error": "boom"})
+    calls = []
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: calls.append(url) or (0, None))  # network fail
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    mp = mounts_mod.mountpoint(c)
+    assert mounts_mod.upstream_url_for(os.path.join(mp, "a.parquet")) is None
+    assert len(calls) == 1
+    # Second request within the negative-cache window: no re-validation.
+    assert mounts_mod.upstream_url_for(os.path.join(mp, "b.parquet")) is None
+    assert len(calls) == 1
+    # Mode was NOT permanently pinned to link on the inconclusive failure.
+    assert mounts_mod._upstream_mode.get("corp:bucket/pre") != "sign"
+
+
+def test_upstream_sign_single_flight_validates_once(home, rcd, fresh_upstream, monkeypatch):
+    # Finding 2: N concurrent first reads must issue ONE validation, not N, and
+    # the losing racer's fallback must never erase the winner's adopted region.
+    import os
+
+    rcd.responses["config/get"] = _CRED_S3_CFG
+    rcd.responses["operations/publiclink"] = {"url": "https://pl.example/x"}
+    calls = []
+    calls_lock = threading.Lock()
+
+    def slow_validate(url):
+        with calls_lock:
+            calls.append(url)
+        time.sleep(0.25)  # hold the flight so siblings pile up
+        return (206, None)
+
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status", slow_validate)
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    mp = mounts_mod.mountpoint(c)
+    results = []
+    res_lock = threading.Lock()
+
+    def worker(i):
+        u = mounts_mod.upstream_url_for(os.path.join(mp, f"obj{i}.parquet"))
+        with res_lock:
+            results.append(u)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert len(calls) == 1  # exactly one validation across all threads
+    assert mounts_mod._upstream_mode["corp:bucket/pre"] == "sign"
+    # Every request got a usable URL — signed (winner + latecomers) or the
+    # publiclink fallback (racers that didn't win the flight).
+    assert all(r is not None for r in results)
 
 
 # -- upstream cache hygiene (Task 4) -----------------------------------------
@@ -2770,6 +2859,9 @@ def s3_urlopen(monkeypatch):
         return _FakeS3Resp(box["body"])
 
     monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", fake)
+    # Signable listings go through the non-redirect opener (so a wrong-region
+    # 301 is observable); intercept it too so it never hits real S3.
+    monkeypatch.setattr(mounts_mod._NO_REDIRECT_OPENER, "open", fake)
     return calls, box
 
 
@@ -2960,6 +3052,32 @@ def test_s3_list_page_signable_403_raises(home, rcd, fresh_upstream, s3_urlopen)
         "https://x", 403, "Forbidden", {}, None)
     with pytest.raises(mounts_mod.S3ListError):
         mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+def test_s3_list_page_signable_region_self_corrects(home, rcd, fresh_upstream, monkeypatch):
+    # A signable listing on a wrong/unset-region remote must observe the 301
+    # (non-redirect opener), adopt x-amz-bucket-region, re-sign and retry — so a
+    # direct list/probe (and the watcher) works instead of a followed 301 -> 403.
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-east-1"}
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    body = _s3_list_xml(contents=[("pre/f.txt", 5, "2024-01-02T03:04:05Z")])
+    seen = []
+
+    def fake_open(req, timeout=None):
+        url = req if isinstance(req, str) else req.get_full_url()
+        seen.append(url)
+        if len(seen) == 1:  # first try in the (wrong) config region -> 301
+            raise mounts_mod.urllib.error.HTTPError(
+                url, 301, "Moved", {"x-amz-bucket-region": "eu-west-1"}, None)
+        return _FakeS3Resp(body)
+
+    monkeypatch.setattr(mounts_mod._NO_REDIRECT_OPENER, "open", fake_open)
+    entries, _tok = mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert [e["Name"] for e in entries] == ["f.txt"]
+    assert len(seen) == 2  # one wrong-region 301 + one retry
+    assert seen[0].startswith("https://bucket.s3.us-east-1.amazonaws.com/")
+    assert seen[1].startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
+    assert mounts_mod._upstream_region["corp:bucket/pre"] == "eu-west-1"
 
 
 def test_s3_list_page_anonymous_url_has_no_xamz(home, rcd, fresh_upstream, s3_urlopen):
@@ -3261,6 +3379,8 @@ def direct_stub(monkeypatch):
                     timeout=timeout)
 
     monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", fake)
+    # Signable probes go through the non-redirect opener; redirect it too.
+    monkeypatch.setattr(mounts_mod._NO_REDIRECT_OPENER, "open", fake)
     yield stub
     stub.close()
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2383,6 +2383,32 @@ def test_adopt_region_retries_when_this_request_signed_stale(fresh_upstream):
         "corp:bucket", 403, headers, "us-east-1") is False
 
 
+def test_adopt_region_on_307_temporary_redirect(fresh_upstream):
+    # S3 answers a newly created bucket with 307 (Temporary Redirect) carrying
+    # x-amz-bucket-region — it must be treated as correctable exactly like 301.
+    headers = {"x-amz-bucket-region": "eu-west-1"}
+    assert mounts_mod._adopt_region_on_301(
+        "corp:bucket", 307, headers, "us-east-1") is True
+    assert mounts_mod._upstream_region["corp:bucket"] == "eu-west-1"
+
+
+def test_upstream_sign_region_self_corrects_on_307(home, rcd, fresh_upstream, monkeypatch):
+    # sign-mode validation must adopt the region from a 307 (new-bucket
+    # Temporary Redirect), not only a 301.
+    import os
+
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-east-1"}
+    seq = [(307, "eu-west-1"), (206, None)]
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: seq.pop(0))
+    c = mounts_mod.add_mount("corp", "corp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    assert url.startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
+    assert mounts_mod._upstream_region["corp:bucket"] == "eu-west-1"
+    assert seq == []  # initial + one retry after the 307 correction
+
+
 def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_upstream, monkeypatch):
     # INVARIANT: an anonymous S3 mount is byte-identical to today — the
     # resolver is never called, no validation GET is issued, the URL carries no
@@ -3095,6 +3121,31 @@ def test_s3_list_page_signable_region_self_corrects(home, rcd, fresh_upstream, m
     assert [e["Name"] for e in entries] == ["f.txt"]
     assert len(seen) == 2  # one wrong-region 301 + one retry
     assert seen[0].startswith("https://bucket.s3.us-east-1.amazonaws.com/")
+    assert seen[1].startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
+    assert mounts_mod._upstream_region["corp:bucket/pre"] == "eu-west-1"
+
+
+def test_s3_list_page_signable_region_self_corrects_on_307(home, rcd, fresh_upstream, monkeypatch):
+    # Same as the 301 case but S3 returns a 307 Temporary Redirect (new bucket):
+    # the direct listing must observe it, adopt x-amz-bucket-region and retry.
+    rcd.responses["config/get"] = {**_CRED_S3_CFG, "region": "us-east-1"}
+    c = mounts_mod.add_mount("corp", "corp:bucket/pre")
+    body = _s3_list_xml(contents=[("pre/f.txt", 5, "2024-01-02T03:04:05Z")])
+    seen = []
+
+    def fake_open(req, timeout=None):
+        url = req if isinstance(req, str) else req.get_full_url()
+        seen.append(url)
+        if len(seen) == 1:  # first try in the (wrong) config region -> 307
+            raise mounts_mod.urllib.error.HTTPError(
+                url, 307, "Temporary Redirect",
+                {"x-amz-bucket-region": "eu-west-1"}, None)
+        return _FakeS3Resp(body)
+
+    monkeypatch.setattr(mounts_mod._NO_REDIRECT_OPENER, "open", fake_open)
+    entries, _tok = mounts_mod.s3_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert [e["Name"] for e in entries] == ["f.txt"]
+    assert len(seen) == 2  # one wrong-region 307 + one retry
     assert seen[1].startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
     assert mounts_mod._upstream_region["corp:bucket/pre"] == "eu-west-1"
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2364,6 +2364,25 @@ def test_upstream_sign_region_self_corrects(home, rcd, fresh_upstream, monkeypat
     assert url2.startswith("https://bucket.s3.eu-west-1.amazonaws.com/")
 
 
+def test_adopt_region_retries_when_this_request_signed_stale(fresh_upstream):
+    # A sibling listing/probe already adopted the corrected region into the
+    # shared map, but THIS request signed with the stale region — it must still
+    # re-sign and retry once, not skip the retry because the map is already
+    # right (which would fail it into the slow rc path).
+    headers = {"x-amz-bucket-region": "eu-west-1"}
+    mounts_mod._upstream_region["corp:bucket"] = "eu-west-1"
+    assert mounts_mod._adopt_region_on_301(
+        "corp:bucket", 301, headers, "us-east-1") is True
+    # A request that already signed with the corrected region does not retry.
+    assert mounts_mod._adopt_region_on_301(
+        "corp:bucket", 301, headers, "eu-west-1") is False
+    # No hint / non-correctable status -> never retries.
+    assert mounts_mod._adopt_region_on_301(
+        "corp:bucket", 301, {}, "us-east-1") is False
+    assert mounts_mod._adopt_region_on_301(
+        "corp:bucket", 403, headers, "us-east-1") is False
+
+
 def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_upstream, monkeypatch):
     # INVARIANT: an anonymous S3 mount is byte-identical to today — the
     # resolver is never called, no validation GET is issued, the URL carries no

--- a/tests/test_shell_pathops.py
+++ b/tests/test_shell_pathops.py
@@ -1,0 +1,186 @@
+"""Unit tests for fused_render.shell.pathops — the mount-aware path-operation
+facade that centralizes the direct→rc listing ladder and the mount-safe
+file-existence probe.
+
+These tests drive pathops in isolation by monkeypatching the mounts-module
+functions it dispatches through (looked up on the module at CALL time, exactly
+as the server's own tests patch them). Two invariants are load-bearing and get
+their own guards:
+  * the direct→rc dispatch/fallback picks the right route and preserves the
+    resume token;
+  * pathops NEVER issues a kernel os.scandir/os.stat on a mount-backed path
+    (the NFS-wedge class the whole mount layer exists to avoid).
+"""
+import os
+
+import pytest
+
+from fused_render.shell import mounts as mounts_mod
+from fused_render.shell import pathops
+
+
+# A mount path is any absolute path; the tests always stub is_mount_backed so no
+# real mounts dir is needed. This is a plausible mountpoint-relative path.
+MOUNT_PATH = "/home/u/.fused-render/mounts/open/some/dir"
+
+
+def _entry(name, *, is_dir=False, size=1, modtime="2024-01-02T03:04:05Z"):
+    return {"Name": name, "IsDir": is_dir, "Size": size, "ModTime": modtime}
+
+
+@pytest.fixture
+def as_mount(monkeypatch):
+    """Treat MOUNT_PATH (and only it) as mount-backed, with NO kernel I/O."""
+    monkeypatch.setattr(mounts_mod, "is_mount_backed",
+                        lambda p: p == MOUNT_PATH)
+    return MOUNT_PATH
+
+
+@pytest.fixture
+def no_kernel_fs(monkeypatch):
+    """Make any kernel directory/stat syscall explode, so a test can prove a
+    mount-backed path never reaches the kernel (the mount-wedge guarantee)."""
+    def boom(*a, **k):
+        raise AssertionError(f"kernel fs call on a mount path: {a!r}")
+
+    monkeypatch.setattr(os, "scandir", boom)
+    monkeypatch.setattr(os, "stat", boom)
+    monkeypatch.setattr(os, "lstat", boom)
+
+
+# --------------------------------------------------------------- list_mount_dir
+
+
+def test_list_direct_route_returns_entries_and_token(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+
+    def fake_page(path, *, max_keys, continuation=None, timeout=None):
+        return [_entry("a.txt"), _entry("b")], "NEXT"
+
+    monkeypatch.setattr(mounts_mod, "direct_list_page", fake_page)
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: pytest.fail("rc used on direct route"))
+
+    # max_entries=2 so the first (2-entry) page fills the cap and the loop stops
+    # with the resume token still set — the partial-listing shape.
+    listing = pathops.list_mount_dir(as_mount, max_entries=2)
+    assert listing.direct is True
+    assert listing.token == "NEXT"
+    assert [e["Name"] for e in listing.entries] == ["a.txt", "b"]
+
+
+def test_list_falls_back_to_rc_on_direct_error(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+
+    def boom_page(path, *, max_keys, continuation=None, timeout=None):
+        raise mounts_mod.DirectListError("kaboom")
+
+    monkeypatch.setattr(mounts_mod, "direct_list_page", boom_page)
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: [_entry("fromrc")])
+
+    listing = pathops.list_mount_dir(as_mount, max_entries=10)
+    assert listing.direct is False
+    assert listing.token is None
+    assert [e["Name"] for e in listing.entries] == ["fromrc"]
+
+
+def test_list_no_rc_fallback_reraises_direct_error(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+
+    def boom_page(path, *, max_keys, continuation=None, timeout=None):
+        raise mounts_mod.DirectListError("kaboom")
+
+    monkeypatch.setattr(mounts_mod, "direct_list_page", boom_page)
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: pytest.fail("rc must not run"))
+
+    with pytest.raises(mounts_mod.DirectListError):
+        pathops.list_mount_dir(as_mount, max_entries=10, allow_rc_fallback=False)
+
+
+def test_list_non_direct_backend_uses_rc(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+    monkeypatch.setattr(mounts_mod, "direct_list_page",
+                        lambda *a, **k: pytest.fail("direct must not run"))
+    seen = {}
+
+    def fake_rc(p, timeout=None):
+        seen["timeout"] = timeout
+        return [_entry("x")]
+
+    monkeypatch.setattr(mounts_mod, "rc_list_dir", fake_rc)
+
+    listing = pathops.list_mount_dir(as_mount, max_entries=10, rc_timeout=7.0)
+    assert listing.direct is False
+    assert seen["timeout"] == 7.0
+    assert [e["Name"] for e in listing.entries] == ["x"]
+
+
+def test_list_rc_errors_propagate(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+
+    def boom(p, timeout=None):
+        raise mounts_mod.RcListTimeout("too big")
+
+    monkeypatch.setattr(mounts_mod, "rc_list_dir", boom)
+    with pytest.raises(mounts_mod.RcListTimeout):
+        pathops.list_mount_dir(as_mount, max_entries=10)
+
+
+def test_list_never_touches_kernel_on_mount(as_mount, no_kernel_fs, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda p, timeout=None: [_entry("x")])
+    # Must complete without tripping the no_kernel_fs booby traps.
+    listing = pathops.list_mount_dir(as_mount, max_entries=10)
+    assert [e["Name"] for e in listing.entries] == ["x"]
+
+
+def test_list_cap_never_overshoots(as_mount, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+
+    def fake_page(path, *, max_keys, continuation=None, timeout=None):
+        # Honour max_keys so accumulation stops exactly at max_entries.
+        return [_entry(f"f{i}") for i in range(max_keys)], "MORE"
+
+    monkeypatch.setattr(mounts_mod, "direct_list_page", fake_page)
+    listing = pathops.list_mount_dir(as_mount, max_entries=3)
+    assert len(listing.entries) == 3
+    assert listing.token == "MORE"  # partial → resumable
+
+
+# ---------------------------------------------------------------- is_file / kind
+
+
+@pytest.mark.parametrize("kind,expected", [
+    ("file", True),
+    ("indeterminate", True),  # fail OPEN: a transient rc hiccup keeps the file
+    ("dir", False),
+    ("missing", False),
+])
+def test_mount_is_file_fail_open(as_mount, monkeypatch, kind, expected):
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", lambda p, **k: kind)
+    assert pathops.mount_is_file(as_mount) is expected
+
+
+def test_is_file_routes_mount_through_rc(as_mount, no_kernel_fs, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "rc_kind_for", lambda p, **k: "file")
+    # no_kernel_fs guarantees os.stat is never called for the mount path.
+    assert pathops.is_file(as_mount) is True
+
+
+def test_is_file_routes_local_through_kernel(tmp_path, monkeypatch):
+    monkeypatch.setattr(mounts_mod, "is_mount_backed", lambda p: False)
+    f = tmp_path / "hello.txt"
+    f.write_text("hi")
+    assert pathops.is_file(str(f)) is True
+    assert pathops.is_file(str(tmp_path / "missing")) is False
+    assert pathops.is_file(str(tmp_path)) is False  # a dir is not a file
+
+
+def test_local_is_file(tmp_path):
+    f = tmp_path / "hello.txt"
+    f.write_text("hi")
+    assert pathops.local_is_file(str(f)) is True
+    assert pathops.local_is_file(str(tmp_path / "nope")) is False

--- a/tests/test_shell_pathops.py
+++ b/tests/test_shell_pathops.py
@@ -99,6 +99,23 @@ def test_list_no_rc_fallback_reraises_direct_error(as_mount, monkeypatch):
         pathops.list_mount_dir(as_mount, max_entries=10, allow_rc_fallback=False)
 
 
+def test_list_no_rc_fallback_raises_when_not_direct_capable(as_mount, monkeypatch):
+    # direct_list_capable can flip to False between the endpoint's gate and this
+    # call (e.g. upstream cache invalidation). With allow_rc_fallback False the rc
+    # route MUST stay unreachable — otherwise a silent rc result would skip the
+    # endpoint's list capping / broken-mount checks, and an RcListError would
+    # escape its `except DirectListError`. Contract: raise DirectListError so the
+    # endpoint's existing fallback handles it.
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
+    monkeypatch.setattr(mounts_mod, "direct_list_page",
+                        lambda *a, **k: pytest.fail("direct must not run"))
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: pytest.fail("rc must not run"))
+
+    with pytest.raises(mounts_mod.DirectListError):
+        pathops.list_mount_dir(as_mount, max_entries=10, allow_rc_fallback=False)
+
+
 def test_list_non_direct_backend_uses_rc(as_mount, monkeypatch):
     monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: False)
     monkeypatch.setattr(mounts_mod, "direct_list_page",


### PR DESCRIPTION
## Summary

- Private-bucket (credentialed) plain-AWS S3 mounts now get the same fast paths public buckets already had: `/api/fs/raw` cold reads 307 to a **locally presigned** URL (in-process SigV4, no rc round trip per object), and directory listings/probes go through the **signed direct ListObjectsV2 pager** instead of the unpaginated `rc_list_dir` route that times out on large flat prefixes (the mount-killer class).
- New pure-stdlib `fused_render/shell/s3sign.py`: SigV4 query presigner (GET/HEAD, session-token aware, always path-style — which also restores the fast path for dotted-name private buckets that signed publiclink URLs had to drop) plus a credential resolver (remote config keys → env vars → `~/.aws/credentials`). No botocore. SSO/IMDS-only remotes keep today's `operations/publiclink` fallback.
- Sign mode is validated once per fs with a `Range: bytes=0-0` GET; a wrong-region config self-corrects via `x-amz-bucket-region`; a 403 falls back to the existing publiclink flow.
- Hygiene for all remotes: upstream config/mode/link caches are invalidated on remote create/delete, the link cache is bounded (4096, expired-then-oldest eviction), and session-token remotes reuse publiclink URLs for 5 min instead of 30.

**Hard invariant held:** anonymous S3/GCS mounts are byte-identical — `_anonymous_s3` is checked first everywhere, anonymous remotes never invoke the resolver or issue a validation request, and the pre-existing anonymous-path test files pass unmodified.

## Visuals

```mermaid
flowchart TD
    A["/api/fs/raw or fs/list on a mount path"] --> B{"anonymous S3/GCS?"}
    B -- yes --> C["mode public: unsigned URL\n(unchanged, byte-identical)"]
    B -- no --> D{"plain-AWS S3 +\nresolvable creds?\n(_s3_signable)"}
    D -- yes --> E["NEW mode sign:\nlocal SigV4 presign, path-style"]
    E --> F{"one-time per-fs validation\nRange: bytes=0-0"}
    F -- "200/206/404/416" --> G["307 / direct pager uses presigned URL"]
    F -- "301/400 + x-amz-bucket-region" --> H["adopt region, re-sign, retry once"] --> F
    F -- "403 / network" --> I["fall back"]
    D -- no --> I["rcd operations/publiclink\n(mode link, unchanged)"]
    I --> J["mode none: serialized VFS serve\n(unchanged last resort)"]
```

Credential resolution (new, in `s3sign.resolve_credentials`): remote config keys → env vars (`env_auth`) → shared credentials file/profile → None (falls back to publiclink).

## Usage

Not user-invocable — behavior is automatic. Add a private plain-AWS S3 remote with keys (Mounts UI or `rclone config`) and mount it; browsing large flat prefixes now paginates via the direct lister, and cold DuckDB/zarr scans through `/api/fs/raw` redirect to presigned URLs at direct-to-S3 parallel speed. `env_auth` remotes backed by `~/.aws/credentials` work the same way; SSO-only remotes behave exactly as before.

## Test Plan

- [x] `tests/test_s3_sign.py` (new, 13 tests): presigner validated against AWS's published SigV4 test vector (exact signature hex), session-token param, HEAD-method signing; resolver ladder incl. profile order and None cases.
- [x] `tests/test_shell_mounts.py` (+353 lines): sign-mode resolution, per-fs validation incl. region self-correction and 403→publiclink fallback, signed `s3_list_page`/`_s3_head`/dir-probe, cache invalidation on remote create/delete, link-cache cap, session-token TTL clamp.
- [x] Anonymous invariant regression tests: unsigned URLs byte-identical (no `X-Amz-*`), resolver never called (spy), mode `public`, no validation request; `test_server_fs_list_mount.py`, `test_server_fs_raw_mount_safe.py`, `test_browse_mount.py` pass **unmodified**.
- [x] Full suite: 1348 passed, 4 skipped; the 2 failures (`test_deploy.py` pip-install pair) reproduce on the base commit `e55815b` — pre-existing, unrelated.
- [x] Manual (signing layer, real creds): against `fused-magic` (private, anon list → 403) with a real STS assumed-role session from `~/.aws/credentials` — resolver picked up key + session token via the env-auth ladder; signed direct `ListObjectsV2` → 200 with keys; presigned ranged object GET → 206; wrong-region signing → 301 `PermanentRedirect` (the self-correction signal); an expired session token → S3 `ExpiredToken` (the failure mode the TTL clamp / sign→link demotion handle).
- [ ] Manual (mounted server UX): large flat prefix paints paginated listing pages in the browser; cold parquet scan matches public-bucket speed; dotted-name private bucket gets direct URLs; SSO-only remote unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

