### PR TITLE
docs: publish-readiness pass over SPEC.md and ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -86,12 +86,12 @@ fused-render [--start-dir DIR] [--port N] [--no-browser]
 All paths in query strings are **absolute filesystem paths**. Server never scopes/rejects by location (v1 has no security layer — deliberate, see SPEC §9). Errors return `{"error": "<message>"}` with 4xx status. Every response carries `Cache-Control: no-cache` (middleware) — app code changes between restarts and user files change on disk; stale cached shell/runtime JS produced half-old UIs during development. The two mutating/executing POSTs (`/api/run`, `/api/fs/write`) require an `X-Fused: 1` header (missing/wrong → 403); it forces a CORS preflight so a foreign page can't fire them blind. Not auth — D3 stands (see DECISIONS.md D36).
 
 ### `GET /` and `GET /view/{path:path}` → shell.html
-Same static shell for both; shell JS reads `location.pathname` to route. `/view/Users/vasu/data` means fs path `/Users/vasu/data` (strip `/view/`, prepend `/`).
+Same static shell for both; shell JS reads `location.pathname` to route. `/view/Users/you/data` means fs path `/Users/you/data` (strip `/view/`, prepend `/`).
 
 ### `GET /api/fs/stat?path=<abs>`
 ```json
 {
-  "path": "/Users/vasu/data/trips.parquet",
+  "path": "/Users/you/data/trips.parquet",
   "name": "trips.parquet",
   "is_dir": false,
   "size": 123456,
@@ -116,7 +116,7 @@ A `_`-prefixed name appearing in a registry list is valid only for the known sen
 ### `GET /api/fs/list?path=<abs dir>`
 ```json
 {
-  "path": "/Users/vasu/data",
+  "path": "/Users/you/data",
   "entries": [
     {"name": "sub", "is_dir": true,  "size": null,   "mtime": 1751500000.0},
     {"name": "trips.parquet", "is_dir": false, "size": 123456, "mtime": 1751600000.0}
@@ -140,7 +140,7 @@ Returns `text/html`. Used as iframe src by the shell for both user HTML and temp
 ### `POST /api/run`  *(requires `X-Fused: 1`)*
 Request:
 ```json
-{"py": "./sine.py", "html": "/Users/vasu/views/sine.html", "params": {"freq": "2.4"}}
+{"py": "./sine.py", "html": "/Users/you/views/sine.html", "params": {"freq": "2.4"}}
 ```
 - `py` relative → resolved against `dirname(html)`; absolute → used as-is. (`html` may be null only if `py` is absolute.)
 - Response is the executor result verbatim (HTTP 200 even for user-code errors — the `ok` field carries success):
@@ -200,7 +200,7 @@ Top-level `path` handling in shell URL vs iframe URL:
 ## 6. Shell (`frontend/` → `static/shell-dist/`)
 
 SPA, React 18 + Vite (D52/D53; TypeScript, strict). `src/lib/` is non-React and ported ~verbatim from the vanilla shell (router/api/format/bookmarks/layout-codec — same contracts as before); components consume it. Dependency direction is one-way as before: `App → views/Sidebar/Breadcrumb → lib/*`; the router never imports UI (it dispatches a `fused:navigate` event; `lib/hooks.ts` turns it plus `popstate` into a **nav epoch** that keys — i.e. remounts — the active view, the React equivalent of the vanilla per-route DOM rebuild), the bookmark store never touches the DOM (mutations signal via `notifyBookmarksChanged()`). `Breadcrumb.tsx` may import `views/Panel.tsx` (`panelUrl`), and `Sidebar.tsx` may import `views/Tabs.tsx` (`composeFolderTabsUrl`), since no view imports back — no cycles. The history replaceState/pushState wrapping (→ `fused:urlchange`) lives in `main.tsx` and is load-bearing for the iframe runtimes (D46), not just for the shell's own re-renders; chrome (bookmark buttons, active highlight) re-renders on a **url version** signal that also counts `fused:urlchange`, without remounting views. Layout-mode iframes freeze their `src` at mount — React never rewrites it (a src write reloads an iframe); pane crumb clicks write it imperatively via a ref, and tab frames render as a flat keyed list that only appends/removes (never re-parents/reorders). Routing from `location.pathname`:
-- `/` → redirect (replaceState) to `/view/<start-dir>` (start dir from `GET /api/config` → `{"start_dir": "/Users/vasu", "home": …}` — `source_template` was dropped with the html sentinel modes (D62); the code-view path arrives via `stat.templates` like everything else, and the shell `Config` type dropped it too).
+- `/` → redirect (replaceState) to `/view/<start-dir>` (start dir from `GET /api/config` → `{"start_dir": "/Users/you", "home": …}` — `source_template` was dropped with the html sentinel modes (D62); the code-view path arrives via `stat.templates` like everything else, and the shell `Config` type dropped it too).
 - `/view/<path>` → `stat` it:
   - a target with a non-empty `stat.templates` → preview view — **including a directory** (every directory resolves at least the universal `/` key → `["_listing"]`, SPEC PT-13/D81; the built-in listing is the `_listing` sentinel mode)
   - **dir** with an empty `templates` (a `null` binding disabled it) → listing view — the shell's safety net (a folder must always render something)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # fused-render — Requirements Specification
 
-**Status:** Draft v0.1
-**Scope:** Fully local system. Never deployed to cloud. Single user, single machine.
+**Status:** Living specification, maintained alongside the shipped product.
+**Scope:** A fully local, single-user, single-machine app — it runs no cloud service of its own. Publishing a page to a hosted URL delegates to the separately-installed `fused` CLI (§19, §27); see Non-Goals.
 
 ---
 
@@ -74,7 +74,7 @@ The differentiating feature is the **renderable HTML** system: HTML files can ca
 - **FS-7** **DONE (M14):** in-folder filename search over a streamed recursive walk — see §22.
 - **FS-8** "Open raw" escape hatch for any file: streams bytes with correct MIME type (used for download and by templates for images/video/pdf).
 
-### Sidebar & Bookmarks (M2 — next)
+### Sidebar & Bookmarks (M2)
 
 Left sidebar in the shell, always visible:
 
@@ -183,7 +183,7 @@ def main(city: str = "oslo", limit: int = 100):
 
 ### 5.4 Return value serialization
 
-**DECIDED (v1): JSON only.** `main` must return JSON-native values (dict / list / str / num / bool / None). Anything else — including DataFrames and bytes — is a structured "return type not serializable" error; the user converts himself (e.g. `df.to_dict("records")`).
+**DECIDED (v1): JSON only.** `main` must return JSON-native values (dict / list / str / num / bool / None). Anything else — including DataFrames and bytes — is a structured "return type not serializable" error; the user converts it themselves (e.g. `df.to_dict("records")`).
 
 Deferred to later milestones (needed for data templates):
 
@@ -338,11 +338,13 @@ Distribute as a DMG containing a menu-bar app; all UI stays in the browser.
 
 ## 12b. Milestones
 
-- **M1 — Base layer (current focus):** server + shell, whole-disk browsing, raw streaming, live-rendered HTML in plain iframe, `runPython` → `main()` subprocess execution, params ↔ URL sync (strings, replaceState), server-side template registry (dispatch: template > html > fallback) + **parquet, image, text templates**. No security, no WS, no caching.
+*Historical build order, kept for context — not an exhaustive or current status list; later milestones (M10–M12, M15, M17–M18) ship as their own numbered sections (§18–§27), and the numbered requirement sections above are authoritative.*
+
+- **M1 — Base layer:** server + shell, whole-disk browsing, raw streaming, live-rendered HTML in plain iframe, `runPython` → `main()` subprocess execution, params ↔ URL sync (strings, replaceState), server-side template registry + **parquet, image, text templates**. No security, no WS, no caching.
 - **M2 — Sidebar & bookmarks:** SHIPPED.
 - **M3 — DMG distribution:** menu-bar app + bundled CPython + build script (§12).
-- **M4 — Live editing:** autosave + SSE change feed + auto-reloading views (§13).
-- **M5 — Layout mode:** split-pane grid of embed views, layout + merged params in one bookmarkable URL (§14).
+- **M4 — Live editing:** autosave + live change feed (WebSocket, D74) + auto-reloading views (§13).
+- **M5 — Layout mode:** split-pane grid of embed views, layout + pane-local params in one bookmarkable URL (§14, D72).
 - **M6 — Tab mode:** tabbed set of embed views on the §14 URL model; bookmark folders open as tab layouts (§15).
 - **M7 — Custom templates:** user template folders in `~/.fused-render/templates/` + `registry.json` extension bindings, overriding built-ins (§16).
 - **M8 — Template modes:** 1:n extension→template mapping — folder-per-template built-ins (renamed to public names), ordered mode lists (first = default), registry `list|string|null` grammar (the `"..."` splice shipped here was later removed, D94), `_mode` shell param + icon-only mode switcher, stat `templates` array replacing `template`, html folded in as the hardcoded `["_render", "code"]` sentinel list (§7, §16 / PT-6..PT-12, CT-10..CT-11).
@@ -354,7 +356,7 @@ Distribute as a DMG containing a menu-bar app; all UI stays in the browser.
 
 ## 13. Live Editing — Autosave & Auto-Reload (M4)
 
-Goal: a live-preview loop. Edit a file (in our editor or externally) → it saves itself → every open view of it reacts. Combined with embed mode (D39) this gives "source in one tab, rendered output in another, updates as you type".
+Goal: a live-preview loop. Edit a file (in the built-in editor or externally) → it saves itself → every open view of it reacts. Combined with embed mode (D39) this gives "source in one tab, rendered output in another, updates as you type".
 
 ### 13.1 Autosave (code editor)
 
@@ -513,7 +515,7 @@ Goal: users replace or add preview templates using the **exact same mechanism** 
 ## 17. Annotation — An Ordinary View Template (M9, superseded)
 
 Annotation shipped first as an app feature — an orthogonal `_annotate=1` overlay
-injected into every view (AN-1…AN-23, M9) — and was then **rebuilt as an
+injected into every view (M9) — and was then **rebuilt as an
 ordinary view template**, the same pattern as `templates/claude/`:
 `templates/annotate/` is a self-contained template.html, bound in registry.json
 as a trailing mode on annotatable extensions, swappable/shadowable like any
@@ -527,7 +529,7 @@ view they were made on so anchors never cross-resolve between views.
 Rationale: annotation is a review layer, not app chrome — as a template it
 needs no shell code, no server injection, and users can replace or extend it
 by dropping a folder into `~/.fused-render/annotate/`. The `_annotate` render
-param, the header toggle (AN-2/AN-3), the injected `static/annotate.js`, and
+param, the header toggle, the injected `static/annotate.js`, and
 the code template's selection adapter are gone.
 
 **Containment invariant:** every line of annotation logic lives inside
@@ -1112,7 +1114,7 @@ never imports server).
   Deploy-button toggle plus a link to the Fused account tab, where the list
   now renders beside the environments table.
 
-### 20.6 Tabs (D125)
+### 20.5 Tabs (D125)
 
 - **PF-9** The page is split into two tabs, active tab in the URL
   (`?tab=account`, default clean-URL tab is **Render preferences** —
@@ -1124,7 +1126,7 @@ never imports server).
   with nothing pointing at it. This is also where the sidebar footer's
   signed-in dot now points — see AC-1.
 
-### 20.5 Template registry view
+### 20.6 Template registry view
 
 - **PF-7** `GET /api/templates/registry` returns the merged
   extension→templates bindings from both registries (SPEC §16): one row per
@@ -1141,7 +1143,7 @@ never imports server).
 
   **Superseded (2026-07-09, owner call):** the read-only registry section was
   removed from the Preferences page when the full Template Management view
