### PR TITLE
feat(sidebar): resizable width and collapsible with expand bubble

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1029,7 +1029,7 @@ export default function Sidebar({ config }: SidebarProps) {
             />
           </svg>
         </span>{" "}
-        fused-render
+        <span className="brand-title">fused-render</span>
         <span className="brand-version">v{config.version}</span>
         <button
           type="button"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -437,6 +437,12 @@ export default function Sidebar({ config }: SidebarProps) {
   };
 
   const toggleSidebarCollapsed = () => {
+    // Collapsing unmounts the overlay surfaces but not their state — clear it
+    // so expanding doesn't resurrect a stale-anchored icon picker, an
+    // in-progress rename, or a tooltip.
+    setIconPicker(null);
+    setRenamingId(null);
+    setHover(null);
     setSidebarState((s) => {
       const next = { ...s, collapsed: !s.collapsed };
       saveSidebarState(next);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -405,9 +405,24 @@ export default function Sidebar({ config }: SidebarProps) {
   const [resizing, setResizing] = useState(false);
   const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
 
+  // Double-press-to-collapse is detected manually here: preventDefault on
+  // pointerdown (needed to stop a text selection starting before the
+  // body:has(.resizing) rule commits) suppresses the compatibility mouse
+  // events that produce dblclick in several engines, so onDoubleClick on the
+  // handle can't be relied on.
+  const lastHandlePressRef = useRef<{ time: number; x: number } | null>(null);
+
   const onHandlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
     e.preventDefault(); // no text selection while dragging
+    const last = lastHandlePressRef.current;
+    if (last && e.timeStamp - last.time < 350 && Math.abs(e.clientX - last.x) < 5) {
+      // Second press of a double-press: collapse instead of starting a drag.
+      lastHandlePressRef.current = null;
+      toggleSidebarCollapsed();
+      return;
+    }
+    lastHandlePressRef.current = { time: e.timeStamp, x: e.clientX };
     dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: sidebarWidth };
     e.currentTarget.setPointerCapture(e.pointerId);
     setResizing(true);
@@ -416,6 +431,8 @@ export default function Sidebar({ config }: SidebarProps) {
   const onHandlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
     const drag = dragRef.current;
     if (!drag || e.pointerId !== drag.pointerId) return;
+    // A real drag isn't the first half of a double-press.
+    if (Math.abs(e.clientX - drag.startX) >= 5) lastHandlePressRef.current = null;
     const width = Math.min(
       SIDEBAR_MAX_WIDTH,
       Math.max(SIDEBAR_MIN_WIDTH, drag.startWidth + (e.clientX - drag.startX))
@@ -1239,7 +1256,8 @@ export default function Sidebar({ config }: SidebarProps) {
       )}
       {/* Resize handle riding the right border: drag to resize (pointer
           capture keeps the gesture even when the cursor leaves the strip),
-          double-click to collapse. */}
+          double-press to collapse (detected in pointerdown — see
+          lastHandlePressRef). */}
       <div
         className={"sidebar-resize-handle" + (resizing ? " resizing" : "")}
         style={{ left: sidebarWidth - 3 }}
@@ -1247,7 +1265,6 @@ export default function Sidebar({ config }: SidebarProps) {
         onPointerMove={onHandlePointerMove}
         onPointerUp={onHandlePointerUp}
         onPointerCancel={onHandlePointerUp}
-        onDoubleClick={toggleSidebarCollapsed}
       />
     </nav>
   );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,6 +30,12 @@ import IconPicker from "./IconPicker";
 import { FolderIcon, LearnIcon } from "./FileIcons";
 import type { Bookmark, BookmarkFolder, BookmarkItem } from "../lib/bookmarks";
 import { loadRecents, displayRecents, setRecentsCollapsed } from "../lib/recents";
+import {
+  loadSidebarState,
+  saveSidebarState,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
+} from "../lib/sidebarstate";
 import { basename } from "../lib/format";
 import {
   useUrlVersion,
@@ -387,6 +393,56 @@ export default function Sidebar({ config }: SidebarProps) {
     // learnMountReady here would restart the whole bounded poll window
     // from zero every time it changes.
   }, []);
+
+  // Sidebar chrome: draggable width + collapsed flag, persisted once per
+  // gesture (drag end / toggle), not per mousemove. Width lives in React
+  // state — per-pointermove setState is fine (React 18 batches) and there is
+  // no transition during a drag, so no jank.
+  const [{ width: sidebarWidth, collapsed: sidebarCollapsed }, setSidebarState] =
+    useState(loadSidebarState);
+  // True only while the handle is captured — used to suppress the collapse
+  // transition and text selection mid-drag.
+  const [resizing, setResizing] = useState(false);
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+
+  const onHandlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    e.preventDefault(); // no text selection while dragging
+    dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: sidebarWidth };
+    e.currentTarget.setPointerCapture(e.pointerId);
+    setResizing(true);
+  };
+
+  const onHandlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    const width = Math.min(
+      SIDEBAR_MAX_WIDTH,
+      Math.max(SIDEBAR_MIN_WIDTH, drag.startWidth + (e.clientX - drag.startX))
+    );
+    setSidebarState((s) => (s.width === width ? s : { ...s, width }));
+  };
+
+  const onHandlePointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return;
+    dragRef.current = null;
+    setResizing(false);
+    // Persist the final width (functional read — the last pointermove's
+    // setState may not have committed yet).
+    setSidebarState((s) => {
+      saveSidebarState(s);
+      return s;
+    });
+  };
+
+  const toggleSidebarCollapsed = () => {
+    setSidebarState((s) => {
+      const next = { ...s, collapsed: !s.collapsed };
+      saveSidebarState(next);
+      return next;
+    });
+  };
 
   const [renamingId, setRenamingId] = useState<string | null>(null);
   // Bookmark just exported to disk: its save button shows ✓ for a moment.
