### PR TITLE
pdf_studio: protect/unlock, OCR, conversions, camera scan, Tools home

### DIFF
--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -39,6 +39,14 @@ Actions
   extract_pages(doc,pages,name)            -> {name, path, size, dir}
   merge(sources,name,directory)            -> {name, path, dir}
   split(doc,mode,ranges,prefix,directory)  -> {files:[...], dir}
+  protect(doc,password,owner)              -> {name, path, size, dir}  (encrypted copy)
+  unlock(doc,password)                     -> {name, path, dir}  (decrypted copy)
+  ocr(doc,pages,language)                  -> {name, path, dir, ocr_pages, copied_pages}
+  pdf_to_word(doc,pages)                   -> {name, path, size, dir}
+  word_to_pdf(src)                         -> {name, path, dir}
+  excel_to_pdf(src)                        -> {name, path, dir}
+  images_to_pdf(sources,name,directory)    -> {name, path, dir}  (image file paths)
+  save_scan(images_b64,name,directory)     -> {name, path, dir}  (base64 captures)
   reveal(path)                             -> {ok}  (opens the OS file explorer)
   page_text(doc,page)                      -> {width, height, rotation, spans:[...]}
   undo(doc) / redo(doc)                    -> mutation contract shape
@@ -522,6 +530,7 @@ def _compress(doc, level):
     before = os.path.getsize(doc)
 
     def fn(path):
+        tmp = path + ".tmp"
         if level == "aggressive":
             import fitz
 
@@ -530,17 +539,410 @@ def _compress(doc, level):
             d = fitz.open(path)
             d.rewrite_images(dpi_threshold=200, dpi_target=150, quality=75)
             d.subset_fonts()
-            tmp = path + ".tmp"
             d.save(tmp, garbage=4, deflate=True, clean=True,
                    encryption=fitz.PDF_ENCRYPT_KEEP)
             d.close()
-            os.replace(tmp, path)
         else:
-            with pikepdf.open(path, allow_overwriting_input=True) as pdf:
-                pdf.save(path, compress_streams=True, recompress_flate=True,
+            with pikepdf.open(path) as pdf:
+                pdf.save(tmp, compress_streams=True, recompress_flate=True,
                          object_stream_mode=pikepdf.ObjectStreamMode.generate)
-        return {"before": before, "after": os.path.getsize(path)}
+        after = os.path.getsize(tmp)
+        # Recompression can GROW a file that is already well packed — keep the
+        # working copy untouched instead of recording a pointless mutation.
+        if after >= before:
+            os.remove(tmp)
+            raise ValueError(
+                f"already optimized — {level} compression would not shrink the file")
+        os.replace(tmp, path)
+        return {"before": before, "after": after}
     return fn(doc)
+
+
+# ------------------------------------------------------- protect / unlock
+def _protect(doc, password, owner):
+    """Encrypted (AES-256) copy next to the original; the original is untouched."""
+    import pikepdf
+
+    doc = os.path.abspath(doc)
+    if not password:
+        raise ValueError("a password is required")
+    stem = os.path.splitext(os.path.basename(doc))[0]
+    dest = _unique_path(os.path.dirname(doc), f"{stem}-protected.pdf")
+    with pikepdf.open(_cur_path(doc)) as pdf:
+        pdf.save(dest, encryption=pikepdf.Encryption(
+            user=password, owner=owner or password, R=6))
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "size": os.path.getsize(dest), "dir": _fwd(os.path.dirname(dest))}
+
+
+def _unlock(doc, password):
+    """Decrypted copy next to the original (never strips in place)."""
+    import pikepdf
+
+    doc = os.path.abspath(doc)
+    stem = os.path.splitext(os.path.basename(doc))[0]
+    dest = _unique_path(os.path.dirname(doc), f"{stem}-unlocked.pdf")
+    try:
+        with pikepdf.open(doc, password=password or "") as pdf:
+            pdf.save(dest)
+    except pikepdf.PasswordError:
+        raise ValueError("wrong password") from None
+    _add_to_library(dest)
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "dir": _fwd(os.path.dirname(dest))}
+
+
+# ------------------------------------------------------------------------ ocr
+# PyMuPDF wheels ship MuPDF's embedded Tesseract; only the language model file
+# is needed. It is fetched once into DATA_ROOT (tessdata_fast, ~4 MB for eng).
+TESSDATA = os.path.join(DATA_ROOT, "tessdata")
+_TESSDATA_URL = "https://github.com/tesseract-ocr/tessdata_fast/raw/main/{lang}.traineddata"
+
+
+def _ensure_tessdata(lang):
+    import urllib.request
+
+    if not re.fullmatch(r"[a-z_]{3,12}", lang or ""):
+        raise ValueError(f"bad OCR language code: {lang!r}")
+    os.makedirs(TESSDATA, exist_ok=True)
+    p = os.path.join(TESSDATA, f"{lang}.traineddata")
+    if os.path.exists(p):
+        return TESSDATA
+    req = urllib.request.Request(_TESSDATA_URL.format(lang=lang),
+                                 headers={"User-Agent": "fused-render-pdf/1.0"})
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            data = resp.read()
+    except Exception as exc:  # noqa: BLE001 — surface any download failure as one message
+        raise ValueError(f"could not download OCR data for {lang!r} ({exc}) — "
+                         "check the connection and retry") from None
+    tmp = p + ".tmp"
+    with open(tmp, "wb") as f:
+        f.write(data)
+    os.replace(tmp, p)
+    return TESSDATA
+
+
+def _ocr(doc, pages, language):
+    """Searchable copy next to the original: pages that already have text are
+    copied through; image-only pages get an invisible OCR text layer."""
+    import fitz
+
+    doc = os.path.abspath(doc)
+    lang = (language or "eng").strip() or "eng"
+    tessdata = _ensure_tessdata(lang)
+    src = fitz.open(_cur_path(doc))
+    idxs = _parse_pages(pages, src.page_count)
+    todo = [i for i in idxs if not src[i].get_text().strip()] if not pages else idxs
+    if not todo:
+        src.close()
+        raise ValueError("every selected page already has a text layer — "
+                         "pass explicit pages to re-OCR them")
+    if len(todo) > 100:
+        src.close()
+        raise ValueError(f"{len(todo)} pages need OCR — run it in batches (e.g. 1-100)")
+    out = fitz.open()
+    todo_set = set(todo)
+    for i in range(src.page_count):
+        if i not in todo_set:
+            out.insert_pdf(src, from_page=i, to_page=i)
+            continue
+        pix = src[i].get_pixmap(dpi=200)
+        page_pdf = fitz.open("pdf", pix.pdfocr_tobytes(
+            compress=True, language=lang, tessdata=tessdata))
+        out.insert_pdf(page_pdf)
+        page_pdf.close()
+    stem = os.path.splitext(os.path.basename(doc))[0]
+    dest = _unique_path(os.path.dirname(doc), f"{stem}-searchable.pdf")
+    out.save(dest, garbage=3, deflate=True)
+    out.close()
+    copied = src.page_count - len(todo)
+    src.close()
+    _add_to_library(dest)
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "dir": _fwd(os.path.dirname(dest)),
+            "ocr_pages": len(todo), "copied_pages": copied}
+
+
+# ----------------------------------------------------------- word / excel
+_XML_ESC = {"&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;"}
+
+
+def _xesc(s):
+    return "".join(_XML_ESC.get(c, c) for c in s)
+
+
+def _pdf_to_word(doc, pages):
+    """Text-level .docx next to the original (stdlib OOXML writer — bold/italic/
+    size survive, exact layout does not; Word reflows the paragraphs)."""
+    import zipfile
+
+    import fitz
+
+    doc = os.path.abspath(doc)
+    d = fitz.open(_cur_path(doc))
+    idxs = _parse_pages(pages, d.page_count)
+    body = []
+    for k, i in enumerate(idxs):
+        if k:
+            body.append('<w:p><w:r><w:br w:type="page"/></w:r></w:p>')
+        for block in d[i].get_text("dict")["blocks"]:
+            runs = []
+            for line in block.get("lines", []):
+                for s in line.get("spans", []):
+                    txt = s["text"]
+                    if not txt:
+                        continue
+                    props = []
+                    if s["flags"] & 16:
+                        props.append("<w:b/>")
+                    if s["flags"] & 2:
+                        props.append("<w:i/>")
+                    props.append(f'<w:sz w:val="{max(2, round(s["size"] * 2))}"/>')
+                    runs.append(f'<w:r><w:rPr>{"".join(props)}</w:rPr>'
+                                f'<w:t xml:space="preserve">{_xesc(txt)}</w:t></w:r>')
+                runs.append('<w:r><w:t xml:space="preserve"> </w:t></w:r>')
+            if runs:
+                body.append(f"<w:p>{''.join(runs[:-1])}</w:p>")
+    d.close()
+    if not body:
+        raise ValueError("no text found on the selected pages — "
+                         "run Make searchable (OCR) first if this is a scan")
+    document = (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+        f"<w:body>{''.join(body)}<w:sectPr/></w:body></w:document>")
+    stem = os.path.splitext(os.path.basename(doc))[0]
+    dest = _unique_path(os.path.dirname(doc), f"{stem}.docx")
+    with zipfile.ZipFile(dest, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml",
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            '<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+            '<Default Extension="xml" ContentType="application/xml"/>'
+            '<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>'
+            "</Types>")
+        z.writestr("_rels/.rels",
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+            '<Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>'
+            "</Relationships>")
+        z.writestr("word/document.xml", document)
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "size": os.path.getsize(dest), "dir": _fwd(os.path.dirname(dest))}
+
+
+def _find_soffice():
+    """LibreOffice, when installed — the max-fidelity converter for office docs."""
+    cand = shutil.which("soffice")
+    if cand:
+        return cand
+    for p in (r"C:\Program Files\LibreOffice\program\soffice.exe",
+              r"C:\Program Files (x86)\LibreOffice\program\soffice.exe",
+              "/Applications/LibreOffice.app/Contents/MacOS/soffice",
+              "/usr/bin/soffice"):
+        if os.path.isfile(p):
+            return p
+    return ""
+
+
+def _soffice_to_pdf(src, out_dir):
+    import subprocess
+
+    soffice = _find_soffice()
+    if not soffice:
+        return ""
+    before = set(os.listdir(out_dir))
+    subprocess.run([soffice, "--headless", "--convert-to", "pdf",
+                    "--outdir", out_dir, src],
+                   check=True, timeout=180, capture_output=True)
+    made = [f for f in os.listdir(out_dir)
+            if f not in before and f.lower().endswith(".pdf")]
+    return os.path.join(out_dir, made[0]) if made else ""
+
+
+_STORY_CSS = ("body{font-family:sans-serif;font-size:11pt;line-height:1.45}"
+              "h2{font-size:14pt;margin:14pt 0 6pt}"
+              "table{border-collapse:collapse;font-size:9pt}"
+              "td,th{border:0.5pt solid #999;padding:2pt 5pt}"
+              "th{background-color:#eee;font-weight:bold}")
+
+
+def _html_to_pdf(html, dest):
+    import fitz
+
+    story = fitz.Story(html=html, user_css=_STORY_CSS)
+    mediabox = fitz.paper_rect("a4")
+    where = mediabox + (36, 36, -36, -36)
+    writer = fitz.DocumentWriter(dest)
+    while True:
+        dev = writer.begin_page(mediabox)
+        more, _ = story.place(where)
+        story.draw(dev)
+        writer.end_page()
+        if not more:
+            break
+    writer.close()
+
+
+def _word_to_pdf(src):
+    """PDF copy next to the .docx: LibreOffice when installed (full fidelity),
+    else a stdlib docx parse laid out with fitz.Story (text + tables)."""
+    import tempfile
+    import zipfile
+    import xml.etree.ElementTree as ET
+
+    src = os.path.abspath(src)
+    if not os.path.isfile(src):
+        raise ValueError(f"no such file: {src}")
+    out_dir = os.path.dirname(src)
+    stem = os.path.splitext(os.path.basename(src))[0]
+    dest = _unique_path(out_dir, f"{stem}.pdf")
+    with tempfile.TemporaryDirectory() as td:
+        made = _soffice_to_pdf(src, td)
+        if made:
+            shutil.copyfile(made, dest)
+            _add_to_library(dest)
+            return {"name": os.path.basename(dest), "path": _fwd(dest),
+                    "dir": _fwd(out_dir), "via": "libreoffice"}
+    W = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
+    try:
+        with zipfile.ZipFile(src) as z:
+            root = ET.fromstring(z.read("word/document.xml"))
+    except (zipfile.BadZipFile, KeyError):
+        raise ValueError("not a .docx file (older .doc needs LibreOffice installed)") from None
+
+    def para_html(p):
+        style = p.find(f"{W}pPr/{W}pStyle")
+        heading = style is not None and "eading" in (style.get(f"{W}val") or "")
+        parts = []
+        for r in p.iter(f"{W}r"):
+            txt = "".join(t.text or "" for t in r.iter(f"{W}t"))
+            if not txt:
+                continue
+            rpr = r.find(f"{W}rPr")
+            if rpr is not None and rpr.find(f"{W}b") is not None:
+                txt = f"<b>{_xesc(txt)}</b>"
+            elif rpr is not None and rpr.find(f"{W}i") is not None:
+                txt = f"<i>{_xesc(txt)}</i>"
+            else:
+                txt = _xesc(txt)
+            parts.append(txt)
+        inner = "".join(parts) or "&#160;"
+        return f"<h2>{inner}</h2>" if heading else f"<p>{inner}</p>"
+
+    chunks = []
+    for el in root.find(f"{W}body"):
+        if el.tag == f"{W}p":
+            chunks.append(para_html(el))
+        elif el.tag == f"{W}tbl":
+            rows = []
+            for tr in el.iter(f"{W}tr"):
+                cells = ["<td>" + " ".join(
+                    "".join(t.text or "" for t in p.iter(f"{W}t"))
+                    for p in tc.iter(f"{W}p")).strip() + "</td>"
+                    for tc in tr.findall(f"{W}tc")]
+                rows.append(f"<tr>{''.join(cells)}</tr>")
+            chunks.append(f"<table>{''.join(rows)}</table>")
+    if not chunks:
+        raise ValueError("the document has no readable content")
+    _html_to_pdf(f"<body>{''.join(chunks)}</body>", dest)
+    _add_to_library(dest)
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "dir": _fwd(out_dir), "via": "builtin"}
+
+
+def _excel_to_pdf(src):
+    """PDF copy next to the workbook: LibreOffice when installed, else
+    openpyxl values rendered as one table per sheet with fitz.Story."""
+    import tempfile
+
+    src = os.path.abspath(src)
+    if not os.path.isfile(src):
+        raise ValueError(f"no such file: {src}")
+    out_dir = os.path.dirname(src)
+    stem = os.path.splitext(os.path.basename(src))[0]
+    dest = _unique_path(out_dir, f"{stem}.pdf")
+    with tempfile.TemporaryDirectory() as td:
+        made = _soffice_to_pdf(src, td)
+        if made:
+            shutil.copyfile(made, dest)
+            _add_to_library(dest)
+            return {"name": os.path.basename(dest), "path": _fwd(dest),
+                    "dir": _fwd(out_dir), "via": "libreoffice"}
+    try:
+        import openpyxl
+    except ImportError:
+        raise ValueError("Excel conversion needs openpyxl (or LibreOffice) — "
+                         "uv pip install openpyxl") from None
+    wb = openpyxl.load_workbook(src, data_only=True, read_only=True)
+    chunks = []
+    for ws in wb.worksheets:
+        rows = []
+        for r, row in enumerate(ws.iter_rows(values_only=True)):
+            if r >= 2000:
+                rows.append("<tr><td>… truncated at 2000 rows</td></tr>")
+                break
+            tag = "th" if r == 0 else "td"
+            cells = "".join(f"<{tag}>{_xesc('' if v is None else str(v))}</{tag}>"
+                            for v in row)
+            rows.append(f"<tr>{cells}</tr>")
+        if rows:
+            chunks.append(f"<h2>{_xesc(ws.title)}</h2><table>{''.join(rows)}</table>")
+    wb.close()
+    if not chunks:
+        raise ValueError("the workbook has no data to render")
+    _html_to_pdf(f"<body>{''.join(chunks)}</body>", dest)
+    _add_to_library(dest)
+    return {"name": os.path.basename(dest), "path": _fwd(dest),
+            "dir": _fwd(out_dir), "via": "builtin"}
+
+
+# --------------------------------------------------------- images / scanning
+def _build_image_pdf(blobs, name, directory, default_dir):
+    import fitz
+
+    if not blobs:
+        raise ValueError("no images to save")
+    out_dir = _out_dir(directory, default_dir)
+    out = fitz.open()
+    for data in blobs:
+        pix = fitz.Pixmap(data)
+        w = 595.0  # A4 width in points; height keeps the capture's aspect
+        h = w * pix.height / max(1, pix.width)
+        page = out.new_page(width=w, height=h)
+        page.insert_image(page.rect, stream=data)
+    name = _safe_name(name, "scan")
+    if not name.lower().endswith(".pdf"):
+        name += ".pdf"
+    dest = _unique_path(out_dir, name)
+    out.save(dest, deflate=True)
+    out.close()
+    _add_to_library(dest)
+    return {"name": os.path.basename(dest), "path": _fwd(dest), "dir": _fwd(out_dir)}
+
+
+def _images_to_pdf(sources, name, directory):
+    paths = [os.path.abspath(p) for p in json.loads(sources)]
+    for p in paths:
+        if not os.path.isfile(p):
+            raise ValueError(f"no such file: {p}")
+    blobs = []
+    for p in paths:
+        with open(p, "rb") as f:
+            blobs.append(f.read())
+    default_dir = os.path.dirname(paths[0]) if paths else DOWNLOADS
+    if not name:
+        name = os.path.splitext(os.path.basename(paths[0]))[0] if paths else "images"
+    return _build_image_pdf(blobs, name, directory, default_dir)
+
+
+def _save_scan(images_b64, name, directory):
+    import base64
+
+    blobs = [base64.b64decode(b.split(",", 1)[-1]) for b in json.loads(images_b64)]
+    os.makedirs(DOWNLOADS, exist_ok=True)
+    return _build_image_pdf(blobs, name or "scan", directory, DOWNLOADS)
 
 
 # ------------------------------------------------------------------ text edit