-  shipped (§22, `/view/_templates`) — a single home for bindings rather than a
+  shipped (§23, `/view/_templates`) — a single home for bindings rather than a
   glance in one place and an editor in another. The **`GET /api/templates/registry`
   endpoint stays** (unchanged contract, TV-4); it is now consumed by the
   Templates view instead of Preferences.
@@ -1194,7 +1196,7 @@ subtree, and whose truncation is always visible. The searcher is the shell
 and per-keystroke re-ranking must not pay a network round trip); the server's
 job is to deliver the corpus fast, shallow-first, and pruned of machine noise.
 
-### 21.1 Walk order & pruning (server)
+### 22.1 Walk order & pruning (server)
 
 - **SR-1** `GET /api/fs/walk` traverses **breadth-first** (`_walk_bfs`): every
   depth-N entry is emitted before any depth-N+1 entry; within one parent, dirs
@@ -1254,7 +1256,7 @@ job is to deliver the corpus fast, shallow-first, and pruned of machine noise.
   pathological trees (mounted volumes, cache farms). The response carries
   `truncated` so the UI can be honest about it (SR-10).
 
-### 21.2 Streaming wire format
+### 22.2 Streaming wire format
 
 - **SR-6** `?stream=1` returns `application/x-ndjson`: zero or more
   `{"entries": [...]}` batch lines (`WALK_BATCH_SIZE` = 500 per line), then
