### PR TITLE
fix(desktop): stable Windows port, hide protected junctions, bundle Learn

### DIFF
--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -608,6 +608,8 @@ def _walk_bfs(path, include_hidden, max_entries=None, max_depth=None):
                 name = child.name
                 if not include_hidden and name.startswith("."):
                     continue
+                if not mount_backed and _win_protected(child):
+                    continue  # hide protected OS junctions, as /api/fs/list does
                 try:
                     is_dir = child.is_dir()
                 except OSError:

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -412,6 +412,22 @@ def _mount_list_item(de):
     }
 
 
+def _win_protected(entry: "os.DirEntry") -> bool:
+    """True for a Windows hidden+system entry — the "protected operating system
+    files" Explorer hides by default. Checked with follow_symlinks=False so a
+    reparse junction is judged by its own attributes (the deny-ACL
+    Documents\\My Videos / My Music / My Pictures compat junctions are exactly
+    this), not the target it points at. Always False off Windows."""
+    if sys.platform != "win32":
+        return False
+    try:
+        attrs = entry.stat(follow_symlinks=False).st_file_attributes
+    except OSError:
+        return False
+    return bool(attrs & stat_mod.FILE_ATTRIBUTE_HIDDEN
+                and attrs & stat_mod.FILE_ATTRIBUTE_SYSTEM)
+
+
 def _sort_entries(entries):
     """Sort /api/fs/list items in place and return them: dirs first, then
     case-insensitive by name with the exact name as a deterministic tiebreak so
@@ -3236,6 +3252,11 @@ def create_app(start_dir: str) -> FastAPI:
                 return _error(broken, status=503)
         for de in dents:
             try:
+                if _win_protected(de):
+                    # Windows hidden+system entries (e.g. the deny-ACL
+                    # Documents\My Videos compat junction) — Explorer hides
+                    # these, and scandir'ing into them raises WinError 5.
+                    continue
                 st = de.stat()
                 is_dir = de.is_dir()
             except OSError:

--- a/fused_render/supervisor/core.py
+++ b/fused_render/supervisor/core.py
@@ -464,26 +464,27 @@ def _current_python_dir() -> Path:
     return Path(sys.executable).resolve().parent
 
 
+def _port_in_use(port: int) -> bool:
+    """True if something is actively listening on the loopback port. A connect
+    probe — the same one app.pick_port and winopen use — is correct where a bind
+    probe is not: a live listener reads as taken, but a port merely lingering in
+    TIME_WAIT after a clean shutdown reads as free (TIME_WAIT refuses connects),
+    and it can't be fooled by Windows SO_REUSEADDR bind semantics."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
 def _available_port() -> int:
     """Prefer the branch's stable base port (1777 for a shipped build) so the
     server keeps the same origin across restarts — open browser tabs stay valid
     and per-origin localStorage (e.g. the onboarding tour's "seen" flag) isn't
-    wiped every launch. Scan a small range for the first free port; fall back to
-    an OS-assigned ephemeral port only if the whole range is taken."""
+    wiped every launch. Fall back to an OS-assigned ephemeral port only if the
+    whole range is already serving."""
     base = branch_port()
     for port in range(base, base + 11):
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            # SO_REUSEADDR so this probe agrees with uvicorn's own bind (see
-            # cli._port_free): a base port merely lingering in TIME_WAIT after a
-            # clean shutdown reads as free, so a quick relaunch keeps 1777
-            # instead of drifting to 1778. A live listener still fails the bind,
-            # so a real collision is still caught.
-            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-            try:
-                s.bind(("127.0.0.1", port))
-                return port
-            except OSError:
-                continue
+        if not _port_in_use(port):
+            return port
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]

--- a/fused_render/supervisor/core.py
+++ b/fused_render/supervisor/core.py
@@ -473,6 +473,12 @@ def _available_port() -> int:
     base = branch_port()
     for port in range(base, base + 11):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            # SO_REUSEADDR so this probe agrees with uvicorn's own bind (see
+            # cli._port_free): a base port merely lingering in TIME_WAIT after a
+            # clean shutdown reads as free, so a quick relaunch keeps 1777
+            # instead of drifting to 1778. A live listener still fails the bind,
+            # so a real collision is still caught.
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 s.bind(("127.0.0.1", port))
                 return port

--- a/fused_render/supervisor/core.py
+++ b/fused_render/supervisor/core.py
@@ -21,6 +21,7 @@ from enum import Enum, auto
 from pathlib import Path
 
 from fused_render import desktop_probe
+from fused_render._branch import branch_port
 from fused_render._view_url_codec import is_launch_url, open_target_url, view_url
 from fused_render.desktop_probe import DESKTOP_INSTANCE_ID as _INSTANCE_ID
 from fused_render.supervisor import _backend, protocol, tray
@@ -464,6 +465,19 @@ def _current_python_dir() -> Path:
 
 
 def _available_port() -> int:
+    """Prefer the branch's stable base port (1777 for a shipped build) so the
+    server keeps the same origin across restarts — open browser tabs stay valid
+    and per-origin localStorage (e.g. the onboarding tour's "seen" flag) isn't
+    wiped every launch. Scan a small range for the first free port; fall back to
+    an OS-assigned ephemeral port only if the whole range is taken."""
+    base = branch_port()
+    for port in range(base, base + 11):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("127.0.0.1", port))
+                return port
+            except OSError:
+                continue
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]

--- a/fused_render/supervisor/paths.py
+++ b/fused_render/supervisor/paths.py
@@ -220,6 +220,10 @@ class DesktopPaths:
             "FUSED_RENDER_RCLONE_BIN": str(
                 tools_dir / ("rclone.exe" if sys.platform == "win32" else "rclone")
             ),
+            # learn.zip ships in the payload's assets/ (the Windows installer
+            # globs assets\*); mounts.learn_zip_path() reads this override, and
+            # its isfile check no-ops when a build didn't bundle the zip.
+            "FUSED_RENDER_LEARN_ZIP": str(tools_dir.parent / "assets" / "learn.zip"),
             "TEMP": str(self.temp),
             "TMP": str(self.temp),
             # POSIX tempfile consults TMPDIR first (TEMP/TMP are the Windows

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -223,6 +223,10 @@ if (-not (Test-Path -LiteralPath $LearnSrc -PathType Container)) {
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $LearnZip = Join-Path $StageDir "assets\learn.zip"
 [System.IO.Compression.ZipFile]::CreateFromDirectory($LearnSrc, $LearnZip)
+# Smoke-test the archive backend with the just-bundled rclone (mirrors
+# build_dmg.sh 4e): the exact binary and zip the app ships must list, so an
+# rclone bump that drops :archive: fails the build, not the user's first mount.
+Invoke-Native (Join-Path $PythonRoot "rclone.exe") @("lsf", ":archive:$LearnZip")
 Invoke-Native $Uv @(
     "run", "python", (Join-Path $RepoRoot "scripts\windows\generate_installer_registry.py"),
     (Join-Path $StageDir "registry.iss")

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -212,6 +212,17 @@ $icons = Join-Path $StageDir "assets\icons"
 New-Item -ItemType Directory -Force -Path $icons | Out-Null
 Copy-Item -LiteralPath (Join-Path $RepoRoot "fused_render\assets\fused-render.ico") -Destination $icons -Force
 Copy-Item -Path (Join-Path $RepoRoot "fused_render\assets\file_icons\*.ico") -Destination $icons -Force
+
+# Bundle learn.zip into assets\ (mirrors build_dmg.sh step 4e). ZipFile uses
+# forward-slash entry names, which rclone's archive backend reads cleanly;
+# child_environment points FUSED_RENDER_LEARN_ZIP here for ensure_learn_mount.
+$LearnSrc = Join-Path $RepoRoot "learn"
+if (-not (Test-Path -LiteralPath $LearnSrc -PathType Container)) {
+    throw "learn/ content is missing — it is part of the app"
+}
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$LearnZip = Join-Path $StageDir "assets\learn.zip"
+[System.IO.Compression.ZipFile]::CreateFromDirectory($LearnSrc, $LearnZip)
 Invoke-Native $Uv @(
     "run", "python", (Join-Path $RepoRoot "scripts\windows\generate_installer_registry.py"),
     (Join-Path $StageDir "registry.iss")

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -220,13 +220,37 @@ $LearnSrc = Join-Path $RepoRoot "learn"
 if (-not (Test-Path -LiteralPath $LearnSrc -PathType Container)) {
     throw "learn/ content is missing — it is part of the app"
 }
+Add-Type -AssemblyName System.IO.Compression
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 $LearnZip = Join-Path $StageDir "assets\learn.zip"
-[System.IO.Compression.ZipFile]::CreateFromDirectory($LearnSrc, $LearnZip)
+# NOT ZipFile.CreateFromDirectory: on Windows PowerShell (.NET Framework) it
+# writes BACKSLASH entry separators, and the ZIP spec / rclone's archive backend
+# only treat '/' as a directory separator — nested learn/assets/* would surface
+# as literal root names, breaking Learn media. Build entries by hand with
+# forward slashes, matching build_dmg.sh's `zip -r`.
+$LearnSrcFull = (Resolve-Path -LiteralPath $LearnSrc).Path
+$LearnArchive = [System.IO.Compression.ZipFile]::Open(
+    $LearnZip, [System.IO.Compression.ZipArchiveMode]::Create)
+try {
+    foreach ($file in Get-ChildItem -LiteralPath $LearnSrcFull -Recurse -File) {
+        $rel = $file.FullName.Substring($LearnSrcFull.Length + 1).Replace('\', '/')
+        [void][System.IO.Compression.ZipFileExtensions]::CreateEntryFromFile(
+            $LearnArchive, $file.FullName, $rel)
+    }
+} finally {
+    $LearnArchive.Dispose()
+}
 # Smoke-test the archive backend with the just-bundled rclone (mirrors
-# build_dmg.sh 4e): the exact binary and zip the app ships must list, so an
-# rclone bump that drops :archive: fails the build, not the user's first mount.
-Invoke-Native (Join-Path $PythonRoot "rclone.exe") @("lsf", ":archive:$LearnZip")
+# build_dmg.sh 4e), recursively so it also proves the nested assets/ entries are
+# forward-slash separated — a bump that drops :archive: or a backslashed zip
+# fails the build, not the user's first mount.
+$LearnListing = & (Join-Path $PythonRoot "rclone.exe") lsf -R ":archive:$LearnZip"
+if ($LASTEXITCODE -ne 0) {
+    throw "bundled rclone cannot read learn.zip via :archive:"
+}
+if ($LearnListing -notmatch 'assets/') {
+    throw "learn.zip nested entries are not forward-slash separated (assets/ missing)"
+}
 Invoke-Native $Uv @(
     "run", "python", (Join-Path $RepoRoot "scripts\windows\generate_installer_registry.py"),
     (Join-Path $StageDir "registry.iss")

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -248,7 +248,8 @@ $LearnListing = & (Join-Path $PythonRoot "rclone.exe") lsf -R ":archive:$LearnZi
 if ($LASTEXITCODE -ne 0) {
     throw "bundled rclone cannot read learn.zip via :archive:"
 }
-if ($LearnListing -notmatch 'assets/') {
+if (-not ($LearnListing -match 'assets/')) {
+    # -match on the line array filters; -not(non-empty) is the membership test.
     throw "learn.zip nested entries are not forward-slash separated (assets/ missing)"
 }
 Invoke-Native $Uv @(

--- a/tests/test_server_list_sort.py
+++ b/tests/test_server_list_sort.py
@@ -56,3 +56,33 @@ def test_order_is_stable_across_repeated_calls(tmp_path):
         (tmp_path / n).mkdir()
     orders = [_names(tmp_path) for _ in range(5)]
     assert all(o == orders[0] for o in orders)
+
+
+def test_win_protected_short_circuits_off_windows(monkeypatch):
+    # Off Windows the hidden+system filter must not even stat the entry.
+    from fused_render import server
+
+    monkeypatch.setattr(server.sys, "platform", "linux")
+
+    class _Entry:
+        def stat(self, follow_symlinks=True):
+            raise AssertionError("must not stat off win32")
+
+    assert server._win_protected(_Entry()) is False
+
+
+def test_list_hides_windows_hidden_system_entries(tmp_path):
+    # HIDDEN+SYSTEM ("protected OS") entries — like the deny-ACL
+    # Documents\My Videos junction that raises WinError 5 on scandir — are
+    # dropped from the listing, matching Explorer's default.
+    import subprocess
+    import sys
+
+    if sys.platform != "win32":
+        pytest.skip("hidden+system attributes are Windows-only")
+    (tmp_path / "normal.txt").write_text("x", encoding="utf-8")
+    protected = tmp_path / "protected.txt"
+    protected.write_text("y", encoding="utf-8")
+    subprocess.run(["attrib", "+h", "+s", str(protected)], check=True)
+    names = _names(tmp_path)
+    assert "normal.txt" in names and "protected.txt" not in names

--- a/tests/test_server_walk.py
+++ b/tests/test_server_walk.py
@@ -1,5 +1,6 @@
 """Tests for GET /api/fs/walk (fused_render/server.py) — the recursive listing
 backing the explorer search."""
+import pytest
 from fastapi.testclient import TestClient
 
 from fused_render import server
@@ -401,3 +402,20 @@ def test_walk_outside_mounts_keeps_big_cap(tmp_path, monkeypatch):
     data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
     assert data["truncated"] is False
     assert len(data["entries"]) == 10
+
+
+def test_walk_hides_windows_hidden_system_entries(tmp_path):
+    # Search must hide the same HIDDEN+SYSTEM junctions /api/fs/list hides, or
+    # opening one from a search result errors (WinError 5).
+    import subprocess
+    import sys
+
+    if sys.platform != "win32":
+        pytest.skip("hidden+system attributes are Windows-only")
+    (tmp_path / "visible.txt").write_text("v", encoding="utf-8")
+    protected = tmp_path / "protected.txt"
+    protected.write_text("p", encoding="utf-8")
+    subprocess.run(["attrib", "+h", "+s", str(protected)], check=True)
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    rels = {e["rel"] for e in data["entries"]}
+    assert "visible.txt" in rels and "protected.txt" not in rels

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -124,3 +124,25 @@ def _view_path(fs_path: str) -> str:
     from fused_render._view_url_codec import view_url_path
 
     return view_url_path(fs_path)
+
+
+def _free_port() -> int:
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def test_available_port_prefers_branch_base_then_next(monkeypatch):
+    # The desktop server binds the branch base (1777 for a shipped build) so its
+    # origin — and the browser tabs / per-origin localStorage keyed to it —
+    # survives a restart, instead of the old ephemeral :0 that moved every launch.
+    import socket
+
+    base = _free_port()
+    monkeypatch.setattr(core, "branch_port", lambda: base)
+    assert core._available_port() == base  # base free -> reuse it
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as taken:
+        taken.bind(("127.0.0.1", base))
+        assert core._available_port() == base + 1  # base taken -> next in range

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -145,5 +145,5 @@ def test_available_port_prefers_branch_base_then_next(monkeypatch):
     assert core._available_port() == base  # base free -> reuse it
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as taken:
         taken.bind(("127.0.0.1", base))
-        taken.listen()  # a LIVE listener blocks the bind even with SO_REUSEADDR
+        taken.listen()  # a live listener answers the connect probe -> in use
         assert core._available_port() == base + 1  # base taken -> next in range

--- a/tests/test_supervisor_core.py
+++ b/tests/test_supervisor_core.py
@@ -145,4 +145,5 @@ def test_available_port_prefers_branch_base_then_next(monkeypatch):
     assert core._available_port() == base  # base free -> reuse it
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as taken:
         taken.bind(("127.0.0.1", base))
+        taken.listen()  # a LIVE listener blocks the bind even with SO_REUSEADDR
         assert core._available_port() == base + 1  # base taken -> next in range


### PR DESCRIPTION
Three Windows-desktop fixes from testing the 0.3.10 build.

## 1 + 5 — stable port (fixes the walkthrough replaying every launch)
The supervisor bound an OS-assigned ephemeral port (`_available_port` → `bind(:0)`) on every launch, so the server's origin (`127.0.0.1:<port>`) changed each start. Consequences: already-open browser tabs 404'd, and per-origin `localStorage` reset — which is where the onboarding tour's "seen" flag lives, so the walkthrough replayed every time.

`_available_port` now reuses the branch base port (**1777** for a shipped build) via the existing `branch_port()`, scanning `1777..1787` for the first free port and falling back to ephemeral only if the whole range is taken. Because it always tries 1777 first, the origin is stable across restarts/upgrades — old tabs keep working and the tour shows once. This brings Windows in line with the CLI and macOS app, which already use this range.

## 3 — "My Videos" access-denied
Listing `Documents\My Videos` (also `My Music`/`My Pictures`) raised `cannot read directory … [WinError 5]`. These are HIDDEN+SYSTEM+REPARSE compatibility junctions with a deny-all ACL; `is_dir()` follows the junction so they showed as ordinary folders, and `os.scandir` on one is denied. `/api/fs/list` now skips HIDDEN+SYSTEM entries on Windows (`_win_protected`, checked with `follow_symlinks=False` so the junction is judged by its own attributes) — exactly what Explorer hides by default.

## 4 — Learn section missing on Windows
The Learn entry needs a bundled `learn.zip` mounted read-only, but the Windows build bundled none and `learn_zip_path()` only resolved the macOS bundle. The Windows build now zips `learn/` into the payload's `assets/` (already globbed by the installer, forward-slash entries for rclone), and `child_environment` points `FUSED_RENDER_LEARN_ZIP` at it — mirroring how `rclone` is bundled, so `learn_zip_path()`'s existing override handles it with no runtime change. **Note:** Learn still requires WinFsp installed to mount (same as all mounts); this makes it appear automatically once WinFsp is present.

## Tests
New: `_available_port` prefers the branch base then the next free port (`test_supervisor_core.py`); `/api/fs/list` drops a HIDDEN+SYSTEM entry on Windows and `_win_protected` short-circuits off-Windows (`test_server_list_sort.py`). The `child_environment` contract test uses a subset check, so the new env key needs no test change; `learn_zip_path` is unchanged. Remaining local failures are environmental (Windows symlink-creation privilege; Linux-only path tests on a Windows host), not from this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches supervisor port selection (user-visible origin stability) and filesystem listing behavior on Windows; Learn bundling is build-time only with existing runtime env override.
> 
> **Overview**
> Three **Windows desktop** fixes from the 0.3.10 test pass.
> 
> **Stable origin across restarts.** The supervisor no longer binds an ephemeral port every launch. `_available_port` scans `branch_port()` through +10 using a loopback **connect** probe (`_port_in_use`), reusing the branch base (e.g. **1777**) when free so `127.0.0.1` origin, open tabs, and per-origin `localStorage` (onboarding tour) survive restarts—aligned with CLI/macOS.
> 
> **Protected OS junctions hidden.** New `_win_protected` skips Windows **HIDDEN+SYSTEM** entries (with `follow_symlinks=False`) in `/api/fs/list` and `/api/fs/walk`, matching Explorer and avoiding WinError 5 on Documents “My Videos”-style deny-ACL junctions.
> 
> **Learn on Windows.** The installer builds `assets/learn.zip` with **forward-slash** ZIP entries (not `CreateFromDirectory` backslashes) and smoke-tests with bundled `rclone`; `DesktopPaths.child_environment` sets **`FUSED_RENDER_LEARN_ZIP`** so the existing learn mount path resolves like macOS.
> 
> Tests cover port preference, off-Windows `_win_protected`, and Windows-only hidden+system listing/walk behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd16c85c874513037685b6c2aeca5ee51269e7bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->