### PR TITLE
Private-bucket cloud auth: botocore credential chain + private-GCS fast paths

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2191,9 +2191,11 @@ class _WatchEntry:
         self.path = path
         self.is_mount = shell_mounts.is_mount_backed(path)
         # These flags fix the poll interval and change-detection strategy once,
-        # at creation. direct_list_capable can do REMOTE I/O (it consults the
-        # credential resolvers for signable S3 / credentialed GCS), so
-        # _WatchRegistry.subscribe constructs each entry OFF the event loop.
+        # at creation. direct_list_capable can do REMOTE I/O (a memoized
+        # config/get rc call the first time a remote is classified), so
+        # _WatchRegistry.subscribe constructs each entry OFF the event loop. It
+        # resolves NO credentials — the classification is a pure config-shape
+        # check (finding 12).
         if self.is_mount:
             # direct_list_capable: the remote can be enumerated by a cheap,
             # bounded page — unsigned (anonymous S3/GCS) or credentialed (signed

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2238,10 +2238,22 @@ class _WatchEntry:
         synthetic S3/GCS dirs, so create/delete/rename of children never moves
         it — the mount-dir auto-refresh (Listing LS-1) was silently dead. So for
         a directory the signal is a hash of a BOUNDED shallow listing instead:
-        one direct_list_page (anonymous S3/GCS) or a short-timeout rc_list_dir.
+        one direct_list_page (direct-listable S3/GCS) or a short-timeout
+        rc_list_dir.
+
+        direct_list_capable is a PURE config-shape check (finding 12): it's true
+        for a credentialed-SHAPED S3/GCS remote whose creds haven't been resolved.
+        When they don't resolve (cloud-auth libs absent, ambient creds expired)
+        direct_list_page raises DirectListError. On a non-root dir we fall back to
+        rc_list_dir — the recovery the fs/list handler and the
+        s3/gcs_direct_capable docstrings promise — flowing into the shared error
+        ladder below. Two carve-outs keep _UNCHANGED with NO rc fallback: a mount
+        ROOT (an rc listing of its whole prefix is the standing background
+        enumeration refused above) and an ANONYMOUS remote (no creds to fail on;
+        byte-identical to pre-finding-12 behavior).
 
         A FILE reaches the ModTime path differently by branch:
-          - direct-listable (anonymous S3/GCS): direct_list_capable is a pure
+          - direct-listable (S3/GCS): direct_list_capable is a pure
             path/config check that can't tell a file from a directory, and
             direct_list_page on a file KEY returns an EMPTY page (the file's own
             key != the "<key>/" listing prefix). An empty page is
@@ -2271,8 +2283,22 @@ class _WatchEntry:
 
         try:
             if shell_mounts.direct_list_capable(self.path):
-                page, _ = shell_mounts.direct_list_page(
-                    self.path, max_keys=1000, timeout=4)
+                try:
+                    page, _ = shell_mounts.direct_list_page(
+                        self.path, max_keys=1000, timeout=4)
+                except shell_mounts.DirectListError:
+                    # A credentialed-SHAPED remote is "capable" by config shape
+                    # alone (finding 12); when its creds don't resolve the direct
+                    # pager fails. Fall back to rc_list_dir (flowing into the
+                    # error ladder below) — EXCEPT a mount ROOT, whose rc listing
+                    # is the standing enumeration refused above, and an ANONYMOUS
+                    # remote, which has no creds to fail on and stays _UNCHANGED
+                    # with no rc fallback (byte-identical to prior behavior).
+                    if (self._is_mount_root
+                            or shell_mounts.direct_list_anonymous(self.path)):
+                        return _UNCHANGED
+                    listed = shell_mounts.rc_list_dir(self.path, timeout=4)
+                    return _hash_listing(listed)
                 if not page:
                     # Empty: a file (its key isn't under the "<key>/" prefix) or
                     # an empty dir. Use the rc ModTime — moves for a file's
@@ -2289,7 +2315,7 @@ class _WatchEntry:
             m = shell_mounts.rc_mtime_for(self.path)
             return _UNCHANGED if m is None else m
         except Exception:
-            return _UNCHANGED  # DirectListError, etc.
+            return _UNCHANGED  # any other backend failure -> unchanged
 
     async def _read(self):
         """One tick's read with a hard timeout and in-flight de-duplication.

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1777,7 +1777,7 @@ def _proxy_raw(upstream: str, request: Request):
 
 
 async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
-                            request: Request):
+                            request: Request, extra_headers: dict | None = None):
     """Opt-in pooled proxy of a store's *signed* URL (TASK F). Same forwarded
     header set (_PROXY_HEADERS) and status pass-through (206/416/404) as
     _proxy_raw, but streams through a shared keep-alive httpx pool so a burst of
@@ -1785,11 +1785,17 @@ async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
     TLS handshake + redirect round trip per block. Returns None only when the
     store is unreachable at the connection level — the caller then falls back to
     the 307 so the read still completes. Async (awaited on the event loop): the
-    pool is the point, and to_thread'ing a sync client would defeat it."""
+    pool is the point, and to_thread'ing a sync client would defeat it.
+
+    `extra_headers` (e.g. an Authorization: Bearer for the private-GCS bearer
+    tier) is merged onto the OUTBOUND request after the Range header — it never
+    appears on the response, so a token there is never echoed to the client."""
     headers = {}
     rng = request.headers.get("range")
     if rng:
         headers["Range"] = rng
+    if extra_headers:
+        headers.update(extra_headers)
     req = client.build_request(request.method, upstream, headers=headers)
     try:
         r = await client.send(req, stream=True)
@@ -3337,6 +3343,22 @@ def create_app(start_dir: str) -> FastAPI:
                         if resp is not None:
                             return resp
                     return RedirectResponse(direct, status_code=307)
+                # No 307-able URL: a token-only private GCS remote can't hand
+                # the client a signed link (the bearer token must never appear
+                # in a URL), so proxy the bytes through the pooled client with
+                # the Authorization header attached out-of-band — regardless of
+                # the &pooled flag, there is nothing to redirect to. A proxy
+                # that can't reach the store returns None and falls through to
+                # the serve exactly as the pooled path does.
+                bearer = await asyncio.to_thread(
+                    shell_mounts.bearer_upstream_for, path)
+                if bearer is not None:
+                    url, extra_headers = bearer
+                    resp = await _proxy_raw_pooled(
+                        request.app.state.pooled_client, url, request,
+                        extra_headers=extra_headers)
+                    if resp is not None:
+                        return resp
             # Not redirected (browser, warm read, or no direct URL): proxy the
             # bytes. Guard non-files here — a directory proxied through rclone
             # serve comes back as a 200 HTML listing, so resolve shape before

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2176,13 +2176,16 @@ class _WatchEntry:
 
         self.path = path
         self.is_mount = shell_mounts.is_mount_backed(path)
-        # Both flags below are pure path/config checks (no remote I/O): they fix
-        # the poll interval and the change-detection strategy once, at creation.
+        # These flags fix the poll interval and change-detection strategy once,
+        # at creation. direct_list_capable can do REMOTE I/O (it consults the
+        # credential resolvers for signable S3 / credentialed GCS), so
+        # _WatchRegistry.subscribe constructs each entry OFF the event loop.
         if self.is_mount:
             # direct_list_capable: the remote can be enumerated by a cheap,
-            # bounded unsigned page (anonymous AWS S3 / GCS). When it CAN'T, a
-            # directory child-change signal would require a full rc_list_dir of
-            # the prefix — the standing enumeration we avoid (see _mount_signal).
+            # bounded page — unsigned (anonymous S3/GCS) or credentialed (signed
+            # S3 / bearer GCS). When it CAN'T, a directory child-change signal
+            # would require a full rc_list_dir of the prefix — the standing
+            # enumeration we avoid (see _mount_signal).
             self._direct_capable = shell_mounts.direct_list_capable(path)
             # A mount ROOT lists the remote's top prefix (or the whole bucket):
             # never poll-list it on a non-direct remote.
@@ -2325,12 +2328,22 @@ class _WatchRegistry:
     def __init__(self):
         self._entries: dict = {}
 
-    def subscribe(self, path: str, queue):
+    async def subscribe(self, path: str, queue):
         entry = self._entries.get(path)
         if entry is None:
-            entry = _WatchEntry(path)
-            self._entries[path] = entry
-            entry.task = asyncio.create_task(entry.run())
+            # _WatchEntry construction does remote I/O (direct_list_capable now
+            # consults the credential resolvers — google-auth refresh / ADC
+            # metadata / botocore chain), so build it OFF the event loop. This
+            # runs on the async /api/fs/events handler's loop; a bare call would
+            # block it. Re-check after the await in case a concurrent subscribe
+            # created the entry while we were building (only ours starts a task).
+            entry = await asyncio.to_thread(_WatchEntry, path)
+            existing = self._entries.get(path)
+            if existing is not None:
+                entry = existing
+            else:
+                self._entries[path] = entry
+                entry.task = asyncio.create_task(entry.run())
         entry.subscribers.add(queue)
         return entry
 
@@ -3472,7 +3485,7 @@ def create_app(start_dir: str) -> FastAPI:
         paths = ws.query_params.getlist("path")
 
         queue: asyncio.Queue = asyncio.Queue()
-        entries = [_WATCH_REGISTRY.subscribe(p, queue) for p in paths]
+        entries = [await _WATCH_REGISTRY.subscribe(p, queue) for p in paths]
 
         async def pump():
             # Forward change messages; a 15s idle gap emits a keepalive (WF-3).

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1835,41 +1835,55 @@ async def _pooled_response(r, request: Request):
     return StreamingResponse(body(), status_code=r.status_code, headers=out)
 
 
+def _bearer_status_passes(status: int) -> bool:
+    """Whether a bearer-proxy upstream status is a client-facing answer. 2xx/3xx
+    (success/redirect) and the meaningful store answers 404 (absent) and 416
+    (unsatisfiable range) pass through; everything else (401, 403, 429, 5xx) is
+    NOT a client-facing answer in bearer mode — there is no 307 URL for the
+    client to retry against, and on main these reads went via the rclone serve
+    whose pacer retries transient errors — so the caller falls through to the
+    serve instead of leaking the error status (finding 9)."""
+    return 200 <= status < 400 or status in (404, 416)
+
+
 async def _proxy_raw_bearer(request: Request, path: str):
     """Proxy a cold private-GCS read through the pooled client with the bearer
     Authorization header attached out-of-band (the token must never reach the
-    client in a URL/redirect). On a 401/403 — a stale/rotated token — invalidate
-    the cached credential, re-resolve, and retry ONCE; a second 401/403 (or a
-    None bearer resolution) returns None so the caller falls through to the
-    serve. Returns None (never an error status) when the fast path can't serve,
-    so the read still completes via the serve. The open upstream response is
-    always closed before a retry."""
+    client in a URL/redirect).
+
+    On a 401 (stale/rotated token) invalidate the cached credential, re-resolve,
+    and retry ONCE. A 403 is an IAM denial WITH a valid token, so it does NOT
+    invalidate — churning the credential per denied read would evict the live
+    token out from under concurrent legitimate reads (mirrors _gcs_get_direct's
+    401-only policy) — it simply falls through to the serve. Any non-pass-through
+    status (a second 401, 403, 429, 5xx) also falls through by returning None
+    (never an error status to the client), so the read still completes via the
+    serve. The open upstream response is always closed before a retry or a
+    fall-through."""
     from fused_render.shell import mounts as shell_mounts
 
-    bearer = await asyncio.to_thread(shell_mounts.bearer_upstream_for, path)
-    if bearer is None:
-        return None
-    # Only now (a real bearer remote) is the pooled client needed — reaching for
-    # it before the bearer check would break the non-bearer fall-through paths.
-    client = request.app.state.pooled_client
-    url, extra_headers = bearer
-    r = await _pooled_send(client, url, request, extra_headers)
-    if r is None:
-        return None
-    if r.status_code in (401, 403):
-        await r.aclose()
-        await asyncio.to_thread(shell_mounts.invalidate_gcs_token, path)
+    for attempt in (1, 2):
         bearer = await asyncio.to_thread(shell_mounts.bearer_upstream_for, path)
         if bearer is None:
             return None
+        # Only now (a real bearer remote) is the pooled client needed — reaching
+        # for it before the bearer check would break the non-bearer fall-through.
+        client = request.app.state.pooled_client
         url, extra_headers = bearer
         r = await _pooled_send(client, url, request, extra_headers)
         if r is None:
             return None
-        if r.status_code in (401, 403):
-            await r.aclose()
-            return None  # still denied -> fall through to the serve
-    return await _pooled_response(r, request)
+        if _bearer_status_passes(r.status_code):
+            return await _pooled_response(r, request)
+        await r.aclose()
+        # 401 on the first attempt: token went stale/rotated -> re-resolve and
+        # retry once. 403 (IAM denial), transient 429/5xx, and a second 401 all
+        # fall through to the serve WITHOUT invalidating.
+        if attempt == 1 and r.status_code == 401:
+            await asyncio.to_thread(shell_mounts.invalidate_gcs_token, path)
+            continue
+        return None
+    return None
 
 
 def _stat_or_none(path: str) -> os.stat_result | None:

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1790,6 +1790,19 @@ async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
     `extra_headers` (e.g. an Authorization: Bearer for the private-GCS bearer
     tier) is merged onto the OUTBOUND request after the Range header — it never
     appears on the response, so a token there is never echoed to the client."""
+    r = await _pooled_send(client, upstream, request, extra_headers)
+    if r is None:
+        return None
+    return await _pooled_response(r, request)
+
+
+async def _pooled_send(client: httpx.AsyncClient, upstream: str,
+                       request: Request, extra_headers: dict | None = None):
+    """Send one pooled, streamed request to `upstream` (mirroring the request's
+    method + Range, plus `extra_headers`) and return the OPEN httpx response, or
+    None on a connection-level error. The caller must either build a response
+    from it (_pooled_response, which closes it) or aclose it — so a peek-then-
+    retry path (bearer 401/403) can inspect the status and drop the response."""
     headers = {}
     rng = request.headers.get("range")
     if rng:
@@ -1798,9 +1811,15 @@ async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
         headers.update(extra_headers)
     req = client.build_request(request.method, upstream, headers=headers)
     try:
-        r = await client.send(req, stream=True)
+        return await client.send(req, stream=True)
     except httpx.HTTPError:
         return None
+
+
+async def _pooled_response(r, request: Request):
+    """Build the client-facing response from an open httpx response `r`,
+    forwarding only _PROXY_HEADERS and passing the status through. Closes `r`
+    (immediately for HEAD, after streaming for GET)."""
     out = {k: v for k, v in r.headers.items() if k.lower() in _PROXY_HEADERS}
     if request.method == "HEAD":
         await r.aclose()
@@ -1814,6 +1833,43 @@ async def _proxy_raw_pooled(client: httpx.AsyncClient, upstream: str,
             await r.aclose()
 
     return StreamingResponse(body(), status_code=r.status_code, headers=out)
+
+
+async def _proxy_raw_bearer(request: Request, path: str):
+    """Proxy a cold private-GCS read through the pooled client with the bearer
+    Authorization header attached out-of-band (the token must never reach the
+    client in a URL/redirect). On a 401/403 — a stale/rotated token — invalidate
+    the cached credential, re-resolve, and retry ONCE; a second 401/403 (or a
+    None bearer resolution) returns None so the caller falls through to the
+    serve. Returns None (never an error status) when the fast path can't serve,
+    so the read still completes via the serve. The open upstream response is
+    always closed before a retry."""
+    from fused_render.shell import mounts as shell_mounts
+
+    bearer = await asyncio.to_thread(shell_mounts.bearer_upstream_for, path)
+    if bearer is None:
+        return None
+    # Only now (a real bearer remote) is the pooled client needed — reaching for
+    # it before the bearer check would break the non-bearer fall-through paths.
+    client = request.app.state.pooled_client
+    url, extra_headers = bearer
+    r = await _pooled_send(client, url, request, extra_headers)
+    if r is None:
+        return None
+    if r.status_code in (401, 403):
+        await r.aclose()
+        await asyncio.to_thread(shell_mounts.invalidate_gcs_token, path)
+        bearer = await asyncio.to_thread(shell_mounts.bearer_upstream_for, path)
+        if bearer is None:
+            return None
+        url, extra_headers = bearer
+        r = await _pooled_send(client, url, request, extra_headers)
+        if r is None:
+            return None
+        if r.status_code in (401, 403):
+            await r.aclose()
+            return None  # still denied -> fall through to the serve
+    return await _pooled_response(r, request)
 
 
 def _stat_or_none(path: str) -> os.stat_result | None:
@@ -3347,18 +3403,13 @@ def create_app(start_dir: str) -> FastAPI:
                 # the client a signed link (the bearer token must never appear
                 # in a URL), so proxy the bytes through the pooled client with
                 # the Authorization header attached out-of-band — regardless of
-                # the &pooled flag, there is nothing to redirect to. A proxy
-                # that can't reach the store returns None and falls through to
-                # the serve exactly as the pooled path does.
-                bearer = await asyncio.to_thread(
-                    shell_mounts.bearer_upstream_for, path)
-                if bearer is not None:
-                    url, extra_headers = bearer
-                    resp = await _proxy_raw_pooled(
-                        request.app.state.pooled_client, url, request,
-                        extra_headers=extra_headers)
-                    if resp is not None:
-                        return resp
+                # the &pooled flag, there is nothing to redirect to. A stale
+                # token (401/403) self-heals via one re-resolve + retry inside
+                # _proxy_raw_bearer; a still-denied or unreachable read returns
+                # None and falls through to the serve.
+                resp = await _proxy_raw_bearer(request, path)
+                if resp is not None:
+                    return resp
             # Not redirected (browser, warm read, or no direct URL): proxy the
             # bytes. Guard non-files here — a directory proxied through rclone
             # serve comes back as a 200 HTML listing, so resolve shape before

--- a/fused_render/shell/gcssign.py
+++ b/fused_render/shell/gcssign.py
@@ -31,6 +31,7 @@ import datetime
 import hashlib
 import json
 import os
+import re
 import urllib.parse
 from collections import namedtuple
 
@@ -148,14 +149,142 @@ def _sa_info(cfg: dict) -> dict | None:
     return None
 
 
-def _finalize(creds) -> Token | None:
-    """Refresh `creds` if it has no valid token, then map it to a Token. The
-    refresh transport is google-auth's requests-backed Request. None when the
-    credential yields no token. Any exception propagates to the source's own
-    try/except (which moves on to the next source)."""
+def _parse_rclone_expiry(value) -> datetime.datetime | None:
+    """rclone stores an oauth token's expiry as an RFC3339 string
+    (e.g. "2019-08-20T00:00:00.000000000Z" or "...+01:00"). Parse it to a
+    TZ-NAIVE UTC datetime — what google-auth's Credentials.expiry expects, and
+    what makes it treat an already-past token as expired (so _finalize refreshes
+    instead of trusting a dead access_token). None when absent/unparseable."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    s = value.strip()
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    # datetime.fromisoformat on 3.10/3.11 accepts at most 6 fractional digits;
+    # rclone often emits 9 (nanoseconds), so truncate the fraction.
+    m = re.match(r"^(.*T\d\d:\d\d:\d\d)(\.\d+)?(.*)$", s)
+    if m:
+        frac = m.group(2) or ""
+        s = m.group(1) + (frac[:7] if frac else "") + m.group(3)
+    try:
+        dt = datetime.datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+def _refresh_if_needed(creds) -> None:
+    """Refresh `creds` via google-auth's requests transport when it has no valid
+    (present, unexpired) token. A no-op on an already-valid credential, so a
+    cached self-refreshing object only pays a network refresh near expiry."""
     from google.auth.transport.requests import Request
     if not creds.valid:
         creds.refresh(Request())
+
+
+def _creds_from_sa(cfg: dict):
+    """Source 1: a service-account key (inline JSON or file), scoped read-only.
+    Returns a refreshed google-auth credential object, or None (ImportError /
+    parse / refresh failure -> next source)."""
+    info = _sa_info(cfg)
+    if info is None:
+        return None
+    try:
+        from google.oauth2 import service_account
+        creds = service_account.Credentials.from_service_account_info(
+            info, scopes=[_READ_ONLY_SCOPE])
+        _refresh_if_needed(creds)
+        return creds if creds.token else None
+    except Exception:
+        return None
+
+
+def _creds_from_oauth(cfg: dict):
+    """Source 2: rclone's stored oauth token, refreshable only with the config's
+    own client_id/client_secret. SKIPPED when either is absent — that means
+    rclone's built-in oauth client, whose compiled-in secret we won't embed (ADC
+    covers the gcloud-login user anyway). The stored access_token is usually
+    hours-expired, so parse its "expiry" onto the credential (google-auth then
+    treats an expired token as invalid and refreshes it); with no expiry but a
+    refresh_token present, force a refresh rather than trust the stale token.
+    Any failure -> None (next source)."""
+    tok_json = cfg.get("token")
+    client_id = cfg.get("client_id")
+    client_secret = cfg.get("client_secret")
+    if not tok_json or not client_id or not client_secret:
+        return None
+    try:
+        data = json.loads(tok_json) if isinstance(tok_json, str) else tok_json
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    try:
+        from google.auth.transport.requests import Request
+        from google.oauth2.credentials import Credentials
+        creds = Credentials(
+            token=data.get("access_token"),
+            refresh_token=data.get("refresh_token"),
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=client_id, client_secret=client_secret,
+            scopes=[_READ_ONLY_SCOPE])
+        expiry = _parse_rclone_expiry(data.get("expiry"))
+        if expiry is not None:
+            creds.expiry = expiry
+        # No expiry to judge staleness by: an expiry-less token reads as "valid"
+        # forever, so force one refresh when a refresh_token can renew it.
+        if expiry is None and data.get("refresh_token"):
+            creds.refresh(Request())
+        else:
+            _refresh_if_needed(creds)
+        return creds if creds.token else None
+    except Exception:
+        return None
+
+
+def _creds_from_adc(cfg: dict):
+    """Source 3: Application Default Credentials — GOOGLE_APPLICATION_CREDENTIALS,
+    `gcloud auth application-default login`, or GCE metadata. The primary
+    promise for a laptop that already ran gcloud login. Any failure -> None."""
+    try:
+        import google.auth
+        creds, _project = google.auth.default(scopes=[_READ_ONLY_SCOPE])
+        _refresh_if_needed(creds)
+        return creds if creds.token else None
+    except Exception:
+        return None
+
+
+def resolve_credentials(cfg: dict | None):
+    """Resolve a google-auth credential OBJECT for a credentialed GCS remote,
+    trying the sources in order (SA key -> rclone oauth -> ADC) and returning
+    the first that yields a token, else None. Returning the OBJECT (not just a
+    token) lets mounts.py cache it and re-extract tokens cheaply — a
+    self-refreshing credential renews near expiry without re-walking the sources.
+    Non-GCS or anonymous configs return None."""
+    if not _is_gcs_signable_shape(cfg):
+        return None
+    assert cfg is not None
+    for source in (_creds_from_sa, _creds_from_oauth, _creds_from_adc):
+        creds = source(cfg)
+        if creds is not None:
+            return creds
+    return None
+
+
+def token_from_credentials(creds) -> Token | None:
+    """Map a resolved google-auth credential to a Token, refreshing it first if
+    its token has expired (a cached, self-refreshing object thus renews near
+    expiry with a single refresh, no source re-walk). None when the credential
+    yields no token or the refresh fails."""
+    if creds is None:
+        return None
+    try:
+        _refresh_if_needed(creds)
+    except Exception:
+        return None
     if not creds.token:
         return None
     expiry = getattr(creds, "expiry", None)
@@ -171,73 +300,12 @@ def _finalize(creds) -> Token | None:
     return Token(creds.token, expiry_epoch)
 
 
-def _token_from_sa(cfg: dict) -> Token | None:
-    """Source 1: a service-account key (inline JSON or file). Scoped read-only.
-    ImportError (extra absent) or any failure -> None."""
-    info = _sa_info(cfg)
-    if info is None:
-        return None
-    try:
-        from google.oauth2 import service_account
-        creds = service_account.Credentials.from_service_account_info(
-            info, scopes=[_READ_ONLY_SCOPE])
-        return _finalize(creds)
-    except Exception:
-        return None
-
-
-def _token_from_oauth(cfg: dict) -> Token | None:
-    """Source 2: rclone's stored oauth token, refreshable only with the
-    config's own client_id/client_secret. SKIPPED when either is absent — that
-    means rclone's built-in oauth client, whose compiled-in secret we won't
-    embed (ADC covers the gcloud-login user anyway). Any failure -> None."""
-    tok_json = cfg.get("token")
-    client_id = cfg.get("client_id")
-    client_secret = cfg.get("client_secret")
-    if not tok_json or not client_id or not client_secret:
-        return None
-    try:
-        data = json.loads(tok_json) if isinstance(tok_json, str) else tok_json
-    except (ValueError, TypeError):
-        return None
-    try:
-        from google.oauth2.credentials import Credentials
-        creds = Credentials(
-            token=data.get("access_token"),
-            refresh_token=data.get("refresh_token"),
-            token_uri="https://oauth2.googleapis.com/token",
-            client_id=client_id, client_secret=client_secret,
-            scopes=[_READ_ONLY_SCOPE])
-        return _finalize(creds)
-    except Exception:
-        return None
-
-
-def _token_from_adc(cfg: dict) -> Token | None:
-    """Source 3: Application Default Credentials — GOOGLE_APPLICATION_CREDENTIALS,
-    `gcloud auth application-default login`, or GCE metadata. The primary
-    promise for a laptop that already ran gcloud login. Any failure -> None."""
-    try:
-        import google.auth
-        creds, _project = google.auth.default(scopes=[_READ_ONLY_SCOPE])
-        return _finalize(creds)
-    except Exception:
-        return None
-
-
 def resolve_token(cfg: dict | None) -> Token | None:
-    """Resolve a bearer access token for a credentialed GCS remote, trying the
-    sources in order (SA key -> rclone oauth -> ADC) and returning the first
-    that yields a token, else None. Non-GCS or anonymous configs return None
-    (anonymous GCS reaches its objects by plain unsigned URL)."""
-    if not _is_gcs_signable_shape(cfg):
-        return None
-    assert cfg is not None
-    for source in (_token_from_sa, _token_from_oauth, _token_from_adc):
-        tok = source(cfg)
-        if tok is not None:
-            return tok
-    return None
+    """Convenience: resolve a bearer access token in one call (build the
+    credential, then extract a Token). mounts.py uses the two steps separately
+    so it can cache the credential object; this stays for direct callers/tests.
+    None for non-GCS / anonymous / unresolvable configs."""
+    return token_from_credentials(resolve_credentials(cfg))
 
 
 def resolve_signer(cfg: dict | None) -> Signer | None:

--- a/fused_render/shell/gcssign.py
+++ b/fused_render/shell/gcssign.py
@@ -244,11 +244,17 @@ def _creds_from_oauth(cfg: dict):
             client_id=client_id, client_secret=client_secret,
             scopes=[_READ_ONLY_SCOPE])
         expiry = _parse_rclone_expiry(data.get("expiry"))
+        # No expiry to judge staleness by AND no refresh_token to renew with: the
+        # stored access_token would read as "valid forever" (google-auth trusts a
+        # None expiry) so a possibly-dead token would be trusted and ADC never
+        # tried. Treat it as unusable so resolution falls through to ADC (fix 4).
+        if expiry is None and not data.get("refresh_token"):
+            return None
         if expiry is not None:
             creds.expiry = expiry
-        # No expiry to judge staleness by: an expiry-less token reads as "valid"
-        # forever, so force one refresh when a refresh_token can renew it.
-        if expiry is None and data.get("refresh_token"):
+        # No expiry but a refresh_token is present (guarded above): force one
+        # refresh rather than trust the stale, expiry-less token.
+        if expiry is None:
             creds.refresh(Request())
         else:
             _refresh_if_needed(creds)

