### PR TITLE
log_studio: restore the Browse-files picker and the tail/tab listeners

### DIFF
--- a/fused_render/templates/log_studio/reader.py
+++ b/fused_render/templates/log_studio/reader.py
@@ -308,6 +308,151 @@ def _overview(file):
     }
 
 
+def _clean_path(path):
+    return (path or "").strip().strip("\"'").strip()
+
+
+# --- mount-safe directory listing ------------------------------------------
+# A kernel listing (os.scandir/os.listdir/os.walk) on a path under a remote
+# rclone NFS mount forces rclone to enumerate the ENTIRE parent S3 prefix and
+# can DROP the mount, wedging the server. This template stays mount-AGNOSTIC:
+# it never imports shell.mounts and never matches mount paths. Instead the UI
+# passes `src` (server origin + /api/fs/raw?path=) and we ask the server whether
+# a path is remote (/api/fs/stat); if so we list it via the mount-routed,
+# paginated /api/fs/list — never through the kernel. _server_url + _stat are
+# copied verbatim from pyramid/overview_pyramid.py.
+import json as _json
+import urllib.error as _urlerr
+import urllib.parse as _urlparse
+import urllib.request as _urlreq
+
+
+def _server_url(src, endpoint, path):
+    u = _urlparse.urlsplit(src)
+    return (f"{u.scheme}://{u.netloc}{endpoint}?path="
+            + _urlparse.quote(path))
+
+
+def _stat(src, path):
+    url = _server_url(src, "/api/fs/stat", path)
+    try:
+        with _urlreq.urlopen(url, timeout=10) as r:
+            return ("ok", _json.load(r))
+    except _urlerr.HTTPError as e:
+        if e.code == 404:
+            return ("missing", None)
+        return ("unreachable", None)
+    except Exception:  # noqa: BLE001 — any network error -> fall back to local
+        return ("unreachable", None)
+
+
+def _remote_dir(src, path):
+    """True iff the server says `path` is a remote (mount-backed) directory.
+    No src / unreachable / missing -> False (presume local, kernel listing OK)."""
+    if not src or not path:
+        return False
+    status, meta = _stat(src, path)
+    return status == "ok" and bool(meta.get("remote"))
+
+
+def _list_remote(src, path, cap=5000):
+    """List `path` via the server's mount-routed, paginated /api/fs/list — never
+    the kernel. Follows the cursor up to `cap` entries so a huge S3 prefix
+    returns a bounded page set instead of tripping the NFS deadman."""
+    entries, cursor, truncated = [], "", False
+    while True:
+        url = _server_url(src, "/api/fs/list", path)
+        if cursor:
+            url += "&cursor=" + _urlparse.quote(cursor)
+        with _urlreq.urlopen(url, timeout=30) as r:
+            payload = _json.load(r)
+        entries.extend(payload.get("entries") or [])
+        truncated = bool(payload.get("truncated"))
+        cursor = payload.get("cursor") or ""
+        if len(entries) >= cap or not truncated or not cursor:
+            break
+    return entries, truncated
+
+
+def _listdir(file, path, src=""):
+    path = _clean_path(path)
+    if path:
+        directory = os.path.abspath(os.path.expanduser(path))
+    elif file:
+        directory = os.path.dirname(os.path.abspath(file))
+    else:
+        directory = os.path.expanduser("~")
+    if _remote_dir(src, directory):
+        # Mount-backed dir: list via /api/fs/list, never a kernel scan.
+        entries = []
+        try:
+            ents, _ = _list_remote(src, directory, cap=1000)
+        except Exception:  # noqa: BLE001
+            ents = []
+        for ent in ents:
+            if ent["name"].startswith("."):
+                continue
+            is_dir = bool(ent.get("is_dir"))
+            entries.append({
+                "name": ent["name"],
+                "path": os.path.join(directory, ent["name"]).replace(os.sep, "/"),
+                "is_dir": is_dir,
+                "size": None if is_dir else (ent.get("size") or 0),
+            })
+            if len(entries) >= 1000:
+                break
+        entries.sort(key=lambda item: (not item["is_dir"], item["name"].casefold()))
+        parent = os.path.dirname(directory)
+        return {
+            "path": directory.replace(os.sep, "/"),
+            "parent": parent.replace(os.sep, "/") if parent and parent != directory else None,
+            "entries": entries,
+            "truncated": len(entries) >= 1000,
+        }
+    if not os.path.isdir(directory):
+        directory = os.path.dirname(directory) or directory
+    entries = []
+    with os.scandir(directory) as scanned:
+        for entry in scanned:
+            if entry.name.startswith("."):
+                continue
+            is_dir = entry.is_dir()
+            if not is_dir and not entry.is_file():
+                continue
+            try:
+                size = None if is_dir else entry.stat().st_size
+            except OSError:
+                continue
+            entries.append(
+                {
+                    "name": entry.name,
+                    "path": entry.path.replace(os.sep, "/"),
+                    "is_dir": is_dir,
+                    "size": size,
+                }
+            )
+            if len(entries) >= 1000:
+                break
+    entries.sort(key=lambda item: (not item["is_dir"], item["name"].casefold()))
+    parent = os.path.dirname(directory)
+    return {
+        "path": directory.replace(os.sep, "/"),
+        "parent": parent.replace(os.sep, "/") if parent and parent != directory else None,
+        "entries": entries,
+        "truncated": len(entries) >= 1000,
+    }
+
+
+def _resolve(path):
+    target = os.path.abspath(os.path.expanduser(_clean_path(path)))
+    exists = os.path.exists(target)
+    return {
+        "path": target.replace(os.sep, "/"),
+        "exists": exists,
+        "is_dir": exists and os.path.isdir(target),
+    }
+
+
 def _tail_page(file, limit, q, levels, from_epoch, to_epoch):
     size = os.path.getsize(file)
     deadline = time.monotonic() + _SCAN_SECONDS
