### PR TITLE
Fix tray-triggered Windows upgrades

### DIFF
--- a/fused_render/supervisor/_win32/update.py
+++ b/fused_render/supervisor/_win32/update.py
@@ -186,7 +186,10 @@ def _launch_installer(installer: str):
 
     try:
         info = shell.ShellExecuteEx(
-            fMask=shellcon.SEE_MASK_NOCLOSEPROCESS, lpFile=installer, nShow=1
+            fMask=shellcon.SEE_MASK_NOCLOSEPROCESS,
+            lpFile=installer,
+            lpDirectory=os.path.dirname(installer),
+            nShow=1,
         )
     except pywintypes.error as error:
         raise OSError(str(error)) from error

--- a/scripts/windows/installer.iss
+++ b/scripts/windows/installer.iss
@@ -10,7 +10,6 @@
 #ifndef OutputBaseName
   #define OutputBaseName "FusedRenderPy-setup"
 #endif
-
 ; FusedRenderPy: experiment/python-supervisor's own product identity — a
 ; distinct exe name, install dir, ProgID prefix, and AppId GUID from the
 ; shipping "FusedRender" product (Rust supervisor, feat/windows-desktop-
@@ -78,14 +77,14 @@ Type: files; Name: "{group}\FusedRender (Python Supervisor).lnk"
 Type: files; Name: "{group}\Uninstall FusedRender (Python Supervisor).lnk"
 
 [Icons]
-Name: "{group}\FusedRender"; Filename: "{app}\payload\{#ExeName}"; IconFilename: "{#InstalledIcon}"; AppUserModelID: "{#AppUserModelId}"
+Name: "{group}\FusedRender"; Filename: "{app}\payload\{#ExeName}"; WorkingDir: "{localappdata}"; IconFilename: "{#InstalledIcon}"; AppUserModelID: "{#AppUserModelId}"
 Name: "{group}\Uninstall FusedRender"; Filename: "{uninstallexe}"
 
 [Registry]
 #include BundleDir + "\registry.iss"
 
 [Run]
-Filename: "{app}\payload\{#ExeName}"; Description: "Launch FusedRender"; Flags: nowait postinstall skipifsilent
+Filename: "{app}\payload\{#ExeName}"; WorkingDir: "{localappdata}"; Description: "Launch FusedRender"; Flags: nowait postinstall skipifsilent
 
 [UninstallDelete]
 Type: filesandordirs; Name: "{app}"
@@ -95,6 +94,10 @@ Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\temp"
 Type: filesandordirs; Name: "{localappdata}\FusedRender\Desktop\logs"
 
 [Code]
+var
+  PayloadPrepared: Boolean;
+  PayloadActivated: Boolean;
+
 function NextVersionPart(var Version: String): Integer;
 var
   Separator: Integer;
@@ -142,7 +145,18 @@ function InitializeSetup(): Boolean;
 var
   InstalledVersion: String;
 begin
-  Result := True;
+  { Older updaters launch Setup without lpDirectory, so Setup inherits the
+    running app's payload\ working directory and locks the very directory the
+    upgrade must rename. Release that inherited directory before doing anything
+    else. Newer updaters also pass a safe lpDirectory, but the installer must
+    remain self-sufficient for upgrades from already-shipped versions. }
+  Result := SetCurrentDir(ExpandConstant('{tmp}'));
+  if not Result then
+  begin
+    MsgBox('Setup could not switch to its temporary working directory.',
+      mbError, MB_OK);
+    Exit;
+  end;
   if RegQueryStringValue(HKCU, '{#UninstallKey}', 'DisplayVersion', InstalledVersion) and
     (CompareVersions('{#AppVersion}', InstalledVersion) < 0) then
   begin
@@ -219,6 +233,37 @@ begin
   end;
 end;
 
+function PreparePayloadForInstall(): String;
+var
+  CurrentPayload: String;
+  PreviousPayload: String;
+begin
+  Result := '';
+  CurrentPayload := ExpandConstant('{app}\payload');
+  PreviousPayload := ExpandConstant('{app}\previous');
+  if not DirExists(CurrentPayload) then
+    Exit;
+
+  { Move the installed tree before Inno begins applying files or metadata. A
+    lock is therefore a PrepareToInstall failure (exit code 7), not an
+    AfterInstall expression error that Inno reports but then continues past. }
+  if DirExists(PreviousPayload) then
+  begin
+    DelTree(PreviousPayload, True, True, True);
+    if DirExists(PreviousPayload) then
+    begin
+      Result := 'The previous FusedRender payload could not be removed.';
+      Exit;
+    end;
+  end;
+  if not RenameWithRetry(CurrentPayload, PreviousPayload) then
+  begin
+    Result := 'The installed FusedRender payload could not be moved. Exit it from the tray and retry setup.';
+    Exit;
+  end;
+  PayloadPrepared := True;
+end;
+
 function PrepareToInstall(var NeedsRestart: Boolean): String;
 begin
   Result := '';
@@ -231,8 +276,22 @@ begin
     if not ShutdownSupervisor() then
       Result := 'FusedRender could not be stopped. Exit it from the tray and retry setup.'
     else
+    begin
       KillPayloadStragglers();
+      Result := PreparePayloadForInstall();
+    end;
   end;
+end;
+
+procedure RestorePreviousPayload();
+var
+  CurrentPayload: String;
+  PreviousPayload: String;
+begin
+  CurrentPayload := ExpandConstant('{app}\payload');
+  PreviousPayload := ExpandConstant('{app}\previous');
+  if not DirExists(CurrentPayload) and DirExists(PreviousPayload) then
+    RenameWithRetry(PreviousPayload, CurrentPayload);
 end;
 
 procedure ActivatePayload();
@@ -252,18 +311,22 @@ begin
     not FileExists(NewPayload + '\python\Lib\site-packages\fused_render\__init__.py') or
     not FileExists(NewPayload + '\python\Lib\site-packages\win32\win32job.pyd') or
     not FileExists(NewPayload + '\python\Lib\site-packages\fused_render\static\shell-dist\index.html') then
+  begin
+    RestorePreviousPayload();
     RaiseException('The new FusedRender payload is incomplete.');
-  DelTree(PreviousPayload, True, True, True);
+  end;
+  { Fresh installs have no prepared payload. Keep the old fallback for repair
+    installs whose tree appeared between PrepareToInstall and extraction. }
   if DirExists(CurrentPayload) and not RenameWithRetry(CurrentPayload, PreviousPayload) then
     RaiseException('The installed FusedRender payload could not be moved.');
   if not RenameWithRetry(NewPayload, CurrentPayload) then
   begin
     { Roll back with the same retry: the compensation rename races the identical
       transient locks, so a plain RenameFile here could leave no payload dir. }
-    if DirExists(PreviousPayload) then
-      RenameWithRetry(PreviousPayload, CurrentPayload);
+    RestorePreviousPayload();
     RaiseException('The new FusedRender payload could not be activated.');
   end;
+  PayloadActivated := True;
 end;
 
 function InitializeUninstall(): Boolean;
@@ -313,9 +376,21 @@ procedure CurStepChanged(CurStep: TSetupStep);
 begin
   if CurStep = ssPostInstall then
   begin
-    DelTree(ExpandConstant('{app}\previous'), True, True, True);
-    InstallWinFsp();
+    if PayloadActivated then
+    begin
+      DelTree(ExpandConstant('{app}\previous'), True, True, True);
+      InstallWinFsp();
+    end;
   end;
+end;
+
+procedure DeinitializeSetup();
+begin
+  { Cancel, extraction failure, or a failed activation must not strand the old
+    install under previous\. RecoverPayload on the next setup run is the second
+    safety net for hard process termination or power loss. }
+  if PayloadPrepared and not PayloadActivated then
+    RestorePreviousPayload();
 end;
 
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);

