### PR TITLE
feat(sidebar): follow armed bookmark for highlight, mark unsaved with *

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -11,24 +11,14 @@ import {
   armBookmark,
   disarmBookmark,
   getArmedBookmark,
+  sameSearch,
+  splitBookmarkUrl,
 } from "../lib/bookmarks";
 import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "../lib/hooks";
 import { encodePaneSegment, splitShellSearch } from "../lib/layout-codec";
 import { panelUrl } from "../views/Panel";
 import { SplitRightIcon, SplitDownIcon } from "./SplitIcons";
 import { FinderIcon } from "./FinderIcon";
-
-// True when two query strings carry the same decoded `_layout` and the same
-// key/value multiset of remaining params, ignoring encoding and ordering
-// differences. `_layout` may contain literal `&` (D51), so both sides go
-// through the codec's splitShellSearch, never raw URLSearchParams.
-function sameSearch(a: string, b: string): boolean {
-  const norm = (s: string) => {
-    const { layout, params } = splitShellSearch(s);
-    return JSON.stringify([layout, [...params].sort()]);
-  };
-  return norm(a) === norm(b);
-}
 
 // "Update bookmark" visibility (D38). The check has side effects (a pathname
 // change or a deleted bookmark disarms permanently), so it runs in an effect,
@@ -54,9 +44,7 @@ function useUpdateButton(urlVersion: number, bookmarksVersion: number): boolean 
       return setVisible(false);
     }
 
