### PR TITLE
Fix XSS, zip-slip, path-escape, and argv-secret findings from security audit

### DIFF
--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -165,7 +165,7 @@ def parse_github_url(src: str) -> dict:
         if subpath.startswith(("..", "/")) or subpath == ".":
             raise DeeplinkError(f"invalid subdirectory path in URL: {url}")
     name = posixpath.basename(subpath) if subpath else repo
-    if name in (".", "..") or name.startswith(".") or "/" in name or "\\" in name:
+    if name in (".", "..") or name.startswith(".") or "/" in name or "\\" in name or ":" in name:
         raise DeeplinkError(f"unusable destination folder name {name!r} from URL: {url}")
     return {"owner": owner, "repo": repo, "ref": ref, "subpath": subpath, "name": name}
 

--- a/fused_render/shell/mounts.py
+++ b/fused_render/shell/mounts.py
@@ -4890,23 +4890,27 @@ def create_remote(body: dict = Body(...), x_fused: str | None = Header(default=N
     if not bin_:
         return JSONResponse({"error": "rclone is not installed"}, status_code=502)
     p = body.get("params") or {}
-    cmd = [
-        bin_, "config", "create", name, "s3",
-        "provider", p.get("provider") or "Other",
-        "access_key_id", p.get("access_key_id") or "",
-        "secret_access_key", p.get("secret_access_key") or "",
-        "env_auth", "false",
-    ]
+    parameters = {
+        "provider": p.get("provider") or "Other",
+        "access_key_id": p.get("access_key_id") or "",
+        "secret_access_key": p.get("secret_access_key") or "",
+        "env_auth": "false",
+    }
     if p.get("endpoint"):
-        cmd += ["endpoint", p["endpoint"]]
+        parameters["endpoint"] = p["endpoint"]
     if p.get("region"):
-        cmd += ["region", p["region"]]
+        parameters["region"] = p["region"]
+    # Created through the rc daemon (JSON over loopback HTTP) rather than
+    # `rclone config create` on argv: the latter would put the plaintext
+    # secret_access_key in the process's command line, visible to any other
+    # local user via `ps` (same rationale as the rcd auth secret in
+    # _rcd_child_env).
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except subprocess.TimeoutExpired:
-        return JSONResponse({"error": "rclone config create timed out (30s)"}, status_code=502)
-    if r.returncode != 0:
-        return JSONResponse({"error": (r.stderr or r.stdout or "").strip()[-500:]}, status_code=502)
+        port = ensure_rcd()
+        _rc(port, "config/create",
+            {"name": name, "type": "s3", "parameters": parameters}, timeout=30)
+    except RuntimeError as e:
+        return JSONResponse({"error": str(e)[-500:]}, status_code=502)
     _invalidate_upstream_caches()  # new/changed keys must be picked up without restart
     return {"ok": True, "name": name + ":"}
 

--- a/fused_render/templates/photos/template.html
+++ b/fused_render/templates/photos/template.html
@@ -851,13 +851,20 @@ function renderCaption(e) {
   cap.append(hint);
 }
 function renderInfo(e) {
-  const rows = [], kv = (k, v) => rows.push('<div class="kv"><span class="k">' + k + '</span><span class="v">' + v + '</span></div>');
+  const body = q("infoBody");
+  body.innerHTML = "";
+  const kv = (k, v) => {
+    const row = document.createElement("div"); row.className = "kv";
+    const kEl = document.createElement("span"); kEl.className = "k"; kEl.textContent = k;
+    const vEl = document.createElement("span"); vEl.className = "v"; vEl.textContent = v;
+    row.append(kEl, vEl);
+    body.append(row);
+  };
   kv("Name", e.file.name); kv("Size", fmtBytes(e.file.size));
   if (e.image) kv("Dimensions", e.image.w + " × " + e.image.h);
   if (e.image && e.image.format) kv("Format", e.image.format);
   kv("Modified", new Date(e.file.mtime * 1000).toLocaleString());
   for (const key in LABELS) if (e.exif[key]) kv(LABELS[key], e.exif[key]);
-  q("infoBody").innerHTML = rows.join("");
 }
 function closeLightbox() { q("lb").classList.remove("open"); q("lbImg").src = ""; lbCurrentPath = ""; resetZoom(); }
 function navTo(delta) { const idx = currentIndex(); if (idx < 0) return; const j = idx + delta; if (j < 0 || j >= items.length) return; P.set("photo", items[j].name); }

--- a/fused_render/templates/usd/convert_worker.py
+++ b/fused_render/templates/usd/convert_worker.py
@@ -21,6 +21,7 @@ import io
 import json
 import os
 import shutil
+import stat as stat_mod
 import struct
 import sys
 import time
@@ -53,6 +54,30 @@ class Progress:
 
     def fail(self, message):
         self.update("error", 100, message, done=True, error=message)
+
+
+def _is_symlink_entry(info: zipfile.ZipInfo) -> bool:
+    return stat_mod.S_ISLNK(info.external_attr >> 16)
+
+
+def _reject_reason(info: zipfile.ZipInfo, dest_dir: str) -> str | None:
+    """Why this zip entry is unsafe to extract, or None if it is safe. Guards
+    zip-slip (absolute paths, `..` escapes, out-of-root targets) and symlink
+    entries."""
+    name = info.filename
+    if _is_symlink_entry(info):
+        return f"symlink entry not allowed: {name!r}"
+    normalized = name.replace("\\", "/")
+    if normalized.startswith("/") or os.path.isabs(name):
+        return f"absolute path not allowed: {name!r}"
+    parts = normalized.split("/")
+    if any(p == ".." for p in parts):
+        return f"path escape ('..') not allowed: {name!r}"
+    target = os.path.normpath(os.path.join(dest_dir, normalized))
+    root = os.path.normpath(dest_dir)
+    if target != root and not target.startswith(root + os.sep):
+        return f"path escapes the destination directory: {name!r}"
+    return None
 
 
 # ------------------------------------------------------------ nurec layer ---
@@ -680,14 +705,20 @@ def convert(source, cache_dir, budget, crop=1):
         nurec_name = next((n for n in names if n.endswith(".nurec")), None)
         prog.update("extract", 0, "extracting usd layers")
         root_layer = None
-        for n in names:
-            if n.endswith((".usda", ".usd", ".usdc")):
-                dest = os.path.join(src_dir, n)
-                os.makedirs(os.path.dirname(dest), exist_ok=True)
-                with open(dest, "wb") as f:
-                    f.write(zf.read(n))
-                if root_layer is None or n == "default.usda":
-                    root_layer = dest
+        for info in zf.infolist():
+            n = info.filename
+            if not n.endswith((".usda", ".usd", ".usdc")):
+                continue
+            reason = _reject_reason(info, src_dir)
+            if reason is not None:
+                prog.fail(f"unsafe zip entry: {reason}")
+                return
+            dest = os.path.join(src_dir, n)
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "wb") as f:
+                f.write(zf.read(n))
+            if root_layer is None or n == "default.usda":
+                root_layer = dest
         stage_path = root_layer
 
     # ---- gaussian layer

--- a/fused_render/templates/usd/template.html
+++ b/fused_render/templates/usd/template.html
@@ -899,9 +899,14 @@
       n.innerHTML =
         (opts.checked === undefined ? "" :
           `<input type="checkbox" title="show/hide layer" ${opts.checked ? "checked" : ""}>`) +
-        `<span class="ico">${ico}</span><span>${label}</span>` +
-        `<span class="cnt">${cnt || ""}</span>` +
         (opts.remove ? `<span class="x" title="remove from scene">✕</span>` : "");
+      const icoEl = document.createElement("span"); icoEl.className = "ico"; icoEl.textContent = ico;
+      const labelEl = document.createElement("span"); labelEl.textContent = label;
+      const cntEl = document.createElement("span"); cntEl.className = "cnt"; cntEl.textContent = cnt || "";
+      const removeEl = n.querySelector(".x");
+      n.insertBefore(cntEl, removeEl || null);
+      n.insertBefore(labelEl, cntEl);
+      n.insertBefore(icoEl, labelEl);
       el.tree.appendChild(n);
       const cb = n.querySelector("input");
       if (cb) {
@@ -1694,8 +1699,10 @@
     const row = (ico, label, sz, cls) => {
       const r = document.createElement("div");
       r.className = "fmRow" + (cls ? " " + cls : "");
-      r.innerHTML = `<span class="ico">${ico}</span><span>${label}</span>` +
-                    (sz ? `<span class="sz">${sz}</span>` : "");
+      const icoEl = document.createElement("span"); icoEl.className = "ico"; icoEl.textContent = ico;
+      const labelEl = document.createElement("span"); labelEl.textContent = label;
+      r.append(icoEl, labelEl);
+      if (sz) { const szEl = document.createElement("span"); szEl.className = "sz"; szEl.textContent = sz; r.append(szEl); }
       el.fmList.appendChild(r);
       return r;
     };

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -1193,30 +1193,25 @@ def test_delete_rejects_builtin_mount(client, rcd, tmp_path, monkeypatch):
     assert any(m["id"] == builtin["id"] for m in mounts_mod.list_mounts())
 
 
-def test_create_s3_remote_builds_rclone_argv(client, monkeypatch):
-    seen = {}
-
-    def fake_run(cmd, **kw):
-        seen["cmd"] = cmd
-
-        class R:
-            returncode = 0
-            stdout = ""
-            stderr = ""
-
-        return R()
-
-    monkeypatch.setattr(mounts_mod.subprocess, "run", fake_run)
+def test_create_s3_remote_uses_rc_not_argv(client, rcd, monkeypatch):
+    # Credentials must travel over the rc daemon's loopback HTTP body, not a
+    # subprocess argv, so they never show up in `ps` for other local users.
     monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
+    rcd.responses["config/create"] = {}
     r = client.post("/api/mounts/remotes", json={
         "name": "mys3",
         "params": {"access_key_id": "AK", "secret_access_key": "SK",
                    "endpoint": "https://e.example", "region": "us-east-1"},
     }, headers=FUSED)
     assert r.status_code == 200
-    cmd = seen["cmd"]
-    assert cmd[:4] == ["/usr/bin/rclone", "config", "create", "mys3"]
-    assert "s3" in cmd and "AK" in cmd and "https://e.example" in cmd
+    method, body = next(c for c in rcd.calls if c[0] == "config/create")
+    assert body["name"] == "mys3"
+    assert body["type"] == "s3"
+    params = body["parameters"]
+    assert params["access_key_id"] == "AK"
+    assert params["secret_access_key"] == "SK"
+    assert params["endpoint"] == "https://e.example"
+    assert params["region"] == "us-east-1"
 
 
 def test_create_remote_rejects_bad_name(client):
@@ -3294,7 +3289,7 @@ def test_sign_single_flight_defers_when_lock_held(fresh_upstream):
 # -- upstream cache hygiene (Task 4) -----------------------------------------
 
 
-def test_create_remote_invalidates_upstream_caches(client, fresh_upstream, monkeypatch):
+def test_create_remote_invalidates_upstream_caches(client, rcd, fresh_upstream, monkeypatch):
     # The stale-_upstream_cfg bug: a changed key must be picked up without a
     # restart. Creating a remote clears every memoized upstream fact.
     mounts_mod._upstream_cfg["mys3"] = {"type": "s3", "stale": True}
@@ -3303,10 +3298,7 @@ def test_create_remote_invalidates_upstream_caches(client, fresh_upstream, monke
     mounts_mod._cred_cache["mys3"] = (None, 9e18)
     mounts_mod._upstream_region["mys3:bucket"] = "us-east-1"
 
-    class _R:
-        returncode, stdout, stderr = 0, "", ""
-
-    monkeypatch.setattr(mounts_mod.subprocess, "run", lambda cmd, **kw: _R())
+    rcd.responses["config/create"] = {}
     monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/usr/bin/rclone")
     r = client.post("/api/mounts/remotes", json={
         "name": "mys3",


### PR DESCRIPTION
## Summary
- Escape/DOM-safe render EXIF fields in the photos lightbox (`templates/photos/template.html`) and filenames in the usd outliner/file browser (`templates/usd/template.html`) — both built `innerHTML` via string concatenation of file-derived strings (attacker-controlled EXIF/filenames).
- Guard usdz zip extraction (`templates/usd/convert_worker.py`) against zip-slip and symlink entries, mirroring the hardened extractor already in `templates_api.py`.
- Reject `:` in deeplink destination names (`deeplink.py`) to close a Windows drive-letter path escape (e.g. a segment like `D:evil` would discard the intended destination via `ntpath.join`).
- Create rclone S3 remotes through the rc daemon's JSON `config/create` call instead of `rclone config create` on argv (`shell/mounts.py`), so access/secret keys don't appear in `ps` for other local users — consistent with the rcd auth fix in #293.

## Test plan
- [x] `pytest` full targeted run (deeplink/mounts/convert_worker/zip/photos/usd): 446 passed, 4 skipped
- [x] Updated `tests/test_shell_mounts.py` remote-creation tests to assert on the rc daemon call (via existing `StubRcd` fixture) instead of subprocess argv
- [x] Manually verified against real rclone binary that `config/create` over the rc HTTP API persists credentials correctly (env-var approach was tried first and confirmed *not* to persist, hence the rc-daemon approach instead)
- [x] Independent code review pass confirmed all 5 fixes close the described vulnerabilities with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security fixes touch clone paths, zip extraction, and credential handling; behavior changes are intentional but warrant regression checks on deeplink clone, USDZ convert, and remote creation.
> 
> **Overview**
> Closes several security-audit findings around **untrusted strings** and **local secret exposure**.
> 
> **XSS:** The photos lightbox info panel and the USD outliner / file browser no longer build HTML via string concatenation for file names and EXIF values; they use DOM APIs with `textContent` instead.
> 
> **Zip extraction:** USDZ layer extraction in `convert_worker.py` now validates each zip member (symlinks, absolute paths, `..`, out-of-root targets) before writing, aligned with the hardened logic elsewhere.
> 
> **Path handling:** GitHub deeplink clone destination names reject `:` so Windows drive-letter segments cannot break the intended `~/Documents/Fused` target.
> 
> **Credentials:** Creating S3 rclone remotes goes through the local rc daemon’s `config/create` JSON API instead of `rclone config create` on the process argv, so access/secret keys are not visible to other users via `ps`. Mount tests assert on rc calls instead of subprocess argv.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78d9e737270fdd3dbf22c849e77550d48d0b79c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->