### PR TITLE
claude template: argv safety on Windows (stdin message, prompt file, shim handling)

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -212,6 +212,52 @@ def _claude_bin() -> str:
     )
 
 
+def _needs_cmd_shim(bin_path: str) -> bool:
+    """Whether `bin_path` can only be started through cmd.exe.
+
+    npm installs claude as a .cmd/.bat shim, which CreateProcess cannot run
+    directly — only cmd.exe can."""
+    return sys.platform == "win32" and bin_path.lower().endswith((".cmd", ".bat"))
+
+
+def _cmd_quote(arg: str) -> str:
+    """Quote one argument for the verbatim payload of `cmd /d /s /c "..."`.
+
+    EVERY element is quoted, not just the ones with spaces: /s stops cmd from
+    re-parsing the payload's quotes, but it does NOT stop cmd from acting on
+    metacharacters (& | > < ^), and a quoted run is where those are literal.
+    Windows paths cannot contain `"` and every other argv element here is a
+    static literal or charset-validated, so there is no inner quote to escape
+    — assert rather than silently produce a line that means something else."""
+    if '"' in arg:
+        raise ValueError(f"argument may not contain a double quote: {arg!r}")
+    return f'"{arg}"'
+
+
+def _popen_cmd(bin_path: str, args: list[str]):
+    """The `cmd` to hand subprocess.Popen: an argv list, or — behind a Windows
+    .cmd/.bat shim — one command STRING for cmd.exe.
+
+    A list would be joined by subprocess.list2cmdline, which quotes each
+    element that needs it. That is correct for a normal exe, but cmd.exe only
+    preserves inner quoting when the rest of its line carries exactly two
+    quote characters; a shim path with spaces plus any quoted argument makes
+    four, cmd falls through to its strip-the-outermost rule, and the command
+    is re-split at the spaces (the `C:\\Users\\John Doe` failure).
+
+    So build the line ourselves: /s makes cmd strip exactly the first and last
+    quote and treat everything between verbatim, which is the one documented
+    quoting rule that does not depend on how many quotes the payload holds.
+    /d skips AutoRun registry commands, which must not be able to inject
+    anything into this invocation.
+
+    """
+    if not _needs_cmd_shim(bin_path):
+        return [bin_path] + args
+    payload = " ".join(_cmd_quote(a) for a in [bin_path] + args)
+    return f'cmd.exe /d /s /c "{payload}"'
+
+
 def _bad_id(value: str) -> bool:
     """Whether an id from the page is unsafe to join into a filesystem path.
 
@@ -712,6 +758,12 @@ def _deny_pending(run_dir: str, reason: str) -> None:
 
 # ----------------------------------------------------------------- start/poll
 
+# Ids and model names that may enter argv are a closed charset. A SECURITY
+# boundary, not just validation: on the Windows .cmd-shim path cmd.exe
+# re-parses the whole line and cannot be escaped reliably, so argv must hold
+# only static literals, run_dir file paths, and values this regex admitted.
+_SAFE_TOKEN = re.compile(r"[A-Za-z0-9._-]+")
+
 # Detach the run so it outlives this 30 s executor subprocess. start_new_session
 # (setsid) is POSIX-only — Windows ignores it silently, where DETACHED_PROCESS +
 # CREATE_NEW_PROCESS_GROUP is the equivalent (mirrors templates/docs, latex and
@@ -728,6 +780,10 @@ def _start(file: str, message: str, session_id: str, model: str,
     file = os.path.abspath(file)
     if not os.path.isfile(file):
         return {"error": f"target file not found: {file}"}
+    for name, value in (("session_id", session_id), ("model", model),
+                        ("effort", effort)):
+        if value and not _SAFE_TOKEN.fullmatch(value):
+            return {"error": f"invalid {name!r} (letters, digits, . _ -)"}
     if session_id:
         _migrate_session(file, session_id)
 
@@ -743,26 +799,38 @@ def _start(file: str, message: str, session_id: str, model: str,
         else DEFAULT_PERMISSION_MODE
     cli_mode = PERMISSION_MODES[mode]
 
-    cmd = [_claude_bin(), "-p", message,
-           "--output-format", "stream-json",
-           "--verbose", "--include-partial-messages",
-           "--append-system-prompt", _system_prompt(file),
-           "--mcp-config", _write_mcp_config(run_dir),
-           "--permission-prompt-tool",
-           f"mcp__{PERMISSION_SERVER}__{PERMISSION_TOOL}",
-           # Naming a permission-prompt tool also un-gates AskUserQuestion and
-           # ExitPlanMode, which the CLI otherwise disables in headless mode.
-           # This chat renders neither a question picker nor a plan dialog, so
-           # keep them off: the change is about tool approvals and nothing else.
-           "--disallowed-tools", "AskUserQuestion,ExitPlanMode"]
+    # No user-controlled STRING enters argv (the cmd.exe re-parse above): the
+    # message goes over stdin (-p with no positional prompt reads the pipe)
+    # and the system prompt — it embeds the user's file path — rides a file in
+    # run_dir, cleaned up with the run.
+    sp_path = os.path.join(run_dir, "system_prompt.txt")
+    with open(sp_path, "w", encoding="utf-8") as f:
+        f.write(_system_prompt(file))
+    msg_path = os.path.join(run_dir, "message.txt")
+    with open(msg_path, "w", encoding="utf-8") as f:
+        f.write(message)
+
+    args = ["-p",
+            "--output-format", "stream-json",
+            "--verbose", "--include-partial-messages",
+            "--append-system-prompt-file", sp_path,
+            "--mcp-config", _write_mcp_config(run_dir),
+            "--permission-prompt-tool",
+            f"mcp__{PERMISSION_SERVER}__{PERMISSION_TOOL}",
+            # Naming a permission-prompt tool also un-gates AskUserQuestion and
+            # ExitPlanMode, which the CLI otherwise disables in headless mode.
+            # This chat renders neither a question picker nor a plan dialog, so
+            # keep them off: the change is about tool approvals and nothing else.
+            "--disallowed-tools", "AskUserQuestion,ExitPlanMode"]
     if cli_mode:
-        cmd += ["--permission-mode", cli_mode]
+        args += ["--permission-mode", cli_mode]
     if session_id:
-        cmd += ["--resume", session_id]
+        args += ["--resume", session_id]
     if model:
-        cmd += ["--model", model]
+        args += ["--model", model]
     if effort:
-        cmd += ["--effort", effort]
+        args += ["--effort", effort]
+    cmd = _popen_cmd(_claude_bin(), args)
 
     # poll() records the session into the sidecar once claude reports its id;
     # it needs the file + first message, so stash them with the run.
@@ -774,11 +842,15 @@ def _start(file: str, message: str, session_id: str, model: str,
         json.dump({"file": file, "message": message,
                    "resumed_from": session_id, "mode": mode}, f)
 
+    # stdin carries the message (HEAD's argv-safety: no user text on the
+    # command line); _DETACH covers both the detach and, on Windows, the
+    # no-console-window concern (DETACHED_PROCESS creates no console at all).
     with _private_open(os.path.join(run_dir, "out.jsonl")) as out, \
-         _private_open(os.path.join(run_dir, "err.log")) as err:
+         _private_open(os.path.join(run_dir, "err.log")) as err, \
+         open(msg_path, encoding="utf-8") as msg_in:
         proc = subprocess.Popen(cmd, stdout=out, stderr=err,
                                 cwd=os.path.dirname(file),
-                                stdin=subprocess.DEVNULL,
+                                stdin=msg_in,
                                 **_DETACH)
     with _private_open(os.path.join(run_dir, "pid")) as f:
         f.write(str(proc.pid))

--- a/tests/test_claude_agent_windows.py
+++ b/tests/test_claude_agent_windows.py
@@ -98,6 +98,202 @@ def test_missing_claude_error_names_the_override_and_the_locations(monkeypatch):
     assert (r"%USERPROFILE%\nope.exe" if os.name == "nt" else "/nope/claude") in message
 
 
+# ----------------------------------------------------------------- argv safety
+
+def _start_capturing(agent, tmp_path, monkeypatch, bin_path, message="hello",
+                     **kwargs):
+    """Run _start with Popen stubbed; return (cmd, popen_kwargs, run_dir)."""
+    target = tmp_path / "sample.html"
+    target.write_text("<html></html>")
+    monkeypatch.setattr(agent, "_claude_bin", lambda: bin_path)
+    monkeypatch.setattr(agent, "RUNS", str(tmp_path / "runs"))
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, **kw):
+        captured["cmd"] = cmd
+        captured["kwargs"] = kw
+        # stdin is an open file object at this point; read it before it closes
+        captured["stdin_text"] = kw["stdin"].read()
+        return FakeProc()
+
+    monkeypatch.setattr(agent.subprocess, "Popen", fake_popen)
+    result = agent._start(str(target), message, kwargs.get("session_id", ""),
+                          kwargs.get("model", ""), kwargs.get("effort", ""),
+                          kwargs.get("permission_mode", ""))
+    assert "run_id" in result, result
+    return captured, os.path.join(str(tmp_path / "runs"), result["run_id"])
+
+
+def test_the_message_travels_over_stdin_not_argv(tmp_path, monkeypatch):
+    """A message is arbitrary user text. It must never reach the command line:
+    behind a .cmd shim cmd.exe re-parses that line, and cmd-escaping arbitrary
+    text is not reliably possible. `-p` with no positional prompt reads stdin."""
+    agent = _load_agent()
+    message = 'summarize & "quote" | this ^ %PATH%'
+    captured, _ = _start_capturing(
+        agent, tmp_path, monkeypatch, "/usr/local/bin/claude", message=message)
+    assert captured["stdin_text"] == message
+    assert message not in captured["cmd"]
+    assert captured["cmd"][-1] != message
+    # -p is present but carries no positional prompt after it
+    assert "-p" in captured["cmd"]
+    assert captured["cmd"][captured["cmd"].index("-p") + 1].startswith("--")
+
+
+def test_the_system_prompt_rides_a_file_in_the_run_dir(tmp_path, monkeypatch):
+    """The system prompt embeds the user's file path, so it is not argv-safe
+    either. It goes to a file that is cleaned up with the run."""
+    agent = _load_agent()
+    captured, run_dir = _start_capturing(
+        agent, tmp_path, monkeypatch, "/usr/local/bin/claude")
+    cmd = captured["cmd"]
+    sp_path = cmd[cmd.index("--append-system-prompt-file") + 1]
+    assert "--append-system-prompt" not in cmd  # the inline flag is gone
+    assert os.path.dirname(sp_path) == run_dir
+    with open(sp_path, encoding="utf-8") as f:
+        assert "sample.html" in f.read()
+
+
+@pytest.mark.parametrize("field,value", [
+    ("session_id", "abc$(whoami)"),
+    ("model", "haiku & del *"),
+    ("effort", 'high"'),
+])
+def test_start_rejects_tokens_outside_the_argv_charset(tmp_path, monkeypatch,
+                                                       field, value):
+    """These three DO end up in argv, so they are held to a closed charset —
+    the security boundary that lets the rest of the line stay static."""
+    agent = _load_agent()
+    target = tmp_path / "sample.html"
+    target.write_text("<html></html>")
+    monkeypatch.setattr(agent, "RUNS", str(tmp_path / "runs"))
+
+    def no_spawn(*args, **kwargs):
+        raise AssertionError("nothing may be spawned for a rejected token")
+
+    monkeypatch.setattr(agent.subprocess, "Popen", no_spawn)
+    kwargs = {"session_id": "", "model": "", "effort": "", field: value}
+    result = agent._start(str(target), "hi", kwargs["session_id"],
+                          kwargs["model"], kwargs["effort"])
+    assert field in result["error"]
+
+
+def test_start_accepts_the_tokens_we_actually_send(tmp_path, monkeypatch):
+    agent = _load_agent()
+    captured, _ = _start_capturing(
+        agent, tmp_path, monkeypatch, "/usr/local/bin/claude",
+        session_id="3f2b1c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+        model="claude-haiku-4-5-20251001", effort="high")
+    cmd = captured["cmd"]
+    assert cmd[cmd.index("--model") + 1] == "claude-haiku-4-5-20251001"
+    assert cmd[cmd.index("--effort") + 1] == "high"
+
+
+def test_an_exe_is_execed_as_a_plain_argv_list(monkeypatch):
+    """Only a .cmd/.bat shim needs cmd.exe. A real .exe — and anything at all
+    off win32 — is spawned directly, where argv needs no quoting rules."""
+    agent = _load_agent()
+    monkeypatch.setattr(agent.sys, "platform", "win32")
+    assert agent._popen_cmd(r"C:\u\claude.exe", ["-p"]) == [
+        r"C:\u\claude.exe", "-p"]
+    monkeypatch.setattr(agent.sys, "platform", "darwin")
+    # a .cmd off win32 is not a shim, it is just a file with a funny name
+    assert agent._popen_cmd("/usr/local/bin/claude.cmd", ["-p"]) == [
+        "/usr/local/bin/claude.cmd", "-p"]
+
+
+def test_a_shim_is_a_single_cmd_string_with_one_outer_quote_pair(monkeypatch):
+    """The spaces bug: handing Popen the list ["cmd.exe", "/c", shim, ...]
+    lets list2cmdline quote each element that needs it. cmd.exe only preserves
+    inner quoting when the rest of its line holds exactly two quotes — a shim
+    path with spaces plus any quoted argument makes four, cmd strips the
+    outermost pair instead and re-splits at the spaces.
+
+    So we build the line: /s strips exactly the first and last quote and takes
+    everything between verbatim, whatever the payload contains."""
+    agent = _load_agent()
+    monkeypatch.setattr(agent.sys, "platform", "win32")
+    shim = r"C:\Users\John Doe\AppData\Roaming\npm\claude.cmd"
+    sp = r"C:\Users\John Doe\runs\r1\system_prompt.txt"
+    cmd = agent._popen_cmd(shim, ["-p", "--append-system-prompt-file", sp])
+
+    assert isinstance(cmd, str), (
+        "a shim invocation must be one command string — a list would be "
+        "re-joined by list2cmdline and mis-parsed by cmd.exe")
+    # /s: strip exactly the outer pair, rest verbatim. /d: no AutoRun injection.
+    assert cmd.startswith('cmd.exe /d /s /c "')
+    assert cmd.endswith('"')
+    # both space-bearing paths survive intact, each in its own quoted run
+    assert f'"{shim}"' in cmd
+    assert f'"{sp}"' in cmd
+    # the payload between the outer quotes is what cmd will execute verbatim
+    payload = cmd[len('cmd.exe /d /s /c "'):-1]
+    assert payload == f'"{shim}" "-p" "--append-system-prompt-file" "{sp}"'
+
+
+def test_every_shim_argument_is_quoted_so_metacharacters_stay_literal(monkeypatch):
+    """/s stops cmd re-parsing QUOTES, not metacharacters — & | > < ^ are
+    still live outside a quoted run. Quoting every element, not only the ones
+    with spaces, is what keeps them inert."""
+    agent = _load_agent()
+    monkeypatch.setattr(agent.sys, "platform", "win32")
+    cmd = agent._popen_cmd(r"C:\npm\claude.cmd", ["-p", "--verbose"])
+    payload = cmd[len('cmd.exe /d /s /c "'):-1]
+    for token in (r"C:\npm\claude.cmd", "-p", "--verbose"):
+        assert f'"{token}"' in payload
+    assert payload.replace('"', " ").split() == [
+        r"C:\npm\claude.cmd", "-p", "--verbose"]
+
+
+def test_a_double_quote_in_an_argument_is_refused_not_smuggled(monkeypatch):
+    """Nothing we send can contain a `"` (Windows paths cannot hold one, and
+    the rest is static or charset-validated). If that ever changes, fail loudly
+    rather than emit a line that means something else."""
+    agent = _load_agent()
+    monkeypatch.setattr(agent.sys, "platform", "win32")
+    with pytest.raises(ValueError):
+        agent._popen_cmd(r"C:\npm\claude.cmd", ['--model', 'a"b'])
+
+
+def test_start_behind_a_shim_with_spaces_produces_a_runnable_line(
+        tmp_path, monkeypatch):
+    """End to end through _start: a shim path with spaces AND a run_dir with
+    spaces (the reported C:\\Users\\John Doe shape) must still yield a single
+    correctly-quoted command string."""
+    _as_windows(monkeypatch)
+    agent = _load_agent()
+    monkeypatch.setattr(agent.sys, "platform", "win32")
+    spacey = tmp_path / "John Doe"
+    spacey.mkdir()
+    shim = r"C:\Users\John Doe\npm\claude.cmd"
+    target = spacey / "sample.html"
+    target.write_text("<html></html>")
+    monkeypatch.setattr(agent, "_claude_bin", lambda: shim)
+    monkeypatch.setattr(agent, "RUNS", str(spacey / "my runs"))
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, **kw):
+        captured["cmd"] = cmd
+        return FakeProc()
+
+    monkeypatch.setattr(agent.subprocess, "Popen", fake_popen)
+    assert "run_id" in agent._start(str(target), "hello", "", "", "")
+    cmd = captured["cmd"]
+    assert isinstance(cmd, str)
+    assert cmd.startswith('cmd.exe /d /s /c "') and cmd.endswith('"')
+    assert f'"{shim}"' in cmd
+    # the system-prompt file lives under a directory with a space in it
+    sp = [t for t in cmd.split('"') if t.endswith("system_prompt.txt")]
+    assert sp and " " in sp[0]
+    assert f'"{sp[0]}"' in cmd
+
+
 # --------------------------------------------------------------------- detach
 
 def test_detach_kwargs_are_win32_flags_on_windows(monkeypatch):


### PR DESCRIPTION
Extracted from #304 per review: that PR is about `fused.ai()` and the server, and this template work does not belong in it. The two paths share no code — template and shell/server are connected only through the fused api — so this is the same *invocation discipline* applied independently to `fused_render/templates/claude/agent.py`, not a shared helper.

## No user text in argv

`_start` used to put arbitrary user text on the CLI's command line: the message as `-p <text>`, and the target file path inside `--append-system-prompt <text>`. Behind an npm `.cmd`/`.bat` shim that whole line is re-parsed by cmd.exe, and cmd-escaping arbitrary text is not reliably possible.

- the message now travels over **stdin** (`-p` with no positional prompt reads the pipe)
- the system prompt rides a **file in the run dir** (`--append-system-prompt-file`), cleaned up with the run
- what remains in argv is static literals, run-dir paths, and `session_id` / `model` / `effort` — now held to a closed `[A-Za-z0-9._-]` charset, rejected before anything spawns

## Plus the paths-with-spaces fix (bugbot 3672851040)

A `.cmd` shim can't be started by CreateProcess, so it must go through cmd.exe. But handing `Popen` the list `["cmd.exe", "/c", shim, ...]` lets `list2cmdline` quote each element that needs quoting, and cmd.exe only preserves inner quoting when the rest of its line carries **exactly two** quote characters. A shim path with spaces plus any quoted argument makes four — cmd falls through to its strip-the-outermost-pair rule and re-splits at the spaces, so `C:\Users\John Doe\AppData\Roaming\npm\claude.cmd` simply never runs.

Verified with the real thing:

    >>> subprocess.list2cmdline(["cmd.exe","/c",r"C:\p ath\claude.cmd","-p","--system-prompt-file",r"C:\Users\John Doe\t.txt"])
    'cmd.exe /c "C:\\p ath\\claude.cmd" -p --system-prompt-file "C:\\Users\\John Doe\\t.txt"'

`_popen_cmd` builds the line itself instead: `cmd /d /s /c "<payload>"`. `/s` strips exactly the first and last quote and treats everything between verbatim — the one documented cmd quoting rule that doesn't depend on how many quotes the payload holds. `/d` skips AutoRun registry commands so they can't inject into the invocation. Every payload element is quoted, not only the ones with spaces, because `/s` stops cmd re-parsing *quotes* but not metacharacters (`& | > < ^`) — a quoted run is where those stay literal. An argument containing `"` raises instead of silently producing a different command (Windows paths can't contain one, and everything else here is static or charset-validated).

## Tests

`tests/test_claude_agent_windows.py` gains coverage for all of it — message on stdin not argv, system prompt in the run dir, charset rejection/acceptance, `.exe` vs shim dispatch, the single-outer-quote-pair shape, metacharacter quoting, the `"` refusal, and an end-to-end `_start` with **both** a shim path and a run dir containing spaces. Mocked at `subprocess.Popen`, the same layer as the existing tests in that file, since macOS/Linux CI can't run a real cmd.exe. 38 passed; the wider template set (`test_claude_agent_sidecar`, `test_claude_permission_bridge`, `test_templates`, `test_core_templates`) is 217 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes process invocation and argv handling for a security-sensitive spawn path (cmd.exe re-parse, metacharacters); mistakes could break Windows launches or weaken command-line injection defenses.
> 
> **Overview**
> Hardens how the Claude template spawns the CLI on Windows: **user-controlled text no longer appears on the command line**, and **npm `.cmd` shims with spaces in the path actually run**.
> 
> `_start` now sends the chat message on **stdin** (`-p` with no positional prompt), writes the system prompt (which embeds the file path) to **`--append-system-prompt-file`** under the run dir, and rejects `session_id` / `model` / `effort` unless they match a closed `[A-Za-z0-9._-]` charset before spawn.
> 
> For Windows `.cmd`/`.bat` shims, **`_popen_cmd`** builds a single `cmd.exe /d /s /c "..."` string with every argument quoted (fixing cmd’s broken re-parse when paths contain spaces); real `.exe` invocations still use a plain argv list.
> 
> `tests/test_claude_agent_windows.py` adds coverage for stdin vs argv, prompt file, charset validation, shim quoting, and an end-to-end `_start` with spacey shim and run paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad88b4d950903bb7bc6516a552075bc50f62f7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->