### PR TITLE
shell: GNOME-style path bar for the top navigation breadcrumb

### DIFF
--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -196,10 +196,13 @@ export function Breadcrumb({
   // Keep the tail of a long path in view on every path change (same as the
   // panel path bar, Panel.tsx). The strip hides its scrollbar (shell.css), so
   // without this the current folder could sit scrolled off the right edge.
+  // Also re-pins when edit mode closes: the strip remounts fresh (scrollLeft
+  // 0) after the input swap, with fsPath unchanged; the effect no-ops while
+  // editing (ref is null).
   useEffect(() => {
     const el = crumbsRef.current;
     if (el) el.scrollLeft = el.scrollWidth;
-  }, [fsPath]);
+  }, [fsPath, editing]);
 
   // Ctrl/Cmd+L jumps into the editable path (like a browser's location bar).
   // Skip when focus is already in a text field so it never hijacks typing.

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -191,6 +191,7 @@ export function Breadcrumb({
   renderedTitle?: string | null;
 }) {
   const crumbsRef = useRef<HTMLDivElement>(null);
+  const [editing, setEditing] = useState(false);
 
   // Keep the tail of a long path in view on every path change (same as the
   // panel path bar, Panel.tsx). The strip hides its scrollbar (shell.css), so
@@ -199,6 +200,23 @@ export function Breadcrumb({
     const el = crumbsRef.current;
     if (el) el.scrollLeft = el.scrollWidth;
   }, [fsPath]);
+
+  // Ctrl/Cmd+L jumps into the editable path (like a browser's location bar).
+  // Skip when focus is already in a text field so it never hijacks typing.
+  // NOTE: Chrome/Firefox route Ctrl/Cmd+L to their own address bar before the
+  // page sees it, so this only lands in app-mode/standalone windows (D: see
+  // plan). Registered document-level, cleaned up on unmount (Listing.tsx).
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.ctrlKey || e.metaKey) || e.key.toLowerCase() !== "l") return;
+      const t = e.target as HTMLElement | null;
+      if (t && (t.tagName === "INPUT" || t.tagName === "TEXTAREA" || t.isContentEditable)) return;
+      e.preventDefault();
+      setEditing(true);
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
 
   // Map a plain mouse wheel's vertical delta onto horizontal scroll so the
   // scrollbar-less strip is still wheel-scrollable (touchpad horizontal pans
