### PR TITLE
Make the parquet structure view survive a heavy file

### DIFF
--- a/fused_render/executor.py
+++ b/fused_render/executor.py
@@ -78,6 +78,50 @@ INPROCESS_HELPERS = frozenset(
 )
 
 
+# Exactly starlette's JSONResponse.render kwargs — `dumps_result` below IS the
+# response encoding for the in-process path, so its bytes must match what
+# JSONResponse would have produced down to separators/escaping.
+_JSON_KW = {"ensure_ascii": False, "allow_nan": False, "separators": (",", ":")}
+
+
+class _PreEncodedRun(dict):
+    """A run result whose `result` payload is already serialized (D72).
+
+    The in-process path has to serialize main()'s return value anyway, to tell
+    a non-JSON-serializable result apart with a useful message. A parquet
+    structure dump is many MB, so serializing it again on the way out of
+    /api/run doubled the cost of every request. This carries that one encoded
+    string alongside the live payload: dict consumers still read
+    `result["result"]` as a real object, and `dumps_result` splices the string
+    straight into the response body instead of re-encoding it.
+    """
+
+    __slots__ = ("payload_json",)
+
+    def __init__(self, mapping: dict, payload_json: str):
+        super().__init__(mapping)
+        self.payload_json = payload_json
+
+
+def dumps_result(result: dict) -> str:
+    """Render a run result as the /api/run response body.
+
+    Byte-identical to `json.dumps(result, **_JSON_KW)` (a flat object is just
+    "key":value joined by commas), except that a `_PreEncodedRun`'s payload is
+    reused verbatim rather than serialized a second time.
+    """
+    payload_json = getattr(result, "payload_json", None)
+    if payload_json is None:
+        return json.dumps(result, **_JSON_KW)
+    return "{%s}" % ",".join(
+        "%s:%s" % (
+            json.dumps(key, **_JSON_KW),
+            payload_json if key == "result" else json.dumps(value, **_JSON_KW),
+        )
+        for key, value in result.items()
+    )
+
+
 def _error(err_type: str, message: str, detail: str = "") -> dict:
     return {
         "ok": False,
@@ -127,14 +171,18 @@ def _run_inprocess(path: str, params: dict) -> dict:
                 f"{os.path.basename(path)} does not define a callable 'main' function"
             )
         result = fn(**bind_params(fn, params))
+        # Serialize once: this pass both validates the payload (so a bad return
+        # gets the message below instead of an opaque 500 from the response
+        # encoder) and *is* the bytes /api/run sends, via dumps_result. A
+        # multi-MB structure dump used to be encoded twice per request.
         try:
-            json.dumps(result)
+            payload_json = json.dumps(result, **_JSON_KW)
         except (TypeError, ValueError):
             raise TypeError(
                 f"main() returned {type(result).__name__}, which is not JSON-serializable; "
                 "return dict/list/str/number/bool/None (e.g. df.to_dict('records'))"
             ) from None
-        return {"ok": True, "result": result, "stdout": ""}
+        return _PreEncodedRun({"ok": True, "result": result, "stdout": ""}, payload_json)
     except BaseException as e:  # noqa: BLE001 — mirror the child's catch-all
         return {
             "ok": False,

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -52,7 +52,7 @@ from fused_render import __version__
 from fused_render.account import router as account_router
 from fused_render.core_templates import ensure_core_templates
 from fused_render.deploy import router as deploy_router
-from fused_render.executor import run_python
+from fused_render.executor import dumps_result, run_python
 from fused_render.shell import prefs as shell_prefs
 from fused_render.shell import storage
 from fused_render.shell.bookmarks import router as bookmarks_router
@@ -3810,7 +3810,11 @@ def create_app(start_dir: str) -> FastAPI:
         # for auto-reload (LR-2). Set on failed runs too, so a broken py that
         # gets fixed still triggers a reload.
         result["resolved_py"] = resolved
-        return JSONResponse(result)
+        # dumps_result, not JSONResponse: the in-process executor path already
+        # serialized the payload (it has to, to validate it), so this reuses
+        # that string instead of encoding a multi-MB result a second time. The
+        # bytes are identical to JSONResponse's for every other result.
+        return Response(content=dumps_result(result), media_type="application/json")
 
     @app.post("/api/export")
     def api_export(body: dict = Body(...), x_fused: str | None = Header(default=None)):

--- a/fused_render/templates/structure/reader.py
+++ b/fused_render/templates/structure/reader.py
@@ -4,19 +4,30 @@ down to each row group's column chunks (offsets, sizes, compression, encodings
 and statistics). No data pages are read; pyarrow parses only the footer, so
 this stays cheap even on a multi-GB file.
 
-Two views are built from one pass:
-  • metadata — file summary + schema + per-row-group / per-column-chunk detail.
-  • layout   — an ordered list of physical regions (PAR1 header, each row group
-               with its column chunks, PAR1 footer) for the box diagram, each
-               carrying {start, bytes, end} byte offsets on disk.
+Two calls, because a heavy file has O(row_groups × columns) column chunks
+(1000 row groups × 30 columns = 30 000) and one object per chunk is megabytes
+of JSON the page can't render:
+
+  • main(file) — the overview. File summary + schema + one entry per row group
+    carrying *numeric arrays* (chunk_bytes / chunk_starts, indexed by schema
+    leaf order) instead of per-chunk objects, plus `layout`: the ordered list
+    of physical regions (PAR1 header, each row group, PAR1 footer) for the box
+    diagram, each with {start, bytes, end} byte offsets on disk. The layout's
+    row groups carry no per-column entries — the template derives column boxes
+    from the row group's arrays plus schema[j].path, so the offsets are shipped
+    once, not twice.
+
+  • main(file, row_group=i) — the detail for ONE row group: today's full
+    per-column-chunk objects (compression, encodings, num_values, byte range,
+    statistics), fetched lazily when that row group is expanded.
 
 A column chunk starts at its dictionary page when present, else its first data
 page; its on-disk length is total_compressed_size. The footer is the trailing
 FileMetaData thrift (serialized_size) plus a 4-byte length and the 4-byte PAR1
 magic, so it ends exactly at end-of-file.
 
-Returns {file, schema, row_groups, layout}. Called by fused.runPython with
-{file: "<path>"}.
+Called by fused.runPython with {file: "<path>"} and, for the detail,
+{file: "<path>", row_group: <int>}.
 """
 import datetime
 import decimal
@@ -29,19 +40,32 @@ import pyarrow.parquet as pq
 _MAGIC_LEN = 4
 _FOOTER_LEN_FIELD = 4
 
+# Cap on any string this module emits. min/max statistics are arbitrary column
+# values — a non-pyarrow writer can put a whole blob in them, and 30 000 chunks
+# of untruncated min/max dwarf everything else in the detail payload. The
+# diagram only ever shows a short preview anyway.
+_MAX_STR = 64
+
+
+def _clip(text: str) -> str:
+    """Bound a produced string to _MAX_STR chars, marking truncation."""
+    return text if len(text) <= _MAX_STR else text[:_MAX_STR] + "…"
+
 
 def _jsonify(value):
     """Coerce a statistics value (min/max may be bytes, Decimal, date/time)
-    into something json.dumps can encode."""
-    if value is None or isinstance(value, (bool, int, float, str)):
+    into something json.dumps can encode, bounded in length."""
+    if value is None or isinstance(value, (bool, int, float)):
         return value
+    if isinstance(value, str):
+        return _clip(value)
     if isinstance(value, (bytes, bytearray)):
