### PR TITLE
docs(skills): desktop-app usage instructions; template internal-API guardrail

### DIFF
--- a/skills/fused-render-custom-templates/SKILL.md
+++ b/skills/fused-render-custom-templates/SKILL.md
@@ -12,6 +12,21 @@ fused-render resolves an **ordered list of preview templates — modes** — for
 - **This skill:** where files go, how the registry binds extensions, how to test registration.
 - **`skills/fused-render-authoring/SKILL.md`:** how to write the `template.html` and reader `.py` themselves — the `fused` API, the `main()` contract, the params-are-state wiring pattern, the `_file` handling, the pitfalls. **Read it before writing any html/py.** In particular its "Preview templates" section is exactly what a custom template is.
 
+## Guardrail: use fused's internal APIs, never raw OS/shell commands
+
+A custom template runs on every open of its extension, with the local server's privileges, inside the packaged app — which bundles **only** a fixed Python library set plus a few tools (`rclone`/`uv`/`duckdb`), not a general shell. Reach for fused's own APIs, not raw OS or network commands. This is a security and performance boundary, not a style preference.
+
+**In the reader `.py` / `condition.py`:**
+- ❌ Don't shell out — no `subprocess`, `os.system`, `os.popen`, or invoking system binaries (`gdalinfo`, `curl`, `ffmpeg`, …). They may not exist in the packaged app, run with the server's privileges, and pay a process-spawn cost on every preview.
+- ✅ Do the work in-process with the **bundled libraries** (pandas, polars, pyarrow, duckdb, rasterio, pillow, pymupdf, requests/httpx, … — the authoritative set is in `fused-render-authoring`). Reading local files with `open()` / `os.path` relative to your script is fine and idiomatic; spawning commands is not.
+- ✅ In `condition.py`, **keep reads bounded** — sniff a footer/header/prefix, never `read()` a whole file, and never shell out. The gate runs for every file of the extension, some on remote mounts.
+
+**In `template.html`:**
+- ❌ Don't `fetch()` the server's `/api/fs/*` endpoints directly, and don't `<script src>` a runtime or pull data from arbitrary external hosts.
+- ✅ Reach the filesystem only through the injected `window.fused` helpers — `fused.readFile` / `fused.rawUrl` / `fused.stat` / `fused.writeFile`, and `fused.runPython` for anything Python adds value to. They're the stable contract and carry the headers writes require.
+
+**Why:** the internal APIs keep the template working in the sandboxed packaged app (no system dependencies), avoid the security surface of running shell commands with server privileges, and stay fast — no per-open subprocess spawns, and remote-mounted files are streamed through the runtime instead of pulled whole.
+
 ## Layout on disk
 
 One folder per template, self-contained:

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,68 +1,50 @@
 ---
 name: fused-render-usage
