### PR TITLE
Repair mounts whose backend died, instead of crashing on them

### DIFF
--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -3361,6 +3361,27 @@ def _await_ismount(mp: str, deadline: float = _MOUNT_ATTACH_DEADLINE_S) -> bool:
         time.sleep(_MOUNT_ATTACH_POLL_S)
 
 
+def _mount_wedged(mp: str) -> bool:
+    # True when mp is a mountpoint whose backend process is gone: the kernel
+    # still holds the mount, so the path exists, but every stat on it fails.
+    try:
+        os.lstat(mp)
+    except OSError as e:
+        return e.errno in (errno.ENOTCONN, errno.EHOSTDOWN, errno.ESTALE)
+    except ValueError:
+        return False
+    return False
+
+
+def _is_mounted(mp: str) -> bool:
+    # os.path.ismount, but it also sees wedged mounts. posixpath.ismount
+    # swallows the OSError from lstat and reports False for a mountpoint whose
+    # FUSE daemon died (ENOTCONN) — precisely the state reconnect exists to
+    # repair, so the bare predicate skips the force-unmount and then crashes in
+    # attach_mount's makedirs.
+    return os.path.ismount(mp) or _mount_wedged(mp)
+
+
 def attach_mount(m: dict) -> str | None:
     """Mount via rcd; returns an error string or None."""
     mp = mountpoint(m)
@@ -3395,6 +3416,14 @@ def attach_mount(m: dict) -> str | None:
                 # actual failure instead of misblaming it on non-emptiness.
                 return f"could not clear stale mountpoint {mp}: {e}"
     else:
+        if _mount_wedged(mp):
+            # Nothing can be mounted over a path whose stat fails: makedirs'
+            # exist_ok check can't recognise it as a directory and raises
+            # FileExistsError, violating this function's error-string contract.
+            # reconnect_mount clears this before re-attaching; anyone else
+            # (automount, a plain mount) is told to.
+            return (f"mountpoint {mp} is wedged — its backend is gone; "
+                    f"reconnect the mount to repair it")
         os.makedirs(mp, exist_ok=True)
     if os.path.ismount(mp):
         # Already a kernel mount — but is it OURS? A stale mount left by a
@@ -3592,9 +3621,13 @@ def _force_unmount(mp: str) -> str | None:
         except (OSError, subprocess.TimeoutExpired) as e:
             last = str(e)
             continue
-        if not os.path.ismount(mp):
+        # _is_mounted, not the bare predicate: a mountpoint still wedged
+        # (ENOTCONN) reads as ismount False, so plain ismount would call every
+        # failed attempt a success and let the caller remount over a path
+        # nothing can be mounted over.
+        if not _is_mounted(mp):
             return None
-    if not os.path.ismount(mp):
+    if not _is_mounted(mp):
         return None
     return f"force unmount of {mp} failed: {last or 'still mounted'}"
 
@@ -3687,7 +3720,10 @@ def reconnect_mount(m: dict) -> str | None:
             _rc(port, "mount/unmount", {"mountPoint": mp})
         except RuntimeError:
             pass  # wedged: rcd's own umount fails; the force path handles it
-    if os.path.ismount(mp):
+    # _is_mounted: a mount whose FUSE daemon died is invisible to plain ismount,
+    # and skipping the force-unmount here left the wedged path in place for
+    # attach_mount to trip over — the one state this whole function exists for.
+    if _is_mounted(mp):
         err = _force_unmount(mp)
         if err:
             return err
@@ -3745,9 +3781,15 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT,
 
     def probe() -> None:
         try:
-            is_mnt = os.path.ismount(mp)
+            is_mnt = _is_mounted(mp)
             served = mp in rcd_mounts