-        return value.hex()
+        return _clip(value.hex())
     if isinstance(value, decimal.Decimal):
-        return str(value)
+        return _clip(str(value))
     if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
-        return value.isoformat()
-    return str(value)
+        return _clip(value.isoformat())
+    return _clip(str(value))
 
 
 def _chunk_start(cc) -> int:
@@ -84,43 +108,67 @@ def _schema(md):
     return out
 
 
-def _row_groups(md):
-    groups = []
-    for gi in range(md.num_row_groups):
-        rg = md.row_group(gi)
-        cols = []
-        compressed = 0
-        for ci in range(rg.num_columns):
-            cc = rg.column(ci)
-            start = _chunk_start(cc)
-            csize = int(cc.total_compressed_size)
-            compressed += csize
-            cols.append({
-                "path": cc.path_in_schema,
-                "physical_type": cc.physical_type,
-                "compression": cc.compression,
-                "encodings": list(cc.encodings),
-                "num_values": cc.num_values,
-                "has_dictionary": bool(cc.has_dictionary_page),
-                "start": start,
-                "compressed_size": csize,
-                "uncompressed_size": int(cc.total_uncompressed_size),
-                "end": start + csize,
-                "stats": _stats(cc),
-            })
-        groups.append({
-            "index": gi,
-            "num_rows": rg.num_rows,
-            "total_byte_size": int(rg.total_byte_size),
-            "compressed_size": compressed,
-            "columns": cols,
+def _row_group_summary(rg, gi):
+    """Compact per-row-group entry: the two numbers per column chunk the
+    diagram actually needs (on-disk length and first byte), as parallel arrays
+    in row-group column order — which is schema leaf order in parquet, so the
+    template can index them by leaf index. Also returns the aggregates the file
+    summary rolls up (uncompressed total, codec names), computed in this same
+    pass so the footer is only walked once."""
+    sizes = []
+    starts = []
+    uncompressed = 0
+    codecs = set()
+    for ci in range(rg.num_columns):
+        cc = rg.column(ci)
+        sizes.append(int(cc.total_compressed_size))
+        starts.append(_chunk_start(cc))
+        uncompressed += int(cc.total_uncompressed_size)
+        codecs.add(cc.compression)
+    return {
+        "index": gi,
+        "num_rows": rg.num_rows,
+        "total_byte_size": int(rg.total_byte_size),
+        "compressed_size": sum(sizes),
+        "chunk_bytes": sizes,
+        "chunk_starts": starts,
+    }, uncompressed, codecs
+
+
+def _row_group_detail(rg, gi):
+    """Full per-column-chunk detail for one row group — the lazily fetched
+    view behind an expanded row group."""
+    cols = []
+    for ci in range(rg.num_columns):
+        cc = rg.column(ci)
+        start = _chunk_start(cc)
+        csize = int(cc.total_compressed_size)
+        cols.append({
+            "path": cc.path_in_schema,
+            "physical_type": cc.physical_type,
+            "compression": cc.compression,
+            "encodings": list(cc.encodings),
+            "num_values": cc.num_values,
+            "has_dictionary": bool(cc.has_dictionary_page),
+            "start": start,
+            "compressed_size": csize,
+            "uncompressed_size": int(cc.total_uncompressed_size),
+            "end": start + csize,
+            "stats": _stats(cc),
         })
-    return groups
+    return {
+        "index": gi,
+        "num_rows": rg.num_rows,
+        "total_byte_size": int(rg.total_byte_size),
+        "compressed_size": sum(c["compressed_size"] for c in cols),
+        "columns": cols,
+    }
 
 
 def _layout(row_groups, file_size, footer_start, footer_bytes):
-    """Ordered physical regions for the box diagram: PAR1 header, each row group
-    (with its column chunks), then the PAR1 footer."""
+    """Ordered physical regions for the box diagram: PAR1 header, each row
+    group, then the PAR1 footer. Column chunks are deliberately NOT repeated
+    here — they're already in each row group's chunk_starts/chunk_bytes."""
     regions = [{"kind": "header", "label": "PAR1",
                 "start": 0, "bytes": _MAGIC_LEN, "end": _MAGIC_LEN}]
     for rg in row_groups:
@@ -129,9 +177,6 @@ def _layout(row_groups, file_size, footer_start, footer_bytes):
             "index": rg["index"],
             "num_rows": rg["num_rows"],
             "bytes": rg["compressed_size"],
-            "columns": [{"path": c["path"], "start": c["start"],
-                         "bytes": c["compressed_size"], "end": c["end"]}
-                        for c in rg["columns"]],
         })
     if file_size is not None:
         regions.append({"kind": "footer", "label": "PAR1",
@@ -140,9 +185,31 @@ def _layout(row_groups, file_size, footer_start, footer_bytes):
     return regions
 
 
-def main(file: str) -> dict:
+def _row_group_index(value, num_row_groups) -> int:
+    """Parse the requested row group. It arrives from JS as a number, but a
+    param that round-tripped through the URL is a string, so accept both."""
+    try:
+        gi = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(f"row_group must be an integer, got {value!r}") from None
+    if gi < 0 or gi >= num_row_groups:
+        raise ValueError(
+            f"row_group {gi} out of range: file has {num_row_groups} row groups"
+        )
+    return gi
+
+
+def main(file: str, row_group=None) -> dict:
+    # row_group is intentionally unannotated: bind_params only coerces int/
+    # float/str annotations, and an annotation of `int` would blow up on a
+    # JS-sent null. Absent from the params dict it keeps this default, so the
+    # overview call stays `main(file)`.
     pf = pq.ParquetFile(file)
     md = pf.metadata
+
+    if row_group is not None and row_group != "":
+        gi = _row_group_index(row_group, md.num_row_groups)
+        return _row_group_detail(md.row_group(gi), gi)
 
     try:
         file_size = os.path.getsize(file)
@@ -153,12 +220,15 @@ def main(file: str) -> dict:
     footer_bytes = serialized + _FOOTER_LEN_FIELD + _MAGIC_LEN
     footer_start = (file_size - footer_bytes) if file_size is not None else None
 
-    row_groups = _row_groups(md)
-    compressions = sorted({c["compression"] for rg in row_groups
-                           for c in rg["columns"]})
+    row_groups = []
+    total_uncompressed = 0
+    codecs = set()
+    for gi in range(md.num_row_groups):
+        summary, uncompressed, rg_codecs = _row_group_summary(md.row_group(gi), gi)
+        row_groups.append(summary)
+        total_uncompressed += uncompressed
+        codecs |= rg_codecs
     total_compressed = sum(rg["compressed_size"] for rg in row_groups)
-    total_uncompressed = sum(c["uncompressed_size"] for rg in row_groups
-                             for c in rg["columns"])
 
     return {
         "file": {
@@ -174,7 +244,7 @@ def main(file: str) -> dict:
             "footer_bytes": footer_bytes,
             "total_compressed": total_compressed,
             "total_uncompressed": total_uncompressed,
-            "compression": compressions,
+            "compression": sorted(codecs),
         },
         "schema": _schema(md),
         "row_groups": row_groups,

--- a/fused_render/templates/structure/template.html
+++ b/fused_render/templates/structure/template.html
@@ -121,6 +121,17 @@
     margin-top: 8px; border: 1px solid var(--data-border); border-radius: 6px;
     background: var(--data-bg); padding: 8px 10px;
   }
+  /* A row group's column boxes are built on expand, never upfront: a 1000-group
+     × 30-column file would otherwise ship ~180 000 elements into this one tab.
+     <details> buys the collapse for free — but a flex <summary> drops the native
+     disclosure triangle in Chrome, so .caret below draws our own. */
+  details.rg > summary { cursor: pointer; list-style: none; }
+  details.rg > summary::-webkit-details-marker { display: none; }
+  .caret {
+    display: inline-block; color: var(--fg-dim); font-size: 10px; margin-right: 4px;
+    transition: transform 0.12s;
+  }
+  details[open] > summary .caret { transform: rotate(90deg); }
 
   /* ---- Metadata view ---- */
   .meta-section { margin-bottom: 20px; }
@@ -149,9 +160,16 @@
     cursor: pointer; padding: 8px 10px; color: var(--fg-soft); font-weight: 600;
     display: flex; gap: 12px; align-items: baseline;
   }
+  details.rgd > summary { list-style: none; }
+  details.rgd > summary::-webkit-details-marker { display: none; }
   details.rgd > summary .muted { color: var(--fg-muted); font-weight: 400; }
   details.rgd[open] > summary { border-bottom: 1px solid var(--border-cell); }
   details.rgd .rgd-body { padding: 4px 6px 8px; overflow-x: auto; }
+  /* One-line status inside a lazily-filled row-group body (loading / failed /
+     nothing to show) — it stands in for the chunk table, so it lives where the
+     table would. */
+  .rgd-note { color: var(--fg-muted); padding: 8px 6px; }
+  .rgd-note.error { color: var(--error); }
   code.mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; color: var(--mono-fg); }
 
   /* ---- Grid view: whole-file storage profile ---- */
