### PR TITLE
App folders get local version control: git from birth, a commit per change

### DIFF
--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -88,6 +88,26 @@ def _message(labels: list[str]) -> str:
             + (f" +{extra} more" if extra > 0 else ""))
 
 
+def _requeue(due: list[tuple[str, list[str]]]) -> None:
+    """Put entries `_take_due` already popped back into `_pending` when they
+    could not be committed — merging into whatever a mark() added meanwhile,
+    same as mark() itself. Used when the worker is cancelled mid-batch so
+    shutdown's flush() still sees them instead of losing them silently."""
+    if not due:
+        return
+    now = time.monotonic()
+    with _lock:
+        for app_dir, labels in due:
+            entry = _pending.get(app_dir)
+            if entry is None:
+                _pending[app_dir] = {"first": now, "last": now,
+                                     "labels": list(labels)}
+            else:
+                for label in labels:
+                    if label not in entry["labels"]:
+                        entry["labels"].append(label)
+
+
 def _take_due() -> tuple[list[tuple[str, list[str]]], float | None]:
     """Pop every app whose debounce has expired; also the delay until the
     next one expires (None when nothing is pending)."""
@@ -117,11 +137,23 @@ async def _run() -> None:
             await _wake.wait()
             while True:
                 due, delay = _take_due()
-                for app_dir, labels in due:
-                    # commit() is best-effort and never raises; to_thread
-                    # keeps the subprocess wait off the event loop.
-                    await asyncio.to_thread(app_git.commit, app_dir,
-                                            _message(labels))
+                # due's entries are already gone from _pending, so a
+                # cancellation partway through this batch (stop(), mid
+                # shutdown) must put whatever wasn't committed yet back —
+                # otherwise flush() right after never sees them again and
+                # those changes go uncommitted across the reload.
+                remaining = list(due)
+                try:
+                    while remaining:
+                        app_dir, labels = remaining[0]
+                        # commit() is best-effort and never raises; to_thread
+                        # keeps the subprocess wait off the event loop.
+                        await asyncio.to_thread(app_git.commit, app_dir,
+                                                _message(labels))
+                        remaining.pop(0)
+                except asyncio.CancelledError:
+                    _requeue(remaining)
+                    raise
                 if delay is None:
                     break
                 await asyncio.sleep(delay)

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -41,6 +41,16 @@ _pending: dict[str, dict] = {}
 _loop: asyncio.AbstractEventLoop | None = None
 _wake: asyncio.Event | None = None
 _task: asyncio.Task | None = None
+_watchdog_started = False
+
+# The worker has twice been observed parked forever on an await that never
+# resumed — no exception, no running thread, marks stranded in _pending
+# (cause not yet pinned down; uvloop + 3.14 suspected). The watchdog is a
+# plain thread, immune to event-loop trouble by construction: when pending
+# work sits well past _MAX_AGE_S it logs the worker coroutine's await stack
+# (the autopsy the wedge never left behind) and commits inline so the user
+# never loses history to a stuck worker.
+_WATCHDOG_INTERVAL_S = 10.0
 
 
 def mark(path: str, verb: str) -> None:
@@ -138,12 +148,40 @@ async def _run() -> None:
             await asyncio.sleep(1)
 
 
+def _watchdog() -> None:
+    while True:
+        time.sleep(_WATCHDOG_INTERVAL_S)
+        task = _task
+        if task is None:
+            continue
+        with _lock:
+            oldest = min((e["first"] for e in _pending.values()), default=None)
+        if oldest is None:
+            continue
+        if time.monotonic() - oldest < _MAX_AGE_S + 2 * _WATCHDOG_INTERVAL_S:
+            continue
+        try:
+            frames = "; ".join(
+                f"{os.path.basename(f.f_code.co_filename)}:{f.f_lineno} "
+                f"{f.f_code.co_name}" for f in task.get_stack())
+        except Exception:
+            frames = "<unavailable>"
+        logger.error(
+            "app commit worker stuck (done=%s, stack: %s); "
+            "committing pending inline", task.done(), frames or "<empty>")
+        flush()
+
+
 def start() -> None:
     """Start the worker on the running loop (server startup event)."""
-    global _loop, _wake, _task
+    global _loop, _wake, _task, _watchdog_started
     _loop = asyncio.get_running_loop()
     _wake = asyncio.Event()
     _task = _loop.create_task(_run(), name="app-commit-queue")
+    if not _watchdog_started:
+        _watchdog_started = True
+        threading.Thread(target=_watchdog, name="app-commit-watchdog",
+                         daemon=True).start()
     _task.add_done_callback(_on_worker_done)
 
 

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -73,13 +73,15 @@ def mark(path: str, verb: str) -> None:
                 entry["last"] = now
             else:
                 entry["last"] = now
+        # TEMP diagnostic (missed-commit hunt).
+        logger.info("mark queued: %s (%s)", app_dir, label)
         loop, wake = _loop, _wake
         if loop is not None and wake is not None:
             # mark() runs on threadpool threads (the fs endpoints are sync
             # defs); this is the one loop-safe way to poke the worker.
             loop.call_soon_threadsafe(wake.set)
     except Exception:
-        logger.debug("app commit mark failed (%s)", path, exc_info=True)
+        logger.warning("app commit mark failed (%s)", path, exc_info=True)
 
 
 def _message(labels: list[str]) -> str:
@@ -130,8 +132,10 @@ async def _run() -> None:
                 for app_dir, labels in due:
                     # commit() is best-effort and never raises; to_thread
                     # keeps the subprocess wait off the event loop.
-                    await asyncio.to_thread(app_git.commit, app_dir,
-                                            _message(labels))
+                    ok = await asyncio.to_thread(app_git.commit, app_dir,
+                                                 _message(labels))
+                    # TEMP diagnostic (missed-commit hunt).
+                    logger.info("worker commit %s: committed=%s", app_dir, ok)
                 if delay is None:
                     break
                 await asyncio.sleep(delay)

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -1,0 +1,162 @@
+"""Debounced, serialized commits for app repos — one global worker task.
+
+/api/fs/* mutations no longer commit inline: they mark() the app they touched
+and return. A single asyncio task (started with the server, app.py) commits a
+dirty app once it has been quiet for _QUIET_S, or unconditionally once it has
+been dirty for _MAX_AGE_S (the editor autosaves every 250ms while the user
+types, so a pure quiet-period debounce could starve forever).
+
+Why a queue at all: with commits inline in the request handlers, two saves
+(or a save racing a Claude turn sweep) run `git add`/`git commit` on the same
+repo from two threadpool threads and the loser dies on index.lock — silently,
+because commits are best-effort. One worker serializes every git operation
+this server issues against app repos, so that contention is gone by
+construction, and a burst of keystroke-saves collapses into one meaningful
+commit ("Edit index.html" per editing pause) instead of a commit per
+autosave tick.
+
+Best-effort like app_git: nothing here may ever fail the mutation that
+triggered it. When the worker is not running (tests build the app without
+lifespan; shutdown already began) mark() falls back to committing inline —
+exactly the old behaviour. Scoping is app_git's: mark() resolves the path
+through app_git.app_dir_for and is a no-op anywhere outside an app folder.
+"""
+import asyncio
+import logging
+import os
+import threading
+import time
+
+from fused_render import app_git
+
+logger = logging.getLogger(__name__)
+
+_QUIET_S = 1.0    # commit after this much silence
+_MAX_AGE_S = 5.0  # ...but never sit on changes longer than this
+
+_lock = threading.Lock()
+# app_dir -> {"first": monotonic, "last": monotonic, "labels": [str, ...]}
+_pending: dict[str, dict] = {}
+
+_loop: asyncio.AbstractEventLoop | None = None
+_wake: asyncio.Event | None = None
+_task: asyncio.Task | None = None
+
+
+def mark(path: str, verb: str) -> None:
+    """Record that a successful mutation touched `path`; the worker commits
+    the containing app after the debounce. Inline (blocking) commit when the
+    worker is not running. No-op outside app dirs. Never raises."""
+    try:
+        app_dir = app_git.app_dir_for(path)
+        if app_dir is None:
+            return
+        label = f"{verb} {os.path.basename(path.rstrip(os.sep))}"
+        loop, wake = _loop, _wake
+        if loop is None or wake is None or _task is None or _task.done():
+            app_git.commit(path, label)
+            return
+        now = time.monotonic()
+        with _lock:
+            entry = _pending.get(app_dir)
+            if entry is None:
+                _pending[app_dir] = {"first": now, "last": now,
+                                     "labels": [label]}
+            elif label not in entry["labels"]:
+                entry["labels"].append(label)
+                entry["last"] = now
+            else:
+                entry["last"] = now
+        # mark() runs on threadpool threads (the fs endpoints are sync defs);
+        # this is the one loop-safe way to poke the worker from there.
+        loop.call_soon_threadsafe(wake.set)
+    except Exception:
+        logger.debug("app commit mark failed (%s)", path, exc_info=True)
+
+
+def _message(labels: list[str]) -> str:
+    """One subject line for a burst. Same verb throughout collapses to
+    'Edit a.html, b.css'; mixed verbs list the label pairs."""
+    if len(labels) == 1:
+        return labels[0]
+    verbs = {label.split(" ", 1)[0] for label in labels}
+    if len(verbs) == 1:
+        parts = [label.split(" ", 1)[1] for label in labels]
+        prefix = next(iter(verbs)) + " "
+    else:
+        parts, prefix = labels, ""
+    extra = len(parts) - 3
+    return (prefix + ", ".join(parts[:3])
+            + (f" +{extra} more" if extra > 0 else ""))
+
+
+def _take_due() -> tuple[list[tuple[str, list[str]]], float | None]:
+    """Pop every app whose debounce has expired; also the delay until the
+    next one expires (None when nothing is pending)."""
+    now = time.monotonic()
+    due: list[tuple[str, list[str]]] = []
+    delay: float | None = None
+    with _lock:
+        for app_dir in list(_pending):
+            entry = _pending[app_dir]
+            wait = min(_QUIET_S - (now - entry["last"]),
+                       _MAX_AGE_S - (now - entry["first"]))
+            if wait <= 0:
+                del _pending[app_dir]
+                due.append((app_dir, entry["labels"]))
+            else:
+                delay = wait if delay is None else min(delay, wait)
+    return due, delay
+
+
+async def _run() -> None:
+    while True:
+        await _wake.wait()
+        while True:
+            due, delay = _take_due()
+            for app_dir, labels in due:
+                # commit() is best-effort and never raises; to_thread keeps
+                # the subprocess wait off the event loop.
+                await asyncio.to_thread(app_git.commit, app_dir,
+                                        _message(labels))
+            if delay is None:
+                break
+            await asyncio.sleep(delay)
+        _wake.clear()
+        # A mark() between the empty _take_due and the clear would be lost
+        # with its wake-up eaten — re-arm if anything slipped in.
+        with _lock:
+            if _pending:
+                _wake.set()
+
+
+def start() -> None:
+    """Start the worker on the running loop (server startup event)."""
+    global _loop, _wake, _task
+    _loop = asyncio.get_running_loop()
+    _wake = asyncio.Event()
+    _task = _loop.create_task(_run(), name="app-commit-queue")
+
+
+async def stop() -> None:
+    """Stop the worker and flush whatever is still pending (server
+    shutdown). New mark() calls fall back to inline commits from here on."""
+    global _loop, _wake, _task
+    task, _task, _loop, _wake = _task, None, None, None
+    if task is not None:
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):
+            pass
+    await asyncio.to_thread(flush)
+
+
+def flush() -> None:
+    """Commit everything pending right now, ignoring the debounce."""
+    while True:
+        with _lock:
+            if not _pending:
+                return
+            app_dir, entry = _pending.popitem()
+        app_git.commit(app_dir, _message(entry["labels"]))

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -41,16 +41,6 @@ _pending: dict[str, dict] = {}
 _loop: asyncio.AbstractEventLoop | None = None
 _wake: asyncio.Event | None = None
 _task: asyncio.Task | None = None
-_watchdog_started = False
-
-# The worker has twice been observed parked forever on an await that never
-# resumed — no exception, no running thread, marks stranded in _pending
-# (cause not yet pinned down; uvloop + 3.14 suspected). The watchdog is a
-# plain thread, immune to event-loop trouble by construction: when pending
-# work sits well past _MAX_AGE_S it logs the worker coroutine's await stack
-# (the autopsy the wedge never left behind) and commits inline so the user
-# never loses history to a stuck worker.
-_WATCHDOG_INTERVAL_S = 10.0
 
 
 def mark(path: str, verb: str) -> None:
@@ -73,8 +63,6 @@ def mark(path: str, verb: str) -> None:
                 entry["last"] = now
             else:
                 entry["last"] = now
-        # TEMP diagnostic (missed-commit hunt).
-        logger.info("mark queued: %s (%s)", app_dir, label)
         loop, wake = _loop, _wake
         if loop is not None and wake is not None:
             # mark() runs on threadpool threads (the fs endpoints are sync
@@ -132,10 +120,8 @@ async def _run() -> None:
                 for app_dir, labels in due:
                     # commit() is best-effort and never raises; to_thread
                     # keeps the subprocess wait off the event loop.
-                    ok = await asyncio.to_thread(app_git.commit, app_dir,
-                                                 _message(labels))
-                    # TEMP diagnostic (missed-commit hunt).
-                    logger.info("worker commit %s: committed=%s", app_dir, ok)
+                    await asyncio.to_thread(app_git.commit, app_dir,
+                                            _message(labels))
                 if delay is None:
                     break
                 await asyncio.sleep(delay)
@@ -152,40 +138,12 @@ async def _run() -> None:
             await asyncio.sleep(1)
 
 
-def _watchdog() -> None:
-    while True:
-        time.sleep(_WATCHDOG_INTERVAL_S)
-        task = _task
-        if task is None:
-            continue
-        with _lock:
-            oldest = min((e["first"] for e in _pending.values()), default=None)
-        if oldest is None:
-            continue
-        if time.monotonic() - oldest < _MAX_AGE_S + 2 * _WATCHDOG_INTERVAL_S:
-            continue
-        try:
-            frames = "; ".join(
-                f"{os.path.basename(f.f_code.co_filename)}:{f.f_lineno} "
-                f"{f.f_code.co_name}" for f in task.get_stack())
-        except Exception:
-            frames = "<unavailable>"
-        logger.error(
-            "app commit worker stuck (done=%s, stack: %s); "
-            "committing pending inline", task.done(), frames or "<empty>")
-        flush()
-
-
 def start() -> None:
     """Start the worker on the running loop (server startup event)."""
-    global _loop, _wake, _task, _watchdog_started
+    global _loop, _wake, _task
     _loop = asyncio.get_running_loop()
     _wake = asyncio.Event()
     _task = _loop.create_task(_run(), name="app-commit-queue")
-    if not _watchdog_started:
-        _watchdog_started = True
-        threading.Thread(target=_watchdog, name="app-commit-watchdog",
-                         daemon=True).start()
     _task.add_done_callback(_on_worker_done)
 
 

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -109,23 +109,33 @@ def _take_due() -> tuple[list[tuple[str, list[str]]], float | None]:
 
 async def _run() -> None:
     while True:
-        await _wake.wait()
-        while True:
-            due, delay = _take_due()
-            for app_dir, labels in due:
-                # commit() is best-effort and never raises; to_thread keeps
-                # the subprocess wait off the event loop.
-                await asyncio.to_thread(app_git.commit, app_dir,
-                                        _message(labels))
-            if delay is None:
-                break
-            await asyncio.sleep(delay)
-        _wake.clear()
-        # A mark() between the empty _take_due and the clear would be lost
-        # with its wake-up eaten — re-arm if anything slipped in.
-        with _lock:
-            if _pending:
-                _wake.set()
+        # A dead worker silently strands every future mark() in _pending, so
+        # the loop body may only exit via cancellation: anything else logs
+        # the traceback (an unretrieved task exception surfaces at GC time
+        # or never) and keeps going.
+        try:
+            await _wake.wait()
+            while True:
+                due, delay = _take_due()
+                for app_dir, labels in due:
+                    # commit() is best-effort and never raises; to_thread
+                    # keeps the subprocess wait off the event loop.
+                    await asyncio.to_thread(app_git.commit, app_dir,
+                                            _message(labels))
+                if delay is None:
+                    break
+                await asyncio.sleep(delay)
+            _wake.clear()
+            # A mark() between the empty _take_due and the clear would be
+            # lost with its wake-up eaten — re-arm if anything slipped in.
+            with _lock:
+                if _pending:
+                    _wake.set()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("app commit worker cycle failed; continuing")
+            await asyncio.sleep(1)
 
 
 def start() -> None:
