### PR TITLE
Bundle the AI proxy and manage AI accounts from Preferences

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1213,6 +1213,28 @@ never imports server).
   exchanged it and a failed exchange is only visible afterwards. One login at a time (the
   callback ports are fixed, so this is structural, not a policy); an in-flight attempt is
   cancellable, and an attempt started elsewhere is reported rather than silently blocking.
+  A **settled** attempt is neither: it stays readable through the status route so its
+  outcome isn't lost, but it must not read as in-flight — doing so left every Connect
+  button disabled after the first login, making the second provider unconnectable.
+  **Both providers can be connected at once**; they are independent credentials.
+- **PF-13** A provider can equally be authenticated with an **API key**, pasted in the same
+  tab. Keys are config-level credentials, not files in the proxy's auth dir, so they are
+  listed and removed separately from OAuth accounts (a key has no session to expire and no
+  browser to reconnect through). A full key **never leaves the server**: responses carry
+  only a short masked hint, and every mutation is keyed on the server-assigned
+  `auth_index`, so a key never appears in a URL, a log, or shell history. Writes are
+  **read back and verified** rather than trusted — the proxy accepts a Codex key with no
+  `base-url` and then silently discards it, so a write that doesn't survive the re-read is
+  reported as a failure instead of a phantom success.
+- **PF-14** How multiple credentials for one provider are used is a **visible setting**,
+  written explicitly into the proxy's config rather than inherited by omission:
+  `round-robin` (the upstream default) pools OAuth logins and API keys as **peers** and
+  rotates across them with failover on rate limits; `fill-first` drains one before moving
+  to the next, which is what "prefer this credential, fall back to that one" actually
+  requires. Note there is no built-in OAuth-over-key precedence to inherit — the upstream
+  treats them as equals — hence exposing the choice rather than asserting one. The proxy
+  reads config only at spawn, so changing this **restarts** it (respawning lazily on next
+  use).
 
 ### 20.6 Template registry view
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -144,9 +144,13 @@ const { text, model, usage } = await fused.ai(prompt, {
   `fused.env === "local"` and degrading gracefully when `"hosted"`. Both runtimes expose
   it, so the check is a positive signal, not the absence of an API.
 - **RH-11** `fused.ai(prompt, opts?)` asks an AI model through the shell: the server's
-  `/api/ai` relays to a **local OpenAI-compatible proxy** (`/v1/chat/completions`) at a
-  base URL from the `ai_base_url` preference (`FUSED_RENDER_AI_BASE_URL` overrides;
-  default `http://127.0.0.1:8317`). Resolves with `{ text, model, usage }`; rejects with
+  `/api/ai` relays to a **local OpenAI-compatible proxy** (`/v1/chat/completions`).
+  The proxy is **bundled with the app** and supervised by it (RH-12) — a page can call
+  `fused.ai` with no install step, once an account is connected in Preferences (§20.7).
+  An explicitly configured `ai_base_url` preference (or `FUSED_RENDER_AI_BASE_URL`)
+  instead points the relay at a proxy the user runs themselves, in which case the shell
+  supervises nothing; so does a build with no bundled binary, which falls back to the
+  pref's default `http://127.0.0.1:8317`. Resolves with `{ text, model, usage }`; rejects with
   a structured error carrying `.type` — `"bad_request"` (empty prompt / bad options),
   `"ai_unavailable"` (proxy unreachable — the message names the base URL), or
   `"ai_error"` (proxy returned non-200 or an unexpected shape). `opts.effort`
@@ -155,6 +159,17 @@ const { text, model, usage } = await fused.ai(prompt, {
   channel (an AI call is never a slider scrub). No streaming (MVP). **Local-only**:
   the proxy lives on the author's machine, so the exporter rejects a page that calls
   it (§18.2) — gate with `fused.env === "local"` instead.
+- **RH-12** The AI proxy (**CLIProxyAPI**, MIT, a single static Go binary) is **bundled
+  in the app payload** next to `rclone` and supervised by `shell/ai_proxy.py`, which
+  mirrors the rclone-daemon lifecycle (RC-\*): the binary resolves via
+  `FUSED_RENDER_AI_PROXY_BIN` → the packaged bundle path → `PATH`; an instance is spawned
+  **lazily on first use** (never at launch) on an ephemeral loopback port, health-polled,
+  and torn down on quit, only ever signalling a pid proven to be ours. It is configured
+  bound to `127.0.0.1` with two generated per-launch secrets — one gating the
+  OpenAI-compatible surface the relay uses, a second gating account management — because
+  loopback is not a boundary against the browser. Config and state files holding those
+  secrets are written `0600`. Bundling deliberately does **not** remove the one-time OAuth
+  step: the user still signs in to their own provider subscription (§20.7).
 
 ### 4.2 `runPython(path, params)`
 
@@ -654,7 +669,9 @@ nothing. Full detail: `docs/EXPORT.md`.
   assets), and `params` (pure client-side URL state, unchanged). `writeFile`, `stat`,
   and SSE live-reload are **unsupported** — a hosted artifact is immutable and has no
   filesystem behind it. `fused.ai` (RH-11) is also **unsupported**: it relays to a
-  proxy on the author's own machine, which a hosted page cannot reach.
+  proxy on the author's own machine — bundled with their app and holding their own
+  provider logins (RH-12) — which a hosted page can neither reach nor borrow
+  credentials from.
 
 ### 18.3 Static resolution & fail-loud
 
@@ -1167,15 +1184,35 @@ never imports server).
 
 ### 20.5 Tabs (D125)
 
-- **PF-9** The page is split into two tabs, active tab in the URL
-  (`?tab=account`, default clean-URL tab is **Render preferences** —
-  Logs/Execution engine/Deploy to Fused account/Tour, unchanged): **Render preferences**
-  and **Fused account** (§27's account panel, folded in here since it stopped
-  being its own sidebar-footer entry). The **Fused account** tab button is
-  offered only while the PF-8 Deploy toggle is on; requesting `?tab=account`
+- **PF-9** The page is split into tabs, active tab in the URL
+  (`?tab=account`, `?tab=ai`; default clean-URL tab is **Render preferences** —
+  Logs/Execution engine/Deploy to Fused account/Tour, unchanged): **Render preferences**,
+  **Fused account** (§27's account panel, folded in here since it stopped
+  being its own sidebar-footer entry), and **AI accounts** (§20.7). The **Fused account**
+  tab button is offered only while the PF-8 Deploy toggle is on; requesting `?tab=account`
   while it's off falls back to Render preferences rather than showing a tab
   with nothing pointing at it. This is also where the sidebar footer's
-  signed-in dot now points — see AC-1.
+  signed-in dot now points — see AC-1. **AI accounts** is offered unconditionally: no
+  pref gates it, and a user with nothing connected yet is exactly its audience.
+
+### 20.7 AI accounts (RH-12)
+
+- **PF-10** The **AI accounts** tab connects the provider logins that back `fused.ai`
+  (RH-11), served by `/api/ai/accounts` (`ai_accounts.py`). It lists each connected
+  account's provider and sign-in identity, offers **Connect** per provider and
+  **Disconnect** per account (confirmed, matching the Fused-account Forget flow), and
+  reports whether the bundled proxy is currently supervised and running.
+- **PF-11** Scope is **Claude and ChatGPT only**, though the bundled proxy also speaks
+  Gemini, Kimi, xAI and Antigravity: these are the two subscriptions users most often
+  already hold, and each further provider is another OAuth flow to verify.
+- **PF-12** Connecting is an **external browser round-trip the frontend owns** — the
+  server returns an authorization URL and never opens a browser itself (the AC-\* rule for
+  Fused sign-in, applied unchanged). The shell binds the provider's fixed loopback
+  callback port for the duration of one login, so the user never copies a code by hand;
+  the page then **polls** for the outcome, because the proxy accepts a code before it has
+  exchanged it and a failed exchange is only visible afterwards. One login at a time (the
+  callback ports are fixed, so this is structural, not a policy); an in-flight attempt is
+  cancellable, and an attempt started elsewhere is reported rather than silently blocking.
 
 ### 20.6 Template registry view
 

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -38,11 +38,17 @@ builds) → the macOS bundle path under `Contents/Resources/bin/` when
 `sys.frozen == "macosx_app"` → `shutil.which`. The PATH tier is what keeps an
 existing user-run install working untouched.
 
-**Lifecycle** — `ensure_ai_proxy()` spawns lazily on the first `fused.ai()` call
-rather than at app launch: AI calls are occasional, and an idle 20 MB Go process
-in every session is rent we don't need to pay. Under a `threading.Lock` like
-`_rcd_lock`, since the relay is async and two concurrent calls would otherwise
-both spawn. It generates a config under the app state dir with:
+**Lifecycle** — `ensure_ai_proxy()` spawns lazily on **first use**, not at app
+launch: AI calls are occasional, and an idle 20 MB Go process in every session is
+rent we don't need to pay. "First use" is any caller that needs the proxy — a
+`fused.ai()` relay, *or* a management call from the accounts UI (`connect`, an
+add-a-key write). Opening the accounts tab therefore does not require a running
+proxy: the listing is deliberately non-spawning (it reports `running: false` and
+an empty list rather than paying a ~15s startup to draw a page), while the first
+action that genuinely needs the management API brings it up. Under a
+`threading.Lock` like `_rcd_lock`, since the relay is async and two concurrent
+calls would otherwise both spawn. It generates a config under the app state dir
+with:
 
 - an ephemeral port we pick ourselves (bind-0 then close, as `ensure_rcd` does)
 - `host: "127.0.0.1"` — loopback only, never the upstream default of all interfaces
@@ -51,10 +57,26 @@ both spawn. It generates a config under the app state dir with:
 - `auth-dir` under the app state dir, holding the OAuth tokens
 - `disable-control-panel: true` — we drive the API ourselves and don't want it fetching a web panel from GitHub
 
-Then health-polls `/v1/models` to a deadline before reporting ready, writes
+Then health-polls `/v1/models` **with that generated `api-keys` bearer token** —
+the config above makes `/v1/*` authenticated, so an unauthenticated poll would
+401 forever and every spawn would fail its deadline — writes
 `{port, pid, spawner_pid, keys, log}` to a state file, and rotates its log.
+
+A spawn that never passes the health check is **killed before giving up**: no
+state file has been written at that point, so a survivor could never be
+identified or reaped, and each retry would spawn another beside it (worse under
+the dev persist flag, where `setsid` has already detached it). Likewise, a
+*recorded* instance that stops answering while its pid is still alive is killed
+before we overwrite the config and state that describe it — otherwise it keeps
+running, unreachable and unprovable as ours. An unconfirmable stale pid (a
+recycled pid on an unrelated process) is left alone and logged rather than
+blocking the respawn.
+
 Teardown reuses the `stop_local_rcd()` shape: SIGTERM→SIGKILL, refuse to signal
-a pid not confirmed ours, respect a spawner that is still alive.
+a pid not confirmed ours, respect a spawner that is still alive. Ownership is
+provable two ways — the recorded port answering with the recorded key, or the
+pid's command line naming our own config path — so a *hung* (non-answering)
+instance is still confirmably ours via the second.
 
 **Relay change** — `server.py:_ai_relay` currently posts to
 `ai_base_url()/v1/chat/completions` with no credentials. It gains: call
@@ -91,7 +113,13 @@ callback ports (`54545` for Claude, `1455` for Codex) are unoccupied — so the 
 binds one for the duration of a login and reads the `code` straight out of the
 browser redirect. No copy-paste, no CLI subcommand.
 
-1. `POST …/connect {provider}` → we call `<provider>-auth-url`, get `{state, url}`
+1. `POST …/connect {provider}` → we call `<auth_provider>-auth-url`, get
+   `{state, url}`. **Note the slug swap**: the UI/listing provider is `claude`,
+   but the route is `anthropic-auth-url` — the upstream uses two different names
+   for the same product (`claude` in the credential listing, `anthropic` in the
+   route table), so building the path from the listing slug yields a 404.
+   `ai_accounts._CALLBACK` maps `claude → anthropic` (and `codex → codex`) and is
+   the single place that seam is bridged.
 2. we bind the provider's callback port (loopback only) with a one-shot handler
 3. we return `url` to the frontend, which opens it — **the browser is always the
    client's job**; the backend only ever returns a URL string, matching how
@@ -107,6 +135,14 @@ goroutine — so its status proves nothing. `get-auth-status` reports
 `wait`/`ok`/`error` with a real message ("Failed to exchange authorization code
 for tokens"), which means a failed login can be reported as a failure instead of
 being inferred from a timeout.
+
+That earlier draft's "watch `auth-files` grow an entry" test was not merely
+weaker — it was **wrong for re-authentication**. Credentials are named
+`<provider>-<email>.json`, so signing the same account in again *updates* the
+existing file instead of adding one; a count-based check would have waited out
+its timeout and reported a successful re-login as a failure. `get-auth-status`
+keys on the login's own `state`, so it is indifferent to whether the credential
+was created or refreshed.
 
 Failure modes the UI names rather than hangs on: callback port already held (a
 concurrent login, or the user's own proxy mid-login), user abandons the browser

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -92,20 +92,33 @@ binds one for the duration of a login and reads the `code` straight out of the
 browser redirect. No copy-paste, no CLI subcommand.
 
 1. `POST …/connect {provider}` → we call `<provider>-auth-url`, get `{state, url}`
-2. we bind the provider's callback port with a tiny one-shot handler
-3. we hand `url` back to the frontend, which opens it in the user's browser
-4. the user approves; the browser hits our handler; we capture `code` and serve a "return to FusedRender" page
-5. we `POST oauth-callback {state, code}`
-6. **we poll `auth-files` for a new entry** — because `oauth-callback` answers 200 even for a bogus code, so its status proves nothing
+2. we bind the provider's callback port (loopback only) with a one-shot handler
+3. we return `url` to the frontend, which opens it — **the browser is always the
+   client's job**; the backend only ever returns a URL string, matching how
+   `account.py` handles Fused sign-in
+4. the user approves; the browser hits our handler; we capture `code` and serve a
+   short "return to FusedRender" page
+5. we `POST oauth-callback {provider, state, code}`
+6. we poll `GET get-auth-status?state=` until `ok` or `error`
 
-Step 6 is the part that must not be shortcut. Success is a credential appearing;
-anything else within the timeout is a failure the UI reports.
+Step 6 is the part an earlier draft got wrong. `oauth-callback` answers 200 even
+for a bogus code — it only records the code, and the exchange happens in a
+goroutine — so its status proves nothing. `get-auth-status` reports
+`wait`/`ok`/`error` with a real message ("Failed to exchange authorization code
+for tokens"), which means a failed login can be reported as a failure instead of
+being inferred from a timeout.
 
-Failure modes the UI has to name rather than hang on: callback port already held
-(a concurrent login, or the user's own proxy mid-login), user abandons the browser
-(timeout, release the port), token exchange rejected (no credential appears).
-Only one login may be in flight at a time — the fixed ports make that structural,
-so the endpoint should reject a second concurrent attempt outright.
+Failure modes the UI names rather than hangs on: callback port already held (a
+concurrent login, or the user's own proxy mid-login), user abandons the browser
+(timeout; release the port and `DELETE oauth-session`), exchange rejected
+(`get-auth-status` says so). Only one login at a time — the fixed ports make that
+structural, so a second concurrent attempt is rejected outright rather than
+queued. Cancellation is a real operation, not just closing the tab, since the
+proxy holds pending state for 30 minutes.
+
+Because the whole surface is poll-only (no SSE/websocket), the frontend follows
+the existing `useFusedLogin` cadence in `lib/account.ts`: open the URL, poll every
+couple of seconds, and offer Cancel while waiting.
 
 ## Preferences UI
 

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -165,9 +165,19 @@ carries numpy/pandas/pyarrow.
 
 macOS notarization needs no new work: the signing loop enumerates every nested
 Mach-O by magic bytes and signs each with the hardened runtime, so a new binary
-under `Contents/Resources/bin/` is picked up automatically. Worth an explicit
-check that a Go binary accepts the existing entitlements, since Go binaries have
-historically needed care with hardened runtime.
+under `Contents/Resources/bin/` is picked up automatically. Still worth
+confirming on the first signed build that a Go binary is happy with the existing
+entitlements — Go binaries have historically needed care under hardened runtime.
+
+Windows needs no `installer.iss` change: the whole `python\` tree is staged by a
+recursive wildcard, which is already how `rclone.exe` arrives.
+
+Known gap, deliberately not closed here: `ActivatePayload`'s "payload is
+incomplete" check (`installer.iss:247-255`) verifies `python.exe`, `uv.exe`,
+`win32job.pyd` and friends but **not** `rclone.exe`, and so not
+`cli-proxy-api.exe` either. A truncated build would therefore install and only
+fail later, at the point of use. Widening that check is worth doing for both
+binaries at once rather than adding ours alone, so it belongs in its own change.
 
 ## Open questions
 

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -122,11 +122,27 @@ couple of seconds, and offer Cancel while waiting.
 
 ## Preferences UI
 
-A new **"AI accounts"** section following the house idiom exactly — a
-`<section className="prefs-section">` with an `<h2>`, a `.deploy-muted` explainer,
-per-section `busy`/`error` state, and an `ErrorBanner` (`Preferences.tsx`). It
-lists connected accounts with provider and email, a Connect button per provider,
-and Disconnect per account behind a `window.confirm` like Account.tsx's Forget.
+Follows the house idiom exactly — `<section className="prefs-section">` with an
+`<h2>`, a `.deploy-muted` explainer, per-control `busy`/`error` state, and
+`ErrorBanner` on failure. There is no shared Section/Row/Toggle component
+library: every section in `Preferences.tsx` is a bespoke function component
+sharing only CSS classes, so a new one matches by following that shape rather
+than by importing anything. Styles are plain global CSS in `frontend/src/shell.css`
+(prefs classes from ~:3594) — no CSS modules, no Tailwind.
+
+The connect flow reuses an existing hook rather than inventing one: `lib/account.ts`'s
+`useFusedLogin` is already exactly this shape (begin → `window.open` the URL →
+poll every 2s → surface "waiting for the browser" with a Cancel, and reconcile a
+completion that races the cancel). The AI version is that pattern pointed at our
+routes. `views/Account.tsx`'s environments table is the model for the account list
+with a per-row destructive action, including the `window.confirm` before removal.
+
+Note `PUT /api/prefs` returns the **whole fresh `Prefs`** and each control bubbles
+it up via `onChange`, so there is no client-side merge; and every mutating call
+must send `X-Fused: 1` or the server 403s (`mutateJson` in `lib/api.ts` does this).
+Since accounts are an external OAuth surface rather than a simple stored toggle,
+they get their own router module in the shape of `account.py` instead of new keys
+on `/api/prefs` — `prefs.py`'s `ai_base_url()` stays the read-only plumbing it is.
 
 Scope is **Claude and ChatGPT only** for now, though the proxy also speaks Gemini,
 Kimi, xAI and Antigravity — the two that matter are the two most users already

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -1,0 +1,154 @@
+# Bundling the AI proxy + managing AI accounts — design
+
+Follows on from `fused.ai()` (SPEC RH-11), which relays to an OpenAI-compatible
+proxy the **user** installs and runs. That leaves the feature inert until someone
+has independently found CLIProxyAPI, installed it, run a login per provider, and
+kept it running. This design ships the proxy inside the app, supervises it, and
+turns "connect a Claude or ChatGPT account" into a button in Preferences.
+
+The wire contract we build against is in
+[`AI_PROXY_MANAGEMENT_API.md`](AI_PROXY_MANAGEMENT_API.md) — established by
+probing a real v7.2.90 binary, because upstream publishes no doc for it.
+
+## Why this is a small change
+
+CLIProxyAPI is a single static Go binary under MIT — the same shape as **rclone**,
+which this repo already bundles for mounts. So nearly every piece has an in-repo
+precedent to copy rather than invent:
+
+| Need | Existing precedent |
+|---|---|
+| Download + checksum-verify a pinned binary at build time | `scripts/build_dmg.sh:146-184` |
+| Stage it into the .app and smoke-test it | `scripts/build_dmg.sh:449-498` |
+| Same for Linux / Windows payloads | `scripts/build_linux_appimage.sh:90-146`, `supervisor/paths.py:217-222` |
+| Resolve binary at runtime (env → bundled → PATH) | `shell/mounts.py:956-978` `rclone_bin()` |
+| Spawn a local daemon on a random port, auth it, health-poll, persist state | `shell/mounts.py:1038-1108` `ensure_rcd()` |
+| Tear it down killing only a pid proven to be ours | `shell/mounts.py:1117-1199` |
+| Sign a bundled Mach-O for notarization | `scripts/build_dmg.sh:599-620` (enumerates every nested Mach-O) |
+| A Preferences section | `frontend/src/views/Preferences.tsx` `prefs-section` idiom |
+| Listing external connected things with a destructive action | `frontend/src/views/Account.tsx` environments + Revoke |
+
+## Runtime: `fused_render/shell/ai_proxy.py`
+
+A new module mirroring the rcd half of `shell/mounts.py`.
+
+**Binary resolution** — `ai_proxy_bin()`, three tiers exactly like `rclone_bin()`:
+`FUSED_RENDER_AI_PROXY_BIN` (set by the supervisor in packaged Windows/Linux
+builds) → the macOS bundle path under `Contents/Resources/bin/` when
+`sys.frozen == "macosx_app"` → `shutil.which`. The PATH tier is what keeps an
+existing user-run install working untouched.
+
+**Lifecycle** — `ensure_ai_proxy()` spawns lazily on the first `fused.ai()` call
+rather than at app launch: AI calls are occasional, and an idle 20 MB Go process
+in every session is rent we don't need to pay. Under a `threading.Lock` like
+`_rcd_lock`, since the relay is async and two concurrent calls would otherwise
+both spawn. It generates a config under the app state dir with:
+
+- an ephemeral port we pick ourselves (bind-0 then close, as `ensure_rcd` does)
+- `host: "127.0.0.1"` — loopback only, never the upstream default of all interfaces
+- one random `api-keys` entry, so the relay authenticates and nothing else local can drive it
+- a random `remote-management.secret-key` with `allow-remote: false`
+- `auth-dir` under the app state dir, holding the OAuth tokens
+- `disable-control-panel: true` — we drive the API ourselves and don't want it fetching a web panel from GitHub
+
+Then health-polls `/v1/models` to a deadline before reporting ready, writes
+`{port, pid, spawner_pid, keys, log}` to a state file, and rotates its log.
+Teardown reuses the `stop_local_rcd()` shape: SIGTERM→SIGKILL, refuse to signal
+a pid not confirmed ours, respect a spawner that is still alive.
+
+**Relay change** — `server.py:_ai_relay` currently posts to
+`ai_base_url()/v1/chat/completions` with no credentials. It gains: call
+`ensure_ai_proxy()` first, and send `Authorization: Bearer <generated key>`. The
+`fused.ai()` JS surface and its error `type`s do not change, so RH-11's authored
+contract is untouched. When `ai_base_url` is overridden to a user's own proxy we
+skip supervision entirely and behave exactly as today.
+
+**Config precedence**, most specific first: an explicit `FUSED_RENDER_AI_BASE_URL`
+or `ai_base_url` pref means "the user is pointing us somewhere deliberate" — use
+it, supervise nothing. Otherwise use the bundled proxy. A build with no bundled
+binary and no override falls back to probing the default port, so a dev checkout
+against a homebrew install keeps working.
+
+## Accounts: `/api/ai/accounts`
+
+Three shell routes, mutations behind the existing `_require_fused` header guard
+(`prefs.py:54`) so a previewed page can never touch credentials:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/ai/accounts` | List connected accounts + proxy status |
+| `POST /api/ai/accounts/connect` | Begin a login; returns the authorization URL |
+| `DELETE /api/ai/accounts/{name}` | Disconnect one account |
+
+`GET` maps the proxy's `auth-files` listing down to what the UI needs —
+`{provider, email, disabled, expired}` — filtered to `claude` and `codex`, plus
+whether the proxy is running at all. It must never return token material.
+
+### The login flow
+
+The probe established that OAuth is fully drivable over HTTP, and that the fixed
+callback ports (`54545` for Claude, `1455` for Codex) are unoccupied — so the app
+binds one for the duration of a login and reads the `code` straight out of the
+browser redirect. No copy-paste, no CLI subcommand.
+
+1. `POST …/connect {provider}` → we call `<provider>-auth-url`, get `{state, url}`
+2. we bind the provider's callback port with a tiny one-shot handler
+3. we hand `url` back to the frontend, which opens it in the user's browser
+4. the user approves; the browser hits our handler; we capture `code` and serve a "return to FusedRender" page
+5. we `POST oauth-callback {state, code}`
+6. **we poll `auth-files` for a new entry** — because `oauth-callback` answers 200 even for a bogus code, so its status proves nothing
+
+Step 6 is the part that must not be shortcut. Success is a credential appearing;
+anything else within the timeout is a failure the UI reports.
+
+Failure modes the UI has to name rather than hang on: callback port already held
+(a concurrent login, or the user's own proxy mid-login), user abandons the browser
+(timeout, release the port), token exchange rejected (no credential appears).
+Only one login may be in flight at a time — the fixed ports make that structural,
+so the endpoint should reject a second concurrent attempt outright.
+
+## Preferences UI
+
+A new **"AI accounts"** section following the house idiom exactly — a
+`<section className="prefs-section">` with an `<h2>`, a `.deploy-muted` explainer,
+per-section `busy`/`error` state, and an `ErrorBanner` (`Preferences.tsx`). It
+lists connected accounts with provider and email, a Connect button per provider,
+and Disconnect per account behind a `window.confirm` like Account.tsx's Forget.
+
+Scope is **Claude and ChatGPT only** for now, though the proxy also speaks Gemini,
+Kimi, xAI and Antigravity — the two that matter are the two most users already
+subscribe to, and each provider added is another OAuth flow to verify.
+
+Whether this lives as a section in the render tab or its own tab depends on
+whether it should appear before any account is connected; a section is the
+smaller change and is the starting assumption.
+
+## Build
+
+Per platform: pin a version, download the release archive, verify against the
+published `checksums.txt`, extract, stage next to `rclone`, and smoke-test the
+staged binary (`--help`) before it ships — the rclone step's fail-loud discipline.
+Assets are ~19–21 MB per platform, immaterial against a bundle that already
+carries numpy/pandas/pyarrow.
+
+macOS notarization needs no new work: the signing loop enumerates every nested
+Mach-O by magic bytes and signs each with the hardened runtime, so a new binary
+under `Contents/Resources/bin/` is picked up automatically. Worth an explicit
+check that a Go binary accepts the existing entitlements, since Go binaries have
+historically needed care with hardened runtime.
+
+## Open questions
+
+- **Terms of service.** CLIProxyAPI authenticates as a CLI client against Claude /
+  ChatGPT using subscription OAuth, not sanctioned API keys. A user choosing to run
+  that themselves is one risk posture; an app shipping it bundled and inviting the
+  user to log in is a different and larger one. This is a judgement call for the
+  project owner, not an engineering task, and it gates the whole branch.
+- **Version pinning vs. drift.** The management surface is undocumented upstream
+  and was verified against exactly one build. Pin hard, and degrade gracefully:
+  an unexpected 404 should read as "this proxy build can't manage accounts from
+  the app", not a crash.
+- **Reusing an existing auth dir.** A user with a homebrew install already has
+  authed accounts in `~/.cli-proxy-api`. Pointing at it would inherit their logins
+  for free but also let the app mutate a directory it doesn't own. Defaulting to
+  our own state dir is the safer starting position.

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -120,6 +120,18 @@ Because the whole surface is poll-only (no SSE/websocket), the frontend follows
 the existing `useFusedLogin` cadence in `lib/account.ts`: open the URL, poll every
 couple of seconds, and offer Cancel while waiting.
 
+One deliberate asymmetry with `account.py`: `/connect/cancel` clears the tracked
+attempt unconditionally, including one that settled a moment earlier, so
+`/connect/status` afterwards reports `idle` rather than what actually happened.
+It is therefore useless as a post-cancel reconciliation read — unlike
+`getAccountStatus`, which can still answer "did it finish?". Verified that this
+only forgets the *outcome*: a credential written in the race window survives
+untouched, so **the account listing is the reconciliation source of truth after a
+cancel**, and that is what the frontend re-reads. Keeping cancel unconditional is
+the simpler contract (it always means "stop tracking this"), and the listing
+answers the only question that matters afterwards — is there a new account or
+not.
+
 ## Preferences UI
 
 Follows the house idiom exactly — `<section className="prefs-section">` with an

--- a/docs/AI_PROXY_BUNDLING.md
+++ b/docs/AI_PROXY_BUNDLING.md
@@ -119,9 +119,12 @@ Scope is **Claude and ChatGPT only** for now, though the proxy also speaks Gemin
 Kimi, xAI and Antigravity — the two that matter are the two most users already
 subscribe to, and each provider added is another OAuth flow to verify.
 
-Whether this lives as a section in the render tab or its own tab depends on
-whether it should appear before any account is connected; a section is the
-smaller change and is the starting assumption.
+**Placement: its own tab** (decided), a third beside "Render preferences" and
+"Fused account", following how `AccountPanel` occupies a whole tab. Accounts need
+more room than a settings row: per-account provider, email, expiry and disabled
+state, plus a login that involves an external browser round-trip. Unlike the
+Fused account tab, this one is always offered — there is no enabling pref to gate
+it on, and a user with no accounts yet is exactly who the tab is for.
 
 ## Build
 
@@ -139,11 +142,15 @@ historically needed care with hardened runtime.
 
 ## Open questions
 
-- **Terms of service.** CLIProxyAPI authenticates as a CLI client against Claude /
-  ChatGPT using subscription OAuth, not sanctioned API keys. A user choosing to run
-  that themselves is one risk posture; an app shipping it bundled and inviting the
-  user to log in is a different and larger one. This is a judgement call for the
-  project owner, not an engineering task, and it gates the whole branch.
+- **Terms of service — known and accepted (2026-07-28).** CLIProxyAPI
+  authenticates as a CLI client against Claude / ChatGPT using subscription
+  OAuth, not sanctioned API keys, and the proxy even carries a "cloak" feature
+  that disguises requests as Claude Code. Shipping that bundled, with a button
+  inviting the user to log in, is plausibly contrary to those providers' terms —
+  a materially larger exposure than a user independently choosing to run the same
+  tool. The owner reviewed this and chose to proceed; it is recorded here so it
+  is not later rediscovered as an oversight. Revisit before any public launch or
+  distribution beyond current users.
 - **Version pinning vs. drift.** The management surface is undocumented upstream
   and was verified against exactly one build. Pin hard, and degrade gracefully:
   an unexpected 404 should read as "this proxy build can't manage accounts from

--- a/docs/AI_PROXY_MANAGEMENT_API.md
+++ b/docs/AI_PROXY_MANAGEMENT_API.md
@@ -141,6 +141,34 @@ Requested scopes, for the record: Claude asks for `user:profile user:inference
 user:sessions:claude_code …`; Codex asks for `openid email profile
 offline_access`.
 
+## API keys (config-level credentials)
+
+Separate from OAuth credentials: an API key is a *config* entry, not a file in
+`auth-dir`, and it does **not** appear in `auth-files`. Each provider has its own
+route, verified on the pinned build:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/v0/management/claude-api-key` | List Claude API keys → `{"claude-api-key":[…]}` |
+| PUT | `/v0/management/claude-api-key` | Replace the whole list |
+| GET/PUT | `/v0/management/codex-api-key` | Same for ChatGPT/Codex |
+
+`PUT` takes a **bare JSON array** of entries, e.g. `[{"api-key": "sk-…"}]` — not
+an object wrapping the list. An object body (`{"claude-api-key":[…]}`, mirroring
+the GET shape) is rejected `400 invalid body`, which is an easy mistake since GET
+returns exactly that wrapper. `PUT []` clears the list. There is no POST-to-append
+(404), so adding one key means read-modify-write of the whole array. Entries come
+back with `base-url`, `proxy-url`, `models` and a server-assigned `auth-index`.
+Deleting via `DELETE …?api-key=` answers `200 {"status":"ok"}` whether or not the
+key was there, so it is not a useful existence check.
+
+**Trap — a `codex-api-key` entry with no `base-url` is silently dropped.** The
+`PUT` answers `200 {"status":"ok"}` and the subsequent `GET` returns an empty
+list; supplying `base-url` (e.g. `https://api.openai.com/v1`) makes the identical
+entry persist. Claude has no such requirement — `[{"api-key": "sk-ant-…"}]`
+persists with an empty `base-url`. So a caller must **read back after writing**
+rather than trust the 200, and must default a `base-url` for Codex.
+
 ## Credential listing shape
 
 `GET /v0/management/auth-files` → `{"files": [...]}`, one entry per credential:

--- a/docs/AI_PROXY_MANAGEMENT_API.md
+++ b/docs/AI_PROXY_MANAGEMENT_API.md
@@ -1,0 +1,121 @@
+# CLIProxyAPI Management API — verified contract
+
+Empirically probed against a real **CLIProxyAPI v7.2.90** binary (Homebrew build,
+`darwin_aarch64`) on 2026-07-28, by running an isolated instance on port 18317
+with a management `secret-key` under our control. Every row below was observed on
+the wire, not read from documentation — the project's `docs/MANAGEMENT_API.md` is
+a 404 on `main`, so this file is our source of truth for the client we write.
+
+Upstream: <https://github.com/router-for-me/CLIProxyAPI> (Go, MIT).
+
+## Auth
+
+Base path `/v0/management`. Every request needs the management key, **including
+from localhost** (`remote-management.allow-remote: false` only blocks non-local
+callers; it does not make localhost unauthenticated). Two accepted forms — both
+verified 200:
+
+```
+Authorization: Bearer <secret-key>
+X-Management-Key: <secret-key>
+```
+
+A `?key=<secret-key>` query param is **not** accepted (401). Missing key →
+`401 {"error":"missing management key"}`. An empty `secret-key` in config
+disables the whole management surface (404 on every route).
+
+The config file's `secret-key` is hashed on startup if given in plaintext, so the
+plaintext is only knowable to whoever wrote the config — which is why we generate
+it ourselves rather than trying to read an existing one.
+
+## Routes
+
+| Method | Path | Purpose | Response |
+|---|---|---|---|
+| GET | `/v0/management/anthropic-auth-url` | Begin Claude OAuth | `{state, status:"ok", url}` |
+| GET | `/v0/management/codex-auth-url` | Begin ChatGPT/Codex OAuth | `{state, status:"ok", url}` |
+| POST/GET | `/v0/management/oauth-callback` | Finish a login | `{status:"ok"}` |
+| GET | `/v0/management/auth-files` | List credentials | `{files:[…]}` |
+| DELETE | `/v0/management/auth-files?name=<file>` | Remove one credential | `{status:"ok"}` |
+| GET | `/v0/management/config` | Effective config | config object |
+| GET | `/v0/management/request-log` | Request-log toggle state | `{request-log:bool}` |
+
+Confirmed **absent** in 7.2.90 (404), so don't build on them: `version`, `usage`,
+`login-status`, `auth-status`, `<provider>-auth-callback`, `claude-login`.
+
+Other providers also expose `…-auth-url` (`kimi`, `xai`, `antigravity`); `gemini`
+and `qwen` do not. Kimi and xAI return an extra `{flow:"device", expires_in,
+user_code}` — a device-code flow. Anthropic and Codex return **no** `flow` field,
+i.e. they are ordinary redirect flows.
+
+## The login flow
+
+`GET …/anthropic-auth-url` returns a `state` plus an authorization `url` whose
+`redirect_uri` is `http://localhost:54545/callback` (Codex uses `1455`). Probing
+with `lsof` showed the server **does not open a listener** on that port when the
+URL is issued — so the redirect target is not served by the proxy in this flow.
+The caller opens `url` in a browser, the user approves, and the browser lands on
+that (non-listening) callback URL carrying `?code=…&state=…`; the `code` is then
+handed back to the proxy:
+
+```
+POST /v0/management/oauth-callback   {"state": "<from auth-url>", "code": "<from callback>"}
+```
+
+Notable and load-bearing for our design: this returns `200 {"status":"ok"}`
+**even for a deliberately bogus code**, so a 200 means "accepted for processing",
+not "logged in". Token exchange is deferred. An unknown or expired `state` is the
+one thing it does reject up front (`404 unknown or expired state`), and a body
+with `state` but no `code` is a `400 code or error is required`.
+
+Consequence: **success must be confirmed by observing `auth-files` grow a new
+entry**, not by the callback's status code. Our client polls the listing.
+
+## Credential listing shape
+
+`GET /v0/management/auth-files` → `{"files": [...]}`, one entry per credential:
+
+```json
+{
+  "name": "claude-user@example.com.json",
+  "id": "claude-user@example.com.json",
+  "path": "/…/auths/claude-user@example.com.json",
+  "provider": "claude",
+  "account": "user@example.com",
+  "account_type": "oauth",
+  "email": "user@example.com",
+  "label": "user@example.com",
+  "disabled": false,
+  "priority": 0,
+  "failed": 0,
+  "auth_index": "72390572acff0657",
+  "created_at": "2026-07-28T19:19:14.91903+05:30",
+  "modtime": "2026-07-28T19:19:14.918860782+05:30",
+  "recent_requests": [{"time": "16:00-16:10", "success": 0, "failed": 0}]
+}
+```
+
+`provider` is the discriminator we filter the preferences list on (`claude`,
+`codex`). `name` is the handle `DELETE` takes. Deleting with a missing or
+unknown name is a `400 {"error":"invalid name"}`.
+
+The proxy runs a file watcher over `auth-dir`, so a credential dropped in by any
+means is picked up within ~1–2 s without a restart; that watcher latency is why
+the post-login poll needs a couple of seconds of tolerance.
+
+## On-disk credential files
+
+Written by the proxy into `auth-dir`, one JSON per account, named
+`<provider>-<email>.json`. Fields (Claude): `type`, `email`, `access_token`,
+`refresh_token`, `id_token`, `expired`, `last_refresh`, `disabled`, `priority`.
+Codex adds `account_id`. These hold live OAuth tokens for the user's own
+subscription — treat the directory as secret material: never log its contents,
+never copy it into a bundle, and keep it under the app's state dir with the same
+care as other credentials.
+
+## Version skew
+
+Probed only against 7.2.90. The route surface is not covered by any published
+doc, so a client written against it should degrade gracefully rather than assume:
+an unexpected 404 on a management route should surface as "this proxy build
+doesn't support account management from the app", not a crash.

--- a/docs/AI_PROXY_MANAGEMENT_API.md
+++ b/docs/AI_PROXY_MANAGEMENT_API.md
@@ -34,14 +34,23 @@ it ourselves rather than trying to read an existing one.
 |---|---|---|---|
 | GET | `/v0/management/anthropic-auth-url` | Begin Claude OAuth | `{state, status:"ok", url}` |
 | GET | `/v0/management/codex-auth-url` | Begin ChatGPT/Codex OAuth | `{state, status:"ok", url}` |
-| POST/GET | `/v0/management/oauth-callback` | Finish a login | `{status:"ok"}` |
+| POST/GET | `/v0/management/oauth-callback` | Hand back the code | `{status:"ok"}` |
+| GET | `/v0/management/get-auth-status?state=` | **Poll the real login result** | `{status:"wait"\|"ok"\|"error", error?}` |
+| DELETE | `/v0/management/oauth-session?state=` | Cancel a pending login | `{status:"ok", cancelled}` |
 | GET | `/v0/management/auth-files` | List credentials | `{files:[…]}` |
 | DELETE | `/v0/management/auth-files?name=<file>` | Remove one credential | `{status:"ok"}` |
+| PATCH | `/v0/management/auth-files/status` | Enable/disable a credential | `{status:"ok", disabled}` |
 | GET | `/v0/management/config` | Effective config | config object |
 | GET | `/v0/management/request-log` | Request-log toggle state | `{request-log:bool}` |
 
 Confirmed **absent** in 7.2.90 (404), so don't build on them: `version`, `usage`,
-`login-status`, `auth-status`, `<provider>-auth-callback`, `claude-login`.
+`login-status`, `auth-status` (the real path is `get-auth-status` — an easy
+miss), `<provider>-auth-callback`, `claude-login`.
+
+Version/build info is not a JSON route; every management response carries
+`X-CPA-VERSION` / `X-CPA-COMMIT` / `X-CPA-BUILD-DATE` headers. There is no
+dedicated health route — a cheap authenticated GET doubles as a reachability
+check. No SSE or websocket for management state, so status is poll-only.
 
 Other providers also expose `…-auth-url` (`kimi`, `xai`, `antigravity`); `gemini`
 and `qwen` do not. Kimi and xAI return an extra `{flow:"device", expires_in,
@@ -62,14 +71,49 @@ handed back to the proxy:
 POST /v0/management/oauth-callback   {"state": "<from auth-url>", "code": "<from callback>"}
 ```
 
-Notable and load-bearing for our design: this returns `200 {"status":"ok"}`
-**even for a deliberately bogus code**, so a 200 means "accepted for processing",
-not "logged in". Token exchange is deferred. An unknown or expired `state` is the
-one thing it does reject up front (`404 unknown or expired state`), and a body
-with `state` but no `code` is a `400 code or error is required`.
+Notable and load-bearing: this returns `200 {"status":"ok"}` **even for a
+deliberately bogus code**, so a 200 means "the code was recorded", not "logged
+in". The exchange is deferred — `oauth-callback` only writes the code to a
+`.oauth-<provider>-<state>.oauth` file in the auth dir, and a goroutine spawned
+back at `…-auth-url` time picks it up and does the real token exchange. A body
+with `state` but no `code` is `400 code or error is required`; an unknown or
+expired state is `404`.
 
-Consequence: **success must be confirmed by observing `auth-files` grow a new
-entry**, not by the callback's status code. Our client polls the listing.
+`POST` also accepts a whole `redirect_url` instead of a picked-apart `code` — the
+server parses its query string to fill `code`/`state`/`error`. (That field is
+POST-JSON only; the GET form doesn't read it.) Posting `error` instead of `code`
+aborts the flow with a specific message.
+
+### Confirming a login: `get-auth-status`
+
+The result channel is **`GET /v0/management/get-auth-status?state=<state>`**,
+polled after handing back the code:
+
+| Response | Meaning |
+|---|---|
+| `{"status":"wait"}` | Exchange still in flight |
+| `{"status":"ok"}` | Credential saved — it is now in `auth-files` |
+| `{"status":"error","error":"…"}` | Exchange or save failed, with a readable reason |
+
+Verified: a deliberately bogus code yields `{"status":"error","error":"Failed to
+exchange authorization code for tokens"}` within about a second. This is strictly
+better than inferring failure from a timeout on the credential listing, which is
+what an earlier draft of this design did — poll **this**, not `auth-files`.
+
+A state is effectively single-use: completing it shrinks its TTL to a minute, and
+replaying `oauth-callback` on a used state is a `409`. Pending states live in an
+in-memory map with a 30-minute TTL, purged lazily on access — so a state does not
+survive a proxy restart, and an abandoned login expires on its own. A pending
+login can be cancelled outright with `DELETE …/oauth-session?state=`.
+
+### `?is_webui=1` — deliberately not used
+
+Passing `is_webui=1` to an auth-url route makes the proxy bind the callback port
+itself and 302 onward to its bundled control-panel SPA. Verified working, but
+rejected for us on two counts: it binds `*:54545` (**all interfaces**, not
+loopback), and it forwards into a control panel we switch off with
+`disable-control-panel`. Our own loopback-only listener is both tighter and
+fewer moving parts.
 
 ### Callback ports are fixed — and free for us to bind
 

--- a/docs/AI_PROXY_MANAGEMENT_API.md
+++ b/docs/AI_PROXY_MANAGEMENT_API.md
@@ -71,6 +71,32 @@ with `state` but no `code` is a `400 code or error is required`.
 Consequence: **success must be confirmed by observing `auth-files` grow a new
 entry**, not by the callback's status code. Our client polls the listing.
 
+### Callback ports are fixed — and free for us to bind
+
+The `redirect_uri` is hardcoded per provider and **cannot be moved**: passing
+`port`, `callback_port`, `oauth_callback_port`, `redirect_uri`, or `no_browser`
+as query params to the auth-url route leaves it unchanged.
+
+| Provider | Redirect URI |
+|---|---|
+| Claude (`anthropic`) | `http://localhost:54545/callback` |
+| ChatGPT (`codex`) | `http://localhost:1455/auth/callback` |
+
+Since the proxy does not itself listen there, **our app can bind those ports for
+the duration of a login** and capture the `code` out of the browser's redirect
+directly, then hand it to `oauth-callback`. That is what makes a one-click
+"Connect account" possible: without it, the browser would land on a dead port
+and the user would have to copy a code out of a failed page's URL bar.
+
+The ports being fixed also means two logins cannot run concurrently, and a login
+cannot proceed if something else already holds the port (notably the user's own
+separately-installed proxy mid-login). Both are states the UI has to report
+rather than hang on.
+
+Requested scopes, for the record: Claude asks for `user:profile user:inference
+user:sessions:claude_code …`; Codex asks for `openid email profile
+offline_access`.
+
 ## Credential listing shape
 
 `GET /v0/management/auth-files` → `{"files": [...]}`, one entry per credential:

--- a/frontend/src/lib/aiAccounts.ts
+++ b/frontend/src/lib/aiAccounts.ts
@@ -1,0 +1,111 @@
+// The AI-accounts connect flow (fused_render/ai_accounts.py; docs/
+// AI_PROXY_MANAGEMENT_API.md's login-flow section), shared by the Preferences
+// "AI accounts" tab. Mirrors lib/account.ts's useFusedLogin almost exactly:
+// begin() asks the server to start an OAuth login and hand back the
+// provider's authorize URL, the CALLER opens it (window.open — the backend
+// never drives a browser, ai_accounts.py's own house rule), then polls a
+// status route every couple of seconds since there is no push channel.
+//
+// The one real difference from useFusedLogin: that hook has to INFER success
+// by re-reading account status (logged_in flipping true), because the Fused
+// CLI's login has no separate "how did it go" signal. Here the server already
+// tracks discrete phases itself (waiting_browser -> exchanging -> done|failed
+// — ai_accounts.py's _ActiveConnect) precisely because oauth-callback's 200
+// proves nothing (a bogus code still gets a 200 — the exchange is deferred to
+// a goroutine; see the management-API doc's get-auth-status section). So the
+// poll here just relays connect/status's own `state` instead of re-deriving
+// it from a side effect.
+import { useRef, useState } from "react";
+import { cancelAiConnect, getAiConnectStatus, startAiConnect } from "./api";
+import type { AiProvider } from "./api";
+
+const POLL_MS = 2000;
+
+// onDone is called both on a successful login AND after cancel() — see
+// cancel's comment below for why a cancel still needs to trigger a refresh.
+export function useAiLogin(onDone: () => void) {
+  // Which provider is mid-login, so the panel can say "waiting on Claude…"
+  // rather than a provider-less message (relevant because Connect buttons for
+  // BOTH providers are disabled while any one login is in flight — the fixed
+  // callback ports mean only one can ever run at a time).
+  const [provider, setProvider] = useState<AiProvider | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const timer = useRef<number | null>(null);
+  // Latest-ref: the poll always calls the current callback, never a stale
+  // closure from the render when polling started (the useFusedLogin pattern).
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
+
+  const stopPolling = () => {
+    if (timer.current !== null) {
+      window.clearInterval(timer.current);
+      timer.current = null;
+    }
+  };
+
+  const finish = (err: string | null) => {
+    stopPolling();
+    setConnecting(false);
+    setProvider(null);
+    setError(err);
+  };
+
+  const begin = async (p: AiProvider) => {
+    setError(null);
+    setProvider(p);
+    setConnecting(true);
+    let url: string;
+    try {
+      ({ authorize_url: url } = await startAiConnect(p));
+    } catch (e) {
+      finish((e as Error).message);
+      return;
+    }
+    window.open(url, "_blank", "noopener");
+    stopPolling(); // begin() while already polling joins the same server attempt
+    timer.current = window.setInterval(async () => {
+      let status;
+      try {
+        status = await getAiConnectStatus();
+      } catch {
+        return; // transient (server restart, network blip) — keep polling
+      }
+      if (timer.current === null) return; // canceled while the fetch was in flight
+      if (status.state === "done") {
+        finish(null);
+        onDoneRef.current(); // refresh the account list — the new credential is live
+      } else if (status.state === "failed") {
+        finish(status.detail ?? "sign-in failed");
+      } else if (status.state === "idle") {
+        // Only reachable if something else tore down the attempt we started
+        // (e.g. another tab hit cancel) — waiting_browser/exchanging are the
+        // only states a live attempt of OURS should ever report.
+        finish("the sign-in was canceled elsewhere");
+      }
+      // waiting_browser / exchanging: still in progress, keep polling.
+    }, POLL_MS);
+  };
+
+  const cancel = async () => {
+    finish(null);
+    try {
+      await cancelAiConnect();
+    } catch {
+      // Best-effort — a stuck server-side attempt also self-expires (the
+      // proxy's own 30-minute oauth-session TTL).
+    }
+    // The exchange may have completed in the gap before the cancel reached
+    // the server's lock — and unlike account.ts's cancel, there is no status
+    // route left to re-poll for the outcome: /connect/cancel unconditionally
+    // clears the tracked attempt, so a subsequent connect/status call would
+    // just read back "idle" even if the credential was written moments
+    // earlier. The only place that still shows the truth is the account
+    // listing itself, so the reconciling fetch here is "refresh the list",
+    // not "poll the login status" — same intent as account.ts's race guard,
+    // adapted to what this route actually exposes.
+    onDoneRef.current();
+  };
+
+  return { provider, connecting, error, begin, cancel };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -767,6 +767,93 @@ export function deleteStoreEnv(name: string): Promise<AccountStatus> {
   return postJson<AccountStatus>("/api/account/envs/delete", { name });
 }
 
+// -- AI accounts (fused_render/ai_accounts.py; docs/AI_PROXY_BUNDLING.md) -----
+// Connect/disconnect Claude and ChatGPT (codex) logins against the bundled AI
+// proxy that backs fused.ai(). Scope is deliberately these two providers only
+// (the doc's "Claude and ChatGPT only for now" note) even though the proxy
+// speaks more.
+
+export type AiProvider = "claude" | "codex";
+
+// One connected credential, mapped field-by-field server-side from the
+// proxy's auth-files listing — never the raw entry (which carries token
+// material this app must never see, let alone render).
+export interface AiAccount {
+  provider: AiProvider;
+  email: string | null;
+  label: string | null;
+  disabled: boolean;
+  // The handle DELETE takes (the credential file's name) — opaque, not
+  // necessarily the email (a re-auth of the same email keeps the same file).
+  name: string;
+}
+
+// The phases a connect attempt moves through server-side (ai_accounts.py's
+// _ActiveConnect.phase), plus "idle" for connect/status when nothing is
+// tracked. The accounts listing's own `login` field never reports "idle" —
+// an idle/finished attempt is simply `login: null` there.
+export type AiConnectPhase = "idle" | "waiting_browser" | "exchanging" | "done" | "failed";
+
+// An attempt reported by GET /api/ai/accounts — may have been started from a
+// different tab/page than the one reading this, since only one login can be
+// in flight at a time across the whole app (the callback ports are fixed per
+// provider, so a second concurrent attempt is rejected outright).
+export interface AiLoginInfo {
+  provider: AiProvider;
+  state: Exclude<AiConnectPhase, "idle">;
+  detail: string | null;
+}
+
+export interface AiAccountsResult {
+  // Whether this app spawned/manages the proxy vs. an independent install on
+  // the default port (docs/AI_PROXY_BUNDLING.md's config-precedence note).
+  supervised: boolean;
+  running: boolean;
+  accounts: AiAccount[];
+  login: AiLoginInfo | null;
+}
+
+export function getAiAccounts(): Promise<AiAccountsResult> {
+  return getJson<AiAccountsResult>("/api/ai/accounts");
+}
+
+// Begin (or 409-reject, if one is already running) a provider login. OPENING
+// the returned URL is the caller's job (window.open) — the server never
+// drives a browser, same house rule as startAccountLogin.
+export function startAiConnect(
+  provider: AiProvider
+): Promise<{ authorize_url: string; state: string }> {
+  return postJson<{ authorize_url: string; state: string }>("/api/ai/accounts/connect", {
+    provider,
+  });
+}
+
+export interface AiConnectStatus {
+  state: AiConnectPhase;
+  detail: string | null;
+}
+
+export function getAiConnectStatus(): Promise<AiConnectStatus> {
+  return getJson<AiConnectStatus>("/api/ai/accounts/connect/status");
+}
+
+export function cancelAiConnect(): Promise<{ ok: boolean; canceled: boolean }> {
+  return postJson<{ ok: boolean; canceled: boolean }>("/api/ai/accounts/connect/cancel", {});
+}
+
+// Disconnect one account by its listing `name`. Not through mutateJson (PUT/
+// POST only) since this is a DELETE — same direct-fetch shape as deleteMount.
+export function deleteAiAccount(name: string): Promise<{ ok: boolean }> {
+  return fetch(`/api/ai/accounts/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+    headers: { "X-Fused": "1" },
+  }).then(async (r) => {
+    const data = await r.json();
+    if (!r.ok) throw httpError(data, r.status);
+    return data as { ok: boolean };
+  });
+}
+
 // -- Preferences (shell/prefs.py; SPEC §20) -----------------------------------
 
 export interface EnginePrefs {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -804,12 +804,33 @@ export interface AiLoginInfo {
   detail: string | null;
 }
 
+// One pasted API key (ai_accounts.py's "API keys" section) — a config-level
+// credential, never a file, so it has no `disabled`/`label` (nothing to
+// re-authorize in a browser) and no `email` (the proxy never learns one).
+// `hint` is a masked display string ("...cdef") — never the key itself, and
+// there is no route that returns the full value once written.
+export interface AiApiKey {
+  provider: AiProvider;
+  hint: string;
+  // The handle DELETE .../keys/{auth_index} takes. Opaque and NOT stable
+  // across a proxy restart (the module docstring: PUT regenerates it from
+  // array position) — never cache this across a page reload, always use
+  // whatever the latest GET /api/ai/accounts returned.
+  auth_index: string;
+}
+
+// PUT /api/ai/accounts/routing-strategy's two values (ai_accounts.py /
+// shell/prefs.py). Upstream default is round-robin.
+export type AiRoutingStrategy = "round-robin" | "fill-first";
+
 export interface AiAccountsResult {
   // Whether this app spawned/manages the proxy vs. an independent install on
   // the default port (docs/AI_PROXY_BUNDLING.md's config-precedence note).
   supervised: boolean;
   running: boolean;
   accounts: AiAccount[];
+  api_keys: AiApiKey[];
+  routing_strategy: AiRoutingStrategy;
   login: AiLoginInfo | null;
 }
 
@@ -852,6 +873,49 @@ export function deleteAiAccount(name: string): Promise<{ ok: boolean }> {
     if (!r.ok) throw httpError(data, r.status);
     return data as { ok: boolean };
   });
+}
+
+// Add one API key for a provider (read-modify-write of the whole per-provider
+// array server-side, then read back to confirm it actually persisted — see
+// ai_accounts.py's api_ai_accounts_add_key docstring on the codex base-url
+// trap). A 502 here means the proxy accepted-then-dropped the key, not that
+// this request failed to reach the server — surface it as such, not as a
+// generic error.
+export function addAiApiKey(
+  provider: AiProvider,
+  apiKey: string
+): Promise<{ ok: boolean; provider: AiProvider; hint: string; auth_index: string }> {
+  return postJson<{ ok: boolean; provider: AiProvider; hint: string; auth_index: string }>(
+    "/api/ai/accounts/keys",
+    { provider, api_key: apiKey }
+  );
+}
+
+// Remove one API key by its (restart-unstable) auth_index. Not through
+// mutateJson (PUT/POST only) since this is a DELETE — same direct-fetch shape
+// as deleteAiAccount; the key itself never appears in the URL, only the index.
+export function deleteAiApiKey(authIndex: string): Promise<{ ok: boolean }> {
+  return fetch(`/api/ai/accounts/keys/${encodeURIComponent(authIndex)}`, {
+    method: "DELETE",
+    headers: { "X-Fused": "1" },
+  }).then(async (r) => {
+    const data = await r.json();
+    if (!r.ok) throw httpError(data, r.status);
+    return data as { ok: boolean };
+  });
+}
+
+// The proxy only reads this at startup, so the server force-restarts it on
+// change (see ai_accounts.py's api_ai_accounts_set_routing_strategy) —
+// `restarted` just reflects whether there was a live instance to kill, not
+// whether anything went wrong.
+export function putAiRoutingStrategy(
+  strategy: AiRoutingStrategy
+): Promise<{ ok: boolean; strategy: AiRoutingStrategy; restarted: boolean }> {
+  return putJson<{ ok: boolean; strategy: AiRoutingStrategy; restarted: boolean }>(
+    "/api/ai/accounts/routing-strategy",
+    { strategy }
+  );
 }
 
 // -- Preferences (shell/prefs.py; SPEC §20) -----------------------------------

--- a/frontend/src/views/Preferences.tsx
+++ b/frontend/src/views/Preferences.tsx
@@ -1,5 +1,6 @@
 // Preferences page (SPEC §20) — the `/view/_prefs` sentinel route, entered
-// from the sidebar's bottom-left gear. Two tabs (D125):
+// from the sidebar's bottom-left gear. Three tabs (D125; AI accounts added
+// alongside the bundled AI proxy work — docs/AI_PROXY_BUNDLING.md):
 //   Render preferences — Appearance, Call log (capture/redaction/retention for
 //     fused_render/calls.py), Deploy to Fused account (the opt-in Deploy-button
 //     toggle), Accessibility, and last Execution engine. Always present; the
@@ -9,15 +10,23 @@
 //     temp-dir output (D68) reached from the desktop tray's "Open app logs", and a
 //     second "Logs" heading next to the Call log section only ever read as the
 //     call log's own settings.
+//   AI accounts         — connect/disconnect Claude and ChatGPT logins against
+//     the bundled AI proxy that backs fused.ai() (fused_render/ai_accounts.py).
+//     Always offered, unlike Fused account below — there is no enabling pref
+//     to gate it on, and a user with no accounts yet is exactly who the tab is
+//     for (docs/AI_PROXY_BUNDLING.md's "Preferences UI" section).
 //   Fused account       — the account/sign-in/environments panel (formerly
 //     its own `/view/_account` page, folded in once it stopped being a
 //     separate sidebar entry). Shown only once Deploy is enabled — that's
 //     the only reason this app cares about a Fused account.
-// The active tab lives in the URL (`?tab=account`), same pattern as
-// Templates' bindings/library tabs.
+// The active tab lives in the URL (`?tab=account` / `?tab=ai`), same pattern
+// as Templates' bindings/library tabs.
 // Template bindings live in the dedicated /view/_templates view.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
+  deleteAiAccount,
+  cancelAiConnect,
+  getAiAccounts,
   getPrefs,
   putCallsEnabled,
   putCallsParamsMode,
@@ -26,14 +35,15 @@ import {
   putEnginePref,
   putReaderEnabled,
 } from "../lib/api";
-import type { CallsParamsMode, Prefs } from "../lib/api";
+import type { AiAccount, AiAccountsResult, AiProvider, CallsParamsMode, Prefs } from "../lib/api";
+import { useAiLogin } from "../lib/aiAccounts";
 import { navigate, navigateUrl } from "../lib/router";
 import { notifyPrefsChanged } from "../lib/prefs";
 import { ErrorBanner } from "../components/ErrorBanner";
 import { useThemePref } from "../lib/theme";
 import { AccountPanel } from "./Account";
 
-type PrefsTab = "render" | "account";
+type PrefsTab = "render" | "ai" | "account";
 
 // The one section on this page that is deliberately NOT server-backed. Every
 // other control here round-trips /api/prefs (shell/prefs.py); Appearance is
@@ -418,6 +428,217 @@ function DeploymentsSection({
   );
 }
 
+function aiProviderLabel(p: AiProvider): string {
+  return p === "claude" ? "Claude" : "ChatGPT";
+}
+
+// The "AI accounts" tab (fused_render/ai_accounts.py). No enabling pref gates
+// it — unlike AccountPanel this is offered to everyone, since a user with
+// nothing connected yet is exactly who it's for. Connect flow follows
+// useAiLogin (lib/aiAccounts.ts, mirroring useFusedLogin); the account list
+// and its per-row Disconnect follow Account.tsx's environments table.
+function AiAccountsPanel() {
+  const [data, setData] = useState<AiAccountsResult | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  // The account (by listing `name`) currently being disconnected — disables
+  // just that row's button rather than the whole panel.
+  const [rowBusy, setRowBusy] = useState<string | null>(null);
+
+  const alive = useRef(true);
+  useEffect(
+    () => () => {
+      alive.current = false;
+    },
+    []
+  );
+
+  const load = async () => {
+    try {
+      const fresh = await getAiAccounts();
+      if (alive.current) {
+        setData(fresh);
+        setLoadError(null);
+      }
+    } catch (e) {
+      if (alive.current) setLoadError((e as Error).message);
+    }
+  };
+  useEffect(() => {
+    void load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const loadRef = useRef(load);
+  loadRef.current = load;
+  const login = useAiLogin(() => void loadRef.current());
+
+  // A login started from another page/tab shows up as the listing's own
+  // `login` field (Account.tsx's inFlightElsewhere pattern) — this tab never
+  // called connect itself, so connect/status was never subscribed to here;
+  // polling the LISTING is the only way to notice it resolve.
+  const inFlightElsewhere = data?.login != null && !login.connecting;
+  useEffect(() => {
+    if (!inFlightElsewhere) return;
+    const id = window.setInterval(() => void loadRef.current(), 2000);
+    return () => window.clearInterval(id);
+  }, [inFlightElsewhere]);
+
+  const onCancelElsewhere = async () => {
+    setActionError(null);
+    try {
+      await cancelAiConnect();
+    } catch (e) {
+      if (alive.current) setActionError((e as Error).message);
+    }
+    void load();
+  };
+
+  const onDisconnect = (account: AiAccount) => {
+    const label = account.email ?? account.label ?? account.name;
+    // Reversible by reconnecting — the tone Account.tsx's "Forget…" confirm
+    // uses for its local-only removals, adapted: this one really does delete
+    // the credential file server-side, but signing in again recreates it.
+    if (!window.confirm(`Disconnect ${label}? You can reconnect it any time.`)) return;
+    void (async () => {
+      setRowBusy(account.name);
+      setActionError(null);
+      try {
+        await deleteAiAccount(account.name);
+        await load();
+      } catch (e) {
+        if (alive.current) setActionError((e as Error).message);
+      } finally {
+        if (alive.current) setRowBusy(null);
+      }
+    })();
+  };
+
+  if (loadError) {
+    return (
+      <section className="prefs-section">
+        <h2>AI accounts</h2>
+        <div className="deploy-error">{loadError}</div>
+        <button type="button" onClick={() => void load()}>
+          Retry
+        </button>
+      </section>
+    );
+  }
+  if (!data) {
+    return (
+      <section className="prefs-section">
+        <h2>AI accounts</h2>
+        <div className="deploy-muted">Loading…</div>
+      </section>
+    );
+  }
+
+  // Both Connect buttons disable together, not just the in-flight provider's:
+  // the callback ports are fixed per provider, so only one login can run at
+  // all across the whole app, regardless of which provider it's for.
+  const connectDisabled = login.connecting || inFlightElsewhere;
+
+  return (
+    <section className="prefs-section">
+      <h2>AI accounts</h2>
+      <p className="deploy-muted">
+        Connects a Claude or ChatGPT subscription so pages can call <code>fused.ai()</code> —
+        a one-time browser sign-in, no API key to manage.
+        {!data.running && " The AI proxy isn't running yet; it starts on the first fused.ai() call."}
+      </p>
+
+      {data.accounts.length === 0 ? (
+        <p className="deploy-muted">
+          No accounts connected yet — connect one below and pages in this app can start calling{" "}
+          <code>fused.ai()</code>.
+        </p>
+      ) : (
+        <table className="deploy-shares-table">
+          <thead>
+            <tr>
+              <th>Provider</th>
+              <th>Account</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.accounts.map((a) => (
+              <tr key={a.name}>
+                <td>{aiProviderLabel(a.provider)}</td>
+                <td>
+                  {a.email ?? a.label ?? a.name}
+                  {a.disabled && <span className="deploy-muted"> (disabled)</span>}
+                </td>
+                <td className="row-actions-cell">
+                  {rowBusy === a.name ? (
+                    <span className="deploy-muted">Disconnecting…</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="btn btn-danger"
+                      disabled={rowBusy !== null}
+                      onClick={() => onDisconnect(a)}
+                    >
+                      Disconnect
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {login.connecting ? (
+        <div className="deploy-form-row">
+          <span className="deploy-spinner" />
+          <span className="deploy-muted">
+            Waiting for the browser sign-in
+            {login.provider ? ` (${aiProviderLabel(login.provider)})` : ""}… finish signing in in
+            the tab that just opened.
+          </span>
+          <button type="button" onClick={() => void login.cancel()}>
+            Cancel
+          </button>
+        </div>
+      ) : inFlightElsewhere ? (
+        <div className="deploy-form-row">
+          <span className="deploy-muted">
+            A sign-in is already in progress
+            {data.login ? ` (${aiProviderLabel(data.login.provider)})` : ""} — started from
+            another page or tab.
+          </span>
+          <button type="button" onClick={() => void onCancelElsewhere()}>
+            Cancel it
+          </button>
+        </div>
+      ) : (
+        <div className="deploy-form-row">
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={connectDisabled}
+            onClick={() => void login.begin("claude")}
+          >
+            Connect Claude
+          </button>
+          <button
+            type="button"
+            className="btn btn-primary"
+            disabled={connectDisabled}
+            onClick={() => void login.begin("codex")}
+          >
+            Connect ChatGPT
+          </button>
+        </div>
+      )}
+      {login.error && <div className="deploy-error">{login.error}</div>}
+      {actionError && <div className="deploy-error">{actionError}</div>}
+    </section>
+  );
+}
+
 export default function Preferences() {
   const [prefs, setPrefs] = useState<Prefs | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -432,14 +653,16 @@ export default function Preferences() {
     };
   }, []);
 
-  // Requested tab lives in the URL (`?tab=account`) — bookmarkable, and how
-  // the Deploy modal and the old `/view/_account` redirect (App.tsx) land
-  // here directly on the account tab. Falls back to "render" whenever the
+  // Requested tab lives in the URL (`?tab=account` / `?tab=ai`) — bookmarkable,
+  // and how the Deploy modal and the old `/view/_account` redirect (App.tsx)
+  // land here directly on the account tab. Falls back to "render" whenever the
   // account tab wouldn't be offered (Deploy not enabled) rather than showing
-  // a tab with no button pointing at it.
-  const requestedTab: PrefsTab =
-    new URLSearchParams(location.search).get("tab") === "account" ? "account" : "render";
-  const tab: PrefsTab = requestedTab === "account" && prefs?.deploy.enabled ? "account" : "render";
+  // a tab with no button pointing at it; "ai" needs no such fallback — it has
+  // no gating pref.
+  const rawTab = new URLSearchParams(location.search).get("tab");
+  const requestedTab: PrefsTab = rawTab === "account" ? "account" : rawTab === "ai" ? "ai" : "render";
+  const tab: PrefsTab =
+    requestedTab === "account" && !prefs?.deploy.enabled ? "render" : requestedTab;
   const setTab = (next: PrefsTab) => {
     const params = new URLSearchParams(location.search);
     if (next === "render") params.delete("tab");
@@ -461,6 +684,13 @@ export default function Preferences() {
               onClick={() => setTab("render")}
             >
               Render preferences
+            </button>
+            <button
+              type="button"
+              className={"prefs-tab" + (tab === "ai" ? " active" : "")}
+              onClick={() => setTab("ai")}
+            >
+              AI accounts
             </button>
             {prefs.deploy.enabled && (
               <button
@@ -490,6 +720,7 @@ export default function Preferences() {
                 <EngineSection prefs={prefs} onChange={setPrefs} />
               </>
             )}
+            {tab === "ai" && <AiAccountsPanel />}
             {tab === "account" && prefs.deploy.enabled && <AccountPanel />}
           </div>
         </>

--- a/frontend/src/views/Preferences.tsx
+++ b/frontend/src/views/Preferences.tsx
@@ -24,10 +24,13 @@
 // Template bindings live in the dedicated /view/_templates view.
 import { useEffect, useRef, useState } from "react";
 import {
+  addAiApiKey,
   deleteAiAccount,
+  deleteAiApiKey,
   cancelAiConnect,
   getAiAccounts,
   getPrefs,
+  putAiRoutingStrategy,
   putCallsEnabled,
   putCallsParamsMode,
   putCallsRetentionDays,
@@ -35,11 +38,20 @@ import {
   putEnginePref,
   putReaderEnabled,
 } from "../lib/api";
-import type { AiAccount, AiAccountsResult, AiProvider, CallsParamsMode, Prefs } from "../lib/api";
+import type {
+  AiAccount,
+  AiAccountsResult,
+  AiApiKey,
+  AiProvider,
+  AiRoutingStrategy,
+  CallsParamsMode,
+  Prefs,
+} from "../lib/api";
 import { useAiLogin } from "../lib/aiAccounts";
 import { navigate, navigateUrl } from "../lib/router";
 import { notifyPrefsChanged } from "../lib/prefs";
 import { ErrorBanner } from "../components/ErrorBanner";
+import { Field, Select, TextInput } from "../components/field/fields";
 import { useThemePref } from "../lib/theme";
 import { AccountPanel } from "./Account";
 
@@ -432,6 +444,215 @@ function aiProviderLabel(p: AiProvider): string {
   return p === "claude" ? "Claude" : "ChatGPT";
 }
 
+// A pasted API key (ai_accounts.py's "API keys" section) — a second,
+// config-level way to authenticate one of the same two providers OAuth
+// connects above. Its own section rather than folded into the accounts
+// table: a key has no session to expire and no browser to reconnect
+// through, and removing one is a config write, not a file deletion — enough
+// of a different affordance that sharing a table would force the reader to
+// sniff which kind each row is. Rendered as plain rows (deploy-form-row), not
+// a table, so it reads as visually distinct from the OAuth table above it.
+//
+// One shared form with a provider selector, not two per-provider forms: the
+// add flow (paste a key, submit) is identical for both providers, so a
+// second copy of the same three fields would only be duplicated markup, not
+// a meaningfully different experience.
+function ApiKeysSection({ apiKeys, onChanged }: { apiKeys: AiApiKey[]; onChanged: () => void }) {
+  const [provider, setProvider] = useState<AiProvider>("claude");
+  const [apiKey, setApiKey] = useState("");
+  const [addBusy, setAddBusy] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  // The auth_index currently being removed — row-scoped busy, same pattern as
+  // AiAccountsPanel's rowBusy for Disconnect above.
+  const [rowBusy, setRowBusy] = useState<string | null>(null);
+  const [rowError, setRowError] = useState<string | null>(null);
+
+  const submit = async () => {
+    if (addBusy || !apiKey) return;
+    setAddBusy(true);
+    setAddError(null);
+    try {
+      await addAiApiKey(provider, apiKey);
+      // Cleared the instant the request settles, success or not: the module
+      // docstring's "never reaches a client" rule cuts both ways — this app
+      // must not hold a pasted key in React state any longer than the POST
+      // needs it, so a stale tab can't leak it back out via devtools.
+      setApiKey("");
+      onChanged();
+    } catch (e) {
+      setAddError((e as Error).message);
+    } finally {
+      setAddBusy(false);
+    }
+  };
+
+  const remove = (key: AiApiKey) => {
+    if (
+      !window.confirm(`Remove this ${aiProviderLabel(key.provider)} API key (${key.hint})?`)
+    ) {
+      return;
+    }
+    void (async () => {
+      setRowBusy(key.auth_index);
+      setRowError(null);
+      try {
+        await deleteAiApiKey(key.auth_index);
+        onChanged();
+      } catch (e) {
+        setRowError((e as Error).message);
+      } finally {
+        setRowBusy(null);
+      }
+    })();
+  };
+
+  return (
+    <section className="prefs-section">
+      <h2>API keys</h2>
+      <p className="deploy-muted">
+        A second way to authenticate Claude or ChatGPT for <code>fused.ai()</code>, alongside the
+        accounts above — paste a key from the provider's own dashboard instead of signing in with
+        a subscription. Useful for a pay-per-token key, or when there's no interactive login to
+        use. The full key is never stored by this app past the request that adds it, and there is
+        no way to read it back — only the masked hint below ever comes back from the server.
+      </p>
+      {apiKeys.length === 0 ? (
+        <p className="deploy-muted">No API keys added yet.</p>
+      ) : (
+        apiKeys.map((k) => (
+          <div className="deploy-form-row" key={k.auth_index}>
+            <span>
+              <b>{aiProviderLabel(k.provider)}</b> <code>{k.hint}</code>
+            </span>
+            {rowBusy === k.auth_index ? (
+              <span className="deploy-muted">Removing…</span>
+            ) : (
+              <button
+                type="button"
+                className="btn btn-danger"
+                disabled={rowBusy !== null}
+                onClick={() => remove(k)}
+              >
+                Remove
+              </button>
+            )}
+          </div>
+        ))
+      )}
+      {rowError && <div className="deploy-error">{rowError}</div>}
+      <form
+        className="deploy-form-row"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit();
+        }}
+      >
+        <Field label="Provider">
+          <Select
+            value={provider}
+            disabled={addBusy}
+            onChange={(e) => setProvider(e.target.value as AiProvider)}
+          >
+            <option value="claude">Claude</option>
+            <option value="codex">ChatGPT</option>
+          </Select>
+        </Field>
+        <Field label="API key">
+          {/* type="password": a pasted key must never render as plain text on
+              screen, matching the backend's own "never reveal a full key"
+              rule. autoComplete off so the browser doesn't offer to save/fill
+              a provider secret into its own password store. */}
+          <TextInput
+            type="password"
+            autoComplete="off"
+            placeholder="paste key"
+            style={{ minWidth: 220 }}
+            value={apiKey}
+            disabled={addBusy}
+            onChange={(e) => setApiKey(e.target.value)}
+          />
+        </Field>
+        {/* Blank caption reserves the label row's height so the button aligns
+            with the inputs, not the captions above them (AddRemote's pattern). */}
+        <Field label={" "}>
+          <button type="submit" className="btn btn-primary" disabled={addBusy || !apiKey}>
+            {addBusy ? "Adding…" : "Add key"}
+          </button>
+        </Field>
+      </form>
+      {addError && <div className="deploy-error">{addError}</div>}
+    </section>
+  );
+}
+
+// PUT /api/ai/accounts/routing-strategy. Mirrors EngineSection's register
+// (a locked-looking radio pair with a plain-language tradeoff line each), but
+// nothing here is ever locked — there is no env override for this pref.
+function RoutingStrategySection({
+  strategy,
+  onChanged,
+}: {
+  strategy: AiRoutingStrategy;
+  onChanged: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const select = async (value: AiRoutingStrategy) => {
+    if (busy || value === strategy) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await putAiRoutingStrategy(value);
+      onChanged();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="prefs-section">
+      <h2>Routing strategy</h2>
+      <p className="deploy-muted">
+        How <code>fused.ai()</code> picks a credential when a provider has more than one —
+        signed-in accounts and API keys are pooled together here, not treated separately.
+        Changing this restarts the AI proxy; it respawns lazily with the new setting on its next
+        use, so it's normal to see it briefly report not running right after.
+      </p>
+      <label className="prefs-radio">
+        <input
+          type="radio"
+          name="ai-routing-strategy"
+          checked={strategy === "round-robin"}
+          disabled={busy}
+          onChange={() => select("round-robin")}
+        />
+        <span>
+          <b>Round-robin</b> — every credential for a provider is rotated between calls, with
+          failover to the next one when one hits a rate limit. The upstream default.
+        </span>
+      </label>
+      <label className="prefs-radio">
+        <input
+          type="radio"
+          name="ai-routing-strategy"
+          checked={strategy === "fill-first"}
+          disabled={busy}
+          onChange={() => select("fill-first")}
+        />
+        <span>
+          <b>Fill-first</b> — one credential is used until it fails (rate limit, expiry), only
+          then does the next one take over. Pick this to keep a preferred account or key in use
+          for as long as possible before falling back.
+        </span>
+      </label>
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+    </section>
+  );
+}
+
 // The "AI accounts" tab (fused_render/ai_accounts.py). No enabling pref gates
 // it — unlike AccountPanel this is offered to everyone, since a user with
 // nothing connected yet is exactly who it's for. Connect flow follows
@@ -540,6 +761,7 @@ function AiAccountsPanel() {
   const connectDisabled = login.connecting || inFlightElsewhere;
 
   return (
+    <>
     <section className="prefs-section">
       <h2>AI accounts</h2>
       <p className="deploy-muted">
@@ -550,8 +772,20 @@ function AiAccountsPanel() {
 
       {data.accounts.length === 0 ? (
         <p className="deploy-muted">
-          No accounts connected yet — connect one below and pages in this app can start calling{" "}
-          <code>fused.ai()</code>.
+          {data.api_keys.length === 0 ? (
+            <>
+              Nothing connected yet. Connect Claude or ChatGPT below for one-click access to a
+              subscription you already have, or add an API key in the API keys section further
+              down instead — better for a pay-per-token key, or a provider account with no
+              interactive login. Either one is enough for pages to start calling{" "}
+              <code>fused.ai()</code>.
+            </>
+          ) : (
+            <>
+              No signed-in accounts yet — connect one below, or rely on the API key(s) already
+              configured further down.
+            </>
+          )}
         </p>
       ) : (
         <table className="deploy-shares-table">
@@ -636,6 +870,9 @@ function AiAccountsPanel() {
       {login.error && <div className="deploy-error">{login.error}</div>}
       {actionError && <div className="deploy-error">{actionError}</div>}
     </section>
+    <ApiKeysSection apiKeys={data.api_keys} onChanged={() => void load()} />
+    <RoutingStrategySection strategy={data.routing_strategy} onChanged={() => void load()} />
+    </>
   );
 }
 

--- a/fused_render/ai_accounts.py
+++ b/fused_render/ai_accounts.py
@@ -1,0 +1,420 @@
+"""AI account management: /api/ai/accounts — list/connect/disconnect Claude
+and ChatGPT (Codex) logins against the bundled AI proxy (shell/ai_proxy.py).
+
+Follow-on to fused.ai() (SPEC RH-11) and its bundled-proxy design
+(docs/AI_PROXY_BUNDLING.md) — that design turns "connect an account" into a
+button in Preferences instead of a terminal `cli-proxy-api` invocation the
+user has to run themselves. The wire contract this drives is
+docs/AI_PROXY_MANAGEMENT_API.md, verified against a real CLIProxyAPI
+v7.2.90 binary; every design choice below cites the section of that doc it
+answers.
+
+Shaped after account.py (the existing "external OAuth thing" router): a
+single in-flight operation guarded by one module lock, a background thread
+doing the actual waiting, and a poll-only status endpoint — because, like
+that CLI login, this OAuth exchange has no push channel either. No import of
+server.py (server includes this router — keep it acyclic); the X-Fused guard
+is duplicated locally like account.py's is.
+
+The one piece with no account.py precedent is the callback listener: the
+provider's redirect_uri is a FIXED localhost port the proxy itself never
+listens on (54545 for Claude, 1455 for Codex — see the doc's "Callback ports
+are fixed" section), so grabbing the `code` out of the browser's redirect
+requires binding that port ourselves for the duration of one login. That is
+what makes this a one-click flow instead of a copy-the-code-out-of-a-dead-
+page-URL flow.
+"""
+from __future__ import annotations
+
+import dataclasses
+import html
+import threading
+import time
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from fastapi import APIRouter, Body, Header
+from fastapi.responses import JSONResponse
+
+from fused_render.shell import ai_proxy
+
+router = APIRouter()
+
+# UI-facing provider id -> the proxy's own naming + the fixed OAuth redirect
+# it uses. "auth_provider" is what goes into "/{auth_provider}-auth-url" and
+# into oauth-callback's "provider" field (ai_proxy.start_login/
+# submit_login_code) — it does NOT match the credential listing's "provider"
+# field (which says "claude", never "anthropic"); the doc's route table and
+# credential-listing shape use the two different names for the same product,
+# so the mapping below is the one place that seam is bridged.
+_CALLBACK = {
+    "claude": {"port": 54545, "path": "/callback", "auth_provider": "anthropic"},
+    "codex": {"port": 1455, "path": "/auth/callback", "auth_provider": "codex"},
+}
+
+# How long a bound callback port waits for the browser before the login is
+# reported failed and the port released. account.py's URL_CAPTURE_TIMEOUT is
+# the same idea (bound the pathological hang) but sized for a subprocess
+# printing a line in well under a second; this waits on an actual human
+# reading a consent screen in a browser, hence minutes not seconds.
+_CALLBACK_TIMEOUT_S = 300.0
+
+
+def _require_fused(x_fused: str | None) -> JSONResponse | None:
+    # Same D3 guard as server._require_fused / account._require_fused.
+    # Duplicated deliberately: this module must not import server (no cycle
+    # — server includes this router).
+    if x_fused != "1":
+        return JSONResponse({"error": "missing or invalid X-Fused header"}, status_code=403)
+    return None
+
+
+def _error(message: str, status: int = 400) -> JSONResponse:
+    return JSONResponse({"error": message}, status_code=status)
+
+
+def _valid_credential_name(name: str) -> bool:
+    """`name` is handed straight to ai_proxy.delete_credential(), which puts
+    it in a `?name=` query param that names a file on disk server-side
+    (auth-dir/<name>) — reject anything that could walk out of that
+    directory. Legitimate names come from our own GET /api/ai/accounts
+    listing and never contain a separator, so this is purely a defense-in-
+    depth check against a hand-crafted request, not a normal-path concern."""
+    return bool(name) and "/" not in name and "\\" not in name and ".." not in name
+
+
+# -- the callback listener -----------------------------------------------------
+#
+# One HTTPServer per login attempt, bound to 127.0.0.1 only (never 0.0.0.0 —
+# the doc's ?is_webui=1 section is explicit that the proxy's own equivalent
+# shortcut was rejected for exactly this reason). It answers exactly one
+# request (the provider's redirect carrying ?code=&state=), then closes.
+
+
+_CALLBACK_OK_HTML = """<!doctype html>
+<html><head><title>FusedRender</title></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+             text-align: center; margin-top: 4rem; color: #222;">
+<h2>You're all set</h2>
+<p>Return to FusedRender to finish connecting your account.</p>
+<p style="color: #888;">You can close this tab.</p>
+</body></html>
+"""
+
+_CALLBACK_ERROR_HTML = """<!doctype html>
+<html><head><title>FusedRender</title></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+             text-align: center; margin-top: 4rem; color: #222;">
+<h2>Sign-in was not completed</h2>
+<p>{error}</p>
+<p>Return to FusedRender and try again.</p>
+</body></html>
+"""
+
+
+def _make_handler(expected_path: str) -> type:
+    """A BaseHTTPRequestHandler subclass bound to one expected callback path.
+
+    Stashes the captured code/state/error on `self.server` (an attribute of
+    the one HTTPServer instance this login attempt owns), not a module
+    global — so there is no cross-attempt leakage even in the pathological
+    case of two listener threads somehow existing at once."""
+
+    class _CallbackHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - stdlib-mandated name
+            parsed = urllib.parse.urlsplit(self.path)
+            if parsed.path != expected_path:
+                # Something other than the OAuth redirect hit this port
+                # (browser prefetch, favicon, a stray manual request) —
+                # a 404 both is honest and, unlike capturing garbage,
+                # doesn't fail the login over noise.
+                self.send_response(404)
+                self.end_headers()
+                return
+            qs = urllib.parse.parse_qs(parsed.query)
+            error = (qs.get("error") or [None])[0]
+            self.server.captured = {
+                "code": (qs.get("code") or [None])[0],
+                "state": (qs.get("state") or [None])[0],
+                "error": error,
+            }
+            page = _CALLBACK_OK_HTML if error is None else _CALLBACK_ERROR_HTML.format(
+                error=html.escape(error))
+            body = page.encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, fmt: str, *args) -> None:
+            # BaseHTTPRequestHandler logs every request to stderr by default
+            # — silence it; a one-shot localhost OAuth callback isn't
+            # something the app's console needs to see.
+            pass
+
+    return _CallbackHandler
+
+
+def _bind_callback_server(port: int, path: str) -> HTTPServer:
+    """Bind the provider's fixed callback port, loopback-only.
+
+    An OSError here almost always means the port is already held — by a
+    concurrent login (shouldn't happen past the single-flight check below,
+    but TOCTOU is possible), or by the user's own separately-installed
+    CLIProxyAPI mid-login (docs/AI_PROXY_MANAGEMENT_API.md's "Callback ports
+    are fixed" section calls this out by name). Either way we fail fast with
+    a message naming the likely cause rather than hanging."""
+    try:
+        return HTTPServer(("127.0.0.1", port), _make_handler(path))
+    except OSError as e:
+        raise RuntimeError(
+            f"could not bind 127.0.0.1:{port} for the OAuth callback ({e}); this "
+            "usually means a login is already in progress, or you have your own "
+            "CLIProxyAPI mid-login on this machine"
+        ) from e
+
+
+@dataclasses.dataclass
+class _ActiveConnect:
+    """The one in-flight (or just-finished) account-connect attempt.
+
+    `phase` moves waiting_browser -> exchanging -> done|failed, written by
+    the listener thread (_listen) and by the status route's live poll; plain
+    attribute writes are fine under the GIL, same discipline as account.py's
+    _ActiveLogin/_SetupJob. `http_server` and `cancel_event` exist only to
+    let /connect/cancel unblock the listener thread and free the port —
+    once phase reaches "exchanging" the server is already closed and both
+    become inert.
+    """
+
+    provider: str
+    auth_provider: str
+    state: str
+    http_server: HTTPServer
+    cancel_event: threading.Event = dataclasses.field(default_factory=threading.Event)
+    phase: str = "waiting_browser"
+    detail: str | None = None
+
+
+_LOCK = threading.Lock()
+_active: _ActiveConnect | None = None
+
+
+def _listen(entry: _ActiveConnect) -> None:
+    """Serve exactly one request on entry's callback port, then hand any
+    captured code to the proxy. Runs on a daemon thread for the life of one
+    login attempt.
+
+    Uses handle_request() in a loop rather than serve_forever(): the stdlib
+    only allows stopping serve_forever() via shutdown() called from ANOTHER
+    thread (calling it from the same thread deadlocks, per the socketserver
+    docs) — handle_request() with server.timeout set just returns on a
+    socket timeout, so this loop can poll the cancel event and the overall
+    deadline with no cross-thread signaling at all.
+    """
+    server = entry.http_server
+    server.timeout = 1.0
+    deadline = time.monotonic() + _CALLBACK_TIMEOUT_S
+    captured = None
+    while time.monotonic() < deadline:
+        if entry.cancel_event.is_set():
+            break
+        server.handle_request()
+        captured = getattr(server, "captured", None)
+        if captured is not None:
+            break
+    # Release the port the instant we're done needing it: everything past
+    # this point is talking to the proxy's management API, not the browser.
+    server.server_close()
+
+    if entry.cancel_event.is_set():
+        return  # /connect/cancel already decided the outcome; nothing to report
+    if captured is None:
+        entry.phase = "failed"
+        entry.detail = f"timed out waiting for the browser after {int(_CALLBACK_TIMEOUT_S)}s"
+        return
+    if captured["error"]:
+        entry.phase = "failed"
+        entry.detail = f"authorization was not granted: {captured['error']}"
+        return
+    if captured["state"] != entry.state:
+        # The doc calls this the CSRF token: a callback carrying a state we
+        # didn't hand out for THIS login must never be submitted.
+        entry.phase = "failed"
+        entry.detail = "callback state did not match the login we started"
+        return
+    if not captured["code"]:
+        entry.phase = "failed"
+        entry.detail = "callback did not include an authorization code"
+        return
+
+    entry.phase = "exchanging"
+    try:
+        ai_proxy.submit_login_code(entry.auth_provider, entry.state, captured["code"])
+    except RuntimeError as e:
+        entry.phase = "failed"
+        entry.detail = str(e)
+    # On success entry.phase stays "exchanging" — oauth-callback's 200 proves
+    # nothing (see ai_proxy.submit_login_code's docstring); the status route
+    # below polls get-auth-status for the real outcome.
+
+
+def _poll_status(entry: _ActiveConnect | None) -> dict:
+    if entry is None:
+        return {"state": "idle", "detail": None}
+    if entry.phase != "exchanging":
+        # waiting_browser/done/failed are all settled without touching the
+        # network — only "exchanging" needs a live call.
+        return {"state": entry.phase, "detail": entry.detail}
+    try:
+        result = ai_proxy.poll_login_status(entry.state)
+    except RuntimeError as e:
+        entry.phase, entry.detail = "failed", str(e)
+        return {"state": entry.phase, "detail": entry.detail}
+    status = result.get("status")
+    if status == "ok":
+        entry.phase, entry.detail = "done", None
+    elif status == "error":
+        entry.phase = "failed"
+        entry.detail = result.get("error") or "login failed"
+    # status == "wait" (or anything unrecognized): stay "exchanging" and let
+    # the client poll again.
+    return {"state": entry.phase, "detail": entry.detail}
+
+
+# -- routes --------------------------------------------------------------------
+
+
+@router.get("/api/ai/accounts")
+def api_ai_accounts():
+    # Cheap and non-spawning by construction: status() never spawns the
+    # proxy, and list_credentials() (which does hit the network) only runs
+    # when status() says something is already there to ask.
+    st = ai_proxy.status()
+    accounts = []
+    if st.get("running"):
+        try:
+            files = ai_proxy.list_credentials()
+        except RuntimeError:
+            # Best-effort: the proxy could have died in the gap between the
+            # health probe above and this call, or be a version this app
+            # wasn't built against (see the doc's version-skew note). Either
+            # way a listing hiccup degrades to "no accounts shown", not a
+            # 500 — the tab should never hard-fail over this.
+            files = []
+        for f in files:
+            provider = f.get("provider")
+            if provider not in ("claude", "codex"):
+                continue
+            # Map explicitly, field by field — never pass the raw entry
+            # through. It carries an id_token sub-object and an on-disk path
+            # (docs/AI_PROXY_MANAGEMENT_API.md's credential listing shape);
+            # neither belongs in a response any page on this server can read.
+            accounts.append({
+                "provider": provider,
+                "email": f.get("email"),
+                "label": f.get("label"),
+                "disabled": bool(f.get("disabled")),
+                "name": f.get("name"),
+            })
+    with _LOCK:
+        entry = _active
+    login = None
+    if entry is not None:
+        login = {"provider": entry.provider, "state": entry.phase, "detail": entry.detail}
+    return {
+        "supervised": bool(st.get("supervised")),
+        "running": bool(st.get("running")),
+        "accounts": accounts,
+        "login": login,
+    }
+
+
+@router.post("/api/ai/accounts/connect")
+def api_ai_accounts_connect(body: dict = Body(...), x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    provider = body.get("provider")
+    if provider not in _CALLBACK:
+        return _error(f"'provider' must be one of: {', '.join(_CALLBACK)}")
+
+    global _active
+    with _LOCK:
+        if _active is not None and _active.phase in ("waiting_browser", "exchanging"):
+            # Structural, not a race we chose: the callback ports are fixed
+            # per provider, and the doc is explicit that two logins can't run
+            # concurrently — so this is rejected outright rather than queued.
+            return _error(
+                f"a login for {_active.provider} is already in progress; cancel it "
+                "first or wait for it to finish",
+                409,
+            )
+        spec = _CALLBACK[provider]
+        try:
+            server_ = _bind_callback_server(spec["port"], spec["path"])
+        except RuntimeError as e:
+            return _error(str(e), 409)
+        try:
+            result = ai_proxy.start_login(spec["auth_provider"])
+        except RuntimeError as e:
+            server_.server_close()
+            return _error(str(e), 502)
+        state, url = result.get("state"), result.get("url")
+        if not isinstance(state, str) or not state or not isinstance(url, str) or not url:
+            server_.server_close()
+            return _error("the AI proxy did not return a login state/url", 502)
+        entry = _ActiveConnect(
+            provider=provider, auth_provider=spec["auth_provider"],
+            state=state, http_server=server_,
+        )
+        _active = entry
+        threading.Thread(target=_listen, args=(entry,), daemon=True).start()
+    # The frontend opens this URL itself (window.open) — this route only ever
+    # returns the string, never a browser action taken server-side (the same
+    # house rule account.py's login flow follows).
+    return {"authorize_url": url, "state": state}
+
+
+@router.get("/api/ai/accounts/connect/status")
+def api_ai_accounts_connect_status():
+    with _LOCK:
+        entry = _active
+    return _poll_status(entry)
+
+
+@router.post("/api/ai/accounts/connect/cancel")
+def api_ai_accounts_connect_cancel(x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    global _active
+    with _LOCK:
+        entry, _active = _active, None
+    if entry is None:
+        return {"ok": True, "canceled": False}
+    entry.cancel_event.set()  # wakes _listen within its <=1s poll tick
+    # Best-effort: also drop the proxy's own pending OAuth session so it
+    # doesn't sit around for its 30-minute TTL. Safe even if the state
+    # already completed, failed, or was never reached by the listener —
+    # ai_proxy.cancel_login's own contract is a no-op past TTL/completion.
+    try:
+        ai_proxy.cancel_login(entry.state)
+    except RuntimeError:
+        pass
+    return {"ok": True, "canceled": True}
+
+
+@router.delete("/api/ai/accounts/{name}")
+def api_ai_accounts_delete(name: str, x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    if not _valid_credential_name(name):
+        return _error("'name' is not a valid credential name")
+    try:
+        ai_proxy.delete_credential(name)
+    except RuntimeError as e:
+        return _error(str(e), 502)
+    return {"ok": True}

--- a/fused_render/ai_accounts.py
+++ b/fused_render/ai_accounts.py
@@ -175,6 +175,13 @@ def _bind_callback_server(port: int, path: str) -> HTTPServer:
         ) from e
 
 
+# The phases in which an attempt still owns its callback port and so blocks a
+# new login. Anything else (done/failed) is a finished attempt kept only so
+# /connect/status can report its outcome — it must not block the next login,
+# nor be reported as in-flight by the accounts listing.
+_IN_FLIGHT_PHASES = ("waiting_browser", "exchanging")
+
+
 @dataclasses.dataclass
 class _ActiveConnect:
     """The one in-flight (or just-finished) account-connect attempt.
@@ -320,8 +327,16 @@ def api_ai_accounts():
             })
     with _LOCK:
         entry = _active
+    # Only a GENUINELY in-flight attempt belongs here. _active is also kept
+    # after an attempt settles (so /connect/status can still report the
+    # outcome), but reporting a settled attempt as the listing's `login` reads
+    # to the page as "a login is in progress" forever — which disabled every
+    # Connect button after the FIRST login finished, making it impossible to
+    # connect a second provider without restarting. The phases below are the
+    # same two api_ai_accounts_connect treats as blocking, deliberately: this
+    # field exists to mirror that gate, so it must not be broader than it.
     login = None
-    if entry is not None:
+    if entry is not None and entry.phase in _IN_FLIGHT_PHASES:
         login = {"provider": entry.provider, "state": entry.phase, "detail": entry.detail}
     return {
         "supervised": bool(st.get("supervised")),
@@ -342,7 +357,7 @@ def api_ai_accounts_connect(body: dict = Body(...), x_fused: str | None = Header
 
     global _active
     with _LOCK:
-        if _active is not None and _active.phase in ("waiting_browser", "exchanging"):
+        if _active is not None and _active.phase in _IN_FLIGHT_PHASES:
             # Structural, not a race we chose: the callback ports are fixed
             # per provider, and the doc is explicit that two logins can't run
             # concurrently — so this is rejected outright rather than queued.

--- a/fused_render/ai_accounts.py
+++ b/fused_render/ai_accounts.py
@@ -23,6 +23,16 @@ are fixed" section), so grabbing the `code` out of the browser's redirect
 requires binding that port ourselves for the duration of one login. That is
 what makes this a one-click flow instead of a copy-the-code-out-of-a-dead-
 page-URL flow.
+
+This module also owns API keys — a second, config-level way to authenticate
+a provider, alongside OAuth (docs/AI_PROXY_MANAGEMENT_API.md's "API keys"
+section). They get their own routes and their own array in the listing
+response (never merged into `accounts`: a key has no session to expire, no
+browser to reconnect through, and is deleted by a config write, not a file
+removal). The one rule that overrides every other design choice down there:
+a full API key must NEVER reach a client, appear in a URL, or be logged —
+only a short masked hint travels outward, and `auth_index` (not the key) is
+the handle every mutation uses.
 """
 from __future__ import annotations
 
@@ -36,7 +46,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
 
-from fused_render.shell import ai_proxy
+from fused_render.shell import ai_proxy, prefs
 
 router = APIRouter()
 
@@ -58,6 +68,26 @@ _CALLBACK = {
 # printing a line in well under a second; this waits on an actual human
 # reading a consent screen in a browser, hence minutes not seconds.
 _CALLBACK_TIMEOUT_S = 300.0
+
+# API keys are config-level credentials for the same two providers OAuth
+# connects — reusing _CALLBACK's key set (rather than a second literal
+# tuple) means the two provider whitelists can never drift apart.
+_API_KEY_PROVIDERS = tuple(_CALLBACK)
+
+# Sane bounds on a pasted API key, not a claim about what a genuine key looks
+# like (only the provider knows that) — this only exists to reject obviously
+# wrong input (empty/whitespace-only, or something absurdly long that could
+# never be a real key) before it's written into the proxy's config. Real
+# provider keys observed in the wild run well under 200 characters; 4096
+# leaves generous headroom for an unusual format without accepting garbage.
+_MIN_API_KEY_LEN = 8
+_MAX_API_KEY_LEN = 4096
+
+# THE TRAP (docs/AI_PROXY_MANAGEMENT_API.md): a codex-api-key entry with no
+# base-url is accepted 200 and then silently dropped by the proxy on the
+# next read. Claude has no such requirement. Defaulting this for every
+# Codex key we write is what makes the write actually stick.
+_CODEX_DEFAULT_BASE_URL = "https://api.openai.com/v1"
 
 
 def _require_fused(x_fused: str | None) -> JSONResponse | None:
@@ -81,6 +111,37 @@ def _valid_credential_name(name: str) -> bool:
     listing and never contain a separator, so this is purely a defense-in-
     depth check against a hand-crafted request, not a normal-path concern."""
     return bool(name) and "/" not in name and "\\" not in name and ".." not in name
+
+
+def _mask_api_key(key: str) -> str:
+    """A display hint good enough to tell two of a provider's keys apart —
+    NEVER the key itself (see the module docstring's rule: a full API key
+    must never reach a client). Trailing characters, not a prefix: most
+    provider keys share a fixed prefix (sk-ant-, sk-proj-, ...), so a
+    prefix hint would barely distinguish two keys at all, while the
+    trailing characters are the actually-random part."""
+    if len(key) <= 4:
+        return "*" * len(key)
+    return "..." + key[-4:]
+
+
+def _normalize_api_key(value: object) -> str | None:
+    """Trim the whitespace a paste commonly adds (a trailing newline is the
+    single most common paste artifact) and validate what's left is a
+    plausible single-token key within _MIN/_MAX_API_KEY_LEN. Returns None
+    for anything that fails, so the route can turn that into one clear 400 —
+    not a validator that raises, since "not a key" is an ordinary bad-input
+    case here, not an exceptional one. Whitespace INSIDE the trimmed value
+    is rejected outright: a real key is one token, and silently accepting
+    "sk-abc 123" would persist something that can never authenticate."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped or any(c.isspace() for c in stripped):
+        return None
+    if not (_MIN_API_KEY_LEN <= len(stripped) <= _MAX_API_KEY_LEN):
+        return None
+    return stripped
 
 
 # -- the callback listener -----------------------------------------------------
@@ -325,6 +386,36 @@ def api_ai_accounts():
                 "disabled": bool(f.get("disabled")),
                 "name": f.get("name"),
             })
+    # API keys are a SEPARATE array from `accounts`, deliberately: an OAuth
+    # account and a pasted key are different things with different
+    # affordances (a key can't be "re-authorized" in a browser, and deleting
+    # it is a config write, not a file removal) — merging them into one list
+    # would force the frontend to sniff which kind each entry is instead of
+    # just being told. Gated on st.get("running") for the same reason the
+    # credential listing above is: fetching this hits the management API,
+    # and api_ai_accounts() must stay cheap and non-spawning when nothing is
+    # up yet (module docstring's contract for this route).
+    api_keys = []
+    if st.get("running"):
+        for provider in _API_KEY_PROVIDERS:
+            try:
+                entries = ai_proxy.list_api_keys(provider)
+            except RuntimeError:
+                # Same degrade-gracefully rule as list_credentials() above: a
+                # listing hiccup on one provider must not blank the response.
+                entries = []
+            for e in entries:
+                key = e.get("api-key")
+                if not isinstance(key, str) or not key:
+                    continue
+                # Explicit field mapping, same discipline as the accounts
+                # loop above — never pass a raw entry through, since it
+                # carries the plaintext key itself.
+                api_keys.append({
+                    "provider": provider,
+                    "hint": _mask_api_key(key),
+                    "auth_index": e.get("auth-index"),
+                })
     with _LOCK:
         entry = _active
     # Only a GENUINELY in-flight attempt belongs here. _active is also kept
@@ -342,6 +433,13 @@ def api_ai_accounts():
         "supervised": bool(st.get("supervised")),
         "running": bool(st.get("running")),
         "accounts": accounts,
+        "api_keys": api_keys,
+        # The pref, not a probe of the live config: it's what the NEXT
+        # spawn will use, which is also what the page needs to show as
+        # "current" for a control it can flip (see restart_ai_proxy()) —
+        # reading it out of a running instance would need a config-echo
+        # route the proxy doesn't have.
+        "routing_strategy": prefs.ai_routing_strategy(),
         "login": login,
     }
 
@@ -433,3 +531,125 @@ def api_ai_accounts_delete(name: str, x_fused: str | None = Header(default=None)
     except RuntimeError as e:
         return _error(str(e), 502)
     return {"ok": True}
+
+
+# -- API keys (config-level credentials) ----------------------------------------
+#
+# Everything below talks to ai_proxy.list_api_keys/replace_api_keys, never to
+# the auth-files routes above — these are config entries, not credential
+# files (docs/AI_PROXY_MANAGEMENT_API.md's "API keys" section), so they need
+# their own add/remove dance: there is no POST-to-append, so every mutation
+# is read-modify-write of the WHOLE per-provider array.
+
+
+@router.post("/api/ai/accounts/keys")
+def api_ai_accounts_add_key(body: dict = Body(...), x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    provider = body.get("provider")
+    if provider not in _API_KEY_PROVIDERS:
+        return _error(f"'provider' must be one of: {', '.join(_API_KEY_PROVIDERS)}")
+    key = _normalize_api_key(body.get("api_key"))
+    if key is None:
+        return _error(
+            "'api_key' must be a single-token string between "
+            f"{_MIN_API_KEY_LEN} and {_MAX_API_KEY_LEN} characters long "
+            "(missing, whitespace-only, containing whitespace, or absurdly "
+            "long values are all rejected)"
+        )
+    try:
+        current = ai_proxy.list_api_keys(provider)
+    except RuntimeError as e:
+        return _error(str(e), 502)
+    # Carry every existing entry forward VERBATIM except its server-assigned
+    # auth-index — an output-only field the doc never shows being accepted
+    # back in (PUT regenerates it from array position on the next GET), so
+    # sending it back is either ignored or, worse, misread as a request to
+    # target that position. Dropping any OTHER field here would silently
+    # narrow an unrelated existing key's base-url/proxy-url/models on an add
+    # that has nothing to do with it — this is why read-modify-write reads
+    # the current list instead of just appending to an empty one.
+    new_entries = [{k: v for k, v in e.items() if k != "auth-index"} for e in current]
+    new_entry = {"api-key": key}
+    if provider == "codex":
+        new_entry["base-url"] = _CODEX_DEFAULT_BASE_URL
+    new_entries.append(new_entry)
+    try:
+        ai_proxy.replace_api_keys(provider, new_entries)
+    except RuntimeError as e:
+        return _error(str(e), 502)
+    # Never trust the PUT's 200 — the codex trap answers ok and silently
+    # drops the entry. Read back and confirm the key is actually there
+    # before reporting success to the caller.
+    try:
+        verify = ai_proxy.list_api_keys(provider)
+    except RuntimeError as e:
+        return _error(f"key was written but could not be verified: {e}", 502)
+    match = next((e for e in verify if e.get("api-key") == key), None)
+    if match is None:
+        return _error(
+            f"the {provider} API key was written but did not persist on "
+            "read-back (the proxy silently dropped it — this is the known "
+            "codex-api-key base-url trap if it recurs, something upstream "
+            "changed)",
+            502,
+        )
+    return {
+        "ok": True,
+        "provider": provider,
+        "hint": _mask_api_key(key),
+        "auth_index": match.get("auth-index"),
+    }
+
+
+@router.delete("/api/ai/accounts/keys/{auth_index}")
+def api_ai_accounts_delete_key(auth_index: str, x_fused: str | None = Header(default=None)):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    # auth_index, NEVER the key, is the handle here — the whole point of
+    # using it (module docstring's constraint) is that a key must never
+    # travel in a URL, where it would land in logs/browser history/proxy
+    # access logs. The route doesn't scope by provider (an auth-index is
+    # already unique across a proxy instance), so search each provider's
+    # list in turn.
+    for provider in _API_KEY_PROVIDERS:
+        try:
+            current = ai_proxy.list_api_keys(provider)
+        except RuntimeError as e:
+            return _error(str(e), 502)
+        remaining = [e for e in current if str(e.get("auth-index")) != auth_index]
+        if len(remaining) == len(current):
+            continue  # not this provider's list — try the other one
+        new_entries = [{k: v for k, v in e.items() if k != "auth-index"} for e in remaining]
+        try:
+            ai_proxy.replace_api_keys(provider, new_entries)
+        except RuntimeError as e:
+            return _error(str(e), 502)
+        return {"ok": True}
+    return _error(f"no API key with auth_index {auth_index!r}", 404)
+
+
+@router.put("/api/ai/accounts/routing-strategy")
+def api_ai_accounts_set_routing_strategy(
+    body: dict = Body(...), x_fused: str | None = Header(default=None)
+):
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    value = body.get("strategy")
+    try:
+        prefs.set_ai_routing_strategy(value)
+    except ValueError as e:
+        return _error(str(e))
+    # The proxy only reads routing.strategy at process startup — there is no
+    # hot-reload on this build, so the new choice does nothing until a fresh
+    # instance picks it up. Kill the current one now (best-effort: there may
+    # be none running yet, in which case this is a no-op) rather than
+    # leaving a live proxy silently serving the OLD strategy after the user
+    # was just told the change was saved. The next call that actually needs
+    # the proxy respawns it lazily with the new config — same laziness
+    # discipline as every other ensure_ai_proxy() call site in this app.
+    restarted = ai_proxy.restart_ai_proxy()
+    return {"ok": True, "strategy": value, "restarted": restarted}

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -402,6 +402,19 @@ def main() -> None:
             stop_local_rcd()
         except Exception:
             logger.warning("rcd teardown on quit failed", exc_info=True)
+        # Same story for the bundled AI proxy (shell/ai_proxy.py, SPEC RH-12):
+        # it is spawned lazily by the in-process server, so on quit it would
+        # reparent to launchd and keep both its port and the user's OAuth
+        # credentials loaded with no app left to use them. Independently gated
+        # (FUSED_RENDER_AI_PROXY_PERSIST) and ownership-checked internally, so
+        # this is safe to call unconditionally; kept in its own try so an
+        # rcd-side failure can't skip it, or vice versa.
+        try:
+            from fused_render.shell.ai_proxy import stop_local_ai_proxy
+
+            stop_local_ai_proxy()
+        except Exception:
+            logger.warning("ai-proxy teardown on quit failed", exc_info=True)
         rumps.quit_application()
 
     status_app = FusedRenderStatusApp()

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -3047,6 +3047,21 @@ def create_app(start_dir: str) -> FastAPI:
         if client is not None:
             await client.aclose()
 
+    @app.on_event("shutdown")
+    async def _stop_bundled_ai_proxy():
+        # The AI proxy (SPEC RH-12) is spawned lazily by THIS process, so
+        # whoever owns the process has to reap it: a bare `fused-render serve`
+        # has no supervisor and no menu-bar quit path, and without this the
+        # proxy would outlive the server holding a port and the user's OAuth
+        # credentials. Blocking (it signals and waits), hence to_thread; the
+        # call is internally gated on the dev persist flag and refuses to
+        # signal any pid it cannot prove is ours. Never let a teardown failure
+        # turn into a noisy shutdown — log and move on, as app.py does.
+        try:
+            await asyncio.to_thread(shell_ai_proxy.stop_local_ai_proxy)
+        except Exception:
+            logger.warning("ai-proxy teardown on server shutdown failed", exc_info=True)
+
     @app.exception_handler(Exception)
     async def unhandled_exception(request, exc):
         # A bare "Internal Server Error" with an empty body is undebuggable on

--- a/fused_render/server.py
+++ b/fused_render/server.py
@@ -53,9 +53,11 @@ from fused_render import __version__
 from fused_render import calls as shell_calls
 from fused_render._view_url_codec import canonical_fs_path
 from fused_render.account import router as account_router
+from fused_render.ai_accounts import router as ai_accounts_router
 from fused_render.core_templates import ensure_core_templates
 from fused_render.deploy import router as deploy_router
 from fused_render.executor import dumps_result, run_python
+from fused_render.shell import ai_proxy as shell_ai_proxy
 from fused_render.shell import prefs as shell_prefs
 from fused_render.shell import storage
 from fused_render.shell.bookmarks import router as bookmarks_router
@@ -885,12 +887,39 @@ async def _ai_relay(body: dict) -> JSONResponse:
         messages.append({"role": "system", "content": system_prompt})
     messages.append({"role": "user", "content": prompt})
 
-    base = shell_prefs.ai_base_url().rstrip("/")
+    # Supervised (the default): no explicit ai_base_url/env override exists,
+    # so route through the bundled proxy — spawn/reuse it and authenticate
+    # with its generated api_key. Unsupervised (the user pointed ai_base_url
+    # at something of their own): behave EXACTLY as before this change — no
+    # supervision, no auth header, straight to that base URL. is_supervised()
+    # is keyed on explicit configuration, not on ai_base_url()'s resolved
+    # value, so this branch can't be fooled by the pref's own unset-default
+    # (see shell/ai_proxy.is_supervised's docstring).
+    # Supervising also requires a binary to supervise. A dev checkout has no
+    # bundled cli-proxy-api, and neither does an existing install that predates
+    # bundling — in both cases ai_base_url()'s default (127.0.0.1:8317, the port
+    # a user-run CLIProxyAPI conventionally listens on) is exactly what worked
+    # before this change, so fall through to it instead of failing. Without this
+    # gate, bundling would REGRESS every dev checkout and every user who relied
+    # on the documented default port without explicitly setting the pref: they
+    # have a proxy running and answering, and we'd have reported ai_unavailable.
+    headers = None
+    if shell_ai_proxy.is_supervised() and shell_ai_proxy.ai_proxy_bin() is not None:
+        try:
+            base, api_key, _mgmt_key = await asyncio.to_thread(shell_ai_proxy.ensure_ai_proxy)
+        except RuntimeError as e:
+            # Same {ok, error} contract as any other proxy-unreachable case —
+            # RH-11's three error `type`s don't grow a fourth for this.
+            return _ai_error("ai_unavailable", str(e))
+        headers = {"Authorization": f"Bearer {api_key}"}
+    else:
+        base = shell_prefs.ai_base_url()
+    base = base.rstrip("/")
     url = base + "/v1/chat/completions"
     payload = {"model": model, "max_tokens": max_tokens, "messages": messages}
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(_AI_TIMEOUT_S)) as client:
-            r = await client.post(url, json=payload)
+            r = await client.post(url, json=payload, headers=headers)
     except httpx.HTTPError as exc:
         return _ai_error(
             "ai_unavailable",
@@ -3230,6 +3259,10 @@ def create_app(start_dir: str) -> FastAPI:
     # Fused account (in-app `fused cloud login/logout`, account.py) — the
     # sign-in the managed-env deploys need, without a terminal.
     app.include_router(account_router)
+    # AI account management (ai_accounts.py) — list/connect/disconnect Claude
+    # and Codex logins against the bundled AI proxy (shell/ai_proxy.py) that
+    # backs fused.ai(). See docs/AI_PROXY_BUNDLING.md.
+    app.include_router(ai_accounts_router)
     # Template management (templates_api.py) — the Templates view backend:
     # inventory across sources, registry bindings edit, import/export. It owns
     # GET /api/templates/registry (the extended §2.2 shape). Imported here

--- a/fused_render/shell/ai_proxy.py
+++ b/fused_render/shell/ai_proxy.py
@@ -291,6 +291,43 @@ def _yaml_str(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
+def _preserved_api_key_blocks() -> str:
+    """The provider API-key sections of the EXISTING config, verbatim.
+
+    _write_config regenerates config.yaml from scratch on every spawn, but
+    provider API keys (claude-api-key / codex-api-key) live in that same file —
+    the proxy itself writes them there when the management API adds one. So a
+    naive regenerate DESTROYS every key the user has added: verified by adding a
+    key, changing the routing strategy (which restarts), and finding the key
+    gone. Unlike OAuth credentials, which live as separate files under auth-dir
+    and are therefore untouched by this, keys have no home outside the config.
+
+    Rather than model these blocks (entries carry base-url/proxy-url/models and
+    a server-assigned auth-index, and the shapes differ per provider), the old
+    text is carried across unparsed: this function owns nothing about their
+    meaning, it just refuses to lose them. Everything from a top-level
+    `<provider>-api-key:` line up to the next top-level key is kept.
+
+    Best-effort by design — a missing or unreadable config simply means there
+    is nothing to preserve, which is the correct answer for a first spawn.
+    """
+    try:
+        with open(_config_path(), encoding="utf-8") as f:
+            lines = f.read().splitlines()
+    except OSError:
+        return ""
+    kept: list[str] = []
+    keeping = False
+    for line in lines:
+        if line[:1] not in (" ", "\t", "", "#"):
+            # A new top-level key ends any block we were copying, and starts a
+            # new one only if it is a provider api-key section.
+            keeping = line.split(":", 1)[0] in _API_KEY_ROUTE.values()
+        if keeping:
+            kept.append(line)
+    return ("\n".join(kept) + "\n") if kept else ""
+
+
 def _write_config(port: int, api_key: str, management_key: str,
                    routing_strategy: str) -> str:
     """Write the proxy's YAML config and return its path.
@@ -323,6 +360,10 @@ def _write_config(port: int, api_key: str, management_key: str,
     except OSError:
         pass
     os.makedirs(_auth_dir(), exist_ok=True)
+    # Read the outgoing config's provider key blocks BEFORE the write below
+    # clobbers it — see _preserved_api_key_blocks for why losing them is data
+    # loss and not just a reset.
+    preserved = _preserved_api_key_blocks()
     config = (
         'host: "127.0.0.1"\n'
         f'port: {port}\n'
@@ -336,6 +377,7 @@ def _write_config(port: int, api_key: str, management_key: str,
         '  allow-remote: false\n'
         f'  secret-key: "{_yaml_str(management_key)}"\n'
         '  disable-control-panel: true\n'
+        + preserved
     )
     path = _config_path()
     with open(path, "w", encoding="utf-8") as f:

--- a/fused_render/shell/ai_proxy.py
+++ b/fused_render/shell/ai_proxy.py
@@ -291,7 +291,8 @@ def _yaml_str(value: str) -> str:
     return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
-def _write_config(port: int, api_key: str, management_key: str) -> str:
+def _write_config(port: int, api_key: str, management_key: str,
+                   routing_strategy: str) -> str:
     """Write the proxy's YAML config and return its path.
 
     host is pinned to 127.0.0.1 (never the upstream default of all
@@ -303,6 +304,15 @@ def _write_config(port: int, api_key: str, management_key: str) -> str:
     rotated log instead (see _rotate_log) — there is no --log-file flag on
     this binary, so config-side logging and our redirect would otherwise be
     two independent, un-rotated log destinations.
+
+    routing.strategy is written out EXPLICITLY rather than left to omission:
+    the upstream default ("round-robin" — pool every credential for a
+    provider and fail over between them) is otherwise invisible in this
+    file, and prefs.ai_routing_strategy() already resolves an unset pref to
+    that same default, so a caller reading this config can't tell "chose
+    round-robin" from "never asked." Written from the pref at spawn time
+    because the binary only reads its config at startup (see
+    restart_ai_proxy()) — there is no hot-reload to short-circuit that with.
 
     Written 0600 immediately after creation: the file holds both secrets in
     plaintext, and CLIProxyAPI hashes a plaintext secret-key on startup, so
@@ -320,6 +330,8 @@ def _write_config(port: int, api_key: str, management_key: str) -> str:
         f'  - "{_yaml_str(api_key)}"\n'
         f'auth-dir: "{_yaml_str(_auth_dir())}"\n'
         'logging-to-file: false\n'
+        'routing:\n'
+        f'  strategy: "{_yaml_str(routing_strategy)}"\n'
         'remote-management:\n'
         '  allow-remote: false\n'
         f'  secret-key: "{_yaml_str(management_key)}"\n'
@@ -428,7 +440,8 @@ def _ensure_locked() -> tuple[str, str, str]:
 
     api_key = secrets.token_urlsafe(32)
     management_key = secrets.token_urlsafe(32)
-    config_path = _write_config(port, api_key, management_key)
+    routing_strategy = prefs.ai_routing_strategy()
+    config_path = _write_config(port, api_key, management_key, routing_strategy)
     log_path = _rotate_log()
 
     with open(log_path, "ab") as log_f:
@@ -510,6 +523,44 @@ def _kill_current_ai_proxy() -> None:
     raise RuntimeError(f"ai-proxy pid {pid} did not exit after {sigs[-1].name}")
 
 
+def restart_ai_proxy() -> bool:
+    """Force-kill the current supervised instance so the NEXT ensure_ai_proxy()
+    call spawns a fresh one, picking up a config change that only takes
+    effect at process startup — routing.strategy today (see _write_config
+    and prefs.ai_routing_strategy()). Returns True if a live instance was
+    actually killed, False if there was nothing running to kill (nothing
+    spawned yet, or it belongs to a process we can't confirm — see
+    _confirmed_ours).
+
+    Deliberately does NOT respawn here: that would make a routing-strategy
+    change block its caller (an accounts-page PUT) on the same ~15s startup
+    poll ensure_ai_proxy() pays once per session, for a change that doesn't
+    need the proxy back up immediately. The next call that actually needs
+    the proxy (an accounts refresh, or the next fused.ai()) respawns it
+    lazily, same discipline as every other ensure_ai_proxy() call site.
+
+    Unlike stop_local_ai_proxy() (the app-quit path), this ignores
+    _should_persist(): a dev convenience for surviving watchfiles restarts
+    across app-process restarts is not a reason to keep serving a stale
+    routing strategy after the user explicitly changed it from the
+    accounts page."""
+    with _lock:
+        entry = storage.read_json(_state_path())
+        if not isinstance(entry, dict):
+            return False
+        pid = entry.get("pid") or 0
+        if not _pid_alive(pid):
+            return False
+        try:
+            _kill_current_ai_proxy()
+        except RuntimeError:
+            # Not confirmed ours (e.g. pid recycled to an unrelated process,
+            # or owned by something else entirely) — nothing safe to kill;
+            # the next ensure call still spawns fresh with the new config.
+            return False
+        return True
+
+
 def stop_local_ai_proxy() -> None:
     """Best-effort teardown of the proxy we spawned, for the app's quit path
     — stop_local_rcd's exact contract, applied to this daemon.
@@ -554,14 +605,17 @@ def status() -> dict:
     return {"supervised": True, "running": False}
 
 
-def management_request(method: str, path: str, body: dict | None = None,
+def management_request(method: str, path: str, body: dict | list | None = None,
                         *, timeout: float = 10.0) -> dict:
     """One authenticated call to the proxy's /v0/management API.
 
     `path` is the suffix after /v0/management (e.g. "/auth-files",
     "/auth-files?name=foo.json", "/anthropic-auth-url", "/oauth-callback")
     — the routes layer builds the exact route; this is transport only, with
-    no FastAPI/route awareness. Ensures a live proxy first (same lazy-spawn
+    no FastAPI/route awareness. `body` is a dict for every route except the
+    API-key PUTs, which the doc is explicit take a bare JSON array (see
+    replace_api_keys) — json.dumps handles either with no branching needed
+    here. Ensures a live proxy first (same lazy-spawn
     discipline as ensure_ai_proxy(), since a management call to an instance
     that isn't running is meaningless) and authenticates with
     `management_key` — the account-management surface's own secret,
@@ -685,3 +739,53 @@ def set_credential_disabled(name: str, disabled: bool,
     if auth_index is not None:
         body["auth_index"] = auth_index
     return management_request("PATCH", "/auth-files/status", body)
+
+
+# -- API keys (config-level credentials) --------------------------------------
+#
+# Separate surface from the auth-files/OAuth wrappers above: an API key is a
+# config entry, not a file in auth-dir, so it never shows up in list_credentials
+# (docs/AI_PROXY_MANAGEMENT_API.md's "API keys" section). Our provider names
+# ("claude"/"codex") already match the route names 1:1 here — unlike the OAuth
+# routes, there is no anthropic/claude naming seam to bridge.
+#
+# This layer stays exactly as thin as the wrappers above: no read-modify-write
+# policy, no key masking, no base-url defaulting. Those are the routes layer's
+# job (ai_accounts.py) precisely because they need to reason about what a
+# client is allowed to see and about the codex-base-url trap, neither of
+# which belongs in a transport-only module.
+
+_API_KEY_ROUTE = {"claude": "claude-api-key", "codex": "codex-api-key"}
+
+
+def list_api_keys(provider: str) -> list:
+    """Every API-key entry configured for `provider`, proxy-native shape:
+    {api-key, base-url, proxy-url, models, auth-index}. Returns the raw
+    entries — including the plaintext api-key field — unfiltered; masking a
+    key down to a display hint before it can reach a client is the routes
+    layer's job, same division of labor as list_credentials()/
+    api_ai_accounts(). Callers holding this return value must treat it with
+    the same care as any other live credential material: never log it,
+    never let it further than the one response that needed it."""
+    route = _API_KEY_ROUTE[provider]
+    result = management_request("GET", f"/{route}")
+    entries = result.get(route)
+    return entries if isinstance(entries, list) else []
+
+
+def replace_api_keys(provider: str, entries: list) -> dict:
+    """Overwrite `provider`'s ENTIRE api-key list with `entries`. There is no
+    POST-to-append on this API (confirmed 404 in the doc), so every add or
+    remove is a read-modify-write of the whole array, and this wrapper is
+    deliberately dumb about that — it PUTs exactly the list it's given, no
+    more and no less.
+
+    `entries` MUST be a bare list (not a dict wrapping it under the route
+    name) — the proxy's 400 on the object shape is the exact trap the doc
+    calls out, since GET returns that wrapper and it's an easy shape to
+    carry over by mistake. Defaulting Codex's base-url (the doc's silent-
+    drop trap) and reading back to confirm a write landed are both the
+    caller's job; this function does not know which provider it's talking
+    to beyond picking the route."""
+    route = _API_KEY_ROUTE[provider]
+    return management_request("PUT", f"/{route}", entries)

--- a/fused_render/shell/ai_proxy.py
+++ b/fused_render/shell/ai_proxy.py
@@ -459,12 +459,51 @@ def ensure_ai_proxy() -> tuple[str, str, str]:
         return _ensure_locked()
 
 
+def _terminate_unhealthy_child(proc: subprocess.Popen) -> None:
+    """Kill a just-spawned instance that never became healthy, and reap it.
+
+    Only ever called with a Popen WE created moments ago, so ownership needs no
+    proving — unlike _kill_current_ai_proxy, whose pid comes from a state file
+    and could have been recycled. SIGTERM then SIGKILL, then wait() so the dead
+    child doesn't linger as a zombie (see _reap_child). Best-effort throughout:
+    this runs on a path that is already failing, and must not replace the
+    caller's "never became healthy" error with a teardown one."""
+    global _child
+    try:
+        proc.terminate()
+        try:
+            proc.wait(timeout=_KILL_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=_KILL_TIMEOUT_S)
+    except (OSError, ValueError, subprocess.TimeoutExpired):
+        logger.warning("ai-proxy: could not terminate an unhealthy spawn",
+                       exc_info=True)
+    if _child is proc:
+        _child = None
+
+
 def _ensure_locked() -> tuple[str, str, str]:
     state = storage.read_json(_state_path())
     if isinstance(state, dict) and state.get("port") and state.get("api_key"):
         if _probe_models(int(state["port"]), state["api_key"]):
             return (_base_url(state["port"]), state["api_key"],
                     state.get("management_key", ""))
+        # Recorded but not answering. If that pid is still alive it is a HUNG
+        # instance, not a dead one — and we are about to overwrite the config
+        # and state file it is described by, which would leave it running,
+        # unreachable, and unprovable as ours (so never reapable). Kill it
+        # first, while the state file that identifies it still exists.
+        # Best-effort: an unconfirmable pid raises here and we carry on to the
+        # spawn, since refusing to start a proxy because an unrelated process
+        # inherited a recycled pid would be worse than the leak.
+        if _pid_alive(state.get("pid") or 0):
+            try:
+                _kill_current_ai_proxy()
+            except RuntimeError:
+                logger.warning(
+                    "ai-proxy: recorded instance is unreachable but its pid "
+                    "could not be confirmed as ours; leaving it alone")
 
     bin_ = ai_proxy_bin()
     if not bin_:
@@ -512,10 +551,20 @@ def _ensure_locked() -> tuple[str, str, str]:
                          config_path, log_path)
             return (_base_url(port), api_key, management_key)
         if proc.poll() is not None:
+            _child = None  # already dead; nothing to reap but don't keep the handle
             raise RuntimeError(
                 f"ai-proxy exited immediately (code {proc.returncode}); "
                 f"see {log_path}")
         time.sleep(0.2)
+    # Unhealthy but ALIVE — kill it before giving up. Without this the process
+    # leaks permanently: no state file was written, so nothing afterwards knows
+    # its pid, _confirmed_ours can never prove it is ours, and every later
+    # retry spawns another one beside it. Worse under
+    # FUSED_RENDER_AI_PROXY_PERSIST, where start_new_session has already
+    # detached it from this process group, so app teardown won't collect it
+    # either. Signal directly rather than via _kill_current_ai_proxy: that
+    # reads the state file, which deliberately does not exist yet.
+    _terminate_unhealthy_child(proc)
     raise RuntimeError(
         f"ai-proxy did not become healthy within {_STARTUP_TIMEOUT_S:g}s; "
         f"see {log_path}")

--- a/fused_render/shell/ai_proxy.py
+++ b/fused_render/shell/ai_proxy.py
@@ -1,0 +1,631 @@
+"""Bundled AI proxy — supervises a local CLIProxyAPI instance for fused.ai().
+
+Follow-on to fused.ai() (SPEC RH-11), which relays to an OpenAI-compatible
+proxy the user was expected to install and run themselves. This module ships
+that proxy inside the app instead: it resolves the binary, spawns it lazily
+on first use, and tears it down — the exact shape of shell/mounts.py's rcd
+half (`rclone_bin()` / `ensure_rcd()` / `stop_local_rcd()`), because
+CLIProxyAPI is, like rclone, a single static Go binary we bundle and drive
+over a local HTTP API. See docs/AI_PROXY_BUNDLING.md for the design and
+docs/AI_PROXY_MANAGEMENT_API.md for the wire contract this was verified
+against (CLIProxyAPI v7.2.90 — pin hard, degrade gracefully on version skew).
+
+Sync vs. async: every function here is a plain blocking call, not a
+coroutine — the same choice mounts.py made for `ensure_rcd()`/`_rc()`, and
+the one this codebase already has a house idiom for (shell/prefetch.py:
+"Blocking — run via asyncio.to_thread"; server.py calls sync shell helpers
+from async routes via `await asyncio.to_thread(...)` throughout, e.g.
+shell_mounts.bearer_upstream_for). Spawning a process and health-polling it
+for up to ~15s is exactly the kind of blocking work that pattern exists for;
+making this module's functions `async def` would just push the same
+event-loop-blocking problem into the network calls it makes, so the caller
+in server.py (owned by another worker) is expected to hop this off the loop
+with `asyncio.to_thread` rather than this module reinventing an async
+transport on top of plain HTTP.
+
+Security posture, mirroring mounts.py's rcd auth block: the proxy is bound
+to 127.0.0.1 only (never the upstream default of all interfaces) and every
+call — chat completions and management alike — requires a random per-launch
+secret we mint ourselves, because loopback is not a boundary against the
+browser: any page the user has open could otherwise drive an unauthenticated
+local API. Two secrets, two blast radii: `api_key` gates the OpenAI-compatible
+surface fused.ai() relays through; `management_key` gates account
+management (listing/deleting credentials, OAuth login) — a strictly more
+sensitive surface, kept on its own key so the relay's routine traffic never
+carries a credential that can delete someone's login.
+"""
+import json
+import logging
+import os
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from urllib.parse import quote
+
+from fused_render.shell import prefs, storage
+
+logger = logging.getLogger(__name__)
+
+BIN_NAME = "cli-proxy-api.exe" if sys.platform == "win32" else "cli-proxy-api"
+
+# How long ensure_ai_proxy() waits for a freshly spawned instance to answer
+# an authenticated /v1/models before giving up — generous relative to
+# rclone's 10s in ensure_rcd(), since this is a bigger Go binary doing OAuth
+# client setup on top of an HTTP server, and it only pays this cost once per
+# app session (lazy spawn, then reused for every later fused.ai() call).
+_STARTUP_TIMEOUT_S = 15.0
+
+# rclone's rcd has no built-in log rotation and neither does this binary in
+# our config (logging-to-file: false — see _write_config); cap our own
+# stdout/stderr capture the same way _rotate_rcd_log does.
+LOG_MAX_BYTES = 10 * 1024 * 1024
+
+# Spawn-or-reuse must be serialized: fused.ai() is called from async request
+# handlers, and two concurrent calls racing "no live instance" would each
+# spawn their own proxy, with the loser's orphaned and its state clobbered —
+# the same race _rcd_lock exists to close for rclone's rcd.
+_lock = threading.Lock()
+
+
+def _state_dir() -> str:
+    return os.path.join(storage.home_dir(), "ai-proxy")
+
+
+def _config_path() -> str:
+    return os.path.join(_state_dir(), "config.yaml")
+
+
+def _auth_dir() -> str:
+    return os.path.join(_state_dir(), "auths")
+
+
+def _log_path() -> str:
+    return os.path.join(_state_dir(), "proxy.log")
+
+
+def _state_path() -> str:
+    return os.path.join(storage.home_dir(), "ai_proxy.json")
+
+
+def ai_proxy_bin() -> str | None:
+    """Path to the CLIProxyAPI binary to run.
+
+    Resolution order, exactly rclone_bin()'s shape:
+    1. An explicit FUSED_RENDER_AI_PROXY_BIN pointing at a real file. Set by
+       the supervisor in packaged Windows/Linux builds to the binary staged
+       in the payload. A stale/wrong override (not a file) is ignored so it
+       can't shadow a working binary in a dev checkout.
+    2. The packaged macOS app bundle (py2app sets sys.frozen = "macosx_app"):
+       Contents/Resources/bin/cli-proxy-api, staged the same way rclone is.
+    3. The system binary on PATH — keeps a dev checkout against a homebrew
+       install working, and is what a user's own separately-installed proxy
+       would already satisfy (though see is_supervised(): that case is
+       normally reached via an explicit ai_base_url instead, not this tier).
+    """
+    override = os.environ.get("FUSED_RENDER_AI_PROXY_BIN")
+    if override and os.path.isfile(override):
+        return override
+    if getattr(sys, "frozen", None) == "macosx_app":
+        contents = os.path.dirname(os.path.dirname(os.path.abspath(sys.executable)))
+        bundled = os.path.join(contents, "Resources", "bin", BIN_NAME)
+        if os.path.isfile(bundled):
+            return bundled
+    return shutil.which(BIN_NAME)
+
+
+def is_supervised() -> bool:
+    """False when the user has explicitly pointed ai_base_url somewhere of
+    their own choosing — in which case we supervise nothing and the relay
+    behaves exactly as it does today (talks straight to that base URL, no
+    generated credentials involved). True (the default) means no explicit
+    override exists, so the relay should route through ensure_ai_proxy().
+
+    Deliberately keyed on *explicit* configuration (the env var, or the pref
+    key being present with a non-empty value) rather than on ai_base_url()'s
+    return value equaling some particular string: prefs.DEFAULT_AI_BASE_URL
+    (127.0.0.1:8317) is just what an UNSET pref happens to resolve to — a
+    user-run CLIProxyAPI's conventional default port — not a signal that the
+    user asked for anything. Our bundled instance runs on an unrelated
+    ephemeral port picked at spawn time, so "the pref is unset" must still
+    mean "supervise it ourselves," not "the user chose 8317."
+    """
+    if os.environ.get("FUSED_RENDER_AI_BASE_URL"):
+        return False
+    value = prefs.read_prefs().get("ai_base_url")
+    return not (isinstance(value, str) and value)
+
+
+def _should_persist() -> bool:
+    """Whether a freshly spawned proxy should detach (setsid) and outlive
+    this process, or stay a normal child that dies with it.
+
+    Own env var (FUSED_RENDER_AI_PROXY_PERSIST), not rclone's — this is a
+    separate daemon with a separate lifecycle, and coupling the two would
+    mean a dev-mode rclone convenience silently also changed how the AI
+    proxy tears down. Same dev-iteration rationale as mounts.py's
+    _rclone_should_persist: OFF by default (production: quitting the app
+    kills it), ON only when a dev script opts in (skip the respawn +
+    re-login cost across watchfiles restarts)."""
+    return os.environ.get("FUSED_RENDER_AI_PROXY_PERSIST") not in (None, "", "0")
+
+
+def _pid_alive(pid: int) -> bool:
+    """True if `pid` names a running process. Duplicated from
+    mounts._pid_alive rather than imported: this module is meant to stand on
+    its own (transport-only, no coupling to rclone's daemon), and the check
+    itself is generic OS plumbing, not rcd-specific."""
+    if not pid or pid <= 0:
+        return False
+    if sys.platform == "win32":
+        import ctypes
+        handle = ctypes.windll.kernel32.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return False
+        try:
+            code = ctypes.c_ulong()
+            if not ctypes.windll.kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+                return False
+            return code.value == 259  # STILL_ACTIVE
+        finally:
+            ctypes.windll.kernel32.CloseHandle(handle)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pid_looks_like_our_proxy(pid: int, config_path: str) -> bool:
+    """True only when pid's command line names OUR config file.
+
+    Unlike mounts._pid_looks_like_rcd (which matches on "rclone"+"rcd",
+    since any such process IS the daemon we care about), a generic
+    "cli-proxy-api" substring match isn't a strong enough identity proof
+    here: a user could independently be running their own CLIProxyAPI
+    instance on the same machine, and we must never signal that one. The
+    exact -config path we generated is unique to this instance, so matching
+    on it is the actual ownership proof — the same role _confirmed_our_rcd's
+    core/pid-vs-recorded-pid check plays for rclone, adapted to a binary
+    whose HTTP API has no equivalent "give me my own pid" call.
+    Best-effort and fails closed: any `ps` failure (including "no `ps` on
+    this platform") reads as unconfirmed, never as confirmed."""
+    if not pid or pid <= 0 or not config_path:
+        return False
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=3,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return config_path in out
+
+
+def _probe_models(port: int, api_key: str, timeout: float = 2.0) -> bool:
+    """True iff the proxy on `port` answers GET /v1/models with `api_key`.
+
+    Used both for the post-spawn health-poll and to decide whether a
+    recorded instance is still the one to reuse. Never raises — a probe
+    failure just means "not up yet" or "not this one any more"; callers
+    treat that as "go spawn a fresh one," not as an error in its own right."""
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/models",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.status == 200
+    except (urllib.error.URLError, OSError, ValueError):
+        return False
+    except urllib.error.HTTPError:
+        return False
+
+
+def _confirmed_ours(entry: dict) -> bool:
+    """Proof entry's pid IS the ai-proxy we spawned, gating a kill — the
+    same two-of-either-suffices shape as mounts._confirmed_our_rcd: (1) the
+    recorded port still answers /v1/models with the recorded api key, or (2)
+    the pid's command line names our own config file. Both fail closed."""
+    pid = entry.get("pid") or 0
+    port = entry.get("port")
+    api_key = entry.get("api_key")
+    if port and api_key and _probe_models(int(port), api_key):
+        return True
+    return _pid_looks_like_our_proxy(pid, entry.get("config") or "")
+
+
+def _yaml_str(value: str) -> str:
+    """Escape a value for a double-quoted YAML scalar.
+
+    No yaml dependency: pyyaml is not in pyproject.toml's core deps, the
+    config shape we emit is fixed and entirely our own construction, and the
+    only variable inputs are our own state-dir paths and secrets.token_urlsafe
+    output (already backslash/quote-free) — so this only needs to handle
+    backslashes and double quotes, not the general YAML grammar, and adding
+    a real YAML writer for that would be all cost, no benefit."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _write_config(port: int, api_key: str, management_key: str) -> str:
+    """Write the proxy's YAML config and return its path.
+
+    host is pinned to 127.0.0.1 (never the upstream default of all
+    interfaces — see the module docstring's security note); api-keys holds
+    our one generated key; remote-management is locked to loopback-only with
+    our second generated key and disable-control-panel set, since we drive
+    the API ourselves and don't want it fetching a web panel from GitHub.
+    logging-to-file is off because we capture stdout/stderr to our own
+    rotated log instead (see _rotate_log) — there is no --log-file flag on
+    this binary, so config-side logging and our redirect would otherwise be
+    two independent, un-rotated log destinations.
+
+    Written 0600 immediately after creation: the file holds both secrets in
+    plaintext, and CLIProxyAPI hashes a plaintext secret-key on startup, so
+    this is the only place either key is ever readable at rest."""
+    os.makedirs(_state_dir(), exist_ok=True)
+    try:
+        os.chmod(_state_dir(), 0o700)
+    except OSError:
+        pass
+    os.makedirs(_auth_dir(), exist_ok=True)
+    config = (
+        'host: "127.0.0.1"\n'
+        f'port: {port}\n'
+        'api-keys:\n'
+        f'  - "{_yaml_str(api_key)}"\n'
+        f'auth-dir: "{_yaml_str(_auth_dir())}"\n'
+        'logging-to-file: false\n'
+        'remote-management:\n'
+        '  allow-remote: false\n'
+        f'  secret-key: "{_yaml_str(management_key)}"\n'
+        '  disable-control-panel: true\n'
+    )
+    path = _config_path()
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(config)
+    os.chmod(path, 0o600)
+    return path
+
+
+def _rotate_log() -> str:
+    """Before spawning, roll proxy.log -> proxy.log.1 if it's grown past the
+    cap, and return the (current) log path — the same one-generation
+    rotation as mounts._rotate_rcd_log, for the same reason: this binary has
+    no rotation of its own, and stdout/stderr redirected into it otherwise
+    grows unbounded across the life of a long-running app. Best-effort: a
+    stat/rename failure just means we append to whatever is there."""
+    log = _log_path()
+    try:
+        if os.path.getsize(log) > LOG_MAX_BYTES:
+            os.replace(log, log + ".1")
+    except OSError:
+        pass
+    return log
+
+
+def _base_url(port: int) -> str:
+    return f"http://127.0.0.1:{port}"
+
+
+def _write_state(port: int, pid: int, api_key: str, management_key: str,
+                  config_path: str, log_path: str) -> None:
+    """Persist the live instance's identity and secrets to the state file.
+
+    spawner_pid records WHO spawned it, so a later process that reuses this
+    instance (or the same process restarted) can tell on teardown whether it
+    is theirs to stop — see stop_local_ai_proxy's ownership gate, mirroring
+    write_rcd_state's spawner_pid field.
+
+    Chmod 0600 after write: storage.write_json has no notion of permissions,
+    and this file carries the same two live secrets the config does."""
+    state = {
+        "port": port,
+        "pid": pid,
+        "spawner_pid": os.getpid(),
+        "api_key": api_key,
+        "management_key": management_key,
+        "config": config_path,
+        "log": log_path,
+    }
+    path = _state_path()
+    storage.write_json(path, state)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def ensure_ai_proxy() -> tuple[str, str, str]:
+    """Ensure a supervised proxy instance is up; return (base_url, api_key,
+    management_key). Spawns lazily — this is meant to be called right before
+    the first request that needs the proxy, not at app launch, so an idle AI
+    proxy process isn't rent every session pays (see AI_PROXY_BUNDLING.md).
+
+    Reuses a live instance when the recorded state answers a health probe;
+    otherwise spawns a fresh one under _lock, so two racing callers (two
+    concurrent fused.ai() calls hitting "no live instance" at once) can't
+    both spawn.
+
+    Raises RuntimeError naming what went wrong: no binary resolved, the
+    binary exited immediately, or it never became healthy within
+    _STARTUP_TIMEOUT_S. Callers (the /api/ai relay) are expected to map that
+    into the house {ok, error} contract, same as any other proxy-unreachable
+    case.
+
+    Does NOT check is_supervised() itself — that's the caller's decision
+    (skip calling this entirely when the user pointed ai_base_url somewhere
+    of their own), so this function has exactly one job: get a bundled
+    instance running and hand back how to reach it."""
+    with _lock:
+        return _ensure_locked()
+
+
+def _ensure_locked() -> tuple[str, str, str]:
+    state = storage.read_json(_state_path())
+    if isinstance(state, dict) and state.get("port") and state.get("api_key"):
+        if _probe_models(int(state["port"]), state["api_key"]):
+            return (_base_url(state["port"]), state["api_key"],
+                    state.get("management_key", ""))
+
+    bin_ = ai_proxy_bin()
+    if not bin_:
+        raise RuntimeError(
+            "the AI proxy (cli-proxy-api) is not installed or bundled; "
+            "set FUSED_RENDER_AI_PROXY_BIN to a real binary, or point "
+            "ai_base_url at a proxy you run yourself")
+
+    # Pick the port ourselves (parsing the binary's own startup log for a
+    # bound port is brittle) — same bind-0-then-close trick as
+    # _ensure_rcd_locked.
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+
+    api_key = secrets.token_urlsafe(32)
+    management_key = secrets.token_urlsafe(32)
+    config_path = _write_config(port, api_key, management_key)
+    log_path = _rotate_log()
+
+    with open(log_path, "ab") as log_f:
+        proc = subprocess.Popen(
+            [bin_, "-config", config_path],
+            stdout=log_f,
+            stderr=subprocess.STDOUT,
+            # Dev (FUSED_RENDER_AI_PROXY_PERSIST set): setsid so the instance
+            # outlives server restarts, same convenience as rclone's rcd.
+            # Production (unset): a normal child, reaped with the app.
+            start_new_session=_should_persist(),
+        )
+
+    deadline = time.time() + _STARTUP_TIMEOUT_S
+    while time.time() < deadline:
+        if _probe_models(port, api_key):
+            _write_state(port, proc.pid, api_key, management_key,
+                         config_path, log_path)
+            return (_base_url(port), api_key, management_key)
+        if proc.poll() is not None:
+            raise RuntimeError(
+                f"ai-proxy exited immediately (code {proc.returncode}); "
+                f"see {log_path}")
+        time.sleep(0.2)
+    raise RuntimeError(
+        f"ai-proxy did not become healthy within {_STARTUP_TIMEOUT_S:g}s; "
+        f"see {log_path}")
+
+
+# How long _kill_current_ai_proxy waits for a signalled instance to actually
+# exit before escalating / giving up — mirrors mounts._KILL_TIMEOUT_S.
+_KILL_TIMEOUT_S = 5.0
+
+
+def _kill_current_ai_proxy() -> None:
+    """Terminate the recorded ai-proxy instance, if there is one to
+    terminate. Only ever signals a pid PROVEN to be ours (_confirmed_ours) —
+    the single most important constraint here, reused verbatim from
+    mounts._kill_current_rcd's rationale: pids get recycled, so an alive but
+    unconfirmed pid must raise rather than risk killing an unrelated
+    process. No recorded instance / an already-dead pid is a clean no-op."""
+    entry = storage.read_json(_state_path())
+    if not isinstance(entry, dict):
+        return
+    pid = entry.get("pid") or 0
+    if not _pid_alive(pid):
+        return
+    if not _confirmed_ours(entry):
+        raise RuntimeError(
+            f"refusing to kill pid {pid}: not confirmed to be our ai-proxy")
+    sigs = (signal.SIGTERM,) if sys.platform == "win32" else (signal.SIGTERM, signal.SIGKILL)
+    for sig in sigs:
+        try:
+            os.kill(pid, sig)
+        except ProcessLookupError:
+            return  # raced us and exited between the check and the signal
+        except OSError as e:
+            if not _pid_alive(pid):
+                return
+            raise RuntimeError(f"failed to signal ai-proxy pid {pid}: {e}") from e
+        deadline = time.time() + _KILL_TIMEOUT_S
+        while time.time() < deadline:
+            if not _pid_alive(pid):
+                return
+            time.sleep(0.1)
+    raise RuntimeError(f"ai-proxy pid {pid} did not exit after {sigs[-1].name}")
+
+
+def stop_local_ai_proxy() -> None:
+    """Best-effort teardown of the proxy we spawned, for the app's quit path
+    — stop_local_rcd's exact contract, applied to this daemon.
+
+    Gated on NOT persisting (FUSED_RENDER_AI_PROXY_PERSIST unset): a
+    detached dev instance is meant to outlive this process. Ownership gate:
+    when the recorded spawner_pid is a DIFFERENT, still-alive process, this
+    instance is shared and someone else is using it — leave it alone (a
+    missing spawner_pid, from a state file written before the field existed,
+    preserves the old kill-it behavior). Swallows every error — a reap
+    failure must never block app quit."""
+    if _should_persist():
+        return
+    with _lock:
+        entry = storage.read_json(_state_path())
+        if isinstance(entry, dict):
+            spawner_pid = entry.get("spawner_pid") or 0
+            if spawner_pid and spawner_pid != os.getpid() and _pid_alive(spawner_pid):
+                logger.info(
+                    "stop_local_ai_proxy: instance was spawned by pid %s "
+                    "which is still alive; leaving it to its owner",
+                    spawner_pid,
+                )
+                return
+        try:
+            _kill_current_ai_proxy()
+        except Exception:
+            logger.warning("stop_local_ai_proxy: teardown failed", exc_info=True)
+
+
+def status() -> dict:
+    """Cheap, non-spawning snapshot for the accounts UI: {"supervised":
+    bool, "running": bool}. Never spawns and never raises — a page merely
+    checking proxy status shouldn't pay the spawn cost or fail loudly; that
+    only happens on an actual management call or fused.ai() request."""
+    if not is_supervised():
+        return {"supervised": False, "running": False}
+    state = storage.read_json(_state_path())
+    if isinstance(state, dict) and state.get("port") and state.get("api_key"):
+        return {"supervised": True,
+                "running": _probe_models(int(state["port"]), state["api_key"])}
+    return {"supervised": True, "running": False}
+
+
+def management_request(method: str, path: str, body: dict | None = None,
+                        *, timeout: float = 10.0) -> dict:
+    """One authenticated call to the proxy's /v0/management API.
+
+    `path` is the suffix after /v0/management (e.g. "/auth-files",
+    "/auth-files?name=foo.json", "/anthropic-auth-url", "/oauth-callback")
+    — the routes layer builds the exact route; this is transport only, with
+    no FastAPI/route awareness. Ensures a live proxy first (same lazy-spawn
+    discipline as ensure_ai_proxy(), since a management call to an instance
+    that isn't running is meaningless) and authenticates with
+    `management_key` — the account-management surface's own secret,
+    distinct from the api_key fused.ai() traffic uses (see module docstring).
+
+    Raises RuntimeError. A 404 specifically reads as "this proxy build
+    doesn't support account management from the app" per the doc's
+    version-skew note, rather than a bare HTTPError — we pin one verified
+    version, but a mismatched bundled binary should degrade gracefully, not
+    crash the accounts UI."""
+    base_url, _api_key, management_key = ensure_ai_proxy()
+    url = base_url.rstrip("/") + "/v0/management" + path
+    data = json.dumps(body).encode() if body is not None else None
+    headers = {"Authorization": f"Bearer {management_key}"}
+    if data is not None:
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            raise RuntimeError(
+                "this proxy build does not support account management from "
+                "the app (404 on a management route) — it may be a "
+                "different version than this app was built against"
+            ) from e
+        try:
+            detail = json.loads(e.read() or b"{}").get("error", "")
+        except ValueError:
+            detail = ""
+        raise RuntimeError(
+            detail or f"ai-proxy management {method} {path}: HTTP {e.code}"
+        ) from e
+    except OSError as e:
+        raise RuntimeError(f"ai-proxy management {method} {path}: {e}") from e
+
+
+# --- Login-flow and credential helpers ---------------------------------------
+#
+# Thin, named wrappers over management_request for the exact routes the
+# accounts UI needs (docs/AI_PROXY_MANAGEMENT_API.md, re-verified 2026-07-28
+# after an earlier draft of that doc wrongly claimed there was no login-status
+# channel). Each one just fixes the path/method/body shape for its route —
+# still no FastAPI/route awareness, still just transport, but named so the
+# routes layer isn't hand-assembling query strings and reading raw dicts.
+#
+# NOT wrapped here, deliberately: binding the fixed OAuth callback ports
+# (54545 / 1455) and the ?is_webui=1 control-panel shortcut (rejected — binds
+# all interfaces, forwards into the control panel we disable). Both are the
+# routes worker's job.
+
+
+def start_login(provider: str) -> dict:
+    """Begin OAuth for `provider` (e.g. "anthropic", "codex"). Returns the
+    proxy's own `{state, status, url}` — `state` must be handed back
+    unchanged to submit_login_code/poll_login_status/cancel_login, and `url`
+    is what the frontend opens in the user's browser."""
+    return management_request("GET", f"/{quote(provider)}-auth-url")
+
+
+def submit_login_code(provider: str, state: str, code: str) -> dict:
+    """Hand the code captured off the provider's callback redirect to the
+    proxy. A 200 here means "code recorded for exchange," NOT "logged in" —
+    the exchange happens asynchronously; poll_login_status is what actually
+    confirms success or failure. Replaying a state that already completed is
+    a 409, surfaced as a RuntimeError like any other non-2xx."""
+    return management_request(
+        "POST", "/oauth-callback",
+        {"provider": provider, "state": state, "code": code})
+
+
+def poll_login_status(state: str) -> dict:
+    """The real result channel for a login: {"status": "wait"|"ok"|"error",
+    "error"?: str}. Callers should poll this — not auth-files — since
+    oauth-callback's own 200 proves nothing about the exchange outcome."""
+    return management_request("GET", f"/get-auth-status?state={quote(state)}")
+
+
+def cancel_login(state: str) -> dict:
+    """Cancel a pending login (e.g. the user closed the browser tab, or the
+    UI is releasing a callback port it bound for the duration of one login).
+    A no-op past the state's TTL/completion is fine — the proxy's own
+    {status, cancelled} reply carries whether there was anything to cancel."""
+    return management_request("DELETE", f"/oauth-session?state={quote(state)}")
+
+
+def list_credentials() -> list:
+    """Every connected account, proxy-native shape (see the doc's Credential
+    listing shape) — filtering down to {provider, email, disabled, expired}
+    and restricting to claude/codex is the routes layer's job, not this
+    module's; this just returns `files` unmodified. Never returns token
+    material itself (auth-files doesn't include it)."""
+    result = management_request("GET", "/auth-files")
+    files = result.get("files")
+    return files if isinstance(files, list) else []
+
+
+def delete_credential(name: str) -> dict:
+    """Remove one credential by its `name` (the handle auth-files lists it
+    under). An unknown/missing name is the proxy's own 400, surfaced as a
+    RuntimeError like any other management error."""
+    return management_request("DELETE", f"/auth-files?name={quote(name)}")
+
+
+def set_credential_disabled(name: str, disabled: bool,
+                             auth_index: str | None = None) -> dict:
+    """Enable/disable a credential without deleting it. `auth_index`
+    disambiguates when a provider has multiple accounts sharing routing
+    priority (per-entry field in the auth-files listing) — omit it to target
+    by name alone."""
+    body: dict = {"name": name, "disabled": disabled}
+    if auth_index is not None:
+        body["auth_index"] = auth_index
+    return management_request("PATCH", "/auth-files/status", body)

--- a/fused_render/shell/ai_proxy.py
+++ b/fused_render/shell/ai_proxy.py
@@ -73,6 +73,12 @@ LOG_MAX_BYTES = 10 * 1024 * 1024
 # the same race _rcd_lock exists to close for rclone's rcd.
 _lock = threading.Lock()
 
+# The Popen handle for an instance THIS process spawned, kept solely so the
+# child can be reaped after we signal it (see _reap_child). None when the live
+# instance was spawned by some earlier process — that case needs no reaping,
+# since a child is only ever a zombie to its own parent.
+_child: subprocess.Popen | None = None
+
 
 def _state_dir() -> str:
     return os.path.join(storage.home_dir(), "ai-proxy")
@@ -156,11 +162,41 @@ def _should_persist() -> bool:
     return os.environ.get("FUSED_RENDER_AI_PROXY_PERSIST") not in (None, "", "0")
 
 
+def _reap_child(pid: int) -> None:
+    """Collect the exit status of a child THIS process spawned, so a killed
+    instance stops being a zombie.
+
+    Without this, os.kill(pid, 0) keeps succeeding for a dead-but-unreaped
+    child — a zombie is still a process table entry — so _pid_alive reports
+    it alive forever and _kill_current_ai_proxy escalates SIGTERM to SIGKILL
+    and then raises "did not exit", for a process that in fact died on the
+    first signal. Measured: a 10s stall plus a bogus error on every quit.
+
+    Only the spawning process can reap, hence the pid guard: a stale handle
+    from a different instance must not be waited on. Non-blocking-ish by
+    design (the child is already signalled, so the wait returns at once) with
+    a bounded timeout so a wedged child can never hang app teardown."""
+    global _child
+    proc = _child
+    if proc is None or proc.pid != pid:
+        return
+    try:
+        proc.wait(timeout=_KILL_TIMEOUT_S)
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return  # genuinely still running, or already reaped elsewhere
+    _child = None
+
+
 def _pid_alive(pid: int) -> bool:
-    """True if `pid` names a running process. Duplicated from
-    mounts._pid_alive rather than imported: this module is meant to stand on
-    its own (transport-only, no coupling to rclone's daemon), and the check
-    itself is generic OS plumbing, not rcd-specific."""
+    """True if `pid` names a running process.
+
+    Adapted from mounts._pid_alive rather than imported (this module stays
+    decoupled from rclone's daemon internals, and the check is generic OS
+    plumbing). One deliberate difference: on POSIX a zombie — a child that
+    has exited but whose status nobody collected — still answers
+    os.kill(pid, 0), so this would call a dead process alive. Callers that
+    signal a child of ours reap it first via _reap_child; see the note there
+    for the 10s-stall-and-false-error this closes."""
     if not pid or pid <= 0:
         return False
     if sys.platform == "win32":
@@ -405,6 +441,14 @@ def _ensure_locked() -> tuple[str, str, str]:
             # Production (unset): a normal child, reaped with the app.
             start_new_session=_should_persist(),
         )
+    # Keep the handle: a Popen whose child we later signal must be WAITED on,
+    # or the dead child lingers as a zombie — and a zombie still answers
+    # os.kill(pid, 0), so _pid_alive would keep reporting it alive and the
+    # teardown poll below would spin its full timeout and then wrongly report
+    # "did not exit after SIGKILL" for a process that died instantly. Storing
+    # it is what lets _reap_child() actually collect the exit status.
+    global _child
+    _child = proc
 
     deadline = time.time() + _STARTUP_TIMEOUT_S
     while time.time() < deadline:
@@ -453,6 +497,11 @@ def _kill_current_ai_proxy() -> None:
             if not _pid_alive(pid):
                 return
             raise RuntimeError(f"failed to signal ai-proxy pid {pid}: {e}") from e
+        # Reap before polling: if this is our own child it is now a zombie,
+        # which _pid_alive cannot distinguish from a live process, so without
+        # this the loop below would run its full timeout on an already-dead
+        # instance and then raise a false "did not exit".
+        _reap_child(pid)
         deadline = time.time() + _KILL_TIMEOUT_S
         while time.time() < deadline:
             if not _pid_alive(pid):
@@ -518,11 +567,16 @@ def management_request(method: str, path: str, body: dict | None = None,
     `management_key` — the account-management surface's own secret,
     distinct from the api_key fused.ai() traffic uses (see module docstring).
 
-    Raises RuntimeError. A 404 specifically reads as "this proxy build
-    doesn't support account management from the app" per the doc's
-    version-skew note, rather than a bare HTTPError — we pin one verified
-    version, but a mismatched bundled binary should degrade gracefully, not
-    crash the accounts UI."""
+    Raises RuntimeError. A 404 is ambiguous on this API and the two cases
+    are told apart by the BODY, not the status code alone (verified against
+    the real binary): an unrouted path (a route this build genuinely lacks)
+    is Gin's bare NoRoute 404 with an EMPTY body, whereas a business-logic
+    404 on a route that exists (e.g. auth-files DELETE for an unknown name)
+    carries a normal `{"error": "..."}` JSON body. Only the empty-body case
+    is reported as "this proxy build doesn't support account management from
+    the app" per the doc's version-skew note; a 404 WITH an error body is
+    just that error, raised like any other non-2xx — conflating the two
+    would misreport an ordinary "no such credential" as a version mismatch."""
     base_url, _api_key, management_key = ensure_ai_proxy()
     url = base_url.rstrip("/") + "/v0/management" + path
     data = json.dumps(body).encode() if body is not None else None
@@ -535,16 +589,18 @@ def management_request(method: str, path: str, body: dict | None = None,
             raw = resp.read()
             return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as e:
-        if e.code == 404:
+        raw = e.read() or b""
+        try:
+            detail = json.loads(raw).get("error", "") if raw else ""
+        except (ValueError, AttributeError):
+            detail = ""
+        if e.code == 404 and not detail:
             raise RuntimeError(
                 "this proxy build does not support account management from "
-                "the app (404 on a management route) — it may be a "
-                "different version than this app was built against"
+                "the app (404 with no error body on a management route) — "
+                "it may be a different version than this app was built "
+                "against"
             ) from e
-        try:
-            detail = json.loads(e.read() or b"{}").get("error", "")
-        except ValueError:
-            detail = ""
         raise RuntimeError(
             detail or f"ai-proxy management {method} {path}: HTTP {e.code}"
         ) from e

--- a/fused_render/shell/prefs.py
+++ b/fused_render/shell/prefs.py
@@ -50,6 +50,17 @@ VALID_CALLS_PARAMS = ("full", "keys", "off")
 DEFAULT_CALLS_RETENTION_DAYS = 14
 DEFAULT_AI_BASE_URL = "http://127.0.0.1:8317"
 
+# The bundled proxy's two supported credential-pooling behaviours (see
+# ai_proxy._write_config's routing.strategy). "round-robin" is the upstream
+# default (pool every credential for a provider — OAuth accounts and API
+# keys alike — and fail over between them); "fill-first" instead drains one
+# credential before moving to the next ("prefer one, fall back" behaviour).
+# Named DEFAULT_ (not just "the fallback") because ai_proxy writes it out
+# EXPLICITLY into the generated config rather than relying on omission, so
+# the effective value is always visible in the file, not just in this pref.
+VALID_AI_ROUTING_STRATEGIES = ("round-robin", "fill-first")
+DEFAULT_AI_ROUTING_STRATEGY = "round-robin"
+
 
 def _require_fused(x_fused: str | None) -> JSONResponse | None:
     # Same D3 guard as server._require_fused, duplicated to keep shell↛server
@@ -147,6 +158,42 @@ def ai_base_url() -> str:
         return forced
     value = read_prefs().get("ai_base_url")
     return value if isinstance(value, str) and value else DEFAULT_AI_BASE_URL
+
+
+def ai_routing_strategy() -> str:
+    """The persisted routing-strategy pref for the bundled AI proxy; unset
+    or unrecognized values read as DEFAULT_AI_ROUTING_STRATEGY — same
+    validated-fallback idiom as selected_engine()/calls_params_mode(). Read
+    by ai_proxy._ensure_locked() at spawn time (the binary only reads config
+    at startup, so this value is only picked up by a FRESH instance — see
+    ai_proxy.restart_ai_proxy()), and by the accounts listing so the page
+    can show the current choice."""
+    value = read_prefs().get("ai_routing_strategy")
+    return value if value in VALID_AI_ROUTING_STRATEGIES else DEFAULT_AI_ROUTING_STRATEGY
+
+
+def set_ai_routing_strategy(value: str) -> None:
+    """Persist the routing-strategy pref. Raises ValueError for anything
+    outside VALID_AI_ROUTING_STRATEGIES — the same set the getter falls back
+    across, so a rejected write can never silently become a different stored
+    value than the one the caller asked for.
+
+    Lives here rather than as an inline PUT /api/prefs branch because the
+    caller (ai_accounts.py's routing-strategy route) also needs to restart
+    the proxy for the change to take effect, and ai_proxy.py already imports
+    THIS module (is_supervised, ai_base_url) — so prefs.py importing
+    ai_proxy.py back would be a cycle. Keeping the write (and its
+    validation) here, with the restart triggered by the caller after this
+    returns, is what keeps prefs.json's single-writer discipline (every
+    other mutation in this file also goes through read_prefs()/
+    storage.write_json in one place) without introducing that cycle."""
+    if value not in VALID_AI_ROUTING_STRATEGIES:
+        raise ValueError(
+            f"'routing_strategy' must be one of: {', '.join(VALID_AI_ROUTING_STRATEGIES)}"
+        )
+    prefs = read_prefs()
+    prefs["ai_routing_strategy"] = value
+    storage.write_json(_path(), prefs)
 
 
 def fused_engine_available() -> bool:

--- a/fused_render/supervisor/paths.py
+++ b/fused_render/supervisor/paths.py
@@ -220,6 +220,13 @@ class DesktopPaths:
             "FUSED_RENDER_RCLONE_BIN": str(
                 tools_dir / ("rclone.exe" if sys.platform == "win32" else "rclone")
             ),
+            # cli-proxy-api (CLIProxyAPI, docs/AI_PROXY_BUNDLING.md) is bundled
+            # in the payload right next to rclone, so ai_proxy.ai_proxy_bin()
+            # can resolve a packaged Windows/Linux build without a user
+            # install - the same rationale as FUSED_RENDER_RCLONE_BIN above.
+            "FUSED_RENDER_AI_PROXY_BIN": str(
+                tools_dir / ("cli-proxy-api.exe" if sys.platform == "win32" else "cli-proxy-api")
+            ),
             # learn.zip ships in the payload's assets/ (the Windows installer
             # globs assets\*); mounts.learn_zip_path() reads this override, and
             # its isfile check no-ops when a build didn't bundle the zip.

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -185,6 +185,55 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 2c. Stage cli-proxy-api (docs/AI_PROXY_BUNDLING.md): CLIProxyAPI is, like
+#     rclone, a single static Go binary under a permissive license, so this
+#     step is a straight copy of 2b above - same pin/checksum/cache/skip
+#     shape, different upstream. shell/ai_proxy.py's ai_proxy_bin() resolves
+#     the packaged app to Contents/Resources/bin/cli-proxy-api, the same tier
+#     rclone_bin() uses for rclone.
+#
+#     macOS-arm64 only, matching this script's Apple Silicon-only py2app
+#     target (see the FRAMEWORK_PYTHON note above): the release asset is
+#     "darwin_aarch64". Note the asset name has NO leading "v" in the
+#     version, but the upstream git tag DOES - that's a real upstream
+#     inconsistency, not a typo here.
+# ---------------------------------------------------------------------------
+
+CLIPROXY_VERSION="7.2.104"
+CLIPROXY_ASSET="CLIProxyAPI_${CLIPROXY_VERSION}_darwin_aarch64.tar.gz"
+CLIPROXY_SHA256="3d52c292af57ea7114bacf35fb1b76c9552448940d3e9f10d39c1ec57229c0e0"
+CLIPROXY_STAGE_DIR="$BUILD_DIR/cli-proxy-api-bin/${CLIPROXY_VERSION}"
+CLIPROXY_STAGED_BIN="$CLIPROXY_STAGE_DIR/cli-proxy-api"
+
+if [[ ! -x "$CLIPROXY_STAGED_BIN" ]]; then
+  echo "==> downloading cli-proxy-api ${CLIPROXY_VERSION} (darwin_aarch64)"
+  CLIPROXY_DL_DIR="$BUILD_DIR/cli-proxy-api-download"
+  rm -rf "$CLIPROXY_DL_DIR"
+  mkdir -p "$CLIPROXY_DL_DIR"
+  curl -fsSL "https://github.com/router-for-me/CLIProxyAPI/releases/download/v${CLIPROXY_VERSION}/${CLIPROXY_ASSET}" \
+    -o "$CLIPROXY_DL_DIR/$CLIPROXY_ASSET"
+
+  ACTUAL_SHA256="$(shasum -a 256 "$CLIPROXY_DL_DIR/$CLIPROXY_ASSET" | cut -d' ' -f1)"
+  if [[ "$ACTUAL_SHA256" != "$CLIPROXY_SHA256" ]]; then
+    echo "FATAL: cli-proxy-api download checksum mismatch." >&2
+    echo "       expected: $CLIPROXY_SHA256" >&2
+    echo "       actual:   $ACTUAL_SHA256" >&2
+    exit 1
+  fi
+
+  # The archive's top level is the executable plus README/LICENSE/an example
+  # config - no version-named subdirectory the way rclone's zip has, so
+  # extract straight into the download dir.
+  (cd "$CLIPROXY_DL_DIR" && tar -xzf "$CLIPROXY_ASSET")
+  mkdir -p "$CLIPROXY_STAGE_DIR"
+  cp "$CLIPROXY_DL_DIR/cli-proxy-api" "$CLIPROXY_STAGED_BIN"
+  chmod +x "$CLIPROXY_STAGED_BIN"
+  rm -rf "$CLIPROXY_DL_DIR"
+else
+  echo "==> cli-proxy-api ${CLIPROXY_VERSION} already staged, skipping download"
+fi
+
+# ---------------------------------------------------------------------------
 # 3. App icon: a fresh, high-res render of the same four-pointed sparkle used
 #    for the menu-bar glyph (fused_render/assets/menubar-template.png, 36px,
 #    template/monochrome) on a rounded dark card, at the sizes iconutil wants.
@@ -468,7 +517,36 @@ fi
 echo "    $(echo "$RCLONE_SMOKE_OUT" | head -1)"
 
 # ---------------------------------------------------------------------------
-# 4e. Bundle learn.zip (D123): the repo's learn/ content ships as a single
+# 4e. Bundle cli-proxy-api (docs/AI_PROXY_BUNDLING.md, staged in step 2c
+#     above) at the same Contents/Resources/bin/ spot as rclone - a real
+#     Mach-O binary, so it's picked up and signed by the nested-binary
+#     signing sweep below (step 5) with no extra rule needed there.
+#     shell/ai_proxy.py's ai_proxy_bin() looks here first, exactly like
+#     rclone_bin() does for rclone.
+#
+#     Smoke test runs `--help`, which this binary's flag parser treats as a
+#     recognized flag (exit 0) unlike an unrecognized one (exit 2) - and its
+#     first output line is always a version banner regardless of which flag
+#     triggered it, so this is the cheapest way to prove the staged binary
+#     both runs and reports the version we pinned.
+# ---------------------------------------------------------------------------
+
+echo "==> bundling cli-proxy-api ${CLIPROXY_VERSION}"
+CLIPROXY_DEST="$APP_DIR/Contents/Resources/bin/cli-proxy-api"
+mkdir -p "$(dirname "$CLIPROXY_DEST")"
+cp "$CLIPROXY_STAGED_BIN" "$CLIPROXY_DEST"
+chmod +x "$CLIPROXY_DEST"
+
+CLIPROXY_SMOKE_OUT="$("$CLIPROXY_DEST" --help)"
+if ! echo "$CLIPROXY_SMOKE_OUT" | head -1 | grep -q "CLIProxyAPI Version: ${CLIPROXY_VERSION}"; then
+  echo "FATAL: bundled cli-proxy-api failed to report its version:" >&2
+  echo "$CLIPROXY_SMOKE_OUT" >&2
+  exit 1
+fi
+echo "    $(echo "$CLIPROXY_SMOKE_OUT" | head -1)"
+
+# ---------------------------------------------------------------------------
+# 4f. Bundle learn.zip (D123): the repo's learn/ content ships as a single
 #     zip at Contents/Resources/learn.zip, and shell/mounts.py's
 #     ensure_learn_mount() mounts it read-only at startup via rclone's
 #     archive backend (:archive:<path>, new in v1.74) — the bundled default

--- a/scripts/build_linux_appimage.sh
+++ b/scripts/build_linux_appimage.sh
@@ -107,6 +107,31 @@ echo "${RCLONE_SHA256}  ${RCLONE_ZIP}" | sha256sum --check --status \
     "import zipfile, sys, shutil, os; z = zipfile.ZipFile(sys.argv[1]); member = [n for n in z.namelist() if n.endswith('/rclone')][0]; dst = open(sys.argv[2], 'wb'); shutil.copyfileobj(z.open(member), dst); dst.close(); os.chmod(sys.argv[2], 0o755)" \
     "$RCLONE_ZIP" "$PYTHON_ROOT/bin/rclone"
 
+# --- cli-proxy-api bundled next to rclone (docs/AI_PROXY_BUNDLING.md) --------
+# CLIProxyAPI is, like rclone, a single static Go binary - same pin/verify/
+# stage shape as the rclone block just above, different upstream and archive
+# format (a .tar.gz, not a .zip). shell/ai_proxy.py's ai_proxy_bin() looks
+# here first on a packaged Linux build, the same tier rclone_bin() uses.
+# x86_64 only, matching this script's scope (see the ARCH note at the top).
+# Note the asset name has NO leading "v" in the version, but the upstream git
+# tag DOES - a real upstream inconsistency, not a typo here.
+log "Bundling cli-proxy-api"
+require sha256sum
+CLIPROXY_VERSION="7.2.104"
+CLIPROXY_ASSET="CLIProxyAPI_${CLIPROXY_VERSION}_linux_amd64.tar.gz"
+CLIPROXY_SHA256="993babb37b6de831600f0eb31527ca0f938337e1d1f837d5cf846263affa9724"
+CLIPROXY_TARBALL="$BUILD_DIR/${CLIPROXY_ASSET}"
+[ -f "$CLIPROXY_TARBALL" ] || curl -fsSL \
+    "https://github.com/router-for-me/CLIProxyAPI/releases/download/v${CLIPROXY_VERSION}/${CLIPROXY_ASSET}" \
+    -o "$CLIPROXY_TARBALL"
+echo "${CLIPROXY_SHA256}  ${CLIPROXY_TARBALL}" | sha256sum --check --status \
+    || { echo "cli-proxy-api tarball SHA256 mismatch" >&2; exit 1; }
+# The archive's top level is the executable plus README/LICENSE/an example
+# config - no version-named subdirectory the way rclone's zip has - so a
+# plain extract lands the binary directly.
+tar -xzf "$CLIPROXY_TARBALL" -C "$PYTHON_ROOT/bin" cli-proxy-api
+chmod 0755 "$PYTHON_ROOT/bin/cli-proxy-api"
+
 # --- prune dead weight (mirrors build_dmg.sh's D116/D118 pruning) ------------
 # manylinux wheels ship native libs with full debug + local symbol tables that
 # the Windows PE / macOS Mach-O wheels of the same libraries don't — the main
@@ -144,6 +169,14 @@ log "Smoke tests"
     "import duckdb, fused_render, fused_render.cli, fused_render.supervisor.core, fused_render.supervisor._linux.tree, fused_render.supervisor._linux.instance, fused_render.supervisor._linux.tray, dbus_fast; print('bundle imports ok')"
 "$PYTHON_ROOT/bin/uv" --version
 "$PYTHON_ROOT/bin/rclone" version
+# --help exits 0 for this binary's flag parser (unlike an unrecognized flag,
+# which exits 2) and its first output line is always a version banner - the
+# cheapest proof the staged binary both runs and matches the pinned version.
+CLIPROXY_SMOKE_OUT="$("$PYTHON_ROOT/bin/cli-proxy-api" --help)"
+case "$(echo "$CLIPROXY_SMOKE_OUT" | head -1)" in
+    *"CLIProxyAPI Version: ${CLIPROXY_VERSION}"*) : ;;
+    *) echo "bundled cli-proxy-api failed to report its version: $CLIPROXY_SMOKE_OUT" >&2; exit 1 ;;
+esac
 SMOKE_REQUEST="$(mktemp)"
 SMOKE_PROBE="$(mktemp --suffix=.py)"
 trap 'rm -f "$SMOKE_REQUEST" "$SMOKE_PROBE"' EXIT

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -208,6 +208,33 @@ if (-not $rcloneExe) {
 }
 Copy-Item -LiteralPath $rcloneExe.FullName -Destination (Join-Path $PythonRoot "rclone.exe") -Force
 
+# cli-proxy-api.exe bundled next to rclone.exe (the supervisor's
+# child_environment points FUSED_RENDER_AI_PROXY_BIN here) so "connect a
+# Claude or ChatGPT account" works with zero user setup, matching the macOS
+# DMG and the Linux AppImage (docs/AI_PROXY_BUNDLING.md). Pinned release,
+# published-SHA256 verified (same discipline as the rclone pin above). Note
+# the asset name has NO leading "v" in the version, but the upstream git tag
+# DOES - a real upstream inconsistency, not a typo here.
+$CliProxyVersion = "7.2.104"
+$CliProxySha256 = "5c2a5ab399bc9ee752a16f5b83c539e1d7f5caa0b78e8ec2c9bf3449356f71a7"
+$cliProxyZip = Join-Path $BuildDir "CLIProxyAPI_${CliProxyVersion}_windows_amd64.zip"
+if (-not (Test-Path -LiteralPath $cliProxyZip)) {
+    Invoke-WebRequest -Uri "https://github.com/router-for-me/CLIProxyAPI/releases/download/v$CliProxyVersion/CLIProxyAPI_${CliProxyVersion}_windows_amd64.zip" -OutFile $cliProxyZip
+}
+$actualSha = (Get-FileHash -LiteralPath $cliProxyZip -Algorithm SHA256).Hash.ToLower()
+if ($actualSha -ne $CliProxySha256) {
+    throw "cli-proxy-api zip SHA256 mismatch: expected $CliProxySha256, got $actualSha"
+}
+$cliProxyExtract = Join-Path $BuildDir "cli-proxy-api-extract"
+Remove-Item -LiteralPath $cliProxyExtract -Recurse -Force -ErrorAction SilentlyContinue
+Expand-Archive -Path $cliProxyZip -DestinationPath $cliProxyExtract -Force
+$cliProxyExe = Get-ChildItem -Path $cliProxyExtract -Recurse -Filter "cli-proxy-api.exe" |
+    Select-Object -First 1
+if (-not $cliProxyExe) {
+    throw "cli-proxy-api.exe not found in the downloaded zip"
+}
+Copy-Item -LiteralPath $cliProxyExe.FullName -Destination (Join-Path $PythonRoot "cli-proxy-api.exe") -Force
+
 # WinFsp MSI staged for installer.iss to chain-install when the driver is
 # missing (D133 - reverses D132's user-installs stance), so mounts work with
 # zero user setup. The app itself stays per-user; only this MSI elevates, from
@@ -281,6 +308,13 @@ Invoke-Native $bundlePython @(
 )
 Invoke-Native (Join-Path $PythonRoot "uv.exe") @("--version")
 Invoke-Native (Join-Path $PythonRoot "rclone.exe") @("version")
+# --help exits 0 for this binary's flag parser (unlike an unrecognized flag,
+# which exits 2) and its first output line is always a version banner - the
+# cheapest proof the staged .exe both runs and matches the pinned version.
+$cliProxyOutput = & (Join-Path $PythonRoot "cli-proxy-api.exe") --help
+if ($LASTEXITCODE -ne 0 -or -not ($cliProxyOutput[0] -match "CLIProxyAPI Version: $CliProxyVersion")) {
+    throw "bundled cli-proxy-api.exe failed to report its version: $cliProxyOutput"
+}
 $probe = Join-Path $env:TEMP "fused_render_installer_probe_$PID.py"
 $request = Join-Path $env:TEMP "fused_render_installer_request_$PID.json"
 try {

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -49,6 +49,48 @@ export FUSED_RENDER_CORE_TEMPLATES="${FUSED_RENDER_CORE_TEMPLATES:-$REPO_ROOT/fu
 # production dies-with-server behavior).
 export FUSED_RENDER_RCLONE_PERSIST="${FUSED_RENDER_RCLONE_PERSIST:-1}"
 
+# Same treatment for the bundled AI proxy (SPEC RH-12): keep it alive across the
+# watchfiles restarts that fire on every .py edit, so a connected Claude/ChatGPT
+# login and the proxy's warm state survive an edit instead of being torn down and
+# respawned each time. Production leaves this unset (quitting the app reaps it).
+export FUSED_RENDER_AI_PROXY_PERSIST="${FUSED_RENDER_AI_PROXY_PERSIST:-1}"
+
+# A dev checkout has no bundled cli-proxy-api — that binary is staged into the
+# payload at build time (build_dmg.sh), so nothing resolves it here and the AI
+# accounts tab would have no proxy to manage. Stage the pinned release into
+# build/ on first run and point the resolver at it, so dev matches a packaged
+# build. Kept in build/ (gitignored, shared with the DMG's own staging dir) and
+# skipped entirely when already present, so this costs one ~19MB download once
+# per version. Respect an already-set value: a caller who has their own
+# CLIProxyAPI can point at it, and FUSED_RENDER_AI_BASE_URL still bypasses
+# supervision altogether.
+if [[ -z "${FUSED_RENDER_AI_PROXY_BIN:-}" && -z "${FUSED_RENDER_AI_BASE_URL:-}" ]]; then
+  # Keep in step with CLIPROXY_VERSION in scripts/build_dmg.sh.
+  DEV_CLIPROXY_VERSION="7.2.104"
+  DEV_CLIPROXY_SHA256="3d52c292af57ea7114bacf35fb1b76c9552448940d3e9f10d39c1ec57229c0e0"
+  DEV_CLIPROXY_BIN="$REPO_ROOT/build/cli-proxy-api-bin/${DEV_CLIPROXY_VERSION}/cli-proxy-api"
+  if [[ ! -x "$DEV_CLIPROXY_BIN" ]]; then
+    # Best-effort: a download failure must not stop the dev loop — everything
+    # except the AI accounts tab works without it, so warn and carry on.
+    echo "==> staging cli-proxy-api ${DEV_CLIPROXY_VERSION} for the AI accounts tab (one-time)"
+    if _dev_dl="$(mktemp -d)" \
+      && curl -fsSL "https://github.com/router-for-me/CLIProxyAPI/releases/download/v${DEV_CLIPROXY_VERSION}/CLIProxyAPI_${DEV_CLIPROXY_VERSION}_darwin_aarch64.tar.gz" \
+           -o "$_dev_dl/cliproxy.tar.gz" \
+      && [[ "$(shasum -a 256 "$_dev_dl/cliproxy.tar.gz" | cut -d' ' -f1)" == "$DEV_CLIPROXY_SHA256" ]] \
+      && tar -xzf "$_dev_dl/cliproxy.tar.gz" -C "$_dev_dl" \
+      && mkdir -p "$(dirname "$DEV_CLIPROXY_BIN")" \
+      && cp "$_dev_dl/cli-proxy-api" "$DEV_CLIPROXY_BIN" \
+      && chmod +x "$DEV_CLIPROXY_BIN"; then
+      rm -rf "$_dev_dl"
+    else
+      rm -rf "${_dev_dl:-}"
+      echo "    WARNING: could not stage cli-proxy-api — the AI accounts tab will"
+      echo "             report no proxy. Everything else runs normally."
+    fi
+  fi
+  [[ -x "$DEV_CLIPROXY_BIN" ]] && export FUSED_RENDER_AI_PROXY_BIN="$DEV_CLIPROXY_BIN"
+fi
+
 # Isolate each branch/worktree onto its own port + state dir. Without this every
 # dev.sh run (main checkout and every worktree) defaults to the baseline port
 # 1777 and clobbers the same ~/.fused-render state, so a server left running in

--- a/tests/test_ai_accounts.py
+++ b/tests/test_ai_accounts.py
@@ -476,6 +476,39 @@ def test_listing_includes_login_snapshot(client, monkeypatch):
     assert body["login"] == {"provider": "claude", "state": "exchanging", "detail": None}
 
 
+@pytest.mark.parametrize("settled", ["done", "failed"])
+def test_listing_reports_no_login_once_an_attempt_settles(client, monkeypatch, settled):
+    """A finished attempt must not read as in-flight.
+
+    Regression guard for a bug that made the SECOND provider unconnectable.
+    _active is deliberately kept after an attempt settles so /connect/status
+    can still report its outcome, but the listing's `login` field is what the
+    page uses to decide "is a login in progress" — and reporting a settled
+    attempt there left every Connect button disabled forever, so connecting
+    Claude locked the user out of ChatGPT until a restart.
+    """
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+    _install_active(phase=settled, state="st-settled")
+    assert client.get("/api/ai/accounts").json()["login"] is None
+    # ...while the status route still reports the outcome to whoever was polling.
+    assert client.get("/api/ai/accounts/connect/status").json()["state"] == settled
+
+
+@pytest.mark.parametrize("settled", ["done", "failed"])
+def test_connect_is_allowed_again_once_the_previous_attempt_settles(
+    client, monkeypatch, settled
+):
+    """The other half of the same bug: a settled attempt must not hold the
+    single-flight gate either, or a second provider could never start."""
+    monkeypatch.setattr(ai_accounts.ai_proxy, "start_login",
+                         lambda p: {"state": "st-new", "url": "https://example.test/auth"})
+    _install_active(phase=settled, state="st-old")
+    resp = client.post("/api/ai/accounts/connect", json={"provider": "codex"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["state"] == "st-new"
+
+
 # -- delete --------------------------------------------------------------------
 
 

--- a/tests/test_ai_accounts.py
+++ b/tests/test_ai_accounts.py
@@ -820,3 +820,108 @@ def test_write_config_with_no_existing_file_is_a_clean_first_spawn(tmp_path, mon
     out = (tmp_path / "config.yaml").read_text(encoding="utf-8")
     assert "api-key" in out  # our own generated inbound key
     assert "claude-api-key" not in out  # nothing to preserve, nothing invented
+
+
+# -- spawn failure must not leak a process (bugbot) -----------------------------
+
+
+class _FakePopen:
+    """A spawned process that stays ALIVE but never becomes healthy."""
+
+    def __init__(self, pid=424242):
+        self.pid = pid
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+
+    def poll(self):
+        return None  # still running, the whole point
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        self.waited = True
+        return self.returncode
+
+
+def _stub_spawn(monkeypatch, tmp_path, proc):
+    """Point ai_proxy at a throwaway home and make Popen return `proc`."""
+    from fused_render.shell import ai_proxy as ap
+
+    monkeypatch.setattr(ap, "_state_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(ap, "_auth_dir", lambda: str(tmp_path / "auths"))
+    monkeypatch.setattr(ap, "_config_path", lambda: str(tmp_path / "config.yaml"))
+    monkeypatch.setattr(ap, "_state_path", lambda: str(tmp_path / "ai_proxy.json"))
+    monkeypatch.setattr(ap, "_log_path", lambda: str(tmp_path / "proxy.log"))
+    monkeypatch.setattr(ap, "ai_proxy_bin", lambda: "/fake/cli-proxy-api")
+    monkeypatch.setattr(ap, "_probe_models", lambda *a, **k: False)  # never healthy
+    monkeypatch.setattr(ap, "_STARTUP_TIMEOUT_S", 0.3)
+    monkeypatch.setattr(ap.subprocess, "Popen", lambda *a, **k: proc)
+    return ap
+
+
+def test_unhealthy_spawn_is_terminated_not_leaked(monkeypatch, tmp_path):
+    """An alive-but-unhealthy spawn must be killed before giving up.
+
+    Otherwise it leaks forever: no state file is written, so nothing later
+    knows its pid, ownership can never be proven, and each retry spawns another
+    beside it — and under FUSED_RENDER_AI_PROXY_PERSIST setsid has already
+    detached it, so app teardown won't collect it either.
+    """
+    proc = _FakePopen()
+    ap = _stub_spawn(monkeypatch, tmp_path, proc)
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        ap.ensure_ai_proxy()
+    assert proc.terminated, "the unhealthy child was left running"
+    assert proc.waited, "the killed child was never reaped"
+    assert ap._child is None  # handle cleared, nothing stale to reap later
+    assert not (tmp_path / "ai_proxy.json").exists()  # no state for a failed spawn
+
+
+def test_hung_recorded_instance_is_killed_before_a_respawn(monkeypatch, tmp_path):
+    """A recorded instance that stops answering but is still ALIVE must be
+    killed before we overwrite the config and state that describe it — else it
+    keeps running, unreachable and unidentifiable, so nothing can ever reap it.
+    """
+    proc = _FakePopen(pid=515151)
+    ap = _stub_spawn(monkeypatch, tmp_path, proc)
+    (tmp_path / "ai_proxy.json").write_text(
+        '{"port": 65000, "pid": 999001, "api_key": "old", '
+        '"management_key": "old-m", "config": "/old/config.yaml"}',
+        encoding="utf-8")
+    monkeypatch.setattr(ap, "_pid_alive", lambda pid: pid == 999001)
+    killed = []
+    monkeypatch.setattr(ap, "_kill_current_ai_proxy", lambda: killed.append(True))
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        ap.ensure_ai_proxy()
+    assert killed == [True], "the hung instance was left behind"
+
+
+def test_unconfirmable_hung_instance_does_not_block_a_respawn(monkeypatch, tmp_path):
+    """If the stale pid can't be proven ours (a recycled pid on an unrelated
+    process), refusing to spawn would be worse than the leak — so the kill
+    failure is logged and the spawn proceeds."""
+    proc = _FakePopen(pid=525252)
+    ap = _stub_spawn(monkeypatch, tmp_path, proc)
+    (tmp_path / "ai_proxy.json").write_text(
+        '{"port": 65001, "pid": 999002, "api_key": "old", '
+        '"management_key": "old-m", "config": "/old/config.yaml"}',
+        encoding="utf-8")
+    monkeypatch.setattr(ap, "_pid_alive", lambda pid: pid == 999002)
+
+    def _refuse():
+        raise RuntimeError("refusing to kill pid 999002: not confirmed ours")
+
+    monkeypatch.setattr(ap, "_kill_current_ai_proxy", _refuse)
+    # Reaches the spawn (and so the unhealthy path) rather than propagating the
+    # kill refusal.
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        ap.ensure_ai_proxy()
+    assert proc.terminated

--- a/tests/test_ai_accounts.py
+++ b/tests/test_ai_accounts.py
@@ -746,3 +746,77 @@ def test_put_routing_strategy_requires_x_fused_header(client, monkeypatch):
     resp = client.put("/api/ai/accounts/routing-strategy", json={"strategy": "fill-first"})
     assert resp.status_code == 403
     assert ai_accounts.prefs.ai_routing_strategy() == "round-robin"  # unchanged
+
+
+# -- config regeneration must not destroy API keys -----------------------------
+#
+# shell/ai_proxy._write_config rewrites config.yaml from scratch on every spawn,
+# and provider API keys live in that same file (the proxy writes them there when
+# the management API adds one). So a regenerate that ignores them is silent data
+# loss for every key the user added — including via the routing-strategy control,
+# whose whole job is to restart the proxy. OAuth credentials are unaffected: they
+# are separate files under auth-dir.
+
+
+def _config_with_keys(tmp_path, monkeypatch, body: str) -> str:
+    from fused_render.shell import ai_proxy as ap
+
+    monkeypatch.setattr(ap, "_state_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(ap, "_auth_dir", lambda: str(tmp_path / "auths"))
+    cfg = tmp_path / "config.yaml"
+    monkeypatch.setattr(ap, "_config_path", lambda: str(cfg))
+    cfg.write_text(body, encoding="utf-8")
+    ap._write_config(1234, "gen-api-key", "gen-mgmt-key", "fill-first")
+    return cfg.read_text(encoding="utf-8")
+
+
+def test_write_config_preserves_existing_api_keys(tmp_path, monkeypatch):
+    existing = (
+        'host: "127.0.0.1"\n'
+        "port: 9\n"
+        "claude-api-key:\n"
+        "  - api-key: sk-ant-KEEP-1\n"
+        '    base-url: ""\n'
+        "codex-api-key:\n"
+        "  - api-key: sk-KEEP-2\n"
+        "    base-url: https://api.openai.com/v1\n"
+    )
+    out = _config_with_keys(tmp_path, monkeypatch, existing)
+    assert "sk-ant-KEEP-1" in out
+    assert "sk-KEEP-2" in out
+    # ...and the regenerated settings still took effect.
+    assert 'strategy: "fill-first"' in out
+    assert "gen-api-key" in out
+
+
+def test_write_config_drops_unrelated_trailing_sections(tmp_path, monkeypatch):
+    """Only the api-key blocks are carried over.
+
+    The proxy rewrites this file itself and appends its own resolved settings
+    (credential-concurrency, ws-auth, ...). Those are its defaults to
+    regenerate, not ours to pin — copying them forward would freeze whatever
+    the previous version happened to emit.
+    """
+    existing = (
+        "claude-api-key:\n"
+        "  - api-key: sk-ant-KEEP-3\n"
+        "credential-concurrency:\n"
+        "  reclaim-grace: 5s\n"
+        "ws-auth: true\n"
+    )
+    out = _config_with_keys(tmp_path, monkeypatch, existing)
+    assert "sk-ant-KEEP-3" in out
+    assert "credential-concurrency" not in out
+    assert "reclaim-grace" not in out
+
+
+def test_write_config_with_no_existing_file_is_a_clean_first_spawn(tmp_path, monkeypatch):
+    from fused_render.shell import ai_proxy as ap
+
+    monkeypatch.setattr(ap, "_state_dir", lambda: str(tmp_path))
+    monkeypatch.setattr(ap, "_auth_dir", lambda: str(tmp_path / "auths"))
+    monkeypatch.setattr(ap, "_config_path", lambda: str(tmp_path / "config.yaml"))
+    ap._write_config(1234, "gen-api-key", "gen-mgmt-key", "round-robin")
+    out = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+    assert "api-key" in out  # our own generated inbound key
+    assert "claude-api-key" not in out  # nothing to preserve, nothing invented

--- a/tests/test_ai_accounts.py
+++ b/tests/test_ai_accounts.py
@@ -1,0 +1,460 @@
+"""Tests for fused_render/ai_accounts.py: /api/ai/accounts list/connect/
+disconnect against the bundled AI proxy.
+
+ai_proxy.py's thin wrappers (start_login/submit_login_code/poll_login_status/
+cancel_login/list_credentials/delete_credential/status) are mocked directly —
+no test here spawns a real cli-proxy-api or talks to a real management API,
+mirroring test_server_ai.py's "avoid the real proxy" discipline.
+
+The callback listener IS exercised for real: an actual HTTP GET is fired at
+the bound port to prove capture + release. The fixed provider ports
+(54545/1455) are patched to ephemeral ones for every test so nothing here can
+collide with a genuine login in progress on the machine running them.
+"""
+import socket
+import time
+import urllib.request
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fused_render import ai_accounts
+
+FUSED = {"X-Fused": "1"}
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    # Give every test its own ephemeral callback ports — never the real fixed
+    # 54545/1455, which could collide with an actual login in progress on the
+    # machine running these tests.
+    monkeypatch.setitem(ai_accounts._CALLBACK, "claude",
+                         {**ai_accounts._CALLBACK["claude"], "port": _free_port()})
+    monkeypatch.setitem(ai_accounts._CALLBACK, "codex",
+                         {**ai_accounts._CALLBACK["codex"], "port": _free_port()})
+    # Real timeout is 5 minutes; tests that exercise the timeout path can't
+    # wait that long.
+    monkeypatch.setattr(ai_accounts, "_CALLBACK_TIMEOUT_S", 2.0)
+    yield
+    # A listener thread left running by a failed test must never leak into
+    # the next one (it would hold its ephemeral port and keep polling).
+    with ai_accounts._LOCK:
+        entry, ai_accounts._active = ai_accounts._active, None
+    if entry is not None:
+        entry.cancel_event.set()
+        try:
+            entry.http_server.server_close()
+        except OSError:
+            pass
+
+
+@pytest.fixture
+def client():
+    app = FastAPI()
+    app.include_router(ai_accounts.router)
+    return TestClient(app)
+
+
+def _wait_for(fn, deadline: float = 5.0):
+    end = time.monotonic() + deadline
+    while True:
+        value = fn()
+        if value:
+            return value
+        assert time.monotonic() < end, "timed out waiting"
+        time.sleep(0.02)
+
+
+# -- provider / name validation --------------------------------------------------
+
+
+def test_connect_rejects_unknown_provider(client):
+    resp = client.post("/api/ai/accounts/connect", json={"provider": "gemini"}, headers=FUSED)
+    assert resp.status_code == 400
+    assert "provider" in resp.json()["error"]
+
+
+def test_connect_rejects_missing_provider(client):
+    resp = client.post("/api/ai/accounts/connect", json={}, headers=FUSED)
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("bad", [
+    "..",
+    "a/b",
+    "a\\b",
+    "claude-user..json",   # ".." as a substring, not a whole path segment
+    "../../etc/passwd",
+])
+def test_valid_credential_name_rejects_traversal(bad):
+    assert ai_accounts._valid_credential_name(bad) is False
+
+
+@pytest.mark.parametrize("ok", ["claude-user@example.com.json", "codex-a@b.json"])
+def test_valid_credential_name_accepts_normal_names(ok):
+    assert ai_accounts._valid_credential_name(ok) is True
+
+
+def test_delete_rejects_bad_name_at_the_route(client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(ai_accounts.ai_proxy, "delete_credential",
+                         lambda name: calls.append(name))
+    resp = client.request(
+        "DELETE", "/api/ai/accounts/claude-user..json", headers=FUSED)
+    assert resp.status_code == 400
+    assert calls == []  # never reached the proxy with an unvalidated name
+
+
+# -- X-Fused guard on mutations ---------------------------------------------------
+
+
+def test_mutations_require_x_fused_header(client):
+    assert client.post("/api/ai/accounts/connect", json={"provider": "claude"}).status_code == 403
+    assert client.post("/api/ai/accounts/connect/cancel").status_code == 403
+    assert client.request("DELETE", "/api/ai/accounts/claude-a@b.json").status_code == 403
+
+
+def test_get_routes_do_not_require_x_fused_header(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+    assert client.get("/api/ai/accounts").status_code == 200
+    assert client.get("/api/ai/accounts/connect/status").status_code == 200
+
+
+# -- listing -----------------------------------------------------------------------
+
+
+def test_listing_is_cheap_when_not_running(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+
+    def _boom():
+        raise AssertionError("list_credentials must not be called when not running")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", _boom)
+    resp = client.get("/api/ai/accounts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"supervised": True, "running": False, "accounts": [], "login": None}
+
+
+def test_listing_filters_providers_and_omits_token_material(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": True})
+    files = [
+        {
+            "name": "claude-a@b.com.json", "provider": "claude", "email": "a@b.com",
+            "label": "a@b.com", "disabled": False,
+            "id_token": {"sub": "should-never-appear"},
+            "path": "/secret/state/dir/auths/claude-a@b.com.json",
+            "access_token": "super-secret",
+        },
+        {
+            "name": "codex-c@d.com.json", "provider": "codex", "email": "c@d.com",
+            "label": "c@d.com", "disabled": True,
+        },
+        {"name": "gemini-e@f.com.json", "provider": "gemini", "email": "e@f.com"},
+    ]
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", lambda: files)
+    resp = client.get("/api/ai/accounts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["supervised"] is True
+    assert body["running"] is True
+    assert body["accounts"] == [
+        {"provider": "claude", "email": "a@b.com", "label": "a@b.com",
+         "disabled": False, "name": "claude-a@b.com.json"},
+        {"provider": "codex", "email": "c@d.com", "label": "c@d.com",
+         "disabled": True, "name": "codex-c@d.com.json"},
+    ]
+    # No token material or on-disk paths anywhere in the response.
+    dumped = str(body)
+    assert "id_token" not in dumped
+    assert "access_token" not in dumped
+    assert "secret/state/dir" not in dumped
+
+
+def test_listing_degrades_gracefully_on_a_listing_failure(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": True})
+
+    def _boom():
+        raise RuntimeError("this proxy build does not support account management")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", _boom)
+    resp = client.get("/api/ai/accounts")
+    assert resp.status_code == 200  # never a 500 over a listing hiccup
+    assert resp.json()["accounts"] == []
+
+
+# -- connect: single-flight ---------------------------------------------------------
+
+
+def test_connect_is_single_flight(client, monkeypatch):
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: {"state": "st-1", "url": "https://auth.example/1", "status": "ok"})
+    first = client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert first.status_code == 200, first.text
+    assert first.json() == {"authorize_url": "https://auth.example/1", "state": "st-1"}
+
+    second = client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert second.status_code == 409
+    assert "already in progress" in second.json()["error"]
+
+    # Even a DIFFERENT provider is refused — only one login in flight overall
+    # (the doc: ports are fixed, so concurrency is structural, not queued).
+    third = client.post("/api/ai/accounts/connect", json={"provider": "codex"}, headers=FUSED)
+    assert third.status_code == 409
+
+
+def test_connect_maps_ui_provider_to_proxy_auth_provider(client, monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: seen.append(provider) or {"state": "s", "url": "https://x"})
+    client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert seen == ["anthropic"]
+
+
+def test_connect_start_login_failure_frees_the_port(client, monkeypatch):
+    def _boom(provider):
+        raise RuntimeError("management surface unreachable")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "start_login", _boom)
+    resp = client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert resp.status_code == 502
+    assert ai_accounts._active is None
+    # The port must be free again — a fresh bind on it must succeed.
+    port = ai_accounts._CALLBACK["claude"]["port"]
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", port))
+
+
+# -- cancel ---------------------------------------------------------------------
+
+
+def test_cancel_is_a_safe_noop_when_idle(client):
+    resp = client.post("/api/ai/accounts/connect/cancel", headers=FUSED)
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "canceled": False}
+
+
+def test_cancel_tears_down_an_in_flight_login(client, monkeypatch):
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: {"state": "st-1", "url": "https://auth.example/1"})
+    canceled = []
+    monkeypatch.setattr(ai_accounts.ai_proxy, "cancel_login", lambda state: canceled.append(state))
+    assert client.post(
+        "/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED
+    ).status_code == 200
+
+    resp = client.post("/api/ai/accounts/connect/cancel", headers=FUSED)
+    assert resp.json() == {"ok": True, "canceled": True}
+    assert canceled == ["st-1"]
+    assert ai_accounts._active is None
+
+    # A new connect is accepted immediately — cancel actually freed the slot.
+    port = ai_accounts._CALLBACK["claude"]["port"]
+    _wait_for(lambda: _can_bind(port))
+    resp2 = client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert resp2.status_code == 200, resp2.text
+
+
+def _can_bind(port: int) -> bool:
+    # Match HTTPServer's own allow_reuse_address=1 so a lingering TIME_WAIT
+    # connection socket from the just-finished one-shot request doesn't make
+    # a released port look "still busy" to this probe.
+    try:
+        with socket.socket() as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            s.bind(("127.0.0.1", port))
+        return True
+    except OSError:
+        return False
+
+
+# -- the callback listener --------------------------------------------------------
+
+
+def test_callback_listener_captures_code_and_releases_port(client, monkeypatch):
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: {"state": "abc123", "url": "https://auth.example/abc"})
+    submitted = []
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "submit_login_code",
+        lambda provider, state, code: submitted.append((provider, state, code)))
+
+    resp = client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    port = ai_accounts._CALLBACK["claude"]["port"]
+
+    # Simulate the browser landing on our loopback listener after the user
+    # approves in the provider's consent screen.
+    with urllib.request.urlopen(
+        f"http://127.0.0.1:{port}/callback?code=CODE-1&state=abc123", timeout=5
+    ) as r:
+        assert r.status == 200
+        assert b"FusedRender" in r.read()
+
+    _wait_for(lambda: submitted)
+    assert submitted == [("anthropic", "abc123", "CODE-1")]
+    assert ai_accounts._active.phase == "exchanging"
+
+    # The port must be released promptly once the one-shot request lands —
+    # not held for the rest of the (multi-minute) callback timeout.
+    _wait_for(lambda: _can_bind(port))
+
+
+def test_callback_listener_rejects_state_mismatch(client, monkeypatch):
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: {"state": "expected-state", "url": "https://auth.example/x"})
+    submitted = []
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "submit_login_code",
+        lambda provider, state, code: submitted.append((provider, state, code)))
+
+    client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    port = ai_accounts._CALLBACK["claude"]["port"]
+    urllib.request.urlopen(
+        f"http://127.0.0.1:{port}/callback?code=CODE-1&state=WRONG", timeout=5).close()
+
+    entry = _wait_for(lambda: ai_accounts._active if ai_accounts._active.phase == "failed" else None)
+    assert "did not match" in entry.detail
+    assert submitted == []  # never handed a mismatched code to the proxy
+
+
+def test_callback_listener_times_out_when_browser_never_arrives(client, monkeypatch):
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "start_login",
+        lambda provider: {"state": "st-1", "url": "https://auth.example/x"})
+    client.post("/api/ai/accounts/connect", json={"provider": "claude"}, headers=FUSED)
+    port = ai_accounts._CALLBACK["claude"]["port"]
+
+    entry = _wait_for(
+        lambda: ai_accounts._active if ai_accounts._active.phase == "failed" else None,
+        deadline=5.0)
+    assert "timed out" in entry.detail
+    _wait_for(lambda: _can_bind(port))
+
+
+# -- status polling -----------------------------------------------------------------
+
+
+class _DummyServer:
+    """Stands in for the real HTTPServer in status-only tests, which install
+    an _ActiveConnect directly and never run the listener thread. Shaped
+    enough to survive the autouse teardown's cancel/close, so those tests
+    don't need a real bound socket just to satisfy cleanup."""
+
+    timeout = 1.0
+    captured = None
+
+    def handle_request(self) -> None:
+        raise AssertionError("status-only tests must never run the listener")
+
+    def server_close(self) -> None:
+        pass
+
+
+def _install_active(state="st-1", phase="exchanging"):
+    entry = ai_accounts._ActiveConnect(
+        provider="claude", auth_provider="anthropic", state=state,
+        http_server=_DummyServer(), phase=phase,
+    )
+    ai_accounts._active = entry
+    return entry
+
+
+def test_status_idle_when_nothing_in_flight(client):
+    assert client.get("/api/ai/accounts/connect/status").json() == {
+        "state": "idle", "detail": None,
+    }
+
+
+def test_status_reports_waiting_browser_without_polling_the_proxy(client, monkeypatch):
+    _install_active(phase="waiting_browser")
+
+    def _boom(state):
+        raise AssertionError("must not poll the proxy while still waiting on the browser")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "poll_login_status", _boom)
+    assert client.get("/api/ai/accounts/connect/status").json() == {
+        "state": "waiting_browser", "detail": None,
+    }
+
+
+def test_status_maps_wait_ok_and_error(client, monkeypatch):
+    _install_active(phase="exchanging")
+    monkeypatch.setattr(ai_accounts.ai_proxy, "poll_login_status", lambda state: {"status": "wait"})
+    assert client.get("/api/ai/accounts/connect/status").json() == {
+        "state": "exchanging", "detail": None,
+    }
+    assert ai_accounts._active.phase == "exchanging"
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "poll_login_status", lambda state: {"status": "ok"})
+    assert client.get("/api/ai/accounts/connect/status").json() == {
+        "state": "done", "detail": None,
+    }
+    assert ai_accounts._active.phase == "done"
+
+    _install_active(phase="exchanging")
+    monkeypatch.setattr(
+        ai_accounts.ai_proxy, "poll_login_status",
+        lambda state: {"status": "error", "error": "Failed to exchange authorization code"})
+    resp = client.get("/api/ai/accounts/connect/status").json()
+    assert resp["state"] == "failed"
+    assert "Failed to exchange" in resp["detail"]
+    assert ai_accounts._active.phase == "failed"
+
+
+def test_status_poll_failure_maps_to_failed(client, monkeypatch):
+    _install_active(phase="exchanging")
+
+    def _boom(state):
+        raise RuntimeError("this proxy build does not support account management")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "poll_login_status", _boom)
+    resp = client.get("/api/ai/accounts/connect/status").json()
+    assert resp["state"] == "failed"
+    assert "does not support account management" in resp["detail"]
+
+
+def test_listing_includes_login_snapshot(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+    _install_active(phase="exchanging", state="st-9")
+    body = client.get("/api/ai/accounts").json()
+    assert body["login"] == {"provider": "claude", "state": "exchanging", "detail": None}
+
+
+# -- delete --------------------------------------------------------------------
+
+
+def test_delete_calls_proxy_and_returns_ok(client, monkeypatch):
+    calls = []
+    monkeypatch.setattr(ai_accounts.ai_proxy, "delete_credential", lambda name: calls.append(name))
+    resp = client.request("DELETE", "/api/ai/accounts/claude-a@b.com.json", headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True}
+    assert calls == ["claude-a@b.com.json"]
+
+
+def test_delete_surfaces_proxy_error(client, monkeypatch):
+    def _boom(name):
+        raise RuntimeError("invalid name")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "delete_credential", _boom)
+    resp = client.request("DELETE", "/api/ai/accounts/claude-a@b.com.json", headers=FUSED)
+    assert resp.status_code == 502
+    assert "invalid name" in resp.json()["error"]

--- a/tests/test_ai_accounts.py
+++ b/tests/test_ai_accounts.py
@@ -31,7 +31,12 @@ def _free_port() -> int:
 
 
 @pytest.fixture(autouse=True)
-def _reset_state(monkeypatch):
+def _reset_state(monkeypatch, tmp_path):
+    # Redirect FUSED_RENDER_HOME so the routing-strategy pref (read on every
+    # GET, written by the new PUT route) never touches a developer's real
+    # ~/.fused-render/prefs.json — same discipline as test_shell_prefs.py's
+    # _client(). Must be set before anything in this module reads prefs.
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
     # Give every test its own ephemeral callback ports — never the real fixed
     # 54545/1455, which could collide with an actual login in progress on the
     # machine running these tests.
@@ -139,10 +144,15 @@ def test_listing_is_cheap_when_not_running(client, monkeypatch):
         raise AssertionError("list_credentials must not be called when not running")
 
     monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", _boom)
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys",
+                         lambda provider: _boom())
     resp = client.get("/api/ai/accounts")
     assert resp.status_code == 200
     body = resp.json()
-    assert body == {"supervised": True, "running": False, "accounts": [], "login": None}
+    assert body == {
+        "supervised": True, "running": False, "accounts": [], "api_keys": [],
+        "routing_strategy": "round-robin", "login": None,
+    }
 
 
 def test_listing_filters_providers_and_omits_token_material(client, monkeypatch):
@@ -163,6 +173,7 @@ def test_listing_filters_providers_and_omits_token_material(client, monkeypatch)
         {"name": "gemini-e@f.com.json", "provider": "gemini", "email": "e@f.com"},
     ]
     monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", lambda: files)
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys", lambda provider: [])
     resp = client.get("/api/ai/accounts")
     assert resp.status_code == 200
     body = resp.json()
@@ -181,6 +192,29 @@ def test_listing_filters_providers_and_omits_token_material(client, monkeypatch)
     assert "secret/state/dir" not in dumped
 
 
+def test_listing_masks_api_keys(client, monkeypatch):
+    # The one non-negotiable rule for this surface: a full API key must
+    # never appear anywhere in a response the client can read.
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": True})
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", lambda: [])
+    full_key = "sk-ant-super-secret-do-not-leak-1234"
+
+    def _list_api_keys(provider):
+        if provider == "claude":
+            return [{"api-key": full_key, "base-url": "", "auth-index": "idx-1"}]
+        return []
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys", _list_api_keys)
+    resp = client.get("/api/ai/accounts")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["api_keys"] == [
+        {"provider": "claude", "hint": "..." + full_key[-4:], "auth_index": "idx-1"},
+    ]
+    assert full_key not in str(body)
+
+
 def test_listing_degrades_gracefully_on_a_listing_failure(client, monkeypatch):
     monkeypatch.setattr(ai_accounts.ai_proxy, "status",
                          lambda: {"supervised": True, "running": True})
@@ -189,9 +223,13 @@ def test_listing_degrades_gracefully_on_a_listing_failure(client, monkeypatch):
         raise RuntimeError("this proxy build does not support account management")
 
     monkeypatch.setattr(ai_accounts.ai_proxy, "list_credentials", _boom)
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys",
+                         lambda provider: (_ for _ in ()).throw(
+                             RuntimeError("this proxy build does not support account management")))
     resp = client.get("/api/ai/accounts")
     assert resp.status_code == 200  # never a 500 over a listing hiccup
     assert resp.json()["accounts"] == []
+    assert resp.json()["api_keys"] == []
 
 
 # -- connect: single-flight ---------------------------------------------------------
@@ -458,3 +496,220 @@ def test_delete_surfaces_proxy_error(client, monkeypatch):
     resp = client.request("DELETE", "/api/ai/accounts/claude-a@b.com.json", headers=FUSED)
     assert resp.status_code == 502
     assert "invalid name" in resp.json()["error"]
+
+
+# -- API keys ------------------------------------------------------------------
+
+
+def _install_fake_key_store(monkeypatch, store=None):
+    """A tiny in-memory stand-in for the proxy's per-provider api-key arrays,
+    faithful to the one behaviour these tests care about: replace_api_keys
+    hands back auth-index by array position, exactly like the real PUT
+    (docs/AI_PROXY_MANAGEMENT_API.md — auth-index is server-assigned)."""
+    store = store if store is not None else {"claude": [], "codex": []}
+
+    def list_api_keys(provider):
+        return [dict(e) for e in store.get(provider, [])]
+
+    def replace_api_keys(provider, entries):
+        store[provider] = [
+            {**{k: v for k, v in e.items() if k != "auth-index"},
+             "auth-index": f"{provider}-{i}"}
+            for i, e in enumerate(entries)
+        ]
+        return {"status": "ok"}
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys", list_api_keys)
+    monkeypatch.setattr(ai_accounts.ai_proxy, "replace_api_keys", replace_api_keys)
+    return store
+
+
+def test_add_key_rejects_unknown_provider(client, monkeypatch):
+    _install_fake_key_store(monkeypatch)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "gemini", "api_key": "sk-abcdefgh"},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert "provider" in resp.json()["error"]
+
+
+@pytest.mark.parametrize("bad_key", [
+    None, "", "   ", "short", "has space", "\t\n", "x" * 5000,
+])
+def test_add_key_rejects_bad_api_key(client, monkeypatch, bad_key):
+    _install_fake_key_store(monkeypatch)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": bad_key},
+        headers=FUSED,
+    )
+    assert resp.status_code == 400
+    assert "api_key" in resp.json()["error"]
+
+
+def test_add_key_requires_x_fused_header(client, monkeypatch):
+    _install_fake_key_store(monkeypatch)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": "sk-ant-abcdefgh"})
+    assert resp.status_code == 403
+
+
+def test_add_key_persists_and_returns_masked_hint(client, monkeypatch):
+    _install_fake_key_store(monkeypatch)
+    key = "sk-ant-abcdefgh12345"
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": key}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["provider"] == "claude"
+    assert body["hint"] == "..." + key[-4:]
+    assert body["auth_index"] == "claude-0"
+    assert key not in resp.text  # the full key never travels back to the client
+
+
+def test_add_key_is_read_modify_write(client, monkeypatch):
+    # A pre-existing key for the provider (and an unrelated one for the OTHER
+    # provider) must both survive an add — the whole point of read-modify-
+    # write over a naive PUT [{new}] is that it can't clobber what's there.
+    store = {
+        "claude": [{"api-key": "sk-ant-existing-key", "base-url": "", "auth-index": "old-0"}],
+        "codex": [{"api-key": "sk-codex-existing", "base-url": "https://api.openai.com/v1",
+                   "auth-index": "old-0"}],
+    }
+    _install_fake_key_store(monkeypatch, store)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": "sk-ant-new-key-999"},
+        headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    claude_keys = {e["api-key"] for e in store["claude"]}
+    assert claude_keys == {"sk-ant-existing-key", "sk-ant-new-key-999"}
+    # The codex list (a different provider entirely) is untouched.
+    assert [e["api-key"] for e in store["codex"]] == ["sk-codex-existing"]
+
+
+def test_add_key_defaults_base_url_for_codex(client, monkeypatch):
+    store = {"claude": [], "codex": []}
+    _install_fake_key_store(monkeypatch, store)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "codex", "api_key": "sk-codex-abcdefgh"},
+        headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert store["codex"][0]["base-url"] == ai_accounts._CODEX_DEFAULT_BASE_URL
+
+    # Claude gets no such default — the doc shows Claude persisting fine
+    # with an empty base-url, so forcing one there would be pure guesswork.
+    resp2 = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": "sk-ant-abcdefgh"},
+        headers=FUSED)
+    assert resp2.status_code == 200, resp2.text
+    assert "base-url" not in store["claude"][0]
+
+
+def test_add_key_surfaces_error_when_write_does_not_persist(client, monkeypatch):
+    # The trap, generalized: whatever the reason (the codex-no-base-url
+    # silent drop, or anything else), if a read-back after PUT does not show
+    # the key, this must be a clean error — never a false "ok".
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys", lambda provider: [])
+    monkeypatch.setattr(ai_accounts.ai_proxy, "replace_api_keys",
+                         lambda provider, entries: {"status": "ok"})
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "codex", "api_key": "sk-codex-abcdefgh"},
+        headers=FUSED)
+    assert resp.status_code == 502
+    assert "did not persist" in resp.json()["error"]
+
+
+def test_add_key_surfaces_proxy_error_on_write(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "list_api_keys", lambda provider: [])
+
+    def _boom(provider, entries):
+        raise RuntimeError("management surface unreachable")
+
+    monkeypatch.setattr(ai_accounts.ai_proxy, "replace_api_keys", _boom)
+    resp = client.post(
+        "/api/ai/accounts/keys", json={"provider": "claude", "api_key": "sk-ant-abcdefgh"},
+        headers=FUSED)
+    assert resp.status_code == 502
+    assert "management surface unreachable" in resp.json()["error"]
+
+
+def test_delete_key_by_auth_index_removes_only_target(client, monkeypatch):
+    store = {
+        "claude": [
+            {"api-key": "sk-ant-keep", "base-url": "", "auth-index": "keep-me"},
+            {"api-key": "sk-ant-gone", "base-url": "", "auth-index": "delete-me"},
+        ],
+        "codex": [
+            {"api-key": "sk-codex-untouched", "base-url": "https://api.openai.com/v1",
+             "auth-index": "delete-me"},  # same auth-index string, different provider
+        ],
+    }
+    _install_fake_key_store(monkeypatch, store)
+    resp = client.request("DELETE", "/api/ai/accounts/keys/delete-me", headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True}
+    # Only the claude entry with that exact auth-index is gone.
+    assert [e["api-key"] for e in store["claude"]] == ["sk-ant-keep"]
+    # The codex entry sharing the same auth-index string is untouched: the
+    # route stops at the first provider whose list actually shrank.
+    assert [e["api-key"] for e in store["codex"]] == ["sk-codex-untouched"]
+
+
+def test_delete_key_requires_x_fused_header(client, monkeypatch):
+    _install_fake_key_store(monkeypatch)
+    resp = client.request("DELETE", "/api/ai/accounts/keys/anything")
+    assert resp.status_code == 403
+
+
+def test_delete_key_bogus_auth_index_is_a_clean_error(client, monkeypatch):
+    store = {
+        "claude": [{"api-key": "sk-ant-keep", "base-url": "", "auth-index": "real-index"}],
+        "codex": [],
+    }
+    _install_fake_key_store(monkeypatch, store)
+    resp = client.request("DELETE", "/api/ai/accounts/keys/no-such-index", headers=FUSED)
+    assert resp.status_code == 404
+    # Nothing was mutated.
+    assert [e["api-key"] for e in store["claude"]] == ["sk-ant-keep"]
+
+
+# -- routing strategy ------------------------------------------------------------
+
+
+def test_routing_strategy_defaults_to_round_robin_in_listing(client, monkeypatch):
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+    body = client.get("/api/ai/accounts").json()
+    assert body["routing_strategy"] == "round-robin"
+
+
+def test_put_routing_strategy_persists_and_restarts(client, monkeypatch):
+    restarted = []
+    monkeypatch.setattr(ai_accounts.ai_proxy, "restart_ai_proxy", lambda: restarted.append(1) or True)
+    resp = client.put(
+        "/api/ai/accounts/routing-strategy", json={"strategy": "fill-first"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "strategy": "fill-first", "restarted": True}
+    assert restarted == [1]
+    # Persisted — the next read (e.g. the listing) sees the new choice.
+    assert ai_accounts.prefs.ai_routing_strategy() == "fill-first"
+    monkeypatch.setattr(ai_accounts.ai_proxy, "status",
+                         lambda: {"supervised": True, "running": False})
+    assert client.get("/api/ai/accounts").json()["routing_strategy"] == "fill-first"
+
+
+def test_put_routing_strategy_rejects_bad_value(client, monkeypatch):
+    restarted = []
+    monkeypatch.setattr(ai_accounts.ai_proxy, "restart_ai_proxy", lambda: restarted.append(1))
+    resp = client.put(
+        "/api/ai/accounts/routing-strategy", json={"strategy": "fastest"}, headers=FUSED)
+    assert resp.status_code == 400
+    assert restarted == []  # rejected before any attempt to restart the proxy
+    assert ai_accounts.prefs.ai_routing_strategy() == "round-robin"  # unchanged
+
+
+def test_put_routing_strategy_requires_x_fused_header(client, monkeypatch):
+    resp = client.put("/api/ai/accounts/routing-strategy", json={"strategy": "fill-first"})
+    assert resp.status_code == 403
+    assert ai_accounts.prefs.ai_routing_strategy() == "round-robin"  # unchanged

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -23,6 +23,18 @@ _STATIC = Path(fused_render.__file__).parent / "static"
 RUNTIME = (_STATIC / "runtime.js").read_text(encoding="utf-8")
 
 
+@pytest.fixture(autouse=True)
+def _default_unsupervised(monkeypatch):
+    # Every pre-existing test in this file exercises the plain, unsupervised
+    # relay path (the one that existed before the bundled-proxy supervision
+    # was added) — pin is_supervised() False so a stray ai_base_url pref/env
+    # on the machine running these tests, or the default-supervised behavior
+    # itself, can't turn a fake-httpx-client test into an attempt to spawn a
+    # real cli-proxy-api. The supervised-path tests below override this
+    # explicitly.
+    monkeypatch.setattr(server.shell_ai_proxy, "is_supervised", lambda: False)
+
+
 def _relay(body):
     return asyncio.run(server._ai_relay(body))
 
@@ -37,7 +49,7 @@ class _FakeClient:
     def __init__(self, response=None, exc=None):
         self._response = response
         self._exc = exc
-        self.requests = []  # (url, json_payload) of every post
+        self.requests = []  # (url, json_payload, headers) of every post
 
     def __call__(self, *args, **kwargs):  # the AsyncClient(...) constructor call
         return self
@@ -48,8 +60,8 @@ class _FakeClient:
     async def __aexit__(self, *exc_info):
         return False
 
-    async def post(self, url, json=None):
-        self.requests.append((url, json))
+    async def post(self, url, json=None, headers=None):
+        self.requests.append((url, json, headers))
         if self._exc is not None:
             raise self._exc
         return self._response
@@ -85,7 +97,7 @@ def test_relay_happy_path(monkeypatch):
     assert data["result"]["usage"]["completion_tokens"] == 2
     # One POST to the proxy's chat/completions with the default model and the
     # medium effort default (4096 tokens), user message only (no system prompt).
-    (url, payload), = fake.requests
+    (url, payload, _), = fake.requests
     assert url.endswith("/v1/chat/completions")
     assert payload["model"] == server._AI_DEFAULT_MODEL
     assert payload["max_tokens"] == 4096
@@ -96,7 +108,7 @@ def test_relay_options_reach_the_proxy(monkeypatch):
     fake = _proxy_ok(monkeypatch, _COMPLETION)
     _relay({"prompt": "hello", "system_prompt": "be terse",
             "model": "claude-sonnet-5", "effort": "high"})
-    (_, payload), = fake.requests
+    (_, payload, _headers), = fake.requests
     assert payload["model"] == "claude-sonnet-5"
     assert payload["max_tokens"] == 16384  # effort: high
     assert payload["messages"][0] == {"role": "system", "content": "be terse"}
@@ -106,7 +118,7 @@ def test_relay_options_reach_the_proxy(monkeypatch):
 def test_relay_explicit_max_tokens_beats_effort(monkeypatch):
     fake = _proxy_ok(monkeypatch, _COMPLETION)
     _relay({"prompt": "hello", "effort": "low", "max_tokens": 99})
-    (_, payload), = fake.requests
+    (_, payload, _headers), = fake.requests
     assert payload["max_tokens"] == 99
 
 
@@ -192,8 +204,83 @@ def test_relay_uses_configured_base_url(monkeypatch):
     fake = _proxy_ok(monkeypatch, _COMPLETION)
     monkeypatch.setenv("FUSED_RENDER_AI_BASE_URL", "http://127.0.0.1:4242/")
     _relay({"prompt": "hello"})
-    (url, _), = fake.requests
+    (url, _, _headers), = fake.requests
     assert url == "http://127.0.0.1:4242/v1/chat/completions"
+
+
+def test_relay_unsupervised_sends_no_auth_header(monkeypatch):
+    # The unsupervised path (this file's default fixture) must send exactly
+    # what it always sent — no Authorization header baked in for a proxy the
+    # user runs and controls themselves.
+    fake = _proxy_ok(monkeypatch, _COMPLETION)
+    _relay({"prompt": "hello"})
+    (_, _, headers), = fake.requests
+    assert headers is None
+
+
+# -- supervised (bundled proxy) relay path -----------------------------------
+
+
+def test_relay_supervised_uses_proxy_base_url_and_bearer_key(monkeypatch):
+    monkeypatch.setattr(server.shell_ai_proxy, "is_supervised", lambda: True)
+    # A resolvable binary is the second half of the supervised gate — see
+    # test_relay_supervised_without_a_binary_falls_back_to_the_base_url.
+    monkeypatch.setattr(server.shell_ai_proxy, "ai_proxy_bin", lambda: "/fake/cli-proxy-api")
+    monkeypatch.setattr(
+        server.shell_ai_proxy, "ensure_ai_proxy",
+        lambda: ("http://127.0.0.1:55123", "sekret-key", "mgmt-key"))
+    fake = _proxy_ok(monkeypatch, _COMPLETION)
+    resp = _relay({"prompt": "hello"})
+    assert resp.status_code == 200
+    (url, _, headers), = fake.requests
+    assert url == "http://127.0.0.1:55123/v1/chat/completions"
+    assert headers == {"Authorization": "Bearer sekret-key"}
+
+
+def test_relay_supervised_ensure_failure_is_ai_unavailable(monkeypatch):
+    # ensure_ai_proxy() raising (no binary, failed to become healthy, ...)
+    # maps to the existing "ai_unavailable" error type — RH-11's error
+    # surface does not grow a fourth type for this.
+    monkeypatch.setattr(server.shell_ai_proxy, "is_supervised", lambda: True)
+    monkeypatch.setattr(server.shell_ai_proxy, "ai_proxy_bin", lambda: "/fake/cli-proxy-api")
+
+    def _boom():
+        raise RuntimeError("ai-proxy did not become healthy within 15s")
+
+    monkeypatch.setattr(server.shell_ai_proxy, "ensure_ai_proxy", _boom)
+    fake = _proxy_ok(monkeypatch, _COMPLETION)  # must never be reached
+    resp = _relay({"prompt": "hello"})
+    assert resp.status_code == 502
+    data = _data(resp)
+    assert data["error"]["type"] == "ai_unavailable"
+    assert "did not become healthy" in data["error"]["message"]
+    assert fake.requests == []
+
+
+def test_relay_supervised_without_a_binary_falls_back_to_the_base_url(monkeypatch):
+    """No bundled binary must NOT become an ai_unavailable.
+
+    Regression guard. Supervision is the default (no explicit ai_base_url), but
+    a dev checkout — and any install predating bundling — has no cli-proxy-api
+    to supervise, while very often DOES have a user-run CLIProxyAPI answering on
+    ai_base_url()'s default port. Gating only on is_supervised() broke exactly
+    that case: fused.ai() reported the proxy as unavailable while it sat there
+    serving requests. So a missing binary falls through to the unsupervised
+    path, unauthenticated, precisely as it behaved before bundling existed.
+    """
+    monkeypatch.setattr(server.shell_ai_proxy, "is_supervised", lambda: True)
+    monkeypatch.setattr(server.shell_ai_proxy, "ai_proxy_bin", lambda: None)
+
+    def _never():  # ensure_ai_proxy must not even be attempted
+        raise AssertionError("ensure_ai_proxy() called with no binary resolved")
+
+    monkeypatch.setattr(server.shell_ai_proxy, "ensure_ai_proxy", _never)
+    fake = _proxy_ok(monkeypatch, _COMPLETION)
+    resp = _relay({"prompt": "hello"})
+    assert resp.status_code == 200
+    (url, _, headers), = fake.requests
+    assert url == prefs.ai_base_url().rstrip("/") + "/v1/chat/completions"
+    assert headers is None  # unsupervised: no generated key to send
 
 
 # -- runtime surface --------------------------------------------------------------


### PR DESCRIPTION
Stacked on #304 (`fused-ai-api`) — review that one first.

#304 shipped `fused.ai()` as a relay to an OpenAI-compatible proxy the user
installs and runs themselves. That works, but it makes the feature invisible
until someone has independently discovered CLIProxyAPI, installed it, run an
OAuth login per provider, and left it running. This branch removes that
prerequisite: the proxy ships inside the app, the app supervises it, and
connecting a Claude or ChatGPT account becomes a button in Preferences.

## Approach

CLIProxyAPI is a single static Go binary (MIT), which is the same shape as
rclone — already bundled for mounts. So the bundling and lifecycle work is a
copy of an established in-repo pattern rather than a new one: pinned version
downloaded and checksum-verified at build time, staged into the app payload,
resolved at runtime through an env override → bundled path → PATH fallback
chain, spawned lazily with a generated config on a random port, health-polled,
and torn down with the same only-kill-a-pid-we-can-prove-is-ours safety gates
`shell/mounts.py` uses for the rclone daemon.

Account management uses the proxy's Management API, whose contract is not
documented upstream (`docs/MANAGEMENT_API.md` 404s), so it was established by
probing a real v7.2.90 binary — see `docs/AI_PROXY_MANAGEMENT_API.md`. The
important result is that OAuth can be driven entirely over HTTP, so Preferences
can offer a real "Connect account" flow without shelling out to CLI login
subcommands.

Scope of the Preferences UI is deliberately Claude and ChatGPT only for now,
even though the proxy also speaks Gemini, Kimi, xAI and Antigravity.

A user who already runs their own proxy keeps working unchanged — the PATH
fallback and the existing `FUSED_RENDER_AI_BASE_URL` / `ai_base_url` overrides
still point at it, so nothing about #304's contract changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces local credential storage, OAuth subscription login flows, and authenticated relay to a third-party proxy; misconfiguration or teardown bugs could leak or orphan secrets/processes, and the design doc flags provider ToS exposure.
> 
> **Overview**
> **Bundles CLIProxyAPI** (pinned in DMG/AppImage/Windows/dev scripts) and supervises it from `shell/ai_proxy.py` on the same model as rclone: lazy spawn on loopback with generated API/management secrets, health checks, config preservation for API keys, and ownership-checked teardown on app/server quit.
> 
> **`/api/ai` relay** now uses the supervised proxy (Bearer auth) when no explicit `ai_base_url` / `FUSED_RENDER_AI_BASE_URL` override exists; otherwise behavior stays as before, including dev checkouts without a bundled binary.
> 
> **New `ai_accounts` router and Preferences “AI accounts” tab** (`?tab=ai`): list proxy status, OAuth connect via fixed localhost callback ports + polling `get-auth-status`, disconnect, masked API key add/remove with Codex read-back verification, and **round-robin** vs **fill-first** routing (persists in prefs and restarts the proxy).
> 
> **SPEC RH-12 / PF-10–14** and design docs (`AI_PROXY_BUNDLING.md`, `AI_PROXY_MANAGEMENT_API.md`) document the contract; supervisor sets `FUSED_RENDER_AI_PROXY_BIN`; `dev.sh` enables `FUSED_RENDER_AI_PROXY_PERSIST` and optional one-time binary staging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 327b82bf907572742883497498a52afb86a31f8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->