### PR TITLE
feat(linux): tray uninstall item + autostart self-heal after AppImage move

### DIFF
--- a/fused_render/supervisor/_backend.py
+++ b/fused_render/supervisor/_backend.py
@@ -26,6 +26,9 @@ Optional hooks (a backend may omit them; core probes with getattr):
   integrate      — best-effort user-level desktop self-integration at startup
                    (Linux only: .desktop / MIME / icon + deep-link handler;
                    Windows registers via its installer, so it has none)
+  deintegrate    — reverse of integrate(): remove that desktop integration
+                   (Linux only, driven by the tray "Uninstall" item;
+                   integration-only, never app data or the binary)
   update         — auto-updater: start_auto_checks(paths), check(paths)
                    (Windows only: signed-manifest poll + user-approved install)
 """
@@ -46,7 +49,7 @@ if sys.platform == "win32":
     SPAWN_ERRORS: tuple[type[BaseException], ...] = (pywintypes.error,)
 elif sys.platform.startswith("linux"):
     from fused_render.supervisor._linux import instance, startup, ui
-    from fused_render.supervisor._linux.integration import integrate
+    from fused_render.supervisor._linux.integration import deintegrate, integrate
     from fused_render.supervisor._linux.tree import Job
 
     # The Linux keeper spawns via stdlib primitives (subprocess / os), which

--- a/fused_render/supervisor/_linux/integration.py
+++ b/fused_render/supervisor/_linux/integration.py
@@ -76,6 +76,15 @@ def integrate(
     if appimage is None:
         return  # dev / unpackaged: silent no-op
 
+    # Self-heal the autostart Exec= after an AppImage move — before the stamp
+    # short-circuit below, so a stale autostart path is healed even when the
+    # desktop-integration stamp itself is up to date. Best-effort: a heal
+    # failure must never stop integration (log-and-continue).
+    try:
+        startup.refresh_autostart()
+    except Exception as error:  # noqa: BLE001 - autostart heal is never fatal
+        paths.log(f"desktop integration: autostart refresh failed: {error}")
+
     data_home = _xdg_home("XDG_DATA_HOME", ".local/share")
     desktop_file = data_home / "applications" / _DESKTOP_NAME
     mime_file = data_home / "mime" / "packages" / _MIME_PACKAGE_NAME

--- a/fused_render/supervisor/_linux/integration.py
+++ b/fused_render/supervisor/_linux/integration.py
@@ -85,10 +85,7 @@ def integrate(
     except Exception as error:  # noqa: BLE001 - autostart heal is never fatal
         paths.log(f"desktop integration: autostart refresh failed: {error}")
 
-    data_home = _xdg_home("XDG_DATA_HOME", ".local/share")
-    desktop_file = data_home / "applications" / _DESKTOP_NAME
-    mime_file = data_home / "mime" / "packages" / _MIME_PACKAGE_NAME
-    icon_file = data_home / "icons" / "hicolor" / "256x256" / "apps" / _ICON_NAME
+    data_home, desktop_file, mime_file, icon_file, stamp_file = _artifact_paths(paths)
 
     if icon_source is None:
         icon_source = _bundled_icon_source()
@@ -101,7 +98,6 @@ def integrate(
     desktop_text = _desktop_entry(appimage, icon_value)
     mime_text = custom_mime_xml()
 
-    stamp_file = paths.state / _STAMP_NAME
     stamp = _stamp(appimage, desktop_text, mime_text)
     # Skip only when the stamp matches AND every artifact it vouches for still
     # exists: a matching stamp is not proof the files are on disk (manual
@@ -135,6 +131,52 @@ def integrate(
         _write(stamp_file, json.dumps(stamp))
     except OSError as error:  # noqa: BLE001 stamp is an optimization, not correctness
         paths.log(f"desktop integration: could not write stamp: {error}")
+
+
+def _artifact_paths(paths) -> tuple[Path, Path, Path, Path, Path]:
+    """The XDG data home plus the four artifacts integrate() writes and
+    deintegrate() removes — the single source of truth for those paths so the
+    two functions can never drift. Returns
+    (data_home, desktop_file, mime_file, icon_file, stamp_file)."""
+    data_home = _xdg_home("XDG_DATA_HOME", ".local/share")
+    return (
+        data_home,
+        data_home / "applications" / _DESKTOP_NAME,
+        data_home / "mime" / "packages" / _MIME_PACKAGE_NAME,
+        data_home / "icons" / "hicolor" / "256x256" / "apps" / _ICON_NAME,
+        paths.state / _STAMP_NAME,
+    )
+
+
+def deintegrate(paths) -> None:
+    """Reverse integrate(): remove the user-level desktop integration this app
+    installed, best-effort, so nothing is left pointing at a binary the user is
+    about to delete. Integration-only — never touches app data or the binary.
+
+    Every step is wrapped and log-and-continue (matching integrate()): unlink
+    the four installed artifacts, refresh the freedesktop databases (removing
+    the .desktop + this refresh is what drops the "Open with" and scheme
+    associations), and remove the autostart entry. Deliberately does NOT delete
+    ~/.fused-render app data, the cache dir, or the AppImage file itself."""
+    data_home, desktop_file, mime_file, icon_file, stamp_file = _artifact_paths(paths)
+
+    for artifact in (desktop_file, mime_file, icon_file, stamp_file):
+        try:
+            artifact.unlink()
+        except FileNotFoundError:
+            pass  # already gone (never integrated / manual cleanup): fine
+        except OSError as error:  # noqa: BLE001 best-effort — never fatal
+            paths.log(f"desktop deintegration: could not remove {artifact}: {error}")
+
+    # Refresh the databases so the dropped .desktop actually clears the
+    # "Open with" list and the fused-render:// scheme association.
+    _run_tool(["update-mime-database", str(data_home / "mime")], paths)
+    _run_tool(["update-desktop-database", str(data_home / "applications")], paths)
+
+    try:
+        startup.set_enabled(False)
+    except OSError as error:  # noqa: BLE001 best-effort — never fatal
+        paths.log(f"desktop deintegration: could not remove autostart entry: {error}")
 
 
 def _desktop_entry(appimage: Path, icon_value: str) -> str:

--- a/fused_render/supervisor/_linux/startup.py
+++ b/fused_render/supervisor/_linux/startup.py
@@ -112,6 +112,14 @@ def enabled() -> bool:
     return _desktop_file().is_file()
 
 
+def _entry_text(launcher: Path) -> str:
+    """The autostart `.desktop` contents for `launcher` — the single source of
+    truth shared by `set_enabled(True)` (which writes it) and
+    `refresh_autostart` (which compares against it), so the two never drift."""
+    exec_line = f"{_exec_quote(str(launcher))} --startup"
+    return _ENTRY_TEMPLATE.format(exec_line=exec_line)
+
+
 def set_enabled(value: bool) -> None:
     desktop = _desktop_file()
     if not value:
@@ -122,6 +130,34 @@ def set_enabled(value: bool) -> None:
         return
 
     launcher = _launcher_path()  # raises before any write if unresolvable
-    exec_line = f"{_exec_quote(str(launcher))} --startup"
     desktop.parent.mkdir(parents=True, exist_ok=True)
-    desktop.write_text(_ENTRY_TEMPLATE.format(exec_line=exec_line), encoding="utf-8")
+    desktop.write_text(_entry_text(launcher), encoding="utf-8")
+
+
+def refresh_autostart() -> None:
+    """Self-heal the autostart entry after the AppImage moved. If autostart is
+    enabled and the launcher path is resolvable, rewrite the entry only when its
+    current contents differ from what set_enabled(True) would write now. No-op
+    when disabled or when the launcher can't be resolved (dev/unpackaged).
+
+    The parallel "Open with"/deep-link `.desktop` is already re-healed on every
+    packaged start by integration.integrate() (its stamp includes the resolved
+    AppImage path), but the autostart entry set_enabled(True) writes had no such
+    healing — after a move, login-autostart pointed at a dead path forever. This
+    closes that gap while never writing a broken entry (the module's discipline):
+    an unresolvable launcher is left strictly as-is."""
+    if not enabled():
+        return
+    try:
+        launcher = _launcher_path()
+    except FileNotFoundError:
+        return  # unresolvable (dev/unpackaged, or $APPIMAGE now missing): leave as-is
+    desired = _entry_text(launcher)
+    desktop = _desktop_file()
+    try:
+        current = desktop.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        current = None
+    if current == desired:
+        return  # already correct: no needless rewrite / mtime churn
+    set_enabled(True)

--- a/fused_render/supervisor/_linux/tray.py
+++ b/fused_render/supervisor/_linux/tray.py
@@ -44,6 +44,7 @@ _ID_OPEN_LOGS = 5
 _ID_LOGIN = 6
 _ID_SEP2 = 7
 _ID_EXIT = 8
+_ID_UNINSTALL = 9
 
 # Menu ids that map straight to a queued TrayAction. The login id is handled
 # inline (see _dispatch_event), and "Default apps..." is Windows-only so it is
@@ -53,6 +54,7 @@ _ACTION_BY_ID: dict[int, TrayAction] = {
     _ID_OPEN: TrayAction.OPEN,
     _ID_OPEN_FILE: TrayAction.OPEN_FILE,
     _ID_OPEN_LOGS: TrayAction.OPEN_LOGS,
+    _ID_UNINSTALL: TrayAction.UNINSTALL,
     _ID_EXIT: TrayAction.EXIT,
 }
 
@@ -131,6 +133,10 @@ def _menu_layout(login_enabled: bool, port: int) -> tuple[int, list]:
             },
         ),
         _item(_ID_SEP2, {"type": "separator", "visible": True}),
+        _item(
+            _ID_UNINSTALL,
+            {"label": "Uninstall FusedRender…", "enabled": True, "visible": True},
+        ),
         _item(_ID_EXIT, {"label": "Exit", "enabled": True, "visible": True}),
     ]
     return _ROOT_ID, children

--- a/fused_render/supervisor/_linux/ui.py
+++ b/fused_render/supervisor/_linux/ui.py
@@ -63,6 +63,23 @@ def confirm_exit() -> bool:
     return bool(_tk_message("askyesno", title, message))
 
 
+def confirm_uninstall() -> bool:
+    message = (
+        "Remove FusedRender's desktop integration (Open-with entries, MIME "
+        "types, autostart) and quit?\n\n"
+        "This does not delete your data or the app file."
+    )
+    title = "Uninstall FusedRender"
+    tool = _dialog_tool()
+    if tool == "zenity":
+        result = _run(["zenity", "--question", "--title", title, "--text", message])
+        return result is not None and result.returncode == 0
+    if tool == "kdialog":
+        result = _run(["kdialog", "--title", title, "--yesno", message])
+        return result is not None and result.returncode == 0
+    return bool(_tk_message("askyesno", title, message))
+
+
 def report_open_rejected(path: str) -> None:
     alert(f"FusedRender could not open:\n\n{path}")
 

--- a/fused_render/supervisor/_win32/ui.py
+++ b/fused_render/supervisor/_win32/ui.py
@@ -42,6 +42,21 @@ def confirm_exit() -> bool:
     return result == _IDYES
 
 
+def confirm_uninstall() -> bool:
+    """Yes/No confirmation for the tray Uninstall action. True iff the user
+    confirmed. Part of the uniform `ui` surface core.py depends on (like
+    open_default_apps); the Windows tray builds no Uninstall item — Windows
+    uninstalls through the installer — so this is never reached at runtime."""
+    result = ctypes.windll.user32.MessageBoxW(
+        0,
+        "Remove FusedRender's desktop integration and quit?\n\n"
+        "This does not delete your data or the app file.",
+        "Uninstall FusedRender",
+        _MB_YESNO | _MB_ICONQUESTION,
+    )
+    return result == _IDYES
+
+
 def report_open_rejected(path: str) -> None:
     """Warn that a forwarded open failed. The primary already logged the
     underlying reason; this is just accurate user-facing feedback, not a

--- a/fused_render/supervisor/core.py
+++ b/fused_render/supervisor/core.py
@@ -33,6 +33,7 @@ instance = _backend.instance
 startup = _backend.startup
 ui = _backend.ui
 update = getattr(_backend, "update", None)  # optional hook (Windows only)
+deintegrate = getattr(_backend, "deintegrate", None)  # optional hook (Linux only)
 
 _READY_TIMEOUT_S = 20.0
 _SHUTDOWN_TIMEOUT_S = 5.0
@@ -40,6 +41,7 @@ _STOP_PIPE_TIMEOUT_S = 10.0
 
 _dialog_lock = threading.Lock()
 _exit_dialog_lock = threading.Lock()
+_uninstall_dialog_lock = threading.Lock()
 
 
 class SupervisorStoppedError(RuntimeError):
@@ -152,6 +154,7 @@ def _event_loop(
     opens are dispatched via _spawn_open, never awaited, so a hung open can't
     stall answering a concurrent ShutdownForUpgrade in its 20s window."""
     exit_confirm: "queue.Queue[bool]" = queue.Queue()
+    uninstall_confirm: "queue.Queue[bool]" = queue.Queue()
     while True:
         while True:
             try:
@@ -168,11 +171,30 @@ def _event_loop(
                 _spawn_call(paths, ui.open_default_apps)
             elif action is tray.TrayAction.CHECK_UPDATES:
                 _spawn_update_check(paths)
+            elif action is tray.TrayAction.UNINSTALL:
+                _spawn_uninstall_confirm(uninstall_confirm)
             elif action is tray.TrayAction.EXIT:
                 _spawn_exit_confirm(exit_confirm)
 
         try:
             if exit_confirm.get_nowait():  # False (user clicked No) just resumes
+                return _ExitReason.TRAY_EXIT, None
+        except queue.Empty:
+            pass
+
+        try:
+            if uninstall_confirm.get_nowait():  # False (clicked No) just resumes
+                # Reverse the first-launch desktop integration before exiting, so
+                # nothing is left pointing at a binary the user is about to
+                # delete. Best-effort and guarded: a missing hook (non-Linux) or
+                # a failure must still let the app exit through the normal
+                # teardown path below (tray stop -> pipe -> graceful shutdown ->
+                # job.close()). Integration-only — never the app data or binary.
+                if deintegrate is not None:
+                    try:
+                        deintegrate(paths)
+                    except Exception as error:  # noqa: BLE001 - never blocks exit
+                        paths.log(f"uninstall: deintegrate failed: {error}")
                 return _ExitReason.TRAY_EXIT, None
         except queue.Empty:
             pass
@@ -373,6 +395,26 @@ def _spawn_exit_confirm(results: "queue.Queue[bool]") -> None:
             _exit_dialog_lock.release()
 
     threading.Thread(target=worker, daemon=True, name="fused-render-exit-confirm").start()
+
+
+def _spawn_uninstall_confirm(results: "queue.Queue[bool]") -> None:
+    """Uninstall confirmation on a dedicated thread — same idiom as
+    `_spawn_exit_confirm`: the modal dialog must not block the loop, so a
+    ShutdownForUpgrade arriving while it's up is still answered in the pipe
+    server's window. A separate lock from the exit/file dialogs drops a second
+    click while one uninstall dialog is already open rather than stacking them."""
+    if not _uninstall_dialog_lock.acquire(blocking=False):
+        return
+
+    def worker():
+        try:
+            results.put(ui.confirm_uninstall())
+        finally:
+            _uninstall_dialog_lock.release()
+
+    threading.Thread(
+        target=worker, daemon=True, name="fused-render-uninstall-confirm"
+    ).start()
 
 
 def _open_command(port: int, command: protocol.Command) -> None:

--- a/fused_render/supervisor/core.py
+++ b/fused_render/supervisor/core.py
@@ -176,12 +176,10 @@ def _event_loop(
             elif action is tray.TrayAction.EXIT:
                 _spawn_exit_confirm(exit_confirm)
 
-        try:
-            if exit_confirm.get_nowait():  # False (user clicked No) just resumes
-                return _ExitReason.TRAY_EXIT, None
-        except queue.Empty:
-            pass
-
+        # Poll uninstall BEFORE exit: both confirmations resolve to a TRAY_EXIT,
+        # but uninstall is the superset (it must deintegrate first). Checking
+        # exit first would let a plain exit win a race where the user confirmed
+        # both dialogs, silently skipping the cleanup they asked for.
         try:
             if uninstall_confirm.get_nowait():  # False (clicked No) just resumes
                 # Reverse the first-launch desktop integration before exiting, so
@@ -195,6 +193,12 @@ def _event_loop(
                         deintegrate(paths)
                     except Exception as error:  # noqa: BLE001 - never blocks exit
                         paths.log(f"uninstall: deintegrate failed: {error}")
+                return _ExitReason.TRAY_EXIT, None
+        except queue.Empty:
+            pass
+
+        try:
+            if exit_confirm.get_nowait():  # False (user clicked No) just resumes
                 return _ExitReason.TRAY_EXIT, None
         except queue.Empty:
             pass

--- a/fused_render/supervisor/tray.py
+++ b/fused_render/supervisor/tray.py
@@ -38,6 +38,7 @@ class TrayAction(Enum):
     OPEN_LOGS = auto()
     DEFAULT_APPS = auto()
     CHECK_UPDATES = auto()
+    UNINSTALL = auto()
     EXIT = auto()
 
 

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -124,3 +124,78 @@ def _view_path(fs_path: str) -> str:
     from fused_render._view_url_codec import view_url_path
 
     return view_url_path(fs_path)
+
+
+# ---- tray UNINSTALL: confirm -> deintegrate -> TRAY_EXIT ----------------------
+
+
+class _FakeProcess:
+    """Stand-in for the supervised server process: `wait(0)` reports "still
+    running" (0) until `die_after` loop polls have passed, then "exited" (1) so
+    the run loop terminates deterministically in a declined-uninstall test."""
+
+    def __init__(self, die_after=None):
+        self.calls = 0
+        self.die_after = die_after
+
+    def wait(self, timeout):
+        self.calls += 1
+        if self.die_after is not None and self.calls > self.die_after:
+            return 1  # truthy: the server exited
+        return 0  # falsy: still running
+
+
+def test_uninstall_confirmed_deintegrates_and_exits(monkeypatch):
+    monkeypatch.setattr(core.ui, "confirm_uninstall", lambda: True)
+    deintegrated = []
+    monkeypatch.setattr(core, "deintegrate", lambda paths: deintegrated.append(paths))
+
+    paths = _Paths()
+    tray_actions = queue.Queue()
+    tray_actions.put(core.tray.TrayAction.UNINSTALL)
+    process = _FakeProcess()  # never dies on its own
+
+    reason, upgrade = core._event_loop(
+        9000, process, paths, tray_actions, queue.Queue()
+    )
+
+    assert reason is core._ExitReason.TRAY_EXIT
+    assert upgrade is None
+    assert deintegrated == [paths]  # the backend hook ran, with paths
+
+
+def test_uninstall_declined_neither_deintegrates_nor_exits(monkeypatch):
+    monkeypatch.setattr(core.ui, "confirm_uninstall", lambda: False)
+    deintegrated = []
+    monkeypatch.setattr(core, "deintegrate", lambda paths: deintegrated.append(paths))
+
+    paths = _Paths()
+    tray_actions = queue.Queue()
+    tray_actions.put(core.tray.TrayAction.UNINSTALL)
+    process = _FakeProcess(die_after=6)  # loop continues, then the server exits
+
+    reason, _upgrade = core._event_loop(
+        9000, process, paths, tray_actions, queue.Queue()
+    )
+
+    # A declined uninstall must NOT deintegrate and must NOT be a TRAY_EXIT: the
+    # loop resumed and only ended because the fake server later died.
+    assert deintegrated == []
+    assert reason is core._ExitReason.SERVER_DIED
+
+
+def test_uninstall_confirmed_exits_cleanly_without_deintegrate_hook(monkeypatch):
+    # On a backend with no deintegrate hook, a confirmed uninstall still tears
+    # down cleanly (guarded call) rather than raising AttributeError.
+    monkeypatch.setattr(core.ui, "confirm_uninstall", lambda: True)
+    monkeypatch.setattr(core, "deintegrate", None)
+
+    paths = _Paths()
+    tray_actions = queue.Queue()
+    tray_actions.put(core.tray.TrayAction.UNINSTALL)
+
+    reason, _upgrade = core._event_loop(
+        9000, _FakeProcess(), paths, tray_actions, queue.Queue()
+    )
+
+    assert reason is core._ExitReason.TRAY_EXIT

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -199,3 +199,27 @@ def test_uninstall_confirmed_exits_cleanly_without_deintegrate_hook(monkeypatch)
     )
 
     assert reason is core._ExitReason.TRAY_EXIT
+
+
+def test_uninstall_and_exit_both_confirmed_still_deintegrates(monkeypatch):
+    # Bugbot regression: with BOTH the Exit and Uninstall dialogs confirmed,
+    # the confirmed uninstall must still deintegrate. Uninstall is the superset
+    # (it must clean up first) and is polled before exit, so a plain exit can't
+    # win the race and silently skip the cleanup the user asked for.
+    monkeypatch.setattr(core.ui, "confirm_exit", lambda: True)
+    monkeypatch.setattr(core.ui, "confirm_uninstall", lambda: True)
+    deintegrated = []
+    monkeypatch.setattr(core, "deintegrate", lambda paths: deintegrated.append(paths))
+
+    paths = _Paths()
+    tray_actions = queue.Queue()
+    tray_actions.put(core.tray.TrayAction.EXIT)
+    tray_actions.put(core.tray.TrayAction.UNINSTALL)
+    process = _FakeProcess()  # never dies on its own
+
+    reason, _upgrade = core._event_loop(
+        9000, process, paths, tray_actions, queue.Queue()
+    )
+
+    assert reason is core._ExitReason.TRAY_EXIT
+    assert deintegrated == [paths]  # cleanup ran despite exit also being confirmed

--- a/tests/test_supervisor_linux_integration.py
+++ b/tests/test_supervisor_linux_integration.py
@@ -197,6 +197,65 @@ def test_icon_falls_back_to_theme_name_without_source(env, monkeypatch):
     assert not env.icon_file.exists()
 
 
+# ---- deintegrate(): the reverse of integrate() (Uninstall) -------------------
+# Integration-only teardown: removes the four artifacts integrate() writes and
+# the autostart entry, refreshes the freedesktop databases, and NEVER touches
+# app data or the AppImage binary.
+
+
+def test_deintegrate_removes_all_artifacts_and_refreshes(env, monkeypatch):
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    assert env.desktop_file.exists() and env.mime_file.exists()
+    assert env.icon_file.exists() and env.stamp_file.exists()
+
+    # Enable autostart too, so we can assert deintegrate removes it.
+    monkeypatch.setenv("APPIMAGE", str(env.appimage))
+    integration.startup.set_enabled(True)
+    autostart = integration.startup._desktop_file()
+    assert autostart.exists()
+
+    env.tool_calls.clear()
+    integration.deintegrate(env.paths)
+
+    # All four installed artifacts are gone.
+    assert not env.desktop_file.exists()
+    assert not env.mime_file.exists()
+    assert not env.icon_file.exists()
+    assert not env.stamp_file.exists()
+    # Autostart entry removed.
+    assert not autostart.exists()
+    # Databases refreshed (dropping "Open with" + scheme associations).
+    tools = [c[0] for c in env.tool_calls]
+    assert "update-mime-database" in tools
+    assert "update-desktop-database" in tools
+
+
+def test_deintegrate_leaves_binary_and_data_untouched(env, monkeypatch):
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    # Integration-only: the AppImage binary and the state dir itself survive.
+    integration.deintegrate(env.paths)
+    assert env.appimage.exists()  # the binary is never deleted
+    assert env.paths.state.exists()  # app data / state dir untouched
+
+
+def test_deintegrate_is_best_effort_when_artifacts_absent(env):
+    # A never-integrated (or partially cleaned) install: unlinking missing files
+    # must not raise, and the run must still complete.
+    integration.deintegrate(env.paths)  # no integrate() first
+    assert not env.desktop_file.exists()
+
+
+def test_deintegrate_swallows_tool_failures(env, monkeypatch):
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+
+    def boom(argv, **kw):
+        raise OSError("update tool crashed")
+
+    monkeypatch.setattr(integration.subprocess, "run", boom)
+    integration.deintegrate(env.paths)  # must not raise
+    assert not env.desktop_file.exists()  # artifacts still removed
+
+
 # ---- Desktop Entry Spec Exec= quoting (NOT shell/shlex quoting) --------------
 # freedesktop only recognizes double-quote quoting in Exec; shlex's single
 # quotes are rejected by some launchers. An argument with reserved characters

--- a/tests/test_supervisor_linux_integration.py
+++ b/tests/test_supervisor_linux_integration.py
@@ -156,6 +156,38 @@ def test_appimage_env_resolution(env, monkeypatch):
     assert env.desktop_file.exists()
 
 
+def test_integrate_refreshes_autostart_best_effort(env, monkeypatch):
+    # integrate() must self-heal the autostart entry on every packaged start
+    # (so a stale Exec= path is healed even when the desktop-integration stamp
+    # is up to date) — see startup.refresh_autostart.
+    calls = []
+    monkeypatch.setattr(integration.startup, "refresh_autostart", lambda: calls.append(True))
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    assert calls == [True]
+
+
+def test_integrate_refreshes_autostart_before_stamp_short_circuit(env, monkeypatch):
+    # A stale autostart path must be healed even when the desktop-integration
+    # stamp itself is up to date (the second, idempotent run): refresh_autostart
+    # runs before integrate()'s stamp short-circuit return.
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    calls = []
+    monkeypatch.setattr(integration.startup, "refresh_autostart", lambda: calls.append(True))
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    assert calls == [True]  # ran despite the stamp being current
+
+
+def test_integrate_swallows_refresh_autostart_failure(env, monkeypatch):
+    # Best-effort: a raise from refresh_autostart must be logged and must not
+    # propagate out of integrate() (log-and-continue discipline).
+    def boom():
+        raise OSError("autostart heal failed")
+
+    monkeypatch.setattr(integration.startup, "refresh_autostart", boom)
+    integration.integrate(env.paths, appimage=env.appimage, icon_source=env.icon_src)
+    assert env.desktop_file.exists()  # the rest of integrate() still ran
+
+
 def test_icon_falls_back_to_theme_name_without_source(env, monkeypatch):
     # No icon source resolvable ($APPDIR unset): the entry still writes, with
     # the theme icon name rather than an absolute path.

--- a/tests/test_supervisor_linux_paths.py
+++ b/tests/test_supervisor_linux_paths.py
@@ -247,6 +247,30 @@ def test_ui_falls_back_to_tkinter(monkeypatch):
     assert ui._dialog_tool() == "tkinter"
 
 
+class _CompletedRun:
+    def __init__(self, returncode):
+        self.returncode = returncode
+        self.stdout = ""
+
+
+@pytest.mark.parametrize("tool", ["zenity", "kdialog"])
+@pytest.mark.parametrize("returncode, expected", [(0, True), (1, False)])
+def test_confirm_uninstall_maps_returncode(monkeypatch, tool, returncode, expected):
+    # confirm_uninstall mirrors confirm_exit: a Yes (returncode 0) is True, a No
+    # (non-zero) is False, for both the zenity and kdialog question dialogs.
+    monkeypatch.setattr(ui, "_dialog_tool", lambda: tool)
+    monkeypatch.setattr(ui, "_run", lambda argv: _CompletedRun(returncode))
+    assert ui.confirm_uninstall() is expected
+
+
+def test_confirm_uninstall_false_when_dialog_unavailable(monkeypatch):
+    # _run returning None (tool missing / timed out) is a declined uninstall,
+    # never an accidental teardown — same guard as confirm_exit.
+    monkeypatch.setattr(ui, "_dialog_tool", lambda: "zenity")
+    monkeypatch.setattr(ui, "_run", lambda argv: None)
+    assert ui.confirm_uninstall() is False
+
+
 class _FakePopen:
     def __init__(self, returncode=0, hang=False):
         self._returncode = returncode

--- a/tests/test_supervisor_linux_startup.py
+++ b/tests/test_supervisor_linux_startup.py
@@ -49,3 +49,85 @@ def test_autostart_entry_plain_launcher_unquoted(monkeypatch, tmp_path):
     appimage = tmp_path / "FusedRender.AppImage"
     appimage.write_text("#!/bin/sh\n")
     assert _autostart_exec(monkeypatch, tmp_path, appimage) == f"Exec={appimage} --startup"
+
+
+# ---- refresh_autostart: self-heal the autostart Exec= after an AppImage move --
+# integrate() self-heals the "Open with"/deep-link .desktop on every packaged
+# start, but the parallel autostart entry (Exec=<appimage> --startup) had no such
+# healing, so after a move login-autostart pointed at a dead path forever.
+
+
+def _enable_autostart(monkeypatch, tmp_path, appimage):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    monkeypatch.setenv("APPIMAGE", str(appimage))
+    startup.set_enabled(True)
+    return tmp_path / "config" / "autostart" / "fused-render.desktop"
+
+
+def test_refresh_autostart_rewrites_stale_exec_path(monkeypatch, tmp_path):
+    old = tmp_path / "FusedRender.AppImage"
+    old.write_text("#!/bin/sh\n")
+    desktop = _enable_autostart(monkeypatch, tmp_path, old)
+    assert f"Exec={old} --startup" in desktop.read_text()
+
+    # The AppImage moved: $APPIMAGE now points at the new location.
+    moved = tmp_path / "moved" / "FusedRender.AppImage"
+    moved.parent.mkdir()
+    moved.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("APPIMAGE", str(moved))
+
+    startup.refresh_autostart()
+
+    assert f"Exec={moved} --startup" in desktop.read_text()
+
+
+def test_refresh_autostart_is_noop_when_entry_already_matches(monkeypatch, tmp_path):
+    appimage = tmp_path / "FusedRender.AppImage"
+    appimage.write_text("#!/bin/sh\n")
+    desktop = _enable_autostart(monkeypatch, tmp_path, appimage)
+    before = desktop.read_text()
+    mtime_before = desktop.stat().st_mtime_ns
+
+    # No write must happen when the on-disk entry already matches: guard against
+    # a needless rewrite (and mtime churn) on the common no-move start.
+    written = []
+    monkeypatch.setattr(
+        startup.Path, "write_text",
+        lambda self, *a, **kw: written.append(self),
+    )
+    startup.refresh_autostart()
+
+    assert written == []
+    assert desktop.read_text() == before
+    assert desktop.stat().st_mtime_ns == mtime_before
+
+
+def test_refresh_autostart_is_noop_when_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "config"))
+    appimage = tmp_path / "FusedRender.AppImage"
+    appimage.write_text("#!/bin/sh\n")
+    monkeypatch.setenv("APPIMAGE", str(appimage))
+    # Autostart never enabled: the entry file is absent and must stay absent.
+    assert not startup.enabled()
+
+    startup.refresh_autostart()
+
+    assert not (tmp_path / "config" / "autostart" / "fused-render.desktop").exists()
+
+
+def test_refresh_autostart_is_noop_when_launcher_unresolvable(monkeypatch, tmp_path):
+    appimage = tmp_path / "FusedRender.AppImage"
+    appimage.write_text("#!/bin/sh\n")
+    desktop = _enable_autostart(monkeypatch, tmp_path, appimage)
+    before = desktop.read_text()
+
+    # $APPIMAGE now points at a missing file: _launcher_path() raises, and
+    # refresh must leave the (stale) entry as-is rather than write a broken one
+    # or raise — matching the module's never-write-a-broken-entry discipline.
+    monkeypatch.setenv("APPIMAGE", str(tmp_path / "gone.AppImage"))
+
+    startup.refresh_autostart()  # must not raise
+
+    assert desktop.read_text() == before

--- a/tests/test_supervisor_linux_tray.py
+++ b/tests/test_supervisor_linux_tray.py
@@ -116,6 +116,20 @@ def test_menu_layout_structure(login_enabled):
     assert len(separators) == 2
 
 
+def test_menu_layout_includes_uninstall_above_exit():
+    # The "Uninstall FusedRender..." item sits just above Exit, set off from the
+    # login toggle by the second separator: ..., login, _SEP2, uninstall, exit.
+    _root_id, children = linux_tray._menu_layout(False, port=1777)
+    labels = _labels(children)
+    assert "Uninstall FusedRender…" in labels or "Uninstall FusedRender..." in labels
+
+    uninstall_label = next(l for l in labels if l and l.startswith("Uninstall FusedRender"))
+    assert labels.index(uninstall_label) == labels.index("Exit") - 1
+
+    by_id = {c["id"]: c for c in children}
+    assert by_id[linux_tray._ID_UNINSTALL]["properties"]["label"] == uninstall_label
+
+
 def test_menu_layout_status_line_is_first():
     # The greyed status line sits at the very top, set off by a separator.
     _root_id, children = linux_tray._menu_layout(False, port=1777)
@@ -152,6 +166,7 @@ def test_root_props_encode_to_string_variant():
         (linux_tray._ID_OPEN, tray.TrayAction.OPEN),
         (linux_tray._ID_OPEN_FILE, tray.TrayAction.OPEN_FILE),
         (linux_tray._ID_OPEN_LOGS, tray.TrayAction.OPEN_LOGS),
+        (linux_tray._ID_UNINSTALL, tray.TrayAction.UNINSTALL),
         (linux_tray._ID_EXIT, tray.TrayAction.EXIT),
     ],
 )
@@ -245,7 +260,7 @@ def test_get_layout_root_returns_revision_and_children():
     assert isinstance(revision, int)
     node_id, _props, children = layout
     assert node_id == linux_tray._ROOT_ID
-    assert len(children) == 8  # the eight menu items under the root
+    assert len(children) == 9  # the nine menu items under the root
 
 
 def test_get_layout_nonzero_parent_returns_matching_node():


### PR DESCRIPTION
## Summary

Two related Linux-AppImage desktop-integration fixes:

- **Autostart self-heals after the AppImage is moved.** The "Open with"/deep-link `.desktop` already rewrites its `Exec=` path on the next launch from a new location (its integration stamp includes the AppImage path). The **autostart** entry (`~/.config/autostart/fused-render.desktop`) had no such healing, so login-autostart pointed at a dead path forever after a move. `startup.refresh_autostart()` now rewrites it on next packaged launch when the on-disk path is stale.
- **New tray "Uninstall FusedRender…" item (Linux).** Reverses the first-launch desktop integration — removes the `.desktop`, MIME package, icon, and stamp, refreshes the freedesktop databases, and drops the autostart entry — then quits via the normal teardown path. **Integration-only by design:** it never deletes `~/.fused-render` app data (shared with the CLI/dev/macOS app) or the AppImage binary itself.

## Visuals

Autostart self-heal — folded into the existing startup integration pass:

```mermaid
flowchart TD
    A[Packaged supervisor start] --> B["integrate() on daemon thread"]
    B --> C{"$APPIMAGE resolves?"}
    C -->|no: dev/unpackaged| Z[no-op]
    C -->|yes| D["startup.refresh_autostart()  (best-effort)"]
    D --> E{autostart enabled?}
    E -->|no| F[skip]
    E -->|yes| G{on-disk Exec == current launcher?}
    G -->|same| F
    G -->|stale| H["rewrite autostart .desktop with new path"]
    D --> I[stamp short-circuit / desktop+MIME+icon rewrite]
```

Tray uninstall — click to clean teardown:

```mermaid
sequenceDiagram
    participant U as User
    participant T as Linux tray (dbusmenu)
    participant L as core run loop
    participant UI as ui.confirm_uninstall()
    participant I as integration.deintegrate()
    U->>T: click "Uninstall FusedRender…"
    T->>L: enqueue TrayAction.UNINSTALL
    L->>UI: spawn confirm dialog (own lock/thread)
    UI-->>L: True / False
    alt confirmed
        L->>I: deintegrate(paths) — remove .desktop/MIME/icon/stamp,<br/>refresh DBs, disable autostart
        L->>L: return _ExitReason.TRAY_EXIT → normal teardown
    else declined
        L->>L: resume loop
    end
```

## Usage

- **Uninstall:** left-/right-click the FusedRender tray icon → **Uninstall FusedRender…** → confirm. The desktop integration and autostart entry are removed and the app exits. Delete the AppImage file yourself if you want it gone (it is intentionally left in place).
- **Autostart self-heal:** no user action — after moving/renaming the AppImage, launch it once from the new location and the autostart entry is corrected automatically (same "self-heal on next launch" model as the Open-with entry).

## Test Plan

- [x] **Automated — autostart** (`tests/test_supervisor_linux_startup.py`): `refresh_autostart()` rewrites on stale path; no-op when contents already match; no-op when disabled; no-op (no raise/write) when launcher unresolvable.
- [x] **Automated — deintegrate** (`tests/test_supervisor_linux_integration.py`): removes the four artifacts, refreshes both databases, disables autostart; and `integrate()` invokes `refresh_autostart()` best-effort without propagating a raise.
- [x] **Automated — tray** (`tests/test_supervisor_linux_tray.py`): `_menu_layout` includes the uninstall leaf in the right position; `_dispatch_event` enqueues `TrayAction.UNINSTALL`.
- [x] **Automated — dialog** (`tests/test_supervisor_linux_paths.py`): `ui.confirm_uninstall()` resolution across zenity/kdialog/tkinter.
- [x] **Automated — run loop** (`tests/test_supervisor_core.py`): confirmed UNINSTALL calls the `deintegrate` hook then returns `TRAY_EXIT`; declined does neither; absent hook exits cleanly.
- [x] Supervisor suite green: **168 passed, 21 skipped**. The one failure (`test_alert_is_a_no_op_when_tk_cannot_start`) is **pre-existing/environmental** — this CI box lacks `libtk8.6.so`, unrelated to these changes and in a file this PR does not touch.
- [ ] **Manual (needs a real Linux desktop + AppImage):** move the AppImage, relaunch, confirm autostart `Exec=` updated; click Uninstall and confirm `~/.local/share/applications/fused-render.desktop`, the MIME package, icon, stamp, and `~/.config/autostart/fused-render.desktop` are all gone and `~/.fused-render` is untouched.
