### PR TITLE
Replace per-row "App" chips with directory-level "Open as app" button

### DIFF
--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -922,6 +922,18 @@ table.listing-table td.mtime {
   gap: 12px;
 }
 
+/* Groups the name with whatever renders right after it (e.g. the directory
+   listing's "Open as app" button, D81's `_listing` header) — min-width:0 so
+   the group (and h1's own ellipsis) can still shrink to make room for
+   .preview-actions on narrow windows. */
+.preview-title {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
 .preview-header h1 {
   font-size: 15px;
   font-weight: 600;
@@ -931,10 +943,10 @@ table.listing-table td.mtime {
   white-space: nowrap;
 }
 
-/* Sits between the directory name and the mode switcher (D81's `_listing`
-   header) — shown only when the folder holds exactly one HTML file. Same
-   accent tint the old per-row "App" chip used, so the launchable-app
-   language carries over to its replacement. */
+/* Rendered right after the directory name (D81's `_listing` header) — shown
+   only when the folder holds exactly one HTML file. Same accent tint the old
+   per-row "App" chip used, so the launchable-app language carries over to
+   its replacement. */
 .open-as-app-btn {
   flex: 0 0 auto;
   font: inherit;

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1228,6 +1228,40 @@ body.embed .preview-browse-chip:hover {
   border-color: var(--accent);
 }
 
+/* Embed counterpart of .open-as-app-btn (embed hides .preview-header, so the
+   header button can't reach it) — opposite corner from .preview-browse-chip
+   so a directory carrying both can show both at once. Same accent tint as
+   the header button / the old per-row "App" chip. */
+.open-as-app-chip {
+  display: none;
+}
+
+body.embed .open-as-app-chip {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  padding: 5px 9px;
+  border: 1px solid rgba(229, 255, 68, 0.45);
+  border-radius: 8px;
+  /* Opaque (unlike .open-as-app-btn's translucent tint) — this one is pinned
+     OVER the listing's search input, and a see-through fill let its
+     placeholder text bleed through underneath. */
+  background: var(--bg-alt);
+  color: #c9d95e;
+  cursor: pointer;
+}
+
+body.embed .open-as-app-chip:hover {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
 /* Panel mode (/view/_panel, /embed/_panel): a split-pane grid of /embed iframes (SPEC §14).
    Modeled on the reference grid-viewer's pane styles, using our palette. The
    root is position:relative so a maximized pane fills the panel area (inside

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -932,22 +932,25 @@ table.listing-table td.mtime {
 }
 
 /* Sits between the directory name and the mode switcher (D81's `_listing`
-   header) — shown only when the folder holds exactly one HTML file. */
+   header) — shown only when the folder holds exactly one HTML file. Same
+   accent tint the old per-row "App" chip used, so the launchable-app
+   language carries over to its replacement. */
 .open-as-app-btn {
   flex: 0 0 auto;
   font: inherit;
   font-size: 12px;
   padding: 5px 10px;
-  border: 1px solid var(--border);
+  border: 1px solid rgba(229, 255, 68, 0.35);
   border-radius: 6px;
-  background: var(--bg);
-  color: var(--fg);
+  background: rgba(229, 255, 68, 0.08);
+  color: #c9d95e;
   cursor: pointer;
 }
 
 .open-as-app-btn:hover {
-  background: var(--bg-alt);
+  background: rgba(229, 255, 68, 0.16);
   border-color: var(--accent);
+  color: var(--accent);
 }
 
 .preview-actions {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -898,19 +898,6 @@ table.listing-table .icon {
 .file-icon--db      { color: #82abbf; }
 .file-icon--file    { color: #868c93; }
 
-/* "App" chip on html rows (Listing + search results) — a small muted-accent
-   pill after the filename. Sized well under the 16px icon height so it never
-   changes row height. */
-.app-chip {
-  flex: 0 0 auto;
-  padding: 0 5px;
-  border: 1px solid rgba(229, 255, 68, 0.35);
-  border-radius: 7px;
-  font-size: 10px;
-  line-height: 14px;
-  color: #c9d95e;
-}
-
 table.listing-table td.size,
 table.listing-table td.mtime {
   color: var(--fg-muted);
@@ -942,6 +929,25 @@ table.listing-table td.mtime {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Sits between the directory name and the mode switcher (D81's `_listing`
+   header) — shown only when the folder holds exactly one HTML file. */
+.open-as-app-btn {
+  flex: 0 0 auto;
+  font: inherit;
+  font-size: 12px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+}
+
+.open-as-app-btn:hover {
+  background: var(--bg-alt);
+  border-color: var(--accent);
 }
 
 .preview-actions {

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -788,9 +788,17 @@ export default function Listing({
   // ("app") file. Keyed off the plain listing, not the search results — the
   // button this drives describes the folder's own contents, regardless of
   // what's currently typed into the in-folder search box.
+  //   • A truncated listing (the server-cap banner) only ever holds a partial
+  //     page, so a lone HTML match there doesn't mean it's the folder's only
+  //     one — withhold the report rather than risk a false "app" button.
+  //   • "loading" reports nothing either way (neither null nor a path) so a
+  //     same-path remount (e.g. switching a mode away from `_listing` and
+  //     back) doesn't flicker an already-known button off for the length of
+  //     the refetch; only "ok"/"error" settle the caller's state.
   useEffect(() => {
     if (!onSingleApp) return;
-    if (state.status !== "ok") {
+    if (state.status === "loading") return;
+    if (state.status !== "ok" || state.truncated) {
       onSingleApp(null);
       return;
     }

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -261,7 +261,19 @@ const IDLE_WALK: WalkState = { status: "idle" };
 // resolving and will drive the correct final view (a file <Preview>) a beat
 // later, so we show the neutral loading body and let stat commit the real view.
 // Absent/false (the committed post-stat render), errors show normally.
-export default function Listing({ fsPath, provisional = false }: { fsPath: string; provisional?: boolean }) {
+export default function Listing({
+  fsPath,
+  provisional = false,
+  onSingleApp,
+}: {
+  fsPath: string;
+  provisional?: boolean;
+  // Reports the path of this directory's lone top-level HTML file (an
+  // "app"), or null when there isn't exactly one — the caller (Preview's
+  // header) uses this to surface an "Open as app" button. Fires whenever the
+  // plain (non-search) listing settles, so it tracks dir-watch refreshes too.
+  onSingleApp?: (path: string | null) => void;
+}) {
   const [state, setState] = useState<ListingState>({ status: "loading" });
   // Sort lives in the URL; mirror it in state so clicks re-render without a
   // navigation (vanilla re-ran renderListing after its replaceState).
@@ -772,6 +784,20 @@ export default function Listing({ fsPath, provisional = false }: { fsPath: strin
 
   const base = fsPath.replace(/\/$/, "");
 
+  // Tell the caller whether this folder's top level holds exactly one HTML
+  // ("app") file. Keyed off the plain listing, not the search results — the
+  // button this drives describes the folder's own contents, regardless of
+  // what's currently typed into the in-folder search box.
+  useEffect(() => {
+    if (!onSingleApp) return;
+    if (state.status !== "ok") {
+      onSingleApp(null);
+      return;
+    }
+    const apps = state.entries.filter((e) => isAppEntry(e.name, e.is_dir));
+    onSingleApp(apps.length === 1 ? base + "/" + apps[0].name : null);
+  }, [state, base, onSingleApp]);
+
   // Flat, ordered list of the paths the arrow keys step through: the rendered
   // search hits while searching, otherwise the sorted listing. Keyed off the
   // same memoized arrays the table renders, so selection never drifts from view.
@@ -1244,7 +1270,6 @@ export default function Listing({ fsPath, provisional = false }: { fsPath: strin
                   <td className="name">
                     <span className="icon">{iconForEntry(entry.rel.split("/").pop() ?? entry.rel, entry.is_dir)}</span>
                     <span className="search-path">{renderHighlight(entry.rel, positions)}</span>
-                    {isAppEntry(entry.rel, entry.is_dir) && <span className="app-chip">App</span>}
                   </td>
                   <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
                   <td className="mtime">{formatMtime(entry.mtime)}</td>
@@ -1339,7 +1364,6 @@ export default function Listing({ fsPath, provisional = false }: { fsPath: strin
           <td className="name">
             <span className="icon">{iconForEntry(entry.name, entry.is_dir)}</span>
             {entry.name}
-            {isAppEntry(entry.name, entry.is_dir) && <span className="app-chip">App</span>}
           </td>
           <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
           <td className="mtime">{formatMtime(entry.mtime)}</td>

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -43,16 +43,20 @@ interface HeaderProps {
   fsPath: string;
   stat: StatResult;
   children?: ReactNode;
+  // Sits between the name and the right-side actions (e.g. the directory
+  // listing's "Open as app" button) — nothing renders there by default.
+  center?: ReactNode;
   // Right-click on the header chrome opens the file context menu for the open
   // file (views hosting a real preview wire this; transient resolving/loading
   // headers leave it undefined).
   onContextMenu?: (e: React.MouseEvent) => void;
 }
 
-function Header({ fsPath, stat, children, onContextMenu }: HeaderProps) {
+function Header({ fsPath, stat, children, center, onContextMenu }: HeaderProps) {
   return (
     <div className="preview-header" onContextMenu={onContextMenu}>
       <h1 title={fsPath}>{stat.name}</h1>
+      {center}
       <div className="preview-actions">{children}</div>
     </div>
   );
@@ -401,6 +405,10 @@ function TemplatePreview({
   // single `_listing` mode), so the preview header is uniform across files and
   // dirs.
   const isListing = entry.mode === "_listing";
+  // Path of the directory's lone top-level HTML file, reported by Listing
+  // (null when there isn't exactly one) — drives the "Open as app" button
+  // between the directory name and the mode switcher.
+  const [singleAppPath, setSingleAppPath] = useState<string | null>(null);
 
   // Tab title (App's StatView owns the actual document.title write, and it
   // also feeds the default bookmark name and the Recents row — see
@@ -546,7 +554,22 @@ function TemplatePreview({
 
   return (
     <>
-      <Header fsPath={fsPath} stat={stat} onContextMenu={fileMenu.onContextMenu}>
+      <Header
+        fsPath={fsPath}
+        stat={stat}
+        onContextMenu={fileMenu.onContextMenu}
+        center={
+          isListing && singleAppPath ? (
+            <button
+              type="button"
+              className="open-as-app-btn"
+              onClick={() => navigate(singleAppPath, { isDir: false })}
+            >
+              Open as app
+            </button>
+          ) : null
+        }
+      >
         {/* Deployable = the mode list carries the "_render" sentinel AND the
             file is .html/.htm — the exporter's actual contract. The extension
             check matters because a registry rebind can put "_render" on any
@@ -576,7 +599,7 @@ function TemplatePreview({
             Checking if this view applies…
           </div>
         ) : isListing ? (
-          <Listing fsPath={fsPath} />
+          <Listing fsPath={fsPath} onSingleApp={setSingleAppPath} />
         ) : (
           /* key: switching mode replaces the iframe (fresh document per switch). */
           <iframe key={mode} src={src as string} onLoad={onRenderFrameLoad} />

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -615,6 +615,21 @@ function TemplatePreview({
                 : modeTitle(counterpart as string)}
           </button>
         )}
+        {/* Embed hides .preview-header (see afterName above), so the "Open as
+            app" affordance also rides as a corner chip pinned over the
+            listing, revealed only in embed — same pattern as
+            preview-browse-chip. Opposite corner so the two can coexist (a
+            directory can have both a browsable counterpart mode AND a lone
+            HTML file). */}
+        {isListing && singleAppPath && (
+          <button
+            type="button"
+            className="open-as-app-chip"
+            onClick={() => navigate(singleAppPath, { isDir: false })}
+          >
+            Open as app
+          </button>
+        )}
       </div>
       {fileMenu.overlays}
     </>

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -43,20 +43,22 @@ interface HeaderProps {
   fsPath: string;
   stat: StatResult;
   children?: ReactNode;
-  // Sits between the name and the right-side actions (e.g. the directory
+  // Rendered right after the name, in the same group (e.g. the directory
   // listing's "Open as app" button) — nothing renders there by default.
-  center?: ReactNode;
+  afterName?: ReactNode;
   // Right-click on the header chrome opens the file context menu for the open
   // file (views hosting a real preview wire this; transient resolving/loading
   // headers leave it undefined).
   onContextMenu?: (e: React.MouseEvent) => void;
 }
 
-function Header({ fsPath, stat, children, center, onContextMenu }: HeaderProps) {
+function Header({ fsPath, stat, children, afterName, onContextMenu }: HeaderProps) {
   return (
     <div className="preview-header" onContextMenu={onContextMenu}>
-      <h1 title={fsPath}>{stat.name}</h1>
-      {center}
+      <div className="preview-title">
+        <h1 title={fsPath}>{stat.name}</h1>
+        {afterName}
+      </div>
       <div className="preview-actions">{children}</div>
     </div>
   );
@@ -558,7 +560,7 @@ function TemplatePreview({
         fsPath={fsPath}
         stat={stat}
         onContextMenu={fileMenu.onContextMenu}
-        center={
+        afterName={
           isListing && singleAppPath ? (
             <button
               type="button"


### PR DESCRIPTION
## Summary
Replaces the per-row "App" indicator chips in file listings with a single "Open as app" button that appears in the directory header when exactly one HTML file is present at the top level. This provides a clearer, more discoverable way to launch HTML files as applications.

## Key Changes
- **Removed per-row app indicators**: Deleted the `.app-chip` CSS class and removed the inline "App" badge that appeared next to HTML files in both the main listing and search results
- **Added directory-level button**: Introduced `.open-as-app-btn` CSS class with styling (border, background, hover states) that matches the accent color scheme of the old chips
- **Updated Listing component**: 
  - Added `onSingleApp` callback prop to report when a directory contains exactly one top-level HTML file
  - Implemented `useEffect` hook to detect single HTML files and notify the parent component
  - Removed inline app-chip rendering from table rows
- **Updated Preview component**:
  - Added `center` prop to Header to support content between the title and action buttons
  - Added state to track the single app path reported by Listing
  - Conditionally renders "Open as app" button in the header when a single HTML file is detected
  - Wires up button click to navigate to the HTML file

## Implementation Details
- The detection logic uses the existing `isAppEntry()` function to identify HTML files
- The button only appears when `state.status === "ok"` and exactly one app file exists
- The callback fires whenever the plain listing settles, ensuring it tracks directory watch refreshes
- Button styling maintains visual consistency with the previous per-row chips while being more prominent in the header

https://claude.ai/code/session_01BdLQP2DJD8NM5jyWKjV33D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation affordance with conservative detection (full non-truncated listing, exactly one HTML); no auth, API, or data-model changes.
> 
> **Overview**
> **Launchable HTML apps** are surfaced at the **directory level** instead of inline on every listing row.
> 
> The per-row **"App"** chip (`.app-chip`) is removed from normal and search listing tables. **`Listing`** gains an optional **`onSingleApp`** callback that reports when the plain listing is complete, not truncated, and contains exactly one top-level HTML file (via existing **`isAppEntry`**); it stays quiet while loading to avoid flicker on remount.
> 
> **`Preview`** wraps the directory title in **`.preview-title`** and passes an **"Open as app"** button through **`Header`**’s new **`afterName`** slot when **`_listing`** mode is active and a lone app path is known; clicks **`navigate`** to that HTML file. **Embed** mode gets a matching **`.open-as-app-chip`** (top-left, opaque over the search input) because embed hides the preview header—the same pattern as **Browse contents**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba2c3a9fc92b5d69f2052c829fb30c27715aed73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->