@@ -935,8 +991,32 @@ export default function Sidebar({ config }: SidebarProps) {
       );
     });
 
+  if (sidebarCollapsed) {
+    // Collapsed: the whole sidebar shrinks to a slim strip that expands it
+    // back. Still the same #sidebar node, so the <=700px media hide applies.
+    return (
+      <nav id="sidebar" className="sidebar-collapsed">
+        <button
+          type="button"
+          className="sidebar-expand-strip"
+          aria-label="Expand sidebar"
+          title="Expand sidebar"
+          onClick={toggleSidebarCollapsed}
+        >
+          {/* Bubble protruding into the content area — the visible half of
+              the affordance; the whole strip is still the click target. */}
+          <span className="sidebar-expand-bubble" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="m9 18 6-6-6-6" />
+            </svg>
+          </span>
+        </button>
+      </nav>
+    );
+  }
+
   return (
-    <nav id="sidebar">
+    <nav id="sidebar" style={{ flexBasis: sidebarWidth, width: sidebarWidth }}>
       <div className="sidebar-brand">
         {/* Fused cube mark (brand asset logo-black-bg-transparent.svg), stroke
             follows .logo's color so it stays on the accent token. */}
@@ -951,6 +1031,17 @@ export default function Sidebar({ config }: SidebarProps) {
         </span>{" "}
         fused-render
         <span className="brand-version">v{config.version}</span>
+        <button
+          type="button"
+          className="icon-btn sidebar-collapse-btn"
+          aria-label="Collapse sidebar"
+          title="Collapse sidebar"
+          onClick={toggleSidebarCollapsed}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </button>
       </div>
       <div className="sidebar-section">
         <a href="#" id="fused-link" className="sidebar-item" onClick={onFusedClick}>
@@ -1140,6 +1231,18 @@ export default function Sidebar({ config }: SidebarProps) {
           onClose={() => setIconPicker(null)}
         />
       )}
+      {/* Resize handle riding the right border: drag to resize (pointer
+          capture keeps the gesture even when the cursor leaves the strip),
+          double-click to collapse. */}
+      <div
+        className={"sidebar-resize-handle" + (resizing ? " resizing" : "")}
+        style={{ left: sidebarWidth - 3 }}
+        onPointerDown={onHandlePointerDown}
+        onPointerMove={onHandlePointerMove}
+        onPointerUp={onHandlePointerUp}
+        onPointerCancel={onHandlePointerUp}
+        onDoubleClick={toggleSidebarCollapsed}
+      />
     </nav>
   );
 }

