### PR TITLE
Windows installer: keep the build off the project-wide uv resolution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,7 +271,12 @@ jobs:
           # failure there must not withhold an otherwise-good link).
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "installer_url=${BASE_URL}/$(basename "$INSTALLER")" >> "$GITHUB_OUTPUT"
-          uv run scripts/windows/generate_update_manifest.py \
+          # --no-project --with cryptography: the script's only third-party
+          # import. Resolving the whole project here buys nothing and can fail
+          # for reasons unrelated to signing a manifest (see the same flag on
+          # the registry script in scripts/build_windows_installer.ps1).
+          uv run --no-project --with cryptography \
+            scripts/windows/generate_update_manifest.py \
             "$VERSION" "$INSTALLER" "$BASE_URL" dist/latest.json
           # no-cache: the updater polls this fixed name; a stale CDN copy
           # would mask a release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,15 @@ bundled = [
     "rasterio",
     # Matches zarr_aoi/tile_server.py's header (and its DAEMON_DEPS): it reads
     # v3 stores through the 3.x API, so a bare pin could resolve to 2.x here.
-    "zarr>=3.0.8",
+    # Marked 3.11+ like the `fused` pins below: every zarr 3.x requires
+    # Python>=3.11 (3.2+ wants 3.12), so an unmarked floor makes this extra
+    # unresolvable on the 3.10 that `requires-python` still promises — which is
+    # not a hypothetical, it broke v0.3.13's Windows installer build (the
+    # project-level `uv run` in scripts/build_windows_installer.ps1 resolves
+    # every version split, not just the bundle's 3.12). The desktop bundles all
+    # ship 3.12, so they still get zarr; a 3.10 pip install loses the zarr_aoi
+    # template's in-process path and falls back to its own daemon venv.
+    'zarr>=3.0.8 ; python_version >= "3.11"',
     "pymupdf>=1.25",
     "pikepdf>=9",
     "drain3>=0.9.11",

--- a/scripts/build_windows_installer.ps1
+++ b/scripts/build_windows_installer.ps1
@@ -269,8 +269,15 @@ if (-not ($LearnListing -match 'assets/')) {
     # -match on the line array filters; -not(non-empty) is the membership test.
     throw "learn.zip nested entries are not forward-slash separated (assets/ missing)"
 }
+# --no-project: the script is stdlib-only (plus its sibling file_associations),
+# so a plain `uv run` would resolve+install the WHOLE project — minutes of work
+# whose only effect on this build is a new way to fail. It is how v0.3.13 lost
+# its installer: an extra's dependency was unresolvable on one of the Python
+# versions `requires-python` allows, and this line, not the bundle, is what uv
+# refused.
 Invoke-Native $Uv @(
-    "run", "python", (Join-Path $RepoRoot "scripts\windows\generate_installer_registry.py"),
+    "run", "--no-project", "python",
+    (Join-Path $RepoRoot "scripts\windows\generate_installer_registry.py"),
     (Join-Path $StageDir "registry.iss")
 )
 Set-Content -Path (Join-Path $StageDir "payload.complete") -Encoding Ascii -Value $Version


### PR DESCRIPTION
## Summary

- **v0.3.13 shipped with no `.exe`.** [`build-windows-release`](https://github.com/fusedio/fused-render/actions/runs/30523554137) failed before the installer was built, so the release got the AppImage, the DMG and the wheel — and nothing for Windows.
- **Cause:** `scripts/build_windows_installer.ps1` generates `registry.iss` with a project-aware `uv run`, which resolves `pyproject.toml` across *every* Python version `requires-python = ">=3.10"` allows. #315 added `zarr>=3.0.8` to `[bundled]`, and no zarr 3.x supports 3.10 (3.x needs `>=3.11`, 3.2+ needs `>=3.12`), so the `python_full_version < '3.11'` split is unsatisfiable. There is no committed `uv.lock`, so CI re-resolves on every build.
- **Fix 1 — the metadata:** mark the pin `zarr>=3.0.8 ; python_version >= "3.11"`, matching the existing `fused==2.9.3b2 ; python_version >= "3.11"` pins. 3.10 is still in the test matrix and the classifiers, so a plain `pip install "fused-render[bundled]"` being unsatisfiable there was a real user-facing bug, not only a CI one. All three desktop bundles ship 3.12 and still get zarr.
- **Fix 2 — the blast radius:** run both `scripts/windows/*.py` build steps with `uv run --no-project` (`--with cryptography` for the manifest signer, its one third-party import). Neither script needs the project installed, so a future project-resolution break can no longer cost a release its installer.

## Visuals

The delta is which resolution the installer build depends on — the bundle's concrete 3.12 (fine) versus the project's whole 3.10–3.13 range (the failure).

```mermaid
flowchart TD
    A[build_windows_installer.ps1] --> B[uv pip install --python 3.12<br/>the bundle payload]
    A --> C[uv run<br/>generate_installer_registry.py]
    B --> D[resolves one interpreter<br/>always worked]
    C --> E{project resolution<br/>3.10 - 3.13}
    E -->|before: zarr 3.x has no 3.10| F[no solution<br/>no .exe on the release]
    E -->|after: --no-project + 3.11 marker| G[registry.iss<br/>installer uploaded]
```

## Usage

Not user-invocable — build and packaging metadata only. Two visible effects:

- Windows release builds produce `FusedRender-<version>-Setup.exe` again.
- On Python 3.10, `pip install "fused-render[bundled]"` now resolves instead of erroring; it installs without zarr, so the `zarr_aoi` template falls back to provisioning its own daemon venv (`DAEMON_DEPS`) rather than using the in-process path. 3.11+ and every packaged desktop build are unchanged.

## Test Plan

- [x] **Reproduced the CI failure locally** — with the pin unmarked, `uv lock --dry-run --upgrade` (a fresh resolution, like CI's) emits the exact release-log error: `Because fused-render[bundled] depends on zarr>=3.0.8 ... your project's requirements are unsatisfiable`.
- [x] **Confirmed the fix** — with the marker, the same fresh resolution succeeds (155 packages; zarr resolves to 3.1.6 / 3.2.1 for 3.11 / 3.12+, absent on 3.10).
- [x] **Both `--no-project` invocations run** — `generate_installer_registry.py` writes a 580-line `registry.iss`; `generate_update_manifest.py` imports `cryptography` and reaches its argv check.
- [x] **Marker-sensitive suites pass** — `pytest tests/test_bundle_contents.py tests/test_engine_requirements.py tests/test_deploy.py tests/test_windows_registry.py` → 352 passed. The `[bundled]` parsing already handles markers via `engine._marker_applies`.
- [x] **Full suite** — 3080 passed, 38 skipped, 6 failed. The 6 (`tests/test_browse_mount.py::test_remote_*`) fail identically on `main` with these changes stashed: `zarr_aoi/browse.py:103` calls `os.path.isdir` on a remote path. **Pre-existing, unrelated, not fixed here.**
- [ ] **Reviewer check that needs CI:** the PowerShell edit cannot run on Linux (no `pwsh`) — the Windows release job on the next tag is the real proof. Verify the run produces and uploads the `.exe`.

### Re-cutting the Windows installer

v0.3.13's tag does not contain this fix, so re-running its failed job would fail the same way, and moving a published tag would desync the download page and the updater manifest. Recommended path after merge: bump to **v0.3.14** (`making-a-release`), which rebuilds all three platforms with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