-description: How to run and use a fused-render project — open files and views by driving the FusedRender desktop app (which launches or reuses a single local instance) and browse the filesystem. Use this whenever the user wants to open, run, launch, start, show, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
+description: How to run and use a fused-render project — open files and views in the FusedRender desktop app and browse the filesystem. Use this whenever the user wants to open, run, launch, start, show, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
 ---
 
 # Using a fused-render project
 
 fused-render is a **local file-explorer desktop app** that runs entirely on `127.0.0.1` — no accounts, no cloud. It browses any directory in the browser, previews files, and live-renders `.html` views that call local Python. This skill covers **running and using** the app; it does not cover writing views (that's `fused-render-authoring`).
 
-## Drive the desktop app — never a raw server
+This skill assumes **the FusedRender desktop app is already running** — there's a single instance per user, serving on `127.0.0.1`. Everything below is a way to open something into that running instance.
 
-There is **one** FusedRender instance per user. Launching the app again does **not** start a second server: it elects a single instance (an `flock` on Linux, a named mutex on Windows, LaunchServices on macOS) and **forwards** your request to the instance already running — or starts one if none is. Launch-if-necessary-else-reuse is built into the app's own entrypoint; you never orchestrate it, probe for it, or reproduce it.
+## Opening a file, view, or directory
 
-To open a file, a view, or a directory, **hand its path to the FusedRender app**. It opens that path as a full-shell view (`/view/<path>`) in a browser tab, reusing the running instance.
+Hand the path to the app — it opens as a full-shell view (`/view/<path>`) in a browser tab, reusing the running instance:
 
-| Platform | Open a path (launch-or-reuse) | Open home |
-|---|---|---|
-| macOS | `open -a FusedRender <path>` | `open -a FusedRender` |
-| Linux | `gtk-launch fused-render <path>`, the AppImage binary `FusedRender-<ver>.AppImage <path>`, or right-click → *Open With → FusedRender* | same without a path |
-| Windows | `FusedRender.exe <path>`, or right-click → *Open with → FusedRender* | `FusedRender.exe` |
+| Platform | Open a path |
+|---|---|
+| macOS | `open -a FusedRender <path>` |
+| Linux | `gtk-launch fused-render <path>`, right-click → *Open With → FusedRender*, or the AppImage binary `FusedRender-<ver>.AppImage <path>` |
+| Windows | `FusedRender.exe <path>`, or right-click → *Open with → FusedRender* |
 
-Under the hood the Linux/Windows launcher execs `python -I -m fused_render.supervisor <path>` (the AppImage's `AppRun`); the macOS `.app` does the same job natively. Invoke the app, not this module.
+Opening a directory lands the explorer there; opening a file previews it; opening an `.html` view renders it.
 
-### Guardrail: internal entrypoint only — never raw OS commands
+## Opening by URL (view / embed / preview templates)
 
-Driving the app through its own entrypoint is a **security and performance boundary**, not a style preference.
+Everything the app shows is a URL, so any view is bookmarkable and shareable. The running app already has a tab open — reuse its `http://127.0.0.1:<port>` from the address bar and swap the path.
 
-**Do NOT:**
-- ❌ Start the server yourself — no `uvicorn`, no `fused-render serve`, no `python -m fused_render.cli`, no `scripts/dev.sh`.
-- ❌ Kill / `pkill` / `taskkill` the app or its server, and do not `POST /api/desktop/shutdown` (a token-gated internal endpoint — the tray owns shutdown).
-- ❌ Scan ports, read or write the pidfile, or otherwise hunt for or free a port.
-- ❌ Hand-roll a second instance, or point a raw `webbrowser` / `xdg-open` / `start` at a server you spawned.
-
-**DO:** open files and views by handing the path to the FusedRender app, and let the app own the server lifecycle.
-
-**Why (security):** the app runs its Python server in a sandboxed child environment — a per-launch 256-bit instance token, a token-gated shutdown endpoint, and an isolated tools dir that wires the bundled `rclone` / `uv` / `duckdb`. A hand-spawned bare server bypasses all of that isolation, and killing processes by hand can corrupt the single-instance lock and leave `rclone` mounts dangling.
-
-**Why (performance):** reusing the elected instance avoids duplicate servers fighting over ports and re-paying cold startup on every open — `rclone` remounts and the `uv` / `duckdb` / warm VFS caches survive across opens only in the one long-lived instance.
-
-## How the app addresses pages (URLs)
-
-The filesystem path rides in the URL after a mode prefix, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `.../view/Users/me/proj/dash.html`.
+The filesystem path rides in the URL after a **mode prefix**, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `…/view/Users/me/proj/dash.html`.
 
 | Path | Renders |
 |---|---|
 | `/` | The explorer at `start_dir` — click to browse. |
-| `/view/<path>` | **Full-shell mode** — the page wrapped in explorer chrome (sidebar, breadcrumb, preview header). **This is what the app opens when you hand it a path** — the natural desktop experience. |
-| `/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). Useful for a bare view or a screenshot. |
+| `/view/<path>` | **Full-shell mode** — the page wrapped in explorer chrome (sidebar, breadcrumb, preview header). What the app opens when you hand it a path. |
+| `/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). Best for opening a specific view on its own or for a screenshot. |
 
-**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `/view/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. You don't point at the template html; you point at the data file.
+View vs embed is a fixed page-load mode set by the prefix — it can't toggle without a full navigation. Both serve the same page and sync URL params the same way; embed just hides the chrome.
 
-View state lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to share the exact state.
+**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `…/view/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. Point at the data file, not the template html. When a file has more than one mode, add `?_mode=<name>` to open a specific one (or use the switcher in the preview header).
 
-### Opening a specific URL (embed mode, preset params)
+## Params are the shareable state
 
-Handing the app a path always opens full-shell `/view/` at default params. To open **embed mode** or a **preset param state**, open that URL in the browser against the **already-running** app server — that is navigation *within* the running instance, not lifecycle management, so it still starts no new server. You need the instance's port:
-
-- **macOS:** the port is persisted at `~/Library/Application Support/fused-render/server.port`.
-- **Linux/Windows:** the port is ephemeral (OS-assigned) and is **not** persisted — prefer handing the app the path and toggling to embed / adjusting params from within the open view.
+View state (paging, sort, selection) lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to reproduce or share the exact state.
 
 ## Where things live in a project
 
 - A **view** is usually a sibling pair: an `.html` page (UI) + a `.py` file (data it fetches via `fused.runPython`).
 - Built-in preview templates live under `fused_render/templates/<name>/`; user-owned ones under `~/.fused-render/` (see `fused-render-custom-templates`).
-- View state lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to share the exact state.
 
 ## When to switch skills
 

--- a/skills/fused-render-usage/SKILL.md
+++ b/skills/fused-render-usage/SKILL.md
@@ -1,45 +1,62 @@
 ---
 name: fused-render-usage
-description: How to run and use a fused-render project — start the local server, browse the filesystem, and open views/files in the browser. Use this whenever the user wants to open, run, launch, start, serve, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
+description: How to run and use a fused-render project — open files and views by driving the FusedRender desktop app (which launches or reuses a single local instance) and browse the filesystem. Use this whenever the user wants to open, run, launch, start, show, or explore a fused-render project or its views/files; asks to "open this in fused-render", "run fused-render", "show me this view", "look at this file in the explorer"; or is orienting inside a fused-render repo without yet authoring code. For creating/editing/debugging an .html view or .py data file, use fused-render-authoring instead; for registering custom preview templates, use fused-render-custom-templates.
 ---
 
 # Using a fused-render project
 
-fused-render is a **local file explorer** that runs entirely on `127.0.0.1` — no accounts, no cloud. It browses any directory in the browser, previews files, and live-renders `.html` views that call local Python. This skill covers **running and using** an existing project; it does not cover writing views (that's `fused-render-authoring`).
+fused-render is a **local file-explorer desktop app** that runs entirely on `127.0.0.1` — no accounts, no cloud. It browses any directory in the browser, previews files, and live-renders `.html` views that call local Python. This skill covers **running and using** the app; it does not cover writing views (that's `fused-render-authoring`).
 
-## Running the server
+## Drive the desktop app — never a raw server
 
-```
-fused-render                                    # opens a tab at http://127.0.0.1:1777/, starting in ~/Documents/Fused
-fused-render --start-dir ~/data --port 9000     # different start dir + port
-fused-render --port 1777 --no-browser           # don't steal focus (best when driving it yourself)
-```
+There is **one** FusedRender instance per user. Launching the app again does **not** start a second server: it elects a single instance (an `flock` on Linux, a named mutex on Windows, LaunchServices on macOS) and **forwards** your request to the instance already running — or starts one if none is. Launch-if-necessary-else-reuse is built into the app's own entrypoint; you never orchestrate it, probe for it, or reproduce it.
 
-`--start-dir` only sets the initial location (default `~/Documents/Fused`, override with `$FUSED_RENDER_DIR`); the whole filesystem stays browsable from there. On first run the server seeds that Fused directory with example content and opens a landing/showcase page rather than a bare listing. When you launch it to open something for the user or to test a change, prefer `--no-browser` and open the specific URL yourself (see below) rather than landing them on that page.
+To open a file, a view, or a directory, **hand its path to the FusedRender app**. It opens that path as a full-shell view (`/view/<path>`) in a browser tab, reusing the running instance.
 
-### macOS desktop app
+| Platform | Open a path (launch-or-reuse) | Open home |
+|---|---|---|
+| macOS | `open -a FusedRender <path>` | `open -a FusedRender` |
+| Linux | `gtk-launch fused-render <path>`, the AppImage binary `FusedRender-<ver>.AppImage <path>`, or right-click → *Open With → FusedRender* | same without a path |
+| Windows | `FusedRender.exe <path>`, or right-click → *Open with → FusedRender* | `FusedRender.exe` |
 
-On macOS, fused-render also ships as a standalone **`FusedRender.app`** (packaged as `dist/FusedRender-<version>.dmg` via `bash scripts/build_dmg.sh`). It bundles Python and a prebuilt shell — no `pip install`, no Node — so a non-developer just double-clicks it to launch the same local server and browser tab. The `.app` also ships an offline wheelhouse (numpy, pandas, pyarrow, duckdb, polars, requests, matplotlib, scipy, pillow, openpyxl, shapely, geopandas, rasterio, zarr, pymupdf, and more — see the `[bundled]` extra in `pyproject.toml` for the full set), so views built on those packages work with no network. Everything below — URLs, modes, params — is identical whether the server was started by the CLI or the app.
+Under the hood the Linux/Windows launcher execs `python -I -m fused_render.supervisor <path>` (the AppImage's `AppRun`); the macOS `.app` does the same job natively. Invoke the app, not this module.
 
-Source checkout only: the React shell must be built once before the server starts (`cd frontend && npm install && npm run build`, Node 22), or use `scripts/dev.sh` for the watch+server dev loop. Wheels and the `.app` ship the shell prebuilt.
+### Guardrail: internal entrypoint only — never raw OS commands
 
-## Opening files and views by URL
+Driving the app through its own entrypoint is a **security and performance boundary**, not a style preference.
 
-The filesystem path rides in the URL after a mode prefix, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `.../embed/Users/me/proj/dash.html`.
+**Do NOT:**
+- ❌ Start the server yourself — no `uvicorn`, no `fused-render serve`, no `python -m fused_render.cli`, no `scripts/dev.sh`.
+- ❌ Kill / `pkill` / `taskkill` the app or its server, and do not `POST /api/desktop/shutdown` (a token-gated internal endpoint — the tray owns shutdown).
+- ❌ Scan ports, read or write the pidfile, or otherwise hunt for or free a port.
+- ❌ Hand-roll a second instance, or point a raw `webbrowser` / `xdg-open` / `start` at a server you spawned.
+
+**DO:** open files and views by handing the path to the FusedRender app, and let the app own the server lifecycle.
+
+**Why (security):** the app runs its Python server in a sandboxed child environment — a per-launch 256-bit instance token, a token-gated shutdown endpoint, and an isolated tools dir that wires the bundled `rclone` / `uv` / `duckdb`. A hand-spawned bare server bypasses all of that isolation, and killing processes by hand can corrupt the single-instance lock and leave `rclone` mounts dangling.
+
+**Why (performance):** reusing the elected instance avoids duplicate servers fighting over ports and re-paying cold startup on every open — `rclone` remounts and the `uv` / `duckdb` / warm VFS caches survive across opens only in the one long-lived instance.
+
+## How the app addresses pages (URLs)
+
+The filesystem path rides in the URL after a mode prefix, with its **leading slash dropped** and each segment URL-encoded (space → `%20`). `/Users/me/proj/dash.html` → `.../view/Users/me/proj/dash.html`.
 
 | Path | Renders |
 |---|---|
 | `/` | The explorer at `start_dir` — click to browse. |
-| `/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). **Default for opening a specific view.** |
-| `/view/<path>` | **Full-shell mode** — the same page wrapped in the explorer chrome (sidebar, breadcrumb, preview header). |
+| `/view/<path>` | **Full-shell mode** — the page wrapped in explorer chrome (sidebar, breadcrumb, preview header). **This is what the app opens when you hand it a path** — the natural desktop experience. |
+| `/embed/<path>` | **Embed mode** — the page chrome-free (no sidebar/breadcrumb/header). Useful for a bare view or a screenshot. |
 
-### Default to embed mode
+**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `/view/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. You don't point at the template html; you point at the data file.
 
-**When you open a link to a specific view/file for the user or to show a change, use `/embed/` by default.** Embed shows only the view itself — the thing the user actually cares about — without the explorer chrome around it. Reach for `/view/` only when the user is *browsing* (wants the sidebar/breadcrumb to navigate) or explicitly asks to see the file inside the full explorer shell.
+View state lives in **URL params**, so any view is refresh-proof and bookmarkable — copy the URL to share the exact state.
 
-View vs embed is a fixed page-load mode set by the prefix — it cannot toggle without a full navigation. Both serve the same page, route identically, and sync URL params the same way; embed just hides the chrome.
+### Opening a specific URL (embed mode, preset params)
 
-**Preview templates** (parquet/image/text viewers, etc.) open at the *target file's* path — `/embed/<abs path to the data file>` — and the shell resolves the template by extension, handing it the file via a read-only `_file` param. You don't point at the template html; you point at the data file.
+Handing the app a path always opens full-shell `/view/` at default params. To open **embed mode** or a **preset param state**, open that URL in the browser against the **already-running** app server — that is navigation *within* the running instance, not lifecycle management, so it still starts no new server. You need the instance's port:
+
+- **macOS:** the port is persisted at `~/Library/Application Support/fused-render/server.port`.
+- **Linux/Windows:** the port is ephemeral (OS-assigned) and is **not** persisted — prefer handing the app the path and toggling to embed / adjusting params from within the open view.
 
 ## Where things live in a project
 


### PR DESCRIPTION
## Summary

Two skill docs, retargeted from "start a dev server every time" to the installed FusedRender desktop app, with responsibilities split cleanly:

- **`fused-render-usage`** — now plain, guardrail-free instructions for **opening things into the already-running desktop app**: hand a path to the app (per-platform commands), or open by URL in `/view/` (full shell), `/embed/` (chrome-free), preview-template (`?_mode=`), and param-encoded shareable state. Drops all dev-server / CLI / build ceremony and the earlier DO/DON'T block.
- **`fused-render-custom-templates`** — gains the safeguard, because that's where template code actually runs: **use fused's internal APIs — bundled libraries + `window.fused` helpers — never raw OS/shell commands or direct `/api/fs` fetches.** No `subprocess`/`os.system`/system binaries in `reader.py`/`condition.py`; no `fetch('/api/fs/*')` from `template.html`; keep `condition.py` reads bounded.

## Visuals

Docs-only. The diagram shows the responsibility split this PR establishes across the two skills.

```mermaid
flowchart TD
    subgraph U[fused-render-usage · how to OPEN]
        U1[Hand a path to the app → /view/]
        U2[Open by URL: /view · /embed · ?_mode · params]
    end
    subgraph C[fused-render-custom-templates · guardrail]
        C1[reader.py / condition.py:<br/>bundled libs, no subprocess/shell]
        C2[template.html:<br/>window.fused helpers, not raw /api/fs fetch]
        C3[condition.py: bounded reads]
    end
    U -. no guardrails, just usage .-> C
```

## Usage

Usage skill instructs opening a path into the running app, e.g.:

- macOS: `open -a FusedRender <path>`
- Linux: `gtk-launch fused-render <path>` (or *Open With* / AppImage binary)
- Windows: `FusedRender.exe <path>`

…or by URL against the running server: `…/embed/<path>`, `…/view/<path>`, preview templates at the data-file path with `?_mode=<name>`.

## Test Plan

- [ ] N/A — documentation-only change to two skill markdown files; no automated test suite covers `skills/**`.
- [x] Per-platform launcher names verified against the repo (`scripts/linux/fused-render.desktop.in`, `fused_render/supervisor/_linux/integration.py`, `scripts/build_dmg.sh`, `scripts/linux/AppRun`).
- [x] URL modes (`/view`, `/embed`, `_mode`, `_file`) and `window.fused` helper names verified against `fused_render/_view_url_codec.py` and `skills/fused-render-authoring/SKILL.md`.
- [x] Guardrail scope verified against `fused-render-authoring` (bundled library set; "reach the filesystem only through these helpers") and the existing `condition.py` "keep reads bounded" guidance in `fused-render-custom-templates`.
