### PR TITLE
Fix test compatibility with minimal Python builds and improve dev setup docs

### DIFF
--- a/.claude/skills/setting-up-dev-env/SKILL.md
+++ b/.claude/skills/setting-up-dev-env/SKILL.md
@@ -25,6 +25,7 @@ scripts/dev.sh --port 9000     # extra args pass through to the server
 ```bash
 uv venv --python 3.14 .venv                                         # 3.14 wheels now exist for the whole stack
 uv pip install --python .venv/bin/python -e ".[dev,bundled,fused]"  # dev extra now includes pytest-xdist
+uv pip install --python .venv/bin/python pip                        # uv venv doesn't seed pip; test_deploy.py needs it
 ```
 
 For `shell-dist/`: if you've run `scripts/dev.sh`, it's already built. If you'll *only* run tests and never start the server, build it once directly (repo uses npm, per `package-lock.json`):
@@ -44,6 +45,6 @@ Verify: `ls fused_render/static/shell-dist/index.html` and `.venv/bin/python -m 
 | `bundled` extra | duckdb, rasterio, zarr, pandas, geopandas… (templates + daemons) |
 | `fused` extra | compute-engine wheel for `/api/run` |
 | frontend build | `create_app()` refuses to start without `shell-dist/` |
-| `ensurepip` | only for the Deploy one-click path, not the suite |
+| seeded `pip` | `uv venv` makes a pip-less venv; `test_deploy.py`'s install/one-click-installable tests exercise the *real* `_pip_available()` against this interpreter, so they fail without it |
 
 Parallel tests: the suite is xdist-safe (process isolation), so `pytest -n auto` works (~4.5x faster). Process-based only — `os.chdir` + `importlib.reload` would race under a threaded runner.

--- a/tests/test_supervisor_linux_paths.py
+++ b/tests/test_supervisor_linux_paths.py
@@ -316,9 +316,10 @@ def test_open_default_apps_raises_on_linux(monkeypatch):
 def test_alert_is_a_no_op_when_tk_cannot_start(monkeypatch):
     # On a display-less session Tk() raises TclError; alert() is the unguarded
     # fatal-error reporter in __main__.py and must degrade to a no-op, not crash.
+    # Some minimal/sandboxed Python builds ship without the tkinter stdlib
+    # module at all (no display, no Tk libs) — skip rather than fail there.
+    tkinter = pytest.importorskip("tkinter")
     monkeypatch.setattr(ui.shutil, "which", lambda tool: None)  # force the tkinter path
-
-    import tkinter
 
     def boom():
         raise tkinter.TclError("no display name and no $DISPLAY environment variable")


### PR DESCRIPTION
## Summary
This PR improves test robustness for minimal/sandboxed Python environments and clarifies development setup requirements.

## Key Changes

- **Test robustness**: Updated `test_alert_is_a_no_op_when_tk_cannot_start()` to use `pytest.importorskip("tkinter")` instead of a bare import. This allows the test to gracefully skip on Python builds that don't include tkinter (e.g., minimal or sandboxed distributions) rather than failing with an import error.

- **Dev setup documentation**: 
  - Added explicit `pip` installation step to the uv venv setup instructions, since `uv venv` doesn't seed pip by default
  - Updated the dependency table to clarify that `test_deploy.py` requires a seeded `pip` in the venv to properly test the real `_pip_available()` function against the interpreter

## Implementation Details

The tkinter import change moves the skip logic to the test setup phase, making the test more resilient to different Python distributions while maintaining the original test intent (verifying alert() degrades gracefully when Tk cannot start).

The documentation updates ensure developers following the setup instructions will have a properly configured environment for running the full test suite, particularly the deployment tests that exercise pip availability checks.

https://claude.ai/code/session_01M8JneUwf1Dtxr9vb82htmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-environment hardening only; no production runtime or security paths change.
> 
> **Overview**
> **Dev setup docs** now tell developers to `uv pip install pip` after creating the venv, and the reference table explains that deploy tests hit real `_pip_available()` against a pip-less `uv` venv without this step.
> 
> **`test_alert_is_a_no_op_when_tk_cannot_start`** uses `pytest.importorskip("tkinter")` so minimal Python builds without the tkinter stdlib skip instead of failing on import; the TclError/no-display behavior is unchanged when tkinter is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df2fe3a5a0746966be3ef0796ca2bd821c972fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->