### PR TITLE
fix(excel template): column-resize hang and a concurrent cache-build race

### DIFF
--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -252,7 +252,17 @@ def _clean_stale(keep_dir):
 
 
 def _ensure_cache(file):
-    """Build (or reuse) the parquet cache + metadata for a workbook."""
+    """Build (or reuse) the parquet cache + metadata for a workbook.
+
+    Each call runs in its own fresh subprocess (excel/reader.py isn't on the
+    in-process allowlist — see executor.py), so a plain threading.Lock can't
+    stop two concurrent cold-open requests for the same file from both
+    building the cache at once. Build into a private per-process tmp dir and
+    claim the real cache dir with one atomic os.rename: only one builder
+    wins, and a loser discards its (redundant but harmless) work and reads
+    the winner's meta.json instead of two writers racing on the same
+    parquet/meta paths.
+    """
     file = os.path.abspath(file)
     d = _cache_dir(file)
     meta_path = os.path.join(d, "meta.json")
@@ -260,40 +270,56 @@ def _ensure_cache(file):
         with open(meta_path) as f:
             return json.load(f)
     _clean_stale(d)
-    os.makedirs(d, exist_ok=True)
-    ext = os.path.splitext(file)[1].lower()
-    sheets = []
-    if ext in (".xlsx", ".xlsm"):
-        for i, (name, nr, nc) in enumerate(_xlsx_dims(file)):
-            entry = {"name": name, "kind": "xlsx", "big": _is_big(nr, nc),
-                     "nrows": nr, "ncols": nc, "header": None}
-            if entry["big"]:
-                pq = os.path.join(d, f"s{i}.parquet")
-                nr2, nc2 = _xlsx_sheet_to_parquet(file, name, pq)
-                entry.update(nrows=nr2, ncols=nc2, parquet=os.path.basename(pq))
-            sheets.append(entry)
-    elif ext == ".csv":
-        con = _duck()
-        pq = os.path.join(d, "s0.parquet")
-        nr, nc, _ = _copy_to_parquet(
-            con, f"SELECT * FROM read_csv({_q(file)}, header=false, all_varchar=true, null_padding=true)", pq
-        )
-        sheets.append({"name": os.path.splitext(os.path.basename(file))[0], "kind": "csv",
-                       "big": _is_big(nr, nc), "nrows": nr, "ncols": nc, "header": None,
-                       "parquet": "s0.parquet"})
-    elif ext == ".parquet":
-        con = _duck()
-        pq = os.path.join(d, "s0.parquet")
-        nr, nc, cols = _copy_to_parquet(con, f"SELECT * FROM read_parquet({_q(file)})", pq)
-        sheets.append({"name": os.path.splitext(os.path.basename(file))[0], "kind": "parquet",
-                       "big": _is_big(nr, nc), "nrows": nr, "ncols": nc, "header": cols,
-                       "parquet": "s0.parquet"})
-    else:
-        raise ValueError(f"unsupported file type {ext!r}")
-    meta = {"file": file, "mtime": os.path.getmtime(file), "sheets": sheets}
-    with open(meta_path, "w") as f:
-        json.dump(meta, f)
-    return meta
+    import shutil
+    import uuid
+
+    tmp_d = f"{d}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    os.makedirs(tmp_d, exist_ok=True)
+    try:
+        ext = os.path.splitext(file)[1].lower()
+        sheets = []
+        if ext in (".xlsx", ".xlsm"):
+            for i, (name, nr, nc) in enumerate(_xlsx_dims(file)):
+                entry = {"name": name, "kind": "xlsx", "big": _is_big(nr, nc),
+                         "nrows": nr, "ncols": nc, "header": None}
+                if entry["big"]:
+                    pq = os.path.join(tmp_d, f"s{i}.parquet")
+                    nr2, nc2 = _xlsx_sheet_to_parquet(file, name, pq)
+                    entry.update(nrows=nr2, ncols=nc2, parquet=os.path.basename(pq))
+                sheets.append(entry)
+        elif ext == ".csv":
+            con = _duck()
+            pq = os.path.join(tmp_d, "s0.parquet")
+            nr, nc, _ = _copy_to_parquet(
+                con, f"SELECT * FROM read_csv({_q(file)}, header=false, all_varchar=true, null_padding=true)", pq
+            )
+            sheets.append({"name": os.path.splitext(os.path.basename(file))[0], "kind": "csv",
+                           "big": _is_big(nr, nc), "nrows": nr, "ncols": nc, "header": None,
+                           "parquet": "s0.parquet"})
+        elif ext == ".parquet":
+            con = _duck()
+            pq = os.path.join(tmp_d, "s0.parquet")
+            nr, nc, cols = _copy_to_parquet(con, f"SELECT * FROM read_parquet({_q(file)})", pq)
+            sheets.append({"name": os.path.splitext(os.path.basename(file))[0], "kind": "parquet",
+                           "big": _is_big(nr, nc), "nrows": nr, "ncols": nc, "header": cols,
+                           "parquet": "s0.parquet"})
+        else:
+            raise ValueError(f"unsupported file type {ext!r}")
+        meta = {"file": file, "mtime": os.path.getmtime(file), "sheets": sheets}
+        with open(os.path.join(tmp_d, "meta.json"), "w") as f:
+            json.dump(meta, f)
+        try:
+            os.rename(tmp_d, d)
+        except OSError:
+            # Lost the race: another process's build already claimed `d`.
+            # Discard ours and read theirs rather than raising or clobbering.
+            shutil.rmtree(tmp_d, ignore_errors=True)
+            with open(meta_path) as f:
+                return json.load(f)
+        return meta
+    except BaseException:
+        shutil.rmtree(tmp_d, ignore_errors=True)
+        raise
 
 
 def _rekey_cache(file):

--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -287,6 +287,7 @@ def _ensure_cache(file):
             return json.load(f)
     _clean_stale(d)
     import shutil
