### PR TITLE
Add event listeners for tail toggle and view tab navigation

### DIFF
--- a/fused_render/templates/log_studio/template.html
+++ b/fused_render/templates/log_studio/template.html
@@ -1738,6 +1738,19 @@
     if (chartData) requestAnimationFrame(resizeCanvas);
   }).observe(document.documentElement, { attributeFilter: ["data-theme"] });
 
+  tailToggle.addEventListener("click", () => {
+    const state = currentState();
+    const size = overviewData && (overviewData.size ?? overviewData.file_size ?? overviewData.bytes);
+    if (!state.tail) {
+      tailEndOffset = number(size);
+      tailPageOffset = Math.max(0, tailEndOffset - 65536);
+    }
+    setParams({ page: tailPageOffset, back: "", tail: state.tail ? "0" : "1" });
+  });
+
+  linesTab.addEventListener("click", () => setParams({ view: "lines", page: "0", back: "" }));
+  patternsTab.addEventListener("click", () => setParams({ view: "patterns", page: "0", back: "", tail: "0" }));
+
   levelList.addEventListener("click", (event) => {
     const button = event.target.closest("[data-level]");
     if (!button || !overviewData) return;

--- a/fused_render/templates/log_studio/template.html
+++ b/fused_render/templates/log_studio/template.html
@@ -1752,7 +1752,14 @@
     setParams({ page: tailPageOffset, back: "", tail: turningOn ? "1" : "0", view: turningOn ? "lines" : state.view });
   });
 
-  linesTab.addEventListener("click", () => setParams({ view: "lines", page: "0", back: "" }));
+  // No-op while already on lines: `page` is part of dataKey, so resetting it
+  // on a redundant click would abandon the current offset (including a
+  // tail-established end-of-file position) and force a full reload for a
+  // click that looks like it did nothing.
+  linesTab.addEventListener("click", () => {
+    if (currentState().view === "lines") return;
+    setParams({ view: "lines", page: "0", back: "" });
+  });
   patternsTab.addEventListener("click", () => setParams({ view: "patterns", page: "0", back: "", tail: "0" }));
 
   levelList.addEventListener("click", (event) => {

--- a/fused_render/templates/log_studio/template.html
+++ b/fused_render/templates/log_studio/template.html
@@ -1741,11 +1741,15 @@
   tailToggle.addEventListener("click", () => {
     const state = currentState();
     const size = overviewData && (overviewData.size ?? overviewData.file_size ?? overviewData.bytes);
-    if (!state.tail) {
+    const turningOn = !state.tail;
+    if (turningOn) {
       tailEndOffset = number(size);
       tailPageOffset = Math.max(0, tailEndOffset - 65536);
     }
-    setParams({ page: tailPageOffset, back: "", tail: state.tail ? "0" : "1" });
+    // Tail only polls in the lines view (pollTail/syncTailTimer both guard on
+    // it), so turning tail on from Patterns must switch back to lines or the
+    // button reads as pressed while nothing updates and autoReload sits off.
+    setParams({ page: tailPageOffset, back: "", tail: turningOn ? "1" : "0", view: turningOn ? "lines" : state.view });
   });
 
   linesTab.addEventListener("click", () => setParams({ view: "lines", page: "0", back: "" }));


### PR DESCRIPTION
## Summary
Added event listener handlers for tail mode toggling and view tab navigation in the log studio template.

## Key Changes
- **Tail toggle functionality**: Added click event listener to `tailToggle` that:
  - Toggles tail mode on/off via URL parameters
  - When enabling tail mode, calculates the appropriate page offset to show the end of the file
  - Uses file size from `overviewData` with fallback options (`size`, `file_size`, or `bytes`)
  - Sets `tailPageOffset` to show the last 65KB of the file when tail mode is enabled

- **View tab navigation**: Added click event listeners for:
  - `linesTab`: Switches to lines view and resets pagination
  - `patternsTab`: Switches to patterns view, resets pagination, and disables tail mode

## Implementation Details
- The tail toggle intelligently calculates the starting page offset (`tailPageOffset`) based on file size to avoid loading the entire file
- Tab navigation handlers reset the page parameter to "0" and clear the back parameter for clean state transitions
- The patterns view explicitly disables tail mode (`tail: "0"`) to prevent incompatible state combinations

https://claude.ai/code/session_01RGLkuUhkBNgHr3RUHsVpDL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Front-end navigation and URL parameter updates only; no server, auth, or data-model changes.
> 
> **Overview**
> Wires **Tail** and the **Lines** / **Patterns** tabs to URL-driven state so those controls actually drive loading and tail polling.
> 
> **Tail** toggles `tail` via `setParams`. When turning on, it seeds `tailEndOffset` / `tailPageOffset` from overview file size (with `size` / `file_size` / `bytes` fallbacks) so the initial page is the last ~64KB, sets `page` to that offset, and **forces `view: lines`** because tail polling only runs in lines view. Turning off leaves the current view unchanged.
> 
> **Lines** switches to lines and resets `page` / `back`, but does nothing if already on lines so a redundant click does not reset `page` (which would trigger a full reload and drop a tail end-of-file position).
> 
> **Patterns** switches to patterns, resets pagination, and sets **`tail: "0"`** so tail and patterns cannot stay combined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d78819391ea9f8c4e848a290b51f34bb0a500c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->