### PR TITLE
Improve responsive design and touch device accessibility

### DIFF
--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -386,7 +386,9 @@
   @media (hover: hover) {
     .btn:hover { transform: translateY(-2px); box-shadow: 0 6px 24px var(--accent-dim); }
     .grid figure:hover { transform: translateY(-4px); border-color: rgba(229, 255, 68, 0.4); }
-    .nav-dot:hover::after { background: var(--muted); }
+    /* :not(.active) because this block sits after the .active rule and matches
+       at the same specificity — a bare :hover would grey out the current dot. */
+    .nav-dot:not(.active):hover::after { background: var(--muted); }
     .ticker:hover .ticker-inner { animation-play-state: paused; }
   }
   a:focus-visible, .btn:focus-visible, .tab:focus-visible, .nav-dot:focus-visible {

--- a/scripts/download_page/index.html
+++ b/scripts/download_page/index.html
@@ -55,7 +55,9 @@
   }
   a { color: inherit; }
   img { max-width: 100%; display: block; }
-  .wrap { width: min(1080px, 92vw); margin: 0 auto; }
+  /* Wide gutters on desktop, but never less than 18px of breathing room on a
+     phone (92vw alone leaves 15px at 375px). */
+  .wrap { width: min(1080px, 100% - clamp(36px, 8vw, 86px)); margin: 0 auto; }
   code, pre, .mono {
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   }
@@ -63,6 +65,7 @@
   /* ---------- top bar ---------- */
   .top {
     display: flex; align-items: center; justify-content: space-between;
+    flex-wrap: wrap; row-gap: 12px;
     padding: 22px 0 0;
   }
   .brand { display: flex; align-items: center; gap: 9px; font-weight: 600; }
@@ -77,6 +80,11 @@
   .top nav { display: flex; gap: 22px; font-size: 14px; color: var(--muted); }
   .top nav a { text-decoration: none; }
   .top nav a:hover { color: var(--text); }
+  /* Too narrow to sit beside the brand: the nav wraps onto its own row rather
+     than disappearing (it is the only route to about.html above the footer). */
+  @media (max-width: 560px) {
+    .top nav { gap: 18px; font-size: 13px; }
+  }
 
   /* ---------- hero ---------- */
   .hero {
@@ -101,8 +109,11 @@
     color: var(--muted);
     font-size: 17px;
   }
+  /* The text lives in a <span> so that a wrapping line keeps <strong> inline —
+     as bare flex items the bold run would be pushed into its own column. */
   .sub-points li { display: flex; gap: 10px; align-items: baseline; margin: 8px 0; }
-  .sub-points li::before { content: "✦"; color: var(--accent); font-size: 12px; }
+  .sub-points li::before { content: "✦"; color: var(--accent); font-size: 12px; flex: none; }
+  .sub-points li > span { min-width: 0; }
   .sub-points strong { color: var(--text); font-weight: 600; }
   .cta-row { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
   .btn {
@@ -117,7 +128,6 @@
     transition: transform 0.18s cubic-bezier(0.22, 1, 0.36, 1),
                 box-shadow 0.18s cubic-bezier(0.22, 1, 0.36, 1);
   }
-  .btn:hover { transform: translateY(-2px); box-shadow: 0 6px 24px var(--accent-dim); }
   .btn-ghost {
     display: inline-block;
     color: var(--text);
@@ -158,6 +168,7 @@
   }
   .url span {
     position: absolute; inset: 6px 10px;
+    overflow: hidden; text-overflow: ellipsis;
     opacity: 0;
     transition: opacity 0.3s ease-out;
   }
@@ -171,15 +182,21 @@
   }
   .shots a.active { opacity: 1; pointer-events: auto; }
   .shots img { width: 100%; height: 100%; object-fit: cover; }
-  .hero-dots { display: flex; gap: 10px; justify-content: center; padding-top: 16px; }
+  /* The dot is drawn by ::after so the <button> itself can carry a ~32px
+     touch target without growing the 9px visual. */
+  .hero-dots { display: flex; justify-content: center; padding-top: 4px; }
   .nav-dot {
-    appearance: none; border: none; padding: 0; cursor: pointer;
+    appearance: none; border: none; background: none; cursor: pointer;
+    display: grid; place-items: center;
+    padding: 12px 9px;
+  }
+  .nav-dot::after {
+    content: "";
     width: 9px; height: 9px; border-radius: 50%;
     background: #3a3a3e;
     transition: background 0.2s ease-out, transform 0.2s ease-out;
   }
-  .nav-dot:hover { background: var(--muted); }
-  .nav-dot.active { background: var(--accent); transform: scale(1.25); }
+  .nav-dot.active::after { background: var(--accent); transform: scale(1.25); }
 
   /* ---------- format ticker ---------- */
   .ticker-block { padding: clamp(36px, 6vh, 64px) 0; border-top: 1px solid var(--border); }
