### PR TITLE
Pin the fused engine to PyPI (fused==2.9.3b2) instead of the S3 wheel URL

### DIFF
--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -14,7 +14,7 @@ child process, exactly the pattern the flow app uses for project deploys
     the ONE autodetected source, the `fused` package importable in this
     interpreter via the `_fused_cli.py` shim) lives in fusedcli.py, shared
     with the account surface (account.py). `POST /api/deploy/install`
-    pip-installs the wheel pinned by `PINNED_FUSED_REQUIREMENT` into the
+    pip-installs the release pinned by `PINNED_FUSED_REQUIREMENT` into the
     server's interpreter when it is missing (Python 3.11+ with pip).
   * **Export to a temporary bundle.** Each deploy re-exports the page into a
     fresh temp directory (`export.export_page`) and hands that bundle to
@@ -130,19 +130,17 @@ def _now_iso() -> str:
 # -- the one-click install (the CLI seam itself is fusedcli.py) ---------------
 
 
-# The fused wheel the one-click install lands (POST /api/deploy/install) —
+# The fused release the one-click install lands (POST /api/deploy/install) —
 # the single IN-CODE source of the pin. pyproject.toml's `[fused]` extra must
-# point at the SAME wheel; tests/test_deploy.py pins the two together. A code
+# point at the SAME version; tests/test_deploy.py pins the two together. A code
 # constant, deliberately NOT importlib.metadata.requires("fused-render"):
 # dist-info metadata is absent on a source-tree run and on app bundles that
 # strip dist-info, and it goes STALE on an editable install that predates the
 # extra (metadata only refreshes on reinstall) — all of which disabled the
 # install button exactly when it mattered. The constant ships in the same
 # file as the code that uses it, so it is always as current as the server.
-PINNED_FUSED_REQUIREMENT = (
-    "fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post10-py3-none-any.whl"
-)
-# The wheel's own environment marker (python_version >= "3.11"), enforced here
+PINNED_FUSED_REQUIREMENT = "fused==2.9.3b2"
+# The release's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.
 FUSED_MIN_PYTHON = (3, 11)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ bundled = [
     # The requirement string must stay byte-identical to `[fused]`'s — see the
     # comment there and
     # tests/test_bundle_contents.py::test_the_bundled_and_fused_extras_pin_the_same_wheel.
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post10-py3-none-any.whl ; python_version >= "3.11"',
+    'fused==2.9.3b2 ; python_version >= "3.11"',
 ]
 # Private-cloud credential chains (optional). botocore buys the AWS provider
 # chain (SSO / credential_process / assume-role / IMDS) for s3sign's resolver
@@ -140,10 +140,10 @@ app = [
 ]
 # Optional execution engine (D69): when installed, /api/run runs code through
 # the fused local compute backend; absent, the built-in executor runs. Pinned
-# to the same wheel the managed Fused service serves hosted pages from, so local and
+# to the same release the managed Fused service serves hosted pages from, so local and
 # hosted execution stay on one build. The engine needs 3.11+; on 3.10 the
 # marker skips it and the built-in executor runs.
-# The wheel URL must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
+# The version pin must match deploy.PINNED_FUSED_REQUIREMENT (the Deploy modal's
 # one-click install, SPEC DP-4) — a test pins the two together.
 #
 # This extra is KEPT even though the same requirement now also sits in
