### PR TITLE
Add optional custom link names to deploy modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,11 +157,11 @@ The modal handles the whole flow:
   serving plane `fused infra serve` provisioned (still a terminal flow).
   `local` envs have no serving plane and are never offered.
 - **The URL.** Deploys mint a **public share link** shown with copy/open
-  actions. By default the token is an opaque, unguessable one; the modal's
-  **Link name** field (fresh deploys only — a redeploy keeps its existing
-  token either way) lets you pass an explicit `--token` instead, trading
-  unguessability for a URL you chose. Redeploying the same page republishes to
-  the **same URL**; Revoke takes it down (deploying again restores the link).
+  actions. A **Link** picker (fresh deploys only — a redeploy keeps its
+  existing token either way) chooses between an **unguessable** random token
+  (the default) and a **custom name** you pick, trading unguessability for a
+  memorable URL. Redeploying the same page republishes to the **same URL**;
+  Revoke takes it down (deploying again restores the link).
 - **What's deployed.** A per-page pointer (`~/.fused-render/deployments.json`)
   marks deployed files in the preview header, and the Fused account tab's
   Deployments section (`fused share list`) shows every mount on the chosen

--- a/README.md
+++ b/README.md
@@ -157,11 +157,14 @@ The modal handles the whole flow:
   serving plane `fused infra serve` provisioned (still a terminal flow).
   `local` envs have no serving plane and are never offered.
 - **The URL.** Deploys mint a **public share link** shown with copy/open
-  actions. A **Link** picker (fresh deploys only — a redeploy keeps its
-  existing token either way) chooses between an **unguessable** random token
-  (the default) and a **custom name** you pick, trading unguessability for a
-  memorable URL. Redeploying the same page republishes to the **same URL**;
-  Revoke takes it down (deploying again restores the link).
+  actions. A collapsible **Link** section chooses between an **unguessable**
+  random token (the default) and a **custom name** you pick, trading
+  unguessability for a memorable URL. Redeploying the same page republishes to
+  the **same URL** (the token is kept), so once deployed the Link section shows
+  the current setting read-only with a **Change link** action that mints a new
+  URL (and takes the old one down). Revoke takes it down (deploying again
+  restores the link). Every deploy is **public — no sign-in required**,
+  whichever link style you pick.
 - **What's deployed.** A per-page pointer (`~/.fused-render/deployments.json`)
   marks deployed files in the preview header, and the Fused account tab's
   Deployments section (`fused share list`) shows every mount on the chosen

--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ The modal handles the whole flow:
   default — created in-app from the account tab) or an `aws` env whose
   serving plane `fused infra serve` provisioned (still a terminal flow).
   `local` envs have no serving plane and are never offered.
-- **The URL.** Deploys mint a **public share link** — an opaque, unguessable
-  URL shown with copy/open actions. Redeploying the same page republishes to
+- **The URL.** Deploys mint a **public share link** shown with copy/open
+  actions. By default the token is an opaque, unguessable one; the modal's
+  **Link name** field (fresh deploys only — a redeploy keeps its existing
+  token either way) lets you pass an explicit `--token` instead, trading
+  unguessability for a URL you chose. Redeploying the same page republishes to
   the **same URL**; Revoke takes it down (deploying again restores the link).
 - **What's deployed.** A per-page pointer (`~/.fused-render/deployments.json`)
   marks deployed files in the preview header, and the Fused account tab's

--- a/SPEC.md
+++ b/SPEC.md
@@ -860,18 +860,23 @@ the product gains network access.
   (not authed): authed mounts cannot serve a hosted page's browser asset GETs
   yet (fused repo, spec/serve/fused-render.md § Limitations); gate pickers
   become an option when that lands.
-- **DP-9a** The token itself is choosable: the modal's **Link name** field
-  (form-visible only when the next Deploy click would mint a FRESH mount —
-  no deployment yet, a different env, or the recorded mount absent from
-  `share list`; hidden on a same-env redeploy, DP-10, since `repoint`/
-  `recreate --same-token` keep the existing token either way and take no
-  `--token` argument) sends the name through to `deploy_page`'s `custom_token`,
-  which appends `--token <name>` to that `share create --public` call — the
-  fused CLI's own allowed combination (a public mount with a chosen name is a
-  **deliberately guessable** URL; it is never produced by an omitted field,
-  only an explicit one). Left blank (the default), the token is the existing
-  crypto-random opaque one. Client-side the name is checked against the CLI's
-  own token shape (`^[a-z0-9][a-z0-9_-]*$`) before Deploy is enabled; an
+- **DP-9a** The token itself is choosable, via an explicit **random-vs-named
+  radio** ("Link"): **Unguessable link** (default) keeps the crypto-random
+  opaque token, **Custom name** reveals a name input whose value rides through
+  to `deploy_page`'s `custom_token`, appended as `--token <name>` on that
+  `share create --public` call — the fused CLI's own allowed combination (a
+  public mount with a chosen name is a **deliberately guessable** URL; it is
+  never produced by an omitted field, only an explicit choice, so the picker is
+  a two-way toggle rather than a "blank = random" field). The picker is
+  form-visible only when the next Deploy click would mint a FRESH mount — no
+  deployment yet, a different env, or the recorded mount absent from `share
+  list`; hidden once the mount's liveness is CONFIRMED (active/revoked) on the
+  same env, since `repoint`/`recreate --same-token` (DP-10) keep the existing
+  token either way and take no `--token` argument (an *unconfirmed* same-env
+  status — env unreachable at open — leaves it up, and a name is ignored
+  server-side if the click turns out to repoint). Client-side the name is
+  checked against the CLI's own token shape (`^[a-z0-9][a-z0-9_-]*$`) and a
+  missing name (Custom name chosen, field empty) both disable Deploy; an
   already-taken name is a `share create` rejection the CLI itself reports
   (surfaced verbatim, same as every other CLI-side deploy error, DP-15).
 - **DP-10** Redeploy keeps the URL. Same-env pointer + mount active per

--- a/SPEC.md
+++ b/SPEC.md
@@ -728,7 +728,12 @@ the product gains network access.
   install panel; no hosted env configured → guidance (`fused env create` /
   `fused cloud setup`, naming the envs file); else the form — env picker,
   current-deployment card (status chip, URL with copy/open), a **"Will
-  publish" preview** (DP-2a), Deploy/Redeploy, and Revoke. The modal is scoped
+  publish" preview** (DP-2a), a collapsible **Link** section (DP-9a), a
+  collapsible **Caching** section (DP-17), an owner-only collapsible **Recent
+  errors** diagnostics section (the deployed mount's captured failures via
+  `fused share errors`; rendered for an undeployed page too, but **disabled**
+  with a hint, so the chrome is consistent rather than popping in on first
+  deploy), Deploy/Redeploy, and Revoke. The modal is scoped
   to the current page; the **env-wide** deployment list (DP-13) lives on the
   Fused account tab's Deployments section (AC-11, moved from Preferences
   when the account surface landed), not in the modal.
@@ -860,25 +865,39 @@ the product gains network access.
   (not authed): authed mounts cannot serve a hosted page's browser asset GETs
   yet (fused repo, spec/serve/fused-render.md § Limitations); gate pickers
   become an option when that lands.
