### PR TITLE
learn: trim Home card B — drop Claude prompt box, shrink demo iframe

### DIFF
--- a/learn/index.html
+++ b/learn/index.html
@@ -155,6 +155,7 @@
            background:var(--panel); margin:0 0 16px; }
   .frame iframe { display:block; width:100%; border:0; background:var(--panel); }
   .frame.short iframe { height:380px; }
+  #demoFrame iframe { height:310px; }
   .frame.tall iframe { height:540px; }
   .framebar { display:flex; align-items:center; justify-content:space-between; gap:12px;
               padding:9px 14px; border-bottom:1px solid var(--border); background:var(--panel2); }
@@ -593,11 +594,6 @@
           </div>
         </div>
         <p>One HTML file + one Python file = a live tool. Drag the slider — that's <b>Python running on your machine</b> right now.</p>
-        <div class="door-promptlab">✦ Faster with Claude Code</div>
-        <div class="promptbox">
-          <button class="copybtn" data-copy="homePrompt">Copy</button>
-          <pre id="homePrompt">Create a Fused Render app that shows my CPU and memory usage as live gauges.</pre>
-        </div>
         <div class="door-cta">
           <a class="door-go" href="?page=build" data-intent="build">Build your first app <span class="arr">→</span></a>
         </div>


### PR DESCRIPTION
Removes the ✦ Faster with Claude Code label and prompt copy box from the "Build a tiny app" card on the Learn home page, and shrinks the embedded `pi.html` demo iframe from 380px to 310px so the right column's height matches the left card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only HTML/CSS on the Learn home page; no runtime or API behavior changes.
> 
> **Overview**
> On the Learn **Home** page, the right-hand **“Build a tiny app”** door card is tightened for layout balance with the left card.
> 
> The **“✦ Faster with Claude Code”** label and the copyable CPU/memory prompt block are **removed** from that card; the primary CTA to **Build your first app** is unchanged. Claude prompts remain on the dedicated **Building with Fused Render** page.
> 
> The embedded **`pi.html`** live demo iframe height is reduced from **380px to 310px** via a `#demoFrame`-specific CSS override so the demo column doesn’t dominate the two-door row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37e4b6c7c866f5ec9254a62ec32b53cd8431943a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->