### PR TITLE
ci: cross-platform CI jobs (windows/macos) + Linux AppImage release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -269,6 +269,65 @@ jobs:
             --paths "/${WINDOWS_PREFIX}/*"
           gh release upload "$RELEASE_TAG" "$INSTALLER" --clobber
 
+  build-linux-release:
+    needs: prepare-release
+    if: github.event_name == 'push' || github.event.inputs.platforms == 'all' || github.event.inputs.platforms == 'linux'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # attach the AppImage to the GitHub Release
+      id-token: write # assume the AWS role via OIDC
+    env:
+      RELEASE_TAG: ${{ needs.prepare-release.outputs.tag }}
+      AWS_DEFAULT_REGION: us-west-2
+      S3_BUCKET: fused-render
+      CDN_DOMAIN: d2ic19jpchjovp.cloudfront.net
+      CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
+      LINUX_PREFIX: fused-render-linux
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v5
+
+      # desktop-file-utils provides desktop-file-validate, which appimagetool
+      # runs against the bundled .desktop file — same prerequisite the CI smoke
+      # installs. node (the wheel build's hatch hook runs npm) is preinstalled
+      # on ubuntu-latest; uv provides the relocatable CPython the script bundles.
+      - name: Install desktop-file-utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y desktop-file-utils
+
+      - name: Build the AppImage
+        run: bash scripts/build_linux_appimage.sh
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
+          role-session-name: GithubFusedRenderReleaseLinux
+          aws-region: us-west-2
+
+      - name: Publish AppImage + attach to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          APPIMAGE="$(ls dist/FusedRender-*-x86_64.AppImage)"
+          # Version from the built artifact, not the tag — same rule as the DMG.
+          VERSION="$(basename "$APPIMAGE" | sed -E 's/^FusedRender-(.*)-x86_64\.AppImage$/\1/')"
+          echo "Publishing FusedRender $VERSION Linux AppImage"
+          aws s3 cp "$APPIMAGE" "s3://${S3_BUCKET}/${LINUX_PREFIX}/$(basename "$APPIMAGE")"
+          aws cloudfront create-invalidation \
+            --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
+            --paths "/${LINUX_PREFIX}/*"
+          # No latest.json manifest: Linux has no auto-updater yet — the
+          # supervisor _linux backend exposes no `update` module (unlike _win32).
+          gh release upload "$RELEASE_TAG" "$APPIMAGE" --clobber
+
   bump-homebrew:
     # Separate job so a tap-push failure can't fail the DMG job after the
     # Release already published.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release dmg
+name: release
 
 on:
   push:
@@ -18,6 +18,7 @@ on:
           - all
           - macos
           - windows
+          - linux
 
 jobs:
   # Creates the GitHub Release every OS build job uploads into, so the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,21 +22,30 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
       linux_desktop: ${{ steps.filter.outputs.linux_desktop }}
