### PR TITLE
Open files whose names are written in any language

### DIFF
--- a/docs/CALL_LOG_DESIGN.md
+++ b/docs/CALL_LOG_DESIGN.md
@@ -253,6 +253,11 @@ worth the small refactor: it is also where `client_ms` and the
   exactly the filter §2 wanted.
 - `X-Fused-Page` is a custom header, so like `X-Fused` it forces a CORS
   preflight; it changes no security posture (D3/D36 stand — this is not auth).
+- The value is **percent-encoded** (`calls.begin` decodes it), as is
+  `X-Fused-Target`. A header value is ISO-8859-1 only, and `fetch` throws
+  rather than sends when one is not — so a path outside that range (a filename
+  in any non-Latin-1 script) killed every call the page made, not just its
+  attribution.
 - In panel/tab mode each pane's iframe has its own `path`, so per-pane
   attribution is automatic.
 

--- a/docs/CALL_LOG_DESIGN.md
+++ b/docs/CALL_LOG_DESIGN.md
@@ -253,11 +253,9 @@ worth the small refactor: it is also where `client_ms` and the
   exactly the filter §2 wanted.
 - `X-Fused-Page` is a custom header, so like `X-Fused` it forces a CORS
   preflight; it changes no security posture (D3/D36 stand — this is not auth).
-- The value is **percent-encoded** (`calls.begin` decodes it), as is
-  `X-Fused-Target`. A header value is ISO-8859-1 only, and `fetch` throws
-  rather than sends when one is not — so a path outside that range (a filename
-  in any non-Latin-1 script) killed every call the page made, not just its
-  attribution.
+- Both path headers are **percent-encoded** (`calls.begin` decodes them): a
+  header value is ISO-8859-1 only, and `fetch` throws rather than sending one
+  that is not.
 - In panel/tab mode each pane's iframe has its own `path`, so per-pane
   attribution is automatic.
 

--- a/fused_render/calls.py
+++ b/fused_render/calls.py
@@ -1068,14 +1068,8 @@ def sweep(now: float | None = None) -> int:
 # ------------------------------------------- middleware / handler integration
 
 def _header_path(value: str | None) -> str | None:
-    """The path a runtime attribution header names, percent-decoded.
-
-    Undoes runtime.js's encodeURIComponent, which exists because a header value
-    is ISO-8859-1 only: fetch() throws rather than sending a path outside that
-    range, so a filename in any other script took down every call the page made
-    instead of just this record. A path sent raw is left alone — decoding is the
-    identity for the plain ASCII a hand-written request (curl, the tests) carries.
-    """
+    """Undo runtime.js's encodeURIComponent. A path sent raw is left alone:
+    decoding is the identity for the ASCII a curl or a test carries."""
     if not value:
         return None
     return unquote(value)

--- a/fused_render/calls.py
+++ b/fused_render/calls.py
@@ -58,6 +58,7 @@ import threading
 import time
 import uuid
 from datetime import datetime, timezone
+from urllib.parse import unquote
 
 from fastapi import APIRouter, Body, Header, Request
 from fastapi.responses import JSONResponse
@@ -73,6 +74,7 @@ RECORD_VERSION = 1
 
 # Attribution + correlation headers set by static/runtime.js. X-Fused-Page is
 # what makes a request an "app call" at all; the other two are additive context.
+# The two PATH headers arrive percent-encoded — see _header_path.
 PAGE_HEADER = "x-fused-page"
 CALL_HEADER = "x-fused-call"
 TARGET_HEADER = "x-fused-target"
@@ -1065,6 +1067,20 @@ def sweep(now: float | None = None) -> int:
 
 # ------------------------------------------- middleware / handler integration
 
