### PR TITLE
Ignore local build artifacts (.agents, Rust supervisor target, *.obj)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ fused_render/_baked_branch.py
 .coverage.*
 coverage.xml
 htmlcov/
+# Local agent skills dir (per-checkout tooling, not part of the repo).
+.agents/
+# Legacy Rust supervisor build cache, superseded by the Python supervisor.
+windows/supervisor/target/
+# C launcher build byproduct (scripts/build_windows_installer.ps1).
+*.obj


### PR DESCRIPTION
Stops three local, non-repo artifacts from cluttering `git status`:

- `.agents/` — per-checkout agent skills dir, not part of the repo.
- `windows/supervisor/target/` — leftover Cargo build cache from the legacy Rust supervisor (superseded by the Python supervisor on `main`).
- `*.obj` — the C launcher build byproduct from `scripts/build_windows_installer.ps1`.

Ignore-only; nothing tracked is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only ignore rules with no runtime or tracked-file impact.
> 
> **Overview**
> Extends **`.gitignore`** so three local-only artifacts stop showing up in `git status`.
> 
> **`.agents/`** is documented as per-checkout agent tooling, not repo content. **`windows/supervisor/target/`** covers leftover Cargo output from the old Rust supervisor (replaced by the Python supervisor on `main`). **`*.obj`** ignores MSVC object files from the C launcher build in `scripts/build_windows_installer.ps1`.
> 
> Ignore-only change; nothing already tracked is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7cc3e1038fefca5f8c7fc8b980aced5ee1ea8d56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->