### PR TITLE
Extend cache duration presets to 7d and 14d

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -884,9 +884,15 @@ the product gains network access.
   bundle classification as a follow-up. fused-render passes the CLI's own
   error through verbatim rather than second-guessing the installed version.
 - **DP-17** The modal carries a **caching control**: a checkbox ("Cache page
-  results") plus a duration select (1m/5m/15m/1h/6h/1d presets, default **1h**,
-  plus the current value verbatim when it isn't one of them — e.g. set by a
-  direct `share create --cache-max-age` outside this dialog), seeded on open
+  results") plus a duration select (1m/5m/15m/1h/6h/1d/7d/14d presets, default
+  **1h**, plus the current value verbatim when it isn't one of them — e.g. set by a
+  direct `share create --cache-max-age` outside this dialog). 30 days is the true
+  ceiling (the `results/` cache-bucket lifecycle GC backstop both backends fix at
+  30 days — `RESULTS_CACHE_LIFECYCLE_DAYS` for a managed environment,
+  `openfused-gc-results` for self-hosted AWS; a managed environment's
+  `_build_cache_settings` rejects anything beyond it), but 30d itself is
+  deliberately not offered as a preset — it would leave no margin against that
+  backstop, whereas 14d keeps a comfortable half-window of slack. Seeded on open
   from the stored deployment record like `include`/`exclude` (DP-2c) and
   re-sent as `cache_max_age` on every Deploy — there is no "leave it as it
   was". It reaches the two backends **differently**, because they model

--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -47,8 +47,18 @@ import { Select } from "./field/fields";
 const relKey = (p: string) => p.replace(/^\.\//, "");
 
 // Caching duration presets (fused's cache_max_age format — a non-negative integer +
-// s/m/h/d unit; see fused/agent_core/caching.py's parse_cache_max_age). "0s" is off
-// and not itself an option here — the checkbox controls that axis.
+// s/m/h/d unit; see fused/agent_core/caching.py's parse_cache_max_age, which itself
+// has no upper bound). The real ceiling is the env's `results/` cache-bucket
+// lifecycle rule, which hard-expires cached objects and is a GC backstop meant to
+// stay comfortably ABOVE any TTL in use (fused repo's spec/caching/storage.md;
+// application repo's openfused_server/app/serving.py rejects a `cache_max_age`
+// beyond it outright). That rule is fixed at 30 days
+// (RESULTS_CACHE_LIFECYCLE_DAYS, application/openfused_server/app/managed/
+// provisioning.py) for a managed environment, and matches for a self-hosted AWS
+// backend (`openfused-gc-results`, fused/src/fused/agent_core/backends/aws/manage.py).
+// 30d itself is deliberately NOT offered here — it would leave zero margin against
+// that backstop; 14d keeps a comfortable half-window of slack. "0s" is off and not
+// itself an option here — the checkbox controls that axis.
 const CACHE_DURATION_PRESETS: { value: string; label: string }[] = [
   { value: "1m", label: "1 minute" },
   { value: "5m", label: "5 minutes" },
@@ -56,6 +66,8 @@ const CACHE_DURATION_PRESETS: { value: string; label: string }[] = [
   { value: "1h", label: "1 hour" },
   { value: "6h", label: "6 hours" },
   { value: "1d", label: "1 day" },
+  { value: "7d", label: "7 days" },
+  { value: "14d", label: "14 days" },
 ];
 const DEFAULT_CACHE_DURATION = "1h";
 


### PR DESCRIPTION
## Summary
Extended the caching duration presets in the Deploy modal to include 7-day and 14-day options, with comprehensive documentation explaining the caching architecture and why 30 days (the true ceiling) is deliberately excluded.

## Changes
- **DeployModal.tsx**: Added two new cache duration presets (`7d` and `14d`) to `CACHE_DURATION_PRESETS`
- **DeployModal.tsx**: Expanded the comment block documenting cache duration limits to explain:
  - The 30-day hard ceiling imposed by the `results/` cache-bucket lifecycle rule (GC backstop)
  - How this limit is enforced identically across managed and self-hosted AWS backends
  - Why 30d is not offered as a preset (leaves no safety margin)
  - Why 14d is the maximum recommended preset (maintains a comfortable half-window of slack)
- **SPEC.md**: Updated DP-17 specification to reflect the new presets and document the caching architecture rationale

## Implementation Details
The cache duration presets now span from 1 minute to 14 days, with 14 days deliberately chosen as the maximum user-facing option to maintain a safety margin below the 30-day backend lifecycle limit. This prevents users from accidentally setting cache durations that would be immediately expired by the GC backstop, while still offering substantial caching windows for appropriate use cases.

https://claude.ai/code/session_01MC44wdQWZ8vxqHmoV7x83D

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI preset and documentation-only changes to deploy cache duration; no deploy API or backend behavior changes.
> 
> **Overview**
> **Deploy caching** now offers **7-day** and **14-day** choices in the Deploy modal duration dropdown, on top of the existing minute-through-1-day presets. Default remains **1h**; non-preset values from the CLI still appear verbatim in the select.
> 
> **SPEC DP-17** and the `DeployModal` comment block are aligned to explain that both managed and AWS backends enforce a **30-day** `results/` lifecycle GC backstop, that **30d is intentionally not a preset** (no margin vs. expiry), and that **14d** is the longest offered option to keep slack below that limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8167978a9ff139151625d3b5467f38ad6d050ca1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->