@@ -649,12 +794,14 @@ def main(
     tail: bool = False,
     bins: int = 100,
     context: int = 5,
-    # `path`/`src` are gone with the Browse-files picker: they existed so the
-    # in-template file browser could ask the server whether a directory was
-    # mount-backed before listing it. Opening a log is the app's job now, so the
-    # reader only ever reads the file it is handed.
+    path: str = "",
+    src: str = "",
     **params: str,
 ) -> dict:
+    if op == "list":
+        return _listdir(file, path, src)
+    if op == "resolve":
+        return _resolve(path)
     from_epoch = float(params.get("from") or from_epoch)
     to_epoch = float(params.get("to") or to_epoch)
     if op == "overview":
@@ -667,4 +814,4 @@ def main(
         return _patterns(file, limit, q, level, from_epoch, to_epoch)
     if op == "context":
         return _context(file, page, context)
-    return {"error": f"Unknown operation: {op}", "operations": ["overview", "page", "histogram", "patterns", "context"]}
+    return {"error": f"Unknown operation: {op}", "operations": ["overview", "list", "resolve", "page", "histogram", "patterns", "context"]}

--- a/fused_render/templates/log_studio/template.html
+++ b/fused_render/templates/log_studio/template.html
@@ -46,6 +46,8 @@
     --notice-bg: rgba(230, 180, 80, 0.08);
     --notice-border: #665322;
     --notice-text: #d9bf7b;
+    --scrim: rgba(8, 11, 15, 0.55);
+    --picker-shadow: rgba(0, 0, 0, 0.4);
     font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
 
@@ -89,6 +91,8 @@
     --notice-bg: rgba(183, 121, 31, 0.10);
     --notice-border: #e0c48a;
     --notice-text: #7a5a12;
+    --scrim: rgba(16, 23, 34, 0.4);
+    --picker-shadow: rgba(16, 23, 34, 0.22);
   }
 
   * { box-sizing: border-box; }
@@ -181,7 +185,155 @@
   .brand-mark i:nth-child(2) { width: 70%; }
   .brand-mark i:nth-child(3) { width: 88%; }
 
