### PR TITLE
Reuse the standard Claude config dir so the in-app CLI stays logged in

### DIFF
--- a/fused_render/supervisor/paths.py
+++ b/fused_render/supervisor/paths.py
@@ -210,8 +210,16 @@ class DesktopPaths:
             "RCLONE_CONFIG": str(rclone / "rclone.conf"),
             "RCLONE_CACHE_DIR": str(self.cache / "rclone"),
             "UV_CACHE_DIR": str(self.cache / "uv"),
-            "FUSED_RENDER_CLAUDE_DIR": str(self.state / "claude"),
-            "CLAUDE_CONFIG_DIR": str(self.state / "claude"),
+            # CLAUDE_CONFIG_DIR is deliberately NOT set here. It used to point at
+            # <state>/claude to keep our run transcripts out of ~/.claude/projects,
+            # but that dir is also where Claude Code keeps `.credentials.json` on
+            # Linux and Windows — so relocating it logged the user out of a CLI
+            # they were already logged into, with no way back: both spawn paths run
+            # headless (`claude -p`), where the "run /login" it prints can never be
+            # actioned. macOS hid the bug, its credentials living in the login
+            # Keychain rather than the config dir. The app now reuses the standard
+            # config dir, and environment_block passes an explicitly-set
+            # CLAUDE_CONFIG_DIR through untouched, so a user who sets one still wins.
             "FUSED_RENDER_DUCKDB_EXTENSION_DIR": str(tools_dir / "duckdb_extensions"),
             "FUSED_RENDER_DUCKDB_TEMP_DIR": str(self.cache / "duckdb" / "temp"),
             # rclone is bundled in the payload next to the interpreter (and uv),

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -84,10 +84,11 @@ def _runs_root() -> str:
 
 RUNS = _runs_root()
 
-# Claude Code's own data dir. CLAUDE_CONFIG_DIR wins where it is set: the
-# supervisor sets it for every packaged build (supervisor/paths.py
-# child_environment), so the transcripts claude writes for OUR runs land there
-# and not under ~/.claude — reading the wrong dir loses history and resume.
+# Claude Code's own data dir, and it must be the SAME one the CLI itself uses —
+# reading the wrong dir loses history and resume. CLAUDE_CONFIG_DIR wins where
+# it is set, which now means only where the user set it: the supervisor no
+# longer overrides it, because that dir also holds the login credentials on
+# Linux and Windows (see supervisor/paths.py child_environment).
 CLAUDE_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
 PROJECTS = os.path.join(CLAUDE_DIR, "projects")
 

--- a/fused_render/templates/claude_split/agent.py
+++ b/fused_render/templates/claude_split/agent.py
@@ -86,10 +86,11 @@ def _runs_root() -> str:
 
 RUNS = _runs_root()
 
-# Claude Code's own data dir. CLAUDE_CONFIG_DIR wins where it is set: the
-# supervisor sets it for every packaged build (supervisor/paths.py
-# child_environment), so the transcripts claude writes for OUR runs land there
-# and not under ~/.claude — reading the wrong dir loses history and resume.
+# Claude Code's own data dir, and it must be the SAME one the CLI itself uses —
+# reading the wrong dir loses history and resume. CLAUDE_CONFIG_DIR wins where
+# it is set, which now means only where the user set it: the supervisor no
+# longer overrides it, because that dir also holds the login credentials on
+# Linux and Windows (see supervisor/paths.py child_environment).
 CLAUDE_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
 PROJECTS = os.path.join(CLAUDE_DIR, "projects")
 

--- a/tests/test_claude_agent_windows.py
+++ b/tests/test_claude_agent_windows.py
@@ -251,9 +251,10 @@ def test_poll_and_history_refuse_a_windows_escaping_id(tmp_path, monkeypatch):
 # ------------------------------------------------------------- transcript dir
 
 def test_projects_follows_claude_config_dir(tmp_path, monkeypatch):
-    """The supervisor points CLAUDE_CONFIG_DIR at the app's own state dir in
-    every packaged build, so that — not ~/.claude — is where the transcripts
-    for our runs live."""
+    """Wherever CLAUDE_CONFIG_DIR points, that is where the transcripts for our
+    runs live. The supervisor no longer sets it (it carries the login too — see
+    test_supervisor_linux_paths), so in practice this covers the user who sets
+    one themselves; we have to follow them there or lose history and resume."""
     configured = tmp_path / "state" / "claude"
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(configured))
     agent = _load_agent()

--- a/tests/test_supervisor_linux_paths.py
+++ b/tests/test_supervisor_linux_paths.py
@@ -117,6 +117,38 @@ def test_child_environment_keys_are_contract_identical(monkeypatch, tmp_path):
     assert env["FUSED_RENDER_DESKTOP_INSTANCE_ID"] == "inst-id"
 
 