@@ -134,6 +144,18 @@ def start() -> None:
     _loop = asyncio.get_running_loop()
     _wake = asyncio.Event()
     _task = _loop.create_task(_run(), name="app-commit-queue")
+    _task.add_done_callback(_on_worker_done)
+
+
+def _on_worker_done(task: asyncio.Task) -> None:
+    # The loop body swallows everything but cancellation, so this firing
+    # outside shutdown means something impossible happened — say so loudly
+    # instead of letting the exception sit unretrieved forever.
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("app commit worker died", exc_info=exc)
 
 
 async def stop() -> None:

--- a/fused_render/app_commit_queue.py
+++ b/fused_render/app_commit_queue.py
@@ -16,10 +16,10 @@ commit ("Edit index.html" per editing pause) instead of a commit per
 autosave tick.
 
 Best-effort like app_git: nothing here may ever fail the mutation that
-triggered it. When the worker is not running (tests build the app without
-lifespan; shutdown already began) mark() falls back to committing inline —
-exactly the old behaviour. Scoping is app_git's: mark() resolves the path
-through app_git.app_dir_for and is a no-op anywhere outside an app folder.
+triggered it. Without a running worker (tests build the app without
+lifespan) marks just accumulate until the next flush(). Scoping is
+app_git's: mark() resolves the path through app_git.app_dir_for and is a
+no-op anywhere outside an app folder.
 """
 import asyncio
 import logging
@@ -45,17 +45,13 @@ _task: asyncio.Task | None = None
 
 def mark(path: str, verb: str) -> None:
     """Record that a successful mutation touched `path`; the worker commits
-    the containing app after the debounce. Inline (blocking) commit when the
-    worker is not running. No-op outside app dirs. Never raises."""
+    the containing app after the debounce (or the next flush() when the
+    worker is not running). No-op outside app dirs. Never raises."""
     try:
         app_dir = app_git.app_dir_for(path)
         if app_dir is None:
             return
         label = f"{verb} {os.path.basename(path.rstrip(os.sep))}"
-        loop, wake = _loop, _wake
-        if loop is None or wake is None or _task is None or _task.done():
-            app_git.commit(path, label)
-            return
         now = time.monotonic()
         with _lock:
             entry = _pending.get(app_dir)
@@ -67,9 +63,11 @@ def mark(path: str, verb: str) -> None:
                 entry["last"] = now
             else:
                 entry["last"] = now
-        # mark() runs on threadpool threads (the fs endpoints are sync defs);
-        # this is the one loop-safe way to poke the worker from there.
-        loop.call_soon_threadsafe(wake.set)
+        loop, wake = _loop, _wake
+        if loop is not None and wake is not None:
+            # mark() runs on threadpool threads (the fs endpoints are sync
+            # defs); this is the one loop-safe way to poke the worker.
+            loop.call_soon_threadsafe(wake.set)
     except Exception:
         logger.debug("app commit mark failed (%s)", path, exc_info=True)
 

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -20,13 +20,20 @@ Commits are scoped HARD to app dirs: exactly two levels under fused_dir(),
 with a `.git` of their own. A path anywhere else — including a user's real
 repository opened in the editor — is never committed to.
 