@@ -779,7 +1181,8 @@ def _list_remote(origin, path, cap=5000):
     return entries, truncated
 
 
-def _listdir(path, origin=""):
+def _listdir(path, origin="", exts=""):
+    want = tuple(e.strip().lower() for e in (exts or ".pdf").split(",") if e.strip())
     path = os.path.abspath(os.path.expanduser(path or "~"))
     # Ask the server once: is this a remote (mount-backed) path, and is it a dir?
     status, meta = _stat(origin, path) if origin else ("", None)
@@ -803,7 +1206,7 @@ def _listdir(path, origin=""):
                 continue
             if ent.get("is_dir"):
                 dirs.append(name)
-            elif name.lower().endswith(".pdf"):
+            elif name.lower().endswith(want):
                 files.append({"name": name, "size": ent.get("size") or 0})
         dirs.sort(key=str.lower)
         files.sort(key=lambda f: f["name"].lower())
@@ -825,7 +1228,7 @@ def _listdir(path, origin=""):
         try:
             if os.path.isdir(full):
                 dirs.append(name)
-            elif name.lower().endswith(".pdf"):
+            elif name.lower().endswith(want):
                 files.append({"name": name, "size": os.path.getsize(full)})
         except OSError:
             continue
@@ -893,6 +1296,10 @@ def _health():
         out["pikepdf"] = pikepdf.__version__
     except Exception as e:
         out["ok"], out["pikepdf_error"] = False, str(e)
+    out["soffice"] = bool(_find_soffice())
+    out["ocr_langs"] = sorted(
+        f[:-len(".traineddata")] for f in os.listdir(TESSDATA)
+        if f.endswith(".traineddata")) if os.path.isdir(TESSDATA) else []
     return out
 
 
