### PR TITLE
pdf_studio: retry the atomic replace that Windows intermittently denies

### DIFF
--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -51,8 +51,10 @@ Actions
 import hashlib
 import json
 import os
+import random
 import re
 import shutil
+import time
 
 # NOTE: bare `def main` (no @fused.udf) is deliberate — under the built-in
 # executor the worker calls main() by its own signature; @fused.udf hides that
@@ -99,6 +101,23 @@ def _unique_path(directory, name):
         dest = os.path.join(directory, f"{stem}-{i}{ext}")
         i += 1
     return dest
+
+
+def _replace(tmp, dst):
+    """os.replace, retried until a 1.5s deadline: on Windows the rename fails
+    outright while anyone else still holds a handle on dst — a superseded worker
+    on its way out, an AV scanner that opened the file behind us. The waits are
+    short and randomized on purpose, to sample many small windows rather than a
+    handful of long ones (a backoff can resonate with a periodic holder)."""
+    deadline = time.monotonic() + 1.5
+    while True:
+        try:
+            os.replace(tmp, dst)
+            return
+        except OSError:
+            if time.monotonic() >= deadline:
+                raise
+            time.sleep(random.uniform(0.01, 0.04))
 
 
 def _parse_pages(spec: str, n: int):
@@ -220,7 +239,7 @@ def _work_rename(old, new):
     ow, om = _work_paths(old)
     nw, _ = _work_paths(new)
     if os.path.exists(ow):
-        os.replace(ow, nw)
+        _replace(ow, nw)
     meta["src"] = _fwd(os.path.abspath(new))
     _work_save_state(new, meta)
     os.remove(om)
@@ -243,7 +262,7 @@ def _save(doc, force):
         return {"conflict": True}
     tmp = src + ".tmp"
     shutil.copyfile(wpath, tmp)
-    os.replace(tmp, src)
+    _replace(tmp, src)
     meta["base_mtime"] = os.path.getmtime(src)
     meta["dirty"] = False
     _work_save_state(src, meta)
@@ -314,7 +333,7 @@ def _push_snapshot(doc, op, pre):
 def _restore(doc, snap):
     tmp = doc + ".tmp"
     shutil.copyfile(snap, tmp)
-    os.replace(tmp, doc)
+    _replace(tmp, doc)
 
 
 def _undo(doc):
@@ -400,10 +419,12 @@ def _rotate_pages(doc, pages, degrees):
     import pikepdf
 
     def fn(path):
-        with pikepdf.open(path, allow_overwriting_input=True) as pdf:
+        tmp = path + ".tmp"
+        with pikepdf.open(path) as pdf:
             for i in _parse_pages(pages, len(pdf.pages)):
                 pdf.pages[i].rotate(degrees, relative=True)
-            pdf.save(path)
+            pdf.save(tmp)
+        _replace(tmp, path)
     return fn(doc)
 
 
@@ -411,13 +432,15 @@ def _delete_pages(doc, pages):
     import pikepdf
 
     def fn(path):
-        with pikepdf.open(path, allow_overwriting_input=True) as pdf:
+        tmp = path + ".tmp"
+        with pikepdf.open(path) as pdf:
             idxs = _parse_pages(pages, len(pdf.pages))
             if len(idxs) >= len(pdf.pages):
                 raise ValueError("cannot delete every page")
             for i in reversed(idxs):
                 del pdf.pages[i]
-            pdf.save(path)
+            pdf.save(tmp)
+        _replace(tmp, path)
     return fn(doc)
 
 
@@ -425,7 +448,8 @@ def _reorder_pages(doc, order):
     import pikepdf
 
     def fn(path):
-        with pikepdf.open(path, allow_overwriting_input=True) as pdf:
+        tmp = path + ".tmp"
+        with pikepdf.open(path) as pdf:
             n = len(pdf.pages)
             idxs = [int(t) - 1 for t in order.split(",") if t.strip()]
             if sorted(idxs) != list(range(n)):
@@ -433,7 +457,8 @@ def _reorder_pages(doc, order):
             for i in idxs:
                 pdf.pages.append(pdf.pages[i])
             del pdf.pages[0:n]
-            pdf.save(path)
+            pdf.save(tmp)
+        _replace(tmp, path)
     return fn(doc)
 
 
