### PR TITLE
fix(zarr_aoi): publish actual bound origin so tile daemon uses real port

### DIFF
--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -26,7 +26,7 @@ import uvicorn
 from fused_render import desktop_probe
 from fused_render._branch import branch_dir, branch_port
 from fused_render.logs import log_path, setup_logging
-from fused_render.server import create_app
+from fused_render.server import create_app, set_server_origin_env
 from fused_render.shell.seed import ensure_fused_dir_and_landing
 
 logger = logging.getLogger("fused_render")
@@ -181,6 +181,9 @@ def _start_server_thread(port: int) -> tuple[uvicorn.Server, str | None]:
     # First-run onboarding (D81): create ~/Documents/Fused and seed it once.
     start_dir, landing = ensure_fused_dir_and_landing()
     app = create_app(start_dir=start_dir)
+    # Publish the real bound origin so runPython children (e.g. the zarr_aoi
+    # tile daemon) read store bytes from THIS port, not the branch default.
+    set_server_origin_env(port, host="127.0.0.1")
     config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)

--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -111,6 +111,10 @@ def _run_serve(args: argparse.Namespace) -> None:
 
     port = args.port if args.port is not None else DEFAULT_PORT
     _check_port_free(port)
+    # Publish the real bound origin so runPython children (e.g. the zarr_aoi
+    # tile daemon) read store bytes from THIS port, not the branch default.
+    from fused_render.server import set_server_origin_env
+    set_server_origin_env(port, host=_HOST)
 
     url = f"http://{_HOST}:{port}/"
     branch_note = f" (branch {branch_ref()})" if branch_ref() else ""

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -2810,6 +2810,23 @@ def _fs_copy(body: dict, x_fused: str | None):
     return _stat_payload(dst, os.path.isdir(dst))
 
 
+def set_server_origin_env(port: int, host: str = "127.0.0.1") -> str:
+    """Publish the server's ACTUAL bound origin so in-process runPython
+    children read store bytes from the port the server is really on.
+
+    The zarr_aoi tile daemon (and any other child that fetches bytes back
+    through ``/api/fs/raw``) reads the origin from ``FUSED_RENDER_ORIGIN``.
+    Without this, it falls back to ``_branch.branch_port()`` — the baseline
+    default ``1777`` — which is wrong under any ``--port`` override (e.g. the
+    desktop launcher's auto-picked free port), sending every read to a dead
+    port and surfacing "No group found in store" from zarr. Set it before the
+    server starts serving so every child process inherits the correct origin.
+    """
+    origin = f"http://{host}:{port}"
+    os.environ["FUSED_RENDER_ORIGIN"] = origin
+    return origin
+
+
 def create_app(start_dir: str) -> FastAPI:
     # Engine (D69/D70 + SPEC §20): validate any FUSED_RENDER_ENGINE override
     # ONCE at startup — this raises on a bad value and fails loudly for

--- a/tests/test_server_origin.py
+++ b/tests/test_server_origin.py
@@ -1,0 +1,27 @@
+"""The server must publish its ACTUAL bound origin to the environment.
+
+runPython children (notably the zarr_aoi tile daemon) read store bytes back
+through the server's ``/api/fs/raw`` and learn the server's origin from
+``FUSED_RENDER_ORIGIN``. Before this wiring existed the daemon fell back to
+``branch_port()`` (baseline ``1777``), which is wrong whenever the server was
+started on any other port (e.g. ``--port 32953`` from the desktop launcher):
+every chunk read hit a dead port and zarr reported "No group found in store".
+"""
+import os
+
+from fused_render import server
+
+
+def test_set_server_origin_env_uses_actual_port(monkeypatch):
+    monkeypatch.delenv("FUSED_RENDER_ORIGIN", raising=False)
+    origin = server.set_server_origin_env(32953)
+    assert origin == "http://127.0.0.1:32953"
+    assert os.environ["FUSED_RENDER_ORIGIN"] == "http://127.0.0.1:32953"
+
+
+def test_set_server_origin_env_overrides_stale_value(monkeypatch):
+    # A stale origin from a previous bind (or a wrong branch default) must be
+    # replaced by the port this process is really serving on.
+    monkeypatch.setenv("FUSED_RENDER_ORIGIN", "http://127.0.0.1:1777")
+    server.set_server_origin_env(9000)
+    assert os.environ["FUSED_RENDER_ORIGIN"] == "http://127.0.0.1:9000"


