### PR TITLE
pdf_studio: cap the sidebar at the 5 most-recently-opened PDFs

### DIFF
--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -75,6 +75,7 @@ import shutil
 DATA_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "data", "pdf_studio"))
 CACHE_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "cache", "pdf_studio"))
 LIBRARY = os.path.join(DATA_ROOT, "library.json")   # recent PDF paths, newest first
+_LIB_VERSION = 2                                     # bump migrates library.json on load
 RECENT_MAX = 5                                       # keep only the N most-recently-opened
 DOWNLOADS = os.path.join(DATA_ROOT, "downloads")    # PDFs fetched via import_url
 EXPORTS = os.path.join(CACHE_ROOT, "exports")
@@ -1059,7 +1060,16 @@ def _lib_load():
         try:
             with open(LIBRARY, encoding="utf-8") as f:
                 data = json.load(f)
-            return data.get("paths") or []
+            paths = data.get("paths") or []
+            if data.get("v") != _LIB_VERSION:
+                # Pre-v2 libraries were append-only (oldest first); v2 is
+                # newest first. Reverse once and re-persist so recency order
+                # is right — otherwise the cap would keep the oldest entries
+                # and evict the newest. Non-destructive: nothing is dropped
+                # here, the cap only bites on the next open.
+                paths = list(reversed(paths))
+                _lib_save(paths)
+            return paths
         except Exception:
             pass
     return []
@@ -1069,7 +1079,7 @@ def _lib_save(paths):
     os.makedirs(DATA_ROOT, exist_ok=True)
     tmp = LIBRARY + ".tmp"
     with open(tmp, "w", encoding="utf-8") as f:
-        json.dump({"paths": paths}, f)
+        json.dump({"v": _LIB_VERSION, "paths": paths}, f)
     os.replace(tmp, LIBRARY)
 
 