@@ -449,7 +474,7 @@ def _insert_blank(doc, at, width, height):
         tmp = path + ".tmp"
         d.save(tmp, deflate=True, encryption=fitz.PDF_ENCRYPT_KEEP)
         d.close()
-        os.replace(tmp, path)
+        _replace(tmp, path)
     return fn(doc)
 
 
@@ -550,7 +575,7 @@ def _compress(doc, level):
             os.remove(tmp)
             raise ValueError(
                 f"already optimized — {level} compression would not shrink the file")
-        os.replace(tmp, path)
+        _replace(tmp, path)
         return {"before": before, "after": after}
     return fn(doc)
 


### PR DESCRIPTION
## What

PDF Studio mutations intermittently failed on Windows (~1 in 200 calls) with:

```
PermissionError: [WinError 5] Access is denied:
  '...\.fused-render\cache\pdf_studio\work\.pikepdf.<hash>.pdf<rand>'
  -> '...\cache\pdf_studio\work\<hash>.pdf'
```

Reproduced while driving `rotate_pages` in a Playwright loop. User-visible symptom was a red error status plus a toast; the working copy was left untouched, so no data was lost.

## Why

`os.replace` is `MoveFileExW`, which has to delete the destination's directory entry. That fails outright while any other process holds a handle on the destination that lacks `FILE_SHARE_DELETE` — a superseded worker subprocess on its way out, or an AV scanner that opened the file behind us. Nothing is wrong with the PDF or the write; the rename just needs to happen a moment later.

## How

New helper `_replace(tmp, dst)` retries until a 1.5 s deadline with short randomized waits, then raises. Every swap that targets a PDF now goes through it:

- the three pikepdf page ops (`_rotate_pages`, `_delete_pages`, `_reorder_pages`)
- `_insert_blank`, `_compress`
- `_restore` (undo/redo)
- `_save` (writes the original) and `_work_rename`

The JSON sidecar writes (`_work_save_state`, `_stack_save`, `_lib_save`) stay on plain `os.replace` — they overwrite small files we just created in our own dirs and have never shown contention.

## Reviewer notes

**The page ops needed a structural change first.** With `allow_overwriting_input=True` the rename happens inside pikepdf's own `atomic_overwrite` (`pikepdf/_io.py`), out of reach of any retry we add. They now drop the flag, `pdf.save(tmp)` inside the `with`, and replace after close — the shape `_compress` and `_insert_blank` already used. I verified pikepdf leaves no lingering handle on the input once the context exits: 15 rounds of mixed ops with **no** external holder produced 0 failures, so dropping the flag introduces no self-contention.

**The randomized waits are load-bearing, not decoration.** My first attempt used a fixed 5-attempt 50–200 ms backoff and it still failed ~10% of the time under test — a fixed delay sequence resonates with a periodic holder and can miss every free window. Polling densely at 10–40 ms samples ~60 windows in the same wall-clock budget.

**A bounded retry deliberately does not save you from a permanent holder.** If another process holds the file forever, the call still raises `PermissionError` after ~1.5 s. That is the correct outcome: the working copy is intact and a retry from the UI works.

**Not changed:** `_edit_text` saves with `incremental=True` directly into the working copy, so it has no replace step to retry. It does open the file for write and could hit a sharing violation under the same contention, but that would surface as a different traceback (from MuPDF, not `atomic_overwrite`), and converting it to a full save would change its fidelity/speed characteristics. Left alone.

## Verification

A second process doing plain `open(path, "rb")` is enough to reproduce — CPython's `open()` shares read+write but **not** delete, exactly what `MoveFileEx` needs.

| Scenario | Result |
| --- | --- |
| `rotate_pages` x40, holder 80 ms on / 40 ms off | 40 ok / 0 fail |
| same conditions, `_replace` swapped back to bare `os.replace` | 16 ok / **24 fail** — reproduces the reported traceback verbatim |
| all 7 mutations x10 each, same holder | 0 fail |
| 200 mixed mutations, AV-shaped holder (random 5–60 ms holds, 20–300 ms gaps) | 200 ok / 0 fail |
| permanent holder | raises after 1.54 s, working copy intact |

`tests/test_pdf_studio_readonly.py`: 5 passed.