@@ -177,6 +195,21 @@
   }
   .g-size .muted { color: var(--fg-dim); }
   .grid-note { max-width: 700px; margin: 16px 0 0; color: var(--fg-muted); font-size: 12px; line-height: 1.5; }
+
+  /* ---- "Show more": the visible half of every render cap ----
+     Grid rows, Layout groups, Metadata groups and the legend all render a
+     bounded slice; this strip states how much of the whole is on screen and
+     reveals the next slice, so a truncated list is never silently truncated. */
+  .more-row {
+    display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+    margin: 12px 0; color: var(--fg-muted); font-size: 12px;
+  }
+  .more-row b { color: var(--fg-soft); font-weight: 600; }
+  .more-btn {
+    font: inherit; font-size: 12px; padding: 3px 10px; border: 1px solid var(--border);
+    border-radius: 6px; background: var(--bg); color: var(--fg-soft); cursor: pointer;
+  }
+  .more-btn:hover { border-color: var(--tab-active-border); color: var(--tab-active-fg); }
 
   /* ---- Loading skeleton ----
      Shimmering placeholders shaped like whichever tab is about to render
@@ -227,6 +260,29 @@
     const summaryEl = el("summary");
     let data = null;
 
+    // ---- render caps -------------------------------------------------------
+    // The overview payload is O(row_groups × columns) numbers, which is cheap to
+    // hold but ruinous to render all at once: 1000 row groups × 30 columns is
+    // 30 000 column chunks, and one DOM node per chunk freezes (or kills) the
+    // tab. Every list that grows with row-group count therefore renders a
+    // bounded slice, with a "Show more" strip that names the cap (see .more-row).
+    const RG_CAP = 300;      // row-group rows per paint, per tab
+    const LEGEND_CAP = 32;   // legend entries before the rest collapse into one
+    const SEG_MIN_PCT = 0.4; // a bar segment thinner than this merges into "other"
+    const SEG_MAX = 40;      // …and at most this many segments survive per bar
+    const SHOW_ALL_MAX = 5000; // offer "Show all" only when that can't itself hang
+
+    // How many row groups each tab currently shows, and whether the Grid legend
+    // is fully expanded. Reset per file load (see load()), kept across tab
+    // switches so "Show more" doesn't undo itself when you glance at another tab.
+    const rgLimit = { grid: RG_CAP, layout: RG_CAP, metadata: RG_CAP };
+    let legendAll = false;
+
+    // Per-row-group chunk detail fetched lazily by the Metadata tab, keyed by row
+    // group index: {ok:true, detail} or {ok:false, type, message}. Cleared on file
+    // change so a re-opened <details> can never show the previous file's chunks.
+    const rgDetail = new Map();
+
     const esc = (s) => String(s)
       .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
     const n = (x) => (x == null ? "—" : Number(x).toLocaleString());
@@ -242,6 +298,8 @@
 
     // Stable-ish colour per column so a column keeps its hue across row groups.
     function colColor(i) { return `hsl(${(i * 47) % 360} 45% 45%)`; }
+    // Deliberately hueless, so the merged "other" bucket never reads as a column.
+    const OTHER_COLOR = "hsl(0 0% 42%)";
 
     function currentTab() {
       const t = fused.params.get("view");
@@ -262,39 +320,83 @@
         .join(`<span class="sep">·</span>`);
     }
 
-    function renderLayout() {
-      const f = data.file;
-      const parts = [];
-      for (const r of data.layout) {
-        if (r.kind === "header" || r.kind === "footer") {
-          parts.push(`<div class="box magic">
-            <div class="box-head">
-              <span class="box-title">${esc(r.label)}<span class="muted">${r.kind}</span></span>
-              <span class="box-range">start <b>${n(r.start)}</b><br>bytes <b>${n(r.bytes)}</b><br>end <b>${n(r.end)}</b></span>
-            </div></div>`);
-        } else if (r.kind === "row_group") {
-          const cols = r.columns.map((c, i) => `
+    // The "Show more" strip for a capped list. `which` names the counter in
+    // rgLimit (or "legend"); `total` is the untruncated length, so the copy can
+    // say exactly what is being held back. Returns "" when nothing is hidden.
+    function moreControl(which, shown, total, noun) {
+      if (shown >= total) return "";
+      const next = Math.min(RG_CAP, total - shown);
+      const all = total <= SHOW_ALL_MAX
+        ? `<button class="more-btn" data-more="${esc(which)}" data-all="1">Show all ${n(total)}</button>`
+        : "";
+      return `<div class="more-row">
+        <span>Showing the first <b>${n(shown)}</b> of <b>${n(total)}</b> ${esc(noun)}.</span>
+        <button class="more-btn" data-more="${esc(which)}">Show ${n(next)} more</button>${all}
+      </div>`;
+    }
+
+    // Layout: the file as nested byte-range boxes — magic header, one box per row
+    // group, and inside an expanded row group one box per column chunk with its
+    // own Data box. Row groups render COLLAPSED (summary line only) and build
+    // their column boxes on first expand from row_groups[i].chunk_starts /
+    // chunk_bytes + schema[j].path — the overview payload already carries those,
+    // so expanding costs no fetch, only the ~6 elements per column it draws.
+    function layoutColsHtml(i) {
+      const rg = data.row_groups[i];
+      if (!rg) return `<div class="rgd-note">No column offsets for this row group.</div>`;
+      const starts = rg.chunk_starts || [];
+      const bytes = rg.chunk_bytes || [];
+      // Row-group chunk order is schema leaf order, but stay defensive about a
+      // short array rather than printing "NaN" for a column the reader omitted.
+      const cols = data.schema.map((s, j) => {
+        const b = bytes[j], st = starts[j];
+        const end = (st == null || b == null) ? null : st + b;
+        return `
             <div class="box col">
               <div class="box-head">
-                <span class="box-title">Column <code class="mono">${esc(c.path)}</code></span>
-                <span class="box-range">bytes <b>${n(c.bytes)}</b></span>
+                <span class="box-title">Column <code class="mono">${esc(s.path)}</code></span>
+                <span class="box-range">bytes <b>${n(b)}</b></span>
               </div>
               <div class="data">
                 <div class="box-head">
                   <span class="box-title" style="font-weight:400;color:var(--fg-muted)">Data</span>
-                  <span class="box-range">start <b>${n(c.start)}</b><br>bytes <b>${n(c.bytes)}</b><br>end <b>${n(c.end)}</b></span>
+                  <span class="box-range">start <b>${n(st)}</b><br>bytes <b>${n(b)}</b><br>end <b>${n(end)}</b></span>
                 </div>
               </div>
-            </div>`).join("");
-          parts.push(`<div class="box rg">
+            </div>`;
+      }).join("");
+      return `<div class="cols">${cols}</div>`;
+    }
+
+    function renderLayout() {
+      const total = data.layout.reduce((s, r) => s + (r.kind === "row_group" ? 1 : 0), 0);
+      const limit = rgLimit.layout;
+      const parts = [];
+      let seen = 0, truncatedAt = -1;
+      for (const r of data.layout) {
+        if (r.kind === "header" || r.kind === "footer") {
+          parts.push(`<div class="box magic">
             <div class="box-head">
-              <span class="box-title">RowGroup ${r.index}<span class="muted">${n(r.num_rows)} rows</span></span>
+              <span class="box-title">${esc(r.label)}<span class="muted">${esc(r.kind)}</span></span>
+              <span class="box-range">start <b>${n(r.start)}</b><br>bytes <b>${n(r.bytes)}</b><br>end <b>${n(r.end)}</b></span>
+            </div></div>`);
+        } else if (r.kind === "row_group") {
+          // Past the cap the groups are skipped, and the strip is spliced in
+          // where they stopped — so the footer box still closes the file.
+          if (seen >= limit) {
+            if (truncatedAt < 0) { truncatedAt = parts.length; parts.push(""); }
+            continue;
+          }
+          seen++;
+          parts.push(`<details class="box rg" data-rg="${r.index}">
+            <summary><div class="box-head">
+              <span class="box-title"><span class="caret">&#9654;</span>RowGroup ${esc(r.index)}<span class="muted">${n(r.num_rows)} rows</span></span>
               <span class="box-range">bytes <b>${n(r.bytes)}</b></span>
-            </div>
-            <div class="cols">${cols}</div>
-          </div>`);
+            </div></summary>
+          </details>`);
         }
       }
+      if (truncatedAt >= 0) parts[truncatedAt] = moreControl("layout", seen, total, "row groups");
       content.innerHTML = `<div class="lay">${parts.join("")}</div>`;
     }
 
@@ -318,33 +420,24 @@
         <td class="num">${c.max_def}</td>
         <td class="num">${c.max_rep}</td></tr>`).join("");
 
-      const rgDetails = data.row_groups.map((rg) => {
-        const chunkRows = rg.columns.map((c) => {
-          const st = c.stats || {};
-          const mm = (st.min == null && st.max == null) ? "—"
-            : `${esc(String(st.min))} … ${esc(String(st.max))}`;
-          return `<tr>
-            <td><code class="mono">${esc(c.path)}</code></td>
-            <td>${esc(c.physical_type)}</td>
-            <td>${esc(c.compression)}</td>
-            <td>${esc(c.encodings.join(", "))}</td>
-            <td class="num">${n(c.num_values)}</td>
-            <td class="num">${humanBytes(c.compressed_size)}</td>
-            <td class="num">${humanBytes(c.uncompressed_size)}</td>
-            <td class="num">${n(c.start)}</td>
-            <td>${mm}</td>
-            <td class="num">${st.nulls == null ? "—" : n(st.nulls)}</td></tr>`;
-        }).join("");
-        return `<details class="rgd">
-          <summary>RowGroup ${rg.index}
+      // Row groups: SUMMARY ROWS ONLY. Everything a summary shows (index, rows,
+      // compressed, raw) is in the overview payload; the chunk table behind it is
+      // fetched per row group on first expand (see loadRgDetail). Building them
+      // upfront cost ~300 000 table cells on a 1000-group file for content that
+      // sits inside a collapsed <details> and is never seen.
+      const total = data.row_groups.length;
+      const shown = Math.min(total, rgLimit.metadata);
+      const rgDetails = [];
+      for (let i = 0; i < shown; i++) {
+        const rg = data.row_groups[i];
+        rgDetails.push(`<details class="rgd" data-rg="${esc(rg.index)}">
+          <summary><span class="caret">&#9654;</span>RowGroup ${esc(rg.index)}
             <span class="muted">${n(rg.num_rows)} rows · ${humanBytes(rg.compressed_size)} compressed · ${humanBytes(rg.total_byte_size)} raw</span>
           </summary>
-          <div class="rgd-body"><table><thead><tr>
-            <th>Column</th><th>Type</th><th>Codec</th><th>Encodings</th><th>Values</th>
-            <th>Compressed</th><th>Uncompressed</th><th>Offset</th><th>Min … Max</th><th>Nulls</th>
-          </tr></thead><tbody>${chunkRows}</tbody></table></div>
-        </details>`;
-      }).join("");
+          <div class="rgd-body"></div>
+        </details>`);
+      }
+      rgDetails.push(moreControl("metadata", shown, total, "row groups"));
 
       content.innerHTML = `
         <div class="meta-section"><h3>File</h3><dl class="kv">${fileRows}</dl></div>
@@ -352,7 +445,73 @@
           <table><thead><tr><th>Column</th><th>Physical type</th><th>Logical type</th>
           <th class="num">Max def</th><th class="num">Max rep</th></tr></thead>
           <tbody>${schemaRows}</tbody></table></div>
-        <div class="meta-section"><h3>Row groups</h3>${rgDetails}</div>`;
+        <div class="meta-section"><h3>Row groups</h3>${rgDetails.join("")}</div>`;
+    }
+
+    // ---- lazy per-row-group chunk detail (Metadata tab) ---------------------
+    // A row group's chunk table is only built when its <details> is opened, from
+    // a reader.py call scoped to that one group. The detail is cached forever
+    // (per file), so collapsing and re-opening repaints without refetching.
+    const CHUNK_HEAD = `<thead><tr>
+      <th>Column</th><th>Type</th><th>Codec</th><th>Encodings</th><th>Values</th>
+      <th>Compressed</th><th>Uncompressed</th><th>Offset</th><th>Min … Max</th><th>Nulls</th>
+    </tr></thead>`;
+
+    function chunkTable(detail) {
+      const cols = detail.columns || [];
+      if (!cols.length) return `<div class="rgd-note">No column chunks in this row group.</div>`;
+      const rows = cols.map((c) => {
+        const st = c.stats || {};
+        const mm = (st.min == null && st.max == null) ? "—"
+          : `${esc(String(st.min))} … ${esc(String(st.max))}`;
+        return `<tr>
+          <td><code class="mono">${esc(c.path)}</code></td>
+          <td>${esc(c.physical_type)}</td>
+          <td>${esc(c.compression)}</td>
+          <td>${esc((c.encodings || []).join(", "))}</td>
+          <td class="num">${n(c.num_values)}</td>
+          <td class="num">${humanBytes(c.compressed_size)}</td>
+          <td class="num">${humanBytes(c.uncompressed_size)}</td>
+          <td class="num">${n(c.start)}</td>
+          <td>${mm}</td>
+          <td class="num">${st.nulls == null ? "—" : n(st.nulls)}</td></tr>`;
+      }).join("");
+      return `<table>${CHUNK_HEAD}<tbody>${rows}</tbody></table>`;
+    }
+
+    // Write into the live body for row group `i`, if it is still on screen — the
+    // tab may have been re-rendered (or switched away from) while we awaited.
+    function paintRgBody(i, html) {
+      const body = content.querySelector(`details.rgd[data-rg="${i}"] > .rgd-body`);
+      if (body) body.innerHTML = html;
+    }
+
+    function rgBodyHtml(entry) {
+      if (entry.ok) return chunkTable(entry.detail);
+      return `<div class="rgd-note error"><strong>${esc(entry.type)}</strong>: ${esc(entry.message)}</div>`;
+    }
+
+    async function loadRgDetail(i) {
+      const cached = rgDetail.get(i);
+      if (cached) { paintRgBody(i, rgBodyHtml(cached)); return; }
+      const seq = loadSeq;      // same stale-guard as the overview load
+      const file = fused.params.get("_file");
+      paintRgBody(i, skeletonChunkTable(4));
+      let entry;
+      try {
+        // The distinct `key` is REQUIRED. runPython's default latest-wins channel
+        // is the .py path, so an unkeyed call here would abort the overview load
+        // and every sibling row group's in-flight detail call.
+        const detail = await fused.runPython("./reader.py", { file, row_group: i }, { key: "rg-" + i });
+        entry = { ok: true, detail };
+      } catch (err) {
+        entry = { ok: false, type: (err && err.type) || "Error", message: (err && err.message) || String(err) };
+      }
+      if (seq !== loadSeq) return; // a newer file load superseded this one
+      // Only successes are cached: a failure should be retried by re-opening,
+      // not remembered as this row group's permanent answer.
+      if (entry.ok) rgDetail.set(i, entry);
+      paintRgBody(i, rgBodyHtml(entry));
     }
 
     // Grid: the whole file's storage profile at a glance. One row per row group;
@@ -367,40 +526,96 @@
       // not from row group 0 — so the legend and totals cover every column even
       // if some row group happens to hold fewer chunks.
       const cols = data.schema.map((s) => s.path);
-      const maxRg = Math.max(...rgs.map((r) => r.compressed_size), 1);
+      // reduce, not Math.max(...rgs.map(…)): spreading an array into a call puts
+      // one argument per element on the stack, so a file with ~100 k row groups
+      // threw RangeError before the tab drew anything.
+      const maxRg = rgs.reduce((m, r) => (r.compressed_size > m ? r.compressed_size : m), 1);
 
-      // File-wide bytes per column, summed across every row group (biggest first).
-      const totals = cols.map((path, i) => ({
-        path, i,
-        bytes: rgs.reduce((s, r) => s + (r.columns[i] ? r.columns[i].compressed_size : 0), 0),
-      }));
+      // File-wide bytes per column, summed across every row group. O(groups ×
+      // columns) arithmetic over the numeric chunk_bytes arrays — no objects.
+      const totals = cols.map((path, i) => ({ path, i, bytes: 0 }));
+      for (const r of rgs) {
+        const cb = r.chunk_bytes || [];
+        for (let i = 0; i < totals.length; i++) totals[i].bytes += cb[i] || 0;
+      }
       const grand = totals.reduce((s, c) => s + c.bytes, 0) || 1;
-      const legend = [...totals].sort((a, b) => b.bytes - a.bytes).map((c) => `
+
+      // Legend: biggest column first, capped — a wide file would otherwise print
+      // a swatch per column above a chart you can no longer see. The tail folds
+      // into one "+N more columns" entry until "Show all" is clicked.
+      const byBytes = totals.slice().sort((a, b) => b.bytes - a.bytes);
+      const legShown = legendAll ? byBytes.length : Math.min(byBytes.length, LEGEND_CAP);
+      const legItems = byBytes.slice(0, legShown).map((c) => `
         <span class="leg-item" title="${esc(c.path)}: ${humanBytes(c.bytes)}">
           <span class="swatch" style="background:${colColor(c.i)}"></span>
           <code class="mono">${esc(c.path)}</code>
           <span class="leg-pct">${humanBytes(c.bytes)} · ${(c.bytes / grand * 100).toFixed(0)}%</span>
-        </span>`).join("");
+        </span>`);
+      if (legShown < byBytes.length) {
+        const rest = byBytes.slice(legShown).reduce((s, c) => s + c.bytes, 0);
+        legItems.push(`
+        <span class="leg-item">
+          <span class="swatch" style="background:${OTHER_COLOR}"></span>
+          <span class="leg-pct">+${n(byBytes.length - legShown)} more columns · ${humanBytes(rest)}
+            · ${(rest / grand * 100).toFixed(0)}%</span>
+          <button class="more-btn" data-more="legend">Show all</button>
+        </span>`);
+      }
 
-      const rows = rgs.map((r) => {
-        const rgTotal = r.columns.reduce((s, c) => s + c.compressed_size, 0) || 1;
-        const seg = r.columns.map((c, i) =>
-          `<span class="g-seg" title="${esc(c.path)}: ${humanBytes(c.compressed_size)} (${(c.compressed_size / rgTotal * 100).toFixed(1)}% of group)"
-                 style="width:${(c.compressed_size / rgTotal * 100).toFixed(3)}%;background:${colColor(i)}"></span>`).join("");
-        return `<div class="g-row">
-          <span class="g-label" title="RowGroup ${r.index}">RG ${r.index}</span>
+      // One row per row group, capped at RG_CAP per paint. Within a bar, any
+      // column thinner than SEG_MIN_PCT (and everything past the SEG_MAX widest)
+      // merges into a single grey "other" segment: a sub-pixel span is invisible
+      // yet still costs a DOM node, which is where 34 000 <span> came from.
+      const shownRgs = Math.min(rgs.length, rgLimit.grid);
+      const rows = [];
+      for (let k = 0; k < shownRgs; k++) {
+        const r = rgs[k];
+        const cb = r.chunk_bytes || [];
+        let rgTotal = 0;
+        for (let i = 0; i < cols.length; i++) rgTotal += cb[i] || 0;
+        if (!rgTotal) rgTotal = 1;
+
+        let keep = [];
+        for (let i = 0; i < cols.length; i++) {
+          const b = cb[i] || 0;
+          if (b / rgTotal * 100 >= SEG_MIN_PCT) keep.push({ i, b });
+        }
+        if (keep.length > SEG_MAX) {
+          keep = keep.sort((a, b) => b.b - a.b).slice(0, SEG_MAX).sort((a, b) => a.i - b.i);
+        }
+        const kept = new Set(keep.map((k2) => k2.i));
+
+        const segs = [];
+        let other = 0, otherCols = 0;
+        for (let i = 0; i < cols.length; i++) {
+          const b = cb[i] || 0;
+          if (!kept.has(i)) { other += b; if (b) otherCols++; continue; }
+          const pct = b / rgTotal * 100;
+          segs.push(`<span class="g-seg" title="${esc(cols[i])}: ${humanBytes(b)} (${pct.toFixed(1)}% of group)"
+                 style="width:${pct.toFixed(3)}%;background:${colColor(i)}"></span>`);
+        }
+        if (other) {
+          const pct = other / rgTotal * 100;
+          segs.push(`<span class="g-seg" title="${n(otherCols)} smaller columns: ${humanBytes(other)} (${pct.toFixed(1)}% of group)"
+                 style="width:${pct.toFixed(3)}%;background:${OTHER_COLOR}"></span>`);
+        }
+        rows.push(`<div class="g-row">
+          <span class="g-label" title="RowGroup ${esc(r.index)}">RG ${esc(r.index)}</span>
           <span class="g-track">
-            <span class="g-bar" style="width:${(r.compressed_size / maxRg * 100).toFixed(3)}%">${seg}</span>
+            <span class="g-bar" style="width:${(r.compressed_size / maxRg * 100).toFixed(3)}%">${segs.join("")}</span>
           </span>
           <span class="g-size">${humanBytes(r.compressed_size)}<span class="muted"> · ${n(r.num_rows)} rows</span></span>
-        </div>`;
-      }).join("");
+        </div>`);
+      }
 
       content.innerHTML = `
-        <div class="grid-legend">${legend}</div>
-        <div class="grid-chart">${rows}</div>
+        <div class="grid-legend">${legItems.join("")}</div>
+        <div class="grid-chart">${rows.join("")}</div>
+        ${moreControl("grid", shownRgs, rgs.length, "row groups")}
         <p class="grid-note">Bar length is each row group's compressed size on disk, relative to the largest group.
-        Segments show how those bytes split across columns — hover any segment for exact sizes.</p>`;
+        Segments show how those bytes split across columns — hover any segment for exact sizes.
+        Columns holding under ${SEG_MIN_PCT}% of a group (and anything past its ${n(SEG_MAX)} widest)
+        are merged into one grey “other” segment.</p>`;
     }
 
     // ---- Loading skeletons: same-shaped stand-ins for renderSummary/renderGrid/
@@ -426,35 +641,32 @@
       return `<div class="grid-legend">${legend}</div><div class="grid-chart">${rows}</div>`;
     }
 
+    // Mirrors the real Layout tab, which now lands as COLLAPSED row-group boxes —
+    // so the skeleton is a magic box plus a stack of summary-only rg boxes.
     function skeletonLayout() {
-      const col = () => `
-        <div class="box col">
-          <div class="box-head">
-            <span class="box-title">${skelText(120)}</span>
-            <span class="box-range">${skelText(70)}</span>
-          </div>
-          <div class="data">
-            <div class="box-head">
-              <span class="box-title">${skelText(40)}</span>
-              <span class="box-range">${skelText(90)}</span>
-            </div>
-          </div>
-        </div>`;
-      const rg = (n) => `
-        <div class="box rg">
-          <div class="box-head">
-            <span class="box-title">${skelText(100)}</span>
-            <span class="box-range">${skelText(60)}</span>
-          </div>
-          <div class="cols">${Array.from({ length: n }, col).join("")}</div>
-        </div>`;
-      return `<div class="lay">
+      const magic = () => `
         <div class="box magic"><div class="box-head">
           <span class="box-title">${skelText(90)}</span>
           <span class="box-range">${skelText(100)}</span>
-        </div></div>
-        ${rg(2)}${rg(3)}
-      </div>`;
+        </div></div>`;
+      const rg = () => `
+        <div class="box rg">
+          <div class="box-head">
+            <span class="box-title"><span class="caret">&#9654;</span>${skelText(100)}</span>
+            <span class="box-range">${skelText(60)}</span>
+          </div>
+        </div>`;
+      return `<div class="lay">${magic()}${Array.from({ length: 5 }, rg).join("")}</div>`;
+    }
+
+    // The stand-in painted inside a row group's body while its chunk detail is
+    // in flight — same 10-column table the real detail lands as.
+    function skeletonChunkTable(rows) {
+      const chunkRow = () => `<tr>
+        <td>${skelText(100)}</td><td>${skelText(50)}</td><td>${skelText(50)}</td><td>${skelText(70)}</td>
+        <td class="num">${skelText(40)}</td><td class="num">${skelText(50)}</td><td class="num">${skelText(50)}</td>
+        <td class="num">${skelText(40)}</td><td>${skelText(80)}</td><td class="num">${skelText(24)}</td></tr>`;
+      return `<table>${CHUNK_HEAD}<tbody>${Array.from({ length: rows }, chunkRow).join("")}</tbody></table>`;
     }
 
     function skeletonMetadata() {
@@ -463,16 +675,10 @@
       const schemaRows = [110, 95, 80, 120, 90].map((w) => `<tr>
         <td>${skelText(w)}</td><td>${skelText(60)}</td><td>${skelText(70)}</td>
         <td class="num">${skelText(16)}</td><td class="num">${skelText(16)}</td></tr>`).join("");
-      const chunkRow = () => `<tr>
-        <td>${skelText(100)}</td><td>${skelText(50)}</td><td>${skelText(50)}</td><td>${skelText(70)}</td>
-        <td class="num">${skelText(40)}</td><td class="num">${skelText(50)}</td><td class="num">${skelText(50)}</td>
-        <td class="num">${skelText(40)}</td><td>${skelText(80)}</td><td class="num">${skelText(24)}</td></tr>`;
-      const rgSkel = [3, 2].map((n) => `<details class="rgd" open>
-          <summary>${skelText(90)}<span class="muted">${skelText(150)}</span></summary>
-          <div class="rgd-body"><table><thead><tr>
-            <th>Column</th><th>Type</th><th>Codec</th><th>Encodings</th><th>Values</th>
-            <th>Compressed</th><th>Uncompressed</th><th>Offset</th><th>Min … Max</th><th>Nulls</th>
-          </tr></thead><tbody>${Array.from({ length: n }, chunkRow).join("")}</tbody></table></div>
+      // Row groups arrive collapsed now (their chunk tables are fetched on
+      // expand), so the skeleton is a stack of closed summary rows.
+      const rgSkel = Array.from({ length: 5 }, () => `<details class="rgd">
+          <summary><span class="caret">&#9654;</span>${skelText(90)}<span class="muted">${skelText(190)}</span></summary>
         </details>`).join("");
       return `
         <div class="meta-section"><h3>File</h3><dl class="kv">${kv}</dl></div>
@@ -507,6 +713,11 @@
       // Drop any prior file's data up front so a tab switch mid-load (or after
       // a failure) can't repaint stale layout/metadata for the wrong file.
       data = null;
+      // Same reason the per-row-group chunk cache and the render caps reset: they
+      // are all keyed to the file that is going away.
+      rgDetail.clear();
+      rgLimit.grid = rgLimit.layout = rgLimit.metadata = RG_CAP;
+      legendAll = false;
       summaryEl.innerHTML = skeletonSummary();
       content.innerHTML = skeletonMarkup(currentTab());
       if (!file) {
@@ -525,6 +736,37 @@
         content.innerHTML = `<div id="status" class="error"><strong>${esc(err.type || "Error")}</strong>: ${esc(err.message || "")}</div>`;
       }
     }
+
+    // Both lazy tabs hang off one delegated `toggle` listener on #content, which
+    // survives every innerHTML repaint. It is registered in the CAPTURE phase
+    // because `toggle` does not bubble — capture still reaches the <details>.
+    content.addEventListener("toggle", (ev) => {
+      const d = ev.target;
+      if (!data || !d || d.tagName !== "DETAILS" || !d.open) return;
+      const i = Number(d.dataset.rg);
+      if (!Number.isInteger(i)) return;
+      if (d.classList.contains("rgd")) {
+        loadRgDetail(i); // Metadata: fetch this group's chunk table
+      } else if (d.classList.contains("rg") && !d.dataset.built) {
+        d.dataset.built = "1"; // Layout: build column boxes once, from the overview
+        d.insertAdjacentHTML("beforeend", layoutColsHtml(i));
+      }
+    }, true);
+
+    // "Show more" / "Show all" for any capped list. Raising a cap only changes how
+    // much of `data` is drawn, so re-rendering the tab is the whole action.
+    content.addEventListener("click", (ev) => {
+      const btn = ev.target.closest ? ev.target.closest("button[data-more]") : null;
+      if (!btn || !data) return;
+      const which = btn.dataset.more;
+      if (which === "legend") { legendAll = true; renderTab(); return; }
+      if (!(which in rgLimit)) return;
+      const total = which === "layout"
+        ? data.layout.reduce((s, r) => s + (r.kind === "row_group" ? 1 : 0), 0)
+        : data.row_groups.length;
+      rgLimit[which] = btn.dataset.all ? total : rgLimit[which] + RG_CAP;
+      renderTab();
+    });
 
     el("tab-layout").addEventListener("click", () => fused.params.set("view", "layout"));
     el("tab-grid").addEventListener("click", () => fused.params.set("view", "grid"));

--- a/tests/test_structure_reader.py
+++ b/tests/test_structure_reader.py
@@ -1,6 +1,9 @@
 """Tests for the structure template's reader.py — parquet metadata + physical
 byte layout (row-group / column-chunk level), built on pyarrow.
 
+Two calls under test: the compact overview main(file) and the per-row-group
+detail main(file, row_group=i).
+
 Skipped when pyarrow isn't installed.
 """
 import importlib.util
@@ -37,6 +40,18 @@ def pq_file(tmp_path):
     return str(p)
 
 
+@pytest.fixture
+def blob_file(tmp_path):
+    """One row group whose string column's min/max statistics are far longer
+    than the 64-char cap the reader applies."""
+    long_a = "a" * 500
+    long_b = "b" * 500
+    t = pa.table({"blob": pa.array([long_a, long_b])})
+    p = tmp_path / "blob.parquet"
+    pq.write_table(t, str(p), compression="snappy")
+    return str(p)
+
+
 # ---------------------------------------------------------------- file summary
 
 def test_file_summary(pq_file):
@@ -63,32 +78,105 @@ def test_schema_columns(pq_file):
     assert "STRING" in str(n["logical_type"]).upper() or n["converted_type"] == "UTF8"
 
 
-# ---------------------------------------------------------------- row groups
+# ------------------------------------------------- row groups (overview shape)
 
-def test_row_groups_and_chunks(pq_file):
-    rgs = reader.main(pq_file)["row_groups"]
+def test_row_groups_are_compact_arrays(pq_file):
+    out = reader.main(pq_file)
+    rgs = out["row_groups"]
     assert len(rgs) == 2
     rg0 = rgs[0]
     assert rg0["index"] == 0
     assert rg0["num_rows"] == 2
-    assert len(rg0["columns"]) == 2
+    assert rg0["total_byte_size"] > 0
 
-    # Every column chunk's byte range is self-consistent: end = start + bytes.
-    for col in rg0["columns"]:
+    # Numeric arrays instead of per-chunk objects: one entry per leaf column.
+    assert "columns" not in rg0
+    n = out["file"]["num_columns"]
+    for rg in rgs:
+        assert len(rg["chunk_bytes"]) == n
+        assert len(rg["chunk_starts"]) == n
+        assert all(isinstance(v, int) for v in rg["chunk_bytes"])
+        assert all(isinstance(v, int) for v in rg["chunk_starts"])
+        assert all(v > 0 for v in rg["chunk_bytes"])
+        assert rg["compressed_size"] == sum(rg["chunk_bytes"])
+
+    # The very first chunk begins right after the 4-byte PAR1 header, and
+    # chunks are laid out in ascending on-disk order within a row group.
+    assert rg0["chunk_starts"][0] == 4
+    assert rg0["chunk_starts"] == sorted(rg0["chunk_starts"])
+
+
+def test_overview_arrays_match_detail(pq_file):
+    out = reader.main(pq_file)
+    # Arrays are in schema leaf order, so schema[j] describes column j.
+    paths = [c["path"] for c in out["schema"]]
+    for rg in out["row_groups"]:
+        detail = reader.main(pq_file, row_group=rg["index"])
+        assert [c["path"] for c in detail["columns"]] == paths
+        assert rg["chunk_bytes"] == [c["compressed_size"] for c in detail["columns"]]
+        assert rg["chunk_starts"] == [c["start"] for c in detail["columns"]]
+        assert rg["compressed_size"] == detail["compressed_size"]
+
+
+# ------------------------------------------------------- row group detail call
+
+def test_row_group_detail(pq_file):
+    out = reader.main(pq_file, row_group=1)
+    assert out["index"] == 1
+    assert out["num_rows"] == 2
+    assert len(out["columns"]) == 2
+    # The detail is the only place per-chunk objects live, and it carries the
+    # full physical description of each chunk.
+    for col in out["columns"]:
         assert col["end"] == col["start"] + col["compressed_size"]
         assert col["compressed_size"] > 0
+        assert col["uncompressed_size"] > 0
+        assert col["encodings"]
+        assert col["compression"]
+        assert col["num_values"] == 2
+    # A detail response is just that row group — no file/schema/layout keys.
+    assert "layout" not in out and "schema" not in out
 
-    # The very first chunk begins right after the 4-byte PAR1 header.
-    first = rg0["columns"][0]
-    assert first["start"] == 4
+
+def test_row_group_detail_accepts_numeric_string(pq_file):
+    # Params that round-trip through the URL arrive as strings.
+    assert reader.main(pq_file, row_group="0")["index"] == 0
+
+
+@pytest.mark.parametrize("bad", [2, 99, -1])
+def test_row_group_out_of_range(pq_file, bad):
+    with pytest.raises(ValueError, match="out of range"):
+        reader.main(pq_file, row_group=bad)
+
+
+def test_row_group_not_an_integer(pq_file):
+    with pytest.raises(ValueError, match="integer"):
+        reader.main(pq_file, row_group="nope")
 
 
 def test_column_statistics(pq_file):
-    rgs = reader.main(pq_file)["row_groups"]
-    id_col = next(c for c in rgs[0]["columns"] if c["path"] == "id")
+    cols = reader.main(pq_file, row_group=0)["columns"]
+    id_col = next(c for c in cols if c["path"] == "id")
     assert id_col["stats"]["min"] == 1
     assert id_col["stats"]["max"] == 2
     assert id_col["stats"]["nulls"] == 0
+
+
+def test_statistics_strings_are_truncated(blob_file):
+    cols = reader.main(blob_file, row_group=0)["columns"]
+    stats = cols[0]["stats"]
+    for key in ("min", "max"):
+        assert len(stats[key]) == 65  # 64 chars + the truncation marker
+        assert stats[key].endswith("…")
+    assert stats["min"].startswith("a")
+    assert stats["max"].startswith("b")
+
+
+def test_short_statistics_are_left_alone(pq_file):
+    cols = reader.main(pq_file, row_group=0)["columns"]
+    name_col = next(c for c in cols if c["path"] == "name")
+    assert name_col["stats"]["min"] == "a"
+    assert name_col["stats"]["max"] == "bb"
 
 
 # ---------------------------------------------------------------- layout boxes
@@ -108,13 +196,16 @@ def test_layout_header_and_footer(pq_file):
 
 
 def test_layout_row_group_regions(pq_file):
-    layout = reader.main(pq_file)["layout"]
-    rgs = [r for r in layout if r["kind"] == "row_group"]
-    assert len(rgs) == 2
-    assert rgs[0]["index"] == 0
-    # each row-group region lists its column chunks with byte ranges
-    for col in rgs[0]["columns"]:
-        assert col["end"] == col["start"] + col["bytes"]
+    out = reader.main(pq_file)
+    regions = [r for r in out["layout"] if r["kind"] == "row_group"]
+    assert len(regions) == 2
+    for region, rg in zip(regions, out["row_groups"]):
+        assert region["index"] == rg["index"]
+        assert region["num_rows"] == rg["num_rows"]
+        assert region["bytes"] == rg["compressed_size"]
+        # per-column offsets are not duplicated here — the template derives
+        # column boxes from the row group's arrays plus schema[j].path
+        assert "columns" not in region
 
 
 # ---------------------------------------------------------------- json safety
@@ -122,3 +213,17 @@ def test_layout_row_group_regions(pq_file):
 def test_output_is_json_serializable(pq_file):
     import json
     json.dumps(reader.main(pq_file))  # must not raise
+    json.dumps(reader.main(pq_file, row_group=0))  # must not raise
+
+
+# ------------------------------------------------------------- param binding
+
+def test_row_group_is_optional_through_bind_params(pq_file):
+    """The overview call ships no row_group at all; bind_params must accept
+    that and leave the default in place (fused.runPython binds by name)."""
+    from fused_render._binding import bind_params
+
+    assert bind_params(reader.main, {"file": pq_file}) == {"file": pq_file}
+    bound = bind_params(reader.main, {"file": pq_file, "row_group": 1})
+    assert bound["row_group"] == 1
+    assert reader.main(**bound)["index"] == 1


### PR DESCRIPTION
## Summary

- **Opening the `structure` mode on a heavy local parquet no longer lags or kills the tab.** A 333 MB zstd file with 1000 row groups × 30 columns (30 000 column chunks) shipped a **12 MB** JSON payload and then built one giant `innerHTML` per tab: ~34 000 spans in Grid, ~180 000 elements in Layout, ~300 000 table cells in Metadata. Nothing was bounded by row-group or column count. (duckdb mode was fine on the same file because it queries with `LIMIT`.)
- **The reader ships numbers, not objects.** `main(file)` now returns per-row-group `chunk_bytes` / `chunk_starts` arrays (schema leaf order) instead of an object per column chunk, and `layout` stops repeating the per-column offsets those arrays already carry: **12.04 MB → 0.73 MB**. Full per-chunk detail (codec, encodings, statistics, byte range) moved to a second call, `main(file, row_group=i)`, fetched only for a row group you actually expand (~10 KB).
- **Every list that grows with the file is capped, visibly.** Metadata row groups are summary rows whose chunk table loads on first expand; Layout row groups render collapsed and build their column boxes on expand from the overview arrays (no fetch); Grid renders 300 rows per paint with a "Show more" strip, merges sub-pixel column segments into one grey "other", and caps the legend. Node counts on that file: Grid 34 000 → 10 929 (43 ms), Layout 180 000 → 2 427, Metadata 300 000 cells → 1 746 (17 ms).
- **Two latent bugs fixed along the way.** Grid's `Math.max(...rgs.map(…))` threw `RangeError` on a file with ~100 k row groups before drawing anything (now a `reduce`), and statistics `min`/`max` — arbitrary column values a non-pyarrow writer can fill with a whole blob — are clipped to 64 chars.
- **`/api/run` serializes a result once instead of twice.** The in-process executor path had to `json.dumps` the payload anyway to tell a non-serializable return apart with a useful message, then FastAPI encoded the same object again. The response now reuses that string: byte-identical output, **121 ms → 78 ms** on a 10.7 MB body.

## Visuals

**Payload: one call carrying every chunk → an overview plus on-demand detail**

```mermaid
flowchart TD
    P[template.html] -->|"main(file)"| O[overview]
    O --> S["file + schema"]
    O --> A["per row group:<br/>chunk_bytes[]<br/>chunk_starts[]"]
    O --> L["layout regions<br/>no column entries"]
    P -->|"main(file, row_group=i)<br/>on expand only"| D["one group's<br/>chunk detail"]
```

**Rendering: each tab draws a bounded slice**

```mermaid
flowchart TD
    T{tab} --> G[Grid]
    T --> Y[Layout]
    T --> M[Metadata]
    G --> GC["300 rows per paint<br/>thin segments merged"]
    Y --> YC["groups collapsed"]
    YC -->|expand| YB["column boxes<br/>from overview arrays"]
    M --> MC["summary rows only"]
    MC -->|expand| MB["fetch that group<br/>cache it"]
```

## Usage

Not a new feature — the same view, on files that previously broke it. Open any `.parquet` in fused-render and switch to the **structure** mode (duckdb remains the default mode for `.parquet`).

New in the UI: row groups in **Layout** and **Metadata** start collapsed and fill in when clicked; **Grid** shows a `Showing the first 300 of 1,000 row groups.` strip with **Show 300 more** / **Show all** ("Show all" is withheld above 5000 groups so the escape hatch can't itself hang).

For anyone calling the reader directly:

```python
main("/path/to/file.parquet")                 # overview: file, schema, row_groups[], layout[]
main("/path/to/file.parquet", row_group=7)    # full per-column-chunk detail for group 7
```

## Test Plan

- [x] **Automated** — `tests/test_structure_reader.py` extended to 17 tests: new overview shape (arrays present, per-chunk objects absent, `layout` without `columns`), array length equals `num_columns`, overview arrays agree with the detail call's `compressed_size`/`start` per column and align with `schema[j].path`, detail call for a valid index, out-of-range `row_group` raising `ValueError`, and stats truncation.
- [x] **Full suite** — `pytest -q -n auto`: 1921 passed, 30 skipped. 3 pre-existing environmental failures, unrelated to this diff and untouched by it: `test_supervisor_linux_paths.py::test_alert_is_a_no_op_when_tk_cannot_start` (`ImportError: libtk8.6.so`) and two `test_deploy.py` tests that assert the `fused` CLI is *absent* while this venv installed the `[fused]` extra.
- [x] **Browser, heavy file** (1000 RG × 30 cols, 333 MB) — all three tabs, tab round-trips, Layout expand (30 column boxes with correct start/bytes/end), two Metadata groups expanded simultaneously and both correct (proves the per-group `runPython` key doesn't abort the overview load or its siblings), collapse + re-open repaints with **0** extra `runPython` calls, "Show 300 more" → 600 rows, "Show all" → 1000. Zero console messages throughout. Dark and light theme both checked.
- [x] **Browser, small file** (2 RG × 10 cols) — 75 nodes, 1.4 ms; all 10 columns, no "other" merge, no cap strip. Small files look exactly as before.
- [x] **RangeError regression** — a 120 000-row-group fixture renders (2112 nodes, 14 ms) where the old `Math.max(...)` spread would have thrown; "Show all" correctly suppressed.
- [x] **File switch** — expanding a group then changing `_file` shows the skeleton, then the new file's groups, none open, no stale chunk rows (per-file detail cache and caps reset in `load()`).
- [x] **`/api/run` byte-equivalence** — checked against the previous `JSONResponse` rendering for a multi-MB body, non-ASCII strings, `datetime`, a non-serializable `object()`, and NaN: identical status, body bytes and content-type. One deliberate behavior change, noted for review: a NaN/Infinity float returned by an in-process helper used to reach the response encoder and 500; it now fails through the normal `{"ok": false, "error": …}` envelope instead of emitting invalid JSON.
- [ ] **Not verified** — narrow-viewport layout of the new "Show more" strip; a file with more columns than the legend/segment caps (32/40) exercised only at a lowered cap during development; the detail-fetch *error* path (`.rgd-note.error`) is code-only, since the reader never failed in testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
