### PR TITLE
fix(appimage): strip libs, drop dead-weight ty, max-level zstd — 478MB→392MB

### DIFF
--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -108,13 +108,12 @@ echo "${RCLONE_SHA256}  ${RCLONE_ZIP}" | sha256sum --check --status \
     "$RCLONE_ZIP" "$PYTHON_ROOT/bin/rclone"
 
 # --- prune dead weight (mirrors build_dmg.sh's D116/D118 pruning) ------------
-# manylinux wheels ship native libs with full debug + local symbol tables
-# (polars/pyarrow/GDAL alone carry tens of MB each). strip -S drops debug info,
-# -x drops local symbols; globals stay so dlopen/linking is untouched. This is
-# the single biggest AppImage-size lever — the macOS DMG strips the same way,
-# which is why the unstripped Linux payload was ~200 MB heavier. Per-file
-# `|| true`: `find` matches by extension and a stray non-ELF .so (e.g. a text
-# stub) must not fail the build.
+# manylinux wheels ship native libs with full debug + local symbol tables that
+# the Windows PE / macOS Mach-O wheels of the same libraries don't — the main
+# reason the Linux payload dwarfed the other platforms. strip -S drops debug
+# info, -x drops local symbols; globals stay so dlopen/linking is untouched.
+# The macOS DMG strips the same way. Per-file `|| true`: `find` matches by
+# extension and a stray non-ELF .so (e.g. a text stub) must not fail the build.
 log "Stripping bundled native libraries"
 require strip
 find "$PYTHON_ROOT" -type f \( -name '*.so' -o -name '*.so.*' \) \
@@ -125,6 +124,15 @@ find "$PYTHON_ROOT" -type f \( -name '*.so' -o -name '*.so.*' \) \
 # as the DMG build. Only directories literally named `tests`/`test`.
 find "$PYTHON_ROOT/lib/python3.12/site-packages" -type d \
     \( -name tests -o -name test \) -prune -exec rm -rf {} + 2>/dev/null || true
+
+# Drop `ty` (Astral's type checker, ~27 MB): the `fused` wheel declares it as a
+# runtime dependency, but nothing in fused_render imports it and the packaged
+# app never type-checks — it's pure dead weight in the bundle. Remove both the
+# console-script binary and the package. macOS/Windows can prune it the same
+# way; keep this in sync if that lands there too.
+rm -rf "$PYTHON_ROOT/bin/ty" \
+    "$PYTHON_ROOT"/lib/python3.12/site-packages/ty \
+    "$PYTHON_ROOT"/lib/python3.12/site-packages/ty-*.dist-info
 
 find "$PYTHON_ROOT" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
 
@@ -189,7 +197,15 @@ OUTPUT_APPIMAGE="$DIST_DIR/FusedRender-${VERSION}-${ARCH}.AppImage"
 rm -f "$OUTPUT_APPIMAGE"
 # --appimage-extract-and-run avoids needing libfuse2 to RUN appimagetool itself
 # in CI; --runtime-file embeds the static type-2 runtime in the OUTPUT.
+# Compression: appimagetool's bundled mksquashfs only supports zstd (no xz), so
+# push zstd to its max level (22, vs the level-15 default) and use 1 MiB blocks
+# — larger blocks give the dictionary more cross-file redundancy to exploit
+# across the many similar native libs. Worth ~55 MB here and closes most of the
+# compression gap to the Windows installer (LZMA) and macOS DMG (LZFSE).
 ARCH="$ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
+    --comp zstd \
+    --mksquashfs-opt -b --mksquashfs-opt 1M \
+    --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
     --runtime-file "$RUNTIME_FILE" "$STAGE_DIR" "$OUTPUT_APPIMAGE"
 [ -f "$OUTPUT_APPIMAGE" ] || { echo "appimagetool did not produce $OUTPUT_APPIMAGE" >&2; exit 1; }
 chmod +x "$OUTPUT_APPIMAGE"

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -107,7 +107,25 @@ echo "${RCLONE_SHA256}  ${RCLONE_ZIP}" | sha256sum --check --status \
     "import zipfile, sys, shutil, os; z = zipfile.ZipFile(sys.argv[1]); member = [n for n in z.namelist() if n.endswith('/rclone')][0]; dst = open(sys.argv[2], 'wb'); shutil.copyfileobj(z.open(member), dst); dst.close(); os.chmod(sys.argv[2], 0o755)" \
     "$RCLONE_ZIP" "$PYTHON_ROOT/bin/rclone"
 
