### PR TITLE
Sort listings by name alphabetically, without splitting folders from files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -66,7 +66,7 @@ The differentiating feature is the **renderable HTML** system: HTML files can ca
 
 ### Requirements
 
-- **FS-1** Directory listing with name, size, modified time, type; sortable columns (sort state in URL params `sort`/`order`, dirs always grouped first).
+- **FS-1** Directory listing with name, size, modified time, type; sortable columns (sort state in URL params `sort`/`order`; **name** sorts purely alphabetically with dirs and files interleaved, **size**/**mtime** group dirs first since a dir has neither meaningfully; dot-entries always last).
 - **FS-2** Breadcrumb navigation. *(tree pane, keyboard nav: follow-up)*
 - **FS-3** **DECIDED:** the explorer browses the **entire computer** — there is no root-scoping concept. The CLI may take a *start directory* (`--start-dir`, default home) but it is only the initial UI location, not a restriction.
 - **FS-4** v1 shows all files including dotfiles. *(hide/toggle: follow-up)*

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -166,7 +166,10 @@ function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEnt
     const aDot = a.name.startsWith(".");
     const bDot = b.name.startsWith(".");
     if (aDot !== bDot) return aDot ? 1 : -1; // dot entries always group last
-    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1; // dirs group first within each
+    // Name sort is purely alphabetical — folders and files interleave. The
+    // size/mtime sorts still group dirs first: a dir has no size and its mtime
+    // means something different from a file's, so mixing them there is noise.
+    if (sort !== "name" && a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
     let cmp: number;
     if (sort === "size") cmp = (a.size ?? -1) - (b.size ?? -1);
     else if (sort === "mtime") cmp = (a.mtime ?? 0) - (b.mtime ?? 0);

--- a/fused_render/templates/preview/template.html
+++ b/fused_render/templates/preview/template.html
@@ -492,7 +492,10 @@
       return [...ENTRIES].sort((a, b) => {
         const aDot = a.name.startsWith("."), bDot = b.name.startsWith(".");
         if (aDot !== bDot) return aDot ? 1 : -1;              // dot entries last
-        if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;  // dirs first
+        // Name sort is purely alphabetical — folders and files interleave.
+        // size/mtime still group dirs first (a dir has no size). Mirrors
+        // views/Listing.tsx sortEntries.
+        if (sortKey !== "name" && a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
         let c;
         if (sortKey === "size") c = (a.size ?? -1) - (b.size ?? -1);
         else if (sortKey === "mtime") c = (a.mtime ?? 0) - (b.mtime ?? 0);


### PR DESCRIPTION
## Summary

- **Sorting a folder by name is now actually alphabetical.** Previously every directory was forced ahead of every file, so a folder named `zebra` sat above a file named `apple`. When you sort by name to find a name you already know, that grouping is the thing standing between you and it.
- **`size` and `mtime` keep the dirs-first grouping.** A directory has no size, and its mtime means something different from a file's — interleaving them under those keys is noise, not information. Only `name` changed.
- **Nothing else moved.** Dot-entries still group last under every sort key. The default is still `name`/`asc`, and per-folder saved sort state (`lib/viewstate`) is untouched — it stores the key and order, never the grouping.
- Fixed in **both** copies of the comparator: the React listing (`views/Listing.tsx`) and the server-rendered `preview` template that mirrors it, so the two don't drift.
- `SPEC.md` **FS-1** restated — it previously documented "dirs always grouped first", which is now only true of two of the three keys.

## Visuals

The comparator is a cascade of tiebreakers. This PR gates exactly one rung of it on the active sort key:

```mermaid
flowchart TD
    A["compare(a, b)"] --> B{"one is a dot-entry?"}
    B -->|yes| C["dot-entry last<br/><i>unchanged</i>"]
    B -->|no| D{"sort === 'name'?"}
    D -->|"yes ✦ new"| F["compare names<br/><b>dirs and files interleave</b>"]
    D -->|no| E{"is_dir differs?"}
    E -->|yes| G["dirs first<br/><i>unchanged</i>"]
    E -->|no| H["compare size / mtime<br/>name as tiebreak"]

    style D fill:#2d5016,stroke:#5a9e2f,color:#fff
    style F fill:#2d5016,stroke:#5a9e2f,color:#fff
```

What a mixed folder looks like under `sort=name&order=asc`:

| Before | After |
|---|---|
| 📁 `docs/`<br/>📁 `zebra/`<br/>📄 `apple.txt`<br/>📄 `mango.csv` | 📄 `apple.txt`<br/>📁 `docs/`<br/>📄 `mango.csv`<br/>📁 `zebra/` |

## Usage

Not a new feature — it changes what an existing control does. Click the **Name** column header in any directory listing, or hit a URL directly:

```
http://localhost:8000/some/folder?sort=name&order=asc   # interleaved (also the default)
http://localhost:8000/some/folder?sort=size&order=desc  # dirs still grouped first
```

Since `name`/`asc` is the fallback when no `?sort` is present and the folder has no saved state, the default listing view is the one that visibly changes.

## Test Plan

- [x] `bun run typecheck` (`tsc --noEmit`) and `bun run build` pass in `frontend/`; bundle emitted to `fused_render/static/shell-dist/`.
- [x] `pytest tests/test_fs_walk_bound.py tests/test_server_fs_events.py tests/test_export.py` — 92 passed.
- [x] `pytest tests/test_docs_readonly.py` — 3 passed (SPEC.md edit).
- [ ] **Manual:** open a folder holding both dirs and files whose names interleave (e.g. `apple.txt`, `docs/`, `mango.csv`, `zebra/`). Under **Name ▲** they read in one alphabetical run; **Name ▼** reverses that same single run rather than reversing two blocks.
- [ ] **Manual regression — other keys:** click **Size** and **Modified**; directories still form a leading block under both asc and desc.
- [ ] **Manual regression — dot-entries:** confirm `.git`, `.env` etc. still sort into a trailing group under every key.
- [ ] **Manual regression — persistence:** sort one folder by size, navigate into a sibling and back; each folder still restores its own sort key/order.
- [ ] **Manual — the mirrored copy:** the server-rendered `preview` listing (non-React path) shows the same interleaved order, so the two implementations agree.

### Not covered

There is no existing unit test around `sortEntries` and no JS test runner configured in `frontend/` (`package.json` has `dev`/`build`/`watch`/`typecheck` only), so the comparator change is verified by typecheck plus the manual steps above rather than by an automated assertion. Standing up a test runner felt out of scope for a three-line ordering fix — happy to add one if you'd rather this rung be pinned.

### Left out of scope

The tar and zip archive viewers (`templates/{tar,zip}/template.html`) keep their own always-dirs-first ordering. They sort two separate `dirs`/`files` arrays of synthesized entries rather than one flat list, so matching them is a different edit; say the word and it's a quick follow-up.
