### PR TITLE
Bump duckdb minimum version requirement to 1.5.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # The duckdb template reads AND edits every tabular file format (parquet,
     # csv/tsv, json) through one engine, so it's a core dependency, not an
     # optional extra — a plain `pip install fused-render` ships the viewer.
-    "duckdb>=1.1",
+    "duckdb>=1.5.5",
     # FastAPI's /api/templates/import endpoint accepts multipart form/file
     # uploads, which requires python-multipart at import time (FastAPI raises
     # at route registration otherwise).


### PR DESCRIPTION
## Summary
Updated the minimum required version of duckdb from 1.1 to 1.5.5 in the project dependencies.

## Changes
- Updated `duckdb` dependency constraint in `pyproject.toml` from `>=1.1` to `>=1.5.5`

## Details
This version bump ensures that users have access to features and bug fixes available in duckdb 1.5.5 and later. Since duckdb is a core dependency for the fused-render viewer (used for reading and editing tabular file formats like parquet, csv/tsv, and json), this change affects all installations of the package.

https://claude.ai/code/session_01UraQ7nmKchPCtgnzv8WBnQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only constraint change with no code edits; main effect is stricter installs and possible resolver failures on environments pinned below 1.5.5.
> 
> **Overview**
> Raises the **core** `duckdb` floor in `pyproject.toml` from `>=1.1` to `>=1.5.5`, so fresh `pip install fused-render` resolves DuckDB 1.5.5+.
> 
> No application code changes—only the declared dependency constraint for the in-package tabular viewer engine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c14ff78173cee7af8b6b3fd50b6964eafb107f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->