-- **DP-9a** The token itself is choosable, via an explicit **random-vs-named
-  radio** ("Link"): **Unguessable link** (default) keeps the crypto-random
-  opaque token, **Custom name** reveals a name input whose value rides through
-  to `deploy_page`'s `custom_token`, appended as `--token <name>` on that
-  `share create --public` call — the fused CLI's own allowed combination (a
-  public mount with a chosen name is a **deliberately guessable** URL; it is
-  never produced by an omitted field, only an explicit choice, so the picker is
-  a two-way toggle rather than a "blank = random" field). The picker is
-  form-visible only when the next Deploy click would mint a FRESH mount — no
-  deployment yet, a different env, or the recorded mount absent from `share
-  list`; hidden once the mount's liveness is CONFIRMED (active/revoked) on the
-  same env, since `repoint`/`recreate --same-token` (DP-10) keep the existing
-  token either way and take no `--token` argument (an *unconfirmed* same-env
-  status — env unreachable at open — leaves it up, and a name is ignored
-  server-side if the click turns out to repoint). Client-side the name is
-  checked against the CLI's own token shape (`^[a-z0-9][a-z0-9_-]*$`) and a
-  missing name (Custom name chosen, field empty) both disable Deploy; an
-  already-taken name is a `share create` rejection the CLI itself reports
-  (surfaced verbatim, same as every other CLI-side deploy error, DP-15).
+- **DP-9a** The token is choosable through a **collapsible "Link" section**
+  (like Caching, DP-17) whose one-line summary shows the current setting
+  (`unguessable` / `custom: <name>`). It has two body modes:
+  - **Picking** — a **random-vs-named radio**: **Unguessable link** (default)
+    keeps the crypto-random opaque token; **Custom name** reveals a name input
+    whose value rides through to `deploy_page`'s `custom_token`, appended as
+    `--token <name>` on that `share create --public` call (the fused CLI's own
+    allowed combination — a public mount with a chosen name is a **deliberately
+    guessable** URL, never produced by an omitted field, only an explicit
+    choice, so it is a two-way toggle rather than a "blank = random" field).
+    Shown when the next Deploy would mint a FRESH mount (no deployment yet, a
+    different env, or the recorded mount absent from `share list`), and in the
+    Change-link flow below. Client-side the name is checked against the CLI's
+    own token shape (`^[a-z0-9][a-z0-9_-]*$`); a malformed name (red error) and
+    a missing one (Custom name chosen, field empty — a quiet prompt) both
+    disable Deploy. An already-taken name is a `share create` rejection the CLI
+    itself reports (surfaced verbatim, DP-15).
+  - **Read-only summary** — once the mount's liveness is CONFIRMED
+    (active/revoked) on the same env, the picker is replaced by a summary of the
+    current link (custom name vs unguessable, read from the record's `named`
+    provenance) plus a **Change link** action. A plain redeploy keeps the token
+    (`repoint`/`recreate --same-token` take no `--token`, DP-10), so changing
+    the URL needs `force_new`: Change link re-reveals the picker and the next
+    Deploy takes the `force_new` path (mint a new token, best-effort revoke the
+    old — DP-10). An *unconfirmed* same-env status (env unreachable at open)
+    shows the picker, not the summary, since the next click may still fall
+    through to a fresh create.
+  The record persists a **`named`** boolean (whether the token is a chosen name
+  vs the opaque default), set at the fresh create that minted it and carried
+  forward unchanged on every token-reuse redeploy — the summary reads it rather
+  than re-deriving named-ness from the token string. The always-public,
+  **no-auth** posture (which the guessable/unguessable choice does not itself
+  state) is a note kept directly beneath the Link section, always visible.
 - **DP-10** Redeploy keeps the URL. Same-env pointer + mount active per
   `share list` → `share repoint <token>` (stable URL); revoked tombstone →
   `share recreate --same-token` then repoint (a failed repoint best-effort

--- a/SPEC.md
+++ b/SPEC.md
@@ -855,11 +855,25 @@ the product gains network access.
 - **DP-8** Each deploy re-exports the page (§18) into a fresh temp directory
   and hands that bundle to the CLI; the bundle is deleted afterwards. An export
   error blocks the deploy (400, all problems at once — nothing is uploaded).
-- **DP-9** Deploys are **public share links** (`share create --public`, no
-  `--token`): an opaque, unguessable capability URL. Rationale: authed mounts
-  cannot serve a hosted page's browser asset GETs yet (fused repo,
-  spec/serve/fused-render.md § Limitations); gate pickers become an option when
-  that lands.
+- **DP-9** Deploys are **public share links** (`share create --public`): an
+  opaque, unguessable capability URL by default. Rationale for staying public
+  (not authed): authed mounts cannot serve a hosted page's browser asset GETs
+  yet (fused repo, spec/serve/fused-render.md § Limitations); gate pickers
+  become an option when that lands.
+- **DP-9a** The token itself is choosable: the modal's **Link name** field
+  (form-visible only when the next Deploy click would mint a FRESH mount —
+  no deployment yet, a different env, or the recorded mount absent from
+  `share list`; hidden on a same-env redeploy, DP-10, since `repoint`/
+  `recreate --same-token` keep the existing token either way and take no
+  `--token` argument) sends the name through to `deploy_page`'s `custom_token`,
+  which appends `--token <name>` to that `share create --public` call — the
+  fused CLI's own allowed combination (a public mount with a chosen name is a
+  **deliberately guessable** URL; it is never produced by an omitted field,
+  only an explicit one). Left blank (the default), the token is the existing
+  crypto-random opaque one. Client-side the name is checked against the CLI's
+  own token shape (`^[a-z0-9][a-z0-9_-]*$`) before Deploy is enabled; an
+  already-taken name is a `share create` rejection the CLI itself reports
+  (surfaced verbatim, same as every other CLI-side deploy error, DP-15).
 - **DP-10** Redeploy keeps the URL. Same-env pointer + mount active per
   `share list` → `share repoint <token>` (stable URL); revoked tombstone →
   `share recreate --same-token` then repoint (a failed repoint best-effort

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -494,12 +494,18 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // How the NEXT create's link is named — an explicit either/or, not "blank =
   // random" (which read as an unfinished field). "random" (the default, safe
   // choice) mints the opaque unguessable token; "named" uses `customToken` as
-  // an explicit, deliberately guessable URL segment. Both are only meaningful
-  // before a mount exists on the selected env — once deployed the token is
-  // fixed — so neither is seeded from the stored record; both reset on a fresh
-  // open (see `load`).
+  // an explicit, deliberately guessable URL segment. Reset on a fresh open (see
+  // `load`); re-seeded from the current mount when the user clicks "Change
+  // link" on a live deployment (see `enterChangeLink`).
   const [tokenMode, setTokenMode] = useState<"random" | "named">("random");
   const [customToken, setCustomToken] = useState("");
+  // A live mount's token is fixed (repoint/recreate keep it), so the Link
+  // picker is normally hidden once deployed — replaced by a read-only summary.
+  // "Change link" flips this on to re-reveal the picker; deploying then takes
+  // the force_new path (mint a NEW token, best-effort revoke the old one), the
+  // only way to actually change a mount's URL. Reset on a fresh open and after
+  // a successful deploy.
+  const [changingLink, setChangingLink] = useState(false);
   // The result of the last "Clear cache" click (deleted/scope), shown as a status
   // line until the next load/action clears it.
   const [clearCacheResult, setClearCacheResult] = useState<CacheClearResult | null>(null);
@@ -509,6 +515,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // mounted at all, so it never fetches until opened).
   const [cachingOpen, setCachingOpen] = useState(false);
   const [errorsOpen, setErrorsOpen] = useState(false);
+  // The Link section collapses like Caching — a one-line summary of the current
+  // setting is enough until the user wants to change it.
+  const [linkOpen, setLinkOpen] = useState(false);
   // True while a preview fetch is in flight — the shown "Files to publish" list may
   // not yet reflect the latest include/exclude edit, so Deploy is held until it
   // catches up (keeps the click WYSIWYG: never deploy a set the list doesn't show).
@@ -604,6 +613,8 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // that hasn't been asked about yet.
       setCachingOpen(false);
       setErrorsOpen(false);
+      setLinkOpen(false);
+      setChangingLink(false);
       setTokenMode("random");
       setCustomToken("");
     }
@@ -722,7 +733,12 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // ignored server-side if the click turns out to repoint after all
   // (deploy_page only applies custom_token on its create branches).
   const confirmedRedeployToken = samePointerEnv && (live === "active" || live === "revoked");
-  const namedTokenActive = !confirmedRedeployToken && tokenMode === "named";
+  // The link picker (radios) is shown for a fresh create — no confirmed live
+  // mount whose token a redeploy would reuse — OR when the user has explicitly
+  // asked to Change a live mount's link (which deploys force_new). Otherwise a
+  // confirmed mount shows a read-only summary of its current link instead.
+  const pickingLink = !confirmedRedeployToken || changingLink;
+  const namedTokenActive = pickingLink && tokenMode === "named";
   const trimmedToken = customToken.trim();
   // Two distinct not-ready states for a named link, kept apart so the UI can
   // treat them differently: a malformed name (non-empty but wrong shape) is a
@@ -761,6 +777,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       if (!alive.current) return;
       setReconciled(true);
       setLive("active");
+      // The change-link flow is done once the new mount is live — drop back to
+      // the read-only summary (now reflecting the just-minted token).
+      setChangingLink(false);
       // Re-seed from what was actually persisted, so the list reflects the
       // stored record (e.g. server-side dedup) rather than the raw local lists.
       setInclude(record.include ?? include);
@@ -833,23 +852,63 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     }
   };
 
+  // Enter/leave the change-link flow (see `changingLink`). Entering seeds the
+  // picker from the current mount so the user starts where they are; leaving
+  // restores the default (a fresh create's default is an unguessable link).
+  const enterChangeLink = () => {
+    setChangingLink(true);
+    setLinkOpen(true);
+    if (deployment?.named) {
+      setTokenMode("named");
+      setCustomToken(deployment.token);
+    } else {
+      setTokenMode("random");
+      setCustomToken("");
+    }
+  };
+  const cancelChangeLink = () => {
+    setChangingLink(false);
+    setTokenMode("random");
+    setCustomToken("");
+  };
+
   // Deploy/Redeploy: the button label stays stable ("Deploy" / "Redeploy" /
   // "Deploying…"); the URL nuance (same link, restored link, fresh link,
   // unconfirmed) moves to a single status line below, driven by `live` — the