@@ -928,6 +1335,11 @@ def main(
     color: str = "",
     expected_mtime: str = "",
     force: int = 0,
+    password: str = "",
+    owner: str = "",
+    language: str = "",
+    images_b64: str = "",
+    exts: str = "",
 ):
     if action == "health":
         return _health()
@@ -966,7 +1378,7 @@ def main(
     if action == "listdir":
         # `src` on the listdir action carries the server ORIGIN (mount-safe
         # routing), distinct from its add_to_library meaning (a file path).
-        return _listdir(path, src)
+        return _listdir(path, src, exts)
     if action == "import_url":
         return _import_url(url, name)
     if action == "rename_doc":
@@ -1026,6 +1438,22 @@ def main(
         return _merge(sources, name, directory)
     if action == "split":
         return _split(doc, mode, ranges, prefix, directory)
+    if action == "protect":
+        return _protect(doc, password, owner)
+    if action == "unlock":
+        return _unlock(doc, password)
+    if action == "ocr":
+        return _ocr(doc, pages, language)
+    if action == "pdf_to_word":
+        return _pdf_to_word(doc, pages)
+    if action == "word_to_pdf":
+        return _word_to_pdf(src)
+    if action == "excel_to_pdf":
+        return _excel_to_pdf(src)
+    if action == "images_to_pdf":
+        return _images_to_pdf(sources, name, directory)
+    if action == "save_scan":
+        return _save_scan(images_b64, name, directory)
     if action == "reveal":
         p = os.path.normpath(os.path.abspath(os.path.expanduser(path)))
         if not os.path.exists(p):

--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -838,9 +838,9 @@ def _word_to_pdf(src):
         elif el.tag == f"{W}tbl":
             rows = []
             for tr in el.iter(f"{W}tr"):
-                cells = ["<td>" + " ".join(
+                cells = ["<td>" + _xesc(" ".join(
                     "".join(t.text or "" for t in p.iter(f"{W}t"))
-                    for p in tc.iter(f"{W}p")).strip() + "</td>"
+                    for p in tc.iter(f"{W}p")).strip()) + "</td>"
                     for tc in tr.findall(f"{W}tc")]
                 rows.append(f"<tr>{''.join(cells)}</tr>")
             chunks.append(f"<table>{''.join(rows)}</table>")

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -153,7 +153,7 @@
   .modal h3 { margin: 0 0 12px; font-size: 16px; }
   .modal p { margin: 0 0 10px; color: var(--ink-2); line-height: 1.45; }
   .modal label { display: block; font-size: 12px; color: var(--ink-2); font-weight: 600; margin: 10px 0 4px; }
-  .modal input[type=text], .modal select { width: 100%; padding: 8px 10px; border: 1px solid var(--hair); border-radius: var(--radius); font: inherit; }
+  .modal input[type=text], .modal input[type=password], .modal select { width: 100%; padding: 8px 10px; border: 1px solid var(--hair); border-radius: var(--radius); font: inherit; }
   .modal .row { display: flex; gap: 8px; justify-content: flex-end; margin-top: 18px; }
   .modal .radio { display: flex; align-items: flex-start; gap: 8px; padding: 8px; border: 1px solid var(--hair);
     border-radius: var(--radius); margin-top: 6px; cursor: pointer; }
@@ -224,6 +224,39 @@
   .thumb.skel-thumb { border-radius: 4px; cursor: default; }
   #banner { background: #fff7e8; border-bottom: 1px solid #f2dfb8; color: #8a6116; padding: 7px 14px;
     font-size: 12.5px; flex: 0 0 auto; }
+
+  /* ---- tools home (ihatepdf-style card grid over the viewer) ---- */
+  #main { position: relative; }
+  #toolsHome { position: absolute; inset: 0; overflow-y: auto; background: var(--canvas); z-index: 20;
+    padding: 26px 34px 40px; }
+  #toolsHome .th-head { display: flex; align-items: baseline; gap: 12px; max-width: 1060px; margin: 0 auto 4px; }
+  #toolsHome h2 { margin: 0; font-size: 19px; }
+  #toolsHome .th-head p { margin: 0; color: var(--ink-3); font-size: 12.5px; }
+  #toolsHome h5 { max-width: 1060px; margin: 22px auto 8px; font-size: 11px; text-transform: uppercase;
+    letter-spacing: .8px; color: var(--ink-3); }
+  .tool-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 10px;
+    max-width: 1060px; margin: 0 auto; }
+  .tool-card { display: flex; align-items: flex-start; gap: 11px; text-align: left; background: var(--chrome);
+    border: 1px solid var(--hair); border-radius: var(--radius-lg); padding: 13px 14px; cursor: pointer; }
+  .tool-card:hover { border-color: var(--blue); box-shadow: var(--shadow-1); }
+  .tool-card .ic { flex: 0 0 auto; width: 34px; height: 34px; border-radius: 8px; display: grid; place-items: center;
+    background: var(--blue-soft); color: var(--blue-ink); }
+  .tool-card .ic svg { width: 17px; height: 17px; }
+  .tool-card[data-tone=green] .ic { background: #e5f6ee; color: var(--ok); }
+  .tool-card[data-tone=red] .ic { background: var(--danger-soft); color: var(--danger); }
+  .tool-card[data-tone=amber] .ic { background: #fdf3e2; color: var(--amber); }
+  .tool-card b { display: block; font-size: 13px; margin-bottom: 2px; }
+  .tool-card small { color: var(--ink-3); line-height: 1.4; display: block; }
+  #toolsClose { margin-left: auto; }
+
+  /* ---- scanner ---- */
+  .scan-wrap { position: relative; background: #111; border-radius: var(--radius); overflow: hidden; margin-top: 6px; }
+  .scan-wrap video { display: block; width: 100%; max-height: 320px; object-fit: contain; }
+  .scan-strip { display: flex; gap: 8px; overflow-x: auto; padding: 8px 0 2px; min-height: 20px; }
+  .scan-strip .cap { position: relative; flex: 0 0 auto; }
+  .scan-strip img { height: 74px; border: 1px solid var(--hair); border-radius: 4px; display: block; }
+  .scan-strip .rm { position: absolute; top: -6px; right: -6px; width: 18px; height: 18px; border-radius: 50%;
+    border: none; background: var(--danger); color: #fff; font-size: 11px; line-height: 1; padding: 0; }
 </style>
 <script src="/template-shared/ro-badge.js"></script>
 </head>
@@ -255,6 +288,10 @@
   <span id="docPages"></span>
   <div class="spacer"></div>
   <div id="status"><span class="dot"></span><span class="txt">idle</span></div>
+  <button class="btn" id="toolsBtn" title="All tools">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7" rx="1.5"/><rect x="14" y="3" width="7" height="7" rx="1.5"/><rect x="3" y="14" width="7" height="7" rx="1.5"/><rect x="14" y="14" width="7" height="7" rx="1.5"/></svg>
+    Tools
+  </button>
   <div class="seg" id="modeSeg">
     <button data-mode="edit"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"/></svg> Edit</button>
     <button data-mode="view" class="on"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z"/><circle cx="12" cy="12" r="3"/></svg> View</button>
@@ -298,6 +335,20 @@
     <div class="mi" data-act="merge">Merge PDFs…</div>
     <div class="mi" data-act="split">Split…</div>
     <div class="mi" data-act="compress">Compress…</div>
+    <div class="divider"></div>
+    <div class="mi" data-act="protect">Protect with password…</div>
+    <div class="mi" data-act="removePassword">Remove password…</div>
+    <div class="mi" data-act="ocr">Make searchable (OCR)…</div>
+  </div></div>
+  <div class="menu" data-menu>Convert<div class="dropdown">
+    <div class="mi" data-act="toWord">PDF to Word…</div>
+    <div class="mi" data-act="toPng">PDF to PNG…</div>
+    <div class="divider"></div>
+    <div class="mi" data-act="fromWord">Word to PDF…</div>
+    <div class="mi" data-act="fromExcel">Excel to PDF…</div>
+    <div class="mi" data-act="imagesToPdf">Images to PDF…</div>
+    <div class="divider"></div>
+    <div class="mi" data-act="scan">Scan document…</div>
   </div></div>
   <div class="menu" data-menu>View<div class="dropdown">
     <div class="mi" data-act="togglePanel">Toggle side panel <span class="kbd">Ctrl+\</span></div>
@@ -322,6 +373,35 @@
     </div>
   </div>
   <div id="canvasWrap"><div id="pages"></div><div id="pagesNote" class="hidden"></div></div>
+  <div id="toolsHome" class="hidden">
+    <div class="th-head"><h2>Tools</h2><p>Everything runs locally — files never leave this machine.</p>
+      <button class="btn" id="toolsClose">Back to document</button></div>
+    <h5>Organize</h5>
+    <div class="tool-grid">
+      <button class="tool-card" data-tool="merge"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M8 7 4 12l4 5"/><path d="m16 7 4 5-4 5"/><path d="M4 12h16"/></svg></span><span><b>Merge PDFs</b><small>Combine documents into one file, in the order you pick.</small></span></button>
+      <button class="tool-card" data-tool="split"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v18"/><path d="M5 8h4M5 16h4M15 8h4M15 16h4"/></svg></span><span><b>Split PDF</b><small>One file per page, or by page ranges.</small></span></button>
+      <button class="tool-card" data-tool="extractPages"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/></svg></span><span><b>Extract pages</b><small>Copy chosen pages into a new PDF.</small></span></button>
+      <button class="tool-card" data-tool="compress" data-tone="green"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M12 3v7m0 0 3-3m-3 3L9 7"/><path d="M12 21v-7m0 0 3 3m-3-3-3 3"/><path d="M4 12h16"/></svg></span><span><b>Compress PDF</b><small>Lossless repack, or aggressive image downsampling.</small></span></button>
+    </div>
+    <h5>Convert</h5>
+    <div class="tool-grid">
+      <button class="tool-card" data-tool="toWord"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="m8.5 13 1.2 5 1.8-4 1.8 4 1.2-5"/></svg></span><span><b>PDF to Word</b><small>Editable .docx from the document text.</small></span></button>
+      <button class="tool-card" data-tool="toPng"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="m21 15-4-4-8 8"/></svg></span><span><b>PDF to PNG</b><small>One image per page, also JPG or plain text.</small></span></button>
+      <button class="tool-card" data-tool="fromWord" data-tone="green"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V9z"/><path d="M14 3v6h6"/><path d="M8 15h8M8 18h5"/></svg></span><span><b>Word to PDF</b><small>Convert a .docx into a PDF.</small></span></button>
+      <button class="tool-card" data-tool="fromExcel" data-tone="green"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M3 15h18M9 3v18M15 3v18"/></svg></span><span><b>Excel to PDF</b><small>Render workbook sheets as PDF tables.</small></span></button>
+      <button class="tool-card" data-tool="imagesToPdf"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="3" y="7" width="14" height="14" rx="2"/><path d="M7 7V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-2"/></svg></span><span><b>Images to PDF</b><small>Bundle JPG/PNG images into one PDF.</small></span></button>
+    </div>
+    <h5>Secure</h5>
+    <div class="tool-grid">
+      <button class="tool-card" data-tool="protect" data-tone="red"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 8 0v4"/></svg></span><span><b>Protect PDF</b><small>AES-256 password-encrypt a copy of this document.</small></span></button>
+      <button class="tool-card" data-tool="removePassword" data-tone="red"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><rect x="5" y="11" width="14" height="10" rx="2"/><path d="M8 11V7a4 4 0 0 1 7.2-2.4"/></svg></span><span><b>Remove password</b><small>Save an unlocked copy of a protected PDF.</small></span></button>
+    </div>
+    <h5>Scan &amp; OCR</h5>
+    <div class="tool-grid">
+      <button class="tool-card" data-tool="scan" data-tone="amber"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z"/><circle cx="12" cy="13" r="4"/></svg></span><span><b>Scan document</b><small>Capture pages with the camera and save them as a PDF.</small></span></button>
+      <button class="tool-card" data-tool="ocr" data-tone="amber"><span class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M4 7V5a1 1 0 0 1 1-1h2M17 4h2a1 1 0 0 1 1 1v2M20 17v2a1 1 0 0 1-1 1h-2M7 20H5a1 1 0 0 1-1-1v-2"/><path d="M8 12h8M8 9h5M8 15h6"/></svg></span><span><b>Searchable PDF (OCR)</b><small>Add a text layer to scanned pages so they can be searched and copied.</small></span></button>
+    </div>
+  </div>
 </div>
 
 <div id="modalHost"></div>
@@ -385,10 +465,10 @@ function modal(html) {
   return { el: bg.firstElementChild, done, close };
 }
 
-function dialog({ title, message = "", label = "", value = "", okText = "OK", danger = false, input = true }) {
+function dialog({ title, message = "", label = "", value = "", okText = "OK", danger = false, input = true, password = false }) {
   const m = modal(`
     <h3></h3>${message ? "<p></p>" : ""}
-    ${input ? `<input type="text" id="dlgInput" placeholder="${label.replace(/"/g, "&quot;")}">` : ""}
+    ${input ? `<input type="${password ? "password" : "text"}" id="dlgInput" placeholder="${label.replace(/"/g, "&quot;")}">` : ""}
     <div class="row">
       <button class="btn" data-x="cancel">Cancel</button>
       <button class="btn primary" data-x="ok" ${danger ? 'style="background:var(--danger);border-color:var(--danger)"' : ""}></button>
@@ -413,7 +493,8 @@ function dialog({ title, message = "", label = "", value = "", okText = "OK", da
 const cleanPath = (s) => (s || "").trim().replace(/^["']+|["']+$/g, "").replace(/\\/g, "/");
 const docDir = () => state.doc.split("/").slice(0, -1).join("/");
 
-function browseModal({ title, okText = "Open", pickDir = false, dirOnly = false, filename = "", start = "" }) {
+function browseModal({ title, okText = "Open", pickDir = false, dirOnly = false, filename = "", start = "", exts = ".pdf" }) {
+  const extRe = new RegExp(`(${exts.split(",").map((e) => e.trim().replace(".", "\\.")).join("|")})$`, "i");
   const m = modal(`
     <h3></h3>
     <input type="text" id="fbPath" class="fb-path" placeholder="Paste a full path and press Enter" spellcheck="false" autocomplete="off">
@@ -450,7 +531,7 @@ function browseModal({ title, okText = "Open", pickDir = false, dirOnly = false,
     if (/^[A-Za-z]:$/.test(path)) path += "/";
     // src (origin only) lets the worker route a mount-backed dir via
     // /api/fs/list instead of a kernel scan that could drop the mount.
-    const res = await py({ action: "listdir", path,
+    const res = await py({ action: "listdir", path, exts,
       src: `${location.origin}/api/fs/raw?path=${encodeURIComponent(path || "")}` });
     if (res.error) { toast(res.error, true); return; }
     cur = res.path;
@@ -495,13 +576,13 @@ function browseModal({ title, okText = "Open", pickDir = false, dirOnly = false,
       list.appendChild(b);
     }
     if (!res.dirs.length && !res.files.length)
-      list.innerHTML = `<div class="fb-empty">No folders or PDFs here.</div>`;
+      list.innerHTML = `<div class="fb-empty">No folders or ${exts.replace(/\./g, "").toUpperCase()} files here.</div>`;
   }
   pathInp.addEventListener("keydown", (e) => {
     if (e.key !== "Enter") return;
     let p = cleanPath(pathInp.value);
     if (!p) return;
-    if (/\.pdf$/i.test(p)) {
+    if (extRe.test(p)) {
       if (!pickDir && !dirOnly) return m.close(p);
       if (nameInp) nameInp.value = p.split("/").pop();
       p = p.split("/").slice(0, -1).join("/") || "/";
@@ -725,7 +806,10 @@ async function renderAll() {
       if (gen !== renderGen) return;
       await renderThumb(pdf, n, gen);
     }
-  })().catch((err) => { if (gen === renderGen) toast(err?.message || String(err), true); });
+  })().catch((err) => {
+    if (err?.name === "RenderingCancelledException") return;
+    if (gen === renderGen) toast(err?.message || String(err), true);
+  });
 }
 
 let pageWatcher = null;
@@ -887,7 +971,17 @@ function renderDocList() {
 async function openDoc(path) {
   cancelEdit();
   const info = await py({ action: "open_doc", doc: path });
-  if (info.encrypted) throw new Error("this PDF is password-protected — decrypt it first");
+  if (info.encrypted) {
+    const pw = await dialog({ title: "Password-protected PDF", password: true,
+      message: `${info.name} is encrypted. Enter its password to save an unlocked copy next to it and open that.`,
+      label: "Password", okText: "Unlock" });
+    if (!pw) throw new Error("this PDF is password-protected");
+    setStatus("unlocking…", "busy");
+    const res = await py({ action: "unlock", doc: path, password: pw });
+    await refreshLib();
+    toast(`Unlocked copy saved as ${res.name}`);
+    return openDoc(res.path);
+  }
   state.doc = info.path; state.work = info.work; state.info = info; state.mtime = info.mtime;
   state.dirty = !!info.dirty;
   state.curPage = 1; state.spans = {};
@@ -1102,7 +1196,18 @@ const acts = {
     const level = await compressModal();
     if (!level) return;
     setStatus("compressing…", "busy");
-    const res = await mutate("compress", { level });
+    let res;
+    try {
+      res = await mutate("compress", { level });
+    } catch (err) {
+      // Not a failure — the file was simply already smaller than a recompress.
+      if (/already optimized/.test(err?.message || "")) {
+        setStatus(state.dirty ? "unsaved changes" : "", state.dirty ? "warn" : "");
+        toast(err.message);
+        return;
+      }
+      throw err;
+    }
     if (!res) return;
     const pct = Math.round((1 - res.after / res.before) * 100);
     await resultModal({ title: "Compression complete",
@@ -1111,9 +1216,9 @@ const acts = {
         + " The change is not saved yet: press Ctrl+S to keep it, or Ctrl+Z to undo." });
   },
 
-  export: async () => {
+  export: async (kind) => {
     needDoc();
-    const opt = await exportModal();
+    const opt = await exportModal(typeof kind === "string" ? kind : "");
     if (!opt) return;
     setStatus("exporting…", "busy");
     const res = await py({ action: "export", doc: state.doc, kind: opt.kind,
@@ -1123,6 +1228,98 @@ const acts = {
       note: `${res.files.length} file${res.files.length === 1 ? "" : "s"} saved to ${res.dir}.`,
       files: res.files, dir: res.dir });
   },
+  toPng: () => acts.export("png"),
+
+  protect: async () => {
+    needDoc();
+    const pw = await dialog({ title: "Protect with password", password: true,
+      message: "An AES-256 encrypted copy is saved next to the document — the original stays as it is.",
+      label: "Password", okText: "Protect" });
+    if (!pw) return;
+    setStatus("encrypting…", "busy");
+    const res = await py({ action: "protect", doc: state.doc, password: pw });
+    setStatus("protected", "ok");
+    await resultModal({ title: "Protected copy created",
+      note: `${res.name} needs the password to open. Keep the password safe — there is no way to recover it.`,
+      files: [res], dir: res.dir });
+  },
+  removePassword: async () => {
+    const src = await browseModal({ title: "Choose the password-protected PDF" });
+    if (!src) return;
+    // openDoc prompts for the password and saves the unlocked copy.
+    await openDoc(src);
+  },
+  ocr: async () => {
+    needDoc();
+    const firstRun = !(state.health?.ocr_langs || []).length;
+    const ok = await dialog({ title: "Make searchable (OCR)", input: false, okText: "Run OCR",
+      message: "Pages without a text layer are OCR'd (English) into a searchable copy saved next to the document."
+        + (firstRun ? " First run downloads the language model (~4 MB) once." : "") });
+    if (!ok) return;
+    setStatus("running OCR…", "busy");
+    const res = await py({ action: "ocr", doc: state.doc });
+    await refreshLib();
+    await openDoc(res.path);
+    setStatus("OCR done", "ok");
+    toast(`${res.name}: ${res.ocr_pages} page${res.ocr_pages === 1 ? "" : "s"} OCR'd, ${res.copied_pages} already had text`);
+  },
+  toWord: async () => {
+    needDoc();
+    const pages = await dialog({ title: "PDF to Word", value: "all", okText: "Convert",
+      label: "all or 1,3-5",
+      message: "The document text becomes an editable .docx next to the PDF. Word reflows the paragraphs — exact layout is not preserved." });
+    if (!pages) return;
+    setStatus("converting…", "busy");
+    const res = await py({ action: "pdf_to_word", doc: state.doc, pages });
+    setStatus("converted", "ok");
+    await resultModal({ title: "Word document created", files: [res], dir: res.dir });
+  },
+  fromWord: async () => {
+    const src = await browseModal({ title: "Choose a Word document", exts: ".docx" });
+    if (!src) return;
+    setStatus("converting…", "busy");
+    const res = await py({ action: "word_to_pdf", src });
+    await refreshLib();
+    await openDoc(res.path);
+    setStatus("converted", "ok");
+    toast(`Created ${res.name}${res.via === "libreoffice" ? "" : " (text-level conversion — install LibreOffice for full fidelity)"}`);
+  },
+  fromExcel: async () => {
+    const src = await browseModal({ title: "Choose an Excel workbook", exts: ".xlsx,.xlsm" });
+    if (!src) return;
+    setStatus("converting…", "busy");
+    const res = await py({ action: "excel_to_pdf", src });
+    await refreshLib();
+    await openDoc(res.path);
+    setStatus("converted", "ok");
+    toast(`Created ${res.name}`);
+  },
+  imagesToPdf: async () => {
+    const picked = await imagesModal();
+    if (!picked) return;
+    setStatus("building…", "busy");
+    const res = await py({ action: "images_to_pdf", sources: JSON.stringify(picked.sources),
+      name: picked.name, directory: picked.dir });
+    await refreshLib();
+    await openDoc(res.path);
+    setStatus("created", "ok");
+    toast(`Created ${res.name}`);
+  },
+  scan: async () => {
+    const caps = await scanModal();
+    if (!caps || !caps.length) return;
+    const picked = await browseModal({ title: "Save the scan", okText: "Save",
+      pickDir: true, filename: "scan.pdf", start: "~" });
+    if (!picked) return;
+    setStatus("saving scan…", "busy");
+    const res = await py({ action: "save_scan", images_b64: JSON.stringify(caps),
+      name: picked.name, directory: picked.dir });
+    await refreshLib();
+    await openDoc(res.path);
+    setStatus("saved", "ok");
+    toast(`Saved ${res.name} (${caps.length} page${caps.length === 1 ? "" : "s"})`);
+  },
+  tools: () => showTools(!document.body.classList.contains("tools-open")),
 
   togglePanel: () => {
     document.body.classList.toggle("panel-off");
@@ -1137,6 +1334,9 @@ async function act(name, arg) {
   try {
     await acts[name]?.(arg);
   } catch (err) {
+    // A superseded pdf.js render (fast rotate/zoom, hidden pane) is not a
+    // user-facing failure — the newer render already owns the canvas.
+    if (err?.name === "RenderingCancelledException") return;
     console.error(err);
     setStatus("error", "err");
     toast(err?.message || String(err), true);
@@ -1260,7 +1460,7 @@ async function compressModal() {
   return m.done;
 }
 
-async function exportModal() {
+async function exportModal(presetKind = "") {
   const m = modal(`<h3>Export</h3>
     <label>Format</label>
     <select id="exKind">
@@ -1276,6 +1476,7 @@ async function exportModal() {
     <div class="row"><button class="btn" data-x="cancel">Cancel</button>
     <button class="btn primary" data-x="ok">Export</button></div>`);
   const nameInp = m.el.querySelector("#exName");
+  if (presetKind) m.el.querySelector("#exKind").value = presetKind;
   const getDir = destRow(m, "exDir", docDir(),
     (f) => { nameInp.value = f.replace(/\.[a-z0-9]+$/i, ""); });
   m.el.querySelector("[data-x=cancel]").onclick = () => m.close(null);
@@ -1289,6 +1490,102 @@ async function exportModal() {
     });
   };
   return m.done;
+}
+
+async function imagesModal() {
+  const m = modal(`<h3>Images to PDF</h3>
+    <p>Pick images in the order they should appear — one page per image.</p>
+    <div class="checklist" id="imList"><div class="fb-empty">No images yet.</div></div>
+    <button class="btn ghost" id="imBrowse" style="margin-top:8px">＋ Add an image…</button>
+    <label>Output name</label><input type="text" id="imName" value="images">
+    <label>Save to</label>
+    <div class="destrow"><input type="text" id="imDir" spellcheck="false"><button class="btn" id="imDirBtn">Browse…</button></div>
+    <div class="row"><button class="btn" data-x="cancel">Cancel</button>
+    <button class="btn primary" data-x="ok">Create PDF</button></div>`);
+  const getDir = destRow(m, "imDir", state.doc ? docDir() : "~");
+  const list = m.el.querySelector("#imList");
+  const sources = [];
+  function render() {
+    list.innerHTML = sources.length ? "" : `<div class="fb-empty">No images yet.</div>`;
+    sources.forEach((p, i) => {
+      const lab = document.createElement("label");
+      const span = document.createElement("span");
+      span.textContent = `${i + 1}. ${p.split("/").pop()}`;
+      const rm = document.createElement("button");
+      rm.className = "btn ghost"; rm.textContent = "✕"; rm.style.marginLeft = "auto";
+      rm.onclick = (e) => { e.preventDefault(); sources.splice(i, 1); render(); };
+      lab.append(span, rm);
+      list.appendChild(lab);
+    });
+  }
+  m.el.querySelector("#imBrowse").onclick = async () => {
+    const src = await browseModal({ title: "Add an image", exts: ".png,.jpg,.jpeg,.webp,.bmp,.tif,.tiff" });
+    if (src) { sources.push(src); render(); }
+  };
+  m.el.querySelector("[data-x=cancel]").onclick = () => m.close(null);
+  m.el.querySelector("[data-x=ok]").onclick = () => {
+    if (!sources.length) { toast("Add at least one image"); return; }
+    m.close({ sources, name: m.el.querySelector("#imName").value.trim() || "images", dir: getDir() });
+  };
+  return m.done;
+}
+
+async function scanModal() {
+  const m = modal(`<h3>Scan document</h3>
+    <div class="scan-wrap"><video id="scVideo" autoplay playsinline muted></video></div>
+    <div class="scan-strip" id="scStrip"></div>
+    <div class="row">
+      <button class="btn" data-x="cancel">Cancel</button>
+      <button class="btn" id="scCap">Capture page</button>
+      <button class="btn primary" data-x="ok">Save as PDF…</button></div>`);
+  m.el.classList.add("wide");
+  const video = m.el.querySelector("#scVideo");
+  let stream = null;
+  try {
+    stream = await navigator.mediaDevices.getUserMedia({
+      video: { width: { ideal: 2560 }, height: { ideal: 1440 }, facingMode: "environment" },
+      audio: false,
+    });
+  } catch (err) {
+    m.close(null);
+    throw new Error(`camera unavailable: ${err?.message || err}`);
+  }
+  video.srcObject = stream;
+  const caps = [];
+  const strip = m.el.querySelector("#scStrip");
+  function render() {
+    strip.innerHTML = "";
+    caps.forEach((c, i) => {
+      const d = document.createElement("div");
+      d.className = "cap";
+      d.innerHTML = `<img alt="page ${i + 1}"><button class="rm" title="Remove">✕</button>`;
+      d.querySelector("img").src = c;
+      d.querySelector(".rm").onclick = () => { caps.splice(i, 1); render(); };
+      strip.appendChild(d);
+    });
+  }
+  m.el.querySelector("#scCap").onclick = () => {
+    if (!video.videoWidth) return toast("Camera is still starting…");
+    const cv = document.createElement("canvas");
+    cv.width = video.videoWidth; cv.height = video.videoHeight;
+    cv.getContext("2d").drawImage(video, 0, 0);
+    caps.push(cv.toDataURL("image/jpeg", 0.87));
+    render();
+  };
+  const stop = () => stream.getTracks().forEach((t) => t.stop());
+  m.el.querySelector("[data-x=cancel]").onclick = () => m.close(null);
+  m.el.querySelector("[data-x=ok]").onclick = () => {
+    if (!caps.length) { toast("Capture at least one page"); return; }
+    m.close(caps);
+  };
+  m.done.then(stop, stop);
+  return m.done;
+}
+
+// ---------- tools home ----------
+function showTools(on) {
+  document.body.classList.toggle("tools-open", on);
+  $("toolsHome").classList.toggle("hidden", !on);
 }
 
 // ---------- icons ----------
@@ -1336,6 +1633,14 @@ function setMode(mode) {
 
 $("exportBtn").addEventListener("click", () => act("export"));
 $("importBtn").addEventListener("click", () => act("addPdf"));
+$("toolsBtn").addEventListener("click", () => act("tools"));
+$("toolsClose").addEventListener("click", () => showTools(false));
+$("toolsHome").addEventListener("click", (e) => {
+  const card = e.target.closest("[data-tool]");
+  if (!card) return;
+  showTools(false);
+  act(card.dataset.tool);
+});
 
 $("pages").addEventListener("click", (e) => {
   const wrap = e.target.closest(".pdf-page");
@@ -1393,6 +1698,7 @@ async function boot() {
     let health;
     try { health = await py({ action: "health" }); }
     catch { health = await py({ action: "health" }); }   // one retry: engine warm-up
+    state.health = health;
     if (!health.ok) {
       libP.catch(() => {});
       $("boot").innerHTML = "";
@@ -1420,9 +1726,10 @@ async function boot() {
     catch (err) { console.error(err); toast(`Could not open ${wanted.split("/").pop()}: ${err?.message || err}`, true); }
   }
   if (state.docs.length) {
-    try { await openDoc(state.docs[0].path); }
+    try { await openDoc(state.docs[0].path); return; }
     catch (err) { console.error(err); }
   }
+  showTools(true);  // nothing to show — land on the tools grid
 }
 boot();
 </script>

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -1319,7 +1319,7 @@ const acts = {
     setStatus("saved", "ok");
     toast(`Saved ${res.name} (${caps.length} page${caps.length === 1 ? "" : "s"})`);
   },
-  tools: () => showTools(!document.body.classList.contains("tools-open")),
+  tools: () => showTools($("toolsHome").classList.contains("hidden")),
 
   togglePanel: () => {
     document.body.classList.toggle("panel-off");
@@ -1584,7 +1584,6 @@ async function scanModal() {
 
 // ---------- tools home ----------
 function showTools(on) {
-  document.body.classList.toggle("tools-open", on);
   $("toolsHome").classList.toggle("hidden", !on);
 }
 
@@ -1623,9 +1622,8 @@ $("modeSeg").addEventListener("click", (e) => {
   setMode(b.dataset.mode);
 });
 function setMode(mode) {
-  const panelOff = document.body.classList.contains("panel-off");
-  document.body.className = mode === "view" ? "mode-view" : "mode-edit";
-  if (panelOff) document.body.classList.add("panel-off");
+  document.body.classList.toggle("mode-view", mode === "view");
+  document.body.classList.toggle("mode-edit", mode !== "view");
   document.querySelectorAll("#modeSeg [data-mode]").forEach((b) => b.classList.toggle("on", b.dataset.mode === mode));
   fused.params.set("mode", mode);
   if (mode === "edit" && state.pdf) primeOverlays();


### PR DESCRIPTION
New Features & UI: Upgrades the local-first pdf_studio template with a new Tools grid (Organize, Convert, Secure, Scan & OCR). Key capabilities include AES-256 PDF protection/password removal, OCR searchable PDFs, camera scanning (getUserMedia), PDF to Word/PNG, Images to PDF, and Word/Excel to PDF (using headless LibreOffice with a fitz.Story fallback).

Bug Fixes: Compression now compares file sizes to report "already optimized" rather than growing the file, and superseded pdf.js renders (RenderingCancelledException) no longer trigger red error statuses.

Dependencies & Testing: Keeps a minimal footprint with no new startup dependencies—specialized tools load lazily on demand with clear install prompts if packages like openpyxl are missing. Fully verified on Windows via Playwright (18 backend, 15 UI, 11 regression checks) with all pytest suites passing.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new surface area (subprocess LibreOffice, network tessdata fetch, camera/base64 payloads) in a local file template; originals are mostly left untouched but new copies are written beside user files.
> 
> **Overview**
> Adds a **Tools** home (card grid over the viewer) plus menubar entries for organize/convert/secure/scan workflows, wired to new `pdf.py` actions and UI modals (password fields, multi-ext file browse, camera capture).
> 
> **Backend (`pdf.py`):** New sidecar outputs — `protect` / `unlock` (AES-256 encrypted or decrypted copies), `ocr` (searchable PDF with on-demand tessdata download), `pdf_to_word`, `word_to_pdf` / `excel_to_pdf` (LibreOffice when present, otherwise stdlib/`fitz.Story`/`openpyxl` fallbacks), `images_to_pdf` and `save_scan`. `listdir` accepts an `exts` filter; `health` reports LibreOffice and installed OCR langs. **Compress** writes via a temp file and errors with *already optimized* if recompression would not shrink the file (avoids growing the working copy).
> 
> **Frontend:** Opening an encrypted PDF prompts for a password and unlocks via a new copy. Compress surfaces that message as a toast; cancelled pdf.js renders no longer show as errors. Boot shows the tools grid when no document opens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ebd5c85c3cf8765f721f2e7acc54bf45cfb3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->