### PR TITLE
claude template: "Open preview" button after successful replies

### DIFF
--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -148,19 +148,20 @@
   .error { color: var(--error); }
   .error::before { content: "✗ "; }
 
-  /* the "Open preview" hop offered under a successful reply */
+  /* the "Open preview" hop offered under a successful reply — brand orange,
+     same accent as the banner and permission cards */
   .viewout { margin: -8px 0 14px 20px; }
   .viewout button {
     font: inherit;
     font-size: 12px;
     padding: 3px 10px;
-    border: 1px solid var(--border);
+    border: 1px solid var(--orange);
     border-radius: 5px;
     background: transparent;
-    color: var(--dim);
+    color: var(--orange);
     cursor: pointer;
   }
-  .viewout button:hover { color: var(--fg); border-color: var(--border-focus); }
+  .viewout button:hover { background: var(--orange); color: var(--on-orange); }
 
   /* ── permission cards (the approval bridge) ─────────────────── */
   /* Claude runs headless here, so a tool the session's rules don't already

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -148,6 +148,20 @@
   .error { color: var(--error); }
   .error::before { content: "✗ "; }
 
+  /* the "Open preview" hop offered under a successful reply */
+  .viewout { margin: -8px 0 14px 20px; }
+  .viewout button {
+    font: inherit;
+    font-size: 12px;
+    padding: 3px 10px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: transparent;
+    color: var(--dim);
+    cursor: pointer;
+  }
+  .viewout button:hover { color: var(--fg); border-color: var(--border-focus); }
+
   /* ── permission cards (the approval bridge) ─────────────────── */
   /* Claude runs headless here, so a tool the session's rules don't already
      allow becomes one of these instead of a terminal prompt. Bordered in the
@@ -742,24 +756,30 @@ function formatComments(arr) {
 // Claude" sets these same top params the same way.
 const HANDOFF_PARAMS = ["claudeComments", "claudeReturn"];
 
+// Split a raw shell query string into the balanced `_layout=(…)` span — whose
+// `&` is literal, so URLSearchParams must never see it — and the rest. Every
+// caller reattaches the span byte-for-byte after editing the rest.
+function spliceLayoutSpan(full) {
+  const m = /(^|&)_layout=\(/.exec(full);
+  if (!m) return { span: null, rest: full };
+  const start = m.index + m[1].length;
+  let i = start + "_layout=(".length, depth = 1;
+  while (i < full.length && depth > 0) {
+    if (full[i] === "(") depth++;
+    else if (full[i] === ")") depth--;
+    i++;
+  }
+  return {
+    span: full.slice(start, i),
+    rest: (full.slice(0, m.index) + full.slice(i)).replace(/^&|&$/g, ""),
+  };
+}
+
 function clearTopClaudeComments() {
   let top;
   try { top = window.top; void top.location.href; } catch (e) { return; }  // cross-origin
   const full = (top.location.search || "").replace(/^\?/, "");
-  const m = /(^|&)_layout=\(/.exec(full);
-  let span = null;
-  let rest = full;
-  if (m) {
-    const start = m.index + m[1].length;
-    let i = start + "_layout=(".length, depth = 1;
-    while (i < full.length && depth > 0) {
-      if (full[i] === "(") depth++;
-      else if (full[i] === ")") depth--;
-      i++;
-    }
-    span = full.slice(start, i);
-    rest = (full.slice(0, m.index) + full.slice(i)).replace(/^&|&$/g, "");
-  }
+  const { span, rest } = spliceLayoutSpan(full);
   const params = new URLSearchParams(rest);
   if (!HANDOFF_PARAMS.some((k) => params.has(k))) return;
   HANDOFF_PARAMS.forEach((k) => params.delete(k));
@@ -803,22 +823,12 @@ function returnToMode(mode) {
   // early is exactly what it is for.
   try { window.dispatchEvent(new Event("pagehide")); } catch (e) { /* best-effort */ }
   const full = (top.location.search || "").replace(/^\?/, "");
