### PR TITLE
UX: motion system for the shell + listing search/sort interaction fixes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -35,9 +35,41 @@
       document.documentElement.setAttribute("data-theme", theme);
     })();
   </script>
+  <!-- First-paint placeholder. main.tsx mounts React only after /api/config
+       resolves, which on a cold start (or a slow local server) left the body
+       completely empty — an unexplained blank window. This paints a centred
+       pulsing mark immediately and is replaced wholesale the moment React
+       renders into #root.
+
+       Styles are inline and the colours are literals, unavoidably: shell.css
+       arrives with the module bundle, i.e. strictly after this has to paint.
+       The two values are the --bg/--fg-muted pair from each palette in
+       shell.css and are keyed off the same `data-theme` the bootstrap above
+       just stamped, so the placeholder can't flash the wrong appearance.
+       Honours prefers-reduced-motion like everything in shell.css does. -->
+  <style>
+    body { margin: 0; background: #131417; }
+    html[data-theme="light"] body { background: #ffffff; }
+    #boot {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font: 600 15px/1 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      letter-spacing: 0.04em;
+      color: #9aa0a6;
+      animation: boot-pulse 1.4s ease-in-out infinite;
+    }
+    html[data-theme="light"] #boot { color: #61656c; }
+    @keyframes boot-pulse { 50% { opacity: 0.45; } }
+    @media (prefers-reduced-motion: reduce) {
+      #boot { animation: none; opacity: 0.7; }
+    }
+  </style>
 </head>
 <body>
-  <div id="root"></div>
+  <div id="root"><div id="boot">fused</div></div>
   <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -437,6 +437,17 @@ export default function App({ config }: { config: Config }) {
     return () => clearTimeout(id);
   }, [pathname]);
 
