### PR TITLE
learn: value-first landing page + dedicated "Building with Fused Render"

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -302,6 +302,56 @@
 
   /* ---------- build page: prominent prompt + api table ---------- */
   .promptbox.big pre { font-size:14px; line-height:1.6; padding:18px 74px 18px 18px; }
+
+  /* hero prompt — the "grab this" Claude prompt, made the focal point */
+  .heroprompt { border:1px solid #5c5c2e; background:linear-gradient(180deg,#1c1c10,#181811);
+       border-radius:14px; overflow:hidden; margin:4px 0 14px;
+       box-shadow:0 0 0 1px rgba(229,255,68,.05), 0 12px 34px rgba(0,0,0,.4); }
+  .heroprompt .hp-head { display:flex; align-items:center; gap:8px; padding:11px 18px;
+       border-bottom:1px solid #45451f; background:#21210f;
+       font-size:11px; text-transform:uppercase; letter-spacing:.8px; font-weight:700; color:var(--yellow); }
+  .heroprompt .hp-head .spark { font-size:13px; }
+  .heroprompt .hp-body { padding:17px 20px 4px; }
+  .heroprompt pre { background:transparent; border:0; padding:0; margin:0; font-size:15px; line-height:1.6;
+       color:#f3f3e8; white-space:pre-wrap; font-family:"SF Mono",ui-monospace,Menlo,monospace; }
+  .heroprompt .hp-copy { position:static; display:flex; align-items:center; justify-content:center; gap:8px;
+       width:100%; margin:15px 0 17px; padding:12px; border-radius:10px; cursor:pointer;
+       border:1px solid var(--yellow); background:var(--yellow); color:#141414;
+       font:700 13.5px/1 inherit; transition:filter .15s; }
+  .heroprompt .hp-copy:hover { filter:brightness(1.06); }
+  .heroprompt .hp-copy.done { background:#141414; color:var(--yellow); border-color:var(--yellow); }
+
+  /* mental-model file tree */
+  .filetree { background:var(--code-bg); border:1px solid var(--border); border-radius:12px; padding:18px 20px; margin:0 0 14px; }
+  .filetree .ft-dir { font:600 14.5px/1.4 "SF Mono",ui-monospace,Menlo,monospace; color:var(--text); }
+  .filetree .ft-item { display:grid; grid-template-columns:auto auto auto 1fr; align-items:baseline; gap:10px;
+       margin-top:11px; font-family:"SF Mono",ui-monospace,Menlo,monospace; font-size:13px; }
+  .filetree .ft-branch { color:var(--mut); }
+  .filetree .ft-name { color:var(--text); white-space:nowrap; }
+  .filetree .ft-arrow { color:var(--mut); }
+  .filetree .ft-role { font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; font-size:12.5px; color:var(--dim); }
+  .filetree .ft-role b { color:var(--text); font-weight:600; }
+  .filetree .ft-bridge { margin:17px 0 0; padding:11px 12px; text-align:center; background:var(--panel);
+       border:1px solid var(--border); border-radius:9px; font-size:12.5px; color:var(--dim); }
+  .filetree .ft-bridge b { color:var(--yellow); }
+  .filetree .ft-live { margin-top:14px; padding-top:13px; border-top:1px solid var(--border); font-size:12.5px; color:var(--dim); }
+  .filetree .ft-live code { color:var(--text); font-size:11.5px; background:var(--panel2);
+       border:1px solid var(--border); border-radius:5px; padding:1px 5px; }
+
+  /* URL-state demo: a live browser address bar */
+  .urldemo { margin:0 0 12px; }
+  .urldemo .ub-bar { display:flex; align-items:center; gap:11px; padding:10px 14px; background:var(--panel2);
+       border:1px solid var(--border); border-radius:11px; }
+  .urldemo .dots { display:flex; gap:6px; flex-shrink:0; }
+  .urldemo .dots i { width:11px; height:11px; border-radius:50%; display:block; }
+  .urldemo .ub-url { flex:1; min-width:0; background:var(--bg); border:1px solid var(--border); border-radius:8px;
+       padding:8px 13px; font:12.5px/1.4 "SF Mono",ui-monospace,Menlo,monospace;
+       white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .urldemo .ub-dim { color:var(--mut); }
+  .urldemo .ub-q { color:var(--yellow); font-weight:600; }
+  .urldemo .ub-q b { color:#141414; background:var(--yellow); border-radius:4px; padding:1px 6px;
+       font-variant-numeric:tabular-nums; transition:transform .12s ease; display:inline-block; }
+  .urldemo .ub-q.flash b { transform:scale(1.14); }
   .apitable { width:100%; border-collapse:collapse; margin:0 0 10px; font-size:12.5px; }
   .apitable td { border:1px solid var(--border); padding:9px 11px; vertical-align:top; }
   .apitable td:first-child { white-space:nowrap; width:1%; }
@@ -424,9 +474,12 @@
     <h1 class="title">Building with Fused Render</h1>
     <p class="lede">A project is just a <b>folder</b> with a page and a Python file. The fastest way to make one is to ask <b>Claude Code</b> — it already knows the Fused Render layout. Here's the prompt.</p>
 
-    <div class="promptbox big">
-      <button class="copybtn" data-copy="buildPrompt">Copy</button>
-      <pre id="buildPrompt">Create a new Fused Render project that shows my computer's CPU and memory usage as live gauges, refreshing every second.</pre>
+    <div class="heroprompt">
+      <div class="hp-head"><span class="spark">✦</span> Paste this into Claude Code</div>
+      <div class="hp-body">
+        <pre id="buildPrompt">Create a new Fused Render project that shows my computer's CPU and memory usage as live gauges, refreshing every second.</pre>
+        <button class="copybtn hp-copy" data-copy="buildPrompt">📋&nbsp; Copy prompt</button>
+      </div>
     </div>
     <p class="sub">Swap in your own idea after <em>“…that”</em>: <em>a treemap of my Downloads folder</em>, <em>a searchable table from a CSV I pick</em>, <em>a world clock for three time zones</em>. No need to mention HTML or Python — Claude fills that in.</p>
 
@@ -441,11 +494,23 @@ claude plugin install fused-render@fused-render</pre>
     </div>
 
     <h2>The mental model</h2>
-    <p class="sub">Two files in a folder. The HTML is what you see; the Python is the work. They talk over the <span class="y mono">fused</span> bridge injected into every page.</p>
-    <div class="steps">
-      <div class="step"><div class="num">1</div><h4>Make a folder</h4><p>Anywhere Fused Render can see — <code>~/Documents/Fused/my_tool/</code> works.</p></div>
-      <div class="step"><div class="num">2</div><h4>Drop in two files</h4><p>An <code>index.html</code> for what you see, a <code>tool.py</code> for the work.</p></div>
-      <div class="step"><div class="num">3</div><h4>Click the HTML file</h4><p>It renders as a live page. Edit either file and the page reloads itself.</p></div>
+    <p class="sub">A project is just a folder with two files. The HTML is what you see; the Python is the work. That's the whole structure:</p>
+    <div class="filetree">
+      <div class="ft-dir">📁 my_tool/</div>
+      <div class="ft-item">
+        <span class="ft-branch">├──</span>
+        <span class="ft-name">📄 index.html</span>
+        <span class="ft-arrow">→</span>
+        <span class="ft-role"><b>what you see</b> — the UI, in HTML &amp; JS</span>
+      </div>
+      <div class="ft-item">
+        <span class="ft-branch">└──</span>
+        <span class="ft-name">🐍 tool.py</span>
+        <span class="ft-arrow">→</span>
+        <span class="ft-role"><b>the work</b> — a <code>main()</code> that returns JSON</span>
+      </div>
+      <div class="ft-bridge">HTML&nbsp; <b>⇄</b> &nbsp;Python — they talk over the <span class="y mono">fused</span> bridge injected into every page</div>
+      <div class="ft-live">▸ Click <code>index.html</code> and it renders as a live page. Edit either file and the page reloads itself.</div>
     </div>
 
     <h3>HTML calls Python</h3>
@@ -468,16 +533,21 @@ claude plugin install fused-render@fused-render</pre>
     </div>
 
     <h3>State lives in the URL</h3>
-    <p class="sub">Controls don't keep private state — they write to the page's URL through <code>fused.params</code>. Refresh, bookmark, or share the link and the page comes back exactly as you left it.</p>
+    <p class="sub">Controls don't keep private state — they write to the page's URL through <code>fused.params</code>. Drag the slider and watch the address bar: the <b class="y">?level=</b> value updates live. Refresh, bookmark, or share that link and the page comes back exactly as you left it.</p>
+    <div class="urldemo">
+      <div class="ub-bar">
+        <div class="dots"><i style="background:#ff5f56"></i><i style="background:#ffbd2e"></i><i style="background:#27c93f"></i></div>
+        <div class="ub-url"><span class="ub-dim">127.0.0.1:1777/view/~/Fused/my_tool/index.html</span><span class="ub-q" id="ubQ">?level=<b id="urlVal">40</b></span></div>
+      </div>
+    </div>
     <div class="grid2">
       <div class="card ctrl">
         <label>Level <b id="vLevel">40</b></label>
         <input type="range" id="level" min="0" max="100" step="1" value="40">
+        <div class="meter" style="margin-bottom:0"><i id="bar"></i></div>
       </div>
       <div class="card">
-        <div class="meter"><i id="bar"></i></div>
-        <div class="urlbox">this page's URL now ends in&nbsp; ?<b>level</b>=<span id="urlVal">40</span></div>
-        <p style="margin:8px 0 0;font-size:12px">Move the slider, then refresh — the level survives, because the URL is the state.</p>
+        <p style="margin:0;font-size:12.5px">The slider writes <code>fused.params.set("level", …)</code>, which appends <code>?level=</code> to the URL. Nothing is stored in hidden JS state — the URL <em>is</em> the state, so it survives a refresh and travels in a shared link.</p>
       </div>
     </div>
 
@@ -506,28 +576,6 @@ claude plugin install fused-render@fused-render</pre>
 
     <h2>Next</h2>
     <p class="sub">Render other file types through <a href="?page=templates">Templates</a>, pull in remote data with <a href="?page=mount">Mount</a>, then <a href="?page=deploy">Deploy</a> so others can open your app in a browser. Or see finished projects in the <a href="?page=showcase">Showcase</a>.</p>
-  </section>
-
-  <!-- ============================ USING FUSED RENDER (the app / UI guide) ============================ -->
-  <section class="page" data-slug="using" data-title="Using Fused Render">
-    <p class="crumb">The app</p>
-    <h1 class="title">Using Fused Render</h1>
-    <p class="lede">The Fused Render window is a file explorer for your project folders — click an HTML file and it renders live. Here's how to get around it.</p>
-
-    <h2>Bookmarks</h2>
-    <p class="sub">Pin any page you're working on so it's one click away — the <b>+ Bookmark</b> button, top right. Bookmarks live in the left sidebar (and group into folders); each stores the file <em>and</em> its query params, so you return to the exact state.</p>
-    <figure class="figure"><img data-shot="assets/shot_bookmarks.webp" alt="Bookmarks sidebar in the Fused Render shell">
-      <figcaption><b>The shell sidebar</b> — bookmarks and folders on the left, the <b>+ Bookmark</b> button top right.</figcaption></figure>
-
-    <h2>Split view</h2>
-    <p class="sub">Open two files side by side — a page and its Python, or two previews — and work across them without losing either. Each pane keeps its own URL and state.</p>
-    <figure class="figure"><img data-shot="assets/shot_splitview.webp" alt="Two panes side by side in Fused Render">
-      <figcaption><b>Split view</b> — two panes, each an independent preview.</figcaption></figure>
-
-    <h2>Opening files with templates</h2>
-    <p class="sub">Any file on your machine can render through a <b>template</b> — right-click it and pick <em>Open with FusedRender</em> (registered by the desktop app). See <a href="?page=templates">Templates</a> for how templates are chosen and customized.</p>
-    <figure class="figure"><video data-shot="assets/open_with_right_click.mp4" autoplay muted loop playsinline style="width:100%;display:block"></video>
-      <figcaption><b>Right-click → Open with FusedRender</b> — any file renders through its matching template.</figcaption></figure>
   </section>
 
   <!-- ============================ 2 · CLAUDE CODE ============================ -->
@@ -622,6 +670,28 @@ claude plugin install fused-render@fused-render</pre>
       </div>
       <div class="cond-out" id="condOut"></div>
     </div>
+  </section>
+
+  <!-- ============================ USING FUSED RENDER (the app / UI guide) ============================ -->
+  <section class="page" data-slug="using" data-title="Using Fused Render">
+    <p class="crumb">The app</p>
+    <h1 class="title">Using Fused Render</h1>
+    <p class="lede">The Fused Render window is a file explorer for your project folders — click an HTML file and it renders live. Here's how to get around it.</p>
+
+    <h2>Bookmarks</h2>
+    <p class="sub">Pin any page you're working on so it's one click away — the <b>+ Bookmark</b> button, top right. Bookmarks live in the left sidebar (and group into folders); each stores the file <em>and</em> its query params, so you return to the exact state.</p>
+    <figure class="figure"><img data-shot="assets/shot_bookmarks.webp" alt="Bookmarks sidebar in the Fused Render shell">
+      <figcaption><b>The shell sidebar</b> — bookmarks and folders on the left, the <b>+ Bookmark</b> button top right.</figcaption></figure>
+
+    <h2>Split view</h2>
+    <p class="sub">Open two files side by side — a page and its Python, or two previews — and work across them without losing either. Each pane keeps its own URL and state.</p>
+    <figure class="figure"><img data-shot="assets/shot_splitview.webp" alt="Two panes side by side in Fused Render">
+      <figcaption><b>Split view</b> — two panes, each an independent preview.</figcaption></figure>
+
+    <h2>Opening files with templates</h2>
+    <p class="sub">Any file on your machine can render through a <b>template</b> — right-click it and pick <em>Open with FusedRender</em> (registered by the desktop app). See <a href="?page=templates">Templates</a> for how templates are chosen and customized.</p>
+    <figure class="figure"><video data-shot="assets/open_with_right_click.mp4" autoplay muted loop playsinline style="width:100%;display:block"></video>
+      <figcaption><b>Right-click → Open with FusedRender</b> — any file renders through its matching template.</figcaption></figure>
   </section>
 
   <!-- ============================ 4 · MOUNT ============================ -->
@@ -1163,6 +1233,8 @@ async function checkClaude(){
 /* URL-state slider */
 function drawLevel(v){
   $("#level").value = v; $("#vLevel").textContent = v; $("#bar").style.width = v+"%"; $("#urlVal").textContent = v;
+  const q = $("#ubQ");
+  if (q) { q.classList.add("flash"); clearTimeout(q._t); q._t = setTimeout(() => q.classList.remove("flash"), 130); }
 }
 if (hasFused && fused.params){
   const P = fused.params;

--- a/learn/index.html
+++ b/learn/index.html
@@ -275,6 +275,54 @@
   .pager .nxt { text-align:right; }
   .pager .cap { display:block; font-size:10.5px; color:var(--mut); text-transform:uppercase; letter-spacing:.6px; margin-bottom:2px; }
 
+  /* ---------- landing / home ---------- */
+  .hero-cta { display:flex; gap:12px; flex-wrap:wrap; margin:20px 0 10px; }
+  .cta { display:inline-flex; align-items:center; text-decoration:none; font:600 14px/1 inherit;
+       padding:12px 20px; border-radius:10px; border:1px solid var(--border); color:var(--text); background:var(--panel); }
+  .cta:hover { border-color:#4a4a4e; color:var(--text); }
+  .cta.primary { background:var(--yellow); color:#141414; border-color:var(--yellow); }
+  .cta.primary:hover { color:#141414; filter:brightness(1.05); }
+
+  .modecard { display:flex; flex-direction:column; text-decoration:none; color:var(--text);
+       background:var(--panel); border:1px solid var(--border); border-radius:14px; padding:20px 22px; }
+  .modecard:hover { border-color:#4a4a4e; }
+  .modecard .mc-ic { font-size:28px; margin-bottom:8px; }
+  .modecard h3 { margin:0 0 6px; font-size:16px; }
+  .modecard p { margin:0 0 12px; font-size:13px; color:var(--dim); }
+  .modecard .mc-go { margin-top:auto; font-size:12.5px; color:var(--yellow); font-weight:600; }
+
+  .navtiles { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin:0 0 8px; }
+  .navtile { display:flex; align-items:flex-start; gap:12px; text-decoration:none; color:var(--text);
+       background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:15px 17px; }
+  .navtile:hover { border-color:#4a4a4e; }
+  .navtile .nt-ic { font-size:20px; line-height:1.2; flex-shrink:0; }
+  .navtile h4 { margin:0 0 3px; font-size:14px; }
+  .navtile p { margin:0; font-size:12px; color:var(--dim); }
+  .home-foot { display:flex; gap:18px; flex-wrap:wrap; margin-top:8px; font-size:13px; }
+
+  /* ---------- build page: prominent prompt + api table ---------- */
+  .promptbox.big pre { font-size:14px; line-height:1.6; padding:18px 74px 18px 18px; }
+  .apitable { width:100%; border-collapse:collapse; margin:0 0 10px; font-size:12.5px; }
+  .apitable td { border:1px solid var(--border); padding:9px 11px; vertical-align:top; }
+  .apitable td:first-child { white-space:nowrap; width:1%; }
+  .apitable code { color:var(--text); background:var(--code-bg); border:1px solid var(--border);
+       border-radius:5px; padding:1px 6px; font-size:11.5px; }
+  .apitable td:last-child { color:var(--dim); }
+  .ideagrid { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin:0 0 8px; }
+  .idea { position:relative; background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:14px 15px; }
+  .idea .it { font-size:12.5px; color:var(--text); font-weight:600; margin:0 0 8px; }
+  .idea pre { font-size:11px; padding:10px 11px; white-space:pre-wrap; }
+  .idea .copybtn { position:static; margin-top:9px; width:100%; text-align:center; }
+
+  /* per-remote mount examples */
+  .remote-eg { margin:0 0 12px; }
+  .remote-eg .re-head { display:flex; align-items:center; gap:9px; font-size:13.5px; font-weight:600;
+       color:var(--text); margin:0 0 8px; }
+  .remote-eg .re-tag { font-size:9.5px; text-transform:uppercase; letter-spacing:.5px; font-weight:700;
+       border:1px solid var(--border); border-radius:5px; padding:2px 7px; color:var(--mut); }
+  .remote-eg .re-tag.inapp { color:#5fd35f; border-color:#2e5a2e; background:#132013; }
+  .remote-eg .re-tag.cli { color:#8ab4ff; border-color:#3a3a4a; background:#16161f; }
+
   .menuBtn { display:none; }
   @media (max-width:960px){
     .cards { grid-template-columns:repeat(2,1fr); } .cards .feat { grid-column:span 2; }
@@ -285,6 +333,7 @@
     .rail.open { transform:none; }
     main { margin-left:0; padding:64px 18px 80px; }
     .grid2 { grid-template-columns:1fr; }
+    .navtiles, .ideagrid { grid-template-columns:1fr; }
     .cards { grid-template-columns:1fr; } .cards .feat { grid-column:auto; }
     .menuBtn { display:flex; position:fixed; top:12px; left:12px; z-index:25; width:38px; height:38px;
        align-items:center; justify-content:center; background:var(--panel); border:1px solid var(--border);
@@ -308,18 +357,23 @@
 <main>
 <div class="wrap">
 
-  <!-- ============================ 1 · USING FUSED RENDER ============================ -->
-  <section class="page" data-slug="using" data-title="Using Fused Render" data-ix="1">
-    <p class="crumb">Get started</p>
-    <h1 class="title">Using Fused Render</h1>
-    <p class="lede">Fused Render turns folders on your machine into <b>live pages</b>. Any HTML file renders as an app, and a <span class="y mono">fused</span> global lets that page run the Python sitting right next to it — <b>no server, no build step</b>.</p>
+  <!-- ============================ HOME (landing / value) ============================ -->
+  <section class="page" data-slug="home" data-title="Home">
+    <p class="crumb">Fused Render</p>
+    <h1 class="title">Turn folders on your machine into live apps</h1>
+    <p class="lede">Fused Render runs on <b>your computer</b>. Point it at a folder and any HTML file becomes a live app — with a <span class="y mono">fused</span> bridge that lets the page run the <b>Python sitting right next to it</b>. No server, no build step, no upload. Your files, your machine.</p>
 
-    <h2><span class="n">1</span>The basics</h2>
-    <p class="sub">A project is just a folder with a page and a Python file. Here's one embedded live — drag the slider to throw more darts, and the Python next to it estimates <b>π</b> from the share that land inside the circle.</p>
+    <div class="hero-cta">
+      <a class="cta primary" href="?page=build">Build your own app →</a>
+      <a class="cta" href="?page=templates">Open your data →</a>
+    </div>
+
+    <h2>See it run</h2>
+    <p class="sub">This isn't a video. Drag the slider — a <b>Python file on this machine</b> throws darts and estimates <b>π</b> from how many land inside the circle. That round trip, HTML asking Python for an answer, is what every Fused Render app is built on.</p>
     <div class="frame short" id="demoFrame">
       <div class="framebar">
         <span class="cap"><b>pi.html</b> — a slider, a canvas, and a few lines of Python</span>
-        <a id="demoOpen" target="_blank" rel="noopener">open in the app ↗</a>
+        <a id="demoOpen" target="_blank" rel="noopener">Show code ↗</a>
       </div>
       <iframe id="demoIf" title="Estimate π, embedded live"></iframe>
       <div class="ph r16 miss">
@@ -330,8 +384,72 @@
       </div>
     </div>
 
+    <h2>Two ways to use it</h2>
+    <p class="sub">Fused Render does two distinct things. Start with either — nothing locks you in, so you can move between them whenever you want.</p>
+    <div class="grid2">
+      <a class="modecard" href="?page=build">
+        <div class="mc-ic">🛠️</div>
+        <h3>Build an app</h3>
+        <p>Describe what you want and get a live tool: a dashboard, a control panel, an interactive chart — front-end in HTML, logic in Python. Great with Claude Code.</p>
+        <span class="mc-go">Building with Fused Render →</span>
+      </a>
+      <a class="modecard" href="?page=templates">
+        <div class="mc-ic">📂</div>
+        <h3>Open your data</h3>
+        <p>Right-click a file — a Parquet, a GeoTIFF, a CSV — and it renders through a template as an interactive view. No app to write, nothing to download.</p>
+        <span class="mc-go">Templates →</span>
+      </a>
+    </div>
+
+    <h2>Everything else</h2>
+    <div class="navtiles">
+      <a class="navtile" href="?page=using"><span class="nt-ic">🧭</span><div><h4>Using the app</h4><p>Bookmarks, split view, and getting around the explorer.</p></div></a>
+      <a class="navtile" href="?page=mount"><span class="nt-ic">🔌</span><div><h4>Mount remote data</h4><p>Browse S3, GCS, or Google Drive like a local folder.</p></div></a>
+      <a class="navtile" href="?page=deploy"><span class="nt-ic">🚀</span><div><h4>Deploy <span class="y" style="font-size:11px">· Beta</span></h4><p>Publish a project so anyone can open it in a browser.</p></div></a>
+      <a class="navtile" href="?page=showcase"><span class="nt-ic">✨</span><div><h4>Showcase</h4><p>Working projects you can clone and pick apart.</p></div></a>
+    </div>
+
+    <h2>What people build</h2>
+    <p class="sub">Each of these is just a folder with a page and a Python file. Browse them all in the <a href="?page=showcase">Showcase</a>.</p>
+    <div class="cards" id="homeShowcase"></div>
+    <div class="home-foot">
+      <a href="https://github.com/fusedio/fused-render-examples" target="_blank" rel="noopener">Examples on GitHub ↗</a>
+      <a href="https://www.fused.io" target="_blank" rel="noopener">Get a Fused account ↗</a>
+    </div>
+  </section>
+
+  <!-- ============================ BUILDING WITH FUSED RENDER ============================ -->
+  <section class="page" data-slug="build" data-title="Building with Fused Render">
+    <p class="crumb">Make something</p>
+    <h1 class="title">Building with Fused Render</h1>
+    <p class="lede">A project is just a <b>folder</b> with a page and a Python file. The fastest way to make one is to ask <b>Claude Code</b> — it already knows the Fused Render layout. Here's the prompt.</p>
+
+    <div class="promptbox big">
+      <button class="copybtn" data-copy="buildPrompt">Copy</button>
+      <pre id="buildPrompt">Create a new Fused Render project that shows my computer's CPU and memory usage as live gauges, refreshing every second.</pre>
+    </div>
+    <p class="sub">Swap in your own idea after <em>“…that”</em>: <em>a treemap of my Downloads folder</em>, <em>a searchable table from a CSV I pick</em>, <em>a world clock for three time zones</em>. No need to mention HTML or Python — Claude fills that in.</p>
+
+    <div class="callout"><span class="lab">First time · one-time setup</span>
+      <p style="margin:6px 0 0">For that prompt to work, Claude Code needs the <b>Fused Render skills</b> installed — they teach it the project layout and the <code>fused</code> bridge. Install them once:</p>
+      <div class="promptbox" style="margin-top:11px">
+        <button class="copybtn" data-copy="skillInstall">Copy</button>
+        <pre id="skillInstall">claude plugin marketplace add fusedio/fused-render
+claude plugin install fused-render@fused-render</pre>
+      </div>
+      <p style="margin:9px 0 0;font-size:12px;color:var(--mut)">Then start a new Claude Code session so it picks up the skills. (Don't have Claude Code? <a href="https://claude.com/claude-code" target="_blank" rel="noopener">Get it here ↗</a>.)</p>
+    </div>
+
+    <h2>The mental model</h2>
+    <p class="sub">Two files in a folder. The HTML is what you see; the Python is the work. They talk over the <span class="y mono">fused</span> bridge injected into every page.</p>
+    <div class="steps">
+      <div class="step"><div class="num">1</div><h4>Make a folder</h4><p>Anywhere Fused Render can see — <code>~/Documents/Fused/my_tool/</code> works.</p></div>
+      <div class="step"><div class="num">2</div><h4>Drop in two files</h4><p>An <code>index.html</code> for what you see, a <code>tool.py</code> for the work.</p></div>
+      <div class="step"><div class="num">3</div><h4>Click the HTML file</h4><p>It renders as a live page. Edit either file and the page reloads itself.</p></div>
+    </div>
+
     <h3>HTML calls Python</h3>
-    <p class="sub">Next to this page sits <code>hello.py</code>. The button sends your input to it and renders what comes back — that round trip is the whole product.</p>
+    <p class="sub">Next to a page sits its Python. The page sends input to it and renders what comes back — try it: this calls <code>hello.py</code> for real when opened in the app.</p>
     <div class="grid2">
       <div class="card">
         <div class="helloform">
@@ -345,7 +463,7 @@
 <pre><span class="c"># hello.py — the whole contract</span>
 <span class="k">def</span> <span class="f">main</span>(name: str = <span class="s">"world"</span>):
     <span class="k">return</span> {<span class="s">"greeting"</span>: <span class="s">f"Hello, {name}!"</span>}</pre>
-        <p style="margin:10px 0 0;font-size:12px">The page's side is one line: <code>await fused.runPython("./hello.py", {name})</code>. A function named <code>main()</code> is all it takes.</p>
+        <p style="margin:10px 0 0;font-size:12px">The page's side is one line: <code>await fused.runPython("./hello.py", {name})</code>. A function named <code>main()</code> that returns JSON is all it takes.</p>
       </div>
     </div>
 
@@ -363,38 +481,53 @@
       </div>
     </div>
 
-    <h2><span class="n">2</span>UI guide</h2>
-    <h3>Bookmarks</h3>
+    <h2>The <span class="y mono">fused</span> API</h2>
+    <p class="sub">Everything your page can call. It's injected automatically — never <code>&lt;script src&gt;</code> anything for it. On the Python side, you only ever write a function named <code>main()</code>.</p>
+    <table class="apitable">
+      <tr><td><code>await fused.runPython(path, params)</code></td><td>Runs <code>main(**params)</code> of the <code>.py</code> at <code>path</code> (relative to the page) and resolves with its return value. Params are strings; scrubbing a slider auto-cancels the runs it moves past.</td></tr>
+      <tr><td><code>fused.params.get(k)</code></td><td>Read a URL param (a string, or <code>undefined</code>). The URL is your state.</td></tr>
+      <tr><td><code>fused.params.set(k, v)</code></td><td>Write a URL param — <code>v</code> must be a string, so <code>String(n)</code> yourself. Then fires <code>onChange</code>.</td></tr>
+      <tr><td><code>fused.params.onChange(cb)</code></td><td>Run <code>cb</code> after every applied <code>set</code> — the single place you re-render from.</td></tr>
+      <tr><td><code>await fused.readFile(path)</code></td><td>File contents as text — no Python needed when you just want the bytes.</td></tr>
+      <tr><td><code>await fused.writeFile(path, text)</code></td><td>Write text atomically (optional mtime lock to avoid clobbering).</td></tr>
+      <tr><td><code>await fused.stat(path)</code></td><td>Metadata <code>{size, mtime, is_dir, …}</code> — size-guard before reading big files.</td></tr>
+      <tr><td><code>fused.rawUrl(path)</code></td><td>A URL for the raw bytes — use it as the <code>src</code> of an <code>&lt;img&gt;</code>, <code>&lt;video&gt;</code>, or a download link.</td></tr>
+    </table>
+    <div class="callout"><span class="lab">Good to know</span>
+      <p style="margin:6px 0 0">Each <code>runPython</code> call runs <code>main()</code> in a fresh subprocess that's killed at <b>30&nbsp;seconds</b>. For a genuinely long job, write the result to a file from a separate script and have the page read the finished file.</p></div>
+
+    <h2>Starter ideas</h2>
+    <p class="sub">Copy any of these into Claude Code to see the shape of a project fast.</p>
+    <div class="ideagrid">
+      <div class="idea"><p class="it">🖥️ System monitor</p><pre id="idea1">Create a Fused Render project that shows a live, top-style table of my running processes sorted by memory.</pre><button class="copybtn" data-copy="idea1">Copy</button></div>
+      <div class="idea"><p class="it">📊 CSV explorer</p><pre id="idea2">Create a Fused Render project that lets me pick a CSV file and browse it as a sortable, searchable table.</pre><button class="copybtn" data-copy="idea2">Copy</button></div>
+      <div class="idea"><p class="it">🗂️ Disk treemap</p><pre id="idea3">Create a Fused Render project that shows a treemap of what's using space in a folder I choose.</pre><button class="copybtn" data-copy="idea3">Copy</button></div>
+    </div>
+
+    <h2>Next</h2>
+    <p class="sub">Render other file types through <a href="?page=templates">Templates</a>, pull in remote data with <a href="?page=mount">Mount</a>, then <a href="?page=deploy">Deploy</a> so others can open your app in a browser. Or see finished projects in the <a href="?page=showcase">Showcase</a>.</p>
+  </section>
+
+  <!-- ============================ USING FUSED RENDER (the app / UI guide) ============================ -->
+  <section class="page" data-slug="using" data-title="Using Fused Render">
+    <p class="crumb">The app</p>
+    <h1 class="title">Using Fused Render</h1>
+    <p class="lede">The Fused Render window is a file explorer for your project folders — click an HTML file and it renders live. Here's how to get around it.</p>
+
+    <h2>Bookmarks</h2>
     <p class="sub">Pin any page you're working on so it's one click away — the <b>+ Bookmark</b> button, top right. Bookmarks live in the left sidebar (and group into folders); each stores the file <em>and</em> its query params, so you return to the exact state.</p>
     <figure class="figure"><img data-shot="assets/shot_bookmarks.webp" alt="Bookmarks sidebar in the Fused Render shell">
       <figcaption><b>The shell sidebar</b> — bookmarks and folders on the left, the <b>+ Bookmark</b> button top right.</figcaption></figure>
 
-    <h3>Split view</h3>
+    <h2>Split view</h2>
     <p class="sub">Open two files side by side — a page and its Python, or two previews — and work across them without losing either. Each pane keeps its own URL and state.</p>
     <figure class="figure"><img data-shot="assets/shot_splitview.webp" alt="Two panes side by side in Fused Render">
       <figcaption><b>Split view</b> — two panes, each an independent preview.</figcaption></figure>
 
-    <h2><span class="n">3</span>Opening local files with templates</h2>
-    <p class="sub">Any file on your machine can render through a <b>template</b> — right-click it and pick <em>Open with FusedRender</em> (registered by the desktop app). See the <a href="?page=templates">Templates</a> section for how templates are chosen and customized.</p>
+    <h2>Opening files with templates</h2>
+    <p class="sub">Any file on your machine can render through a <b>template</b> — right-click it and pick <em>Open with FusedRender</em> (registered by the desktop app). See <a href="?page=templates">Templates</a> for how templates are chosen and customized.</p>
     <figure class="figure"><video data-shot="assets/open_with_right_click.mp4" autoplay muted loop playsinline style="width:100%;display:block"></video>
       <figcaption><b>Right-click → Open with FusedRender</b> — any file renders through its matching template.</figcaption></figure>
-
-    <h2><span class="n">4</span>Build your own</h2>
-    <p class="sub">A project is a folder with a page and a Python file. That's the entire setup.</p>
-    <div class="steps">
-      <div class="step"><div class="num">1</div><h4>Make a folder</h4><p>Anywhere Fused Render can see — <code>~/Documents/Fused/my_tool/</code> works.</p></div>
-      <div class="step"><div class="num">2</div><h4>Drop in two files</h4><p>An <code>index.html</code> for what you see, a <code>tool.py</code> for the work.</p></div>
-      <div class="step"><div class="num">3</div><h4>Click the HTML file</h4><p>It renders as a live page. Edit either file and the page reloads itself.</p></div>
-    </div>
-    <p class="sub">Or hand it to <b>Claude Code</b> — copy this prompt to scaffold a project:</p>
-    <div class="promptbox">
-      <button class="copybtn" data-copy="prompt1">Copy</button>
-      <pre id="prompt1">Create a new Fused Render project that shows my computer's CPU and memory usage as live gauges, refreshing every second.</pre>
-    </div>
-    <p class="sub">No need to mention HTML or Python — Claude knows the Fused Render layout. Swap in your own idea after <em>“…that”</em>: a treemap of my Downloads folder, a searchable table from a CSV I pick, a world-clock for three timezones.</p>
-
-    <h2><span class="n">5</span>See what's possible</h2>
-    <p class="sub">Ready for real examples? The <a href="?page=showcase">Showcase</a> has working projects — local tools and geospatial — you can clone into your workspace with one click.</p>
   </section>
 
   <!-- ============================ 2 · CLAUDE CODE ============================ -->
@@ -498,19 +631,54 @@
     <p class="lede">Mount a remote store — <b>S3-compatible buckets, Google Drive, anything rclone speaks</b> — and it shows up in the file tree like a local folder, ready to browse and open through a template.</p>
 
     <h2><span class="n">1</span>Mounting a remote</h2>
-    <p class="sub">Mounts are powered by <b>rclone</b>. Public and credentialed <b>S3</b> remotes can be added right in the app; OAuth backends like Google Drive need a one-time <code>rclone config</code> in a terminal. The <em>Add mount</em> form asks for just three things — a name, a remote, and a path.</p>
+    <p class="sub">Mounts are powered by <b>rclone</b>, so anything rclone speaks works. The <em>Add mount</em> form asks for just three things — a <b>name</b>, a <b>remote</b>, and a <b>path</b>. Public <b>S3</b> works with no setup; other backends (GCS, Google Drive) need a one-time <code>rclone config</code> in a terminal, after which they appear in the <b>Remote</b> dropdown. Below are the exact values to fill in for each.</p>
 
-    <h3>Worked example — mount an open dataset</h3>
-    <p class="sub">Fused Render ships a built-in <b>public-S3</b> remote (no credentials), so mounting open data is a copy-paste. Here we mount building footprints from <a href="https://source.coop" target="_blank" rel="noopener">source.coop</a>. Fill the form like this:</p>
-    <div class="mountform card">
-      <div class="mf-row"><label>Name</label><div class="mf-val">source_coop</div></div>
-      <div class="mf-row"><label>Remote</label><div class="mf-val mf-select">AWS S3 — public buckets (no credentials) <span class="mf-caret">▾</span></div></div>
-      <div class="mf-row"><label>Path</label>
-        <div class="mf-val mf-path"><span id="mountPath">us-west-2.opendata.source.coop/vida/google-microsoft-open-buildings/pmtiles/by_country/country_iso=AND</span>
-        <button class="copybtn mf-copy" data-copy="mountPath">Copy</button></div>
+    <div class="remote-eg">
+      <div class="re-head">🪣 Amazon S3 — public bucket <span class="re-tag inapp">In-app, no setup</span></div>
+      <p class="sub">Fused Render ships a built-in <b>public-S3</b> remote (no credentials), so open data is a copy-paste. Here we mount building footprints from <a href="https://source.coop" target="_blank" rel="noopener">source.coop</a>:</p>
+      <div class="mountform card">
+        <div class="mf-row"><label>Name</label><div class="mf-val">source_coop</div></div>
+        <div class="mf-row"><label>Remote</label><div class="mf-val mf-select">AWS S3 — public buckets (no credentials) <span class="mf-caret">▾</span></div></div>
+        <div class="mf-row"><label>Path</label>
+          <div class="mf-val mf-path"><span id="mountPath">us-west-2.opendata.source.coop/vida/google-microsoft-open-buildings/pmtiles/by_country/country_iso=AND</span>
+          <button class="copybtn mf-copy" data-copy="mountPath">Copy</button></div>
+        </div>
+        <div class="mf-note">Region <code>us-west-2</code> is set by that remote already. For a <b>private</b> bucket, pick the credentialed S3 remote instead and it'll ask for your access keys.</div>
       </div>
-      <div class="mf-note">Region <code>us-west-2</code> is already set by that remote — nothing else to configure.</div>
     </div>
+
+    <div class="remote-eg">
+      <div class="re-head">☁️ Google Cloud Storage <span class="re-tag cli">rclone config first</span></div>
+      <p class="sub">GCS needs a one-time remote. In a terminal run <code>rclone config</code>, add a remote of type <code>google cloud storage</code>, and name it <code>gcs</code> (for public buckets, answer <em>yes</em> to anonymous access; otherwise point it at a service-account key):</p>
+      <div class="promptbox"><button class="copybtn" data-copy="gcsCfg">Copy</button><pre id="gcsCfg">rclone config          # n) New remote → name: gcs → storage: google cloud storage</pre></div>
+      <p class="sub">Then in the <em>Add mount</em> form, the <code>gcs</code> remote is now in the dropdown:</p>
+      <div class="mountform card">
+        <div class="mf-row"><label>Name</label><div class="mf-val">gcs_landsat</div></div>
+        <div class="mf-row"><label>Remote</label><div class="mf-val mf-select">gcs <span class="mf-caret">▾</span></div></div>
+        <div class="mf-row"><label>Path</label>
+          <div class="mf-val mf-path"><span id="gcsPath">gcp-public-data-landsat/LC08/01/044/034</span>
+          <button class="copybtn mf-copy" data-copy="gcsPath">Copy</button></div>
+        </div>
+        <div class="mf-note">Path is <code>bucket/prefix</code>. <code>gcp-public-data-landsat</code> is an open Google bucket — no credentials needed with anonymous access.</div>
+      </div>
+    </div>
+
+    <div class="remote-eg">
+      <div class="re-head">📁 Google Drive <span class="re-tag cli">rclone config first</span></div>
+      <p class="sub">Google Drive is an OAuth backend, so the browser sign-in happens during <code>rclone config</code>. Add a remote of type <code>drive</code>, name it <code>gdrive</code>, and complete the sign-in it opens:</p>
+      <div class="promptbox"><button class="copybtn" data-copy="gdriveCfg">Copy</button><pre id="gdriveCfg">rclone config          # n) New remote → name: gdrive → storage: drive → sign in when the browser opens</pre></div>
+      <p class="sub">Then mount a folder from your Drive by name (leave the path blank for the whole Drive):</p>
+      <div class="mountform card">
+        <div class="mf-row"><label>Name</label><div class="mf-val">my_drive</div></div>
+        <div class="mf-row"><label>Remote</label><div class="mf-val mf-select">gdrive <span class="mf-caret">▾</span></div></div>
+        <div class="mf-row"><label>Path</label>
+          <div class="mf-val mf-path"><span id="gdrivePath">Reports/2026</span>
+          <button class="copybtn mf-copy" data-copy="gdrivePath">Copy</button></div>
+        </div>
+        <div class="mf-note">Path is a folder inside your Drive (e.g. <code>Reports/2026</code>), or empty for the root.</div>
+      </div>
+    </div>
+
     <figure class="figure"><img data-shot="assets/shot_mount.webp" alt="The Fused Render Mounts page with the Add mount form and existing mounts">
       <figcaption><b>The Mounts page</b> — the <em>Add mount</em> form (name · remote · path) plus mounts already connected, like open datasets on source.coop and CMIP6.</figcaption></figure>
 
@@ -536,9 +704,12 @@
 
     <h2><span class="n">1</span>Requirements</h2>
     <ul>
+      <li><b>Turn Deploy on</b> — it's off by default while in beta. Open <b>Preferences</b> and enable the Deploy button; it then appears on every page.</li>
       <li>A <b>Fused account</b> — sign up at <a href="https://www.fused.io" target="_blank" rel="noopener">fused.io</a> and sign in with the <code>fused</code> CLI.</li>
       <li>Your project should already run locally the way you want it.</li>
     </ul>
+    <div class="callout beta"><span class="lab">Enable it first</span>
+      <p style="margin:6px 0 0">Don't see a <b>Deploy</b> button on your pages? It's hidden until you switch it on in <b>Preferences</b> — that's expected during the beta.</p></div>
 
     <h2><span class="n">2</span>Deploying</h2>
     <p class="sub">Hit <b>Deploy</b> on any page. Pick which files ship (the page, its Python, and any bundled data), choose a managed Fused environment, and you get a shareable <code>open.fused.io</code> URL — redeploying keeps the same link.</p>
@@ -632,18 +803,26 @@ function imgSrc(rel){
   return rel;
 }
 function assetUrl(name){ return imgSrc("assets/" + name + ".jpg"); }
-function renderCards(el, list, prefix){
-  el.innerHTML = list.map(p => {
-    const tags = p.tags.map(t => '<span class="t">'+t+'</span>').join("") + (p.key ? '<span class="t key">needs API key (free)</span>' : "");
-    return '<a class="scard'+(p.feat?' feat':'')+'" href="fused-render://open?git='+REPO+prefix+p.n+'">'+
-      '<div class="media"><span class="mono-fb">'+monogram(p.n)+'</span>'+
-      '<img loading="lazy" alt="" src="'+assetUrl(p.n)+'" onerror="this.remove()"></div>'+
-      '<div class="cbody"><h4>'+p.t+' <span class="cn">'+p.n+'</span></h4><p>'+p.d+'</p>'+
-      '<div class="tags">'+tags+'</div></div></a>';
-  }).join("");
+function cardHtml(p, prefix){
+  const tags = p.tags.map(t => '<span class="t">'+t+'</span>').join("") + (p.key ? '<span class="t key">needs API key (free)</span>' : "");
+  return '<a class="scard'+(p.feat?' feat':'')+'" href="fused-render://open?git='+REPO+prefix+p.n+'">'+
+    '<div class="media"><span class="mono-fb">'+monogram(p.n)+'</span>'+
+    '<img loading="lazy" alt="" src="'+assetUrl(p.n)+'" onerror="this.remove()"></div>'+
+    '<div class="cbody"><h4>'+p.t+' <span class="cn">'+p.n+'</span></h4><p>'+p.d+'</p>'+
+    '<div class="tags">'+tags+'</div></div></a>';
 }
+function renderCards(el, list, prefix){ if (el) el.innerHTML = list.map(p => cardHtml(p, prefix)).join(""); }
 renderCards($("#localCards"), LOCAL, "local-tools/");
 renderCards($("#geoCards"), GEO, "geospatial/");
+
+// Home page shows a curated, mixed row (local + geo). Strip `feat` so they render
+// as equal-width cards in the 3-column grid.
+const HOME_PICKS = [["visual_claude","local-tools/"],["hexagon_lab","geospatial/"],["pytop","local-tools/"]];
+const findCard = n => LOCAL.concat(GEO).find(x => x.n === n);
+const homeShow = $("#homeShowcase");
+if (homeShow) homeShow.innerHTML = HOME_PICKS.map(([n, pfx]) => {
+  const p = findCard(n); return p ? cardHtml(Object.assign({}, p, { feat:false }), pfx) : "";
+}).join("");
 
 /* ---------------- assign stable ids to headings (for deep links + search) ---------------- */
 const slugify = s => s.toLowerCase().replace(/[^a-z0-9]+/g,"-").replace(/^-|-$/g,"");
@@ -841,8 +1020,16 @@ function mountFrame(frameSel, ifSel, absPath, useShell){
 // The demo lives in this folder, so the embed works wherever the Learn page is
 // opened (no dependency on a sibling example).
 const demoPath = ownDir ? ownDir + "/pi.html" : null;
+const demoPy   = ownDir ? ownDir + "/pi.py"   : null;
 mountFrame("#demoFrame", "#demoIf", demoPath, false);
-if (hasFused && demoPath) $("#demoOpen").href = viewUrl(demoPath);
+// "Show code": open the page and its Python side by side in a split view so you
+// can see exactly what's driving the demo. The `_layout` codec keeps slashes
+// literal and only escapes % , ; ( ) ? per segment (see frontend layout-codec.ts),
+// so we escape exactly those — NOT a generic per-segment encodeURIComponent.
+const paneSeg = p => p.replace(/%/g,"%25").replace(/,/g,"%2C").replace(/;/g,"%3B")
+  .replace(/\(/g,"%28").replace(/\)/g,"%29").replace(/\?/g,"%3F");
+const splitUrl = (a, b) => "/view/_panel?_layout=(" + paneSeg(a) + "," + paneSeg(b) + ")";
+if (hasFused && demoPath) $("#demoOpen").href = splitUrl(demoPath, demoPy);
 else $("#demoOpen").style.display = "none";
 
 /* hello.py round trip */

--- a/learn/index.html
+++ b/learn/index.html
@@ -897,6 +897,7 @@ function render(slug, hash){
   buildPager(p);
   if (p.slug === "claude") checkClaude();
   if (p.slug === "templates") loadTemplates();
+  if (p.slug === "build") maybeHello();
   // scroll: to heading if hash, else top of content
   if (hash) {
     const t = document.getElementById(hash);
@@ -1056,6 +1057,11 @@ async function hello(){
 }
 $("#helloBtn").addEventListener("click", hello);
 $("#nameInput").addEventListener("keydown", e => { if (e.key === "Enter") hello(); });
+// The hello demo lives on the Build page (not the default Home), so pre-populate
+// it lazily the first time Build is opened — never on initial Learn load, so we
+// don't fire a hidden runPython round-trip for users who stay on Home.
+let helloPrimed = false;
+function maybeHello(){ if (helloPrimed) return; helloPrimed = true; hello(); }
 
 /* live templates list (runs once, when the Templates page opens) */
 let tplLoaded = false, coreTpls = [], customTpls = [];
@@ -1173,7 +1179,7 @@ if (hasFused && fused.params){
 (function boot(){
   const slug = currentParams().get("page") || PAGES[0].slug;
   render(slug, location.hash ? location.hash.slice(1) : null);
-  hello();
+  // hello() is primed lazily via maybeHello() when the Build page opens — see render().
 })();
 </script>
 </body>

--- a/learn/index.html
+++ b/learn/index.html
@@ -430,14 +430,14 @@
     </div>
     <p class="sub">Swap in your own idea after <em>“…that”</em>: <em>a treemap of my Downloads folder</em>, <em>a searchable table from a CSV I pick</em>, <em>a world clock for three time zones</em>. No need to mention HTML or Python — Claude fills that in.</p>
 
-    <div class="callout"><span class="lab">First time · one-time setup</span>
-      <p style="margin:6px 0 0">For that prompt to work, Claude Code needs the <b>Fused Render skills</b> installed — they teach it the project layout and the <code>fused</code> bridge. Install them once:</p>
+    <div class="callout beta"><span class="lab">Coming soon · Fused Render skills</span>
+      <p style="margin:6px 0 0">A one-line install that teaches Claude Code the Fused Render layout and the <code>fused</code> bridge is on the way. It'll look like this:</p>
       <div class="promptbox" style="margin-top:11px">
         <button class="copybtn" data-copy="skillInstall">Copy</button>
         <pre id="skillInstall">claude plugin marketplace add fusedio/fused-render
 claude plugin install fused-render@fused-render</pre>
       </div>
-      <p style="margin:9px 0 0;font-size:12px;color:var(--mut)">Then start a new Claude Code session so it picks up the skills. (Don't have Claude Code? <a href="https://claude.com/claude-code" target="_blank" rel="noopener">Get it here ↗</a>.)</p>
+      <p style="margin:9px 0 0;font-size:12px;color:var(--mut)">Until it lands, Claude still does well when it can see an existing project — open one from the <a href="?page=showcase">Showcase</a> and ask it to build something similar. (Don't have Claude Code? <a href="https://claude.com/claude-code" target="_blank" rel="noopener">Get it here ↗</a>.)</p>
     </div>
 
     <h2>The mental model</h2>

--- a/learn/index.html
+++ b/learn/index.html
@@ -534,12 +534,6 @@ claude plugin install fused-render@fused-render</pre>
 
     <h3>State lives in the URL</h3>
     <p class="sub">Controls don't keep private state — they write to the page's URL through <code>fused.params</code>. Drag the slider and watch the address bar: the <b class="y">?level=</b> value updates live. Refresh, bookmark, or share that link and the page comes back exactly as you left it.</p>
-    <div class="urldemo">
-      <div class="ub-bar">
-        <div class="dots"><i style="background:#ff5f56"></i><i style="background:#ffbd2e"></i><i style="background:#27c93f"></i></div>
-        <div class="ub-url"><span class="ub-dim">127.0.0.1:1777/view/~/Fused/my_tool/index.html</span><span class="ub-q" id="ubQ">?level=<b id="urlVal">40</b></span></div>
-      </div>
-    </div>
     <div class="grid2">
       <div class="card ctrl">
         <label>Level <b id="vLevel">40</b></label>
@@ -548,6 +542,13 @@ claude plugin install fused-render@fused-render</pre>
       </div>
       <div class="card">
         <p style="margin:0;font-size:12.5px">The slider writes <code>fused.params.set("level", …)</code>, which appends <code>?level=</code> to the URL. Nothing is stored in hidden JS state — the URL <em>is</em> the state, so it survives a refresh and travels in a shared link.</p>
+      </div>
+    </div>
+    <p class="sub" style="margin:4px 0 8px;font-size:12px;color:var(--mut)">The page's address bar tracks it live:</p>
+    <div class="urldemo">
+      <div class="ub-bar">
+        <div class="dots"><i style="background:#ff5f56"></i><i style="background:#ffbd2e"></i><i style="background:#27c93f"></i></div>
+        <div class="ub-url"><span class="ub-dim">127.0.0.1:1777/view/…/my_tool/index.html</span><span class="ub-q" id="ubQ">?level=<b id="urlVal">40</b></span></div>
       </div>
     </div>
 
@@ -720,7 +721,7 @@ claude plugin install fused-render@fused-render</pre>
     <div class="remote-eg">
       <div class="re-head">☁️ Google Cloud Storage <span class="re-tag cli">rclone config first</span></div>
       <p class="sub">GCS needs a one-time remote. In a terminal run <code>rclone config</code>, add a remote of type <code>google cloud storage</code>, and name it <code>gcs</code> (for public buckets, answer <em>yes</em> to anonymous access; otherwise point it at a service-account key):</p>
-      <div class="promptbox"><button class="copybtn" data-copy="gcsCfg">Copy</button><pre id="gcsCfg">rclone config          # n) New remote → name: gcs → storage: google cloud storage</pre></div>
+      <div class="promptbox"><button class="copybtn" data-copy="gcsCfg">Copy</button><pre id="gcsCfg">rclone config          # New remote → name: gcs → storage: google cloud storage</pre></div>
       <p class="sub">Then in the <em>Add mount</em> form, the <code>gcs</code> remote is now in the dropdown:</p>
       <div class="mountform card">
         <div class="mf-row"><label>Name</label><div class="mf-val">gcs_landsat</div></div>
@@ -736,7 +737,7 @@ claude plugin install fused-render@fused-render</pre>
     <div class="remote-eg">
       <div class="re-head">📁 Google Drive <span class="re-tag cli">rclone config first</span></div>
       <p class="sub">Google Drive is an OAuth backend, so the browser sign-in happens during <code>rclone config</code>. Add a remote of type <code>drive</code>, name it <code>gdrive</code>, and complete the sign-in it opens:</p>
-      <div class="promptbox"><button class="copybtn" data-copy="gdriveCfg">Copy</button><pre id="gdriveCfg">rclone config          # n) New remote → name: gdrive → storage: drive → sign in when the browser opens</pre></div>
+      <div class="promptbox"><button class="copybtn" data-copy="gdriveCfg">Copy</button><pre id="gdriveCfg">rclone config          # New remote → name: gdrive → storage: drive → sign in when the browser opens</pre></div>
       <p class="sub">Then mount a folder from your Drive by name (leave the path blank for the whole Drive):</p>
       <div class="mountform card">
         <div class="mf-row"><label>Name</label><div class="mf-val">my_drive</div></div>
@@ -1099,7 +1100,12 @@ mountFrame("#demoFrame", "#demoIf", demoPath, false);
 // so we escape exactly those — NOT a generic per-segment encodeURIComponent.
 const paneSeg = p => p.replace(/%/g,"%25").replace(/,/g,"%2C").replace(/;/g,"%3B")
   .replace(/\(/g,"%28").replace(/\)/g,"%29").replace(/\?/g,"%3F");
-const splitUrl = (a, b) => "/view/_panel?_layout=(" + paneSeg(a) + "," + paneSeg(b) + ")";
+// After per-segment escaping, the app runs a urlSafeLayout pass over the whole
+// codec string (%, #, space) before wrapping in _layout=(…); one decodeURIComponent
+// on read reverses it. Replicate it so a path with a space or # still yields a
+// valid URL (frontend layout-codec.ts).
+const urlSafeLayout = s => s.replace(/%/g,"%25").replace(/#/g,"%23").replace(/ /g,"%20");
+const splitUrl = (a, b) => "/view/_panel?_layout=(" + urlSafeLayout(paneSeg(a) + "," + paneSeg(b)) + ")";
 if (hasFused && demoPath) $("#demoOpen").href = splitUrl(demoPath, demoPy);
 else $("#demoOpen").style.display = "none";
 


### PR DESCRIPTION
Implements the standup feedback (Circleback 2026-07-21) on the Fused Render Learn docs — the five items assigned to @max.

## What changed
- **New Home page** (now the default route) — a value/marketing "command center": hero + a **dual CTA that splits the two modes** (build an app vs. open data with templates), the live π demo as proof, mode cards, a nav grid, and a curated "what people build" row. The how-to now lives *behind* the value page.
- **New "Building with Fused Render" page** (leads right after Home): the Claude scaffold prompt up top, a one-time **"install the Fused Render skills"** prerequisite, the mental model, a `fused.*` API cheat-sheet, and starter ideas. Absorbs the old cramped build section; **Using Fused Render** is now a clean UI/shell guide.
- **"Show code"** — the demo's "open in app" link now opens the page + its Python in a split view.
- **Deploy** — notes that Deploy must be toggled on in Preferences (off by default in beta).
- **Mount** — per-remote worked examples for **S3, GCS, and Google Drive**.

Nav order is app-building-first; section numbers dropped so any section can be hidden without gaps.

## Notes for review
- The skill-install command (`claude plugin marketplace add fusedio/fused-render`) works once this repo goes public — matching the standup decision to add the instruction now and flip the repo on ship.
- Verified headlessly (Home, Build, Using, Mount, Deploy all render; split-view "Show code" confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static documentation and client-side Learn page changes only; no runtime product code paths affected beyond in-app doc URLs and demos.
> 
> **Overview**
> Reframes **Fused Render Learn** so visitors hit **value first**, then how-to. The old monolithic **Using** page is split into a marketing **Home** (default route), a **Building with Fused Render** guide, and a slimmer **Using** shell/UI section.
> 
> **Home** adds a hero with dual CTAs (build vs. templates), the live π embed, mode cards, a nav tile grid, and a curated showcase row (`#homeShowcase`). **Build** centralizes the Claude scaffold prompt (hero copy block), coming-soon skills install, mental-model file tree, `fused.*` API table, starter idea cards, and the interactive hello/URL-state demos (with a faux address bar that flashes on slider changes).
> 
> **Using** keeps only bookmarks, split view, and “open with template” — build/mount/deploy content moves elsewhere. **Mount** gains copy-paste **S3, GCS, and Google Drive** mount examples with in-app vs. `rclone config` tags. **Deploy** documents enabling Deploy in **Preferences** (off by default in beta).
> 
> JS behavior: π demo **“Show code”** opens `pi.html` + `pi.py` via `_layout` split-view URLs (layout codec–aware escaping); `hello()` runs on first visit to **Build** only; showcase cards refactored through shared `cardHtml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcedcec5997a17586fbc552d120de5916271acac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->