### PR TITLE
Fix per-folder-open SIGSEGV: close_fds=False on remaining server spawn sites

### DIFF
--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -199,6 +199,9 @@ def _kill_process_tree(proc) -> None:
         subprocess.run(
             ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
             capture_output=True,
+            # close_fds=False → posix_spawn, skipping PROJ's crashing atfork
+            # handler; see executor.py's run call for the full story.
+            close_fds=False,
             creationflags=subprocess.CREATE_NO_WINDOW)
     try:
         proc.kill()

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -262,6 +262,9 @@ def _move_to_trash(path: str) -> None:
             ],
             check=True,
             capture_output=True,
+            # close_fds=False → posix_spawn, skipping PROJ's crashing atfork
+            # handler; see executor.py's run call for the full story.
+            close_fds=False,
         )
 
 

--- a/fused_render/server/gitignore.py
+++ b/fused_render/server/gitignore.py
@@ -25,6 +25,10 @@ def _empty_git_dir():
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
+                # close_fds=False → posix_spawn, skipping PROJ's crashing
+                # atfork handler; see executor.py's run call for the full
+                # story. Same on every spawn in this file.
+                close_fds=False,
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
             _EMPTY_GIT_DIR = os.path.join(root, ".git")
@@ -76,6 +80,7 @@ class _IgnoreOracle:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.DEVNULL,
                 env=env,
+                close_fds=False,  # posix_spawn, not fork — see _empty_git_dir
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
         except OSError:
@@ -144,6 +149,7 @@ def _repo_toplevel(path):
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=5,
+            close_fds=False,  # posix_spawn, not fork — see _empty_git_dir
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -182,6 +188,7 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
             stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             timeout=5,
+            close_fds=False,  # posix_spawn, not fork — see _empty_git_dir
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
     except (OSError, subprocess.SubprocessError):

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -655,5 +655,9 @@ def api_fs_reveal(body: dict = Body(...), x_fused: str | None = Header(default=N
         cmd = ["explorer", win_path] if is_dir else f'explorer /select,"{win_path}"'
     else:
         cmd = ["xdg-open", path if is_dir else os.path.dirname(path)]
-    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    # close_fds=False → posix_spawn, skipping PROJ's crashing atfork handler;
+    # see executor.py's run call for the full story.
+    subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, close_fds=False
+    )
     return JSONResponse({"ok": True})


### PR DESCRIPTION
## Problem

Opening any folder produced a macOS crash report: a forked Python child dies with SIGSEGV pre-exec ("crashed on child side of fork pre-exec"), stack: `fork → _pthread_atfork_child_handlers → PROJ SQLiteHandleCache → sqlite3Close → segfault`.

The server has libproj resident (pyproj pulled transitively via the `fused` package) with a live SQLite handle to proj.db. Any `subprocess` call with the default `close_fds=True` takes CPython's fork()+exec path on macOS; fork runs PROJ's atfork child handler against the inherited-invalid handle and the child segfaults before exec. The per-folder trigger is the gitignore `git check-ignore` oracle; the walk silently falls back to "nothing ignored", so the only symptom is a crash report per folder open (plus dead gitignore dimming).

## Fix

`close_fds=False` forces posix_spawn, which does not run atfork handlers. This is the same fix `executor.py` already carries for /api/run (with the full rationale comment). Applied to the remaining server spawn sites, each with a short pointer comment:

- `server/gitignore.py` — git init + check-ignore Popen + 2 one-shot runs
- `server/routers/fs_read.py` — Finder/Explorer reveal
- `server/fs_mutate.py` — osascript trash fallback
- `server/ai.py` — taskkill (Windows-only; kwarg harmless, kept for uniformity)

## Verification

- `python3 -m compileall` clean on all 4 files.
- Crash requires pyproj-resident server; mechanism identical to the already-fixed executor.py case verified against the attached crash report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical subprocess spawn flag only, aligned with an existing proven fix; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **macOS SIGSEGV on folder open** when the server has **pyproj/PROJ** loaded: default `subprocess` with `close_fds=True` uses **fork+exec**, which runs PROJ’s **atfork** handler on an inherited **proj.db** SQLite handle and crashes the child before `exec` (often triggered by **git check-ignore** during listing).
> 
> Applies the same **`close_fds=False`** pattern already used in **`executor.py`** (forces **posix_spawn**, no atfork) to the remaining server spawn sites, with short comments pointing at that rationale:
> 
> - **`gitignore.py`** — `git init`, `check-ignore` **Popen**, and one-shot **`git`** runs  
> - **`fs_read.py`** — Finder/Explorer **reveal** (`open` / `explorer` / `xdg-open`)  
> - **`fs_mutate.py`** — **osascript** trash fallback  
> - **`ai.py`** — Windows **taskkill** (harmless on other platforms; kept for consistency)
> 
> Behavior is unchanged aside from avoiding the crash; gitignore dimming should work again instead of silently falling back when the oracle dies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96541449f74e7c5f92b2deaf9a3c1760fb7de0f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->