@@ -154,7 +154,7 @@ app = [
 # (README, docs/usage.md) and CI's `fused-engine` job (`.[dev,fused]`), both of
 # which want the engine WITHOUT the ~650 MB scientific stack.
 fused = [
-    'fused @ https://fused-magic.s3.us-west-2.amazonaws.com/fused-2.9.3.post10-py3-none-any.whl ; python_version >= "3.11"',
+    'fused==2.9.3b2 ; python_version >= "3.11"',
 ]
 # Windows desktop supervisor backend (fused_render/supervisor/_win32,
 # docs/DESKTOP_SUPERVISOR.md). Windows-only; not a core dependency so
@@ -224,8 +224,9 @@ exclude_lines = [
 path = "fused_render/__init__.py"
 
 [tool.hatch.metadata]
-# The `fused` extra pins a direct wheel URL (not a PyPI dependency) — hatchling
-# refuses that unless explicitly allowed.
+# Kept enabled so a direct URL requirement (e.g. pinning a pre-release wheel
+# instead of a PyPI version) can be dropped in without a metadata error —
+# hatchling refuses direct references unless explicitly allowed.
 allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]

--- a/tests/test_bundle_contents.py
+++ b/tests/test_bundle_contents.py
@@ -308,7 +308,7 @@ def test_the_bundled_and_fused_extras_pin_the_same_wheel():
     without the ~650 MB scientific stack. Keeping both is the deliberate call;
     the cost is a duplicated requirement string, and this is the guard that makes
     the duplication safe instead of hopeful. Byte-identical, not merely
-    same-version: the direct wheel URL and the `python_version` marker are both
+    same-version: the version pin and the `python_version` marker are both
     load-bearing, and a mismatch would mean the bundle and the pip path ship
     different engines.
     """

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -275,7 +275,7 @@ def test_external_override_scrubs_interpreter_env(tmp_path, monkeypatch):
 
 def test_pinned_requirement_matches_pyproject_extra():
     # deploy.PINNED_FUSED_REQUIREMENT is the in-code source of the pin; the
-    # pyproject [fused] extra must reference the SAME wheel or a wheel install
+    # pyproject [fused] extra must reference the SAME version, or a pip install
     # and the one-click install would land different builds.
     import pathlib
 


### PR DESCRIPTION
## Summary

- The optional `fused` execution engine now installs from **PyPI (`fused==2.9.3b2`)** instead of a direct URL to a wheel in the `fused-magic` S3 bucket. Users on the light path (`pip install "fused-render[fused]"`), the DMG/Linux/Windows bundles, and the Deploy modal's one-click install all resolve through the index — no dependency on an S3 object staying put, and pip picks the wheel.
- The pin lives in **three places kept byte-identical by tests** — pyproject's `[bundled]` extra, its `[fused]` extra, and `deploy.PINNED_FUSED_REQUIREMENT` — and all three moved together. The `python_version >= "3.11"` marker and the `FUSED_MIN_PYTHON` gate are unchanged; 2.9.3b2's own `requires_python` is `>=3.11`, so they still match.
- `allow-direct-references` stays enabled even though no direct reference remains, so a future pre-release URL pin can be dropped back in without a hatchling metadata error.
- Comments and two test docstrings that described the pin as "a direct wheel URL" / "the SAME wheel" are reworded to say version pin. No behavior beyond the source of the package.

## Visuals

```mermaid
flowchart TD
    A["fused engine pin<br/>(3 synced locations)"] --> B["[bundled] extra<br/>DMG / installers"]
    A --> C["[fused] extra<br/>pip install fused-render[fused]"]
    A --> D["PINNED_FUSED_REQUIREMENT<br/>Deploy one-click install"]
    B --> E
    C --> E
    D --> E
    E["was: fused-magic S3 wheel URL<br/>now: fused==2.9.3b2 on PyPI"]
```

## Usage

Nothing new is user-invocable — the same commands now pull the engine from PyPI:

```bash
pip install "fused-render[fused]"        # light path, engine without the sci stack
pip install "fused-render[bundled]"      # what the packaged builds install
```

The Deploy modal's **Install fused** button (`POST /api/deploy/install`) hands pip the same `fused==2.9.3b2` string.

## Test Plan

- [x] `pytest tests/test_deploy.py tests/test_bundle_contents.py` — 217 passed. Covers the two guards that matter here: `test_pinned_requirement_matches_pyproject_extra` (code constant vs. `[fused]` extra) and `test_the_bundled_and_fused_extras_pin_the_same_wheel` (`[bundled]` vs. `[fused]`, byte-identical).
- [x] Confirmed `fused==2.9.3b2` exists on PyPI with a `py3-none-any` wheel + sdist, and `requires_python >=3.11` — so the retained marker and `FUSED_MIN_PYTHON = (3, 11)` are still correct.
- [ ] Reviewer: `pip install "fused-render[fused]"` into a clean 3.11+ venv and check `pip show fused` reports `2.9.3b2`.
- [ ] Reviewer: on Python 3.10, confirm the marker still skips the engine and the built-in executor runs (no install attempt).
- [ ] Edge case: a packaged build (DMG) — engine is bundled at build time, so this only changes where the build fetches it from; a DMG build is running alongside this PR to confirm.
