### PR TITLE
fix(cli): connect-probe ports so a live server isn't read as free on Windows

### DIFF
--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -86,23 +86,20 @@ _HOST = "127.0.0.1"
 
 
 def _port_free(port: int) -> bool:
-    """True if uvicorn could bind ``port`` on the loopback right now.
+    """True if no server is listening on ``port`` on the loopback right now.
 
-    Mirror uvicorn's own bind by setting SO_REUSEADDR so the probe agrees with
-    it in both directions: an active listener (a stale server) still makes bind
-    fail — SO_REUSEADDR does not permit two live binds to the same address, that
-    needs SO_REUSEPORT — so a real collision is still caught, while a port merely
-    lingering in TIME_WAIT after a clean shutdown reads as free (uvicorn, which
-    also sets SO_REUSEADDR, would bind it). A plain bind here would reject those
-    TIME_WAIT ports and wrongly block an immediate dev.sh restart.
-    """
+    A connect probe, not a bind probe — the same one app.pick_port, winopen and
+    the supervisor use. A bind probe must set SO_REUSEADDR to tolerate a port
+    lingering in TIME_WAIT after a clean shutdown (uvicorn, which also sets it,
+    would happily bind that), but on Windows SO_REUSEADDR *also* lets a bind
+    succeed against a port an old server is actively listening on: the probe
+    would then read a live collision as "free", uvicorn would bind the same port
+    a second time, and connections would split nondeterministically between the
+    two servers. Connect instead: a live listener answers (taken), while a
+    TIME_WAIT port refuses the connect (free)."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        try:
-            s.bind((_HOST, port))
-            return True
-        except OSError:
-            return False
+        s.settimeout(0.25)
+        return s.connect_ex((_HOST, port)) != 0
 
 
 def _check_port_free(port: int) -> None:


### PR DESCRIPTION
On Windows `SO_REUSEADDR` lets a bind succeed against an actively-listening port, so `cli._port_free`'s bind probe read a surviving old server's port as free. uvicorn (also `SO_REUSEADDR`) then dual-bound it and the token-checked readiness probe hit the old server → "Python server did not become ready" on upgrade-while-running.

Fix: connect-probe instead, matching `app.py`/`winopen.py`/`supervisor/core.py`. Still tolerates TIME_WAIT.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to pre-start port checking; behavior improves on Windows and matches existing connect-probe patterns elsewhere.
> 
> **Overview**
> **`fused-render serve`** now decides whether a port is free with a **TCP connect** to `127.0.0.1` (0.25s timeout) instead of trying to **bind** with `SO_REUSEADDR`.
> 
> On Windows, `SO_REUSEADDR` can make a bind succeed even when another process is already listening, so the old probe could treat a stale server as “free”, let uvicorn bind the same port twice, and break token-based readiness (“Python server did not become ready” on upgrade-while-running). A connect probe still treats **TIME_WAIT** as free (no listener) while a live server reads as taken, aligned with **`app.pick_port`**, **winopen**, and the **supervisor**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd7cfefc0fb8409773864298113424ee01c07c07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->