### PR TITLE
Home: add Learn doorway card

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
   takeLastAddedBookmarkId,
 } from "../lib/bookmarks";
 import { bookmarkSaveTarget } from "../lib/bookmark-file";
-import { exportBookmarkFile, getConfig, statPath } from "../lib/api";
+import { exportBookmarkFile, statPath } from "../lib/api";
 import IconPicker from "./IconPicker";
 import { FolderIcon, LearnIcon } from "./FileIcons";
 import type { Bookmark, BookmarkFolder, BookmarkItem } from "../lib/bookmarks";
@@ -45,6 +45,7 @@ import {
   notifyBookmarksChanged,
   useRecentsVersion,
   useArmedVersion,
+  useLearnMountReady,
 } from "../lib/hooks";
 import type { Config } from "../lib/api";
 import { splitShellSearch } from "../lib/layout-codec";
@@ -344,77 +345,9 @@ export default function Sidebar({ config }: SidebarProps) {
   const accountLoggedIn = useAccountLoggedIn();
   const deployEnabled = useDeployEnabled();
 
-  // BUGBOT: config (and its learn_mount_ready flag) is fetched exactly ONCE
-  // at page load (main.tsx), well before the server's background automount
-  // thread has finished attaching the learn mount — ensure_learn_mount now
-  // force-detaches and remounts it on every startup, so the one-shot fetch
-  // essentially always sees false and the Learn entry would never appear
-  // for the whole session. Re-poll /api/config on a short bounded interval
-  // (mirrors main.tsx's own bookmark-poll pattern) until it flips true;
-  // capped at MAX_ATTEMPTS so a dev checkout with no bundled learn.zip
-  // (never becomes ready) doesn't poll forever.
-  //
-  // BUGBOT: the bound must comfortably exceed attach_mount's own worst case
-  // — up to ~10s for ensure_rcd to spawn/confirm the rclone daemon, plus a
-  // full 60s mount/mount rc timeout (shell/mounts.py) — or a slow-but-
-  // eventually-successful mount finishes after the poll gives up and the
-  // entry never appears without a full page reload. 2s x 60 = 120s, safely
-  // past that ~70s worst case with margin.
-  //
-  // BUGBOT: gating the poll on "only start if the INITIAL fetch saw false"
-  // was itself racy — rcd survives server restarts, so the boot-time
-  // /api/config fetch can catch a still-live mount from the PRIOR run and
-  // report true, moments before ensure_learn_mount's own forced detach (see
-  // its docstring) rips that very mount out from under it. Polling would
-  // then never engage at all, and the entry would point at an empty
-  // mountpoint for the remount window — or the whole session, if the
-  // remount fails. So this always re-verifies via a live poll after mount,
-  // regardless of the seeded initial value, and follows whatever the fresh
-  // answer says (including back to not-ready, if the detach window is
-  // caught mid-poll) rather than trusting the one-shot snapshot as final.
-  const [learnMountReady, setLearnMountReady] = useState(config.learn_mount_ready);
-  useEffect(() => {
-    let cancelled = false;
-    let attempts = 0;
-    // BUGBOT: setInterval fires a new getConfig() every tick without
-    // waiting for the previous one to settle, so responses can arrive
-    // out of order (a slow earlier request resolving AFTER a faster later
-    // one). Unconditionally applying whatever resolves most recently in
-    // WALL-CLOCK order let a stale `false` from an earlier in-flight
-    // request overwrite a `true` a later request already reported —
-    // permanently, since that `true` had already cleared the interval.
-    // latestRequestId tracks which tick's request is the newest ISSUED
-    // one; only that request's response is applied, so a straggler from
-    // an earlier tick is discarded as stale rather than overwriting it.
-    let latestRequestId = 0;
-    const MAX_ATTEMPTS = 60;
-    const POLL_MS = 2000;
-    const timer = window.setInterval(() => {
-      attempts += 1;
-      const requestId = ++latestRequestId;
-      getConfig().then(
-        (fresh) => {
-          if (cancelled || requestId !== latestRequestId) return;
-          setLearnMountReady(fresh.learn_mount_ready);
-          if (fresh.learn_mount_ready || attempts >= MAX_ATTEMPTS) {
-            window.clearInterval(timer);
-          }
-        },
-        () => {
-          if (cancelled || requestId !== latestRequestId) return;
-          // Transient fetch failure — just try again next tick.
-          if (attempts >= MAX_ATTEMPTS) window.clearInterval(timer);
-        }
-      );
-    }, POLL_MS);
-    return () => {
-      cancelled = true;
-      window.clearInterval(timer);
-    };
-    // Deliberately empty deps: run once on mount only. Depending on
-    // learnMountReady here would restart the whole bounded poll window
-    // from zero every time it changes.
-  }, []);
+  // Bounded /api/config re-poll for the learn mount (see useLearnMountReady
+  // for the full race notes — the boot snapshot is stale in both directions).
+  const learnMountReady = useLearnMountReady(config.learn_mount_ready);
 
   // Sidebar chrome: draggable width + collapsed flag, persisted once per
   // gesture (drag end / toggle), not per mousemove. Width lives in React

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -159,10 +159,22 @@ export function useDocumentTitle(label: string | null | undefined): void {
 // = 120s) comfortably exceeds attach_mount's ~70s worst case (ensure_rcd
 // spawn + full 60s mount rc timeout, shell/mounts.py) so a slow-but-
 // successful mount isn't missed; the cap keeps a dev checkout with no
-// bundled learn.zip (never becomes ready) from polling forever.
+// bundled learn.zip (never becomes ready) from polling forever. Once any
+// mount confirms true, that result is cached at module scope (below) so a
+// later remount of the hook doesn't re-litigate it against a stale seed.
+// Module-level cache of the last CONFIRMED-true readiness, shared by every
+// mount of the hook. Home unmounts/remounts on every visit to "/" (it's a
+// route, not persistent chrome like Sidebar), so without this a return visit
+// re-seeds from the stale boot `initial` (still false) and restarts the
+// bounded poll from scratch — the Learn card would vanish for up to 2s and
+// reflow the grid on every trip back to Home, even though readiness was
+// already confirmed earlier in the session.
+let cachedReady = false;
+
 export function useLearnMountReady(initial: boolean): boolean {
-  const [ready, setReady] = useState(initial);
+  const [ready, setReady] = useState(cachedReady || initial);
   useEffect(() => {
+    if (cachedReady) return; // already confirmed — nothing left to poll for
     let cancelled = false;
     let attempts = 0;
     // setInterval fires a new getConfig() every tick without waiting for the
@@ -181,7 +193,10 @@ export function useLearnMountReady(initial: boolean): boolean {
         (fresh) => {
           if (cancelled || requestId !== latestRequestId) return;
           setReady(fresh.learn_mount_ready);
-          if (fresh.learn_mount_ready || attempts >= MAX_ATTEMPTS) {
+          if (fresh.learn_mount_ready) {
+            cachedReady = true;
+            window.clearInterval(timer);
+          } else if (attempts >= MAX_ATTEMPTS) {
             window.clearInterval(timer);
           }
         },

--- a/frontend/src/lib/hooks.ts
+++ b/frontend/src/lib/hooks.ts
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { NAV_EVENT } from "./router";
 import { createCloseDeferrer } from "./exit-animation";
+import { getConfig } from "./api";
 
 function useEventCounter(events: readonly string[]): number {
   const [n, setN] = useState(0);
@@ -145,4 +146,60 @@ export function useDocumentTitle(label: string | null | undefined): void {
     if (label === undefined) return;
     document.title = label ? `${label} – Fused Render` : "Fused Render";
   }, [label]);
+}
+
+// Whether the builtin learn mount is attached and browsable. Seeded from the
+// boot-time config snapshot, then re-verified by a bounded /api/config poll —
+// the one-shot fetch (main.tsx) lands well before the server's background
+// automount thread finishes attaching the mount, so the snapshot essentially
+// always says false; and the inverse race exists too (rcd survives server
+// restarts, so boot can catch the PRIOR run's still-live mount reporting true
+// moments before ensure_learn_mount's forced detach rips it out), so the poll
+// always runs and follows whatever the fresh answer says. The bound (2s x 60
+// = 120s) comfortably exceeds attach_mount's ~70s worst case (ensure_rcd
+// spawn + full 60s mount rc timeout, shell/mounts.py) so a slow-but-
+// successful mount isn't missed; the cap keeps a dev checkout with no
+// bundled learn.zip (never becomes ready) from polling forever.
+export function useLearnMountReady(initial: boolean): boolean {
+  const [ready, setReady] = useState(initial);
+  useEffect(() => {
+    let cancelled = false;
+    let attempts = 0;
+    // setInterval fires a new getConfig() every tick without waiting for the
+    // previous one to settle, so responses can arrive out of order. Only the
+    // newest ISSUED request's response is applied — a straggler from an
+    // earlier tick is discarded as stale rather than overwriting a `true` a
+    // later request already reported (which would stick permanently, since
+    // that `true` had already cleared the interval).
+    let latestRequestId = 0;
+    const MAX_ATTEMPTS = 60;
+    const POLL_MS = 2000;
+    const timer = window.setInterval(() => {
+      attempts += 1;
+      const requestId = ++latestRequestId;
+      getConfig().then(
+        (fresh) => {
+          if (cancelled || requestId !== latestRequestId) return;
+          setReady(fresh.learn_mount_ready);
+          if (fresh.learn_mount_ready || attempts >= MAX_ATTEMPTS) {
+            window.clearInterval(timer);
+          }
+        },
+        () => {
+          if (cancelled || requestId !== latestRequestId) return;
+          // Transient fetch failure — just try again next tick.
+          if (attempts >= MAX_ATTEMPTS) window.clearInterval(timer);
+        }
+      );
+    }, POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+    // Deliberately empty deps: run once on mount only. Depending on `ready`
+    // here would restart the whole bounded poll window from zero every time
+    // it changes, and `initial` is only a seed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return ready;
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -5982,10 +5982,14 @@ select.field-control:has(option[value=""]:checked) {
 
 /* Doorways: equal cards, one per entry point (3, or 4 once the learn mount
    is ready). Glyph square repaints from the inline per-card hue (file-icon
-   palette). auto-fit keeps the row full either way. */
+   palette). auto-fit keeps the row full either way. 150px (not a rounder
+   180px) is deliberate: it's the largest track width that still lets all
+   four cards fit on one row all the way down to the 761px single-column
+   breakpoint below, inside .home-inner's padding — anything bigger strands
+   the 4th card onto its own row at common tablet widths (e.g. 768px). */
 .home-doors {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 14px;
 }
 

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -5980,11 +5980,12 @@ select.field-control:has(option[value=""]:checked) {
   padding: 5px 8px;
 }
 
-/* Doorways: three equal cards, one per entry point. Glyph square repaints
-   from the inline per-card hue (file-icon palette). */
+/* Doorways: equal cards, one per entry point (3, or 4 once the learn mount
+   is ready). Glyph square repaints from the inline per-card hue (file-icon
+   palette). auto-fit keeps the row full either way. */
 .home-doors {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 14px;
 }
 

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -3,16 +3,17 @@
 //   1. Hero card — headline + blurb + the prompt composer (describe an app,
 //      haiku names it, POST /api/apps/new scaffolds it). The structured
 //      NewAppPanel is exported from here but opens from /apps.
-//   2. Doorways — three equal cards for the app's entry points: file
-//      explorer, apps hub (the Fused workspace dir), templates manager.
+//   2. Doorways — equal cards for the app's entry points: file explorer,
+//      apps hub (the Fused workspace dir), templates manager, and — once
+//      the bundled learn mount is ready — the Learn lessons.
 //   3. Recent — the 10 most recently updated apps (GET /api/apps), sorted
 //      once per fetch so the grid never reorders under interaction; keys
 //      are stable paths.
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { aiComplete, createApp, getApps } from "../lib/api";
+import { aiComplete, createApp, getApps, statPath } from "../lib/api";
 import type { Config } from "../lib/api";
-import { navigate, navigateUrl, urlForFsPath } from "../lib/router";
+import { currentUrl, navigate, navigateUrl, urlForFsPath } from "../lib/router";
 import { ErrorBanner } from "../components/ErrorBanner";
 import { TextInput, TextArea } from "../components/field/fields";
 import { basename } from "../lib/format";
@@ -661,6 +662,29 @@ function Doorway({
 export default function Home({ config }: { config: Config }) {
   const [apps, reloadApps] = useLoad(getApps);
 
+  // Same landing logic as the Sidebar's Learn entry (D123): the bundled
+  // learn.zip is mounted read-only at `${mounts_root}/learn`; prefer its
+  // index.html as the landing page, fall back to the mount folder.
+  const openLearn = async () => {
+    if (!config.mounts_root) return;
+    const root = `${config.mounts_root.replace(/\/+$/, "")}/learn`;
+    // The stat can be slow (mount-backed read); if the user navigated
+    // elsewhere while it was in flight, don't yank them back.
+    const before = currentUrl();
+    let dest = root;
+    let destIsDir = true;
+    try {
+      const st = await statPath(`${root}/index.html`);
+      if (!st.is_dir) {
+        dest = `${root}/index.html`;
+        destIsDir = false;
+      }
+    } catch {
+      // stat 404s (or the mount is briefly not attached) — open the folder.
+    }
+    if (currentUrl() === before) navigate(dest, { isDir: destIsDir });
+  };
+
   return (
     <div className="home-page">
       <div className="home-inner">
@@ -728,6 +752,21 @@ export default function Home({ config }: { config: Config }) {
               </svg>
             }
           />
+          {config.learn_mount_ready && (
+            <Doorway
+              hue="var(--icon-data)"
+              title="Learn"
+              desc="Guided lessons that teach fused-render by example, right in the app."
+              onClick={openLearn}
+              glyph={
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M12 7v13" />
+                  <path d="M3 6a2 2 0 0 1 2-2h4a3 3 0 0 1 3 3v13a2.5 2.5 0 0 0-2.5-2.5H3Z" />
+                  <path d="M21 6a2 2 0 0 0-2-2h-4a3 3 0 0 0-3 3v13a2.5 2.5 0 0 1 2.5-2.5H21Z" />
+                </svg>
+              }
+            />
+          )}
         </div>
 
         <section className="home-section">

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -18,7 +18,7 @@ import { ErrorBanner } from "../components/ErrorBanner";
 import { TextInput, TextArea } from "../components/field/fields";
 import { basename } from "../lib/format";
 import { isMod, MOD_LABEL } from "../lib/platform";
-import { useDeferredClose } from "../lib/hooks";
+import { useDeferredClose, useLearnMountReady } from "../lib/hooks";
 import { PANEL_EXIT_MS } from "../lib/exit-animation";
 import { AppCard } from "../components/AppCard";
 import { SkeletonLines } from "../components/Skeleton";
@@ -661,6 +661,10 @@ function Doorway({
 
 export default function Home({ config }: { config: Config }) {
   const [apps, reloadApps] = useLoad(getApps);
+  // The boot-time config snapshot's learn_mount_ready is stale in both
+  // directions (see useLearnMountReady) — without the bounded re-poll the
+  // Learn doorway would essentially never appear.
+  const learnMountReady = useLearnMountReady(config.learn_mount_ready);
 
   // Same landing logic as the Sidebar's Learn entry (D123): the bundled
   // learn.zip is mounted read-only at `${mounts_root}/learn`; prefer its
@@ -752,7 +756,7 @@ export default function Home({ config }: { config: Config }) {
               </svg>
             }
           />
-          {config.learn_mount_ready && (
+          {learnMountReady && (
             <Doorway
               hue="var(--icon-data)"
               title="Learn"


### PR DESCRIPTION
## Summary
- Adds a **Learn** doorway card to the homepage entry-point grid, shown once the bundled learn mount is ready (`config.learn_mount_ready`).
- Clicking reuses the Sidebar's D123 landing logic: stat `${mounts_root}/learn/index.html` and open it if present, otherwise open the mount folder; navigation is skipped if the user moved elsewhere while the stat was in flight.
- `.home-doors` now uses `repeat(auto-fit, minmax(180px, 1fr))` so the row stays full with either three or four cards.

## Testing
- `npm run build` (typecheck + vite build) passes.
- Dev preview: `FUSED_RENDER_LEARN_ZIP=/tmp/learn.zip ./scripts/dev.sh` after zipping the `learn/` dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only entry point and hook refactor; navigation uses the same guarded stat pattern as the sidebar with no auth or data-model changes.
> 
> **Overview**
> Adds a **Learn** doorway on the home page when the bundled learn mount is ready, using the same landing behavior as the sidebar (prefer `${mounts_root}/learn/index.html`, skip navigation if the user moved away during `statPath`).
> 
> **Learn mount readiness** is no longer polled only in the sidebar: logic moves into **`useLearnMountReady`** in `hooks.ts`, with a session-level cache so remounting Home does not restart polling or briefly hide Learn after it was already confirmed.
> 
> The home doorway grid uses **`repeat(auto-fit, minmax(150px, 1fr))`** so three or four cards lay out cleanly on typical tablet widths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebab32304351ce07222a62eac72fdc7c8eb3841f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->