--- a/tests/test_win_supervisor_update.py
+++ b/tests/test_win_supervisor_update.py
@@ -5,9 +5,11 @@ import base64
 import hashlib
 import json
 import os
+import sys
 import tempfile
 import threading
 import time
+import types
 
 import pytest
 
@@ -61,6 +63,34 @@ def _install_key(monkeypatch) -> Ed25519PrivateKey:
 )
 def test_is_newer(candidate, current, expected):
     assert update._is_newer(candidate, current) is expected
+
+
+def test_launch_installer_uses_directory_outside_installed_payload(monkeypatch, tmp_path):
+    calls = []
+    shell = types.SimpleNamespace(
+        ShellExecuteEx=lambda **kwargs: calls.append(kwargs) or {"hProcess": object()}
+    )
+    shellcon = types.SimpleNamespace(SEE_MASK_NOCLOSEPROCESS=0x40)
+    shell_module = types.ModuleType("win32com.shell")
+    shell_module.shell = shell
+    shell_module.shellcon = shellcon
+    pywintypes = types.ModuleType("pywintypes")
+    pywintypes.error = OSError
+
+    monkeypatch.setitem(sys.modules, "pywintypes", pywintypes)
+    monkeypatch.setitem(sys.modules, "win32event", types.ModuleType("win32event"))
+    monkeypatch.setitem(sys.modules, "win32com.shell", shell_module)
+
+    installer = tmp_path / "FusedRenderPy-update.exe"
+    handle = update._launch_installer(str(installer))
+
+    assert handle is not None
+    assert calls == [{
+        "fMask": shellcon.SEE_MASK_NOCLOSEPROCESS,
+        "lpFile": str(installer),
+        "lpDirectory": str(tmp_path),
+        "nShow": 1,
+    }]
 
 
 def test_fetch_manifest_rejects_malformed(monkeypatch):


