### PR TITLE
Annotate → Claude is a round trip, and each comment rides it once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,18 @@ fused_render/_baked_branch.py
 .coverage.*
 coverage.xml
 htmlcov/
-# Runtime sidecar written next to an opened *.html (bookmark/session state,
-# e.g. learn/index.html.json); it's per-machine state, never source.
+# Runtime sidecar written next to an opened file: the server writes `<file>.json`
+# beside ANY file you open, whatever its extension (bookmark/session/comment
+# state — e.g. learn/index.html.json, ARCHITECTURE.md.json). It is per-machine
+# state and never source: a committed one hijacks the default view for everyone,
+# because an empty-query open restores its `lastSession` (ARCHITECTURE.md.json
+# was committed by accident and pinned the doc to one machine's git-mode
+# session). The rule was `*.html.json` only, so every other extension slipped
+# through. Listed per extension rather than as a `*.*.json` wildcard, which would
+# also swallow genuine configs (tsconfig.build.json, settings.local.json, …) —
+# add extensions here as they come up; nothing tracked has ever matched these.
 *.html.json
+*.md.json
+*.markdown.json
+*.py.json
+*.txt.json

--- a/ARCHITECTURE.md.json
+++ b/ARCHITECTURE.md.json
@@ -1,0 +1,6 @@
+{
+  "lastSession": {
+    "search": "_mode=git&sel=32ac2717bd3f59dad702e39a9c0eef8ea909daae",
+    "updated_at": 1785511598.5263305
+  }
+}

--- a/ARCHITECTURE.md.json
+++ b/ARCHITECTURE.md.json
@@ -1,6 +1,0 @@
-{
-  "lastSession": {
-    "search": "_mode=git&sel=32ac2717bd3f59dad702e39a9c0eef8ea909daae",
-    "updated_at": 1785511598.5263305
-  }
-}

--- a/SPEC.md
+++ b/SPEC.md
@@ -741,11 +741,21 @@ budget is the binding constraint and the sidecar's own `updated_at` already date
 the write. The flag is stripped from what the agent sees (the payload is
 serialized before stamping) — it is bookkeeping for the URL store, not something
 `formatComments` should hand the model to reason about. A comment **being sent
-right now is off-limits to eviction**: the save that stamps `sent` is the save
-that can evict on it, so the payload's ids are passed to `save()` as protected and
-an over-budget write is preferred over trading a live comment for a flag (the
-"removed" bar note would be destroyed by the navigation milliseconds later, making
-that loss silent). A sent card shows a "sent ↗" chip so its exclusion is visible; the
+right now is off-limits to eviction**: the save that stamps `sent` is the save that
+can evict on it, and since the stamp is what pushes the list over budget the
+payload is then the whole sent tier — so the payload's ids are passed to `save()`
+as protected, and an over-budget write is preferred over dropping a comment from
+the live review to make room for a flag (the "removed" bar note explaining it
+would be destroyed by the navigation milliseconds later, making that loss silent).
+Eviction is not annihilation — the same `save()` mirrors every comment into the
+`<file>.json` log, where absence never deletes, so an evicted comment stays
+recoverable through the history view (§24); what it leaves is the **live** store,
+the rail and pins and the shared URL, which for a comment mid-send is loss enough.
+A sent card shows a "sent ↗" chip so its exclusion is visible — but **not** on a
+resolved card, which is the terminal state, already explains the exclusion, and
+takes the stronger dim (`.card.resolved.sent` encodes that precedence in
+specificity, because the equal-specificity pair it replaced handed the win to
+whichever rule was written second). The
 **Reopen** action clears the flag, which is the one way to hand a comment over
 again; and when nothing is sendable the button writes the inline bar note instead
 of navigating. The URL budget's eviction order gains a second tier — oldest

--- a/SPEC.md
+++ b/SPEC.md
@@ -730,6 +730,43 @@ hydration for a deep link whose id is absent from the live set, not a live-store
 sync back from the sidecar. An unreadable/unparseable sidecar or a missing id
 fails silently (no error UI, no focus).
 
+**Send to Claude is a ROUND TRIP, and each comment rides it once** (fixed
+2026-07-31; it was previously a one-way trip that re-sent the whole review every
+time). The handoff sends only the comments that are neither `resolved` nor
+`sent` — `sent: 1` is an ordinary per-comment field, stamped on exactly the
+comments in the payload and `save()`d *before* the mode switch so it lands in the
+`comments` URL param and, through annotate.py's verbatim field merge, in the
+`<file>.json` log. The flag is a bare truthy `1` because the URL store's ~6 KB
+budget is the binding constraint and the sidecar's own `updated_at` already dates
+the write. A sent card shows a "sent ↗" chip so its exclusion is visible; the
+**Reopen** action clears the flag, which is the one way to hand a comment over
+again; and when nothing is sendable the button writes the inline bar note instead
+of navigating. The URL budget's eviction order gains a second tier — oldest
+`resolved` first, then oldest `sent` (already in a chat transcript), never an
+open unsent comment. `sent` is deliberately **not** surfaced in the history
+timeline (§24): the sidecar is a write-only log where absence never deletes, so
+the un-send that Reopen performs (the key simply leaves the URL) cannot be
+represented there, and a label that can go stale is worse than no label.
+
+The return leg is the chat's: annotate sets `claudeReturn=<mode>` alongside
+`claudeComments` (and re-asserts `view`, the param naming which sibling view is
+framed), the claude template captures both into memory at boot and strips both
+from the shell URL in the same `replaceState` (a Back entry must not re-attach a
+review that was already sent), and the *one* run whose message actually carried
+attached comments navigates the shell back to that mode when it reports `done`
+without an error. It is an in-memory one-shot: a later turn in the same session
+stays in the chat, an errored or aborted run stays put (there is nothing new to
+look at, and leaving would hide the error), and a run re-attached on a fresh boot
+never returns. This is necessary because the chat calls `fused.autoReload(false)`
+and owns the viewport — nothing else would ever bring the reviewer back to the
+edited file. Both directions are **deliberate standard-breaks** documented in the
+template comments: `_mode` is a reserved param name that `fused.params.set`
+refuses, and in a pane the shell URL sits above the param boundary (D72), so a
+top-level URL write is the only mechanism; the navigation reuses the history
+template's `navigateShell` idiom (pushState + a `fused:navigate` event, with a
+`location.href` fallback), and both sides excise and reattach the balanced
+`_layout=(…)` span byte-for-byte before `URLSearchParams` sees the query.
+
 ## 18. Export — Portable Bundles for Hosted Serving (M10)
 
 Goal: pack a renderable page into a portable *bundle* that a **separate** hosting

--- a/SPEC.md
+++ b/SPEC.md
@@ -738,7 +738,14 @@ comments in the payload and `save()`d *before* the mode switch so it lands in th
 `comments` URL param and, through annotate.py's verbatim field merge, in the
 `<file>.json` log. The flag is a bare truthy `1` because the URL store's ~6 KB
 budget is the binding constraint and the sidecar's own `updated_at` already dates
-the write. A sent card shows a "sent ↗" chip so its exclusion is visible; the
+the write. The flag is stripped from what the agent sees (the payload is
+serialized before stamping) — it is bookkeeping for the URL store, not something
+`formatComments` should hand the model to reason about. A comment **being sent
+right now is off-limits to eviction**: the save that stamps `sent` is the save
+that can evict on it, so the payload's ids are passed to `save()` as protected and
+an over-budget write is preferred over trading a live comment for a flag (the
+"removed" bar note would be destroyed by the navigation milliseconds later, making
+that loss silent). A sent card shows a "sent ↗" chip so its exclusion is visible; the
 **Reopen** action clears the flag, which is the one way to hand a comment over
 again; and when nothing is sendable the button writes the inline bar note instead
 of navigating. The URL budget's eviction order gains a second tier — oldest
@@ -754,10 +761,19 @@ framed), the claude template captures both into memory at boot and strips both
 from the shell URL in the same `replaceState` (a Back entry must not re-attach a
 review that was already sent), and the *one* run whose message actually carried
 attached comments navigates the shell back to that mode when it reports `done`
-without an error. It is an in-memory one-shot: a later turn in the same session
+without an error. The ticket is **threaded, not latched** — it travels as an
+argument from `composeAndSend` → `sendMessage` → `pollLoop`, so it is bound to one
+message and, past `start`, to one run id. A module-scoped flag was the first
+attempt and leaked: a failed `start` never reaches `pollLoop`, so the flag stayed
+armed and the user's next unrelated question navigated the shell away mid-thread,
+for a run that carried no comments. A later turn in the same session therefore
 stays in the chat, an errored or aborted run stays put (there is nothing new to
 look at, and leaving would hide the error), and a run re-attached on a fresh boot
-never returns. This is necessary because the chat calls `fused.autoReload(false)`
+never returns. A `start` that fails **hands the comment chips back** (`attached`
+is restored and the user is told), because annotate has already stamped those
+comments `sent` and nothing else would ever offer them again; past `start` the
+agent has the message, so restoring would send them twice.
+This is necessary because the chat calls `fused.autoReload(false)`
 and owns the viewport — nothing else would ever bring the reviewer back to the
 edited file. Both directions are **deliberate standard-breaks** documented in the
 template comments: `_mode` is a reserved param name that `fused.params.set`
@@ -766,6 +782,20 @@ top-level URL write is the only mechanism; the navigation reuses the history
 template's `navigateShell` idiom (pushState + a `fused:navigate` event, with a
 `location.href` fallback), and both sides excise and reattach the balanced
 `_layout=(…)` span byte-for-byte before `URLSearchParams` sees the query.
+
+Both legs read `window.top`'s search **raw**, so both must reckon with the
+runtime's coalesced history write (D99): a param this page just set may still be
+at its pre-click value in that string, and copying it forward silently reverts it.
+Annotate sweeps every key the top URL already carries against
+`fused.params.getAll()` (which reads through the pending overlay) before writing
+its own — that covers the `sent` stamps, and `offset`/`sheet` from a reveal inside
+the coalescing window, without pushing a pane-local param onto the shell URL; it
+then re-asserts `comments` from what `save()` actually persisted, which the sweep
+cannot know. The return leg fires `pagehide` — the runtime's own documented flush
+hook — before reading the URL and pushing its entry, so a pending write neither
+goes missing from the copy nor lands *after* the push and `replaceState` the
+pre-return search over it. Known gap: the return discards whatever the user had
+typed into the chat input when it fires.
 
 ## 18. Export — Portable Bundles for Hosted Serving (M10)
 

--- a/fused_render/templates/annotate/template.html
+++ b/fused_render/templates/annotate/template.html
@@ -472,18 +472,28 @@
     // braces percent-encode, roughly tripling), not the raw JSON.
     const urlSize = (arr) => encodeURIComponent(JSON.stringify(arr)).length;
     // Oldest evictable comment, resolved tier before sent tier, or null when
