### PR TITLE
Home: open recents in claude_split like the app cards

### DIFF
--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -665,10 +665,11 @@ function Doorway({
 }
 
 // One row in the Recent list: name, tag, last-used — no icon. Same open
-// behavior as the /apps cards: entry HTML if present, else the folder.
+// behavior as the /apps cards: the app FOLDER in the claude_split view when
+// an entry exists, else the plain folder.
 function RecentRow({ app }: { app: AppInfo }) {
   const open = () => {
-    if (app.entry_html) navigate(app.entry_html, { isDir: false });
+    if (app.entry_html) navigate(app.path, { isDir: true, mode: "claude_split" });
     else navigate(app.path, { isDir: true });
   };
   const title = app.title || app.name;


### PR DESCRIPTION
## Summary
Recent rows on the homepage were navigating straight to the app's `index.html`, while every other app link (AppCard, AppPreviewCard) opens the app folder in the `claude_split` view. This aligns RecentRow with the same behavior: apps with an entry open their folder with `mode: "claude_split"`, apps without an entry open the plain folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single navigation-path change in Home.tsx with no API or auth impact; behavior matches existing app card patterns.
> 
> **Overview**
> **Home recent apps** now use the same navigation as **AppCard** and **AppPreviewCard** on `/apps`.
> 
> Clicking a recent row with an `entry_html` no longer goes straight to that HTML file. It opens the **app folder** with `mode: "claude_split"` so the app renders beside Claude chat. Apps without an entry still open as a plain folder listing.
> 
> The `RecentRow` comment is updated to describe this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571ca6c365f62e538b71946f0678770c71b69749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->