### PR TITLE
fix(seed): normalize drive-letter backslashes in Sine demo panel bookmark URL

### DIFF
--- a/fused_render/shell/seed.py
+++ b/fused_render/shell/seed.py
@@ -20,7 +20,7 @@ import shutil
 import time
 import uuid
 
-from fused_render._view_url_codec import view_url_path
+from fused_render._view_url_codec import _is_drive_path, view_url_path
 from fused_render.shell import storage
 
 # Seed examples live at the repo root (examples_seed/) and are force-included
@@ -114,8 +114,9 @@ def _sine_panel_url(abs_path: str) -> str:
     where L = the page in default render mode and R = the same page with
     `_mode=code`. `,` is the row (side-by-side) separator; the whole layout is
     parenthesized and emitted last, per the D51 grammar in buildSentinelUrl()."""
-    left = _encode_pane_segment(abs_path, "")
-    right = _encode_pane_segment(abs_path, "?_mode=code")
+    norm = abs_path.replace("\\", "/") if _is_drive_path(abs_path) else abs_path
+    left = _encode_pane_segment(norm, "")
+    right = _encode_pane_segment(norm, "?_mode=code")
     codec = left + "," + right
     return "/view/_panel?_layout=(" + _url_safe_layout(codec) + ")"
 

--- a/tests/test_shell_seed.py
+++ b/tests/test_shell_seed.py
@@ -95,7 +95,7 @@ def test_bookmarks_created_when_absent_with_view_urls(tmp_path, monkeypatch):
     assert marks[1]["url"] == "/view" + _encoded(
         str(fdir / "showcase" / "index.html")
     )
-    sine = str(fdir / "sine" / "sine.html")
+    sine = (fdir / "sine" / "sine.html").as_posix()
     assert marks[2]["url"] == f"/view/_panel?_layout=({sine},{sine}?_mode=code)"
     assert marks[3]["url"] == "/view" + _encoded(
         str(fdir / "how_it_works" / "explainer.html")


### PR DESCRIPTION
## Problem

Clicking the **Sine demo** starter bookmark on Windows failed with `Failed to stat /C:\Users\...\sine.html: no such file or directory`.

The seeded bookmark URL held Windows backslashes:
```
/view/_panel?_layout=(C:\Users\...\sine.html, ...)
```
The frontend's `rootedFsPath` only recognizes a drive root as `C:/` (forward slash). A `C:\` leaf is treated as a POSIX path and gets a stray leading `/` prepended → `/C:\Users\...`, which fails to stat.

Windows-only; macOS/Linux are unaffected (POSIX paths already use forward slashes, so the normalization is a no-op there).

## Cause

Pre-existing bug in `_sine_panel_url` ([seed.py](../blob/main/fused_render/shell/seed.py)) since PR #76 — it fed the raw absolute path into the layout codec without normalizing backslashes. PR #222 fixed the sibling single-view bookmarks (Tutorial/Showcase/How-it-works) by routing them through `view_url_path` + `_is_drive_path`, but the one-off panel URL builder was missed.

## Fix

`_sine_panel_url` now normalizes drive-letter backslashes to `/` before encoding, mirroring `view_url_path`. New installs get a correct Sine bookmark:
```
/view/_panel?_layout=(C:/Users/.../sine.html,C:/Users/.../sine.html?_mode=code)
```

`test_shell_seed.py` updated (it had baked in the broken backslash form via `str(fdir/...)`; now uses `.as_posix()`). All seed/codec tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Windows-specific seed URL fix mirroring existing `view_url_path` behavior; no auth, data, or API surface changes.
> 
> **Overview**
> On Windows, the **Sine demo** starter bookmark could embed raw `C:\...` paths in the `_panel?_layout=(...)` URL. The frontend expects drive roots as `C:/`, so those bookmarks failed to stat. Other seeded bookmarks were already fixed via `view_url_path`; this aligns **`_sine_panel_url`** with the same **`_is_drive_path`** backslash-to-slash normalization before pane encoding.
> 
> The seed bookmark test now expects forward-slash paths for the Sine panel layout (`.as_posix()`), matching what new installs produce on Windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d328e3192f4eed07c05c491472feb28179589592. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->