-    // every remaining comment is open and unsent.
-    function evictTarget(arr) {
+    // every remaining comment is open and unsent. `keep` is a Set of ids that
+    // are off-limits whatever their flags: the save that STAMPS `sent` is also
+    // the save that could evict on it, and a comment being handed to Claude
+    // right now must never be the victim (the stamp itself is what pushed the
+    // list over budget, so the payload was the whole sent tier — one click
+    // could delete a live comment from the only store there is, with the
+    // "removed" note written into a bar the navigation destroys milliseconds
+    // later). When that leaves nothing evictable we take the over-budget write:
+    // a long URL beats trading a comment for a flag, and the send proceeds
+    // either way.
+    function evictTarget(arr, keep) {
+      const pool0 = keep ? arr.filter((c) => !keep.has(c.id)) : arr;
       for (const tier of [(c) => c.resolved, (c) => c.sent && !c.resolved]) {
-        const pool = arr.filter(tier);
+        const pool = pool0.filter(tier);
         if (pool.length) return pool.reduce((a, b) => (a.createdAt <= b.createdAt ? a : b));
       }
       return null;
     }
-    function save(arr, deletedIds) {
+    function save(arr, deletedIds, keep) {
       let dropped = 0;
       while (urlSize(arr) > BUDGET) {
-        const oldest = evictTarget(arr);
+        const oldest = evictTarget(arr, keep);
         if (!oldest) break;
         arr = arr.filter((c) => c.id !== oldest.id);
         dropped++;
@@ -1366,12 +1376,20 @@
       } catch (e) {
         return;
       }
+      // Serialize the wire form BEFORE stamping: `sent` is an internal
+      // lifecycle flag of the URL store, and formatComments (claude template)
+      // hands the agent the raw JSON with every field intact — it has no
+      // business reading, explaining or reasoning about our bookkeeping.
+      const wire = JSON.stringify(payload);
       // Stamp and persist BEFORE navigating: save() is what writes the `comments`
       // URL param (and, via the verbatim field merge in annotate.py, the
       // `<file>.json` sidecar), and this frame is about to be torn down by the
       // mode switch — a stamp applied after the navigation would never land.
+      // The payload's ids are handed to save() as off-limits for eviction: the
+      // stamp is what can push the list over BUDGET, and the comments being sent
+      // are then the entire sent tier (see evictTarget).
       for (const c of payload) c.sent = 1;
-      const persisted = save(all);
+      const persisted = save(all, undefined, new Set(payload.map((c) => c.id)));
       const top = window.top.location;
       const full = (top.search || "").replace(/^\?/, "");
       const rest = withoutLayoutSpan(top.search);
@@ -1389,13 +1407,24 @@
         span = full.slice(start, i);
       }
       const params = new URLSearchParams(rest);
+      // D99 staleness sweep. `rest` is a RAW read of window.top's search, but
+      // fused.params.set COALESCES its history write — so ANY param this page
+      // owns may still sit at its pre-click value in that string, and writing it
+      // back verbatim silently reverts it: the `sent` stamps (re-sending the
+      // whole review next visit), and `offset`/`sheet` written by a reveal
+      // within the coalescing window (returning to page 1 of a table/pdf).
+      // fused.params.getAll() reads through the pending overlay, so it is the
+      // live truth. Only keys the top URL ALREADY carries are touched — this
+      // must not push a pane-local param onto the shell URL.
+      const live = fused.params.getAll();
+      for (const k of [...params.keys()]) {
+        if (typeof live[k] === "string") params.set(k, live[k]);
+      }
       params.set("_mode", "claude");
-      params.set("claudeComments", JSON.stringify(payload));
-      // Re-assert the review from what save() actually persisted. This URL is
-      // built from a raw read of window.top's search, and fused.params.set
-      // COALESCES its history write (D99) — so the `sent` stamps may not be in
-      // that string yet, and writing it back verbatim would silently undo them
-      // and re-send the same comments on the next visit.
+      params.set("claudeComments", wire);
+      // The review as save() actually PERSISTED it (post-eviction) — narrower
+      // than the sweep above, which cannot know that save may have dropped a
+      // comment, and correct even if `comments` was absent from the top URL.
       params.set("comments", JSON.stringify(persisted));
       // Return ticket: the chat has nothing else that would ever bring the user
       // back (it turns auto-reload off and lives entirely inside its own frame),

--- a/fused_render/templates/annotate/template.html
+++ b/fused_render/templates/annotate/template.html
@@ -231,6 +231,16 @@
   /* Already handed to Claude — excluded from the next send, but not settled, so
      it dims less than a resolved card. The "sent ↗" chip carries the meaning. */
   .card.sent { opacity: 0.8; }
+  /* RESOLVED WINS. The two flags are independent, so a card can carry both, and
+     with only the two rules above the equal-specificity tie went to whichever
+     was written second — a resolved card then rendered at the weaker 0.8 and a
+     harmless CSS reorder silently flipped which state you were looking at.
+     Resolved is the terminal state, so it takes the stronger dim, and the
+     compound selector encodes that in SPECIFICITY rather than declaration
+     order. Matching rule in render(): a resolved card shows no "sent ↗" chip —
+     one state, one signal — and Reopen clears `sent` anyway, so the chip can
+     never come back stale. */
+  .card.resolved.sent { opacity: 0.6; }
   .card.active { background: var(--bg); border-left: 3px solid var(--accent); padding-left: 13px; }
   .card .lbl {
     display: inline-flex; align-items: center; justify-content: center;
@@ -475,13 +485,18 @@
     // every remaining comment is open and unsent. `keep` is a Set of ids that
     // are off-limits whatever their flags: the save that STAMPS `sent` is also
     // the save that could evict on it, and a comment being handed to Claude
-    // right now must never be the victim (the stamp itself is what pushed the
-    // list over budget, so the payload was the whole sent tier — one click
-    // could delete a live comment from the only store there is, with the
-    // "removed" note written into a bar the navigation destroys milliseconds
-    // later). When that leaves nothing evictable we take the over-budget write:
-    // a long URL beats trading a comment for a flag, and the send proceeds
-    // either way.
+    // right now must never be the victim. The stamp itself is what pushes the
+    // list over budget, so the payload IS the whole sent tier — one click would
+    // drop a live comment out of the review the user is in the middle of
+    // sending, and the "removed" note explaining it goes into a bar the
+    // navigation destroys milliseconds later. (Not annihilation: the same save
+    // mirrors every comment into the `<file>.json` log below, where absence
+    // never deletes, so an evicted comment is still recoverable through the
+    // history view. It leaves the LIVE store — the rail, the pins, the shared
+    // URL — which for a comment being sent right now is loss enough.) When that
+    // leaves nothing evictable we take the over-budget write: a long URL beats
+    // dropping a comment from the live review to make room for a flag, and the
+    // send proceeds either way.
     function evictTarget(arr, keep) {
       const pool0 = keep ? arr.filter((c) => !keep.has(c.id)) : arr;
       for (const tier of [(c) => c.resolved, (c) => c.sent && !c.resolved]) {
@@ -882,7 +897,11 @@
         // A sent comment is excluded from the NEXT handoff (see `sendable`), so
         // say so on the card — otherwise "Send to Claude" silently ignoring it
         // reads as the button being broken. Reopen clears the flag.
-        const sentTag = c.sent ? chip("sent ↗") : "";
+        // Not on a resolved card: resolved is the terminal state and already
+        // explains the exclusion (and owns the stronger dim, see .card.resolved
+        // .sent), so stacking a second "why this is skipped" chip on it is
+        // noise. The handoff still shows in the file's history log either way.
+        const sentTag = c.sent && !c.resolved ? chip("sent ↗") : "";
         card.innerHTML = `
           <div class="when"><span class="lbl">${label}</span> ${new Date(c.createdAt).toLocaleString()} ${tag}${sentTag}</div>
           <div class="body"></div>

--- a/fused_render/templates/annotate/template.html
+++ b/fused_render/templates/annotate/template.html
@@ -228,6 +228,9 @@
   }
   .card button:hover { border-color: var(--accent); }
   .card.resolved { opacity: 0.6; }
+  /* Already handed to Claude — excluded from the next send, but not settled, so
+     it dims less than a resolved card. The "sent ↗" chip carries the meaning. */
+  .card.sent { opacity: 0.8; }
   .card.active { background: var(--bg); border-left: 3px solid var(--accent); padding-left: 13px; }
   .card .lbl {
     display: inline-flex; align-items: center; justify-content: center;
@@ -451,27 +454,44 @@
         return [];
       }
     }
+    // A comment is handed to Claude ONCE: `sent: 1` (see the Send to Claude
+    // handler) marks the ones a previous handoff carried, `resolved` marks the
+    // settled ones, and only the remainder rides the next send. The flag is
+    // deliberately the shortest truthy value that survives JSON — the URL store
+    // has a hard byte BUDGET below, so a timestamp string would buy nothing the
+    // sidecar's own `updated_at` doesn't already record.
+    const sendable = (arr) => arr.filter((c) => !c.resolved && !c.sent);
     // The URL is the store, so it has a budget (~6 KB, matching the removed
-    // overlay): over it, evict oldest RESOLVED threads first — open comments
-    // are never dropped silently; if still over, keep the write (a long URL
-    // beats lost data) and say so in the bar.
+    // overlay): over it, evict the oldest RESOLVED thread first, then the oldest
+    // SENT one — a sent comment is already in the chat transcript, so it is the
+    // next-cheapest thing to lose, while an OPEN, UNSENT comment exists nowhere
+    // else and is never dropped silently; if still over, keep the write (a long
+    // URL beats lost data) and say so in the bar.
     const BUDGET = 6000;
     // Measure what actually lands on the URL — the encoded form (quotes and
     // braces percent-encode, roughly tripling), not the raw JSON.
     const urlSize = (arr) => encodeURIComponent(JSON.stringify(arr)).length;
+    // Oldest evictable comment, resolved tier before sent tier, or null when
+    // every remaining comment is open and unsent.
+    function evictTarget(arr) {
+      for (const tier of [(c) => c.resolved, (c) => c.sent && !c.resolved]) {
+        const pool = arr.filter(tier);
+        if (pool.length) return pool.reduce((a, b) => (a.createdAt <= b.createdAt ? a : b));
+      }
+      return null;
+    }
     function save(arr, deletedIds) {
       let dropped = 0;
       while (urlSize(arr) > BUDGET) {
-        const resolved = arr.filter((c) => c.resolved);
-        if (!resolved.length) break;
-        const oldest = resolved.reduce((a, b) => (a.createdAt <= b.createdAt ? a : b));
+        const oldest = evictTarget(arr);
+        if (!oldest) break;
         arr = arr.filter((c) => c.id !== oldest.id);
         dropped++;
       }
       const over = urlSize(arr) > BUDGET;
       const note = document.getElementById("budgetnote");
       note.textContent = dropped
-        ? `${dropped} oldest resolved comment${dropped === 1 ? "" : "s"} removed — URL size limit`
+        ? `${dropped} oldest resolved/sent comment${dropped === 1 ? "" : "s"} removed — URL size limit`
         : over
           ? "comment list exceeds the URL budget — resolve or delete some"
           : "";
@@ -494,6 +514,11 @@
         // history write (this call is fire-and-forget, so no error would surface).
       }, { key: null }).catch(() => {});
       render();
+      // The list as PERSISTED (post-eviction) — the Send to Claude handler needs
+      // it to write `comments` into its own top-URL navigation, because set()
+      // above may only have written the coalesced overlay (D99) and not yet the
+      // real history entry the handler reads back.
+      return arr;
     }
 
     // --- anchors (tag:nth-of-type path inside the framed doc) ---------------
@@ -842,10 +867,14 @@
                 ? chip(off.r.label(off.m, doc) || "off-page")
                 : "<span style='color:var(--error)'>detached</span>";
         const card = document.createElement("div");
-        card.className = "card" + (c.resolved ? " resolved" : "") + (c.id === activeId ? " active" : "");
+        card.className = "card" + (c.resolved ? " resolved" : "") + (c.sent ? " sent" : "") + (c.id === activeId ? " active" : "");
         card.setAttribute("data-id", c.id);
+        // A sent comment is excluded from the NEXT handoff (see `sendable`), so
+        // say so on the card — otherwise "Send to Claude" silently ignoring it
+        // reads as the button being broken. Reopen clears the flag.
+        const sentTag = c.sent ? chip("sent ↗") : "";
         card.innerHTML = `
-          <div class="when"><span class="lbl">${label}</span> ${new Date(c.createdAt).toLocaleString()} ${tag}</div>
+          <div class="when"><span class="lbl">${label}</span> ${new Date(c.createdAt).toLocaleString()} ${tag}${sentTag}</div>
           <div class="body"></div>
           <div class="acts">
             <button data-a="resolve">${c.resolved ? "Reopen" : "Resolve"}</button>
@@ -863,7 +892,15 @@
           }
         };
         card.querySelector('[data-a="resolve"]').onclick = () => {
-          c.resolved = !c.resolved; save(comments);
+          c.resolved = !c.resolved;
+          // Reopen also un-sends: reopening says "this isn't done", and the only
+          // way to hand the same comment to Claude again is to clear the flag
+          // that excludes it. (Resolving does NOT set `sent` — the two flags are
+          // independent reasons to skip a comment.) `delete` rather than
+          // `sent = 0`, so the key leaves the URL entirely and the sidecar's
+          // None-guard merge (annotate.py) doesn't carry a falsy value forward.
+          if (!c.resolved) delete c.sent;
+          save(comments);
         };
         card.querySelector('[data-a="delete"]').onclick = () => {
           // Local delete is just absence from the URL array; the id also rides
@@ -1291,15 +1328,34 @@
       render();
       focusFromParam(); // consume a `comment` deep link once the frame is wired
     });
-    // Send to Claude: hand the whole review to the claude chat mode. Copies
-    // the current comments verbatim into a `claudeComments` param and flips
-    // the BROWSER URL (window.top — the address bar, not this iframe) to
-    // _mode=claude. `comments` stays untouched, so switching back to annotate
-    // shows the same review. The framed editor is flushed first (same contract
-    // as every other mode switch), and the `_layout=(…)` span — whose `&` is
-    // literal — is excised before URLSearchParams touches the query, then
-    // reattached last, byte-for-byte.
+    // Send to Claude: hand the NEW comments to the claude chat mode. Copies the
+    // comments that are neither resolved nor already `sent` (see `sendable`)
+    // verbatim into a `claudeComments` param and flips the BROWSER URL
+    // (window.top — the address bar, not this iframe) to _mode=claude.
+    // `comments` stays untouched apart from the `sent` stamp, so switching back
+    // to annotate shows the same review. The framed editor is flushed first
+    // (same contract as every other mode switch), and the `_layout=(…)` span —
+    // whose `&` is literal — is excised before URLSearchParams touches the
+    // query, then reattached last, byte-for-byte.
+    //
+    // ⚠️ DELIBERATE STANDARD-BREAK (mirror of clearTopClaudeComments in
+    // templates/claude/template.html): this writes window.top's URL directly
+    // instead of going through fused.params. `_mode` is a RESERVED param name —
+    // fused.params.set THROWS on it (runtime.js isReserved) — and in a pane the
+    // param boundary (D72) puts the shell URL out of fused.params' reach
+    // anyway, so a top-level URL write is the only way to switch mode. The
+    // handoff params (`claudeComments`, `claudeReturn`) ride the same write.
     document.getElementById("toclaude").addEventListener("click", async () => {
+      // Nothing new to hand over: say so in the bar (the same inline note the
+      // budget uses) and stay put — navigating to a chat with an empty
+      // attachment list would look like the review had been sent.
+      const all = load();
+      const payload = sendable(all);
+      if (!payload.length) {
+        document.getElementById("budgetnote").textContent =
+          all.length ? "nothing new to send — reopen a comment to send it again" : "no comments to send";
+        return;
+      }
       const flush = window.__fusedFlushEdits;
       try {
         const res = await Promise.race([
@@ -1310,6 +1366,12 @@
       } catch (e) {
         return;
       }
+      // Stamp and persist BEFORE navigating: save() is what writes the `comments`
+      // URL param (and, via the verbatim field merge in annotate.py, the
+      // `<file>.json` sidecar), and this frame is about to be torn down by the
+      // mode switch — a stamp applied after the navigation would never land.
+      for (const c of payload) c.sent = 1;
+      const persisted = save(all);
       const top = window.top.location;
       const full = (top.search || "").replace(/^\?/, "");
       const rest = withoutLayoutSpan(top.search);
@@ -1328,7 +1390,24 @@
       }
       const params = new URLSearchParams(rest);
       params.set("_mode", "claude");
-      params.set("claudeComments", JSON.stringify(load()));
+      params.set("claudeComments", JSON.stringify(payload));
+      // Re-assert the review from what save() actually persisted. This URL is
+      // built from a raw read of window.top's search, and fused.params.set
+      // COALESCES its history write (D99) — so the `sent` stamps may not be in
+      // that string yet, and writing it back verbatim would silently undo them
+      // and re-send the same comments on the next visit.
+      params.set("comments", JSON.stringify(persisted));
+      // Return ticket: the chat has nothing else that would ever bring the user
+      // back (it turns auto-reload off and lives entirely inside its own frame),
+      // so the run that carries these comments navigates the shell back to this
+      // mode when it finishes. The value names the mode to return to, so the
+      // chat needs no knowledge of who sent it. `view` rides along explicitly —
+      // it is the annotate param that picks WHICH sibling view is framed, and
+      // re-asserting it here means the round trip can't land on the default
+      // view if the shell hadn't synced it yet.
+      params.set("claudeReturn", "annotate");
+      const view = fused.params.get("view");
+      if (view) params.set("view", view);
       let search = params.toString();
       if (span) search += (search ? "&" : "") + span;
       window.top.location.href = top.pathname + (search ? "?" + search : "");

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -664,10 +664,13 @@ let attached = parseComments();
 // immediately, so the URL cannot be consulted later. Empty when this chat was
 // opened normally — then nothing ever navigates away.
 const returnMode = fused.params.get("claudeReturn") || "";
-// Armed only by the send that actually carries comments (composeAndSend), and
-// consumed by that run's completion (pollLoop). A plain chat turn afterwards
-// must not teleport the user out of the conversation.
-let pendingReturn = false;
+// The ticket is deliberately NOT a module-scoped latch. It travels as a
+// `handoff` argument from composeAndSend → sendMessage → pollLoop, so it is
+// bound to ONE message and, past the start, to one run id. A latch leaked: a
+// `start` that failed left it armed with no run to consume it, and the user's
+// next unrelated question then navigated the shell away mid-thread — for a run
+// that carried no comments, while annotate had already stamped those comments
+// `sent`. Threading it makes that unrepresentable.
 
 function buildChip(c, i) {
   const chip = document.createElement("div");
@@ -789,6 +792,16 @@ function clearTopClaudeComments() {
 function returnToMode(mode) {
   let top;
   try { top = window.top; void top.location.href; } catch (e) { return; }  // cross-origin
+  // Land any history write the runtime is still coalescing (D99) BEFORE reading
+  // the URL, and before pushing our own entry. Two ways it bites otherwise:
+  // this function reads `location.search` RAW, so a pending `session_id`/`run`
+  // write would not be in the string it copies forward; and the trailing timer
+  // would fire after our pushState and replaceState the PRE-return search
+  // (`_mode=claude`, stale `run=`) straight over the entry we just created.
+  // `pagehide` is the runtime's own documented flush hook (runtime.js), and
+  // this document is about to be replaced by the re-route anyway, so firing it
+  // early is exactly what it is for.
+  try { window.dispatchEvent(new Event("pagehide")); } catch (e) { /* best-effort */ }
   const full = (top.location.search || "").replace(/^\?/, "");
   const m = /(^|&)_layout=\(/.exec(full);
   let span = null;
@@ -826,17 +839,19 @@ function returnToMode(mode) {
 // clearTopClaudeComments); the comments live only in `attached` from here on.
 function composeAndSend(typed) {
   let message = typed;
+  // Non-null only for the ONE send that actually carries comments: it holds the
+  // return ticket (empty `mode` when this chat was opened normally, i.e. no
+  // ticket, so nothing navigates) and the comments themselves, so a `start`
+  // that never ran can hand them back instead of swallowing them.
+  let handoff = null;
   if (attached.length) {
     const block = formatComments(attached);
     message = typed ? block + "\n\n" + typed : block;
+    handoff = { mode: returnMode, comments: attached };
     attached = [];
     renderAttachments();
-    // Arm the return trip for THIS run only (consumed in pollLoop). Set here,
-    // not at boot, because the user may never send: an unsent handoff must
-    // leave them wherever they are.
-    if (returnMode) pendingReturn = true;
   }
-  sendMessage(message);
+  sendMessage(message, handoff);
 }
 
 // ── log rendering ──
@@ -1280,7 +1295,10 @@ let sending = false;
 // if this frame dies mid-loop (mode switch, reload), the subprocess keeps
 // going and the next boot re-attaches via resumeRun. Cleared only when a
 // poll reports the run finished.
-async function pollLoop(run_id) {
+async function pollLoop(run_id, handoff) {
+  // The return ticket for THIS run only (see composeAndSend). Undefined for a
+  // plain turn and for a run re-attached at boot (resumeRun) — neither returns.
+  const returnTo = (handoff && handoff.mode) || "";
   const w = addWorking();
   let reply = null;
   let typer = null;
@@ -1314,12 +1332,12 @@ async function pollLoop(run_id) {
         }
         // The comment-carrying run finished cleanly: hand the shell back to the
         // mode that sent it, so the reviewer sees the edited file instead of
-        // sitting in a chat that never reloads. Consumed either way — one send,
-        // one return, so a follow-up turn in this session stays in the chat.
-        // Deliberately NOT on the error path (nor in the catch below): a run
-        // that failed or was aborted has changed nothing to go back and look
-        // at, and navigating away would hide the error message.
-        if (pendingReturn && !data.error) returnToMode(returnMode);
+        // sitting in a chat that never reloads. `returnTo` is this call's own
+        // argument, so a follow-up turn in this session has none and stays in
+        // the chat. Deliberately NOT on the error path (nor in the catch below):
+        // a run that failed or was aborted has changed nothing to go back and
+        // look at, and navigating away would hide the error message.
+        if (returnTo && !data.error) returnToMode(returnTo);
         break;
       }
       await sleep(400);
@@ -1333,18 +1351,17 @@ async function pollLoop(run_id) {
     if (reply) reply.remove();
     addError(err.message);
   } finally {
-    // One send, one return: cleared however this run ended (done, errored, or
-    // the poll itself threw) so a later turn in the same session can never
-    // inherit the ticket and teleport the user out of the conversation.
-    pendingReturn = false;
     if (w.el.isConnected) { w.stop(); w.el.remove(); }
   }
 }
 
-async function sendMessage(message) {
+async function sendMessage(message, handoff) {
   if (sending) return;
   sending = true;
   addUser(message);
+  // Until `start` hands back a run id, nothing has received the message — so a
+  // failure up to that point must not consume the attached comments.
+  let started = false;
   try {
     const { run_id, error } = await fused.runPython("./agent.py", {
       action: "start",
@@ -1360,9 +1377,21 @@ async function sendMessage(message) {
     }, { key: null });
     if (error) throw new Error(error);
     fused.params.set("run", run_id);
-    await pollLoop(run_id);
+    // The agent has the message; from here the handoff belongs to this run id.
+    started = true;
+    await pollLoop(run_id, handoff);
   } catch (err) {
     addError(err.message);
+    // The run never started (bad model, agent.py raised, …) and the composed
+    // message died with it — so put the comment chips back rather than silently
+    // eating a review that annotate has already stamped `sent`. Only on the
+    // pre-start path: once the agent has the message, restoring the chips would
+    // send the same comments twice.
+    if (!started && handoff) {
+      attached = handoff.comments;
+      renderAttachments();
+      addError("Those comments were not sent — they are attached again, ready to retry.");
+    }
   } finally {
     sending = false;
   }

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -658,6 +658,17 @@ function parseComments() {
 
 let attached = parseComments();
 
+// The return ticket that came with those comments (`claudeReturn=<mode>`, set by
+// annotate's "Send to Claude"). Captured into JS memory at boot for the same
+// reason `attached` is: clearTopClaudeComments strips it from the shell URL
+// immediately, so the URL cannot be consulted later. Empty when this chat was
+// opened normally — then nothing ever navigates away.
+const returnMode = fused.params.get("claudeReturn") || "";
+// Armed only by the send that actually carries comments (composeAndSend), and
+// consumed by that run's completion (pollLoop). A plain chat turn afterwards
+// must not teleport the user out of the conversation.
+let pendingReturn = false;
+
 function buildChip(c, i) {
   const chip = document.createElement("div");
   chip.className = "chip";
@@ -719,10 +730,15 @@ function formatComments(arr) {
 //      the bug. Clearing the live entry in place with replaceState (never a
 //      push) means the comments were never on any reachable entry. We keep
 //      them only in the in-memory `attached` array for the send.
-// Surgical + best-effort: only this one key is deleted, the balanced
-// `_layout=(…)` span (its `&` is literal) is excised first and reattached last
-// byte-for-byte, and any failure is swallowed. Mirror of the write side —
-// annotate's "Send to Claude" sets this same top param the same way.
+// Surgical + best-effort: only the handoff keys are deleted (`claudeComments`
+// and its `claudeReturn` return ticket — both are one-shot boot inputs, already
+// in memory as `attached`/`returnMode`, and a Back entry still carrying them
+// would re-attach a review that was already sent), the balanced `_layout=(…)`
+// span (its `&` is literal) is excised first and reattached last byte-for-byte,
+// and any failure is swallowed. Mirror of the write side — annotate's "Send to
+// Claude" sets these same top params the same way.
+const HANDOFF_PARAMS = ["claudeComments", "claudeReturn"];
+
 function clearTopClaudeComments() {
   let top;
   try { top = window.top; void top.location.href; } catch (e) { return; }  // cross-origin
@@ -742,8 +758,8 @@ function clearTopClaudeComments() {
     rest = (full.slice(0, m.index) + full.slice(i)).replace(/^&|&$/g, "");
   }
   const params = new URLSearchParams(rest);
-  if (!params.has("claudeComments")) return;
-  params.delete("claudeComments");
+  if (!HANDOFF_PARAMS.some((k) => params.has(k))) return;
+  HANDOFF_PARAMS.forEach((k) => params.delete(k));
   let search = params.toString();
   if (span) search += (search ? "&" : "") + span;
   const url = top.location.pathname + (search ? "?" + search : "");
@@ -751,6 +767,58 @@ function clearTopClaudeComments() {
     top.history.replaceState(top.history.state, "", url);
     top.dispatchEvent(new Event("fused:urlchange"));  // let the shell re-sync
   } catch (e) { /* best-effort — a failed clear must not break the send */ }
+}
+
+// ── the return trip ───────────────────────────────────────────
+// Send the shell back to the mode that handed us the comments, once that run is
+// done. Without this the handoff is one-way: this frame calls
+// fused.autoReload(false) and owns the whole viewport, so a user who sent a
+// review sat in the chat and never saw the edited file.
+//
+// ⚠️ DELIBERATE STANDARD-BREAK, for the same two reasons as
+// clearTopClaudeComments above: `_mode` lives on the SHELL url (above this
+// pane's param boundary, D72) and is a RESERVED param name that
+// fused.params.set refuses outright (runtime.js isReserved), so switching mode
+// can only be done by writing window.top's URL. The navigation itself reuses
+// the history template's navigateShell idiom — pushState + a `fused:navigate`
+// event so the React shell re-routes in place, with a hard `location.href`
+// assignment as the cross-origin/no-shell fallback — rather than inventing a
+// third way to move the shell. Every other param (`comments`, `view`,
+// `session_id`, the `_layout` span) is preserved byte-for-byte, so the review
+// and the framed sibling view come back exactly as they were.
+function returnToMode(mode) {
+  let top;
+  try { top = window.top; void top.location.href; } catch (e) { return; }  // cross-origin
+  const full = (top.location.search || "").replace(/^\?/, "");
+  const m = /(^|&)_layout=\(/.exec(full);
+  let span = null;
+  let rest = full;
+  if (m) {
+    const start = m.index + m[1].length;
+    let i = start + "_layout=(".length, depth = 1;
+    while (i < full.length && depth > 0) {
+      if (full[i] === "(") depth++;
+      else if (full[i] === ")") depth--;
+      i++;
+    }
+    span = full.slice(start, i);
+    rest = (full.slice(0, m.index) + full.slice(i)).replace(/^&|&$/g, "");
+  }
+  const params = new URLSearchParams(rest);
+  params.set("_mode", mode);
+  // `run` marks a chat run as in-flight and is what the next boot re-attaches
+  // to (resumeRun). The run we are returning FROM has finished, so carrying the
+  // id back would make a later hop into chat re-poll a dead run.
+  params.delete("run");
+  let search = params.toString();
+  if (span) search += (search ? "&" : "") + span;
+  const url = top.location.pathname + (search ? "?" + search : "");
+  try {
+    top.history.pushState(null, "", url);
+    top.dispatchEvent(new Event("fused:navigate"));
+    return;
+  } catch (e) { /* fall through */ }
+  try { top.location.href = url; } catch (e) { location.href = url; }
 }
 
 // Fold any attached comments into the outgoing message, then hand off to the
@@ -763,6 +831,10 @@ function composeAndSend(typed) {
     message = typed ? block + "\n\n" + typed : block;
     attached = [];
     renderAttachments();
+    // Arm the return trip for THIS run only (consumed in pollLoop). Set here,
+    // not at boot, because the user may never send: an unsent handoff must
+    // leave them wherever they are.
+    if (returnMode) pendingReturn = true;
   }
   sendMessage(message);
 }
@@ -1240,6 +1312,14 @@ async function pollLoop(run_id) {
         } else if (data.text) {
           addAssistant("").lastChild.innerHTML = renderMd(data.text);
         }
+        // The comment-carrying run finished cleanly: hand the shell back to the
+        // mode that sent it, so the reviewer sees the edited file instead of
+        // sitting in a chat that never reloads. Consumed either way — one send,
+        // one return, so a follow-up turn in this session stays in the chat.
+        // Deliberately NOT on the error path (nor in the catch below): a run
+        // that failed or was aborted has changed nothing to go back and look
+        // at, and navigating away would hide the error message.
+        if (pendingReturn && !data.error) returnToMode(returnMode);
         break;
       }
       await sleep(400);
@@ -1253,6 +1333,10 @@ async function pollLoop(run_id) {
     if (reply) reply.remove();
     addError(err.message);
   } finally {
+    // One send, one return: cleared however this run ended (done, errored, or
+    // the poll itself threw) so a later turn in the same session can never
+    // inherit the ticket and teleport the user out of the conversation.
+    pendingReturn = false;
     if (w.el.isConnected) { w.stop(); w.el.remove(); }
   }
 }

--- a/fused_render/templates/history/template.html
+++ b/fused_render/templates/history/template.html
@@ -519,6 +519,12 @@
           content: { type: "string" },
           createdAt: { type: "number" },
           resolved: { type: "boolean" },
+          // Set to 1 by annotate's Send to Claude handoff (§17). Declared so a
+          // hand-edited log gets the same type check as `resolved`; NOT surfaced
+          // as a timeline label, because Reopen clears it by removing the key
+          // and absence never deletes here — the stored flag can outlive the
+          // truth, and a label that lies is worse than no label.
+          sent: { type: "number" },
           view: { type: "string" },
           anchorPath: { type: "string" },
           recorded_at: { type: "number" },

--- a/tests/test_annotate_comments.py
+++ b/tests/test_annotate_comments.py
@@ -88,6 +88,32 @@ def test_resolved_change_flows_through_as_update(tmp_path):
     assert log[0]["resolved"] is True
 
 
+def test_the_sent_flag_rides_the_verbatim_field_merge(tmp_path):
+    # The template stamps `sent: 1` on the comments a Send to Claude handoff
+    # carried and save()s BEFORE the mode switch (§17). Nothing here knows the
+    # field by name — the merge copies whatever the comment carries — so this
+    # pins that a new lifecycle flag reaches the log for free, and that the
+    # SHORT truthy value the URL budget wants survives as-is (not coerced to a
+    # bool, not dropped as falsy).
+    ann = _load_annotate()
+    f = _target(tmp_path)
+    ann._record(str(f), [{"id": "c1", "content": "hi", "createdAt": 1}], [])
+    ann._record(str(f), [
+        {"id": "c1", "content": "hi", "createdAt": 1, "sent": 1}], [])
+
+    log = json.loads(_sidecar(tmp_path).read_text())["comments"]
+    assert len(log) == 1
+    assert log[0]["sent"] == 1
+
+    # Reopen clears the flag by DELETING the key (URL-minimal, matching the
+    # template's other optional fields), and absence never deletes here — so the
+    # log keeps its last-seen `sent`. That asymmetry is why the history timeline
+    # deliberately does not surface `sent` as a label (§17): it can go stale.
+    ann._record(str(f), [{"id": "c1", "content": "hi", "createdAt": 1}], [])
+    log = json.loads(_sidecar(tmp_path).read_text())["comments"]
+    assert log[0]["sent"] == 1
+
+
 def test_dropped_comment_stays_in_sidecar(tmp_path):
     ann = _load_annotate()
     f = _target(tmp_path)

--- a/tests/test_annotate_template.py
+++ b/tests/test_annotate_template.py
@@ -9,15 +9,31 @@ notes view, a CodeMirror editor whose lineNumbers gutter is present but
 **hidden**, so these pin the detection rule and the container rule that keep it
 working.
 
+It also covers the **Send to Claude round trip** (§17): which comments ride a
+handoff (`sent`), how the URL budget evicts them, and the `claudeReturn` ticket
+that brings the shell back to annotate when the run finishes. The return leg's
+code lives in `templates/claude/template.html`, but the contract is annotate's —
+annotate is the only thing that sets the ticket, and a silent regression there
+means a reviewer is stranded in a chat that never reloads. Those pieces run the
+template's REAL functions under node (the `_js_block` approach of
+test_map_template_escaping.py / test_calls.py — a copy would keep passing after
+the shipping code regressed).
+
 The sidecar writer next door has its own behavioural tests
 (tests/test_annotate_comments.py).
 """
+import json
 import os
+import shutil
+import subprocess
 
 import pytest
 
 TEMPLATE = os.path.join(
     os.path.dirname(__file__), "..", "fused_render", "templates", "annotate",
+    "template.html")
+CLAUDE_TEMPLATE = os.path.join(
+    os.path.dirname(__file__), "..", "fused_render", "templates", "claude",
     "template.html")
 
 
@@ -25,6 +41,30 @@ TEMPLATE = os.path.join(
 def source():
     with open(TEMPLATE, encoding="utf-8") as handle:
         return handle.read()
+
+
+@pytest.fixture(scope="module")
+def claude_source():
+    with open(CLAUDE_TEMPLATE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _block(src, start, end):
+    """The shipping source from `start` up to and including `end`, verbatim."""
+    i = src.index(start)
+    j = src.index(end, i) + len(end)
+    return src[i:j]
+
+
+def _node(script, tmp_path):
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - node is preinstalled on the CI runners
+        pytest.skip("node is required to drive the template's own JS")
+    harness = tmp_path / "harness.mjs"
+    harness.write_text(script, encoding="utf-8")
+    out = subprocess.run([node, str(harness)], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
 
 
 def test_the_line_strategy_needs_a_gutter_that_is_actually_laid_out(source):
@@ -58,3 +98,237 @@ def test_a_quote_in_a_gutterless_editor_anchors_on_the_stable_content_element(
     body = body[:body.index('doc.addEventListener("click"')]
     assert 'cont.closest(".cm-content")' in body
     assert "if (content) cont = content;" in body
+
+
+# --- the Send to Claude payload (`sent`) ------------------------------------
+
+
+def test_a_handoff_only_carries_comments_that_are_neither_resolved_nor_sent(
+        source, tmp_path):
+    # The bug: the button sent load() in full, so every Claude turn re-received
+    # the entire review — resolved threads and threads the previous turn had
+    # already answered — and the agent re-did work it had just done.
+    fn = _block(source, "const sendable = (arr) =>", ";")
+    got = _node(
+        fn + "\nconsole.log(JSON.stringify(sendable(" + json.dumps([
+            {"id": "open"},
+            {"id": "done", "resolved": True},
+            {"id": "already", "sent": 1},
+            {"id": "both", "resolved": True, "sent": 1},
+            {"id": "reopened"},
+        ]) + ").map((c) => c.id)));\n", tmp_path)
+    assert got == ["open", "reopened"]
+
+
+def test_the_send_handler_stamps_and_saves_before_it_navigates(source):
+    # Ordering is the whole fix: save() is what writes the `comments` URL param
+    # (and the sidecar), and the navigation tears this frame down — a stamp
+    # applied after `window.top.location.href` would never land, so the next
+    # visit would re-send everything again.
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    assert "const payload = sendable(all);" in body
+    assert "for (const c of payload) c.sent = 1;" in body
+    assert body.index("const persisted = save(all);") < body.index(
+        "window.top.location.href")
+    # And the payload is what crosses over — not the whole store.
+    assert 'params.set("claudeComments", JSON.stringify(payload));' in body
+    # The navigation URL is built from a RAW read of window.top's search, but
+    # fused.params.set coalesces its history write (D99) — so the stamps may not
+    # be in that string yet. Writing it back verbatim would undo them and
+    # re-send the same comments next time; the persisted list is re-asserted.
+    assert 'params.set("comments", JSON.stringify(persisted));' in body
+    assert "return arr;" in _block(source, "function save(arr, deletedIds) {",
+                                   "return arr;")
+
+
+def test_nothing_new_to_send_reports_in_the_bar_instead_of_navigating(source):
+    # An empty payload must not open a chat with no attachments (which reads as
+    # "the review was sent"). The affordance is the template's existing inline
+    # note, not an alert.
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    early = body[:body.index("const flush = window.__fusedFlushEdits;")]
+    assert "if (!payload.length) {" in early
+    assert 'document.getElementById("budgetnote").textContent' in early
+    assert "return;" in early
+    assert "alert(" not in body
+
+
+def test_reopen_clears_sent_so_a_comment_can_be_sent_again(source):
+    # Reopen is the ONLY way back into the payload; without this the flag is a
+    # one-way door and a comment can never be re-raised with Claude.
+    body = _block(source, "card.querySelector('[data-a=\"resolve\"]').onclick",
+                  "save(comments);")
+    assert "c.resolved = !c.resolved;" in body
+    assert "if (!c.resolved) delete c.sent;" in body
+
+
+def test_a_sent_card_says_so(source):
+    # Otherwise the exclusion is invisible and the button looks broken.
+    assert 'const sentTag = c.sent ? chip("sent ↗") : "";' in source
+    assert '(c.sent ? " sent" : "")' in source
+    assert ".card.sent {" in source
+
+
+# --- URL budget eviction order ---------------------------------------------
+
+
+def test_eviction_drops_resolved_before_sent_and_never_an_open_comment(
+        source, tmp_path):
+    fn = _block(source, "function evictTarget(arr) {", "\n    }")
+    pool = json.dumps([
+        {"id": "open-oldest", "createdAt": 1},
+        {"id": "sent-old", "createdAt": 2, "sent": 1},
+        {"id": "resolved-new", "createdAt": 9, "resolved": True},
+        {"id": "sent-new", "createdAt": 10, "sent": 1},
+        {"id": "resolved-old", "createdAt": 3, "resolved": True},
+    ])
+    # Drain the pool the way save() does and record the eviction order.
+    got = _node(
+        fn.strip() + "\nlet arr = " + pool + ";\nconst order = [];\n"
+        "for (;;) { const t = evictTarget(arr); if (!t) break;"
+        " order.push(t.id); arr = arr.filter((c) => c.id !== t.id); }\n"
+        "console.log(JSON.stringify({ order, left: arr.map((c) => c.id) }));\n",
+        tmp_path)
+    # Resolved tier first (oldest within it), then the sent tier — and the open,
+    # unsent comment survives even though it is the oldest thing in the list.
+    assert got["order"] == ["resolved-old", "resolved-new", "sent-old", "sent-new"]
+    assert got["left"] == ["open-oldest"]
+
+
+def test_the_budget_loop_uses_that_order_and_still_stops(source):
+    body = _block(source, "function save(arr, deletedIds) {", "URL size limit")
+    assert "const oldest = evictTarget(arr);" in body
+    assert "if (!oldest) break;" in body  # an all-open list must not spin forever
+    assert "resolved/sent" in body  # the bar note names both tiers now
+
+
+# --- the return trip (annotate → claude → annotate) -------------------------
+#
+# The chat calls fused.autoReload(false) and owns the viewport, so nothing else
+# would ever bring the reviewer back to the edited file. The code below lives in
+# templates/claude/template.html; the contract is annotate's.
+
+# A shell URL with everything that must survive a round trip: the review itself,
+# the annotate `view` param, and the balanced `_layout=(…)` span whose `&` is
+# LITERAL — hand that to URLSearchParams unexcised and the layout is shredded.
+_LAYOUT = "_layout=(h:(t:code&t:claude),v:preview)"
+_SHELL_STUB = """
+class Event { constructor(t) { this.type = t; } }
+const seen = [];
+let search = SEARCH;
+const window = { top: {
+  location: { get search() { return search; }, pathname: "/view/tmp/note.md",
+              href: "http://127.0.0.1:8765/view/tmp/note.md" },
+  history: { state: { k: 1 },
+             replaceState: (s, t, u) => { seen.push(["replaceState", u]); },
+             pushState: (s, t, u) => { seen.push(["pushState", u]); } },
+  dispatchEvent: (e) => { seen.push(["event", e.type]); },
+} };
+"""
+
+
+def _shell_harness(fns, search, call):
+    return (_SHELL_STUB.replace("SEARCH", json.dumps("?" + search))
+            + "\n".join(fns) + "\n" + call
+            + "\nconsole.log(JSON.stringify(seen));\n")
+
+
+def test_the_return_ticket_is_stripped_from_the_shell_url_like_the_comments(
+        claude_source, tmp_path):
+    # claudeReturn is a one-shot boot input, already in memory as `returnMode`.
+    # Left on the URL, a Back entry (or a refresh) re-attaches a review that was
+    # already sent and re-arms the return — so it rides the SAME replaceState.
+    fns = [_block(claude_source, "const HANDOFF_PARAMS = [", "];"),
+           _block(claude_source, "function clearTopClaudeComments() {", "\n}")]
+    seen = _node(_shell_harness(
+        fns,
+        "_mode=claude&comments=%5B%7B%22id%22%3A%22c1%22%7D%5D&view=markdown"
+        "&claudeComments=%5B%7B%22id%22%3A%22c1%22%7D%5D&claudeReturn=annotate"
+        "&" + _LAYOUT,
+        "clearTopClaudeComments();"), tmp_path)
+    assert [k for k, _ in seen] == ["replaceState", "event"]
+    url = seen[0][1]
+    assert "claudeComments" not in url
+    assert "claudeReturn" not in url
+    # The review, the framed view and the layout span come through untouched.
+    assert "comments=%5B%7B%22id%22%3A%22c1%22%7D%5D" in url
+    assert "view=markdown" in url
+    assert url.endswith("&" + _LAYOUT)
+    assert seen[1][1] == "fused:urlchange"
+
+
+def test_a_chat_opened_normally_never_rewrites_the_shell_url(
+        claude_source, tmp_path):
+    fns = [_block(claude_source, "const HANDOFF_PARAMS = [", "];"),
+           _block(claude_source, "function clearTopClaudeComments() {", "\n}")]
+    seen = _node(_shell_harness(fns, "_mode=claude&session_id=abc",
+                                "clearTopClaudeComments();"), tmp_path)
+    assert seen == []
+
+
+def test_the_return_navigation_flips_the_mode_and_keeps_the_review(
+        claude_source, tmp_path):
+    fn = _block(claude_source, "function returnToMode(mode) {", "\n}")
+    seen = _node(_shell_harness(
+        [fn],
+        "_mode=claude&comments=%5B%7B%22id%22%3A%22c1%22%2C%22sent%22%3A1%7D%5D"
+        "&view=markdown&session_id=abc&run=r-42&" + _LAYOUT,
+        'returnToMode("annotate");'), tmp_path)
+    # navigateShell's idiom (history/template.html): pushState + fused:navigate,
+    # so the React shell re-routes in place instead of reloading the world.
+    assert [k for k, _ in seen] == ["pushState", "event"]
+    assert seen[1][1] == "fused:navigate"
+    url = seen[0][1]
+    assert url.startswith("/view/tmp/note.md?")
+    assert "_mode=annotate" in url and "_mode=claude" not in url
+    # The review survives verbatim — same comments, same sent stamps — and so do
+    # the framed view and the resumable session.
+    assert "comments=%5B%7B%22id%22%3A%22c1%22%2C%22sent%22%3A1%7D%5D" in url
+    assert "view=markdown" in url
+    assert "session_id=abc" in url
+    # The finished run's id does not ride back: the next hop into chat would
+    # re-attach (resumeRun) to a dead run.
+    assert "run=" not in url
+    assert url.endswith("&" + _LAYOUT)
+
+
+def test_only_the_comment_carrying_run_returns_and_only_when_it_succeeded(
+        claude_source):
+    # An in-memory one-shot. A plain follow-up turn must stay in the chat, a
+    # failed/aborted run must stay put (nothing to go back and look at, and
+    # leaving would hide the error), and a run re-attached on a fresh boot has
+    # no ticket at all.
+    compose = _block(claude_source, "function composeAndSend(typed) {", "\n}")
+    assert "if (returnMode) pendingReturn = true;" in compose
+    # Armed inside the `attached.length` branch — never for a bare turn.
+    assert compose.index("if (attached.length)") < compose.index("pendingReturn = true")
+
+    poll = _block(claude_source, "async function pollLoop(run_id) {", "\n}")
+    assert "if (pendingReturn && !data.error) returnToMode(returnMode);" in poll
+    # Cleared however the run ended — including the catch path, which is why the
+    # reset lives in `finally` rather than next to the navigation.
+    tail = poll[poll.index("} finally {"):]
+    assert "pendingReturn = false;" in tail
+    assert poll.count("pendingReturn = false;") == 1
+
+    boot = _block(claude_source, "const returnMode =", ";")
+    assert 'fused.params.get("claudeReturn")' in boot
+
+
+def test_annotate_is_what_sets_the_ticket(source):
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    assert 'params.set("claudeReturn", "annotate");' in body
+    # `view` is re-asserted so the round trip can't land on the default sibling
+    # view if the shell had not synced annotate's own param yet.
+    assert 'const view = fused.params.get("view");' in body
+    assert 'if (view) params.set("view", view);' in body
+    # `_mode` cannot go through fused.params (reserved name → throws), so the
+    # standard-break has to be spelled out where the write happens — this repo
+    # documents them in the template comment, next to the code that breaks it.
+    preamble = _block(source, "// Send to Claude: hand the NEW comments",
+                      'document.getElementById("toclaude").addEventListener')
+    assert "DELIBERATE STANDARD-BREAK" in preamble
+    assert "reserved" in preamble.lower()

--- a/tests/test_annotate_template.py
+++ b/tests/test_annotate_template.py
@@ -129,17 +129,43 @@ def test_the_send_handler_stamps_and_saves_before_it_navigates(source):
                   "window.top.location.href = top.pathname")
     assert "const payload = sendable(all);" in body
     assert "for (const c of payload) c.sent = 1;" in body
-    assert body.index("const persisted = save(all);") < body.index(
+    assert body.index("const persisted = save(all,") < body.index(
         "window.top.location.href")
     # And the payload is what crosses over — not the whole store.
-    assert 'params.set("claudeComments", JSON.stringify(payload));' in body
+    assert 'params.set("claudeComments", wire);' in body
     # The navigation URL is built from a RAW read of window.top's search, but
     # fused.params.set coalesces its history write (D99) — so the stamps may not
     # be in that string yet. Writing it back verbatim would undo them and
     # re-send the same comments next time; the persisted list is re-asserted.
     assert 'params.set("comments", JSON.stringify(persisted));' in body
-    assert "return arr;" in _block(source, "function save(arr, deletedIds) {",
+    assert "return arr;" in _block(source, "function save(arr, deletedIds, keep) {",
                                    "return arr;")
+
+
+def test_the_agent_never_sees_the_internal_sent_flag(source):
+    # `sent` is bookkeeping for the URL store. formatComments (claude template)
+    # hands the agent the raw JSON with every field intact and enumerates the
+    # fields by name, so a stamp serialized into the payload would show up as a
+    # mystery key for the model to reason about.
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    assert body.index("const wire = JSON.stringify(payload);") < body.index(
+        "for (const c of payload) c.sent = 1;")
+
+
+def test_the_staleness_sweep_covers_every_param_the_top_url_carries(source):
+    # Re-asserting `comments` and `view` by hand missed offset/sheet: a reveal
+    # inside the 400 ms coalescing window would return the user to page 1 of a
+    # table/pdf. The sweep is the general fix — and it must only touch keys the
+    # top URL already has, so a pane-local param is never pushed onto the shell.
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    assert "const live = fused.params.getAll();" in body
+    assert "for (const k of [...params.keys()]) {" in body
+    assert 'if (typeof live[k] === "string") params.set(k, live[k]);' in body
+    # Before the handoff params are written, so the sweep cannot revert them.
+    assert body.index("const live = fused.params.getAll();") < body.index(
+        'params.set("_mode", "claude");')
 
 
 def test_nothing_new_to_send_reports_in_the_bar_instead_of_navigating(source):
@@ -176,7 +202,7 @@ def test_a_sent_card_says_so(source):
 
 def test_eviction_drops_resolved_before_sent_and_never_an_open_comment(
         source, tmp_path):
-    fn = _block(source, "function evictTarget(arr) {", "\n    }")
+    fn = _block(source, "function evictTarget(arr, keep) {", "\n    }")
     pool = json.dumps([
         {"id": "open-oldest", "createdAt": 1},
         {"id": "sent-old", "createdAt": 2, "sent": 1},
@@ -197,9 +223,47 @@ def test_eviction_drops_resolved_before_sent_and_never_an_open_comment(
     assert got["left"] == ["open-oldest"]
 
 
+def test_a_comment_being_sent_is_never_the_eviction_victim(source, tmp_path):
+    # The save that STAMPS `sent` is also the save that can evict on it. With
+    # nothing resolved and the list sitting just under BUDGET, the stamp pushes
+    # it over, the sent tier is then the ENTIRE payload, and the oldest comment
+    # in the review gets deleted from the only store there is — silently, since
+    # the "removed" note lands in a bar the navigation destroys milliseconds
+    # later. Ids being sent right now are off-limits.
+    fn = _block(source, "function evictTarget(arr, keep) {", "\n    }")
+    arr = json.dumps([
+        {"id": "a", "createdAt": 1, "sent": 1},
+        {"id": "b", "createdAt": 2, "sent": 1},
+        {"id": "c", "createdAt": 3},
+    ])
+    got = _node(
+        fn.strip() + "\nconst arr = " + arr + ";\n"
+        # The whole sent tier is the payload being handed over right now.
+        "const sending = evictTarget(arr, new Set(['a', 'b']));\n"
+        # Same list, but 'a' rode an EARLIER handoff — then it is fair game.
+        "const earlier = evictTarget(arr, new Set(['b']));\n"
+        "console.log(JSON.stringify({ sending: sending && sending.id,"
+        " earlier: earlier && earlier.id, none: evictTarget(arr, new Set()) }));\n",
+        tmp_path)
+    assert got["sending"] is None  # nothing evictable → over-budget write kept
+    assert got["earlier"] == "a"
+    assert got["none"] == {"id": "a", "createdAt": 1, "sent": 1}
+
+
+def test_the_send_protects_its_own_payload_from_eviction(source):
+    body = _block(source, 'document.getElementById("toclaude").addEventListener',
+                  "window.top.location.href = top.pathname")
+    assert ("const persisted = save(all, undefined, "
+            "new Set(payload.map((c) => c.id)));") in body
+    # An over-budget write that keeps every comment is the accepted outcome —
+    # trading a live comment for a flag is not — and the send still proceeds.
+    assert body.index("const persisted = save(all,") < body.index(
+        'params.set("_mode", "claude")')
+
+
 def test_the_budget_loop_uses_that_order_and_still_stops(source):
-    body = _block(source, "function save(arr, deletedIds) {", "URL size limit")
-    assert "const oldest = evictTarget(arr);" in body
+    body = _block(source, "function save(arr, deletedIds, keep) {", "URL size limit")
+    assert "const oldest = evictTarget(arr, keep);" in body
     assert "if (!oldest) break;" in body  # an all-open list must not spin forever
     assert "resolved/sent" in body  # the bar note names both tiers now
 
@@ -226,6 +290,8 @@ const window = { top: {
              pushState: (s, t, u) => { seen.push(["pushState", u]); } },
   dispatchEvent: (e) => { seen.push(["event", e.type]); },
 } };
+// The pane's own window: `pagehide` is the runtime's documented flush hook.
+window.dispatchEvent = (e) => { seen.push(["self", e.type]); };
 """
 
 
@@ -276,11 +342,13 @@ def test_the_return_navigation_flips_the_mode_and_keeps_the_review(
         "_mode=claude&comments=%5B%7B%22id%22%3A%22c1%22%2C%22sent%22%3A1%7D%5D"
         "&view=markdown&session_id=abc&run=r-42&" + _LAYOUT,
         'returnToMode("annotate");'), tmp_path)
-    # navigateShell's idiom (history/template.html): pushState + fused:navigate,
-    # so the React shell re-routes in place instead of reloading the world.
-    assert [k for k, _ in seen] == ["pushState", "event"]
-    assert seen[1][1] == "fused:navigate"
-    url = seen[0][1]
+    # The runtime's coalesced history write is flushed first, then navigateShell's
+    # idiom (history/template.html): pushState + fused:navigate, so the React
+    # shell re-routes in place instead of reloading the world.
+    assert [k for k, _ in seen] == ["self", "pushState", "event"]
+    assert seen[0][1] == "pagehide"
+    assert seen[2][1] == "fused:navigate"
+    url = seen[1][1]
     assert url.startswith("/view/tmp/note.md?")
     assert "_mode=annotate" in url and "_mode=claude" not in url
     # The review survives verbatim — same comments, same sent stamps — and so do
@@ -296,25 +364,62 @@ def test_the_return_navigation_flips_the_mode_and_keeps_the_review(
 
 def test_only_the_comment_carrying_run_returns_and_only_when_it_succeeded(
         claude_source):
-    # An in-memory one-shot. A plain follow-up turn must stay in the chat, a
-    # failed/aborted run must stay put (nothing to go back and look at, and
-    # leaving would hide the error), and a run re-attached on a fresh boot has
-    # no ticket at all.
+    # The ticket is threaded, not latched. A plain follow-up turn must stay in
+    # the chat, a failed/aborted run must stay put (nothing to go back and look
+    # at, and leaving would hide the error), and a run re-attached on a fresh
+    # boot has no ticket at all.
     compose = _block(claude_source, "function composeAndSend(typed) {", "\n}")
-    assert "if (returnMode) pendingReturn = true;" in compose
-    # Armed inside the `attached.length` branch — never for a bare turn.
-    assert compose.index("if (attached.length)") < compose.index("pendingReturn = true")
+    assert "handoff = { mode: returnMode, comments: attached };" in compose
+    # Built inside the `attached.length` branch — a bare turn passes null.
+    assert compose.index("if (attached.length)") < compose.index("handoff = {")
+    assert "sendMessage(message, handoff);" in compose
 
-    poll = _block(claude_source, "async function pollLoop(run_id) {", "\n}")
-    assert "if (pendingReturn && !data.error) returnToMode(returnMode);" in poll
-    # Cleared however the run ended — including the catch path, which is why the
-    # reset lives in `finally` rather than next to the navigation.
-    tail = poll[poll.index("} finally {"):]
-    assert "pendingReturn = false;" in tail
-    assert poll.count("pendingReturn = false;") == 1
+    poll = _block(claude_source, "async function pollLoop(run_id, handoff) {", "\n}")
+    assert 'const returnTo = (handoff && handoff.mode) || "";' in poll
+    assert "if (returnTo && !data.error) returnToMode(returnTo);" in poll
 
     boot = _block(claude_source, "const returnMode =", ";")
     assert 'fused.params.get("claudeReturn")' in boot
+
+
+def test_a_run_that_never_started_leaves_no_ticket_and_hands_the_chips_back(
+        claude_source):
+    # The regression this replaces: the ticket was a module-scoped latch armed
+    # BEFORE sendMessage, and `if (error) throw` on a failed `agent.py start`
+    # never reaches pollLoop — the only place that cleared it. The user's next,
+    # unrelated question then navigated the shell away mid-thread, for a run that
+    # carried no comments, while annotate had already stamped them `sent`.
+    assert "pendingReturn" not in claude_source, (
+        "the return ticket must stay an argument — a module-scoped latch "
+        "outlives the send that armed it")
+    send = _block(claude_source, "async function sendMessage(message, handoff) {",
+                  "\n}")
+    # Bound to a run id: armed only once `start` handed one back.
+    assert "let started = false;" in send
+    assert send.index("started = true;") > send.index('if (error) throw')
+    assert send.index("started = true;") < send.index("await pollLoop(run_id, handoff)")
+    # And the comments are not silently consumed by a run that never ran.
+    assert "if (!started && handoff) {" in send
+    assert "attached = handoff.comments;" in send
+    assert "renderAttachments();" in send
+    assert "were not sent" in send  # the user is told, rather than left guessing
+
+    # A resumed run gets no second argument, so it can never return.
+    resume = _block(claude_source, "async function resumeRun(run_id) {", "\n}")
+    assert "pollLoop(run_id)" in resume
+    assert "handoff" not in resume
+
+
+def test_the_return_flushes_the_runtimes_pending_history_write_first(
+        claude_source):
+    # returnToMode reads location.search RAW and then pushState()s. A history
+    # write the runtime is still coalescing (D99) would both be missing from the
+    # string it copies forward (a pending session_id) and, worse, land AFTER our
+    # push — replaceState-ing the pre-return search over the entry we just made.
+    fn = _block(claude_source, "function returnToMode(mode) {", "\n}")
+    flush = fn.index('dispatchEvent(new Event("pagehide"))')
+    assert flush < fn.index("top.location.search")
+    assert flush < fn.index("top.history.pushState")
 
 
 def test_annotate_is_what_sets_the_ticket(source):

--- a/tests/test_annotate_template.py
+++ b/tests/test_annotate_template.py
@@ -24,6 +24,7 @@ The sidecar writer next door has its own behavioural tests
 """
 import json
 import os
+import re
 import shutil
 import subprocess
 
@@ -54,6 +55,30 @@ def _block(src, start, end):
     i = src.index(start)
     j = src.index(end, i) + len(end)
     return src[i:j]
+
+
+def _card_opacity(src, classes, reverse_order=False):
+    """Resolve the real CSS cascade for a card carrying `classes`.
+
+    Class-chain rules only (`.card.resolved` …), which is all the card styling
+    is. Winner = highest specificity (class count), then declaration order —
+    `reverse_order` flips that tie-break to prove a result does NOT depend on it.
+    """
+    style = src[src.index("<style>"):src.index("</style>")]
+    style = re.sub(r"/\*.*?\*/", "", style, flags=re.S)
+    best = None
+    for order, m in enumerate(re.finditer(r"([^{}]+)\{([^{}]*)\}", style)):
+        sel = m.group(1).strip()
+        hit = re.search(r"(?:^|;)\s*opacity\s*:\s*([0-9.]+)", m.group(2))
+        if not hit or not re.fullmatch(r"(?:\.[A-Za-z0-9_-]+)+", sel):
+            continue
+        need = set(sel.split(".")[1:])
+        if not need <= set(classes):
+            continue
+        key = (len(need), -order if reverse_order else order)
+        if best is None or key > best[0]:
+            best = (key, float(hit.group(1)))
+    return None if best is None else best[1]
 
 
 def _node(script, tmp_path):
@@ -142,6 +167,31 @@ def test_the_send_handler_stamps_and_saves_before_it_navigates(source):
                                    "return arr;")
 
 
+def test_resolved_outranks_sent_on_a_card_that_is_both(source):
+    # The two flags are independent, so a card can carry both. `.card.resolved`
+    # and `.card.sent` are equal specificity, so the tie went to whichever was
+    # written second — `.sent` was, so a RESOLVED card rendered at the weaker 0.8
+    # and read as prominent as an open one. Resolved is the terminal state and
+    # takes the stronger dim; the point of this test is that the precedence holds
+    # on SPECIFICITY, so reordering the stylesheet cannot silently flip it.
+    both = {"card", "resolved", "sent"}
+    assert _card_opacity(source, {"card", "resolved"}) == 0.6
+    assert _card_opacity(source, {"card", "sent"}) == 0.8
+    assert _card_opacity(source, both) == 0.6
+    # Same answer with the declaration-order tie-break inverted.
+    assert _card_opacity(source, both, reverse_order=True) == 0.6
+    # An open card is undimmed by any of these rules.
+    assert _card_opacity(source, {"card"}) is None
+
+
+def test_a_resolved_card_does_not_also_claim_to_be_sent(source):
+    # One state, one signal: resolved already explains why the comment is skipped
+    # (and owns the dim), so the "sent ↗" chip would be a second, weaker reason
+    # stacked on the terminal one. Reopen clears `sent`, so the chip can never
+    # reappear stale on a reopened card either.
+    assert 'const sentTag = c.sent && !c.resolved ? chip("sent ↗") : "";' in source
+
+
 def test_the_agent_never_sees_the_internal_sent_flag(source):
     # `sent` is bookkeeping for the URL store. formatComments (claude template)
     # hands the agent the raw JSON with every field intact and enumerates the
@@ -192,7 +242,7 @@ def test_reopen_clears_sent_so_a_comment_can_be_sent_again(source):
 
 def test_a_sent_card_says_so(source):
     # Otherwise the exclusion is invisible and the button looks broken.
-    assert 'const sentTag = c.sent ? chip("sent ↗") : "";' in source
+    assert 'chip("sent ↗")' in source
     assert '(c.sent ? " sent" : "")' in source
     assert ".card.sent {" in source
 


### PR DESCRIPTION
## Summary

- **The handoff comes back.** "Send to Claude" navigated the shell to `_mode=claude` and nothing ever navigated back — the chat calls `fused.autoReload(false)` and owns the viewport, so a reviewer who sent a review sat in the chat and never saw the edited file. Annotate now sends a `claudeReturn=annotate` ticket, and the run that actually carried the comments returns the shell to annotate when it finishes cleanly.
- **Each comment rides the handoff once.** The payload was `load()` in full, so every turn re-received the whole review — resolved threads and threads the previous turn had already answered. A per-comment `sent: 1` flag now marks what a handoff carried; the next send is the comments that are neither `resolved` nor `sent`.
- **Nothing new to send says so.** An empty payload writes the template's existing inline bar note instead of opening a chat with no attachments (which read as "the review was sent").
- **Reopen is the way back in**, and the ~6 KB URL budget gained a second eviction tier — oldest `resolved` first, then oldest `sent` (already in a chat transcript), never an open unsent comment.
- Both directions write `window.top`'s URL directly: `_mode` is a **reserved** param name `fused.params.set` refuses, and in a pane the shell URL sits above the param boundary (D72). Documented as standard-breaks in the template comments, in this repo's existing style. The return navigation reuses `history/template.html`'s `navigateShell` idiom (pushState + `fused:navigate`, `location.href` fallback) rather than inventing a third way to move the shell.

## Visuals

```mermaid
flowchart TD
    A[Annotate: Send to Claude] --> B{sendable comments?<br/>not resolved, not sent}
    B -->|none| C[Bar note, stay put]
    B -->|some| D[Stamp sent:1 + save<br/>then set _mode, claudeComments, claudeReturn]
    D --> E[Claude chat: capture ticket,<br/>strip params, arm pendingReturn]
    E --> F{run done?}
    F -->|clean| G[returnToMode: back to annotate]
    F -->|error / abort| H[Stay in chat with the error]
```

The `comments` param, the annotate `view` param and the balanced `_layout=(…)` span (its `&` is literal) survive both legs byte-for-byte.

## Usage

Not a new API — the existing button behaves correctly now:

1. Open a file in `_mode=annotate`, add a couple of comments, click **Send to Claude**. Only the open, unsent comments become chips in the chat.
2. Send the turn. When the run finishes, the shell returns to annotate on the same file and view, with the refreshed content.
3. Those comments now show a **"sent ↗"** chip and are excluded from the next handoff. Clicking **Send to Claude** again with nothing new writes *"nothing new to send — reopen a comment to send it again"* in the bar.
4. **Reopen** on a card clears `sent`, putting the comment back into the next payload.

The flag reaches `<file>.json` for free through `annotate.py`'s verbatim field merge. It is deliberately a bare truthy `1` (not a timestamp) — the URL store's byte budget is the binding constraint and the sidecar's own `updated_at` already dates the write.

| Param / field | Where it lives | Lifetime |
|---|---|---|
| `sent: 1` | per comment, in the `comments` URL param + `<file>.json` | until Reopen |
| `claudeReturn=annotate` | shell URL, one-shot | stripped at claude boot, kept in memory as `returnMode` |
| `pendingReturn` | JS memory in the claude template | armed by a send with attachments, cleared in `pollLoop`'s `finally` |

## Test Plan

- [x] **Automated, new** in `tests/test_annotate_template.py` (12 tests). The behavioural ones extract the template's **real** functions and run them under node — the repo's `_js_block` idiom from `test_map_template_escaping.py`, so a copy can't keep passing after the shipping code regresses:
  - `test_a_handoff_only_carries_comments_that_are_neither_resolved_nor_sent` — runs `sendable` over resolved/sent/both/open comments.
  - `test_eviction_drops_resolved_before_sent_and_never_an_open_comment` — drains `evictTarget` and asserts the order `resolved-old → resolved-new → sent-old → sent-new`, with the (oldest) open comment surviving.
  - `test_the_return_ticket_is_stripped_from_the_shell_url_like_the_comments` / `test_the_return_navigation_flips_the_mode_and_keeps_the_review` — run `clearTopClaudeComments` and `returnToMode` against a stubbed shell window, asserting the handoff params are gone, `_mode` flips, the finished `run` id is dropped, and `comments`/`view`/`session_id`/`_layout=(…)` come through untouched.
  - `test_a_chat_opened_normally_never_rewrites_the_shell_url`, `test_only_the_comment_carrying_run_returns_and_only_when_it_succeeded`, `test_reopen_clears_sent_so_a_comment_can_be_sent_again`, `test_nothing_new_to_send_reports_in_the_bar_instead_of_navigating`, `test_the_send_handler_stamps_and_saves_before_it_navigates`, `test_a_sent_card_says_so`, `test_the_budget_loop_uses_that_order_and_still_stops`, `test_annotate_is_what_sets_the_ticket`.
- [x] **Automated, new** in `tests/test_annotate_comments.py`: `test_the_sent_flag_rides_the_verbatim_field_merge` — `sent: 1` reaches the sidecar unchanged (not coerced, not dropped as falsy) and the log keeps its last-seen value after Reopen, since absence never deletes there.
- [x] `.venv/bin/python -m pytest tests/ -q -n auto` → **3198 passed, 21 skipped, 6 failed**. The 6 failures are all `tests/test_browse_mount.py::test_remote_*`, **pre-existing on `main`** (verified by stashing this branch's changes and re-running that file).
- [x] All three touched templates pass `node --check` on their inline script.
- [ ] Manual: walk the 4 Usage steps above against `scripts/dev.sh` on a `.md` file, including a run you abort mid-flight (must stay in the chat, showing the error) and a follow-up plain turn after a successful return (must stay in the chat).

### Ordering hazard closed on the way

`fused.params.set` **coalesces** its history write (D99), so `window.top.location.search` can still be the pre-stamp string immediately after `save()`. The nav URL is built from a raw read of that string, so writing it back verbatim would have silently undone the `sent` stamps and re-sent everything next visit. `save()` now returns the persisted (post-eviction) list and the handler re-asserts `comments` from it.

### Deliberately not done

- **`sent` is not surfaced as a history-timeline label.** The sidecar is a write-only log where absence never deletes, and Reopen clears the flag by removing the key — so a stored `sent` can outlive the truth. The field *is* declared in the sidecar schema (so a hand-edited log gets the same type check as `resolved`), with the reason inline.
- **No new orphan/anchor handling.** A comment whose anchor went stale after Claude's edit falls through to the existing detached/off-page affordances, per the issue.


---

## Review round (05b35db1)

**Finding 1 — the return ticket outlived a run that never started.** It was a module-scoped `pendingReturn` latch armed *before* `sendMessage`, with its only reset in `pollLoop`'s `finally`. `if (error) throw` on a failed `agent.py start` never reaches `pollLoop`, so the latch stayed armed with no run to consume it — and the user's next unrelated question navigated the shell away mid-thread, for a run that carried no comments, while annotate had already stamped them `sent`.

Fixed by taking the preferred route: **the ticket is threaded, not latched.** `composeAndSend` builds `handoff = { mode, comments }` and passes it to `sendMessage(message, handoff)` → `pollLoop(run_id, handoff)`, so it is bound to one message and, past `start`, to one run id. `resumeRun` calls `pollLoop(run_id)` with no handoff, so a re-attached run still never returns. A regression test asserts `pendingReturn` appears nowhere in the template.

On the "silently lost comments" half: a pre-`start` failure now **restores `attached`** and says so (*"Those comments were not sent — they are attached again, ready to retry."*). It is gated on a `started` flag set only after `start` returns a run id — past that point the agent has the message and restoring would send the same comments twice. Un-stamping annotate's `sent` from inside the chat frame was not attempted: that is another template's param, below its own boundary.

**Finding 2 — the send could evict a comment it was sending.** Real data loss, and impossible on `main`. `evictTarget(arr, keep)` / `save(arr, deletedIds, keep)` now take a set of protected ids, and the send passes `new Set(payload.map(c => c.id))`. When that leaves nothing evictable the loop breaks and the **over-budget write is kept** — a long URL beats trading a live comment for a flag — and the send proceeds unaffected. Documented at `evictTarget`, including *why* the loss would have been invisible (the note goes into a bar `window.top.location.href` destroys milliseconds later).

**Minors, all three fixed:**

| Item | Fix |
|---|---|
| Agent saw `"sent": 1` in the JSON block | `const wire = JSON.stringify(payload)` *before* the stamp; `claudeComments` gets `wire`. |
| `offset`/`sheet` not re-asserted against D99 staleness | Replaced the hand-picked `comments`/`view` re-assertion with a **general sweep**: for every key the top URL already carries, take `fused.params.getAll()`'s value (it reads through the pending overlay). Only pre-existing keys are touched, so no pane-local param is pushed onto the shell URL. `comments` is still re-asserted explicitly afterwards from `persisted`, which the sweep cannot know about (post-eviction). |
| `returnToMode` raced the runtime's coalesced write | Fires `pagehide` — the runtime's own documented flush hook — at the *top* of `returnToMode`, before it reads `location.search` (a pending `session_id` would otherwise be missing from the copy) and before the `pushState` (the trailing timer would otherwise `replaceState` the pre-return search over our new entry). |

**New tests** (`tests/test_annotate_template.py`, 41 passing in the two annotate files):
- `test_a_comment_being_sent_is_never_the_eviction_victim` — runs `evictTarget` under node: the payload protected → `null` (over-budget write kept); the same id protected as an *earlier* handoff → evictable; unprotected → evictable.
- `test_a_run_that_never_started_leaves_no_ticket_and_hands_the_chips_back` — no `pendingReturn` anywhere, `started` set after `throw` and before `pollLoop`, chips restored only on `!started`, user told, and `resumeRun` passes no handoff.
- `test_the_return_flushes_the_runtimes_pending_history_write_first` + the stubbed-shell test now asserts the event order `pagehide → pushState → fused:navigate`.
- `test_the_agent_never_sees_the_internal_sent_flag`, `test_the_staleness_sweep_covers_every_param_the_top_url_carries`, `test_the_send_protects_its_own_payload_from_eviction`.

Suite after the fixes: `6 failed, 3204 passed, 21 skipped in 61.88s` — same 6 pre-existing `test_browse_mount.py::test_remote_*` failures as before.

### Known gap (not fixed)

The one-shot return **discards whatever the user had typed into `#inputbox`** when it fires. Left as-is by agreement; a follow-up could stash the draft into a param or defer the navigation while the box is dirty.


---

## Bugbot round (2b9f9165)

**"Sent dims over resolved cards" (Low) — real, fixed.** `.card.resolved { opacity: .6 }` and `.card.sent { opacity: .8 }` are equal specificity, so the tie went to whichever was declared second — `.sent` was. A card carrying **both** flags (they're independent) rendered at the weaker 0.8, so a resolved comment read as prominent as an open sent one.

Precedence decided: **resolved wins**, it's the terminal state. `.card.resolved.sent { opacity: 0.6 }` encodes it in *specificity*, so reordering the stylesheet cannot flip it. Same call on the chip question Bugbot raised — a resolved card no longer renders `sent ↗` (`c.sent && !c.resolved`): resolved already explains why the comment is skipped and owns the dim, so a second, weaker reason stacked on the terminal one is noise. Reopen clears `sent`, so the chip can never reappear stale on a reopened card. The handoff is still visible in the file's history log.

`test_resolved_outranks_sent_on_a_card_that_is_both` doesn't string-match the CSS — it **resolves the real cascade** (class-count specificity, then declaration order) over the extracted `<style>` block, asserts 0.6 for `{card,resolved,sent}`, and re-runs with the order tie-break **inverted** to prove the answer isn't order-dependent. Verified it reports 0.8 against the pre-fix stylesheet, i.e. it would have caught this.

**Comment/SPEC accuracy — fixed.** The eviction-protection rationale said one click "could delete a live comment from *the only store there is*". Overclaimed: the same `save()` mirrors every comment into `<file>.json` (upsert-by-id, absence never deletes), so an evicted comment stays recoverable through the history view. Both the code comment at `evictTarget` and the SPEC §17 paragraph now say what's true — it leaves the **live** store (rail, pins, shared URL), which for a comment mid-send is loss enough — so nobody later removes the protection on a false premise. The decision itself is unchanged.

**Bugbot's other finding** ("Return ticket survives start failure", High) was filed against `b314dfb2` and is the same bug already fixed in `05b35db1` by threading the handoff.

Suite: `6 failed, 3206 passed, 21 skipped in 53.65s` — the same 6 pre-existing `test_browse_mount.py::test_remote_*` failures.


---

## Housekeeping (cadd44d8)

**Accidental session sidecar removed.** `ARCHITECTURE.md.json` rode along in `2b9f9165` — a runtime `lastSession` sidecar from one machine's browsing, not source. Not cosmetic: an empty-query open restores `lastSession`, so after a merge anyone opening `ARCHITECTURE.md` would land on a git-mode view pinned to commit `32ac2717` from someone else's session instead of the document. Deleted; `git diff --stat main...HEAD` and the HEAD tree are both clean of it.

**Gitignore hole closed.** The rule was `*.html.json`, but the server writes `<file>.json` beside *any* opened file, so every other extension slipped through — which is exactly how this got committed. Now:

```
*.html.json
*.md.json
*.markdown.json
*.py.json
*.txt.json
```

Per-extension rather than a `*.*.json` wildcard, which would also swallow genuine configs (`tsconfig.build.json`, `settings.local.json`). Verified via `git ls-files | git check-ignore --stdin --no-index` that **no tracked file** in the repo matches any of the new patterns, and that `package.json` / `registry.json` / `tsconfig.build.json` are untouched. The comment now names the general `<file>.json` convention, the concrete hijack failure mode, and why the wildcard was rejected.
