### PR TITLE
Deploy is scoped to managed apps and publishes a live copy in deploy/<name>

### DIFF
--- a/frontend/src/components/DeployModal.tsx
+++ b/frontend/src/components/DeployModal.tsx
@@ -38,7 +38,7 @@ import { useFusedLogin } from "../lib/account";
 import DeploymentErrors from "./DeploymentErrors";
 import { basename, dirname, formatSize } from "../lib/format";
 import { useRefreshOnReturn } from "../lib/hooks";
-import { navigateUrl } from "../lib/router";
+import { navigate, navigateUrl } from "../lib/router";
 import { Modal } from "./modal/Modal";
 import { ErrorBanner } from "./ErrorBanner";
 import { Select, TextInput } from "./field/fields";
@@ -566,6 +566,17 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     alive.current = false;
   }, []);
 
+  // Set when a deploy in THIS dialog published a live copy at a different path
+  // than the page it was opened on (a dev-copy deploy): closing the dialog then
+  // navigates to the live copy — the deploy folder is what's actually deployed,
+  // so that's where the user should land. Cleared by a revoke (the live copy is
+  // deleted with it — navigating there would 404 the view).
+  const deployedPageRef = useRef<string | null>(null);
+  const closeModal = () => {
+    onClose();
+    if (deployedPageRef.current) navigate(deployedPageRef.current, { isDir: false });
+  };
+
   const applyDeployment = (d: Deployment | null) => {
     if (alive.current) setDeployment(d);
     onChange(d);
@@ -806,6 +817,10 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
         namedTokenActive ? trimmedToken : undefined,
       );
       applyDeployment(record);
+      // What was published is the LIVE COPY (<ws>/deploy/<name>/…) — when this
+      // deploy was launched from a dev copy, remember the live page so closing
+      // the dialog lands the user on what's actually deployed.
+      if (record.page && record.page !== fsPath) deployedPageRef.current = record.page;
       if (!alive.current) return;
       setReconciled(true);
       setLive("active");