--- a/frontend/src/lib/sidebarstate.ts
+++ b/frontend/src/lib/sidebarstate.ts
@@ -1,0 +1,37 @@
+// Sidebar chrome state — resizable width + collapsed flag. Persisted so the
+// layout the user dragged into place survives reloads. Same defensive
+// localStorage pattern as viewstate.ts: best-effort, silent on failure.
+const KEY = "fused-render:sidebar";
+
+export const SIDEBAR_MIN_WIDTH = 180;
+export const SIDEBAR_MAX_WIDTH = 400;
+export const SIDEBAR_DEFAULT_WIDTH = 232;
+
+export interface SidebarState {
+  width: number;
+  collapsed: boolean;
+}
+
+export function loadSidebarState(): SidebarState {
+  const fallback: SidebarState = { width: SIDEBAR_DEFAULT_WIDTH, collapsed: false };
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return fallback;
+    const parsed = JSON.parse(raw) as Partial<SidebarState>;
+    const width =
+      typeof parsed.width === "number" && Number.isFinite(parsed.width)
+        ? Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, parsed.width))
+        : SIDEBAR_DEFAULT_WIDTH;
+    return { width, collapsed: parsed.collapsed === true };
+  } catch {
+    return fallback; // private-mode / quota / malformed JSON — behave as default
+  }
+}
+
+export function saveSidebarState(state: SidebarState): void {
+  try {
+    localStorage.setItem(KEY, JSON.stringify(state));
+  } catch {
+    // storage unavailable — state is best-effort, so a failed write is fine
+  }
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -34,7 +34,8 @@ body {
   height: 100vh;
 }
 
-/* Sidebar */
+/* Sidebar — the 232px basis is only the pre-hydration default; the component
+   overrides flex-basis/width inline from persisted state (drag to resize). */
 #sidebar {
   flex: 0 0 232px;
   width: 232px;
@@ -43,6 +44,105 @@ body {
   background: var(--bg-alt);
   border-right: 1px solid var(--border);
   overflow-y: auto;
+}
+
+/* Drag handle riding the sidebar's right border. Fixed-positioned (the
+   component sets `left` inline) so the sidebar's own overflow-y scroll can't
+   clip or move it; a 6px hit area around the 1px border line. */
+.sidebar-resize-handle {
+  position: fixed;
+  top: 0;
+  width: 6px;
+  height: 100vh;
+  cursor: col-resize;
+  z-index: 10;
+}
+
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle.resizing {
+  background: var(--accent);
+  opacity: 0.35;
+}
+
+/* While a drag is captured, keep the cursor stable and text unselected
+   everywhere the pointer sweeps. */
+body:has(.sidebar-resize-handle.resizing) {
+  cursor: col-resize;
+  user-select: none;
+}
+
+/* Collapse chevron in the brand row, pushed to the right edge. */
+.sidebar-collapse-btn {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+}
+
+/* Collapsed sidebar = a slim full-height strip that expands it back.
+   overflow: visible (not the expanded state's auto) so the bubble can
+   protrude past the strip into the content area. */
+#sidebar.sidebar-collapsed {
+  flex: 0 0 10px;
+  width: 10px;
+  overflow: visible;
+  /* The bubble overhangs #content; lift the whole strip above it so a
+     stacking context inside #content can't paint over the bubble. */
+  position: relative;
+  z-index: 10;
+}
+
+.sidebar-expand-strip {
+  position: relative;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.sidebar-expand-strip:hover {
+  background: rgba(255, 255, 255, 0.06);
+}
+
+/* Circular expand bubble, vertically centered, half overlapping the strip's
+   right edge (classic collapsed-panel pill). Purely visual — the strip is
+   the button; hover/focus styling keys off the strip's state. */
+.sidebar-expand-bubble {
+  position: absolute;
+  top: 50%;
+  left: 100%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);
+  color: var(--fg-muted);
+  /* Protrudes over #content — stay above its content. */
+  z-index: 10;
+}
+
+.sidebar-expand-strip:hover .sidebar-expand-bubble {
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--fg);
+}
+
+.sidebar-expand-strip:focus-visible {
+  outline: none;
+}
+
+.sidebar-expand-strip:focus-visible .sidebar-expand-bubble {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+  color: var(--fg);
 }
 
 /* Phones: give the whole width to the rendered view */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -55,6 +55,9 @@ body {
   width: 6px;
   height: 100vh;
   cursor: col-resize;
+  /* Touch input: without this the browser claims the drag as a pan/scroll
+     and fires pointercancel mid-resize, despite pointer capture. */
+  touch-action: none;
   z-index: 10;
 }
 