+  .open-file-list { display: grid; gap: 3px; }
+  .browse-button { width: 100%; margin-top: 9px; }
+
+  .picker-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 50;
+    display: grid;
+    place-items: center;
+    padding: 24px;
+    background: var(--scrim);
+  }
+
+  .picker {
+    width: min(720px, 100%);
+    max-height: 82vh;
+    display: flex;
+    flex-direction: column;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    background: var(--panel);
+    box-shadow: 0 18px 50px var(--picker-shadow);
+    overflow: hidden;
+  }
+
+  .picker-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 13px 15px;
+    border-bottom: 1px solid var(--line);
+  }
+
+  .picker-title {
+    flex: 1;
+    margin: 0;
+    color: var(--strong);
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .picker-close {
+    width: 28px;
+    height: 28px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--faint);
+    font-size: 20px;
+    cursor: pointer;
+  }
+
+  .picker-close:hover { color: var(--danger); background: var(--hover); }
+
+  .picker-path-form {
+    display: flex;
+    gap: 8px;
+    padding: 13px 15px;
+    border-bottom: 1px solid var(--line-soft);
+  }
+
+  #picker-path {
+    flex: 1;
+    height: 32px;
+    padding: 0 10px;
+    border: 1px solid var(--line);
+    border-radius: 3px;
+    background: var(--input);
+    color: var(--strong);
+    font: 12px ui-monospace, SFMono-Regular, Consolas, monospace;
+  }
+
+  #picker-path::placeholder { color: var(--faint); }
+
+  .picker-crumbs {
+    padding: 9px 15px;
+    border-bottom: 1px solid var(--line-soft);
+    color: var(--muted);
+    font: 11px ui-monospace, monospace;
+    word-break: break-all;
+  }
+
+  .picker-crumbs a { color: var(--accent); cursor: pointer; }
+  .picker-crumbs a:hover { text-decoration: underline; }
+
+  .picker-list {
+    flex: 1;
+    min-height: 120px;
+    overflow: auto;
+    padding: 6px 0;
+  }
+
+  .picker-entry {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 15px;
+    border: 0;
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    text-align: left;
+    font-size: 12px;
+  }
+
+  .picker-entry:hover { background: var(--hover); }
+  .picker-name { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .picker-size { color: var(--faint); font-size: 10px; font-variant-numeric: tabular-nums; }
+  .picker-empty { padding: 14px 15px; color: var(--faint); font-size: 12px; }
+
+  .picker-error {
+    padding: 11px 15px;
+    border-top: 1px solid var(--line-soft);
+    color: var(--danger);
+    font-size: 12px;
+  }
+
+  .open-file {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 22px;
+    align-items: center;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: transparent;
+  }
+
+  .open-file.active { border-color: var(--accent); background: var(--accent-dim); }
+
+  .open-file-select {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 6px 7px;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .open-file-select:hover { background: var(--hover); }
+  .open-file-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .open-file.active .open-file-name { color: var(--strong); font-weight: 650; }
   .file-kind { width: 26px; flex: 0 0 26px; color: var(--faint); font: 9px ui-monospace, monospace; }
+  .close-file { width: 22px; height: 26px; border: 0; background: transparent; color: var(--faint); cursor: pointer; }
+  .close-file:hover { color: var(--danger); }
 
   .facet-section {
     padding: 17px 13px;
@@ -513,6 +665,8 @@
 
   dd.skel-dd { display: flex; justify-content: flex-end; }
 
+  .skel-picker-row, .skel-picker-row:hover { background: transparent; cursor: default; }
+
   .hist-skel {
     position: absolute;
     z-index: 2;
@@ -732,6 +886,11 @@
         <span class="brand-label">LOG STUDIO</span>
       </div>
       <div class="facets-inner" id="facets-inner">
+        <section class="facet-section">
+          <h2 class="facet-title">Open files</h2>
+          <div class="open-file-list" id="open-files"></div>
+          <button class="button browse-button" id="browse-open" type="button">Browse files&hellip;</button>
+        </section>
         <section class="facet-section" id="file-overview">
           <h2 class="facet-title">Active file</h2>
           <div class="file-name"><span class="skel-bar" style="width:70%;height:12px"></span></div>
@@ -808,6 +967,22 @@
     </main>
   </div>
 
+  <div class="picker-overlay" id="picker-overlay" hidden>
+    <div class="picker" role="dialog" aria-modal="true" aria-label="Open a file">
+      <div class="picker-head">
+        <h2 class="picker-title">Open a file</h2>
+        <button class="picker-close" id="picker-close" type="button" aria-label="Close">&times;</button>
+      </div>
+      <form class="picker-path-form" id="picker-path-form">
+        <input id="picker-path" type="text" spellcheck="false" autocomplete="off" placeholder="Paste a full path, e.g. C:\logs\app.log or ~/logs/app.log" aria-label="File path" />
+        <button class="button query-submit" type="submit">Open</button>
+      </form>
+      <div class="picker-crumbs" id="picker-crumbs"></div>
+      <div class="picker-list" id="picker-list"></div>
+      <div class="picker-error" id="picker-error" hidden></div>
+    </div>
+  </div>
+
 <script>
   const PAGE_LIMIT = 200;
   const LEVEL_ORDER = ["FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "OTHER"];
@@ -824,6 +999,15 @@
 
   const fileOverview = document.getElementById("file-overview");
   const app = document.querySelector(".app");
+  const openFiles = document.getElementById("open-files");
+  const browseButton = document.getElementById("browse-open");
+  const pickerOverlay = document.getElementById("picker-overlay");
+  const pickerClose = document.getElementById("picker-close");
+  const pickerPathForm = document.getElementById("picker-path-form");
+  const pickerPath = document.getElementById("picker-path");
+  const pickerCrumbs = document.getElementById("picker-crumbs");
+  const pickerList = document.getElementById("picker-list");
+  const pickerError = document.getElementById("picker-error");
   const levelList = document.getElementById("level-list");
   const queryForm = document.getElementById("query-form");
   const queryInput = document.getElementById("query");
@@ -900,12 +1084,28 @@
         </div>`).join("")}</div>`;
   }
 
+  function pickerSkeleton() {
+    const widths = [62, 44, 78, 50, 68];
+    return widths.map((width) => `
+      <div class="picker-entry skel-picker-row">
+        <span class="file-kind">${skelBar("22px", "8px")}</span>
+        <span class="picker-name">${skelBar(`${width}%`)}</span>
+      </div>`).join("");
+  }
+
   function currentState() {
     const rawPage = fused.params.get("page") || "0";
     const target = fused.params.get("_file") || "";
     const file = fused.params.get("file") || target;
+    let opened = [];
+    try {
+      const parsed = JSON.parse(fused.params.get("open") || "[]");
+      if (Array.isArray(parsed)) opened = parsed.filter((value) => typeof value === "string");
+    } catch (_) {}
+    if (file && !opened.some((value) => samePath(value, file))) opened.push(file);
     return {
       file,
+      opened,
       q: fused.params.get("q") || "",
       level: fused.params.get("level") || "",
       levels: (fused.params.get("level") || "").split(",").map((item) => item.trim().toUpperCase()).filter(Boolean),
@@ -1058,6 +1258,104 @@
       min: data.from ?? data.min_time ?? data.first_timestamp ?? range.from ?? range.min ?? "",
       max: data.to ?? data.max_time ?? data.last_timestamp ?? range.to ?? range.max ?? ""
     };
+  }
+
+  function renderOpenFiles(state) {
+    openFiles.innerHTML = state.opened.map((path) => {
+      const active = samePath(path, state.file);
+      const name = basename(path);
+      const dot = name.lastIndexOf(".");
+      const kind = dot > 0 ? name.slice(dot + 1, dot + 5).toUpperCase() : "FILE";
+      return `
+        <div class="open-file ${active ? "active" : ""}" title="${escapeHtml(path)}">
+          <button class="open-file-select" type="button" data-open-file="${escapeHtml(path)}">
+            <span class="file-kind">${escapeHtml(kind)}</span>
+            <span class="open-file-name">${escapeHtml(name)}</span>
+          </button>
+          <button class="close-file" type="button" data-close-file="${escapeHtml(path)}" aria-label="Close ${escapeHtml(name)}">x</button>
+        </div>`;
+    }).join("");
+  }
+
+  function crumbHtml(path) {
+    const parts = String(path).split("/").filter(Boolean);
+    const winRoot = /^[A-Za-z]:$/.test(parts[0] || "");
+    const crumbs = winRoot ? [] : [`<a data-path="/">/</a>`];
+    parts.forEach((part, index) => {
+      const acc = (winRoot ? "" : "/") + parts.slice(0, index + 1).join("/") + (winRoot && !index ? "/" : "");
+      crumbs.push(`<a data-path="${escapeHtml(acc)}">${escapeHtml(part)}</a>`);
+    });
+    return crumbs.join(` <span style="color:var(--faint)">/</span> `);
+  }
+
+  function renderPickerDir(data) {
+    pickerCrumbs.innerHTML = crumbHtml(data.path);
+    const rows = [];
+    if (data.parent && data.parent !== data.path) {
+      rows.push(`<button class="picker-entry" type="button" data-dir="${escapeHtml(data.parent)}"><span class="file-kind">UP</span><span class="picker-name">..</span></button>`);
+    }
+    for (const entry of data.entries) {
+      const attr = entry.is_dir ? "data-dir" : "data-file";
+      rows.push(`
+        <button class="picker-entry" type="button" ${attr}="${escapeHtml(entry.path)}" title="${escapeHtml(entry.path)}">
+          <span class="file-kind">${entry.is_dir ? "DIR" : "FILE"}</span>
+          <span class="picker-name">${escapeHtml(entry.name)}</span>
+          ${entry.is_dir ? "" : `<span class="picker-size">${escapeHtml(formatBytes(entry.size))}</span>`}
+        </button>`);
+    }
+    pickerList.innerHTML = rows.length ? rows.join("") : `<div class="picker-empty">This folder is empty.</div>`;
+  }
+
+  async function loadPickerDir(path) {
+    pickerError.hidden = true;
+    pickerList.innerHTML = pickerSkeleton();
+    try {
+      // src (origin only) lets the reader route a mount-backed dir via
+      // /api/fs/list instead of a kernel scan that could drop the mount.
+      renderPickerDir(await runReader("list", currentState(), { path: path || "",
+        src: `${location.origin}/api/fs/raw?path=${encodeURIComponent(path || "")}` }));
+    } catch (error) {
+      pickerList.innerHTML = "";
+      showPickerError(errorMessage(error));
+    }
+  }
+
+  function openPickedFile(path) {
+    const state = currentState();
+    const opened = state.opened.some((value) => samePath(value, path)) ? state.opened : [...state.opened, path];
+    closePicker();
+    activateFile(path, opened);
+  }
+
+  function showPickerError(message) {
+    pickerError.textContent = message;
+    pickerError.hidden = false;
+  }
+
+  function openPicker() {
+    pickerOverlay.hidden = false;
+    pickerPath.value = "";
+    pickerError.hidden = true;
+    loadPickerDir("");
+    pickerPath.focus();
+  }
+
+  function closePicker() {
+    pickerOverlay.hidden = true;
+  }
+
+  function activateFile(path, opened) {
+    setParams({
+      file: path,
+      open: JSON.stringify(opened),
+      q: "",
+      level: "",
+      from: "",
+      to: "",
+      page: "0",
+      back: "",
+      tail: "0"
+    });
   }
 
   function renderOverview(data, state) {
@@ -1652,13 +1950,14 @@
     const state = currentState();
     if (!state.file) {
       renderState(state);
+      renderOpenFiles(state);
       fileOverview.innerHTML = "";
       levelList.innerHTML = "";
       resultSummary.textContent = "No file open";
       noticeArea.innerHTML = "";
       pager.hidden = true;
       histSkel.hidden = true;
-      results.innerHTML = `<div class="status"><strong>No log file open</strong><span>Open a <code>.log</code> file from the file explorer to view it here.</span></div>`;
+      results.innerHTML = `<div class="status"><strong>No log file open</strong><span>Use "Browse files..." to pick a log.</span></div>`;
       return;
     }
     const nextDataKey = dataKey(state);
@@ -1671,6 +1970,7 @@
     }
     lastTailState = state.tail;
     renderState(state);
+    renderOpenFiles(state);
     if (loadingDataKey === nextDataKey) return;
     if (dataReadyKey === nextDataKey && overviewData && overviewFile === state.file) {
       renderOverview(overviewData, state);
@@ -1728,6 +2028,81 @@
   clearRange.addEventListener("click", () => setParams({ from: "", to: "", page: "0", back: "" }));
 
   railCollapse.addEventListener("click", () => setParams({ facets: currentState().facets ? "0" : "1" }));
+
+  openFiles.addEventListener("click", (event) => {
+    const state = currentState();
+    const close = event.target.closest("[data-close-file]");
+    if (close) {
+      if (state.opened.length <= 1) return;
+      const remaining = state.opened.filter((path) => !samePath(path, close.dataset.closeFile));
+      if (samePath(close.dataset.closeFile, state.file)) activateFile(remaining[remaining.length - 1], remaining);
+      else setParams({ open: JSON.stringify(remaining) });
+      return;
+    }
+    const select = event.target.closest("[data-open-file]");
+    if (select && !samePath(select.dataset.openFile, state.file)) activateFile(select.dataset.openFile, state.opened);
+  });
+
+  browseButton.addEventListener("click", openPicker);
+  pickerClose.addEventListener("click", closePicker);
+  pickerOverlay.addEventListener("mousedown", (event) => {
+    if (event.target === pickerOverlay) closePicker();
+  });
+
+  pickerCrumbs.addEventListener("click", (event) => {
+    const crumb = event.target.closest("[data-path]");
+    if (crumb) loadPickerDir(crumb.dataset.path);
+  });
+
+  pickerList.addEventListener("click", (event) => {
+    const dir = event.target.closest("[data-dir]");
+    if (dir) {
+      loadPickerDir(dir.dataset.dir);
+      return;
+    }
+    const file = event.target.closest("[data-file]");
+    if (file) openPickedFile(file.dataset.file);
+  });
+
+  pickerPathForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const value = pickerPath.value.trim();
+    if (!value) return;
+    pickerError.hidden = true;
+    try {
+      const info = await runReader("resolve", currentState(), { path: value });
+      if (!info.exists) {
+        showPickerError(`No such file or folder: ${info.path}`);
+        return;
+      }
+      if (info.is_dir) {
+        pickerPath.value = "";
+        loadPickerDir(info.path);
+        return;
+      }
+      openPickedFile(info.path);
+    } catch (error) {
+      showPickerError(errorMessage(error));
+    }
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !pickerOverlay.hidden) closePicker();
+  });
+
+  tailToggle.addEventListener("click", () => {
+    const state = currentState();
+    const size = overviewData && (overviewData.size ?? overviewData.file_size ?? overviewData.bytes);
+    if (!state.tail) {
+      tailEndOffset = number(size);
+      tailPageOffset = Math.max(0, tailEndOffset - 65536);
+    }
+    setParams({ page: tailPageOffset, back: "", tail: state.tail ? "0" : "1" });
+  });
+
+  linesTab.addEventListener("click", () => setParams({ view: "lines", page: "0", back: "" }));
+  patternsTab.addEventListener("click", () => setParams({ view: "patterns", page: "0", back: "", tail: "0" }));
+
   // runtime.js owns `data-theme` now (the `data-fused-theme` opt-in above), so
   // nothing here resolves or applies a theme. The charts still have to know:
   // they read the palette through getComputedStyle at DRAW time, so a theme

--- a/tests/test_template_listing_mount.py
+++ b/tests/test_template_listing_mount.py
@@ -11,11 +11,6 @@ These tests stand up a threaded localhost HTTP server for /api/fs/stat +
 while the fake server reports it as a remote directory. Any accidental kernel
 fallback would fail to find the path (empty/NotADirectory) instead of returning
 the HTTP-served entries — so a silent-fallback regression fails loudly.
-
-log_studio is deliberately absent: its Browse-files picker (the only thing that
-listed directories from that template) was removed, and its reader's `list`/
-`resolve` ops went with it. If a directory listing ever returns to that reader,
-it must come back mount-routed and regain a case here.
 """
 import json
 import threading
@@ -24,6 +19,7 @@ from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
+from fused_render.templates.log_studio import reader as log_studio
 from fused_render.templates.map import discover as map_discover
 from fused_render.templates.photos import reader as photos
 from fused_render.templates.excel import reader as excel
@@ -189,6 +185,13 @@ def test_photos_list_dir_routes_remote(fs):
     assert res["ok"] is True
     assert [i["name"] for i in res["items"]] == ["p.jpg"]
     assert [d["name"] for d in res["subdirs"]] == ["sub"]
+
+
+def test_log_studio_listdir_routes_remote(fs):
+    s = fs([_ent("sub", is_dir=True), _ent("app.log", size=10), _ent(".hidden")])
+    res = log_studio._listdir("", REMOTE_DIR, src=s.src)
+    assert [(e["name"], e["is_dir"]) for e in res["entries"]] == [
+        ("sub", True), ("app.log", False)]
 
 
 def test_reader_unreachable_falls_back_to_kernel_local(tmp_path):


### PR DESCRIPTION
## What

Brings the Browse-files UI from the `examples/log_studio` app back into the built-in `log_studio` template, and fixes controls that #283 accidentally killed.

- **Browse-files picker + Open-files rail restored.** #283 removed them in favor of opening logs from the app's file explorer, but with no `file` in the URL the template should offer browsing on its own. The reader regains its mount-safe `list`/`resolve` ops, with the mount routing intact: remote dirs go through `/api/fs/stat` + paginated `/api/fs/list`, never a kernel scan.
- **Dead controls fixed.** #283's removal hunk also swept away the `tailToggle`, `linesTab`, and `patternsTab` click handlers, so at HEAD the Tail button and the Lines/Patterns tabs did nothing. The restored listener block fixes both.
- **Everything #283 improved stays.** Shell-owned theming (the template's own default is the dark palette; light applies only when the app's appearance setting asks), structured-detail field table, tail DOM reconciliation, `facetLevels`, skeleton UI, and the global `[hidden]` fix — the picker's old per-element `[hidden]` rules are not re-added.
- The picker's two remaining colour literals (overlay scrim, dialog shadow) are tokenised into both palettes so the tier-one theme test keeps passing.
- `test_template_listing_mount.py` regains the log_studio case its docstring reserved for exactly this return.

## Testing

- `test_template_listing_mount.py`, `test_log_studio_detail.py`, `test_theme.py`, `test_calls.py` pass (the pre-existing Windows-only failures at HEAD are unchanged).
- Manual smoke test via `/view` on Windows: the no-file default shows the Browse card, the picker lists local dirs, the path form resolves and opens a real log (346 lines), the Open-files rail renders, the Patterns tab and Tail toggle work, and there are no console errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch mount-routed directory listing on remote storage; incorrect kernel fallback could drop NFS mounts, though the pattern matches other templates and is covered by mount-safety tests.
> 
> **Overview**
> **Log Studio** works again without an external file explorer: the sidebar **Open files** list and **Browse files…** modal are back, with multi-tab paths tracked in the `open` URL param.
> 
> The reader again exposes **`list`** and **`resolve`**. Remote directories are listed only through **`/api/fs/stat`** and paginated **`/api/fs/list`** (via a `src` origin from the UI)—not kernel `scandir`, so rclone NFS mounts are not wedged by full-prefix enumeration. Local dirs still use `os.scandir`.
> 
> **Tail**, **Lines**, and **Patterns** controls get their click listeners restored so tailing and view switching work. Picker overlay colours use **`--scrim`** and **`--picker-shadow`** in both themes. **`test_log_studio_listdir_routes_remote`** is added to the mount-listing test suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a3de9520e7fc46bc4f160876045f37339eb0d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->