### PR TITLE
Make AppImage compression level configurable for CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -267,6 +267,13 @@ jobs:
         # Step-gated to desktop/packaging changes: it's minutes of toolchain
         # downloads, pointless on a server-only PR.
         if: needs.detect-changes.outputs.linux_desktop == 'true'
+        env:
+          # The default (level 22, release.yml doesn't set this so it keeps
+          # getting the smallest real download) took ~4 of this job's ~5
+          # minutes compressing the sci-stack-heavy payload with mksquashfs —
+          # CPU the smoke build throws away seconds later. This artifact is
+          # never shipped, so trade compression ratio for speed.
+          FUSED_RENDER_APPIMAGE_COMPRESSION_LEVEL: "3"
         run: bash scripts/build_linux_appimage.sh
 
   # Windows desktop supervisor (docs/PYTHON_SUPERVISOR_SPEC.md). The _win32

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -198,16 +198,23 @@ rm -f "$OUTPUT_APPIMAGE"
 # --appimage-extract-and-run avoids needing libfuse2 to RUN appimagetool itself
 # in CI; --runtime-file embeds the static type-2 runtime in the OUTPUT.
 # Compression: appimagetool's bundled mksquashfs only supports zstd (no xz), so
-# push zstd to its max level (22, vs the level-15 default). We deliberately keep
-# the DEFAULT squashfs block size (128 KiB): raising it (e.g. -b 1M) shaves ~30
-# MB more but amplifies random-read latency at every launch — this payload is a
-# large Python tree read as many small files at import time, and appimagetool
-# 1.9.0 returned to the default block size precisely to avoid that startup
-# regression. The level bump costs nothing at decompress time (zstd decode speed
-# is ~independent of level), so it's a free ~33 MB with no runtime penalty.
+# push zstd to its max level (22, vs the level-15 default) for real releases.
+# We deliberately keep the DEFAULT squashfs block size (128 KiB): raising it
+# (e.g. -b 1M) shaves ~30 MB more but amplifies random-read latency at every
+# launch — this payload is a large Python tree read as many small files at
+# import time, and appimagetool 1.9.0 returned to the default block size
+# precisely to avoid that startup regression. The level bump costs nothing at
+# decompress time (zstd decode speed is ~independent of level), so it's a free
+# ~33 MB with no runtime penalty for anyone who downloads the artifact.
+# Compressing this (numpy/pandas/scipy/geopandas/rasterio/...-sized) payload at
+# level 22 takes minutes of CPU time, which only pays for itself when the
+# result is actually shipped — the CI smoke build (test.yml) throws its
+# AppImage away immediately, so it overrides this to a fast level via the env
+# var below instead of eating that cost on every PR.
+COMPRESSION_LEVEL="${FUSED_RENDER_APPIMAGE_COMPRESSION_LEVEL:-22}"
 ARCH="$ARCH" "$APPIMAGETOOL" --appimage-extract-and-run \
     --comp zstd \
-    --mksquashfs-opt -Xcompression-level --mksquashfs-opt 22 \
+    --mksquashfs-opt -Xcompression-level --mksquashfs-opt "$COMPRESSION_LEVEL" \
     --runtime-file "$RUNTIME_FILE" "$STAGE_DIR" "$OUTPUT_APPIMAGE"
 [ -f "$OUTPUT_APPIMAGE" ] || { echo "appimagetool did not produce $OUTPUT_APPIMAGE" >&2; exit 1; }
 chmod +x "$OUTPUT_APPIMAGE"


### PR DESCRIPTION
## Summary
This change makes the AppImage compression level configurable via an environment variable, allowing CI smoke builds to use faster compression while release builds maintain maximum compression.

## Key Changes
- **build_linux_appimage.sh**: Introduced `FUSED_RENDER_APPIMAGE_COMPRESSION_LEVEL` environment variable (defaults to 22 for release builds) to control zstd compression level passed to mksquashfs
- **test.yml**: Set compression level to 3 for the Linux AppImage smoke build to reduce CI job time from ~4-5 minutes to seconds, since the artifact is discarded immediately after testing

## Implementation Details
- The compression level variable uses bash parameter expansion with a default value of 22: `"${FUSED_RENDER_APPIMAGE_COMPRESSION_LEVEL:-22}"`
- Release builds (release.yml) don't set this variable, so they continue using level 22 for optimal compression
- CI smoke builds (test.yml) override to level 3, trading compression ratio for speed since the AppImage is never shipped
- Updated comments explain the rationale: level 22 compression of the scipy/numpy/pandas-heavy payload takes minutes of CPU time that only pays off when the result is actually distributed

https://claude.ai/code/session_01Axow2GCrAWPyNzdTFALqCf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging/CI-only change; shipped release AppImages still use the default max compression unless the env var is set.
> 
> **Overview**
> Linux AppImage builds can now tune **mksquashfs zstd** compression via **`FUSED_RENDER_APPIMAGE_COMPRESSION_LEVEL`**, defaulting to **22** so release pipelines keep maximum compression when the variable is unset.
> 
> The **linux-desktop** CI smoke step sets the level to **3** because level-22 compression was consuming most of the job time on a discarded artifact; comments in **`build_linux_appimage.sh`** document when the slower setting is worth it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b117db8a728e17cb47fd67343d77657c1ee7fbc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->