-            if not is_mnt and not served:
+            if is_mnt and _mount_wedged(mp):
+                # Backend gone, kernel mount still held: every stat ENOTCONNs.
+                # Classified here rather than left to the listdir below, so the
+                # probe_io=False caller (the health monitor) sees it too — and
+                # so plain ismount answering False can't read as "unmounted".
+                out["state"] = "disconnected"
+            elif not is_mnt and not served:
                 out["state"] = "unmounted"
             elif served and not is_mnt:
                 # rcd tracks a mount the kernel dropped (INCIDENT split-brain).
@@ -4625,7 +4667,14 @@ def reconnect_endpoint(cid: str, x_fused: str | None = Header(default=None)):
     m = get_mount(cid)
     if m is None:
         return JSONResponse({"error": "unknown mount"}, status_code=404)
-    err = reconnect_mount(m)
+    # Belt-and-braces like restart_endpoint below: reconnect_mount contracts to
+    # return an error string, but it drives kernel unmounts and stat()s on a
+    # mountpoint that is by definition broken — a surprise from down there
+    # should read as a 502 on the Mounts page, never a raw 500 traceback.
+    try:
+        err = reconnect_mount(m)
+    except Exception as e:
+        return JSONResponse({"error": str(e)}, status_code=502)
     if err:
         return JSONResponse({"error": err}, status_code=502)
     return mount_view(m)

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -5,7 +5,9 @@ rclone is never invoked), and the /api/mounts endpoints.
 FUSED_RENDER_HOME is redirected per test so no test touches the real
 ~/.fused-render or a real mount.
 """
+import errno
 import json
+import posixpath
 import stat
 import threading
 import time
@@ -1739,6 +1741,70 @@ def _make_mount(home, rcd, name="data", remote="remote:bucket", served=True):
     return c, mp
 
 
+# The wedged-mount variant of the above, and the reason it needs its own
+# scaffolding: when a FUSE backend dies the kernel keeps the mount, so the path
+# is still in mountinfo, but EVERY stat on it fails ENOTCONN — and
+# posixpath.ismount swallows that OSError and answers False. The `rcd` fixture
+# replaces os.path.ismount with a lookup in the stub's mount table, so no other
+# test in this file ever runs the real predicate; these must, or the swallowed
+# OSError (the whole bug) stays invisible.
+def _wedge(monkeypatch, mp, *, also_mounted=None):
+    """Make `mp` stat like a mount whose backend process is gone. Restores the
+    genuine os.path.ismount (optionally OR'd with the stub rcd's mount table, so
+    a remount later in the same test can still be seen) and fails lstat/stat on
+    `mp` alone. Returns a {"v": True} flag a test flips to un-wedge the path
+    once its umount has "succeeded"."""
+    # Bound before patching: os.path IS posixpath, so a lambda that referenced
+    # posixpath.ismount by attribute would call the patched name — itself.
+    real_ismount = posixpath.ismount
+    monkeypatch.setattr(
+        mounts_mod.os.path, "ismount",
+        real_ismount if also_mounted is None
+        else lambda p: real_ismount(p) or p in also_mounted)
+    wedged = {"v": True}
+
+    def stub(real):
+        def probe(path, *a, **kw):
+            if wedged["v"] and path == mp:
+                raise OSError(errno.ENOTCONN,
+                              "Transport endpoint is not connected")
+            return real(path, *a, **kw)
+        return probe
+
+    # Patched on the os module itself so posixpath.ismount (which looks up
+    # os.lstat at call time) sees the wedge exactly as it would in production.
+    monkeypatch.setattr(mounts_mod.os, "lstat", stub(_os.lstat))
+    monkeypatch.setattr(mounts_mod.os, "stat", stub(_os.stat))
+    return wedged
+
+
+def test_mount_wedged_detects_enotconn(tmp_path, monkeypatch):
+    mp = str(tmp_path / "mnt")
+    _os.makedirs(mp)
+    _wedge(monkeypatch, mp)
+    assert mounts_mod._mount_wedged(mp) is True
+    # ...and _is_mounted sees it even though the bare predicate does not.
+    assert mounts_mod.os.path.ismount(mp) is False
+    assert mounts_mod._is_mounted(mp) is True
+
+
+def test_mount_wedged_false_for_missing_and_healthy_paths(tmp_path, monkeypatch):
+    missing = str(tmp_path / "gone")
+    healthy = str(tmp_path / "plain")
+    _os.makedirs(healthy)
+    _wedge(monkeypatch, str(tmp_path / "mnt"))  # wedges a DIFFERENT path
+    for p in (missing, healthy):
+        assert mounts_mod._mount_wedged(p) is False
+        assert mounts_mod._is_mounted(p) is False
+
+
+def test_is_mounted_true_for_a_healthy_real_mount(monkeypatch):
+    # A genuine mount that is NOT wedged: _is_mounted must still be ismount.
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", posixpath.ismount)
+    assert mounts_mod._mount_wedged("/") is False
+    assert mounts_mod._is_mounted("/") is True
+
+
 def test_state_mounted_when_served_and_listable(home, rcd, monkeypatch):
     c, mp = _make_mount(home, rcd)
     monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
@@ -1783,6 +1849,18 @@ def test_state_disconnected_when_listing_hangs(home, rcd, monkeypatch):
 def test_state_unmounted_when_nothing_there(home, rcd):
     c, mp = _make_mount(home, rcd, served=False)
     assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "unmounted"
+
+
+@pytest.mark.parametrize("served", [True, False])
+def test_state_disconnected_when_stat_returns_enotconn(home, rcd, monkeypatch,
+                                                      served):
+    # The dead-FUSE-backend wedge: ismount answers False (it swallows the
+    # ENOTCONN), so the state used to come out "unmounted"/"stale" and the UI
+    # offered "Mount" instead of "Reconnect". Both rcd views must read
+    # "disconnected" — the mount exists, it just isn't serving.
+    c, mp = _make_mount(home, rcd, served=served)
+    _wedge(monkeypatch, mp)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "disconnected"
 
 
 # -- broken_mount_error: expired detected credentials ----------------------
@@ -1906,6 +1984,73 @@ def test_reconnect_force_unmounts_dead_mount_then_remounts(home, rcd, monkeypatc
     assert mounts_mod.reconnect_mount(c) is None
     assert forced and forced[0][:1] == ["umount"]
     assert any(m == "mount/mount" for m, _ in rcd.calls)
+
+
+def test_reconnect_force_unmounts_enotconn_mount_that_ismount_cannot_see(
+        home, rcd, monkeypatch):
+    # Same repair as the test above, but through the REAL os.path.ismount on a
+    # mount whose FUSE daemon died: ismount says False, so reconnect skipped the
+    # force-unmount entirely and then attach_mount's makedirs raised
+    # FileExistsError (its exist_ok check calls isdir, which also ENOTCONNs) —
+    # a raw 500 traceback out of /reconnect instead of a repaired mount.
+    c, mp = _make_mount(home, rcd, served=False)
+    rcd.responses["mount/unmount"] = (500, {"error": "failed to umount the NFS volume"})
+    wedged = _wedge(monkeypatch, mp, also_mounted=rcd.mounted)
+    forced = []
+
+    def fake_run(cmd, **kw):
+        forced.append(cmd)
+        wedged["v"] = False  # umount succeeded: mp is a plain empty dir again
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
+    assert mounts_mod.reconnect_mount(c) is None
+    assert forced and forced[0][:1] == ["umount"]
+    assert any(m == "mount/mount" for m, _ in rcd.calls)
+
+
+def test_attach_refuses_wedged_mountpoint_instead_of_raising(home, rcd, monkeypatch):
+    # attach_mount's contract is an error string, never an exception — but
+    # os.makedirs(exist_ok=True) over a wedged mountpoint re-raises
+    # FileExistsError because isdir() can't confirm the path is a directory.
+    c, mp = _make_mount(home, rcd, served=False)
+    _wedge(monkeypatch, mp)
+    err = mounts_mod.attach_mount(c)  # must not raise FileExistsError
+    assert err is not None
+    assert "wedged" in err and "reconnect" in err
+    assert not any(m == "mount/mount" for m, _ in rcd.calls)
+
+
+def test_force_unmount_reports_failure_when_path_still_wedged(tmp_path, monkeypatch):
+    # POSIX ladder (the three tests above are win32-only): every umount attempt
+    # "succeeds" but the mount stays wedged. The success checks are ismount-based
+    # and were vacuously true for a wedged path, so this reported None — reconnect
+    # then walked on into attach_mount with the mountpoint still unusable.
+    mp = str(tmp_path / "mnt")
+    _os.makedirs(mp)
+    _wedge(monkeypatch, mp)
+    ran = []
+
+    def fake_run(cmd, **kw):
+        ran.append(cmd)
+
+        class R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
+    err = mounts_mod._force_unmount(mp)
+    assert ran and ran[0][:1] == ["umount"]
+    assert err is not None and "force unmount" in err
 
 
 def test_reconnect_stops_serve_so_it_rebinds_to_fresh_vfs(home, rcd):


### PR DESCRIPTION
## Summary

- **Reconnect now repairs a mount whose backend died, instead of returning a 500.** When an rclone FUSE daemon dies the kernel keeps the mount, so the path exists, but every `stat` on it fails `ENOTCONN`. `posixpath.ismount` calls `os.lstat` inside `except OSError: return False`, so it answers **False** for exactly that state — `reconnect_mount` skipped its force-unmount, and `attach_mount`'s `os.makedirs(mp, exist_ok=True)` then raised `FileExistsError` (its `exist_ok` branch calls `path.isdir()`, which `ENOTCONN`s too).
- **The same crash had three exits, all closed here:** `POST /api/mounts/<id>/reconnect` → 500 traceback, `POST /api/mounts/restart` → 500, and an unguarded `FileExistsError` killing the `mounts-automount` background thread via `run_automount`.
- **A wedged mount is now labelled `disconnected`, not `unmounted`,** so the UI offers **Reconnect** rather than **Mount** — the latter hit the identical crash.
- **`_force_unmount` no longer reports success on a path it failed to clear** — its POSIX checks were `not os.path.ismount(mp)`, vacuously true for a wedged mount.
- `errno.ENOTCONN` appeared nowhere in `mounts.py`, and nowhere in this repo's history. The commit that introduced the gate ([`8e933a0`](../../commit/8e933a0)) stated the opposite assumption — "ismount() still says True" for a dead mount. That holds for wedged NFS on macOS; it is false for dead FUSE on Linux.

## Visuals

**Before** — the gate is blind, so the repair is skipped and `makedirs` raises:

```mermaid
flowchart TD
    A[POST /reconnect] --> B[rcd mount/unmount]
    B --> C{"os.path.ismount"}
    C -->|"False — lstat ENOTCONN<br/>swallowed"| D[force-unmount SKIPPED]
    D --> E[attach_mount]
    E --> F["os.makedirs exist_ok=True"]
    F --> G["FileExistsError"]
    G --> H["500 traceback"]
    style G fill:#f8d7da,stroke:#b02a37
    style H fill:#f8d7da,stroke:#b02a37
```

**After** — `_is_mounted` sees the wedge, so the repair runs:

```mermaid
flowchart TD
    A[POST /reconnect] --> B[rcd mount/unmount]
    B --> C{"_is_mounted"}
    C -->|"True — wedged"| D[_force_unmount]
    D --> E{cleared?}
    E -->|yes| F[attach_mount remounts]
    E -->|"no, still wedged"| G["502 with message"]
    F --> H["200 — state: mounted"]
    style H fill:#d1e7dd,stroke:#0f5132
    style G fill:#fff3cd,stroke:#997404
```

**Where `_is_mounted` is now consulted** (four sites; the other `ismount` callers are deliberately untouched — see Follow-ups):

```mermaid
flowchart TD
    A["_is_mounted = ismount or _mount_wedged"] --> B["reconnect_mount<br/>repair gate"]
    A --> C["_force_unmount<br/>POSIX success checks"]
    A --> D["mount_state<br/>disconnected vs unmounted"]
    A --> E["attach_mount<br/>refuse with a string"]
```

## Usage

No new API. Existing behaviour is repaired:

```bash
# On a mount whose backend has died (ls -> "Transport endpoint is not connected")
curl -s -X POST -H 'X-Fused: 1' localhost:1777/api/mounts/<id>/reconnect
# was: 500 + FileExistsError traceback
# now: 200 {"state":"mounted", ...}

curl -s localhost:1777/api/mounts/health   # wedged mounts read "disconnected", not "unmounted"
```

In the UI: a mount whose backend has died now shows **disconnected** and its **Reconnect** button works.

## Test Plan

- [x] **8 new tests** in `tests/test_shell_mounts.py`, written first and observed failing for the diagnosed reasons: `test_mount_wedged_detects_enotconn`, `test_mount_wedged_false_for_missing_and_healthy_paths`, `test_is_mounted_true_for_a_healthy_real_mount`, `test_state_disconnected_when_stat_returns_enotconn[True]`/`[False]`, `test_reconnect_force_unmounts_enotconn_mount_that_ismount_cannot_see`, `test_attach_refuses_wedged_mountpoint_instead_of_raising`, `test_force_unmount_reports_failure_when_path_still_wedged`.
- [x] `pytest tests/test_shell_mounts.py tests/test_learn_mount.py` → **334 passed, 3 skipped** (baseline 326 passed).
- [x] **Verified against four real wedged rclone FUSE mounts**, not just the suite: each `POST /reconnect` returned 200 in ~1s, `os.listdir` on each mountpoint returned real entries, and `/api/mounts/health` settled on `mounted` for all four. A large parquet on one of the repaired mounts then opened normally through the duckdb and structure templates.
- [x] Health classification confirmed live: the wedged mounts reported `disconnected` before repair (pre-fix they read `unmounted`/`stale`).
- [ ] **Reviewer, note the new tests must bypass a fixture to be meaningful:** the `rcd` fixture monkeypatches `mounts_mod.os.path.ismount` to a lookup in the stub's mount table, so **no other test in the file ever runs the real predicate** — which is why this bug was invisible. The new `_wedge()` helper restores genuine `posixpath.ismount` and raises `ENOTCONN` from `os.lstat`/`os.stat` for one path only. The four pre-existing reconnect tests and the whole `mount_state` block assert on the fixture's boolean and stay green either way; they do not validate this fix.
- [ ] Full suite: 8 failures in `tests/test_browse_mount.py` and `tests/test_deploy.py`, **pre-existing** — identical with this change stashed.

### Deviation worth reviewing

`mount_state` needed a wedged branch *ahead of* its ladder, not just the swapped predicate. With `probe_io=True` the wedged case does reach `"disconnected"` via `os.listdir` raising, but the health monitor probes with `probe_io=False` — a wedged mount that rcd still lists would then have flipped from `"stale"` to `"mounted"`, i.e. a green dot over a dead mount. Cost is one extra cheap `lstat`.

### Follow-ups (deliberately out of scope)

The same `ismount` blind spot still affects ~6 other call sites, each its own bug: `detach_mount` (:3613, :3629, :3638) returns success for a mount it never unmounted; `delete_mount` (:4689) drops the record while stranding the live kernel mount — the exact hazard its own comment warns about; plus `_force_detach_learn_mount` (:4059) and `run_automount` (:4247). Worth converging on `_is_mounted` alongside the Windows `_ismount()` wrapper on `feat/db-console-webhook-templates-and-windows-mount-fixes`, which fixes the identical class of bug (`ntpath.ismount` raising WinError 123 on a disconnected WinFsp mount).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