+  // Route fade (A5). Every route hard-remounts on the nav epoch, so a cross-fade
+  // between old and new content is impossible — instead #content plays a short
+  // fade-in (shell.css) so a navigation cut reads as intentional rather than as
+  // a flicker. A CSS animation only replays on a NEWLY CREATED element, and the
+  // `<div id="content">` wrappers below outlive an epoch change (only their
+  // keyed child remounts), hence `key={epoch}` on each of them. StatView's own
+  // #content needs no key: StatView is already keyed on epoch+fsPath.
+  //
+  // Deliberately keyed on the nav epoch and nothing else: an iframe writing view
+  // params bumps useUrlVersion, which re-renders chrome without remounting, so
+  // param changes never re-trigger the fade.
   let main;
   if (isPanel) {
     main = (
@@ -444,7 +455,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Panel" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <Panel key={epoch} config={config} />
         </div>
       </>
@@ -455,7 +466,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Tabs" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <Tabs key={epoch} config={config} />
         </div>
       </>
@@ -469,7 +480,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Preferences" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <Preferences key={epoch} />
         </div>
       </>
@@ -482,7 +493,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Templates" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <Templates key={epoch} />
         </div>
       </>
@@ -494,7 +505,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Mounts" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <Mounts key={epoch} />
         </div>
       </>
@@ -504,7 +515,7 @@ export default function App({ config }: { config: Config }) {
     // itself (old /view/_home sentinel redirects here above). No breadcrumb
     // bar: no path/bookmark actions make sense above a landing page.
     main = (
-      <div id="content">
+      <div id="content" key={epoch}>
         <Home key={epoch} config={config} />
       </div>
     );
@@ -512,7 +523,7 @@ export default function App({ config }: { config: Config }) {
     // Apps hub — same chrome-free treatment as Home: no breadcrumb bar, no
     // sidebar (excluded below), the page owns its own header and back link.
     main = (
-      <div id="content">
+      <div id="content" key={epoch}>
         <Apps key={epoch} />
       </div>
     );
@@ -525,7 +536,7 @@ export default function App({ config }: { config: Config }) {
         <div id="breadcrumb">
           <StaticBreadcrumb label="Bookmark" />
         </div>
-        <div id="content">
+        <div id="content" key={epoch}>
           <BookmarkOpen key={epoch} file={bookmarkFile ?? undefined} />
         </div>
       </>
@@ -534,7 +545,7 @@ export default function App({ config }: { config: Config }) {
     main = (
       <>
         <div id="breadcrumb" />
-        <div id="content">
+        <div id="content" key={epoch}>
           <div className="status-message error">Unrecognized URL: {pathname}</div>
         </div>
       </>

--- a/frontend/src/components/ContextMenu.tsx
+++ b/frontend/src/components/ContextMenu.tsx
@@ -91,9 +91,19 @@ function groupHasIcon(entries: MenuEntry[]): boolean {
   return entries.some((e) => e !== "separator" && e.icon != null);
 }
 
+// How long the pointer has to rest on a row before its submenu opens (or, when
+// it leaves for a sibling, before the open one closes). Diagonal travel across a
+// menu clips the rows between source and target, and without this window each of
+// those flickered a submenu open/shut on the way past.
+const HOVER_INTENT_MS = 120;
+
 export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
   const rootRef = useRef<HTMLDivElement | null>(null);
-  const [pos, setPos] = useState({ left: x, top: y });
+  // null until the clamp below has run: the menu is rendered hidden for that
+  // first (pre-paint) pass, because its final position isn't known until its own
+  // size is measurable, and painting at the raw cursor coords first is what made
+  // an edge-of-screen menu appear to jump into place.
+  const [pos, setPos] = useState<{ left: number; top: number } | null>(null);
   // Index of the top-level item whose submenu is open (null = none), plus its
   // resolved items (null while the loader is still in flight).
   const [openSub, setOpenSub] = useState<number | null>(null);
@@ -101,7 +111,8 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
   // Guards against a stale loader resolving after the user moved to another row.
   const loadToken = useRef(0);
 
-  // Clamp into the viewport after first paint, when the real size is known.
+  // Clamp into the viewport before the first paint, when the real size is known
+  // (getBoundingClientRect reads correctly through `visibility: hidden`).
   useLayoutEffect(() => {
     const el = rootRef.current;
     if (!el) return;
@@ -146,25 +157,28 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     };
   }, [onClose]);
 
+  // Pending hover-intent open/close (see HOVER_INTENT_MS).
+  const hoverTimer = useRef<number | null>(null);
+  const cancelHover = () => {
+    if (hoverTimer.current === null) return;
+    window.clearTimeout(hoverTimer.current);
+    hoverTimer.current = null;
+  };
+
   // Invalidate any in-flight submenu load on unmount so a late resolve can't
-  // setState on a closed menu.
+  // setState on a closed menu, and drop a pending hover-intent timer with it.
   useEffect(() => {
     return () => {
       loadToken.current++;
+      cancelHover();
     };
   }, []);
 
-  const enterItem = (idx: number, item: MenuItem) => {
-    if (!item.submenu) {
-      setOpenSub(null);
-      setSubItems(null);
-      return;
-    }
-    if (openSub === idx) return;
+  const openSubmenu = (idx: number, item: MenuItem) => {
     const token = ++loadToken.current;
     setOpenSub(idx);
     setSubItems(null);
-    item.submenu().then(
+    item.submenu!().then(
       (r) => {
         if (loadToken.current === token) setSubItems(r);
       },
@@ -174,22 +188,54 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
     );
   };
 
+  const enterItem = (idx: number, item: MenuItem) => {
+    cancelHover();
+    if (!item.submenu) {
+      if (openSub === null) return;
+      // The close waits out the same window as the open: travelling diagonally
+      // from a submenu row back into the submenu clips the siblings in between,
+      // and closing on those would shut the submenu the pointer is heading for.
+      hoverTimer.current = window.setTimeout(() => {
+        hoverTimer.current = null;
+        setOpenSub(null);
+        setSubItems(null);
+      }, HOVER_INTENT_MS);
+      return;
+    }
+    if (openSub === idx) return;
+    hoverTimer.current = window.setTimeout(() => {
+      hoverTimer.current = null;
+      openSubmenu(idx, item);
+    }, HOVER_INTENT_MS);
+  };
+
   const activate = (item: MenuItem) => {
     if (item.disabled || item.submenu) return; // submenus open on hover, not click
+    cancelHover();
     onClose();
     item.onClick?.();
   };
 
   // Open the submenu to the left when the menu sits in the right portion of the
   // viewport, so a right-edge right-click doesn't push it off-screen.
-  const subLeft = pos.left > window.innerWidth * 0.6;
+  const left = pos?.left ?? x;
+  const top = pos?.top ?? y;
+  const subLeft = left > window.innerWidth * 0.6;
+  // Grow from whichever corner is anchored at the cursor: a menu clamped
+  // upwards/leftwards was pushed away from the click, and scaling it from its
+  // top-left then reads as the menu sliding off the pointer.
+  const origin = `${left < x ? "right" : "left"} ${top < y ? "bottom" : "top"}`;
 
   // Reserve the icon column only when some item in the group actually has one.
   const topHasIcon = groupHasIcon(items);
   const subHasIcon = subItems !== null && groupHasIcon(subItems);
 
   return (
-    <div ref={rootRef} className="context-menu" style={{ left: pos.left, top: pos.top }}>
+    <div
+      ref={rootRef}
+      className={"context-menu" + (pos ? " placed" : " measuring")}
+      style={{ left, top, transformOrigin: origin }}
+    >
       {items.map((it, i) =>
         it === "separator" ? (
           <div key={i} className="context-menu-sep" />
@@ -203,7 +249,12 @@ export default function ContextMenu({ x, y, items, onClose }: ContextMenuProps) 
               onActivate={() => activate(it)}
             />
             {it.submenu && openSub === i && (
-              <div className={"context-menu context-submenu" + (subLeft ? " left" : "")}>
+              <div
+                className={"context-menu context-submenu placed" + (subLeft ? " left" : "")}
+                /* Moving into the submenu must cancel a close that a sibling
+                   row queued on the way here. */
+                onMouseEnter={cancelHover}
+              >
                 {subItems === null ? (
                   <div className="context-menu-item disabled">Loading…</div>
                 ) : (

--- a/frontend/src/components/FsDialogs.tsx
+++ b/frontend/src/components/FsDialogs.tsx
@@ -8,6 +8,8 @@
 //     non-empty directory is spelled out in the message the caller passes).
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { ErrorBanner } from "./ErrorBanner";
+import { useDeferredClose } from "../lib/hooks";
+import { OVERLAY_EXIT_MS } from "../lib/exit-animation";
 
 // Validate a single path SEGMENT (a file/folder name, never a path). Returns an
 // inline error message or null when the (already-trimmed) name is usable. Beyond
@@ -26,7 +28,35 @@ export function nameError(trimmed: string): string | null {
   return null;
 }
 
-function Overlay({ onCancel, children }: { onCancel: () => void; children: ReactNode }) {
+// Both dialogs are unmounted by their CALLER (`{dialog && <PromptDialog …/>}`),
+// so neither can hold itself on screen for an exit animation — it defers the
+// callback that makes the caller unmount it (lib/exit-animation). BOTH close
+// paths go through here: an exit that plays on Cancel but not on Confirm reads
+// as a bug, so the deferrer's single callback dispatches to whichever path asked
+// first. `fired` is a ref, not the `closing` state, because two clicks in one
+// tick would both see the state as false.
+function useDialogClose(onCancel: () => void) {
+  const action = useRef(onCancel);
+  const fired = useRef(false);
+  const { closing, requestClose } = useDeferredClose(() => action.current(), OVERLAY_EXIT_MS);
+  const close = (fn: () => void) => {
+    if (fired.current) return;
+    fired.current = true;
+    action.current = fn;
+    requestClose();
+  };
+  return { closing, close };
+}
+
+function Overlay({
+  onCancel,
+  closing,
+  children,
+}: {
+  onCancel: () => void;
+  closing: boolean;
+  children: ReactNode;
+}) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -41,7 +71,7 @@ function Overlay({ onCancel, children }: { onCancel: () => void; children: React
 
   return (
     <div
-      className="modal-overlay deploy-overlay"
+      className={"modal-overlay deploy-overlay" + (closing ? " closing" : "")}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
@@ -77,6 +107,8 @@ export function PromptDialog({
 }) {
   const [value, setValue] = useState(initialValue);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const { closing, close } = useDialogClose(onCancel);
+  const cancel = () => close(onCancel);
 
   // Focus on open, preselecting the stem (name without extension) for a rename
   // and the whole value otherwise. Reads `initialValue`, never the live `value`,
@@ -95,14 +127,14 @@ export function PromptDialog({
 
   const submit = () => {
     if (error) return;
-    onConfirm(trimmed);
+    close(() => onConfirm(trimmed));
   };
 
   return (
-    <Overlay onCancel={onCancel}>
+    <Overlay onCancel={cancel} closing={closing}>
       <div className="modal-head deploy-head">
         <h2>{title}</h2>
-        <button type="button" className="modal-close deploy-close" onClick={onCancel} aria-label="Close">
+        <button type="button" className="modal-close deploy-close" onClick={cancel} aria-label="Close">
           ✕
         </button>
       </div>
@@ -125,7 +157,7 @@ export function PromptDialog({
         />
         {error && trimmed !== "" && <ErrorBanner>{error}</ErrorBanner>}
         <div className="fs-dialog-actions">
-          <button type="button" className="btn btn-secondary" onClick={onCancel}>
+          <button type="button" className="btn btn-secondary" onClick={cancel}>
             Cancel
           </button>
           <button type="button" className="btn btn-primary" disabled={!!error} onClick={submit}>
@@ -153,6 +185,9 @@ export function ConfirmDialog({
   onCancel: () => void;
 }) {
   const confirmRef = useRef<HTMLButtonElement | null>(null);
+  const { closing, close } = useDialogClose(onCancel);
+  const cancel = () => close(onCancel);
+  const confirm = () => close(onConfirm);
 
   // Move focus into the modal on open so the confirm button owns Enter/Space —
   // otherwise focus stays on document.body and the listing's document-level
@@ -163,10 +198,10 @@ export function ConfirmDialog({
   }, []);
 
   return (
-    <Overlay onCancel={onCancel}>
+    <Overlay onCancel={cancel} closing={closing}>
       <div className="modal-head deploy-head">
         <h2>{title}</h2>
-        <button type="button" className="modal-close deploy-close" onClick={onCancel} aria-label="Close">
+        <button type="button" className="modal-close deploy-close" onClick={cancel} aria-label="Close">
           ✕
         </button>
       </div>
@@ -181,20 +216,20 @@ export function ConfirmDialog({
             e.stopPropagation();
             if (e.target instanceof HTMLButtonElement) return;
             e.preventDefault();
-            onConfirm();
+            confirm();
           }
         }}
       >
         <p>{message}</p>
         <div className="fs-dialog-actions">
-          <button type="button" className="btn btn-secondary" onClick={onCancel}>
+          <button type="button" className="btn btn-secondary" onClick={cancel}>
             Cancel
           </button>
           <button
             ref={confirmRef}
             type="button"
             className={"btn " + (danger ? "btn-danger" : "btn-primary")}
-            onClick={onConfirm}
+            onClick={confirm}
           >
             {confirmLabel}
           </button>

--- a/frontend/src/components/ModeSwitcher.tsx
+++ b/frontend/src/components/ModeSwitcher.tsx
@@ -35,25 +35,45 @@ export function modeTitle(mode: string): string {
 interface ModeSwitcherProps<M extends string> {
   entries: ModeSwitcherEntry<M>[];
   active: M;
+  // The mode a click is currently switching TO, if any. The switch is async
+  // (the preview asks the open editor to flush its buffer first, bounded at
+  // 10s) and clicks landing mid-switch are dropped, so the entry that was
+  // clicked shows a spinner until the iframe swap starts — otherwise a slow
+  // switch reads as a dead button.
+  busy?: M | null;
   onSelect: (mode: M) => void;
 }
 
-export default function ModeSwitcher<M extends string>({ entries, active, onSelect }: ModeSwitcherProps<M>) {
+export default function ModeSwitcher<M extends string>({ entries, active, busy, onSelect }: ModeSwitcherProps<M>) {
   if (entries.length <= 1) return null;
   return (
     <div className="mode-switcher">
-      {entries.map((e) => (
-        <button
-          key={e.mode}
-          type="button"
-          className={"mode-switcher-btn" + (e.mode === active ? " active" : "") + (e.pending ? " pending" : "")}
-          title={e.pending ? `${modeTitle(e.mode)} — checking if this view applies…` : modeTitle(e.mode)}
-          disabled={e.pending}
-          onClick={() => onSelect(e.mode)}
-        >
-          {e.pending ? <span className="mode-icon-spinner" /> : e.icon}
-        </button>
-      ))}
+      {entries.map((e) => {
+        const waiting = busy === e.mode;
+        return (
+          <button
+            key={e.mode}
+            type="button"
+            className={
+              "mode-switcher-btn" +
+              (e.mode === active ? " active" : "") +
+              (e.pending ? " pending" : "") +
+              (waiting ? " switching" : "")
+            }
+            title={
+              waiting
+                ? `${modeTitle(e.mode)} — switching…`
+                : e.pending
+                  ? `${modeTitle(e.mode)} — checking if this view applies…`
+                  : modeTitle(e.mode)
+            }
+            disabled={e.pending || waiting}
+            onClick={() => onSelect(e.mode)}
+          >
+            {e.pending || waiting ? <span className="mode-icon-spinner" /> : e.icon}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/frontend/src/components/NotificationHost.tsx
+++ b/frontend/src/components/NotificationHost.tsx
@@ -27,14 +27,20 @@ export default function NotificationHost() {
   const toasts = useToasts();
   return (
     <div className="notif-host">
+      {/* Each toast rides in a grid-row wrapper (.toast-slot) whose row
+          collapses 1fr → 0fr on the way out, so the cards below it GLIDE up
+          instead of snapping the moment one is dismissed. The wrapper is what
+          animates height; the card itself only fades and slides (shell.css). */}
       {toasts.map((t) => (
-        <Toast
-          key={t.id}
-          msg={t.msg}
-          tone={t.tone}
-          action={t.action}
-          onClose={() => dismissToast(t.id)}
-        />
+        <div key={t.id} className={"toast-slot" + (t.leaving ? " leaving" : "")}>
+          <Toast
+            msg={t.msg}
+            tone={t.tone}
+            action={t.action}
+            leaving={t.leaving}
+            onClose={() => dismissToast(t.id)}
+          />
+        </div>
       ))}
       {!IS_EMBED && <ServerStatusBanner />}
     </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -265,6 +265,9 @@ interface FolderRowProps {
   folder: BookmarkFolder;
   child?: boolean;
   parentId?: string;
+  // Optimistic expand/collapse state (see isCollapsed in Sidebar): the store's
+  // own `folder.collapsed` lags a click by a store write, so the row is told.
+  collapsed: boolean;
   activeHint: boolean;
   isRenaming: boolean;
   onGlyphClick: (e: React.MouseEvent<HTMLSpanElement>) => void;
@@ -279,10 +282,10 @@ interface FolderRowProps {
 
 // activeHint: folder is collapsed but holds the current view's bookmark —
 // highlight the row so the selection isn't invisible while folded away.
-function FolderRow({ folder, child, parentId, activeHint, isRenaming, onGlyphClick, onRowClick, onRename, onDelete, onCommitRename, onCancelRename, registerRef, dragProps }: FolderRowProps) {
+function FolderRow({ folder, child, parentId, collapsed, activeHint, isRenaming, onGlyphClick, onRowClick, onRename, onDelete, onCommitRename, onCancelRename, registerRef, dragProps }: FolderRowProps) {
   return (
     <div
-      className={"bookmark-row folder-row" + (child ? " child-row" : "") + (folder.collapsed ? " collapsed" : "") + (activeHint ? " active" : "")}
+      className={"bookmark-row folder-row" + (child ? " child-row" : "") + (collapsed ? " collapsed" : "") + (activeHint ? " active" : "")}
       data-id={folder.id}
       data-parent={child ? parentId : undefined}
       draggable="true"
@@ -753,11 +756,35 @@ export default function Sidebar({ config }: SidebarProps) {
 
   // --- folder row handlers ----------------------------------------------------
 
-  const onFolderGlyphClick = async (e: React.MouseEvent<HTMLSpanElement>, id: string) => {
+  // Expand/collapse is a store write (bookmarks.json, through a serial mutation
+  // queue), and awaiting it before the UI moved meant the chevron and the
+  // children lagged the click by a round trip. Flip optimistically instead: the
+  // override wins over the store's value until the write lands and the store
+  // notify re-renders with the same answer. Keyed per id, so two folders toggled
+  // in quick succession don't clobber each other.
+  const [collapseOverride, setCollapseOverride] = useState<Record<string, boolean>>({});
+  const isCollapsed = (folder: BookmarkFolder): boolean =>
+    collapseOverride[folder.id] ?? !!folder.collapsed;
+  const applyToggle = async (folder: BookmarkFolder) => {
+    const next = !isCollapsed(folder);
+    setCollapseOverride((m) => ({ ...m, [folder.id]: next }));
+    try {
+      await toggleFolder(folder.id);
+      notifyBookmarksChanged();
+    } finally {
+      // Drop the override either way: on success the store now agrees, and on
+      // failure the row must fall back to the truth rather than lie forever.
+      setCollapseOverride((m) => {
+        const { [folder.id]: _dropped, ...rest } = m;
+        return rest;
+      });
+    }
+  };
+
+  const onFolderGlyphClick = (e: React.MouseEvent<HTMLSpanElement>, folder: BookmarkFolder) => {
     e.preventDefault();
     e.stopPropagation(); // don't also trigger the row's open handler
-    await toggleFolder(id);
-    notifyBookmarksChanged();
+    void applyToggle(folder);
   };
 
   // Name or row click opens the folder as tabs, except over the glyph, the
@@ -779,13 +806,12 @@ export default function Sidebar({ config }: SidebarProps) {
     if (!folder || !tabChildren.length) {
       // Nothing to open as tabs, but still expand a collapsed folder so its
       // nested contents become reachable.
-      if (folder && folder.collapsed && folder.children.length) {
-        await toggleFolder(folder.id);
-        notifyBookmarksChanged();
+      if (folder && isCollapsed(folder) && folder.children.length) {
+        void applyToggle(folder);
       }
       return;
     }
-    if (folder.collapsed) await toggleFolder(folder.id); // expand only — never re-collapse
+    if (isCollapsed(folder)) void applyToggle(folder); // expand only — never re-collapse
     // No notifyBookmarksChanged() here: navigateUrl re-renders the sidebar
     // via useUrlVersion (mirrors the vanilla route()-driven re-render).
     navigateUrl(composeFolderTabsUrl(tabChildren));
@@ -997,17 +1023,19 @@ export default function Sidebar({ config }: SidebarProps) {
     list.map((it) => {
       const child = parentId !== null;
       if (isFolder(it)) {
-        const activeHint = it.collapsed && subtreeHoldsActive(it.children);
+        const collapsed = isCollapsed(it);
+        const activeHint = collapsed && subtreeHoldsActive(it.children);
         return (
           <React.Fragment key={it.id}>
             <FolderRow
               folder={it}
               child={child}
               parentId={parentId ?? undefined}
+              collapsed={collapsed}
               activeHint={activeHint}
               isRenaming={renamingId === it.id}
               registerRef={registerRow(it.id)}
-              onGlyphClick={(e) => onFolderGlyphClick(e, it.id)}
+              onGlyphClick={(e) => onFolderGlyphClick(e, it)}
               onRowClick={(e) => onFolderRowClick(e, it)}
               onRename={(e) => {
                 e.preventDefault();
@@ -1018,7 +1046,7 @@ export default function Sidebar({ config }: SidebarProps) {
               onCancelRename={cancelRename}
               dragProps={dragProps(it.id, true, child)}
             />
-            {!it.collapsed && (
+            {!collapsed && (
               <div className="folder-children">{renderItems(it.children, it.id)}</div>
             )}
           </React.Fragment>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1082,7 +1082,7 @@ export default function Sidebar({ config }: SidebarProps) {
     // Collapsed: the whole sidebar shrinks to a slim strip that expands it
     // back. Still the same #sidebar node, so the <=700px media hide applies.
     return (
-      <nav id="sidebar" className="sidebar-collapsed">
+      <nav id="sidebar" className={"sidebar-collapsed" + (resizing ? " sidebar-no-transition" : "")}>
         <button
           type="button"
           className="sidebar-expand-strip"
@@ -1103,7 +1103,15 @@ export default function Sidebar({ config }: SidebarProps) {
   }
 
   return (
-    <nav id="sidebar" style={{ flexBasis: sidebarWidth, width: sidebarWidth }}>
+    // The collapse/expand width change glides (shell.css); a pointer DRAG must
+    // not, or every pointermove would chase a 200ms transition and the handle
+    // would lag the cursor. `sidebar-no-transition` is that suppression — the
+    // mechanism the comment on `resizing` above has always described.
+    <nav
+      id="sidebar"
+      className={resizing ? "sidebar-no-transition" : undefined}
+      style={{ flexBasis: sidebarWidth, width: sidebarWidth }}
+    >
       <div className="sidebar-brand">
         {/* Logo + name are one click target that goes Home — the front door is
             always one click away from anywhere. The collapse button stays its

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,31 @@
+// A few shimmer bars standing in for a block of content while it loads — the
+// same .skel-bar pattern the listing's placeholder rows use (shell.css), pulled
+// out so the pages that showed a bare "Loading…" share one voice. Deliberately
+// approximate: a handful of ragged bars reads as "content is coming" without
+// pretending to be a pixel-accurate ghost of the real layout.
+//
+// aria-busy + a label so a screen reader gets what the "Loading…" text used to
+// say; the bars themselves are decoration.
+const DEFAULT_WIDTHS = [72, 54, 63];
+
+export function SkeletonLines({
+  rows = 3,
+  widths = DEFAULT_WIDTHS,
+  label = "Loading",
+}: {
+  rows?: number;
+  // Bar widths as percentages of the container, cycled when there are more rows
+  // than entries.
+  widths?: number[];
+  label?: string;
+}) {
+  return (
+    <div className="skel-lines" role="status" aria-busy="true" aria-label={label}>
+      {Array.from({ length: rows }, (_, i) => (
+        <span key={i} className="skel-bar" style={{ width: `${widths[i % widths.length]}%` }} />
+      ))}
+    </div>
+  );
+}
+
+export default SkeletonLines;

--- a/frontend/src/components/Toast.tsx
+++ b/frontend/src/components/Toast.tsx
@@ -16,23 +16,30 @@ export default function Toast({
   msg,
   tone,
   action,
+  leaving = false,
   onClose,
 }: {
   msg: string;
   tone: ToastTone;
   action?: ToastAction;
+  // Dismissed and playing its exit animation (lib/toast keeps it in the queue
+  // for that long). Its controls are inert while it leaves — a click landing on
+  // a card that is already fading out should do nothing.
+  leaving?: boolean;
   onClose: () => void;
 }) {
   return (
     <div
-      className={"toast" + (tone === "info" ? " toast-info" : "")}
+      className={"toast" + (tone === "info" ? " toast-info" : "") + (leaving ? " toast-leaving" : "")}
       role={tone === "info" ? "status" : "alert"}
+      aria-hidden={leaving || undefined}
     >
       <span className="toast-msg">{msg}</span>
       {action && (
         <button
           type="button"
           className="toast-action"
+          disabled={leaving}
           onClick={action.onClick}
         >
           {action.label}
@@ -42,6 +49,7 @@ export default function Toast({
         type="button"
         className="toast-close"
         onClick={onClose}
+        disabled={leaving}
         aria-label="Dismiss"
       >
         ✕

--- a/frontend/src/components/modal/Modal.tsx
+++ b/frontend/src/components/modal/Modal.tsx
@@ -21,6 +21,8 @@ import {
   type RefObject,
 } from "react";
 import { createPortal } from "react-dom";
+import { useDeferredClose } from "../../lib/hooks";
+import { OVERLAY_EXIT_MS } from "../../lib/exit-animation";
 
 const FOCUSABLE =
   'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
@@ -59,6 +61,15 @@ export function Modal({
   closeTitle,
 }: ModalProps) {
   const titleId = useId();
+  // Exit animation. Callers render this as `{open && <Modal …/>}`, so the modal
+  // cannot keep itself mounted — it defers the onClose that makes the caller
+  // unmount it, and paints `.closing` in the meantime (lib/exit-animation).
+  // Consequences worth knowing: the caller's state (and therefore the
+  // overlay-lock count in lib/ui-overlay, which is keyed on that state) stays
+  // held for the whole exit, and focus restore still runs on the real unmount.
+  // Only the chassis' own close paths (Esc / backdrop / ✕) animate; a caller
+  // that calls its own onClose from a footer action closes immediately.
+  const { closing, requestClose } = useDeferredClose(onClose, OVERLAY_EXIT_MS);
   const dialogRef = useRef<HTMLDivElement>(null);
   const restoreRef = useRef<Element | null>(null);
   const [confirmClose, setConfirmClose] = useState(false);
@@ -136,8 +147,8 @@ export function Modal({
       confirmTimer.current = window.setTimeout(() => setConfirmClose(false), 2000);
       return;
     }
-    onClose();
-  }, [busy, dirty, confirmClose, onClose]);
+    requestClose();
+  }, [busy, dirty, confirmClose, requestClose]);
 
   // Esc is handled at the document level (bubble phase), not on the dialog
   // subtree — so it keeps working even if focus momentarily escapes to <body>.
@@ -185,7 +196,7 @@ export function Modal({
   // leaking into the dialog chrome (boxed ✕ on Deploy only).
   return createPortal(
     <div
-      className="modal-overlay deploy-overlay"
+      className={"modal-overlay deploy-overlay" + (closing ? " closing" : "")}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) attemptClose();
       }}

--- a/frontend/src/lib/exit-animation.test.ts
+++ b/frontend/src/lib/exit-animation.test.ts
@@ -1,0 +1,80 @@
+// The deferred-close primitive every overlay's exit animation is built on.
+// Dialogs and the slide-over are unmounted by their CALLER (`{open && <Modal/>}`),
+// so an overlay cannot delay its own removal — it can only delay the onClose
+// that triggers it. createCloseDeferrer owns that delay.
+import { expect, test } from "bun:test";
+
+import { createCloseDeferrer } from "./exit-animation";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+const DUR = 40;
+
+test("holds the close for the exit duration, announcing the closing phase first", async () => {
+  const phases: boolean[] = [];
+  let closed = 0;
+  const d = createCloseDeferrer(DUR, () => closed++, (c) => phases.push(c));
+
+  d.request();
+  // The caller must not unmount yet — this is the frame the exit runs in.
+  expect(closed).toBe(0);
+  expect(phases).toEqual([true]);
+  expect(d.closing).toBe(true);
+
+  await sleep(DUR + 40);
+  expect(closed).toBe(1);
+  expect(d.closing).toBe(false);
+});
+
+test("repeated requests collapse into one close", async () => {
+  let closed = 0;
+  const d = createCloseDeferrer(DUR, () => closed++, () => {});
+  d.request(); // ✕
+  d.request(); // Esc landing during the animation
+  d.request(); // backdrop click too
+  await sleep(DUR + 40);
+  expect(closed).toBe(1);
+});
+
+test("a request after the close completed starts a fresh exit", async () => {
+  let closed = 0;
+  const d = createCloseDeferrer(DUR, () => closed++, () => {});
+  d.request();
+  await sleep(DUR + 40);
+  d.request();
+  expect(d.closing).toBe(true);
+  await sleep(DUR + 40);
+  expect(closed).toBe(2);
+});
+
+test("cancel drops a pending close and leaves the phase clean", async () => {
+  const phases: boolean[] = [];
+  let closed = 0;
+  const d = createCloseDeferrer(DUR, () => closed++, (c) => phases.push(c));
+  d.request();
+  d.cancel(); // the overlay unmounted for another reason (a navigation)
+  expect(d.closing).toBe(false);
+  expect(phases).toEqual([true, false]);
+  await sleep(DUR + 40);
+  expect(closed).toBe(0);
+});
+
+test("cancel with nothing pending is a no-op", () => {
+  const phases: boolean[] = [];
+  const d = createCloseDeferrer(DUR, () => {}, (c) => phases.push(c));
+  d.cancel();
+  expect(phases).toEqual([]);
+  expect(d.closing).toBe(false);
+});
+
+test("a zero duration still defers past the current frame, never inline", async () => {
+  // Reduced motion / a zero-duration caller must not turn request() into a
+  // synchronous onClose: callers unmount in that callback, and unmounting from
+  // inside an event handler that is still reading the node is the bug this
+  // whole indirection avoids.
+  let closed = 0;
+  const d = createCloseDeferrer(0, () => closed++, () => {});
+  d.request();
+  expect(closed).toBe(0);
+  await sleep(20);
+  expect(closed).toBe(1);
+});

--- a/frontend/src/lib/exit-animation.ts
+++ b/frontend/src/lib/exit-animation.ts
@@ -1,0 +1,58 @@
+// Exit animations for overlays that are unmounted by their CALLER.
+//
+// Every dialog in the app is rendered as `{open && <Modal …/>}` and the
+// slide-over the same way, so an overlay has no `open` prop of its own and
+// cannot keep itself mounted for an exit animation — the only thing it can
+// delay is the `onClose` that makes the caller unmount it. That is exactly what
+// this does: `request()` puts the overlay into a `closing` phase (the class the
+// exit CSS keys off) and fires the real `onClose` once the animation has had its
+// duration.
+//
+// DOM- and React-free on purpose so the timing is unit-testable
+// (exit-animation.test.ts); `useDeferredClose` in lib/hooks.ts is the thin React
+// wrapper that every overlay actually uses.
+
+// Exit durations, pinned by comment to the motion tokens in shell.css: the CSS
+// owns the actual transition, these only decide when the caller may unmount.
+export const OVERLAY_EXIT_MS = 150; // --dur-med: modals, dialogs
+export const PANEL_EXIT_MS = 200; // --dur-slow: the Home slide-over
+
+export interface CloseDeferrer {
+  // Begin (or keep) the exit. Idempotent: a second ✕/Esc/backdrop click landing
+  // mid-animation must not restart it or queue a second onClose.
+  request(): void;
+  // Drop a pending close without firing onClose — for unmount cleanup, so a
+  // timer can't call back into a component that is already gone.
+  cancel(): void;
+  readonly closing: boolean;
+}
+
+export function createCloseDeferrer(
+  durationMs: number,
+  onClose: () => void,
+  onPhase: (closing: boolean) => void,
+): CloseDeferrer {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return {
+    request() {
+      if (timer !== null) return;
+      onPhase(true);
+      // setTimeout even at duration 0: callers unmount inside onClose, and
+      // doing that synchronously from the event handler that is still reading
+      // the overlay's node is the hazard this indirection exists to avoid.
+      timer = setTimeout(() => {
+        timer = null;
+        onClose();
+      }, durationMs);
+    },
+    cancel() {
+      if (timer === null) return;
+      clearTimeout(timer);
+      timer = null;
+      onPhase(false);
+    },
+    get closing() {
+      return timer !== null;
+    },
+  };
+}

--- a/frontend/src/lib/flip.test.ts
+++ b/frontend/src/lib/flip.test.ts
@@ -1,0 +1,58 @@
+// The two pure diffs behind the listing's row animations: what moved (FLIP) and
+// what just appeared (the dir-watch "new row" cue). Both are keyed by row path,
+// which is what makes them survive a re-sort or a refetch that replaces every
+// object in the list.
+import { expect, test } from "bun:test";
+
+import { appearedKeys, flipDeltas } from "./flip";
+
+test("a reorder yields each moved row's inverse offset", () => {
+  const before = new Map([["a", 0], ["b", 30], ["c", 60]]);
+  const after = new Map([["c", 0], ["b", 30], ["a", 60]]);
+  // Positive delta = the row must start BELOW where it landed, i.e. it moved up.
+  // Insertion order follows the NEW render order, which is the order the caller
+  // walks the DOM in.
+  expect([...flipDeltas(before, after)]).toEqual([
+    ["c", 60],
+    ["a", -60],
+  ]);
+});
+
+test("rows that did not move are omitted, so nothing is animated pointlessly", () => {
+  const before = new Map([["a", 0], ["b", 30]]);
+  expect(flipDeltas(before, new Map([["a", 0], ["b", 30]])).size).toBe(0);
+});
+
+test("rows only in one snapshot are skipped — an entrance is not a move", () => {
+  const before = new Map([["a", 0], ["gone", 30]]);
+  const after = new Map([["a", 30], ["fresh", 0]]);
+  expect([...flipDeltas(before, after)]).toEqual([["a", -30]]);
+});
+
+test("an empty before snapshot animates nothing (first render)", () => {
+  expect(flipDeltas(new Map(), new Map([["a", 0], ["b", 30]])).size).toBe(0);
+});
+
+test("appearedKeys reports only genuinely new keys", () => {
+  expect([...appearedKeys(["a", "b"], ["a", "b", "c"])]).toEqual(["c"]);
+  expect([...appearedKeys(["a", "b"], ["b", "a"])]).toEqual([]);
+  // A removal is not an appearance, and doesn't make its neighbours new.
+  expect([...appearedKeys(["a", "b", "c"], ["a", "c"])]).toEqual([]);
+});
+
+test("the first listing is never all-new", () => {
+  // No previous snapshot = the folder just opened. Highlighting every row there
+  // would turn the cue into noise, and it would say nothing (of course they are
+  // all new — you weren't looking at this folder before).
+  expect([...appearedKeys(null, ["a", "b", "c"])]).toEqual([]);
+});
+
+test("a key that comes back after being removed counts as new again", () => {
+  expect([...appearedKeys(["a"], ["a", "b"])]).toEqual(["b"]);
+  expect([...appearedKeys(["a", "b"], ["a"])]).toEqual([]);
+  expect([...appearedKeys(["a"], ["a", "b"])]).toEqual(["b"]);
+});
+
+test("duplicate keys in the next list are reported once", () => {
+  expect([...appearedKeys(["a"], ["a", "b", "b"])]).toEqual(["b"]);
+});

--- a/frontend/src/lib/flip.ts
+++ b/frontend/src/lib/flip.ts
@@ -1,0 +1,131 @@
+// FLIP row animation for the listing table, plus the "which rows are new" diff
+// the dir-watch cue needs.
+//
+// FLIP = First, Last, Invert, Play: measure where each row sits BEFORE the
+// commit, let React reorder the DOM, then translate every moved row back to
+// where it was and transition that transform away. The rows glide to their new
+// slots instead of teleporting, and because it is one CSS transition per row it
+// inherits the global prefers-reduced-motion kill-switch for free.
+//
+// Rows are matched by a stable key (the row's path), never by index — a re-sort
+// or a refetch replaces every object in the list, so index identity is
+// meaningless here. The measure/diff halves are pure and unit-tested
+// (flip.test.ts); only useFlip touches the DOM.
+import { useLayoutEffect, useRef, type RefObject } from "react";
+
+// The attribute useFlip identifies rows by. Rows opt in by carrying it.
+export const FLIP_KEY_ATTR = "data-flip-key";
+
+// Must match the .flip-animating transition in shell.css (--dur-slow): the CSS
+// owns the animation, this only decides when the inline transform is cleaned up.
+export const FLIP_MS = 200;
+
+// key -> offsetTop, in the scroll container's coordinate space.
+export type RowOffsets = Map<string, number>;
+
+// How far each row has to be shifted to APPEAR where it was, given the offsets
+// before and after a commit. Only keys present in both snapshots that actually
+// moved: a row that just appeared has no previous position to come from (it
+// fades/highlights instead), and a row that stayed put must not get a transform
+// at all — an identity transform still creates a compositing layer per row,
+// which on a 5000-row listing is exactly the cost this is meant to avoid.
+export function flipDeltas(before: RowOffsets, after: RowOffsets): Map<string, number> {
+  const deltas = new Map<string, number>();
+  for (const [key, top] of after) {
+    const was = before.get(key);
+    if (was === undefined || was === top) continue;
+    deltas.set(key, was - top);
+  }
+  return deltas;
+}
+
+// Keys in `next` that weren't in `prev`. A null `prev` means there is no
+// previous list to compare against (the folder just opened): nothing counts as
+// new then, because "every row is new" is both noise and a statement about the
+// viewer, not about the folder.
+export function appearedKeys(
+  prev: readonly string[] | null,
+  next: readonly string[],
+): Set<string> {
+  const fresh = new Set<string>();
+  if (prev === null) return fresh;
+  const had = new Set(prev);
+  for (const key of next) if (!had.has(key)) fresh.add(key);
+  return fresh;
+}
+
+function measure(root: HTMLElement): RowOffsets {
+  const offsets: RowOffsets = new Map();
+  for (const el of root.querySelectorAll<HTMLElement>(`[${FLIP_KEY_ATTR}]`)) {
+    const key = el.getAttribute(FLIP_KEY_ATTR);
+    if (key !== null) offsets.set(key, el.offsetTop);
+  }
+  return offsets;
+}
+
+// Animate keyed rows inside `containerRef` to their new positions whenever
+// `signal` changes. `signal` is whatever the caller wants to treat as "a commit
+// that may have reordered rows" — a sort key, a refresh generation, the rendered
+// row list. The measurement is taken on every run and kept for the next one, so
+// the hook needs no explicit before/after bracketing at the call sites.
+//
+// Layout effect: the invert has to be applied in the same frame as the commit,
+// or the browser paints the rows in their new places first and there is nothing
+// left to animate from.
+export function useFlip(
+  containerRef: RefObject<HTMLElement | null>,
+  signal: unknown,
+  enabled = true,
+): void {
+  const previous = useRef<RowOffsets>(new Map());
+  const cleanupTimer = useRef<number | null>(null);
+  useLayoutEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+    const now = measure(root);
+    const before = previous.current;
+    previous.current = now;
+    if (!enabled) return;
+    const deltas = flipDeltas(before, now);
+    if (deltas.size === 0) return;
+
+    const moved: HTMLElement[] = [];
+    for (const el of root.querySelectorAll<HTMLElement>(`[${FLIP_KEY_ATTR}]`)) {
+      const dy = deltas.get(el.getAttribute(FLIP_KEY_ATTR) ?? "");
+      if (dy === undefined) continue;
+      // No transition class yet, so this jump is instant — which is the point:
+      // the row is put back where the user last saw it.
+      el.style.transform = `translateY(${dy}px)`;
+      moved.push(el);
+    }
+
+    const play = requestAnimationFrame(() => {
+      for (const el of moved) {
+        el.classList.add("flip-animating");
+        el.style.transform = "";
+      }
+      // Drop the transition once it's over, so an unrelated later transform
+      // (or a fresh FLIP) isn't animated by a leftover rule.
+      if (cleanupTimer.current !== null) window.clearTimeout(cleanupTimer.current);
+      cleanupTimer.current = window.setTimeout(() => {
+        cleanupTimer.current = null;
+        for (const el of moved) el.classList.remove("flip-animating");
+      }, FLIP_MS);
+    });
+
+    return () => {
+      cancelAnimationFrame(play);
+      // Interrupted mid-animation (another reorder, or unmount): leave no row
+      // holding an inline transform or a stray transition class.
+      for (const el of moved) {
+        el.style.transform = "";
+        el.classList.remove("flip-animating");
+      }
+      if (cleanupTimer.current !== null) {
+        window.clearTimeout(cleanupTimer.current);
+        cleanupTimer.current = null;
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [signal, enabled]);
+}

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -12,8 +12,9 @@
 // (the injected runtime writes params through the parent's history object,
 // which fires no native event) — that wrapping is load-bearing for the
 // layout modes and the update-bookmark flow, not just for these hooks.
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { NAV_EVENT } from "./router";
+import { createCloseDeferrer } from "./exit-animation";
 
 function useEventCounter(events: readonly string[]): number {
   const [n, setN] = useState(0);
@@ -107,6 +108,32 @@ export function useRefreshOnReturn(cb: () => void): void {
       document.removeEventListener("visibilitychange", refresh);
     };
   }, []);
+}
+
+// Exit animation for an overlay whose CALLER owns the unmount (every dialog is
+// `{open && <Modal …/>}`, so the overlay can't hold itself on screen — see
+// lib/exit-animation). Returns `closing` — true while the exit runs, i.e. the
+// frame budget the `.closing` CSS has to play in — and `requestClose`, which
+// every close path (Esc, backdrop, ✕) calls INSTEAD of onClose.
+//
+// The deferrer is created once and reads `onClose` through a ref, so an inline
+// arrow closure as onClose (what every call site passes) doesn't tear down and
+// rebuild a pending exit mid-animation.
+export function useDeferredClose(
+  onClose: () => void,
+  durationMs: number,
+): { closing: boolean; requestClose: () => void } {
+  const [closing, setClosing] = useState(false);
+  const closeRef = useRef(onClose);
+  closeRef.current = onClose;
+  const deferrer = useMemo(
+    () => createCloseDeferrer(durationMs, () => closeRef.current(), setClosing),
+    [durationMs],
+  );
+  // Drop a pending close on unmount: the caller may have unmounted the overlay
+  // for its own reasons (a navigation) and the timer must not fire into it.
+  useEffect(() => () => deferrer.cancel(), [deferrer]);
+  return { closing, requestClose: deferrer.request };
 }
 
 // Tab title reflects whatever's on screen (a file/dir name, or a static

--- a/frontend/src/lib/search-hold.test.ts
+++ b/frontend/src/lib/search-hold.test.ts
@@ -1,0 +1,91 @@
+// Stale-while-revalidate hold for search results. The regression these guard is
+// specific: a dir-watch refresh must keep the previous answer on screen, and a
+// QUERY CHANGE must not — the whole point of tagging the rows.
+import { expect, test } from "bun:test";
+
+import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "./search-hold";
+
+const tagged = (q: string, ...items: string[]): QueryTagged<string> => ({ q, items });
+const display = (
+  query: string,
+  committed: QueryTagged<string> | null,
+  held: QueryTagged<string> | null,
+  walkUnsettled: boolean,
+  searching = true,
+) => resolveDisplayedHits(searching, query, committed, held, walkUnsettled);
+
+test("a fresh ranking for the current query is what renders", () => {
+  const r = display("foo", tagged("foo", "a", "b"), tagged("foo", "old"), false);
+  expect(r).toEqual({ hits: ["a", "b"], showingHeld: false });
+});
+
+test("a refresh invalidation keeps the previous answer for the SAME query", () => {
+  // The walk went idle (refresh generation bumped), so the committed ranking is
+  // empty — but the query is unchanged and the tree is being re-walked.
+  const r = display("foo", tagged("foo"), tagged("foo", "a", "b"), true);
+  expect(r).toEqual({ hits: ["a", "b"], showingHeld: true });
+});
+
+test("a NEW query never renders the old query's matches", () => {
+  // The exact reported bug: while the new walk is unsettled with no hits, the
+  // held rows belong to "foo" and the query on screen is "foobar".
+  const r = display("foobar", tagged("foobar"), tagged("foo", "a", "b"), true);
+  expect(r).toEqual({ hits: [], showingHeld: false });
+});
+
+test("a committed ranking still tagged with the OLD query counts as no rows", () => {
+  // This is the render where the bug lived. `q` has already changed but the
+  // committed ranking state still holds the previous query's rows, because the
+  // commit effect has not run yet. A tag mismatch has to read as empty, or those
+  // rows get relabelled with the new query and then held for the whole walk.
+  const stale = tagged("foo", "a", "b");
+  expect(display("foobar", stale, null, true)).toEqual({ hits: [], showingHeld: false });
+  // …and it must not be promoted into the hold either.
+  expect(nextHeldHits(true, "foobar", stale, null)).toBeNull();
+});
+
+test("a completed walk with no hits replaces the held rows", () => {
+  // walkUnsettled false = the walk finished and genuinely found nothing (the
+  // file was just deleted). Holding forever would be a lie.
+  const r = display("foo", tagged("foo"), tagged("foo", "a", "b"), false);
+  expect(r).toEqual({ hits: [], showingHeld: false });
+});
+
+test("nothing is held once search is left", () => {
+  expect(nextHeldHits(false, "", tagged("", ), tagged("foo", "a"))).toBeNull();
+  expect(display("", tagged(""), tagged("foo", "a"), true, false)).toEqual({
+    hits: [],
+    showingHeld: false,
+  });
+});
+
+test("the hold advances only on a non-empty ranking for the current query", () => {
+  const held = tagged("foo", "a");
+  // Empty ranking (mid-refresh): keep what we had.
+  expect(nextHeldHits(true, "foo", tagged("foo"), held)).toBe(held);
+  // Fresh answer: replace it, tagged with the query it was computed for.
+  expect(nextHeldHits(true, "foo", tagged("foo", "b", "c"), held)).toEqual({
+    q: "foo",
+    items: ["b", "c"],
+  });
+});
+
+test("held rows survive several consecutive refresh invalidations", () => {
+  let held: QueryTagged<string> | null = null;
+  held = nextHeldHits(true, "foo", tagged("foo", "a", "b"), held);
+  for (let i = 0; i < 3; i++) {
+    const r = display("foo", tagged("foo"), held, true);
+    expect(r.showingHeld).toBe(true);
+    expect(r.hits).toEqual(["a", "b"]);
+    held = nextHeldHits(true, "foo", tagged("foo"), held);
+  }
+});
+
+test("a query change clears the hold's usefulness permanently, not just once", () => {
+  // Old hold is never reachable again: a later refresh under the new query must
+  // not resurrect it.
+  const stale = tagged("foo", "a");
+  const held = nextHeldHits(true, "bar", tagged("bar"), stale);
+  expect(held).toBe(stale); // still retained (cheap), but…
+  expect(display("bar", tagged("bar"), held, true).hits).toEqual([]); // …never shown
+});

--- a/frontend/src/lib/search-hold.ts
+++ b/frontend/src/lib/search-hold.ts
@@ -1,0 +1,63 @@
+// Stale-while-revalidate for the listing's search results (Listing.tsx B3).
+//
+// A dir-watch event invalidates the walk, which collapses the ranked hits to
+// nothing, which would blank the whole result list to "Searching…" while the
+// tree re-walks. So the last non-empty answer is HELD and kept on screen
+// (dimmed) until a fresh one is ready.
+//
+// The one thing that must never happen is the previous QUERY's matches showing
+// under a new query, so every set of rows is tagged with the query it was
+// computed for and a tag mismatch reads as "no rows". Crucially the tag has to
+// travel WITH the data, committed at the same moment: tagging at render time is
+// wrong, because on the first render after the query changes the committed
+// ranking is still the PREVIOUS query's rows (the commit effect has not run
+// yet), and a render-time stamp would label those old rows with the new query —
+// which is precisely the failure this guard exists to prevent.
+//
+// Pure and generic so the decision is unit-testable without a DOM
+// (search-hold.test.ts).
+
+export interface QueryTagged<T> {
+  q: string;
+  items: T[];
+}
+
+// The rows of a tagged set, or none when it belongs to a different query.
+function forQuery<T>(tagged: QueryTagged<T> | null, query: string): T[] {
+  return tagged !== null && tagged.q === query ? tagged.items : [];
+}
+
+// What to retain as the held answer after this render. Only a non-empty ranking
+// for the CURRENT query replaces it; anything else keeps whatever was already
+// held (a refresh invalidation empties the ranking without invalidating the
+// answer the user is looking at). Leaving search drops the hold entirely.
+export function nextHeldHits<T>(
+  searching: boolean,
+  query: string,
+  committed: QueryTagged<T> | null,
+  held: QueryTagged<T> | null,
+): QueryTagged<T> | null {
+  if (!searching) return null;
+  const fresh = forQuery(committed, query);
+  return fresh.length ? { q: query, items: fresh } : held;
+}
+
+// Which rows to render, and whether they are held (pre-refresh) rows standing in
+// for a walk that is still running — the caller dims those and keeps the spinner
+// up. Held rows are used only while the walk is UNSETTLED: a completed walk with
+// no hits is a real "no matches" answer and must replace them, not be papered
+// over forever.
+export function resolveDisplayedHits<T>(
+  searching: boolean,
+  query: string,
+  committed: QueryTagged<T> | null,
+  held: QueryTagged<T> | null,
+  walkUnsettled: boolean,
+): { hits: T[]; showingHeld: boolean } {
+  const fresh = forQuery(committed, query);
+  if (fresh.length) return { hits: fresh, showingHeld: false };
+  const standIn = searching && walkUnsettled ? forQuery(held, query) : [];
+  return standIn.length
+    ? { hits: standIn, showingHeld: true }
+    : { hits: fresh, showingHeld: false };
+}

--- a/frontend/src/lib/toast.test.ts
+++ b/frontend/src/lib/toast.test.ts
@@ -1,0 +1,73 @@
+// The toast queue's exit path. A dismissed toast is not removed from the queue
+// straight away: it is flagged `leaving` for the length of the exit animation
+// so the card can fade + collapse and the toasts below it glide up instead of
+// snapping. Both dismiss routes — the TTL timer and a manual ✕ — go through it.
+import { afterEach, beforeEach, expect, test } from "bun:test";
+
+// toast.ts schedules through `window` (browser code); bun's test runtime has no
+// DOM, so point window at the global timers.
+(globalThis as { window?: unknown }).window ??= globalThis;
+
+import { TOAST_EXIT_MS, dismissToast, getToasts, pushToast } from "./toast";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+// One exit window plus slack for timer jitter.
+const afterExit = () => sleep(TOAST_EXIT_MS + 60);
+
+// Dismissal is deliberately not instant, so draining the queue between tests
+// has to wait out the exit window too.
+async function clearAll(): Promise<void> {
+  if (getToasts().length === 0) return;
+  for (const t of getToasts()) dismissToast(t.id);
+  await afterExit();
+}
+
+beforeEach(clearAll);
+afterEach(clearAll);
+
+test("a manual dismiss flags the toast leaving, then removes it", async () => {
+  const id = pushToast({ msg: "Path copied", tone: "info", ttlMs: 0 });
+  expect(getToasts().map((t) => [t.id, t.leaving])).toEqual([[id, false]]);
+
+  dismissToast(id);
+  // Still rendered — this is the frame the exit animation runs in.
+  expect(getToasts().map((t) => [t.id, t.leaving])).toEqual([[id, true]]);
+
+  await afterExit();
+  expect(getToasts()).toEqual([]);
+});
+
+test("the TTL dismiss takes the same leaving path", async () => {
+  const id = pushToast({ msg: "expires", tone: "info", ttlMs: 10 });
+  await sleep(40);
+  const leaving = getToasts();
+  expect(leaving.map((t) => [t.id, t.leaving])).toEqual([[id, true]]);
+  await afterExit();
+  expect(getToasts()).toEqual([]);
+});
+
+test("dismissing twice does not shorten or restart the exit", async () => {
+  const id = pushToast({ msg: "x", tone: "error", ttlMs: 0 });
+  dismissToast(id);
+  await sleep(TOAST_EXIT_MS / 2);
+  dismissToast(id); // a second ✕ click / a TTL landing mid-exit
+  expect(getToasts().map((t) => t.id)).toEqual([id]);
+  await afterExit();
+  expect(getToasts()).toEqual([]);
+});
+
+test("a leaving toast does not block later ones from arriving or expiring", async () => {
+  const first = pushToast({ msg: "first", tone: "info", ttlMs: 0 });
+  dismissToast(first);
+  const second = pushToast({ msg: "second", tone: "info", ttlMs: 0 });
+  // Order is preserved: the leaving card keeps its slot while it collapses.
+  expect(getToasts().map((t) => t.id)).toEqual([first, second]);
+  await afterExit();
+  expect(getToasts().map((t) => t.id)).toEqual([second]);
+});
+
+test("dismissing an unknown id is a no-op", () => {
+  const id = pushToast({ msg: "x", tone: "info", ttlMs: 0 });
+  dismissToast(id + 999);
+  expect(getToasts().map((t) => [t.id, t.leaving])).toEqual([[id, false]]);
+});

--- a/frontend/src/lib/toast.ts
+++ b/frontend/src/lib/toast.ts
@@ -20,13 +20,26 @@ export interface ToastItem {
   msg: string;
   tone: ToastTone;
   action?: ToastAction;
+  // Dismissed, but still rendered while its exit animation plays (see
+  // TOAST_EXIT_MS). The host paints these with `.toast-leaving`; nothing else
+  // should treat them as live.
+  leaving: boolean;
 }
 
 const DEFAULT_TTL_MS = 6000;
 
+// How long a dismissed toast stays in the queue so it can fade + collapse
+// (which is also what makes the toasts below it glide up instead of snapping).
+// Must match the .toast/.toast-slot exit transition in shell.css (--dur-med).
+export const TOAST_EXIT_MS = 150;
+
 let toasts: ToastItem[] = [];
 let nextId = 1;
 const timers = new Map<number, number>();
+// Exit timers, keyed the same way. Separate from `timers`: a toast in its exit
+// window has no TTL left to cancel, and a dismiss landing mid-exit must not
+// restart or shorten the animation.
+const exiting = new Map<number, number>();
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -41,8 +54,9 @@ function subscribe(cb: () => void): () => void {
 }
 
 // Stable snapshot: the array reference only changes when the queue mutates, so
-// useSyncExternalStore stays render-free between pushes/dismisses.
-function getSnapshot(): ToastItem[] {
+// useSyncExternalStore stays render-free between pushes/dismisses. Includes
+// toasts in their exit window (`leaving: true`) — they are still on screen.
+export function getToasts(): ToastItem[] {
   return toasts;
 }
 
@@ -56,7 +70,7 @@ export function pushToast(t: {
   ttlMs?: number;
 }): number {
   const id = nextId++;
-  toasts = [...toasts, { id, msg: t.msg, tone: t.tone, action: t.action }];
+  toasts = [...toasts, { id, msg: t.msg, tone: t.tone, action: t.action, leaving: false }];
   const ttl = t.ttlMs ?? DEFAULT_TTL_MS;
   if (ttl > 0) {
     timers.set(id, window.setTimeout(() => dismissToast(id), ttl));
@@ -65,18 +79,37 @@ export function pushToast(t: {
   return id;
 }
 
+// Dismiss = start the exit animation, not "remove". The toast keeps its slot in
+// the queue (and therefore its place in the column) with `leaving: true` for
+// TOAST_EXIT_MS, then goes. Both dismiss routes land here: the TTL timer above
+// calls this, and so does the ✕ / a caller dismissing its own toast.
 export function dismissToast(id: number): void {
   const timer = timers.get(id);
   if (timer !== undefined) {
     window.clearTimeout(timer);
     timers.delete(id);
   }
+  if (exiting.has(id)) return; // already animating out — don't restart it
+  let found = false;
+  const next = toasts.map((t) => {
+    if (t.id !== id) return t;
+    found = true;
+    return { ...t, leaving: true };
+  });
+  if (!found) return; // already gone — stay render-free
+  toasts = next;
+  exiting.set(id, window.setTimeout(() => removeToast(id), TOAST_EXIT_MS));
+  emit();
+}
+
+function removeToast(id: number): void {
+  exiting.delete(id);
   const next = toasts.filter((t) => t.id !== id);
-  if (next.length === toasts.length) return; // already gone — stay render-free
+  if (next.length === toasts.length) return;
   toasts = next;
   emit();
 }
 
 export function useToasts(): ToastItem[] {
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(subscribe, getToasts);
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -168,6 +168,52 @@
   --ease-out: ease-out;
 }
 
+/* ---- Shared hover/press easing ------------------------------------------- */
+/* One rule for every interactive surface in the shell, grouped here rather than
+   as a `transition` bolted onto sixteen scattered declarations — that way the
+   set is auditable and can't drift apart. Colour properties only: each of these
+   selectors already has hover/active rules that repaint background, text or
+   border, and this is purely what makes that repaint ease instead of snap. Their
+   own rules keep owning the colours. */
+.sidebar-item,
+.bookmark-row,
+.icon-btn,
+#breadcrumb .path-crumb,
+.star-btn,
+table.listing-table tr.row,
+table.listing-table th.sortable,
+.preview-actions button,
+.tab,
+.tab-close,
+.tab-add,
+.tab-open-plain,
+.context-menu-item,
+.toast-close,
+.toast-action,
+.panel-btn,
+.listing-pane-toggle,
+.listing-load-more {
+  transition:
+    background-color var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+/* Press feedback on the button-shaped members of the set above. Deliberately
+   one shared 1px nudge and nothing else: a filter/opacity press reads as a
+   disabled state, and a transform on a table row looks like a layout bug, so
+   rows are left out. */
+.icon-btn:active:not(:disabled),
+.star-btn:active,
+.preview-actions button:active:not(:disabled),
+.panel-btn:active,
+.tab-add:active,
+.toast-action:active:not(:disabled),
+.listing-pane-toggle:active,
+.listing-load-more:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
 * {
   box-sizing: border-box;
 }
@@ -593,10 +639,18 @@ body:has(.sidebar-resize-handle.resizing) {
   background: rgba(var(--tint), 0.07);
   border-radius: 8px;
   padding: 3px 6px;
+  /* Hidden on hover so the action buttons can take the slot. Faded rather than
+     `display: none`d: the count and the buttons overlay the same spot, so this
+     one has to disappear — but a display flip can't ease, which made the
+     handover the sharpest pop in the sidebar. pointer-events go with the fade so
+     the invisible chip can't eat clicks meant for the buttons. */
+  opacity: 1;
+  transition: opacity var(--dur-fast) var(--ease-out);
 }
 
 .folder-row:hover .folder-count {
-  display: none;
+  opacity: 0;
+  pointer-events: none;
 }
 
 /* Indent rail: children sit inside a wrapper whose left border draws the
@@ -647,7 +701,17 @@ a.bookmark-name::after {
   top: 50%;
   transform: translateY(-50%);
   display: flex;
+  /* Revealed on hover. `visibility` alone stepped straight to visible, so the
+     cluster popped in; opacity carries the fade while visibility stays in the
+     transition list on purpose — it holds `visible` for the whole fade-out and
+     only flips at the end, which keeps the buttons out of the tab order and
+     click-inert while hidden (exactly what visibility bought us before). An
+     opacity-only reveal would have made every row's buttons a tab stop. */
   visibility: hidden;
+  opacity: 0;
+  transition:
+    opacity var(--dur-fast) var(--ease-out),
+    visibility var(--dur-fast) var(--ease-out);
   gap: 2px;
   z-index: 1;
   padding-left: 26px;
@@ -656,6 +720,7 @@ a.bookmark-name::after {
 
 .bookmark-row:hover .bookmark-actions {
   visibility: visible;
+  opacity: 1;
 }
 
 /* Bookmark hover card (params preview) */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1451,6 +1451,16 @@ table.listing-table tr.skel-row:hover {
   background: transparent;
 }
 
+/* Shared "content is loading" block (components/Skeleton.tsx): a few ragged
+   shimmer bars, used where a bare "Loading…" line used to sit. */
+.skel-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  max-width: 420px;
+  padding: 6px 0;
+}
+
 .listing-pane .pane-skel {
   flex: 1 1 auto;
   margin: 14px;

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2497,6 +2497,30 @@ body.embed .open-as-app-chip:hover {
 /* Default is the error variant (red border); .toast-info is the neutral
    confirmation variant (e.g. "Path copied"). Capped at the column's width so
    the stack reads as one system rather than a ragged pile. */
+/* One row of the stack. The card fades/slides; the SLOT is what collapses its
+   height (grid row 1fr → 0fr, plus a negative bottom margin that eats the
+   column's 8px gap), so dismissing a toast makes the ones below it glide up
+   instead of snapping. lib/toast keeps a dismissed toast in the queue for
+   TOAST_EXIT_MS — the same --dur-med these transitions run for. */
+.toast-slot {
+  display: grid;
+  grid-template-rows: 1fr;
+  max-width: 100%;
+  transition:
+    grid-template-rows var(--dur-med) var(--ease-out),
+    margin-bottom var(--dur-med) var(--ease-out);
+}
+
+.toast-slot > .toast {
+  min-height: 0;
+  overflow: hidden;
+}
+
+.toast-slot.leaving {
+  grid-template-rows: 0fr;
+  margin-bottom: -8px; /* cancels .notif-host's gap as the row closes */
+}
+
 .toast {
   display: flex;
   align-items: center;
@@ -2509,6 +2533,25 @@ body.embed .open-as-app-chip:hover {
   border: 1px solid var(--error);
   border-radius: 8px;
   box-shadow: 0 6px 20px var(--shadow-lg);
+  animation: toast-in var(--dur-med) var(--ease-out);
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+}
+
+.toast.toast-leaving {
+  /* A toast dismissed inside its own enter window would otherwise keep being
+     driven by the animation above, which wins over a transition. */
+  animation: none;
+  opacity: 0;
+  transform: translateY(4px);
+  transition:
+    opacity var(--dur-med) var(--ease-out),
+    transform var(--dur-med) var(--ease-out);
 }
 
 .toast-info {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2451,6 +2451,26 @@ body.embed .open-as-app-chip:hover {
   user-select: none;
 }
 
+/* The clamp pass (components/ContextMenu.tsx) needs the menu's real size before
+   it can decide where the menu goes, so the first — pre-paint — render is
+   hidden rather than painted at the raw cursor coords and then moved. */
+.context-menu.measuring {
+  visibility: hidden;
+}
+
+/* Grows out of whichever corner sits under the cursor; ContextMenu sets
+   transform-origin inline from the clamp result. */
+.context-menu.placed {
+  animation: context-menu-in 110ms var(--ease-out);
+}
+
+@keyframes context-menu-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+}
+
 /* Wrapper for an item + its (absolutely positioned) submenu. */
 .context-menu-row {
   position: relative;
@@ -2533,6 +2553,8 @@ body.embed .open-as-app-chip:hover {
   top: -5px;
   left: 100%;
   margin-left: 2px;
+  /* Grows out of the parent row's edge, i.e. the side it's attached to. */
+  transform-origin: left top;
 }
 
 .context-submenu.left {
@@ -2540,6 +2562,7 @@ body.embed .open-as-app-chip:hover {
   right: 100%;
   margin-left: 0;
   margin-right: 2px;
+  transform-origin: right top;
 }
 
 /* ---- File-operation dialogs (components/FsDialogs.tsx) -------------------- */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -2748,6 +2748,53 @@ body.embed .open-as-app-chip:hover {
   z-index: 1000;
 }
 
+/* Enter/exit for EVERY dialog in the app: the scrim fades and the dialog scales
+   up a hair. `.closing` is painted by the chassis (components/modal/Modal.tsx
+   and the FsDialogs overlay) for the length of --dur-med before the caller
+   unmounts it — see lib/exit-animation for why the delay lives in JS. The enter
+   is an animation (the node is newly mounted, so there is no `from` value for a
+   transition); the exit is a transition off the mounted state. */
+.modal-overlay {
+  animation: modal-scrim-in var(--dur-med) var(--ease-out);
+}
+
+.modal-overlay .modal-dialog {
+  animation: modal-dialog-in var(--dur-med) var(--ease-out);
+}
+
+@keyframes modal-scrim-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes modal-dialog-in {
+  from {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+}
+
+.modal-overlay.closing {
+  /* A dialog closed inside its own enter window would otherwise stay driven by
+     the animation above, which wins over a transition. */
+  animation: none;
+  opacity: 0;
+  /* Nothing behind a dialog that is already leaving should be clickable, and
+     neither should the dialog itself. */
+  pointer-events: none;
+  transition: opacity var(--dur-med) var(--ease-out);
+}
+
+.modal-overlay.closing .modal-dialog {
+  animation: none;
+  opacity: 0;
+  transform: scale(0.98);
+  transition:
+    opacity var(--dur-med) var(--ease-out),
+    transform var(--dur-med) var(--ease-out);
+}
+
 .deploy-dialog {
   background: var(--bg-alt);
   border: 1px solid var(--border);
@@ -5962,7 +6009,10 @@ select.field-control:has(option[value=""]:checked) {
   z-index: 1000;
   background: var(--scrim);
   opacity: 0;
-  transition: opacity 200ms ease-out;
+  /* Bidirectional: NewAppPanel takes `is-open` back off (and defers its own
+     unmount by PANEL_EXIT_MS, lib/exit-animation) so the same rule slides the
+     panel out again. */
+  transition: opacity var(--dur-slow) var(--ease-out);
 }
 
 .app-panel-overlay.is-open {
@@ -5981,7 +6031,7 @@ select.field-control:has(option[value=""]:checked) {
   border-left: 1px solid var(--border);
   box-shadow: 0 0 40px var(--shadow-lg);
   transform: translateX(100%);
-  transition: transform 200ms ease-out;
+  transition: transform var(--dur-slow) var(--ease-out);
 }
 
 .app-panel-overlay.is-open .app-panel {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1645,6 +1645,26 @@ table.listing-table .sort-arrow.desc {
   }
 }
 
+/* A row that just appeared in the folder (dir-watch refresh, views/Listing.tsx):
+   an accent wash that fades out over ROW_NEW_MS, so a file that landed while you
+   were looking elsewhere is visible instead of silently slotting in. On the cells
+   rather than the row, because the row's own background is the hover/selection
+   channel and must keep working underneath. Removals need no cue beyond the
+   FLIP. Reduced motion collapses the animation, which drops the cue entirely —
+   correct: it is decoration, and nothing depends on seeing it. */
+table.listing-table tr.row.row-new > td {
+  animation: row-new-fade 1.5s var(--ease-out);
+}
+
+@keyframes row-new-fade {
+  from {
+    background-color: rgba(var(--accent-rgb), 0.2);
+  }
+  to {
+    background-color: rgba(var(--accent-rgb), 0);
+  }
+}
+
 /* Rows glide to their new slots after a reorder (lib/flip). Higher specificity
    than the shared hover-transition rule so it wins for the length of the
    animation; the class is added for exactly FLIP_MS and then removed. */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1043,6 +1043,19 @@ a.bookmark-name::after {
   min-height: 0;
   display: flex;
   flex-direction: column;
+  /* Route fade (App.tsx): routes hard-remount per navigation, so there is no
+     old-and-new overlap to cross-fade — a short fade-in on the content area
+     alone makes the cut read as intentional. Shorter than --dur-med on purpose:
+     it must not delay reading the page. The sidebar and breadcrumb chrome sit
+     OUTSIDE this element and never flash. Replays because App keys this node on
+     the nav epoch (an iframe's param write doesn't bump it). */
+  animation: content-in 110ms var(--ease-out);
+}
+
+@keyframes content-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* Listing view — a fixed search header above a scrolling table, so the search

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -200,6 +200,34 @@ body {
   background: var(--bg-alt);
   border-right: 1px solid var(--border);
   overflow-y: auto;
+  /* Collapsing squeezes the rows before the subtree swaps; without this the
+     squeeze pops a horizontal scrollbar for the length of the animation. */
+  overflow-x: hidden;
+  /* Collapse/expand glides instead of jumping 232px → 10px. Suppressed during a
+     resize drag (below): a transition there would make the edge chase the
+     cursor. */
+  transition:
+    flex-basis var(--dur-slow) var(--ease-out),
+    width var(--dur-slow) var(--ease-out);
+}
+
+/* Set while the resize handle is captured (Sidebar.tsx `resizing`). */
+#sidebar.sidebar-no-transition {
+  transition: none;
+}
+
+/* The collapsed strip and the expanded rows are two different subtrees, swapped
+   at the animation boundary; fading whichever one is newly mounted keeps that
+   swap from reading as a pop. Only replays on a real subtree swap — React reuses
+   these children across ordinary re-renders. */
+#sidebar > * {
+  animation: sidebar-content-in var(--dur-slow) var(--ease-out);
+}
+
+@keyframes sidebar-content-in {
+  from {
+    opacity: 0;
+  }
 }
 
 /* Drag handle riding the sidebar's right border. Fixed-positioned (the
@@ -244,6 +272,8 @@ body:has(.sidebar-resize-handle.resizing) {
 #sidebar.sidebar-collapsed {
   flex: 0 0 10px;
   width: 10px;
+  /* Wins over the base rule's overflow-x: hidden — the expand bubble has to be
+     able to protrude past the strip. */
   overflow: visible;
   /* The bubble overhangs #content; lift the whole strip above it so a
      stacking context inside #content can't paint over the bubble. */

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -150,6 +150,24 @@
   --icon-file: #6b7178;
 }
 
+/* ---- Motion tokens ------------------------------------------------------- */
+/* Three durations, one easing — every transition/animation in this file picks
+   one of these rather than inventing a number, so the whole shell moves at the
+   same speed:
+     --dur-fast  hover / press colour changes
+     --dur-med   overlays, toasts, fades, context menus
+     --dur-slow  panels, slide-overs, sidebar collapse, FLIP row reorders
+   Deliberately its own `:root` block, NOT merged into the palettes above: the
+   theme contract (tests/test_theme.py) requires every token in the dark
+   palette to have a light counterpart, and a duration has no light value.
+   prefers-reduced-motion (bottom of this file) collapses all of them. */
+:root {
+  --dur-fast: 80ms;
+  --dur-med: 150ms;
+  --dur-slow: 200ms;
+  --ease-out: ease-out;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -1824,11 +1842,37 @@ table.listing-table td.mtime {
   position: relative;
 }
 
+/* Held-frame mode swap (views/Preview.tsx): during a switch the outgoing frame
+   and the incoming one are BOTH mounted, so they stack absolutely inside this
+   wrapper instead of sharing the flex row. The visible one is `.is-shown`
+   (z-index above the frame it replaces); the other fades to nothing and is
+   unmounted a beat later. `background: var(--bg)` is what kills the white flash
+   an unpainted iframe shows on its own. */
+.preview-frames {
+  flex: 1 1 auto;
+  position: relative;
+  min-width: 0;
+}
+
 .preview-body iframe {
   flex: 1 1 auto;
   width: 100%;
   height: 100%;
   border: none;
+  background: var(--bg);
+}
+
+.preview-frames iframe.preview-frame {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  z-index: 0;
+  transition: opacity var(--dur-med) var(--ease-out);
+}
+
+.preview-frames iframe.preview-frame.is-shown {
+  opacity: 1;
+  z-index: 1;
 }
 
 .metadata-card {
@@ -2096,6 +2140,14 @@ body.embed .open-as-app-chip:hover {
   width: 100%;
   border: none;
   background: var(--bg);
+  /* Fade in on load; views/Panel.tsx arms/clears `.is-loaded` around every
+     (imperative) src write. */
+  opacity: 0;
+  transition: opacity var(--dur-med) var(--ease-out);
+}
+
+.panel-pane iframe.is-loaded {
+  opacity: 1;
 }
 
 /* Tab mode (/view/_tab, /embed/_tab): a tabbed set of /embed iframes, one
@@ -2601,6 +2653,21 @@ body.embed .open-as-app-chip:hover {
   height: 100%;
   border: none;
   background: var(--bg);
+}
+
+/* First paint of a lazily-mounted tab (and of an imperative src rewrite from
+   the tab bar's mode menu) fades in rather than snapping from an unpainted
+   frame; views/Tabs.tsx adds `.is-loaded` on the iframe's own load event.
+   Inactive tabs stay hidden with `display: none` (TM-5) — an iframe must be
+   layout-hidden, not merely transparent — so this opacity is only ever the
+   load fade, never the tab-visibility mechanism. */
+.tabs-body iframe.tab-frame {
+  opacity: 0;
+  transition: opacity var(--dur-med) var(--ease-out);
+}
+
+.tabs-body iframe.tab-frame.is-loaded {
+  opacity: 1;
 }
 
 /* React mount point (frontend/index.html) — transparent to the flex layout

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1623,9 +1623,65 @@ table.listing-table th.sorted {
   color: var(--accent);
 }
 
+/* One glyph (▲) for both directions: desc rotates it, so flipping the order
+   turns the arrow over instead of swapping one character for another (a swap
+   replaces the element, and a replaced element can only pop). Moving the arrow
+   to a different column DOES replace it — that one fades in. */
 table.listing-table .sort-arrow {
+  display: inline-block;
   margin-left: 5px;
   font-size: 9px;
+  transition: transform 100ms var(--ease-out);
+  animation: sort-arrow-in 100ms var(--ease-out);
+}
+
+table.listing-table .sort-arrow.desc {
+  transform: rotate(180deg);
+}
+
+@keyframes sort-arrow-in {
+  from {
+    opacity: 0;
+  }
+}
+
+/* Rows glide to their new slots after a reorder (lib/flip). Higher specificity
+   than the shared hover-transition rule so it wins for the length of the
+   animation; the class is added for exactly FLIP_MS and then removed. */
+table.listing-table tr.row.flip-animating {
+  transition: transform var(--dur-slow) var(--ease-out);
+}
+
+/* Current ordering of the search results, and the click that restores relevance
+   (views/Listing.tsx). Disabled = already in relevance order, i.e. a readout. */
+.listing-sort-chip {
+  flex: 0 0 auto;
+  font: inherit;
+  font-size: 11px;
+  line-height: 1;
+  padding: 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+  color: var(--fg-muted);
+  cursor: pointer;
+  white-space: nowrap;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.listing-sort-chip:disabled {
+  cursor: default;
+}
+
+.listing-sort-chip.sorted {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.listing-sort-chip:hover:not(:disabled) {
+  color: var(--fg);
 }
 
 table.listing-table td {

--- a/frontend/src/views/Apps.tsx
+++ b/frontend/src/views/Apps.tsx
@@ -15,6 +15,7 @@ import { navigateUrl } from "../lib/router";
 import { ErrorBanner } from "../components/ErrorBanner";
 import { AppPreviewCard } from "../components/AppPreviewCard";
 import { NewAppPanel } from "./Home";
+import { SkeletonLines } from "../components/Skeleton";
 
 type Loaded<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "error"; message: string };
 
@@ -163,7 +164,7 @@ export default function Apps() {
         </div>
 
         {apps.status === "error" && <ErrorBanner>{apps.message}</ErrorBanner>}
-        {apps.status === "loading" && <div className="home-loading">Loading…</div>}
+        {apps.status === "loading" && <SkeletonLines rows={4} label="Loading apps" />}
         {apps.status === "ok" && (
           <>
             <div className="apps-count">

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -20,6 +20,7 @@ import { isMod, MOD_LABEL } from "../lib/platform";
 import { useDeferredClose } from "../lib/hooks";
 import { PANEL_EXIT_MS } from "../lib/exit-animation";
 import { AppCard } from "../components/AppCard";
+import { SkeletonLines } from "../components/Skeleton";
 
 type Loaded<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "error"; message: string };
 
@@ -745,7 +746,7 @@ export default function Home({ config }: { config: Config }) {
             }
           />
           {apps.status === "error" && <ErrorBanner>{apps.message}</ErrorBanner>}
-          {apps.status === "loading" && <div className="home-loading">Loading…</div>}
+          {apps.status === "loading" && <SkeletonLines rows={3} label="Loading apps" />}
           {apps.status === "ok" && apps.data.apps.length === 0 && (
             <div className="home-empty">
               No apps yet. Describe one in the box above — it lands in{" "}

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -17,6 +17,8 @@ import { ErrorBanner } from "../components/ErrorBanner";
 import { TextInput, TextArea } from "../components/field/fields";
 import { basename } from "../lib/format";
 import { isMod, MOD_LABEL } from "../lib/platform";
+import { useDeferredClose } from "../lib/hooks";
+import { PANEL_EXIT_MS } from "../lib/exit-animation";
 import { AppCard } from "../components/AppCard";
 
 type Loaded<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "error"; message: string };
@@ -402,6 +404,10 @@ const APP_STEPS: { title: string; desc: string }[] = [
 // exists (session error or not) so the caller's list can refresh underneath —
 // it never closes the panel, whose own success/error state still has to be read.
 export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCreated?: () => void }) {
+  // Slide OUT as well as in. The caller unmounts this panel, so closing is
+  // deferred by the slide duration and `is-open` comes off immediately — the
+  // same CSS that animated the entry runs backwards (lib/exit-animation).
+  const { closing, requestClose } = useDeferredClose(onClose, PANEL_EXIT_MS);
   const [name, setName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [busy, setBusy] = useState(false);
@@ -466,11 +472,11 @@ export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCre
   // exactly like the modal chassis this panel replaced.
   useEffect(() => {
     const onDocKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape" && !busy) onClose();
+      if (e.key === "Escape" && !busy) requestClose();
     };
     document.addEventListener("keydown", onDocKey);
     return () => document.removeEventListener("keydown", onDocKey);
-  }, [busy, onClose]);
+  }, [busy, requestClose]);
 
   // Cmd/Ctrl+Enter submits from either field (plain Enter in the textarea
   // inserts a newline as usual).
@@ -483,9 +489,9 @@ export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCre
 
   return createPortal(
     <div
-      className={"app-panel-overlay" + (open ? " is-open" : "")}
+      className={"app-panel-overlay" + (open && !closing ? " is-open" : "")}
       onMouseDown={(e) => {
-        if (e.target === e.currentTarget && !busy) onClose();
+        if (e.target === e.currentTarget && !busy) requestClose();
       }}
     >
       <div
@@ -506,7 +512,7 @@ export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCre
             aria-label="Close"
             title="Close"
             disabled={busy}
-            onClick={onClose}
+            onClick={requestClose}
           >
             ✕
           </button>
@@ -586,7 +592,7 @@ export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCre
           <span className="app-panel-hint">
             <kbd>{MOD_LABEL}</kbd> + <kbd>↵</kbd> to create
           </span>
-          <button type="button" className="btn btn-secondary" onClick={onClose} disabled={busy}>
+          <button type="button" className="btn btn-secondary" onClick={requestClose} disabled={busy}>
             Cancel
           </button>
           <button type="button" className="btn btn-primary" onClick={create} disabled={!canCreate}>

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -45,7 +45,7 @@ import { formatSize, formatMtime, basename } from "../lib/format";
 import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 import { iconForEntry, isAppEntry } from "../components/FileIcons";
 import { getViewState, setViewState } from "../lib/viewstate";
-import { useFlip } from "../lib/flip";
+import { appearedKeys, useFlip, FLIP_KEY_ATTR } from "../lib/flip";
 import { getClipboard, setClipboard, useClipboard } from "../lib/fs-clipboard";
 import { pushToast } from "../lib/toast";
 import ContextMenu, { type MenuEntry, type MenuItem } from "../components/ContextMenu";
@@ -119,6 +119,31 @@ const FLIP_MAX_ROWS = 600;
 // purpose: that one bounds how often results are re-scored, this one bounds how
 // often the rows on screen are allowed to move.
 const RERANK_COMMIT_MS = 280;
+
+// How long a row that just appeared in the folder keeps its tint. Long enough to
+// catch the eye if you weren't looking at that part of the list, short enough
+// that it doesn't become part of the row's normal appearance.
+const ROW_NEW_MS = 1500;
+
+// Where the scroll position is pinned across a dir-watch refresh: the lead
+// (selected) row, or failing that the topmost row still in view. Returns null
+// when there is nothing to anchor to (empty or unmounted listing).
+function measureScrollAnchor(
+  scroller: HTMLElement,
+): { key: string; top: number; scrollTop: number } | null {
+  let el = scroller.querySelector<HTMLElement>("tr.row.lead");
+  if (!el) {
+    for (const row of scroller.querySelectorAll<HTMLElement>(`[${FLIP_KEY_ATTR}]`)) {
+      if (row.offsetTop + row.offsetHeight > scroller.scrollTop) {
+        el = row;
+        break;
+      }
+    }
+  }
+  const key = el?.getAttribute(FLIP_KEY_ATTR);
+  if (!el || !key) return null;
+  return { key, top: el.offsetTop, scrollTop: scroller.scrollTop };
+}
 
 // Debounce for mirroring the query into the URL. Safari rate-limits
 // history.replaceState (~100 calls / 30s, then it THROWS); per-keystroke
@@ -874,6 +899,7 @@ export default function Listing({
     const cursor = state.cursor;
     const gen = refresh; // discard the response if a refresh supersedes it
     setLoadingMore(true);
+    skipNewCue.current = true; // an appended page isn't a dir-watch change
     listDir(fsPath, cursor).then(
       (data) => {
         if (refreshRef.current !== gen) return; // stale: a refresh replaced the listing
@@ -1291,6 +1317,54 @@ export default function Listing({
   // moves nothing already on screen, so paging animates nothing.
   const scrollRef = useRef<HTMLDivElement>(null);
   useFlip(scrollRef, navRows, navRows.length <= FLIP_MAX_ROWS);
+
+  // Dir-watch change cue (B5). A refresh that adds entries used to slot them in
+  // silently — a file that just landed in the folder was indistinguishable from
+  // one that had been there all along. Newly appeared rows carry `.row-new` for
+  // ROW_NEW_MS (a tint that fades out; removals need no cue beyond the FLIP).
+  // Names are the plain listing's row identity. The FIRST listing of a folder is
+  // never "new" — appearedKeys returns nothing for a null previous list.
+  const prevNamesRef = useRef<string[] | null>(null);
+  const [newNames, setNewNames] = useState<Set<string>>(() => new Set());
+  // Set by loadMore: an appended page is the user's own gesture, and tinting
+  // 250 rows they just asked for is noise, not a cue.
+  const skipNewCue = useRef(false);
+  useEffect(() => {
+    if (state.status !== "ok") return;
+    const names = state.entries.map((e) => e.name);
+    const fresh = skipNewCue.current ? new Set<string>() : appearedKeys(prevNamesRef.current, names);
+    skipNewCue.current = false;
+    prevNamesRef.current = names;
+    if (fresh.size === 0) return;
+    setNewNames(fresh);
+    const id = window.setTimeout(() => setNewNames(new Set()), ROW_NEW_MS);
+    return () => window.clearTimeout(id);
+  }, [state]);
+
+  // Scroll anchoring (B5). A dir-watch refresh that inserts or removes rows
+  // ABOVE the viewport shifts everything below it, so the rows the user was
+  // reading slid out from under them. Re-apply the scroll offset the anchor row
+  // had. The anchor is re-measured on EVERY commit (it has to be current), but
+  // the correction is applied only when the refresh generation changed: a sort
+  // or a page reveal is the user's own gesture and must not be undone.
+  const anchorRef = useRef<{ key: string; top: number; scrollTop: number } | null>(null);
+  const anchorGenRef = useRef(refresh);
+  useLayoutEffect(() => {
+    const scroller = scrollRef.current;
+    if (!scroller) return;
+    const prev = anchorRef.current;
+    if (prev && refresh !== anchorGenRef.current) {
+      const el = scroller.querySelector<HTMLElement>(
+        `[${FLIP_KEY_ATTR}="${CSS.escape(prev.key)}"]`,
+      );
+      if (el) {
+        const shift = el.offsetTop - prev.top;
+        if (shift !== 0) scroller.scrollTop = prev.scrollTop + shift;
+      }
+    }
+    anchorGenRef.current = refresh;
+    anchorRef.current = measureScrollAnchor(scroller);
+  }, [navRows, refresh]);
 
   // Keep the keyboard selection scrolled into view as it moves. Follows the LEAD
   // row (`.lead`), not merely the first selected one: extending a Shift-range
@@ -2160,6 +2234,7 @@ export default function Listing({
           data-flip-key={childPath}
           className={
             (entry.ignored ? "row ignored" : "row") +
+            (newNames.has(entry.name) ? " row-new" : "") + // brief dir-watch tint
             (selectedSet.has(childPath) ? " selected" : "") +
             (childPath === selectedPath ? " lead" : "") + // scroll-into-view marker
             (cutSet.has(childPath) ? " cut" : "") +

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -46,6 +46,7 @@ import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 import { iconForEntry, isAppEntry } from "../components/FileIcons";
 import { getViewState, setViewState } from "../lib/viewstate";
 import { appearedKeys, useFlip, FLIP_KEY_ATTR } from "../lib/flip";
+import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "../lib/search-hold";
 import { getClipboard, setClipboard, useClipboard } from "../lib/fs-clipboard";
 import { pushToast } from "../lib/toast";
 import ContextMenu, { type MenuEntry, type MenuItem } from "../components/ContextMenu";
@@ -1175,7 +1176,17 @@ export default function Listing({
   // accumulation underneath and the live "N matches · M scanned…" counter both
   // keep running at full speed: they cost nothing and they are the honest
   // progress signal.
-  const [rankedForRender, setRankedForRender] = useState<SearchHit[]>(hits);
+  //
+  // The committed ranking carries the QUERY it was computed for. That tag is
+  // load-bearing for the hold below and it has to be committed WITH the data:
+  // on the first render after `q` changes this state still holds the previous
+  // query's rows (this effect hasn't run yet), so anything that tags it at
+  // render time labels the old query's rows with the new query. See
+  // lib/search-hold.
+  const [rankedForRender, setRankedForRender] = useState<QueryTagged<SearchHit>>(() => ({
+    q,
+    items: hits,
+  }));
   const lastRankCommit = useRef(0);
   // Declared BEFORE the commit effect so it runs first in the same flush: a
   // query change (or a sort change) is a direct response to a gesture and must
@@ -1189,13 +1200,13 @@ export default function Listing({
     // and the final ranking must not be held back.
     if (validWalk.status !== "streaming") {
       lastRankCommit.current = 0;
-      setRankedForRender(hits);
+      setRankedForRender({ q, items: hits });
       return;
     }
     const wait = RERANK_COMMIT_MS - (Date.now() - lastRankCommit.current);
     const commit = () => {
       lastRankCommit.current = Date.now();
-      setRankedForRender(hits);
+      setRankedForRender({ q, items: hits });
     };
     if (wait <= 0) {
       commit(); // includes the first flush of a stream — first paint isn't delayed
@@ -1203,7 +1214,7 @@ export default function Listing({
     }
     const id = window.setTimeout(commit, wait);
     return () => window.clearTimeout(id);
-  }, [hits, validWalk.status]);
+  }, [hits, q, validWalk.status]);
 
   // --- Stale-while-revalidate for search results (B3) -----------------------
   // A dir-watch event bumps `refresh`, which makes validWalk read idle for the
@@ -1217,22 +1228,25 @@ export default function Listing({
   // remains derived from validWalk alone, and these held rows are not fed back
   // into scoring.
   //
-  // Tagged with the query they were computed for, because the ONE thing this
-  // must never do is show the previous query's matches under a new query. A
-  // query change gives a different tag and falls through to "Searching…" as
-  // before; only a same-query invalidation holds.
-  const heldHits = useRef<{ q: string; hits: SearchHit[] } | null>(null);
-  if (!searching) heldHits.current = null;
-  else if (rankedForRender.length) heldHits.current = { q, hits: rankedForRender };
-  // Only while the current-generation walk is genuinely unsettled. A COMPLETED
-  // walk with no hits is a real "no matches" answer (the file was just deleted,
-  // say) and must replace the held rows rather than preserve them forever.
+  // Both halves of the decision — what to retain, and what to render — live in
+  // lib/search-hold, pure and query-tagged: rows are only ever shown under the
+  // query they were computed for, so the ONE thing this must never do (show the
+  // previous query's matches under a new query) is structurally impossible
+  // rather than a condition someone has to remember. A query change falls
+  // through to "Searching…" exactly as before; only a same-query invalidation
+  // holds. The hold applies only while the current-generation walk is unsettled
+  // — a COMPLETED walk with no hits is a real "no matches" answer (the file was
+  // just deleted, say) and replaces the held rows.
+  const heldHits = useRef<QueryTagged<SearchHit> | null>(null);
+  heldHits.current = nextHeldHits(searching, q, rankedForRender, heldHits.current);
   const walkUnsettled = validWalk.status === "idle" || validWalk.status === "streaming";
-  const showingHeld =
-    searching && rankedForRender.length === 0 && walkUnsettled && heldHits.current?.q === q;
-  const displayHits = showingHeld
-    ? (heldHits.current as { hits: SearchHit[] }).hits
-    : rankedForRender;
+  const { hits: displayHits, showingHeld } = resolveDisplayedHits(
+    searching,
+    q,
+    rankedForRender,
+    heldHits.current,
+    walkUnsettled,
+  );
 
   const visibleHits = useMemo(() => displayHits.slice(0, visibleCount), [displayHits, visibleCount]);
 

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -114,6 +114,12 @@ const PAGE_SIZE = 250;
 // glide costs more than the snap it replaces.
 const FLIP_MAX_ROWS = 600;
 
+// Minimum gap between commits of the RENDERED search ranking while a walk
+// streams (see the throttle in the component). Longer than STREAM_FLUSH_MS on
+// purpose: that one bounds how often results are re-scored, this one bounds how
+// often the rows on screen are allowed to move.
+const RERANK_COMMIT_MS = 280;
+
 // Debounce for mirroring the query into the URL. Safari rate-limits
 // history.replaceState (~100 calls / 30s, then it THROWS); per-keystroke
 // sync trips that on fast typing. State stays immediate — only the URL lags.
@@ -1135,6 +1141,44 @@ export default function Listing({
     });
   }, [searching, q, validWalk, searchSort]);
 
+  // --- Streaming re-rank throttle (B4) --------------------------------------
+  // Every stream flush re-scores the newly arrived entries and merges them into
+  // the ranked list, which reshuffles the visible rows several times a second —
+  // unreadable on its own, and worse now that the rows animate. The RENDERED
+  // ranking is therefore committed at most once per RERANK_COMMIT_MS. The
+  // accumulation underneath and the live "N matches · M scanned…" counter both
+  // keep running at full speed: they cost nothing and they are the honest
+  // progress signal.
+  const [rankedForRender, setRankedForRender] = useState<SearchHit[]>(hits);
+  const lastRankCommit = useRef(0);
+  // Declared BEFORE the commit effect so it runs first in the same flush: a
+  // query change (or a sort change) is a direct response to a gesture and must
+  // paint immediately, never wait out a throttle window opened by the stream.
+  useEffect(() => {
+    lastRankCommit.current = 0;
+  }, [q, searchSort]);
+  useEffect(() => {
+    // Only a streaming walk churns. Anything else (settled, errored, or
+    // invalidated to idle) commits at once — there is nothing left to smooth
+    // and the final ranking must not be held back.
+    if (validWalk.status !== "streaming") {
+      lastRankCommit.current = 0;
+      setRankedForRender(hits);
+      return;
+    }
+    const wait = RERANK_COMMIT_MS - (Date.now() - lastRankCommit.current);
+    const commit = () => {
+      lastRankCommit.current = Date.now();
+      setRankedForRender(hits);
+    };
+    if (wait <= 0) {
+      commit(); // includes the first flush of a stream — first paint isn't delayed
+      return;
+    }
+    const id = window.setTimeout(commit, wait);
+    return () => window.clearTimeout(id);
+  }, [hits, validWalk.status]);
+
   // --- Stale-while-revalidate for search results (B3) -----------------------
   // A dir-watch event bumps `refresh`, which makes validWalk read idle for the
   // stale generation, which collapses `hits` to [] — so the entire visible
@@ -1153,14 +1197,16 @@ export default function Listing({
   // before; only a same-query invalidation holds.
   const heldHits = useRef<{ q: string; hits: SearchHit[] } | null>(null);
   if (!searching) heldHits.current = null;
-  else if (hits.length) heldHits.current = { q, hits };
+  else if (rankedForRender.length) heldHits.current = { q, hits: rankedForRender };
   // Only while the current-generation walk is genuinely unsettled. A COMPLETED
   // walk with no hits is a real "no matches" answer (the file was just deleted,
   // say) and must replace the held rows rather than preserve them forever.
   const walkUnsettled = validWalk.status === "idle" || validWalk.status === "streaming";
   const showingHeld =
-    searching && hits.length === 0 && walkUnsettled && heldHits.current?.q === q;
-  const displayHits = showingHeld ? (heldHits.current as { hits: SearchHit[] }).hits : hits;
+    searching && rankedForRender.length === 0 && walkUnsettled && heldHits.current?.q === q;
+  const displayHits = showingHeld
+    ? (heldHits.current as { hits: SearchHit[] }).hits
+    : rankedForRender;
 
   const visibleHits = useMemo(() => displayHits.slice(0, visibleCount), [displayHits, visibleCount]);
 

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -45,6 +45,7 @@ import { formatSize, formatMtime, basename } from "../lib/format";
 import { fuzzyMatch, highlightSegments } from "../lib/fuzzy";
 import { iconForEntry, isAppEntry } from "../components/FileIcons";
 import { getViewState, setViewState } from "../lib/viewstate";
+import { useFlip } from "../lib/flip";
 import { getClipboard, setClipboard, useClipboard } from "../lib/fs-clipboard";
 import { pushToast } from "../lib/toast";
 import ContextMenu, { type MenuEntry, type MenuItem } from "../components/ContextMenu";
@@ -106,6 +107,12 @@ type SortOrder = "asc" | "desc";
 // bottom reveals the next page (see the sentinel row below); the full ranked
 // list always exists in memory for the count text.
 const PAGE_SIZE = 250;
+
+// Above this many rendered rows the FLIP reorder animation is dropped. Measuring
+// every row's offsetTop on each commit is one forced layout, but the per-row
+// transform (a compositing layer each) is not free — on a listing this long the
+// glide costs more than the snap it replaces.
+const FLIP_MAX_ROWS = 600;
 
 // Debounce for mirroring the query into the URL. Safari rate-limits
 // history.replaceState (~100 calls / 30s, then it THROWS); per-keystroke
@@ -1067,12 +1074,16 @@ export default function Listing({
     setViewState(fsPath, "?" + saved.toString());
   };
 
+  // Search headers cycle asc → desc → relevance. Relevance (the fuzzy rank) is
+  // the mode search results are actually FOR, and before this there was no way
+  // back to it short of retyping the query — the toggle only ever flipped
+  // between two column orders.
   const setSearchSortKey = (key: SortKey) => {
-    setSearchSort((prev) =>
-      prev && prev.sort === key
-        ? { sort: key, order: prev.order === "asc" ? "desc" : "asc" }
-        : { sort: key, order: "asc" }
-    );
+    setSearchSort((prev) => {
+      if (!prev || prev.sort !== key) return { sort: key, order: "asc" };
+      if (prev.order === "asc") return { sort: key, order: "desc" };
+      return null;
+    });
   };
 
   // Incremental-scoring cache for the streamed validWalk. As long as the query,
@@ -1200,10 +1211,20 @@ export default function Listing({
   // selection). Only the transient `loading` status suppresses reconcile.
   const listingLoaded = searching ? true : state.status !== "loading";
 
+  // FLIP the rows to their new slots whenever the rendered set changes: a column
+  // sort, a dir-watch refresh of the plain listing, or a streaming search
+  // re-rank (which B4 throttles, so the glide has time to read). navRows is the
+  // rendered order itself, so one signal covers all three; growing it by a page
+  // moves nothing already on screen, so paging animates nothing.
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useFlip(scrollRef, navRows, navRows.length <= FLIP_MAX_ROWS);
+
   // Keep the keyboard selection scrolled into view as it moves. Follows the LEAD
   // row (`.lead`), not merely the first selected one: extending a Shift-range
   // downward must keep the moving end visible, and the top of the range is
   // usually the one that would otherwise win a `.selected` query.
+  // row. This is also what keeps the selection in view across a SORT: navRows is
+  // a dependency, and a sort click produces a new navRows.
   useEffect(() => {
     if (!selectedPath) return;
     (
@@ -1958,6 +1979,7 @@ export default function Listing({
               return (
                 <tr
                   key={entry.rel}
+                  data-flip-key={childPath}
                   className={
                     "row" +
                     (selectedSet.has(childPath) ? " selected" : "") +
@@ -2062,6 +2084,7 @@ export default function Listing({
       return (
         <tr
           key={entry.name}
+          data-flip-key={childPath}
           className={
             (entry.ignored ? "row ignored" : "row") +
             (selectedSet.has(childPath) ? " selected" : "") +
@@ -2192,6 +2215,26 @@ export default function Listing({
             <span className="listing-search-count">{sel.paths.length} selected</span>
           )}
         </div>
+        {/* Current result ordering, and the way back to relevance. Without it
+            "no arrow anywhere" was the only signal that results were in fuzzy
+            rank order, and a column sort had no explicit escape. */}
+        {searching && (
+          <button
+            type="button"
+            className={"listing-sort-chip" + (searchSort ? " sorted" : "")}
+            disabled={!searchSort}
+            title={
+              searchSort
+                ? "Results are column-sorted — click for relevance order"
+                : "Results are in relevance order (best match first)"
+            }
+            onClick={() => setSearchSort(null)}
+          >
+            {searchSort
+              ? `${SORT_KEYS[searchSort.sort].toLowerCase()} ${searchSort.order}`
+              : "relevance"}
+          </button>
+        )}
         <button
           type="button"
           className={"listing-pane-toggle" + (pane.on ? " active" : "")}
@@ -2204,6 +2247,7 @@ export default function Listing({
       </div>
       <div className="listing-split" ref={splitRef}>
         <div
+          ref={scrollRef}
           className={"listing-scroll" + (isStale ? " listing-stale" : "")}
           onContextMenu={openBackgroundMenu}
         >
@@ -2217,11 +2261,19 @@ export default function Listing({
                     <th
                       key={key}
                       className={"sortable" + (searchSort?.sort === key ? " sorted" : "")}
+                      title={
+                        searchSort?.sort === key && searchSort.order === "desc"
+                          ? `Back to relevance order`
+                          : `Sort results by ${label.toLowerCase()}`
+                      }
                       onClick={() => setSearchSortKey(key)}
                     >
                       {label}
+                      {/* One glyph that ROTATES for desc (see .sort-arrow):
+                          swapping ▲ for ▼ replaced the element, so the change
+                          could only ever pop. */}
                       {searchSort?.sort === key && (
-                        <span className="sort-arrow">{searchSort.order === "asc" ? "▲" : "▼"}</span>
+                        <span className={"sort-arrow" + (searchSort.order === "desc" ? " desc" : "")}>▲</span>
                       )}
                     </th>
                   ) : (
@@ -2231,7 +2283,9 @@ export default function Listing({
                       onClick={() => setSort(key)}
                     >
                       {label}
-                      {key === sort && <span className="sort-arrow">{order === "asc" ? "▲" : "▼"}</span>}
+                      {key === sort && (
+                        <span className={"sort-arrow" + (order === "desc" ? " desc" : "")}>▲</span>
+                      )}
                     </th>
                   )
                 )}

--- a/frontend/src/views/Listing.tsx
+++ b/frontend/src/views/Listing.tsx
@@ -1135,13 +1135,40 @@ export default function Listing({
     });
   }, [searching, q, validWalk, searchSort]);
 
-  const visibleHits = useMemo(() => hits.slice(0, visibleCount), [hits, visibleCount]);
+  // --- Stale-while-revalidate for search results (B3) -----------------------
+  // A dir-watch event bumps `refresh`, which makes validWalk read idle for the
+  // stale generation, which collapses `hits` to [] — so the entire visible
+  // result list used to blank to "Searching…" while the tree re-walked, for as
+  // long as that takes on a big folder. Hold the last ranked answer and keep
+  // rendering it (dimmed, with the spinner) until the fresh one is ready.
+  //
+  // This changes only what is DISPLAYED. The invalidation machinery is
+  // untouched: a stale walk is still never scored against a new tree — `hits`
+  // remains derived from validWalk alone, and these held rows are not fed back
+  // into scoring.
+  //
+  // Tagged with the query they were computed for, because the ONE thing this
+  // must never do is show the previous query's matches under a new query. A
+  // query change gives a different tag and falls through to "Searching…" as
+  // before; only a same-query invalidation holds.
+  const heldHits = useRef<{ q: string; hits: SearchHit[] } | null>(null);
+  if (!searching) heldHits.current = null;
+  else if (hits.length) heldHits.current = { q, hits };
+  // Only while the current-generation walk is genuinely unsettled. A COMPLETED
+  // walk with no hits is a real "no matches" answer (the file was just deleted,
+  // say) and must replace the held rows rather than preserve them forever.
+  const walkUnsettled = validWalk.status === "idle" || validWalk.status === "streaming";
+  const showingHeld =
+    searching && hits.length === 0 && walkUnsettled && heldHits.current?.q === q;
+  const displayHits = showingHeld ? (heldHits.current as { hits: SearchHit[] }).hits : hits;
+
+  const visibleHits = useMemo(() => displayHits.slice(0, visibleCount), [displayHits, visibleCount]);
 
   // Reveal the next page when the sentinel row (rendered only while more rows
   // exist) scrolls into view. rootMargin pre-triggers a bit before the bottom
   // so the next page is usually mounted by the time the user reaches it.
   const sentinelRef = useRef<HTMLTableRowElement | null>(null);
-  const hasMore = searching && hits.length > visibleCount;
+  const hasMore = searching && displayHits.length > visibleCount;
   useEffect(() => {
     const el = sentinelRef.current;
     if (!el || !hasMore) return;
@@ -1970,10 +1997,11 @@ export default function Listing({
           </td>
         </tr>
       );
-    } else if (validWalk.status === "ok" || validWalk.status === "streaming") {
-      if (hits.length) {
-        body = (
-          <>
+    } else if (displayHits.length) {
+      // Rows exist: either the fresh ranking, or the held one from the same
+      // query while a refresh-invalidated walk re-runs (showingHeld).
+      body = (
+        <>
             {visibleHits.map(({ entry, positions }) => {
               const childPath = base + "/" + entry.rel;
               return (
@@ -2031,27 +2059,26 @@ export default function Listing({
                 </td>
               </tr>
             )}
-          </>
-        );
-      } else {
-        // No matches. Say so honestly: distinguish "still looking" (stream
-        // running) and "the walk didn't even cover everything" (truncated) —
-        // the old UI showed a bare "No matches" even when the file existed
-        // in a region the capped walk never reached.
-        const message =
-          validWalk.status === "streaming"
-            ? `No matches yet — still searching (${validWalk.count.toLocaleString()} entries scanned)`
-            : validWalk.truncated
-            ? `No matches in the first ${validWalk.total.toLocaleString()} entries — this folder tree is too large to search fully`
-            : "No matches";
-        body = (
-          <tr>
-            <td colSpan={3} className="status-message">
-              {message}
-            </td>
-          </tr>
-        );
-      }
+        </>
+      );
+    } else if (validWalk.status === "ok" || validWalk.status === "streaming") {
+      // No matches. Say so honestly: distinguish "still looking" (stream
+      // running) and "the walk didn't even cover everything" (truncated) —
+      // the old UI showed a bare "No matches" even when the file existed
+      // in a region the capped walk never reached.
+      const message =
+        validWalk.status === "streaming"
+          ? `No matches yet — still searching (${validWalk.count.toLocaleString()} entries scanned)`
+          : validWalk.truncated
+          ? `No matches in the first ${validWalk.total.toLocaleString()} entries — this folder tree is too large to search fully`
+          : "No matches";
+      body = (
+        <tr>
+          <td colSpan={3} className="status-message">
+            {message}
+          </td>
+        </tr>
+      );
     } else {
       body = (
         <tr>
@@ -2248,7 +2275,9 @@ export default function Listing({
       <div className="listing-split" ref={splitRef}>
         <div
           ref={scrollRef}
-          className={"listing-scroll" + (isStale ? " listing-stale" : "")}
+          /* Dimmed both when the deferred render lags a keystroke and while
+             held (pre-refresh) results stand in for a re-running walk. */
+          className={"listing-scroll" + (isStale || showingHeld ? " listing-stale" : "")}
           onContextMenu={openBackgroundMenu}
         >
           <table className="listing-table">

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -154,7 +154,17 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
     }
   };
 
+  // The pane's iframe fades in on load (`.panel-pane iframe` starts at opacity
+  // 0, see shell.css) so a crumb click or a mode switch — both imperative src
+  // writes — dissolves through --bg instead of flashing an unpainted frame.
+  // Toggled directly on the node, like Tabs': the src writes below are already
+  // imperative by necessity (React must never rewrite a pane's src), so the
+  // fade is armed the same way. `className` is a constant prop, so React never
+  // rewrites the attribute and cannot clobber the token.
+  const armFade = () => iframeRef.current?.classList.remove("is-loaded");
+
   const onLoad = () => {
+    iframeRef.current?.classList.add("is-loaded");
     onUrlChange();
     // null when this document is already hooked — keep the existing hook.
     if (!iframeRef.current) return;
@@ -188,7 +198,9 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
           // Clicking a crumb navigates the pane's iframe to that prefix
           // (drops the pane-local query — a fresh location). Imperative src
           // write, exactly like vanilla — no React re-render involved.
-          if (iframeRef.current) iframeRef.current.src = embedSrc(targetPath, "");
+          if (!iframeRef.current) return;
+          armFade();
+          iframeRef.current.src = embedSrc(targetPath, "");
         }}
       >
         {label}
@@ -226,7 +238,9 @@ function Pane({ node, ctx }: { node: LayoutLeaf; ctx: PaneCtx }) {
           path={loc.path}
           query={loc.query}
           onNavigate={(q) => {
-            if (iframeRef.current) iframeRef.current.src = embedSrc(loc.path, q);
+            if (!iframeRef.current) return;
+            armFade();
+            iframeRef.current.src = embedSrc(loc.path, q);
           }}
         />
         <button className="panel-btn split-right" title="Split right" onClick={() => ctx.split(node.id, "row")}>

--- a/frontend/src/views/Preferences.tsx
+++ b/frontend/src/views/Preferences.tsx
@@ -30,6 +30,7 @@ import type { CallsParamsMode, Prefs } from "../lib/api";
 import { navigate, navigateUrl } from "../lib/router";
 import { notifyPrefsChanged } from "../lib/prefs";
 import { ErrorBanner } from "../components/ErrorBanner";
+import { SkeletonLines } from "../components/Skeleton";
 import { useThemePref } from "../lib/theme";
 import { AccountPanel } from "./Account";
 
@@ -451,7 +452,7 @@ export default function Preferences() {
   return (
     <div className="prefs-page">
       {error && <ErrorBanner>{error}</ErrorBanner>}
-      {!prefs && !error && <div className="deploy-muted">Loading…</div>}
+      {!prefs && !error && <SkeletonLines rows={4} label="Loading preferences" />}
       {prefs && (
         <>
           <div className="prefs-tabs">

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -311,6 +311,16 @@ function useConditions(fsPath: string, templates: TemplateEntry[]): Record<strin
 // reconciles against `share list`. A user who rebinds .html away from
 // "_render" loses the button too, consistently with losing the rendered view.
 
+// --- Held-frame mode swap (A1) ----------------------------------------------
+// How long the incoming preview frame takes to fade in over the outgoing one.
+// Must match `--dur-med` in shell.css (the CSS owns the actual transition; this
+// only decides when the outgoing frame may be unmounted).
+const FRAME_FADE_MS = 150;
+// Upper bound on holding the outgoing frame. A document that never fires `load`
+// (a /render 500, a wedged template daemon) must not strand the user on the
+// previous mode's content forever — past this the swap completes regardless.
+const FRAME_SWAP_TIMEOUT_MS = 4000;
+
 const DEPLOY_ICON = (
   <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
     <path d="M12 19V5" />
@@ -428,12 +438,15 @@ function TemplatePreview({
       onRenderedTitle?.(null);
     };
   }, [onRenderedTitle]);
-  const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>) => {
-    if (entry.mode !== "_render") return;
+  const onRenderFrameLoad = (e: React.SyntheticEvent<HTMLIFrameElement>, frameMode: string) => {
+    if (frameMode !== "_render" || entry.mode !== frameMode) return;
     // Guards a slow "_render" iframe's load firing AFTER a switch away from
-    // it: React already detached this exact node (key={mode} swaps it out),
-    // so a late event here is stale regardless of what entry.mode's closure
-    // says — isConnected is checked at call time, not closure-capture time.
+    // it. Two independent guards, both needed: the frame may still be
+    // CONNECTED (the held-frame swap keeps the outgoing frame mounted while the
+    // incoming one fades in), so the mode comparison above is what rejects a
+    // late load from a frame that is no longer the active one; isConnected
+    // still covers a frame React has already detached, checked at call time
+    // rather than closure-capture time.
     const frame = e.currentTarget;
     if (!frame.isConnected) return;
     const doc = frame.contentDocument;
@@ -459,16 +472,24 @@ function TemplatePreview({
   // mid-flight could resolve in either order, desyncing iframe key / local
   // state / shell `_mode`. Clicks during a pending switch are dropped.
   const switching = useRef(false);
+  // The mode a click is currently switching TO, or null. The flush in
+  // doSetMode can block for up to 10s on __fusedFlushEdits, and clicks landing
+  // in the meantime are dropped — with nothing on screen that read as a dead
+  // button, so the switcher shows a spinner on this entry until the iframe swap
+  // begins (A4).
+  const [switchingTo, setSwitchingTo] = useState<string | null>(null);
   const setMode = async (next: string) => {
     if (next === mode || switching.current) return;
     // Unresolved gate: not selectable (the switcher disables it too).
     const target = templates.find((t) => t.mode === next);
     if (target && isPending(target)) return;
     switching.current = true;
+    setSwitchingTo(next);
     try {
       await doSetMode(next);
     } finally {
       switching.current = false;
+      setSwitchingTo(null);
     }
   };
 
@@ -486,7 +507,10 @@ function TemplatePreview({
     // own banner explains). The 10s bound only catches a truly hung write so
     // the switcher can't wedge forever; timing out aborts the switch, never
     // the save.
-    const frame = document.querySelector<HTMLIFrameElement>(".preview-body iframe");
+    // `.is-shown` picks the ACTIVE frame: the held-frame swap can leave an
+    // outgoing frame mounted alongside it, and flushing that one's (already
+    // detached) editor buffer would be a no-op that silently loses edits.
+    const frame = document.querySelector<HTMLIFrameElement>(".preview-body iframe.is-shown");
     const flush = frame?.contentWindow && (frame.contentWindow as any).__fusedFlushEdits;
     if (typeof flush === "function") {
       try {
@@ -516,11 +540,54 @@ function TemplatePreview({
   // page can prefer ranged HTTP reads (/api/fs/raw) over local file I/O.
   // `_listing` builds no src — it renders a shell component, not an iframe.
   const remote = stat.remote ? "&_remote=1" : "";
-  const src = isListing
-    ? null
-    : entry.mode === "_render"
-      ? `/render?path=${encodeURIComponent(fsPath)}`
-      : `/render?path=${encodeURIComponent(entry.path as string)}&_file=${encodeURIComponent(fsPath)}${remote}`;
+  const srcFor = (m: string): string | null => {
+    if (m === "_listing") return null;
+    if (m === "_render") return `/render?path=${encodeURIComponent(fsPath)}`;
+    const t = templates.find((x) => x.mode === m);
+    return t ? `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(fsPath)}${remote}` : null;
+  };
+
+  // Held-frame swap. Switching mode used to destroy the iframe and mount the
+  // next one bare (`key={mode}`), so the user watched a blank pane for as long
+  // as the new document took to load. Now the OUTGOING frame stays mounted and
+  // visible while the incoming one mounts at opacity 0 and fades in on its own
+  // load event; the outgoing one is unmounted once the fade is over.
+  //
+  // `frames` is append-only in insertion order and is NEVER reordered: React
+  // re-parents a moved child, and re-parenting an iframe reloads its document
+  // (the same discipline Tabs.tsx keeps for its keep-alive frames). A→B→A
+  // therefore keeps [A, B] rather than swapping to [B, A]. Stacking is done
+  // with z-index (shell.css), not DOM order.
+  const [frames, setFrames] = useState<string[]>(() => (isListing ? [] : [mode]));
+  // Which frame is visible. Lags `mode` for the length of a swap; the initial
+  // frame is shown immediately (it fades from --bg, not from white, so there is
+  // nothing to hold back for).
+  const [shown, setShown] = useState<string>(mode);
+  const framePending = isListing || isPending(entry);
+  useLayoutEffect(() => {
+    // Layout effect: the incoming frame must be in the DOM before the paint
+    // that starts its fade, or the transition has no `from` value to run from.
+    if (framePending) {
+      setFrames([]);
+      setShown(mode);
+      return;
+    }
+    setFrames((f) => (f.includes(mode) ? f : [...f, mode]));
+  }, [mode, framePending]);
+  // A frame whose document never fires `load` must not strand the user on the
+  // previous mode's content: past FRAME_SWAP_TIMEOUT_MS the swap completes
+  // regardless of what the incoming frame did.
+  useEffect(() => {
+    if (shown === mode || framePending) return;
+    const id = window.setTimeout(() => setShown(mode), FRAME_SWAP_TIMEOUT_MS);
+    return () => window.clearTimeout(id);
+  }, [shown, mode, framePending]);
+  // Retire the frames the swap left behind, once the incoming one has faded in.
+  useEffect(() => {
+    if (frames.length <= 1 || shown !== mode) return;
+    const id = window.setTimeout(() => setFrames([mode]), FRAME_FADE_MS);
+    return () => window.clearTimeout(id);
+  }, [frames, shown, mode]);
 
   // Embed hides the whole preview-header, hence the switcher (shell.css). A
   // directory whose mode list carries `_listing` alongside another mode (a
@@ -579,6 +646,10 @@ function TemplatePreview({
         <ModeSwitcher
           entries={templates.map((t) => ({ mode: t.mode, icon: templateModeIcon(t), pending: isPending(t) }))}
           active={entry.mode}
+          /* Spinner from the click until the incoming frame has actually taken
+             over — the flush wait AND the new document's load are both time the
+             user is waiting on that button. */
+          busy={switchingTo ?? (shown !== mode ? mode : null)}
           onSelect={setMode}
         />
       </Header>
@@ -594,8 +665,24 @@ function TemplatePreview({
         ) : isListing ? (
           <Listing fsPath={fsPath} onSingleApp={setSingleAppPath} />
         ) : (
-          /* key: switching mode replaces the iframe (fresh document per switch). */
-          <iframe key={mode} src={src as string} onLoad={onRenderFrameLoad} />
+          /* One frame per mounted mode (see the held-frame swap above). Each
+             key is its own mode, so a frame is created once and never
+             re-created by a switch away and back within the swap window. */
+          <div className="preview-frames">
+            {frames.map((m) => (
+              <iframe
+                key={m}
+                className={"preview-frame" + (m === shown ? " is-shown" : "")}
+                src={srcFor(m) as string}
+                onLoad={(e) => {
+                  // Completes the swap: the incoming document has painted, so
+                  // it can take over from the frame being held.
+                  if (m === mode) setShown(m);
+                  onRenderFrameLoad(e, m);
+                }}
+              />
+            ))}
+          </div>
         )}
         {toggleListing && (
           <button type="button" className="preview-browse-chip" onClick={toggleListing}>

--- a/frontend/src/views/Preview.tsx
+++ b/frontend/src/views/Preview.tsx
@@ -563,6 +563,14 @@ function TemplatePreview({
   // frame is shown immediately (it fades from --bg, not from white, so there is
   // nothing to hold back for).
   const [shown, setShown] = useState<string>(mode);
+  // Modes whose frame has fired `load` at least once and is STILL mounted. A
+  // frame the append-only list kept alive will never fire `load` again, so
+  // switching back to it (A→B→A inside the swap window) has no event to complete
+  // the swap with — without this the 4s fallback below was the only thing that
+  // ever made it visible again, i.e. the user sat on mode B for four seconds
+  // after asking for A. Entries are dropped when their frame is retired: a later
+  // mount of the same mode is a NEW document that has to load again.
+  const loadedFrames = useRef<Set<string>>(new Set());
   const framePending = isListing || isPending(entry);
   useLayoutEffect(() => {
     // Layout effect: the incoming frame must be in the DOM before the paint
@@ -570,9 +578,16 @@ function TemplatePreview({
     if (framePending) {
       setFrames([]);
       setShown(mode);
+      loadedFrames.current.clear(); // every frame unmounts with them
       return;
     }
     setFrames((f) => (f.includes(mode) ? f : [...f, mode]));
+    // Already mounted AND already loaded: complete the swap now rather than
+    // waiting for a load event that cannot come. The `.is-shown` flip still
+    // cross-fades through the CSS transition, so this is the same swap, just
+    // without the wait. Frames that are mounted but not yet loaded keep the
+    // load/timeout path below.
+    if (loadedFrames.current.has(mode)) setShown(mode);
   }, [mode, framePending]);
   // A frame whose document never fires `load` must not strand the user on the
   // previous mode's content: past FRAME_SWAP_TIMEOUT_MS the swap completes
@@ -585,7 +600,11 @@ function TemplatePreview({
   // Retire the frames the swap left behind, once the incoming one has faded in.
   useEffect(() => {
     if (frames.length <= 1 || shown !== mode) return;
-    const id = window.setTimeout(() => setFrames([mode]), FRAME_FADE_MS);
+    const id = window.setTimeout(() => {
+      setFrames([mode]);
+      // Their documents are gone with them, so they are no longer "loaded".
+      for (const m of [...loadedFrames.current]) if (m !== mode) loadedFrames.current.delete(m);
+    }, FRAME_FADE_MS);
     return () => window.clearTimeout(id);
   }, [frames, shown, mode]);
 
@@ -676,7 +695,10 @@ function TemplatePreview({
                 src={srcFor(m) as string}
                 onLoad={(e) => {
                   // Completes the swap: the incoming document has painted, so
-                  // it can take over from the frame being held.
+                  // it can take over from the frame being held. Recorded so a
+                  // switch BACK to this still-mounted frame can complete
+                  // without a second load event (see loadedFrames).
+                  loadedFrames.current.add(m);
                   if (m === mode) setShown(m);
                   onRenderFrameLoad(e, m);
                 }}

--- a/frontend/src/views/Tabs.tsx
+++ b/frontend/src/views/Tabs.tsx
@@ -150,6 +150,13 @@ function TabFrame({
   };
 
   const onLoad = () => {
+    // Fade in instead of flashing an unpainted frame (`.tabs-body iframe`
+    // starts at opacity 0, see shell.css). Toggled on the DOM node rather than
+    // through state because the tab bar's mode menu also writes this iframe's
+    // src imperatively (framesRef) and has to be able to re-arm the fade
+    // without owning React state here; `className` is a constant prop, so
+    // React never rewrites the attribute and can't clobber the token.
+    iframeRef.current?.classList.add("is-loaded");
     onUrlChange();
     // null when this document is already hooked — keep the existing hook.
     if (!iframeRef.current) return;
@@ -165,6 +172,7 @@ function TabFrame({
         iframeRef.current = el;
         onFrame(el);
       }}
+      className="tab-frame"
       src={srcRef.current}
       onLoad={onLoad}
       style={active ? undefined : { display: "none" }}
@@ -314,7 +322,11 @@ export default function Tabs({ config }: { config: Config }) {
                 query={t.query}
                 onNavigate={(q) => {
                   const f = framesRef.current.get(t.id);
-                  if (f) f.src = embedSrc(t.path, q);
+                  if (!f) return;
+                  // Re-arm the load fade (TabFrame.onLoad puts it back) so the
+                  // reload dissolves through --bg instead of flashing white.
+                  f.classList.remove("is-loaded");
+                  f.src = embedSrc(t.path, q);
                 }}
               />
             )}

--- a/frontend/src/views/Templates.tsx
+++ b/frontend/src/views/Templates.tsx
@@ -19,6 +19,7 @@ import { NewTemplateModal } from "./templates/NewTemplateModal";
 import { RowEditorModal } from "./templates/RowEditorModal";
 import { navigateUrl } from "../lib/router";
 import { ErrorBanner } from "../components/ErrorBanner";
+import { SkeletonLines } from "../components/Skeleton";
 
 type PageTab = "bindings" | "library";
 
@@ -98,7 +99,7 @@ export default function Templates() {
         </button>
       </div>
       {error && <ErrorBanner>{error}</ErrorBanner>}
-      {!error && (!inventory || !registry) && <div className="deploy-muted">Loading…</div>}
+      {!error && (!inventory || !registry) && <SkeletonLines rows={5} label="Loading templates" />}
       {inventory && registry && tab === "bindings" && (
         <BindingsTable
           registry={registry}


### PR DESCRIPTION
## Summary

- Gives the shell a consistent motion system (three duration tokens — 80/150/200ms, `ease-out`) and applies it everywhere state changes used to hard-cut: iframe swaps no longer white-flash, toasts/modals/context menus animate in *and* out, routes fade in, the sidebar collapse glides, and hover/press states ease instead of snapping.
- Fixes the worst listing interaction: a dir-watch event mid-search no longer blanks the entire result list while the tree re-walks — previous results stay rendered (dimmed) until fresh ones arrive, and streaming re-ranks are batched (≤1 visible update per 280ms) so rows stop shuffling under the cursor.
- Sorting is now legible: rows FLIP to their new positions instead of teleporting, search headers cycle asc → desc → back to relevance (previously unreachable), and an ordering chip shows/reset the current search sort. Dir-watch changes in the plain listing get a fading highlight on new rows plus scroll anchoring.
- Slow clicks get immediate feedback: mode switches show a spinner during the (up to 10s) edit-flush guard, and sidebar folder toggles flip optimistically before the async store write.

All CSS transitions/animations inherit the existing global `prefers-reduced-motion` kill-switch. No new runtime dependencies.

## Visuals

The highest-impact change — mode switches used to destroy and recreate the iframe, flashing blank on every switch. Now the old frame is held until the new one has painted:

```mermaid
flowchart TD
    A[User clicks mode] --> B[Spinner on clicked entry]
    B --> C[Flush pending edits]
    C --> D[New iframe mounts on top, opacity 0]
    D --> E{New frame load fires}
    E -->|yes| F[Cross-fade 150ms, old frame stays visible beneath]
    E -->|no load within 4s| F
    F --> G[Old iframe unmounted]
```

The same held-frame/fade-on-load treatment applies to panel pane navigation and first tab activation.

## Usage

Not user-invocable — pure UX polish; every existing interaction behaves the same, just with motion. Two small behavior additions:

- While searching, clicking a column header a third time now returns to relevance ranking; the chip next to the match count shows the active ordering and clicking it restores relevance.
- New files appearing in a watched folder are briefly highlighted.

## Test Plan

- [x] 19 new unit tests (`toast.test.ts`, `exit-animation.test.ts`, `flip.test.ts`) — toast leaving-state, deferred-close hook, FLIP key-diff; `bun test`: 40 pass / 0 fail
- [x] `bun run build` (tsc + vite) green; standalone `tsc --noEmit` clean
- [x] Full Python suite from a fresh worktree: 3769 passed, 125 skipped (one pre-existing macOS-only failure, `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, reads `/proc/self/fd` — unrelated)
- [x] Browser-verified: iframe cross-fade (both frames mounted mid-fade), toast exit mid-animation, modal enter/exit + Escape + focus restore, slide-over slide-out, FLIP on sort click, search sort cycle + relevance chip, context-menu clamp/origin, new-row highlight — zero console errors throughout
- [ ] Not visually exercised (logic verified, animation not watched): sidebar collapse glide, search stale-while-revalidate hold on a large tree being written mid-search, scroll anchoring with insertions above the viewport, `prefers-reduced-motion` on

🤖 Generated with [Claude Code](https://claude.com/claude-code)
