### PR TITLE
Download page: description, hero GIF, examples link

### DIFF
--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -105,14 +105,6 @@
     margin: 8px 0;
   }
   a { color: inherit; }
-  .hero-gif {
-    display: block;
-    width: 100%;
-    max-width: 280px;
-    margin: 2px auto 12px;
-    border-radius: 8px;
-    border: 1px solid var(--border);
-  }
   footer {
     text-align: center;
     color: var(--muted);
@@ -136,11 +128,6 @@
   </header>
 
   <section class="hero">
-    <!-- Same demo GIF as the README's hero: right-click a file in Explorer,
-         pick "Open with" → fused-render, and it opens in the browser.
-         Served straight from the main branch so this page never drifts
-         from the README's copy and doesn't need a release-pipeline upload. -->
-    <img class="hero-gif" alt="fused-render: right-click a file in Explorer, pick &quot;Open with&quot; → fused-render, and it opens in the browser" src="https://raw.githubusercontent.com/fusedio/fused-render/main/learn/assets/open_with_right_click.gif">
     <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
     fused-render, and it opens in your browser, ready to preview.</p>
     <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -123,8 +123,7 @@
     </div>
     <p class="tagline">A local file explorer with Python-powered interactive
     HTML views — browse any directory in the browser, preview your data, and
-    author pages that call local Python. No accounts, no cloud, no sandboxing.
-    Runs entirely on your computer.</p>
+    author pages that call local Python. Runs entirely on your computer.</p>
   </header>
 
   <section class="hero">

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -105,6 +105,13 @@
     margin: 8px 0;
   }
   a { color: inherit; }
+  .hero-gif {
+    display: block;
+    width: 100%;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    margin: 2px 0 12px;
+  }
   footer {
     text-align: center;
     color: var(--muted);
@@ -123,8 +130,21 @@
     </div>
     <p class="tagline">A local file explorer with Python-powered interactive
     HTML views — browse any directory in the browser, preview your data, and
-    author pages that call local Python.</p>
+    author pages that call local Python. Runs entirely on <code>127.0.0.1</code> —
+    no accounts, no cloud, no sandboxing.</p>
   </header>
+
+  <section class="hero">
+    <!-- Same demo GIF as the README's hero: right-click a file in Explorer,
+         pick "Open with" → fused-render, and it opens in the browser.
+         Served straight from the main branch so this page never drifts
+         from the README's copy and doesn't need a release-pipeline upload. -->
+    <img class="hero-gif" alt="fused-render: right-click a file in Explorer, pick &quot;Open with&quot; → fused-render, and it opens in the browser" src="https://raw.githubusercontent.com/fusedio/fused-render/main/learn/assets/open_with_right_click.gif">
+    <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
+    fused-render, and it opens in your browser, ready to preview.</p>
+    <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>
+    <span class="muted">copy any of them into your own install and run them as-is.</span></p>
+  </section>
 
   <section>
     <h2>macOS</h2>
@@ -166,6 +186,7 @@
 
   <footer>
     <a href="https://github.com/fusedio/fused-render/releases">All releases</a>
+    · <a href="https://github.com/fusedio/fused-render-examples">Examples</a>
     · <a href="https://www.fused.io">fused.io</a>
   </footer>
 </main>

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -105,22 +105,12 @@
     margin: 8px 0;
   }
   a { color: inherit; }