--- a/fused_render/shell/gcssign.py
+++ b/fused_render/shell/gcssign.py
@@ -1,0 +1,260 @@
+"""Stdlib GCS V4 URL signer + local GCS bearer-token resolver.
+
+The GCS analog of shell/s3sign.py. rclone's GCS backend reports
+PublicLink: False, so a credentialed GCS mount has no fast path today — every
+read crawls the serialized VFS serve. This module gives mounts.py the two
+pieces it needs to change that, kept separate exactly as s3sign.py keeps its
+two:
+  - sign_url: given a storage.googleapis.com object URL + a service-account
+    signer, return the URL with the X-Goog-* query parameters that make GCS
+    accept it unauthenticated for the URL's expiry window. GOOG4-RSA-SHA256 is
+    a well-specified canonical-request computation with published conformance
+    vectors, so it lives here in pure stdlib (hashlib/urllib.parse); the RSA
+    itself is delegated to an injected signer (google-auth's SA signer in
+    production), so this module never depends on a crypto library to build a
+    URL. The timestamp is a parameter so the output is reproducible under test.
+  - resolve_token / resolve_signer: the credential sources. resolve_token
+    yields a short-lived bearer access token (SA key -> rclone oauth token ->
+    Application Default Credentials), used to authorize direct JSON-API
+    listings and the bearer read proxy. resolve_signer yields the SA signer for
+    URL signing, which ONLY a service-account key can do locally — user oauth
+    and ADC tokens can't sign, so they take the bearer path instead.
+
+Both resolvers are lazily backed by google-auth (the optional [cloud-auth]
+extra); absent, they return None and the caller keeps today's behavior.
+
+This module is PURE: no caching, no rc calls, no logging of tokens or URLs.
+Caching (token TTL keyed off expiry) and the one-time signed-URL validation
+live in shell/mounts.py, which composes the object URL and hands it here.
+"""
+import datetime
+import hashlib
+import json
+import os
+import urllib.parse
+from collections import namedtuple
+
+# GOOG4 signing constants — the GCS counterparts of s3sign's SigV4 constants.
+_ALGORITHM = "GOOG4-RSA-SHA256"
+_UNSIGNED_PAYLOAD = "UNSIGNED-PAYLOAD"
+# GCS's signing "region" is the literal "auto" and the service is "storage".
+_CREDENTIAL_SCOPE_SUFFIX = "auto/storage/goog4_request"
+# Read-only is all the fast paths need (listings, HEAD/GET); asking for less
+# keeps a leaked token harmless.
+_READ_ONLY_SCOPE = "https://www.googleapis.com/auth/devstorage.read_only"
+
+# A resolved bearer token and the epoch its access token expires at — the
+# expiry drives the mounts-side cache TTL so a dying token is re-resolved
+# before GCS starts rejecting it.
+Token = namedtuple("Token", ["access_token", "expiry_epoch"])
+
+# A service-account signer (an object with .sign(bytes) -> bytes) and the SA
+# email that goes into X-Goog-Credential. Only an SA key yields one.
+Signer = namedtuple("Signer", ["signer", "sa_email"])
+
+
+def _uri_encode(value: str) -> str:
+    """RFC3986 percent-encoding for a query key/value: only the unreserved set
+    A-Za-z0-9-_.~ stays literal (so '/' in X-Goog-Credential becomes %2F and a
+    space becomes %20, never '+') — exactly what GOOG4 canonicalization and the
+    final query string both require. (Copied from s3sign rather than imported:
+    the two signers are independent pure modules.)"""
+    return urllib.parse.quote(str(value), safe="-_.~")
+
+
+def sign_url(url: str, *, method: str, signer, sa_email: str,
+             expires: int = 900, extra_query: dict | None = None,
+             timestamp: datetime.datetime | None = None) -> str:
+    """Return `url` with the GOOG4-RSA-SHA256 query parameters that authorize
+    `method` on it for `expires` seconds. The host is taken from `url` verbatim
+    (storage.googleapis.com, path-style — GCS always carries the bucket in the
+    path, so there is no dotted-bucket / virtual-host rule and no region).
+
+    `signer` is any object exposing `.sign(bytes) -> bytes` (google-auth's SA
+    signer in production); the RSA math is delegated to it and the result is
+    hex-encoded, so this module needs no crypto library. `extra_query` (e.g.
+    objects.list's prefix/delimiter) is merged in and signed, so those
+    parameters are canonicalized in this one place. The path in `url` is the
+    canonical URI unchanged: callers pass keys already quoted with '/' kept."""
+    if timestamp is None:
+        timestamp = datetime.datetime.now(datetime.timezone.utc)
+    goog_date = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    date_stamp = timestamp.strftime("%Y%m%d")
+
+    parts = urllib.parse.urlsplit(url)
+    host = parts.netloc
+    canonical_uri = parts.path or "/"
+    scope = f"{date_stamp}/{_CREDENTIAL_SCOPE_SUFFIX}"
+
+    # Every query parameter is part of the signature except the signature
+    # itself. Start from any params already on the URL, then the caller's
+    # extras, then the fixed X-Goog-* set.
+    query: dict = dict(urllib.parse.parse_qsl(parts.query,
+                                              keep_blank_values=True))
+    if extra_query:
+        query.update(extra_query)
+    query["X-Goog-Algorithm"] = _ALGORITHM
+    query["X-Goog-Credential"] = f"{sa_email}/{scope}"
+    query["X-Goog-Date"] = goog_date
+    query["X-Goog-Expires"] = str(int(expires))
+    query["X-Goog-SignedHeaders"] = "host"
+
+    canonical_qs = "&".join(f"{_uri_encode(k)}={_uri_encode(v)}"
+                            for k, v in sorted(query.items()))
+    canonical_headers = f"host:{host}\n"
+    canonical_request = "\n".join([
+        method.upper(), canonical_uri, canonical_qs,
+        canonical_headers, "host", _UNSIGNED_PAYLOAD])
+    string_to_sign = "\n".join([
+        _ALGORITHM, goog_date, scope,
+        hashlib.sha256(canonical_request.encode("utf-8")).hexdigest()])
+    signature = signer.sign(string_to_sign.encode("utf-8")).hex()
+
+    # GCS's published URL layout appends X-Goog-Signature AFTER the sorted
+    # signed query (the signature is not itself a signed parameter, and
+    # re-sorting it in would reorder SignedHeaders/Signature and diverge from
+    # Google's conformance vectors), so build the final query by appending.
+    return urllib.parse.urlunsplit(
+        (parts.scheme, parts.netloc, canonical_uri,
+         canonical_qs + "&X-Goog-Signature=" + _uri_encode(signature), ""))
+
+
+def _is_gcs_signable_shape(cfg: dict | None) -> bool:
+    """Cheap config-shape gate shared by both resolvers: a Google Cloud Storage
+    remote that is NOT anonymous. Anonymous GCS carries no credentials and is
+    handled by the plain public-URL path (callers check it first regardless)."""
+    return (isinstance(cfg, dict)
+            and cfg.get("type") == "google cloud storage"
+            and str(cfg.get("anonymous", "")).lower() != "true")
+
+
+def _sa_info(cfg: dict) -> dict | None:
+    """The service-account key JSON for a remote, from rclone's inline
+    `service_account_credentials` (a JSON string) or a `service_account_file`
+    path. None when neither is present or parseable."""
+    inline = cfg.get("service_account_credentials")
+    if inline:
+        try:
+            return json.loads(inline) if isinstance(inline, str) else inline
+        except (ValueError, TypeError):
+            return None
+    path = cfg.get("service_account_file")
+    if path:
+        try:
+            with open(os.path.expanduser(path), encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, ValueError):
+            return None
+    return None
+
+
+def _finalize(creds) -> Token | None:
+    """Refresh `creds` if it has no valid token, then map it to a Token. The
+    refresh transport is google-auth's requests-backed Request. None when the
+    credential yields no token. Any exception propagates to the source's own
+    try/except (which moves on to the next source)."""
+    from google.auth.transport.requests import Request
+    if not creds.valid:
+        creds.refresh(Request())
+    if not creds.token:
+        return None
+    expiry = getattr(creds, "expiry", None)
+    if expiry is None:
+        # Unknown expiry: assume a conservative hour so the cache still re-reads.
+        expiry_epoch = (datetime.datetime.now(datetime.timezone.utc).timestamp()
+                        + 3600.0)
+    else:
+        # google-auth exposes a naive UTC datetime; treat a naive value as UTC.
+        if expiry.tzinfo is None:
+            expiry = expiry.replace(tzinfo=datetime.timezone.utc)
+        expiry_epoch = expiry.timestamp()
+    return Token(creds.token, expiry_epoch)
+
+
+def _token_from_sa(cfg: dict) -> Token | None:
+    """Source 1: a service-account key (inline JSON or file). Scoped read-only.
+    ImportError (extra absent) or any failure -> None."""
+    info = _sa_info(cfg)
+    if info is None:
+        return None
+    try:
+        from google.oauth2 import service_account
+        creds = service_account.Credentials.from_service_account_info(
+            info, scopes=[_READ_ONLY_SCOPE])
+        return _finalize(creds)
+    except Exception:
+        return None
+
+
+def _token_from_oauth(cfg: dict) -> Token | None:
+    """Source 2: rclone's stored oauth token, refreshable only with the
+    config's own client_id/client_secret. SKIPPED when either is absent — that
+    means rclone's built-in oauth client, whose compiled-in secret we won't
+    embed (ADC covers the gcloud-login user anyway). Any failure -> None."""
+    tok_json = cfg.get("token")
+    client_id = cfg.get("client_id")
+    client_secret = cfg.get("client_secret")
+    if not tok_json or not client_id or not client_secret:
+        return None
+    try:
+        data = json.loads(tok_json) if isinstance(tok_json, str) else tok_json
+    except (ValueError, TypeError):
+        return None
+    try:
+        from google.oauth2.credentials import Credentials
+        creds = Credentials(
+            token=data.get("access_token"),
+            refresh_token=data.get("refresh_token"),
+            token_uri="https://oauth2.googleapis.com/token",
+            client_id=client_id, client_secret=client_secret,
+            scopes=[_READ_ONLY_SCOPE])
+        return _finalize(creds)
+    except Exception:
+        return None
+
+
+def _token_from_adc(cfg: dict) -> Token | None:
+    """Source 3: Application Default Credentials — GOOGLE_APPLICATION_CREDENTIALS,
+    `gcloud auth application-default login`, or GCE metadata. The primary
+    promise for a laptop that already ran gcloud login. Any failure -> None."""
+    try:
+        import google.auth
+        creds, _project = google.auth.default(scopes=[_READ_ONLY_SCOPE])
+        return _finalize(creds)
+    except Exception:
+        return None
+
+
+def resolve_token(cfg: dict | None) -> Token | None:
+    """Resolve a bearer access token for a credentialed GCS remote, trying the
+    sources in order (SA key -> rclone oauth -> ADC) and returning the first
+    that yields a token, else None. Non-GCS or anonymous configs return None
+    (anonymous GCS reaches its objects by plain unsigned URL)."""
+    if not _is_gcs_signable_shape(cfg):
+        return None
+    assert cfg is not None
+    for source in (_token_from_sa, _token_from_oauth, _token_from_adc):
+        tok = source(cfg)
+        if tok is not None:
+            return tok
+    return None
+
+
+def resolve_signer(cfg: dict | None) -> Signer | None:
+    """The service-account signer (signer object + SA email) for a GCS remote,
+    or None. ONLY a service-account key can sign a URL locally — user oauth and
+    ADC tokens cannot, so they get the bearer proxy instead. Kept separate from
+    resolve_token so the raw-read tiering (mounts.py) reads cleanly."""
+    if not _is_gcs_signable_shape(cfg):
+        return None
+    assert cfg is not None
+    info = _sa_info(cfg)
+    if info is None:
+        return None
+    try:
+        from google.oauth2 import service_account
+        creds = service_account.Credentials.from_service_account_info(
+            info, scopes=[_READ_ONLY_SCOPE])
+        return Signer(creds.signer, creds.signer_email)
+    except Exception:
+        return None

--- a/fused_render/shell/gcssign.py
+++ b/fused_render/shell/gcssign.py
@@ -129,6 +129,19 @@ def _is_gcs_signable_shape(cfg: dict | None) -> bool:
             and str(cfg.get("anonymous", "")).lower() != "true")
 
 
+def _is_sa_configured(cfg: dict | None) -> bool:
+    """Cheap config-SHAPE gate: a non-anonymous GCS remote that carries a
+    service-account key (inline `service_account_credentials` or a
+    `service_account_file` path). Says a remote is SIGNABLE-SHAPED without
+    reading/parsing the key or importing google-auth — so the caller can decide
+    the gsign-vs-bearer tier on shape and treat a momentarily-unresolvable signer
+    as transient (serve bearer now, keep retrying gsign) rather than as a
+    permanent token-only remote (finding 2)."""
+    return (_is_gcs_signable_shape(cfg)
+            and bool(cfg.get("service_account_credentials")
+                     or cfg.get("service_account_file")))
+
+
 def _sa_info(cfg: dict) -> dict | None:
     """The service-account key JSON for a remote, from rclone's inline
     `service_account_credentials` (a JSON string) or a `service_account_file`

--- a/fused_render/shell/gcssign.py
+++ b/fused_render/shell/gcssign.py
@@ -285,7 +285,13 @@ def token_from_credentials(creds) -> Token | None:
         _refresh_if_needed(creds)
     except Exception:
         return None
-    if not creds.token:
+    # Read the token ONCE into a local and reuse it: a concurrent refresh of the
+    # shared credential object could otherwise pair an old .token with the new
+    # .expiry, caching a dead token until the false expiry (finding 7). The
+    # mounts-side per-name single-flight makes a concurrent refresh unlikely, but
+    # reading once removes the non-atomicity by construction.
+    token = creds.token
+    if not token:
         return None
     expiry = getattr(creds, "expiry", None)
     if expiry is None:
@@ -297,7 +303,7 @@ def token_from_credentials(creds) -> Token | None:
         if expiry.tzinfo is None:
             expiry = expiry.replace(tzinfo=datetime.timezone.utc)
         expiry_epoch = expiry.timestamp()
-    return Token(creds.token, expiry_epoch)
+    return Token(token, expiry_epoch)
 
 
 def resolve_token(cfg: dict | None) -> Token | None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1547,6 +1547,7 @@ _cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry
 _botocore_creds_cache: dict = {}  # remote name -> (botocore creds obj|None, exp)
 _gcs_token_cache: dict = {}  # remote name -> (gcssign.Token|None, monotonic exp)
 _gcs_creds_cache: dict = {}  # remote name -> (google-auth creds obj|None, mono exp)
+_gcs_signer_cache: dict = {}  # remote name -> (gcssign.Signer|None, monotonic exp)
 _sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
 _validation_locks: dict = {}  # fs -> Lock: per-fs single-flight for validation
 
@@ -1604,6 +1605,7 @@ def _invalidate_upstream_caches() -> None:
         _botocore_creds_cache.clear()
         _gcs_token_cache.clear()
         _gcs_creds_cache.clear()
+        _gcs_signer_cache.clear()
         _upstream_links.clear()
         _sign_neg_cache.clear()
         _validation_locks.clear()
@@ -1925,26 +1927,48 @@ def _gcs_object_url(fs: str, rel: str) -> str | None:
     return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
 
 
+def _gcs_signer(name: str, cfg: dict | None):
+    """gcssign.resolve_signer for a remote, cached per name for _CRED_TTL_S — the
+    signer analog of _signable_credentials / _gcs_bearer_token. Without this the
+    SA key file is re-opened, re-parsed and re-deserialized on EVERY gsign read
+    (once per object) — and a transient open() error would otherwise stick as a
+    permanent demotion; the cache bounds that window to one TTL. None (also
+    cached) when the remote has no signer-capable SA key. Returns a
+    gcssign.Signer or None."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = _gcs_signer_cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+    signer = gcssign.resolve_signer(cfg)
+    with _upstream_lock:
+        _gcs_signer_cache[name] = (signer, now + _CRED_TTL_S)
+    return signer
+
+
 def _gcs_signable(name: str, cfg: dict | None) -> bool:
     """True when the remote is a GCS remote whose SERVICE-ACCOUNT KEY resolves —
     the class we can V4-sign locally (raw reads 307 to a signed URL). NOT
     anonymous GCS (public URL) and NOT a token-only GCS remote (user oauth / ADC
     tokens can't sign — those take the bearer proxy). Callers check
-    _gcs_anonymous FIRST."""
+    _gcs_anonymous FIRST. Rides the cached _gcs_signer so the predicate is
+    hot-path safe."""
     if not isinstance(cfg, dict) or cfg.get("type") != "google cloud storage":
         return False
     if _gcs_anonymous(cfg):
         return False
-    return gcssign.resolve_signer(cfg) is not None
+    return _gcs_signer(name, cfg) is not None
 
 
 def _gcs_signed_url(fs: str, rel: str) -> str | None:
     """A locally V4-signed GET URL for one object on an SA-key GCS remote, or
-    None when the remote isn't signer-capable (no SA key / [cloud-auth] absent)
-    or carries no bucket. Mints per object — gsign mode never caches links,
-    same rationale as S3 sign mode."""
-    cfg = _remote_config(fs.partition(":")[0])
-    signer = gcssign.resolve_signer(cfg)
+    None when the remote isn't signer-capable (no SA key / [cloud-auth] absent /
+    a transient key-read error) or carries no bucket. The signer rides the
+    cached _gcs_signer (no per-object key re-parse); mints per object — gsign
+    mode never caches links, same rationale as S3 sign mode."""
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
+    signer = _gcs_signer(name, cfg)
     if signer is None:
         return None
     url = _gcs_object_url(fs, rel)
@@ -2260,9 +2284,12 @@ def _gcs_get_direct(url: str, name: str, cfg: dict | None,
     the pre-existing code (no Authorization header, resolver never consulted).
 
     CREDENTIALED remote: the same GET carrying `Authorization: Bearer <token>`.
-    On a 401/403 the cached token is dropped ONCE and re-resolved, then the GET
-    retried — a token that expired early self-heals; a second rejection
-    propagates. The token value is never logged and never placed in the URL.
+    On a 401 (stale/rotated token) the cached credential is dropped ONCE and
+    re-resolved, then the GET retried — a token that expired early self-heals; a
+    second 401 propagates. A 403 is a permission denial WITH a valid token (a
+    per-object/prefix IAM policy), so it propagates immediately — re-resolving
+    the token wouldn't help and would churn the credential per denied probe. The
+    token value is never logged and never placed in the URL.
 
     Propagates HTTPError/URLError/OSError to the caller's error mapping (each
     keeps its own DirectListError / DirectProbeError wrapping and 404 handling);