@@ -193,15 +210,16 @@
   }
   .ticker {
     overflow: hidden;
-    -webkit-mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
-    mask-image: linear-gradient(90deg, transparent, #000 8%, #000 92%, transparent);
+    /* 8% is only ~30px on a phone — too abrupt to read as a fade, so the edge
+       falloff never drops below 44px. */
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 max(8%, 44px), #000 calc(100% - max(8%, 44px)), transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 max(8%, 44px), #000 calc(100% - max(8%, 44px)), transparent);
   }
   .ticker-run { display: flex; gap: 12px; padding-right: 12px; }
   .ticker-inner {
     display: flex; width: max-content;
     animation: scroll 46s linear infinite;
   }
-  .ticker:hover .ticker-inner { animation-play-state: paused; }
   @keyframes scroll { to { transform: translateX(-50%); } }
   .ext {
     font: 14px/1 ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -221,20 +239,27 @@
   }
 
   /* ---------- three truths ---------- */
+  /* One column on phones (separated by rules), two on tablets, three with
+     vertical dividers on desktop. auto-fit + a blanket "max-width: 899px"
+     rule used to draw a top border on the second column's first cell too. */
   .truths {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: clamp(24px, 4vw, 56px);
     padding: clamp(36px, 6vh, 64px) 0;
     border-top: 1px solid var(--border);
   }
   .truths p { margin: 0; color: var(--muted); font-size: 15.5px; text-wrap: pretty; }
+  @media (max-width: 619px) {
+    .truths { gap: 22px; }
+    .truths p + p { border-top: 1px solid var(--border); padding-top: 22px; }
+  }
+  @media (min-width: 620px) {
+    .truths { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
   @media (min-width: 900px) {
     .truths { grid-template-columns: repeat(3, minmax(0, 1fr)); }
     .truths p + p { border-left: 1px solid var(--border); padding-left: clamp(24px, 3vw, 48px); }
-  }
-  @media (max-width: 899px) {
-    .truths p + p { border-top: 1px solid var(--border); padding-top: 22px; }
   }
   .truths strong { display: block; color: var(--text); font-size: 19px; letter-spacing: -0.01em; margin-bottom: 6px; }
 
@@ -258,7 +283,6 @@
     transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
                 border-color 0.22s ease-out;
   }
-  .grid figure:hover { transform: translateY(-4px); border-color: rgba(229, 255, 68, 0.4); }
   .grid img { aspect-ratio: 1400 / 813; object-fit: cover; }
   .grid figcaption { padding: 12px 14px; font-size: 13.5px; color: var(--muted); }
   .grid figcaption b { color: var(--text); font-weight: 600; }
@@ -266,7 +290,9 @@
   /* ---------- how ---------- */
   .how { padding: clamp(36px, 6vh, 64px) 0; border-top: 1px solid var(--border); }
   .how h2 { margin: 0 0 22px; }
-  .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; }
+  /* min() so a 375px phone gets one full-width step instead of an overflowing
+     240px track; the low floor keeps all three side by side from tablet up. */
+  .steps { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(190px, 100%), 1fr)); gap: 18px; }
   .steps li { list-style: none; color: var(--muted); font-size: 15.5px; }
   .steps { padding: 0; margin: 0; counter-reset: step; }
   .steps li::before {
@@ -301,6 +327,7 @@
   }
   .tab:hover { color: var(--text); }
   .tab.active { color: var(--accent); border-bottom-color: var(--accent); }
+  @media (pointer: coarse) { .tab { padding: 15px 16px; } }
   .dl {
     display: none;
     padding: 28px 2px 4px;
@@ -321,6 +348,24 @@
     color: var(--text);
     margin: 10px 0 0;
   }
