### PR TITLE
Learn: first-visit onboarding chooser on Home

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -291,6 +291,25 @@
   .modecard p { margin:0 0 12px; font-size:13px; color:var(--dim); }
   .modecard .mc-go { margin-top:auto; font-size:12.5px; color:var(--yellow); font-weight:600; }
 
+  /* first-visit onboarding chooser */
+  .chooser { border:1px solid #4a4a2a; background:linear-gradient(180deg,#1e1e17,#1a1a1a);
+       border-radius:14px; padding:17px 19px 15px; margin:22px 0 6px; animation:chFade .45s ease both; }
+  .chooser .ch-q { font-size:14px; font-weight:600; color:var(--text); margin:0 0 12px;
+       display:flex; align-items:center; gap:8px; }
+  .chooser .ch-q .spark { color:var(--yellow); }
+  .ch-opts { display:grid; grid-template-columns:repeat(3,1fr); gap:11px; }
+  .ch-opt { display:flex; flex-direction:column; gap:3px; text-decoration:none; color:var(--text);
+       background:var(--panel); border:1px solid var(--border); border-radius:11px; padding:14px 15px;
+       transition:border-color .12s, transform .12s; }
+  .ch-opt:hover { border-color:var(--yellow); transform:translateY(-1px); }
+  .ch-opt .ch-ic { font-size:22px; }
+  .ch-opt b { font-size:13.5px; }
+  .ch-opt .ch-sub { font-size:11.5px; color:var(--mut); line-height:1.35; }
+  .ch-skip { appearance:none; background:none; border:0; color:var(--mut); font:inherit; font-size:12px;
+       cursor:pointer; margin:11px 0 0; padding:2px 0; text-decoration:underline; text-underline-offset:2px; }
+  .ch-skip:hover { color:var(--dim); }
+  @keyframes chFade { from{opacity:0; transform:translateY(-6px)} to{opacity:1; transform:none} }
+
   .navtiles { display:grid; grid-template-columns:repeat(2,1fr); gap:12px; margin:0 0 8px; }
   .navtile { display:flex; align-items:flex-start; gap:12px; text-decoration:none; color:var(--text);
        background:var(--panel); border:1px solid var(--border); border-radius:12px; padding:15px 17px; }
@@ -383,7 +402,7 @@
     .rail.open { transform:none; }
     main { margin-left:0; padding:64px 18px 80px; }
     .grid2 { grid-template-columns:1fr; }
-    .navtiles, .ideagrid { grid-template-columns:1fr; }
+    .navtiles, .ideagrid, .ch-opts { grid-template-columns:1fr; }
     .cards { grid-template-columns:1fr; } .cards .feat { grid-column:auto; }
     .menuBtn { display:flex; position:fixed; top:12px; left:12px; z-index:25; width:38px; height:38px;
        align-items:center; justify-content:center; background:var(--panel); border:1px solid var(--border);
@@ -416,6 +435,28 @@
     <div class="hero-cta">
       <a class="cta primary" href="?page=build">Build your own app →</a>
       <a class="cta" href="?page=templates">Open your data →</a>
+    </div>
+
+    <div class="chooser" id="chooser" hidden>
+      <div class="ch-q"><span class="spark">✦</span> New here? What do you want to do first?</div>
+      <div class="ch-opts">
+        <a class="ch-opt" href="?page=build" data-intent="build">
+          <span class="ch-ic">🛠️</span>
+          <b>Build an app from scratch</b>
+          <span class="ch-sub">Describe a tool, get a live page backed by Python</span>
+        </a>
+        <a class="ch-opt" href="?page=templates" data-intent="templates">
+          <span class="ch-ic">📂</span>
+          <b>Open data I already have</b>
+          <span class="ch-sub">Render a file you have through a template</span>
+        </a>
+        <a class="ch-opt" href="?page=showcase" data-intent="showcase">
+          <span class="ch-ic">✨</span>
+          <b>Just show me what's possible</b>
+          <span class="ch-sub">Browse finished projects you can clone</span>
+        </a>
+      </div>
+      <button class="ch-skip" id="chSkip">I'll explore on my own</button>
     </div>
 
     <h2>See it run</h2>
@@ -969,6 +1010,7 @@ function render(slug, hash){
   if (p.slug === "claude") checkClaude();
   if (p.slug === "templates") loadTemplates();
   if (p.slug === "build") maybeHello();
+  if (p.slug === "home") initChooser();
   // scroll: to heading if hash, else top of content
   if (hash) {
     const t = document.getElementById(hash);
@@ -1138,6 +1180,26 @@ $("#nameInput").addEventListener("keydown", e => { if (e.key === "Enter") hello(
 // don't fire a hidden runPython round-trip for users who stay on Home.
 let helloPrimed = false;
 function maybeHello(){ if (helloPrimed) return; helloPrimed = true; hello(); }
+
+/* ---- first-visit onboarding chooser (Layer 1 prototype) ----
+   Shows one lightweight question on the first visit to Home, routing the user
+   toward Build / Templates / Showcase. Non-invasive (no personal data), stored
+   only in localStorage, and never a gate — every path stays available below. */
+const chooserEl = $("#chooser");
+let chooserWired = false;
+function readIntent(){ try { return localStorage.getItem("fused.learn.intent"); } catch(e){ return null; } }
+function setIntent(v){ try { localStorage.setItem("fused.learn.intent", v); } catch(e){} }
+function initChooser(){
+  if (!chooserEl) return;
+  chooserEl.hidden = !!readIntent();          // hide once a choice (or skip) is stored
+  if (chooserWired) return;
+  chooserWired = true;
+  // Options keep their ?page= hrefs, so the global router handles navigation;
+  // we only record which path was chosen.
+  chooserEl.querySelectorAll(".ch-opt").forEach(a =>
+    a.addEventListener("click", () => setIntent(a.dataset.intent)));
+  $("#chSkip").addEventListener("click", () => { setIntent("skip"); chooserEl.hidden = true; });
+}
 
 /* live templates list (runs once, when the Templates page opens) */
 let tplLoaded = false, coreTpls = [], customTpls = [];


### PR DESCRIPTION
Adds a lightweight "What do you want to do first?" card to the Learn Home page for first-time visitors, routing them to **Build**, **Templates**, or **Showcase**.

- Shows only on the first visit; the choice is saved in `localStorage` (`fused.learn.intent`) so it doesn't reappear.
- Never a gate — every path stays available elsewhere on the page, and there's an "I'll explore on my own" skip.
- Pure client-side, no personal data collected.

To preview the first-visit state again, clear the key: `localStorage.removeItem('fused.learn.intent')`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static Learn page UI and local-only persistence; no auth, APIs, or backend changes.
> 
> **Overview**
> Adds a **first-visit onboarding card** on Learn Home (“What do you want to do first?”) with three links to **Build**, **Templates**, and **Showcase**, plus **I'll explore on my own**.
> 
> Visibility is controlled client-side: `initChooser()` runs when Home is shown, reveals the card only if `localStorage` has no `fused.learn.intent`, and stores the chosen intent (or `skip`) on click. Existing hero CTAs and nav stay unchanged—it is not a gate.
> 
> Includes new `.chooser` styles, a mobile single-column layout for `.ch-opts`, and the markup starts `hidden` until JS decides to show it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e858541571681f9d0c937fcf578985f82e94edfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->