-  // mount's VERIFIED `share list` classification. (samePointerEnv/mountAbsent/
-  // isRedeploy are computed above, alongside the env memo — onDeploy needs
-  // isRedeploy too.)
-  const deployLabel = busy === "deploy" ? "Deploying…" : isRedeploy ? "Redeploy" : "Deploy";
-  // One status line for the same-env case, spelling out what happens to the URL.
-  const deployStatus = !samePointerEnv
-    ? null
-    : live === "active"
-      ? "Redeploying keeps the same URL."
-      : live === "revoked"
-        ? "Redeploying restores the previous URL."
-        : mountAbsent
-          ? "The recorded deployment no longer exists — deploying mints a new URL."
-          : "Environment unreachable — the current deployment couldn't be confirmed.";
+  // mount's VERIFIED `share list` classification. The change-link flow is the
+  // one case that overrides both — it force_news a new URL and takes the old
+  // one down, so it says so rather than "keeps the same URL".
+  const deployLabel =
+    busy === "deploy"
+      ? "Deploying…"
+      : changingLink
+        ? "Deploy new link"
+        : isRedeploy
+          ? "Redeploy"
+          : "Deploy";
+  const deployStatus = changingLink
+    ? "Deploying mints a new link and takes the current one down."
+    : !samePointerEnv
+      ? null
+      : live === "active"
+        ? "Redeploying keeps the same URL."
+        : live === "revoked"
+          ? "Redeploying restores the previous URL."
+          : mountAbsent
+            ? "The recorded deployment no longer exists — deploying mints a new URL."
+            : "Environment unreachable — the current deployment couldn't be confirmed.";
+
+  // The Link section's collapsed one-liner (like Caching's "off"/"on, 5m"):
+  // the pending choice while picking, else the live mount's current setting.
+  const linkSummary = pickingLink
+    ? tokenMode === "named"
+      ? trimmedToken
+        ? `custom: ${trimmedToken}`
+        : "custom name"
+      : "unguessable"
+    : deployment?.named
+      ? `custom: ${deployment.token}`
+      : "unguessable";
 
   const body = () => {
     if (loadError) {
@@ -993,23 +1052,36 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             failures behind its opaque 500s (fused share errors). Collapsed by
             default — DeploymentErrors is only mounted (and so only fetches)
             once opened, mirroring the account Deployments list's per-row
-            toggle; viewers of the page never see any of this either way. */}
-        {deployment?.env && deployment?.token && (
-          <div className="deploy-files">
-            <button
-              type="button"
-              className="deploy-files-head"
-              aria-expanded={errorsOpen}
-              onClick={() => setErrorsOpen((o) => !o)}
-            >
-              <span className="deploy-files-chevron" aria-hidden="true">
-                {errorsOpen ? "▾" : "▸"}
-              </span>
-              <span className="deploy-files-title">Recent errors</span>
-            </button>
-            {errorsOpen && <DeploymentErrors env={deployment.env} token={deployment.token} />}
-          </div>
-        )}
+            toggle; viewers of the page never see any of this either way. The
+            section always renders — for an as-yet-undeployed ("unshared") page
+            it shows disabled, with a hint, so the modal's chrome is consistent
+            rather than a control that pops into existence on first deploy. */}
+        {(() => {
+          const hasDeployment = !!(deployment?.env && deployment?.token);
+          return (
+            <div className="deploy-files">
+              <button
+                type="button"
+                className="deploy-files-head"
+                aria-expanded={hasDeployment ? errorsOpen : undefined}
+                disabled={!hasDeployment}
+                onClick={() => setErrorsOpen((o) => !o)}
+                title={hasDeployment ? undefined : "Available once this page is deployed"}
+              >
+                <span className="deploy-files-chevron" aria-hidden="true">
+                  {hasDeployment && errorsOpen ? "▾" : "▸"}
+                </span>
+                <span className="deploy-files-title">Recent errors</span>
+                {!hasDeployment && (
+                  <span className="deploy-files-count">available after you deploy</span>
+                )}
+              </button>
+              {hasDeployment && errorsOpen && (
+                <DeploymentErrors env={deployment!.env} token={deployment!.token} />
+              )}
+            </div>
+          );
+        })()}
 
         {preview && (
           <FileSelection
@@ -1088,64 +1160,85 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </div>
           )}
         </div>
