### PR TITLE
Prevent layout shift when loading preview header

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -149,10 +149,19 @@ function StatErrorView({
 function LoadingScaffold({ fsPath, isDir }: { fsPath: string; isDir: boolean }) {
   return (
     <>
+      {/* Mirror the loaded Header exactly (Preview.tsx `Header`): the name in a
+          `.preview-title` group, and a `.mode-switcher-placeholder` that reserves
+          the mode switcher's button height in the actions slot. Without this the
+          header grows (spinner → 28px buttons) when stat resolves, dropping the
+          name and the whole body — a visible layout shift on every navigation. */}
       <div className="preview-header">
-        <h1 title={fsPath}>{basename(fsPath)}</h1>
+        <div className="preview-title">
+          <h1 title={fsPath}>{basename(fsPath)}</h1>
+        </div>
         <div className="preview-actions">
-          <span className="mode-icon-spinner" aria-label="Loading" />
+          <span className="mode-switcher-placeholder" aria-label="Loading">
+            <span className="mode-icon-spinner" />
+          </span>
         </div>
       </div>
       <div className="preview-body">

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1058,6 +1058,11 @@ table.listing-table td.mtime {
   padding: 10px 16px;
   border-bottom: 1px solid var(--border);
   gap: 12px;
+  /* Pin the height to the tallest state (28px mode-switcher button + 10px×2
+     padding + 1px border) so the header can't grow when the loading spinner is
+     replaced by the real switcher on stat resolve — otherwise the name and the
+     whole body below shift down on every navigation. */
+  min-height: 49px;
 }
 
 /* Groups the name with whatever renders right after it (e.g. the directory
@@ -1165,6 +1170,18 @@ table.listing-table td.mtime {
   background: var(--accent);
   color: #10131a;
   border-color: var(--accent);
+}
+
+/* Loading placeholder in the header actions slot (App.tsx LoadingScaffold):
+   a borderless box the size of one .mode-switcher-btn so the header holds the
+   switcher's height while stat is in flight — no growth/shift when the real
+   switcher lands. */
+.preview-actions .mode-switcher-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
 }
 
 /* Template-mode icon: monochrome SVG tinted via mask-image + currentColor


### PR DESCRIPTION
## Summary
This PR fixes a layout shift that occurs when navigating between files in the preview panel. The header would grow when the loading spinner is replaced by the actual mode switcher buttons, causing the file name and entire preview body to shift down.

## Key Changes
- **CSS updates (`shell.css`)**:
  - Added `min-height: 49px` to `.preview-header` to pin the header height to accommodate the tallest state (28px mode-switcher button + padding + border)
  - Added new `.preview-actions .mode-switcher-placeholder` styles to create a fixed-size placeholder (28px × 28px) that reserves space for the mode switcher during loading

- **Component updates (`App.tsx`)**:
  - Wrapped the title in a `.preview-title` div to match the structure of the loaded `Header` component
  - Replaced the bare spinner with a `.mode-switcher-placeholder` container that holds the spinner, ensuring consistent height during the loading state
  - Added explanatory comments documenting the layout shift prevention strategy

## Implementation Details
The fix works by ensuring the loading scaffold (`LoadingScaffold`) mirrors the exact structure and dimensions of the fully-loaded header (`Header` from `Preview.tsx`). By reserving the correct height for the mode switcher placeholder during loading, the header maintains a constant height throughout the stat resolution process, eliminating the visual shift when the spinner is replaced with actual buttons.

https://claude.ai/code/session_01NEL2w8Wi7HbZjowst7c8JL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading scaffold and CSS tweaks with no API, auth, or data-path changes.
> 
> **Overview**
> Fixes a **layout shift** on preview navigation: the header used to grow when the loading spinner was replaced by the real mode switcher, pushing the title and body down.
> 
> **`LoadingScaffold`** now mirrors **`Preview`’s `Header`**: title inside `.preview-title`, and a **28×28** `.mode-switcher-placeholder` around the spinner instead of a bare spinner in `.preview-actions`.
> 
> **`shell.css`** pins `.preview-header` with **`min-height: 49px`** and styles the placeholder to match `.mode-switcher-btn` dimensions so height stays stable through stat resolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9e6657af3a78547aecf20e4923f5e70da577e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->