-# --- prune caches ------------------------------------------------------------
+# --- prune dead weight (mirrors build_dmg.sh's D116/D118 pruning) ------------
+# manylinux wheels ship native libs with full debug + local symbol tables
+# (polars/pyarrow/GDAL alone carry tens of MB each). strip -S drops debug info,
+# -x drops local symbols; globals stay so dlopen/linking is untouched. This is
+# the single biggest AppImage-size lever — the macOS DMG strips the same way,
+# which is why the unstripped Linux payload was ~200 MB heavier. Per-file
+# `|| true`: `find` matches by extension and a stray non-ELF .so (e.g. a text
+# stub) must not fail the build.
+log "Stripping bundled native libraries"
+require strip
+find "$PYTHON_ROOT" -type f \( -name '*.so' -o -name '*.so.*' \) \
+    -exec strip -S -x {} + 2>/dev/null || true
+
+# Package test suites (numpy/pandas/pyarrow/... ship `tests` dirs full of
+# fixtures) are never imported by the app or by user scripts — drop them, same
+# as the DMG build. Only directories literally named `tests`/`test`.
+find "$PYTHON_ROOT/lib/python3.12/site-packages" -type d \
+    \( -name tests -o -name test \) -prune -exec rm -rf {} + 2>/dev/null || true
+
 find "$PYTHON_ROOT" -type d -name __pycache__ -prune -exec rm -rf {} + 2>/dev/null || true
 
 # --- smoke tests (drop the pywin32 imports; add supervisor + tray) -----------

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -198,13 +198,15 @@ rm -f "$OUTPUT_APPIMAGE"
 # --appimage-extract-and-run avoids needing libfuse2 to RUN appimagetool itself
 # in CI; --runtime-file embeds the static type-2 runtime in the OUTPUT.
 # Compression: appimagetool's bundled mksquashfs only supports zstd (no xz), so
-# push zstd to its max level (22, vs the level-15 default) and use 1 MiB blocks
-# — larger blocks give the dictionary more cross-file redundancy to exploit
-# across the many similar native libs. Worth ~55 MB here and closes most of the
-# compression gap to the Windows installer (LZMA) and macOS DMG (LZFSE).
+# push zstd to its max level (22, vs the level-15 default). We deliberately keep
+# the DEFAULT squashfs block size (128 KiB): raising it (e.g. -b 1M) shaves ~30
+# MB more but amplifies random-read latency at every launch — this payload is a
+# large Python tree read as many small files at import time, and appimagetool
+# 1.9.0 returned to the default block size precisely to avoid that startup
+# regression. The level bump costs nothing at decompress time (zstd decode speed
+# is ~independent of level), so it's a free ~33 MB with no runtime penalty.
 ARCH="$ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
     --comp zstd \
-    --mksquashfs-opt -b --mksquashfs-opt 1M \
     --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
     --runtime-file "$RUNTIME_FILE" "$STAGE_DIR" "$OUTPUT_APPIMAGE"
 [ -f "$OUTPUT_APPIMAGE" ] || { echo "appimagetool did not produce $OUTPUT_APPIMAGE" >&2; exit 1; }


### PR DESCRIPTION
## Summary

The Linux AppImage shipped **~200 MB larger** than the macOS DMG and Windows installer (478 MB vs ~250 MB) despite bundling the same CPython 3.12 + data stack — not an Electron issue; the whole payload is the Python environment. `build_linux_appimage.sh` did none of the size reduction the other two builds do. This PR adds it, taking the AppImage **478 MB → 392 MB**.

Root causes, ranked, and what each lever recovers (measured on the real 0.3.10 build):

