### PR TITLE
ci: refuse dispatch releases whose tag points at a different commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,16 @@ jobs:
           TAG: ${{ steps.resolve.outputs.tag }}
         run: |
           set -euo pipefail
+          # A dispatch can name an existing tag pointing at a different
+          # commit — never publish artifacts that don't match the tagged source.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            TAG_SHA="$(git rev-parse "$TAG^{commit}")"
+            RUN_SHA="$(git rev-parse "${{ github.sha }}^{commit}")"
+            if [ "$TAG_SHA" != "$RUN_SHA" ]; then
+              echo "::error::tag $TAG points at $TAG_SHA but this run builds $RUN_SHA — refusing to publish mismatched artifacts"
+              exit 1
+            fi
+          fi
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "Release $TAG already exists, reusing it."
             exit 0


### PR DESCRIPTION
On a manual `workflow_dispatch`, the `tag` input can name a tag that already exists and points at a different commit than the one the run checks out — but the release step reused the existing tag/release without any check, so the build jobs would upload artifacts built from `github.sha` into a release whose tag names different source (`--target` only applies when the tag doesn't exist yet). This adds a guard before the reuse path: if the tag exists locally, peel it to a commit and compare against the run's commit, failing loudly on mismatch. Tag-push runs are unaffected since the tag always matches `github.sha` there.

Fixes Cursor Bugbot finding: https://github.com/fusedio/fused-render/pull/234#discussion_r3643819876

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard in the release workflow; no application or runtime behavior changes.
> 
> **Overview**
> Adds a **safety check** in the `prepare-release` job before reusing or creating a GitHub Release: when the resolved tag already exists locally, it compares the tag’s peeled commit to **`github.sha`** for the run and **fails the workflow** if they differ.
> 
> This closes a **`workflow_dispatch`** hole where you could name an existing tag while building from another commit; parallel build jobs would still upload artifacts to that release even though `--target` only applies on first create. **Tag-push releases are unchanged** because the tag always matches the checked-out commit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c912f11974689c32ea49df4ee179ba2327e606e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->