@@ -2280,10 +2307,9 @@ def _gcs_get_direct(url: str, name: str, cfg: dict | None,
             with urllib.request.urlopen(req, timeout=timeout) as resp:
                 return resp.read()
         except urllib.error.HTTPError as e:
-            # A stale/rotated token reads as 401/403; drop it and re-resolve
-            # once. Any other status (incl. a 404 the caller treats as a
-            # trustworthy negative) propagates unchanged.
-            if attempt == 1 and e.code in (401, 403):
+            # 401 (bad/expired token) self-heals once; 403 (permission denial
+            # with a valid token) and every other status propagate unchanged.
+            if attempt == 1 and e.code == 401:
                 _invalidate_gcs_creds(name)  # force a freshly-resolved token
                 continue
             raise
@@ -2649,13 +2675,19 @@ def upstream_url_for(path: str) -> str | None:
 
 def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
     """(plain object URL, {"Authorization": "Bearer <token>"}) for a mount-backed
-    file on a token-only credentialed GCS remote — the tier the server proxies
-    through the pooled client because no URL may carry the token. None for
-    anonymous GCS (reachable by public URL), SA-key GCS (307-signable via
-    _upstream_url_for), and every non-GCS backend. Anonymous and signable are
-    checked FIRST, so an anonymous remote never consults the token resolver.
-    The token value is never logged and never placed in a URL. Never raises —
-    this sits on the raw-proxy hot path alongside upstream_url_for."""
+    file on a credentialed GCS remote the server should proxy (no URL may carry
+    the token). None for anonymous GCS (reachable by public URL) and every
+    non-GCS backend. Anonymous is checked FIRST, so it never consults the token
+    resolver.
+
+    Signability is only a TIE-BREAKER: when _upstream_url_for has PINNED
+    mode="bearer" (a gsign validation reject, or a token-only remote), we serve
+    the bearer token regardless of whether an SA key also parses — the signed
+    URL was rejected, so the token is the only working fast path (finding 1).
+    Only when no bearer mode is pinned do we defer to _gcs_signable (that remote
+    307s via _upstream_url_for instead). The token value is never logged and
+    never placed in a URL. Never raises — this sits on the raw-proxy hot path
+    alongside upstream_url_for."""
     try:
         m, rel = _mount_for(path)
         if m is None:
@@ -2663,8 +2695,12 @@ def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
         fs = m["remote"]
         name = fs.partition(":")[0]
         cfg = _remote_config(name)
-        if _gcs_anonymous(cfg or {}) or _gcs_signable(name, cfg):
+        if _gcs_anonymous(cfg or {}):
             return None
+        with _upstream_lock:
+            pinned_bearer = _upstream_mode.get(fs) == "bearer"
+        if not pinned_bearer and _gcs_signable(name, cfg):
+            return None  # 307-signable and not pinned to bearer -> not our path
         if not _gcs_credentialed(name, cfg):
             return None
         tok = _gcs_bearer_token(name, cfg)
@@ -2851,7 +2887,7 @@ def _gcs_sign_mode_url(fs: str, rel: str,
                 won = True
         if not won:  # a racer finished validating while we took the lock
             return _gcs_signed_url(fs, rel), "gsign"
-        signer = gcssign.resolve_signer(cfg)
+        signer = _gcs_signer(fs.partition(":")[0], cfg)
         if signer is None:  # not signer-capable -> bearer path
             return None, "bearer"
         signed, verdict = _gcs_validate_and_sign(fs, rel, signer)
@@ -2910,11 +2946,13 @@ def _upstream_url_for(path: str) -> str | None:
         signed = _gcs_signed_url(fs, rel)
         if signed is not None:
             return signed
-        # Signer rotated away -> demote to the bearer path (the token may still
-        # resolve); the server calls bearer_upstream_for when we return None.
+        # Signer unavailable (rotated key, or a transient cached-None window):
+        # UN-PIN the mode rather than pin "bearer" permanently, so the next
+        # request re-derives — bearer for now if a token resolves, gsign again
+        # once the signer comes back (the demotion is non-permanent, finding 5).
         with _upstream_lock:
             if _upstream_mode.get(fs) == "gsign":
-                _upstream_mode[fs] = "bearer"
+                _upstream_mode.pop(fs, None)
         return None
     if mode == "bearer":
         # Token-only GCS: no URL may carry the token, so there is nothing to
@@ -2954,11 +2992,11 @@ def _upstream_url_for(path: str) -> str | None:
             signed, disp = _gcs_sign_mode_url(fs, rel, cfg)
             if disp == "gsign" and signed is not None:
                 return signed
-            if disp == "gsign":  # active but signer vanished -> demote (find. 4)
+            if disp == "gsign":  # won validation but signer vanished mid-flight
                 with _upstream_lock:
                     if _upstream_mode.get(fs) == "gsign":
-                        _upstream_mode[fs] = "bearer"
-                mode = "bearer"
+                        _upstream_mode.pop(fs, None)  # un-pin, re-derive next time
+                return None
             elif disp == "retry":
                 cache_mode = False  # serve via bearer now, keep retrying gsign
                 mode = "bearer"

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1550,6 +1550,62 @@ _gcs_creds_cache: dict = {}  # remote name -> (google-auth creds obj|None, mono 
 _gcs_signer_cache: dict = {}  # remote name -> (gcssign.Signer|None, monotonic exp)
 _sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
 _validation_locks: dict = {}  # fs -> Lock: per-fs single-flight for validation
+# fs -> monotonic expiry: a signable-shaped GCS remote whose gsign is in its
+# retry window (contended validation, neg-cached, or a momentarily-unresolvable
+# signer) should serve THIS request via the bearer proxy rather than dead-end at
+# the serve — so bearer_upstream_for treats the remote as bearer-eligible while
+# this is live even though its SA key still parses (finding 1).
+_gcs_bearer_fallback: dict = {}
+# Per-(cache, name) single-flight locks: a cold miss on any upstream resolver
+# runs the (network-blocking) source ONCE across N concurrent readers instead of
+# each thread independently walking it. Keyed by the cache's id() so every
+# per-name cache shares this one registry (the GCS token refresh also serializes
+# through it, giving the shared google-auth credential object a single refresher,
+# finding 7).
+_cache_locks: dict = {}
+
+# Registries so an invalidator can't miss a cache. _NAME_CACHES are the per-
+# remote-name resolver caches; _GCS_NAME_CACHES the subset _invalidate_gcs_creds
+# drops (the GCS token + credential object); _UPSTREAM_MAPS the per-fs / per-
+# remote state that full invalidation also clears.
+_GCS_NAME_CACHES = (_gcs_token_cache, _gcs_creds_cache)
+_NAME_CACHES = (_cred_cache, _botocore_creds_cache, _gcs_signer_cache,
+                *_GCS_NAME_CACHES)
+_UPSTREAM_MAPS = (_upstream_cfg, _upstream_mode, _upstream_region,
+                  _upstream_links, _sign_neg_cache, _validation_locks,
+                  _gcs_bearer_fallback)
+
+
+def _cached_resolve(cache: dict, name: str, ttl, resolve):
+    """Per-name TTL cache with per-name single-flight, shared by every upstream
+    resolver cache. `cache` maps name -> (value, monotonic expiry); on a miss,
+    exactly ONE thread (per name) runs `resolve()` while the rest wait on the
+    per-name lock and then read the value it cached — so N concurrent cold reads
+    don't each walk a black-holed IMDS probe / OAuth+ADC round trip.
+
+    `ttl` is the lifetime in seconds, or a callable value->seconds when the
+    lifetime depends on the resolved value (the GCS bearer token runs to its own
+    expiry). A None result IS cached — the negative caching is load-bearing (it
+    bounds how often an absent [cloud-auth] / black-holed metadata endpoint is
+    re-probed). Double-checked: the cache is re-read after the lock is acquired
+    so a racer that already resolved is reused, not re-resolved. resolve() runs
+    WITHOUT _upstream_lock held, so it may call other _cached_resolve caches."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+        lock = _cache_locks.setdefault((id(cache), name), threading.Lock())
+    with lock:
+        with _upstream_lock:
+            hit = cache.get(name)
+            if hit is not None and hit[1] > time.monotonic():
+                return hit[0]
+        value = resolve()
+        ttl_s = ttl(value) if callable(ttl) else ttl
+        with _upstream_lock:
+            cache[name] = (value, time.monotonic() + ttl_s)
+        return value
 
 
 class _NoRedirect(urllib.request.HTTPRedirectHandler):
@@ -1598,17 +1654,9 @@ def _invalidate_upstream_caches() -> None:
     are rare, user-initiated events, and for anonymous remotes it only forces a
     cheap re-derivation of the public mode."""
     with _upstream_lock:
-        _upstream_cfg.clear()
-        _upstream_mode.clear()
-        _upstream_region.clear()
-        _cred_cache.clear()
-        _botocore_creds_cache.clear()
-        _gcs_token_cache.clear()
-        _gcs_creds_cache.clear()
-        _gcs_signer_cache.clear()
-        _upstream_links.clear()
-        _sign_neg_cache.clear()
-        _validation_locks.clear()
+        for d in (*_UPSTREAM_MAPS, *_NAME_CACHES):
+            d.clear()
+        _cache_locks.clear()
 
 
 def _store_upstream_link(key, url: str, expiry: float, now: float) -> None:
@@ -1806,16 +1854,10 @@ def _botocore_chain(name: str, cfg: dict | None):
     per _BOTOCORE_CHAIN_TTL_S; the cached object self-refreshes STS near expiry,
     so frozen_from_botocore on it is cheap between walks. Cleared by
     _invalidate_upstream_caches. None (also cached) when the chain yields
-    nothing."""
-    now = time.monotonic()
-    with _upstream_lock:
-        hit = _botocore_creds_cache.get(name)
-        if hit is not None and hit[1] > now:
-            return hit[0]
-    chain = s3sign.resolve_botocore_chain(cfg)
-    with _upstream_lock:
-        _botocore_creds_cache[name] = (chain, now + _BOTOCORE_CHAIN_TTL_S)
-    return chain
+    nothing. Single-flight per name via _cached_resolve so a black-holed IMDS
+    probe is walked once, not once per concurrent cold reader (finding 10)."""
+    return _cached_resolve(_botocore_creds_cache, name, _BOTOCORE_CHAIN_TTL_S,
+                           lambda: s3sign.resolve_botocore_chain(cfg))
 
 
 def _signable_credentials(name: str, cfg: dict | None):
@@ -1825,18 +1867,14 @@ def _signable_credentials(name: str, cfg: dict | None):
     path. The botocore rung rides the LONGER-lived, self-refreshing chain-object
     cache (_botocore_chain), so the expensive provider-chain walk isn't repeated
     every _CRED_TTL_S — only get_frozen_credentials runs per window. None (also
-    cached) when nothing resolves."""
-    now = time.monotonic()
-    with _upstream_lock:
-        hit = _cred_cache.get(name)
-        if hit is not None and hit[1] > now:
-            return hit[0]
-    creds = s3sign.resolve_static_credentials(cfg)
-    if creds is None and s3sign.needs_botocore(cfg):
-        creds = s3sign.frozen_from_botocore(_botocore_chain(name, cfg))
-    with _upstream_lock:
-        _cred_cache[name] = (creds, now + _CRED_TTL_S)
-    return creds
+    cached) when nothing resolves. Single-flight per name via _cached_resolve
+    (finding 10)."""
+    def resolve():
+        creds = s3sign.resolve_static_credentials(cfg)
+        if creds is None and s3sign.needs_botocore(cfg):
+            creds = s3sign.frozen_from_botocore(_botocore_chain(name, cfg))
+        return creds
+    return _cached_resolve(_cred_cache, name, _CRED_TTL_S, resolve)
 
 
 def _gcs_credentials(name: str, cfg: dict | None):
@@ -1846,16 +1884,11 @@ def _gcs_credentials(name: str, cfg: dict | None):
     token_from_credentials renews it near expiry WITHOUT rebuilding the chain.
     Re-derived from config only once per window (picks up a rotated key), and
     dropped by _invalidate_upstream_caches / invalidate_gcs_token. None (also
-    cached) when nothing resolves."""
-    now = time.monotonic()
-    with _upstream_lock:
-        hit = _gcs_creds_cache.get(name)
-        if hit is not None and hit[1] > now:
-            return hit[0]
-    creds = gcssign.resolve_credentials(cfg)
-    with _upstream_lock:
-        _gcs_creds_cache[name] = (creds, now + _CRED_TTL_S)
-    return creds
+    cached) when nothing resolves. Single-flight per name via _cached_resolve so
+    the ADC/GCE-metadata probe is walked once, not per concurrent cold reader,
+    and the shared credential object gets a single refresher (findings 7, 10)."""
+    return _cached_resolve(_gcs_creds_cache, name, _CRED_TTL_S,
+                           lambda: gcssign.resolve_credentials(cfg))
 
 
 def _gcs_bearer_token(name: str, cfg: dict | None):
@@ -1865,35 +1898,35 @@ def _gcs_bearer_token(name: str, cfg: dict | None):
     forcing an OAuth round trip per _CRED_TTL_S window. The token cache runs to
     expiry minus _GCS_TOKEN_SLACK_S (re-resolved before GCS would reject it); a
     None result (not credentialed / [cloud-auth] absent) is cached for
-    _CRED_TTL_S. Returns a gcssign.Token or None."""
-    now = time.monotonic()
-    with _upstream_lock:
-        hit = _gcs_token_cache.get(name)
-        if hit is not None and hit[1] > now:
-            return hit[0]
-    creds = _gcs_credentials(name, cfg)
-    tok = gcssign.token_from_credentials(creds) if creds is not None else None
-    if tok is None:
-        expiry = now + _CRED_TTL_S
-    else:
+    _CRED_TTL_S. Returns a gcssign.Token or None. Single-flight per name via
+    _cached_resolve — the one refresher requirement of finding 7 (the shared
+    google-auth credential's refresh() runs under this per-name lock)."""
+    def resolve():
+        creds = _gcs_credentials(name, cfg)
+        return (gcssign.token_from_credentials(creds)
+                if creds is not None else None)
+
+    def ttl(tok):
+        if tok is None:
+            return _CRED_TTL_S  # None (not credentialed / no [cloud-auth])
         # token.expiry_epoch is wall-clock (time.time); map its remaining life
-        # onto the monotonic clock the cache keys off. Runs to expiry-slack (not
-        # clamped to _CRED_TTL_S) — the self-refreshing creds object is what
-        # picks up rotation on the next _CRED_TTL_S re-derivation.
-        remaining = tok.expiry_epoch - time.time() - _GCS_TOKEN_SLACK_S
-        expiry = now + max(0.0, remaining)
-    with _upstream_lock:
-        _gcs_token_cache[name] = (tok, expiry)
-    return tok
+        # onto the monotonic clock _cached_resolve keys off. Runs to expiry-slack
+        # (not clamped to _CRED_TTL_S) — the self-refreshing creds object picks
+        # up rotation on the next _CRED_TTL_S re-derivation.
+        return max(0.0, tok.expiry_epoch - time.time() - _GCS_TOKEN_SLACK_S)
+
+    return _cached_resolve(_gcs_token_cache, name, ttl, resolve)
 
 
 def _invalidate_gcs_creds(name: str) -> None:
     """Drop a remote's cached bearer token AND credential object so the next
     resolution re-derives from config (forces a fresh token). Used by the direct
-    fetch helper and the bearer read proxy on a 401 (stale/rotated token)."""
+    fetch helper and the bearer read proxy on a 401 (stale/rotated token). Clears
+    exactly the GCS token + credential-object caches (the registry keeps this in
+    lockstep with what those caches are)."""
     with _upstream_lock:
-        _gcs_token_cache.pop(name, None)
-        _gcs_creds_cache.pop(name, None)
+        for cache in _GCS_NAME_CACHES:
+            cache.pop(name, None)
 
 
 def _gcs_credentialed(name: str, cfg: dict | None) -> bool:
@@ -1934,16 +1967,10 @@ def _gcs_signer(name: str, cfg: dict | None):
     (once per object) — and a transient open() error would otherwise stick as a
     permanent demotion; the cache bounds that window to one TTL. None (also
     cached) when the remote has no signer-capable SA key. Returns a
-    gcssign.Signer or None."""
-    now = time.monotonic()
-    with _upstream_lock:
-        hit = _gcs_signer_cache.get(name)
-        if hit is not None and hit[1] > now:
-            return hit[0]
-    signer = gcssign.resolve_signer(cfg)
-    with _upstream_lock:
-        _gcs_signer_cache[name] = (signer, now + _CRED_TTL_S)
-    return signer
+    gcssign.Signer or None. Single-flight per name via _cached_resolve
+    (finding 10)."""
+    return _cached_resolve(_gcs_signer_cache, name, _CRED_TTL_S,
+                           lambda: gcssign.resolve_signer(cfg))
 
 
 def _gcs_signable(name: str, cfg: dict | None) -> bool:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1539,6 +1539,7 @@ _upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
 _upstream_region: dict = {}  # fs -> region (self-corrected from x-amz-bucket-region)
 _cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry)
 _gcs_token_cache: dict = {}  # remote name -> (gcssign.Token|None, monotonic exp)
+_gcs_creds_cache: dict = {}  # remote name -> (google-auth creds obj|None, mono exp)
 _sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
 _validation_locks: dict = {}  # fs -> Lock: per-fs single-flight for validation
 
@@ -1594,6 +1595,7 @@ def _invalidate_upstream_caches() -> None:
         _upstream_region.clear()
         _cred_cache.clear()
         _gcs_token_cache.clear()
+        _gcs_creds_cache.clear()
         _upstream_links.clear()
         _sign_neg_cache.clear()
         _validation_locks.clear()
@@ -1804,30 +1806,61 @@ def _signable_credentials(name: str, cfg: dict | None):
     return creds
 
 
+def _gcs_credentials(name: str, cfg: dict | None):
+    """The google-auth credential OBJECT for a GCS remote, cached per name for
+    _CRED_TTL_S so the sources (SA key parse / rclone oauth / ADC + GCE metadata
+    probe) aren't re-walked per object. The cached object is self-refreshing, so
+    token_from_credentials renews it near expiry WITHOUT rebuilding the chain.
+    Re-derived from config only once per window (picks up a rotated key), and
+    dropped by _invalidate_upstream_caches / invalidate_gcs_token. None (also
+    cached) when nothing resolves."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = _gcs_creds_cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+    creds = gcssign.resolve_credentials(cfg)
+    with _upstream_lock:
+        _gcs_creds_cache[name] = (creds, now + _CRED_TTL_S)
+    return creds
+
+
 def _gcs_bearer_token(name: str, cfg: dict | None):
-    """gcssign.resolve_token for a GCS remote, cached per name — the GCS analog
-    of _signable_credentials. TTL is the shorter of the _CRED_TTL_S re-read
-    window and the token's own remaining life minus _GCS_TOKEN_SLACK_S, so a
-    dying token is re-resolved before GCS starts rejecting it. A None result
-    (not credentialed / [cloud-auth] absent) is cached for _CRED_TTL_S so the
-    listing/probe hot path doesn't re-resolve per object. Returns a
-    gcssign.Token or None."""
+    """A bearer access Token for a GCS remote, cached per name — the GCS analog
+    of _signable_credentials. Derives the token from the cached (self-refreshing)
+    credential object, so a live token is reused for its whole life instead of
+    forcing an OAuth round trip per _CRED_TTL_S window. The token cache runs to
+    expiry minus _GCS_TOKEN_SLACK_S (re-resolved before GCS would reject it); a
+    None result (not credentialed / [cloud-auth] absent) is cached for
+    _CRED_TTL_S. Returns a gcssign.Token or None."""
     now = time.monotonic()
     with _upstream_lock:
         hit = _gcs_token_cache.get(name)
         if hit is not None and hit[1] > now:
             return hit[0]
-    tok = gcssign.resolve_token(cfg)
+    creds = _gcs_credentials(name, cfg)
+    tok = gcssign.token_from_credentials(creds) if creds is not None else None
     if tok is None:
         expiry = now + _CRED_TTL_S
     else:
         # token.expiry_epoch is wall-clock (time.time); map its remaining life
-        # onto the monotonic clock the cache keys off, clamped to [0, TTL].
+        # onto the monotonic clock the cache keys off. Runs to expiry-slack (not
+        # clamped to _CRED_TTL_S) — the self-refreshing creds object is what
+        # picks up rotation on the next _CRED_TTL_S re-derivation.
         remaining = tok.expiry_epoch - time.time() - _GCS_TOKEN_SLACK_S
-        expiry = now + max(0.0, min(_CRED_TTL_S, remaining))
+        expiry = now + max(0.0, remaining)
     with _upstream_lock:
         _gcs_token_cache[name] = (tok, expiry)
     return tok
+
+
+def _invalidate_gcs_creds(name: str) -> None:
+    """Drop a remote's cached bearer token AND credential object so the next
+    resolution re-derives from config (forces a fresh token). Used by the direct
+    fetch helper and the bearer read proxy on a 401 (stale/rotated token)."""
+    with _upstream_lock:
+        _gcs_token_cache.pop(name, None)
+        _gcs_creds_cache.pop(name, None)
 
 
 def _gcs_credentialed(name: str, cfg: dict | None) -> bool:
@@ -2220,8 +2253,7 @@ def _gcs_get_direct(url: str, name: str, cfg: dict | None,
             # once. Any other status (incl. a 404 the caller treats as a
             # trustworthy negative) propagates unchanged.
             if attempt == 1 and e.code in (401, 403):
-                with _upstream_lock:
-                    _gcs_token_cache.pop(name, None)
+                _invalidate_gcs_creds(name)  # force a freshly-resolved token
                 continue
             raise
     raise urllib.error.URLError(f"{name}: GCS bearer retry exhausted")

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -44,7 +44,7 @@ from datetime import datetime
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
 
-from fused_render.shell import s3sign, storage
+from fused_render.shell import gcssign, s3sign, storage
 
 logger = logging.getLogger(__name__)
 
@@ -1520,6 +1520,9 @@ _LINK_TTL_S = 30 * 60.0
 _SIGN_EXPIRY_S = 15 * 60
 _SIGN_VALIDATE_TIMEOUT_S = 5.0
 _CRED_TTL_S = 60.0  # re-read env / ~/.aws so a rotated key / STS refresh lands
+# Re-resolve a GCS bearer token this many seconds BEFORE its stated expiry, so a
+# read never hands GCS a token that expires mid-flight.
+_GCS_TOKEN_SLACK_S = 60.0
 # When sign-mode validation fails while no fallback can be committed (rcd down,
 # so publiclink can't cache a "link" mode either), negative-cache the failed
 # validation per fs for this window so every raw read doesn't re-run the 1-2
@@ -1531,10 +1534,11 @@ _UPSTREAM_LINKS_CAP = 4096  # bound the publiclink cache (sign mode never insert
 _SESSION_TOKEN_LINK_TTL_S = 5 * 60.0
 _upstream_lock = threading.Lock()
 _upstream_links: dict = {}  # (fs, rel) -> (url, monotonic expiry)
-_upstream_mode: dict = {}   # fs -> "link" | "public" | "none" | "sign"
+_upstream_mode: dict = {}   # fs -> "link"|"public"|"none"|"sign"|"gsign"|"bearer"
 _upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
 _upstream_region: dict = {}  # fs -> region (self-corrected from x-amz-bucket-region)
 _cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry)
+_gcs_token_cache: dict = {}  # remote name -> (gcssign.Token|None, monotonic exp)
 _sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
 _validation_locks: dict = {}  # fs -> Lock: per-fs single-flight for validation
 
@@ -1589,6 +1593,7 @@ def _invalidate_upstream_caches() -> None:
         _upstream_mode.clear()
         _upstream_region.clear()
         _cred_cache.clear()
+        _gcs_token_cache.clear()
         _upstream_links.clear()
         _sign_neg_cache.clear()
         _validation_locks.clear()
@@ -1795,6 +1800,48 @@ def _signable_credentials(name: str, cfg: dict | None):
     with _upstream_lock:
         _cred_cache[name] = (creds, now + _CRED_TTL_S)
     return creds
+
+
+def _gcs_bearer_token(name: str, cfg: dict | None):
+    """gcssign.resolve_token for a GCS remote, cached per name — the GCS analog
+    of _signable_credentials. TTL is the shorter of the _CRED_TTL_S re-read
+    window and the token's own remaining life minus _GCS_TOKEN_SLACK_S, so a
+    dying token is re-resolved before GCS starts rejecting it. A None result
+    (not credentialed / [cloud-auth] absent) is cached for _CRED_TTL_S so the
+    listing/probe hot path doesn't re-resolve per object. Returns a
+    gcssign.Token or None."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = _gcs_token_cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+    tok = gcssign.resolve_token(cfg)
+    if tok is None:
+        expiry = now + _CRED_TTL_S
+    else:
+        # token.expiry_epoch is wall-clock (time.time); map its remaining life
+        # onto the monotonic clock the cache keys off, clamped to [0, TTL].
+        remaining = tok.expiry_epoch - time.time() - _GCS_TOKEN_SLACK_S
+        expiry = now + max(0.0, min(_CRED_TTL_S, remaining))
+    with _upstream_lock:
+        _gcs_token_cache[name] = (tok, expiry)
+    return tok
+
+
+def _gcs_credentialed(name: str, cfg: dict | None) -> bool:
+    """True when the remote is GCS, NOT anonymous, and a bearer token resolves —
+    the class we can list/probe/read directly with an Authorization header
+    instead of crawling the serialized VFS serve. Anonymous GCS carries no
+    credentials and is handled first by _gcs_anonymous, so callers must check it
+    FIRST (an anonymous remote's token resolves to None, so this returns False
+    anyway); the guard keeps the resolver off the anonymous path. Token
+    resolution rides the cached _gcs_bearer_token so the predicate is hot-path
+    safe and can't disagree with the fetch helper within a _CRED_TTL_S window."""
+    if not isinstance(cfg, dict) or cfg.get("type") != "google cloud storage":
+        return False
+    if _gcs_anonymous(cfg):
+        return False
+    return _gcs_bearer_token(name, cfg) is not None
 
 
 def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
@@ -2080,13 +2127,58 @@ _GCS_LIST_URL = "https://storage.googleapis.com/storage/v1/b/{bucket}/o"
 
 
 def gcs_direct_capable(path: str) -> bool:
-    """True when `path` is mount-backed by an anonymous GCS remote — the one
-    GCS backend class gcs_list_page can enumerate unsigned. Mirrors
-    s3_direct_capable for the GCS side."""
+    """True when `path` is mount-backed by a GCS remote gcs_list_page can
+    enumerate directly — anonymous (unsigned) OR credentialed (a bearer token
+    resolves). Mirrors s3_direct_capable, which unions anonymous and signable.
+    _gcs_anonymous is tested first, so an anonymous remote never reaches the
+    token resolver."""
     m, _ = _mount_for(path)
     if m is None:
         return False
-    return _gcs_anonymous(_remote_config(m["remote"].partition(":")[0]) or {})
+    name = m["remote"].partition(":")[0]
+    cfg = _remote_config(name)
+    return _gcs_anonymous(cfg or {}) or _gcs_credentialed(name, cfg)
+
+
+def _gcs_get_direct(url: str, name: str, cfg: dict | None,
+                    timeout: float) -> bytes:
+    """Body bytes of a direct GCS listing/probe/metadata GET, shared by
+    gcs_list_page, _gcs_head and _gcs_has_children so they can't diverge on
+    transport (the GCS analog of _s3_get_direct's role).
+
+    ANONYMOUS remote: a plain urlopen on the unsigned URL — byte-identical to
+    the pre-existing code (no Authorization header, resolver never consulted).
+
+    CREDENTIALED remote: the same GET carrying `Authorization: Bearer <token>`.
+    On a 401/403 the cached token is dropped ONCE and re-resolved, then the GET
+    retried — a token that expired early self-heals; a second rejection
+    propagates. The token value is never logged and never placed in the URL.
+
+    Propagates HTTPError/URLError/OSError to the caller's error mapping (each
+    keeps its own DirectListError / DirectProbeError wrapping and 404 handling);
+    a missing token surfaces as URLError, which both callers already map."""
+    if _gcs_anonymous(cfg or {}):
+        with urllib.request.urlopen(url, timeout=timeout) as resp:
+            return resp.read()
+    for attempt in (1, 2):
+        tok = _gcs_bearer_token(name, cfg)
+        if tok is None:
+            raise urllib.error.URLError(f"{name}: no GCS bearer token")
+        req = urllib.request.Request(
+            url, headers={"Authorization": f"Bearer {tok.access_token}"})
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return resp.read()
+        except urllib.error.HTTPError as e:
+            # A stale/rotated token reads as 401/403; drop it and re-resolve
+            # once. Any other status (incl. a 404 the caller treats as a
+            # trustworthy negative) propagates unchanged.
+            if attempt == 1 and e.code in (401, 403):
+                with _upstream_lock:
+                    _gcs_token_cache.pop(name, None)
+                continue
+            raise
+    raise urllib.error.URLError(f"{name}: GCS bearer retry exhausted")
 
 
 def _gcs_bucket_prefix(fs: str) -> tuple[str, str] | None:
@@ -2123,9 +2215,14 @@ def gcs_list_page(path: str, *, max_keys: int, continuation: str | None = None,
     if m is None:
         raise DirectListError(f"{path} is under no known mount")
     fs = m["remote"]
-    cfg = _remote_config(fs.partition(":")[0])
-    if not _gcs_anonymous(cfg or {}):
-        raise DirectListError(f"{path}: remote {fs!r} is not anonymous GCS")
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
+    # Anonymous FIRST: an anonymous remote never resolves a token, never sends
+    # an Authorization header — its request is the exact unsigned one today's
+    # code produces.
+    if not (_gcs_anonymous(cfg or {}) or _gcs_credentialed(name, cfg)):
+        raise DirectListError(
+            f"{path}: remote {fs!r} is not direct-listable GCS")
     derived = _gcs_bucket_prefix(fs)
     if derived is None:
         raise DirectListError(f"{path}: remote {fs!r} carries no bucket")
@@ -2137,9 +2234,10 @@ def gcs_list_page(path: str, *, max_keys: int, continuation: str | None = None,
         params["pageToken"] = continuation
     query = urllib.parse.urlencode(params)
     url = f"{_GCS_LIST_URL.format(bucket=bucket)}?{query}"
+    # _gcs_get_direct fetches unsigned (anonymous — byte-identical) or with a
+    # bearer header (credentialed), self-healing one stale-token 401/403.
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
+        body = _gcs_get_direct(url, name, cfg, timeout)
     except urllib.error.HTTPError as e:
         raise DirectListError(f"GCS list {path}: HTTP {e.code}") from e
     except (urllib.error.URLError, OSError) as e:
@@ -2342,6 +2440,8 @@ def _gcs_head(path: str, timeout: float) -> DirectHead:
     if rel == ".":
         return DirectHead(False, None, None)  # the mountpoint is not an object
     fs = m["remote"]
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
     derived = _gcs_bucket_prefix(fs)
     if derived is None:
         raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
@@ -2349,9 +2449,10 @@ def _gcs_head(path: str, timeout: float) -> DirectHead:
     key = (store_prefix + "/" if store_prefix else "") + rel
     url = _GCS_OBJ_URL.format(bucket=bucket,
                               key=urllib.parse.quote(key, safe=""))
+    # Unsigned for anonymous (byte-identical), bearer-authorized for
+    # credentialed — the same transport the pager uses via _gcs_get_direct.
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
+        body = _gcs_get_direct(url, name, cfg, timeout)
     except urllib.error.HTTPError as e:
         if e.code == 404:
             return DirectHead(False, None, None)  # trustworthy negative
@@ -2401,6 +2502,8 @@ def _s3_has_children(path: str, timeout: float) -> bool:
 def _gcs_has_children(path: str, timeout: float) -> bool:
     m, rel = _mount_for(path)
     fs = m["remote"]
+    name = fs.partition(":")[0]
+    cfg = _remote_config(name)
     derived = _gcs_bucket_prefix(fs)
     if derived is None:
         raise DirectProbeError(f"{path}: remote {fs!r} carries no bucket")
@@ -2409,9 +2512,10 @@ def _gcs_has_children(path: str, timeout: float) -> bool:
     params = {"prefix": prefix, "maxResults": "1"}
     query = urllib.parse.urlencode(params)
     url = f"{_GCS_LIST_URL.format(bucket=bucket)}?{query}"
+    # Unsigned for anonymous, bearer-authorized for credentialed (via
+    # _gcs_get_direct) — the same transport the pager and head probe use.
     try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            body = resp.read()
+        body = _gcs_get_direct(url, name, cfg, timeout)
     except urllib.error.HTTPError as e:
         raise DirectProbeError(f"GCS list {path}: HTTP {e.code}") from e
     except (urllib.error.URLError, OSError) as e:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1835,17 +1835,13 @@ def _gcs_public_object_url(fs: str, rel: str) -> str | None:
     (storage.googleapis.com/<bucket>/<key>), so there is no region and no
     dotted-bucket rule. Credentialed or non-GCS remotes return None (their
     objects aren't reachable unsigned). Pure string building once
-    _remote_config has memoized the config — no rc round trip per object."""
+    _remote_config has memoized the config — no rc round trip per object. Gates
+    on anonymous, then delegates the URL construction to _gcs_object_url so the
+    path-style layout and key quoting live in one place (C2)."""
     cfg = _remote_config(fs.partition(":")[0])
     if not _gcs_anonymous(cfg or {}):
         return None
-    derived = _gcs_bucket_prefix(fs)
-    if derived is None:
-        return None
-    bucket, prefix = derived
-    key = (prefix + "/" if prefix else "") + rel
-    # Match _public_object_url's key quoting (same default safe chars).
-    return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
+    return _gcs_object_url(fs, rel)
 
 
 def _botocore_chain(name: str, cfg: dict | None):
@@ -2952,6 +2948,16 @@ def _gcs_sign_mode_url(fs: str, rel: str,
         reject_disp="bearer")
 
 
+def _demote_gsign(fs: str) -> None:
+    """Un-pin gsign mode for `fs` (idempotent), so the next request re-derives
+    the mode from scratch — gsign again once the signer returns, bearer meanwhile
+    if a token resolves. The demotion is NON-permanent (findings 4, 5). Shared by
+    both un-pin sites so they can't drift (C5)."""
+    with _upstream_lock:
+        if _upstream_mode.get(fs) == "gsign":
+            _upstream_mode.pop(fs, None)
+
+
 def _upstream_url_for(path: str) -> str | None:
     m, rel = _mount_for(path)
     if m is None:
@@ -2996,9 +3002,7 @@ def _upstream_url_for(path: str) -> str | None:
         # UN-PIN the mode rather than pin "bearer" permanently, so the next
         # request re-derives — bearer for now if a token resolves, gsign again
         # once the signer comes back (the demotion is non-permanent, finding 5).
-        with _upstream_lock:
-            if _upstream_mode.get(fs) == "gsign":
-                _upstream_mode.pop(fs, None)
+        _demote_gsign(fs)
         return None
     if mode == "bearer":
         # Token-only GCS: no URL may carry the token, so there is nothing to
@@ -3041,9 +3045,7 @@ def _upstream_url_for(path: str) -> str | None:
             if disp == "gsign" and signed is not None:
                 return signed
             if disp == "gsign":  # won validation but signer vanished mid-flight
-                with _upstream_lock:
-                    if _upstream_mode.get(fs) == "gsign":
-                        _upstream_mode.pop(fs, None)  # un-pin, re-derive next time
+                _demote_gsign(fs)  # un-pin, re-derive next time
                 return None
             elif disp == "retry":
                 # Contended / neg-cached / signer momentarily unresolvable: serve

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1520,6 +1520,12 @@ _LINK_TTL_S = 30 * 60.0
 _SIGN_EXPIRY_S = 15 * 60
 _SIGN_VALIDATE_TIMEOUT_S = 5.0
 _CRED_TTL_S = 60.0  # re-read env / ~/.aws so a rotated key / STS refresh lands
+# The botocore provider chain (SSO/IMDS/credential_process) is expensive to walk
+# — a black-holed IMDS probe stalls ~1-2s — so its self-refreshing credentials
+# object is cached far longer than the 60s frozen-credential window; the object
+# refreshes STS itself near expiry, and this bound just lets a fresh `aws sso
+# login` be picked up without a restart.
+_BOTOCORE_CHAIN_TTL_S = 10 * 60.0
 # Re-resolve a GCS bearer token this many seconds BEFORE its stated expiry, so a
 # read never hands GCS a token that expires mid-flight.
 _GCS_TOKEN_SLACK_S = 60.0
@@ -1538,6 +1544,7 @@ _upstream_mode: dict = {}   # fs -> "link"|"public"|"none"|"sign"|"gsign"|"beare
 _upstream_cfg: dict = {}    # remote name -> config/get dict (successes only)
 _upstream_region: dict = {}  # fs -> region (self-corrected from x-amz-bucket-region)
 _cred_cache: dict = {}      # remote name -> (Credentials|None, monotonic expiry)
+_botocore_creds_cache: dict = {}  # remote name -> (botocore creds obj|None, exp)
 _gcs_token_cache: dict = {}  # remote name -> (gcssign.Token|None, monotonic exp)
 _gcs_creds_cache: dict = {}  # remote name -> (google-auth creds obj|None, mono exp)
 _sign_neg_cache: dict = {}  # fs -> monotonic expiry: skip sign validation until
@@ -1594,6 +1601,7 @@ def _invalidate_upstream_caches() -> None:
         _upstream_mode.clear()
         _upstream_region.clear()
         _cred_cache.clear()
+        _botocore_creds_cache.clear()
         _gcs_token_cache.clear()
         _gcs_creds_cache.clear()
         _upstream_links.clear()
@@ -1790,17 +1798,40 @@ def _gcs_public_object_url(fs: str, rel: str) -> str | None:
     return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
 
 
+def _botocore_chain(name: str, cfg: dict | None):
+    """Cached botocore provider-chain credentials OBJECT per remote. The chain
+    walk (which can stall ~1-2s on a black-holed IMDS probe) runs at most once
+    per _BOTOCORE_CHAIN_TTL_S; the cached object self-refreshes STS near expiry,
+    so frozen_from_botocore on it is cheap between walks. Cleared by
+    _invalidate_upstream_caches. None (also cached) when the chain yields
+    nothing."""
+    now = time.monotonic()
+    with _upstream_lock:
+        hit = _botocore_creds_cache.get(name)
+        if hit is not None and hit[1] > now:
+            return hit[0]
+    chain = s3sign.resolve_botocore_chain(cfg)
+    with _upstream_lock:
+        _botocore_creds_cache[name] = (chain, now + _BOTOCORE_CHAIN_TTL_S)
+    return chain
+
+
 def _signable_credentials(name: str, cfg: dict | None):
     """resolve_credentials for a remote, cached per name for _CRED_TTL_S so a
     rotated ~/.aws/credentials or an STS refresh is picked up without a
     restart, but the env/file reads aren't paid per object on the sign hot
-    path. None (also cached) when nothing resolves."""
+    path. The botocore rung rides the LONGER-lived, self-refreshing chain-object
+    cache (_botocore_chain), so the expensive provider-chain walk isn't repeated
+    every _CRED_TTL_S — only get_frozen_credentials runs per window. None (also
+    cached) when nothing resolves."""
     now = time.monotonic()
     with _upstream_lock:
         hit = _cred_cache.get(name)
         if hit is not None and hit[1] > now:
             return hit[0]
-    creds = s3sign.resolve_credentials(cfg)
+    creds = s3sign.resolve_static_credentials(cfg)
+    if creds is None and s3sign.needs_botocore(cfg):
+        creds = s3sign.frozen_from_botocore(_botocore_chain(name, cfg))
     with _upstream_lock:
         _cred_cache[name] = (creds, now + _CRED_TTL_S)
     return creds

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2707,14 +2707,17 @@ def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
     non-GCS backend. Anonymous is checked FIRST, so it never consults the token
     resolver.
 
-    Signability is only a TIE-BREAKER: when _upstream_url_for has PINNED
-    mode="bearer" (a gsign validation reject, or a token-only remote), we serve
-    the bearer token regardless of whether an SA key also parses — the signed
-    URL was rejected, so the token is the only working fast path (finding 1).
-    Only when no bearer mode is pinned do we defer to _gcs_signable (that remote
-    307s via _upstream_url_for instead). The token value is never logged and
-    never placed in a URL. Never raises — this sits on the raw-proxy hot path
-    alongside upstream_url_for."""
+    Signability is only a TIE-BREAKER, and only when the remote is NOT already
+    on the bearer path. We serve the bearer token when EITHER (a) _upstream_url_for
+    has PINNED mode="bearer" (a gsign validation reject, or a token-only remote),
+    OR (b) the fs is in a gsign RETRY window (_gcs_bearer_fallback — validation
+    contended / neg-cached / signer momentarily unresolvable): in both cases the
+    signed-URL path can't serve THIS request, so the token is the only working
+    fast path (finding 1). Only when neither holds do we defer to _gcs_signable
+    (that remote 307s via _upstream_url_for instead) — without this the retry
+    window would dead-end at the slow serve despite a resolvable token. The token
+    value is never logged and never placed in a URL. Never raises — this sits on
+    the raw-proxy hot path alongside upstream_url_for."""
     try:
         m, rel = _mount_for(path)
         if m is None:
@@ -2724,14 +2727,14 @@ def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
         cfg = _remote_config(name)
         if _gcs_anonymous(cfg or {}):
             return None
+        now = time.monotonic()
         with _upstream_lock:
-            pinned_bearer = _upstream_mode.get(fs) == "bearer"
-        if not pinned_bearer and _gcs_signable(name, cfg):
-            return None  # 307-signable and not pinned to bearer -> not our path
-        if not _gcs_credentialed(name, cfg):
-            return None
+            on_bearer_path = (_upstream_mode.get(fs) == "bearer"
+                              or _gcs_bearer_fallback.get(fs, 0.0) > now)
+        if not on_bearer_path and _gcs_signable(name, cfg):
+            return None  # 307-signable and not on the bearer path -> not ours
         tok = _gcs_bearer_token(name, cfg)
-        if tok is None:
+        if tok is None:  # not credentialed / no [cloud-auth] -> fall to serve
             return None
         url = _gcs_object_url(fs, rel)
         if url is None:
@@ -2913,15 +2916,18 @@ def _gcs_validate_and_sign(fs: str, rel: str,
 
 def _gcs_sign_mode_url(fs: str, rel: str,
                        cfg: dict) -> tuple[str | None, str]:
-    """GCS gsign mode via the shared single-flight machine. The signer-capability
-    pre-check is hoisted BEFORE the machine — a remote with no SA key can't sign
-    at all, so it goes straight to the bearer path without touching the neg-cache
-    or validation lock. Otherwise mint a V4-signed URL when active/won, validate
-    once, and fall to the bearer proxy ("bearer") on a definite reject (see
-    _sign_single_flight)."""
+    """GCS gsign mode via the shared single-flight machine. Only called for a
+    SIGNABLE-SHAPED remote (an SA key is configured); the signer resolution is
+    hoisted BEFORE the machine. When the signer momentarily fails to resolve (SA
+    file transiently unreadable, [cloud-auth] absent this window) we return
+    "retry", NOT "bearer": a signable-shaped remote must serve bearer for THIS
+    request WITHOUT permanently pinning bearer, so gsign is retried after the
+    cache TTL (finding 2). Only a genuine validation reject pins bearer.
+    Otherwise mint a V4-signed URL when active/won, validate once, and fall to
+    the bearer proxy on a definite reject (see _sign_single_flight)."""
     signer = _gcs_signer(fs.partition(":")[0], cfg)
-    if signer is None:  # not signer-capable -> bearer path
-        return None, "bearer"
+    if signer is None:  # signer momentarily unresolvable -> transient, retry
+        return None, "retry"
     return _sign_single_flight(
         fs, "gsign",
         mint_fn=lambda: _gcs_signed_url(fs, rel),
@@ -3007,11 +3013,13 @@ def _upstream_url_for(path: str) -> str | None:
             elif disp == "retry":
                 cache_mode = False
             # disp == "link": mode stays None; publiclink below caches "link"
-        elif _gcs_signable(name, cfg):
-            # SA-key GCS: V4-sign locally instead of a publiclink rc call (which
-            # ALWAYS fails for GCS — rclone reports PublicLink: False). Single-
-            # flight validation the first time; on a definite reject or a
-            # transient failure fall to the bearer proxy for this request.
+        elif gcssign._is_sa_configured(cfg):
+            # SA-key-SHAPED GCS: V4-sign locally instead of a publiclink rc call
+            # (which ALWAYS fails for GCS — rclone reports PublicLink: False).
+            # The tier is decided on config SHAPE, not a live signer resolution,
+            # so a momentarily-unresolvable signer is treated as transient rather
+            # than pinning bearer permanently (finding 2). Single-flight
+            # validation the first time.
             signed, disp = _gcs_sign_mode_url(fs, rel, cfg)
             if disp == "gsign" and signed is not None:
                 return signed
@@ -3021,13 +3029,22 @@ def _upstream_url_for(path: str) -> str | None:
                         _upstream_mode.pop(fs, None)  # un-pin, re-derive next time
                 return None
             elif disp == "retry":
-                cache_mode = False  # serve via bearer now, keep retrying gsign
+                # Contended / neg-cached / signer momentarily unresolvable: serve
+                # bearer for THIS request but DON'T pin bearer, so gsign is
+                # retried after the window. Mark the fs so bearer_upstream_for
+                # serves the token now even though the SA key still parses —
+                # otherwise its tie-breaker would dead-end at the serve (finding
+                # 1). The mark expires with the neg-cache window.
+                cache_mode = False
                 mode = "bearer"
-            else:  # "bearer": definite reject -> bearer path
+                with _upstream_lock:
+                    _gcs_bearer_fallback[fs] = time.monotonic() + _SIGN_NEG_TTL_S
+            else:  # "bearer": definite validation reject -> pin bearer
                 mode = "bearer"
-        elif _gcs_credentialed(name, cfg):
-            # Token-only GCS (no SA key to sign with): bearer proxy. Skip the
-            # publiclink rc call — it always fails for GCS (PublicLink: False).
+        elif gcssign._is_gcs_signable_shape(cfg):
+            # Token-only-SHAPED GCS (no SA key to sign with): bearer proxy, safe
+            # to pin — no SA key will ever let it sign locally. Skip the
+            # publiclink rc call; it always fails for GCS (PublicLink: False).
             mode = "bearer"
     if mode == "bearer":
         with _upstream_lock:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2461,6 +2461,25 @@ def direct_list_capable(path: str) -> bool:
     return s3_direct_capable(path) or gcs_direct_capable(path)
 
 
+def direct_list_anonymous(path: str) -> bool:
+    """True when `path` is mount-backed by an ANONYMOUS direct-listable remote
+    (anonymous plain AWS S3 or anonymous GCS), as opposed to a credentialed-
+    SHAPED one. A PURE config-shape check that resolves NO credentials/token
+    (finding 12), mirroring direct_list_capable.
+
+    An anonymous remote carries no credentials that can fail to resolve, so its
+    direct pager never raises DirectListError for a missing/expired credential —
+    callers that can't fall back to rc (the mount-root watch) use this to keep
+    anonymous behavior byte-identical while letting a credentialed-shaped remote
+    whose creds don't resolve fall through to rc."""
+    m, _ = _mount_for(path)
+    if m is None:
+        return False
+    name = m["remote"].partition(":")[0]
+    cfg = _remote_config(name)
+    return _anonymous_s3(cfg) or _gcs_anonymous(cfg or {})
+
+
 def direct_list_page(path: str, *, max_keys: int, continuation: str | None = None,
                      timeout: float | None = None) -> tuple[list, str | None]:
     """One direct (unsigned) listing page for `path`, routed to the S3 or GCS

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -1645,7 +1645,9 @@ def _cannot_presign(cfg: dict | None) -> bool:
     classes that can never presign (S3's "unsupported signer type noAuth", and
     anonymous GCS carrying no signing key at all) but reach their public
     objects by a plain unsigned URL instead. Lets _upstream_url_for skip the
-    wasted publiclink rc call for either backend."""
+    wasted publiclink rc call for either backend. (Credentialed GCS is NOT here:
+    it presigns via gsign or reads via the bearer proxy — handled by the
+    _gcs_signable / _gcs_credentialed branches after this gate.)"""
     return cfg is not None and (_anonymous_s3(cfg) or _gcs_anonymous(cfg))
 
 
@@ -1842,6 +1844,50 @@ def _gcs_credentialed(name: str, cfg: dict | None) -> bool:
     if _gcs_anonymous(cfg):
         return False
     return _gcs_bearer_token(name, cfg) is not None
+
+
+def _gcs_object_url(fs: str, rel: str) -> str | None:
+    """Plain path-style storage.googleapis.com URL for an object on a GCS remote
+    — the unsigned URL both the V4 signer and the bearer proxy start from. Same
+    key quoting as _gcs_public_object_url (default safe chars, '/' kept). None
+    when the fs carries no bucket. Unlike _gcs_public_object_url this does NOT
+    gate on anonymous — the caller has already decided the remote is signable /
+    credentialed."""
+    derived = _gcs_bucket_prefix(fs)
+    if derived is None:
+        return None
+    bucket, prefix = derived
+    key = (prefix + "/" if prefix else "") + rel
+    return f"https://storage.googleapis.com/{bucket}/{urllib.parse.quote(key)}"
+
+
+def _gcs_signable(name: str, cfg: dict | None) -> bool:
+    """True when the remote is a GCS remote whose SERVICE-ACCOUNT KEY resolves —
+    the class we can V4-sign locally (raw reads 307 to a signed URL). NOT
+    anonymous GCS (public URL) and NOT a token-only GCS remote (user oauth / ADC
+    tokens can't sign — those take the bearer proxy). Callers check
+    _gcs_anonymous FIRST."""
+    if not isinstance(cfg, dict) or cfg.get("type") != "google cloud storage":
+        return False
+    if _gcs_anonymous(cfg):
+        return False
+    return gcssign.resolve_signer(cfg) is not None
+
+
+def _gcs_signed_url(fs: str, rel: str) -> str | None:
+    """A locally V4-signed GET URL for one object on an SA-key GCS remote, or
+    None when the remote isn't signer-capable (no SA key / [cloud-auth] absent)
+    or carries no bucket. Mints per object — gsign mode never caches links,
+    same rationale as S3 sign mode."""
+    cfg = _remote_config(fs.partition(":")[0])
+    signer = gcssign.resolve_signer(cfg)
+    if signer is None:
+        return None
+    url = _gcs_object_url(fs, rel)
+    if url is None:
+        return None
+    return gcssign.sign_url(url, method="GET", signer=signer.signer,
+                            sa_email=signer.sa_email, expires=_SIGN_EXPIRY_S)
 
 
 def _s3_request_url(fs: str, rel: str, *, method: str = "GET",
@@ -2538,6 +2584,38 @@ def upstream_url_for(path: str) -> str | None:
         return None
 
 
+def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
+    """(plain object URL, {"Authorization": "Bearer <token>"}) for a mount-backed
+    file on a token-only credentialed GCS remote — the tier the server proxies
+    through the pooled client because no URL may carry the token. None for
+    anonymous GCS (reachable by public URL), SA-key GCS (307-signable via
+    _upstream_url_for), and every non-GCS backend. Anonymous and signable are
+    checked FIRST, so an anonymous remote never consults the token resolver.
+    The token value is never logged and never placed in a URL. Never raises —
+    this sits on the raw-proxy hot path alongside upstream_url_for."""
+    try:
+        m, rel = _mount_for(path)
+        if m is None:
+            return None
+        fs = m["remote"]
+        name = fs.partition(":")[0]
+        cfg = _remote_config(name)
+        if _gcs_anonymous(cfg or {}) or _gcs_signable(name, cfg):
+            return None
+        if not _gcs_credentialed(name, cfg):
+            return None
+        tok = _gcs_bearer_token(name, cfg)
+        if tok is None:
+            return None
+        url = _gcs_object_url(fs, rel)
+        if url is None:
+            return None
+        return url, {"Authorization": f"Bearer {tok.access_token}"}
+    except Exception:
+        logger.warning("bearer upstream for %r failed", path, exc_info=True)
+        return None
+
+
 def _sign_validation_status(url: str) -> tuple[int, str | None]:
     """Sign mode's one validation probe: a Range: bytes=0-0 GET against a
     presigned URL, redirects NOT followed (see _NoRedirect). Returns (HTTP
@@ -2651,6 +2729,84 @@ def _sign_mode_url(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
         lock.release()
 
 
+def _gcs_validate_and_sign(fs: str, rel: str,
+                           signer) -> tuple[str | None, str]:
+    """One-time gsign-mode validation for a GCS remote — the slim, region-less
+    GCS analog of _validate_and_sign (there is no x-amz-bucket-region machinery,
+    so a single attempt suffices). Signs a GET for `rel` and probes it once via
+    _sign_validation_status (a Range: bytes=0-0 GET), returning (url, verdict):
+      - (url, "ok")            GCS accepted the signature (200/206/404/416);
+      - (None, "reject")       definitely rejected (403/401 or other <500) —
+                               gsign can't serve this remote;
+      - (None, "inconclusive") network error / 5xx — transient; caller must NOT
+                               pin a mode so gsign is re-attempted later."""
+    url = _gcs_object_url(fs, rel)
+    if url is None:
+        return None, "reject"
+    signed = gcssign.sign_url(url, method="GET", signer=signer.signer,
+                              sa_email=signer.sa_email, expires=_SIGN_EXPIRY_S)
+    status, _region = _sign_validation_status(signed)
+    if status in (200, 206, 404, 416):
+        return signed, "ok"
+    return None, ("reject" if 0 < status < 500 else "inconclusive")
+
+
+def _gcs_sign_mode_url(fs: str, rel: str,
+                       cfg: dict) -> tuple[str | None, str]:
+    """Resolve/serve gsign mode for one request with per-fs single-flight — the
+    GCS analog of _sign_mode_url. Returns (url, disposition):
+      - (url, "gsign")  gsign active/just-validated -> use this signed URL (url
+                        may be None if the signer rotated away mid-flight — the
+                        caller then demotes and falls through);
+      - (None, "bearer") validated as a definite reject, OR the remote isn't
+                        signer-capable, OR another thread owns validation -> the
+                        caller serves this request via the bearer proxy; safe to
+                        cache mode="bearer";
+      - (None, "retry") validation inconclusive or negative-cached -> bearer for
+                        THIS request but DON'T pin a mode, so gsign is
+                        re-attempted once the window lapses."""
+    now = time.monotonic()
+    with _upstream_lock:
+        if _upstream_mode.get(fs) == "gsign":
+            active = True
+        else:
+            active = False
+            if _sign_neg_cache.get(fs, 0.0) > now:
+                return None, "retry"
+        lock = _validation_locks.setdefault(fs, threading.Lock())
+    if active:
+        return _gcs_signed_url(fs, rel), "gsign"
+    if not lock.acquire(blocking=False):
+        return None, "retry"  # another thread is validating; don't pile on
+    try:
+        with _upstream_lock:
+            if _upstream_mode.get(fs) == "gsign":
+                won = False
+            elif _sign_neg_cache.get(fs, 0.0) > time.monotonic():
+                return None, "retry"
+            else:
+                won = True
+        if not won:  # a racer finished validating while we took the lock
+            return _gcs_signed_url(fs, rel), "gsign"
+        signer = gcssign.resolve_signer(cfg)
+        if signer is None:  # not signer-capable -> bearer path
+            return None, "bearer"
+        signed, verdict = _gcs_validate_and_sign(fs, rel, signer)
+        if verdict == "ok":
+            with _upstream_lock:
+                _upstream_mode[fs] = "gsign"
+                _sign_neg_cache.pop(fs, None)
+            return signed, "gsign"
+        # Failed: negative-cache so we don't re-run the blocking validation GET
+        # on every request; a definite reject settles on bearer, an
+        # inconclusive one leaves the mode open (retry).
+        with _upstream_lock:
+            _sign_neg_cache[fs] = time.monotonic() + _SIGN_NEG_TTL_S
+        return None, ("bearer" if verdict == "reject" else "retry")
+    finally:
+        lock.release()
+
+
 def _upstream_url_for(path: str) -> str | None:
     m, rel = _mount_for(path)
     if m is None:
@@ -2684,6 +2840,24 @@ def _upstream_url_for(path: str) -> str | None:
             if _upstream_mode.get(fs) == "sign":
                 _upstream_mode[fs] = "link"
         mode = "link"
+    if mode == "gsign":
+        # SA-key GCS: mint a V4 signed URL per object (in-process signing is
+        # microseconds and creds rotate), never caching a link — same rationale
+        # as S3 sign mode.
+        signed = _gcs_signed_url(fs, rel)
+        if signed is not None:
+            return signed
+        # Signer rotated away -> demote to the bearer path (the token may still
+        # resolve); the server calls bearer_upstream_for when we return None.
+        with _upstream_lock:
+            if _upstream_mode.get(fs) == "gsign":
+                _upstream_mode[fs] = "bearer"
+        return None
+    if mode == "bearer":
+        # Token-only GCS: no URL may carry the token, so there is nothing to
+        # 307 to — the server proxies via bearer_upstream_for. Returning None
+        # here routes it there.
+        return None
     url = None
     if mode is None:
         cfg = _remote_config(name)
@@ -2709,6 +2883,33 @@ def _upstream_url_for(path: str) -> str | None:
             elif disp == "retry":
                 cache_mode = False
             # disp == "link": mode stays None; publiclink below caches "link"
+        elif _gcs_signable(name, cfg):
+            # SA-key GCS: V4-sign locally instead of a publiclink rc call (which
+            # ALWAYS fails for GCS — rclone reports PublicLink: False). Single-
+            # flight validation the first time; on a definite reject or a
+            # transient failure fall to the bearer proxy for this request.
+            signed, disp = _gcs_sign_mode_url(fs, rel, cfg)
+            if disp == "gsign" and signed is not None:
+                return signed
+            if disp == "gsign":  # active but signer vanished -> demote (find. 4)
+                with _upstream_lock:
+                    if _upstream_mode.get(fs) == "gsign":
+                        _upstream_mode[fs] = "bearer"
+                mode = "bearer"
+            elif disp == "retry":
+                cache_mode = False  # serve via bearer now, keep retrying gsign
+                mode = "bearer"
+            else:  # "bearer": definite reject -> bearer path
+                mode = "bearer"
+        elif _gcs_credentialed(name, cfg):
+            # Token-only GCS (no SA key to sign with): bearer proxy. Skip the
+            # publiclink rc call — it always fails for GCS (PublicLink: False).
+            mode = "bearer"
+    if mode == "bearer":
+        with _upstream_lock:
+            if cache_mode:
+                _upstream_mode[fs] = "bearer"
+        return None  # no URL may carry the token; server uses bearer_upstream_for
     if mode in (None, "link"):
         port = _live_rcd_port()
         if port is None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2165,17 +2165,29 @@ S3ListError = DirectListError
 
 
 def s3_direct_capable(path: str) -> bool:
-    """True when `path` is mount-backed by a plain-AWS-S3 remote s3_list_page
-    can enumerate directly — anonymous (unsigned) OR signable (locally
-    presigned). Lets the server pick the fast path without re-deriving the
-    predicates. _anonymous_s3 is tested first, so an anonymous remote never
-    reaches the credential resolver."""
+    """True when `path` is mount-backed by a plain-AWS-S3 remote s3_list_page can
+    enumerate directly — anonymous (unsigned) OR credentialed-SHAPED (static keys
+    present, or ambient auth opted into via env_auth/profile/shared_credentials).
+
+    A PURE config-shape check: it resolves NO credentials (finding 12). The
+    conditions/stat callers gate on this unbudgeted, and a live provider-chain
+    walk here (~1-2s on a black-holed IMDS) stalled fs/stat and fs/conditions.
+    Actual credential resolution happens inside the budgeted fetch paths
+    (s3_list_page / direct_head), which fall back to rc on failure — so a
+    credentialed-shaped remote whose creds don't resolve costs one cheap direct
+    attempt, not a stalled predicate."""
     m, _ = _mount_for(path)
     if m is None:
         return False
     name = m["remote"].partition(":")[0]
     cfg = _remote_config(name)
-    return _anonymous_s3(cfg) or _s3_signable(name, cfg)
+    if _anonymous_s3(cfg):
+        return True
+    if not _s3_signable_shape(cfg):  # plain AWS S3, no custom endpoint
+        return False
+    assert cfg is not None
+    return bool(cfg.get("access_key_id") and cfg.get("secret_access_key")) \
+        or s3sign.needs_botocore(cfg)
 
 
 def _s3_listing_prefix(store_prefix: str, rel: str) -> str:
@@ -2288,17 +2300,22 @@ _GCS_LIST_URL = "https://storage.googleapis.com/storage/v1/b/{bucket}/o"
 
 
 def gcs_direct_capable(path: str) -> bool:
-    """True when `path` is mount-backed by a GCS remote gcs_list_page can
-    enumerate directly — anonymous (unsigned) OR credentialed (a bearer token
-    resolves). Mirrors s3_direct_capable, which unions anonymous and signable.
-    _gcs_anonymous is tested first, so an anonymous remote never reaches the
-    token resolver."""
+    """True when `path` is mount-backed by a Google Cloud Storage remote
+    gcs_list_page can enumerate directly — anonymous (unsigned) OR credentialed
+    (bearer). Credentialed covers SA-key, oauth-token and ADC-only remotes alike;
+    an ADC-only remote carries no config marker, so the shape check is permissive
+    — ANY GCS remote qualifies.
+
+    A PURE config-shape check that resolves NO token (finding 12): a live
+    ADC/GCE-metadata probe here stalled the unbudgeted conditions/stat callers.
+    Actual token resolution happens inside the budgeted fetch paths
+    (gcs_list_page / direct_head), which fall back to rc on failure."""
     m, _ = _mount_for(path)
     if m is None:
         return False
     name = m["remote"].partition(":")[0]
     cfg = _remote_config(name)
-    return _gcs_anonymous(cfg or {}) or _gcs_credentialed(name, cfg)
+    return isinstance(cfg, dict) and cfg.get("type") == "google cloud storage"
 
 
 def _gcs_get_direct(url: str, name: str, cfg: dict | None,

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2789,23 +2789,32 @@ def _validate_and_sign(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
     return None, verdict
 
 
-def _sign_mode_url(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
-    """Resolve/serve sign mode for one request with per-fs single-flight, so N
-    concurrent first reads issue ONE validation GET instead of N. Returns
-    (url, disposition):
-      - (url, "sign")  sign mode active/just-validated -> use this presigned URL
-                       (url may be None if creds rotated away mid-flight — the
-                       caller then demotes and falls through, finding 4);
-      - (None, "link") validated as a definite reject, OR another thread owns
-                       validation -> use the publiclink ladder for this request;
-                       it's safe to cache mode="link";
-      - (None, "retry") validation inconclusive or negative-cached -> use the
-                       publiclink ladder for THIS request but DON'T pin a mode,
-                       so sign is re-attempted once the window lapses (findings
-                       5 and 7)."""
+def _sign_single_flight(fs: str, mode_name: str, mint_fn, validate_fn,
+                        reject_disp: str) -> tuple[str | None, str]:
+    """The per-fs single-flight state machine shared by S3 sign mode and GCS
+    gsign mode, so N concurrent first reads issue ONE validation GET instead of
+    N. Parameterized on:
+      - mode_name    the mode string pinned on success ("sign" / "gsign");
+      - mint_fn()    -> url|None, the per-object URL when the mode is
+                     active/just-validated (a presigned S3 URL / a signed GCS
+                     URL); None means creds/signer rotated away mid-flight;
+      - validate_fn() -> (url, verdict) with verdict "ok"/"reject"/
+                     "inconclusive" — the one-time validation probe;
+      - reject_disp  the disposition returned on a definite reject ("link" for
+                     S3's publiclink ladder, "bearer" for GCS's proxy).
+    Returns (url, disposition):
+      - (url, mode_name)  mode active/just-validated -> use this URL (url may be
+                     None if creds/signer rotated away mid-flight — the caller
+                     demotes and falls through, finding 4);
+      - (None, reject_disp)  validated as a definite reject -> caller settles on
+                     the fallback path; safe to cache that mode;
+      - (None, "retry")  validation inconclusive OR negative-cached OR ANOTHER
+                     THREAD holds the validation lock -> serve THIS request via
+                     the fallback but DON'T pin a mode, so the mode is
+                     re-attempted once the window lapses (findings 5 and 7)."""
     now = time.monotonic()
     with _upstream_lock:
-        if _upstream_mode.get(fs) == "sign":
+        if _upstream_mode.get(fs) == mode_name:
             active = True
         else:
             active = False
@@ -2813,33 +2822,44 @@ def _sign_mode_url(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
                 return None, "retry"  # recently failed -> skip validation window
         lock = _validation_locks.setdefault(fs, threading.Lock())
     if active:
-        return _s3_request_url(fs, rel, method="GET"), "sign"
+        return mint_fn(), mode_name
     if not lock.acquire(blocking=False):
         return None, "retry"  # another thread is validating; don't pile on
     try:
         with _upstream_lock:
-            if _upstream_mode.get(fs) == "sign":
+            if _upstream_mode.get(fs) == mode_name:
                 won = False
             elif _sign_neg_cache.get(fs, 0.0) > time.monotonic():
                 return None, "retry"
             else:
                 won = True
         if not won:  # a racer finished validating while we took the lock
-            return _s3_request_url(fs, rel, method="GET"), "sign"
-        url, verdict = _validate_and_sign(fs, rel, cfg)
+            return mint_fn(), mode_name
+        url, verdict = validate_fn()
         if verdict == "ok":
             with _upstream_lock:
-                _upstream_mode[fs] = "sign"
+                _upstream_mode[fs] = mode_name
                 _sign_neg_cache.pop(fs, None)
-            return url, "sign"
-        # Failed: negative-cache so we don't re-run the blocking validation GETs
-        # on every request while no fallback is committed (rcd down); a definite
-        # reject settles on "link", an inconclusive one leaves the mode open.
+            return url, mode_name
+        # Failed: negative-cache so we don't re-run the blocking validation GET
+        # on every request while no fallback is committed; a definite reject
+        # settles on the fallback mode, an inconclusive one leaves it open.
         with _upstream_lock:
             _sign_neg_cache[fs] = time.monotonic() + _SIGN_NEG_TTL_S
-        return None, ("link" if verdict == "reject" else "retry")
+        return None, (reject_disp if verdict == "reject" else "retry")
     finally:
         lock.release()
+
+
+def _sign_mode_url(fs: str, rel: str, cfg: dict) -> tuple[str | None, str]:
+    """S3 sign mode via the shared single-flight machine: mint a presigned URL
+    when active/won, validate once otherwise, and fall to the publiclink ladder
+    ("link") on a definite reject (findings 4, 5, 7 — see _sign_single_flight)."""
+    return _sign_single_flight(
+        fs, "sign",
+        mint_fn=lambda: _s3_request_url(fs, rel, method="GET"),
+        validate_fn=lambda: _validate_and_sign(fs, rel, cfg),
+        reject_disp="link")
 
 
 def _gcs_validate_and_sign(fs: str, rel: str,
@@ -2866,58 +2886,20 @@ def _gcs_validate_and_sign(fs: str, rel: str,
 
 def _gcs_sign_mode_url(fs: str, rel: str,
                        cfg: dict) -> tuple[str | None, str]:
-    """Resolve/serve gsign mode for one request with per-fs single-flight — the
-    GCS analog of _sign_mode_url. Returns (url, disposition):
-      - (url, "gsign")  gsign active/just-validated -> use this signed URL (url
-                        may be None if the signer rotated away mid-flight — the
-                        caller then demotes and falls through);
-      - (None, "bearer") validated as a definite reject, OR the remote isn't
-                        signer-capable, OR another thread owns validation -> the
-                        caller serves this request via the bearer proxy; safe to
-                        cache mode="bearer";
-      - (None, "retry") validation inconclusive or negative-cached -> bearer for
-                        THIS request but DON'T pin a mode, so gsign is
-                        re-attempted once the window lapses."""
-    now = time.monotonic()
-    with _upstream_lock:
-        if _upstream_mode.get(fs) == "gsign":
-            active = True
-        else:
-            active = False
-            if _sign_neg_cache.get(fs, 0.0) > now:
-                return None, "retry"
-        lock = _validation_locks.setdefault(fs, threading.Lock())
-    if active:
-        return _gcs_signed_url(fs, rel), "gsign"
-    if not lock.acquire(blocking=False):
-        return None, "retry"  # another thread is validating; don't pile on
-    try:
-        with _upstream_lock:
-            if _upstream_mode.get(fs) == "gsign":
-                won = False
-            elif _sign_neg_cache.get(fs, 0.0) > time.monotonic():
-                return None, "retry"
-            else:
-                won = True
-        if not won:  # a racer finished validating while we took the lock
-            return _gcs_signed_url(fs, rel), "gsign"
-        signer = _gcs_signer(fs.partition(":")[0], cfg)
-        if signer is None:  # not signer-capable -> bearer path
-            return None, "bearer"
-        signed, verdict = _gcs_validate_and_sign(fs, rel, signer)
-        if verdict == "ok":
-            with _upstream_lock:
-                _upstream_mode[fs] = "gsign"
-                _sign_neg_cache.pop(fs, None)
-            return signed, "gsign"
-        # Failed: negative-cache so we don't re-run the blocking validation GET
-        # on every request; a definite reject settles on bearer, an
-        # inconclusive one leaves the mode open (retry).
-        with _upstream_lock:
-            _sign_neg_cache[fs] = time.monotonic() + _SIGN_NEG_TTL_S
-        return None, ("bearer" if verdict == "reject" else "retry")
-    finally:
-        lock.release()
+    """GCS gsign mode via the shared single-flight machine. The signer-capability
+    pre-check is hoisted BEFORE the machine — a remote with no SA key can't sign
+    at all, so it goes straight to the bearer path without touching the neg-cache
+    or validation lock. Otherwise mint a V4-signed URL when active/won, validate
+    once, and fall to the bearer proxy ("bearer") on a definite reject (see
+    _sign_single_flight)."""
+    signer = _gcs_signer(fs.partition(":")[0], cfg)
+    if signer is None:  # not signer-capable -> bearer path
+        return None, "bearer"
+    return _sign_single_flight(
+        fs, "gsign",
+        mint_fn=lambda: _gcs_signed_url(fs, rel),
+        validate_fn=lambda: _gcs_validate_and_sign(fs, rel, signer),
+        reject_disp="bearer")
 
 
 def _upstream_url_for(path: str) -> str | None:

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -2715,6 +2715,20 @@ def bearer_upstream_for(path: str) -> tuple[str, dict] | None:
         return None
 
 
+def invalidate_gcs_token(path: str) -> None:
+    """Drop the cached bearer token + credential object for `path`'s remote so
+    the next bearer_upstream_for re-resolves from config. Called by the raw read
+    proxy when a bearer GET comes back 401/403 (the token went stale/rotated),
+    so a single retry can self-heal. Never raises — sits on the raw hot path."""
+    try:
+        m, _ = _mount_for(path)
+        if m is None:
+            return
+        _invalidate_gcs_creds(m["remote"].partition(":")[0])
+    except Exception:
+        logger.warning("invalidate gcs token for %r failed", path, exc_info=True)
+
+
 def _sign_validation_status(url: str) -> tuple[int, str | None]:
     """Sign mode's one validation probe: a Range: bytes=0-0 GET against a
     presigned URL, redirects NOT followed (see _NoRedirect). Returns (HTTP

--- a/fused_render/shell/s3sign.py
+++ b/fused_render/shell/s3sign.py
@@ -154,53 +154,16 @@ def _from_shared_file(cfg: dict) -> Credentials | None:
     return None
 
 
-def _from_botocore(cfg: dict) -> Credentials | None:
-    """The optional last rung: botocore's full provider chain (SSO, IMDS,
-    credential_process, assume-role, container). Lazily imported so a plain
-    `pip install fused-render` — without the [cloud-auth] extra — never needs
-    botocore; ImportError -> None. Honors the remote's profile /
-    shared_credentials_file when set, then freezes the resolved credentials into
-    the local namedtuple (a frozen STS credential carries its session token so
-    the mounts-side link-TTL clamp still fires). ANY failure — library absent,
-    expired SSO login, no providers, an IMDS timeout — returns None so the
-    caller keeps today's publiclink path. Never logs credential values."""
-    try:
-        import botocore.session
-    except ImportError:
-        return None
-    try:
-        session = botocore.session.Session(profile=cfg.get("profile") or None)
-        shared = cfg.get("shared_credentials_file")
-        if shared:
-            session.set_config_variable(
-                "credentials_file", os.path.expanduser(shared))
-        creds = session.get_credentials()
-        if creds is None:
-            return None
-        frozen = creds.get_frozen_credentials()
-        if not frozen.access_key or not frozen.secret_key:
-            return None
-        return Credentials(frozen.access_key, frozen.secret_key,
-                           frozen.token or None)
-    except Exception:
-        return None
-
-
-def resolve_credentials(cfg: dict | None) -> Credentials | None:
-    """Resolve AWS credentials for an S3 remote config, cheapest source first,
-    or None when nothing resolves — then the caller keeps today's publiclink
-    path:
+def resolve_static_credentials(cfg: dict | None) -> Credentials | None:
+    """The three cheap, NO-NETWORK credential rungs, cheapest first, or None:
       1. explicit access_key_id/secret_access_key in the remote config
          (rclone's config/get returns the plaintext secret on the pinned
          version, so no config-dump fallback is needed);
       2. environment (AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN) when env_auth;
       3. the shared credentials file when env_auth or a profile /
-         shared_credentials_file is configured;
-      4. botocore's full provider chain (SSO / IMDS / credential_process) via
-         _from_botocore, resolved when installed [cloud-auth], else None — same
-         ambient-auth gate as source 3, so a plain keyed remote never triggers
-         an ambient-credential lookup.
-    Non-S3 or empty configs return None."""
+         shared_credentials_file is configured.
+    None when only the ambient botocore-chain source (rung 4) remains — the
+    caller then consults resolve_botocore_chain. Non-S3 configs return None."""
     if not isinstance(cfg, dict) or cfg.get("type") != "s3":
         return None
     access = cfg.get("access_key_id")
@@ -215,8 +178,74 @@ def resolve_credentials(cfg: dict | None) -> Credentials | None:
             return Credentials(access, secret,
                                os.environ.get("AWS_SESSION_TOKEN") or None)
     if env_auth or cfg.get("profile") or cfg.get("shared_credentials_file"):
-        from_file = _from_shared_file(cfg)
-        if from_file is not None:
-            return from_file
-        return _from_botocore(cfg)
+        return _from_shared_file(cfg)
+    return None
+
+
+def needs_botocore(cfg: dict | None) -> bool:
+    """True when the remote opted into ambient auth (env_auth / profile /
+    shared_credentials_file), so botocore's provider chain should be consulted
+    when the static rungs found nothing — the same gate as rung 3, so a plain
+    keyed remote never triggers an ambient-credential lookup. Cheap; no network,
+    no import."""
+    if not isinstance(cfg, dict) or cfg.get("type") != "s3":
+        return False
+    env_auth = str(cfg.get("env_auth", "")).lower() == "true"
+    return bool(env_auth or cfg.get("profile")
+                or cfg.get("shared_credentials_file"))
+
+
+def resolve_botocore_chain(cfg: dict):
+    """Rung 4: build a botocore session and walk its full provider chain (SSO,
+    IMDS, credential_process, assume-role, container), returning the RAW,
+    self-refreshing credentials OBJECT — NOT frozen — so mounts can cache it and
+    re-freeze near expiry (via frozen_from_botocore) without re-walking the
+    chain. Lazily imported so a plain `pip install fused-render` never needs
+    botocore; ANY failure (library absent, expired SSO login, no providers, an
+    IMDS timeout) -> None. Never logs credential values."""
+    try:
+        import botocore.session
+    except ImportError:
+        return None
+    try:
+        session = botocore.session.Session(profile=cfg.get("profile") or None)
+        shared = cfg.get("shared_credentials_file")
+        if shared:
+            session.set_config_variable(
+                "credentials_file", os.path.expanduser(shared))
+        return session.get_credentials()
+    except Exception:
+        return None
+
+
+def frozen_from_botocore(creds) -> Credentials | None:
+    """Freeze a botocore credentials object into the local namedtuple (a frozen
+    STS credential carries its session token, so the mounts-side link-TTL clamp
+    still fires). None when `creds` is None, refreshes to nothing, or lacks the
+    key pair. Cheap and self-refreshing — get_frozen_credentials refreshes STS
+    only near expiry, so callers can call it per window on a cached object."""
+    if creds is None:
+        return None
+    try:
+        frozen = creds.get_frozen_credentials()
+    except Exception:
+        return None
+    if not frozen.access_key or not frozen.secret_key:
+        return None
+    return Credentials(frozen.access_key, frozen.secret_key,
+                       frozen.token or None)
+
+
+def resolve_credentials(cfg: dict | None) -> Credentials | None:
+    """Resolve AWS credentials for an S3 remote config, or None when nothing
+    resolves — the static rungs (config keys / env / shared file), then
+    botocore's provider chain when the remote opted into ambient auth. A
+    convenience combining resolve_static_credentials + resolve_botocore_chain;
+    mounts calls the pieces separately so it can cache the self-refreshing chain
+    object. Non-S3 or empty configs return None."""
+    creds = resolve_static_credentials(cfg)
+    if creds is not None:
+        return creds
+    if needs_botocore(cfg):
+        return frozen_from_botocore(resolve_botocore_chain(cfg))
     return None

--- a/fused_render/shell/s3sign.py
+++ b/fused_render/shell/s3sign.py
@@ -15,8 +15,11 @@ Two concerns, kept separate:
     with host the only signed header. The timestamp is a parameter so the
     output is reproducible under test.
   - resolve_credentials: the three cheap credential sources (remote config
-    keys, environment, shared credentials file). SSO/IMDS/credential_process
-    return None — the caller keeps its existing publiclink path for those.
+    keys, environment, shared credentials file), then — for a remote that opted
+    into ambient auth (env_auth / profile) — an optional last rung that consults
+    botocore's full provider chain (SSO / IMDS / credential_process /
+    assume-role) when [cloud-auth] is installed. With botocore absent, or when
+    it resolves nothing, the caller keeps its existing publiclink path.
 
 This module is PURE: no caching, no rc calls, no logging of URLs. Caching and
 the one-time signature validation live in shell/mounts.py, which composes the
@@ -151,16 +154,52 @@ def _from_shared_file(cfg: dict) -> Credentials | None:
     return None
 
 
+def _from_botocore(cfg: dict) -> Credentials | None:
+    """The optional last rung: botocore's full provider chain (SSO, IMDS,
+    credential_process, assume-role, container). Lazily imported so a plain
+    `pip install fused-render` — without the [cloud-auth] extra — never needs
+    botocore; ImportError -> None. Honors the remote's profile /
+    shared_credentials_file when set, then freezes the resolved credentials into
+    the local namedtuple (a frozen STS credential carries its session token so
+    the mounts-side link-TTL clamp still fires). ANY failure — library absent,
+    expired SSO login, no providers, an IMDS timeout — returns None so the
+    caller keeps today's publiclink path. Never logs credential values."""
+    try:
+        import botocore.session
+    except ImportError:
+        return None
+    try:
+        session = botocore.session.Session(profile=cfg.get("profile") or None)
+        shared = cfg.get("shared_credentials_file")
+        if shared:
+            session.set_config_variable(
+                "credentials_file", os.path.expanduser(shared))
+        creds = session.get_credentials()
+        if creds is None:
+            return None
+        frozen = creds.get_frozen_credentials()
+        if not frozen.access_key or not frozen.secret_key:
+            return None
+        return Credentials(frozen.access_key, frozen.secret_key,
+                           frozen.token or None)
+    except Exception:
+        return None
+
+
 def resolve_credentials(cfg: dict | None) -> Credentials | None:
-    """Resolve static AWS credentials for an S3 remote config, cheapest source
-    first, or None when only out-of-scope sources exist (SSO / IMDS /
-    credential_process) — then the caller keeps today's publiclink path:
+    """Resolve AWS credentials for an S3 remote config, cheapest source first,
+    or None when nothing resolves — then the caller keeps today's publiclink
+    path:
       1. explicit access_key_id/secret_access_key in the remote config
          (rclone's config/get returns the plaintext secret on the pinned
          version, so no config-dump fallback is needed);
       2. environment (AWS_ACCESS_KEY_ID/SECRET/SESSION_TOKEN) when env_auth;
       3. the shared credentials file when env_auth or a profile /
-         shared_credentials_file is configured.
+         shared_credentials_file is configured;
+      4. botocore's full provider chain (SSO / IMDS / credential_process) via
+         _from_botocore, resolved when installed [cloud-auth], else None — same
+         ambient-auth gate as source 3, so a plain keyed remote never triggers
+         an ambient-credential lookup.
     Non-S3 or empty configs return None."""
     if not isinstance(cfg, dict) or cfg.get("type") != "s3":
         return None
@@ -176,5 +215,8 @@ def resolve_credentials(cfg: dict | None) -> Credentials | None:
             return Credentials(access, secret,
                                os.environ.get("AWS_SESSION_TOKEN") or None)
     if env_auth or cfg.get("profile") or cfg.get("shared_credentials_file"):
-        return _from_shared_file(cfg)
+        from_file = _from_shared_file(cfg)
+        if from_file is not None:
+            return from_file
+        return _from_botocore(cfg)
     return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,17 @@ bundled = [
     "pikepdf>=9",
     "drain3>=0.9.11",
 ]
+# Private-cloud credential chains (optional). botocore buys the AWS provider
+# chain (SSO / credential_process / assume-role / IMDS) for s3sign's resolver
+# rung; google-auth buys the GCS bearer-token chain (SA key / ADC) for gcssign.
+# requests is google-auth's refresh transport. The signing math stays in-repo
+# (s3sign/gcssign are pure stdlib), so a plain install still serves public
+# buckets with the libs absent — this extra only lights up private ones.
+cloud-auth = [
+    "botocore",
+    "google-auth",
+    "requests",
+]
 # Menu-bar app shell (SPEC DM-3/DM-7). macOS-only; not a core dependency so
 # `pip install fused-render` stays cross-platform. Only the packaged .app
 # build (scripts/build_dmg.sh) installs this extra.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,14 +22,16 @@ dependencies = [
     # uploads, which requires python-multipart at import time (FastAPI raises
     # at route registration otherwise).
     "python-multipart>=0.0.9",
+    # server.py hard-imports httpx at module top for the pooled raw-proxy client
+    # (TASK F) — and fastapi.testclient needs it too — so a plain
+    # `pip install fused-render` is broken without it. Core, not an extra.
+    "httpx",
 ]
 
 [project.optional-dependencies]
 # Test/dev tooling. `pip install -e ".[dev]"` then `pytest`.
 dev = [
     "pytest",
-    # fastapi.testclient hard-requires httpx at import time.
-    "httpx",
     # Parallel test runs (see [tool.pytest.ini_options] addopts -n auto). The
     # suite is xdist-safe via process isolation: conftest re-points
     # FUSED_RENDER_HOME/DIR per worker, tests use tmp_path + monkeypatch, and
@@ -66,6 +68,15 @@ bundled = [
     "pymupdf>=1.25",
     "pikepdf>=9",
     "drain3>=0.9.11",
+    # Private-cloud credential chains (the [cloud-auth] extra), folded into the
+    # bundled app: DMG users cannot pip install, and the feature's promise —
+    # "an authenticated aws/gcloud CLI ⇒ your private buckets just work" — is
+    # hollow for them otherwise. botocore adds ~80 MB installed; this line is
+    # the size-tradeoff approval point — strip it here if that's unacceptable
+    # (public buckets still work: the signers are pure stdlib). requests is
+    # already above; google-auth's refresh transport reuses it.
+    "botocore",
+    "google-auth",
 ]
 # Private-cloud credential chains (optional). botocore buys the AWS provider
 # chain (SSO / credential_process / assume-role / IMDS) for s3sign's resolver

--- a/tests/test_fs_raw_bearer_proxy.py
+++ b/tests/test_fs_raw_bearer_proxy.py
@@ -49,6 +49,10 @@ class _FakeStore:
         # When set, any Authorization != accept_auth is answered 401 (models a
         # stale/rotated token that self-heals only after re-resolution).
         self.accept_auth = None
+        # When set, every GET is answered with this HTTP status (models an IAM
+        # denial / transient upstream error the proxy must handle without leaking
+        # it to the client).
+        self.force_status = None
         store = self
 
         class H(BaseHTTPRequestHandler):
@@ -58,6 +62,9 @@ class _FakeStore:
             def do_GET(self):
                 auth = self.headers.get("Authorization")
                 store.auth_seen.append(auth)
+                if store.force_status is not None:
+                    self.send_error(store.force_status)
+                    return
                 if store.accept_auth is not None and auth != store.accept_auth:
                     self.send_error(401)
                     return
@@ -210,3 +217,47 @@ def test_bearer_persistent_401_falls_through_to_serve(cold_bearer_dynamic, monke
                    follow_redirects=False)
     assert r.status_code == 503  # mount serve unavailable, not a 401
     assert len(store.auth_seen) == 2  # exactly one retry
+
+
+# ----------------------------------- fix 3 + 9: 403/error statuses fall through
+
+
+def test_bearer_403_falls_through_without_invalidating(cold_bearer, monkeypatch):
+    # FINDING 3: a 403 is an IAM denial WITH a valid token — the proxy must NOT
+    # invalidate/re-resolve (that would churn the credential per denied read and
+    # evict the live token out from under concurrent legitimate reads). It closes
+    # and falls through to the serve. Serve base is unreachable -> 503.
+    client, file_path, store = cold_bearer
+    store.force_status = 403
+    invalidated = []
+    monkeypatch.setattr(mounts_mod, "invalidate_gcs_token",
+                        lambda p: invalidated.append(p))
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 503  # fell through to the serve, not a leaked 403
+    assert len(store.auth_seen) == 1  # no retry
+    assert invalidated == []  # token never invalidated on a 403
+
+
+def test_bearer_503_falls_through_to_serve(cold_bearer):
+    # FINDING 9: a transient upstream 503 is NOT passed through to the client
+    # (bearer mode has no 307 URL to retry against); it falls through to the
+    # serve, which on main's rclone pacer would retry it. Serve unreachable ->
+    # 503 from the serve-unavailable path, never a leaked upstream error status.
+    client, file_path, store = cold_bearer
+    store.force_status = 503
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 503
+    assert len(store.auth_seen) == 1  # no retry on a 5xx
+
+
+def test_bearer_404_passes_through(cold_bearer):
+    # FINDING 9: 404 is a meaningful store answer (object absent) — it passes
+    # through to the client rather than falling to the serve.
+    client, file_path, store = cold_bearer
+    store.force_status = 404
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 404
+    assert len(store.auth_seen) == 1

--- a/tests/test_fs_raw_bearer_proxy.py
+++ b/tests/test_fs_raw_bearer_proxy.py
@@ -1,0 +1,145 @@
+"""Private-GCS bearer proxy on /api/fs/raw (Task 4, fused_render/server.py).
+
+A token-only credentialed GCS remote can't hand the client a signed link — the
+bearer token must never appear in a URL, log, or response header. So for a COLD
+mount-backed read, when upstream_url_for returns None but bearer_upstream_for
+returns (url, {Authorization: Bearer ...}), the handler proxies the store's
+bytes through the shared keep-alive httpx pool with the Authorization header
+attached OUT-OF-BAND — regardless of the &pooled flag, since there is nothing to
+307 to.
+
+These tests pin the contract:
+  * the outbound request to the store carries the Authorization header;
+  * the response is 200/206 with the bytes and NO 307;
+  * the token never appears in any response header (it rides the outbound
+    request only).
+
+A threaded localhost server stands in for the private store; it records the
+Authorization header it saw. upstream_url_for is stubbed to None and
+bearer_upstream_for to point at it. prefetch is stubbed so the read stays cold.
+
+Shared fixtures/helpers (home, _mount) live in _mount_safe_helpers, mirroring
+test_fs_raw_pooled_proxy.
+"""
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as mounts_mod
+from fused_render.server import create_app
+from _mount_safe_helpers import (  # noqa: F401 — `home` is a reused fixture
+    _mount,
+    home,
+)
+
+_TOKEN = "ya29.SECRET-BEARER-TOKEN"
+
+
+class _FakeStore:
+    """Stands in for the private GCS object URL: serves a fixed blob, honours
+    Range with a 206, and records the Authorization header of each request so a
+    test can confirm the proxy attached it out-of-band."""
+
+    def __init__(self, blob: bytes):
+        self.blob = blob
+        self.auth_seen = []
+        store = self
+
+        class H(BaseHTTPRequestHandler):
+            def log_message(self, *a):
+                pass
+
+            def do_GET(self):
+                store.auth_seen.append(self.headers.get("Authorization"))
+                rng = self.headers.get("Range")
+                if rng and rng.startswith("bytes="):
+                    s, _, e = rng[6:].partition("-")
+                    s = int(s)
+                    e = int(e) if e else len(store.blob) - 1
+                    chunk = store.blob[s:e + 1]
+                    self.send_response(206)
+                    self.send_header("Content-Range",
+                                     f"bytes {s}-{e}/{len(store.blob)}")
+                    self.send_header("Content-Length", str(len(chunk)))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(chunk)
+                else:
+                    self.send_response(200)
+                    self.send_header("Content-Length", str(len(store.blob)))
+                    self.send_header("Accept-Ranges", "bytes")
+                    self.end_headers()
+                    self.wfile.write(store.blob)
+
+        self._srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        self.port = self._srv.server_address[1]
+        threading.Thread(target=self._srv.serve_forever, daemon=True).start()
+
+    @property
+    def url(self):
+        return f"http://127.0.0.1:{self.port}/private/object.parquet"
+
+    def close(self):
+        self._srv.shutdown()
+
+
+@pytest.fixture()
+def cold_bearer(home, monkeypatch):
+    """A TestClient over a cold mount-backed file whose remote is token-only
+    private GCS: a serve is armed, prefetch is stubbed cold, upstream_url_for
+    returns None (no 307-able URL) and bearer_upstream_for points at a
+    _FakeStore with an Authorization header. Yields (client, file_path, store)."""
+    import fused_render.shell.prefetch as prefetch
+    monkeypatch.setattr(prefetch, "schedule", lambda *a, **k: None)
+    monkeypatch.setattr(prefetch, "is_done", lambda *a, **k: False)
+
+    store = _FakeStore(b"GCS-PRIVATE-BYTES-" + bytes(range(64)) * 4)
+
+    mp = _mount("gcp", read_only=False)
+    from fused_render.shell import storage
+    storage.write_json(mounts_mod.serves_path(), {mp: "http://127.0.0.1:1"})
+    monkeypatch.setattr(mounts_mod, "upstream_url_for", lambda p: None)
+    monkeypatch.setattr(
+        mounts_mod, "bearer_upstream_for",
+        lambda p: (store.url, {"Authorization": f"Bearer {_TOKEN}"}))
+
+    file_path = os.path.join(mp, "data.parquet")
+    try:
+        with TestClient(create_app(start_dir=str(home))) as client:
+            yield client, file_path, store
+    finally:
+        store.close()
+
+
+def test_bearer_read_proxies_bytes_with_auth_header(cold_bearer):
+    client, file_path, store = cold_bearer
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 200  # proxied, never a 307
+    assert r.content == store.blob
+    # The Authorization header rode the OUTBOUND request to the store.
+    assert store.auth_seen == [f"Bearer {_TOKEN}"]
+
+
+def test_bearer_read_forwards_range_206(cold_bearer):
+    client, file_path, store = cold_bearer
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   headers={"Range": "bytes=4-11"}, follow_redirects=False)
+    assert r.status_code == 206
+    assert r.content == store.blob[4:12]
+    assert store.auth_seen[-1] == f"Bearer {_TOKEN}"
+
+
+def test_bearer_token_never_in_response(cold_bearer):
+    client, file_path, store = cold_bearer
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 200
+    assert "location" not in r.headers  # no redirect carrying anything
+    # The token must never be echoed back to the client in any header.
+    for name, value in r.headers.items():
+        assert _TOKEN not in value
+        assert name.lower() != "authorization"

--- a/tests/test_fs_raw_bearer_proxy.py
+++ b/tests/test_fs_raw_bearer_proxy.py
@@ -46,6 +46,9 @@ class _FakeStore:
     def __init__(self, blob: bytes):
         self.blob = blob
         self.auth_seen = []
+        # When set, any Authorization != accept_auth is answered 401 (models a
+        # stale/rotated token that self-heals only after re-resolution).
+        self.accept_auth = None
         store = self
 
         class H(BaseHTTPRequestHandler):
@@ -53,7 +56,11 @@ class _FakeStore:
                 pass
 
             def do_GET(self):
-                store.auth_seen.append(self.headers.get("Authorization"))
+                auth = self.headers.get("Authorization")
+                store.auth_seen.append(auth)
+                if store.accept_auth is not None and auth != store.accept_auth:
+                    self.send_error(401)
+                    return
                 rng = self.headers.get("Range")
                 if rng and rng.startswith("bytes="):
                     s, _, e = rng[6:].partition("-")
@@ -143,3 +150,63 @@ def test_bearer_token_never_in_response(cold_bearer):
     for name, value in r.headers.items():
         assert _TOKEN not in value
         assert name.lower() != "authorization"
+
+
+# ----------------------------------- fix 4: 401 self-heal + serve fallback
+
+
+@pytest.fixture()
+def cold_bearer_dynamic(home, monkeypatch):
+    """Like cold_bearer, but the bearer token is mutable and
+    invalidate_gcs_token swaps it — so a 401 on the stale token can self-heal
+    after one re-resolve. Yields (client, file_path, store, holder)."""
+    import fused_render.shell.prefetch as prefetch
+    monkeypatch.setattr(prefetch, "schedule", lambda *a, **k: None)
+    monkeypatch.setattr(prefetch, "is_done", lambda *a, **k: False)
+
+    store = _FakeStore(b"GCS-PRIVATE-" + bytes(range(48)) * 4)
+    holder = {"tok": "STALE"}
+
+    mp = _mount("gcp", read_only=False)
+    from fused_render.shell import storage
+    storage.write_json(mounts_mod.serves_path(), {mp: "http://127.0.0.1:1"})
+    monkeypatch.setattr(mounts_mod, "upstream_url_for", lambda p: None)
+    monkeypatch.setattr(
+        mounts_mod, "bearer_upstream_for",
+        lambda p: (store.url, {"Authorization": f"Bearer {holder['tok']}"}))
+    # Re-resolution rotates the token to a fresh value.
+    monkeypatch.setattr(mounts_mod, "invalidate_gcs_token",
+                        lambda p: holder.update(tok="FRESH"))
+
+    file_path = os.path.join(mp, "data.parquet")
+    try:
+        with TestClient(create_app(start_dir=str(home))) as client:
+            yield client, file_path, store, holder
+    finally:
+        store.close()
+
+
+def test_bearer_401_reresolves_and_retries(cold_bearer_dynamic):
+    client, file_path, store, holder = cold_bearer_dynamic
+    store.accept_auth = "Bearer FRESH"  # only the re-resolved token works
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 200
+    assert r.content == store.blob
+    # First attempt used the stale token (401), retry used the fresh one.
+    assert store.auth_seen == ["Bearer STALE", "Bearer FRESH"]
+    for _name, value in r.headers.items():
+        assert "STALE" not in value and "FRESH" not in value
+
+
+def test_bearer_persistent_401_falls_through_to_serve(cold_bearer_dynamic, monkeypatch):
+    client, file_path, store, holder = cold_bearer_dynamic
+    # Re-resolution does NOT fix it (token stays rejected): after one retry the
+    # bearer proxy gives up and the read falls through to the serve. The serve
+    # base is unreachable (127.0.0.1:1), so the handler answers 503 rather than
+    # leaking the 401 to the client.
+    store.accept_auth = "Bearer NEVER"
+    r = client.get("/api/fs/raw", params={"path": file_path},
+                   follow_redirects=False)
+    assert r.status_code == 503  # mount serve unavailable, not a 401
+    assert len(store.auth_seen) == 2  # exactly one retry

--- a/tests/test_gcs_sign.py
+++ b/tests/test_gcs_sign.py
@@ -418,6 +418,18 @@ def test_oauth_absent_expiry_with_refresh_token_forces_refresh(google_stub):
     assert gcssign.resolve_token(cfg).access_token == "NEW"
 
 
+def test_oauth_no_expiry_no_refresh_token_falls_through_to_adc(google_stub):
+    # FINDING 4: a stored oauth token with NO parseable expiry AND NO
+    # refresh_token would read as valid forever (expiry=None), trusting a
+    # possibly-dead access_token and never trying ADC. _creds_from_oauth must
+    # return None so resolution falls through to ADC.
+    google_stub.user_handler = lambda kw: _FakeCreds(token="OLD", valid=True)
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    cfg = {**_GCS, "client_id": "cid", "client_secret": "csec",
+           "token": json.dumps({"access_token": "OLD"})}  # no expiry/refresh
+    assert gcssign.resolve_token(cfg).access_token == "ADC_TOK"
+
+
 def test_resolve_credentials_returns_object_and_token_extracts(google_stub):
     marker = _FakeCreds(token="TOK", expiry=datetime.datetime(2030, 1, 1))
     google_stub.adc_handler = lambda scopes: (marker, "p")

--- a/tests/test_gcs_sign.py
+++ b/tests/test_gcs_sign.py
@@ -195,6 +195,14 @@ class _FakeCreds:
 
     @property
     def valid(self):
+        # Mirror google-auth: a token that is present but past its expiry is
+        # NOT valid (so _finalize refreshes it).
+        if self.expiry is not None:
+            exp = self.expiry
+            if exp.tzinfo is None:
+                exp = exp.replace(tzinfo=datetime.timezone.utc)
+            if datetime.datetime.now(datetime.timezone.utc) >= exp:
+                return False
         return self._valid
 
     def refresh(self, request):
@@ -204,6 +212,7 @@ class _FakeCreds:
         if self._refresh_to is not None:
             self.token = self._refresh_to
             self._valid = True
+            self.expiry = None  # refreshed token: clear the stale expiry
 
 
 class _GoogleStub:
@@ -373,3 +382,46 @@ def test_resolve_signer_only_for_service_account_key(google_stub):
     # A remote with no SA key can't sign locally even if ADC has a token.
     assert gcssign.resolve_signer(_GCS) is None
     assert gcssign.resolve_signer({**_GCS, "anonymous": "true"}) is None
+
+
+# --------------------------------------- fix 2: rclone oauth expiry handling
+
+
+def test_parse_rclone_expiry_formats():
+    p = gcssign._parse_rclone_expiry
+    assert p("2019-08-20T00:00:00Z") == datetime.datetime(2019, 8, 20, 0, 0, 0)
+    # nanosecond precision (9 digits) is truncated to microseconds
+    assert p("2019-08-20T00:00:00.123456789Z") == \
+        datetime.datetime(2019, 8, 20, 0, 0, 0, 123456)
+    # an offset is converted to a TZ-naive UTC datetime
+    assert p("2019-08-20T01:00:00+01:00") == datetime.datetime(2019, 8, 20, 0, 0, 0)
+    assert p("") is None and p(None) is None and p("garbage") is None
+
+
+def test_oauth_stale_expiry_forces_refresh(google_stub):
+    # rclone's stored access_token is past its expiry: google-auth must treat it
+    # as expired and refresh, not hand back the dead token.
+    google_stub.user_handler = lambda kw: _FakeCreds(token="OLD", refresh_to="NEW")
+    cfg = {**_GCS, "client_id": "cid", "client_secret": "csec",
+           "token": json.dumps({"access_token": "OLD", "refresh_token": "r",
+                                 "expiry": "2000-01-01T00:00:00Z"})}
+    assert gcssign.resolve_token(cfg).access_token == "NEW"
+
+
+def test_oauth_absent_expiry_with_refresh_token_forces_refresh(google_stub):
+    # No expiry to judge staleness by, but a refresh_token can renew it — force
+    # a refresh rather than trust an expiry-less (=> "valid forever") token.
+    google_stub.user_handler = lambda kw: _FakeCreds(
+        token="OLD", refresh_to="NEW", valid=True)
+    cfg = {**_GCS, "client_id": "cid", "client_secret": "csec",
+           "token": json.dumps({"access_token": "OLD", "refresh_token": "r"})}
+    assert gcssign.resolve_token(cfg).access_token == "NEW"
+
+
+def test_resolve_credentials_returns_object_and_token_extracts(google_stub):
+    marker = _FakeCreds(token="TOK", expiry=datetime.datetime(2030, 1, 1))
+    google_stub.adc_handler = lambda scopes: (marker, "p")
+    obj = gcssign.resolve_credentials(_GCS)
+    assert obj is marker  # the OBJECT is returned (mounts caches it)
+    assert gcssign.token_from_credentials(obj).access_token == "TOK"
+    assert gcssign.token_from_credentials(None) is None

--- a/tests/test_gcs_sign.py
+++ b/tests/test_gcs_sign.py
@@ -1,0 +1,375 @@
+"""Unit tests for the stdlib GOOG4 URL signer and the local GCS bearer-token
+resolver (shell/gcssign.py). Pure — no network, no rclone, no google SDK on the
+resolver path (google.auth/google.oauth2 are faked via sys.modules so the tests
+pin the DEGRADE contract regardless of whether [cloud-auth] is installed).
+
+The signer is checked against Google's published V4 signing conformance vector
+(googleapis/conformance-tests storage/v1/v4_signatures.json "Simple GET"): the
+public test service-account key + a fixed timestamp/expiry yield one exact
+signed URL. RSA PKCS#1 v1.5 is deterministic, so a fixed key + string-to-sign
+gives a fixed signature. The key/URL are public test fixtures, not secrets.
+"""
+import datetime
+import json
+import sys
+import types
+import urllib.parse
+
+import pytest
+
+import fused_render.shell.gcssign as gcssign
+
+# ------------------------------------------------------------- conformance data
+# Google's public V4 conformance test service account (never a real account),
+# and the expected signed URL for the "Simple GET" vector.
+_TEST_EMAIL = "test-iam-credentials@dummy-project-id.iam.gserviceaccount.com"
+_TEST_PRIVATE_KEY = (
+    "-----BEGIN PRIVATE KEY-----\n"
+    "MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCsPzMirIottfQ2\n"
+    "ryjQmPWocSEeGo7f7Q4/tMQXHlXFzo93AGgU2t+clEj9L5loNhLVq+vk+qmnyDz5\n"
+    "Q04y8jVWyMYzzGNNrGRW/yaYqnqlKZCy1O3bmnNjV7EDbC/jE1ZLBY0U3HaSHfn6\n"
+    "S9ND8MXdgD0/ulRTWwq6vU8/w6i5tYsU7n2LLlQTl1fQ7/emO9nYcCFJezHZVa0H\n"
+    "meWsdHwWsok0skwQYQNIzP3JF9BpR5gJT2gNge6KopDesJeLoLzaX7cUnDn+CAnn\n"
+    "LuLDwwSsIVKyVxhBFsFXPplgpaQRwmGzwEbf/Xpt9qo26w2UMgn30jsOaKlSeAX8\n"
+    "cS6ViF+tAgMBAAECggEACKRuJCP8leEOhQziUx8Nmls8wmYqO4WJJLyk5xUMUC22\n"
+    "SI4CauN1e0V8aQmxnIc0CDkFT7qc9xBmsMoF+yvobbeKrFApvlyzNyM7tEa/exh8\n"
+    "DGD/IzjbZ8VfWhDcUTwn5QE9DCoon9m1sG+MBNlokB3OVOt8LieAAREdEBG43kJu\n"
+    "yQTOkY9BGR2AY1FnAl2VZ/jhNDyrme3tp1sW1BJrawzR7Ujo8DzlVcS2geKA9at7\n"
+    "55ua5GbHz3hfzFgjVXDfnkWzId6aHypUyqHrSn1SqGEbyXTaleKTc6Pgv0PgkJjG\n"
+    "hZazWWdSuf1T5Xbs0OhAK9qraoAzT6cXXvMEvvPt6QKBgQDXcZKqJAOnGEU4b9+v\n"
+    "Odoh+nssdrIOBNMu1m8mYbUVYS1aakc1iDGIIWNM3qAwbG+yNEIi2xi80a2RMw2T\n"
+    "9RyCNB7yqCXXVKLBiwg9FbKMai6Vpk2bWIrzahM9on7AhCax/X2AeOp+UyYhFEy6\n"
+    "UFG4aHb8THscL7b515ukSuKb5QKBgQDMq+9PuaB0eHsrmL6q4vHNi3MLgijGg/zu\n"
+    "AXaPygSYAwYW8KglcuLZPvWrL6OG0+CrfmaWTLsyIZO4Uhdj7MLvX6yK7IMnagvk\n"
+    "L3xjgxSklEHJAwi5wFeJ8ai/1MIuCn8p2re3CbwISKpvf7Sgs/W4196P4vKvTiAz\n"
+    "jcTiSYFIKQKBgCjMpkS4O0TakMlGTmsFnqyOneLmu4NyIHgfPb9cA4n/9DHKLKAT\n"
+    "oaWxBPgatOVWs7RgtyGYsk+XubHkpC6f3X0+15mGhFwJ+CSE6tN+l2iF9zp52vqP\n"
+    "Qwkjzm7+pdhZbmaIpcq9m1K+9lqPWJRz/3XXuqi+5xWIZ7NaxGvRjqaNAoGAdK2b\n"
+    "utZ2y48XoI3uPFsuP+A8kJX+CtWZrlE1NtmS7tnicdd19AtfmTuUL6fz0FwfW4Su\n"
+    "lQZfPT/5B339CaEiq/Xd1kDor+J7rvUHM2+5p+1A54gMRGCLRv92FQ4EON0RC1o9\n"
+    "m2I4SHysdO3XmjmdXmfp4BsgAKJIJzutvtbqlakCgYB+Cb10z37NJJ+WgjDt+yT2\n"
+    "yUNH17EAYgWXryfRgTyi2POHuJitd64Xzuy6oBVs3wVveYFM6PIKXlj8/DahYX5I\n"
+    "R2WIzoCNLL3bEZ+nC6Jofpb4kspoAeRporj29SgesK6QBYWHWX2H645RkRGYGpDo\n"
+    "51gjy9m/hSNqBbH2zmh04A==\n"
+    "-----END PRIVATE KEY-----\n"
+)
+_EXPECTED_URL = (
+    "https://storage.googleapis.com/test-bucket/test-object"
+    "?X-Goog-Algorithm=GOOG4-RSA-SHA256"
+    "&X-Goog-Credential=test-iam-credentials%40dummy-project-id.iam."
+    "gserviceaccount.com%2F20190201%2Fauto%2Fstorage%2Fgoog4_request"
+    "&X-Goog-Date=20190201T090000Z&X-Goog-Expires=10"
+    "&X-Goog-SignedHeaders=host"
+    "&X-Goog-Signature=95e6a13d43a1d1962e667f17397f2b80ac9bdd1669210d5e08e0"
+    "135df9dff4e56113485dbe429ca2266487b9d1796ebdee2d7cf682a6ef3bb9fbb4c3516"
+    "86fba90d7b621cf1c4eb1fdf126460dd25fa0837dfdde0a9fd98662ce60844c458448fb"
+    "2b352c203d9969cb74efa4bdb742287744a4f2308afa4af0e0773f55e32e9297361924"
+    "9214b97283b2daa14195244444e33f938138d1e5f561088ce8011f4986dda33a556412"
+    "594db7c12fc40e1ff3f1bedeb7a42f5bcda0b9567f17f65855f65071fabb88ea123718"
+    "77f3f77f10e1466fff6ff6973b74a933322ff0949ce357e20abe96c3dd5cfab42c9c83"
+    "e740a4d32b9e11e146f0eb3404d2e975896f74"
+)
+_TS = datetime.datetime(2019, 2, 1, 9, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+def _query(url):
+    return dict(urllib.parse.parse_qsl(urllib.parse.urlsplit(url).query))
+
+
+# --------------------------------------------------------------------- signer
+
+
+class _StubSigner:
+    """Records each string-to-sign and returns a fixed signature — lets the
+    canonical-request construction be asserted without any crypto."""
+
+    SIG = b"\x01\x02\x03\xff"
+
+    def __init__(self):
+        self.messages = []
+
+    def sign(self, data):
+        self.messages.append(data)
+        return self.SIG
+
+
+def test_sign_url_matches_google_v4_conformance_vector():
+    # Exact-hex guarantee against Google's published vector (needs a real RSA
+    # backend; cryptography is a google-auth transitive dep, skip if absent).
+    crypto = pytest.importorskip("cryptography")
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding
+    pk = serialization.load_pem_private_key(
+        _TEST_PRIVATE_KEY.encode(), password=None)
+
+    class _RealSigner:
+        def sign(self, data):
+            return pk.sign(data, padding.PKCS1v15(), hashes.SHA256())
+
+    url = gcssign.sign_url(
+        "https://storage.googleapis.com/test-bucket/test-object",
+        method="GET", signer=_RealSigner(), sa_email=_TEST_EMAIL,
+        expires=10, timestamp=_TS)
+    assert url == _EXPECTED_URL
+
+
+def test_sign_url_canonical_structure_and_hex_signature():
+    signer = _StubSigner()
+    ts = datetime.datetime(2020, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    url = gcssign.sign_url(
+        "https://storage.googleapis.com/b/k.parquet", method="GET",
+        signer=signer, sa_email="svc@p.iam.gserviceaccount.com",
+        expires=900, timestamp=ts)
+    q = _query(url)
+    assert q["X-Goog-Algorithm"] == "GOOG4-RSA-SHA256"
+    assert q["X-Goog-Credential"] == (
+        "svc@p.iam.gserviceaccount.com/20200601/auto/storage/goog4_request")
+    assert q["X-Goog-Date"] == "20200601T120000Z"
+    assert q["X-Goog-Expires"] == "900"
+    assert q["X-Goog-SignedHeaders"] == "host"
+    # The hex of the signer's bytes lands verbatim in X-Goog-Signature.
+    assert q["X-Goog-Signature"] == "010203ff"
+    # String-to-sign is GOOG4 header lines + the canonical-request hash.
+    sts = signer.messages[0].decode()
+    lines = sts.split("\n")
+    assert lines[0] == "GOOG4-RSA-SHA256"
+    assert lines[1] == "20200601T120000Z"
+    assert lines[2] == "20200601/auto/storage/goog4_request"
+    assert len(lines) == 4 and len(lines[3]) == 64  # sha256 hex
+
+
+def test_sign_url_signature_appended_after_signed_headers():
+    # Google's URL layout: X-Goog-Signature comes AFTER X-Goog-SignedHeaders
+    # (it is appended, not re-sorted into the signed query).
+    signer = _StubSigner()
+    url = gcssign.sign_url(
+        "https://storage.googleapis.com/b/o", method="GET", signer=signer,
+        sa_email="s@p.iam", expires=900, timestamp=_TS)
+    assert url.index("X-Goog-SignedHeaders") < url.index("X-Goog-Signature")
+
+
+def test_sign_url_head_differs_from_get():
+    # HEAD must be signed as HEAD (the method is part of the canonical request).
+    s1, s2 = _StubSigner(), _StubSigner()
+    common = dict(sa_email="s@p.iam", expires=900, timestamp=_TS)
+    gcssign.sign_url("https://storage.googleapis.com/b/o", method="GET",
+                     signer=s1, **common)
+    gcssign.sign_url("https://storage.googleapis.com/b/o", method="HEAD",
+                     signer=s2, **common)
+    assert s1.messages[0] != s2.messages[0]
+
+
+def test_sign_url_extra_query_is_merged_encoded_and_signed():
+    s1, s2 = _StubSigner(), _StubSigner()
+    common = dict(method="GET", sa_email="s@p.iam", expires=900, timestamp=_TS)
+    with_q = gcssign.sign_url(
+        "https://storage.googleapis.com/storage/v1/b/bkt/o", signer=s1,
+        extra_query={"prefix": "a/b c/", "delimiter": "/"}, **common)
+    without_q = gcssign.sign_url(
+        "https://storage.googleapis.com/storage/v1/b/bkt/o", signer=s2,
+        **common)
+    assert "prefix=a%2Fb%20c%2F" in with_q  # space %20, slash %2F, never '+'
+    assert "delimiter=%2F" in with_q
+    # The extra params changed what was signed.
+    assert s1.messages[0] != s2.messages[0]
+
+
+# ------------------------------------------------------------------- resolver
+
+
+class _FakeCreds:
+    """Stand-in for a google-auth credential: .valid/.token/.expiry/.refresh,
+    plus .signer/.signer_email for the SA case."""
+
+    def __init__(self, *, token=None, expiry=None, valid=None,
+                 refresh_to=None, refresh_raises=False,
+                 signer=None, signer_email=None):
+        self.token = token
+        self.expiry = expiry
+        self._valid = bool(token) if valid is None else valid
+        self._refresh_to = refresh_to
+        self._refresh_raises = refresh_raises
+        self.signer = signer
+        self.signer_email = signer_email
+        self.refreshed = False
+
+    @property
+    def valid(self):
+        return self._valid
+
+    def refresh(self, request):
+        self.refreshed = True
+        if self._refresh_raises:
+            raise RuntimeError("refresh failed")
+        if self._refresh_to is not None:
+            self.token = self._refresh_to
+            self._valid = True
+
+
+class _GoogleStub:
+    """Installs a fake google.auth / google.oauth2 tree in sys.modules. Each
+    source's behavior is a handler the test sets; an unset handler raises, so
+    that source is treated as unavailable (mirrors ImportError/failure)."""
+
+    def __init__(self, monkeypatch):
+        self.calls = []
+        self.sa_handler = None     # (info, scopes) -> creds
+        self.user_handler = None   # (kwargs) -> creds
+        self.adc_handler = None    # (scopes) -> (creds, project)
+        stub = self
+
+        google = types.ModuleType("google")
+        auth = types.ModuleType("google.auth")
+        transport = types.ModuleType("google.auth.transport")
+        treq = types.ModuleType("google.auth.transport.requests")
+        oauth2 = types.ModuleType("google.oauth2")
+        sa_mod = types.ModuleType("google.oauth2.service_account")
+        creds_mod = types.ModuleType("google.oauth2.credentials")
+
+        def default(scopes=None, **kw):
+            stub.calls.append(("default", scopes))
+            if stub.adc_handler is None:
+                raise RuntimeError("no ADC")
+            return stub.adc_handler(scopes)
+        auth.default = default
+
+        class Request:
+            def __init__(self, *a, **k):
+                pass
+        treq.Request = Request
+
+        class SACreds:
+            @classmethod
+            def from_service_account_info(cls, info, scopes=None):
+                stub.calls.append(("sa_info", info, scopes))
+                if stub.sa_handler is None:
+                    raise RuntimeError("no SA handler")
+                return stub.sa_handler(info, scopes)
+        sa_mod.Credentials = SACreds
+
+        def user_credentials(**kwargs):
+            stub.calls.append(("user_creds", kwargs))
+            if stub.user_handler is None:
+                raise RuntimeError("no user handler")
+            return stub.user_handler(kwargs)
+        creds_mod.Credentials = user_credentials
+
+        google.auth = auth
+        google.oauth2 = oauth2
+        auth.transport = transport
+        transport.requests = treq
+        oauth2.service_account = sa_mod
+        oauth2.credentials = creds_mod
+        for name, mod in [
+                ("google", google), ("google.auth", auth),
+                ("google.auth.transport", transport),
+                ("google.auth.transport.requests", treq),
+                ("google.oauth2", oauth2),
+                ("google.oauth2.service_account", sa_mod),
+                ("google.oauth2.credentials", creds_mod)]:
+            monkeypatch.setitem(sys.modules, name, mod)
+
+
+@pytest.fixture()
+def google_stub(monkeypatch):
+    return _GoogleStub(monkeypatch)
+
+
+_GCS = {"type": "google cloud storage"}
+_SA_CFG = {**_GCS, "service_account_credentials":
+           json.dumps({"client_email": "svc@p.iam", "private_key": "x"})}
+
+
+def test_resolve_token_prefers_service_account(google_stub):
+    google_stub.sa_handler = lambda info, scopes: _FakeCreds(
+        valid=False, refresh_to="SA_TOK",
+        expiry=datetime.datetime(2030, 1, 1))
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    tok = gcssign.resolve_token(_SA_CFG)
+    assert tok.access_token == "SA_TOK"
+    # ADC never consulted once the SA key resolved.
+    assert not any(c[0] == "default" for c in google_stub.calls)
+
+
+def test_resolve_token_oauth_when_client_creds_present(google_stub):
+    google_stub.user_handler = lambda kw: _FakeCreds(token="OAUTH_TOK")
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    cfg = {**_GCS, "token": json.dumps({"access_token": "a", "refresh_token": "r"}),
+           "client_id": "cid", "client_secret": "csec"}
+    tok = gcssign.resolve_token(cfg)
+    assert tok.access_token == "OAUTH_TOK"
+    kw = [c[1] for c in google_stub.calls if c[0] == "user_creds"][0]
+    assert kw["client_id"] == "cid" and kw["client_secret"] == "csec"
+
+
+def test_resolve_token_skips_oauth_without_client_creds(google_stub):
+    # rclone's built-in oauth client (no config client_id/secret) is skipped —
+    # we won't embed rclone's compiled-in secret; ADC serves the user instead.
+    google_stub.user_handler = lambda kw: _FakeCreds(token="OAUTH_TOK")
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    cfg = {**_GCS, "token": json.dumps({"access_token": "a"})}
+    tok = gcssign.resolve_token(cfg)
+    assert tok.access_token == "ADC_TOK"
+    assert not any(c[0] == "user_creds" for c in google_stub.calls)
+
+
+def test_resolve_token_adc_fallback_and_scope(google_stub):
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    tok = gcssign.resolve_token(_GCS)
+    assert tok.access_token == "ADC_TOK"
+    scopes = [c[1] for c in google_stub.calls if c[0] == "default"][0]
+    assert scopes == ["https://www.googleapis.com/auth/devstorage.read_only"]
+
+
+def test_resolve_token_refreshes_when_invalid(google_stub):
+    c = _FakeCreds(valid=False, refresh_to="REFRESHED")
+    google_stub.adc_handler = lambda scopes: (c, "p")
+    tok = gcssign.resolve_token(_GCS)
+    assert c.refreshed is True and tok.access_token == "REFRESHED"
+
+
+def test_resolve_token_maps_expiry_epoch(google_stub):
+    exp = datetime.datetime(2030, 1, 1, 0, 0, 0)  # naive UTC, google-auth style
+    google_stub.adc_handler = lambda scopes: (
+        _FakeCreds(token="T", expiry=exp), "p")
+    tok = gcssign.resolve_token(_GCS)
+    assert tok.expiry_epoch == exp.replace(
+        tzinfo=datetime.timezone.utc).timestamp()
+
+
+def test_resolve_token_refresh_failure_falls_through(google_stub):
+    google_stub.sa_handler = lambda info, scopes: _FakeCreds(
+        valid=False, refresh_raises=True)
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="ADC_TOK"), "p")
+    assert gcssign.resolve_token(_SA_CFG).access_token == "ADC_TOK"
+
+
+def test_resolve_token_none_when_google_auth_absent(monkeypatch):
+    # [cloud-auth] not installed: every source's lazy import raises -> None.
+    for name in ("google.auth", "google.auth.transport.requests",
+                 "google.oauth2.service_account", "google.oauth2.credentials"):
+        monkeypatch.setitem(sys.modules, name, None)
+    assert gcssign.resolve_token(_SA_CFG) is None
+    assert gcssign.resolve_token(_GCS) is None
+
+
+def test_resolve_token_none_for_non_gcs_and_anonymous(google_stub):
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="X"), "p")
+    assert gcssign.resolve_token({"type": "s3"}) is None
+    assert gcssign.resolve_token(None) is None
+    assert gcssign.resolve_token({**_GCS, "anonymous": "true"}) is None
+    # None of those consulted a credential source.
+    assert google_stub.calls == []
+
+
+def test_resolve_signer_only_for_service_account_key(google_stub):
+    marker = object()
+    google_stub.sa_handler = lambda info, scopes: _FakeCreds(
+        token="T", signer=marker, signer_email="svc@p.iam.gserviceaccount.com")
+    google_stub.adc_handler = lambda scopes: (_FakeCreds(token="T"), "p")
+    s = gcssign.resolve_signer(_SA_CFG)
+    assert s.signer is marker
+    assert s.sa_email == "svc@p.iam.gserviceaccount.com"
+    # A remote with no SA key can't sign locally even if ADC has a token.
+    assert gcssign.resolve_signer(_GCS) is None
+    assert gcssign.resolve_signer({**_GCS, "anonymous": "true"}) is None

--- a/tests/test_s3_sign.py
+++ b/tests/test_s3_sign.py
@@ -7,10 +7,27 @@ a fixed key pair, region, timestamp and expiry yield one exact signature hex.
 The resolver is checked with monkeypatched env vars and tmp credentials files.
 """
 import datetime
+import sys
+import types
 
 import pytest
 
 import fused_render.shell.s3sign as s3sign
+
+
+@pytest.fixture(autouse=True)
+def _neutralize_ambient_aws(tmp_path, monkeypatch):
+    """Keep every resolver test deterministic and fast even though the dev venv
+    ships botocore: clear AWS_* env, point the shared/config files at absent
+    paths, and disable the IMDS probe so the botocore rung (when reached with no
+    static source) resolves to None immediately instead of stalling on metadata.
+    Tests that exercise a source explicitly re-set what they need afterwards."""
+    for var in ("AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY",
+                "AWS_SESSION_TOKEN", "AWS_PROFILE"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "no-creds"))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-config"))
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
 
 # AWS's published example (SigV4 query-string auth, "GET Object"):
 #   key    AKIAIOSFODNN7EXAMPLE / wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
@@ -210,3 +227,109 @@ def test_resolver_expands_tilde_in_shared_credentials_file(tmp_path, monkeypatch
     assert s3sign.resolve_credentials(
         {"type": "s3", "env_auth": "true"}) == \
         s3sign.Credentials("AKIATILDE", "TILDESEC", None)
+
+
+# ------------------------------------------------- botocore chain rung (opt-in)
+#
+# The optional last rung consults botocore's full provider chain (SSO / IMDS /
+# credential_process / assume-role) only when the static ladder found nothing
+# AND the remote opted into ambient auth (env_auth or a profile). botocore is
+# faked via sys.modules so the tests pin the DEGRADE contract regardless of
+# whether the [cloud-auth] extra is installed.
+
+
+def _install_fake_botocore(monkeypatch, *, frozen=None, raises=False):
+    """Replace botocore.session with a stub whose Session records the profile
+    and any set credentials_file and returns `frozen` (access_key, secret_key,
+    token) as frozen credentials — or None. `raises=True` makes get_credentials
+    blow up (expired SSO login / no providers). Returns the record dict so a
+    test can assert what reached the session (empty => never constructed)."""
+    rec: dict = {}
+    bc = types.ModuleType("botocore")
+    session_mod = types.ModuleType("botocore.session")
+
+    class _Frozen:
+        def __init__(self, ak, sk, tok):
+            self.access_key, self.secret_key, self.token = ak, sk, tok
+
+    class _Creds:
+        def __init__(self, f):
+            self._f = f
+
+        def get_frozen_credentials(self):
+            return self._f
+
+    class Session:
+        def __init__(self, profile=None):
+            rec["profile"] = profile
+
+        def set_config_variable(self, name, value):
+            rec[name] = value
+
+        def get_credentials(self):
+            if raises:
+                raise RuntimeError("expired SSO login")
+            return None if frozen is None else _Creds(_Frozen(*frozen))
+
+    session_mod.Session = Session
+    bc.session = session_mod
+    monkeypatch.setitem(sys.modules, "botocore", bc)
+    monkeypatch.setitem(sys.modules, "botocore.session", session_mod)
+    return rec
+
+
+def test_botocore_not_consulted_when_config_keys_present(monkeypatch):
+    rec = _install_fake_botocore(monkeypatch, frozen=("AKIABOTO", "BSEC", "BTOK"))
+    cfg = {"type": "s3", "access_key_id": "AKIACFG",
+           "secret_access_key": "SEC", "env_auth": "true"}
+    assert s3sign.resolve_credentials(cfg) == \
+        s3sign.Credentials("AKIACFG", "SEC", None)
+    assert rec == {}  # static config keys win — botocore session never built
+
+
+def test_botocore_not_consulted_when_env_keys_present(monkeypatch):
+    rec = _install_fake_botocore(monkeypatch, frozen=("AKIABOTO", "BSEC", None))
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIAENV")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "ENVSEC")
+    assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) == \
+        s3sign.Credentials("AKIAENV", "ENVSEC", None)
+    assert rec == {}
+
+
+def test_botocore_resolves_when_static_sources_empty(monkeypatch):
+    # No static keys, no env, no shared file — env_auth opts in, so the botocore
+    # rung resolves and its STS session token is mapped through.
+    _install_fake_botocore(monkeypatch, frozen=("AKIASSO", "SSOSEC", "SSOTOK"))
+    assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) == \
+        s3sign.Credentials("AKIASSO", "SSOSEC", "SSOTOK")
+
+
+def test_botocore_exception_yields_none(monkeypatch):
+    _install_fake_botocore(monkeypatch, raises=True)
+    assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) is None
+
+
+def test_botocore_absent_yields_none(monkeypatch):
+    # [cloud-auth] not installed: the lazy import raises ImportError -> None,
+    # and the caller keeps today's publiclink path.
+    monkeypatch.setitem(sys.modules, "botocore", None)
+    monkeypatch.setitem(sys.modules, "botocore.session", None)
+    assert s3sign.resolve_credentials({"type": "s3", "env_auth": "true"}) is None
+
+
+def test_botocore_not_consulted_without_ambient_optin(monkeypatch):
+    # A remote that never opted into ambient auth (no env_auth, no profile, no
+    # shared_credentials_file) must NOT trigger an ambient-credential lookup.
+    rec = _install_fake_botocore(monkeypatch, frozen=("AKIASSO", "SSOSEC", None))
+    assert s3sign.resolve_credentials({"type": "s3"}) is None
+    assert rec == {}
+
+
+def test_botocore_receives_profile_and_shared_file(monkeypatch):
+    rec = _install_fake_botocore(monkeypatch, frozen=("AKIAP", "PSEC", None))
+    creds = s3sign.resolve_credentials(
+        {"type": "s3", "profile": "work",
+         "shared_credentials_file": "~/x/creds"})
+    assert creds == s3sign.Credentials("AKIAP", "PSEC", None)
+    assert rec["profile"] == "work"
+    assert rec["credentials_file"].endswith("/x/creds")  # expanded, not verbatim

--- a/tests/test_server_fs_events.py
+++ b/tests/test_server_fs_events.py
@@ -284,6 +284,73 @@ def test_mount_dir_signal_unchanged_on_failure(home, monkeypatch):
     assert entry._mount_signal() is server._UNCHANGED
 
 
+def test_mount_dir_signal_credentialed_direct_error_falls_back_to_rc(home, monkeypatch):
+    # (finding 12 regression) direct_list_capable is now a PURE config-shape
+    # check, so a credentialed-SHAPED S3/GCS remote is "capable" without its
+    # creds having been resolved. When they don't resolve (cloud-auth libs
+    # absent, ambient creds expired) direct_list_page raises DirectListError.
+    # A non-root dir must fall back to rc_list_dir — the same recovery the
+    # fs/list handler and the s3/gcs_direct_capable docstrings promise — rather
+    # than landing in the blanket except and going permanently _UNCHANGED.
+    entry = server._WatchEntry(str(home / "mounts" / "priv" / "dir"))
+    assert entry.is_mount is True and entry._is_mount_root is False
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "direct_list_anonymous", lambda p: False)
+    monkeypatch.setattr(
+        mounts_mod, "direct_list_page",
+        lambda path, *, max_keys, continuation=None, timeout=None:
+        (_ for _ in ()).throw(mounts_mod.DirectListError("creds unresolved")))
+    listing = [{"Name": "a", "Size": 1, "ModTime": "t1"}]
+    rc_calls = []
+
+    def fake_rc(p, timeout=None):
+        rc_calls.append(p)
+        return list(listing)
+
+    monkeypatch.setattr(mounts_mod, "rc_list_dir", fake_rc)
+    sig = entry._mount_signal()
+    assert sig.startswith("L")  # rc listing hash, not _UNCHANGED
+    assert rc_calls == [str(home / "mounts" / "priv" / "dir")]
+
+
+def test_mount_root_credentialed_direct_error_unchanged_no_rc(home, monkeypatch):
+    # A credentialed-shaped mount ROOT whose direct page fails must NOT fall
+    # through to rc_list_dir: an rc listing of the whole top prefix every tick is
+    # the standing background enumeration the watcher deliberately refuses
+    # (P1 #4). It stays best-effort _UNCHANGED.
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "is_mount_root", lambda p: True)
+    entry = server._WatchEntry(str(home / "mounts" / "privbucket"))
+    assert entry._is_mount_root is True and entry._direct_capable is True
+    monkeypatch.setattr(mounts_mod, "direct_list_anonymous", lambda p: False)
+    monkeypatch.setattr(
+        mounts_mod, "direct_list_page",
+        lambda path, *, max_keys, continuation=None, timeout=None:
+        (_ for _ in ()).throw(mounts_mod.DirectListError("creds unresolved")))
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            AssertionError("rc_list_dir called on a mount root")))
+    assert entry._mount_signal() is server._UNCHANGED
+
+
+def test_mount_dir_signal_anonymous_direct_error_unchanged_no_rc(home, monkeypatch):
+    # HARD INVARIANT: an anonymous S3/GCS remote carries no creds to fail on and
+    # historically returned _UNCHANGED on DirectListError. That behavior stays
+    # byte-identical — NO rc fallback for anonymous, even on a non-root dir.
+    entry = server._WatchEntry(str(home / "mounts" / "open" / "dir"))
+    assert entry._is_mount_root is False
+    monkeypatch.setattr(mounts_mod, "direct_list_capable", lambda p: True)
+    monkeypatch.setattr(mounts_mod, "direct_list_anonymous", lambda p: True)
+    monkeypatch.setattr(
+        mounts_mod, "direct_list_page",
+        lambda path, *, max_keys, continuation=None, timeout=None:
+        (_ for _ in ()).throw(mounts_mod.DirectListError("boom")))
+    monkeypatch.setattr(mounts_mod, "rc_list_dir",
+                        lambda *a, **k: (_ for _ in ()).throw(
+                            AssertionError("rc_list_dir called for anonymous remote")))
+    assert entry._mount_signal() is server._UNCHANGED
+
+
 def test_read_consumes_a_completed_slow_stat(tmp_path, monkeypatch):
     # (3.3) A stat that outlives its wait_for keeps running; the NEXT tick must
     # CONSUME its finished result rather than discard the done future and start

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -13,6 +13,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+import fused_render.shell.gcssign as gcssign_mod
 import fused_render.shell.mounts as mounts_mod
 
 
@@ -2133,6 +2134,7 @@ def fresh_upstream():
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._gcs_token_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
     yield
@@ -2141,6 +2143,7 @@ def fresh_upstream():
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._gcs_token_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
 
@@ -3351,6 +3354,179 @@ def test_gcs_list_page_non_anonymous_raises_directlisterror(home, rcd, fresh_ups
     c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
     with pytest.raises(mounts_mod.DirectListError):
         mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+
+
+# -- credentialed GCS: bearer-authorized direct listings and probes ---------
+#
+# A non-anonymous GCS remote whose bearer token resolves (gcssign.resolve_token)
+# joins the direct fast path: the same JSON-API pager and HEAD/list probes, now
+# with an `Authorization: Bearer` header. Anonymous GCS stays byte-identical (no
+# header, resolver never consulted). resolve_token is stubbed so the tests need
+# no google-auth and pin the degrade contract.
+
+_CRED_GCS_CFG = {"type": "google cloud storage",
+                 "service_account_file": "/keys/sa.json"}
+
+
+def _stub_gcs_token(monkeypatch, *, token="TOKENVAL", expiry_offset=3600.0,
+                    calls=None):
+    def fake(cfg):
+        if calls is not None:
+            calls.append(cfg)
+        if token is None:
+            return None
+        return gcssign_mod.Token(token, time.time() + expiry_offset)
+    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token", fake)
+
+
+@pytest.fixture()
+def gcs_bearer_urlopen(monkeypatch):
+    """Capture (url, Authorization-header) for GCS API GETs and hand back canned
+    JSON. box['body'] is the reply; box['raises'] a per-call list of exceptions
+    (None entry = succeed). rc calls (loopback rcd) delegate to real urlopen."""
+    calls = []
+    box = {"body": _gcs_list_json()}
+    real = mounts_mod.urllib.request.urlopen
+
+    def fake(req, timeout=None):
+        target = req if isinstance(req, str) else req.get_full_url()
+        if "storage.googleapis.com" not in target:
+            return real(req, timeout=timeout)
+        auth = None if isinstance(req, str) else req.get_header("Authorization")
+        calls.append((target, auth))
+        seq = box.get("raises")
+        if seq:
+            exc = seq.pop(0)
+            if exc is not None:
+                raise exc
+        return _FakeS3Resp(box["body"])
+
+    monkeypatch.setattr(mounts_mod.urllib.request, "urlopen", fake)
+    return calls, box
+
+
+def test_gcs_direct_capable_true_for_credentialed(home, rcd, fresh_upstream, monkeypatch):
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token="TOK")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+
+
+def test_gcs_direct_capable_false_when_token_absent(home, rcd, fresh_upstream, monkeypatch):
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token=None)
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    assert not mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+
+
+def test_gcs_list_page_credentialed_carries_bearer(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    calls, _box = gcs_bearer_urlopen
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    [(url, auth)] = calls
+    assert url.startswith(
+        "https://storage.googleapis.com/storage/v1/b/bucket/o?")
+    assert auth == "Bearer TOKENVAL"
+
+
+def test_gcs_head_credentialed_carries_bearer(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    calls, box = gcs_bearer_urlopen
+    box["body"] = b'{"size": "42", "updated": "2024-01-02T03:04:05Z"}'
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    got = mounts_mod.direct_head(mounts_mod.mountpoint(c) + "/x.json")
+    assert got.exists is True and got.size == 42
+    assert calls[-1][1] == "Bearer TOKENVAL"
+
+
+def test_gcs_has_children_credentialed_carries_bearer(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    calls, box = gcs_bearer_urlopen
+    box["body"] = _gcs_list_json(items=[("pre/x", 1, "2024-01-01T00:00:00Z")])
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    assert mounts_mod.direct_is_dir(mounts_mod.mountpoint(c) + "/sub") is True
+    assert calls[-1][1] == "Bearer TOKENVAL"
+
+
+def test_gcs_anonymous_never_carries_bearer_or_consults_resolver(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    # INVARIANT: anonymous GCS is byte-identical — no Authorization header, and
+    # the token resolver is never consulted (mirrors the S3 anonymous guard).
+    calls, _box = gcs_bearer_urlopen
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    resolver_calls = []
+    _stub_gcs_token(monkeypatch, token="TOK", calls=resolver_calls)
+    c = mounts_mod.add_mount("open", "gcs-open:bucket/pre")
+    mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    [(_url, auth)] = calls
+    assert auth is None
+    assert resolver_calls == []
+
+
+def test_gcs_list_page_401_reresolves_then_retries(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    calls, box = gcs_bearer_urlopen
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    resolver_calls = []
+    _stub_gcs_token(monkeypatch, token="TOK", calls=resolver_calls)
+    box["raises"] = [
+        mounts_mod.urllib.error.HTTPError("https://x", 401, "no", {}, None),
+        None]  # first 401, retry succeeds
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    entries, _tok = mounts_mod.gcs_list_page(
+        mounts_mod.mountpoint(c), max_keys=1000)
+    assert len(calls) == 2  # one 401 + one retry
+    assert calls[1][1] == "Bearer TOK"
+    # capability probe cached the token; the 401 dropped it and forced one
+    # re-resolve for the retry.
+    assert len(resolver_calls) == 2
+
+
+def test_gcs_list_page_second_401_raises(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    calls, box = gcs_bearer_urlopen
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_token(monkeypatch, token="TOK")
+    box["raises"] = [
+        mounts_mod.urllib.error.HTTPError("https://x", 403, "no", {}, None),
+        mounts_mod.urllib.error.HTTPError("https://x", 403, "no", {}, None)]
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    with pytest.raises(mounts_mod.DirectListError):
+        mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert len(calls) == 2  # retried exactly once
+
+
+def test_invalidate_upstream_caches_clears_gcs_token_cache(fresh_upstream):
+    mounts_mod._gcs_token_cache["gcp"] = (
+        gcssign_mod.Token("T", time.time() + 999), time.time() + 999)
+    mounts_mod._invalidate_upstream_caches()
+    assert mounts_mod._gcs_token_cache == {}
+
+
+def test_gcs_bearer_token_ttl_tracks_expiry(fresh_upstream, monkeypatch):
+    # A short-lived token caches for < its expiry (minus slack); a long-lived
+    # one is capped at the _CRED_TTL_S re-read window.
+    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token",
+                        lambda cfg: gcssign_mod.Token("T", time.time() + 65))
+    mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
+    _tok, exp = mounts_mod._gcs_token_cache["gcp"]
+    assert 0 < exp - time.monotonic() <= 10  # ~5s (65s - 60s slack)
+
+    mounts_mod._gcs_token_cache.clear()
+    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token",
+                        lambda cfg: gcssign_mod.Token("T", time.time() + 86400))
+    mounts_mod._gcs_bearer_token("gcp2", _CRED_GCS_CFG)
+    _tok2, exp2 = mounts_mod._gcs_token_cache["gcp2"]
+    assert abs((exp2 - time.monotonic()) - mounts_mod._CRED_TTL_S) < 2
+
+
+def test_gcs_bearer_token_caches_within_ttl(fresh_upstream, monkeypatch):
+    calls = []
+    _stub_gcs_token(monkeypatch, token="TOK", calls=calls)
+    mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
+    mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
+    assert len(calls) == 1  # second call served from cache
 
 
 # -- unified direct-listing dispatchers (S3 + GCS) --------------------------

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2142,6 +2142,7 @@ def fresh_upstream():
     mounts_mod._botocore_creds_cache.clear()
     mounts_mod._gcs_token_cache.clear()
     mounts_mod._gcs_creds_cache.clear()
+    mounts_mod._gcs_signer_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
     yield
@@ -2153,6 +2154,7 @@ def fresh_upstream():
     mounts_mod._botocore_creds_cache.clear()
     mounts_mod._gcs_token_cache.clear()
     mounts_mod._gcs_creds_cache.clear()
+    mounts_mod._gcs_signer_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
 
@@ -3511,12 +3513,29 @@ def test_gcs_list_page_second_401_raises(home, rcd, fresh_upstream, monkeypatch,
     rcd.responses["config/get"] = _CRED_GCS_CFG
     _stub_gcs_token(monkeypatch, token="TOK")
     box["raises"] = [
-        mounts_mod.urllib.error.HTTPError("https://x", 403, "no", {}, None),
-        mounts_mod.urllib.error.HTTPError("https://x", 403, "no", {}, None)]
+        mounts_mod.urllib.error.HTTPError("https://x", 401, "no", {}, None),
+        mounts_mod.urllib.error.HTTPError("https://x", 401, "no", {}, None)]
     c = mounts_mod.add_mount("gcp", "gcp:bucket")
     with pytest.raises(mounts_mod.DirectListError):
         mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
     assert len(calls) == 2  # retried exactly once
+
+
+def test_gcs_list_page_403_propagates_without_retry(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
+    # 403 = permission denial with a VALID token (per-object IAM); re-resolving
+    # wouldn't help, so it propagates immediately — no retry, no token churn.
+    calls, box = gcs_bearer_urlopen
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    resolver_calls = []
+    _stub_gcs_token(monkeypatch, token="TOK", calls=resolver_calls)
+    box["raises"] = [
+        mounts_mod.urllib.error.HTTPError("https://x", 403, "no", {}, None),
+        None]  # a retry (if it happened) would succeed — it must NOT happen
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    with pytest.raises(mounts_mod.DirectListError):
+        mounts_mod.gcs_list_page(mounts_mod.mountpoint(c), max_keys=1000)
+    assert len(calls) == 1  # no retry on 403
+    assert len(resolver_calls) == 1  # token not invalidated / re-resolved
 
 
 def test_invalidate_upstream_caches_clears_gcs_token_and_creds_caches(fresh_upstream):
@@ -3658,17 +3677,23 @@ def test_upstream_gsign_signs_sa_key_gcs(home, rcd, fresh_upstream, monkeypatch)
     assert seen == []
 
 
-def test_upstream_gsign_403_falls_to_bearer_mode(home, rcd, fresh_upstream, monkeypatch):
+def test_upstream_gsign_403_falls_to_bearer_and_bearer_serves(home, rcd, fresh_upstream, monkeypatch):
     import os
 
     rcd.responses["config/get"] = _CRED_GCS_CFG
-    _stub_gcs_signer(monkeypatch)
+    _stub_gcs_signer(monkeypatch, present=True)    # SA key parses...
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")  # ...and a token resolves
     monkeypatch.setattr(mounts_mod, "_sign_validation_status",
                         lambda url: (403, None))
     c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
     f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
-    assert mounts_mod.upstream_url_for(f) is None
+    assert mounts_mod.upstream_url_for(f) is None  # signature rejected, no 307
     assert mounts_mod._upstream_mode["gcp:bucket/pre"] == "bearer"
+    # FINDING 1: a remote pinned to bearer serves the token even though the SA
+    # key still parses (_gcs_signable True) — no dead-end back to the serve.
+    url, headers = mounts_mod.bearer_upstream_for(f)
+    assert url == "https://storage.googleapis.com/bucket/pre/a.parquet"
+    assert headers == {"Authorization": "Bearer TOKENVAL"}
     # publiclink is never attempted for a credentialed GCS remote.
     assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
 
@@ -3687,7 +3712,7 @@ def test_upstream_gsign_inconclusive_not_pinned(home, rcd, fresh_upstream, monke
     assert mounts_mod._sign_neg_cache.get("gcp:bucket", 0.0) > 0.0
 
 
-def test_upstream_gsign_demotes_when_signer_vanishes(home, rcd, fresh_upstream, monkeypatch):
+def test_upstream_gsign_unpins_when_signer_vanishes(home, rcd, fresh_upstream, monkeypatch):
     import os
 
     rcd.responses["config/get"] = _CRED_GCS_CFG
@@ -3698,10 +3723,14 @@ def test_upstream_gsign_demotes_when_signer_vanishes(home, rcd, fresh_upstream, 
     f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
     assert mounts_mod.upstream_url_for(f) is not None
     assert mounts_mod._upstream_mode["gcp:bucket"] == "gsign"
-    # SA key rotated away: gsign mints nothing, so demote to bearer cleanly.
+    # SA key rotated away (and its cached signer expires): gsign mints nothing.
     _stub_gcs_signer(monkeypatch, present=False)
+    mounts_mod._gcs_signer_cache.clear()
     assert mounts_mod.upstream_url_for(f) is None
-    assert mounts_mod._upstream_mode["gcp:bucket"] == "bearer"
+    # FINDING 5: the demotion is NON-permanent — the mode is un-pinned, so the
+    # next request re-derives (gsign again once the signer returns) rather than
+    # being stuck on a wrong mode forever.
+    assert "gcp:bucket" not in mounts_mod._upstream_mode
 
 
 def test_upstream_bearer_token_only_gcs(home, rcd, fresh_upstream, monkeypatch):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2233,15 +2233,19 @@ def test_upstream_url_public_gcs_when_anonymous(home, rcd, fresh_upstream):
 def test_upstream_url_non_anonymous_gcs_gets_no_public_url(home, rcd, fresh_upstream):
     import os
 
-    # A non-anonymous GCS remote whose publiclink fails has no reachable
-    # unsigned URL — the verdict is cached like the credentialed-S3 case.
+    # A non-anonymous GCS remote has no reachable unsigned URL. With no SA key
+    # configured it is token-only-SHAPED, so it pins the bearer mode WITHOUT ever
+    # calling publiclink (which always fails for GCS, PublicLink: False); with no
+    # resolvable token (google-auth absent) upstream_url_for stays None and the
+    # read falls through to the serve.
     rcd.responses["operations/publiclink"] = (500, {"error": "boom"})
     rcd.responses["config/get"] = {"type": "google cloud storage"}
     c = mounts_mod.add_mount("gcp", "gcp:bucket")
     f = os.path.join(mounts_mod.mountpoint(c), "x.parquet")
     assert mounts_mod.upstream_url_for(f) is None
     assert mounts_mod.upstream_url_for(f) is None
-    assert len([x for x in rcd.calls if x[0] == "operations/publiclink"]) == 1
+    assert mounts_mod._upstream_mode["gcp:bucket"] == "bearer"
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
 
 
 def test_upstream_url_none_is_remembered(home, rcd, fresh_upstream):
@@ -3712,6 +3716,57 @@ def test_upstream_gsign_inconclusive_not_pinned(home, rcd, fresh_upstream, monke
     assert mounts_mod._sign_neg_cache.get("gcp:bucket", 0.0) > 0.0
 
 
+def test_upstream_gsign_retry_window_serves_bearer_without_pinning(
+        home, rcd, fresh_upstream, monkeypatch):
+    # FINDING 1: while gsign validation is inconclusive (its retry window), a raw
+    # read must still be served via the bearer proxy in the SAME request even
+    # though the SA key parses (_gcs_signable True) — not dead-end at the serve —
+    # AND bearer must NOT be permanently pinned, so gsign is retried after the
+    # window.
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch, present=True)      # SA key parses (signable)
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")   # ...and a token resolves
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (0, None))  # network error -> inconclusive
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) is None  # no 307 URL this window
+    assert "gcp:bucket/pre" not in mounts_mod._upstream_mode  # NOT pinned bearer
+    # ...but the bearer proxy serves the token in the same window (not a dead-end)
+    # even though the SA key still parses.
+    assert mounts_mod._gcs_signable("gcp", _CRED_GCS_CFG) is True
+    url, headers = mounts_mod.bearer_upstream_for(f)
+    assert url == "https://storage.googleapis.com/bucket/pre/a.parquet"
+    assert headers == {"Authorization": "Bearer TOKENVAL"}
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+
+
+def test_upstream_gsign_transient_signer_none_not_pinned_bearer(
+        home, rcd, fresh_upstream, monkeypatch):
+    # FINDING 2: a signable-SHAPED remote (SA key configured) whose signer
+    # momentarily resolves None must NOT be pinned to bearer permanently — once
+    # the signer comes back the remote ends up in gsign mode, not stuck bearer.
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG  # carries service_account_file
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (206, None))
+    _stub_gcs_signer(monkeypatch, present=False)  # SA file momentarily unreadable
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) is None            # served via bearer
+    assert "gcp:bucket/pre" not in mounts_mod._upstream_mode  # NOT pinned bearer
+    # Signer comes back and its cache expires: gsign now validates and pins.
+    _stub_gcs_signer(monkeypatch, present=True)
+    mounts_mod._gcs_signer_cache.clear()
+    url = mounts_mod.upstream_url_for(f)
+    assert url is not None and "X-Goog-Signature=" in url
+    assert mounts_mod._upstream_mode["gcp:bucket/pre"] == "gsign"
+
+
 def test_upstream_gsign_unpins_when_signer_vanishes(home, rcd, fresh_upstream, monkeypatch):
     import os
 
@@ -3736,8 +3791,10 @@ def test_upstream_gsign_unpins_when_signer_vanishes(home, rcd, fresh_upstream, m
 def test_upstream_bearer_token_only_gcs(home, rcd, fresh_upstream, monkeypatch):
     import os
 
-    rcd.responses["config/get"] = _CRED_GCS_CFG
-    _stub_gcs_signer(monkeypatch, present=False)  # no SA key -> not signable
+    # Token-only SHAPE: a non-anonymous GCS remote with no SA key configured
+    # (oauth / ADC). It pins bearer straight away (never signable) and a token
+    # resolves, so the bearer proxy serves.
+    rcd.responses["config/get"] = {"type": "google cloud storage"}
     _stub_gcs_token(monkeypatch, token="TOKENVAL")
     c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
     f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2139,6 +2139,7 @@ def fresh_upstream():
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._botocore_creds_cache.clear()
     mounts_mod._gcs_token_cache.clear()
     mounts_mod._gcs_creds_cache.clear()
     mounts_mod._sign_neg_cache.clear()
@@ -2149,6 +2150,7 @@ def fresh_upstream():
     mounts_mod._upstream_cfg.clear()
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
+    mounts_mod._botocore_creds_cache.clear()
     mounts_mod._gcs_token_cache.clear()
     mounts_mod._gcs_creds_cache.clear()
     mounts_mod._sign_neg_cache.clear()
@@ -2464,7 +2466,8 @@ def test_upstream_sign_demotes_to_link_when_creds_vanish(home, rcd, fresh_upstre
     assert first.startswith("https://bucket.s3.")  # presigned
     assert mounts_mod._upstream_mode["corp:bucket/pre"] == "sign"
     # Creds rotate away: the resolver now returns None and the cache expires.
-    monkeypatch.setattr(mounts_mod.s3sign, "resolve_credentials", lambda cfg: None)
+    monkeypatch.setattr(mounts_mod.s3sign, "resolve_static_credentials",
+                        lambda cfg: None)
     mounts_mod._cred_cache.clear()
     got = mounts_mod.upstream_url_for(
         os.path.join(mounts_mod.mountpoint(c), "b.parquet"))
@@ -3559,6 +3562,58 @@ def test_gcs_credentials_object_cached_across_token_reresolves(fresh_upstream, m
     mounts_mod._gcs_token_cache.clear()
     mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
     assert len(calls) == 1  # creds object reused from the 60s creds cache
+
+
+class _FakeBotocoreChain:
+    """A self-refreshing botocore credentials object: get_frozen_credentials
+    always answers, so re-freezing is cheap and needs no re-walk."""
+
+    def __init__(self, token=None):
+        self._token = token
+
+    def get_frozen_credentials(self):
+        class _F:
+            access_key = "AKIACHAIN"
+            secret_key = "CHAINSEC"
+        _F.token = self._token
+        return _F
+
+
+def test_signable_credentials_caches_botocore_chain_object(fresh_upstream, monkeypatch):
+    # The (IMDS-slow) provider-chain walk runs at most once per its own window;
+    # get_frozen_credentials is re-run per _CRED_TTL_S on the cached object.
+    builds = []
+
+    def fake_chain(cfg):
+        builds.append(cfg)
+        return _FakeBotocoreChain(token="STSTOK")
+
+    monkeypatch.setattr(mounts_mod.s3sign, "resolve_botocore_chain", fake_chain)
+    cfg = {"type": "s3", "env_auth": "true"}  # opts into ambient auth, no static
+    c1 = mounts_mod._signable_credentials("corp", cfg)
+    assert c1 == mounts_mod.s3sign.Credentials("AKIACHAIN", "CHAINSEC", "STSTOK")
+    # The 60s frozen cache lapses but the chain OBJECT is reused (not re-walked).
+    mounts_mod._cred_cache.clear()
+    c2 = mounts_mod._signable_credentials("corp", cfg)
+    assert c2 == c1
+    assert len(builds) == 1  # chain walked once; frozen re-extracted each window
+
+
+def test_signable_credentials_static_keys_skip_botocore(fresh_upstream, monkeypatch):
+    # A remote with static keys never triggers the chain walk.
+    builds = []
+    monkeypatch.setattr(mounts_mod.s3sign, "resolve_botocore_chain",
+                        lambda cfg: builds.append(cfg))
+    cfg = {"type": "s3", "access_key_id": "AKIACFG", "secret_access_key": "SEC"}
+    assert mounts_mod._signable_credentials("corp", cfg) == \
+        mounts_mod.s3sign.Credentials("AKIACFG", "SEC", None)
+    assert builds == []
+
+
+def test_invalidate_upstream_caches_clears_botocore_chain_cache(fresh_upstream):
+    mounts_mod._botocore_creds_cache["corp"] = (object(), time.time() + 999)
+    mounts_mod._invalidate_upstream_caches()
+    assert mounts_mod._botocore_creds_cache == {}
 
 
 # -- tiered private-GCS raw reads: gsign 307 / bearer proxy -----------------

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -3529,6 +3529,139 @@ def test_gcs_bearer_token_caches_within_ttl(fresh_upstream, monkeypatch):
     assert len(calls) == 1  # second call served from cache
 
 
+# -- tiered private-GCS raw reads: gsign 307 / bearer proxy -----------------
+
+
+class _StubGcsSigner:
+    """A signer object (gcssign.Signer.signer) that returns fixed bytes, so a
+    signed URL carries a real X-Goog-Signature without any crypto."""
+
+    def sign(self, data):
+        return b"\xab\xcd\xef"
+
+
+def _stub_gcs_signer(monkeypatch, present=True):
+    signer = (gcssign_mod.Signer(_StubGcsSigner(), "svc@p.iam.gserviceaccount.com")
+              if present else None)
+    monkeypatch.setattr(mounts_mod.gcssign, "resolve_signer", lambda cfg: signer)
+
+
+def test_upstream_gsign_signs_sa_key_gcs(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch)
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (206, None))
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a", "b.parquet")
+    url = mounts_mod.upstream_url_for(f)
+    assert url.startswith(
+        "https://storage.googleapis.com/bucket/pre/a/b.parquet?")
+    assert "X-Goog-Signature=" in url and "X-Goog-Algorithm=GOOG4-RSA-SHA256" in url
+    assert mounts_mod._upstream_mode["gcp:bucket/pre"] == "gsign"
+    assert mounts_mod._upstream_links == {}  # gsign never caches a link
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+    # Validation is one-time per fs: a second object does not re-validate.
+    seen = []
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: seen.append(url) or (206, None))
+    mounts_mod.upstream_url_for(
+        os.path.join(mounts_mod.mountpoint(c), "c.parquet"))
+    assert seen == []
+
+
+def test_upstream_gsign_403_falls_to_bearer_mode(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch)
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (403, None))
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) is None
+    assert mounts_mod._upstream_mode["gcp:bucket/pre"] == "bearer"
+    # publiclink is never attempted for a credentialed GCS remote.
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+
+
+def test_upstream_gsign_inconclusive_not_pinned(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch)
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (0, None))  # network error -> inconclusive
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) is None
+    assert "gcp:bucket" not in mounts_mod._upstream_mode  # not pinned -> retried
+    assert mounts_mod._sign_neg_cache.get("gcp:bucket", 0.0) > 0.0
+
+
+def test_upstream_gsign_demotes_when_signer_vanishes(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch, present=True)
+    monkeypatch.setattr(mounts_mod, "_sign_validation_status",
+                        lambda url: (206, None))
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.upstream_url_for(f) is not None
+    assert mounts_mod._upstream_mode["gcp:bucket"] == "gsign"
+    # SA key rotated away: gsign mints nothing, so demote to bearer cleanly.
+    _stub_gcs_signer(monkeypatch, present=False)
+    assert mounts_mod.upstream_url_for(f) is None
+    assert mounts_mod._upstream_mode["gcp:bucket"] == "bearer"
+
+
+def test_upstream_bearer_token_only_gcs(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch, present=False)  # no SA key -> not signable
+    _stub_gcs_token(monkeypatch, token="TOKENVAL")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket/pre")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    # No URL may carry the token -> upstream_url_for returns None, mode bearer.
+    assert mounts_mod.upstream_url_for(f) is None
+    assert mounts_mod._upstream_mode["gcp:bucket/pre"] == "bearer"
+    url, headers = mounts_mod.bearer_upstream_for(f)
+    assert url == "https://storage.googleapis.com/bucket/pre/a.parquet"
+    assert headers == {"Authorization": "Bearer TOKENVAL"}
+    # publiclink (PublicLink: False for GCS) is never called.
+    assert [x for x in rcd.calls if x[0] == "operations/publiclink"] == []
+
+
+def test_bearer_upstream_none_for_anonymous_gcs(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _ANON_GCS_CFG
+    resolver_calls = []
+    _stub_gcs_token(monkeypatch, token="X", calls=resolver_calls)
+    c = mounts_mod.add_mount("open", "gcs-open:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.bearer_upstream_for(f) is None
+    assert resolver_calls == []  # anonymous never consults the token resolver
+
+
+def test_bearer_upstream_none_for_sa_key_gcs(home, rcd, fresh_upstream, monkeypatch):
+    import os
+
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    _stub_gcs_signer(monkeypatch, present=True)  # signable -> 307 path, not bearer
+    _stub_gcs_token(monkeypatch, token="X")
+    c = mounts_mod.add_mount("gcp", "gcp:bucket")
+    f = os.path.join(mounts_mod.mountpoint(c), "a.parquet")
+    assert mounts_mod.bearer_upstream_for(f) is None
+
+
+def test_bearer_upstream_none_outside_mounts(fresh_upstream):
+    assert mounts_mod.bearer_upstream_for("/somewhere/else.parquet") is None
+
+
 # -- unified direct-listing dispatchers (S3 + GCS) --------------------------
 
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2140,6 +2140,7 @@ def fresh_upstream():
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
     mounts_mod._gcs_token_cache.clear()
+    mounts_mod._gcs_creds_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
     yield
@@ -2149,6 +2150,7 @@ def fresh_upstream():
     mounts_mod._upstream_region.clear()
     mounts_mod._cred_cache.clear()
     mounts_mod._gcs_token_cache.clear()
+    mounts_mod._gcs_creds_cache.clear()
     mounts_mod._sign_neg_cache.clear()
     mounts_mod._validation_locks.clear()
 
@@ -3375,13 +3377,25 @@ _CRED_GCS_CFG = {"type": "google cloud storage",
 
 def _stub_gcs_token(monkeypatch, *, token="TOKENVAL", expiry_offset=3600.0,
                     calls=None):
-    def fake(cfg):
+    """Stub the two-step GCS credential resolution (build the credential object,
+    then extract a Token). `calls` records each credential-OBJECT build — i.e.
+    each creds-cache miss — so a test can assert re-resolution behaviour."""
+    marker = object()
+
+    def fake_resolve_credentials(cfg):
         if calls is not None:
             calls.append(cfg)
-        if token is None:
+        return marker if token is not None else None
+
+    def fake_token_from_credentials(creds):
+        if creds is None or token is None:
             return None
         return gcssign_mod.Token(token, time.time() + expiry_offset)
-    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token", fake)
+
+    monkeypatch.setattr(mounts_mod.gcssign, "resolve_credentials",
+                        fake_resolve_credentials)
+    monkeypatch.setattr(mounts_mod.gcssign, "token_from_credentials",
+                        fake_token_from_credentials)
 
 
 @pytest.fixture()
@@ -3502,28 +3516,29 @@ def test_gcs_list_page_second_401_raises(home, rcd, fresh_upstream, monkeypatch,
     assert len(calls) == 2  # retried exactly once
 
 
-def test_invalidate_upstream_caches_clears_gcs_token_cache(fresh_upstream):
+def test_invalidate_upstream_caches_clears_gcs_token_and_creds_caches(fresh_upstream):
     mounts_mod._gcs_token_cache["gcp"] = (
         gcssign_mod.Token("T", time.time() + 999), time.time() + 999)
+    mounts_mod._gcs_creds_cache["gcp"] = (object(), time.time() + 999)
     mounts_mod._invalidate_upstream_caches()
     assert mounts_mod._gcs_token_cache == {}
+    assert mounts_mod._gcs_creds_cache == {}
 
 
 def test_gcs_bearer_token_ttl_tracks_expiry(fresh_upstream, monkeypatch):
-    # A short-lived token caches for < its expiry (minus slack); a long-lived
-    # one is capped at the _CRED_TTL_S re-read window.
-    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token",
-                        lambda cfg: gcssign_mod.Token("T", time.time() + 65))
+    # The token cache runs to expiry-minus-slack — NOT clamped to _CRED_TTL_S —
+    # so a live ~1h token is reused for its whole life (no per-minute OAuth).
+    _stub_gcs_token(monkeypatch, token="T", expiry_offset=65)
     mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
     _tok, exp = mounts_mod._gcs_token_cache["gcp"]
     assert 0 < exp - time.monotonic() <= 10  # ~5s (65s - 60s slack)
 
     mounts_mod._gcs_token_cache.clear()
-    monkeypatch.setattr(mounts_mod.gcssign, "resolve_token",
-                        lambda cfg: gcssign_mod.Token("T", time.time() + 86400))
+    _stub_gcs_token(monkeypatch, token="T", expiry_offset=3600)
     mounts_mod._gcs_bearer_token("gcp2", _CRED_GCS_CFG)
     _tok2, exp2 = mounts_mod._gcs_token_cache["gcp2"]
-    assert abs((exp2 - time.monotonic()) - mounts_mod._CRED_TTL_S) < 2
+    # ~1h - 60s slack, far beyond the 60s _CRED_TTL_S window it used to clamp to.
+    assert abs((exp2 - time.monotonic()) - (3600 - 60)) < 3
 
 
 def test_gcs_bearer_token_caches_within_ttl(fresh_upstream, monkeypatch):
@@ -3532,6 +3547,18 @@ def test_gcs_bearer_token_caches_within_ttl(fresh_upstream, monkeypatch):
     mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
     mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
     assert len(calls) == 1  # second call served from cache
+
+
+def test_gcs_credentials_object_cached_across_token_reresolves(fresh_upstream, monkeypatch):
+    # The credential OBJECT is built at most once per _CRED_TTL_S window even
+    # when the Token is re-derived from it multiple times (fix 6).
+    calls = []
+    _stub_gcs_token(monkeypatch, token="TOK", expiry_offset=1, calls=calls)
+    mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
+    # Force the short-lived (1s) token cache to lapse, then re-derive.
+    mounts_mod._gcs_token_cache.clear()
+    mounts_mod._gcs_bearer_token("gcp", _CRED_GCS_CFG)
+    assert len(calls) == 1  # creds object reused from the 60s creds cache
 
 
 # -- tiered private-GCS raw reads: gsign 307 / bearer proxy -----------------

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2132,31 +2132,13 @@ def test_fs_raw_proxy_error_keeps_range_headers(client, home, monkeypatch):
 
 @pytest.fixture()
 def fresh_upstream():
-    """The bypass memoizes per-remote capability, config and per-object
-    links in module globals; clear around each test so results don't leak."""
-    mounts_mod._upstream_links.clear()
-    mounts_mod._upstream_mode.clear()
-    mounts_mod._upstream_cfg.clear()
-    mounts_mod._upstream_region.clear()
-    mounts_mod._cred_cache.clear()
-    mounts_mod._botocore_creds_cache.clear()
-    mounts_mod._gcs_token_cache.clear()
-    mounts_mod._gcs_creds_cache.clear()
-    mounts_mod._gcs_signer_cache.clear()
-    mounts_mod._sign_neg_cache.clear()
-    mounts_mod._validation_locks.clear()
+    """The bypass memoizes per-remote capability, config, credentials and per-
+    object links in module globals; clear around each test so results don't leak.
+    Delegates to the production invalidator so every cache (incl. the gsign
+    bearer-fallback marks and single-flight locks) is dropped via one registry."""
+    mounts_mod._invalidate_upstream_caches()
     yield
-    mounts_mod._upstream_links.clear()
-    mounts_mod._upstream_mode.clear()
-    mounts_mod._upstream_cfg.clear()
-    mounts_mod._upstream_region.clear()
-    mounts_mod._cred_cache.clear()
-    mounts_mod._botocore_creds_cache.clear()
-    mounts_mod._gcs_token_cache.clear()
-    mounts_mod._gcs_creds_cache.clear()
-    mounts_mod._gcs_signer_cache.clear()
-    mounts_mod._sign_neg_cache.clear()
-    mounts_mod._validation_locks.clear()
+    mounts_mod._invalidate_upstream_caches()
 
 
 def test_upstream_url_prefers_presigned_link(home, rcd, fresh_upstream):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2439,9 +2439,19 @@ def test_upstream_anonymous_s3_unchanged_and_never_resolves(home, rcd, fresh_ups
     import os
 
     rcd.responses["config/get"] = {**_ANON_S3_CFG, "region": "us-west-2"}
+    # Spy the REAL resolver entry points production uses (resolve_credentials is
+    # no longer called on this path — repointed per finding 8). None must fire on
+    # the anonymous path.
     resolver_calls = []
-    monkeypatch.setattr(mounts_mod.s3sign, "resolve_credentials",
-                        lambda cfg: resolver_calls.append(cfg) or None)
+
+    def _spy(fnname):
+        def f(*a, **k):
+            resolver_calls.append(fnname)
+        return f
+
+    for fnname in ("resolve_static_credentials", "needs_botocore",
+                   "resolve_botocore_chain", "resolve_credentials"):
+        monkeypatch.setattr(mounts_mod.s3sign, fnname, _spy(fnname))
     validated = []
     monkeypatch.setattr(mounts_mod, "_sign_validation_status",
                         lambda url: validated.append(url) or (200, None))
@@ -2961,10 +2971,25 @@ def test_s3_direct_capable_true_for_anonymous_s3(home, rcd, fresh_upstream):
     assert mounts_mod.s3_direct_capable(mounts_mod.mountpoint(c) + "/analysed_sst")
 
 
-def test_s3_direct_capable_false_for_credentialed(home, rcd, fresh_upstream):
+def test_s3_direct_capable_true_for_credentialed_shape_no_resolution(
+        home, rcd, fresh_upstream, monkeypatch):
+    # FINDING 12: a credentialed-SHAPED S3 remote (ambient auth opted in) is
+    # capable by config shape alone — the predicate resolves NO credentials (that
+    # unbudgeted network walk stalled the conditions/stat callers).
     rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    resolved = []
+
+    def _spy(fnname):
+        def f(*a, **k):
+            resolved.append(fnname)
+        return f
+
+    for fnname in ("resolve_static_credentials", "resolve_botocore_chain",
+                   "resolve_credentials"):
+        monkeypatch.setattr(mounts_mod.s3sign, fnname, _spy(fnname))
     c = mounts_mod.add_mount("corp", "corp:bucket")
-    assert not mounts_mod.s3_direct_capable(mounts_mod.mountpoint(c) + "/x")
+    assert mounts_mod.s3_direct_capable(mounts_mod.mountpoint(c) + "/x")
+    assert resolved == []  # no credential resolution from the predicate
 
 
 def test_s3_direct_capable_false_for_custom_endpoint(home, rcd, fresh_upstream):
@@ -3260,10 +3285,13 @@ def test_gcs_direct_capable_true_for_anonymous_gcs(home, rcd, fresh_upstream):
     assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/analysed_sst")
 
 
-def test_gcs_direct_capable_false_for_non_anonymous(home, rcd, fresh_upstream):
+def test_gcs_direct_capable_true_for_non_anonymous_shape(home, rcd, fresh_upstream):
+    # FINDING 12: any non-anonymous GCS remote is capable by shape (bearer), even
+    # a bare one with no config markers (ADC-only) — the predicate resolves no
+    # token; a failed bearer read falls back to rc inside the budgeted fetch path.
     rcd.responses["config/get"] = {"type": "google cloud storage"}
     c = mounts_mod.add_mount("gcp", "gcp:bucket")
-    assert not mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+    assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
 
 
 def test_gcs_direct_capable_false_outside_mount(home, rcd, fresh_upstream):
@@ -3440,11 +3468,16 @@ def test_gcs_direct_capable_true_for_credentialed(home, rcd, fresh_upstream, mon
     assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
 
 
-def test_gcs_direct_capable_false_when_token_absent(home, rcd, fresh_upstream, monkeypatch):
+def test_gcs_direct_capable_true_regardless_of_token(home, rcd, fresh_upstream, monkeypatch):
+    # FINDING 12: capability is shape-based, so it holds even when no token
+    # resolves — the failed bearer read falls back to rc in the fetch path, not
+    # the predicate. The token resolver must not even be consulted here.
     rcd.responses["config/get"] = _CRED_GCS_CFG
-    _stub_gcs_token(monkeypatch, token=None)
+    resolver_calls = []
+    _stub_gcs_token(monkeypatch, token=None, calls=resolver_calls)
     c = mounts_mod.add_mount("gcp", "gcp:bucket")
-    assert not mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+    assert mounts_mod.gcs_direct_capable(mounts_mod.mountpoint(c) + "/x")
+    assert resolver_calls == []  # pure shape check, no token resolution
 
 
 def test_gcs_list_page_credentialed_carries_bearer(home, rcd, fresh_upstream, monkeypatch, gcs_bearer_urlopen):
@@ -3836,6 +3869,32 @@ def test_bearer_upstream_none_outside_mounts(fresh_upstream):
 
 
 # -- unified direct-listing dispatchers (S3 + GCS) --------------------------
+
+
+def test_direct_list_capable_resolves_no_credentials(home, rcd, fresh_upstream, monkeypatch):
+    # FINDING 12: direct_list_capable is a pure config-shape check — it must walk
+    # NONE of the credential/token resolvers, so the unbudgeted conditions/stat
+    # callers can't be stalled by a black-holed metadata endpoint.
+    resolved = []
+
+    def _spy(fnname):
+        def f(*a, **k):
+            resolved.append(fnname)
+        return f
+
+    for fnname in ("resolve_static_credentials", "resolve_botocore_chain",
+                   "resolve_credentials"):
+        monkeypatch.setattr(mounts_mod.s3sign, fnname, _spy("s3:" + fnname))
+    for fnname in ("resolve_credentials", "resolve_token", "resolve_signer"):
+        monkeypatch.setattr(mounts_mod.gcssign, fnname, _spy("gcs:" + fnname))
+    rcd.responses["config/get"] = {"type": "s3", "env_auth": "true"}
+    s = mounts_mod.add_mount("corp", "corp:bucket")
+    assert mounts_mod.direct_list_capable(mounts_mod.mountpoint(s))
+    mounts_mod._upstream_cfg.clear()
+    rcd.responses["config/get"] = _CRED_GCS_CFG
+    g = mounts_mod.add_mount("gcp", "gcp:bucket")
+    assert mounts_mod.direct_list_capable(mounts_mod.mountpoint(g))
+    assert resolved == []  # no credential/token resolution from the predicate
 
 
 def test_direct_list_capable_true_for_both_backends(home, rcd, fresh_upstream):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -36,6 +36,11 @@ def _no_ambient_aws_creds(tmp_path, monkeypatch):
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE",
                        str(tmp_path / "no-aws-credentials"))
     monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "no-aws-config"))
+    # The optional botocore rung (s3sign) is consulted for an env_auth/profile
+    # remote once the static ladder finds nothing; disable the IMDS probe so it
+    # resolves to None immediately (deterministic, and fast) instead of
+    # resolving an EC2/CI role or stalling ~1s on metadata.
+    monkeypatch.setenv("AWS_EC2_METADATA_DISABLED", "true")
 
 
 class StubRcd:


### PR DESCRIPTION
## Summary

- **Any user with an authenticated `aws` or `gcloud` CLI now gets fast direct reads and paginated listings on their private buckets, zero extra setup.** Two independent halves behind one optional `[cloud-auth]` extra (botocore + google-auth), lazily imported — absent, behavior is exactly today's.
- **AWS:** one new rung at the end of `s3sign.resolve_credentials` — when the static ladder (config keys → env → `~/.aws/credentials`) finds nothing and the remote opted into ambient auth (`env_auth`/`profile`), botocore's full provider chain resolves SSO / credential_process / assume-role / IMDS credentials. Everything downstream (the existing sign mode, 60s credential cache, session-token TTL clamps) works unchanged — SSO-only remotes simply become signable.
- **GCS:** rclone's GCS backend reports `PublicLink: False`, so a credentialed GCS mount had **no fast path at all** — every read crawled the serialized VFS serve. New pure module `fused_render/shell/gcssign.py` (the GCS analog of `s3sign.py`): a bearer-token resolver (SA key file → rclone oauth token → Application Default Credentials) plus a V4 `GOOG4-RSA-SHA256` URL signer validated byte-exact against Google's published conformance vector. Wired in as: bearer-authorized direct JSON-API listings/probes (large flat prefixes paginate), and tiered raw reads — SA-key remotes 307 to a locally signed URL (validated once per fs, mirroring S3 sign mode as mode `gsign`); token-only remotes (user oauth/ADC can't sign) stream through the existing pooled httpx proxy with the `Authorization` header attached out-of-band (mode `bearer` — the token never appears in any URL, log, or response header).
- **Packaging:** `httpx` moves from the dev extra to core dependencies (`server.py` has hard-imported it since the pooled-proxy change — a plain `pip install fused-render` was broken); `botocore`/`google-auth` are folded into the `bundled` extra so DMG users get the feature (botocore adds ~80 MB installed — flagged inline as the size-tradeoff approval point).

**Hard invariants held:** anonymous S3/GCS mounts are byte-identical — anonymous predicates are checked first at every dispatch, anonymous remotes never consult a resolver or send an Authorization header, and the pre-existing anonymous-path test files pass unmodified. The suite is green **without** `[cloud-auth]` installed (all botocore/google-auth interactions faked via `sys.modules`) — that degrade contract is itself under test.

## Visuals

```mermaid
flowchart TD
    A["/api/fs/raw or fs/list on a mount path"] --> B{"anonymous S3/GCS?"}
    B -- yes --> C["unsigned URL\n(unchanged, byte-identical)"]
    B -- no --> D{"S3 with creds?"}
    D -- "static ladder" --> E["SigV4 sign mode\n(shipped in #230)"]
    D -- "NEW: botocore chain\n(SSO/IMDS/cred_process)" --> E
    B -- no --> F{"credentialed GCS?"}
    F -- "SA key resolves\n(gcssign.resolve_signer)" --> G["NEW mode gsign:\nV4 GOOG4-RSA-SHA256 signed URL"]
    G --> H{"one-time per-fs validation\nRange: bytes=0-0"}
    H -- "200/206/404/416" --> I["307 → client reads GCS directly"]
    H -- "401/403" --> J["NEW mode bearer"]
    F -- "token only (oauth/ADC)\n(gcssign.resolve_token)" --> J
    J --> K["_proxy_raw_pooled + Authorization header\n(token never in a URL; listings/probes\nsend the same bearer header)"]
    F -- "no token resolves /\n[cloud-auth] absent" --> L["serialized VFS serve\n(unchanged last resort)"]
```

Credential resolution: AWS — config keys → env (`env_auth`) → shared credentials file → **botocore provider chain** → None. GCS — `service_account_file`/inline SA JSON → rclone oauth `token` (skipped without config `client_id`/`client_secret` — rclone's built-in oauth secret is not embedded) → **ADC** (`GOOGLE_APPLICATION_CREDENTIALS`, `gcloud auth application-default login`, GCE metadata) → None.

## Usage

Not user-invocable — behavior is automatic once `[cloud-auth]` is installed (bundled into the DMG). `aws sso login` + an `env_auth` S3 remote, or `gcloud auth application-default login` + a GCS remote (Mounts UI or `rclone config`), and private buckets get paginated direct listings and parallel-speed cold reads. A GCS remote configured with a service-account key file additionally gets client-direct 307 reads via signed URLs. Without the extra, everything degrades to today's behavior.

## Test Plan

- [x] `tests/test_s3_sign.py` (+7): botocore rung — static sources always win, ambient-auth gate (plain keyed remotes never trigger it), profile/shared-file plumbed through, session token mapped, ImportError/any-exception → None. botocore faked via `sys.modules`.
- [x] `tests/test_gcs_sign.py` (new, 15 tests): V4 signer validated **byte-exact against Google's published conformance vector** (public test key); canonical request/scope/sorted-query/HEAD signing via a recording stub signer; resolver source order, client_id-absent skip, refresh-failure fall-through, ImportError/non-GCS/anonymous → None.
- [x] `tests/test_shell_mounts.py` (+~314 lines): `gcs_direct_capable` for credentialed remotes, Bearer header on pager/head/has_children, one 401/403 token-refresh retry then propagate, expiry-aware token cache + invalidation on remote create/delete, gsign validation single-flight/negative-cache/demotion, `bearer_upstream_for` tiering (anonymous and SA-key remotes excluded), publiclink rc call skipped for GCS (spy).
- [x] `tests/test_fs_raw_bearer_proxy.py` (new, 145 lines): server proxies bearer hits through the pooled client with the Authorization header on the OUTBOUND request only — asserted absent from response headers and any redirect; proxy failure falls through to the serve.
- [x] Anonymous invariant: `tests/test_server_fs_list_mount.py`, `tests/test_server_fs_raw_mount_safe.py`, `tests/test_browse_mount.py` pass **unmodified** (empty diff vs main); anonymous requests carry no Authorization header and never consult a resolver (spies).
- [x] Degrade contract: suite runs green in a venv **without** botocore/google-auth installed; additionally verified with both libs blocked via a meta-path finder.
- [x] Full suite: 1462 passed, 4 skipped; only the 2 known pre-existing `test_deploy.py` pip-install failures (reproduce on main).
- [ ] Manual (real creds): AWS-SSO-only remote reads 307 to `X-Amz-Signature` URLs; private GCS bucket after `gcloud auth application-default login` paginates listings and streams cold parquet through the bearer proxy; SA-key GCS remote 307s to `X-Goog-Signature` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