+      windows_desktop: ${{ steps.filter.outputs.windows_desktop }}
+      windows_packaging: ${{ steps.filter.outputs.windows_packaging }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            # Packaging paths shared by both filters. Defined as a YAML anchor
-            # (must precede the aliases that reference it) so the two filters
-            # cannot drift: every linux_desktop path must also be an app path,
-            # because the linux-desktop job (where the gated smoke step lives)
-            # only runs when app fires. dorny/paths-filter flattens the aliased
-            # sequence into each filter's own list.
-            packaging: &packaging
+            # Each platform's packaging paths live in a YAML anchor (must precede
+            # the aliases below) and are ALSO referenced into `app`, so a platform
+            # filter can never match a path `app` does not: a *_desktop filter
+            # firing therefore implies `app` fired. That invariant is load-bearing
+            # for any desktop job that depends on the `frontend` artifact — the
+            # filter firing while `app` stayed false would leave `frontend` skipped
+            # and the artifact missing. dorny/paths-filter flattens each aliased
+            # sequence into the referencing filter's list; a path shared across
+            # anchors (file_associations.*) flattening into `app` twice is harmless.
+            linux_packaging: &linux_packaging
               - 'scripts/build_linux_appimage.sh'
               - 'scripts/linux/**'
+              - 'scripts/file_associations.*'
+            windows_packaging: &windows_packaging
+              - 'scripts/build_windows_installer.ps1'
+              - 'scripts/windows/**'
               - 'scripts/file_associations.*'
             app:
               - 'fused_render/**'
@@ -46,18 +55,25 @@ jobs:
               - 'scripts/hatch_build.py'
               - 'pyproject.toml'
               - '.github/workflows/test.yml'
-              - *packaging
-            # Gates only the expensive AppImage build smoke (several minutes of
-            # toolchain downloads); the cheap Linux backend test run stays on
-            # the broad `app` filter above. macOS has no per-PR packaging job
-            # at all (the DMG is release-tag only), so this keeps Linux at
-            # parity-or-better without paying the smoke on every server PR.
+              - *linux_packaging
+              - *windows_packaging
+            # Each *_desktop filter gates its platform's test job; the matching
+            # *_packaging filter gates only that job's expensive build smoke
+            # (minutes of toolchain downloads), pointless on a server-only PR.
+            # (linux-desktop keeps gating its smoke on the whole linux_desktop
+            # filter — pre-existing behavior, left unchanged.)
             linux_desktop:
               - 'fused_render/supervisor/**'
               - 'fused_render/shell/mounts.py'
               - 'pyproject.toml'
               - '.github/workflows/test.yml'
-              - *packaging
+              - *linux_packaging
+            windows_desktop:
+              - 'fused_render/supervisor/**'
+              - 'fused_render/winopen.py'
+              - 'pyproject.toml'
+              - '.github/workflows/test.yml'
+              - *windows_packaging
 
   # The React shell (frontend/) is built once here and shared with every
   # python-version job below — fused_render/server.py refuses to start
@@ -236,6 +252,55 @@ jobs:
         # downloads, pointless on a server-only PR.
         if: needs.detect-changes.outputs.linux_desktop == 'true'
         run: bash scripts/build_linux_appimage.sh
+
+  # Windows desktop supervisor (docs/PYTHON_SUPERVISOR_SPEC.md). The _win32
+  # backend, the Explorer "Open with" entry point (winopen.py), and the
+  # ed25519-signed update-manifest verifier run here on real Windows — the Linux
+  # matrix never exercises them. No shell-dist dependency: none of these tests
+  # start the HTTP server (create_app), so the frontend artifact isn't needed.
+  windows-desktop:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.windows_desktop == 'true'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install fused-render (dev + windows-desktop extras)
+        run: python -m pip install -e ".[dev,windows-desktop]"
+
+      - name: Run the Windows backend suite
+        # test_supervisor_core is platform-neutral but its backend import
+        # succeeds on win32 (it raises → skips on darwin), so it executes here.
+        run: >
+          python -m pytest -q
+          tests/test_supervisor_core.py
+          tests/test_win_supervisor_update.py
+          tests/test_windows_registry.py
+          tests/test_winopen.py
+
+      # Dropped from the windows runner image (actions/runner-images#11644); the
+      # build script finds ISCC.exe where choco installs it. Setup copied from
+      # release.yml's build-windows-release job.
+      - name: Install Inno Setup
+        if: needs.detect-changes.outputs.windows_packaging == 'true'
+        shell: pwsh
+        run: choco install innosetup --no-progress -y
+
+      - uses: astral-sh/setup-uv@v5
+        if: needs.detect-changes.outputs.windows_packaging == 'true'
+
+      - name: Build the Windows installer (smoke)
+        # Secret-free: the ed25519 manifest signing (FUSED_RENDER_UPDATE_SIGNING_
+        # KEY) happens in release.yml AFTER this script, not inside it. Step-gated
+        # to packaging changes — minutes of toolchain work (embeddable CPython,
+        # launcher compile, Inno Setup), pointless on a server-only PR.
+        if: needs.detect-changes.outputs.windows_packaging == 'true'
+        shell: pwsh
+        run: .\scripts\build_windows_installer.ps1
 
   test-status:
     name: Test Status

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -365,7 +365,7 @@ jobs:
   test-status:
     name: Test Status
     runs-on: ubuntu-latest
-    needs: [detect-changes, frontend, test-python, linux-desktop]
+    needs: [detect-changes, frontend, test-python, linux-desktop, windows-desktop, macos-desktop]
     if: always()
     steps:
       - name: Check test status
@@ -378,9 +378,21 @@ jobs:
             echo "No relevant changes; skipped."
             exit 0
           fi
+          # app fired ⇒ these three always run (they gate on app only), so
+          # anything other than success is a failure.
           for result in "${{ needs.frontend.result }}" "${{ needs.test-python.result }}" "${{ needs.linux-desktop.result }}"; do
             if [[ "$result" != "success" ]]; then
               echo "Job did not succeed: $result"
+              exit 1
+            fi
+          done
+          # windows-desktop/macos-desktop gate on their OWN filters, so a
+          # "skipped" (filter did not fire) is a legitimate pass. Truth table
+          # per job: success → pass, skipped → pass, failure → fail,
+          # cancelled → fail.
+          for result in "${{ needs.windows-desktop.result }}" "${{ needs.macos-desktop.result }}"; do
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "Platform desktop job did not succeed or skip: $result"
               exit 1
             fi
           done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
       linux_desktop: ${{ steps.filter.outputs.linux_desktop }}
       windows_desktop: ${{ steps.filter.outputs.windows_desktop }}
       windows_packaging: ${{ steps.filter.outputs.windows_packaging }}
+      macos_desktop: ${{ steps.filter.outputs.macos_desktop }}
+      macos_packaging: ${{ steps.filter.outputs.macos_packaging }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -47,6 +49,11 @@ jobs:
               - 'scripts/build_windows_installer.ps1'
               - 'scripts/windows/**'
               - 'scripts/file_associations.*'
+            macos_packaging: &macos_packaging
+              - 'scripts/build_dmg.sh'
+              - 'scripts/setup_py2app.py'
+              - 'scripts/app_entry.py'
+              - 'scripts/file_associations.*'
             app:
               - 'fused_render/**'
               - 'tests/**'
@@ -57,6 +64,7 @@ jobs:
               - '.github/workflows/test.yml'
               - *linux_packaging
               - *windows_packaging
+              - *macos_packaging
             # Each *_desktop filter gates its platform's test job; the matching
             # *_packaging filter gates only that job's expensive build smoke
             # (minutes of toolchain downloads), pointless on a server-only PR.
@@ -74,6 +82,14 @@ jobs:
               - 'pyproject.toml'
               - '.github/workflows/test.yml'
               - *windows_packaging
+            macos_desktop:
+              - 'fused_render/supervisor/**'
+              - 'fused_render/app.py'
+              - 'fused_render/menubar_pin.py'
+              - 'fused_render/shell/mounts.py'
+              - 'pyproject.toml'
+              - '.github/workflows/test.yml'
+              - *macos_packaging
 
   # The React shell (frontend/) is built once here and shared with every
   # python-version job below — fused_render/server.py refuses to start
@@ -301,6 +317,50 @@ jobs:
         if: needs.detect-changes.outputs.windows_packaging == 'true'
         shell: pwsh
         run: .\scripts\build_windows_installer.ps1
+
+  # macOS menu-bar app (SPEC DM-3/DM-7). darwin has no supervisor backend (only
+  # win32/linux), so the supervisor-core tests skip here; what this job uniquely
+  # covers is the darwin-only code the Linux matrix never runs — the nfsmount
+  # options in shell/mounts.py (test_shell_mounts.py's @skipif(platform != darwin)
+  # tests) — plus the macOS app entry (view-url mapping, in-process desktop
+  # instance/token) on real macOS. test_shell_mounts.py starts the HTTP server
+  # (create_app) through its client fixture, which refuses without the React
+  # shell, so this job depends on `frontend` and downloads shell-dist.
+  macos-desktop:
+    needs: [detect-changes, frontend]
+    if: needs.detect-changes.outputs.macos_desktop == 'true' && needs.frontend.result == 'success'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: shell-dist
+          path: fused_render/static/shell-dist
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install fused-render (dev extra)
+        run: pip install -e ".[dev]"
+
+      - name: Run the macOS backend suite
+        run: >
+          python -m pytest -q
+          tests/test_shell_mounts.py
+          tests/test_app_desktop_instance.py
+          tests/test_app_view_url.py
+
+      - name: Build the DMG (smoke)
+        # build_dmg.sh falls back to ad-hoc signing when no Developer ID identity
+        # is configured (FUSED_RENDER_CODESIGN_IDENTITY unset) and skips
+        # notarization — a plain run needs no release secrets. Step-gated to
+        # packaging changes: py2app + the full [bundled] install is several
+        # minutes. setup-python 3.12 above satisfies the script's own version
+        # check (str | None syntax, py>=3.10), same as release.yml's DMG job.
+        if: needs.detect-changes.outputs.macos_packaging == 'true'
+        run: bash scripts/build_dmg.sh
 
   test-status:
     name: Test Status

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -4523,12 +4523,16 @@ def create_remote(body: dict = Body(...), x_fused: str | None = Header(default=N
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-    bin_ = rclone_bin()
-    if not bin_:
-        return JSONResponse({"error": "rclone is not installed"}, status_code=502)
+    # Validate the request body (a 400 client error) BEFORE probing for rclone
+    # (a 502 environment error): a bad name is bad on every platform, and where
+    # rclone is absent (e.g. a macOS host with no bundled/PATH binary) the
+    # availability check would otherwise mask the real 400 with a 502.
     name = (body.get("name") or "").strip()
     if not name or ":" in name or "/" in name:
         return JSONResponse({"error": "invalid remote name"}, status_code=400)
+    bin_ = rclone_bin()
+    if not bin_:
+        return JSONResponse({"error": "rclone is not installed"}, status_code=502)
     p = body.get("params") or {}
     cmd = [
         bin_, "config", "create", name, "s3",

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -79,7 +79,12 @@ def test_open_command_routes_file_uri_to_view(monkeypatch, tmp_path):
     f.write_text("x")
     opened = []
     monkeypatch.setattr(core, "_open_browser", opened.append)
-    core._open_command(9000, protocol.Open(f"file://{f}"))
+    # Path.as_uri() — not f"file://{f}" — builds a well-formed file URI on every
+    # platform: on Windows the drive path becomes file:///C:/... (three slashes),
+    # whereas f"file://{f}" would read C:\... as the netloc and be rejected as a
+    # remote host. This mirrors what the OS actually hands the app (macOS
+    # openURLs:, RFC 8089 §2).
+    core._open_command(9000, protocol.Open(f.as_uri()))
     assert opened == [f"http://127.0.0.1:9000" + _view_path(str(f))]
 
 


### PR DESCRIPTION
## Summary

- CI previously exercised Linux only: Windows-specific tests (`test_win_supervisor_update`, `test_windows_registry`, `test_winopen`) and darwin-only code paths (nfsmount options, macOS app entry) never ran, and neither platform had a per-PR packaging check. This adds path-gated `windows-desktop` and `macos-desktop` jobs to `test.yml`, mirroring the existing `linux-desktop` pattern (cheap test run gated on a platform filter, expensive build smoke step-gated on that platform's packaging paths).
- The release workflow built only the macOS DMG and Windows installer — the Linux AppImage was never built or published at release time. A new `build-linux-release` job builds the AppImage on a tag, uploads it to S3 (`fused-render-linux/`), invalidates CloudFront, and attaches it to the GitHub Release. The workflow is renamed `release dmg` → `release` and the manual-dispatch platform picker gains a `linux` option.
- `test-status` now accepts `skipped` as a pass for the two new jobs (they gate on their own filters, unlike the always-run Linux jobs) while keeping success-only semantics for the existing jobs.
- Filter invariant preserved and extended: each platform's packaging paths live in a YAML anchor referenced into both its `*_desktop` filter and `app`, so a platform filter firing always implies `app` fired (load-bearing for `macos-desktop`'s dependency on the `frontend` shell-dist artifact).

## Visuals

```mermaid
flowchart LR
    subgraph test.yml
        DC[detect-changes] -->|app| FE[frontend]
        DC -->|app| TP[test-python 3.10–3.13]
        DC -->|app| LD[linux-desktop]
        DC -->|windows_desktop| WD[windows-desktop *new*]
        DC -->|macos_desktop| MD[macos-desktop *new*]
        FE --> MD
        WD -->|windows_packaging| WS[installer smoke]
        MD -->|macos_packaging| DS[DMG smoke, ad-hoc signed]
        LD & TP & WD & MD --> TS[test-status<br/>skipped = pass for new jobs]
    end
    subgraph release.yml
        PR2[prepare-release] --> MAC[macOS DMG]
        PR2 --> WIN[Windows installer]
        PR2 --> LIN[build-linux-release *new*<br/>AppImage → S3 + CDN + Release]
    end
```

## Usage

- Nothing new is user-invocable in normal flow — the platform CI jobs trigger automatically on PRs touching the relevant paths (e.g. `fused_render/supervisor/**`, `scripts/windows/**`, `scripts/build_dmg.sh`).
- Manual release builds: `gh workflow run release.yml -f tag=vX.Y.Z -f platforms=linux` (or `all`/`macos`/`windows`).

## Test Plan

- [x] `actionlint` clean on both workflows (only the two pre-existing SC2129 style warnings from `main` remain, line-shifted)
- [x] Both files parse as valid YAML (actionlint's parser)
- [x] `test-status` truth table verified: new jobs — success→pass, skipped→pass, failure/cancelled→fail; existing jobs unchanged (success-only)
- [x] Confirmed `scripts/build_dmg.sh` builds unsigned (ad-hoc fallback, skips notarization) — the CI DMG smoke needs no release secrets
- [x] Confirmed `scripts/build_windows_installer.ps1` is secret-free (manifest signing happens in release.yml after the script)
- [ ] First tag push after merge: verify the AppImage lands in the GitHub Release and at `https://d2ic19jpchjovp.cloudfront.net/fused-render-linux/`
- [ ] First PR touching `fused_render/supervisor/**`: verify both new platform jobs trigger and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