-        {/* The link-name picker only applies to a FRESH create (see
-            confirmedRedeployToken above) — hidden only once the existing
-            mount's liveness is CONFIRMED (active/revoked), so an unreachable-
-            env "unconfirmed" state (live === null) leaves it up rather than
-            hide a control that a subsequent fresh create could still use.
-            An explicit random-vs-named choice, not a "blank = random" text
-            field: choosing a name is meant to be a deliberate act, and the
-            radios spell out the security trade-off per option. */}
-        {!confirmedRedeployToken && (
-          <div className="deploy-files">
+        {/* Link section (collapsible, like Caching). Two body modes:
+              - picking (a fresh create, or an explicit "Change link" on a live
+                mount): the random-vs-named radios — an explicit choice, not a
+                "blank = random" field, since naming a public link is a
+                deliberate, security-relevant act;
+              - confirmed live mount: a read-only summary of the current link
+                plus a "Change link" action, because repoint/recreate keep the
+                token — only a force_new deploy (what Change link triggers) can
+                actually change the URL.
+            The public/no-auth note lives BELOW this block (always visible, even
+            when collapsed), since the radios/summary describe guessability but
+            not that the link is unauthenticated. */}
+        <div className="deploy-files">
+          <button
+            type="button"
+            className="deploy-files-head"
+            aria-expanded={linkOpen}
+            onClick={() => setLinkOpen((o) => !o)}
+          >
+            <span className="deploy-files-chevron" aria-hidden="true">
+              {linkOpen ? "▾" : "▸"}
+            </span>
+            <span className="deploy-files-title">Link</span>
+            <span className="deploy-files-count">{linkSummary}</span>
+          </button>
+          {linkOpen && (
             <div className="deploy-files-body">
-              <fieldset className="deploy-token-modes">
-                <legend>Link</legend>
-                <label className="deploy-token-mode">
-                  <input
-                    type="radio"
-                    name="deploy-token-mode"
-                    checked={tokenMode === "random"}
-                    disabled={busy !== null}
-                    onChange={() => setTokenMode("random")}
-                  />
-                  <span>
-                    <b>Unguessable link</b>
-                    <span className="deploy-muted"> — a random URL nobody can guess (default)</span>
-                  </span>
-                </label>
-                <label className="deploy-token-mode">
-                  <input
-                    type="radio"
-                    name="deploy-token-mode"
-                    checked={tokenMode === "named"}
-                    disabled={busy !== null}
-                    onChange={() => setTokenMode("named")}
-                  />
-                  <span>
-                    <b>Custom name</b>
-                    <span className="deploy-muted">
-                      {" "}
-                      — you pick the URL; anyone who knows or guesses it can open it
-                    </span>
-                  </span>
-                </label>
-              </fieldset>
-              {namedTokenActive && (
+              {pickingLink ? (
                 <>
-                  <div className="deploy-form-row">
-                    <label htmlFor="deploy-token-input">Name</label>
-                    <TextInput
-                      id="deploy-token-input"
-                      type="text"
-                      placeholder="my-dashboard"
-                      value={customToken}
-                      disabled={busy !== null}
-                      autoFocus
-                      onChange={(e) => setCustomToken(e.target.value)}
-                    />
-                  </div>
-                  {(tokenFormatError || tokenIncomplete) && (
+                  <fieldset className="deploy-token-modes">
+                    <legend>{changingLink ? "New link" : "Link"}</legend>
+                    <label className="deploy-token-mode">
+                      <input
+                        type="radio"
+                        name="deploy-token-mode"
+                        checked={tokenMode === "random"}
+                        disabled={busy !== null}
+                        onChange={() => setTokenMode("random")}
+                      />
+                      <span>
+                        <b>Unguessable link</b>
+                        <span className="deploy-muted">
+                          {" "}
+                          — a random URL nobody can guess (default)
+                        </span>
+                      </span>
+                    </label>
+                    <label className="deploy-token-mode">
+                      <input
+                        type="radio"
+                        name="deploy-token-mode"
+                        checked={tokenMode === "named"}
+                        disabled={busy !== null}
+                        onChange={() => setTokenMode("named")}
+                      />
+                      <span>
+                        <b>Custom name</b>
+                        <span className="deploy-muted">
+                          {" "}
+                          — you pick the URL; anyone who knows or guesses it can open it
+                        </span>
+                      </span>
+                    </label>
+                  </fieldset>
+                  {namedTokenActive && (
+                    <div className="deploy-form-row">
+                      <label htmlFor="deploy-token-input">Name</label>
+                      <TextInput
+                        id="deploy-token-input"
+                        type="text"
+                        placeholder="my-dashboard"
+                        value={customToken}
+                        disabled={busy !== null}
+                        autoFocus
+                        onChange={(e) => setCustomToken(e.target.value)}
+                      />
+                    </div>
+                  )}
+                  {namedTokenActive && (tokenFormatError || tokenIncomplete) && (
                     <div
                       className={
                         "deploy-token-hint deploy-muted" + (tokenFormatError ? " err" : "")
@@ -1155,11 +1248,47 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                         "Enter a name for the link, or switch to an unguessable link."}
                     </div>
                   )}
+                  {changingLink && (
+                    <div className="deploy-form-row">
+                      <button type="button" onClick={cancelChangeLink} disabled={busy !== null}>
+                        Cancel
+                      </button>
+                    </div>
+                  )}
+                </>
+              ) : (
+                <>
+                  <div className="deploy-muted">
+                    {deployment?.named ? (
+                      <>
+                        This link uses a <b>custom name</b> you chose.
+                      </>
+                    ) : (
+                      <>
+                        This link is an <b>unguessable</b> random URL.
+                      </>
+                    )}
+                  </div>
+                  <div className="deploy-form-row">
+                    <button
+                      type="button"
+                      className="btn btn-secondary"
+                      onClick={enterChangeLink}
+                      disabled={busy !== null}
+                      title="Mint a new link (the current one is taken down)"
+                    >
+                      Change link…
+                    </button>
+                  </div>
                 </>
               )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
+        <div className="deploy-muted deploy-about">
+          Deploys are <b>public</b> — no sign-in required, so anyone with the link can open it,
+          whether it's the unguessable default or a name you chose.
+        </div>
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
           <Select
@@ -1177,7 +1306,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
           <button
             type="button"
             className="btn btn-primary"
-            onClick={() => onDeploy()}
+            // In the change-link flow this is the force_new deploy (mint a new
+            // token, revoke the old); otherwise a normal create/redeploy.
+            onClick={() => onDeploy(changingLink)}
             // Hold Deploy until the shown "Files to publish" list matches the current
             // selection: preview === null (still resolving, or cleared on a page
             // switch) or previewPending (a refresh is in flight after an edit) both
@@ -1268,18 +1399,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             {signin.error && <ErrorBanner>{signin.error}</ErrorBanner>}
           </div>
         )}
-        {/* The guessable-vs-unguessable trade-off now lives in the "Link"
-            radios above, so this disclosure keeps only what they DON'T say:
-            that every deploy is UNAUTHENTICATED (even the unguessable link is
-            open to anyone who has it). It also covers the redeploy case, where
-            the picker is hidden but this note still applies. */}
-        <details className="deploy-disclosure">
-          <summary>About public links</summary>
-          <div className="deploy-muted">
-            Deploys are <b>public</b> — no sign-in required, so anyone with the link can open it,
-            whether it's the unguessable default or a name you chose.
-          </div>
-        </details>
+        {/* The old "About public links" disclosure was removed — its content
+            now lives inline beneath the Link section above (always visible),
+            so the bottom-of-modal toggle is redundant. */}
         {actionError && <ErrorBanner>{actionError}</ErrorBanner>}
       </>
     );

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -1268,15 +1268,16 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             {signin.error && <ErrorBanner>{signin.error}</ErrorBanner>}
           </div>
         )}
-        {/* The always-on public-link boilerplate lives behind a disclosure so it
-            doesn't compete with the action every time. */}
+        {/* The guessable-vs-unguessable trade-off now lives in the "Link"
+            radios above, so this disclosure keeps only what they DON'T say:
+            that every deploy is UNAUTHENTICATED (even the unguessable link is
+            open to anyone who has it). It also covers the redeploy case, where
+            the picker is hidden but this note still applies. */}
         <details className="deploy-disclosure">
           <summary>About public links</summary>
           <div className="deploy-muted">
-            Deploys publish as a <b>public share link</b> — anyone with the link can open it. The
-            "Link" choice above (fresh deploys only) sets the URL: an <b>unguessable</b> random one
-            (the default), or a <b>custom name</b> you pick — memorable, but guessable by anyone who
-            knows the pattern.
+            Deploys are <b>public</b> — no sign-in required, so anyone with the link can open it,
+            whether it's the unguessable default or a name you chose.
           </div>
         </details>
         {actionError && <ErrorBanner>{actionError}</ErrorBanner>}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -750,7 +750,15 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       ? "Use lowercase letters, numbers, - and _ only, starting with a letter or number."
       : null;
   const tokenIncomplete = namedTokenActive && trimmedToken === "";
-  const tokenBlocksDeploy = tokenFormatError !== null || tokenIncomplete;
+  // Change-link is a force_new: `share create --token <name>` runs BEFORE the
+  // old mount is revoked (create-then-revoke is the safe order — a failed
+  // create must never take the live page down), so reusing the CURRENT name
+  // would collide on create and fail. Block it up front with a clear prompt
+  // rather than let the "Deploy new link" click 400 on a token clash — keeping
+  // the same name isn't a change anyway.
+  const tokenUnchanged =
+    changingLink && namedTokenActive && trimmedToken !== "" && trimmedToken === deployment?.token;
+  const tokenBlocksDeploy = tokenFormatError !== null || tokenIncomplete || tokenUnchanged;
 
   // Each handler applies its result (onChange always propagates to the header
   // dot), then guards the modal's OWN setState on `alive` — the dialog may
@@ -1238,14 +1246,16 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                       />
                     </div>
                   )}
-                  {namedTokenActive && (tokenFormatError || tokenIncomplete) && (
+                  {namedTokenActive && (tokenFormatError || tokenIncomplete || tokenUnchanged) && (
                     <div
                       className={
                         "deploy-token-hint deploy-muted" + (tokenFormatError ? " err" : "")
                       }
                     >
                       {tokenFormatError ??
-                        "Enter a name for the link, or switch to an unguessable link."}
+                        (tokenUnchanged
+                          ? "That's already this link's name — pick a different one to change it, or Cancel."
+                          : "Enter a name for the link, or switch to an unguessable link.")}
                     </div>
                   )}
                   {changingLink && (
@@ -1331,7 +1341,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
                     ? tokenFormatError
                     : tokenIncomplete
                       ? "Enter a name for the link, or switch to an unguessable link"
-                      : undefined
+                      : tokenUnchanged
+                        ? "Pick a different name to change the link, or Cancel"
+                        : undefined
             }
           >
             {busy === "deploy" && <span className="deploy-spinner" />}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -491,10 +491,14 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // fused's cache_max_age. Seeded on open from the stored record (like include/
   // exclude) and sent back on every Deploy; there is no "leave it as it was".
   const [cacheMaxAge, setCacheMaxAge] = useState<string>("0s");
-  // A user-chosen link name for the NEXT create (blank = auto-generated opaque
-  // token, today's default). Only meaningful before a mount exists on the
-  // selected env — once deployed the token is fixed, so this is never seeded
-  // from the stored record and is reset on every fresh open (see `load`).
+  // How the NEXT create's link is named — an explicit either/or, not "blank =
+  // random" (which read as an unfinished field). "random" (the default, safe
+  // choice) mints the opaque unguessable token; "named" uses `customToken` as
+  // an explicit, deliberately guessable URL segment. Both are only meaningful
+  // before a mount exists on the selected env — once deployed the token is
+  // fixed — so neither is seeded from the stored record; both reset on a fresh
+  // open (see `load`).
+  const [tokenMode, setTokenMode] = useState<"random" | "named">("random");
   const [customToken, setCustomToken] = useState("");
   // The result of the last "Clear cache" click (deleted/scope), shown as a status
   // line until the next load/action clears it.
@@ -600,6 +604,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // that hasn't been asked about yet.
       setCachingOpen(false);
       setErrorsOpen(false);
+      setTokenMode("random");
       setCustomToken("");
     }
     try {
@@ -706,21 +711,30 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const samePointerEnv = deployment !== null && deployment.env === selectedEnv;
   const mountAbsent = live === "absent";
   const isRedeploy = samePointerEnv && !mountAbsent;
-  // The Link name field's own gate is deliberately NARROWER than isRedeploy:
+  // The link-name picker's gate is deliberately NARROWER than isRedeploy:
   // `live` is null both when reconcile never ran and when it ran but the env
   // was unreachable (deployStatus's "couldn't be confirmed" branch below) —
   // in that case we do NOT actually know yet whether the next Deploy click
   // will repoint or fall through to a fresh create (deploy_page re-checks
   // `share list` live, at click time, independent of this stale read). So
-  // only a CONFIRMED still-live mount (active or revoked) hides the field;
-  // an unconfirmed one leaves it up, and a name typed there is simply
+  // only a CONFIRMED still-live mount (active or revoked) hides the picker;
+  // an unconfirmed one leaves it up, and a name chosen there is simply
   // ignored server-side if the click turns out to repoint after all
   // (deploy_page only applies custom_token on its create branches).
   const confirmedRedeployToken = samePointerEnv && (live === "active" || live === "revoked");
-  const tokenError =
-    !confirmedRedeployToken && customToken && !TOKEN_RE.test(customToken)
+  const namedTokenActive = !confirmedRedeployToken && tokenMode === "named";
+  const trimmedToken = customToken.trim();
+  // Two distinct not-ready states for a named link, kept apart so the UI can
+  // treat them differently: a malformed name (non-empty but wrong shape) is a
+  // hard red error; a not-yet-typed name is a quiet prompt, so picking the
+  // "Custom name" radio doesn't flash red before the user has typed anything.
+  // Both block Deploy.
+  const tokenFormatError =
+    namedTokenActive && trimmedToken !== "" && !TOKEN_RE.test(trimmedToken)
       ? "Use lowercase letters, numbers, - and _ only, starting with a letter or number."
       : null;
+  const tokenIncomplete = namedTokenActive && trimmedToken === "";
+  const tokenBlocksDeploy = tokenFormatError !== null || tokenIncomplete;
 
   // Each handler applies its result (onChange always propagates to the header
   // dot), then guards the modal's OWN setState on `alive` — the dialog may
@@ -731,7 +745,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     setActionError(null);
     setClearCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
-      const wantsCustomToken = !confirmedRedeployToken && customToken.trim() !== "";
+      // A chosen name only rides along on the "named" path (and only for a
+      // fresh create — see confirmedRedeployToken); Deploy is disabled while
+      // that name is missing/malformed, so trimmedToken is a valid name here.
       const record = await deployPage(
         fsPath,
         env.name,
@@ -739,7 +755,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         exclude,
         cacheMaxAge,
         forceNew,
-        wantsCustomToken ? customToken.trim() : undefined,
+        namedTokenActive ? trimmedToken : undefined,
       );
       applyDeployment(record);
       if (!alive.current) return;
@@ -1072,30 +1088,75 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </div>
           )}
         </div>
-        {/* A chosen link name only applies to a FRESH create (see
+        {/* The link-name picker only applies to a FRESH create (see
             confirmedRedeployToken above) — hidden only once the existing
             mount's liveness is CONFIRMED (active/revoked), so an unreachable-
             env "unconfirmed" state (live === null) leaves it up rather than
-            hide a control that a subsequent fresh create could still use. */}
+            hide a control that a subsequent fresh create could still use.
+            An explicit random-vs-named choice, not a "blank = random" text
+            field: choosing a name is meant to be a deliberate act, and the
+            radios spell out the security trade-off per option. */}
         {!confirmedRedeployToken && (
           <div className="deploy-files">
             <div className="deploy-files-body">
-              <div className="deploy-form-row">
-                <label htmlFor="deploy-token-input">Link name</label>
-                <TextInput
-                  id="deploy-token-input"
-                  type="text"
-                  placeholder="auto-generated, unguessable"
-                  value={customToken}
-                  disabled={busy !== null}
-                  onChange={(e) => setCustomToken(e.target.value)}
-                />
-              </div>
-              <div className={"deploy-token-hint deploy-muted" + (tokenError ? " err" : "")}>
-                {tokenError ??
-                  "Leave blank for an unguessable public link (the default). Choosing a name " +
-                    "makes the URL guessable — anyone who knows or guesses it can open it."}
-              </div>
+              <fieldset className="deploy-token-modes">
+                <legend>Link</legend>
+                <label className="deploy-token-mode">
+                  <input
+                    type="radio"
+                    name="deploy-token-mode"
+                    checked={tokenMode === "random"}
+                    disabled={busy !== null}
+                    onChange={() => setTokenMode("random")}
+                  />
+                  <span>
+                    <b>Unguessable link</b>
+                    <span className="deploy-muted"> — a random URL nobody can guess (default)</span>
+                  </span>
+                </label>
+                <label className="deploy-token-mode">
+                  <input
+                    type="radio"
+                    name="deploy-token-mode"
+                    checked={tokenMode === "named"}
+                    disabled={busy !== null}
+                    onChange={() => setTokenMode("named")}
+                  />
+                  <span>
+                    <b>Custom name</b>
+                    <span className="deploy-muted">
+                      {" "}
+                      — you pick the URL; anyone who knows or guesses it can open it
+                    </span>
+                  </span>
+                </label>
+              </fieldset>
+              {namedTokenActive && (
+                <>
+                  <div className="deploy-form-row">
+                    <label htmlFor="deploy-token-input">Name</label>
+                    <TextInput
+                      id="deploy-token-input"
+                      type="text"
+                      placeholder="my-dashboard"
+                      value={customToken}
+                      disabled={busy !== null}
+                      autoFocus
+                      onChange={(e) => setCustomToken(e.target.value)}
+                    />
+                  </div>
+                  {(tokenFormatError || tokenIncomplete) && (
+                    <div
+                      className={
+                        "deploy-token-hint deploy-muted" + (tokenFormatError ? " err" : "")
+                      }
+                    >
+                      {tokenFormatError ??
+                        "Enter a name for the link, or switch to an unguessable link."}
+                    </div>
+                  )}
+                </>
+              )}
             </div>
           </div>
         )}
@@ -1128,14 +1189,18 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               preview === null ||
               previewPending ||
               preview.errors.length > 0 ||
-              tokenError !== null
+              tokenBlocksDeploy
             }
             title={
               preview === null || previewPending
                 ? "Preparing the publish preview…"
                 : preview.errors.length > 0
                   ? "Fix the export problems listed above first"
-                  : (tokenError ?? undefined)
+                  : tokenFormatError
+                    ? tokenFormatError
+                    : tokenIncomplete
+                      ? "Enter a name for the link, or switch to an unguessable link"
+                      : undefined
             }
           >
             {busy === "deploy" && <span className="deploy-spinner" />}