+  /* The brew line is wider than a phone, and a sideways-scrolling <pre> just
+     looks truncated on touch — wrap it instead. */
+  @media (max-width: 640px) {
+    .dl pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+  }
+  /* Mobile visitors can't install a desktop app; say so before they tap a
+     .dmg onto their phone. */
+  .mobile-note { display: none; }
+  @media (pointer: coarse) and (max-width: 900px) {
+    .mobile-note {
+      display: block;
+      margin: -6px 0 20px;
+      padding-left: 12px;
+      border-left: 2px solid var(--accent);
+      color: var(--muted);
+      font-size: 14px;
+    }
+  }
 
   footer {
     text-align: center;
@@ -335,15 +380,25 @@
 
   @media (max-width: 820px) {
     .hero { grid-template-columns: 1fr; }
-    .top nav { display: none; }
   }
-  a:focus-visible, .btn:focus-visible, .tab:focus-visible {
+  /* Transform/pause effects only where a pointer can actually leave again —
+     on touch they stick to the last-tapped element. */
+  @media (hover: hover) {
+    .btn:hover { transform: translateY(-2px); box-shadow: 0 6px 24px var(--accent-dim); }
+    .grid figure:hover { transform: translateY(-4px); border-color: rgba(229, 255, 68, 0.4); }
+    .nav-dot:hover::after { background: var(--muted); }
+    .ticker:hover .ticker-inner { animation-play-state: paused; }
+  }
+  a:focus-visible, .btn:focus-visible, .tab:focus-visible, .nav-dot:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 3px;
   }
   @media (prefers-reduced-motion: reduce) {
     html { scroll-behavior: auto; }
-    .shots a, .url span, .nav-dot { transition: none; }
+    .shots a, .url span, .nav-dot::after { transition: none; }
+    /* Static wrapped list, so the marquee edge fade would just dim the first
+       and last chip of every row. */
+    .ticker { -webkit-mask-image: none; mask-image: none; }
     .ticker-inner { animation: none; flex-wrap: wrap; width: auto; }
     .ticker-run { flex-wrap: wrap; }
     .ticker-run + .ticker-run { display: none; }
@@ -371,9 +426,9 @@
     <div>
       <h1>Your files,<br><span class="lit">rendered.</span></h1>
       <ul class="sub-points">
-        <li>Browse any folder in your browser</li>
-        <li>Parquet, maps, 3D, PDFs — <strong>everything just opens</strong></li>
-        <li>No cloud, no account, no setup</li>
+        <li><span>Browse any folder in your browser</span></li>
+        <li><span>Parquet, maps, 3D, PDFs — <strong>everything just opens</strong></span></li>
+        <li><span>No cloud, no account, no setup</span></li>
       </ul>
       <div class="cta-row">
         <a class="btn" href="#downloads">Download</a>
@@ -450,6 +505,8 @@
 
   <section class="downloads" id="downloads">
     <h2>Get Fused Render</h2>
+    <p class="mobile-note">Fused Render is a desktop app — open this page on your
+    Mac, Windows PC or Linux machine to install it.</p>
     <div class="tabs" role="tablist">
       <button class="tab active" data-os="mac" role="tab">macOS</button>
       <button class="tab" data-os="win" role="tab">Windows</button>


### PR DESCRIPTION
## Summary
This PR enhances the download page's responsive design and accessibility for touch devices. It refines container sizing, improves navigation wrapping behavior, adds touch-friendly interaction targets, and implements pointer-aware hover effects.

## Key Changes

- **Container sizing**: Replaced `92vw` with `100% - clamp(36px, 8vw, 86px)` to ensure minimum 18px gutters on phones while maintaining the 1080px max width
- **Top navigation**: Added `flex-wrap` and `row-gap` to allow nav to wrap onto its own row on narrow screens instead of disappearing, with a media query for screens ≤560px
- **Navigation dots**: Redesigned as larger touch targets (32px) with visual indicator drawn via `::after` pseudo-element, improving accessibility on touch devices
- **Hover effects**: Gated all hover-based transforms and animations behind `@media (hover: hover)` to prevent sticky states on touch devices
- **Three truths section**: Restructured grid layout with explicit breakpoints (1 column on phones, 2 on tablets, 3 on desktop) instead of `auto-fit`
- **Steps section**: Updated grid to use `minmax(min(190px, 100%), 1fr)` so phones get full-width steps instead of overflowing
- **Sub-points list**: Wrapped text in `<span>` elements and added `flex: none` to bullets to prevent layout issues when text wraps
- **Download section**: Added mobile-aware note informing touch users that Fused Render is a desktop app
- **Code formatting**: Added `white-space: pre-wrap` for brew command on phones and improved URL ellipsis handling
- **Ticker mask**: Enhanced fade gradient to use `max(8%, 44px)` ensuring minimum 44px falloff on phones
- **Tab padding**: Added touch-friendly padding via `@media (pointer: coarse)`

## Notable Implementation Details

- Used CSS `clamp()` and `max()` functions extensively for fluid, responsive values
- Leveraged `@media (hover: hover)` and `@media (pointer: coarse)` for pointer-aware styling
- Maintained visual consistency while improving touch interaction targets from 9px to 32px for navigation dots
- Preserved all existing functionality while making the interface more usable on mobile and tablet devices

https://claude.ai/code/session_012DZZFUGXRuWh5hNgT89kYs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing-page CSS/HTML only; no auth, APIs, or release pipeline changes.
> 
> **Overview**
> Improves **mobile and touch usability** on the Fused Render download landing page (`scripts/download_page/index.html`) without changing download logic or manifest behavior.
> 
> **Layout and navigation:** Page gutters use `clamp()` so narrow phones keep at least ~18px side margin. The top nav **wraps** on small screens instead of being hidden below 820px, preserving links to `about.html`. Hero sub-bullets wrap text in `<span>` so bold phrases don’t break across flex columns.
> 
> **Touch and pointer behavior:** Carousel dots get larger hit areas (visual still 9px via `::after`). Hover lifts, gallery hover, ticker pause, and dot hover run only under `@media (hover: hover)` so touch doesn’t leave “stuck” hover states. OS download tabs get extra padding on coarse pointers.
> 
> **Section grids:** “Three truths” uses explicit 1/2/3-column breakpoints; the “how it works” steps grid avoids horizontal overflow on ~375px widths.
> 
> **Downloads on phones:** A **desktop-only** note appears for coarse pointers on smaller viewports. Install `<pre>` blocks wrap instead of sideways scroll; ticker edge fades use a minimum 44px falloff. Reduced-motion mode drops the ticker mask so wrapped chips aren’t dimmed at the edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e756b59482ba2aeb6bafbde8097f917c535976d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->