### PR TITLE
Show the Home hero composer on the /apps page

### DIFF
--- a/frontend/src/views/Apps.tsx
+++ b/frontend/src/views/Apps.tsx
@@ -14,7 +14,7 @@ import { useDeployEnabled } from "../lib/prefs";
 import { navigateUrl } from "../lib/router";
 import { ErrorBanner } from "../components/ErrorBanner";
 import { AppPreviewCard } from "../components/AppPreviewCard";
-import { NewAppPanel } from "./Home";
+import { HomeHero, NewAppPanel } from "./Home";
 import { SkeletonLines } from "../components/Skeleton";
 
 type Loaded<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "error"; message: string };
@@ -92,6 +92,10 @@ export default function Apps() {
             Every app detected in your workspace — search by name or narrow by tag.
           </p>
         </header>
+
+        {/* Same hero as Home: prompt composer that names, scaffolds, and lands
+            in the new app's claude chat. Creating from here refreshes the grid. */}
+        <HomeHero onCreated={() => setNonce((n) => n + 1)} />
 
         <div className="apps-toolbar">
           <div className="apps-search">

--- a/frontend/src/views/Home.tsx
+++ b/frontend/src/views/Home.tsx
@@ -612,6 +612,26 @@ export function NewAppPanel({ onClose, onCreated }: { onClose: () => void; onCre
   );
 }
 
+// The hero card itself — wordmark, headline, and the prompt composer.
+// Exported so /apps can show the exact same hero above its grid; `onCreated`
+// lets each page refresh its own app list once the folder exists.
+export function HomeHero({ onCreated }: { onCreated: () => void }) {
+  return (
+    <header className="home-hero">
+      {/* Fused wordmark, centered. Two theme-matched renders of the same
+          logo; CSS shows the one matching the active theme. */}
+      <img className="home-hero-logo home-hero-logo-dark" src={logoDark} alt="Fused" />
+      <img className="home-hero-logo home-hero-logo-light" src={logoLight} alt="Fused" />
+      <h1 className="home-hero-title">
+        Build your next <span className="home-hero-accent">local app</span>
+      </h1>
+      {/* The hero's only verb, prompt-first: describe the app right here
+          and a named, scaffolded folder + claude session comes back. */}
+      <HeroComposer onCreated={onCreated} />
+    </header>
+  );
+}
+
 // Section heading: mono eyebrow + count, hairline rule filling the middle,
 // optional trailing action link. The mono face is the shell's existing code
 // voice (listings, paths), so the labels read as part of the tool, not chrome.
@@ -715,23 +735,10 @@ export default function Home({ config }: { config: Config }) {
   return (
     <div className="home-page">
       <div className="home-inner">
-        {/* Hero card: the product's pitch plus its two verbs. "New app" is the
-            page's primary action (opens the create modal — the actual fields
-            live there); "Browse files" is the everyday doorway. */}
-        <header className="home-hero">
-          {/* Fused wordmark, centered. Two theme-matched renders of the same
-              logo; CSS shows the one matching the active theme. */}
-          <img className="home-hero-logo home-hero-logo-dark" src={logoDark} alt="Fused" />
-          <img className="home-hero-logo home-hero-logo-light" src={logoLight} alt="Fused" />
-          <h1 className="home-hero-title">
-            Build your next <span className="home-hero-accent">local app</span>
-          </h1>
-          {/* The hero's only verb, prompt-first: describe the app right here
-              and a named, scaffolded folder + claude session comes back. The
-              structured (name-it-yourself) NewAppPanel lives on /apps now,
-              and file browsing has its doorway card below. */}
-          <HeroComposer onCreated={reloadApps} />
-        </header>
+        {/* Hero card: wordmark + headline + the prompt composer (shared with
+            /apps via HomeHero). The structured NewAppPanel lives on /apps,
+            and file browsing has its doorway card below. */}
+        <HomeHero onCreated={reloadApps} />
 
         {/* Doorways: one card per entry point. */}
         <div className="home-doors">


### PR DESCRIPTION
## Summary
- Extract the Home hero (wordmark, headline, prompt composer) into an exported `HomeHero` component in `Home.tsx`
- Render the same hero on `/apps` between the page header and the toolbar
- Creating an app from `/apps` refreshes the grid via the existing nonce; success navigation (claude chat / entry page) is unchanged

## Test plan
- `npm run typecheck` passes
- Visit `/` — hero renders exactly as before
- Visit `/apps` — hero appears above the toolbar; submitting a prompt creates the app and lands in its claude chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI refactor that reuses existing creation flow; no API, auth, or data-layer changes.
> 
> **Overview**
> **Extracts** the Home landing hero (wordmark, headline, and `HeroComposer`) into an exported **`HomeHero`** component and **reuses** it on **`/`** and **`/apps`**.
> 
> On **`/apps`**, the hero sits **between** the page header and the search/sort toolbar so users can **prompt-create** an app without going home. **`onCreated`** bumps the existing **nonce** on Apps to **refetch** the grid after creation; **navigation** into the new app’s Claude chat is unchanged (`HeroComposer` behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc4a3ada012887f40890ce0b118c2ea03ba650a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->