@@ -1208,10 +1273,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         <details className="deploy-disclosure">
           <summary>About public links</summary>
           <div className="deploy-muted">
-            Deploys publish as a <b>public share link</b> — anyone with the link can open it. By
-            default the URL is an unguessable auto-generated token; the "Link name" field above
-            (fresh deploys only) lets you pick the URL's last segment instead, at the cost of it
-            becoming guessable.
+            Deploys publish as a <b>public share link</b> — anyone with the link can open it. The
+            "Link" choice above (fresh deploys only) sets the URL: an <b>unguessable</b> random one
+            (the default), or a <b>custom name</b> you pick — memorable, but guessable by anyone who
+            knows the pattern.
           </div>
         </details>
         {actionError && <ErrorBanner>{actionError}</ErrorBanner>}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -10,7 +10,9 @@
 //   3. no hosted envs — sign in / route to the account tab's setup panel
 //      (AWS env creation stays a named terminal flow, SPEC AC-9)
 //   4. the form — env picker (default: the managed fused-backend env),
-//      current deployment card (URL + copy/open), Deploy/Redeploy, Revoke.
+//      current deployment card (URL + copy/open), an optional "Link name"
+//      (fresh deploys only — picks the URL's token instead of the default
+//      opaque one), Deploy/Redeploy, Revoke.
 // The env-wide share list (every mount on an env, with revoke) lives on the
 // Fused account tab's Deployments section (SPEC AC-11), not here — this
 // modal is scoped to the current page.
@@ -39,7 +41,7 @@ import { useRefreshOnReturn } from "../lib/hooks";
 import { navigateUrl } from "../lib/router";
 import { Modal } from "./modal/Modal";
 import { ErrorBanner } from "./ErrorBanner";
-import { Select } from "./field/fields";
+import { Select, TextInput } from "./field/fields";
 
 // A path's bundle key: what dedup/exclude match on. Mirrors the server's
 // _asset_key (export.py) for the common case — strip a leading "./"; the exact
@@ -58,6 +60,13 @@ const CACHE_DURATION_PRESETS: { value: string; label: string }[] = [
   { value: "1d", label: "1 day" },
 ];
 const DEFAULT_CACHE_DURATION = "1h";
+
+// A chosen link name's allowed shape — mirrors the fused CLI's own mount-token
+// rule (fused repo's agent_core/mounts.py validate_token): lowercase letters,
+// digits, `-`/`_`, starting with a letter or digit. Checked client-side so a
+// bad name is caught before the round trip; the CLI is still the authority
+// (an already-taken name only it can know about surfaces from the deploy call).
+const TOKEN_RE = /^[a-z0-9][a-z0-9_-]*$/;
 
 // The preset list, plus the current value as its own option when it isn't a preset
 // (e.g. a duration set via `share create --cache-max-age` outside this dialog) — so
@@ -482,6 +491,11 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // fused's cache_max_age. Seeded on open from the stored record (like include/
   // exclude) and sent back on every Deploy; there is no "leave it as it was".
   const [cacheMaxAge, setCacheMaxAge] = useState<string>("0s");
+  // A user-chosen link name for the NEXT create (blank = auto-generated opaque
+  // token, today's default). Only meaningful before a mount exists on the
+  // selected env — once deployed the token is fixed, so this is never seeded
+  // from the stored record and is reset on every fresh open (see `load`).
+  const [customToken, setCustomToken] = useState("");
   // The result of the last "Clear cache" click (deleted/scope), shown as a status
   // line until the next load/action clears it.
   const [clearCacheResult, setClearCacheResult] = useState<CacheClearResult | null>(null);
@@ -586,6 +600,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
       // that hasn't been asked about yet.
       setCachingOpen(false);
       setErrorsOpen(false);