@@ -838,6 +853,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     try {
       const record = await revokeDeployment(fsPath);
       applyDeployment(record);
+      deployedPageRef.current = null; // the live copy was just removed
       if (!alive.current) return;
       setLive("revoked");
     } catch (e) {
@@ -1499,7 +1515,7 @@ export default function DeployModal({ fsPath, onClose, onChange }: DeployModalPr
     // trap the user. closeTitle reflects that.
     <Modal
       title={`Deploy ${basename(fsPath)}`}
-      onClose={onClose}
+      onClose={closeModal}
       closeTitle={busy !== null ? "Close (the action keeps running)" : "Close"}
     >
       {body()}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -410,7 +410,11 @@ export interface DeployConfig {
 // The thin per-page deployment pointer (~/.fused-render/deployments.json).
 // url is null when the backend never returned one (AWS prints token+path only).
 export interface Deployment {
+  // The LIVE COPY's entry page (<workspace>/deploy/<name>/…) — what is
+  // actually published. Deploying from a dev copy records that origin in
+  // `source`; the two differ exactly when the deploy made a copy.
   page: string;
+  source?: string;
   env: string;
   backend: string;
   token: string;

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -5,7 +5,9 @@
 // like everything else, via the "_render" sentinel (SPEC PT-12).
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
 import {
+  getConfig,
   getDeployStatus,
+  listDir,
   rawUrl,
   resolveConditions,
   renameEntry,
@@ -364,6 +366,108 @@ function DeployButton({ fsPath }: { fsPath: string }) {
   );
 }
 
+// --- managed-app scoping for the Deploy button --------------------------------
+// Deploy is scoped server-side to managed apps (<fused_dir>/<tag>/<name>/ —
+// deploy.py's _require_app), so the button only shows where a deploy can
+// actually succeed. The workspace root comes from /api/config, fetched once
+// per document and cached (same value main.tsx already loaded — this avoids
+// threading the Config prop through StatView/Preview for one string).
+
+let workspaceDirPromise: Promise<string> | null = null;
+function workspaceDir(): Promise<string> {
+  if (!workspaceDirPromise)
+    workspaceDirPromise = getConfig().then((c) => c.fused_dir.replace(/\\/g, "/").replace(/\/+$/, ""));
+  return workspaceDirPromise;
+}
+
+function useWorkspaceDir(): string | null {
+  const [dir, setDir] = useState<string | null>(null);
+  useEffect(() => {
+    let alive = true;
+    workspaceDir()
+      .then((d) => {
+        if (alive) setDir(d);
+      })
+      .catch(() => {});
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return dir;
+}
+
+// Segments of fsPath below the workspace root, or null when outside it.
+// Hidden tag/app dirs don't count as apps (the Home listing skips them too).
+function segmentsInWorkspace(fsPath: string, ws: string): string[] | null {
+  if (!fsPath.startsWith(ws + "/")) return null;
+  const parts = fsPath.slice(ws.length + 1).split("/").filter(Boolean);
+  if (parts.length >= 1 && parts[0].startsWith(".")) return null;
+  if (parts.length >= 2 && parts[1].startsWith(".")) return null;
+  return parts;
+}
+
+// A file inside a managed app: <ws>/<tag>/<name>/<...at least one more>.
+function isInsideApp(fsPath: string, ws: string): boolean {
+  const parts = segmentsInWorkspace(fsPath, ws);
+  return parts !== null && parts.length >= 3;
+}
+
+// An app folder itself: exactly <ws>/<tag>/<name>.
+function isAppFolder(fsPath: string, ws: string): boolean {
+  const parts = segmentsInWorkspace(fsPath, ws);
+  return parts !== null && parts.length === 2;
+}
+
+// Deploy button on an app FOLDER's listing header: auto-detects the folder's
+// single top-level .html entry (the same rule as apps.py's _app_entry) and
+// deploys that. Zero or several .html files -> the button still shows (the
+// folder IS an app) but clicking explains and points at the file's own
+// Deploy button instead of guessing which page the user meant.
+function AppFolderDeployButton({ dir }: { dir: string }) {
+  // undefined = listing still in flight (render nothing yet — no flicker),
+  // null = no unambiguous entry, string = the entry page's path.
+  const [entry, setEntry] = useState<string | null | undefined>(undefined);
+  useEffect(() => {
+    let alive = true;
+    setEntry(undefined);
+    listDir(dir)
+      .then((r) => {
+        if (!alive) return;
+        const htmls = r.entries.filter(
+          (e) => !e.is_dir && !e.name.startsWith(".") && /\.html?$/i.test(e.name),
+        );
+        // A truncated listing only holds a partial page — a lone .html there
+        // proves nothing, so treat it as ambiguous rather than deploy the
+        // wrong page (same caution as Listing's onSingleApp).
+        setEntry(htmls.length === 1 && !r.truncated ? dir + "/" + htmls[0].name : null);
+      })
+      .catch(() => {
+        if (alive) setEntry(null);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [dir]);
+  if (entry === undefined) return null;
+  if (entry) return <DeployButton fsPath={entry} />;
+  return (
+    <button
+      type="button"
+      className="deploy-btn"
+      title="Deploy this app"
+      onClick={() =>
+        pushToast({
+          msg: "This app folder doesn't have exactly one .html page — open the page you want to deploy and use its Deploy button.",
+          tone: "error",
+        })
+      }
+    >
+      {DEPLOY_ICON}
+      Deploy
+    </button>
+  );
+}
+
 function TemplatePreview({
   fsPath,
   stat,
@@ -392,6 +496,7 @@ function TemplatePreview({
     if (!templates.some((t) => t.mode === mode)) setModeState(defaultEntry.mode);
   }, [templates, mode, defaultEntry.mode]);
   const deployEnabled = useDeployEnabled();
+  const workspace = useWorkspaceDir();
   // `_listing` sentinel (D81): the shell's built-in directory listing, mounted
   // in place of the preview iframe — no iframe, no `_file`. Every directory
   // renders through this same header + body chrome (even a plain folder's
@@ -571,11 +676,22 @@ function TemplatePreview({
             Directories never deploy (no _render binding exists for one today;
             the guard keeps that true even if a registry ever says otherwise).
             Gated on the opt-in Deploy pref (Preferences → Deployments): hidden
-            entirely unless the user has turned Deploy on. */}
+            entirely unless the user has turned Deploy on — and on the page
+            living inside a managed app (<ws>/<tag>/<name>/…), the only scope
+            the server will deploy (deploy.py's _require_app). */}
         {!stat.is_dir &&
           deployEnabled &&
+          workspace !== null &&
+          isInsideApp(fsPath, workspace) &&
           templates.some((t) => t.mode === "_render") &&
           /\.html?$/i.test(fsPath) && <DeployButton fsPath={fsPath} />}
+        {/* The app folder itself deploys too: auto-detects its single .html
+            entry (several/none -> the button explains instead of guessing). */}
+        {stat.is_dir &&
+          isListing &&
+          deployEnabled &&
+          workspace !== null &&
+          isAppFolder(fsPath, workspace) && <AppFolderDeployButton dir={fsPath} />}
         <ModeSwitcher
           entries={templates.map((t) => ({ mode: t.mode, icon: templateModeIcon(t), pending: isPending(t) }))}
           active={entry.mode}

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -434,7 +434,10 @@ function AppFolderDeployButton({ dir }: { dir: string }) {
       .then((r) => {
         if (!alive) return;
         const htmls = r.entries.filter(
-          (e) => !e.is_dir && !e.name.startsWith(".") && /\.html?$/i.test(e.name),
+          // Strict ".html" only — matching apps.py's _app_entry exactly (it does
+          // NOT accept ".htm"), so a folder with one .html and one .htm reads as
+          // the single-entry app apps.py/Home already treat it as, not ambiguous.
+          (e) => !e.is_dir && !e.name.startsWith(".") && /\.html$/i.test(e.name),
         );
         // A truncated listing only holds a partial page — a lone .html there
         // proves nothing, so treat it as ambiguous rather than deploy the

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -433,7 +433,12 @@ def _app_of(page: str) -> tuple[str, str, str] | None:
     them, so they are not apps)."""
     ws = fused_dir()
     abs_page = os.path.abspath(page)
-    rel = os.path.relpath(abs_page, ws)
+    try:
+        rel = os.path.relpath(abs_page, ws)
+    except ValueError:
+        # Windows: a path on a different drive than the workspace has no
+        # relative form — not inside it, same as any other outside path.
+        return None
     parts = rel.split(os.sep)
     if parts[0] == os.pardir or len(parts) < 3:
         return None
@@ -937,9 +942,16 @@ def deploy_page(
             cache_max_age=cache_max_age, allow_clone=allow_clone, named=named,
             fallback=same_env,
         )
-        # Which dev copy this deploy came from — the live copy itself on an
-        # in-place redeploy. UI-facing provenance ("deployed from local/foo").
-        record["source"] = page
+        # Which dev copy this deploy came from — UI-facing provenance
+        # ("deployed from local/foo") AND what preview_deploy's overwrite
+        # check compares against. An in-place redeploy (editing the live copy
+        # directly and redeploying IT) must not overwrite this with the live
+        # path itself — that would orphan the dev copy's identity, so the
+        # overwrite warning would misfire against the app's own dev copy on
+        # its next deploy. Keep whatever source was already recorded (falling
+        # back to this call's page only when there is none yet — e.g. an app
+        # deployed for the first time directly from within the deploy tag).
+        record["source"] = (pointer.get("source") if in_place and pointer else None) or page
         set_deployment(live_page, record)
         # The share is live and the pointer persisted — the deploy succeeded, so
         # the filesystem side commits too (drop the pre-deploy backup). Failures
@@ -1022,6 +1034,11 @@ def revoke_mount(env_name: str, token: str) -> dict:
     and the pointer flip matches any of them — a pointer must never stay
     "active" (stale dot, wrong modal state) for a link that was just taken
     down. Best-effort: an unreadable list degrades to the given token alone.
+
+    Same live-copy cleanup as `revoke_deployment` (best-effort, AFTER the
+    revoke landed): any flipped pointer whose page is inside the `deploy` tag
+    has that live copy removed, so a mount taken down from the account page
+    doesn't leave its app sitting in the deploy folder looking still-live.
     """
     aliases = {token}
     try:
@@ -1035,6 +1052,8 @@ def revoke_mount(env_name: str, token: str) -> dict:
                 aliases.add(value)
     _run_share(env_name, ["revoke", token])
 
+    flipped_pages: list[str] = []
+
     def flip(store: dict) -> None:
         for page, record in store.items():
             if (
@@ -1044,8 +1063,13 @@ def revoke_mount(env_name: str, token: str) -> dict:
                 and record.get("status") != "revoked"
             ):
                 store[page] = {**record, "status": "revoked", "updated_at": _now_iso()}
+                flipped_pages.append(page)
 
     _update_store(flip)
+    for flipped_page in flipped_pages:
+        app = _app_of(flipped_page)
+        if app is not None and app[0] == DEPLOY_TAG:
+            shutil.rmtree(_live_dir_for(app[1]), ignore_errors=True)
     return {"env": env_name, "token": token, "status": "revoked"}
 
 

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -501,6 +501,30 @@ def _stage_live_copy(src_dir: str, live_dir: str) -> str | None:
     return bak if had_prior else None
 
 
+def _deploy_folder_owner_matches(tag: str, name: str) -> bool:
+    """Is `<workspace>/deploy/<name>/` already populated by files sourced from
+    THIS dev app (`tag`, `name`)?
+
+    A multi-page app has one pointer per deployed page (share targets are
+    per-entrypoint, so the store keys on the full live-copy path, rel included)
+    — checking only the SPECIFIC page's own record would misread a sibling
+    page in the SAME app folder that hasn't been individually deployed yet as
+    a foreign app. So this checks every stored record whose live path falls
+    under the folder: any one of them sourced from (tag, name) is enough to
+    call the folder "own". No record found under the folder (or none with a
+    derivable source) reads as unowned — the caller warns.
+    """
+    prefix = _live_dir_for(name) + os.sep
+    for live_path, record in _load_store().items():
+        if not (isinstance(record, dict) and live_path.startswith(prefix)):
+            continue
+        source = record.get("source")
+        owner = _app_of(source) if isinstance(source, str) else None
+        if owner is not None and owner[0] == tag and owner[1] == name:
+            return True
+    return False
+
+
 def _rollback_live_copy(live_dir: str, bak: str | None) -> None:
     """Deploy failed after the swap: put back exactly what was there before."""
     shutil.rmtree(live_dir, ignore_errors=True)
@@ -699,14 +723,14 @@ def preview_deploy(
     auto = plan_export(html, page_dir)
     # Upfront overwrite warning (advisory, rides the existing warnings channel):
     # deploying copies this app over <workspace>/deploy/<name>/ — if that live
-    # copy exists and isn't THIS app's own (per the pointer's recorded source),
-    # say so before the click. A redeploy of the same app overwriting its own
-    # live copy is the normal case and stays silent.
+    # copy exists and isn't THIS app's own (per _deploy_folder_owner_matches,
+    # which checks the whole folder, not just this one page — a sibling page
+    # in the same app that hasn't been individually deployed yet must not read
+    # as a foreign app), say so before the click. A redeploy of the same app
+    # overwriting its own live copy is the normal case and stays silent.
     warnings = list(plan.warnings)
     if tag != DEPLOY_TAG and os.path.isdir(_live_dir_for(name)):
-        record = get_deployment(page)
-        own = isinstance(record, dict) and record.get("source") == os.path.abspath(page)
-        if not own:
+        if not _deploy_folder_owner_matches(tag, name):
             warnings.append(
                 f"deploying will overwrite the existing app {name!r} in the deploy "
                 f"folder ({_live_dir_for(name)}) and replace its live deployment"

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -45,6 +45,18 @@ dialog's "Link name" field lets the user pass an explicit --token instead —
 a deliberately public, guessable URL (fused's own gate: --public + a chosen
 --token is allowed, unlike --public + an auth gate).
 
+Deploys are scoped to **managed apps** (``<workspace>/<tag>/<name>/`` —
+apps.py's model): what actually gets published is a **live copy** of the app
+folder at ``<workspace>/deploy/<name>/``. Deploying copies the whole app
+there first (staged + rename-swapped, with a kept backup so any failure —
+export or CLI — rolls the folder back: copy and share succeed or fail
+together), then exports and shares FROM the copy. The tag folder the user
+develops in is never touched or moved, so bookmarks/recents keep working;
+the pointer store keys on the live-copy path (`_page_key` maps a dev-copy
+path to it), so both copies of one app resolve to the same deployment.
+Revoking removes the live copy again (dev copy stays); the pointer is kept
+so a redeploy revives the same token/URL.
+
 No import of server.py (server imports this router — keep it acyclic); the
 X-Fused guard is duplicated locally like shell/bookmarks.py does.
 """
@@ -80,8 +92,15 @@ from fused_render.fusedcli import (
     setup_cli_hint as _setup_cli_hint,
 )
 from fused_render.shell import storage
+from fused_render.shell.seed import fused_dir
 
 router = APIRouter()
+
+#: The workspace tag that holds live copies. Deploying an app copies its folder
+#: to ``<workspace>/deploy/<name>/`` and publishes THAT copy; the tag folder the
+#: user develops in is never touched. "deploy" is an ordinary tag to the Home
+#: listing (apps.py treats no tag specially) — the convention lives here.
+DEPLOY_TAG = "deploy"
 
 # create/repoint upload the bundle (inline base64 on the fused backend) — give
 # them the same generous budget flow uses; list is a cheap read.
@@ -404,6 +423,94 @@ def _classify_mount(mounts: list[dict], token: str) -> str:
     return "revoked" if mount.get("status") == "revoked" else "active"
 
 
+# -- managed apps and the live copy in <workspace>/deploy/<name>/ --------------
+
+
+def _app_of(page: str) -> tuple[str, str, str] | None:
+    """(tag, name, rel-path-inside-app) when `page` is inside a managed app —
+    ``<workspace>/<tag>/<name>/…`` (apps.py's model) — else None. Path math
+    only, no disk I/O; hidden tag/app dirs don't count (the Home listing skips
+    them, so they are not apps)."""
+    ws = fused_dir()
+    abs_page = os.path.abspath(page)
+    rel = os.path.relpath(abs_page, ws)
+    parts = rel.split(os.sep)
+    if parts[0] == os.pardir or len(parts) < 3:
+        return None
+    tag, name = parts[0], parts[1]
+    if tag.startswith(".") or name.startswith("."):
+        return None
+    return tag, name, os.path.join(*parts[2:])
+
+
+def _require_app(page: str) -> tuple[str, str, str]:
+    """Deploy is scoped to managed apps — reject anything else up front."""
+    app = _app_of(page)
+    if app is None:
+        raise DeployError(
+            f"only apps in the Fused workspace can be deployed: {os.path.abspath(page)} "
+            f"is not inside {fused_dir()}/<tag>/<name>/"
+        )
+    return app
+
+
+def _live_dir_for(name: str) -> str:
+    return os.path.join(fused_dir(), DEPLOY_TAG, name)
+
+
+def _stage_live_copy(src_dir: str, live_dir: str) -> str | None:
+    """Copy `src_dir` into place as `live_dir`, atomically enough to roll back.
+
+    Copies to a hidden sibling first (``.tmp-<name>``), then swaps: an existing
+    live copy is set aside as ``.bak-<name>`` and the fresh copy renamed in.
+    Renames are same-volume, so the swap itself can't half-happen. Returns the
+    backup path (None on a first deploy) — the caller MUST later either
+    `_commit_live_copy` (deploy succeeded: drop the backup) or
+    `_rollback_live_copy` (deploy failed: restore exactly what was there).
+    Stale ``.tmp-``/``.bak-`` leftovers from a crash are cleared first; being
+    dotted, they never showed in the Home listing anyway.
+    """
+    parent = os.path.dirname(live_dir)
+    name = os.path.basename(live_dir)
+    tmp = os.path.join(parent, f".tmp-{name}")
+    bak = os.path.join(parent, f".bak-{name}")
+    try:
+        os.makedirs(parent, exist_ok=True)
+        shutil.rmtree(tmp, ignore_errors=True)
+        shutil.rmtree(bak, ignore_errors=True)
+        shutil.copytree(src_dir, tmp)
+    except OSError as e:
+        shutil.rmtree(tmp, ignore_errors=True)
+        raise DeployError(f"could not copy the app into the deploy folder: {e}") from None
+    try:
+        had_prior = os.path.isdir(live_dir)
+        if had_prior:
+            os.rename(live_dir, bak)
+        os.rename(tmp, live_dir)
+    except OSError as e:
+        # Undo whatever landed; the tmp copy is disposable.
+        shutil.rmtree(tmp, ignore_errors=True)
+        if not os.path.isdir(live_dir) and os.path.isdir(bak):
+            os.rename(bak, live_dir)
+        raise DeployError(f"could not swap the deploy copy into place: {e}") from None
+    return bak if had_prior else None
+
+
+def _rollback_live_copy(live_dir: str, bak: str | None) -> None:
+    """Deploy failed after the swap: put back exactly what was there before."""
+    shutil.rmtree(live_dir, ignore_errors=True)
+    if bak and os.path.isdir(bak):
+        try:
+            os.rename(bak, live_dir)
+        except OSError:
+            pass
+
+
+def _commit_live_copy(bak: str | None) -> None:
+    if bak:
+        shutil.rmtree(bak, ignore_errors=True)
+
+
 # -- the per-page deployment pointer store ------------------------------------
 
 
@@ -466,8 +573,19 @@ def _page_key(page: str) -> str:
     (`os.path.dirname(os.path.abspath(page))`). Without this, two spellings of the
     same file (`/a/b/../p.html` vs `/a/p.html`) would key different pointers, so
     status, the deploy dot, and redeploy could miss an existing deployment.
+
+    A page inside a managed app keys as its LIVE-COPY path —
+    ``<workspace>/deploy/<name>/<rel>`` — regardless of which tag the given
+    path is in. What is deployed is always the live copy, so the dev copy and
+    the live copy of one app resolve to the SAME pointer: the deploy dot,
+    status, redeploy, and revoke agree whichever copy the user has open.
     """
-    return os.path.abspath(page)
+    abs_page = os.path.abspath(page)
+    app = _app_of(abs_page)
+    if app is None:
+        return abs_page
+    _tag, name, rel = app
+    return os.path.join(_live_dir_for(name), rel)
 
 
 def get_deployment(page: str) -> dict | None:
@@ -560,6 +678,7 @@ def preview_deploy(
         raise DeployError(f"no such file: {page}")
     if os.path.splitext(page)[1].lower() not in (".html", ".htm"):
         raise DeployError(f"{page} is not an .html/.htm page")
+    tag, name, _rel = _require_app(page)
     try:
         with open(page, "r", encoding="utf-8", errors="replace") as f:
             html = f.read()
@@ -573,6 +692,20 @@ def preview_deploy(
     # "Excluded" with a restore) from a purely manual include (removing it just
     # drops it). Cheap: a second pure regex scan over the same HTML.
     auto = plan_export(html, page_dir)
+    # Upfront overwrite warning (advisory, rides the existing warnings channel):
+    # deploying copies this app over <workspace>/deploy/<name>/ — if that live
+    # copy exists and isn't THIS app's own (per the pointer's recorded source),
+    # say so before the click. A redeploy of the same app overwriting its own
+    # live copy is the normal case and stays silent.
+    warnings = list(plan.warnings)
+    if tag != DEPLOY_TAG and os.path.isdir(_live_dir_for(name)):
+        record = get_deployment(page)
+        own = isinstance(record, dict) and record.get("source") == os.path.abspath(page)
+        if not own:
+            warnings.append(
+                f"deploying will overwrite the existing app {name!r} in the deploy "
+                f"folder ({_live_dir_for(name)}) and replace its live deployment"
+            )
     return {
         "page": os.path.basename(page),
         "entrypoints": [{"path": e.path, "name": e.name} for e in plan.entrypoints],
@@ -582,7 +715,7 @@ def preview_deploy(
         "assets": [{"path": a.path, "name": a.name, "source": a.source} for a in plan.assets],
         "auto": [e.path for e in auto.entrypoints] + [a.path for a in auto.assets],
         "errors": plan.errors,
-        "warnings": plan.warnings,
+        "warnings": warnings,
     }
 
 
@@ -663,10 +796,15 @@ def deploy_page(
     """
     include = include or []
     exclude = exclude or []
-    # Canonicalize up front so the direct locked store.get below, the record's
-    # `page` field, and set_deployment all key on the same path as get_deployment
-    # / deployment_status (all via _page_key) — one file, one pointer.
     page = os.path.abspath(page)
+    # Deploy is scoped to managed apps, and what actually gets published is the
+    # LIVE COPY at <workspace>/deploy/<name>/ — the dev copy the user pointed at
+    # is copied there first (atomically, with rollback) and the export runs from
+    # the copy. A page already inside the deploy tag redeploys in place, no copy.
+    tag, name, rel = _require_app(page)
+    live_dir = _live_dir_for(name)
+    live_page = os.path.join(live_dir, rel)  # == _page_key(page)
+    in_place = tag == DEPLOY_TAG
     backend = _backend_of(env_name)
     if backend is None:
         raise DeployError(
@@ -693,11 +831,26 @@ def deploy_page(
     #     write touching only this page's key.
     with _STORE_LOCK:
         store = _load_store_for_write()
-        pointer = store.get(page) if isinstance(store.get(page), dict) else None
+        pointer = store.get(live_page) if isinstance(store.get(live_page), dict) else None
+
+    # Copy the app into the deploy folder BEFORE anything is minted. The swap is
+    # rename-based (same volume) with a kept backup, so a failure anywhere below
+    # — export, or any `fused share` call — rolls the folder back to exactly the
+    # pre-deploy state: deploy+copy succeed or fail together.
+    bak: str | None = None
+    copied = False
+    if not in_place:
+        src_dir = os.path.join(fused_dir(), tag, name)
+        if not os.path.isdir(src_dir):
+            raise DeployError(f"app folder not found: {src_dir}")
+        bak = _stage_live_copy(src_dir, live_dir)
+        copied = True
 
     bundle = tempfile.mkdtemp(prefix="fused-render-deploy-")
     try:
-        plan = export_page(page, bundle, include=include, exclude=exclude, cache_max_age=cache_max_age)
+        plan = export_page(
+            live_page, bundle, include=include, exclude=exclude, cache_max_age=cache_max_age
+        )
         entrypoints = [e.name for e in plan.entrypoints]
 
         # force_new deliberately treats any existing pointer as absent — never
@@ -779,12 +932,20 @@ def deploy_page(
                 )
 
         record = _record_from(
-            raw, page=page, env_name=env_name, backend=backend,
+            raw, page=live_page, env_name=env_name, backend=backend,
             entrypoints=entrypoints, include=include, exclude=exclude,
             cache_max_age=cache_max_age, allow_clone=allow_clone, named=named,
             fallback=same_env,
         )
-        set_deployment(page, record)
+        # Which dev copy this deploy came from — the live copy itself on an
+        # in-place redeploy. UI-facing provenance ("deployed from local/foo").
+        record["source"] = page
+        set_deployment(live_page, record)
+        # The share is live and the pointer persisted — the deploy succeeded, so
+        # the filesystem side commits too (drop the pre-deploy backup). Failures
+        # past this point (the best-effort superseded revoke) never roll back.
+        _commit_live_copy(bak)
+        copied = False
         # force_new replace: the new mount is live and the pointer now tracks it,
         # so take the superseded mount down — otherwise the page would serve at two
         # URLs while the pointer (and the modal's Revoke) tracks only the new one,
@@ -801,19 +962,33 @@ def deploy_page(
                 # revoked (account page / `fused share revoke <token>`). Not fatal.
                 pass
         return record
+    except BaseException:
+        # Deploy failed before the pointer/commit — undo the folder swap so the
+        # deploy tag holds exactly what it held before this call.
+        if copied:
+            _rollback_live_copy(live_dir, bak)
+        raise
     finally:
         shutil.rmtree(bundle, ignore_errors=True)
 
 
 def revoke_deployment(page: str) -> dict:
     """`share revoke` the page's mount; the pointer flips to revoked (kept, not
-    cleared — a later deploy revives the same token/URL)."""
+    cleared — a later deploy revives the same token/URL).
+
+    The live copy in <workspace>/deploy/<name>/ is removed too (best-effort,
+    AFTER the revoke landed — a failed revoke deletes nothing): the deploy
+    folder holds only what is actually live, and the dev copy is untouched.
+    """
     pointer = get_deployment(page)
     if pointer is None or not pointer.get("token") or not pointer.get("env"):
         raise DeployError("this page has no recorded deployment to revoke")
     _run_share(pointer["env"], ["revoke", pointer["token"]])
     record = {**pointer, "status": "revoked", "updated_at": _now_iso()}
     set_deployment(page, record)
+    app = _app_of(_page_key(page))
+    if app is not None and app[0] == DEPLOY_TAG:
+        shutil.rmtree(_live_dir_for(app[1]), ignore_errors=True)
     return record
 
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1965,3 +1965,18 @@ def test_app_of_returns_none_on_relpath_failure(tmp_path, monkeypatch):
         lambda *a, **k: (_ for _ in ()).throw(ValueError("no relative path")),
     )
     assert deploy_mod._app_of(str(tmp_path / "Fused" / "local" / "app" / "x.html")) is None
+
+
+def test_preview_of_a_sibling_page_stays_silent(tmp_path, monkeypatch):
+    # A second .html page in the SAME app folder, never individually
+    # deployed itself, must not read as a foreign app just because its own
+    # (per-page) pointer doesn't exist yet — only index.html's does.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+
+    sibling = h.app_dir / "admin.html"
+    sibling.write_text("<html></html>", encoding="utf-8")
+    resp = h.client.post("/api/deploy/preview", json={"path": str(sibling)})
+    assert resp.status_code == 200, resp.text
+    assert not any("overwrite" in w for w in resp.json()["warnings"])

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1875,9 +1875,12 @@ def test_redeploy_in_place_from_the_live_copy_does_not_recopy(tmp_path, monkeypa
         "/api/deploy", json={"page": str(h.live_page), "env": "cloud"}, headers=FUSED
     )
     assert resp.status_code == 200, resp.text
-    # The hotfix edit survives (no copy clobbered it) and source == the live page.
+    # The hotfix edit survives (no copy clobbered it). `source` stays the
+    # ORIGINAL dev copy, not this call's live-copy path — an in-place redeploy
+    # must not sever the record's link back to the app's dev copy (see
+    # test_in_place_redeploy_keeps_the_original_source for why).
     assert "hotfix" in h.live_page.read_text(encoding="utf-8")
-    assert resp.json()["source"] == str(h.live_page)
+    assert resp.json()["source"] == str(h.page)
 
 
 def test_revoke_removes_the_live_copy(tmp_path, monkeypatch):
@@ -1902,3 +1905,63 @@ def test_failed_revoke_leaves_the_live_copy(tmp_path, monkeypatch):
     assert resp.status_code == 400
     assert h.live_dir.is_dir()  # still live -> still there
     assert h.pointer()["status"] == "active"
+
+
+# -- bugbot fixes: account revoke, in-place source, cross-drive path ----------
+
+
+def test_revoke_by_token_removes_the_live_copy(tmp_path, monkeypatch):
+    # The account page's revoke (env+token, no page) must clean up the deploy
+    # folder exactly like the Deploy modal's page-based revoke does.
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert h.live_dir.is_dir()
+    h.set_scenario({"revoke": {"token": "abc123", "status": "revoked"}})
+    resp = h.client.post(
+        "/api/deploy/revoke", json={"env": "cloud", "token": "abc123"}, headers=FUSED
+    )
+    assert resp.status_code == 200, resp.text
+    assert not h.live_dir.exists()
+    assert h.pointer()["status"] == "revoked"
+
+
+def test_in_place_redeploy_keeps_the_original_source(tmp_path, monkeypatch):
+    # Editing the live copy directly and redeploying FROM it must not overwrite
+    # the record's `source` with the live path itself — that would make the
+    # ORIGINAL dev copy's next preview misread itself as "someone else's app".
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert h.pointer()["source"] == str(h.page)
+
+    h.live_page.write_text("<html><body>hotfix</body></html>", encoding="utf-8")
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "repoint": {"token": "abc123", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy", json={"page": str(h.live_page), "env": "cloud"}, headers=FUSED
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["source"] == str(h.page)  # NOT the live path
+    assert h.pointer()["source"] == str(h.page)
+
+    # The original dev copy's preview must stay silent (it IS the owner).
+    resp = h.client.post("/api/deploy/preview", json={"path": str(h.page)})
+    assert resp.status_code == 200, resp.text
+    assert not any("overwrite" in w for w in resp.json()["warnings"])
+
+
+def test_app_of_returns_none_on_relpath_failure(tmp_path, monkeypatch):
+    # A path with no relative form against the workspace (e.g. a different
+    # drive on Windows raises ValueError from os.path.relpath) must read as
+    # "not inside the workspace", not crash the caller.
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(tmp_path / "Fused"))
+    monkeypatch.setattr(
+        deploy_mod.os.path, "relpath",
+        lambda *a, **k: (_ for _ in ()).throw(ValueError("no relative path")),
+    )
+    assert deploy_mod._app_of(str(tmp_path / "Fused" / "local" / "app" / "x.html")) is None

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -99,15 +99,23 @@ class Harness:
         self.set_scenario({})
         monkeypatch.setenv("FUSED_STUB_SCENARIO", str(self.scenario_file))
 
-        # A deployable page with one runPython dependency beside it.
-        self.page = tmp_path / "view.html"
+        # Deploy is scoped to managed apps (<workspace>/<tag>/<name>/), so the
+        # deployable page lives inside one; a deploy copies the app folder to
+        # <workspace>/deploy/<name>/ and the pointer keys on the LIVE copy.
+        self.workspace = tmp_path / "Fused"
+        monkeypatch.setenv("FUSED_RENDER_DIR", str(self.workspace))
+        self.app_dir = self.workspace / "local" / "view"
+        self.app_dir.mkdir(parents=True)
+        self.page = self.app_dir / "view.html"
         self.page.write_text(
             "<html><head></head><body><script>"
             "fused.runPython('./sine.py', {});"
             "</script></body></html>",
             encoding="utf-8",
         )
-        (tmp_path / "sine.py").write_text("def main():\n    return 1\n", encoding="utf-8")
+        (self.app_dir / "sine.py").write_text("def main():\n    return 1\n", encoding="utf-8")
+        self.live_dir = self.workspace / "deploy" / "view"
+        self.live_page = self.live_dir / "view.html"
 
         self.client = TestClient(create_app(start_dir=str(tmp_path)))
 
@@ -123,7 +131,7 @@ class Harness:
         path = self.home / "deployments.json"
         if not path.exists():
             return None
-        return json.loads(path.read_text(encoding="utf-8")).get(str(self.page))
+        return json.loads(path.read_text(encoding="utf-8")).get(str(self.live_page))
 
 
 def _has_flag(argv: list[str], flag: str, value: str) -> bool:
@@ -571,7 +579,7 @@ def test_deploy_custom_token_ignored_on_repoint(tmp_path, monkeypatch):
 
 def test_deploy_bundles_included_file_and_persists_selection(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    (tmp_path / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (h.app_dir / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     h.set_scenario(
         {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
     )
@@ -1525,7 +1533,7 @@ def test_shares_joins_mounts_to_local_pages(tmp_path, monkeypatch):
     mounts = resp.json()["mounts"]
     # Local pages first, live before revoked.
     assert [(m["token"], m["page"]) for m in mounts] == [
-        ("abc123", str(h.page)),
+        ("abc123", str(h.live_page)),  # the store keys on the live copy
         ("zzz999", None),
         ("old111", None),
     ]
@@ -1562,7 +1570,7 @@ def test_preview_lists_what_would_be_published(tmp_path, monkeypatch):
 
 def test_preview_applies_include_and_exclude(tmp_path, monkeypatch):
     h = _harness(tmp_path, monkeypatch)
-    (tmp_path / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (h.app_dir / "data.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     # Include a file the scan can't see; exclude the auto-detected entrypoint.
     resp = h.client.post(
         "/api/deploy/preview",
@@ -1592,10 +1600,10 @@ def test_preview_reports_asset_source(tmp_path, monkeypatch):
         "</body></html>",
         encoding="utf-8",
     )
-    (tmp_path / "logo.png").write_text("PNG", encoding="utf-8")
-    (tmp_path / "tiles").mkdir()
-    (tmp_path / "tiles" / "0.png").write_text("PNG", encoding="utf-8")
-    (tmp_path / "extra.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    (h.app_dir / "logo.png").write_text("PNG", encoding="utf-8")
+    (h.app_dir / "tiles").mkdir()
+    (h.app_dir / "tiles" / "0.png").write_text("PNG", encoding="utf-8")
+    (h.app_dir / "extra.csv").write_text("a,b\n1,2\n", encoding="utf-8")
     resp = h.client.post(
         "/api/deploy/preview", json={"path": str(h.page), "include": ["extra.csv"]}
     )
@@ -1738,3 +1746,159 @@ def test_errors_old_cli_gives_upgrade_hint(tmp_path, monkeypatch):
     with pytest.raises(deploy_mod.DeployError) as ei:
         deploy_mod.list_errors("cloud", "tok")
     assert "too old" in str(ei.value)
+
+
+# -- managed-app scoping and the live copy in <workspace>/deploy/<name>/ -------
+
+
+CREATE_OK = {"create": {"token": "abc123", "url": "https://serve.example/abc123", "status": "active"}}
+
+
+def test_deploy_rejects_a_page_outside_the_workspace(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    stray = tmp_path / "stray.html"
+    stray.write_text("<html></html>", encoding="utf-8")
+    h.set_scenario(CREATE_OK)
+    resp = h.client.post("/api/deploy", json={"page": str(stray), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 400
+    assert "only apps in the Fused workspace" in resp.json()["error"]
+    assert h.calls() == []  # rejected before any CLI call
+
+    # Preview rejects the same way, so the modal says so before the click.
+    resp = h.client.post("/api/deploy/preview", json={"path": str(stray)})
+    assert resp.status_code == 400
+    assert "only apps in the Fused workspace" in resp.json()["error"]
+
+
+def test_deploy_rejects_a_page_directly_under_a_tag(tmp_path, monkeypatch):
+    # <workspace>/<tag>/page.html is not an app (apps are one level deeper).
+    h = _harness(tmp_path, monkeypatch)
+    page = h.workspace / "local" / "loose.html"
+    page.write_text("<html></html>", encoding="utf-8")
+    resp = h.client.post("/api/deploy", json={"page": str(page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 400
+    assert "only apps in the Fused workspace" in resp.json()["error"]
+
+
+def test_deploy_copies_the_app_into_the_deploy_tag(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    # The live copy exists, whole-folder, and the dev copy is untouched.
+    assert h.live_page.is_file()
+    assert (h.live_dir / "sine.py").is_file()
+    assert h.page.is_file() and (h.app_dir / "sine.py").is_file()
+    # No staging leftovers.
+    assert sorted(p.name for p in (h.workspace / "deploy").iterdir()) == ["view"]
+    # The record points at the live copy and remembers the dev source.
+    record = resp.json()
+    assert record["page"] == str(h.live_page)
+    assert record["source"] == str(h.page)
+    assert h.pointer()["page"] == str(h.live_page)
+
+
+def test_deploy_rolls_back_the_copy_when_the_share_fails(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario({})  # stub answers nothing -> `share create` fails
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 400
+    # First deploy failed -> the deploy tag holds nothing for this app.
+    assert not h.live_dir.exists()
+    assert h.pointer() is None
+
+
+def test_failed_redeploy_restores_the_previous_live_copy(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    assert (
+        h.client.post(
+            "/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED
+        ).status_code
+        == 200
+    )
+    old_live = h.live_page.read_text(encoding="utf-8")
+
+    # Change the dev copy, then make the redeploy's CLI step fail.
+    h.page.write_text("<html><body>v2</body></html>", encoding="utf-8")
+    h.set_scenario({})  # list/repoint all fail
+    resp = h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert resp.status_code == 400
+    # The live copy is byte-for-byte what was deployed before, not v2.
+    assert h.live_page.read_text(encoding="utf-8") == old_live
+    assert not (h.workspace / "deploy" / ".bak-view").exists()
+    assert not (h.workspace / "deploy" / ".tmp-view").exists()
+
+
+def test_preview_warns_before_overwriting_another_apps_deployment(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+
+    # A DIFFERENT app with the same name under another tag.
+    other = h.workspace / "team" / "view"
+    other.mkdir(parents=True)
+    other_page = other / "view.html"
+    other_page.write_text("<html></html>", encoding="utf-8")
+    resp = h.client.post("/api/deploy/preview", json={"path": str(other_page)})
+    assert resp.status_code == 200, resp.text
+    assert any("overwrite" in w for w in resp.json()["warnings"])
+
+    # The SAME app redeploying over its own live copy stays silent.
+    resp = h.client.post("/api/deploy/preview", json={"path": str(h.page)})
+    assert resp.status_code == 200, resp.text
+    assert not any("overwrite" in w for w in resp.json()["warnings"])
+
+
+def test_status_reads_the_same_pointer_from_either_copy(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    for path in (str(h.page), str(h.live_page)):
+        resp = h.client.get("/api/deploy/status", params={"path": path})
+        assert resp.json()["deployment"]["token"] == "abc123"
+
+
+def test_redeploy_in_place_from_the_live_copy_does_not_recopy(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    # Edit the live copy directly, then redeploy FROM it.
+    h.live_page.write_text("<html><body>hotfix</body></html>", encoding="utf-8")
+    h.set_scenario(
+        {
+            "list": [{"token": "abc123", "status": "active"}],
+            "repoint": {"token": "abc123", "status": "active"},
+        }
+    )
+    resp = h.client.post(
+        "/api/deploy", json={"page": str(h.live_page), "env": "cloud"}, headers=FUSED
+    )
+    assert resp.status_code == 200, resp.text
+    # The hotfix edit survives (no copy clobbered it) and source == the live page.
+    assert "hotfix" in h.live_page.read_text(encoding="utf-8")
+    assert resp.json()["source"] == str(h.live_page)
+
+
+def test_revoke_removes_the_live_copy(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario({**CREATE_OK, "revoke": {"token": "abc123", "status": "revoked"}})
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    assert h.live_dir.is_dir()
+    resp = h.client.post("/api/deploy/revoke", json={"page": str(h.page)}, headers=FUSED)
+    assert resp.status_code == 200, resp.text
+    # The live copy is gone, the dev copy stays, the pointer keeps the token.
+    assert not h.live_dir.exists()
+    assert h.page.is_file()
+    assert h.pointer()["status"] == "revoked"
+    assert h.pointer()["token"] == "abc123"
+
+
+def test_failed_revoke_leaves_the_live_copy(tmp_path, monkeypatch):
+    h = _harness(tmp_path, monkeypatch)
+    h.set_scenario(CREATE_OK)  # no "revoke" answer -> revoke fails
+    h.client.post("/api/deploy", json={"page": str(h.page), "env": "cloud"}, headers=FUSED)
+    resp = h.client.post("/api/deploy/revoke", json={"page": str(h.page)}, headers=FUSED)
+    assert resp.status_code == 400
+    assert h.live_dir.is_dir()  # still live -> still there
+    assert h.pointer()["status"] == "active"


### PR DESCRIPTION
## What

Reduces deploy scope from any arbitrary `.html` file to **managed apps only** (`~/Documents/Fused/<tag>/<name>/`), and introduces the live-copy model: the `deploy` tag holds live copies that are actually deployed; other tags are local development copies.

- **Scope**: `/api/deploy` and `/api/deploy/preview` reject pages outside `<workspace>/<tag>/<name>/` with a clear 400.
- **Live copy**: deploying copies the whole app folder to `<workspace>/deploy/<name>/` and exports/shares from that copy. The dev copy never moves — bookmarks/recents need no path fixing.
- **Atomicity**: copy is staged to a hidden `.tmp-<name>` and rename-swapped, keeping the prior live copy as `.bak-<name>`. Any failure (export or any `fused share` step) rolls the folder back to exactly the pre-deploy state; deploy+copy succeed or fail together. Stale staging dirs from a crash are swept on the next deploy.
- **One pointer per app**: the deployment store keys on the live-copy path (`_page_key` maps dev paths to it), so the dev and live copies resolve to the same deployment from either side; records carry a new `source` field naming the dev copy deployed from.
- **Overwrite warning**: the preview warns upfront when deploying would overwrite a different app's live copy of the same name (rides the existing warnings channel — zero frontend change). Own redeploys stay silent.
- **In-place redeploy**: a page already inside the `deploy` tag republishes without copying, so direct hotfix edits to the live copy survive.
- **Revoke**: removes the live copy (best-effort, only after the remote revoke landed); the pointer is kept so a later redeploy revives the same token/URL.

No migration: the deploy feature is unused so far, so no existing pointers to convert.

## Tests

Test harness now places the page inside a workspace app; 10 new tests cover scope rejection, copy-on-deploy, first-deploy rollback, failed-redeploy restore, overwrite warning both ways, status from either copy, in-place redeploy, and revoke deleting / failed revoke keeping the live copy.

`tests/test_deploy.py`: 100 pass. Full suite: 3780 pass (3 pre-existing env-specific failures in test_engine/test_calls, unrelated modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core deploy orchestration (filesystem copies, pointer keys, revoke cleanup) and public share publishing; mistakes could leave wrong live folders, orphaned mounts, or inconsistent UI state.
> 
> **Overview**
> Deploy is now limited to **managed apps** (`<workspace>/<tag>/<name>/…`). Deploy and preview APIs return **400** for paths outside that layout; export/share runs from a **live copy** at `<workspace>/deploy/<name>/`, with staged copy + backup so failed export or `fused share` steps **roll the folder back**.
> 
> The deployment store keys on the **live-copy path** (dev and live URLs share one pointer), records **`source`** for the dev page, warns on preview when another app would be **overwritten** in `deploy/<name>/`, supports **in-place** redeploy from the `deploy` tag, and **removes the live folder** on revoke (page or account token revoke).
> 
> **Frontend:** Deploy shows only inside managed apps (and on app folders with a single `.html` entry); **`Deployment.page`** is documented as the live copy; closing the deploy modal after a dev-copy deploy **navigates** to `record.page`. Tests move pages into workspace apps and add coverage for copy, rollback, overwrite warnings, and revoke cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1082a1a025a960fa61c993b49a9fc44779710fdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->