### PR TITLE
docs(skills): refresh user skills against current code + add learn tutorial page

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -426,6 +426,46 @@
     </div>
   </section>
 
+  <!-- ============================ 2b · CLAUDE CODE SKILLS ============================ -->
+  <section class="page" data-slug="skills" data-title="Claude Code skills" data-ix="2">
+    <p class="crumb">Workflow</p>
+    <h1 class="title">Claude Code skills</h1>
+    <p class="lede">Fused Render ships a set of Claude Code <b>skills</b> — packaged instructions that teach the <code>claude</code> CLI how this project works. Install them once and Claude authors views, drives the explorer, and registers templates fluently, without you spelling out the conventions each time.</p>
+    <div class="callout"><span class="lab">Prerequisite</span>
+      <p style="margin:6px 0 0 0">Skills are a feature of <b>Claude Code</b>, so the <code>claude</code> CLI must be installed on your machine and on your PATH. The skills add fused-render know-how on top; they don't replace Claude Code itself.</p></div>
+
+    <h2><span class="n">1</span>What you get</h2>
+    <p class="sub">Three skills cover the whole surface. You never name them — Claude reads their descriptions and picks the right one for what you ask.</p>
+    <div class="card" style="margin-bottom:10px">
+      <h4 style="margin:0 0 6px;font-size:13.5px"><code>fused-render-usage</code></h4>
+      <p style="margin:0;font-size:12.5px">Running and using a project — start the local server, browse the filesystem, and open views or files by URL (embed vs full-shell modes).</p></div>
+    <div class="card" style="margin-bottom:10px">
+      <h4 style="margin:0 0 6px;font-size:13.5px"><code>fused-render-authoring</code></h4>
+      <p style="margin:0;font-size:12.5px">Writing and debugging views — the <code>fused.runPython()</code> bridge to local Python, the <code>main()</code> contract, URL-synced params, and the file-IO helpers (<code>readFile</code>/<code>writeFile</code>/<code>stat</code>/<code>rawUrl</code>).</p></div>
+    <div class="card">
+      <h4 style="margin:0 0 6px;font-size:13.5px"><code>fused-render-custom-templates</code></h4>
+      <p style="margin:0;font-size:12.5px">Registering your own preview template for a file extension under <code>~/.fused-render/templates/</code> — so opening that file type renders <em>your</em> page (or offers it as a switchable mode). Pairs with the <a href="?page=templates">Templates</a> concepts page.</p></div>
+
+    <h2><span class="n">2</span>Install the plugin</h2>
+    <p class="sub">The skills are distributed as a Claude Code <b>plugin</b> from this repo's marketplace. From inside Claude Code, add the marketplace, then install the plugin:</p>
+    <div class="promptbox">
+      <button class="copybtn" data-copy="skillsMkt">Copy</button>
+      <pre id="skillsMkt">/plugin marketplace add fusedio/fused-render</pre></div>
+    <div class="promptbox" style="margin-top:8px">
+      <button class="copybtn" data-copy="skillsInstall">Copy</button>
+      <pre id="skillsInstall">/plugin install fused-render@fused-render</pre></div>
+    <p class="sub">Run <code>/plugin</code> afterwards to confirm <b>fused-render</b> is installed. The skills then load automatically in any session — including when Claude Code is driven from inside the app's Claude panel.</p>
+    <div class="callout"><span class="lab">Working inside the repo?</span>
+      <p style="margin:6px 0 0 0">If you're developing fused-render itself, the skills are already present as <code>./skills/</code> in the checkout — no install needed. Maintainer-only skills (dev-env setup, cutting a release) live separately under <code>.claude/skills/</code> and never ship in the plugin.</p></div>
+
+    <h2><span class="n">3</span>Just ask</h2>
+    <p class="sub">With the plugin installed you describe the outcome in plain language; Claude loads the matching skill and follows its conventions. No need to mention HTML, Python, or the <code>fused</code> API.</p>
+    <div class="promptbox">
+      <button class="copybtn" data-copy="skillsAsk">Copy</button>
+      <pre id="skillsAsk">Build me a Fused Render view that reads the CSV I'm looking at, with a slider to filter rows by value, and keep the filter in the URL.</pre></div>
+    <p class="sub">This is the same promise behind the “hand it to Claude Code” prompt on the <a href="?page=using">Using Fused Render</a> page — the skills are what make “Claude knows the Fused Render layout” true.</p>
+  </section>
+
   <!-- ============================ 3 · TEMPLATES ============================ -->
   <section class="page" data-slug="templates" data-title="Templates" data-ix="3">
     <p class="crumb">Concepts</p>

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -22,7 +22,7 @@ fused-render is a local file explorer that renders `.html` files live in the bro
    └─ fused.readFile / writeFile / stat / rawUrl   ← direct file IO, no Python needed
 ```
 
-Three primitives — `runPython`, `params`, and the file IO helpers — are the entire API. Everything else is ordinary HTML/CSS/JS (no framework, no build step, ES2020 fine).
+Three primitives — `runPython`, `params`, and the file IO helpers — are the core API (plus two auxiliary members, `fused.env` and `fused.autoReload`, covered in the table below). Everything else is ordinary HTML/CSS/JS (no framework, no build step, ES2020 fine).
 
 ## The Python side: `main()` contract
 
@@ -50,7 +50,7 @@ Rules that matter (each has a reason):
 - **Relative paths in your code resolve next to the .py file** (the working directory is set there). `open("./data.csv")` next to your script just works.
 - **Each call is a fresh subprocess.** Edits to the .py apply on the next call — but so does full import cost (pandas ≈ 1 s per call). No state survives between calls; don't cache in globals.
 - **`print()` output goes to the browser console** (prefixed `[python]`) — use it freely for debugging; it cannot corrupt the result.
-- **Calls time out at 30 s** and errors return `{type, message, traceback}` to the page. The environment is whatever Python launched the server — assume stdlib plus whatever the user installed there.
+- **Calls time out at 60 s** and errors return `{type, message, traceback}` to the page. The environment is whatever Python launched the server — assume stdlib plus whatever the user installed there.
 
 ## The HTML side: `window.fused` API
 
@@ -65,9 +65,11 @@ The runtime is injected automatically when the explorer renders the page. Never 
 | `fused.params.onChange(cb)` | `cb(allParams)` after every applied `set`. Returns an unsubscribe function. |
 | `fused.params.get("_file")` | Read-only: the target file a **preview template** was opened for. Keys starting `_` are reserved — `set()` on them throws. |
 | `await fused.readFile(path)` | File contents as **text** (UTF-8). Rejects with an `Error` on failure. Use when a view just needs the bytes as a string — no reader `.py` required. |
-| `await fused.stat(path)` | Metadata object `{path, name, is_dir, size, mtime, templates}` (`templates` is the ordered mode-list array, usually irrelevant to page code). Use for size guards before reading big files, and to capture `mtime` before editing. |
-| `await fused.writeFile(path, content, opts?)` | Writes UTF-8 text **atomically** (never a half-written file). `opts.expectedMtime` arms an optimistic lock: if the file changed on disk since that mtime, rejects with an error whose `.type === "conflict"` (and `.mtime` = current on-disk value) instead of clobbering. Omit it to write unconditionally — also how you create a new file. Resolves with a fresh stat object; keep its `.mtime` to re-arm the lock for the next save. |
+| `await fused.stat(path)` | Metadata object `{path, name, is_dir, size, mtime, writable, remote, templates}` (`templates` is the ordered mode-list array, usually irrelevant to page code; `writable` is false for read-only files — check it before offering an edit UI; `remote` is true for files on a mounted remote bucket — keep reads bounded there). May also carry `template_error` (a bad registry name). Use for size guards before reading big files, and to capture `mtime` before editing. |
+| `await fused.writeFile(path, content, opts?)` | Writes UTF-8 text **atomically** (never a half-written file). `opts.expectedMtime` arms an optimistic lock: if the file changed on disk since that mtime, rejects with an error whose `.type === "conflict"` (and `.mtime` = current on-disk value) instead of clobbering. A read-only file rejects with `.type === "readonly"` (check `stat().writable` first to avoid it). Omit `expectedMtime` to write unconditionally — also how you create a new file. Resolves with a fresh stat object; keep its `.mtime` to re-arm the lock for the next save. |
 | `fused.rawUrl(path)` | **Sync**, returns a URL string serving the file's raw bytes. This is for embedding — `<img src>`, `<video src>`, `<embed>`, download links — where you need a URL, not text. |
+| `fused.env` | String `"local"` (this local server) vs `"hosted"` (the exported/hosted runtime). Branch on it only if a view must behave differently when exported. |
+| `fused.autoReload(enabled)` | Toggle the automatic reload-on-file-change behavior for this page. Pass `false` to opt out (e.g. an in-page editor that manages its own saves and shouldn't reload under the user). |
 
 Notes:
 - Params are **strings only, always**. Parse numbers yourself (`parseInt(fused.params.get("limit") || "50", 10)`), JSON-encode structure yourself if you need it.
@@ -88,6 +90,7 @@ try {
   mtime = fresh.mtime;                   // 3. re-arm for the next save
 } catch (err) {
   if (err.type === "conflict") { /* offer reload vs overwrite (writeFile without expectedMtime) */ }
+  else if (err.type === "readonly") { /* file isn't writable — disable the save UI */ }
   else throw err;
 }
 ```