+def _header_path(value: str | None) -> str | None:
+    """The path a runtime attribution header names, percent-decoded.
+
+    Undoes runtime.js's encodeURIComponent, which exists because a header value
+    is ISO-8859-1 only: fetch() throws rather than sending a path outside that
+    range, so a filename in any other script took down every call the page made
+    instead of just this record. A path sent raw is left alone — decoding is the
+    identity for the plain ASCII a hand-written request (curl, the tests) carries.
+    """
+    if not value:
+        return None
+    return unquote(value)
+
+
 def begin(request: Request) -> dict | None:
     """Start a record for an app call, or return None when this isn't one.
 
@@ -1076,7 +1092,7 @@ def begin(request: Request) -> dict | None:
     path = request.url.path
     if path.startswith(SKIP_PREFIXES):
         return None
-    page = request.headers.get(PAGE_HEADER)
+    page = _header_path(request.headers.get(PAGE_HEADER))
     if not page:
         return None
     if not enabled():
@@ -1101,7 +1117,7 @@ def begin(request: Request) -> dict | None:
         "kind": "call",
         "occurred_at": _now_iso(),
         "page": page,
-        "target_file": request.headers.get(TARGET_HEADER) or None,
+        "target_file": _header_path(request.headers.get(TARGET_HEADER)),
         "first_party": is_first_party(page),
         "route": path,
         "http_method": request.method,

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -430,12 +430,8 @@
   // this iframe's /render URL), X-Fused-Target the file it is previewing
   // (`_file`, set when this page is a template), X-Fused-Call a per-call id.
   //
-  // The two paths ride PERCENT-ENCODED (calls.py decodes them). Header values
-  // are ISO-8859-1 only, so a path holding anything outside that range — any
-  // filename not written in a Latin-1 script — makes fetch() throw
-  // synchronously before the request leaves ("String contains non ISO-8859-1
-  // code point"), and that took down every call the page made rather than
-  // just its attribution.
+  // The paths ride percent-encoded (calls.py decodes them): a header value is
+  // ISO-8859-1 only, and fetch() throws rather than sending one that is not.
   //
   // Only this runtime sends them, so the shell's own requests (/api/fs/list,
   // the conditions probe) carry no attribution and are excluded from the app

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -430,6 +430,13 @@
   // this iframe's /render URL), X-Fused-Target the file it is previewing
   // (`_file`, set when this page is a template), X-Fused-Call a per-call id.
   //
+  // The two paths ride PERCENT-ENCODED (calls.py decodes them). Header values
+  // are ISO-8859-1 only, so a path holding anything outside that range — any
+  // filename not written in a Latin-1 script — makes fetch() throw
+  // synchronously before the request leaves ("String contains non ISO-8859-1
+  // code point"), and that took down every call the page made rather than
+  // just its attribution.
+  //
   // Only this runtime sends them, so the shell's own requests (/api/fs/list,
   // the conditions probe) carry no attribution and are excluded from the app
   // log by construction — no endpoint blocklist to keep in sync. A custom
@@ -457,9 +464,9 @@
   function callHeaders(extra, callId) {
     const headers = Object.assign({}, extra || {});
     const page = ownQuery("path");
-    if (page) headers["X-Fused-Page"] = page;
+    if (page) headers["X-Fused-Page"] = encodeURIComponent(page);
     const target = ownQuery("_file");
-    if (target) headers["X-Fused-Target"] = target;
+    if (target) headers["X-Fused-Target"] = encodeURIComponent(target);
     // A caller-supplied id lets the abort path name the call it cancelled
     // (see reportSuperseded); anything else gets a fresh one.
     headers["X-Fused-Call"] = callId || newCallId();

--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -362,19 +362,8 @@ def test_a_failed_run_records_the_traceback(app_client):
 
 
 def test_a_non_latin1_path_rides_percent_encoded_and_lands_decoded(app_client):
-    """A file named in any script must not take the whole page down.
-
-    A header value is ISO-8859-1 only, so `fetch` REFUSES to send one holding a
-    character outside that range — it throws synchronously, before the request
-    exists. The attribution headers carry paths, so a file whose name is not
-    Latin-1 meant every call the page made died at the door, a template-wide
-    outage caused by the log rather than observed by it. Hence
-    encodeURIComponent on the way out and unquote on the way in — asserted here
-    on the value the browser actually sends.
-
-    The name mixes scripts on purpose: the rule is about the ISO-8859-1
-    boundary, not about one language.
-    """
+    """A file whose name is not Latin-1 must not take the whole page down: a
+    header holding one made `fetch` throw, killing every call the page made."""
     client, d = app_client
     target = d / "调查-обзор-مسح.pdf"
     page = d / "p.html"
@@ -386,18 +375,12 @@ def test_a_non_latin1_path_rides_percent_encoded_and_lands_decoded(app_client):
     got = calls.query(limit=10)["records"][0]
     assert got["page"] == canonical_fs_path(str(page))
     assert got["target_file"] == canonical_fs_path(str(target)), (
-        "the target must land as the path itself, not as its %E8%B0%83… spelling "
-        "— an encoded record matches no filter and names a file nobody has"
-    )
+        "an encoded record matches no filter and names a file nobody has")
 
 
 def test_the_runtime_encodes_the_paths_it_puts_in_headers(store):
-    """The other half of the round trip, on the shipped runtime.
-
-    The decode above is happy to receive a raw path, so it passes on its own
-    even if the runtime stops encoding — which is exactly the state that broke
-    every non-Latin-1 page. This pins the producer.
-    """
+    """The producer half: the decode above passes even if the runtime stops
+    encoding, which is exactly the state that was broken."""
     from pathlib import Path
 
     import fused_render

--- a/tests/test_calls.py
+++ b/tests/test_calls.py
@@ -23,6 +23,7 @@ import subprocess
 import sys
 import threading
 import time
+from urllib.parse import quote
 
 import pytest
 from fastapi.testclient import TestClient
@@ -358,6 +359,53 @@ def test_a_failed_run_records_the_traceback(app_client):
     assert got["outcome"] == "error"
     assert got["error"]["type"] == "ZeroDivisionError"
     assert "ZeroDivisionError" in got["error"]["traceback"]
+
+
+def test_a_non_latin1_path_rides_percent_encoded_and_lands_decoded(app_client):
+    """A file named in any script must not take the whole page down.
+
+    A header value is ISO-8859-1 only, so `fetch` REFUSES to send one holding a
+    character outside that range — it throws synchronously, before the request
+    exists. The attribution headers carry paths, so a file whose name is not
+    Latin-1 meant every call the page made died at the door, a template-wide
+    outage caused by the log rather than observed by it. Hence
+    encodeURIComponent on the way out and unquote on the way in — asserted here
+    on the value the browser actually sends.
+
+    The name mixes scripts on purpose: the rule is about the ISO-8859-1
+    boundary, not about one language.
+    """
+    client, d = app_client
+    target = d / "调查-обзор-مسح.pdf"
+    page = d / "p.html"
+    client.get(f"/api/fs/stat?path={target}", headers={
+        "X-Fused-Page": quote(str(page)), "X-Fused-Target": quote(str(target)),
+    })
+    assert drain()
+
+    got = calls.query(limit=10)["records"][0]
+    assert got["page"] == canonical_fs_path(str(page))
+    assert got["target_file"] == canonical_fs_path(str(target)), (
+        "the target must land as the path itself, not as its %E8%B0%83… spelling "
+        "— an encoded record matches no filter and names a file nobody has"
+    )
+
+
+def test_the_runtime_encodes_the_paths_it_puts_in_headers(store):
+    """The other half of the round trip, on the shipped runtime.
+
+    The decode above is happy to receive a raw path, so it passes on its own
+    even if the runtime stops encoding — which is exactly the state that broke
+    every non-Latin-1 page. This pins the producer.
+    """
+    from pathlib import Path
+
+    import fused_render
+
+    runtime = (Path(fused_render.__file__).parent / "static"
+               / "runtime.js").read_text(encoding="utf-8")
+    assert 'headers["X-Fused-Page"] = encodeURIComponent(page)' in runtime
+    assert 'headers["X-Fused-Target"] = encodeURIComponent(target)' in runtime
 
 
 def test_first_party_flags_a_template_page_not_the_users_own(store):


### PR DESCRIPTION
Opening a file whose name is written in a script outside Latin-1 failed before the view could render anything: it reported that it could not start, and every call it tried to make died before leaving the browser.

The cause was attribution metadata rather than anything to do with reading the file. The runtime passed the page and target paths to the server as request headers, unencoded. A header value may hold only ISO-8859-1 characters, so the browser refused the request outright instead of sending it — which made a diagnostics feature take down the app it exists to observe, in every template, not just one.

Paths now travel percent-encoded and are decoded on the way in, so the store still holds the real path and every existing filter keeps matching. Files named in any language now open and render normally.

Two tests: a round trip over the header contract, and one pinning the encoding at the producer — the decode alone still passes if the producer regresses, which is exactly the state that was broken.

Note for reviewers: this suite has 7 pre-existing failures on Windows (path-separator assertions), unchanged by this branch and present on `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to attribution header encoding/decoding with tests; no auth or data-model changes beyond restoring correct path strings in the call log.
> 
> **Overview**
> **Fixes previews when file or page paths contain characters outside ISO-8859-1** (e.g. CJK or Cyrillic in filenames). Previously `fetch()` threw before any request left the browser because `X-Fused-Page` and `X-Fused-Target` carried raw paths; that broke every API call on those pages, not just call logging.
> 
> `runtime.js` now sets those headers with **`encodeURIComponent`** on the page and target paths. **`calls.begin`** decodes them via new **`_header_path`** (`urllib.parse.unquote`) so stored `page` / `target_file` stay the real paths and existing filters still match. ASCII-only paths and tests that send raw headers remain valid because decoding is a no-op for them.
> 
> **Docs** (`CALL_LOG_DESIGN.md` §4.3) note the encoding contract. **Tests** add a round-trip with a multilingual filename and a source check that the runtime still encodes at the producer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2af977be032c7c1dbc29a2ee2786a06f50dec06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->