### PR TITLE
Open in Claude Code via claude-cli:// deep links

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1258,7 +1258,9 @@ export function createTemplate(name: string, extensions: string[]): Promise<NewT
   return postJson<NewTemplateResult>("/api/templates/new", { name, extensions });
 }
 
-// Open Claude Code in Terminal.app in a user template's folder (macOS only).
-export function openTemplateInClaude(name: string): Promise<{ ok: true }> {
-  return postJson<{ ok: true }>("/api/templates/open-in-claude", { name });
+// Resolve a claude-cli:// deep link into a user template's folder. The
+// caller navigates to the returned URL (window.location.href) so the OS
+// hands it to Claude Code's registered scheme handler.
+export function openTemplateInClaude(name: string): Promise<{ url: string }> {
+  return postJson<{ url: string }>("/api/templates/open-in-claude", { name });
 }

--- a/frontend/src/lib/fs-actions.ts
+++ b/frontend/src/lib/fs-actions.ts
@@ -131,13 +131,18 @@ export async function freePastePath(parentDir: string, name: string, isDir: bool
 
 // claude-cli:// deep link for a listing entry — Claude Code registers this
 // scheme OS-wide (see templates_api.api_open_in_claude, which builds the same
-// shape for a template folder). A dir opens with its own path as cwd; a file
-// opens with its parent as cwd and pre-fills a prompt that @-mentions the file
-// (not auto-sent — the user still hits enter).
+// cwd shape for a template folder, but no starter q there). A dir opens with
+// its own path as cwd; a file opens with its parent as cwd. Both prime a
+// starter prompt telling Claude to load fused-render's skills first — a file's
+// prompt also @-mentions it — with two trailing newlines so the user's actual
+// ask lands on a fresh line below (not auto-sent — the user still hits enter).
 export function claudeDeepLink(path: string, isDir: boolean, name: string, parentDir: string): string {
-  if (isDir) return "claude-cli://open?cwd=" + encodeURIComponent(path);
-  const q = encodeURIComponent("@" + name + " ");
-  return "claude-cli://open?cwd=" + encodeURIComponent(parentDir) + "&q=" + q;
+  if (isDir) {
+    const q = "This is a fused-render project — load its skills first.\n\n";
+    return "claude-cli://open?cwd=" + encodeURIComponent(path) + "&q=" + encodeURIComponent(q);
+  }
+  const q = `This is a fused-render project — load its skills first, then read @${name}.\n\n`;
+  return "claude-cli://open?cwd=" + encodeURIComponent(parentDir) + "&q=" + encodeURIComponent(q);
 }
 
 // Write text to the system clipboard; resolves true on success, false when the

--- a/frontend/src/lib/fs-actions.ts
+++ b/frontend/src/lib/fs-actions.ts
@@ -129,6 +129,17 @@ export async function freePastePath(parentDir: string, name: string, isDir: bool
   return join(dir, candidate);
 }
 
+// claude-cli:// deep link for a listing entry — Claude Code registers this
+// scheme OS-wide (see templates_api.api_open_in_claude, which builds the same
+// shape for a template folder). A dir opens with its own path as cwd; a file
+// opens with its parent as cwd and pre-fills a prompt that @-mentions the file
+// (not auto-sent — the user still hits enter).
+export function claudeDeepLink(path: string, isDir: boolean, name: string, parentDir: string): string {
+  if (isDir) return "claude-cli://open?cwd=" + encodeURIComponent(path);
+  const q = encodeURIComponent("@" + name + " ");
+  return "claude-cli://open?cwd=" + encodeURIComponent(parentDir) + "&q=" + q;
+}
+
 // Write text to the system clipboard; resolves true on success, false when the
 // Clipboard API is missing or the write is denied. Callers decide whether to
 // toast (a failure stays silent — the path is still reachable via Reveal).

--- a/frontend/src/lib/fs-actions.ts
+++ b/frontend/src/lib/fs-actions.ts
@@ -134,14 +134,15 @@ export async function freePastePath(parentDir: string, name: string, isDir: bool
 // cwd shape for a template folder, but no starter q there). A dir opens with
 // its own path as cwd; a file opens with its parent as cwd. Both prime a
 // starter prompt telling Claude to load fused-render's skills first — a file's
-// prompt also @-mentions it — with two trailing newlines so the user's actual
-// ask lands on a fresh line below (not auto-sent — the user still hits enter).
+// prompt names it in quotes (not @-mention: names with spaces don't parse as
+// one mention) — with two trailing newlines so the user's actual ask lands on
+// a fresh line below (not auto-sent — the user still hits enter).
 export function claudeDeepLink(path: string, isDir: boolean, name: string, parentDir: string): string {
   if (isDir) {
     const q = "This is a fused-render project — load its skills first.\n\n";
     return "claude-cli://open?cwd=" + encodeURIComponent(path) + "&q=" + encodeURIComponent(q);
   }
-  const q = `This is a fused-render project — load its skills first, then read @${name}.\n\n`;
+  const q = `This is a fused-render project — load its skills first, then read "${name}".\n\n`;
   return "claude-cli://open?cwd=" + encodeURIComponent(normDir(parentDir)) + "&q=" + encodeURIComponent(q);
 }
 

--- a/frontend/src/lib/fs-actions.ts
+++ b/frontend/src/lib/fs-actions.ts
@@ -142,7 +142,7 @@ export function claudeDeepLink(path: string, isDir: boolean, name: string, paren
     return "claude-cli://open?cwd=" + encodeURIComponent(path) + "&q=" + encodeURIComponent(q);
   }
   const q = `This is a fused-render project — load its skills first, then read @${name}.\n\n`;
-  return "claude-cli://open?cwd=" + encodeURIComponent(parentDir) + "&q=" + encodeURIComponent(q);
+  return "claude-cli://open?cwd=" + encodeURIComponent(normDir(parentDir)) + "&q=" + encodeURIComponent(q);
 }
 
 // Write text to the system clipboard; resolves true on success, false when the

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -36,6 +36,7 @@ import {
   resolveOpenWithModes,
   buildOpenWithItems,
   friendlyFsError,
+  claudeDeepLink,
 } from "../lib/fs-actions";
 import { acquireOverlay, releaseOverlay, isOverlayOpen } from "../lib/ui-overlay";
 import { formatSize, formatMtime, basename } from "../lib/format";
@@ -1086,6 +1087,13 @@ export default function Listing({
     });
   };
 
+  // Open Claude Code via its claude-cli:// scheme handler — a dir cwd's into
+  // itself, a file cwd's into its parent and pre-fills an @-mention prompt.
+  // Setting location.href to a custom scheme does not navigate the SPA away.
+  const doOpenInClaude = (path: string, isDir: boolean, name: string, parentDir: string) => {
+    window.location.href = claudeDeepLink(path, isDir, name, parentDir);
+  };
+
   const startNewFile = (dir: string) =>
     setDialog({
       kind: "prompt",
@@ -1203,6 +1211,11 @@ export default function Listing({
       "separator",
       { label: "Copy Path", icon: MenuIcons.copyPath, onClick: () => doCopyPath(row.path) },
       { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(row.path) },
+      {
+        label: "Open in Claude Code",
+        icon: MenuIcons.openWith,
+        onClick: () => doOpenInClaude(row.path, row.isDir, row.name, row.parentDir),
+      },
     ];
   };
 
@@ -1216,6 +1229,11 @@ export default function Listing({
     "separator",
     { label: "Refresh", icon: MenuIcons.refresh, onClick: refetch },
     { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(normDir(base)) },
+    {
+      label: "Open in Claude Code",
+      icon: MenuIcons.openWith,
+      onClick: () => doOpenInClaude(normDir(base), true, "", normDir(base)),
+    },
   ];
 
   const openRowMenu = (e: React.MouseEvent, row: RowCtx) => {

--- a/frontend/src/views/templates/InventoryPanel.tsx
+++ b/frontend/src/views/templates/InventoryPanel.tsx
@@ -392,7 +392,7 @@ function InventoryRow({
             type="button"
             className="templates-ghost-btn"
             onClick={onOpenInClaude}
-            title="Open Claude Code in this template's folder (Terminal, macOS only)"
+            title="Open Claude Code in this template's folder"
           >
             Open in Claude
           </button>

--- a/frontend/src/views/templates/InventoryPanel.tsx
+++ b/frontend/src/views/templates/InventoryPanel.tsx
@@ -56,7 +56,8 @@ export function InventoryPanel({
   const openClaude = async (name: string) => {
     setError(null);
     try {
-      await openTemplateInClaude(name);
+      const { url } = await openTemplateInClaude(name);
+      window.location.href = url;
     } catch (e) {
       setError((e as Error).message);
     }

--- a/frontend/src/views/templates/NewTemplateModal.tsx
+++ b/frontend/src/views/templates/NewTemplateModal.tsx
@@ -139,7 +139,8 @@ export function NewTemplateModal({
     setOpening(true);
     setOpenError(null);
     try {
-      await openTemplateInClaude(templateName);
+      const { url } = await openTemplateInClaude(templateName);
+      window.location.href = url;
       if (alive.current) onClose();
     } catch (e) {
       if (alive.current) setOpenError((e as Error).message);

--- a/fused_render/templates_api.py
+++ b/fused_render/templates_api.py
@@ -28,12 +28,10 @@ import json
 import os
 import re
 import secrets
-import shlex
 import shutil
 import stat as stat_mod
-import subprocess
-import sys
 import time
+import urllib.parse
 import zipfile
 
 from fastapi import APIRouter, Body, File, Header, Query, UploadFile
@@ -1178,42 +1176,15 @@ def api_new_template(body: dict = Body(...), x_fused: str | None = Header(defaul
     return {"ok": True, "name": name, "path": dest, "bindings": keys}
 
 
-def _claude_bin() -> str:
-    """Locate the `claude` CLI. Mirrors templates/claude/agent.py:_claude_bin —
-    replicated here rather than imported, since a template folder is not an
-    import root (and templates_api must not depend on a template's internals)."""
-    found = shutil.which("claude")
-    if found:
-        return found
-    for candidate in ("~/.local/bin/claude", "/opt/homebrew/bin/claude", "/usr/local/bin/claude"):
-        candidate = os.path.expanduser(candidate)
-        if os.path.exists(candidate):
-            return candidate
-    raise FileNotFoundError(
-        "claude CLI not found — install Claude Code or put `claude` on the PATH "
-        "of the environment that launched fused-render"
-    )
-
-
-def _applescript_str(s: str) -> str:
-    """Quote a Python string as an AppleScript double-quoted literal (escape
-    backslash then double-quote)."""
-    return '"' + s.replace("\\", "\\\\").replace('"', '\\"') + '"'
-
-
 @router.post("/api/templates/open-in-claude")
 def api_open_in_claude(body: dict = Body(...), x_fused: str | None = Header(default=None)):
-    # Open Terminal.app in a user template's folder and start `claude` there so
-    # the author can iterate on the template with the CLI. macOS-only for now.
+    # Build a claude-cli:// deep link into a user template's folder. Claude
+    # Code registers this URL scheme OS-wide; the frontend navigates to it
+    # (window.location.href) and the OS hands it to the CLI's own handler —
+    # no subprocess/osascript needed here, and it works cross-platform.
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
-
-    if sys.platform != "darwin":
-        return _error(
-            "Open in Claude is only supported on macOS (it spawns Terminal.app).",
-            status=400,
-        )
 
     name = body.get("name")
     if not isinstance(name, str) or not name:
@@ -1227,19 +1198,5 @@ def api_open_in_claude(body: dict = Body(...), x_fused: str | None = Header(defa
     if os.path.islink(folder) or not os.path.isdir(folder):
         return _error(f"no user template named {name!r}", status=404)
 
-    try:
-        claude_bin = _claude_bin()
-    except FileNotFoundError as exc:
-        return _error(str(exc))
-
-    # shlex.quote makes the paths safe for the shell that `do script` runs;
-    # _applescript_str then escapes that command for the AppleScript literal.
-    shell_cmd = f"cd {shlex.quote(folder)} && {shlex.quote(claude_bin)}"
-    open_script = 'tell application "Terminal" to do script ' + _applescript_str(shell_cmd)
-    activate_script = 'tell application "Terminal" to activate'
-    try:
-        subprocess.run(["osascript", "-e", open_script, "-e", activate_script], check=True)
-    except (subprocess.CalledProcessError, OSError) as exc:
-        return _error(f"failed to open Terminal: {exc}", status=500)
-
-    return {"ok": True}
+    url = "claude-cli://open?cwd=" + urllib.parse.quote(os.path.abspath(folder))
+    return {"url": url}

--- a/tests/test_templates_api.py
+++ b/tests/test_templates_api.py
@@ -1317,7 +1317,7 @@ def test_open_in_claude_success(ctx):
     ctx.make_template("myview")
     resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "myview"}, headers=FUSED)
     assert resp.status_code == 200
-    expected = "claude-cli://open?cwd=" + urllib.parse.quote(str((ctx.udir / "myview").resolve()))
+    expected = "claude-cli://open?cwd=" + urllib.parse.quote(os.path.abspath(str(ctx.udir / "myview")))
     assert resp.json() == {"url": expected}
 
 

--- a/tests/test_templates_api.py
+++ b/tests/test_templates_api.py
@@ -10,6 +10,7 @@ templates keep resolving from the conftest-staged .core-templates dir.
 import io
 import json
 import os
+import urllib.parse
 import zipfile
 
 import pytest
@@ -1309,44 +1310,35 @@ def test_new_template_requires_fused_header(ctx):
     assert not (ctx.udir / "myview").exists()
 
 
-# --------------------------------------------------------- open in Claude (macOS)
+# --------------------------------------------------------- open in Claude (claude-cli:// deep link)
 
 
-def test_open_in_claude_success(ctx, monkeypatch):
+def test_open_in_claude_success(ctx):
     ctx.make_template("myview")
-    monkeypatch.setattr(templates_api.sys, "platform", "darwin")
-    monkeypatch.setattr(templates_api.shutil, "which", lambda _c: "/fake/bin/claude")
-    calls = []
-    monkeypatch.setattr(templates_api.subprocess, "run", lambda *a, **k: calls.append((a, k)))
     resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "myview"}, headers=FUSED)
     assert resp.status_code == 200
-    assert resp.json() == {"ok": True}
-    # osascript invoked with a `do script` that cd's into the template folder
-    # and runs the located claude binary.
-    (argv,), _kw = calls[0]
-    assert argv[0] == "osascript"
-    joined = " ".join(argv)
-    assert str(ctx.udir / "myview") in joined
-    assert "/fake/bin/claude" in joined
+    expected = "claude-cli://open?cwd=" + urllib.parse.quote(str((ctx.udir / "myview").resolve()))
+    assert resp.json() == {"url": expected}
 
 
-def test_open_in_claude_non_darwin_errors(ctx, monkeypatch):
-    ctx.make_template("myview")
-    monkeypatch.setattr(templates_api.sys, "platform", "linux")
-    resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "myview"}, headers=FUSED)
-    assert resp.status_code == 400
-    assert "macOS" in resp.json()["error"]
+def test_open_in_claude_encodes_space_in_path(ctx):
+    ctx.make_template("my view")
+    resp = ctx.client.post(
+        "/api/templates/open-in-claude", json={"name": "my view"}, headers=FUSED
+    )
+    assert resp.status_code == 200
+    url = resp.json()["url"]
+    assert "%20" in url
+    assert " " not in url
 
 
-def test_open_in_claude_missing_template_404(ctx, monkeypatch):
-    monkeypatch.setattr(templates_api.sys, "platform", "darwin")
+def test_open_in_claude_missing_template_404(ctx):
     resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "nope"}, headers=FUSED)
     assert resp.status_code == 404
 
 
-def test_open_in_claude_core_template_refused(ctx, monkeypatch):
+def test_open_in_claude_core_template_refused(ctx):
     # 'code' is a core template (no user folder) -> 404, core folder untouched.
-    monkeypatch.setattr(templates_api.sys, "platform", "darwin")
     resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "code"}, headers=FUSED)
     assert resp.status_code == 404
 

--- a/tests/test_templates_api.py
+++ b/tests/test_templates_api.py
@@ -1332,6 +1332,18 @@ def test_open_in_claude_encodes_space_in_path(ctx):
     assert " " not in url
 
 
+def test_open_in_claude_encodes_unicode_path(ctx):
+    ctx.make_template("my-view-☃")
+    resp = ctx.client.post(
+        "/api/templates/open-in-claude", json={"name": "my-view-☃"}, headers=FUSED
+    )
+    assert resp.status_code == 200
+    url = resp.json()["url"]
+    assert url.startswith("claude-cli://open?cwd=")
+    assert "%" in url
+    assert "☃" not in url
+
+
 def test_open_in_claude_missing_template_404(ctx):
     resp = ctx.client.post("/api/templates/open-in-claude", json={"name": "nope"}, headers=FUSED)
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- **Templates panel**: replace the macOS-only osascript/Terminal.app launcher with a `claude-cli://open?cwd=<path>` deep link. The endpoint now just validates the user template and returns the URL (`{"url": ...}`); the frontend navigates via `window.location.href`, letting the OS hand the scheme to Claude Code's registered handler. Cross-platform, no subprocess involved.
- **File listing context menu**: add "Open in Claude Code" to both the row menu and the background (current-directory) menu. Pure frontend, no backend/auth involved. A directory opens with its own path as `cwd`; a file opens with its parent as `cwd` and pre-fills an `@filename` prompt (not auto-sent).

## Test plan
- [x] `pytest tests/test_templates_api.py` — 98 passed (rewrote the open-in-claude tests: success returns the encoded deep-link URL, added a space-in-path case asserting `%20` encoding, dropped the darwin-only test since the endpoint is now platform-agnostic, kept 404/403 guard tests)
- [x] `cd frontend && npm run build` (`tsc --noEmit && vite build`) — clean, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Integration/UX change that removes server subprocess/osascript; listing deep links are built client-side from paths the user already sees in the explorer.
> 
> **Overview**
> **Open in Claude** no longer spawns Terminal on macOS. The server validates user template folders and returns a `claude-cli://open?cwd=…` URL; the UI sets `window.location.href` so the OS hands off to Claude Code’s registered handler—cross-platform, no subprocess.
> 
> **File listing** gains **Open in Claude Code** on row and folder background menus (client-only). `claudeDeepLink` sets `cwd` to the directory or a file’s parent and pre-fills a starter `q` prompt (load fused-render skills; files get a quoted name instead of `@` mentions).
> 
> Template inventory and new-template success flows use the same navigate-to-URL pattern; API response shape changes from `{ ok: true }` to `{ url }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31a64996f919d022c4ad7c22394a5c7468340cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->