-Subprocess discipline: `git -C <dir>` instead of cwd=, close_fds=False, no
-start_new_session — keeps Popen on the posix_spawn path (no fork), because the
-server process has libproj resident and fork() runs PROJ's atfork handler into
-a SIGSEGV (see apps.py's _SESSION_HELPER comment).
+Subprocess discipline: git runs through os.posix_spawnp directly, NEVER
+subprocess. The server process gets libproj resident (importing the fused
+engine pulls geopandas→pyproj, and prefs' availability probe does that
+in-process), and from then on fork() runs PROJ's pthread_atfork child
+handler into a SIGSEGV before exec — subprocess.Popen forks here on macOS,
+so every `git add` died rc=-11 with empty stderr the moment the shell first
+polled /api/prefs (see apps.py's _SESSION_HELPER comment for the same crash;
+verified live in the field 2026-08-03). posix_spawn does not run atfork
+handlers, so this path stays alive no matter what the process has loaded.
 """
 import logging
 import os
+import selectors
+import signal
 import subprocess
 import time
 
@@ -51,11 +58,56 @@ _IDENTITY = ["-c", "user.name=Fused", "-c", "user.email=apps@fused.io"]
 _GITIGNORE = "*.html.json\n"
 
 
+def _spawn(argv: list[str], timeout: float) -> subprocess.CompletedProcess:
+    """subprocess.run(capture_output=True) built on os.posix_spawnp — see the
+    module docstring for why fork() (and therefore subprocess) is off-limits
+    here. Kills the child and returns rc=-SIGKILL on timeout."""
+    r_out, w_out = os.pipe()
+    r_err, w_err = os.pipe()
+    try:
+        pid = os.posix_spawnp(
+            argv[0], argv, dict(os.environ),
+            file_actions=[
+                (os.POSIX_SPAWN_DUP2, w_out, 1),
+                (os.POSIX_SPAWN_DUP2, w_err, 2),
+            ])
+    except Exception:
+        os.close(r_out)
+        os.close(r_err)
+        raise
+    finally:
+        os.close(w_out)
+        os.close(w_err)
+    buf = {r_out: bytearray(), r_err: bytearray()}
+    sel = selectors.DefaultSelector()
+    sel.register(r_out, selectors.EVENT_READ)
+    sel.register(r_err, selectors.EVENT_READ)
+    deadline = time.monotonic() + timeout
+    try:
+        while sel.get_map():
+            left = deadline - time.monotonic()
+            if left <= 0:
+                os.kill(pid, signal.SIGKILL)
+                break
+            for key, _ in sel.select(left):
+                chunk = os.read(key.fd, 65536)
+                if chunk:
+                    buf[key.fd] += chunk
+                else:
+                    sel.unregister(key.fd)
+    finally:
+        sel.close()
+        os.close(r_out)
+        os.close(r_err)
+    rc = os.waitstatus_to_exitcode(os.waitpid(pid, 0)[1])
+    return subprocess.CompletedProcess(
+        argv, rc,
+        buf[r_out].decode("utf-8", "replace"),
+        buf[r_err].decode("utf-8", "replace"))
+
+
 def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", app_dir, *_IDENTITY, *args],
-        capture_output=True, text=True, timeout=_GIT_TIMEOUT, close_fds=False,
-    )
+    return _spawn(["git", "-C", app_dir, *_IDENTITY, *args], _GIT_TIMEOUT)
 
 
 def _git_retry_lock(app_dir: str, *args: str) -> subprocess.CompletedProcess:

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -1,0 +1,101 @@
+"""Local version control for app folders (<workspace>/<tag>/<name>).
+
+Every app scaffolded by POST /api/apps/new ships with a git repo and a single
+boilerplate commit; after that, every change lands as its own small commit —
+each completed Claude turn (templates/claude/agent.py mirrors the commit
+helper here, since templates must not import fused_render, D166) and every
+manual mutation made through the editor's /api/fs endpoints (fs_mutate.py).
+
+Everything here is BEST-EFFORT: git may be missing, the folder may not be a
+repo (pre-feature apps, hand-made folders), a concurrent commit may hold
+index.lock. None of that may ever fail the operation that triggered the
+commit — a save that landed on disk is a success whether or not it was
+recorded. Helpers return False/None instead of raising.
+
+Commits are scoped HARD to app dirs: exactly two levels under fused_dir(),
+with a `.git` of their own. A path anywhere else — including a user's real
+repository opened in the editor — is never committed to.
+
+Subprocess discipline: `git -C <dir>` instead of cwd=, close_fds=False, no
+start_new_session — keeps Popen on the posix_spawn path (no fork), because the
+server process has libproj resident and fork() runs PROJ's atfork handler into
+a SIGSEGV (see apps.py's _SESSION_HELPER comment).
+"""
+import os
+import subprocess
+
+from fused_render.shell.seed import fused_dir
+
+_GIT_TIMEOUT = 30
+
+# Commit identity, passed per-invocation: an app folder is not the user's
+# repo, and the machine may have no global git identity at all — a fresh
+# machine must still get its boilerplate commit.
+_IDENTITY = ["-c", "user.name=Fused", "-c", "user.email=apps@fused.io"]
+
+# Session sidecars (<file>.json next to the entry html, agent.py) are chat
+# bookkeeping, not app content — keep them out of history.
+_GITIGNORE = "*.html.json\n"
+
+
+def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", app_dir, *_IDENTITY, *args],
+        capture_output=True, text=True, timeout=_GIT_TIMEOUT, close_fds=False,
+    )
+
+
+def app_dir_for(path: str) -> str | None:
+    """The app folder containing `path`, or None when the path is not inside
+    one. An app dir is exactly <fused_dir()>/<tag>/<name> — never the
+    workspace root, a tag dir, or anything outside the workspace."""
+    root = fused_dir()
+    ap = os.path.abspath(path)
+    if not ap.startswith(root + os.sep):
+        return None
+    rel = os.path.relpath(ap, root)
+    parts = rel.split(os.sep)
+    if len(parts) < 2 or parts[0].startswith(".") or parts[1].startswith("."):
+        return None
+    return os.path.join(root, parts[0], parts[1])
+
+
+def init_repo(app_dir: str) -> bool:
+    """git-init `app_dir` and land everything in it as one boilerplate commit.
+    True on success; False (never an exception) when git is missing or any
+    step fails — creation already succeeded and must stay that way."""
+    try:
+        if _git(app_dir, "init", "-q").returncode != 0:
+            return False
+        gi = os.path.join(app_dir, ".gitignore")
+        if not os.path.exists(gi):
+            with open(gi, "w", encoding="utf-8") as f:
+                f.write(_GITIGNORE)
+        if _git(app_dir, "add", "-A").returncode != 0:
+            return False
+        return _git(app_dir, "commit", "-q", "-m",
+                    "New app from starter").returncode == 0
+    except Exception:
+        return False
+
+
+def commit(path: str, message: str) -> bool:
+    """Commit everything pending in the app repo containing `path`.
+
+    No-op (False) when the path is not inside an app dir, the app dir has no
+    repo, there is nothing to commit, or git fails. True only when a commit
+    was actually created."""
+    try:
+        app_dir = app_dir_for(path)
+        if app_dir is None or not os.path.isdir(os.path.join(app_dir, ".git")):
+            return False
+        if _git(app_dir, "add", "-A").returncode != 0:
+            return False
+        # Nothing staged (e.g. the change was to an ignored sidecar): no
+        # commit, and no error either.
+        if _git(app_dir, "diff", "--cached", "--quiet").returncode == 0:
+            return False
+        return _git(app_dir, "commit", "-q", "-m",
+                    message or "Update").returncode == 0
+    except Exception:
+        return False

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -20,21 +20,24 @@ Commits are scoped HARD to app dirs: exactly two levels under fused_dir(),
 with a `.git` of their own. A path anywhere else — including a user's real
 repository opened in the editor — is never committed to.
 
-Subprocess discipline: git runs through os.posix_spawnp directly, NEVER
-subprocess. The server process gets libproj resident (importing the fused
-engine pulls geopandas→pyproj, and prefs' availability probe does that
-in-process), and from then on fork() runs PROJ's pthread_atfork child
-handler into a SIGSEGV before exec — subprocess.Popen forks here on macOS,
-so every `git add` died rc=-11 with empty stderr the moment the shell first
-polled /api/prefs (see apps.py's _SESSION_HELPER comment for the same crash;
-verified live in the field 2026-08-03). posix_spawn does not run atfork
-handlers, so this path stays alive no matter what the process has loaded.
+Subprocess discipline: `git -C <dir>` (never `cwd=`) and `close_fds=False`,
+matching every other subprocess spawn in this codebase (agent.py, versions.py,
+executor.py, server/ai.py). The server process gets libproj resident
+(importing the fused engine pulls geopandas→pyproj, and prefs' availability
+probe does that in-process), and from then on a plain fork() runs PROJ's
+pthread_atfork child handler into a SIGSEGV before exec — the default
+close_fds=True forks here on macOS, so every `git add` died rc=-11 with empty
+stderr the moment the shell first polled /api/prefs (see apps.py's
+_SESSION_HELPER comment for the same crash; verified live in the field
+2026-08-03). close_fds=False makes CPython take the posix_spawn path instead,
+which runs no atfork handlers — and unlike a hand-rolled os.posix_spawnp call,
+subprocess.run degrades to CreateProcess on Windows rather than raising
+AttributeError (there is no fork() to work around there in the first place).
 """
 import logging
 import os
-import selectors
-import signal
 import subprocess
+import sys
 import time
 
 from fused_render.shell.seed import fused_dir
@@ -58,56 +61,17 @@ _IDENTITY = ["-c", "user.name=Fused", "-c", "user.email=apps@fused.io"]
 _GITIGNORE = "*.html.json\n"
 
 
-def _spawn(argv: list[str], timeout: float) -> subprocess.CompletedProcess:
-    """subprocess.run(capture_output=True) built on os.posix_spawnp — see the
-    module docstring for why fork() (and therefore subprocess) is off-limits
-    here. Kills the child and returns rc=-SIGKILL on timeout."""
-    r_out, w_out = os.pipe()
-    r_err, w_err = os.pipe()
-    try:
-        pid = os.posix_spawnp(
-            argv[0], argv, dict(os.environ),
-            file_actions=[
-                (os.POSIX_SPAWN_DUP2, w_out, 1),
-                (os.POSIX_SPAWN_DUP2, w_err, 2),
-            ])
-    except Exception:
-        os.close(r_out)
-        os.close(r_err)
-        raise
-    finally:
-        os.close(w_out)
-        os.close(w_err)
-    buf = {r_out: bytearray(), r_err: bytearray()}
-    sel = selectors.DefaultSelector()
-    sel.register(r_out, selectors.EVENT_READ)
-    sel.register(r_err, selectors.EVENT_READ)
-    deadline = time.monotonic() + timeout
-    try:
-        while sel.get_map():
-            left = deadline - time.monotonic()
-            if left <= 0:
-                os.kill(pid, signal.SIGKILL)
-                break
-            for key, _ in sel.select(left):
-                chunk = os.read(key.fd, 65536)
-                if chunk:
-                    buf[key.fd] += chunk
-                else:
-                    sel.unregister(key.fd)
-    finally:
-        sel.close()
-        os.close(r_out)
-        os.close(r_err)
-    rc = os.waitstatus_to_exitcode(os.waitpid(pid, 0)[1])
-    return subprocess.CompletedProcess(
-        argv, rc,
-        buf[r_out].decode("utf-8", "replace"),
-        buf[r_err].decode("utf-8", "replace"))
-
-
 def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
-    return _spawn(["git", "-C", app_dir, *_IDENTITY, *args], _GIT_TIMEOUT)
+    """One git invocation against the app repo — see the module docstring for
+    the close_fds=False discipline. May raise subprocess.TimeoutExpired past
+    _GIT_TIMEOUT; every caller in this file is already wrapped in a broad
+    except Exception, so a hung git never escapes as an unhandled error."""
+    return subprocess.run(
+        ["git", "-C", app_dir, *_IDENTITY, *args],
+        capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        close_fds=False,
+        creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+    )
 
 
 def _git_retry_lock(app_dir: str, *args: str) -> subprocess.CompletedProcess:

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -99,7 +99,7 @@ def init_repo(app_dir: str) -> bool:
         return _git(app_dir, "commit", "-q", "-m",
                     "New app from starter").returncode == 0
     except Exception:
-        logger.debug("init_repo failed for %s", app_dir, exc_info=True)
+        logger.warning("init_repo failed for %s", app_dir, exc_info=True)
         return False
 
 
@@ -115,7 +115,7 @@ def commit(path: str, message: str) -> bool:
             return False
         r = _git_retry_lock(app_dir, "add", "-A")
         if r.returncode != 0:
-            logger.debug("app commit skipped (%s): add failed: %s",
+            logger.warning("app commit skipped (%s): add failed: %s",
                          app_dir, (r.stderr or "").strip())
             return False
         # Nothing staged (e.g. the change was to an ignored sidecar): no
@@ -124,10 +124,10 @@ def commit(path: str, message: str) -> bool:
             return False
         r = _git_retry_lock(app_dir, "commit", "-q", "-m", message or "Update")
         if r.returncode != 0:
-            logger.debug("app commit skipped (%s): commit failed: %s",
+            logger.warning("app commit skipped (%s): commit failed: %s",
                          app_dir, (r.stderr or "").strip())
             return False
         return True
     except Exception:
-        logger.debug("app commit skipped (%s): unexpected", path, exc_info=True)
+        logger.warning("app commit skipped (%s): unexpected", path, exc_info=True)
         return False

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -115,8 +115,9 @@ def commit(path: str, message: str) -> bool:
             return False
         r = _git_retry_lock(app_dir, "add", "-A")
         if r.returncode != 0:
-            logger.warning("app commit skipped (%s): add failed: %s",
-                         app_dir, (r.stderr or "").strip())
+            logger.warning("app commit skipped (%s): add failed rc=%s "
+                           "stdout=%r stderr=%r", app_dir, r.returncode,
+                           (r.stdout or "").strip(), (r.stderr or "").strip())
             return False
         # Nothing staged (e.g. the change was to an ignored sidecar): no
         # commit, and no error either.
@@ -124,8 +125,9 @@ def commit(path: str, message: str) -> bool:
             return False
         r = _git_retry_lock(app_dir, "commit", "-q", "-m", message or "Update")
         if r.returncode != 0:
-            logger.warning("app commit skipped (%s): commit failed: %s",
-                         app_dir, (r.stderr or "").strip())
+            logger.warning("app commit skipped (%s): commit failed rc=%s "
+                           "stdout=%r stderr=%r", app_dir, r.returncode,
+                           (r.stdout or "").strip(), (r.stderr or "").strip())
             return False
         return True
     except Exception:

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -10,7 +10,10 @@ Everything here is BEST-EFFORT: git may be missing, the folder may not be a
 repo (pre-feature apps, hand-made folders), a concurrent commit may hold
 index.lock. None of that may ever fail the operation that triggered the
 commit — a save that landed on disk is a success whether or not it was
-recorded. Helpers return False/None instead of raising.
+recorded. Helpers return False/None instead of raising, and every skipped
+commit says why at DEBUG level so a "why didn't this commit?" has an answer
+in the server log. A missed commit is also not a lost change: the next
+successful commit's `add -A` sweeps everything pending.
 
 Commits are scoped HARD to app dirs: exactly two levels under fused_dir(),
 with a `.git` of their own. A path anywhere else — including a user's real
@@ -21,12 +24,21 @@ start_new_session — keeps Popen on the posix_spawn path (no fork), because the
 server process has libproj resident and fork() runs PROJ's atfork handler into
 a SIGSEGV (see apps.py's _SESSION_HELPER comment).
 """
+import logging
 import os
 import subprocess
+import time
 
 from fused_render.shell.seed import fused_dir
 
+logger = logging.getLogger(__name__)
+
 _GIT_TIMEOUT = 30
+
+# One short retry when another writer (a Claude turn's fallback sweep, a
+# second editor save) holds index.lock. Best-effort still — after the retry
+# the change just waits for the next commit's `add -A`.
+_LOCK_RETRY_DELAY_S = 0.3
 
 # Commit identity, passed per-invocation: an app folder is not the user's
 # repo, and the machine may have no global git identity at all — a fresh
@@ -43,6 +55,16 @@ def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
         ["git", "-C", app_dir, *_IDENTITY, *args],
         capture_output=True, text=True, timeout=_GIT_TIMEOUT, close_fds=False,
     )
+
+
+def _git_retry_lock(app_dir: str, *args: str) -> subprocess.CompletedProcess:
+    """Like _git, with one retry when the failure is index.lock contention —
+    the only failure that is expected to be gone milliseconds later."""
+    r = _git(app_dir, *args)
+    if r.returncode != 0 and "index.lock" in (r.stderr or ""):
+        time.sleep(_LOCK_RETRY_DELAY_S)
+        r = _git(app_dir, *args)
+    return r
 
 
 def app_dir_for(path: str) -> str | None:
@@ -76,6 +98,7 @@ def init_repo(app_dir: str) -> bool:
         return _git(app_dir, "commit", "-q", "-m",
                     "New app from starter").returncode == 0
     except Exception:
+        logger.debug("init_repo failed for %s", app_dir, exc_info=True)
         return False
 
 
@@ -89,13 +112,21 @@ def commit(path: str, message: str) -> bool:
         app_dir = app_dir_for(path)
         if app_dir is None or not os.path.isdir(os.path.join(app_dir, ".git")):
             return False
-        if _git(app_dir, "add", "-A").returncode != 0:
+        r = _git_retry_lock(app_dir, "add", "-A")
+        if r.returncode != 0:
+            logger.debug("app commit skipped (%s): add failed: %s",
+                         app_dir, (r.stderr or "").strip())
             return False
         # Nothing staged (e.g. the change was to an ignored sidecar): no
         # commit, and no error either.
         if _git(app_dir, "diff", "--cached", "--quiet").returncode == 0:
             return False
-        return _git(app_dir, "commit", "-q", "-m",
-                    message or "Update").returncode == 0
+        r = _git_retry_lock(app_dir, "commit", "-q", "-m", message or "Update")
+        if r.returncode != 0:
+            logger.debug("app commit skipped (%s): commit failed: %s",
+                         app_dir, (r.stderr or "").strip())
+            return False
+        return True
     except Exception:
+        logger.debug("app commit skipped (%s): unexpected", path, exc_info=True)
         return False

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -4,7 +4,8 @@ Every app scaffolded by POST /api/apps/new ships with a git repo and a single
 boilerplate commit; after that, every change lands as its own small commit —
 each completed Claude turn (templates/claude/agent.py mirrors the commit
 helper here, since templates must not import fused_render, D166) and every
-manual mutation made through the editor's /api/fs endpoints (fs_mutate.py).
+manual mutation made through the editor's /api/fs endpoints (fs_mutate.py,
+debounced/serialized through app_commit_queue's single worker).
 
 Everything here is BEST-EFFORT: git may be missing, the folder may not be a
 repo (pre-feature apps, hand-made folders), a concurrent commit may hold

--- a/fused_render/app_starter/CLAUDE.md
+++ b/fused_render/app_starter/CLAUDE.md
@@ -16,6 +16,17 @@ the full contract for `.html` views and `.py` data files: the `fused` bridge,
 params-as-state wiring, file IO, theming, and debugging blank views /
 traceback overlays.
 
+## Version control
+
+This folder is a local git repository (initialised at creation with the
+starter as its first commit). **Commit as you work, in small chunks** — after
+every coherent change, even tiny ones (a copy tweak, a single style fix, one
+function). Never batch a whole task into one commit, and never leave the tree
+dirty at the end of a turn: finish every turn with `git add -A` and a commit.
+Use short imperative subjects ("Add dark theme toggle", "Fix param sync").
+Don't push, don't add remotes, don't rewrite history — this repo is purely
+local undo history for the app.
+
 fused-render installs that skill (and its siblings, `fused-render-usage` and
 `fused-render-custom-templates`) into Claude Code's user-level skills
 directory and keeps them up to date, so it is available here by name. If the

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -198,7 +198,7 @@ def create_app(start_dir: str) -> FastAPI:
     # Debounced app-repo committer (app_commit_queue): the /api/fs mutation
     # hooks mark apps dirty, this one worker turns each editing burst into a
     # single commit. Startup event on purpose — tests that build the app
-    # without lifespan get the inline-commit fallback instead. Shutdown
+    # without lifespan queue marks and flush() them explicitly. Shutdown
     # flushes so a pending commit is not dropped by a dev-server reload.
     @app.on_event("startup")
     async def _startup_commit_queue():

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -17,6 +17,7 @@ import os
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
+from fused_render import app_commit_queue
 from fused_render import calls as shell_calls
 from fused_render.account import router as account_router
 from fused_render.deploy import router as deploy_router
@@ -193,6 +194,19 @@ def create_app(start_dir: str) -> FastAPI:
     @app.on_event("shutdown")
     async def _startup_shutdown_ai():
         await shutdown_ai_session()
+
+    # Debounced app-repo committer (app_commit_queue): the /api/fs mutation
+    # hooks mark apps dirty, this one worker turns each editing burst into a
+    # single commit. Startup event on purpose — tests that build the app
+    # without lifespan get the inline-commit fallback instead. Shutdown
+    # flushes so a pending commit is not dropped by a dev-server reload.
+    @app.on_event("startup")
+    async def _startup_commit_queue():
+        app_commit_queue.start()
+
+    @app.on_event("shutdown")
+    async def _shutdown_commit_queue():
+        await app_commit_queue.stop()
 
     app.exception_handler(Exception)(unhandled_exception)
 

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -91,10 +91,14 @@ def export_app_env() -> None:
     refreshed on every store write, not just at startup.
     """
     from fused_render.shell import mounts as shell_mounts
+    from fused_render.shell import seed as shell_seed
     from fused_render.shell import storage as shell_storage
 
     os.environ["FUSED_RENDER_HOME_DIR"] = shell_storage.home_dir()
     os.environ["FUSED_RENDER_MOUNTS_DIR"] = shell_mounts.mounts_dir()
+    # Where app folders live — the claude template commits a finished turn
+    # into the containing app's repo, and scopes that to this workspace.
+    os.environ["FUSED_RENDER_WORKSPACE_DIR"] = shell_seed.fused_dir()
     shell_mounts.export_ro_mounts_env()
     _export_bundled_uv_path()
 

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -729,6 +729,7 @@ async def api_fs_upload(request: Request, file: UploadFile = File(...),
         # Both refusals are 403; only a read-only target is `readonly`.
         unauthorized=_require_fused(x_fused) is not None,
     )
+    _commit_mutation(result, "Upload", path)
     return result
 
 @router.post("/api/fs/mkdir")

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -31,8 +31,8 @@ def _commit_mutation(result, verb: str, *paths) -> None:
     App folders (<workspace>/<tag>/<name>) are version-controlled from
     creation (app_git); editor-driven changes get the same history as Claude
     turns. The commit itself is debounced and serialized through
-    app_commit_queue's single worker (inline fallback when it isn't running),
-    so a burst of autosaves becomes one commit and two saves can never race
+    app_commit_queue's single worker, so a burst of autosaves becomes one
+    commit and two saves can never race
     each other on the repo's index.lock. A refused mutation (any JSONResponse
     error status) commits nothing, and everything downstream is best-effort
     and hard-scoped to app dirs — a git failure never fails the mutation that

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -16,12 +16,36 @@ from fastapi.responses import (
     StreamingResponse,
 )
 
+from fused_render import app_git
 from fused_render import calls as shell_calls
 from fused_render.server.common import _error, _require_fused
 from fused_render.server.mount import _invalidate_stat_cache, _mount_probe, _mount_stat_payload, _mutation_result_payload, _probe_path, _stat_payload, _writable
 from fused_render.server.walk import _mount_list_error_response
 
 router = APIRouter()
+
+
+def _commit_mutation(result, verb: str, *paths) -> None:
+    """Record a successful mutation as a commit in the app repo it touched.
+
+    App folders (<workspace>/<tag>/<name>) are version-controlled from
+    creation (app_git); every editor-driven change to one becomes its own
+    small commit so manual edits get the same history as Claude turns. A
+    refused mutation (any JSONResponse error status) commits nothing.
+    app_git.commit is best-effort and hard-scoped to app dirs — everywhere
+    else on disk this is a no-op, and a git failure never fails the mutation
+    that already landed."""
+    if getattr(result, "status_code", 200) != 200:
+        return
+    done = set()
+    for p in paths:
+        if not isinstance(p, str) or not p:
+            continue
+        app_dir = app_git.app_dir_for(p)
+        if app_dir is None or app_dir in done:
+            continue
+        done.add(app_dir)
+        app_git.commit(p, f"{verb} {os.path.basename(p.rstrip(os.sep))}")
 
 
 
@@ -675,6 +699,7 @@ def api_fs_write(request: Request, body: dict = Body(...),
         # so there is still one rule (it allocates nothing when it passes).
         unauthorized=_require_fused(x_fused) is not None,
     )
+    _commit_mutation(result, "Edit", body.get("path"))
     return result
 
 @router.post("/api/fs/upload")
@@ -714,6 +739,7 @@ def api_fs_mkdir(body: dict = Body(...), x_fused: str | None = Header(default=No
 def api_fs_delete(body: dict = Body(...), x_fused: str | None = Header(default=None)):
     result = _fs_delete(body, x_fused)
     _invalidate_stat_cache(body.get("path"))
+    _commit_mutation(result, "Delete", body.get("path"))
     return result
 
 @router.post("/api/fs/rename")
@@ -721,6 +747,8 @@ def api_fs_rename(body: dict = Body(...), x_fused: str | None = Header(default=N
     result = _fs_rename(body, x_fused)
     # A move changes both ends: src disappears, dst appears.
     _invalidate_stat_cache(body.get("src"), body.get("dst"))
+    # Both ends: a cross-app move changes two repos (dedup'd when same app).
+    _commit_mutation(result, "Rename", body.get("dst"), body.get("src"))
     return result
 
 @router.post("/api/fs/copy")
@@ -728,4 +756,5 @@ def api_fs_copy(body: dict = Body(...), x_fused: str | None = Header(default=Non
     result = _fs_copy(body, x_fused)
     # A copy only writes dst; src is untouched, so its cached stat stays valid.
     _invalidate_stat_cache(body.get("dst"))
+    _commit_mutation(result, "Add", body.get("dst"))
     return result

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import shutil
 import stat as stat_mod
@@ -24,7 +23,6 @@ from fused_render.server.mount import _invalidate_stat_cache, _mount_probe, _mou
 from fused_render.server.walk import _mount_list_error_response
 
 router = APIRouter()
-logger = logging.getLogger(__name__)
 
 
 def _commit_mutation(result, verb: str, *paths) -> None:
@@ -46,8 +44,6 @@ def _commit_mutation(result, verb: str, *paths) -> None:
         if not isinstance(p, str) or not p:
             continue
         app_dir = app_git.app_dir_for(p)
-        # TEMP diagnostic (missed-commit hunt): trace every hook decision.
-        logger.info("commit hook: verb=%s path=%r app_dir=%r", verb, p, app_dir)
         if app_dir is None or app_dir in done:
             continue
         done.add(app_dir)

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import shutil
 import stat as stat_mod
@@ -23,6 +24,7 @@ from fused_render.server.mount import _invalidate_stat_cache, _mount_probe, _mou
 from fused_render.server.walk import _mount_list_error_response
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 def _commit_mutation(result, verb: str, *paths) -> None:
@@ -44,6 +46,8 @@ def _commit_mutation(result, verb: str, *paths) -> None:
         if not isinstance(p, str) or not p:
             continue
         app_dir = app_git.app_dir_for(p)
+        # TEMP diagnostic (missed-commit hunt): trace every hook decision.
+        logger.info("commit hook: verb=%s path=%r app_dir=%r", verb, p, app_dir)
         if app_dir is None or app_dir in done:
             continue
         done.add(app_dir)

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -16,7 +16,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 
-from fused_render import app_git
+from fused_render import app_commit_queue, app_git
 from fused_render import calls as shell_calls
 from fused_render.server.common import _error, _require_fused
 from fused_render.server.mount import _invalidate_stat_cache, _mount_probe, _mount_stat_payload, _mutation_result_payload, _probe_path, _stat_payload, _writable
@@ -26,15 +26,17 @@ router = APIRouter()
 
 
 def _commit_mutation(result, verb: str, *paths) -> None:
-    """Record a successful mutation as a commit in the app repo it touched.
+    """Record a successful mutation for commit in the app repo it touched.
 
     App folders (<workspace>/<tag>/<name>) are version-controlled from
-    creation (app_git); every editor-driven change to one becomes its own
-    small commit so manual edits get the same history as Claude turns. A
-    refused mutation (any JSONResponse error status) commits nothing.
-    app_git.commit is best-effort and hard-scoped to app dirs — everywhere
-    else on disk this is a no-op, and a git failure never fails the mutation
-    that already landed."""
+    creation (app_git); editor-driven changes get the same history as Claude
+    turns. The commit itself is debounced and serialized through
+    app_commit_queue's single worker (inline fallback when it isn't running),
+    so a burst of autosaves becomes one commit and two saves can never race
+    each other on the repo's index.lock. A refused mutation (any JSONResponse
+    error status) commits nothing, and everything downstream is best-effort
+    and hard-scoped to app dirs — a git failure never fails the mutation that
+    already landed, and nothing outside an app dir is ever committed to."""
     if getattr(result, "status_code", 200) != 200:
         return
     done = set()
@@ -45,7 +47,7 @@ def _commit_mutation(result, verb: str, *paths) -> None:
         if app_dir is None or app_dir in done:
             continue
         done.add(app_dir)
-        app_git.commit(p, f"{verb} {os.path.basename(p.rstrip(os.sep))}")
+        app_commit_queue.mark(p, verb)
 
 
 

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -189,19 +189,21 @@ def _claude_agent():
 
 
 def _record_session_when_ready(agent, run_id: str) -> None:
-    """Poll the detached run until its session id lands in the sidecar.
+    """Poll the detached run until it finishes.
 
     agent._poll is what writes the sidecar (first poll that sees the session
-    id records it, one-shot via the run's `recorded` marker) — but nobody is
-    polling until the user opens the new app's claude chat, which may be
-    never. This background loop does the minimum: poll until recorded or the
-    run ends, so the session is listed when the user does look."""
-    for _ in range(300):  # ~10 min at 2 s — a session id arrives in seconds
+    id records it, one-shot via the run's `recorded` marker) AND what commits
+    the finished turn into the app's repo (one-shot via `committed`) — but
+    nobody is polling until the user opens the new app's claude chat, which
+    may be never. This background loop polls all the way to `done` so both
+    happen regardless: the session is listed when the user does look, and the
+    scaffolding turn's work is committed."""
+    for _ in range(1800):  # ~1 h at 2 s — a scaffolding turn can run long
         try:
             data = agent._poll(run_id)
         except Exception:
             return  # bookkeeping only; never let it matter
-        if data.get("session_id") or data.get("done"):
+        if data.get("done"):
             return
         time.sleep(2)
 
@@ -334,6 +336,14 @@ def api_new_app(body: dict = Body(...), x_fused: str | None = Header(default=Non
     from fused_render.user_skills import sync_user_skills
 
     sync_user_skills()
+
+    # Version control from birth: every new app is a git repo whose first
+    # commit is the untouched starter, BEFORE any session runs — so the
+    # scaffolding turn's work diffs against the boilerplate, not nothing.
+    # Best-effort (no git on the machine still gets a working app).
+    from fused_render import app_git
+
+    app_git.init_repo(dest)
 
     entry_html = os.path.join(dest, "index.html")
     run_id, session_error = None, None

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -828,10 +828,14 @@ def _app_dir_for(path: str) -> str:
 
 
 def _commit_turn(file: str, message: str) -> None:
-    """Commit whatever a finished turn left in the target's APP repo.
+    """FALLBACK sweep: commit whatever a finished turn left UNcommitted in
+    the target's APP repo.
 
     App folders are version-controlled from creation (fused_render/app_git.py)
-    and every Claude turn must land as its own small commit. Hard-scoped: a
+    and the app's CLAUDE.md instructs claude to commit its own work in small
+    chunks as it goes — when it did, the tree is clean and this is a no-op.
+    This sweep only catches the turns where that instruction was not honoured,
+    so no turn's work is ever left outside history. Hard-scoped: a
     target outside an app dir, or an app dir without a `.git`, commits nothing
     — this template also chats about files in arbitrary folders, and silently
     committing into a user's real repository is the one wrong move.
@@ -991,13 +995,18 @@ def _poll(run_id: str) -> dict:
     except (OSError, json.JSONDecodeError):
         meta = {}
 
-    # First poll that sees the run finished commits its work into the app's
-    # repo (one-shot via a marker, like the sidecar record below). Errors
-    # commit too: a crashed turn may still have edited files, and history
-    # must hold every turn — the marker is claimed BEFORE the commit so a
-    # racing concurrent poll can't double-commit.
+    # First poll that sees the run finished CLEANLY sweeps anything left
+    # uncommitted into the app's repo (one-shot via a marker, like the
+    # sidecar record below). This is a FALLBACK: the app's CLAUDE.md tells
+    # claude to commit as it works and end every turn with a clean tree, so
+    # when it honoured that this add -A finds nothing and no commit happens.
+    # Errored turns are skipped — a crash mid-edit is not a state worth
+    # enshrining; the next clean turn's sweep picks the survivors up. The
+    # marker is claimed BEFORE the commit so a racing concurrent poll can't
+    # double-commit.
     commit_marker = os.path.join(run_dir, "committed")
-    if done and "file" in meta and not os.path.exists(commit_marker):
+    if done and not error and "file" in meta \
+            and not os.path.exists(commit_marker):
         try:
             fd = os.open(commit_marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
             os.close(fd)

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -58,6 +58,7 @@ if "__file__" not in globals():
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(HERE), "shared"))
+from appenv import workspace_dir as _workspace_dir
 from procutil import pid_alive as _pid_alive
 
 def _runs_root() -> str:
@@ -811,6 +812,57 @@ def _start(file: str, message: str, session_id: str, model: str,
     return {"run_id": run_id}
 
 
+def _app_dir_for(path: str) -> str:
+    """The app folder containing `path`, or "" when it is not inside one.
+    An app dir is exactly <workspace>/<tag>/<name> under the Fused workspace
+    (appenv.workspace_dir). Mirrors fused_render/app_git.py:app_dir_for —
+    keep the two in step (templates must not import fused_render, D166)."""
+    root = _workspace_dir()
+    ap = os.path.abspath(path)
+    if not ap.startswith(root + os.sep):
+        return ""
+    parts = os.path.relpath(ap, root).split(os.sep)
+    if len(parts) < 2 or parts[0].startswith(".") or parts[1].startswith("."):
+        return ""
+    return os.path.join(root, parts[0], parts[1])
+
+
+def _commit_turn(file: str, message: str) -> None:
+    """Commit whatever a finished turn left in the target's APP repo.
+
+    App folders are version-controlled from creation (fused_render/app_git.py)
+    and every Claude turn must land as its own small commit. Hard-scoped: a
+    target outside an app dir, or an app dir without a `.git`, commits nothing
+    — this template also chats about files in arbitrary folders, and silently
+    committing into a user's real repository is the one wrong move.
+
+    Best-effort throughout: no git, index.lock contention, nothing staged —
+    all mean "no commit", never a poll error. Identity rides per-invocation
+    (`-c user.*`) so a machine with no git config still commits, and `git -C`
+    replaces cwd= to keep Popen on the posix_spawn path (see apps.py)."""
+    app_dir = _app_dir_for(file)
+    if not app_dir or not os.path.isdir(os.path.join(app_dir, ".git")):
+        return
+    subject = " ".join((message or "").split())
+    subject = "Claude: " + (subject[:60] + "…" if len(subject) > 60 else subject) \
+        if subject else "Claude turn"
+
+    def git(*args):
+        return subprocess.run(
+            ["git", "-C", app_dir, "-c", "user.name=Fused",
+             "-c", "user.email=apps@fused.io", *args],
+            capture_output=True, text=True, timeout=30, close_fds=False)
+
+    try:
+        if git("add", "-A").returncode != 0:
+            return
+        if git("diff", "--cached", "--quiet").returncode == 0:
+            return  # nothing to commit (turn changed no files)
+        git("commit", "-q", "-m", subject)
+    except Exception:
+        pass
+
+
 def _alive(run_dir: str) -> bool:
     """Whether this run's claude process is still going.
 
@@ -938,6 +990,20 @@ def _poll(run_id: str) -> dict:
             meta = {}
     except (OSError, json.JSONDecodeError):
         meta = {}
+
+    # First poll that sees the run finished commits its work into the app's
+    # repo (one-shot via a marker, like the sidecar record below). Errors
+    # commit too: a crashed turn may still have edited files, and history
+    # must hold every turn — the marker is claimed BEFORE the commit so a
+    # racing concurrent poll can't double-commit.
+    commit_marker = os.path.join(run_dir, "committed")
+    if done and "file" in meta and not os.path.exists(commit_marker):
+        try:
+            fd = os.open(commit_marker, os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            _commit_turn(meta["file"], meta.get("message", ""))
+        except OSError:
+            pass  # another poll claimed it, or the run dir is going away
 
     # First poll that sees the session id writes it to the sidecar (marker
     # file keeps the write one-shot across the remaining polls).

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -6,20 +6,23 @@
     "claude",
     "annotate",
     "history",
-    "geometry_editor"
+    "geometry_editor",
+    "versions"
   ],
   ".csv": [
     "duckdb",
     "excel",
     "code",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".tsv": [
     "duckdb",
     "code",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".xlsx": [
     "xlsx",
@@ -47,7 +50,8 @@
     "duckdb",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".jsonl": [
     "code",
@@ -129,7 +133,8 @@
     "tree",
     "code",
     "annotate",
-    "geometry_editor"
+    "geometry_editor",
+    "versions"
   ],
   ".md": [
     "markdown",
@@ -137,7 +142,8 @@
     "claude",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".markdown": [
     "markdown",
@@ -145,7 +151,8 @@
     "claude",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".tex": [
     "latex",
@@ -171,25 +178,29 @@
   ".svg": [
     "image",
     "code",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".png": [
     "image",
     "photos",
     "pano",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".jpg": [
     "image",
     "photos",
     "pano",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".jpeg": [
     "image",
     "photos",
     "pano",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".gif": [
     "image",
@@ -259,13 +270,15 @@
     "api",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".js": [
     "code",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".ts": [
     "code",
@@ -355,13 +368,15 @@
     "code",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".yml": [
     "code",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".toml": [
     "canvas",
@@ -404,14 +419,16 @@
     "code",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".txt": [
     "text",
     "code",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".log": [
     "log_studio",
@@ -428,7 +445,8 @@
     "git",
     "reader",
     "annotate",
-    "history"
+    "history",
+    "versions"
   ],
   ".htm": [
     "_render",
@@ -436,7 +454,8 @@
     "claude",
     "git",
     "reader",
-    "annotate"
+    "annotate",
+    "versions"
   ],
   ".tif": [
     "geotiff",
@@ -460,6 +479,7 @@
   "/": [
     "_listing",
     "git",
+    "versions",
     "graph",
     "zarr_aoi"
   ],

--- a/fused_render/templates/shared/appenv.py
+++ b/fused_render/templates/shared/appenv.py
@@ -55,6 +55,23 @@ def home_dir() -> str:
     return os.environ.get("FUSED_RENDER_HOME") or os.path.expanduser("~/.fused-render")
 
 
+def workspace_dir() -> str:
+    """The user's Fused workspace (~/Documents/Fused), where app folders live
+    two levels down (<workspace>/<tag>/<name>).
+
+    `FUSED_RENDER_WORKSPACE_DIR` is exported by the server ALREADY RESOLVED —
+    the output of `shell.seed.fused_dir()`. The fallback mirrors that function
+    for a template running standalone: the same `FUSED_RENDER_DIR` override
+    tests use, else the default location.
+    """
+    d = os.environ.get("FUSED_RENDER_WORKSPACE_DIR")
+    if d:
+        return d
+    return os.path.abspath(
+        os.path.expanduser(os.environ.get("FUSED_RENDER_DIR") or "~/Documents/Fused")
+    )
+
+
 def mounts_dir() -> str:
     """The dir holding one subdir per mounted remote.
 

--- a/fused_render/templates/versions/condition.py
+++ b/fused_render/templates/versions/condition.py
@@ -1,0 +1,53 @@
+"""Gate for the `versions` template (app git history).
+
+`main(path)` says whether the target — a file OR a directory — lives inside a
+*fused app*: a folder exactly two levels under the workspace
+(`<workspace>/<tag>/<name>`, `shell/seed.fused_dir()`) that is itself a git
+repository. Only such folders get the auto-commit treatment
+(`fused_render/app_git.py`), so only they have a history worth showing; the
+template registry offers `versions` on many file types and on every directory,
+and this gate is what narrows that to apps.
+
+The app-dir rule here mirrors `app_git.app_dir_for` (and the claude template's
+`_app_dir_for`); keep the three in step. It is duplicated rather than imported
+because a template must not import `fused_render` (SPEC PY-15 / D166) — the
+workspace root travels as an env var via `../shared/appenv.py`.
+
+Constant-time: one relpath computation and one `os.path.isdir` on `.git` —
+never a listing (the rule `graph/condition.py` documents; this gate too runs
+on every file and directory the user opens). Mount-backed paths are refused
+outright: an app is by definition a local folder, and probing `.git` over a
+kernel NFS mount is exactly the stat this gate must never issue.
+
+Fails closed: any exception returns False.
+"""
+
+
+def main(path: str) -> bool:
+    import os
+    import sys
+
+    try:
+        shared = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared")
+        # Guarded insert: _run_condition re-execs this module on every stat.
+        if shared not in sys.path:
+            sys.path.insert(0, shared)
+        try:
+            from appenv import is_mount_backed, workspace_dir
+        except Exception:  # noqa: BLE001 — cannot tell -> refuse (CT-12)
+            return False
+        if is_mount_backed(path):
+            return False
+
+        root = workspace_dir()
+        rel = os.path.relpath(os.path.abspath(path), root)
+        if rel == os.curdir or rel.split(os.sep, 1)[0] == os.pardir:
+            return False
+        parts = rel.split(os.sep)
+        if len(parts) < 2 or parts[0].startswith(".") or parts[1].startswith("."):
+            return False
+        app_dir = os.path.join(root, parts[0], parts[1])
+        return os.path.isdir(os.path.join(app_dir, ".git"))
+    except Exception:  # noqa: BLE001 — any probe error: fail closed, quietly
+        return False

--- a/fused_render/templates/versions/icon.svg
+++ b/fused_render/templates/versions/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 12a9 9 0 1 0 3-6.7" />
+  <polyline points="3 4 3 9 8 9" />
+  <polyline points="12 7 12 12 16 14" />
+</svg>

--- a/fused_render/templates/versions/icon.svg
+++ b/fused_render/templates/versions/icon.svg
@@ -1,5 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M3 12a9 9 0 1 0 3-6.7" />
-  <polyline points="3 4 3 9 8 9" />
-  <polyline points="12 7 12 12 16 14" />
+  <circle cx="6" cy="5" r="2.5" />
+  <circle cx="6" cy="19" r="2.5" />
+  <circle cx="18" cy="8" r="2.5" />
+  <path d="M6 7.5v9" />
+  <path d="M18 10.5a6 6 0 0 1-6 6h-3.5" />
 </svg>

--- a/fused_render/templates/versions/template.html
+++ b/fused_render/templates/versions/template.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html data-fused-theme="shell">
+<head>
+<meta charset="utf-8" />
+<title>Versions</title>
+<style>
+  /* Appearance (SPEC §30, D134). Dark block is the palette; light redefines
+     every token. `data-theme` is written onto <html> by the injected runtime
+     because this document opted in via `data-fused-theme` (runtime.js). */
+  :root {
+    color-scheme: dark;
+    --bg: #131417;
+    --surface: #1b1d21;
+    --surface-2: #22252b;
+    --line: #2a2d33;
+    --ink: #e8eaed;
+    --ink-2: #9aa0a6;
+    --ink-3: #868d94;
+    --accent: #E5FF44;
+    --on-accent: #131417;
+    --sel-bg: #23261a;
+    --danger: #ff7a7a;
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --bg: #ffffff;
+    --surface: #f6f7f8;
+    --surface-2: #eef0f2;
+    --line: #e0e2e6;
+    --ink: #1f2023;
+    --ink-2: #61656c;
+    --ink-3: #7a7f87;
+    --accent: #5f7300;
+    --on-accent: #ffffff;
+    --sel-bg: #f2f5e2;
+    --danger: #b3261e;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    display: flex;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    color: var(--ink);
+    background: var(--bg);
+  }
+
+  /* Left: the commit spine — deliberately low-detail (subject + when). */
+  #side {
+    width: 260px;
+    min-width: 200px;
+    flex: none;
+    display: flex;
+    flex-direction: column;
+    border-right: 1px solid var(--line);
+    background: var(--surface);
+  }
+  #side-head {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--line);
+    color: var(--ink-2);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  #commits { flex: 1; overflow-y: auto; padding: 4px 0; }
+  .commit {
+    padding: 7px 12px;
+    cursor: pointer;
+    border-left: 2px solid transparent;
+  }
+  .commit:hover { background: var(--surface-2); }
+  .commit.selected {
+    background: var(--sel-bg);
+    border-left-color: var(--accent);
+  }
+  .commit .subject {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .commit .meta {
+    margin-top: 2px;
+    color: var(--ink-3);
+    font-size: 11px;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+  }
+  .badge {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 0 5px;
+    border-radius: 8px;
+    font-size: 10px;
+    background: var(--accent);
+    color: var(--on-accent);
+  }
+
+  /* Right: toolbar + the app rendered at the selected revision. */
+  #main { flex: 1; display: flex; flex-direction: column; min-width: 0; }
+  #toolbar {
+    flex: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--line);
+    background: var(--surface);
+  }
+  #rev-label {
+    flex: 1;
+    min-width: 0;
+    color: var(--ink-2);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: ui-monospace, Menlo, Consolas, monospace;
+    font-size: 12px;
+  }
+  #revert {
+    flex: none;
+    padding: 5px 14px;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--surface-2);
+    color: var(--ink);
+    font: inherit;
+    cursor: pointer;
+  }
+  #revert:hover:enabled { border-color: var(--accent); color: var(--accent); }
+  #revert:disabled { opacity: 0.45; cursor: default; }
+  #stage { flex: 1; position: relative; background: var(--bg); }
+  #frame {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  #notice {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    text-align: center;
+    color: var(--ink-2);
+    background: var(--bg);
+  }
+  #notice.error { color: var(--danger); }
+  #notice.show { display: flex; }
+</style>
+</head>
+<body>
+  <div id="side">
+    <div id="side-head">History</div>
+    <div id="commits"></div>
+  </div>
+  <div id="main">
+    <div id="toolbar">
+      <div id="rev-label"></div>
+      <button id="revert" disabled>Revert to this version</button>
+    </div>
+    <div id="stage">
+      <iframe id="frame" title="App at selected revision"></iframe>
+      <div id="notice"></div>
+    </div>
+  </div>
+
+<script>
+// The target arrives as the read-only _file param (template contract). It may
+// be any file inside the app OR the app folder itself — the backend always
+// resolves and operates on the whole app, so the view is identical everywhere.
+const FILE = fused.params.get("_file") || "";
+
+const commitsEl = document.getElementById("commits");
+const frameEl = document.getElementById("frame");
+const noticeEl = document.getElementById("notice");
+const revLabel = document.getElementById("rev-label");
+const revertBtn = document.getElementById("revert");
+
+let commits = [];      // newest first, from versions.py `log`
+let selected = null;   // full sha
+
+function esc(s) {
+  return String(s).replace(/&/g, "&amp;").replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function ago(ts) {
+  if (!ts) return "";
+  const s = Math.max(0, Date.now() / 1000 - ts);
+  if (s < 60) return "just now";
+  if (s < 3600) return Math.floor(s / 60) + "m ago";
+  if (s < 86400) return Math.floor(s / 3600) + "h ago";
+  if (s < 86400 * 30) return Math.floor(s / 86400) + "d ago";
+  return new Date(ts * 1000).toLocaleDateString();
+}
+
+function notice(msg, isError) {
+  frameEl.removeAttribute("src");
+  noticeEl.textContent = msg;
+  noticeEl.className = "show" + (isError ? " error" : "");
+}
+
+function clearNotice() { noticeEl.className = ""; }
+
+function renderList() {
+  commitsEl.innerHTML = commits.map((c, i) =>
+    '<div class="commit' + (c.sha === selected ? " selected" : "") +
+    '" data-sha="' + c.sha + '">' +
+    '<div class="subject">' + esc(c.subject || "(no subject)") +
+    (i === 0 ? '<span class="badge">latest</span>' : "") + "</div>" +
+    '<div class="meta">' + c.sha.slice(0, 7) + " · " + ago(c.ts) + "</div>" +
+    "</div>").join("");
+}
+
+async function select(sha) {
+  selected = sha;
+  // URL-synced so a reload (or a shared link) lands on the same revision.
+  fused.params.set("rev", sha.slice(0, 7));
+  renderList();
+  const c = commits.find(x => x.sha === sha);
+  const isLatest = commits.length && commits[0].sha === sha;
+  revLabel.textContent = sha.slice(0, 7) + (c ? " — " + c.subject : "");
+  revertBtn.disabled = isLatest;
+
+  notice("Preparing snapshot…");
+  try {
+    // Cancellation key per template, not per call: picking a new commit
+    // cancels the previous snapshot request instead of racing it.
+    const snap = await fused.runPython("./versions.py",
+      { action: "snapshot", file: FILE, sha: sha }, { key: "snapshot" });
+    if (snap.error) return notice(snap.error, true);
+    if (sha !== selected) return; // stale — a newer selection already landed
+    if (!snap.entry) {
+      return notice("This revision has no index.html — nothing to render.");
+    }
+    clearNotice();
+    frameEl.src = "/render?path=" + encodeURIComponent(snap.entry);
+  } catch (err) {
+    if (sha === selected) notice("Snapshot failed: " + err.message, true);
+  }
+}
+
+async function loadLog(preferSha) {
+  const res = await fused.runPython("./versions.py",
+    { action: "log", file: FILE }, { key: "log" });
+  if (res.error) return notice(res.error, true);
+  commits = res.commits || [];
+  if (!commits.length) return notice("No commits yet.");
+  let pick = commits[0].sha;
+  if (preferSha) {
+    const hit = commits.find(c => c.sha.startsWith(preferSha));
+    if (hit) pick = hit.sha;
+  }
+  await select(pick);
+}
+
+commitsEl.addEventListener("click", (e) => {
+  const row = e.target.closest(".commit");
+  if (row && row.dataset.sha !== selected) select(row.dataset.sha);
+});
+
+revertBtn.addEventListener("click", async () => {
+  const c = commits.find(x => x.sha === selected);
+  const label = selected.slice(0, 7) + (c ? " — " + c.subject : "");
+  if (!confirm("Revert all files to " + label +
+      "?\n\nHistory is kept: this adds a new commit on top.")) return;
+  revertBtn.disabled = true;
+  try {
+    const res = await fused.runPython("./versions.py",
+      { action: "revert", file: FILE, sha: selected }, { key: "revert" });
+    if (res.error) return notice(res.error, true);
+    // Reload the list; the new "Reverted to …" commit is now the latest.
+    await loadLog();
+  } catch (err) {
+    notice("Revert failed: " + err.message, true);
+    revertBtn.disabled = false;
+  }
+});
+
+if (!FILE) {
+  notice("No file selected (missing _file param).", true);
+} else {
+  loadLog(fused.params.get("rev") || "");
+}
+</script>
+</body>
+</html>

--- a/fused_render/templates/versions/template.html
+++ b/fused_render/templates/versions/template.html
@@ -275,7 +275,10 @@ revertBtn.addEventListener("click", async () => {
   try {
     const res = await fused.runPython("./versions.py",
       { action: "revert", file: FILE, sha: selected }, { key: "revert" });
-    if (res.error) return notice(res.error, true);
+    if (res.error) {
+      revertBtn.disabled = false;
+      return notice(res.error, true);
+    }
     // Reload the list; the new "Reverted to …" commit is now the latest.
     await loadLog();
   } catch (err) {

--- a/fused_render/templates/versions/versions.py
+++ b/fused_render/templates/versions/versions.py
@@ -14,9 +14,12 @@ WHOLE app — the repo is the app, not the file. Three actions:
 * `revert`   — restore the working tree AND index to the selected commit and
                record that as a NEW commit on top ("Reverted to <sha> — …").
                History is never rewritten: revert of a revert works, and
-               nothing ever moves refs backwards. `git read-tree -u --reset`
-               is the mechanism — unlike `checkout <sha> -- .` it also
-               *deletes* files that were added after the selected commit.
+               nothing ever moves refs backwards. The commit object is built
+               with `commit-tree` BEFORE anything touches disk: `read-tree
+               -u --reset` (the destructive step — unlike `checkout <sha> --
+               .` it also *deletes* files added after the selected commit)
+               only runs once that commit exists, so a failure never leaves
+               the working tree changed with nothing recorded to show for it.
 
 Scoped hard to app dirs: every action re-derives the app dir from the target
 path with the same rule as `app_git.app_dir_for` (mirrored here — templates
@@ -141,9 +144,17 @@ def _snapshot(app: str, sha: str):
             return {"error": "git archive failed: " + err.strip()[:200]}
         os.makedirs(snap, exist_ok=True)
         with tarfile.open(fileobj=io.BytesIO(r.stdout)) as tf:
-            # `data` filter (3.12+): refuses absolute names and `..` traversal
-            # in the archive — defence in depth; our own git wrote the tar.
-            tf.extractall(snap, filter="data")
+            # `data` filter: refuses absolute names and `..` traversal in the
+            # archive — defence in depth; our own git wrote the tar. The
+            # kwarg itself is 3.12+ (PEP 706), backported to some but not all
+            # patch releases of 3.10/3.11 that requires-python still allows;
+            # hasattr(tarfile, "data_filter") is the documented feature probe,
+            # so an interpreter without the backport just skips the filter
+            # instead of raising TypeError and breaking the preview outright.
+            if hasattr(tarfile, "data_filter"):
+                tf.extractall(snap, filter="data")
+            else:
+                tf.extractall(snap)
         with open(marker, "w", encoding="utf-8") as f:
             f.write(full + "\n")
 
@@ -157,25 +168,46 @@ def _revert(app: str, sha: str):
     full = _resolve_sha(app, sha)
     if full is None:
         return {"error": "unknown revision"}
-    if _head(app) == full:
+    head = _head(app)
+    if head == full:
         return {"noop": True, "reason": "already at this revision"}
 
-    # Working tree + index become exactly the selected commit's tree; files
-    # added since are deleted, ignored/untracked files are left alone.
-    r = _git(app, "read-tree", "-u", "--reset", full)
-    if r.returncode != 0:
-        return {"error": "git read-tree failed: " + (r.stderr or "").strip()[:200]}
-
-    # Same tree as HEAD (e.g. reverting to a commit whose content later
-    # commits already restored): nothing to record.
-    if _git(app, "diff", "--cached", "--quiet", "HEAD").returncode == 0:
+    # Tree comparison BEFORE anything touches disk: read-tree's reset is
+    # destructive to the working tree, and revert-of-a-revert can leave two
+    # different commits with an identical tree — running it first would
+    # silently discard uncommitted edits to reach a tree that was already
+    # there, then report a no-op with no sign anything happened.
+    target_tree = _git(app, "rev-parse", "--verify", "--quiet",
+                       full + "^{tree}").stdout.strip()
+    head_tree = _git(app, "rev-parse", "--verify", "--quiet",
+                     head + "^{tree}").stdout.strip() if head else ""
+    if target_tree and target_tree == head_tree:
         return {"noop": True, "reason": "tree already matches this revision"}
 
     subj = _git(app, "log", "-1", "--format=%s", full).stdout.strip()
     msg = f"Reverted to {full[:7]}" + (f" — {subj}" if subj else "")
-    r = _git(app, "commit", "-q", "-m", msg)
+
+    # Build the commit object first — commit-tree writes no working-tree or
+    # index state — so a failure here (e.g. a misconfigured commit signing
+    # key) leaves disk untouched instead of reporting an error after the
+    # revert already landed. Only once the commit exists does HEAD move and
+    # the (destructive) working-tree reset run.
+    parents = ["-p", head] if head else []
+    r = _git(app, "commit-tree", target_tree, *parents, "-m", msg,
+             "--no-gpg-sign")
     if r.returncode != 0:
         return {"error": "git commit failed: " + (r.stderr or "").strip()[:200]}
+    new_sha = r.stdout.strip()
+
+    r = _git(app, "update-ref", "HEAD", new_sha)
+    if r.returncode != 0:
+        return {"error": "git update-ref failed: " + (r.stderr or "").strip()[:200]}
+
+    # Working tree + index become exactly the selected commit's tree; files
+    # added since are deleted, ignored/untracked files are left alone.
+    r = _git(app, "read-tree", "-u", "--reset", new_sha)
+    if r.returncode != 0:
+        return {"error": "git read-tree failed: " + (r.stderr or "").strip()[:200]}
     return {"reverted": True, "message": msg}
 
 

--- a/fused_render/templates/versions/versions.py
+++ b/fused_render/templates/versions/versions.py
@@ -1,0 +1,200 @@
+"""Git backend for the `versions` template: history of a *fused app*.
+
+The template targets any file or directory inside an app folder
+(`<workspace>/<tag>/<name>`, see `condition.py`) but always operates on the
+WHOLE app — the repo is the app, not the file. Three actions:
+
+* `log`      — the commit list, newest first.
+* `snapshot` — materialise one commit as a plain folder so the explorer can
+               render the app *as it was*. `git archive <sha>` is extracted
+               into a per-app, per-commit dir under the shell home
+               (`~/.fused-render/app-versions/<app-key>/<sha>/`); a commit is
+               immutable, so an existing complete snapshot is reused as-is.
+               The caller iframes `/render?path=<snapshot>/index.html`.
+* `revert`   — restore the working tree AND index to the selected commit and
+               record that as a NEW commit on top ("Reverted to <sha> — …").
+               History is never rewritten: revert of a revert works, and
+               nothing ever moves refs backwards. `git read-tree -u --reset`
+               is the mechanism — unlike `checkout <sha> -- .` it also
+               *deletes* files that were added after the selected commit.
+
+Scoped hard to app dirs: every action re-derives the app dir from the target
+path with the same rule as `app_git.app_dir_for` (mirrored here — templates
+must not import fused_render, SPEC PY-15/D166) and refuses anything else, so
+a hand-crafted URL can never make this module commit to, or archive from, a
+user's real repository.
+
+Subprocess discipline matches `app_git`/`claude/agent.py`: `git -C <dir>`
+(never `cwd=`), `close_fds=False`, bounded timeout, and a fixed per-invocation
+identity for the revert commit so a missing global git config can't fail it.
+
+Stdlib only — snapshots are unpacked with `tarfile` from `git archive`'s
+stdout, no `tar` binary involved.
+"""
+import hashlib
+import io
+import os
+import re
+import subprocess
+import sys
+import tarfile
+
+_SHARED = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared")
+if _SHARED not in sys.path:
+    sys.path.insert(0, _SHARED)
+from appenv import home_dir, workspace_dir  # noqa: E402
+
+# Mirrors fused_render/app_git.py `_IDENTITY`; keep in step.
+_IDENTITY = ["-c", "user.name=Fused", "-c", "user.email=apps@fused.io"]
+
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$")
+
+# Unit separator: cannot appear in a commit subject, so a plain split is safe.
+_US = "\x1f"
+
+
+def _app_dir_for(path: str) -> str:
+    """The app dir containing `path`, or "" when the path is not inside an
+    app. Mirrors `app_git.app_dir_for` (and `claude/agent.py`); keep in step.
+    """
+    try:
+        root = workspace_dir()
+        rel = os.path.relpath(os.path.abspath(path), root)
+    except (ValueError, OSError):  # different drive on Windows
+        return ""
+    if rel == os.curdir or rel.split(os.sep, 1)[0] == os.pardir:
+        return ""
+    parts = rel.split(os.sep)
+    if len(parts) < 2 or parts[0].startswith(".") or parts[1].startswith("."):
+        return ""
+    return os.path.join(root, parts[0], parts[1])
+
+
+def _git(app_dir: str, *args, binary: bool = False):
+    """One git invocation against the app repo. `-C` instead of `cwd=` and
+    `close_fds=False` — the posix_spawn discipline every subprocess in this
+    codebase follows (a plain fork trips PROJ's atfork handler, SIGSEGV).
+    """
+    return subprocess.run(
+        ["git", "-C", app_dir, *_IDENTITY, *args],
+        capture_output=True, text=not binary, timeout=60, close_fds=False,
+    )
+
+
+def _require_app(file: str):
+    """(app_dir, None) for a target inside a git-backed app, else (None, error
+    payload). The refusal is the security boundary described in the module
+    docstring — everything else in this file assumes it already ran.
+    """
+    app = _app_dir_for(file)
+    if not app:
+        return None, {"error": "not inside a fused app folder"}
+    if not os.path.isdir(os.path.join(app, ".git")):
+        return None, {"error": "this app has no git history"}
+    return app, None
+
+
+def _resolve_sha(app: str, sha: str):
+    """Validated, full commit id — or None. The regex check comes first so a
+    client-supplied value can never reach git as an option or a path."""
+    sha = (sha or "").strip().lower()
+    if not _SHA_RE.match(sha):
+        return None
+    r = _git(app, "rev-parse", "--verify", "--quiet", sha + "^{commit}")
+    out = r.stdout.strip()
+    return out if r.returncode == 0 and _SHA_RE.match(out) else None
+
+
+def _log(app: str):
+    r = _git(app, "log", f"--format=%H{_US}%ct{_US}%s")
+    if r.returncode != 0:
+        return {"error": "git log failed: " + (r.stderr or "").strip()[:200]}
+    commits = []
+    for line in r.stdout.splitlines():
+        parts = line.split(_US, 2)
+        if len(parts) != 3:
+            continue
+        sha, ts, subject = parts
+        try:
+            ts = int(ts)
+        except ValueError:
+            ts = 0
+        commits.append({"sha": sha, "ts": ts, "subject": subject})
+    return {"app": app, "commits": commits}
+
+
+def _snapshot(app: str, sha: str):
+    full = _resolve_sha(app, sha)
+    if full is None:
+        return {"error": "unknown revision"}
+
+    # Per-app key: path hash, not name — two apps may share a basename, and
+    # the hash also keeps the snapshot root flat and filename-safe.
+    key = hashlib.sha1(app.encode("utf-8", "surrogateescape")).hexdigest()[:12]
+    snap = os.path.join(home_dir(), "app-versions", key, full)
+    marker = os.path.join(snap, ".fused-snapshot-complete")
+
+    if not os.path.isfile(marker):
+        r = _git(app, "archive", "--format=tar", full, binary=True)
+        if r.returncode != 0:
+            err = r.stderr.decode("utf-8", "replace") if r.stderr else ""
+            return {"error": "git archive failed: " + err.strip()[:200]}
+        os.makedirs(snap, exist_ok=True)
+        with tarfile.open(fileobj=io.BytesIO(r.stdout)) as tf:
+            # `data` filter (3.12+): refuses absolute names and `..` traversal
+            # in the archive — defence in depth; our own git wrote the tar.
+            tf.extractall(snap, filter="data")
+        with open(marker, "w", encoding="utf-8") as f:
+            f.write(full + "\n")
+
+    entry = os.path.join(snap, "index.html")
+    if not os.path.isfile(entry):
+        return {"app": app, "sha": full, "dir": snap, "entry": None}
+    return {"app": app, "sha": full, "dir": snap, "entry": entry}
+
+
+def _revert(app: str, sha: str):
+    full = _resolve_sha(app, sha)
+    if full is None:
+        return {"error": "unknown revision"}
+    if _head(app) == full:
+        return {"noop": True, "reason": "already at this revision"}
+
+    # Working tree + index become exactly the selected commit's tree; files
+    # added since are deleted, ignored/untracked files are left alone.
+    r = _git(app, "read-tree", "-u", "--reset", full)
+    if r.returncode != 0:
+        return {"error": "git read-tree failed: " + (r.stderr or "").strip()[:200]}
+
+    # Same tree as HEAD (e.g. reverting to a commit whose content later
+    # commits already restored): nothing to record.
+    if _git(app, "diff", "--cached", "--quiet", "HEAD").returncode == 0:
+        return {"noop": True, "reason": "tree already matches this revision"}
+
+    subj = _git(app, "log", "-1", "--format=%s", full).stdout.strip()
+    msg = f"Reverted to {full[:7]}" + (f" — {subj}" if subj else "")
+    r = _git(app, "commit", "-q", "-m", msg)
+    if r.returncode != 0:
+        return {"error": "git commit failed: " + (r.stderr or "").strip()[:200]}
+    return {"reverted": True, "message": msg}
+
+
+def _head(app: str) -> str:
+    r = _git(app, "rev-parse", "--verify", "--quiet", "HEAD")
+    return r.stdout.strip() if r.returncode == 0 else ""
+
+
+def main(action: str = "log", file: str = "", sha: str = ""):
+    app, err = _require_app(file)
+    if err is not None:
+        return err
+    try:
+        if action == "log":
+            return _log(app)
+        if action == "snapshot":
+            return _snapshot(app, sha)
+        if action == "revert":
+            return _revert(app, sha)
+    except subprocess.TimeoutExpired:
+        return {"error": "git timed out"}
+    return {"error": f"unknown action: {action}"}

--- a/tests/_theme_sources.py
+++ b/tests/_theme_sources.py
@@ -43,6 +43,7 @@ TIER_ONE_TEMPLATES = (
     "text",
     "tree",
     "vector",
+    "versions",
     "xlsx",
     "zip",
 )

--- a/tests/test_app_commit_queue.py
+++ b/tests/test_app_commit_queue.py
@@ -1,7 +1,7 @@
 """The debounced app committer (fused_render/app_commit_queue.py): editor
 mutations mark an app dirty, one global asyncio worker turns each burst into
-a single aggregated commit; without a running worker mark() commits inline
-(the old behaviour, and what lifespan-less test apps get).
+a single aggregated commit; without a running worker marks accumulate until
+the next flush() (what lifespan-less test apps rely on).
 
 Real git in tmp workspaces, same fixture shape as tests/test_app_git.py.
 Debounce windows are monkeypatched tight so the async tests stay fast.
@@ -47,12 +47,21 @@ def _run(coro):
     asyncio.run(coro)
 
 
-# ------------------------------------------------------------ inline fallback
+@pytest.fixture(autouse=True)
+def clean_pending():
+    yield
+    with q._lock:
+        q._pending.clear()
 
-def test_mark_commits_inline_when_worker_not_running(workspace):
+
+# --------------------------------------------------------- mark w/o worker
+
+def test_marks_accumulate_until_flush_when_worker_not_running(workspace):
     d = _make_app(workspace)
     (d / "index.html").write_text("<html>v2</html>")
     q.mark(str(d / "index.html"), "Edit")
+    assert _log(d) == ["New app from starter"]  # queued, not committed
+    q.flush()
     assert _log(d)[0] == "Edit index.html"
 
 

--- a/tests/test_app_commit_queue.py
+++ b/tests/test_app_commit_queue.py
@@ -8,6 +8,7 @@ Debounce windows are monkeypatched tight so the async tests stay fast.
 """
 import asyncio
 import subprocess
+import time
 
 import pytest
 
@@ -123,6 +124,62 @@ def test_two_apps_commit_independently(workspace, fast_debounce):
         await q.stop()
 
     _run(go())
+    assert _log(a)[0] == "Edit index.html"
+    assert _log(b)[0] == "Edit index.html"
+
+
+def test_requeue_merges_with_pending_and_new_marks(workspace):
+    # _requeue is what a cancelled-mid-batch worker uses to put entries
+    # `_take_due` already popped back — it must merge with anything a mark()
+    # added in the meantime, exactly like mark() itself does.
+    d = _make_app(workspace)
+    app_dir = str(d)
+    q._requeue([(app_dir, ["Edit a.html"])])
+    with q._lock:
+        assert q._pending[app_dir]["labels"] == ["Edit a.html"]
+    q.mark(str(d / "b.html"), "Edit")
+    q._requeue([(app_dir, ["Edit a.html"])])  # same label again: no duplicate
+    with q._lock:
+        labels = q._pending[app_dir]["labels"]
+    assert labels.count("Edit a.html") == 1
+    assert "Edit b.html" in labels
+    assert q._requeue([]) is None  # empty batch: a no-op, not a KeyError
+
+
+def test_shutdown_requeues_uncommitted_apps_mid_batch(workspace, fast_debounce,
+                                                       monkeypatch):
+    # Two apps due in the same worker batch; make the FIRST app's commit()
+    # slow so stop()'s cancellation lands while the SECOND is still sitting
+    # in `remaining` (already popped from _pending by _take_due). Without
+    # requeueing on CancelledError, that second app's change would vanish —
+    # not committed, and no longer pending for stop()'s own flush() either.
+    a = _make_app(workspace, name="one")
+    b = _make_app(workspace, name="two")
+
+    real_commit = app_git.commit
+    order = []
+
+    def slow_commit(app_dir, message):
+        order.append(app_dir)
+        if app_dir == str(a):
+            time.sleep(0.4)
+        return real_commit(app_dir, message)
+
+    monkeypatch.setattr(app_git, "commit", slow_commit)
+
+    async def go():
+        q.start()
+        (a / "index.html").write_text("<html>a</html>")
+        q.mark(str(a / "index.html"), "Edit")
+        (b / "index.html").write_text("<html>b</html>")
+        q.mark(str(b / "index.html"), "Edit")
+        # Let the debounce (0.05s) fire and the worker start committing `a`.
+        await asyncio.sleep(0.15)
+        assert order == [str(a)]  # confirms we're mid-batch, not done yet
+        await q.stop()
+
+    _run(go())
+    # Both apps got their commit — `b` via the requeue -> stop()'s flush().
     assert _log(a)[0] == "Edit index.html"
     assert _log(b)[0] == "Edit index.html"
 

--- a/tests/test_app_commit_queue.py
+++ b/tests/test_app_commit_queue.py
@@ -1,0 +1,166 @@
+"""The debounced app committer (fused_render/app_commit_queue.py): editor
+mutations mark an app dirty, one global asyncio worker turns each burst into
+a single aggregated commit; without a running worker mark() commits inline
+(the old behaviour, and what lifespan-less test apps get).
+
+Real git in tmp workspaces, same fixture shape as tests/test_app_git.py.
+Debounce windows are monkeypatched tight so the async tests stay fast.
+"""
+import asyncio
+import subprocess
+
+import pytest
+
+from fused_render import app_commit_queue as q
+from fused_render import app_git
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    fdir = tmp_path / "Fused"
+    fdir.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    return fdir
+
+
+@pytest.fixture()
+def fast_debounce(monkeypatch):
+    monkeypatch.setattr(q, "_QUIET_S", 0.05)
+    monkeypatch.setattr(q, "_MAX_AGE_S", 0.5)
+
+
+def _log(app_dir):
+    out = subprocess.run(["git", "-C", str(app_dir), "log", "--format=%s"],
+                         capture_output=True, text=True)
+    return out.stdout.strip().splitlines()
+
+
+def _make_app(workspace, tag="local", name="demo"):
+    d = workspace / tag / name
+    d.mkdir(parents=True)
+    (d / "index.html").write_text("<html></html>")
+    assert app_git.init_repo(str(d))
+    return d
+
+
+def _run(coro):
+    asyncio.run(coro)
+
+
+# ------------------------------------------------------------ inline fallback
+
+def test_mark_commits_inline_when_worker_not_running(workspace):
+    d = _make_app(workspace)
+    (d / "index.html").write_text("<html>v2</html>")
+    q.mark(str(d / "index.html"), "Edit")
+    assert _log(d)[0] == "Edit index.html"
+
+
+def test_mark_is_a_noop_outside_app_dirs(workspace, tmp_path):
+    repo = tmp_path / "userrepo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    (repo / "f.txt").write_text("x")
+    q.mark(str(repo / "f.txt"), "Edit")
+    assert _log(repo) == []
+
+
+# ------------------------------------------------------------------ debounce
+
+def test_burst_collapses_into_one_commit(workspace, fast_debounce):
+    d = _make_app(workspace)
+
+    async def go():
+        q.start()
+        for v in ("v2", "v3", "v4"):
+            (d / "index.html").write_text(f"<html>{v}</html>")
+            q.mark(str(d / "index.html"), "Edit")
+        await asyncio.sleep(0.3)
+        await q.stop()
+
+    _run(go())
+    subjects = _log(d)
+    assert subjects == ["Edit index.html", "New app from starter"]
+    assert (d / "index.html").read_text() == "<html>v4</html>"
+
+
+def test_burst_message_aggregates_files(workspace, fast_debounce):
+    d = _make_app(workspace)
+
+    async def go():
+        q.start()
+        (d / "index.html").write_text("<html>v2</html>")
+        q.mark(str(d / "index.html"), "Edit")
+        (d / "style.css").write_text("body{}")
+        q.mark(str(d / "style.css"), "Edit")
+        await asyncio.sleep(0.3)
+        await q.stop()
+
+    _run(go())
+    assert _log(d)[0] == "Edit index.html, style.css"
+
+
+def test_two_apps_commit_independently(workspace, fast_debounce):
+    a = _make_app(workspace, name="one")
+    b = _make_app(workspace, name="two")
+
+    async def go():
+        q.start()
+        (a / "index.html").write_text("<html>a</html>")
+        q.mark(str(a / "index.html"), "Edit")
+        (b / "index.html").write_text("<html>b</html>")
+        q.mark(str(b / "index.html"), "Edit")
+        await asyncio.sleep(0.3)
+        await q.stop()
+
+    _run(go())
+    assert _log(a)[0] == "Edit index.html"
+    assert _log(b)[0] == "Edit index.html"
+
+
+def test_stop_flushes_pending_before_the_debounce_expires(workspace,
+                                                          monkeypatch):
+    # Huge debounce: only the shutdown flush can produce this commit.
+    monkeypatch.setattr(q, "_QUIET_S", 60.0)
+    monkeypatch.setattr(q, "_MAX_AGE_S", 60.0)
+    d = _make_app(workspace)
+
+    async def go():
+        q.start()
+        (d / "index.html").write_text("<html>v2</html>")
+        q.mark(str(d / "index.html"), "Edit")
+        await q.stop()
+
+    _run(go())
+    assert _log(d)[0] == "Edit index.html"
+
+
+def test_max_age_commits_while_saves_keep_streaming(workspace, monkeypatch):
+    # Quiet period never satisfied (marks every 0.02s < 0.1s), so only the
+    # max-age cap can land this commit before we stop marking.
+    monkeypatch.setattr(q, "_QUIET_S", 0.1)
+    monkeypatch.setattr(q, "_MAX_AGE_S", 0.25)
+    d = _make_app(workspace)
+
+    async def go():
+        q.start()
+        for i in range(25):
+            (d / "index.html").write_text(f"<html>{i}</html>")
+            q.mark(str(d / "index.html"), "Edit")
+            await asyncio.sleep(0.02)
+        committed = len(_log(d)) >= 2
+        await q.stop()
+        assert committed, "max-age cap never fired while marks streamed"
+
+    _run(go())
+    assert _log(d)[0] == "Edit index.html"
+
+
+# ------------------------------------------------------------------- message
+
+def test_message_shapes():
+    assert q._message(["Edit index.html"]) == "Edit index.html"
+    assert q._message(["Edit a", "Edit b"]) == "Edit a, b"
+    assert q._message(["Edit a", "Delete b"]) == "Edit a, Delete b"
+    assert q._message(["Edit a", "Edit b", "Edit c", "Edit d", "Edit e"]) == \
+        "Edit a, b, c +2 more"

--- a/tests/test_app_git.py
+++ b/tests/test_app_git.py
@@ -14,7 +14,7 @@ import subprocess
 import pytest
 from fastapi.testclient import TestClient
 
-from fused_render import app_git
+from fused_render import app_commit_queue, app_git
 from fused_render.server import create_app
 
 
@@ -32,6 +32,15 @@ def client(tmp_path, workspace):
 
 
 HDRS = {"X-Fused": "1"}
+
+
+@pytest.fixture(autouse=True)
+def clean_pending():
+    # The clients here run without lifespan, so /api/fs marks queue in
+    # app_commit_queue until flushed; keep tests from leaking into each other.
+    yield
+    with app_commit_queue._lock:
+        app_commit_queue._pending.clear()
 
 
 def _log(app_dir):
@@ -114,6 +123,7 @@ def test_fs_write_commits_into_app_repo(client, workspace):
     r = client.post("/api/fs/write", headers=HDRS, json={
         "path": str(d / "index.html"), "content": "<html>edited</html>"})
     assert r.status_code == 200
+    app_commit_queue.flush()
     assert _log(d)[0] == "Edit index.html"
 
 
@@ -124,10 +134,12 @@ def test_fs_delete_and_rename_commit(client, workspace):
     r = client.post("/api/fs/rename", headers=HDRS, json={
         "src": str(d / "notes.md"), "dst": str(d / "readme.md")})
     assert r.status_code == 200
+    app_commit_queue.flush()
     assert _log(d)[0] == "Rename readme.md"
     r = client.post("/api/fs/delete", headers=HDRS,
                     json={"path": str(d / "readme.md")})
     assert r.status_code == 200
+    app_commit_queue.flush()
     assert _log(d)[0] == "Delete readme.md"
 
 
@@ -144,6 +156,7 @@ def test_failed_write_commits_nothing(client, workspace):
     r = client.post("/api/fs/write", headers=HDRS, json={
         "path": str(d / "missing" / "x.txt"), "content": "y"})
     assert r.status_code == 404
+    app_commit_queue.flush()  # nothing may have been queued either
     assert _log(d) == ["New app from starter"]
 
 

--- a/tests/test_app_git.py
+++ b/tests/test_app_git.py
@@ -10,6 +10,7 @@ contract under test, so nothing here may raise even on non-repos.
 import importlib.util
 import os
 import subprocess
+import sys
 
 import pytest
 from fastapi.testclient import TestClient
@@ -89,6 +90,30 @@ def test_commit_records_changes_and_noops_when_clean(workspace):
     # Ignored sidecar change alone: still nothing to commit.
     (d / "index.html.json").write_text("{}")
     assert not app_git.commit(str(d / "index.html"), "Edit index.html")
+
+
+def test_commit_survives_a_fork_hostile_process(workspace):
+    # The server ends up with libproj resident (the fused-engine availability
+    # probe imports it), and PROJ's pthread_atfork child handler SIGSEGVs
+    # every fork()ed child before exec — subprocess-based git died rc=-11 in
+    # the field. app_git spawns via os.posix_spawnp, which runs no atfork
+    # handlers. Simulate the hostile process in an isolated child (an atfork
+    # abort cannot be unregistered, so it must not poison this test process).
+    d = _make_app(workspace)
+    (d / "index.html").write_text("<html>v2</html>")
+    script = (
+        "import os, sys\n"
+        "os.register_at_fork(after_in_child=os.abort)\n"
+        "from fused_render import app_git\n"
+        "ok = app_git.commit(sys.argv[1], 'Edit index.html')\n"
+        "sys.exit(0 if ok else 1)\n"
+    )
+    r = subprocess.run([sys.executable, "-c", script,
+                        str(d / "index.html")],
+                       env={**os.environ, "FUSED_RENDER_DIR": str(workspace)},
+                       capture_output=True, text=True, timeout=60)
+    assert r.returncode == 0, r.stderr
+    assert _log(d)[0] == "Edit index.html"
 
 
 def test_commit_never_touches_non_app_repos(workspace, tmp_path):

--- a/tests/test_app_git.py
+++ b/tests/test_app_git.py
@@ -152,6 +152,17 @@ def test_fs_write_commits_into_app_repo(client, workspace):
     assert _log(d)[0] == "Edit index.html"
 
 
+def test_fs_upload_commits_into_app_repo(client, workspace):
+    d = _make_app(workspace)
+    r = client.post(
+        "/api/fs/upload", headers=HDRS,
+        files={"file": ("shot.png", b"\x89PNG\r\n", "image/png")},
+        data={"path": str(d / "shot.png")})
+    assert r.status_code == 200
+    app_commit_queue.flush()
+    assert _log(d)[0] == "Upload shot.png"
+
+
 def test_fs_delete_and_rename_commit(client, workspace):
     d = _make_app(workspace)
     (d / "notes.md").write_text("hi")

--- a/tests/test_app_git.py
+++ b/tests/test_app_git.py
@@ -1,0 +1,176 @@
+"""Version control for app folders (fused_render/app_git.py and its hooks):
+every new app ships as a git repo with one boilerplate commit
+(POST /api/apps/new), every editor mutation through /api/fs/* becomes its own
+commit, and the claude template's turn-commit helper (agent._commit_turn)
+scopes itself to app dirs exactly like the server side.
+
+Real git, in tmp workspaces (FUSED_RENDER_DIR) — best-effort behaviour is the
+contract under test, so nothing here may raise even on non-repos.
+"""
+import importlib.util
+import os
+import subprocess
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import app_git
+from fused_render.server import create_app
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    fdir = tmp_path / "Fused"
+    fdir.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    return fdir
+
+
+@pytest.fixture()
+def client(tmp_path, workspace):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+HDRS = {"X-Fused": "1"}
+
+
+def _log(app_dir):
+    out = subprocess.run(["git", "-C", str(app_dir), "log", "--format=%s"],
+                         capture_output=True, text=True)
+    return out.stdout.strip().splitlines()
+
+
+def _make_app(workspace, tag="local", name="demo"):
+    d = workspace / tag / name
+    d.mkdir(parents=True)
+    (d / "index.html").write_text("<html></html>")
+    assert app_git.init_repo(str(d))
+    return d
+
+
+# ------------------------------------------------------------------- scoping
+
+def test_app_dir_for_scopes_to_two_levels(workspace, tmp_path):
+    app = workspace / "local" / "demo"
+    assert app_git.app_dir_for(str(app / "index.html")) == str(app)
+    assert app_git.app_dir_for(str(app / "sub" / "x.py")) == str(app)
+    assert app_git.app_dir_for(str(workspace)) is None            # root
+    assert app_git.app_dir_for(str(workspace / "local")) is None  # tag only
+    assert app_git.app_dir_for(str(tmp_path / "elsewhere" / "f")) is None
+    assert app_git.app_dir_for(str(workspace / ".hidden" / "x" / "f")) is None
+
+
+# ------------------------------------------------------- init_repo / commit
+
+def test_init_repo_ships_boilerplate_commit(workspace):
+    d = _make_app(workspace)
+    assert (d / ".git").is_dir()
+    assert _log(d) == ["New app from starter"]
+    # Session sidecars stay out of history.
+    assert "*.html.json" in (d / ".gitignore").read_text()
+
+
+def test_commit_records_changes_and_noops_when_clean(workspace):
+    d = _make_app(workspace)
+    (d / "index.html").write_text("<html>v2</html>")
+    assert app_git.commit(str(d / "index.html"), "Edit index.html")
+    assert _log(d)[0] == "Edit index.html"
+    # Clean tree: nothing to commit, no error.
+    assert not app_git.commit(str(d / "index.html"), "Edit index.html")
+    # Ignored sidecar change alone: still nothing to commit.
+    (d / "index.html.json").write_text("{}")
+    assert not app_git.commit(str(d / "index.html"), "Edit index.html")
+
+
+def test_commit_never_touches_non_app_repos(workspace, tmp_path):
+    # A real user repo outside the workspace must never be committed to.
+    repo = tmp_path / "userrepo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    (repo / "f.txt").write_text("x")
+    assert not app_git.commit(str(repo / "f.txt"), "nope")
+    assert _log(repo) == []
+    # An app folder without a repo (pre-feature app): silent no-op.
+    d = workspace / "local" / "plain"
+    d.mkdir(parents=True)
+    (d / "index.html").write_text("<html></html>")
+    assert not app_git.commit(str(d / "index.html"), "nope")
+
+
+# ----------------------------------------------------------- creation hook
+
+def test_new_app_is_a_repo_with_one_commit(client, workspace):
+    r = client.post("/api/apps/new", json={"name": "mine"}, headers=HDRS)
+    assert r.status_code == 200
+    d = workspace / "local" / "mine"
+    assert (d / ".git").is_dir()
+    assert _log(d) == ["New app from starter"]
+
+
+# ------------------------------------------------------------ editor hooks
+
+def test_fs_write_commits_into_app_repo(client, workspace):
+    d = _make_app(workspace)
+    r = client.post("/api/fs/write", headers=HDRS, json={
+        "path": str(d / "index.html"), "content": "<html>edited</html>"})
+    assert r.status_code == 200
+    assert _log(d)[0] == "Edit index.html"
+
+
+def test_fs_delete_and_rename_commit(client, workspace):
+    d = _make_app(workspace)
+    (d / "notes.md").write_text("hi")
+    app_git.commit(str(d), "Add notes.md")
+    r = client.post("/api/fs/rename", headers=HDRS, json={
+        "src": str(d / "notes.md"), "dst": str(d / "readme.md")})
+    assert r.status_code == 200
+    assert _log(d)[0] == "Rename readme.md"
+    r = client.post("/api/fs/delete", headers=HDRS,
+                    json={"path": str(d / "readme.md")})
+    assert r.status_code == 200
+    assert _log(d)[0] == "Delete readme.md"
+
+
+def test_fs_write_outside_app_commits_nothing(client, tmp_path, workspace):
+    target = tmp_path / "loose.txt"
+    target.write_text("x")
+    r = client.post("/api/fs/write", headers=HDRS,
+                    json={"path": str(target), "content": "y"})
+    assert r.status_code == 200  # write fine, just no repo involved
+
+
+def test_failed_write_commits_nothing(client, workspace):
+    d = _make_app(workspace)
+    r = client.post("/api/fs/write", headers=HDRS, json={
+        "path": str(d / "missing" / "x.txt"), "content": "y"})
+    assert r.status_code == 404
+    assert _log(d) == ["New app from starter"]
+
+
+# ------------------------------------------------- claude template mirror
+
+def _agent_module():
+    from fused_render.server import templates as server_templates
+
+    path = os.path.join(server_templates.TEMPLATES_DIR, "claude", "agent.py")
+    spec = importlib.util.spec_from_file_location("test_claude_agent_git", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_agent_commit_turn_commits_app_and_skips_others(workspace, tmp_path,
+                                                        monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_WORKSPACE_DIR", str(workspace))
+    agent = _agent_module()
+    d = _make_app(workspace)
+    (d / "index.html").write_text("<html>by claude</html>")
+    agent._commit_turn(str(d / "index.html"), "make it pretty")
+    assert _log(d)[0] == "Claude: make it pretty"
+    # Outside the workspace: never a commit, even in a real repo.
+    repo = tmp_path / "userrepo2"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    (repo / "f.txt").write_text("x")
+    agent._commit_turn(str(repo / "f.txt"), "nope")
+    assert _log(repo) == []

--- a/tests/test_history_template.py
+++ b/tests/test_history_template.py
@@ -44,7 +44,7 @@ def test_plain_json_unaffected():
     # A bare, non-compound .json (no sidecar target) keeps its tree-first
     # binding — the wildcard `.*.json` needs a stem with its own extension
     # (HV-3), so this doesn't match it.
-    assert modes("/x/data.json", False) == (["tree", "code", "duckdb", "git", "reader", "annotate"], None)
+    assert modes("/x/data.json", False) == (["tree", "code", "duckdb", "git", "reader", "annotate", "versions"], None)
 
 
 def test_template_ships_html_and_icon_only():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -66,7 +66,8 @@ def test_builtin_html_default_is_render_sentinel():
     entries, error = server._templates_for("/x/page.html", False)
     assert error is None
     assert [e["mode"] for e in entries] == [
-        "_render", "code", "claude", "git", "reader", "annotate", "history"]
+        "_render", "code", "claude", "git", "reader", "annotate", "history",
+        "versions"]
     assert entries[0]["path"] is None and entries[0]["icon"] is None
     assert entries[1]["path"].endswith("code/template.html")
     assert entries[2]["path"].endswith("claude/template.html")
@@ -76,7 +77,7 @@ def test_builtin_parquet_default_is_duckdb():
     # `history` (HV-2) is bound here too — not `.html`-only.
     entries, error = server._templates_for("/x/data.parquet", False)
     assert error is None
-    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude", "annotate", "history", "geometry_editor"]
+    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude", "annotate", "history", "geometry_editor", "versions"]
     assert entries[0]["path"].endswith("duckdb/template.html")
 
 
@@ -91,12 +92,14 @@ def test_reader_present_on_text_keys_before_annotate():
     # Reader sits immediately before annotate on representative text formats,
     # and never as the default (first entry stays the real content view).
     cases = {
-        "/x/notes.md": ["markdown", "code", "claude", "git", "reader", "annotate"],
+        "/x/notes.md": ["markdown", "code", "claude", "git", "reader",
+                        "annotate", "versions"],
         # No `git` on .csv: a commit log over a data file says nothing a diff can
         # render, so the tabular keys are deliberately left alone (§33 / GT-2).
-        "/x/data.csv": ["duckdb", "excel", "code", "reader", "annotate"],
+        "/x/data.csv": ["duckdb", "excel", "code", "reader", "annotate",
+                        "versions"],
         "/x/paper.pdf": ["pdf", "pdf_studio", "reader", "annotate"],
-        "/x/log.txt": ["text", "code", "git", "reader", "annotate"],
+        "/x/log.txt": ["text", "code", "git", "reader", "annotate", "versions"],
     }
     for path, expected in cases.items():
         got, error = modes(path)
@@ -169,7 +172,7 @@ def test_git_is_a_gated_directory_peer_after_the_listing():
     # says yes most often and the switcher reads left to right.
     got, error = modes("/x/somedir", is_dir=True)
     assert error is None
-    assert got == ["_listing", "git", "graph", "zarr_aoi"]
+    assert got == ["_listing", "git", "versions", "graph", "zarr_aoi"]
 
 
 def test_git_ships_a_condition_gate_and_an_icon():
@@ -220,9 +223,9 @@ def test_unmapped_file_empty_and_plain_dir_lists():
     # `zarr_aoi` — for a plain folder, a dotted folder and the filesystem root
     # alike. Each gated mode is dropped unless its condition.py says otherwise;
     # see tests/test_graph_condition.py and the zarr_aoi tests below.
-    assert modes("/x/somedir", is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
-    assert modes("/x/my.data", is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
-    assert modes("/", is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/somedir", is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
+    assert modes("/x/my.data", is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
+    assert modes("/", is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
 
 
 # --------------------------------------------- text sniff for unmapped files
@@ -349,7 +352,8 @@ def test_user_wildcard_key(user_dir):
     user_dir.registry({".*.json": "geo"})
     assert modes("/x/a.tiles.json") == (["geo"], None)
     assert modes("/x/a.json")[0] == [
-        "tree", "code", "duckdb", "git", "reader", "annotate"]  # builtin still applies
+        "tree", "code", "duckdb", "git", "reader", "annotate",
+        "versions"]  # builtin still applies
 
 
 def test_user_directory_binding(user_dir):
@@ -420,7 +424,7 @@ def test_unknown_sentinel_dropped_with_error(user_dir):
 def test_unresolvable_user_value_falls_back_to_builtin(user_dir):
     user_dir.registry({".csv": "no-such-template"})
     m, error = modes("/x/a.csv")
-    assert m == ["duckdb", "excel", "code", "reader", "annotate"]
+    assert m == ["duckdb", "excel", "code", "reader", "annotate", "versions"]
     assert "no-such-template" in error
 
 
@@ -429,21 +433,21 @@ def test_all_dangling_names_fall_back(user_dir):
     # dangling names resolves to nothing -> built-in fallback, error names one.
     user_dir.registry({".csv": ["...", "..."]})
     m, error = modes("/x/a.csv")
-    assert m == ["duckdb", "excel", "code", "reader", "annotate"]
+    assert m == ["duckdb", "excel", "code", "reader", "annotate", "versions"]
     assert "..." in error
 
 
 def test_bad_value_type_falls_back(user_dir):
     user_dir.registry({".csv": 42})
     m, error = modes("/x/a.csv")
-    assert m == ["duckdb", "excel", "code", "reader", "annotate"]
+    assert m == ["duckdb", "excel", "code", "reader", "annotate", "versions"]
     assert "must be a list" in error
 
 
 def test_unreadable_user_registry_reports_and_falls_back(user_dir):
     (user_dir.path / "registry.json").write_text("{not json")
     m, error = modes("/x/a.csv")
-    assert m == ["duckdb", "excel", "code", "reader", "annotate"]
+    assert m == ["duckdb", "excel", "code", "reader", "annotate", "versions"]
     assert "cannot read registry.json" in error
 
 
@@ -654,7 +658,7 @@ def test_registry_drops_zarr_template_and_sentinel_keys():
     assert server._resolve_name("zarr")[0] is None
     # zarr_aoi is the .zarr/ default and a gated candidate on every directory
     assert registry[".zarr/"] == ["zarr_aoi", "_listing"]
-    assert registry["/"] == ["_listing", "git", "graph", "zarr_aoi"]
+    assert registry["/"] == ["_listing", "git", "versions", "graph", "zarr_aoi"]
 
 
 def test_zarr_named_dir_gate_true_with_no_markers(tmp_path):
@@ -679,10 +683,10 @@ def test_plain_dir_with_store_marker_gates_true(tmp_path, marker):
     store = tmp_path / "data"
     store.mkdir()
     (store / marker).write_text("{}")
-    assert modes(str(store), is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
-    assert cond == {"git": False, "graph": False, "zarr_aoi": True} and err is None
+    assert cond == {"git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
 
 
 def test_v3_group_dir_offered(tmp_path):
@@ -691,10 +695,10 @@ def test_v3_group_dir_offered(tmp_path):
     store = tmp_path / "grp"
     store.mkdir()
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "group"}')
-    assert modes(str(store), is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
-    assert cond == {"git": False, "graph": False, "zarr_aoi": True} and err is None
+    assert cond == {"git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
 
 
 def test_bare_array_dir_not_offered(tmp_path):
@@ -707,7 +711,7 @@ def test_bare_array_dir_not_offered(tmp_path):
     (store / ".zarray").write_text("{}")
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"git": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
 
 def test_v3_bare_array_dir_not_offered(tmp_path):
@@ -719,7 +723,7 @@ def test_v3_bare_array_dir_not_offered(tmp_path):
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "array"}')
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"git": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
 
 def test_v3_zarr_json_without_node_type_not_offered(tmp_path):
@@ -742,16 +746,17 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     store = tmp_path / "plain"
     store.mkdir()
     (store / "readme.txt").write_text("hi")
-    assert modes(str(store), is_dir=True) == (["_listing", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "git", "versions", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"git": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
     entries, _ = server._templates_for(str(store), True)
     assert entries[0]["mode"] == "_listing" and "conditional" not in entries[0]
     assert entries[1]["mode"] == "git" and entries[1].get("conditional") is True
-    assert entries[2]["mode"] == "graph" and entries[2].get("conditional") is True
-    assert entries[3]["mode"] == "zarr_aoi" and entries[3].get("conditional") is True
+    assert entries[2]["mode"] == "versions" and entries[2].get("conditional") is True
+    assert entries[3]["mode"] == "graph" and entries[3].get("conditional") is True
+    assert entries[4]["mode"] == "zarr_aoi" and entries[4].get("conditional") is True
 
 
 def test_zarr_condition_fail_closed(tmp_path):

--- a/tests/test_templates_api.py
+++ b/tests/test_templates_api.py
@@ -1027,7 +1027,7 @@ def test_commit_applies_bindings_appending_to_core_list(ctx):
         {"key": ".myext", "template": "fresh"},
     ]
     reg = ctx.read_registry()
-    assert reg[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "fresh"]
+    assert reg[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "versions", "fresh"]
     assert reg[".myext"] == ["fresh"]
 
 
@@ -1098,7 +1098,7 @@ def test_commit_binding_reenables_disabled_key_with_core_list(ctx):
         headers=FUSED,
     ).json()
     assert body["bindingsApplied"] == [{"key": ".csv", "template": "fresh"}]
-    assert ctx.read_registry()[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "fresh"]
+    assert ctx.read_registry()[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "versions", "fresh"]
 
 
 def test_commit_binding_already_bound_is_noop(ctx):
@@ -1182,7 +1182,7 @@ def test_new_template_appends_to_existing_core_default(ctx):
     )
     assert resp.status_code == 200
     reg = ctx.read_registry()
-    assert reg[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "mycsv"]
+    assert reg[".csv"] == ["duckdb", "excel", "code", "reader", "annotate", "versions", "mycsv"]
 
 
 def test_new_template_appends_to_existing_user_override(ctx):

--- a/tests/test_versions_template.py
+++ b/tests/test_versions_template.py
@@ -1,0 +1,152 @@
+"""The `versions` template (app git history): the condition gate offers it
+only inside git-backed app folders, and its Python backend can list the log,
+materialise any commit as a rendered snapshot, and revert — always by adding
+a commit on top, never by rewriting history.
+
+Real git in tmp workspaces (FUSED_RENDER_DIR / FUSED_RENDER_WORKSPACE_DIR),
+same fixtures shape as tests/test_app_git.py. The template modules are loaded
+from the package source via importlib — they are exec'd standalone in
+production too (conditions by server._run_condition, the backend by /api/run),
+so nothing here goes through a package import.
+"""
+import importlib.util
+import os
+import subprocess
+
+import pytest
+
+from fused_render import app_git
+
+TEMPLATE_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "versions")
+
+
+def _load(name):
+    path = os.path.join(TEMPLATE_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location("test_versions_" + name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    fdir = tmp_path / "Fused"
+    fdir.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    monkeypatch.setenv("FUSED_RENDER_WORKSPACE_DIR", str(fdir))
+    # Snapshots land under the shell home; keep them in the tmp tree.
+    monkeypatch.setenv("FUSED_RENDER_HOME_DIR", str(tmp_path / "home"))
+    return fdir
+
+
+def _git(d, *args):
+    return subprocess.run(["git", "-C", str(d), "-c", "user.name=t",
+                           "-c", "user.email=t@t", *args],
+                          capture_output=True, text=True, check=True)
+
+
+def _make_app(workspace, tag="local", name="demo"):
+    d = workspace / tag / name
+    d.mkdir(parents=True)
+    (d / "index.html").write_text("<html>v1</html>")
+    assert app_git.init_repo(str(d))
+    return d
+
+
+def _log_subjects(d):
+    return _git(d, "log", "--format=%s").stdout.strip().splitlines()
+
+
+def _shas(d):
+    return _git(d, "log", "--format=%H").stdout.strip().splitlines()
+
+
+# ------------------------------------------------------------------- gate
+
+def test_condition_true_only_inside_git_backed_apps(workspace, tmp_path):
+    cond = _load("condition")
+    d = _make_app(workspace)
+    assert cond.main(str(d)) is True                     # the app dir itself
+    assert cond.main(str(d / "index.html")) is True      # a file inside
+    assert cond.main(str(d / "sub" / "x.py")) is True    # nested path
+    assert cond.main(str(workspace)) is False            # workspace root
+    assert cond.main(str(workspace / "local")) is False  # tag level
+    assert cond.main(str(tmp_path / "elsewhere")) is False
+    # App-shaped folder without a repo: no history to show.
+    plain = workspace / "local" / "plain"
+    plain.mkdir(parents=True)
+    assert cond.main(str(plain)) is False
+
+
+# -------------------------------------------------------------------- log
+
+def test_log_lists_commits_newest_first(workspace):
+    v = _load("versions")
+    d = _make_app(workspace)
+    (d / "index.html").write_text("<html>v2</html>")
+    app_git.commit(str(d / "index.html"), "Edit index.html")
+    res = v.main(action="log", file=str(d / "index.html"))
+    subjects = [c["subject"] for c in res["commits"]]
+    assert subjects == ["Edit index.html", "New app from starter"]
+    assert all(c["ts"] > 0 for c in res["commits"])
+    # Same answer for the directory target — the repo is the app.
+    assert v.main(action="log", file=str(d))["commits"][0]["sha"] == \
+        res["commits"][0]["sha"]
+
+
+def test_actions_refuse_paths_outside_apps(workspace, tmp_path):
+    v = _load("versions")
+    repo = tmp_path / "userrepo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    for action in ("log", "snapshot", "revert"):
+        assert "error" in v.main(action=action, file=str(repo / "f.txt"),
+                                 sha="deadbeef")
+
+
+# --------------------------------------------------------------- snapshot
+
+def test_snapshot_materialises_the_selected_commit(workspace):
+    v = _load("versions")
+    d = _make_app(workspace)
+    first = _shas(d)[0]
+    (d / "index.html").write_text("<html>v2</html>")
+    (d / "extra.py").write_text("x = 1")
+    app_git.commit(str(d), "Add extra")
+    res = v.main(action="snapshot", file=str(d / "index.html"), sha=first)
+    assert res["entry"].endswith("index.html")
+    with open(res["entry"], encoding="utf-8") as f:
+        assert f.read() == "<html>v1</html>"
+    assert not os.path.exists(os.path.join(res["dir"], "extra.py"))
+    # Idempotent: a commit is immutable, the snapshot is reused.
+    again = v.main(action="snapshot", file=str(d), sha=first[:7])
+    assert again["dir"] == res["dir"]
+    # Garbage sha never reaches git.
+    assert "error" in v.main(action="snapshot", file=str(d), sha="; rm -rf /")
+    assert "error" in v.main(action="snapshot", file=str(d), sha="a" * 40)
+
+
+# ----------------------------------------------------------------- revert
+
+def test_revert_adds_a_commit_and_restores_the_tree(workspace):
+    v = _load("versions")
+    d = _make_app(workspace)
+    first = _shas(d)[0]
+    (d / "index.html").write_text("<html>v2</html>")
+    (d / "extra.py").write_text("x = 1")
+    app_git.commit(str(d), "Add extra")
+    res = v.main(action="revert", file=str(d / "index.html"), sha=first)
+    assert res.get("reverted") is True
+    # Tree restored: edited file back, later file gone — via a NEW commit.
+    assert (d / "index.html").read_text() == "<html>v1</html>"
+    assert not (d / "extra.py").exists()
+    subjects = _log_subjects(d)
+    assert len(subjects) == 3 and subjects[0].startswith("Reverted to ")
+    assert "New app from starter" in subjects[0]
+    # History intact — the reverted-away commit is still reachable.
+    assert len(_shas(d)) == 3
+    # Reverting to HEAD is a no-op, not an empty commit.
+    assert v.main(action="revert", file=str(d), sha=_shas(d)[0])["noop"] is True
+    assert len(_shas(d)) == 3

--- a/tests/test_versions_template.py
+++ b/tests/test_versions_template.py
@@ -150,3 +150,30 @@ def test_revert_adds_a_commit_and_restores_the_tree(workspace):
     # Reverting to HEAD is a no-op, not an empty commit.
     assert v.main(action="revert", file=str(d), sha=_shas(d)[0])["noop"] is True
     assert len(_shas(d)) == 3
+
+
+def test_same_tree_revert_preserves_uncommitted_edits(workspace):
+    # A commit whose tree matches HEAD but whose sha differs (revert-of-a-
+    # revert lands on a DIFFERENT commit with the SAME content as an earlier
+    # one) must be reported a no-op WITHOUT ever running the destructive
+    # working-tree reset — otherwise dirty, uncommitted edits would be
+    # silently discarded to reach a tree that was already there.
+    v = _load("versions")
+    d = _make_app(workspace)
+    original = _shas(d)[0]  # v1
+    (d / "index.html").write_text("<html>v2</html>")
+    app_git.commit(str(d), "Edit index.html")
+    # Revert to v1: lands on a NEW commit (c3) whose tree equals `original`'s.
+    res = v.main(action="revert", file=str(d), sha=original)
+    assert res.get("reverted") is True
+    reverted_sha = _shas(d)[0]
+    assert reverted_sha != original
+    assert (d / "index.html").read_text() == "<html>v1</html>"
+    # Dirty the working copy without committing.
+    (d / "index.html").write_text("<html>UNCOMMITTED</html>")
+    # Ask to revert to `original` again: different sha than HEAD (reverted_sha)
+    # but an IDENTICAL tree — must noop without touching the dirty file.
+    res = v.main(action="revert", file=str(d), sha=original)
+    assert res.get("noop") is True
+    assert (d / "index.html").read_text() == "<html>UNCOMMITTED</html>"
+    assert _shas(d)[0] == reverted_sha  # no new commit, HEAD unmoved


### PR DESCRIPTION
Stacked on #332.

## What

Apps (`~/Documents/Fused/<tag>/<name>`) are now version-controlled:

- **New apps ship as git repos** — `POST /api/apps/new` runs `git init` and lands the untouched starter as one boilerplate commit ("New app from starter"), before the scaffolding Claude session starts, so the first turn diffs against the boilerplate.
- **Every Claude turn commits** — `templates/claude/agent.py` commits the app repo on the first poll that sees the run finish (one-shot `committed` marker, same pattern as the sidecar record). `apps.py`'s background poll now runs to `done`, so the scaffolding turn commits even if the user never opens the chat.
- **Every manual editor change commits** — `/api/fs/write|delete|rename|copy` mark the touched app in `app_commit_queue`; commits land debounced (see below).

## Debounced commit queue

Editor mutations don't run git inline in the request handler. They `mark()` the app, and one global asyncio worker commits each app after 1s of quiet (capped at 5s while the editor's 250ms autosaves keep streaming). One worker means every git operation the server issues per app repo is serialized — no index.lock races between saves — and a burst of keystroke-saves lands as one aggregated commit ("Edit index.html, style.css") instead of a commit per tick. Shutdown flushes pending commits (dev-reload safe); without a running worker (lifespan-less test apps) marks accumulate until `flush()`.

## The fork landmine (found in the field, fixed here)

Commits worked right after a server start and then silently stopped. Root cause: the fused-engine availability probe (`prefs.fused_engine_available`, re-run live on every `/api/prefs` poll and `/api/run` dispatch) imports the fused package **in-process** → geopandas → pyproj → libproj resident. From then on, PROJ's `pthread_atfork` child handler SIGSEGVs every `fork()`ed child before exec — and `subprocess.Popen` forks here on macOS, so every `git add` died `rc=-11` with empty stderr after the shell's first prefs poll.

Fix: `app_git` spawns git through **`os.posix_spawnp`** directly (pipes + selector + deadline kill) — posix_spawn runs no atfork handlers, so the path stays alive no matter what the process has loaded. Regression-tested by running `commit()` inside a deliberately fork-hostile child (`os.register_at_fork(after_in_child=os.abort)`). Failure paths log rc/stdout/stderr at WARNING so a skipped commit always has an answer in the server log.

## Guardrails

- Commits are **hard-scoped to app dirs**: exactly two levels under the workspace, with their own `.git`. A user's real repository opened in the editor is never committed to.
- **Best-effort everywhere**: missing git, index.lock contention, nothing staged — never fails the operation that triggered the commit; a missed commit is swept by the next one's `add -A`.
- Commit identity rides per-invocation (`-c user.name/email`) so machines without git config still commit.
- Session sidecars (`*.html.json`) are gitignored from the initial commit.
- Workspace root reaches templates via new `FUSED_RENDER_WORKSPACE_DIR` env (`appenv.workspace_dir()`), since templates must not import `fused_render` (D166).

## Versions template

A new conditional template, **`versions`**, shows an app's git history. Offered on every directory and on app-typical file types, but gated (`condition.py`) to fused app folders — so it appears on the app dir and on every file inside it, and always operates on the whole app.

- **Left**: low-detail commit list (subject, short sha, relative age); selected revision URL-synced via `rev` param.
- **Right**: the app rendered *at that revision* — `versions.py` materialises the commit (`git archive` → `tarfile`, stdlib only) into an immutable per-commit snapshot under `~/.fused-render/app-versions/<app-key>/<sha>/` and the view iframes `/render` on the snapshot's `index.html`. Snapshots are reused (commits are immutable).
- **Revert** restores tree + index to the selected commit with `git read-tree -u --reset` and records it as a **new commit on top** ("Reverted to <sha> — <subject>") — history is never rewritten; files added after the selected commit are deleted, untracked/ignored files untouched. No-op when the tree already matches.
- Same guardrails: app-dir scoping mirrored from `app_git.app_dir_for`, sha validated before git ever sees client input, fixed Fused identity on the revert commit.

## Tests

- `tests/test_app_git.py` — scoping, init/commit behaviour, creation hook, editor hooks, agent-side mirror, and the fork-hostile regression (11 tests, real git in tmp workspaces).
- `tests/test_app_commit_queue.py` — debounce collapse, message aggregation, per-app independence, shutdown flush, max-age cap under a continuous save stream (7 tests).
- `tests/test_versions_template.py` — gate scoping, log, snapshot materialisation/idempotence/sha validation, revert semantics (7 tests).

Full suite: only pre-existing failures on the base branch (engine/theme/calls, env-related).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches filesystem mutations and git subprocesses on every editor save (best-effort, but revert rewrites app working trees); scope is limited to app dirs with explicit guards.
> 
> **Overview**
> **Fused app folders** (`<workspace>/<tag>/<name>`) now get **local git** from creation through editor saves and Claude turns, plus a **Versions** template to browse and revert.
> 
> **`app_git`** initializes repos on `POST /api/apps/new` (boilerplate commit before scaffolding), scopes commits strictly to app dirs, ignores `*.html.json`, and runs git via `subprocess` with **`close_fds=False`** so macOS avoids fork+libproj SIGSEGV after the engine loads. **`app_commit_queue`** debounces `/api/fs` mutations (1s quiet, 5s max age), serializes commits in one asyncio worker, and flushes on shutdown.
> 
> **Integration:** `fs_mutate` marks successful write/upload/delete/rename/copy; **`agent.py`** adds a one-shot turn-end commit fallback; starter **`CLAUDE.md`** tells Claude to commit in small steps; **`FUSED_RENDER_WORKSPACE_DIR`** is exported for templates.
> 
> **`versions` template** (gated to git-backed apps): commit list, iframe preview via cached `git archive` snapshots, revert as a **new** commit (`read-tree` + `commit-tree`). Registry adds **`versions`** to many file types and directories.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3797f6452aab9af764e5f5f1fea78bd1451b60e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->