-    const qIdx = armed.url.indexOf("?");
-    const armedPathname = qIdx === -1 ? armed.url : armed.url.slice(0, qIdx);
-    const armedSearch = qIdx === -1 ? "" : armed.url.slice(qIdx);
+    const { pathname: armedPathname, search: armedSearch } = splitBookmarkUrl(armed.url);
 
     if (location.pathname !== armedPathname) {
       disarmBookmark(); // page change = permanent disarm

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,6 +20,8 @@ import {
   disarmBookmark,
   getArmedBookmark,
   setBookmarkIcon,
+  sameSearch,
+  splitBookmarkUrl,
 } from "../lib/bookmarks";
 import { bookmarkSaveTarget } from "../lib/bookmark-file";
 import { exportBookmarkFile, getConfig, statPath } from "../lib/api";
@@ -33,6 +35,7 @@ import {
   useBookmarksVersion,
   notifyBookmarksChanged,
   useRecentsVersion,
+  useArmedVersion,
 } from "../lib/hooks";
 import type { Config } from "../lib/api";
 import { splitShellSearch } from "../lib/layout-codec";
@@ -163,6 +166,8 @@ interface BookmarkRowProps {
   b: Bookmark;
   child?: boolean;
   parentId?: string;
+  active: boolean;
+  dirty: boolean; // active via armed AND current params differ from saved -> "*" suffix
   isRenaming: boolean;
   justSaved: boolean; // transient ✓ on the save button after a successful export
   namePositions?: number[]; // search-match highlight positions in b.name
@@ -180,7 +185,7 @@ interface BookmarkRowProps {
 }
 
 // Template for a bookmark row (top-level or, with child=true, inside a folder).
-function BookmarkRow({ b, child, parentId, isRenaming, justSaved, namePositions, onNameClick, onSave, onRename, onDelete, onCommitRename, onCancelRename, onMouseEnter, onMouseLeave, onGlyphClick, registerRef, dragProps }: BookmarkRowProps) {
+function BookmarkRow({ b, child, parentId, active, dirty, isRenaming, justSaved, namePositions, onNameClick, onSave, onRename, onDelete, onCommitRename, onCancelRename, onMouseEnter, onMouseLeave, onGlyphClick, registerRef, dragProps }: BookmarkRowProps) {
   // Where "Save to disk" would write — shown on the button itself (title) so
   // the destination is visible before the click; null disables the button.
   const saveTarget = bookmarkSaveTarget(b);
@@ -189,7 +194,7 @@ function BookmarkRow({ b, child, parentId, isRenaming, justSaved, namePositions,
     : null;
   return (
     <div
-      className={"bookmark-row" + (child ? " child-row" : "") + (b.url === currentUrl() ? " active" : "")}
+      className={"bookmark-row" + (child ? " child-row" : "") + (active ? " active" : "")}
       data-id={b.id}
       data-parent={child ? parentId : undefined}
       draggable="true"
@@ -210,6 +215,7 @@ function BookmarkRow({ b, child, parentId, isRenaming, justSaved, namePositions,
       ) : (
         <a className="bookmark-name" href={b.url} draggable={false} onClick={onNameClick}>
           {namePositions && namePositions.length ? renderHighlight(b.name, namePositions) : b.name}
+          {dirty && "*"}
         </a>
       )}
       <span className="bookmark-actions">
@@ -298,6 +304,10 @@ export default function Sidebar({ config }: SidebarProps) {
   useUrlVersion();
   useBookmarksVersion();
   useRecentsVersion();
+  // Arm/disarm doesn't always coincide with a url or bookmark-store event —
+  // the Breadcrumb's pathname-change disarm fires from an effect after this
+  // component already rendered — so the armed store notifies separately.
+  useArmedVersion();
   // Signed-in dot on the footer's Preferences entry (SPEC AC-1): shown only
   // once Deploy is enabled, since that's the only reason this app cares about
   // a Fused account at all — a dot for a feature the user hasn't turned on
@@ -840,10 +850,27 @@ export default function Sidebar({ config }: SidebarProps) {
     onDragEnd: onRowDragEnd,
   });
 
-  // True when the current view's bookmark lives anywhere in this subtree —
-  // keeps the collapsed-folder active hint visible at any nesting depth.
+  // Active row = the armed bookmark (the one being "followed"/edited — same
+  // tracking the Update-bookmark button uses), regardless of live param
+  // drift. With nothing armed, fall back to an exact-url match so a pasted or
+  // hand-typed url still highlights its bookmark (matching never arms).
+  const armed = getArmedBookmark();
+  const rowActive = (b: Bookmark): boolean =>
+    armed ? armed.id === b.id : b.url === currentUrl();
+  // Dirty = the armed row's current params differ from its saved url — the
+  // exact visibility condition of the Update-bookmark button (Breadcrumb).
+  // A pathname mismatch isn't dirty: the Breadcrumb disarms on page change,
+  // and until its effect runs this row shouldn't flash a "*".
+  const rowDirty = (b: Bookmark): boolean => {
+    if (!armed || armed.id !== b.id) return false;
+    const { pathname, search } = splitBookmarkUrl(armed.url);
+    return location.pathname === pathname && !sameSearch(location.search, search);
+  };
+
+  // True when the active bookmark lives anywhere in this subtree — keeps the
+  // collapsed-folder active hint visible at any nesting depth.
   const subtreeHoldsActive = (list: BookmarkItem[]): boolean =>
-    list.some((c) => (isFolder(c) ? subtreeHoldsActive(c.children) : c.url === currentUrl()));
+    list.some((c) => (isFolder(c) ? subtreeHoldsActive(c.children) : rowActive(c)));
 
   // Recursive tree render (D121). parentId is the immediate parent's id
   // (null at top level); rows inside any folder carry it via data-parent so
@@ -886,6 +913,8 @@ export default function Sidebar({ config }: SidebarProps) {
           b={it}
           child={child}
           parentId={parentId ?? undefined}
+          active={rowActive(it)}
+          dirty={rowDirty(it)}
           isRenaming={renamingId === it.id}
           justSaved={savedId === it.id}
           registerRef={registerRow(it.id)}
@@ -959,6 +988,8 @@ export default function Sidebar({ config }: SidebarProps) {
                     key={b.id}
                     b={b}
                     namePositions={namePositions}
+                    active={rowActive(b)}
+                    dirty={rowDirty(b)}
                     isRenaming={renamingId === b.id}
                     justSaved={savedId === b.id}
                     registerRef={() => {}}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -19,6 +19,7 @@ import {
   armBookmark,
   disarmBookmark,
   getArmedBookmark,
+  getArmedBookmarkFor,
   setBookmarkIcon,
   sameSearch,
   splitBookmarkUrl,
@@ -852,20 +853,22 @@ export default function Sidebar({ config }: SidebarProps) {
 
   // Active row = the armed bookmark (the one being "followed"/edited — same
   // tracking the Update-bookmark button uses), regardless of live param
-  // drift. With nothing armed, fall back to an exact-url match so a pasted or
-  // hand-typed url still highlights its bookmark (matching never arms).
-  const armed = getArmedBookmark();
+  // drift. Read through the pathname gate: an armed entry whose page the user
+  // has left counts as not-armed here, so the highlight falls back to the
+  // exact-url match immediately instead of waiting on (or, for routes without
+  // CrumbActions, forever missing) the Breadcrumb's disarm effect. With
+  // nothing armed, exact-url match still highlights a pasted/hand-typed url
+  // (matching never arms).
+  const armed = getArmedBookmarkFor(location.pathname);
   const rowActive = (b: Bookmark): boolean =>
     armed ? armed.id === b.id : b.url === currentUrl();
   // Dirty = the armed row's current params differ from its saved url — the
   // exact visibility condition of the Update-bookmark button (Breadcrumb).
-  // A pathname mismatch isn't dirty: the Breadcrumb disarms on page change,
-  // and until its effect runs this row shouldn't flash a "*".
-  const rowDirty = (b: Bookmark): boolean => {
-    if (!armed || armed.id !== b.id) return false;
-    const { pathname, search } = splitBookmarkUrl(armed.url);
-    return location.pathname === pathname && !sameSearch(location.search, search);
-  };
+  // Pathname already matches (the gate above), so only the search differs.
+  const rowDirty = (b: Bookmark): boolean =>
+    !!armed &&
+    armed.id === b.id &&
+    !sameSearch(location.search, splitBookmarkUrl(armed.url).search);
 
   // True when the active bookmark lives anywhere in this subtree — keeps the
   // collapsed-folder active hint visible at any nesting depth.

--- a/frontend/src/lib/bookmarks.ts
+++ b/frontend/src/lib/bookmarks.ts
@@ -439,6 +439,18 @@ export function splitBookmarkUrl(url: string): { pathname: string; search: strin
     : { pathname: url.slice(0, qIdx), search: url.slice(qIdx) };
 }
 
+// The armed bookmark, gated on the current page: null when nothing is armed
+// OR the armed url's pathname differs from `pathname`. Sidebar highlighting
+// reads through this so a stale armed entry (page changed, Breadcrumb's
+// disarm effect not yet run — or never run, on routes without CrumbActions)
+// can't keep the old row lit or block the exact-url fallback. Read-only: the
+// permanent disarm on page change stays Breadcrumb's job.
+export function getArmedBookmarkFor(pathname: string): ArmedBookmark | null {
+  const armed = getArmedBookmark();
+  if (!armed || splitBookmarkUrl(armed.url).pathname !== pathname) return null;
+  return armed;
+}
+
 export function getArmedBookmark(): ArmedBookmark | null {
   try {
     const raw = sessionStorage.getItem(ARMED_KEY);

--- a/frontend/src/lib/bookmarks.ts
+++ b/frontend/src/lib/bookmarks.ts
@@ -9,6 +9,8 @@
 // components still subscribe via useBookmarksVersion (lib/hooks.ts) and call
 // notifyBookmarksChanged() after each mutation they trigger.
 import { getBookmarks, putBookmarks, recordBookmarkHistory } from "./api";
+import { notifyArmedChanged } from "./hooks";
+import { splitShellSearch } from "./layout-codec";
 
 export interface Bookmark {
   id: string;
@@ -403,6 +405,7 @@ export function armBookmark(id: string, url: string): void {
   } catch (e) {
     console.error("[fused] failed to arm bookmark:", e);
   }
+  notifyArmedChanged();
 }
 
 export function disarmBookmark(): void {
@@ -411,6 +414,29 @@ export function disarmBookmark(): void {
   } catch (e) {
     console.error("[fused] failed to disarm bookmark:", e);
   }
+  notifyArmedChanged();
+}
+
+// True when two query strings carry the same decoded `_layout` and the same
+// key/value multiset of remaining params, ignoring encoding and ordering
+// differences. `_layout` may contain literal `&` (D51), so both sides go
+// through the codec's splitShellSearch, never raw URLSearchParams. Shared by
+// the Update-bookmark button (Breadcrumb) and the sidebar's dirty marker.
+export function sameSearch(a: string, b: string): boolean {
+  const norm = (s: string) => {
+    const { layout, params } = splitShellSearch(s);
+    return JSON.stringify([layout, [...params].sort()]);
+  };
+  return norm(a) === norm(b);
+}
+
+// A bookmark url split at its first `?` — the pathname/search halves both
+// armed-state consumers compare against location.
+export function splitBookmarkUrl(url: string): { pathname: string; search: string } {
+  const qIdx = url.indexOf("?");
+  return qIdx === -1
+    ? { pathname: url, search: "" }
+    : { pathname: url.slice(0, qIdx), search: url.slice(qIdx) };
 }
 
 export function getArmedBookmark(): ArmedBookmark | null {

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -50,6 +50,21 @@ export function useBookmarksVersion(): number {
   return useEventCounter([BOOKMARKS_EVENT]);
 }
 
+// Armed-bookmark change signal — same store-owned pattern as recents below:
+// armBookmark()/disarmBookmark() (lib/bookmarks.ts) dispatch it themselves,
+// because not every disarm site coincides with a url or bookmark-store event
+// (the Breadcrumb's pathname-change disarm runs in an effect AFTER the sidebar
+// has already rendered against the stale armed value).
+const ARMED_EVENT = "fused:armchange";
+
+export function notifyArmedChanged(): void {
+  window.dispatchEvent(new Event(ARMED_EVENT));
+}
+
+export function useArmedVersion(): number {
+  return useEventCounter([ARMED_EVENT]);
+}
+
 // Recents store change signal — same pattern as the bookmarks event. The
 // recents store (lib/recents.ts) dispatches it itself after every cache
 // advance (its mutations are triggered by tracking, not by UI clicks alone,


### PR DESCRIPTION
## Problem

Opening a bookmark highlights it in the sidebar, but changing any param on the page drops the highlight — while the Update-bookmark button keeps tracking the bookmark. User loses sight of which bookmark they're updating.

Root cause: two different sources of truth. Sidebar compared the full current URL against each bookmark (`b.url === currentUrl()`), so any query drift broke the match. The Update button reads the armed bookmark from sessionStorage, which survives param changes.

## Change

- Sidebar highlight now follows the armed bookmark: `armed.id === b.id`. Fallback to exact-URL compare only when nothing is armed (pasted/manual URLs still highlight). No auto-arm on URL match.
- When the armed row's query differs from the saved bookmark (same `sameSearch` check as the Update button), a `*` is appended to its sidebar label to denote unsaved changes. It clears immediately after "Update bookmark".
- New `fused:armchange` event (`notifyArmedChanged`/`useArmedVersion` in lib/hooks.ts, dispatched from `armBookmark`/`disarmBookmark`) so the sidebar re-renders on disarm paths that don't coincide with a urlchange.
- `sameSearch`/`splitBookmarkUrl` moved to lib/bookmarks.ts, shared by Breadcrumb and Sidebar — no duplicated comparison logic.
- List order and keys untouched (no-jumpy-lists rule); only className and label text change.

## Verification

- `tsc --noEmit` clean.
- Reviewed: no import cycles, listener cleanup correct, no stale closures, moved helpers behavior-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only bookmark UI and shared URL comparison helpers; armed state in sessionStorage was already used by the breadcrumb update flow.
> 
> **Overview**
> Sidebar bookmark selection now tracks the **armed** bookmark (same source as **Update bookmark**), so changing query params no longer drops the active row. With nothing armed, highlight still falls back to an exact URL match for pasted or manual navigation.
> 
> When the armed bookmark’s saved query differs from the current page (shared **`sameSearch`** logic), the row label gets a **`*`** unsaved indicator, matching when **Update bookmark** would appear.
> 
> **`sameSearch`**, **`splitBookmarkUrl`**, and **`getArmedBookmarkFor`** live in **`lib/bookmarks.ts`** for Breadcrumb and Sidebar; **`armBookmark`** / **`disarmBookmark`** emit **`fused:armchange`** via **`useArmedVersion`** so the sidebar updates on disarm paths that don’t fire a URL or bookmark-store event (e.g. pathname disarm in Breadcrumb’s effect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2f66ffab21d7ca67b6ee027062ea642f65072b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->