### PR TITLE
Add pytest coverage reporting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,6 +124,10 @@ jobs:
             htmlcov/
             coverage.xml
           retention-days: 30
+          # Default "warn" would let this step succeed even if pytest's --cov
+          # never wrote htmlcov/coverage.xml — fail loudly instead of quietly
+          # shipping an empty coverage artifact.
+          if-no-files-found: error
 
   test-status:
     name: Test Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,33 @@ jobs:
           sudo apt-get install -y rclone
 
       - name: Run tests
-        run: python -m pytest tests/ -v
+        run: >
+          python -m pytest tests/ -v
+          --cov=fused_render --cov-report=term-missing --cov-report=xml --cov-report=html
+
+      # One representative version avoids 4 duplicate reports/artifacts for
+      # the same source tree; 3.11 is the floor for the optional fused engine
+      # (D69) so it exercises the most code paths of the matrix.
+      - name: Coverage summary
+        if: matrix.python-version == '3.11'
+        run: |
+          echo "## Coverage Report (Python ${{ matrix.python-version }})" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          python -m coverage report -m >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          TOTAL=$(python -m coverage report --format=total)
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Total coverage: ${TOTAL}%**" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload coverage report
+        if: matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-${{ github.sha }}
+          path: |
+            htmlcov/
+            coverage.xml
+          retention-days: 30
 
   test-status:
     name: Test Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,12 @@ jobs:
   test-python:
     needs: [detect-changes, frontend]
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
+    # Job-level permissions override (not merge with) the workflow-level
+    # block above — restated here because the coverage-comment step below
+    # needs pull-requests: write, which the other jobs must not have.
+    permissions:
+      contents: read
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +134,16 @@ jobs:
           # never wrote htmlcov/coverage.xml — fail loudly instead of quietly
           # shipping an empty coverage artifact.
           if-no-files-found: error
+
+      # Same action + pin as the `fused` and `application/fused-py` CI (org
+      # convention). Reads the .coverage data file pytest-cov just wrote in
+      # this same job/workspace; PR-only (no badge-storage branch on push to
+      # main, unlike some setups — this repo doesn't maintain one).
+      - name: Post coverage comment
+        if: matrix.python-version == '3.11' && github.event_name == 'pull_request'
+        uses: py-cov-action/python-coverage-comment-action@53ff7553078bad69030786e486677315346c2dd2
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
 
   test-status:
     name: Test Status

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ fused_render/static/shell-dist/
 fused_render/template_starter/.claude/skills/
 uv.lock
 fused_render/_baked_branch.py
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
     # servers bind 127.0.0.1:0. Process-based only — os.chdir / importlib.reload
     # would race under a threaded runner.
     "pytest-xdist",
+    # Coverage reporting (pytest --cov=fused_render). Combines per-worker data
+    # under -n auto (xdist) automatically — no extra config needed there.
+    "pytest-cov",
 ]
 # Baked into the bundled CPython of the .app (SPEC DM-2): users of the packaged
 # app cannot pip install, so the interpreter ships with the popular data stack.
@@ -97,6 +100,23 @@ fused-render-open = "fused_render.winopen:main"
 # comment). To debug a single test serially, override: `pytest -n0 -x path::test`.
 [tool.pytest.ini_options]
 addopts = "-n auto"
+
+[tool.coverage.run]
+source = ["fused_render"]
+# Store paths relative to the repo root rather than absolute, so coverage.xml
+# stays meaningful if it's read from a different checkout path than the one
+# that produced it (e.g. a CI runner vs. a contributor's machine).
+relative_files = true
+
+[tool.coverage.report]
+# Defensive-only lines that a normal test run can't reach (platform guards,
+# "this should never happen" branches) — excluding them keeps the percentage
+# meaningful instead of chasing untestable lines.
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if TYPE_CHECKING:",
+]
 
 # Single source of truth for the version: fused_render/__init__.py's
 # __version__. Bump it there only — hatchling reads it at build time for the


### PR DESCRIPTION
## Summary

fused-render had no coverage tooling — no `pytest-cov`/`coverage` dependency, no config, and the CI test step was plain `pytest tests/ -v`.

- `pyproject.toml`: adds `pytest-cov` to the `dev` extra, plus `[tool.coverage.run]`/`[tool.coverage.report]` config (`source = fused_render`, relative file paths, standard `pragma: no cover`-style exclusions).
- `.gitignore`: ignores `.coverage`, `coverage.xml`, `htmlcov/`.
- `.github/workflows/test.yml`: the existing `test-python` job now runs `pytest --cov=fused_render --cov-report=term-missing --cov-report=xml --cov-report=html`. Since it's a 4-version matrix (3.10–3.13) covering the same source tree, only the 3.11 leg (the floor for the optional `fused` engine, so it exercises the most code) writes a coverage table to the job's step summary and uploads the HTML+XML report as a build artifact — avoids 4 redundant copies.

This adds reporting/visibility only — no minimum-coverage gate on CI. Happy to add a fail-under threshold in a follow-up if wanted.

## Test plan

- [x] Built the frontend and ran the exact CI coverage command locally, both as root and as a non-root user (matching the actual GitHub Actions runner)
- [x] `pytest-xdist` (`-n auto`, already in use) combines per-worker coverage data automatically — no extra config needed
- [x] Current baseline: 53% total coverage; the only failing test is the pre-existing rclone-dependent one (`test_create_remote_rejects_bad_name`), unrelated to this change and resolved in CI by the existing `apt-get install rclone` step

https://claude.ai/code/session_014aAeMc8GXBw32VZD1YU9dv


---
_Generated by [Claude Code](https://claude.ai/code/session_014aAeMc8GXBw32VZD1YU9dv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and dev-tooling only; tests still pass/fail the same way with no coverage threshold enforced.
> 
> **Overview**
> Introduces **pytest coverage** for `fused_render`: `pytest-cov` in the dev extra, `[tool.coverage.*]` in `pyproject.toml` (package source, relative paths, standard exclude lines), and `.gitignore` entries for coverage outputs.
> 
> The **`test-python`** job now runs pytest with `--cov=fused_render` and term/xml/html reports. Only the **3.11** matrix leg writes a coverage table to the job summary, uploads `htmlcov/` + `coverage.xml` (with `if-no-files-found: error`), and on pull requests posts a comment via the pinned `python-coverage-comment-action`. That job gets **`pull-requests: write`** at job scope so other jobs keep workflow-level read-only PR permissions.
> 
> There is **no minimum-coverage fail-under** on CI—reporting and visibility only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc68e5098033e271b07ec09db6c7ed94813a0a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->