-  .hero {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-  }
-  .hero-text { flex: 1; min-width: 0; }
   .hero-gif {
     display: block;
-    width: 140px;
-    flex: none;
+    width: 100%;
     border-radius: 8px;
     border: 1px solid var(--border);
-  }
-  @media (max-width: 520px) {
-    .hero { flex-direction: column-reverse; }
-    .hero-gif { width: 100%; max-width: 220px; }
+    margin: 2px 0 12px;
   }
   footer {
     text-align: center;
@@ -142,19 +132,6 @@
     HTML views — browse any directory in the browser, preview your data, and
     author pages that call local Python. Runs entirely on your computer.</p>
   </header>
-
-  <section class="hero">
-    <div class="hero-text">
-      <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
-      fused-render, and it opens in your browser, ready to preview.</p>
-      <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>
-      <span class="muted">copy any of them into your own install and run them as-is.</span></p>
-    </div>
-    <!-- Same demo GIF as the README's hero. Served straight from the main
-         branch so this page never drifts from the README's copy and
-         doesn't need a release-pipeline upload. -->
-    <img class="hero-gif" alt="fused-render: right-click a file in Explorer, pick &quot;Open with&quot; → fused-render, and it opens in the browser" src="https://raw.githubusercontent.com/fusedio/fused-render/main/learn/assets/open_with_right_click.gif">
-  </section>
 
   <section>
     <h2>macOS</h2>
@@ -194,8 +171,21 @@
     Explorer "Open with" integration for every format it previews.</p>
   </section>
 
+  <section class="hero">
+    <!-- Same demo GIF as the README's hero: right-click a file in Explorer,
+         pick "Open with" → fused-render, and it opens in the browser.
+         Served straight from the main branch so this page never drifts
+         from the README's copy and doesn't need a release-pipeline upload. -->
+    <img class="hero-gif" alt="fused-render: right-click a file in Explorer, pick &quot;Open with&quot; → fused-render, and it opens in the browser" src="https://raw.githubusercontent.com/fusedio/fused-render/main/learn/assets/open_with_right_click.gif">
+    <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
+    fused-render, and it opens in your browser, ready to preview.</p>
+    <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>
+    <span class="muted">copy any of them into your own install and run them as-is.</span></p>
+  </section>
+
   <footer>
-    <a href="https://github.com/fusedio/fused-render/releases">All releases</a>
+    <a href="https://github.com/fusedio/fused-render">GitHub</a>
+    · <a href="https://github.com/fusedio/fused-render/releases">All releases</a>
     · <a href="https://github.com/fusedio/fused-render-examples">Examples</a>
     · <a href="https://www.fused.io">fused.io</a>
   </footer>

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -138,8 +138,7 @@
     <!-- Usable before/without latest.json: falls back to the releases page,
          upgraded to the direct DMG link once the manifest loads. -->
     <p><a class="btn" id="dmg" href="https://github.com/fusedio/fused-render/releases">Download for macOS</a></p>
-    <p class="muted">Signed and notarized app, macOS 11+. Bundles its own
-    Python, the fused CLI, and rclone — nothing else to install.</p>
+    <p class="muted">Signed and notarized app, macOS 11+.</p>
     <p class="muted">Or with Homebrew:</p>
     <pre>brew install --cask fusedio/tap/fused-render</pre>
   </section>
@@ -149,8 +148,7 @@
     <!-- Usable before/without latest.json: falls back to the releases page,
          upgraded to the direct installer link once the manifest loads. -->
     <p><a class="btn" id="windows-exe" href="https://github.com/fusedio/fused-render/releases">Download for Windows</a></p>
-    <p class="muted">Installer (.exe), Windows 10+. Bundles its own Python and
-    the fused CLI — nothing else to install.</p>
+    <p class="muted">Installer (.exe), Windows 10+.</p>
   </section>
 
   <section>
@@ -158,8 +156,7 @@
     <!-- Usable before/without latest.json: falls back to the releases page,
          upgraded to the direct AppImage link once the manifest loads. -->
     <p><a class="btn" id="linux-appimage" href="https://github.com/fusedio/fused-render/releases">Download for Linux</a></p>
-    <p class="muted">AppImage (x86_64) — make it executable and run. Bundles
-    its own Python and the fused CLI — nothing else to install.</p>
+    <p class="muted">AppImage (x86_64) — make it executable and run.</p>
   </section>
 
   <section>

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -131,8 +131,8 @@
     </div>
     <p class="tagline">A local file explorer with Python-powered interactive
     HTML views — browse any directory in the browser, preview your data, and
-    author pages that call local Python. Runs entirely on your computer —
-    no accounts, no cloud, no sandboxing.</p>
+    author pages that call local Python. No accounts, no cloud, no sandboxing.
+    Runs entirely on your computer.</p>
   </header>
 
   <section class="hero">

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -108,9 +108,10 @@
   .hero-gif {
     display: block;
     width: 100%;
+    max-width: 280px;
+    margin: 2px auto 12px;
     border-radius: 8px;
     border: 1px solid var(--border);
-    margin: 2px 0 12px;
   }
   footer {
     text-align: center;

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -130,7 +130,7 @@
     </div>
     <p class="tagline">A local file explorer with Python-powered interactive
     HTML views — browse any directory in the browser, preview your data, and
-    author pages that call local Python. Runs entirely on <code>127.0.0.1</code> —
+    author pages that call local Python. Runs entirely on your computer —
     no accounts, no cloud, no sandboxing.</p>
   </header>
 

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -105,6 +105,23 @@
     margin: 8px 0;
   }
   a { color: inherit; }
+  .hero {
+    display: flex;
+    align-items: center;
+    gap: 20px;
+  }
+  .hero-text { flex: 1; min-width: 0; }
+  .hero-gif {
+    display: block;
+    width: 140px;
+    flex: none;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+  }
+  @media (max-width: 520px) {
+    .hero { flex-direction: column-reverse; }
+    .hero-gif { width: 100%; max-width: 220px; }
+  }
   footer {
     text-align: center;
     color: var(--muted);
@@ -127,10 +144,16 @@
   </header>
 
   <section class="hero">
-    <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
-    fused-render, and it opens in your browser, ready to preview.</p>
-    <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>
-    <span class="muted">copy any of them into your own install and run them as-is.</span></p>
+    <div class="hero-text">
+      <p class="muted">Right-click a file in Explorer → <strong>Open with</strong> →
+      fused-render, and it opens in your browser, ready to preview.</p>
+      <p><a href="https://github.com/fusedio/fused-render-examples">Browse example views →</a>
+      <span class="muted">copy any of them into your own install and run them as-is.</span></p>
+    </div>
+    <!-- Same demo GIF as the README's hero. Served straight from the main
+         branch so this page never drifts from the README's copy and
+         doesn't need a release-pipeline upload. -->
+    <img class="hero-gif" alt="fused-render: right-click a file in Explorer, pick &quot;Open with&quot; → fused-render, and it opens in the browser" src="https://raw.githubusercontent.com/fusedio/fused-render/main/learn/assets/open_with_right_click.gif">
   </section>
 
   <section>


### PR DESCRIPTION
## Summary
- Tagline now describes what the product does and ends with "Runs entirely on your computer."
- Adds the README's demo GIF (right-click a file in Explorer → Open with → fused-render) in a section near the bottom of the page, served from raw.githubusercontent.com so it stays in sync with the README without any release-pipeline changes.
- Adds a "Browse example views" link to the fused-render-examples repo, next to the GIF.
- Footer now links to the main GitHub repo (fusedio/fused-render) alongside releases, examples, and fused.io.
- Removed the "Bundles its own Python and the fused CLI — nothing else to install" filler line from each OS section (macOS/Windows/Linux) — didn't add real information.

## Test plan
- [x] Verified visually in Chrome via a local static server — layout, GIF, and links render correctly against the existing dark theme, download buttons appear above the fold.