+def test_child_environment_leaves_the_claude_config_dir_alone(monkeypatch, tmp_path):
+    """The app must NOT relocate Claude Code's config dir. That dir holds
+    `.credentials.json` on Linux and Windows, so pointing it at app-owned state
+    logged the user out of a CLI they were already logged into — unrecoverably,
+    since both spawn paths run headless and `/login` cannot run there."""
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+    p = paths_mod.DesktopPaths.discover_linux()
+    env = p.child_environment("i", "t", tmp_path / "tools")
+    assert "CLAUDE_CONFIG_DIR" not in env
+    # The dead companion var went with it — nothing ever read it.
+    assert "FUSED_RENDER_CLAUDE_DIR" not in env
+    # ...and the full block a child actually receives leaves it unset too, so
+    # the CLI falls back to ~/.claude and finds the login it already has.
+    assert "CLAUDE_CONFIG_DIR" not in paths_mod.environment_block(env)
+
+
+def test_child_environment_passes_a_user_set_claude_config_dir_through(monkeypatch, tmp_path):
+    """Not setting it is not the same as clearing it: someone who runs the whole
+    app against a non-default config dir still wins, because environment_block
+    layers the overrides onto the inherited environment."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "run"))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "mine"))
+    p = paths_mod.DesktopPaths.discover_linux()
+    env = paths_mod.environment_block(p.child_environment("i", "t", tmp_path / "tools"))
+    assert env["CLAUDE_CONFIG_DIR"] == str(tmp_path / "mine")
+
+
 def test_child_environment_points_all_temp_vars_at_temp(monkeypatch, tmp_path):
     # TEMP/TMP cover Windows-conventioned lookups, but POSIX tempfile consults
     # TMPDIR first — without it the child's temp files land outside the


### PR DESCRIPTION
## Summary

- **Claude Code reported "Not logged in. Please run /login" inside the app on Linux and Windows, even for users already logged into the CLI.** `child_environment` pointed `CLAUDE_CONFIG_DIR` at `<state>/claude` to keep our run transcripts out of `~/.claude/projects` — but that directory is also where Claude Code stores `.credentials.json` on those platforms, so relocating it hid the user's existing login behind an empty directory.
- **The prompt was unactionable, not just wrong.** Both spawn paths run the CLI headless (`agent.py` uses `claude -p`, `server/ai.py` uses stream-json), and `/login` cannot run in a headless session — so the app asked for something it made impossible, on every turn.
- **macOS was unaffected, which is why this shipped.** Its credentials live in the login Keychain rather than the config dir, so the same override is auth-neutral there; with a macOS-first release pipeline the defect was invisible in normal development.
- **Fix: stop overriding the variable** so the CLI falls back to `~/.claude` and finds the login it already has. `environment_block` layers overrides onto the inherited environment, so a `CLAUDE_CONFIG_DIR` the user sets themselves still passes through untouched. `FUSED_RENDER_CLAUDE_DIR` is removed alongside it — `paths.py` was its only occurrence in the tree and nothing ever read it.

## Visuals

The delta is which directory the headless CLI resolves its credentials from.

**Before** — the override sends the CLI to app-owned state, where no credential file exists:

```mermaid
flowchart TD
    A[supervisor child_environment] -->|sets CLAUDE_CONFIG_DIR| B[app state dir]
    B --> C[headless claude -p]
    C --> D{credentials found?}
    D -->|"Linux / Windows: no"| E["prints 'run /login'<br/>— impossible headless"]
    D -->|"macOS: yes, Keychain"| F[works]
```

**After** — no override, so the CLI resolves its own default:

```mermaid
flowchart TD
    A[supervisor child_environment] -->|leaves it unset| B{user set one?}
    B -->|no| C[~/.claude]
    B -->|yes| D[their dir]
    C --> E[headless claude -p]
    D --> E
    E --> F[existing login found]
```

## Usage

Not user-invocable — this removes an environment override. The behavior change is that an already-logged-in Claude Code user is now logged in inside the app on Linux and Windows, with no extra step. macOS behavior is unchanged.

Users who worked around this by logging in against the app's private dir need no action; those wanting to verify can confirm the app dir is no longer consulted:

```bash
# before: credentials were looked for here (and were not there)
ls ~/.fused-render/claude/.credentials.json   # absent
# after: the CLI resolves the standard location
ls ~/.claude/.credentials.json                # the login the app now uses
```

## Test Plan

- [x] **Added** `test_child_environment_leaves_the_claude_config_dir_alone` — asserts the key is absent from both `child_environment` and the assembled `environment_block`. Lives in the shared child-env contract section, so it guards Windows as well as Linux.
- [x] **Added** `test_child_environment_passes_a_user_set_claude_config_dir_through` — pins that *not setting* the variable is not the same as clearing it; an explicitly-set value still reaches the child.
- [x] **Updated** `test_projects_follows_claude_config_dir` docstring — the test was still correct, but documented the removed behavior.
- [x] Full suite: **3955 passed**. The 5–6 failures in `tests/test_browse_mount.py` are pre-existing and unrelated (verified failing on a clean tree with these changes stashed); they concern remote HTTP mount listing, not config dirs.
- [x] Comment in `templates/claude_split/agent.py` corrected in lockstep with `templates/claude/agent.py` — both carried the same now-false claim that the supervisor sets the variable, and `claude_split` is the template Home now opens recents in (#364).
- [ ] **Manual, Linux:** with `~/.claude/.credentials.json` present, open a Claude view in the app and send a turn — it should respond instead of asking for `/login`.
- [ ] **Manual, Windows:** same check, since it shares `child_environment` and the same file-based credential store.
- [ ] **Manual, macOS:** regression check only — confirm the Keychain-backed login still works and transcripts still resolve.

### Known follow-ups, deliberately not in this PR

- **Existing in-app transcripts are left behind.** Sessions recorded before this change live under `~/.fused-render/claude/projects`; the app now reads `~/.claude/projects` and will not see them, so resuming an older in-app conversation breaks. A one-time idempotent copy at supervisor start would cover it.
- **The app's skills now sync globally.** `user_skills.py` writes into `<config dir>/skills/`, which is now `~/.claude/skills/` — so `fused-render-authoring`, `fused-render-custom-templates` and `fused-render-usage` become visible in every Claude Code session on the machine. Giving `user_skills.py` its own app-owned target dir would keep auth global while keeping skills local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
