### PR TITLE
skills: document supported Python libraries in the authoring skill

### DIFF
--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -50,7 +50,20 @@ Rules that matter (each has a reason):
 - **Relative paths in your code resolve next to the .py file** (the working directory is set there). `open("./data.csv")` next to your script just works.
 - **Each call is a fresh subprocess.** Edits to the .py apply on the next call — but so does full import cost (pandas ≈ 1 s per call). No state survives between calls; don't cache in globals.
 - **`print()` output goes to the browser console** (prefixed `[python]`) — use it freely for debugging; it cannot corrupt the result.
-- **Calls time out at 60 s** and errors return `{type, message, traceback}` to the page. The environment is whatever Python launched the server — assume stdlib plus whatever the user installed there.
+- **Calls time out at 60 s** and errors return `{type, message, traceback}` to the page.
+
+### Available Python libraries
+
+Write `main()` against **stdlib plus the supported library set** below — the packaged app bundles exactly these (its users cannot pip install), and dev installs get the same set via `pip install -e ".[bundled]"` (the authoritative list is the `[bundled]` extra in `pyproject.toml`, plus core deps):
+
+- **Data:** numpy, pandas, polars, pyarrow, duckdb, scipy, openpyxl, msgpack
+- **Geospatial:** shapely, geopandas, rasterio, zarr
+- **Plots & images:** matplotlib, pillow
+- **Documents:** pymupdf, pikepdf, fpdf2, python-pptx
+- **Network & cloud:** requests, httpx, botocore, google-auth
+- **Logs:** drain3
+
+Anything outside this set (e.g. torch, sklearn, xarray, plotly) may be missing — don't reach for it unless the user confirms it's installed in the Python that launched the server. If a needed import fails, prefer rewriting with the supported set over asking the user to install packages.
 
 ## The HTML side: `window.fused` API
 
@@ -193,6 +206,7 @@ Escape hatch: because fused-render runs your own trusted code on your own machin
 - `main` returning a DataFrame / datetime / Decimal / numpy value → serialization error; convert to JSON-native first.
 - Missing annotation on a numeric param → `main` receives `"50"` (string) and comparisons silently misbehave.
 - Expecting module state to persist between `runPython` calls → each call is a fresh process.
+- Importing a library outside the supported set (torch, sklearn, xarray, plotly, ...) → `ModuleNotFoundError` in the packaged app; stick to the "Available Python libraries" list above.
 - Adding `<script src=".../runtime.js">` manually → double-injection; the explorer injects it.
 - Heavy import + slider wired without debounce → one full subprocess per tick; debounce inputs ~150 ms when `main` is slow.
 - Fetching `/api/fs/raw` (or POSTing `/api/fs/write`) directly instead of using the helpers → writes get rejected (missing required header) and you're coupled to internals.

--- a/skills/fused-render-authoring/SKILL.md
+++ b/skills/fused-render-authoring/SKILL.md
@@ -65,6 +65,25 @@ Write `main()` against **stdlib plus the supported library set** below — the p
 
 Anything outside this set (e.g. torch, sklearn, xarray, plotly) may be missing — don't reach for it unless the user confirms it's installed in the Python that launched the server. If a needed import fails, prefer rewriting with the supported set over asking the user to install packages.
 
+Versions are not pinned — each install resolves its own. When a version matters (an API that changed between majors, a feature gated on a release), **probe the live environment** instead of guessing: `/api/run` executes in the exact interpreter that runs page code. Write a throwaway probe and POST it:
+
+```bash
+cat > /tmp/probe.py <<'EOF'
+def main(names: str = "pandas,numpy"):
+    from importlib import metadata
+    out = {}
+    for n in names.split(","):
+        try: out[n] = metadata.version(n)
+        except Exception: out[n] = None
+    return out
+EOF
+curl -s -X POST http://127.0.0.1:1777/api/run -H 'X-Fused: 1' \
+  -H 'Content-Type: application/json' \
+  -d '{"py": "/tmp/probe.py", "params": {"names": "pandas,geopandas,duckdb"}}'
+```
+
+A `null` version means the package is missing from *this* environment — the same result an `import` in `main()` would hit.
+
 ## The HTML side: `window.fused` API
 
 The runtime is injected automatically when the explorer renders the page. Never add a script tag for it; just use the global.


### PR DESCRIPTION
The authoring skill told Claude to assume "stdlib plus whatever the user installed there", which invites imports the packaged app can't satisfy (its users can't pip install).

- Replace that line with an **Available Python libraries** section listing the supported set — the `[bundled]` extra plus core deps (pyarrow, duckdb, httpx, requests), grouped like the Learn page's supported-libraries table — and guidance to rewrite with the supported set rather than ask users to install packages.
- Add a pitfalls-checklist entry: importing outside the set (torch, sklearn, xarray, plotly) → `ModuleNotFoundError` in the packaged app.

Only `fused-render-authoring` needed this: `custom-templates` defers to it for all html/py authoring, and `usage` already points at the bundled wheelhouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown skill documentation only; no runtime, packaging, or API behavior changes.
> 
> **Overview**
> **Documentation-only** update to `skills/fused-render-authoring/SKILL.md` so agents and authors don’t assume “stdlib + whatever is installed” in view `.py` files.
> 
> Replaces the vague environment line with an **Available Python libraries** section: grouped list aligned with the packaged app’s `[bundled]` extra in `pyproject.toml` (plus core deps), notes that packaged users can’t pip install, and tells authors to rewrite with the supported set rather than asking users to install packages. Adds guidance for **unpinned versions** and a **curl `/api/run` probe** pattern to check what’s actually importable in the live server.
> 
> The **pitfalls checklist** gains an entry for imports outside the set (e.g. torch, sklearn) → `ModuleNotFoundError` in the packaged app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3b8943c7676129dfa08d46b6f19e926ceca485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->