### PR TITLE
fix(windows): embed launcher icon, drop supervisor suffix from app name

### DIFF
--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -67,10 +67,16 @@ function Resolve-VcVars() {
 
 function Build-Launcher([string]$OutputExe) {
     $source = Join-Path $RepoRoot "windows\launcher\launcher.c"
+    # The .rc embeds fused-render.ico so Explorer, the taskbar, and the "Open
+    # with" picker all show the app icon (the picker ignores DefaultIcon and
+    # reads the exe's own icon). rc.exe finds the .ico via the /i include path.
+    $rc = Join-Path $RepoRoot "windows\launcher\launcher.rc"
+    $iconDir = Join-Path $RepoRoot "fused_render\assets"
+    $res = Join-Path $BuildDir "launcher.res"
     $vcvars = Resolve-VcVars
     if ($vcvars) {
         Write-Host "Building launcher with cl.exe ($vcvars)"
-        $cmd = "call `"$vcvars`" >nul 2>&1 && cl.exe /nologo /W3 /O2 /DUNICODE /D_UNICODE `"$source`" /Fe:`"$OutputExe`" /link /SUBSYSTEM:WINDOWS user32.lib"
+        $cmd = "call `"$vcvars`" >nul 2>&1 && rc.exe /nologo /i `"$iconDir`" /fo `"$res`" `"$rc`" && cl.exe /nologo /W3 /O2 /DUNICODE /D_UNICODE `"$source`" `"$res`" /Fe:`"$OutputExe`" /link /SUBSYSTEM:WINDOWS user32.lib"
         cmd.exe /c $cmd
         if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $OutputExe)) {
             throw "cl.exe failed to build the launcher"
@@ -89,7 +95,8 @@ function Build-Launcher([string]$OutputExe) {
         Invoke-WebRequest -Uri "https://ziglang.org/download/$zigVersion/zig-windows-x86_64-$zigVersion.zip" -OutFile $archive
         Expand-Archive -Path $archive -DestinationPath $zigDir -Force
     }
-    Invoke-Native $zigExe @("cc", "-municode", "-mwindows", "-O2", "-DUNICODE", "-D_UNICODE", $source, "-o", $OutputExe, "-luser32")
+    Invoke-Native $zigExe @("rc", "/i", $iconDir, "/fo", $res, $rc)
+    Invoke-Native $zigExe @("cc", "-municode", "-mwindows", "-O2", "-DUNICODE", "-D_UNICODE", $source, $res, "-o", $OutputExe, "-luser32")
 }
 
 $Uv = Resolve-Tool "uv" @()
@@ -102,7 +109,7 @@ $Branch = (& git -C $RepoRoot branch --show-current).Trim()
 if ($LASTEXITCODE -ne 0) {
     throw "could not resolve the Git branch"
 }
-Write-Host "Building FusedRender (Python Supervisor) $Version from $Branch"
+Write-Host "Building FusedRender $Version from $Branch"
 
 New-Item -ItemType Directory -Force -Path $BuildDir, $DistDir | Out-Null
 Get-ChildItem -Path $DistDir -Filter "fused_render-*.whl" -ErrorAction SilentlyContinue |

--- a/scripts/windows/generate_installer_registry.py
+++ b/scripts/windows/generate_installer_registry.py
@@ -15,10 +15,10 @@ def main() -> None:
     output = Path(sys.argv[1])
     command = f'""{{app}}\\payload\\{_EXE_NAME}"" ""%1""'
     lines = [
-        f'Root: HKCU; Subkey: "Software\\Classes\\Applications\\{_EXE_NAME}"; ValueType: string; ValueName: "FriendlyAppName"; ValueData: "FusedRender (Python Supervisor)"; Flags: uninsdeletekey',
+        f'Root: HKCU; Subkey: "Software\\Classes\\Applications\\{_EXE_NAME}"; ValueType: string; ValueName: "FriendlyAppName"; ValueData: "FusedRender"; Flags: uninsdeletekey',
         f'Root: HKCU; Subkey: "Software\\Classes\\Applications\\{_EXE_NAME}\\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: "{{app}}\\payload\\assets\\icons\\fused-render.ico,0"; Flags: uninsdeletevalue uninsdeletekeyifempty',
         f'Root: HKCU; Subkey: "Software\\Classes\\Applications\\{_EXE_NAME}\\shell\\open\\command"; ValueType: string; ValueName: ""; ValueData: "{command}"; Flags: uninsdeletevalue uninsdeletekeyifempty',
-        f'Root: HKCU; Subkey: "Software\\Classes\\*\\shell\\{_CONTEXT_MENU_KEY}"; ValueType: string; ValueName: ""; ValueData: "Open with FusedRender (Python Supervisor)"; Flags: uninsdeletekey',
+        f'Root: HKCU; Subkey: "Software\\Classes\\*\\shell\\{_CONTEXT_MENU_KEY}"; ValueType: string; ValueName: ""; ValueData: "Open with FusedRender"; Flags: uninsdeletekey',
         f'Root: HKCU; Subkey: "Software\\Classes\\*\\shell\\{_CONTEXT_MENU_KEY}"; ValueType: string; ValueName: "Icon"; ValueData: "{{app}}\\payload\\assets\\icons\\fused-render.ico"; Flags: uninsdeletevalue uninsdeletekeyifempty',
         f'Root: HKCU; Subkey: "Software\\Classes\\*\\shell\\{_CONTEXT_MENU_KEY}\\command"; ValueType: string; ValueName: ""; ValueData: "{command}"; Flags: uninsdeletevalue uninsdeletekeyifempty',
     ]

--- a/scripts/windows/installer.iss
+++ b/scripts/windows/installer.iss
@@ -64,6 +64,12 @@ Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\cache"
 Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\runtime"
 Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\temp"
 Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\logs"
+; the [Icons] entries below were renamed from "FusedRender (Python Supervisor)"
+; — Inno's uninstall log only tracks additions per run, so upgrading over an
+; older install would otherwise leave these old .lnk files orphaned in the
+; Start Menu.
+Type: files; Name: "{group}\FusedRender (Python Supervisor).lnk"
+Type: files; Name: "{group}\Uninstall FusedRender (Python Supervisor).lnk"
 
 [Icons]
 Name: "{group}\FusedRender"; Filename: "{app}\payload\{#ExeName}"; IconFilename: "{#InstalledIcon}"; AppUserModelID: "{#AppUserModelId}"

--- a/scripts/windows/installer.iss
+++ b/scripts/windows/installer.iss
@@ -27,7 +27,7 @@
 
 [Setup]
 AppId={{9F1D3C2A-6B4E-4A8F-9C3D-2E7B5A1F8D6C}
-AppName=FusedRender (Python Supervisor)
+AppName=FusedRender
 AppVersion={#AppVersion}
 AppPublisher=Fused
 AppPublisherURL=https://fused.io
@@ -66,14 +66,14 @@ Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\temp"
 Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\logs"
 
 [Icons]
-Name: "{group}\FusedRender (Python Supervisor)"; Filename: "{app}\payload\{#ExeName}"; IconFilename: "{#InstalledIcon}"; AppUserModelID: "{#AppUserModelId}"
-Name: "{group}\Uninstall FusedRender (Python Supervisor)"; Filename: "{uninstallexe}"
+Name: "{group}\FusedRender"; Filename: "{app}\payload\{#ExeName}"; IconFilename: "{#InstalledIcon}"; AppUserModelID: "{#AppUserModelId}"
+Name: "{group}\Uninstall FusedRender"; Filename: "{uninstallexe}"
 
 [Registry]
 #include BundleDir + "\registry.iss"
 
 [Run]
-Filename: "{app}\payload\{#ExeName}"; Description: "Launch FusedRender (Python Supervisor)"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\payload\{#ExeName}"; Description: "Launch FusedRender"; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"
@@ -134,7 +134,7 @@ begin
   if RegQueryStringValue(HKCU, '{#UninstallKey}', 'DisplayVersion', InstalledVersion) and
     (CompareVersions('{#AppVersion}', InstalledVersion) < 0) then
   begin
-    MsgBox('A newer FusedRender (Python Supervisor) version is already installed.', mbError, MB_OK);
+    MsgBox('A newer FusedRender version is already installed.', mbError, MB_OK);
     Result := False;
   end;
 end;

--- a/windows/launcher/launcher.rc
+++ b/windows/launcher/launcher.rc
@@ -1,0 +1,7 @@
+#include <windows.h>
+
+/* The Win11 "Open with" picker reads an .exe's own embedded icon, not the
+ * Applications\<exe>\DefaultIcon registry value, so the app icon has to live
+ * in the exe too. rc.exe finds fused-render.ico via the /i path passed by
+ * scripts/build_windows_installer.ps1. */
+1 ICON "fused-render.ico"


### PR DESCRIPTION
## Summary
- Embeds `fused-render.ico` into `FusedRenderPy.exe` via a new `windows/launcher/launcher.rc` resource script, since Explorer's taskbar and the Win11 "Open with" picker read an exe's own embedded icon rather than the `DefaultIcon` registry value.
- Wires `rc.exe` into the launcher build step in `scripts/build_windows_installer.ps1` (both the cl.exe and zig-cc fallback paths).
- Drops "(Python Supervisor)" from all user-visible app name strings (Open With display name, context menu label, Start-menu shortcuts, install messages), leaving just "FusedRender". Internal identifiers (`FusedRenderPy.exe`, ProgID prefix, AppId GUID) are left untouched since they're intentionally distinct from the shipping product and not user-visible.

## Test plan
- [x] Test-compiled the launcher with the embedded icon and confirmed via `Icon.ExtractAssociatedIcon` that it resolves to a 32x32 icon.
- [x] Ran `scripts/build_windows_installer.ps1` end-to-end; it produced `dist/FusedRenderPy-0.3.7-setup.exe` and the staged launcher exe has the icon embedded.
- [x] Ran the registry generator standalone and confirmed `FriendlyAppName` / context-menu label now read `FusedRender`.
- [ ] Install the built setup.exe and confirm the "Open with" dialog shows the FusedRender icon and name (not run here — installing is a step for the user to confirm on their machine).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging and display-string changes only; no runtime supervisor or auth logic touched, with a small upgrade-time shortcut cleanup step.
> 
> **Overview**
> **Windows launcher and installer branding** now match how Explorer and Win11 show apps: the stub exe carries the real icon, and user-facing strings no longer say "(Python Supervisor)".
> 
> Adds `windows/launcher/launcher.rc` to embed `fused-render.ico`, and updates `Build-Launcher` in `scripts/build_windows_installer.ps1` to compile resources with `rc.exe` (MSVC) or `zig rc` before linking—so taskbar and **Open with** pick up the icon instead of relying only on `DefaultIcon` registry.
> 
> User-visible names are shortened to **FusedRender** in generated registry entries (`FriendlyAppName`, context menu), Inno Setup (`AppName`, shortcuts, post-install launch, downgrade guard), and the build log. `installer.iss` also **deletes** the old Start Menu `.lnk` names on upgrade so renamed shortcuts do not leave orphans.
> 
> Internal ids (`FusedRenderPy.exe`, ProgIDs, AppId) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92cd515334ce9942eaff8e17a888bb77f9447d4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->