### PR DESCRIPTION
## Summary

- launch downloaded Windows installers with a working directory outside the installed payload
- make Setup immediately leave any inherited payload working directory, preserving compatibility with already-shipped tray updaters
- give Start-menu and post-install launches a safe working directory
- move the existing payload during `PrepareToInstall`, fail before extraction/metadata changes when it is locked, and restore the previous payload if installation or activation does not complete
- add a regression test for the updater launch directory

## Root cause

The installed shortcut ran FusedRender with `payload\` as its working directory. The tray updater then launched Setup with `ShellExecuteEx` but did not specify `lpDirectory`. Setup inherited `payload\` as its current directory and consequently held a lock on the directory it later tried to rename.

Launching the same installer manually worked because Explorer supplied a different working directory. In the failing tray flow, the late payload rename raised an Inno Setup expression/runtime error after installation work had already begun.

## Impact

Tray-triggered upgrades can now replace a running installation reliably. The installer also protects users upgrading from older releases: it changes its own working directory before shutdown or payload operations, performs the payload move as a preflight step, and restores the previous payload if installation does not activate successfully.

## Validation

- `uv run --extra dev pytest -q -n 0 -p no:cacheprovider --basetemp <workspace-temp> tests/test_win_supervisor_update.py tests/test_supervisor_shutdown.py`
  - 29 passed, 1 skipped
- built a complete patched 0.3.14 Windows installer
- started an installed, running 0.3.12 build and invoked **Install update 0.3.14** from its tray menu through a controlled local artifact route
- verified Setup reported a successful installation and restarted FusedRender
- verified the installed `payload.complete` marker and dist-info both report 0.3.14

The production update manifest was not changed during the E2E test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Windows install/upgrade orchestration and payload rename timing; mistakes could strand or corrupt installs, but rollback paths and compatibility for old updaters are explicit.
> 
> **Overview**
> Fixes **tray-initiated Windows upgrades** failing when Setup inherited `payload\` as the working directory and could not rename that tree mid-install.
> 
> The tray updater’s `_launch_installer` now passes **`lpDirectory`** to the staged installer’s folder (not the running app’s payload). Inno Setup **`InitializeSetup`** switches to **`{tmp}`** so already-shipped updaters that omit `lpDirectory` still work. Start Menu and post-install launches use **`WorkingDir: {localappdata}`** instead of defaulting into `payload\`.
> 
> The installer **moves the live `payload` to `previous` during `PrepareToInstall`** (before file extraction), fails early if the directory is locked, and **`RestorePreviousPayload`** / **`DeinitializeSetup`** roll back when activation does not complete. A regression test asserts the updater launch directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c39f7bfb3db05a36fdfe275fbe2b07389859b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->