### PR TITLE
Resync the dev venv when pyproject.toml changes

### DIFF
--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -84,23 +84,68 @@ fi
 # reads NSPasteboard through). Leaving it out is how the Finder-paste bridge
 # came to report `supported: false` on every dev machine while the tests that
 # would have caught it skipped for the same missing dependency.
+
+# Install the pinned dependency set into $1 (a venv dir). Runs from REPO_ROOT
+# with the `.[extras]` form: uv rejects an absolute path carrying extras (parses
+# it as a PEP508 requirement). Shared by the bootstrap and the staleness resync
+# below so the two can never drift on which extras a dev venv carries.
+install_python_deps() {
+  if command -v uv >/dev/null 2>&1; then
+    (cd "$REPO_ROOT" && uv pip install --python "$1/bin/python" -e ".[dev,fused,bundled]")
+  else
+    (cd "$REPO_ROOT" && "$1/bin/python" -m pip install -e ".[dev,fused,bundled]")
+  fi
+}
+
 if [[ -n "${VIRTUAL_ENV:-}" ]]; then
   PY="$VIRTUAL_ENV/bin/python"
+  VENV_DIR="$VIRTUAL_ENV"
 elif [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
   PY="$REPO_ROOT/.venv/bin/python"
+  VENV_DIR="$REPO_ROOT/.venv"
 else
   echo "==> no venv found — creating $REPO_ROOT/.venv with the [dev,fused,bundled] extras"
-  # Run the install from REPO_ROOT with the `.[extras]` form: uv rejects an
-  # absolute path carrying extras (parses it as a PEP508 requirement).
   if command -v uv >/dev/null 2>&1; then
     uv venv "$REPO_ROOT/.venv"
-    (cd "$REPO_ROOT" && uv pip install --python "$REPO_ROOT/.venv/bin/python" -e ".[dev,fused,bundled]")
   else
     python3 -m venv "$REPO_ROOT/.venv"
     "$REPO_ROOT/.venv/bin/python" -m pip install --upgrade pip
-    (cd "$REPO_ROOT" && "$REPO_ROOT/.venv/bin/python" -m pip install -e ".[dev,fused,bundled]")
   fi
+  install_python_deps "$REPO_ROOT/.venv"
   PY="$REPO_ROOT/.venv/bin/python"
+  VENV_DIR="$REPO_ROOT/.venv"
+  # Stamp here too, or the freshly-bootstrapped venv would immediately look
+  # unstamped to the resync below and install the same set a second time.
+  touch "$REPO_ROOT/.venv/.fused-render-deps"
+fi
+
+# Resync the venv when pyproject.toml has moved on since the last install — the
+# Python half of the `package-lock.json -nt node_modules/.package-lock.json`
+# check below, and load-bearing for the same reason. Before this, the venv was
+# adopted on *existence* alone, so bumping a pin re-synced nothing on any
+# machine that already had a .venv: `.venv` sat on `fused` 2.9.3.post3 while
+# pyproject pinned post13, and post3's local compute backend spawns its runner
+# with `cwd=` + the default close_fds — a fork(), which trips PROJ's
+# pthread_atfork handler and SIGSEGVs before exec. Every /api/run died with a
+# bare `Runner exited with code -11` and no traceback, in code that had not
+# changed; worktrees ranged across post3/post7/post10/post13 purely by setup
+# date. The `import fused_render` guard below cannot see this — it passes
+# happily against a stale dependency set.
+#
+# A missing stamp reads as stale (`-nt` is true when the target is absent), so
+# venvs predating this check — and any venv restored, copied, or half-built
+# without one — self-heal on the next run instead of needing a manual install.
+# The stamp is only touched AFTER a successful install; with `set -e` a failed
+# resync aborts dev.sh, so a broken sync can never be recorded as a good one.
+DEPS_STAMP="$VENV_DIR/.fused-render-deps"
+if [[ ! -e "$DEPS_STAMP" ]]; then
+  echo "==> syncing python deps into $VENV_DIR (no install stamp yet)"
+  install_python_deps "$VENV_DIR"
+  touch "$DEPS_STAMP"
+elif [[ "$REPO_ROOT/pyproject.toml" -nt "$DEPS_STAMP" ]]; then
+  echo "==> syncing python deps into $VENV_DIR (pyproject.toml changed since last install)"
+  install_python_deps "$VENV_DIR"
+  touch "$DEPS_STAMP"
 fi
 
 command -v npm >/dev/null || { echo "npm not found — the dev loop needs Node 22"; exit 1; }


### PR DESCRIPTION
## Summary

- **`dev.sh` now resyncs the venv when `pyproject.toml` changes.** Previously an existing `.venv` was adopted on *existence* alone, so bumping a dependency pin re-synced nothing on any machine that already had one. The script already did this correctly for npm (`package-lock.json -nt node_modules/.package-lock.json`); the Python half was simply missing.
- **This was breaking every `/api/run` on `main`.** `.venv` sat on `fused` 2.9.3.post3 while `pyproject.toml` pinned post13. post3's local compute backend spawns its runner with `cwd=` plus the default `close_fds=True`, which forces `fork()+exec`; the forked child runs PROJ's `pthread_atfork` handler, closes its inherited-but-invalid `proj.db` SQLite handle, and SIGSEGVs *before* exec. Every run returned a bare `Runner exited with code -11` with no traceback, in code that had not changed. post13 already carries the upstream fix — the venv just never picked it up.
- **Pre-existing venvs self-heal.** A missing stamp reads as stale, so nobody needs a manual `pip install` to recover; worktrees currently range across post3/post7/post10/post13 purely by setup date.
- No production code touched — `scripts/dev.sh` only.

## Visuals

The new gate is the `DEPS_STAMP` check; everything below it is unchanged.

```mermaid
flowchart TD
    A[dev.sh start] --> B{venv present?}
    B -->|no| C[create venv + install + stamp]
    B -->|yes| D{"pyproject newer<br/>than stamp?"}
    D -->|no| E[use as-is]
    D -->|yes, or no stamp| F[resync deps + stamp]
    C --> G[npm gate, build, server]
    E --> G
    F --> G
```

Without the `D`/`F` path, a pin bump reached `G` against a stale dependency set. The existing `import fused_render` guard cannot catch that — it passes happily against stale deps.

## Usage

Not user-invocable; it's automatic. Next `scripts/dev.sh` run in any existing checkout prints:

```
==> syncing python deps into /path/to/.venv (no install stamp yet)
```

and thereafter stays quiet until `pyproject.toml` changes. Measured resync cost on a warm uv cache: **3.1s** (130 packages resolved, 7 installed).

Deliberately kept as a stamp check rather than an unconditional reinstall: syncing on every start would make each `dev.sh` require the network, so offline dev would abort under `set -euo pipefail`. This keeps normal startups network-free.

## Test Plan

- [x] `bash -n scripts/dev.sh` — syntax clean. `shellcheck -S warning` reports only the pre-existing SC2155 on line 68, untouched by this PR.
- [x] All four branches exercised with `install_python_deps` stubbed, in throwaway dirs:
  - no venv → bootstrap installs **once** (verified no double-install, which an earlier draft of this patch had)
  - venv + stamp newer than `pyproject.toml` → no install
  - venv + `pyproject.toml` newer than stamp → resync
  - venv + stamp missing → resync (the self-heal path for today's venvs)
- [x] Real resync on this checkout moved `fused` 2.9.3.post3 → post13, and also un-stuck editable metadata at `fused-render` 0.3.2 → 0.3.18 plus missing `coverage`/`pytest-cov`/`google-auth`.
- [x] End-to-end: `POST /api/run` on `task-forge/downloads.py` went from `{"ok":false,"error":"Runner exited with code -11"}` (12ms, no traceback) to `{"ok":true}` with real data in 69ms. The `claude_split` view rendered `Could not open preview: Runner exited with code -11` before and the full app after (download list, throughput chart, settings), confirmed by screenshot.
- [x] Full suite: `pytest -n auto` → **1 failed, 4130 passed, 79 skipped** in 65s.
- [ ] Reviewer check: on a checkout whose `.venv` predates this change, run `scripts/dev.sh` and confirm it prints the sync line once, then is quiet on the second run.

**The one failure is pre-existing and unrelated:** `tests/test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`. It reproduces deterministically when run in isolation (not an xdist flake), and this PR changes only `scripts/dev.sh` — which pytest never reads. Not investigated further here; flagging it rather than folding an unrelated fix into this PR.

### Not covered

No automated test guards the shell logic itself — the repo has no harness for `scripts/*.sh`. A stronger regression guard would be a Python test asserting the **installed** `fused` version matches the `pyproject.toml` pin (which would have failed loudly here, unlike `import fused_render`). Happy to add that if wanted; left out to keep this PR to the one fix.