@@ -1445,8 +1455,8 @@ def main(
         return _remove_from_library(doc)
     if action == "open_doc":
         p = os.path.abspath(doc)
-        _lib_promote(p)
-        wpath, wmeta = _open_work(p)
+        wpath, wmeta = _open_work(p)   # raises on a missing/unreadable file…
+        _lib_promote(p)                # …so a failed open never reorders or evicts
         info = _docinfo(wpath)
         info["path"] = _fwd(p)
         info["name"] = os.path.basename(p)

--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -1104,6 +1104,8 @@ def _lib_promote(src):
     until it's saved, so edits are never lost silently.
     """
     src = os.path.abspath(src)
+    # _lib_load() returns newest-first (pre-v2 files are reversed on load), so
+    # prepending src and keeping the head keeps the most recent, never the oldest.
     paths = [_fwd(src)] + [p for p in _lib_load() if not _same_path(p, src)]
     kept = paths[:RECENT_MAX]
     for p in paths[RECENT_MAX:]:
@@ -1479,6 +1481,9 @@ def main(
         info["readonly_tooltip"] = "" if info["writable"] else (
             "The file is read-only — edits can't be saved back to it. "
             "Use Save a copy.")
+        # Return the promoted/capped list so the sidebar reflects this open
+        # synchronously — no separate list_library round trip to lag or fail.
+        info["docs"] = _list_library()["docs"]
         return info
     if action == "listdir":
         # `src` on the listdir action carries the server ORIGIN (mount-safe

--- a/fused_render/templates/pdf_studio/pdf.py
+++ b/fused_render/templates/pdf_studio/pdf.py
@@ -11,8 +11,11 @@ Read-only inspection (classification, security scan, Markdown) lives in the
 sibling inspector.py; this module owns the editing actions and the dispatcher.
 
 The source of truth is the .pdf files on disk, wherever they live. A flat
-library (a single JSON file of absolute paths) just remembers which files the
-user added — it never copies them. Edits never touch the original directly:
+library (a single JSON file of absolute paths) remembers the most-recently-
+opened files, newest first, capped at RECENT_MAX — it never copies them.
+Opening a doc moves it to the front; files that fall off the end are dropped
+(their per-doc history and working copy discarded, the file on disk kept).
+Edits never touch the original directly:
 each open doc gets a working copy under .work/ that mutations (and undo/redo
 snapshots) apply to; an explicit save writes the working copy back over the
 original. Each call is a fresh process, so no in-memory state survives.
@@ -71,7 +74,8 @@ import shutil
 # working copies and undo snapshots are transient and belong under `cache/`.
 DATA_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "data", "pdf_studio"))
 CACHE_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "cache", "pdf_studio"))
-LIBRARY = os.path.join(DATA_ROOT, "library.json")   # flat list of PDF paths the user added
+LIBRARY = os.path.join(DATA_ROOT, "library.json")   # recent PDF paths, newest first
+RECENT_MAX = 5                                       # keep only the N most-recently-opened
 DOWNLOADS = os.path.join(DATA_ROOT, "downloads")    # PDFs fetched via import_url
 EXPORTS = os.path.join(CACHE_ROOT, "exports")
 SNAPSHOTS = os.path.join(CACHE_ROOT, "snapshots")   # undo stacks, keyed by doc path
@@ -1078,8 +1082,28 @@ def _list_library():
                          "size": 0, "mtime": 0, "page_count": None, "missing": True})
             continue
         docs.append(_doc_entry(full))
-    docs.sort(key=lambda e: e["name"].lower())
     return {"docs": docs}
+
+
+def _lib_promote(src):
+    """Move src to the front of the recent list and cap it at RECENT_MAX.
+
+    A clean doc pushed past the cap is discarded — its undo history and working
+    copy deleted (the file on disk is kept, so re-opening starts fresh). A doc
+    with unsaved changes is never discarded: it stays in the list past the cap
+    until it's saved, so edits are never lost silently.
+    """
+    src = os.path.abspath(src)
+    paths = [_fwd(src)] + [p for p in _lib_load() if not _same_path(p, src)]
+    kept = paths[:RECENT_MAX]
+    for p in paths[RECENT_MAX:]:
+        if (_work_state(p) or {}).get("dirty"):
+            kept.append(p)
+            continue
+        dropped = os.path.abspath(p)
+        shutil.rmtree(_hist_dir(dropped), ignore_errors=True)
+        _work_drop(dropped)
+    _lib_save(kept)
 
 
 def _add_to_library(src):
@@ -1087,9 +1111,7 @@ def _add_to_library(src):
     src = os.path.abspath(src)
     if not os.path.isfile(src):
         raise ValueError(f"no such file: {src}")
-    paths = _lib_load()
-    if not any(_same_path(p, src) for p in paths):
-        _lib_save(paths + [_fwd(src)])
+    _lib_promote(src)
     return {"name": os.path.basename(src), "path": _fwd(src)}
 
 
@@ -1423,6 +1445,7 @@ def main(
         return _remove_from_library(doc)
     if action == "open_doc":
         p = os.path.abspath(doc)
+        _lib_promote(p)
         wpath, wmeta = _open_work(p)
         info = _docinfo(wpath)
         info["path"] = _fwd(p)

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -1150,8 +1150,9 @@ async function openDoc(path) {
     "This PDF has no text layer (likely scanned) — page operations work, text editing won't find anything to edit.";
   fused.params.set("doc", info.path);
   updateUndoUi();
-  await refreshLib();
+  renderDocList();
   await renderAll();
+  refreshLib().catch(() => {});
 }
 
 function clearOpenDoc() {

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -1133,7 +1133,7 @@ async function openDoc(path) {
     return openDoc(res.path);
   }
   state.doc = info.path; state.work = info.work; state.info = info; state.mtime = info.mtime;
-  state.dirty = !!info.dirty;
+  state.docs = info.docs; state.dirty = !!info.dirty;
   state.curPage = 1; state.spans = {};
   state.undoDepth = info.undo_depth; state.redoDepth = info.redo_depth;
   dropInspect();
@@ -1152,7 +1152,6 @@ async function openDoc(path) {
   updateUndoUi();
   renderDocList();
   await renderAll();
-  refreshLib().catch(() => {});
 }
 
 function clearOpenDoc() {

--- a/fused_render/templates/pdf_studio/template.html
+++ b/fused_render/templates/pdf_studio/template.html
@@ -92,6 +92,12 @@
   #side h4 .add { margin-left: auto; border: none; background: none; color: var(--ink-3); font-size: 15px;
     line-height: 1; padding: 0 4px; border-radius: 4px; }
   #side h4 .add:hover { background: var(--hair-2); color: var(--blue); }
+  #side h4 .sec-toggle { display: flex; align-items: center; gap: 4px; border: none; background: none;
+    font: inherit; color: inherit; text-transform: inherit; letter-spacing: inherit; cursor: pointer; padding: 0; }
+  #side h4 .sec-toggle:hover { color: var(--ink); }
+  #side h4 .caret { width: 11px; height: 11px; flex: 0 0 auto; transition: transform .15s; }
+  body.recent-off #side h4 .caret { transform: rotate(-90deg); }
+  body.recent-off #docList { display: none; }
 
   .doc-row { display: flex; align-items: center; gap: 7px; width: 100%; border: none; background: none;
     color: var(--ink-2); padding: 5px 6px; border-radius: 5px; font-size: 12.5px; cursor: pointer; position: relative; }
@@ -467,7 +473,7 @@
 <div id="main">
   <div id="side">
     <div>
-      <h4>Documents <button class="add" id="importBtn" title="Add a PDF">＋</button></h4>
+      <h4><button class="sec-toggle" id="recentToggle" title="Show/hide recent"><svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>Recent</button><button class="add" id="importBtn" title="Add a PDF">＋</button></h4>
       <div id="docList"></div>
     </div>
     <div>
@@ -1144,7 +1150,7 @@ async function openDoc(path) {
     "This PDF has no text layer (likely scanned) — page operations work, text editing won't find anything to edit.";
   fused.params.set("doc", info.path);
   updateUndoUi();
-  renderDocList();
+  await refreshLib();
   await renderAll();
 }
 
@@ -1498,6 +1504,10 @@ const acts = {
   togglePanel: () => {
     document.body.classList.toggle("panel-off");
     fused.params.set("panel", document.body.classList.contains("panel-off") ? "0" : "1");
+  },
+  toggleRecent: () => {
+    document.body.classList.toggle("recent-off");
+    fused.params.set("recent", document.body.classList.contains("recent-off") ? "0" : "1");
   },
   zoomIn: () => setZoom(state.zoom + 15),
   zoomOut: () => setZoom(state.zoom - 15),
@@ -2133,6 +2143,7 @@ function setMode(mode) {
 
 $("exportBtn").addEventListener("click", () => act("export"));
 $("importBtn").addEventListener("click", () => act("addPdf"));
+$("recentToggle").addEventListener("click", () => act("toggleRecent"));
 $("toolsBtn").addEventListener("click", () => act("tools"));
 $("toolsClose").addEventListener("click", () => showTools(false));
 $("inspectBtn").addEventListener("click", insToggle);
@@ -2222,6 +2233,7 @@ async function boot() {
     }
     state.zoom = +(fused.params.get("zoom") || 100) || 100;
     if (fused.params.get("panel") === "0") document.body.classList.add("panel-off");
+    if (fused.params.get("recent") === "0") document.body.classList.add("recent-off");
     await libP;
     setMode(fused.params.get("mode") === "edit" ? "edit" : "view");
     const tab = fused.params.get("itab");


### PR DESCRIPTION
## What & why

The PDF Studio **Documents** pane was a permanent, alphabetically-sorted library that only ever grew — every PDF you ever opened stayed forever (a real install had 24+ entries, mostly stale test artifacts). This turns it into a **recent list**.

## Changes

**Backend (`pdf.py`)**
- `library.json` now stores paths **newest-first, capped at `RECENT_MAX` (5)**.
- New `_lib_promote()` — move-to-front + cap + evict-cleanup. `open_doc` now calls it, so **opening** a doc registers/promotes it (previously only an explicit "add" touched the library). The open doc is always at the front, so it can never be evicted → true MRU.
- `_list_library` no longer sorts alphabetically; it preserves recency order.
- Docs pushed past the cap are discarded (undo history + working copy deleted, **file on disk kept**) **unless they have unsaved changes** — a dirty doc is retained past the cap until saved, so edits are never dropped silently.

**UI (`template.html`)**
- Heading renamed to **Recent** and made **collapsible** (caret toggle, persisted via a `recent` URL param, mirroring the existing side-panel toggle) so the **Pages** thumbnails sit directly below without scrolling.
- `openDoc` now refreshes the library so promotion/eviction reflect immediately.

## Testing
- Unit-tested the MRU promote/cap/dedup and the dirty-doc retention against the real functions.
- Existing `tests/test_pdf_studio_readonly.py` still passes (5/5).
- Verified live in a dev server: opening 6 sample PDFs capped the list at 5 (oldest evicted), re-opening one jumped it to the top, and the Recent section collapses/expands as intended.

## Reviewer notes
- `.pdf` has PDF Studio as its **2nd** mode in `registry.json` (`["pdf", "pdf_studio", ...]`); the default remains the plain `pdf` viewer. Ordering unchanged here.
- Template edits only take effect once the core-templates cache re-stages (version-gated), or via a fresh dev server / `FUSED_RENDER_CORE_TEMPLATES`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eviction deletes per-doc cache (undo/work copies) and changes library semantics on every open; dirty-doc retention mitigates silent data loss but behavior is user-visible and stateful.
> 
> **Overview**
> Replaces the growing, alphabetically sorted **Documents** sidebar with an **MRU Recent** list (newest first, max **5** entries).
> 
> **Backend:** `library.json` is versioned (v2) with a one-time reverse migration for legacy append-only indexes. `_lib_promote()` move-to-front runs on `open_doc` and `add_to_library`; evicted clean docs lose undo/working-copy state but stay on disk. Docs with **unsaved** changes are kept past the cap until saved. `open_doc` returns `docs` so the UI updates without a separate `list_library` call.
> 
> **UI:** Section renamed to **Recent**, collapsible via caret (`recent` URL param). `openDoc` applies `info.docs` for immediate sidebar refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f412d3080805b88e4b58ffc8b4f7a7d9e0a1d5fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->