### PR TITLE
mounts: stop a healthy WinFsp mount reading as "disconnected" on Windows

### DIFF
--- a/fused_render/shell/mounts/lifecycle.py
+++ b/fused_render/shell/mounts/lifecycle.py
@@ -544,7 +544,7 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT,
     """Health of one mount: "mounted" | "stale" | "disconnected" | "unmounted".
 
     "mounted" requires both that a live rcd serves the mountpoint AND (when
-    `probe_io`) that the filesystem actually answers a listdir. Pass
+    `probe_io`, POSIX only) that the filesystem actually answers a listdir. Pass
     probe_io=False to SKIP that os.listdir — on an S3-backed mount a kernel
     READDIR of the root is itself a wedge trigger (a slow syscall the timeout
     abandons but cannot cancel), so a caller polling on a timer (the health
@@ -594,10 +594,13 @@ def mount_state(m: dict, rcd_mounts: set, timeout: float = PROBE_TIMEOUT,
                 # health-check).
                 out["state"] = "disconnected"
             else:
-                if probe_io:
+                # POSIX only: on win32 this readdir can fail for the lifetime of
+                # one process while the mount is healthy (INCIDENT 2026-07-30).
+                if probe_io and sys.platform != "win32":
                     os.listdir(mp)  # the actual I/O health check
                 out["state"] = "mounted"
-        except OSError:
+        except OSError as e:
+            logger.warning("mount %r probe failed at %s: %s", m["name"], mp, e)
             out["state"] = "disconnected"
 
     t = threading.Thread(target=probe, daemon=True, name=f"mount-probe-{m['name']}")

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2123,7 +2123,9 @@ def test_state_stale_when_rcd_tracks_a_dropped_kernel_mount(home, rcd):
 
 def test_state_disconnected_when_listing_hangs(home, rcd, monkeypatch):
     # A wedged NFS mount blocks listdir forever; the probe times out instead.
+    # POSIX-pinned: only POSIX enumerates the mount.
     c, mp = _make_mount(home, rcd)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
     monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
     ev = threading.Event()
 
@@ -2154,6 +2156,71 @@ def test_state_disconnected_when_stat_returns_enotconn(home, rcd, monkeypatch,
     c, mp = _make_mount(home, rcd, served=served)
     _wedge(monkeypatch, mp)
     assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "disconnected"
+
+
+# -- the win32 listdir carve-out (INCIDENT 2026-07-30) ---------------------
+#
+# A kernel readdir of a HEALTHY WinFsp mount root can fail for the lifetime of
+# one process, which pinned the page to a red dot Reconnect could not clear.
+
+
+def _raise_enotconn(p):
+    raise OSError(errno.ENOTCONN, "Transport endpoint is not connected")
+
+
+def test_state_win32_ignores_a_failing_kernel_listdir(home, rcd, monkeypatch):
+    c, mp = _make_mount(home, rcd)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    monkeypatch.setattr(mounts_mod.os, "listdir", _raise_enotconn)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "mounted"
+
+
+def test_state_win32_does_not_enumerate_the_mount_at_all(home, rcd, monkeypatch):
+    # Not just tolerant of a failure: a blocking mount root can't stall it either.
+    c, mp = _make_mount(home, rcd)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    calls = []
+    monkeypatch.setattr(mounts_mod.os, "listdir", lambda p: calls.append(p))
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "mounted"
+    assert calls == []
+
+
+def test_state_posix_still_disconnected_on_a_failing_listdir(home, rcd,
+                                                            monkeypatch):
+    c, mp = _make_mount(home, rcd)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    monkeypatch.setattr(mounts_mod.os, "listdir", _raise_enotconn)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "disconnected"
+
+
+def test_state_win32_still_disconnected_when_rcd_stops_serving(home, rcd,
+                                                              monkeypatch):
+    # Dropping the listdir must not blind the two signals that remain.
+    c, mp = _make_mount(home, rcd, served=False)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "disconnected"
+
+
+def test_state_win32_still_stale_when_kernel_dropped_the_mount(home, rcd,
+                                                              monkeypatch):
+    c, mp = _make_mount(home, rcd)
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: False)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "stale"
+
+
+def test_state_probe_failure_is_logged(home, rcd, monkeypatch, caplog):
+    # The swallowed errno is the only evidence of WHY a mount reads broken.
+    c, mp = _make_mount(home, rcd, name="logged")
+    monkeypatch.setattr(mounts_mod.sys, "platform", "linux")
+    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    monkeypatch.setattr(mounts_mod.os, "listdir", _raise_enotconn)
+    assert mounts_mod.mount_state(c, mounts_mod.mounted_paths()) == "disconnected"
+    assert "logged" in caplog.text and "not connected" in caplog.text
 
 
 # -- broken_mount_error: expired detected credentials ----------------------
@@ -2416,6 +2483,20 @@ def test_reconnect_endpoint(client, rcd, monkeypatch):
     r = client.post(f"/api/mounts/{m['id']}/reconnect", headers=FUSED)
     assert r.status_code == 200
     assert client.post("/api/mounts/nope/reconnect", headers=FUSED).status_code == 404
+
+
+def test_get_mounts_win32_healthy_despite_a_failing_kernel_listdir(
+        client, rcd, monkeypatch):
+    # The listing the page polls — where the stuck red dot came from.
+    m = client.post("/api/mounts", json={"name": "data", "remote": "r:bucket"},
+                    headers=FUSED).json()
+    rcd.responses["mount/listmounts"] = {
+        "mountPoints": [{"Fs": "r:bucket", "MountPoint": m["mountpoint"]}]}
+    monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    monkeypatch.setattr(mounts_mod.os, "listdir", _raise_enotconn)
+    got = client.get("/api/mounts").json()["mounts"]
+    assert [(c["name"], c["state"], c["mounted"]) for c in got] == [
+        ("data", "mounted", True)]
 
 
 def test_fs_list_errors_for_dead_mount_instead_of_empty(client, rcd, home):

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -2493,6 +2493,9 @@ def test_get_mounts_win32_healthy_despite_a_failing_kernel_listdir(
     rcd.responses["mount/listmounts"] = {
         "mountPoints": [{"Fs": "r:bucket", "MountPoint": m["mountpoint"]}]}
     monkeypatch.setattr(mounts_mod.sys, "platform", "win32")
+    # 3.12+ shutil.which takes a win32 branch needing _winapi, which the faked
+    # platform must not reach on a POSIX runner.
+    monkeypatch.setattr(mounts_mod.shutil, "which", lambda name: "/usr/bin/rclone")
     monkeypatch.setattr(mounts_mod.os, "listdir", _raise_enotconn)
     got = client.get("/api/mounts").json()["mounts"]
     assert [(c["name"], c["state"], c["mounted"]) for c in got] == [


### PR DESCRIPTION
Rebased onto current `main` (the `shell/mounts.py` split in #322 moved this code to `shell/mounts/lifecycle.py`).

## The bug

On Windows the Mounts page showed every mount as **disconnected** while the mounts were perfectly healthy, and **Reconnect could never clear it** — it returned `200 OK`, rclone really did unmount and remount, and the reply *already* said `disconnected`.

Reported from a live install with two mounts (a bundled `:archive:` zip and an `aws-open:` S3 prefix) that had been red for hours.

## Root cause

`mount_state()`'s I/O probe does a kernel `os.listdir()` of the mount root and treats **any** `OSError` as `disconnected`. On Windows that readdir can fail for the lifetime of one process while the mount is fine — WinFsp mount live, rcd serving it, every other process reading it normally.

Evidence from the stuck server (up 5.5 h):

| probe | result |
|---|---|
| `rclone rc mount/listmounts` | both mounts listed, mountpoints match ✅ |
| kernel reparse points | resolve to live `\Device\Volume{…}` ✅ |
| `os.listdir()` from any other process | real remote content, ~10 ms ✅ |
| the server's own `/api/fs/list` on both mounts | real S3 / zip data ✅ |
| **`GET /api/mounts/health`** (same process, `probe_io=False`) | **`mounted`** |
| **`GET /api/mounts`** (same process, `probe_io=True`) | **`disconnected`** |
| `get_mounts()` in a fresh process, same mounts | `mounted` |

Two endpoints in one process disagreeing narrowed it to the one call between them. `py-spy record` on the live server then caught the probe thread reaching exactly that line:

```
probe-thread samples: 162
   129  79.6%  ismount (<frozen ntpath>:336)
    14   8.6%  probe (mounts.py:4028)   <- os.listdir(mp)
     9   5.6%  _ismount (mounts.py:388) <- os.readlink
     5   3.1%  _ismount (mounts.py:382) <- os.lstat
```

8.6 % of probe time in `listdir` (so not the 3 s timeout — a hang would dominate, and the thread count stayed flat) with a `disconnected` verdict means it entered the call and **raised**. Everything the probe does successfully (`lstat`, `readlink`, `GetVolumePathName`) reads metadata *about* the reparse point; `listdir` is the only step that traverses into the WinFsp volume.

Ruled out: rcd auth/port (the server's rc calls work — it drove the remounts), thread exhaustion or leaked probe threads (66 threads, flat across repeated calls), probe timeouts, a stale interpreter (the installed `mounts.py` was byte-identical to `main`), the health monitor being dead (py-spy shows it alive and sleeping between ticks), and cwd/env poisoning (cwd is the payload dir; nothing chdirs).

The Windows-internal reason the readdir fails is not established — and the fix does not depend on it. What is established is that it is not a health signal.

## The change

`os.listdir` in the probe is now POSIX-only, where it is the FUSE/NFS wedge detector INCIDENT 2026-07-16 relies on. Windows classifies from the two authoritative signals it already had — the kernel mountpoint and rcd's mount table — so a dead daemon, a dropped kernel mount and a never-mounted mount are all still detected. On Windows a WinFsp mount dies with its serving process anyway, so "rclone gone" shows up as the mountpoint disappearing, not as a mount that won't enumerate.

The swallowed errno is now logged. Discarding it is what kept this undiagnosable from behind a red dot.

## Tests

8 new tests in `tests/test_shell_mounts.py`, all pinning `sys.platform` so the ubuntu, macos-14 and windows-latest jobs all exercise both branches:

- `test_state_win32_ignores_a_failing_kernel_listdir` — the reported bug
- `test_state_win32_does_not_enumerate_the_mount_at_all` — not merely tolerant of a failure; the enumeration is not issued, so a blocking mount root can't stall the probe either
- `test_state_posix_still_disconnected_on_a_failing_listdir` — the carve-out is win32-only
- `test_state_win32_still_disconnected_when_rcd_stops_serving`, `test_state_win32_still_stale_when_kernel_dropped_the_mount` — dropping the listdir does not blind the remaining signals
- `test_state_probe_failure_is_logged`
- `test_get_mounts_win32_healthy_despite_a_failing_kernel_listdir` — the endpoint contract the page polls
- plus `test_state_disconnected_when_listing_hangs` is now platform-pinned; it described POSIX behaviour but only passed on POSIX

With the source fix reverted, the 4 bug-catching tests fail and the 4 guard tests still pass.

## Verification

**End-to-end**, real WinFsp mount + real rcd + real HTTP API, isolated `FUSED_RENDER_HOME`, with the field failure reproduced inside the server process (a `sitecustomize` that makes the mount-root readdir raise):

| tree | kernel readdir | result |
|---|---|---|
| `main` @17feb19 | broken | **6 checks fail** — create `disconnected`, reconnect returns 200 + `disconnected`, `/api/mounts` and `/api/mounts/health` disagree, while `mount lists real data` **passes** |
| this branch | broken | all pass |
| this branch | healthy | all pass |

Each run also covers: data really flowing through the mount, reconnect, `rcd` killed → correctly *not* healthy, and reconnect recovering from that.

**On the reporter's three real mounts**, with the field failure reproduced (read-only, their app untouched):

```
[MAIN] [('learn', 'disconnected'), ('umbra-open-data-catalog', 'disconnected'), ('release', 'disconnected')]
[FIX ] [('learn', 'mounted'),      ('umbra-open-data-catalog', 'mounted'),      ('release', 'mounted')]
```

**Suite**, Windows, mount-related files (`test_shell_mounts`, `test_learn_mount`, `test_mount_nobrowse`, `test_mounts_rcd_owner`, `test_mounts_rcd_auth`, `test_server_fs_list_mount`, `test_server_fs_mount_safe`): branch 434 passed / 10 failed vs `main` 426 passed / 11 failed, and the branch's failures are a **strict subset** of main's — zero new failures. The pre-existing ones are symlink/POSIX-path assumptions plus two timing-sensitive tests unrelated to this change (`test_get_mounts_probes_credentials_off_serial_path` fails on main under a loaded suite and passes standalone).

**CI**: all jobs green — `test-python` 3.10–3.13 (full suite on ubuntu), `fused-engine`, `linux-desktop`, `frontend`. The first push's `fused-engine` red was `test_netcdf_zarr_mount.py::test_load_meta_consolidated_does_not_scandir_at_all` (a scandir trap catching the engine's own `/tmp/openfused-*/requests`) — a pre-existing flake that fails identically on `main` (run 30520280260) and passed on re-run. The second push's `test-python` red was mine and is fixed in 795f64e: 3.12+ `shutil.which` dereferences `_winapi` under a faked win32 platform, so the endpoint test now stubs it.

Because every `mount_state` test pins `sys.platform`, the ubuntu `test-python` matrix (3.10–3.13, full suite) exercises both the win32 and the POSIX branch. The `macos-desktop` / `windows-desktop` jobs are path-gated and skip for a change like this, so no real-darwin run happens here — the darwin code paths are untouched.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mount health classification used by `/api/mounts` and UI state; win32 no longer catches some I/O failures at the mount root, though rcd/kernel signals still detect dead mounts.
> 
> **Overview**
> Fixes false **disconnected** status on Windows when WinFsp mounts are healthy but the server process’s `os.listdir` on the mount root fails (INCIDENT 2026-07-30), which left the Mounts page stuck red and reconnect unable to clear it.
> 
> **`mount_state`** now runs the root `listdir` I/O probe only when `probe_io` is true **and** `sys.platform != "win32"`. On Windows, **mounted** is decided from kernel mount presence and rcd’s mount table (same split-brain cases as before). POSIX behavior is unchanged: a failing `listdir` still yields **disconnected**. Probe `OSError`s are **logged** with mount name and path instead of being swallowed.
> 
> Tests pin `sys.platform` for win32 vs POSIX branches, cover the API listing path, and assert logging on POSIX probe failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 795f64ea19f70d0ff3d88890e4af71f1fa652012. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