@@ -1271,7 +1273,7 @@ job is to deliver the corpus fast, shallow-first, and pruned of machine noise.
          done + one giant JSON                  ▶ "N matches · M scanned…"
   ```
 
-### 21.3 Shell search behavior
+### 22.3 Shell search behavior
 
 - **SR-7** The listing's search (`?q=`, URL-synced like sort) fetches **one
   hidden-inclusive dataset** (`hidden=1` always) and filters dot-entries at

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,7 @@
 # fused-render — Requirements Specification
 
 **Status:** Living specification, maintained alongside the shipped product.
-**Scope:** A fully local, single-user, single-machine app — it runs no cloud service of its own. Publishing a page to a hosted URL delegates to the separately-installed `fused` CLI (§19, §27); see Non-Goals.
+**Scope:** A fully local, single-user, single-machine app — it runs no cloud service of its own. Publishing a page to a hosted URL delegates to the `fused` CLI (bundled in the macOS app, a pip extra otherwise — §19, §27); see Non-Goals.
 
 ---
 
@@ -24,8 +24,9 @@ The differentiating feature is the **renderable HTML** system: HTML files can ca
 ### Non-Goals
 
 - Cloud or remote deployment, multi-user access, authentication/user accounts.
-  (Unchanged by §19/§27: deploying delegates to the separately-installed fused
-  CLI, and the §27 "Fused account" surface manages the *fused CLI's own*
+  (Unchanged by §19/§27: deploying delegates to the fused CLI — bundled in the
+  packaged macOS app, a pip extra for source/pip installs — and the §27 "Fused
+  account" surface manages the *fused CLI's own*
   credentials for those deploys — fused-render itself still has no accounts,
   no tokens, and no server-side users.)
 - File editing (v1 is read/preview oriented; editing is a possible v2).
@@ -704,7 +705,7 @@ nothing. Full detail: `docs/EXPORT.md`.
 Goal: close the gap between §18's bundle and a working URL, from the shell. The
 local-only invariant (§1) is unchanged in kind: fused-render still binds
 127.0.0.1, hosts nothing, and mints no URLs — **deploying is an explicit user
-action that delegates to the separately-installed `fused` CLI** (`fused share`,
+action that delegates to the `fused` CLI** (bundled in the packaged app, a pip extra otherwise; `fused share`,
 the fused repo's one URL-minting operation — its spec/serve/share-links.md and
 spec/serve/fused-render.md; the same shell-out pattern the flow app uses for
 project deploys). The server orchestrates the child process; nothing else in


### PR DESCRIPTION
## Summary

An editorial pass over the two design docs before the repo goes public. **No hard blockers were present** — I verified neither file contains `fusedlabs/application`/`openfused_server` references, employee names/personal paths, secrets, AWS IDs, or internal hostnames. The changes are stale-framing, factual-consistency, numbering, and inclusive-voice fixes so a public reader isn't misled.

### ARCHITECTURE.md
- Example fs paths embedded a contributor's name (`/Users/vasu/...`) → generic `/Users/you/...` (same rationale as the recent deeplink-fixture cleanup).

### SPEC.md
- **Front matter**: `Draft v0.1` → living-spec status; reworded the `Never deployed to cloud` scope line so it reconciles with the deploy/account sections (the app runs no cloud service of its own; publishing delegates to the `fused` CLI).
- **Milestones (§12b)**: dropped stale `current focus` / `M2 — next` planning language; fixed contradictions with the body (`SSE` → WebSocket change feed per D74; `merged` → pane-local params per D72); added a note that the list is the historical build order and the numbered sections are authoritative (it omits M10–M18).
- **Dangling refs**: removed citations to requirement IDs that don't exist (`AN-1…AN-23`, `AN-2/AN-3` in §17); fixed a broken cross-ref (`§22` → `§23` for Template Management).
- **Numbering bugs**: §22's subsections were mislabeled `21.x` → `22.x`; §20.5/20.6 were out of order.
- **Inclusive/voice**: `converts himself` → `converts it themselves`; `our editor` → `the built-in editor`.

## Flagged, not changed (your call)

These are editorial-voice / decision items, not defects — the docs are an internal design journal you've chosen to ship, so I left them:
- **~9 "owner call/choice/directed" attributions** (several date-stamped) and inline `REMOVED (D94, owner …)` / `Superseded (date, owner call)` churn — reads as an internal decision log. Strip/soften if you want a more external voice.
- **Deep `spec/serve/*` paths into `fusedio/fused` and a `spec/app/connect-fused.md` into `fusedio/flow`** — fine per your "fusedio refs are OK" rule, but a public reader can't open them (flow is private). Soften to prose if desired.
- **§9's candid RCE/exfiltration self-assessment** — honest and `SECURITY.md` covers the posture; kept, but it's alarming out of context.
- **No table of contents** for a ~2,100-line / 29-section doc — worth adding, but a larger structural change.
- **ARCHITECTURE.md is a "Locked for M1" snapshot** (doesn't cover later milestones) and still names old `.js` shell files despite the `.tsx` migration — inherent to a historical blueprint; a real refresh is out of scope for this pass.

## Test plan

- [x] Docs-only; no code touched.
- [x] Grep-verified: no `fusedlabs`/`openfused_server`/employee names/secrets/AWS IDs in either file; all stale markers (`Draft v0.1`, `M2 — next`, `current focus`, `AN-1…AN-23`, `SSE change feed`, `merged params`, `converts himself`, `our editor`) gone; §22 subsections now `22.x`, §20 subsections in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AVZkS3T492HNk68nQEPJDT

---
_Generated by [Claude Code](https://claude.ai/code/session_01AVZkS3T492HNk68nQEPJDT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, API, or security behavior impact.
> 
> **Overview**
> **Docs-only** editorial pass on `SPEC.md` and `ARCHITECTURE.md` ahead of going public—no application code changes.
> 
> In **`ARCHITECTURE.md`**, embedded example filesystem paths that used a contributor-specific home directory (`/Users/vasu/...`) are generalized to `/Users/you/...` in API examples and config snippets.
> 
> In **`SPEC.md`**, the front matter moves from **Draft v0.1** to a **living specification** and the scope line is reworded so “fully local” still allows **hosted publish via the `fused` CLI** (bundled in the macOS app / pip extra). §12b milestones drop stale planning labels (“current focus”, “M2 — next”), align M4/M5 bullets with shipped behavior (WebSocket change feed, pane-local layout params), and note the list is historical build order with numbered sections authoritative. §17 drops dangling `AN-*` requirement citations; §20 subsection order and §22 subsection numbering (`21.x` → `22.x`) are fixed; a Template Management cross-ref is corrected (`§22` → `§23`). Minor voice fixes: inclusive pronouns and “built-in editor” wording; Non-Goals and deploy sections clarify how the CLI fits the local-only product.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd174d6800563c8faa0723b3c757daecdadc429. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->