@@ -76,6 +79,7 @@ body:has(.sidebar-resize-handle.resizing) {
   margin-left: auto;
   display: flex;
   align-items: center;
+  flex-shrink: 0;
 }
 
 /* Collapsed sidebar = a slim full-height strip that expands it back.
@@ -167,6 +171,17 @@ body:has(.sidebar-resize-handle.resizing) {
   color: var(--accent);
   display: flex;
   align-items: center;
+  flex-shrink: 0;
+}
+
+/* Title truncates when the sidebar is dragged narrow (min 180px) so the
+   brand row never overflows; logo, version and collapse button keep their
+   size and the version stays visible beside the ellipsis. */
+.sidebar-brand .brand-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Package version after the name — smaller and muted grey. */
@@ -174,6 +189,7 @@ body:has(.sidebar-resize-handle.resizing) {
   font-size: 10.5px;
   font-weight: 500;
   color: var(--fg-muted);
+  flex-shrink: 0;
 }
 
 .sidebar-section {


### PR DESCRIPTION
## Summary
- Sidebar is now resizable via a drag handle on its right edge (pointer events with capture, width clamped to 180–400px, no transitions during drag so it stays smooth).
- Sidebar is collapsible: a chevron button in the brand row, or double-clicking the drag handle, collapses it to a slim 10px strip.
- The collapsed strip shows a 32px circular bubble with a chevron protruding into the content area as the expand affordance; the whole strip is a single keyboard-accessible button (aria-labels, focus-visible ring on the bubble).
- Width and collapsed state persist in localStorage under `fused-render:sidebar` via the new `frontend/src/lib/sidebarstate.ts` (follows the `viewstate.ts` pattern); saved only on drag end and collapse toggle.
- The existing `<700px` media hide is untouched — the collapsed strip lives inside `#sidebar` so it hides with it.

## Test plan
- [ ] Drag the sidebar's right edge: width follows the pointer, clamps at 180/400px, no text selection or jank during drag.
- [ ] Click the chevron in the brand row: sidebar collapses to a slim strip with a protruding bubble; click the strip/bubble to expand back to the previous width.
- [ ] Double-click the drag handle: toggles collapse.
- [ ] Reload the page: width and collapsed state are restored.
- [ ] Tab to the collapsed strip: focus ring shows on the bubble, Enter expands.
- [ ] Narrow the window below 700px: sidebar (and strip) hidden as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only shell layout changes with defensive localStorage; no auth, API, or data-path changes.
> 
> **Overview**
> Adds **user-resizable sidebar width** and a **collapsible** mode whose width and collapsed flag **persist in `localStorage`** (`fused-render:sidebar` via new `sidebarstate.ts`).
> 
> When expanded, the nav uses inline `flexBasis`/`width` from saved state. A **fixed right-edge drag handle** (pointer capture, 180–400px clamp) resizes live; width is written on pointer up. **Double-press** on the handle toggles collapse (manual detection because `preventDefault` on pointer down blocks `dblclick`). A **chevron in the brand row** also collapses; collapsing clears icon picker, rename, and tooltip state.
> 
> When collapsed, the same `#sidebar` renders a **10px strip** with a full-height **expand button** and a **circular chevron bubble** overlapping the content area. **Brand title** is wrapped for ellipsis when narrow.
> 
> `shell.css` adds handle styling, `body:has(.resizing)` cursor/selection lock, collapsed/expand bubble chrome, and brand-row flex tweaks. The existing **≤700px hide** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4aeb48e9cb94f5bca9c26624a064423113c108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->