-  const m = /(^|&)_layout=\(/.exec(full);
-  let span = null;
-  let rest = full;
-  if (m) {
-    const start = m.index + m[1].length;
-    let i = start + "_layout=(".length, depth = 1;
-    while (i < full.length && depth > 0) {
-      if (full[i] === "(") depth++;
-      else if (full[i] === ")") depth--;
-      i++;
-    }
-    span = full.slice(start, i);
-    rest = (full.slice(0, m.index) + full.slice(i)).replace(/^&|&$/g, "");
-  }
+  const { span, rest } = spliceLayoutSpan(full);
   const params = new URLSearchParams(rest);
-  params.set("_mode", mode);
+  // An empty mode means the file's DEFAULT view: `_mode` absent is how the
+  // shell spells that, and `_mode=` would be a distinct (broken) mode name.
+  if (mode) params.set("_mode", mode);
+  else params.delete("_mode");
   // `run` marks a chat run as in-flight and is what the next boot re-attaches
   // to (resumeRun). The run we are returning FROM has finished, so carrying the
   // id back would make a later hop into chat re-poll a dead run.
@@ -881,6 +891,40 @@ function addError(text) {
   const d = document.createElement("div");
   d.className = "turn error";
   d.textContent = text;
+  log.appendChild(d);
+  log.scrollTop = log.scrollHeight;
+}
+
+// Whether the "Open preview" hop under a reply would actually go anywhere:
+// a same-origin shell whose top-level URL carries `_mode` (this chat was
+// opened as a mode over the file). In a pane whose mode lives inside the
+// `_layout` span — or with no shell at all — deleting top `_mode` is a no-op,
+// so the button is not offered rather than shown dead.
+function canOpenPreview() {
+  try {
+    const { rest } = spliceLayoutSpan((window.top.location.search || "").replace(/^\?/, ""));
+    return new URLSearchParams(rest).has("_mode");
+  } catch (e) { return false; }  // cross-origin
+}
+
+// Offered once per transcript, under the LATEST successful reply. The hop
+// always shows the file's CURRENT state, so an older turn's row would be a
+// second button doing exactly the same thing — earlier rows are removed
+// instead of accumulating.
+function addViewOutput() {
+  if (!canOpenPreview()) return;
+  log.querySelectorAll(".viewout").forEach((el) => el.remove());
+  const d = document.createElement("div");
+  d.className = "turn viewout";
+  const b = document.createElement("button");
+  b.type = "button";
+  b.textContent = "Open preview →";
+  b.title = "See " + BASENAME + " in its default view";
+  // Same guard as #back: navigating mid-turn would orphan the streaming run's
+  // UI (the run itself survives via the `run` param, but the half-drawn turn
+  // would be abandoned without the teardown the error paths do).
+  b.onclick = () => { if (!sending) returnToMode(""); };
+  d.appendChild(b);
   log.appendChild(d);
   log.scrollTop = log.scrollHeight;
 }
@@ -1338,6 +1382,12 @@ async function pollLoop(run_id, handoff) {
         // a run that failed or was aborted has changed nothing to go back and
         // look at, and navigating away would hide the error message.
         if (returnTo && !data.error) returnToMode(returnTo);
+        // A clean finish with no auto-return earns the manual hop instead: a
+        // button back to the file's default preview, so the user can see what
+        // the reply changed without hunting the mode switcher. Never on the
+        // error path — nothing new to look at, and the button would read as
+        // "see the result" of a turn that produced none.
+        else if (!data.error) addViewOutput();
         break;
       }
       await sleep(400);
@@ -1358,6 +1408,10 @@ async function pollLoop(run_id, handoff) {
 async function sendMessage(message, handoff) {
   if (sending) return;
   sending = true;
+  // The previous turn's "Open preview" goes away with the new send: `sending`
+  // makes it a dead button for the whole turn, and the finish that matters is
+  // the new turn's own (which re-adds it on success).
+  log.querySelectorAll(".viewout").forEach((el) => el.remove());
   addUser(message);
   // Until `start` hands back a run id, nothing has received the message — so a
   // failure up to that point must not consume the attached comments.
@@ -1434,11 +1488,13 @@ async function resumeRun(run_id) {
       if (matches) {
         while (lastUser.nextElementSibling) lastUser.nextElementSibling.remove();
         if (probe.text) addAssistant("").lastChild.innerHTML = renderMd(probe.text);
+        addViewOutput();  // clean finish, just seen late — same hop as a live one
       } else if (!users.length && probe.message) {
         // frame died before the transcript had any rows AND the run finished
         // while away: rebuild the whole turn
         addUser(probe.message);
         if (probe.text) addAssistant("").lastChild.innerHTML = renderMd(probe.text);
+        addViewOutput();
       }
       log.scrollTop = log.scrollHeight;
       return;
@@ -1532,6 +1588,13 @@ async function loadHistory(session_id) {
       if (t.role === "user") addUser(t.text);
       else addAssistant("").lastChild.innerHTML = renderMd(t.text);
     }
+    // The hop survives leaving and coming back: a restored transcript that
+    // ends on an assistant reply is a conversation whose last turn finished
+    // cleanly (errored turns never reach the transcript as assistant rows),
+    // so it earns the same button the live finish drew. Without this the
+    // button existed only for the turn's first viewing — hop to the preview,
+    // hop back, gone.
+    if (turns.length && turns[turns.length - 1].role === "assistant") addViewOutput();
     log.scrollTop = log.scrollHeight;
   } catch (err) {
     log.innerHTML = "";  // drop the skeleton, mirror the original blank fallback

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1343,6 +1343,12 @@ async function pollLoop(run_id, handoff) {
   // The return ticket for THIS run only (see composeAndSend). Undefined for a
   // plain turn and for a run re-attached at boot (resumeRun) — neither returns.
   const returnTo = (handoff && handoff.mode) || "";
+  // Any "Open preview" row on screen belongs to a FINISHED turn; with a run
+  // now streaming it is stale. sendMessage already stripped its own, but the
+  // resumeRun re-attach path reaches here with a history-restored row that
+  // its non-matching branch never trims — an error finish would then leave
+  // that button stranded mid-transcript. The finish below re-adds on success.
+  log.querySelectorAll(".viewout").forEach((el) => el.remove());
   const w = addWorking();
   let reply = null;
   let typer = null;

--- a/tests/test_annotate_template.py
+++ b/tests/test_annotate_template.py
@@ -357,6 +357,7 @@ def test_the_return_ticket_is_stripped_from_the_shell_url_like_the_comments(
     # Left on the URL, a Back entry (or a refresh) re-attaches a review that was
     # already sent and re-arms the return — so it rides the SAME replaceState.
     fns = [_block(claude_source, "const HANDOFF_PARAMS = [", "];"),
+           _block(claude_source, "function spliceLayoutSpan(full) {", "\n}"),
            _block(claude_source, "function clearTopClaudeComments() {", "\n}")]
     seen = _node(_shell_harness(
         fns,
@@ -378,6 +379,7 @@ def test_the_return_ticket_is_stripped_from_the_shell_url_like_the_comments(
 def test_a_chat_opened_normally_never_rewrites_the_shell_url(
         claude_source, tmp_path):
     fns = [_block(claude_source, "const HANDOFF_PARAMS = [", "];"),
+           _block(claude_source, "function spliceLayoutSpan(full) {", "\n}"),
            _block(claude_source, "function clearTopClaudeComments() {", "\n}")]
     seen = _node(_shell_harness(fns, "_mode=claude&session_id=abc",
                                 "clearTopClaudeComments();"), tmp_path)
@@ -387,8 +389,9 @@ def test_a_chat_opened_normally_never_rewrites_the_shell_url(
 def test_the_return_navigation_flips_the_mode_and_keeps_the_review(
         claude_source, tmp_path):
     fn = _block(claude_source, "function returnToMode(mode) {", "\n}")
+    splice = _block(claude_source, "function spliceLayoutSpan(full) {", "\n}")
     seen = _node(_shell_harness(
-        [fn],
+        [splice, fn],
         "_mode=claude&comments=%5B%7B%22id%22%3A%22c1%22%2C%22sent%22%3A1%7D%5D"
         "&view=markdown&session_id=abc&run=r-42&" + _LAYOUT,
         'returnToMode("annotate");'), tmp_path)


### PR DESCRIPTION
## What

After a chat turn finishes cleanly (`done && !error`), the claude template now offers an **Open preview →** button under the reply. Clicking it drops the top-level `_mode` param, landing on the file's default view so the user can immediately see what the reply changed — no hunting the mode switcher.

## Behavior

- Appears **only after successful replies** — never on error turns (start failure, claude exiting with an error, mid-stream crash/kill with partial text), and not when the annotate `claudeReturn` auto-return is about to navigate anyway.
- **Persists across round trips**: `session_id` survives the hop, and history restore re-adds the button when the transcript ends on an assistant reply (errored turns never reach the transcript as assistant rows). `resumeRun`'s clean-finish paths add it too, so a run that finished while you were in the preview still offers the hop back.
- Hidden when it would be dead: panes whose mode lives inside the `_layout` span (deleting top `_mode` would be a no-op) and cross-origin shells.
- One row per transcript — the hop always shows the file's current state, so older rows are removed rather than accumulating; removed on a new send.

## Implementation

- `returnToMode("")` now means "the default view": `_mode` is deleted rather than set (absent is how the shell spells default; `_mode=` would be a distinct broken mode name).
- The `_layout=(…)` span excision — previously duplicated in `clearTopClaudeComments` and `returnToMode` — is factored into `spliceLayoutSpan()`, also used by the new `canOpenPreview()` guard.

## Testing

- `pytest tests/test_claude_agent_sidecar.py tests/test_claude_permission_bridge.py tests/test_templates.py tests/test_templates_api.py tests/test_core_templates.py` — 328 passed.
- Playwright end-to-end (headless chromium against a live server + real `claude -p` runs):
  - no button on boot / home;
  - start-error turn (bogus model) → error row, no button;
  - clean haiku turn → button appears, single row, click removes `_mode`, keeps `session_id`, lands on the rendered default view;
  - two full claude → preview → claude round trips → button restored from history each time, exactly one;
  - mid-stream `SIGTERM` of the run's process group after text had streamed → error row, partial reply removed, no button; reload after the kill → transcript ends on the user row, still no button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the claude template’s chat UI and shell URL editing; behavior is guarded and covered by existing shell-contract tests plus described e2e flows.
> 
> **Overview**
> After a **successful** Claude turn (not errors, not when annotate auto-return runs), the chat transcript shows a single **Open preview →** control under the latest reply. It calls `returnToMode("")`, which now **removes** top-level `_mode` so the shell shows the file’s default view instead of treating `_mode=` as a bogus mode.
> 
> **URL handling:** duplicated `_layout=(…)` parsing is centralized in `spliceLayoutSpan()` for comment clearing, return navigation, and `canOpenPreview()` (button hidden when top `_mode` isn’t meaningful). The hop is stripped on new sends and while a run streams; it’s restored on history load when the transcript ends on an assistant message, and on late `resumeRun` clean finishes.
> 
> **Tests:** annotate shell harnesses now load `spliceLayoutSpan` alongside existing claude URL helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c952b5106ad8c220528cba0cee0072f3ae7d04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Screenshots

**Chat after a successful reply — the "Open preview →" button (dark / light):**

<img src="https://cdn.jsdelivr.net/gh/AkshilVT/pr-assets@c3f4987a536ef91978fdba5ef5128ed8c685ca09/fused-render-350/pr-chat-dark.png" width="720" alt="Open preview button, dark theme">

<img src="https://cdn.jsdelivr.net/gh/AkshilVT/pr-assets@c3f4987a536ef91978fdba5ef5128ed8c685ca09/fused-render-350/pr-chat-light.png" width="720" alt="Open preview button, light theme">

**After clicking — landed on the file's default view (`_mode` dropped, `session_id` kept):**

<img src="https://cdn.jsdelivr.net/gh/AkshilVT/pr-assets@c3f4987a536ef91978fdba5ef5128ed8c685ca09/fused-render-350/pr-preview-after.png" width="720" alt="Default preview after the hop">