+      setCustomToken("");
     }
     try {
       const [cfg, status] = await Promise.all([
@@ -684,6 +699,18 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     [envs, selectedEnv],
   );
 
+  // A redeploy targets an existing, still-known mount (repoint / recreate
+  // --same-token) — both keep the mount's ORIGINAL token, so a chosen link
+  // name only ever applies to a fresh `share create`: no deployment yet, a
+  // different env, or the recorded mount gone from `share list` entirely.
+  const samePointerEnv = deployment !== null && deployment.env === selectedEnv;
+  const mountAbsent = live === "absent";
+  const isRedeploy = samePointerEnv && !mountAbsent;
+  const tokenError =
+    !isRedeploy && customToken && !TOKEN_RE.test(customToken)
+      ? "Use lowercase letters, numbers, - and _ only, starting with a letter or number."
+      : null;
+
   // Each handler applies its result (onChange always propagates to the header
   // dot), then guards the modal's OWN setState on `alive` — the dialog may
   // have been closed mid-action (#12).
@@ -693,7 +720,16 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     setActionError(null);
     setClearCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
-      const record = await deployPage(fsPath, env.name, include, exclude, cacheMaxAge, forceNew);
+      const wantsCustomToken = !isRedeploy && customToken.trim() !== "";
+      const record = await deployPage(
+        fsPath,
+        env.name,
+        include,
+        exclude,
+        cacheMaxAge,
+        forceNew,
+        wantsCustomToken ? customToken.trim() : undefined,
+      );
       applyDeployment(record);
       if (!alive.current) return;
       setReconciled(true);
@@ -773,12 +809,9 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   // Deploy/Redeploy: the button label stays stable ("Deploy" / "Redeploy" /
   // "Deploying…"); the URL nuance (same link, restored link, fresh link,
   // unconfirmed) moves to a single status line below, driven by `live` — the
-  // mount's VERIFIED `share list` classification. A redeploy is only when the
-  // pointer's env is the selected one AND the mount still exists; an absent
-  // mount does a fresh create, so it reads as "Deploy".
-  const samePointerEnv = deployment !== null && deployment.env === selectedEnv;
-  const mountAbsent = live === "absent";
-  const isRedeploy = samePointerEnv && !mountAbsent;
+  // mount's VERIFIED `share list` classification. (samePointerEnv/mountAbsent/
+  // isRedeploy are computed above, alongside the env memo — onDeploy needs
+  // isRedeploy too.)
   const deployLabel = busy === "deploy" ? "Deploying…" : isRedeploy ? "Redeploy" : "Deploy";
   // One status line for the same-env case, spelling out what happens to the URL.
   const deployStatus = !samePointerEnv
@@ -1028,6 +1061,31 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </div>
           )}
         </div>
+        {/* A chosen link name only applies to a FRESH create (see isRedeploy
+            above) — once a mount exists its token is fixed, so this control
+            hides on a redeploy rather than imply an edit that can't happen. */}
+        {!isRedeploy && (
+          <div className="deploy-files">
+            <div className="deploy-files-body">
+              <div className="deploy-form-row">
+                <label htmlFor="deploy-token-input">Link name</label>
+                <TextInput
+                  id="deploy-token-input"
+                  type="text"
+                  placeholder="auto-generated, unguessable"
+                  value={customToken}
+                  disabled={busy !== null}
+                  onChange={(e) => setCustomToken(e.target.value)}
+                />
+              </div>
+              <div className={"deploy-token-hint deploy-muted" + (tokenError ? " err" : "")}>
+                {tokenError ??
+                  "Leave blank for an unguessable public link (the default). Choosing a name " +
+                    "makes the URL guessable — anyone who knows or guesses it can open it."}
+              </div>
+            </div>
+          </div>
+        )}
         <div className="deploy-form-row">
           <label htmlFor="deploy-env-select">Deploy to</label>
           <Select
@@ -1056,14 +1114,15 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
               env === null ||
               preview === null ||
               previewPending ||
-              preview.errors.length > 0
+              preview.errors.length > 0 ||
+              tokenError !== null
             }
             title={
               preview === null || previewPending
                 ? "Preparing the publish preview…"
                 : preview.errors.length > 0
                   ? "Fix the export problems listed above first"
-                  : undefined
+                  : (tokenError ?? undefined)
             }
           >
             {busy === "deploy" && <span className="deploy-spinner" />}
@@ -1136,8 +1195,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         <details className="deploy-disclosure">
           <summary>About public links</summary>
           <div className="deploy-muted">
-            Deploys publish as a <b>public share link</b> — an unguessable URL; anyone with the link
-            can open it.
+            Deploys publish as a <b>public share link</b> — anyone with the link can open it. By
+            default the URL is an unguessable auto-generated token; the "Link name" field above
+            (fresh deploys only) lets you pick the URL's last segment instead, at the cost of it
+            becoming guessable.
           </div>
         </details>
         {actionError && <ErrorBanner>{actionError}</ErrorBanner>}

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -706,8 +706,19 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
   const samePointerEnv = deployment !== null && deployment.env === selectedEnv;
   const mountAbsent = live === "absent";
   const isRedeploy = samePointerEnv && !mountAbsent;
+  // The Link name field's own gate is deliberately NARROWER than isRedeploy:
+  // `live` is null both when reconcile never ran and when it ran but the env
+  // was unreachable (deployStatus's "couldn't be confirmed" branch below) —
+  // in that case we do NOT actually know yet whether the next Deploy click
+  // will repoint or fall through to a fresh create (deploy_page re-checks
+  // `share list` live, at click time, independent of this stale read). So
+  // only a CONFIRMED still-live mount (active or revoked) hides the field;
+  // an unconfirmed one leaves it up, and a name typed there is simply
+  // ignored server-side if the click turns out to repoint after all
+  // (deploy_page only applies custom_token on its create branches).
+  const confirmedRedeployToken = samePointerEnv && (live === "active" || live === "revoked");
   const tokenError =
-    !isRedeploy && customToken && !TOKEN_RE.test(customToken)
+    !confirmedRedeployToken && customToken && !TOKEN_RE.test(customToken)
       ? "Use lowercase letters, numbers, - and _ only, starting with a letter or number."
       : null;
 
@@ -720,7 +731,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     setActionError(null);
     setClearCacheResult(null); // a stale "N cleared" note must not survive a redeploy
     try {
-      const wantsCustomToken = !isRedeploy && customToken.trim() !== "";
+      const wantsCustomToken = !confirmedRedeployToken && customToken.trim() !== "";
       const record = await deployPage(
         fsPath,
         env.name,
@@ -1061,10 +1072,12 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
             </div>
           )}
         </div>