### PR DESCRIPTION
## Summary

- The `zarr_aoi` map preview failed with **"No group found in store WrapperStore(FsspecStore(HTTPFileSystem, http://127.0.0.1:1777/api/fs/raw?path=…))"** whenever the server ran on any port other than the branch default `1777`.
- Root cause: the tile daemon reads store bytes back through the server's `/api/fs/raw` and learns the server's origin from `FUSED_RENDER_ORIGIN`. Nothing ever set that env var, so it fell back to `_branch.branch_port()` (baseline `1777`). A server started on a different port — the desktop launcher's auto-picked free port, or `serve --port N` — sent every chunk read to a dead `:1777`, and zarr reported an empty store.
- Fix: add `server.set_server_origin_env(port)` and call it from both server entry points (`cli._run_serve`, `app._start_server_thread`) right before binding, so every in-process `runPython` child inherits the **actual** bound origin. `branch_port()` remains a last-resort fallback.

## Visuals

The daemon reads chunks back over HTTP at the origin in `FUSED_RENDER_ORIGIN`. When the server binds a non-default port (e.g. `32953`) but never publishes it, the daemon falls back to `branch_port()` → `:1777`, which nothing is listening on.

**Before** — origin guessed from `branch_port()`, chunk reads hit a dead `:1777`

```mermaid
flowchart TD
    S["server binds :32953"]
    D["zarr_aoi tile daemon"]
    G["GET /api/fs/raw @ :1777"]
    E["zarr: No group found in store"]
    S -. "FUSED_RENDER_ORIGIN unset" .-> D
    D -->|"branch_port() → :1777"| G
    G -->|"connection refused"| E
```

**After** — server publishes its real bound port, daemon inherits it

```mermaid
flowchart TD
    S["server binds :32953"]
    D["zarr_aoi tile daemon"]
    G["GET /api/fs/raw @ :32953"]
    R["store opens, tiles stream"]
    S -->|"set_server_origin_env(32953)"| D
    D -->|"inherits FUSED_RENDER_ORIGIN"| G
    G -->|"200 OK"| R
```

## Usage

Not directly user-invocable — the wiring is automatic. Any zarr store opened through the `zarr_aoi` mode now works regardless of the server's port:

```
http://127.0.0.1:<port>/view/<path-to-store>?_mode=zarr_aoi
```

Internally, code that starts the server can publish its origin explicitly:

```python
from fused_render.server import set_server_origin_env
set_server_origin_env(port)  # sets FUSED_RENDER_ORIGIN=http://127.0.0.1:<port>
```

## Test Plan

- [x] **Automated** — new `tests/test_server_origin.py`: `set_server_origin_env` sets `FUSED_RENDER_ORIGIN` to the actual bound port, and overrides a stale/wrong value.
- [x] **Regression suite** — `test_server_origin`, `test_zarr_aoi_mount`, `test_branch`, `test_branch_runtime`, `test_supervisor_core`, `test_server_walk`, `test_server_list_sort`: 66 passed, 2 skipped (Windows-only).
- [x] **Manual, end-to-end** — started a source server on a custom port (`serve --no-browser --port 8899`), cleared the stale tile daemon, opened `…/view/…/mounts/zarr-v1?_mode=zarr_aoi`:
  - The "No group found in store" error is gone; the store loads (`variable: analysed_sst`, `time 0 / 6442`, stats/info populated).
  - Verified the freshly spawned daemon's environment: `FUSED_RENDER_ORIGIN=http://127.0.0.1:8899` (the real port, not `1777`).