+    import time
     import uuid
 
     tmp_d = os.path.join(
@@ -338,9 +339,6 @@ def _ensure_cache(file):
         # complete cache there. On Windows the rename-aside also fails while
         # any process holds files inside `d` open, so a cache in active use
         # can't be yanked away; we just retry and end up adopting it.
-        import time
-        import uuid as _uuid
-
         for _ in range(10):
             try:
                 os.rename(tmp_d, d)
@@ -351,7 +349,7 @@ def _ensure_cache(file):
                 shutil.rmtree(tmp_d, ignore_errors=True)
                 with open(meta_path) as f:
                     return json.load(f)
-            junk = os.path.join(CACHE_ROOT, f"{_TMP_PREFIX}junk-{os.getpid()}-{_uuid.uuid4().hex[:8]}")
+            junk = os.path.join(CACHE_ROOT, f"{_TMP_PREFIX}junk-{os.getpid()}-{uuid.uuid4().hex[:8]}")
             try:
                 os.rename(d, junk)
             except OSError:

--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -247,16 +247,23 @@ def _cache_dir(file):
 def _clean_stale(keep_dir):
     if not os.path.isdir(CACHE_ROOT):
         return
+    import shutil
+    import time
+
     prefix = os.path.basename(keep_dir).split("-")[0]
     for n in os.listdir(CACHE_ROOT):
         p = os.path.join(CACHE_ROOT, n)
         # Skip in-flight builds (_TMP_PREFIX): another process may be writing
         # one right now, and wiping it would break its atomic-rename claim.
+        # Old ones (a builder killed mid-run) are safe to sweep by age.
         if n.startswith(_TMP_PREFIX):
+            try:
+                if time.time() - os.path.getmtime(p) > 3600:
+                    shutil.rmtree(p, ignore_errors=True)
+            except OSError:
+                pass
             continue
         if n.startswith(prefix + "-") and p != keep_dir:
-            import shutil
-
             shutil.rmtree(p, ignore_errors=True)
 
 
@@ -318,23 +325,44 @@ def _ensure_cache(file):
         meta = {"file": file, "mtime": os.path.getmtime(file), "sheets": sheets}
         with open(os.path.join(tmp_d, "meta.json"), "w") as f:
             json.dump(meta, f)
-        try:
-            os.rename(tmp_d, d)
-        except OSError:
-            # `d` already exists. Two very different reasons, and only the
-            # first means someone else finished the same work:
+        # Claim `d` with one atomic rename. If it fails, `d` already exists:
+        # either a concurrent builder won (meta.json present — use theirs), or
+        # it's a half-built leftover from an interrupted earlier run, which we
+        # must clear or every future open keeps failing on the same debris.
+        # Debris is never deleted in place: between the meta.json check and the
+        # cleanup another process could publish a complete cache into `d`, and
+        # an rmtree there would destroy it (possibly under a live reader).
+        # Instead the leftover is renamed aside to a _TMP_PREFIX name — atomic,
+        # and if it turns out we moved a just-published winner, our own
+        # equivalent build claims `d` on the next pass so readers still find a
+        # complete cache there. On Windows the rename-aside also fails while
+        # any process holds files inside `d` open, so a cache in active use
+        # can't be yanked away; we just retry and end up adopting it.
+        import time
+        import uuid as _uuid
+
+        for _ in range(10):
+            try:
+                os.rename(tmp_d, d)
+                return meta
+            except OSError:
+                pass
             if os.path.exists(meta_path):
-                # A concurrent builder won the race. Drop ours, use theirs.
                 shutil.rmtree(tmp_d, ignore_errors=True)
                 with open(meta_path) as f:
                     return json.load(f)
-            # `d` is there but has no meta.json: a half-built leftover from an
-            # interrupted earlier run. Clear it and claim it with our complete
-            # build — otherwise every future open keeps failing on the same
-            # debris until the cache is cleared by hand.
-            shutil.rmtree(d, ignore_errors=True)
-            os.rename(tmp_d, d)
-        return meta
+            junk = os.path.join(CACHE_ROOT, f"{_TMP_PREFIX}junk-{os.getpid()}-{_uuid.uuid4().hex[:8]}")
+            try:
+                os.rename(d, junk)
+            except OSError:
+                time.sleep(0.1)
+                continue
+            shutil.rmtree(junk, ignore_errors=True)
+        if os.path.exists(meta_path):
+            shutil.rmtree(tmp_d, ignore_errors=True)
+            with open(meta_path) as f:
+                return json.load(f)
+        raise RuntimeError(f"could not claim cache dir {d!r}")
     except BaseException:
         shutil.rmtree(tmp_d, ignore_errors=True)
         raise

--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -267,6 +267,21 @@ def _clean_stale(keep_dir):
             shutil.rmtree(p, ignore_errors=True)
 
 
+def _load_meta(meta_path):
+    """A published cache's metadata, or None if it isn't readable.
+
+    None covers both "not there" and "there but unreadable": a concurrent
+    builder can rename a winner aside between an existence check and the open,
+    and _rekey_cache rewrites meta.json in place, so a reader can catch a
+    partial file. Callers treat None as "no winner yet" and retry.
+    """
+    try:
+        with open(meta_path) as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return None
+
+
 def _ensure_cache(file):
     """Build (or reuse) the parquet cache + metadata for a workbook.
 
@@ -282,9 +297,9 @@ def _ensure_cache(file):
     file = os.path.abspath(file)
     d = _cache_dir(file)
     meta_path = os.path.join(d, "meta.json")
-    if os.path.exists(meta_path):
-        with open(meta_path) as f:
-            return json.load(f)
+    cached = _load_meta(meta_path)
+    if cached is not None:
+        return cached
     _clean_stale(d)
     import shutil
     import time
@@ -339,16 +354,20 @@ def _ensure_cache(file):
         # complete cache there. On Windows the rename-aside also fails while
         # any process holds files inside `d` open, so a cache in active use
         # can't be yanked away; we just retry and end up adopting it.
+        # Adopting is committed to only once a winner's metadata is actually in
+        # hand: our own complete build is still sitting in tmp_d, so a winner
+        # that vanishes mid-read (renamed aside by yet another builder) means
+        # go round again, never fail.
         for _ in range(10):
             try:
                 os.rename(tmp_d, d)
                 return meta
             except OSError:
                 pass
-            if os.path.exists(meta_path):
+            won = _load_meta(meta_path)
+            if won is not None:
                 shutil.rmtree(tmp_d, ignore_errors=True)
-                with open(meta_path) as f:
-                    return json.load(f)
+                return won
             junk = os.path.join(CACHE_ROOT, f"{_TMP_PREFIX}junk-{os.getpid()}-{uuid.uuid4().hex[:8]}")
             try:
                 os.rename(d, junk)
@@ -356,10 +375,10 @@ def _ensure_cache(file):
                 time.sleep(0.1)
                 continue
             shutil.rmtree(junk, ignore_errors=True)
-        if os.path.exists(meta_path):
+        won = _load_meta(meta_path)
+        if won is not None:
             shutil.rmtree(tmp_d, ignore_errors=True)
-            with open(meta_path) as f:
-                return json.load(f)
+            return won
         raise RuntimeError(f"could not claim cache dir {d!r}")
     except BaseException:
         shutil.rmtree(tmp_d, ignore_errors=True)
@@ -380,14 +399,19 @@ def _rekey_cache(file):
             if n.startswith(prefix + "-"):
                 shutil.move(os.path.join(CACHE_ROOT, n), new_dir)
                 meta_path = os.path.join(new_dir, "meta.json")
-                try:
-                    with open(meta_path) as f:
-                        meta = json.load(f)
+                meta = _load_meta(meta_path)
+                if meta is not None:
                     meta["mtime"] = os.path.getmtime(file)
-                    with open(meta_path, "w") as f:
-                        json.dump(meta, f)
-                except OSError:
-                    pass
+                    # Swap the rewrite in atomically: readers resolve this file
+                    # concurrently, and rewriting in place lets one of them see
+                    # a half-written meta.json.
+                    tmp = meta_path + ".new"
+                    try:
+                        with open(tmp, "w") as f:
+                            json.dump(meta, f)
+                        os.replace(tmp, meta_path)
+                    except OSError:
+                        pass
                 return
 
 

--- a/fused_render/templates/excel/reader.py
+++ b/fused_render/templates/excel/reader.py
@@ -232,6 +232,11 @@ def _is_big(nrows, ncols):
 
 # ---------- parquet cache ----------
 
+# In-flight cache builds live under this prefix, deliberately NOT starting with
+# a cache key, so _clean_stale's "{hash}-" match can never sweep a live build.
+_TMP_PREFIX = ".build-"
+
+
 def _cache_dir(file):
     import hashlib
 
@@ -245,6 +250,10 @@ def _clean_stale(keep_dir):
     prefix = os.path.basename(keep_dir).split("-")[0]
     for n in os.listdir(CACHE_ROOT):
         p = os.path.join(CACHE_ROOT, n)
+        # Skip in-flight builds (_TMP_PREFIX): another process may be writing
+        # one right now, and wiping it would break its atomic-rename claim.
+        if n.startswith(_TMP_PREFIX):
+            continue
         if n.startswith(prefix + "-") and p != keep_dir:
             import shutil
 
@@ -273,7 +282,8 @@ def _ensure_cache(file):
     import shutil
     import uuid
 
-    tmp_d = f"{d}.tmp-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+    tmp_d = os.path.join(
+        CACHE_ROOT, f"{_TMP_PREFIX}{os.getpid()}-{uuid.uuid4().hex[:8]}")
     os.makedirs(tmp_d, exist_ok=True)
     try:
         ext = os.path.splitext(file)[1].lower()
@@ -311,11 +321,19 @@ def _ensure_cache(file):
         try:
             os.rename(tmp_d, d)
         except OSError:
-            # Lost the race: another process's build already claimed `d`.
-            # Discard ours and read theirs rather than raising or clobbering.
-            shutil.rmtree(tmp_d, ignore_errors=True)
-            with open(meta_path) as f:
-                return json.load(f)
+            # `d` already exists. Two very different reasons, and only the
+            # first means someone else finished the same work:
+            if os.path.exists(meta_path):
+                # A concurrent builder won the race. Drop ours, use theirs.
+                shutil.rmtree(tmp_d, ignore_errors=True)
+                with open(meta_path) as f:
+                    return json.load(f)
+            # `d` is there but has no meta.json: a half-built leftover from an
+            # interrupted earlier run. Clear it and claim it with our complete
+            # build — otherwise every future open keeps failing on the same
+            # debris until the cache is cleared by hand.
+            shutil.rmtree(d, ignore_errors=True)
+            os.rename(tmp_d, d)
         return meta
     except BaseException:
         shutil.rmtree(tmp_d, ignore_errors=True)

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -1528,12 +1528,14 @@ function updateViewport(force) {
   const last = Math.min(total, Math.ceil((wrap.scrollTop - HEAD_H + wrap.clientHeight) / ROW_H) + 1);
   if (!force && first >= vgrid.start && last <= vgrid.end) return;
   // Remounting recycles every row between the pads — including the one hosting
-  // an open editor. Commit it first, the same thing clicking away does, and let
-  // commitEdit's own updateViewport do the remount. Skipping the remount
-  // instead (the obvious way to protect the editor) left the spacer pads
-  // showing as blank bands until the edit ended. OVERSCAN means ordinary wheel
-  // nudges while editing never get this far.
-  if (editing && editing.input.isConnected) { commitEdit(); return; }
+  // an open editor. Commit it first, the same thing clicking away does; skipping
+  // the remount instead (the obvious way to protect the editor) left the spacer
+  // pads showing as blank bands until the edit ended. OVERSCAN means ordinary
+  // wheel nudges while editing never get this far. commitEdit runs its own
+  // updateViewport(false), enough for a plain scroll but not for a FORCED update
+  // (appendRows grew vis, so the spacers are stale and the new rows aren't
+  // scrollable yet), so re-run with the original flag against fresh state.
+  if (editing && editing.input.isConnected) { commitEdit(); updateViewport(force); return; }
   const start = Math.max(freeze, first - OVERSCAN);
   const end = Math.min(total, Math.max(start, last) + OVERSCAN);
   for (let tr = padTop.nextSibling; tr && tr !== padBot; ) {
@@ -1971,10 +1973,17 @@ function hideResizeGuide() {
   if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
 }
 function clearColResize() {
-  if (colResizing.raf) cancelAnimationFrame(colResizing.raf);
-  colResizing.grip.classList.remove("on");
-  hideResizeGuide();
+  const { grip, pointerId, raf } = colResizing;
+  if (raf) cancelAnimationFrame(raf);
+  // Null the state before releasing: the release fires lostpointercapture
+  // synchronously, and that handler must see no drag in progress rather than
+  // act on whatever comes next. Releasing at all matters because a drag
+  // dropped mid-flight (a second pointer starting its own) would otherwise
+  // leave capture armed on this grip, and its later loss would end the new one.
   colResizing = null;
+  grip.classList.remove("on");
+  hideResizeGuide();
+  try { grip.releasePointerCapture(pointerId); } catch { /* never captured */ }
 }
 function finishColResize(x) {
   const { c, colEl, table } = colResizing;
@@ -2026,7 +2035,10 @@ function attachColResizeGrip(grip, c, colgroup, table) {
     try { grip.setPointerCapture(e.pointerId); } catch { /* not a live pointer */ }
     showResizeGuide(e.clientX);
   });
-  grip.addEventListener("lostpointercapture", endColResize);
+  grip.addEventListener("lostpointercapture", (e) => {
+    if (!colResizing || e.pointerId !== colResizing.pointerId) return;
+    endColResize();
+  });
   grip.addEventListener("click", (e) => e.stopPropagation());
 }
 document.addEventListener("pointermove", (e) => {

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -122,6 +122,7 @@
     cursor: col-resize; z-index: 7;
   }
   .colResize:hover, .colResize.on { background: var(--anchor); opacity: .55; }
+  #colResizeGuide { border-left: 2px dashed var(--anchor); }
   .funnel {
     position: absolute; top: 50%; right: 5px; transform: translateY(-50%);
     width: 18px; height: 16px; display: flex; align-items: center; justify-content: center;
@@ -1445,9 +1446,10 @@ function renderGrid() {
     grip.addEventListener("mousedown", (e) => {
       e.preventDefault(); e.stopPropagation();
       const colEl = colgroup.querySelector(`col[data-col="${c}"]`);
-      colResizing = { c, colEl, table, startX: e.clientX,
+      colResizing = { c, colEl, table, startX: e.clientX, pendingX: e.clientX,
                       startW: parseFloat(colEl.style.width) || 90, grip };
       grip.classList.add("on");
+      showResizeGuide(e.clientX);
     });
     grip.addEventListener("click", (e) => e.stopPropagation());
     grip.addEventListener("dblclick", (e) => {
@@ -2572,6 +2574,28 @@ $("gridWrap").addEventListener("mousemove", (e) => {
   if (!dragging) return;
   if (td) { sel.r2 = +td.dataset.r; sel.c2 = +td.dataset.c; paintSel(); }
 });
+// Column widths aren't applied live while dragging: on a big/scrolled sheet
+// the grid's DOM can hold tens of thousands of rows, and table-layout:fixed
+// with sticky headers means every width write reflows the WHOLE table — one
+// such reflow can blow past a frame budget by 50-100x, so even rAF-batched
+// writes stall the drag. Instead we drag a cheap position:fixed guide line
+// (no table involved, so no reflow) and pay the one expensive reflow only
+// once, on mouseup.
+let resizeGuide = null;
+function showResizeGuide(x) {
+  if (!resizeGuide) {
+    resizeGuide = document.createElement("div");
+    resizeGuide.id = "colResizeGuide";
+    document.body.appendChild(resizeGuide);
+  }
+  const wrapRect = $("gridWrap").getBoundingClientRect();
+  resizeGuide.style.cssText =
+    `position:fixed; top:${wrapRect.top}px; height:${wrapRect.height}px; ` +
+    `left:${x}px; z-index:50; pointer-events:none;`;
+}
+function hideResizeGuide() {
+  if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
+}
 function applyColResize(x) {
   const w = Math.max(40, Math.round(colResizing.startW + x - colResizing.startX));
   colResizing.colEl.style.width = w + "px";
@@ -2584,13 +2608,14 @@ document.addEventListener("mousemove", (e) => {
   colResizing.raf = requestAnimationFrame(() => {
     if (!colResizing) return;
     colResizing.raf = null;
-    applyColResize(colResizing.pendingX);
+    showResizeGuide(colResizing.pendingX);
   });
 });
 document.addEventListener("mouseup", () => {
   if (colResizing) {
     if (colResizing.raf) { cancelAnimationFrame(colResizing.raf); colResizing.raf = null; }
-    if (colResizing.pendingX !== undefined) applyColResize(colResizing.pendingX);
+    applyColResize(colResizing.pendingX);
+    hideResizeGuide();
     const { c, colEl, grip } = colResizing;
     grip.classList.remove("on");
     S().colw = S().colw || {};

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -2574,12 +2574,19 @@ $("gridWrap").addEventListener("mousemove", (e) => {
 });
 document.addEventListener("mousemove", (e) => {
   if (!colResizing) return;
-  const w = Math.max(40, Math.round(colResizing.startW + e.clientX - colResizing.startX));
-  colResizing.colEl.style.width = w + "px";
-  colResizing.table._syncWidth();
+  colResizing.pendingX = e.clientX;
+  if (colResizing.raf) return;
+  colResizing.raf = requestAnimationFrame(() => {
+    if (!colResizing) return;
+    colResizing.raf = null;
+    const w = Math.max(40, Math.round(colResizing.startW + colResizing.pendingX - colResizing.startX));
+    colResizing.colEl.style.width = w + "px";
+    colResizing.table._syncWidth();
+  });
 });
 document.addEventListener("mouseup", () => {
   if (colResizing) {
+    if (colResizing.raf) cancelAnimationFrame(colResizing.raf);
     const { c, colEl, grip } = colResizing;
     grip.classList.remove("on");
     S().colw = S().colw || {};

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -1443,16 +1443,7 @@ function renderGrid() {
     const grip = document.createElement("div");
     grip.className = "colResize";
     grip.title = "Drag to resize · double-click to auto-fit";
-    grip.addEventListener("mousedown", (e) => {
-      e.preventDefault(); e.stopPropagation();
-      const colEl = colgroup.querySelector(`col[data-col="${c}"]`);
-      const wrapRect = $("gridWrap").getBoundingClientRect();
-      colResizing = { c, colEl, table, startX: e.clientX, pendingX: e.clientX,
-                      startW: parseFloat(colEl.style.width) || 90, grip, wrapRect };
-      grip.classList.add("on");
-      showResizeGuide(e.clientX, wrapRect);
-    });
-    grip.addEventListener("click", (e) => e.stopPropagation());
+    attachColResizeGrip(grip, c, colgroup, table);
     grip.addEventListener("dblclick", (e) => {
       e.preventDefault(); e.stopPropagation();
       let maxLen = 4;
@@ -1860,7 +1851,90 @@ function performFill(base, tgt) {
   paint();
 }
 let fillDrag = null;   // { base, tgt|null }
-let colResizing = null; // { c, colEl, startX, startW, grip }
+let colResizing = null; // { c, colEl, table, grip, startX, startW, wrapRect, raf, pendingX }
+let resizeGuide = null;
+function showResizeGuide(x) {
+  if (!resizeGuide) {
+    resizeGuide = document.createElement("div");
+    resizeGuide.id = "colResizeGuide";
+    resizeGuide.style.cssText =
+      `position:fixed; top:${colResizing.wrapRect.top}px; height:${colResizing.wrapRect.height}px; ` +
+      `z-index:50; pointer-events:none;`;
+    document.body.appendChild(resizeGuide);
+  }
+  resizeGuide.style.left = x + "px";
+}
+function hideResizeGuide() {
+  if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
+}
+function finishColResize(x) {
+  const { c, colEl, table, startX, startW, grip } = colResizing;
+  const w = Math.max(40, Math.round(startW + x - startX));
+  colEl.style.width = w + "px";
+  table._syncWidth();
+  hideResizeGuide();
+  grip.classList.remove("on");
+  S().colw = S().colw || {};
+  S().colw[c] = w;
+  // Resizing stays available read-only (viewing convenience), but must not
+  // flip the dirty flag — widths only persist via a save that can't happen.
+  if (!isBig() && !readOnly) markDirty();   // widths persist into the xlsx on save
+  colResizing = null;
+}
+// Column widths aren't applied live while dragging: on a big/scrolled sheet the
+// grid's DOM can hold tens of thousands of rows, and table-layout:fixed with
+// sticky headers means every width write reflows the WHOLE table. So during
+// the drag we only move a cheap position:fixed guide line (outside the table,
+// so no reflow); its geometry is captured once at drag start and never
+// re-read mid-drag (a getBoundingClientRect() read forces the same layout
+// flush a write would). The real width, and the one expensive reflow, happen
+// exactly once, when the pointer is released.
+//
+// Pointer Events (not Mouse Events) so touch/pen drags work too, but
+// listened for on `document` rather than relying on grip.setPointerCapture():
+// capture only redirects events for a pointer the browser considers
+// "active" (real hardware input) — there is no reliable way to verify its
+// failure mode without a real device, and a silent capture failure would
+// mean losing every event once the cursor leaves the 7px-wide grip strip,
+// breaking the drag outright. Document-level listeners keep receiving
+// events regardless of what's under the cursor, exactly like the mouse-
+// event version this replaces, so there's no such failure mode to worry
+// about.
+function attachColResizeGrip(grip, c, colgroup, table) {
+  function currentColEl() { return colgroup.querySelector(`col[data-col="${c}"]`); }
+  grip.addEventListener("pointerdown", (e) => {
+    if (e.button !== 0) return;
+    e.preventDefault(); e.stopPropagation();
+    const colEl = currentColEl();
+    colResizing = {
+      c, colEl, table, grip,
+      startX: e.clientX, pendingX: e.clientX,
+      startW: parseFloat(colEl.style.width) || 90,
+      wrapRect: $("gridWrap").getBoundingClientRect(),
+      raf: null,
+    };
+    grip.classList.add("on");
+    showResizeGuide(e.clientX);
+  });
+  grip.addEventListener("click", (e) => e.stopPropagation());
+}
+document.addEventListener("pointermove", (e) => {
+  if (!colResizing) return;
+  colResizing.pendingX = e.clientX;
+  if (colResizing.raf) return;
+  colResizing.raf = requestAnimationFrame(() => {
+    if (!colResizing) return;
+    colResizing.raf = null;
+    showResizeGuide(colResizing.pendingX);
+  });
+});
+function endColResize(e) {
+  if (!colResizing) return;
+  if (colResizing.raf) { cancelAnimationFrame(colResizing.raf); colResizing.raf = null; }
+  finishColResize(e.clientX);
+}
+document.addEventListener("pointerup", endColResize);
+document.addEventListener("pointercancel", endColResize);
 function fillPreview(r, c) {
   const b = fillDrag.base;
   const rowOut = r > b.r2 ? r - b.r2 : r < b.r1 ? r - b.r1 : 0;
@@ -2575,61 +2649,7 @@ $("gridWrap").addEventListener("mousemove", (e) => {
   if (!dragging) return;
   if (td) { sel.r2 = +td.dataset.r; sel.c2 = +td.dataset.c; paintSel(); }
 });
-// Column widths aren't applied live while dragging: on a big/scrolled sheet
-// the grid's DOM can hold tens of thousands of rows, and table-layout:fixed
-// with sticky headers means every width write reflows the WHOLE table — one
-// such reflow can blow past a frame budget by 50-100x, so even rAF-batched
-// writes stall the drag. Instead we drag a cheap position:fixed guide line
-// (no table involved, so no reflow) and pay the one expensive reflow only
-// once, on mouseup.
-let resizeGuide = null;
-function showResizeGuide(x, wrapRect) {
-  if (!resizeGuide) {
-    resizeGuide = document.createElement("div");
-    resizeGuide.id = "colResizeGuide";
-    resizeGuide.style.cssText =
-      `position:fixed; top:${wrapRect.top}px; height:${wrapRect.height}px; ` +
-      `z-index:50; pointer-events:none;`;
-    document.body.appendChild(resizeGuide);
-  }
-  // left is the only thing that changes per frame — a plain style write, no
-  // getBoundingClientRect() here: that call forces a layout flush, and doing
-  // it every rAF frame for a slow multi-second drag reintroduces a per-frame
-  // reflow cost on a big table, exactly what this guide line exists to avoid.
-  resizeGuide.style.left = x + "px";
-}
-function hideResizeGuide() {
-  if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
-}
-function applyColResize(x) {
-  const w = Math.max(40, Math.round(colResizing.startW + x - colResizing.startX));
-  colResizing.colEl.style.width = w + "px";
-  colResizing.table._syncWidth();
-}
-document.addEventListener("mousemove", (e) => {
-  if (!colResizing) return;
-  colResizing.pendingX = e.clientX;
-  if (colResizing.raf) return;
-  colResizing.raf = requestAnimationFrame(() => {
-    if (!colResizing) return;
-    colResizing.raf = null;
-    showResizeGuide(colResizing.pendingX, colResizing.wrapRect);
-  });
-});
 document.addEventListener("mouseup", () => {
-  if (colResizing) {
-    if (colResizing.raf) { cancelAnimationFrame(colResizing.raf); colResizing.raf = null; }
-    applyColResize(colResizing.pendingX);
-    hideResizeGuide();
-    const { c, colEl, grip } = colResizing;
-    grip.classList.remove("on");
-    S().colw = S().colw || {};
-    S().colw[c] = parseFloat(colEl.style.width) || 90;
-    // Resizing stays available read-only (viewing convenience), but must not
-    // flip the dirty flag — widths only persist via a save that can't happen.
-    if (!isBig() && !readOnly) markDirty();   // widths persist into the xlsx on save
-    colResizing = null;
-  }
   dragging = false;
   if (fillDrag) {
     const { base, tgt } = fillDrag;

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -1521,13 +1521,19 @@ function makePadRow(cols) {
 }
 function updateViewport(force) {
   if (!vgrid) return;
-  if (editing && editing.input.isConnected) return;   // never recycle the row hosting the editor
   const wrap = $("gridWrap");
   const { vis, cols, freeze, tbody, padTop, padBot } = vgrid;
   const total = vis.length;
   const first = Math.max(freeze, Math.floor((wrap.scrollTop - HEAD_H) / ROW_H));
   const last = Math.min(total, Math.ceil((wrap.scrollTop - HEAD_H + wrap.clientHeight) / ROW_H) + 1);
   if (!force && first >= vgrid.start && last <= vgrid.end) return;
+  // Remounting recycles every row between the pads — including the one hosting
+  // an open editor. Commit it first, the same thing clicking away does, and let
+  // commitEdit's own updateViewport do the remount. Skipping the remount
+  // instead (the obvious way to protect the editor) left the spacer pads
+  // showing as blank bands until the edit ended. OVERSCAN means ordinary wheel
+  // nudges while editing never get this far.
+  if (editing && editing.input.isConnected) { commitEdit(); return; }
   const start = Math.max(freeze, first - OVERSCAN);
   const end = Math.min(total, Math.max(start, last) + OVERSCAN);
   for (let tr = padTop.nextSibling; tr && tr !== padBot; ) {
@@ -2038,12 +2044,19 @@ document.addEventListener("pointermove", (e) => {
 function endColResize() {
   if (colResizing) finishColResize(colResizing.pendingX);
 }
+// Only the pointer that started the drag may end it: with touch/pen in play a
+// second finger going up or being cancelled would otherwise commit the width
+// early and drop the guide mid-drag. A window blur has no pointer of its own,
+// so it ends whatever is active.
 document.addEventListener("pointerup", (e) => {
-  if (!colResizing) return;
-  if (e.pointerId === colResizing.pointerId) colResizing.pendingX = e.clientX;
+  if (!colResizing || e.pointerId !== colResizing.pointerId) return;
+  colResizing.pendingX = e.clientX;
   endColResize();
 });
-document.addEventListener("pointercancel", endColResize);
+document.addEventListener("pointercancel", (e) => {
+  if (!colResizing || e.pointerId !== colResizing.pointerId) return;
+  endColResize();
+});
 window.addEventListener("blur", endColResize);
 function fillPreview(r, c) {
   const b = fillDrag.base;

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -102,7 +102,8 @@
   }
   /* ---- grid ---- */
   #gridWrap { flex: 1; overflow: auto; margin: 0 8px; border: 1px solid var(--border);
-    border-radius: 8px 8px 0 0; background: var(--panel2); outline: none; position: relative; }
+    border-radius: 8px 8px 0 0; background: var(--panel2); outline: none; position: relative;
+    overflow-anchor: none; }
   table { border-collapse: separate; border-spacing: 0; font-size: 12px;
     font-variant-numeric: tabular-nums; user-select: none; table-layout: fixed; }
   td, th { border-right: 1px solid var(--grid); border-bottom: 1px solid var(--grid); padding: 0; }
@@ -1314,8 +1315,8 @@ function cellClassAndStyle(td, r, c) {
   }
 }
 
-function frozenTop(dIdx) {   // sticky offset: letters row (23px) + rows above
-  return 23 + dIdx * 25;
+function frozenTop(dIdx) {   // sticky offset: letters row + rows above
+  return HEAD_H + dIdx * ROW_H;
 }
 function makeRowTr(r, cols, dIdx) {
   const sh = S();
@@ -1472,11 +1473,16 @@ function renderGrid() {
   table.appendChild(thead);
 
   const tbody = document.createElement("tbody");
-  vis.forEach((r, dIdx) => tbody.appendChild(makeRowTr(r, cols, dIdx)));
+  const freeze = Math.min(sh.freeze || 0, vis.length);
+  for (let d = 0; d < freeze; d++) tbody.appendChild(makeRowTr(vis[d], cols, d));
+  const padTop = makePadRow(cols), padBot = makePadRow(cols);
+  tbody.append(padTop, padBot);
   table.appendChild(tbody);
   wrap.innerHTML = "";
   wrap.appendChild(table);
   wrap._tbody = tbody;
+  vgrid = { vis, cols, freeze, tbody, padTop, padBot, pos: null, start: freeze, end: freeze, raf: null };
+  updateViewport(true);
 
   if (sh.big) {
     const bar = document.createElement("div"); bar.id = "moreBar";
@@ -1493,12 +1499,80 @@ function renderGrid() {
   paintSel();
 }
 
+// ---- row virtualization ----------------------------------------------------
+// The tbody only ever holds the rows near the viewport (plus frozen rows),
+// between two spacer rows sized to stand in for everything unmounted. Every
+// layout/paint the grid triggers — scrolling, a column resize, a repaint —
+// stays proportional to the viewport instead of to the loaded row count.
+const ROW_H = 24, HEAD_H = 23, OVERSCAN = 40;   // td.cell is 24px tall incl. border (border-box)
+let vgrid = null;
+function makePadRow(cols) {
+  const tr = document.createElement("tr");
+  const td = document.createElement("td");
+  td.colSpan = Math.min(cols + 1, 1000);
+  td.style.cssText = "padding:0;border:0;height:0";
+  tr.appendChild(td);
+  tr._pad = td;
+  return tr;
+}
+function updateViewport(force) {
+  if (!vgrid) return;
+  if (editing && editing.input.isConnected) return;   // never recycle the row hosting the editor
+  const wrap = $("gridWrap");
+  const { vis, cols, freeze, tbody, padTop, padBot } = vgrid;
+  const total = vis.length;
+  const first = Math.max(freeze, Math.floor((wrap.scrollTop - HEAD_H) / ROW_H));
+  const last = Math.min(total, Math.ceil((wrap.scrollTop - HEAD_H + wrap.clientHeight) / ROW_H) + 1);
+  if (!force && first >= vgrid.start && last <= vgrid.end) return;
+  const start = Math.max(freeze, first - OVERSCAN);
+  const end = Math.min(total, Math.max(start, last) + OVERSCAN);
+  for (let tr = padTop.nextSibling; tr && tr !== padBot; ) {
+    const next = tr.nextSibling;
+    if (tr._vr !== undefined) for (let c = 0; c < cols; c++) tds.delete(tr._vr + "," + c);
+    tr.remove();
+    tr = next;
+  }
+  padTop._pad.style.height = (start - freeze) * ROW_H + "px";
+  padBot._pad.style.height = (total - end) * ROW_H + "px";
+  const frag = document.createDocumentFragment();
+  for (let d = start; d < end; d++) {
+    const tr = makeRowTr(vis[d], cols, d);
+    tr._vr = vis[d];
+    frag.appendChild(tr);
+  }
+  tbody.insertBefore(frag, padBot);
+  vgrid.start = start; vgrid.end = end;
+  paintSelCells();
+}
+function displayIdx(r) {   // sheet row index -> position among rendered rows
+  if (!vgrid) return -1;
+  if (!vgrid.pos) { vgrid.pos = new Map(); vgrid.vis.forEach((rr, i) => vgrid.pos.set(rr, i)); }
+  const d = vgrid.pos.get(r);
+  return d === undefined ? -1 : d;
+}
+function scrollCellIntoView(r, c) {
+  let td = tdAt(r, c);
+  if (!td && vgrid) {
+    const d = displayIdx(r);
+    if (d >= vgrid.freeze) {
+      const wrap = $("gridWrap");
+      const band = HEAD_H + vgrid.freeze * ROW_H;   // sticky header + frozen rows
+      const y = HEAD_H + d * ROW_H;
+      if (y < wrap.scrollTop + band) wrap.scrollTop = y - band;
+      else if (y + ROW_H > wrap.scrollTop + wrap.clientHeight) wrap.scrollTop = y + ROW_H - wrap.clientHeight;
+      updateViewport(false);
+      td = tdAt(r, c);
+    }
+  }
+  if (td) td.scrollIntoView({ block: "nearest", inline: "nearest" });
+}
+
 function appendRows(from) {
   const sh = S();
-  const wrap = $("gridWrap");
-  if (!wrap._tbody) { renderGrid(); return; }
-  const cols = nCols();
-  for (let r = from; r < sh.loaded.length; r++) wrap._tbody.appendChild(makeRowTr(r, cols, r));
+  if (!$("gridWrap")._tbody || !vgrid) { renderGrid(); return; }
+  for (let r = from; r < sh.loaded.length; r++) vgrid.vis.push(r);
+  vgrid.pos = null;
+  updateViewport(true);
   updateMoreBar();
   updateChip();
 }
@@ -1547,7 +1621,7 @@ function paint() {
   paintSel();
 }
 
-function paintSel() {
+function paintSelCells() {   // the DOM half of paintSel — rerun after a remount
   if (!book) return;
   const { r1, c1, r2, c2, ar, ac } = normSel();
   document.querySelectorAll("td.sel, td.anchor").forEach((td) => td.classList.remove("sel", "anchor"));
@@ -1568,6 +1642,12 @@ function paintSel() {
   document.querySelectorAll(`th[data-col]`).forEach((th) => {
     const c = +th.dataset.col; if (c >= c1 && c <= c2) th.classList.add("hl");
   });
+}
+
+function paintSel() {
+  if (!book) return;
+  paintSelCells();
+  const { r1, c1, r2, c2, ar, ac } = normSel();
   $("nameBox").value = r1 === r2 && c1 === c2 ? refName(ar, ac) : `${refName(r1, c1)}:${refName(r2, c2)}`;
   if (!editing) $("fxInput").value = raw(ar, ac);
   const sh = S();
@@ -1619,8 +1699,7 @@ function setSel(r1, c1, r2 = r1, c2 = c1, ar = r1, ac = c1) {
   commitEdit();
   sel = { ar, ac, r1, c1, r2, c2 };
   paintSel();
-  const td = tds.get(ar + "," + ac);
-  if (td) td.scrollIntoView({ block: "nearest", inline: "nearest" });
+  scrollCellIntoView(ar, ac);
 }
 
 function renderTabs() {
@@ -1708,6 +1787,11 @@ function fetchRows(reset) {
 }
 
 $("gridWrap").addEventListener("scroll", () => {
+  if (vgrid && !vgrid.raf) {
+    vgrid.raf = requestAnimationFrame(() => {
+      if (vgrid) { vgrid.raf = null; updateViewport(false); }
+    });
+  }
   if (!book || !isBig()) return;
   const w = $("gridWrap");
   if (w.scrollTop + w.clientHeight > w.scrollHeight - 500) {
@@ -1762,6 +1846,7 @@ function commitEdit() {
     setCell(r, c, input.value);
     markDirty();
   }
+  updateViewport(false);   // catch up on any scrolling deferred while editing
   paint();
   $("gridWrap").focus();
 }
@@ -1769,6 +1854,7 @@ function cancelEdit() {
   if (!editing) return;
   acClose();
   editing = null;
+  updateViewport(false);
   paint();
   $("gridWrap").focus();
 }
@@ -1777,8 +1863,7 @@ function move(dr, dc, extend = false) {
   const C = Math.max(0, Math.min(nCols() - 1, (extend ? sel.c2 : sel.ac) + dc));
   if (extend) { sel.r2 = R; sel.c2 = C; paintSel(); }
   else setSel(R, C);
-  const td = tdAt(R, C);
-  if (td) td.scrollIntoView({ block: "nearest", inline: "nearest" });
+  scrollCellIntoView(R, C);
 }
 
 // ================= drag-fill (fill handle) =================
@@ -1881,10 +1966,10 @@ function finishColResize(x) {
   if (!isBig() && !readOnly) markDirty();   // widths persist into the xlsx on save
   colResizing = null;
 }
-// Column widths aren't applied live while dragging: on a big/scrolled sheet the
-// grid's DOM can hold tens of thousands of rows, and table-layout:fixed with
-// sticky headers means every width write reflows the WHOLE table. So during
-// the drag we only move a cheap position:fixed guide line (outside the table,
+// Column widths aren't applied live while dragging: table-layout:fixed with
+// sticky headers means every width write reflows the whole table (cheap now
+// that the tbody is virtualized, but still pointless work per frame). During
+// the drag we only move a position:fixed guide line (outside the table,
 // so no reflow); its geometry is captured once at drag start and never
 // re-read mid-drag (a getBoundingClientRect() read forces the same layout
 // flush a write would). The real width, and the one expensive reflow, happen

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -2572,6 +2572,11 @@ $("gridWrap").addEventListener("mousemove", (e) => {
   if (!dragging) return;
   if (td) { sel.r2 = +td.dataset.r; sel.c2 = +td.dataset.c; paintSel(); }
 });
+function applyColResize(x) {
+  const w = Math.max(40, Math.round(colResizing.startW + x - colResizing.startX));
+  colResizing.colEl.style.width = w + "px";
+  colResizing.table._syncWidth();
+}
 document.addEventListener("mousemove", (e) => {
   if (!colResizing) return;
   colResizing.pendingX = e.clientX;
@@ -2579,14 +2584,13 @@ document.addEventListener("mousemove", (e) => {
   colResizing.raf = requestAnimationFrame(() => {
     if (!colResizing) return;
     colResizing.raf = null;
-    const w = Math.max(40, Math.round(colResizing.startW + colResizing.pendingX - colResizing.startX));
-    colResizing.colEl.style.width = w + "px";
-    colResizing.table._syncWidth();
+    applyColResize(colResizing.pendingX);
   });
 });
 document.addEventListener("mouseup", () => {
   if (colResizing) {
-    if (colResizing.raf) cancelAnimationFrame(colResizing.raf);
+    if (colResizing.raf) { cancelAnimationFrame(colResizing.raf); colResizing.raf = null; }
+    if (colResizing.pendingX !== undefined) applyColResize(colResizing.pendingX);
     const { c, colEl, grip } = colResizing;
     grip.classList.remove("on");
     S().colw = S().colw || {};

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -1446,10 +1446,11 @@ function renderGrid() {
     grip.addEventListener("mousedown", (e) => {
       e.preventDefault(); e.stopPropagation();
       const colEl = colgroup.querySelector(`col[data-col="${c}"]`);
+      const wrapRect = $("gridWrap").getBoundingClientRect();
       colResizing = { c, colEl, table, startX: e.clientX, pendingX: e.clientX,
-                      startW: parseFloat(colEl.style.width) || 90, grip };
+                      startW: parseFloat(colEl.style.width) || 90, grip, wrapRect };
       grip.classList.add("on");
-      showResizeGuide(e.clientX);
+      showResizeGuide(e.clientX, wrapRect);
     });
     grip.addEventListener("click", (e) => e.stopPropagation());
     grip.addEventListener("dblclick", (e) => {
@@ -2582,16 +2583,20 @@ $("gridWrap").addEventListener("mousemove", (e) => {
 // (no table involved, so no reflow) and pay the one expensive reflow only
 // once, on mouseup.
 let resizeGuide = null;
-function showResizeGuide(x) {
+function showResizeGuide(x, wrapRect) {
   if (!resizeGuide) {
     resizeGuide = document.createElement("div");
     resizeGuide.id = "colResizeGuide";
+    resizeGuide.style.cssText =
+      `position:fixed; top:${wrapRect.top}px; height:${wrapRect.height}px; ` +
+      `z-index:50; pointer-events:none;`;
     document.body.appendChild(resizeGuide);
   }
-  const wrapRect = $("gridWrap").getBoundingClientRect();
-  resizeGuide.style.cssText =
-    `position:fixed; top:${wrapRect.top}px; height:${wrapRect.height}px; ` +
-    `left:${x}px; z-index:50; pointer-events:none;`;
+  // left is the only thing that changes per frame — a plain style write, no
+  // getBoundingClientRect() here: that call forces a layout flush, and doing
+  // it every rAF frame for a slow multi-second drag reintroduces a per-frame
+  // reflow cost on a big table, exactly what this guide line exists to avoid.
+  resizeGuide.style.left = x + "px";
 }
 function hideResizeGuide() {
   if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
@@ -2608,7 +2613,7 @@ document.addEventListener("mousemove", (e) => {
   colResizing.raf = requestAnimationFrame(() => {
     if (!colResizing) return;
     colResizing.raf = null;
-    showResizeGuide(colResizing.pendingX);
+    showResizeGuide(colResizing.pendingX, colResizing.wrapRect);
   });
 });
 document.addEventListener("mouseup", () => {

--- a/fused_render/templates/excel/template.html
+++ b/fused_render/templates/excel/template.html
@@ -429,7 +429,7 @@ const PY = "./reader.py";
 // (D114) would abort an in-flight write. Route every call through this.
 const pyRun = (params) => fused.runPython(PY, params, { key: null });
 const $ = (id) => document.getElementById(id);
-const RENDER_CAP = 1000, MIN_ROWS = 100, MIN_COLS = 26, MAX_UNDO = 60, LOAD_BATCH = 2000;
+const MIN_ROWS = 100, MIN_COLS = 26, MAX_UNDO = 60, LOAD_BATCH = 2000;
 
 // ================= state =================
 let book = null;          // { sheets: [...] }  — small: {rows, styles}; big: {loaded, edits, ...}
@@ -440,7 +440,6 @@ let readOnly = false;      // reader verdict (SPEC §13.5): blocks in-place save
 let sel = { ar: 0, ac: 0, r1: 0, c1: 0, r2: 0, c2: 0 };
 let editing = null;
 let undoStack = [], redoStack = [];
-let renderLimit = RENDER_CAP;
 let tds = new Map();
 let values = [];          // computed matrix (small sheets)
 let valuesStale = true;
@@ -1272,7 +1271,6 @@ function applyFilterMenu() {
     sh.filterVal[c] = excl.length ? { mode: "exclude", vals: excl } : null;
   }
   closeFilterMenu();
-  renderLimit = RENDER_CAP;
   if (sh.big) fetchRows(true); else renderGrid();
 }
 document.addEventListener("mousedown", (e) => {
@@ -1281,6 +1279,25 @@ document.addEventListener("mousedown", (e) => {
 document.addEventListener("keydown", (e) => { if (e.key === "Escape" && fmState) { closeFilterMenu(); e.stopPropagation(); } }, true);
 
 // ================= rendering =================
+// The text a cell shows, without needing the cell to exist in the DOM.
+function cellDisplayText(r, c) {
+  const sh = S();
+  if (sh.big) return raw(r, c);
+  const cv = (values[r] && values[r][c]) ? values[r][c] : EMPTY_CELL;
+  return display(cv, sh.styles[r] && sh.styles[r][c]);
+}
+// Width for double-click auto-fit, measured over the DATA — the tbody is
+// virtualized, so scanning rendered cells would size the column to whatever
+// happens to be scrolled into view. Big sheets can only consider the rows
+// streamed in so far; the rest aren't in the browser to measure.
+function autofitWidth(c) {
+  const sh = S();
+  if (!sh.big) ensureValues();
+  const rows = sh.big ? sh.loaded.keys() : visibleRowIdx();
+  let maxLen = 4;
+  for (const r of rows) maxLen = Math.max(maxLen, cellDisplayText(r, c).length);
+  return Math.max(48, Math.min(420, Math.round(maxLen * 7.2 + 16)));
+}
 function cellClassAndStyle(td, r, c) {
   const sh = S();
   let text, cls = "cell", css = "";
@@ -1394,10 +1411,7 @@ function renderGrid() {
   tds = new Map();
   const cols = nCols();
 
-  const vis = sh.big
-    ? [...Array(sh.loaded.length).keys()]
-    : visibleRowIdx().slice(0, renderLimit === Infinity ? undefined : renderLimit);
-  const totalVis = sh.big ? sh.loaded.length : visibleRowIdx().length;
+  const vis = sh.big ? [...Array(sh.loaded.length).keys()] : visibleRowIdx();
 
   const table = document.createElement("table");
   const colgroup = document.createElement("colgroup");
@@ -1447,11 +1461,7 @@ function renderGrid() {
     attachColResizeGrip(grip, c, colgroup, table);
     grip.addEventListener("dblclick", (e) => {
       e.preventDefault(); e.stopPropagation();
-      let maxLen = 4;
-      for (const [key, td] of tds) {
-        if (key.endsWith("," + c)) maxLen = Math.max(maxLen, td.textContent.length);
-      }
-      const w = Math.max(48, Math.min(420, Math.round(maxLen * 7.2 + 16)));
+      const w = autofitWidth(c);
       colgroup.querySelector(`col[data-col="${c}"]`).style.width = w + "px";
       syncTableWidth();
       sh.colw[c] = w;
@@ -1488,12 +1498,6 @@ function renderGrid() {
     const bar = document.createElement("div"); bar.id = "moreBar";
     wrap.appendChild(bar);
     updateMoreBar();
-  } else if (totalVis > vis.length) {
-    const b = document.createElement("button");
-    b.className = "action"; b.style.margin = "10px";
-    b.textContent = `Show all ${fmtInt(totalVis)} rows (rendering ${fmtInt(vis.length)})`;
-    b.onclick = () => { renderLimit = Infinity; renderGrid(); };
-    wrap.appendChild(b);
   }
   updateChip();
   paintSel();
@@ -1746,7 +1750,7 @@ function renderTabs() {
 function switchSheet(i) {
   commitEdit();
   closeFilterMenu();   // an open menu would apply its filter to the new sheet
-  cur = i; renderLimit = RENDER_CAP; invalidateValues();
+  cur = i; invalidateValues();
   sel = { ar: 0, ac: 0, r1: 0, c1: 0, r2: 0, c2: 0 };
   fused.params.set("sheet", book.sheets[i].name);
   renderTabs(); renderGrid();
@@ -1936,8 +1940,12 @@ function performFill(base, tgt) {
   paint();
 }
 let fillDrag = null;   // { base, tgt|null }
-let colResizing = null; // { c, colEl, table, grip, startX, startW, wrapRect, raf, pendingX }
+let colResizing = null; // { c, colEl, table, grip, startX, startW, wrapRect, raf, pendingX, pointerId }
 let resizeGuide = null;
+const MIN_COL_W = 40;
+function resizeWidthFor(x) {
+  return Math.max(MIN_COL_W, Math.round(colResizing.startW + x - colResizing.startX));
+}
 function showResizeGuide(x) {
   if (!resizeGuide) {
     resizeGuide = document.createElement("div");
@@ -1947,24 +1955,32 @@ function showResizeGuide(x) {
       `z-index:50; pointer-events:none;`;
     document.body.appendChild(resizeGuide);
   }
-  resizeGuide.style.left = x + "px";
+  // Track the edge the column will actually land on, not the raw cursor: past
+  // the minimum width the cursor keeps moving but the edge doesn't, and a
+  // guide that kept following would promise a width release won't deliver.
+  resizeGuide.style.left =
+    (colResizing.startX - colResizing.startW + resizeWidthFor(x)) + "px";
 }
 function hideResizeGuide() {
   if (resizeGuide) { resizeGuide.remove(); resizeGuide = null; }
 }
+function clearColResize() {
+  if (colResizing.raf) cancelAnimationFrame(colResizing.raf);
+  colResizing.grip.classList.remove("on");
+  hideResizeGuide();
+  colResizing = null;
+}
 function finishColResize(x) {
-  const { c, colEl, table, startX, startW, grip } = colResizing;
-  const w = Math.max(40, Math.round(startW + x - startX));
+  const { c, colEl, table } = colResizing;
+  const w = resizeWidthFor(x);
+  clearColResize();
   colEl.style.width = w + "px";
   table._syncWidth();
-  hideResizeGuide();
-  grip.classList.remove("on");
   S().colw = S().colw || {};
   S().colw[c] = w;
   // Resizing stays available read-only (viewing convenience), but must not
   // flip the dirty flag — widths only persist via a save that can't happen.
   if (!isBig() && !readOnly) markDirty();   // widths persist into the xlsx on save
-  colResizing = null;
 }
 // Column widths aren't applied live while dragging: table-layout:fixed with
 // sticky headers means every width write reflows the whole table (cheap now
@@ -1975,36 +1991,42 @@ function finishColResize(x) {
 // flush a write would). The real width, and the one expensive reflow, happen
 // exactly once, when the pointer is released.
 //
-// Pointer Events (not Mouse Events) so touch/pen drags work too, but
-// listened for on `document` rather than relying on grip.setPointerCapture():
-// capture only redirects events for a pointer the browser considers
-// "active" (real hardware input) — there is no reliable way to verify its
-// failure mode without a real device, and a silent capture failure would
-// mean losing every event once the cursor leaves the 7px-wide grip strip,
-// breaking the drag outright. Document-level listeners keep receiving
-// events regardless of what's under the cursor, exactly like the mouse-
-// event version this replaces, so there's no such failure mode to worry
-// about.
+// Pointer Events (not Mouse Events) so touch/pen drags work too. Capture is
+// requested best-effort — it keeps events flowing to the grip even over other
+// elements or outside this iframe — but the document-level listeners below are
+// what actually drive the drag, since setPointerCapture throws for a pointer
+// the browser isn't actively tracking and must never be the only path.
+//
+// This template runs in an iframe, so a release outside the frame can drop the
+// pointerup entirely. The drag therefore commits from the last position it
+// tracked (`pendingX`), never from a terminating event's coordinates, and any
+// of pointerup / pointercancel / lostpointercapture / window blur / a
+// pointermove with no button held will end it. Otherwise a stranded drag stays
+// armed and an unrelated later release resizes from meaningless coordinates.
 function attachColResizeGrip(grip, c, colgroup, table) {
-  function currentColEl() { return colgroup.querySelector(`col[data-col="${c}"]`); }
   grip.addEventListener("pointerdown", (e) => {
     if (e.button !== 0) return;
     e.preventDefault(); e.stopPropagation();
-    const colEl = currentColEl();
+    if (colResizing) clearColResize();   // a stranded drag: drop it, don't commit
+    const colEl = colgroup.querySelector(`col[data-col="${c}"]`);
     colResizing = {
-      c, colEl, table, grip,
+      c, colEl, table, grip, pointerId: e.pointerId,
       startX: e.clientX, pendingX: e.clientX,
       startW: parseFloat(colEl.style.width) || 90,
       wrapRect: $("gridWrap").getBoundingClientRect(),
       raf: null,
     };
     grip.classList.add("on");
+    try { grip.setPointerCapture(e.pointerId); } catch { /* not a live pointer */ }
     showResizeGuide(e.clientX);
   });
+  grip.addEventListener("lostpointercapture", endColResize);
   grip.addEventListener("click", (e) => e.stopPropagation());
 }
 document.addEventListener("pointermove", (e) => {
-  if (!colResizing) return;
+  if (!colResizing || e.pointerId !== colResizing.pointerId) return;
+  // Button already up: the release happened somewhere we never saw it.
+  if (!(e.buttons & 1)) { endColResize(); return; }
   colResizing.pendingX = e.clientX;
   if (colResizing.raf) return;
   colResizing.raf = requestAnimationFrame(() => {
@@ -2013,13 +2035,16 @@ document.addEventListener("pointermove", (e) => {
     showResizeGuide(colResizing.pendingX);
   });
 });
-function endColResize(e) {
-  if (!colResizing) return;
-  if (colResizing.raf) { cancelAnimationFrame(colResizing.raf); colResizing.raf = null; }
-  finishColResize(e.clientX);
+function endColResize() {
+  if (colResizing) finishColResize(colResizing.pendingX);
 }
-document.addEventListener("pointerup", endColResize);
+document.addEventListener("pointerup", (e) => {
+  if (!colResizing) return;
+  if (e.pointerId === colResizing.pointerId) colResizing.pendingX = e.clientX;
+  endColResize();
+});
 document.addEventListener("pointercancel", endColResize);
+window.addEventListener("blur", endColResize);
 function fillPreview(r, c) {
   const b = fillDrag.base;
   const rowOut = r > b.r2 ? r - b.r2 : r < b.r1 ? r - b.r1 : 0;
@@ -2150,7 +2175,7 @@ async function load() {
     normalizeLoaded(res);
     mtime = res.mtime;
     setReadOnly(res.editable === false, res.readonly_message || "", res.readonly_tooltip || "");
-    undoStack = []; redoStack = []; renderLimit = RENDER_CAP; invalidateValues();
+    undoStack = []; redoStack = []; invalidateValues();
     const want = fused.params.get("sheet");
     cur = Math.max(0, book.sheets.findIndex((s2) => s2.name === want));
     sel = { ar: 0, ac: 0, r1: 0, c1: 0, r2: 0, c2: 0 };
@@ -2624,7 +2649,6 @@ async function act(name) {
       const sh = S();
       sh.filterOn = !sh.filterOn;
       closeFilterMenu();
-      renderLimit = RENDER_CAP;
       if (!sh.filterOn) {   // turning filters off clears every column filter
         const had = activeFilters(sh).length;
         sh.filterQ = []; sh.filterVal = [];
@@ -2946,7 +2970,6 @@ $("nameBox").addEventListener("keydown", (e) => {
       setSel(ref.r, Math.min(ref.c, nCols() - 1));
     } else {
       ensureRect(S(), ref.r + 1, ref.c + 1);
-      if (ref.r >= renderLimit) renderLimit = Infinity;
       invalidateValues(); renderGrid(); setSel(ref.r, ref.c);
     }
   }


### PR DESCRIPTION
## Summary

Dragging a column edge to resize it in the built-in Excel app template could hang the browser for anywhere from seconds to minutes. This took several rounds, as each fix uncovered a deeper cause:

1. **`05f2da9`** — the resize's `mousemove` handler wrote the column width and forced a full table reflow on every raw event, unthrottled.
2. **`049a18c`** — fixed a `mouseup`/rAF race (review-flagged) that could drop the final drag position.
3. **`42c2a7a`** — rAF-batching alone wasn't enough on big/scrolled sheets: switched to a lightweight guide line during the drag, applying the real width (and the one expensive reflow) only on release.
4. **`723046c`** — the guide line itself read `getBoundingClientRect()` every animation frame, which forces a layout flush; cached once at drag start instead.
5. **`a9f0814`** — consolidated the interaction into one Pointer Events module (was Mouse Events split across several listeners), for touch/pen support and to clear out the accumulated incremental cruft.
6. **`8321415`** — the actual remaining cause: the grid had **no row virtualization**, so a big/scrolled sheet could hold thousands of real DOM rows, each with a `position: sticky` cell. The single reflow on release still forced a full re-raster across every sticky layer — compositor work that is invisible to both the JS Long Tasks API and to synthetic event timing, which is why earlier fixes measured clean in automation yet still hung in practice. Rows are now virtualized to ~110 DOM rows (viewport + overscan) regardless of dataset size.
7. **`a5f80ac`** — a latent bug found while reviewing the above (not a cause of the hang): `excel/reader.py` isn't on the in-process allowlist, so every request runs in a fresh subprocess and concurrent cold opens of the same file could race building the same cache files. Fixed with build-into-temp-dir + atomic rename.
8. **`e7189eb`** — review round: fixes for six findings, plus removal of the now-obsolete `renderLimit`/`RENDER_CAP` machinery (it capped rendering at 1000 rows to bound the DOM — virtualization does that properly now, and leaving it in truncated small sheets behind a "Show all rows" button that no longer had anything to fix).

9. **`b2b094b`** ^W second review round: the recovery path added in `e7189eb` still had a TOCTOU ^W a losing builder could `rmtree` the target dir just as another process published a complete cache into it (possibly under a live reader), and its unguarded second rename could raise even though a valid cache then existed. Debris is now renamed *aside* inside a bounded retry loop that re-checks for a published `meta.json` each pass, so a winner is never destroyed and a loser never errors when a cache is available.

10. **`c179688e`** — third review round: a column resize was ended by *any* pointer's `pointerup`/`pointercancel`, so with touch/pen support a second finger could commit the width early; and `updateViewport` bailed out entirely while an in-cell editor was open, so scrolling mid-edit left the spacer pads showing as blank bands (a virtualization regression). Terminators are now scoped to the drag's own `pointerId`, and a window change during an edit commits it and remounts instead of skipping.

11. **`d50a118d`** — fourth review round: the cache adopt path deleted this process's finished build *before* reading the winner's `meta.json`, so a winner renamed aside in that gap raised instead of retrying (intermittent failures on concurrent cold opens). Adoption now commits only once the metadata is parsed; the same read-after-`exists` gap on the fast path is closed, and `_rekey_cache` writes `meta.json` atomically instead of in place.

12. **`ea39523a`** — fifth review round, both regressions from rounds 3-4: `lostpointercapture` ended a resize regardless of `pointerId` (and `clearColResize` abandoned a drag without releasing its capture), so a second pointer's drag could be committed early by the first's capture loss; and `updateViewport` dropped a *forced* remount when it committed an open editor, since `commitEdit` only re-runs it unforced — leaving spacer heights stale after `appendRows` so newly streamed rows weren't scrollable.

### Review findings addressed in `e7189eb`
- **Cache temp dirs wiped concurrently** (high) — build dirs were named `{cache_dir}.tmp-…`, so their basename still matched the `{hash}-` prefix `_clean_stale` treats as stale; concurrent cold opens could delete each other's work mid-build. Build dirs now use a `.build-` prefix that can't match a cache key, and `_clean_stale` skips it regardless.
- **Rename failure assumed meta exists** (high) — every rename failure was treated as "another builder won", then `meta.json` was opened unconditionally, so a half-built leftover dir made a workbook permanently unopenable until the cache was cleared by hand. That path is now taken only when `meta.json` is really there; otherwise the debris is cleared and claimed.
- **Stranded resize committed a wrong width** (medium) — this template runs in an iframe, so a release outside the frame can drop the `pointerup`, leaving the drag armed for an unrelated later release. The commit now always uses the last tracked position, and `pointercancel` / `lostpointercapture` / window blur / a buttonless `pointermove` all end the drag; `pointerdown` drops a stranded one.
- **Auto-fit ignored offscreen rows** (medium) — a real regression from virtualization: double-click auto-fit scanned rendered cells, which is now only the mounted window. It measures the data model instead.
- **Guide mismatched the final column edge** (low) — the guide sat at the raw cursor without the width clamp, so past the 40px minimum it promised a width release wouldn't deliver.

## Test plan
- [x] Real-viewport Playwright run against a 2501-row sheet: deep scroll reaches rows 2432–2501 with only 72 rows in the DOM; a slow wobbly **real-mouse** drag (real input pipeline, so it drives hit-testing/hover unlike `dispatchEvent`) produces **zero** long tasks, zero reflows during the drag and exactly one on release; no page errors
- [x] Resize reflow on a 30k-row sheet measured at ~4ms
- [x] Guide clamp, stranded-drag recovery, `pointercancel`, window blur, no-movement click and stray post-drag events all verified
- [x] Auto-fit verified against a 90-char value in unmounted row 2400 (returns the 420px cap; the old DOM scan returned ~64px)
- [x] Cache concurrency verified with two independently written **multi-process** harnesses (real subprocesses ^W an earlier thread-based test is why the first race slipped through): N cold builds from a wiped cache; the same with pre-seeded half-built debris; and a deterministic reproduction of the winner-publish TOCTOU via a flag-file hook that pauses a worker between its meta check and the move-aside. All assert no worker errors, consistent metadata, referenced parquet present under `_cache_dir`, exactly one cache dir, no `.build-` leftovers
- [x] In-flight build survives `_clean_stale`; half-built leftover self-heals; stale `.build-` dirs swept by age
- [x] `tests/test_excel_readonly.py` passes (the 2 `tests/test_templates.py` failures are pre-existing Windows path-separator issues, reproduced on a clean `main`)
- [x] Unrelated-pointer `pointerup`/`pointercancel` verified not to end a drag; edit-scroll verified to remount with full viewport coverage, commit the edit, and leave small mid-edit nudges alone (Enter-commit / Escape-cancel re-checked)
- [x] Confirmed fixed by the reporting user on their real file and machine




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Excel load/render paths and on-disk cache coordination; logic is defensive but concurrent filesystem behavior and virtualization edge cases (scroll while editing) warrant careful regression testing.
> 
> **Overview**
> Fixes **browser hangs** when resizing columns on large scrolled sheets and **race conditions** when multiple subprocesses cold-open the same workbook.
> 
> **Grid (`template.html`):** Adds **row virtualization** so the tbody only mounts viewport rows plus overscan (~110 DOM rows) with spacer pads, removing the old `RENDER_CAP` / “Show all rows” cap. Column resize is reworked to use **Pointer Events**, a **fixed guide line** during drag (no per-frame table reflow), and a **single width apply on release**; auto-fit measures **data** instead of rendered cells. Scroll/editing integrates via `updateViewport`, `scrollCellIntoView`, and committing in-cell edits before forced remounts; resize termination is scoped to the drag’s `pointerId`.
> 
> **Cache (`reader.py`):** `_ensure_cache` builds into a **`.build-` temp dir** and claims the real cache with **atomic rename** plus a bounded retry loop that **renames debris aside** (never `rmtree` on a possibly live winner), adopts only after **`_load_meta`** succeeds, and uses **`_load_meta`** on the fast path. `_clean_stale` skips in-flight `.build-` dirs and sweeps stale ones by age; `_rekey_cache` writes **`meta.json` via `os.replace`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea39523ae09024793e249c0aafad4e9e7893b656. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