@@ -148,7 +151,7 @@ const page = await fused.runPython("./my_reader.py", { file, offset: fused.param
 
 A reader `.py` is only needed when Python adds value (parsing parquet/xlsx, paging, aggregation). Text formats can skip it entirely — `fused.stat` for a size guard, then `fused.readFile(file)` and render in JS (the markdown/JSON/code templates work this way); media formats just point a tag at `fused.rawUrl(file)`.
 
-Ship the reader `.py` next to the template html and call it with a relative path. Paging/sort/filter state goes in normal params (`offset`, `sort` …) exactly like any view. Built-in templates live one folder per template under `fused_render/templates/<name>/` and follow this pattern (see `templates/table/template.html` + `templates/table/reader.py` for a worked example); each extension maps to an **ordered list of mode names** (first = default) in the built-in registry `fused_render/templates/registry.json`. **User-owned** templates that override, reorder, or extend that list live under `~/.fused-render/` and are bound via `registry.json` — layout, the mode-list/registry grammar, and registration are covered by the `fused-render-custom-templates` skill (this skill still owns how the html/py themselves are written).
+Ship the reader `.py` next to the template html and call it with a relative path. Paging/sort/filter state goes in normal params (`offset`, `sort` …) exactly like any view. Built-in templates live one folder per template under `fused_render/templates/<name>/` and follow this pattern (see `templates/csv/template.html` + `templates/csv/reader.py` for a worked example); each extension maps to an **ordered list of mode names** (first = default) in the built-in registry `fused_render/templates/registry.json`. **User-owned** templates that override, reorder, or extend that list live under `~/.fused-render/` and are bound via `registry.json` — layout, the mode-list/registry grammar, and registration are covered by the `fused-render-custom-templates` skill (this skill still owns how the html/py themselves are written).
 
 ## Testing in the browser: URL paths & modes
 
@@ -172,12 +175,12 @@ Path encoding: the fs path rides in the URL after the prefix with its **leading 
 
 Sanity loop: page renders → interact with a control → URL query updates → hard refresh → identical view. Python errors appear as the red overlay (with full traceback) and `print()` output in the browser console (prefixed `[python]`).
 
-## Long-running work and the 30 s timeout
+## Long-running work and the 60 s timeout
 
-Every `fused.runPython` call runs `main()` in a fresh subprocess that the server **kills at 30 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`). On timeout the call rejects with a `TimeoutError` — which, uncaught, becomes the red overlay. The `/api/run` route does not expose a per-call override, so you cannot raise the limit from the page; design around it instead:
+Every `fused.runPython` call runs `main()` in a fresh subprocess that the server **kills at 60 s** (`DEFAULT_TIMEOUT` in `fused_render/executor.py`). On timeout the call rejects with a `TimeoutError` — which, uncaught, becomes the red overlay. The `/api/run` route does not expose a per-call override, so you cannot raise the limit from the page; design around it instead:
 
 - **Precompute and cache to disk.** Do the expensive work once, write the result next to the script (`.json`/`.parquet`), and have `main()` return the cached bytes when they're fresh (compare mtimes) — recompute only when the input changed. Reading a cached file is near-instant.
-- **Chunk / paginate.** Slice the work so each call stays well under 30 s, pass an `offset`/`page` param, and accumulate results in JS across several `runPython` calls. This also keeps the UI responsive.
+- **Chunk / paginate.** Slice the work so each call stays well under 60 s, pass an `offset`/`page` param, and accumulate results in JS across several `runPython` calls. This also keeps the UI responsive.
 - **Move the heavy job out of band.** For a genuinely long build, run it as a separate process/script that writes an output file, and have the view just `fused.readFile`/`runPython` the finished result.
 - **Cut per-call cost.** Each call re-pays import cost (pandas ≈ 1 s); import lazily inside `main`, and debounce sliders (~150 ms) so a drag doesn't spawn a subprocess per tick.
 

--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -5,7 +5,7 @@ description: How to create and register a custom preview template for fused-rend
 
 # Custom templates for fused-render
 
-fused-render resolves an **ordered list of preview templates — modes** — for each file by extension; the first mode is the default, and when a file has more than one the shell shows an icon-only switcher to flip between them. Built-ins ship inside the package; a user can override, reorder, or extend the list with templates under `~/.fused-render/`. A custom template is an **ordinary renderable-HTML page** — same injected `window.fused` runtime, same `_file` param, same sibling-`.py` pattern as every built-in, optionally with an `icon.svg` for the switcher. Nothing about authoring is special; only *registration* is.
+fused-render resolves an **ordered list of preview templates — modes** — for each file by extension; the first mode is the default, and when a file has more than one the shell shows an icon-only switcher to flip between them. Built-ins ship inside the package; a user can override, reorder, or extend the list with templates under `~/.fused-render/templates/`. A custom template is an **ordinary renderable-HTML page** — same injected `window.fused` runtime, same `_file` param, same sibling-`.py` pattern as every built-in, optionally with an `icon.svg` for the switcher. Nothing about authoring is special; only *registration* is.
 
 **Division of labor between skills (do not duplicate):**
 
@@ -17,7 +17,7 @@ fused-render resolves an **ordered list of preview templates — modes** — for
 One folder per template, self-contained:
 
 ```
-~/.fused-render/
+~/.fused-render/templates/
 ├── registry.json          ← bindings: extension → mode list (names)
 ├── geo/                   ← a template — the folder name IS its name
 │   ├── template.html      ← required, this is what renders
@@ -27,7 +27,7 @@ One folder per template, self-contained:
 └── wip-thing/             ← no registry entry → inert draft
 ```
 
-- **The folder name is the template's public name** — it's what a registry list references, the `_mode=<name>` URL value, and the switcher's tooltip label. One name-resolution rule everywhere: a name resolves to `~/.fused-render/<name>/template.html` if that exists, else the built-in `fused_render/templates/<name>/template.html`, else it's unusable. **Naming your folder after a built-in shadows it** — `table`, `csv`, `xlsx`, `tree`, `markdown`, `image`, `media`, `pdf`, `code`, `api`, `text`, `geotiff`, `netcdf`, `zarr` are the built-in names; reuse one deliberately to replace that built-in everywhere it's referenced, including inside a `"..."` splice (below).
+- **The folder name is the template's public name** — it's what a registry list references, the `_mode=<name>` URL value, and the switcher's tooltip label. One name-resolution rule everywhere: a name resolves to `~/.fused-render/templates/<name>/template.html` if that exists, else the built-in `fused_render/templates/<name>/template.html`, else it's unusable. **Naming your folder after a built-in shadows it** — the built-in names include `code`, `csv`, `xlsx`, `duckdb` (the tabular viewer), `sqlite`, `structure`, `tree`, `markdown`, `image`, `media`, `pdf`, `text`, `geotiff`, `netcdf`, `zarr_aoi`, `map`, `vector`, `pmtiles`, `h3`, `api`, plus many more (the authoritative set is every folder under `fused_render/templates/` that contains a `template.html`, also visible in the app's Templates → Library). Reuse one deliberately to replace that built-in everywhere it's referenced.
 - `template.html` is the fixed entry-point filename.
 - Sibling files are referenced relatively, e.g. `fused.runPython("./reader.py", {...})` — the template renders from its real path, so relative resolution just works.
 - `icon.svg` is optional: a monochrome single-fill SVG (`currentColor` or plain black — the shell tints it via a CSS mask, so only alpha matters), square viewBox (24×24 suggested), simple enough to read at 16px. No icon → the switcher shows a first-letter placeholder for that mode instead.
@@ -38,7 +38,7 @@ Flat JSON object. Keys are **dotted extension patterns** (compound extensions, `
 
 ```json
 {
-  ".parquet": ["geo", "..."],
+  ".parquet": ["geo", "duckdb"],
   ".geojson": "geo",
   ".tar.gz": "archive",
   ".*.json": "config-view",
@@ -49,16 +49,15 @@ Flat JSON object. Keys are **dotted extension patterns** (compound extensions, `
 
 Rules:
 
-- **List = the full ordered mode list for that extension — replace semantics.** Order matters: the first entry is the default mode, later entries only show up (as a switcher) when the file has more than one mode. Each entry is a name resolved by the rule above.
-- **`"..."` splices in the built-in list, in place** — add modes without knowing (or hand-maintaining) the built-in names, and future built-in additions flow in automatically. `["code", "..."]` promotes `code` to the default and keeps everything the built-in table had, without duplicating it. Rules: names already listed explicitly are skipped when the splice expands (no duplicates); **at most one `"..."` per list** — a second one makes the whole entry invalid (falls back to the built-in list, `template_error` set); splicing an extension with no built-in list expands to nothing (harmless).
+- **List = the full ordered mode list for that extension — replace semantics.** Order matters: the first entry is the default mode, later entries only show up (as a switcher) when the file has more than one mode. Each entry is a name resolved by the rule above. A user list **replaces** the built-in list for that extension outright — there is no splice/merge with the built-ins, so if you want a built-in mode alongside yours, name it explicitly in your list (e.g. `["geo", "duckdb"]` to keep the tabular viewer as a second mode).
 - **String = shorthand for a single-mode list of that one name** — exactly `["geo"]`. This is the pre-modes registry shape; existing registries keep working unchanged.
-- **`null` disables templating** for that extension entirely: no template renders; the explorer shows its plain metadata/raw-download fallback.
+- **`null` (or an empty list `[]`) disables templating** for that extension entirely: no template renders; the explorer shows its plain metadata/raw-download fallback.
 - **Dotted keys, most-specific wins, case-insensitive.** A key is a dot-anchored suffix pattern of one or more segments. More segments beats fewer (`.tar.gz` beats `.gz` for `backup.tar.gz`); at equal length, comparing from the rightmost segment, a literal beats a wildcard (`.xyz.json` > `.*.json` > `.json` for `data.xyz.json`). Always include the leading dot. A match needs something before the suffix — a file literally named `.json` doesn't match the `.json` key (but `.hidden.json` does).
 - **`*` = exactly one whole segment.** `.*.json` matches `data.tiles.json` but not `data.json` (nothing for the `*`) and not partially (`.geo*.json` is invalid — a key like that never matches anything).
-- **Trailing `/` binds a directory.** `".obt/"` matches a *directory* named `data.obt` — the way built-in `.zarr` stores are bound (`".zarr/": ["zarr"]`). Directory keys never match files and vice versa. A `null` on a directory key gives the plain listing view.
+- **Trailing `/` binds a directory.** `".obt/"` matches a *directory* named `data.obt` — the way built-in `.zarr` stores are bound (`".zarr/": ["zarr_aoi", "_listing"]`). Directory keys never match files and vice versa. A `null` on a directory key gives the plain listing view.
 - **Many-to-one is normal** — several extension keys may reference the same template name.
-- **Any extension is allowed**, including ones fused-render has no built-in for — and including `.html`/`.htm`: the rendered-page-first default (`["_render", "code"]`) is just the built-in registry entry, and you can rebind or reorder it (e.g. `[ "code", "..." ]` to make the source editor the default).
-- **Names starting with `_` are shell sentinels** — modes the shell itself implements, not template folders. The only one you may reference is **`_render`** ("render the HTML file itself"); any other `_`-prefixed name in a registry list is invalid: dropped, `template_error` set, rest of the list still works. Same reservation as `_mode`/`_file` params.
+- **Any extension is allowed**, including ones fused-render has no built-in for — and including `.html`/`.htm`: the rendered-page-first default (built-in `".html": ["_render", "code", "claude", "annotate", "history"]`) is just a built-in registry entry, and you can rebind or reorder it (e.g. `["code", "_render"]` to make the source editor the default). Remember a user list replaces the built-in one, so re-list any built-in modes you want to keep.
+- **Names starting with `_` are shell sentinels** — modes the shell itself implements, not template folders. The referenceable ones are **`_render`** ("render the HTML file itself") and **`_listing`** (the plain directory listing, used on directory keys); any *other* `_`-prefixed name in a registry list is invalid: dropped, `template_error` set, rest of the list still works. Sentinels can't be shadowed by a folder (`.` and leading `_` are banned in folder names). Same reservation as `_mode`/`_file` params.
 - Registry (any matching key) beats the built-in table — even a plain user `.json` key beats a more specific built-in `.xyz.json` one; no registry entry (or no `registry.json` at all) means built-in behavior.
 - A folder without a registry entry does nothing — that's the draft state. Registering = adding the line; unregistering = deleting it. No restart needed: the registry is re-read on every file open, so the next navigation/refresh picks changes up.
 
@@ -67,7 +66,7 @@ Rules:
 The registry decides *which* templates apply to an extension. A template folder can additionally decide *whether* it shows for a **specific file** by dropping a **`condition.py`** beside its `template.html`:
 
 ```python
-# ~/.fused-render/reports-view/condition.py
+# ~/.fused-render/templates/reports-view/condition.py
 def main(path):
     # path is the absolute path of the file being previewed.
     # Return True to show this template for this file, False to hide it.
@@ -79,7 +78,7 @@ def main(path):
 - **Runs after registry resolution**, for both user and built-in folders (whichever `template.html` resolves). So `".csv": ["reports-view", "csv", "code"]` offers `reports-view` only for files where its `main` returns True; the others always show.
 - **Evaluated in the background, not at stat time.** Stat only marks the entry `"conditional": true`; the shell renders the first *unconditional* template immediately and resolves the gates via `GET /api/fs/conditions?path=<file>` while a pending spinner shows in the switcher. This means a gate MAY read the file's contents (e.g. sniff a parquet footer) without slowing every preview — but keep reads bounded (metadata/footers/prefixes, not whole files), especially for files on remote mounts.
 - **Never the default while a normal template exists:** a gated template can only be the default mode when every template in the list is gated.
-- **Re-evaluated on every file open** (like the registry) — edit `condition.py` and the next navigation/refresh picks it up, no restart.
+- **Re-evaluated when its verdict isn't cached** — the `condition.py` module is re-loaded fresh each time it runs (edit it, no restart needed), but the conditions endpoint keeps a short **~60 s TTL cache** per file, so a re-navigation within that window returns the cached verdict rather than re-running the gate. (The registry itself, by contrast, is re-read with no cache on every open.)
 - **Concurrent:** when an extension has several gated templates they're evaluated concurrently, so the cost is the slowest gate, not the sum — but every gate still runs on every file of that extension (a gate that returns False still had to run to decide that).
 - **A broken condition drops that template** (no callable `main`, an exception, etc.) and reports the reason as `error` on the conditions response — same fail-closed posture as a bad registry name. It's never silently shown.
 - **Sentinel modes** (`_render`, `_listing`) have no folder and can't be gated.
@@ -87,18 +86,20 @@ def main(path):
 
 ## Workflow: create and register a template
 
-1. **Make the folder:** `mkdir -p ~/.fused-render/<name>` — the name is public: it's the registry reference, the `_mode` URL value, and the switcher tooltip. Pick a real name, or reuse a built-in name on purpose to shadow it.
+1. **Make the folder:** `mkdir -p ~/.fused-render/templates/<name>` — the name is public: it's the registry reference, the `_mode` URL value, and the switcher tooltip. Pick a real name, or reuse a built-in name on purpose to shadow it. (Or let the app scaffold it for you — Templates → Library → New — which creates the folder from a starter kit and binds it; see the note after this list.)
 2. **Author `template.html` (+ readers) following `fused-render-authoring`.** The template reads its target from the read-only `_file` param and keeps UI state (paging, sort) in normal params. A reader `.py` is only needed where Python adds value — text formats can `fused.readFile(file)` directly, media can point at `fused.rawUrl(file)`.
 3. **Optionally add `icon.svg`** — monochrome, square, simple at 16px (see above). Skip it and the mode shows a first-letter placeholder in the switcher.
 4. **Develop before registering (optional):** the draft folder is invisible to dispatch, but the template is a plain fused page — open `http://127.0.0.1:1777/view/<abs path to template.html>?_file=<abs path to a sample file>` to iterate on it directly. Saving the html or a reader auto-reloads the open view.
-5. **Register:** add the extension line to `~/.fused-render/registry.json` — a bare name string for a single-mode override, or a list (optionally with `"..."`) to add it alongside the built-ins (create the file with `{}` around the first entry if it doesn't exist).
+5. **Register:** add the extension line to `~/.fused-render/templates/registry.json` — a bare name string for a single-mode override, or a list to set the full ordered mode list (re-listing any built-in modes you want to keep, since a user list replaces the built-in one). Create the file with `{}` around the first entry if it doesn't exist.
 6. **Test dispatch:** open a file of that extension in the explorer. A single-mode list renders directly; with more than one mode, the preview header shows an icon-only switcher — click your mode's icon (or its first-letter placeholder), or navigate straight to `…?_mode=<name>`. Editing `template.html` afterwards live-reloads any open preview.
+
+You don't have to hand-edit JSON at all: the app ships a **Templates → Library** page (backed by `/api/templates/*`) to inspect the merged inventory, edit registry bindings per-extension, scaffold a new template, and export/import — the same operations this workflow does by hand.
 
 ## Troubleshooting
 
 - **One mode missing, rest of the list fine:** a single bad entry (typo, folder name mismatch, `template.html` missing in both locations) is dropped silently — everything else in the list still renders. Check `template_error` on the stat response (`fused.stat(path)` or `GET /api/fs/stat?path=…`) for the first bad name.
-- **Whole extension falls back to built-ins:** happens when the registry value resolves to nothing at all — invalid JSON, an empty list, or two `"..."` in one list (only one splice per list is allowed).
-- **Folder name rejected:** names must be a single path segment — no `/`, no `..`, no `.` (dots are reserved for the `"..."` splice token), no leading `_` (reserved for shell sentinels), not empty.
+- **Whole extension falls back to built-ins:** happens when the registry value is a shape-level error — invalid JSON, or a value that isn't a list/string/null. (An empty list `[]` and `null` are *not* errors — they deliberately disable previews.)
+- **Folder name rejected:** names must be a single path segment — no `/`, no `\`, no `.` at all (dots are banned to keep names unambiguous against dotted registry keys), no leading `_` (reserved for shell sentinels), not empty.
 - **Template renders but is blank / errors:** that's an authoring problem, not registration — debug with the `fused-render-authoring` skill (red traceback overlay, `print()` → browser console).
 - **Registry edits not applying to an already-open preview:** open previews watch their files, not the registry — refresh or re-navigate.
 - **Mode switcher doesn't show up:** it only renders when a file has more than one mode (`templates.length > 1`) — a single-mode extension, or a `null` override, never shows it.

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -10,16 +10,16 @@ fused-render is a **local file explorer** that runs entirely on `127.0.0.1` — 
 ## Running the server
 
 ```
-fused-render                                    # opens a tab at http://127.0.0.1:1777/, starting in $HOME
+fused-render                                    # opens a tab at http://127.0.0.1:1777/, starting in ~/Documents/Fused
 fused-render --start-dir ~/data --port 9000     # different start dir + port
 fused-render --port 1777 --no-browser           # don't steal focus (best when driving it yourself)
 ```
 
-`--start-dir` only sets the initial location; the whole filesystem stays browsable from there. When you launch it to open something for the user or to test a change, prefer `--no-browser` and open the specific URL yourself (see below) rather than landing them on the home directory.
+`--start-dir` only sets the initial location (default `~/Documents/Fused`, override with `$FUSED_RENDER_DIR`); the whole filesystem stays browsable from there. On first run the server seeds that Fused directory with example content and opens a landing/showcase page rather than a bare listing. When you launch it to open something for the user or to test a change, prefer `--no-browser` and open the specific URL yourself (see below) rather than landing them on that page.
 
 ### macOS desktop app
 
-On macOS, fused-render also ships as a standalone **`FusedRender.app`** (packaged as `dist/FusedRender-<version>.dmg` via `bash scripts/build_dmg.sh`). It bundles Python and a prebuilt shell — no `pip install`, no Node — so a non-developer just double-clicks it to launch the same local server and browser tab. The `.app` also ships an offline wheelhouse (numpy, pandas, requests, duckdb, polars, matplotlib, scipy, pillow, openpyxl, shapely, geopandas + pyarrow), so views built on those packages work with no network. Everything below — URLs, modes, params — is identical whether the server was started by the CLI or the app.
+On macOS, fused-render also ships as a standalone **`FusedRender.app`** (packaged as `dist/FusedRender-<version>.dmg` via `bash scripts/build_dmg.sh`). It bundles Python and a prebuilt shell — no `pip install`, no Node — so a non-developer just double-clicks it to launch the same local server and browser tab. The `.app` also ships an offline wheelhouse (numpy, pandas, pyarrow, duckdb, polars, requests, matplotlib, scipy, pillow, openpyxl, shapely, geopandas, rasterio, zarr, pymupdf, and more — see the `[bundled]` extra in `pyproject.toml` for the full set), so views built on those packages work with no network. Everything below — URLs, modes, params — is identical whether the server was started by the CLI or the app.
 
 Source checkout only: the React shell must be built once before the server starts (`cd frontend && bun install && bun run build`, Node 22), or use `scripts/dev.sh` for the watch+server dev loop. Wheels and the `.app` ship the shell prebuilt.
 


### PR DESCRIPTION
## Summary

- **Refreshed the three user-facing skills** (`skills/fused-render-*`) against the current codebase — every concrete claim (CLI flags, `window.fused` API, endpoints, registry grammar, built-in template names, file paths) was verified against source and corrected where stale.
- **Biggest correctness fixes:** the `"..."` registry splice no longer exists (a user list now *replaces* the built-in list, so the old `["code", "..."]` advice produced a broken dangling ref); the `runPython` timeout is **60 s, not 30 s**; user templates live under `~/.fused-render/templates/` (not `~/.fused-render/`); the tabular built-in is `duckdb`/`zarr_aoi`, not `table`/`zarr`.
- **Filled real API gaps:** documented `fused.env` and `fused.autoReload`, added `writable`/`remote` to the `stat` shape and the `writeFile` `readonly` rejection type.
- **Added a "Claude Code skills" page** to the `learn/` tutorial explaining the three skills and how to install the plugin — backing the tutorial's existing "Claude knows the Fused Render layout" promise.

## Visuals

Docs-only change; the one structural delta is the new tutorial page inserted into the learn nav/router/pager (which key off DOM order + `.page` sections, so it auto-wires):

```mermaid
flowchart LR
    U[Using Fused Render] --> S["Claude Code skills<br/>(NEW)"]
    S --> T[Templates]
    T --> M[Mount]
    M --> D[Deploy]
    D --> H[Showcase]
    S -.explains.-> S1[fused-render-usage]
    S -.explains.-> S2[fused-render-authoring]
    S -.explains.-> S3[fused-render-custom-templates]
```

## Usage

Nothing new is code-invocable. The skills continue to load automatically for Claude Code, and the new tutorial page documents the install path users follow:

```
/plugin marketplace add fusedio/fused-render
/plugin install fused-render@fused-render
```

View the new page locally by opening the learn tutorial in the explorer and navigating to **Claude Code skills** (or `?page=skills`).

## Test Plan

- [x] No code changed — this is documentation only (3 markdown skills + one static HTML tutorial page), so there is no unit test to add.
- [x] Every skill claim was cross-checked against current source (`fused_render/server.py`, `executor.py`, `cli.py`, `static/runtime.js`, `templates/registry.json`) before editing.
- [x] `learn/index.html` structurally validated: `<section>` tags balanced (7/7), no duplicate `id`s, all new copy-buttons resolve to their `<pre>` targets, and the new page appears as a visible `.page` in DOM order.
- [ ] Reviewer: open the learn tutorial in a running server and confirm the **Claude Code skills** page renders, shows in the sidebar/pager between *Using* and *Templates*, and its three Copy buttons work. (Not done here — the worktree branched clean from origin/main with the React shell unbuilt.)