-        {/* A chosen link name only applies to a FRESH create (see isRedeploy
-            above) — once a mount exists its token is fixed, so this control
-            hides on a redeploy rather than imply an edit that can't happen. */}
-        {!isRedeploy && (
+        {/* A chosen link name only applies to a FRESH create (see
+            confirmedRedeployToken above) — hidden only once the existing
+            mount's liveness is CONFIRMED (active/revoked), so an unreachable-
+            env "unconfirmed" state (live === null) leaves it up rather than
+            hide a control that a subsequent fresh create could still use. */}
+        {!confirmedRedeployToken && (
           <div className="deploy-files">
             <div className="deploy-files-body">
               <div className="deploy-form-row">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -521,6 +521,10 @@ export function deployPage(
   exclude: string[],
   cacheMaxAge: string,
   forceNew?: boolean,
+  // A chosen link name for a FRESH `share create` (see deploy.py's
+  // deploy_page) — omit for the default auto-generated opaque token. Ignored
+  // server-side on a redeploy that reuses an existing token (repoint/recreate).
+  token?: string,
 ): Promise<Deployment> {
   return postJson<Deployment>("/api/deploy", {
     page: fsPath,
@@ -529,6 +533,7 @@ export function deployPage(
     exclude,
     cache_max_age: cacheMaxAge,
     force_new: forceNew ?? false,
+    ...(token ? { token } : {}),
   });
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -425,6 +425,11 @@ export interface Deployment {
   // Reopening the modal reloads it, same as include/exclude. Optional — records
   // written before this feature omit it (read as "0s").
   cache_max_age?: string;
+  // Whether this mount's token is a user-chosen name (a deliberately guessable
+  // public URL) vs the default crypto-random opaque one — so the modal shows
+  // "custom name" vs "unguessable" without re-deriving it from the token string.
+  // Optional — records written before this feature omit it (read as false).
+  named?: boolean;
   updated_at: string;
 }
 

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2219,6 +2219,38 @@ select.field-control:has(option[value=""]:checked) {
   color: var(--error);
 }
 
+/* The random-vs-named link picker: a borderless fieldset (the enclosing
+   .deploy-files card already frames it) with a small caption and two stacked
+   radio rows. */
+.deploy-token-modes {
+  border: 0;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.deploy-token-modes > legend {
+  padding: 0;
+  color: var(--fg-muted);
+}
+
+.deploy-token-mode {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.deploy-token-mode input {
+  /* Keep the control aligned with the first text line of a wrapping label. */
+  margin: 0;
+  position: relative;
+  top: 2px;
+  flex: 0 0 auto;
+}
+
 /* Error card (also rendered by components/ErrorBanner.tsx as .error-banner):
    full 1px error-tinted border + a subtle error-tinted wash, no left stripe. */
 .deploy-error,

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2251,6 +2251,14 @@ select.field-control:has(option[value=""]:checked) {
   flex: 0 0 auto;
 }
 
+/* The public/no-auth note that sits directly under the Link section — snug it
+   up against that card (overriding the body's 12px gap) so it reads as the
+   section's footnote, not a section of its own. */
+.deploy-about {
+  margin-top: -6px;
+  font-size: 12px;
+}
+
 /* Error card (also rendered by components/ErrorBanner.tsx as .error-banner):
    full 1px error-tinted border + a subtle error-tinted wash, no left stripe. */
 .deploy-error,

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2212,6 +2212,13 @@ select.field-control:has(option[value=""]:checked) {
   color: var(--fg-muted);
 }
 
+/* Inline hint under the "Link name" input when it fails the token-shape check
+   — a plain color swap, not the bordered .deploy-error card (too heavy for an
+   inline field hint that appears/disappears on every keystroke). */
+.deploy-token-hint.err {
+  color: var(--error);
+}
+
 /* Error card (also rendered by components/ErrorBanner.tsx as .error-banner):
    full 1px error-tinted border + a subtle error-tinted wash, no left stripe. */
 .deploy-error,

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -398,7 +398,7 @@ def set_deployment(page: str, record: dict) -> None:
 
 def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
                  entrypoints: list[str], include: list[str], exclude: list[str],
-                 cache_max_age: str, fallback: dict | None) -> dict:
+                 cache_max_age: str, named: bool, fallback: dict | None) -> dict:
     # `cache_max_age` here is simply what the caller requested this deploy — every
     # branch in deploy_page (create, repoint, recreate+repoint) now actually applies
     # it (`application` repo spec 021 §3.1, amended: a managed Fused mount's
@@ -435,6 +435,13 @@ def _record_from(raw: dict, *, page: str, env_name: str, backend: str,
         # redeploy that doesn't touch it re-sends the same value (the fused CLI has no
         # "preserve on omit" for this — every deploy is an explicit, full statement).
         "cache_max_age": cache_max_age,
+        # Whether this mount's token is a user-chosen name (a deliberately
+        # guessable public URL) vs the default crypto-random opaque one. Set at
+        # the fresh-create that minted the token and carried forward unchanged
+        # on every token-reuse redeploy (repoint/recreate keep the token, so
+        # they keep its provenance) — the modal shows "custom name" vs
+        # "unguessable" from this without re-deriving it from the token string.
+        "named": named,
         "updated_at": _now_iso(),
     }
 
@@ -598,7 +605,14 @@ def deploy_page(
             if force_new and pointer and pointer.get("env") == env_name
             else None
         )
+        # Token provenance for the stored record: a fresh create's is set by
+        # whether a name was chosen this call; a token-reuse redeploy inherits
+        # the existing record's (repoint/recreate keep the token, so its
+        # named-ness is unchanged). Old records predating this field read as
+        # False (unguessable) — the token can't be reclassified retroactively.
+        named = bool(same_env.get("named")) if same_env else False
         if not token:
+            named = bool(custom_token)
             create_args = ["create", bundle, "--public", "--cache-max-age", cache_max_age]
             if custom_token:
                 create_args += ["--token", custom_token]
@@ -650,6 +664,7 @@ def deploy_page(
                     )
                     raise
             else:  # absent — e.g. after an infra teardown; nothing to revive
+                named = bool(custom_token)  # a fresh create, like the first-deploy path
                 create_args = ["create", bundle, "--public", "--cache-max-age", cache_max_age]
                 if custom_token:
                     create_args += ["--token", custom_token]
@@ -658,7 +673,7 @@ def deploy_page(
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
             entrypoints=entrypoints, include=include, exclude=exclude,
-            cache_max_age=cache_max_age, fallback=same_env,
+            cache_max_age=cache_max_age, named=named, fallback=same_env,
         )
         set_deployment(page, record)
         # force_new replace: the new mount is live and the pointer now tracks it,

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -37,10 +37,13 @@ child process, exactly the pattern the flow app uses for project deploys
     and the share list endpoint joins mounts back to local pages via the
     pointer store.
 
-Deploys are **public share links** (opaque, unguessable capability tokens —
-`share create --public` with no --token): per spec/serve/fused-render.md,
-authed mounts can't serve a hosted page's asset GETs yet, so public is the one
-posture that works fully today.
+Deploys are **public share links** (`share create --public`): per
+spec/serve/fused-render.md, authed mounts can't serve a hosted page's asset
+GETs yet, so public is the one posture that works fully today. The token
+itself defaults to an opaque, unguessable one (no --token), but the Deploy
+dialog's "Link name" field lets the user pass an explicit --token instead —
+a deliberately public, guessable URL (fused's own gate: --public + a chosen
+--token is allowed, unlike --public + an auth gate).
 
 No import of server.py (server imports this router — keep it acyclic); the
 X-Fused guard is duplicated locally like shell/bookmarks.py does.
@@ -487,6 +490,7 @@ def deploy_page(
     exclude: list[str] | None = None,
     cache_max_age: str = "0s",
     force_new: bool = False,
+    custom_token: str | None = None,
 ) -> dict:
     """Export `page` to a temp bundle and publish it on `env_name`; returns the
     stored deployment record (token, URL when the backend returned one).
@@ -527,6 +531,17 @@ def deploy_page(
     revoked tombstone -> `share recreate --same-token` then repoint (same URL
     comes back); token absent from `share list` entirely -> fresh create
     (nothing left to revive).
+
+    `custom_token`, when given, rides along as `share create`'s `--token` on
+    every branch above that actually mints a FRESH mount (first deploy, a
+    different env, or an absent mount) — it picks the URL's token instead of
+    the default crypto-random opaque one (a deliberately public, guessable
+    link — `fused`'s own `share create --public --token` gate, spec/serve/
+    share-links.md §2). It is ignored on the two branches that redeploy an
+    EXISTING mount (`repoint`, `recreate --same-token`): neither takes a token
+    argument, because both keep the mount's original token, named or not —
+    there is nothing to apply a new choice to. An already-taken or malformed
+    name surfaces as the fused CLI's own error (via `_run_share`/DeployError).
     """
     include = include or []
     exclude = exclude or []
@@ -584,9 +599,10 @@ def deploy_page(
             else None
         )
         if not token:
-            raw = _run_share(
-                env_name, ["create", bundle, "--public", "--cache-max-age", cache_max_age]
-            )
+            create_args = ["create", bundle, "--public", "--cache-max-age", cache_max_age]
+            if custom_token:
+                create_args += ["--token", custom_token]
+            raw = _run_share(env_name, create_args)
         else:
             live = _classify_mount(_list_mounts(env_name), token)
             # `--cache-max-age` on every branch below: AWS re-reads the bundle's own
@@ -634,9 +650,10 @@ def deploy_page(
                     )
                     raise
             else:  # absent — e.g. after an infra teardown; nothing to revive
-                raw = _run_share(
-                    env_name, ["create", bundle, "--public", "--cache-max-age", cache_max_age]
-                )
+                create_args = ["create", bundle, "--public", "--cache-max-age", cache_max_age]
+                if custom_token:
+                    create_args += ["--token", custom_token]
+                raw = _run_share(env_name, create_args)
 
         record = _record_from(
             raw, page=page, env_name=env_name, backend=backend,
@@ -1030,9 +1047,25 @@ def api_deploy(body: dict = Body(...), x_fused: str | None = Header(default=None
     force_new = body.get("force_new", False)
     if not isinstance(force_new, bool):
         return _error("'force_new' must be a boolean")
+    # Optional chosen link name (a fresh-create-only knob — deploy_page ignores
+    # it on a redeploy path that reuses an existing token). Format/uniqueness
+    # aren't re-validated here: the fused CLI's own --token validation and
+    # "already taken" check are the authority, and DeployError passes that
+    # message through verbatim, same as every other CLI-side rejection.
+    custom_token = body.get("token")
+    if custom_token is not None and (
+        not isinstance(custom_token, str) or not custom_token.strip()
+    ):
+        return _error("'token' must be a non-empty string")
     try:
         return deploy_page(
-            page, env_name, include, exclude, cache_max_age=cache_max_age, force_new=force_new
+            page,
+            env_name,
+            include,
+            exclude,
+            cache_max_age=cache_max_age,
+            force_new=force_new,
+            custom_token=custom_token,
         )
     except ExportError as e:
         return _error(str(e))

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -1068,10 +1068,14 @@ def api_deploy(body: dict = Body(...), x_fused: str | None = Header(default=None
     # "already taken" check are the authority, and DeployError passes that
     # message through verbatim, same as every other CLI-side rejection.
     custom_token = body.get("token")
-    if custom_token is not None and (
-        not isinstance(custom_token, str) or not custom_token.strip()
-    ):
-        return _error("'token' must be a non-empty string")
+    if custom_token is not None:
+        if not isinstance(custom_token, str) or not custom_token.strip():
+            return _error("'token' must be a non-empty string")
+        # Normalize at the boundary: forward the trimmed value, never the raw
+        # one — otherwise "my-link " passes the non-empty check but reaches
+        # `share create --token` with surrounding whitespace, which disagrees
+        # with the client's TOKEN_RE and the CLI's own token rules.
+        custom_token = custom_token.strip()
     try:
         return deploy_page(
             page,

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -394,6 +394,81 @@ def test_deploy_creates_public_share_and_stores_pointer(tmp_path, monkeypatch):
     assert h.pointer()["token"] == "abc123"
 
 
+def test_deploy_passes_custom_token_to_create(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {
+            "create": {
+                "token": "my-name",
+                "url": "https://serve.example/my-name",
+                "status": "active",
+            }
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "my-name"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token"] == "my-name"
+
+    (call,) = h.calls()
+    assert call["argv"][0] == "share" and call["argv"][1] == "create"
+    assert call["argv"][-2:] == ["--token", "my-name"]
+
+
+def test_deploy_rejects_blank_token(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "   "},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert "token" in resp.json()["error"]
+    assert h.calls() == []
+
+
+def test_deploy_rejects_non_string_token(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": 123},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert h.calls() == []
+
+
+def test_deploy_custom_token_ignored_on_repoint(tmp_path, monkeypatch):
+    # A redeploy of an already-active mount repoints the EXISTING token — the
+    # fused CLI's `share repoint` takes no --token argument at all, so a token
+    # supplied on a redeploy must never reach that call.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "repoint": {"token": "abc123", "url": "https://serve.example/abc123"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "ignored-name"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    repoint_call = h.calls()[-1]
+    assert repoint_call["argv"][1] == "repoint"
+    assert "--token" not in repoint_call["argv"]
+    assert "ignored-name" not in repoint_call["argv"]
+
+
 def test_deploy_bundles_included_file_and_persists_selection(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     (tmp_path / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -853,6 +853,35 @@ def test_redeploy_absent_mount_falls_back_to_fresh_create(tmp_path, monkeypatch)
     assert h.calls()[-1]["argv"][-2:] == ["--cache-max-age", "1h"]
 
 
+def test_redeploy_absent_mount_honors_a_custom_token(tmp_path, monkeypatch):
+    # The "absent" branch (a distinct create call site from the very-first-deploy
+    # one) must also thread a chosen link name through to `share create`.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+
+    h.set_scenario(
+        {
+            "list": [],
+            "create": {
+                "token": "chosen-name",
+                "url": "https://serve.example/chosen-name",
+                "status": "active",
+            },
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "chosen-name"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token"] == "chosen-name"
+    assert h.calls()[-1]["argv"][-2:] == ["--token", "chosen-name"]
+
+
 def test_fresh_create_with_new_token_never_keeps_the_old_url(tmp_path, monkeypatch):
     # AWS-style create output carries no url. When the token CHANGED (absent
     # mount -> fresh create), the old pointer's url must be dropped, not kept —

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -412,10 +412,81 @@ def test_deploy_passes_custom_token_to_create(tmp_path, monkeypatch):
     )
     assert resp.status_code == 200, resp.text
     assert resp.json()["token"] == "my-name"
+    # A user-chosen name is recorded as `named` so the modal shows "custom name".
+    assert resp.json()["named"] is True
+    assert h.pointer()["named"] is True
 
     (call,) = h.calls()
     assert call["argv"][0] == "share" and call["argv"][1] == "create"
     assert call["argv"][-2:] == ["--token", "my-name"]
+
+
+def test_deploy_default_token_is_not_named(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+    )
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    # No name chosen -> the opaque default -> named is False.
+    assert resp.json()["named"] is False
+
+
+def test_named_flag_carried_forward_on_repoint(tmp_path, monkeypatch):
+    # A named mount stays "named" across a token-reuse redeploy: repoint keeps
+    # the token, so its provenance must not silently flip to unguessable.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "my-name", "url": "https://serve.example/my-name", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "my-name"},
+        headers=FUSED,
+    )
+    assert h.pointer()["named"] is True
+
+    h.set_scenario(
+        {
+            "list": [{"token": "my-name", "status": "active"}],
+            "repoint": {"token": "my-name", "url": "https://serve.example/my-name"},
+        }
+    )
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["named"] is True
+    assert h.pointer()["named"] is True
+
+
+def test_force_new_to_unguessable_clears_named(tmp_path, monkeypatch):
+    # "Change link" from a custom name back to the unguessable default: force_new
+    # mints a fresh opaque token, and the record's `named` must follow it to
+    # False (not inherit the superseded mount's True).
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "my-name", "url": "https://serve.example/my-name", "status": "active"}}
+    )
+    h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "my-name"},
+        headers=FUSED,
+    )
+
+    h.set_scenario(
+        {
+            "create": {"token": "xyz789", "url": "https://serve.example/xyz789", "status": "active"},
+            "revoke": {"token": "my-name", "status": "revoked"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "force_new": True},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["token"] == "xyz789"
+    assert resp.json()["named"] is False
+    assert h.pointer()["named"] is False
 
 
 def test_deploy_rejects_blank_token(tmp_path, monkeypatch):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -489,6 +489,24 @@ def test_force_new_to_unguessable_clears_named(tmp_path, monkeypatch):
     assert h.pointer()["named"] is False
 
 
+def test_deploy_trims_token_before_the_cli(tmp_path, monkeypatch):
+    # Surrounding whitespace must be stripped at the API boundary, not forwarded
+    # to `share create --token` (where it disagrees with the client's TOKEN_RE
+    # and the CLI's own token rules).
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(
+        {"create": {"token": "my-name", "url": "https://serve.example/my-name", "status": "active"}}
+    )
+    resp = h.client.post(
+        "/api/deploy",
+        json={"page": str(h.page), "env": "cloud", "token": "  my-name  "},
+        headers=FUSED,
+    )
+    assert resp.status_code == 200, resp.text
+    (call,) = h.calls()
+    assert call["argv"][-2:] == ["--token", "my-name"]
+
+
 def test_deploy_rejects_blank_token(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
     resp = h.client.post(


### PR DESCRIPTION
## Summary
Adds support for users to optionally choose custom, human-readable names for deployed public share links instead of always using auto-generated opaque tokens. This feature is only available when creating fresh deployments, not when redeploying to an existing mount.

## Key Changes

- **Frontend (DeployModal.tsx)**
  - Added `customToken` state to track user-entered link names
  - Added `TOKEN_RE` regex pattern (`^[a-z0-9][a-z0-9_-]*$`) to validate token format client-side before deploy
  - Introduced `isRedeploy` logic to determine when the link name field should be visible (only on fresh creates, hidden on redeployments)
  - Added "Link name" input field with validation error messaging and helpful hint text
  - Disabled Deploy button when token validation fails
  - Pass `customToken` to `deployPage()` API call only when user provides a non-empty value and it's a fresh deploy
  - Updated help text to explain the tradeoff between unguessable auto-generated tokens and chosen names

- **Backend (deploy.py)**
  - Added `custom_token` parameter to `deploy_page()` function
  - Appends `--token <name>` to `share create --public` calls only on fresh mount creation branches (first deploy, different env, or absent mount)
  - Explicitly ignores `custom_token` on redeploy paths (`repoint`, `recreate --same-token`) since those keep the existing token
  - Added server-side validation in `api_deploy()` to ensure token is a non-empty string if provided
  - Updated docstrings to explain the feature and its constraints

- **API (api.ts)**
  - Added optional `token` parameter to `deployPage()` function
  - Conditionally includes token in request body only when provided

- **Tests (test_deploy.py)**
  - Added `test_deploy_passes_custom_token_to_create()` to verify custom tokens are passed to CLI
  - Added `test_deploy_rejects_blank_token()` to validate empty token rejection
  - Added `test_deploy_rejects_non_string_token()` to validate type checking
  - Added `test_deploy_custom_token_ignored_on_repoint()` to ensure tokens are ignored on redeployments

- **Documentation (SPEC.md, README.md)**
  - Updated specs to document the new Link name feature and its constraints
  - Clarified that custom names create deliberately guessable URLs
  - Documented client-side validation and server-side error handling

## Implementation Details

- The feature respects the fused CLI's own token validation rules and gate constraints (`share create --public --token` is allowed)
- Client-side validation prevents unnecessary round trips for obviously invalid names
- Server-side validation ensures only non-empty strings are accepted
- The custom token is only applied to fresh mount creation; redeploys always preserve the existing token since `repoint` and `recreate --same-token` don't accept a `--token` argument
- Already-taken or malformed names surface as fused CLI errors, reported verbatim to the user
- The UI clearly indicates this is a fresh-deploy-only feature by hiding the field on redeployments

https://claude.ai/code/session_01Li7Acw1QqWQ5nmM8rotdm3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public share URL minting and persistence (`named`, `--token`); mistakes could expose guessable links or orphan mounts on change-link, but behavior is gated to fresh creates and covered by new tests.
> 
> **Overview**
> Adds a collapsible **Link** section to the Deploy modal so users can choose an **unguessable** random token (default) or a **custom name** on fresh `share create` paths, with client-side `TOKEN_RE` validation and optional `token` on `POST /api/deploy` forwarded as `share create --public --token`.
> 
> Once a mount is confirmed live on the same env, the picker becomes a read-only summary plus **Change link**, which runs `force_new` deploy (new URL, best-effort revoke of the old). Redeploy/repoint paths ignore custom tokens; deployment records gain a persisted **`named`** flag for UI provenance.
> 
> **Recent errors** always renders (disabled with a hint before first deploy). Public/no-auth copy moves inline under Link instead of a bottom disclosure. SPEC/README and deploy tests cover token threading, trimming, repoint ignore, and `named` carry-forward.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c52de34498e3fe3e2872d760cabee743470cb40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->