@@ -212,6 +230,22 @@ export function Breadcrumb({
   const underHome = home !== undefined && fsPath.startsWith(home + "/");
   const rest = underHome ? fsPath.slice(home.length) : fsPath;
   const parts = rest.split("/").filter((s) => s.length > 0);
+
+  // Edit mode seeds the same "~"-contracted path the crumbs display; Enter
+  // expands a leading "~" back to the real home before navigating.
+  const displayPath = underHome ? "~" + rest : fsPath;
+  const submitEdit = (raw: string) => {
+    let path = raw.trim();
+    if (home !== undefined) {
+      if (path === "~") path = home;
+      else if (path.startsWith("~/")) path = home + path.slice(1);
+    }
+    if (path.length > 1) path = path.replace(/\/+$/, ""); // drop trailing slash, keep lone "/"
+    setEditing(false);
+    // No isDir hint — a typed path's kind is unknown; the destination view's
+    // stat/error handling covers a bad path (see plan: no pre-validation).
+    if (path) navigate(path);
+  };
   const pieces: React.ReactNode[] = [
     <a
       key="root"
@@ -265,10 +299,39 @@ export function Breadcrumb({
 
   return (
     <>
-      <div className="crumbs" ref={crumbsRef} onWheel={onWheel}>
-        {pieces}
-        <RevealButton fsPath={fsPath} />
-      </div>
+      {editing ? (
+        <input
+          className="crumb-edit"
+          defaultValue={displayPath}
+          spellCheck={false}
+          autoFocus
+          onFocus={(e) => e.target.select()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              submitEdit(e.currentTarget.value);
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setEditing(false); // discard, no navigation
+            }
+          }}
+          onBlur={() => setEditing(false)} // a stray click cancels rather than commits
+        />
+      ) : (
+        // A click on the strip itself (whitespace right of the crumbs), not on
+        // a crumb or the reveal button, switches to the editable path.
+        <div
+          className="crumbs"
+          ref={crumbsRef}
+          onWheel={onWheel}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) setEditing(true);
+          }}
+        >
+          {pieces}
+          <RevealButton fsPath={fsPath} />
+        </div>
+      )}
       <CrumbActions name={renderedTitle || basename(fsPath)} onSplit={(dir) => enterPanel(fsPath, dir)} />
     </>
   );

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 // Crumb bar + "+ Bookmark" / "Update bookmark" / split right/down buttons.
 // Rendered by every view: path crumbs for listing/preview, a static label for
 // the layout modes (LM-11 / TM-9 — ★/update still operate on currentUrl()).
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { navigate, navigateUrl, urlForFsPath, currentUrl, IS_EMBED } from "../lib/router";
 import { basename } from "../lib/format";
 import {
@@ -190,6 +190,24 @@ export function Breadcrumb({
   // Recents, for its sidebar row) so "My DB app" beats "index.html".
   renderedTitle?: string | null;
 }) {
+  const crumbsRef = useRef<HTMLDivElement>(null);
+
+  // Keep the tail of a long path in view on every path change (same as the
+  // panel path bar, Panel.tsx). The strip hides its scrollbar (shell.css), so
+  // without this the current folder could sit scrolled off the right edge.
+  useEffect(() => {
+    const el = crumbsRef.current;
+    if (el) el.scrollLeft = el.scrollWidth;
+  }, [fsPath]);
+
+  // Map a plain mouse wheel's vertical delta onto horizontal scroll so the
+  // scrollbar-less strip is still wheel-scrollable (touchpad horizontal pans
+  // already work via the native overflow-x).
+  const onWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (e.deltaY === 0) return;
+    e.currentTarget.scrollLeft += e.deltaY;
+  };
+
   // Strictly below home only — home itself shows its full path, not a lone "~".
   const underHome = home !== undefined && fsPath.startsWith(home + "/");
   const rest = underHome ? fsPath.slice(home.length) : fsPath;
@@ -223,7 +241,7 @@ export function Breadcrumb({
     if (i > 0 || underHome) pieces.push(<span key={"sep" + i} className="path-crumb-sep">/</span>);
     if (isLast) {
       pieces.push(
-        <span key={target} className="path-crumb last">
+        <span key={target} className="path-crumb last" title={part}>
           {part}
         </span>
       );
@@ -233,6 +251,7 @@ export function Breadcrumb({
           key={target}
           href="#"
           className="path-crumb"
+          title={part}
           onClick={(e) => {
             e.preventDefault();
             navigatePreservingMode(target);
@@ -246,7 +265,7 @@ export function Breadcrumb({
 
   return (
     <>
-      <div className="crumbs">
+      <div className="crumbs" ref={crumbsRef} onWheel={onWheel}>
         {pieces}
         <RevealButton fsPath={fsPath} />
       </div>

--- a/frontend/src/components/Breadcrumb.tsx
+++ b/frontend/src/components/Breadcrumb.tsx
@@ -272,13 +272,21 @@ export function Breadcrumb({
     else acc = acc + (acc.endsWith("/") ? "" : "/") + part;
     const target = acc;
     const isLast = i === parts.length - 1;
+    // GNOME path-bar compression (nautilus-pathbar.c): a crumb may flex-shrink
+    // (ellipsizing under space pressure, .shrink in shell.css) only when its
+    // name is longer than 1.5x its min-width floor — 7ch for ancestors, 4x
+    // that for the current dir so the tail compresses last. Shorter names
+    // never shrink; the floors guarantee real overflow, so the strip scrolls
+    // once everything is compressed.
+    const shrink = part.length > (isLast ? 28 : 7) * 1.5;
+    const cls = "path-crumb" + (isLast ? " last" : "") + (shrink ? " shrink" : "");
     // Separator only between segments (root already carries the leading
     // slash) — matches the panel path bar's tight `/Users/name/...` format.
     // The "~" crumb carries no slash, so its first segment needs one too.
     if (i > 0 || underHome) pieces.push(<span key={"sep" + i} className="path-crumb-sep">/</span>);
     if (isLast) {
       pieces.push(
-        <span key={target} className="path-crumb last" title={part}>
+        <span key={target} className={cls} title={part}>
           {part}
         </span>
       );
@@ -287,7 +295,7 @@ export function Breadcrumb({
         <a
           key={target}
           href="#"
-          className="path-crumb"
+          className={cls}
           title={part}
           onClick={(e) => {
             e.preventDefault();

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -684,6 +684,21 @@ a.bookmark-name::after {
   font-size: 12px;
 }
 
+/* GNOME-path-bar behaviour, main bar only (the panel pane does the same at
+   .panel-crumbs below). flex:1 1 auto makes the strip own the bar's free
+   width — the whitespace right of the last crumb is the click-to-edit target.
+   The scrollbar is hidden (scrollbar-width + ::-webkit-scrollbar) so the
+   wheel-scrollable strip carries no chrome; the tail is pinned into view from
+   JS on every path change. */
+#breadcrumb .crumbs {
+  flex: 1 1 auto;
+  scrollbar-width: none;
+}
+
+#breadcrumb .crumbs::-webkit-scrollbar {
+  display: none;
+}
+
 .path-crumb,
 .panel-crumb {
   color: var(--fg-muted);
@@ -691,6 +706,18 @@ a.bookmark-name::after {
   cursor: pointer;
   padding: 2px 1px;
   border-radius: 3px;
+}
+
+/* Truncate a single over-long folder name so it can't eat the whole strip
+   (main bar only — the panel pane keeps its crumbs untruncated). inline-block
+   is what lets text-overflow apply to these inline <a>/<span> crumbs; the full
+   name stays reachable via the title tooltip and horizontal scroll. */
+#breadcrumb .path-crumb {
+  display: inline-block;
+  vertical-align: bottom;
+  max-width: 16em;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .path-crumb.last,

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -729,20 +729,29 @@ a.bookmark-name::after {
   border-radius: 3px;
 }
 
-/* Truncate a single over-long folder name so it can't eat the whole strip
-   (main bar only — the panel pane keeps its crumbs untruncated). inline-block
-   is what lets text-overflow apply to these inline <a>/<span> crumbs; the full
-   name stays reachable via the title tooltip and horizontal scroll.
-   flex-shrink 0 is load-bearing: overflow:hidden zeroes a flex item's
-   automatic minimum size, so shrinkable crumbs would all squeeze to slivers
-   and the strip would never overflow — i.e. never scroll. */
+/* GNOME-style compress-then-scroll truncation, main bar only (the panel pane
+   keeps its crumbs untruncated). Crumbs never shrink by default; ones marked
+   .shrink (names longer than 1.5x their floor, Breadcrumb.tsx) may compress
+   under space pressure down to a min-width floor, ellipsizing as they go.
+   The floors are load-bearing twice over: overflow:hidden zeroes a flex
+   item's automatic minimum size (without a floor everything squeezes to
+   slivers), and flex can't shrink below min-width, so once every .shrink
+   crumb hits its floor the strip genuinely overflows and scrolling takes
+   over. The current dir's 4x floor makes the tail compress last; full names
+   stay reachable via the title tooltip. */
 #breadcrumb .path-crumb {
-  display: inline-block;
-  vertical-align: bottom;
   flex: 0 0 auto;
-  max-width: 16em;
+}
+
+#breadcrumb .path-crumb.shrink {
+  flex-shrink: 1;
+  min-width: 7ch;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+#breadcrumb .path-crumb.last.shrink {
+  min-width: 28ch;
 }
 
 .path-crumb.last,

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -699,6 +699,27 @@ a.bookmark-name::after {
   display: none;
 }
 
+/* Click-to-edit / Ctrl+L path field: swaps in for the crumb row. Same
+   monospace as the crumbs, fills the strip, and takes the bar's own
+   background so it reads as the bar turning editable rather than a popped-in
+   widget; a quiet border picks up the accent on focus. */
+#breadcrumb .crumb-edit {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 2px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-alt);
+  color: var(--fg);
+}
+
+#breadcrumb .crumb-edit:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 .path-crumb,
 .panel-crumb {
   color: var(--fg-muted);

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -732,10 +732,14 @@ a.bookmark-name::after {
 /* Truncate a single over-long folder name so it can't eat the whole strip
    (main bar only — the panel pane keeps its crumbs untruncated). inline-block
    is what lets text-overflow apply to these inline <a>/<span> crumbs; the full
-   name stays reachable via the title tooltip and horizontal scroll. */
+   name stays reachable via the title tooltip and horizontal scroll.
+   flex-shrink 0 is load-bearing: overflow:hidden zeroes a flex item's
+   automatic minimum size, so shrinkable crumbs would all squeeze to slivers
+   and the strip would never overflow — i.e. never scroll. */
 #breadcrumb .path-crumb {
   display: inline-block;
   vertical-align: bottom;
+  flex: 0 0 auto;
   max-width: 16em;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary

- The top navigation breadcrumb no longer grows a scrollbar when the path overflows — the strip scrolls with the mouse wheel / touchpad instead, and the tail (current folder) is kept pinned into view on every navigation, GNOME-Files style.
- Truncation follows nautilus's compress-then-scroll model: crumbs only ellipsize under space pressure (no fixed cap), shrinking to a 7ch floor — 28ch for the current folder so the tail compresses last — and only names longer than 1.5× their floor are shrinkable at all; full names stay on hover tooltips. Once everything hits its floor the strip overflows into the scrollbar-less scroll.
- Clicking the whitespace right of the crumbs — or pressing Ctrl/Cmd+L — swaps the strip for an editable text path (seeded with the `~`-contracted display path, pre-selected). Enter expands `~` and navigates; Escape or blur cancels without navigating.
- The panel pane's own path bar (`.panel-crumbs`) is deliberately untouched; only the top-level bar changes.

## Visuals

```mermaid
flowchart LR
    A[Crumb strip<br/>scrollbar-less, wheel-scrollable,<br/>tail pinned, names ellipsized] -->|click whitespace| B[Edit mode<br/>input with ~-contracted path,<br/>text pre-selected]
    A -->|Ctrl/Cmd+L| B
    B -->|Enter| C[expand leading ~ → navigate&#40;path&#41;]
    B -->|Escape / blur| A
    C --> A
```

## Usage

- Open any deeply nested folder: the crumb bar shows no scrollbar; scroll it with the wheel/touchpad; hover a truncated segment for its full name.
- Click the empty space to the right of the crumbs (or Ctrl/Cmd+L) to edit the path as text; type e.g. `~/some/other/path` and press Enter to jump there; Escape restores the crumbs.
- Note: Chrome/Firefox reserve Ctrl/Cmd+L for the address bar in normal tabs, so the shortcut lands in app-mode/standalone windows; click-to-edit works everywhere.

## Test Plan

- [x] `bun run typecheck` and `bun run build` pass (the shell frontend has no JS test harness; the Python suite doesn't cover it — these are the automated gate).
- [ ] Manual: deep path shows no scrollbar; wheel/touchpad scrolls the strip; tail visible after navigating and after cancelling edit mode; long names compress (ancestors first, tail last) before the strip starts scrolling; tooltips show full names.
- [ ] Manual: whitespace click / Cmd+L opens edit; Enter on `~/…` navigates (including a nonexistent path surfacing the normal stat error); Escape/blur cancels; crumb clicks still navigate; panel pane path bar unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