- **Unstripped native libs (~53 MB).** manylinux ELF `.so` carry debug + local symbol tables that the Windows PE / macOS Mach-O wheels of the same libraries don't — the main reason Linux dwarfed the others. `strip -S -x` (globals kept, so linking is untouched), mirroring `build_dmg.sh`.
- **Weak compression (~33 MB).** The AppImage shipped zstd level-15; Windows uses Inno/LZMA and macOS uses LZFSE. appimagetool's bundled mksquashfs only supports zstd (no xz), so we bump it to level 22. We keep the **default 128 KiB block size** — larger blocks compress a little better but amplify per-launch random-read latency on this small-file Python tree (see review thread). The level bump alone is free at runtime (zstd decode speed is ~independent of level).
- **Dead-weight `ty` (~9 MB).** The `fused` wheel declares Astral's type checker (`ty>=0.0.1a1`) as a runtime dependency, but nothing in `fused_render` imports it and the packaged app never type-checks. Dropped.
- **Test suites (~small, compressed).** numpy/pandas/pyarrow `tests/` fixture dirs, dropped as in `build_dmg.sh`.

Residual gap to macOS (~140 MB) is mostly the bundled `uv` (60 MB, needed on Linux to create user venvs at runtime — macOS bundles no uv), LZFSE-vs-zstd, and arm64 wheels being smaller than x86_64 manylinux. Diminishing returns beyond this.

> Note: my first pass assumed the ~277 MB of *uncompressed* strip/prune savings would map proportionally to the compressed AppImage. It didn't — symbol tables and fixtures compress well, so strip+prune alone only bought 53 MB; the zstd level bump does most of the rest.

## Visuals

New prune + compression steps in the AppImage pipeline:

```mermaid
flowchart TB
    A[pip install wheel + DuckDB ext] --> B[bundle uv + rclone]
    B --> C{Prune dead weight}
    subgraph C [ ]
        direction TB
        C1[strip -S -x all .so / .so.*]
        C2[rm tests / test dirs]
        C3[rm ty type checker ~27MB]
        C4[rm __pycache__ - existing]
        C1 --> C2 --> C3 --> C4
    end
    C --> D[smoke tests on pruned tree]
    D --> E{appimagetool}
    E -->|zstd level 22, default 128KiB blocks| F[AppImage 392 MB]

    style C1 fill:#1f6f43,color:#fff
    style C2 fill:#1f6f43,color:#fff
    style C3 fill:#1f6f43,color:#fff
    style E fill:#1f6f43,color:#fff
```

Size progression (measured):

| Build | Size |
|---|---|
| 0.3.10 release (before) | 478 MB |
| + strip + prune tests (zstd-15) | 425 MB |
| + drop `ty` | ~416 MB |
| + zstd level 22, default blocks | **392 MB** |

Block-size tradeoff considered and rejected (per review): 256 KiB → 380 MB, 512 KiB → 369 MB, 1 MiB → 360 MB, each multiplying random-read amplification at launch. Kept the default 128 KiB.

## Usage

Not user-invocable — build-time only:

```bash
bash scripts/build_linux_appimage.sh
# → dist/FusedRender-<version>-x86_64.AppImage
```

`strip` is now a required build tool (`require strip`), alongside `uv`/`curl`/`sha256sum`.

## Test Plan

- [x] `bash -n scripts/build_linux_appimage.sh` passes
- [x] Full clean build via `bash scripts/build_linux_appimage.sh` runs green — the pipeline's own smoke tests (bundle imports for duckdb/dbus_fast/supervisor, `uv`/`rclone --version`, `_child.py` duckdb probe) run *after* the prune, so they validate the stripped + `ty`-removed tree
- [x] Produced `FusedRender-0.3.10-x86_64.AppImage` = 392 MB (from 478 MB); verified squashfs superblock is zstd with block_size=131072 (default), so no startup read-amplification regression
- [ ] Reviewer sanity: launch the AppImage and confirm a preview view renders (exercises stripped pyarrow/GDAL/duckdb through the real runtime)
