### PR TITLE
Land #369's fixes without the artifact sources; app cards open in a new tab

### DIFF
--- a/frontend/src/apps/builder/AppCard.tsx
+++ b/frontend/src/apps/builder/AppCard.tsx
@@ -4,7 +4,7 @@
 // a tile never changes colour across visits, and the hues are the same family
 // the listing already paints file icons with.
 import type { AppInfo } from "@platform/lib/api";
-import { navigate } from "@platform/lib/router";
+import { hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
 
 const APP_HUES = [
   "var(--icon-folder)",
@@ -24,16 +24,17 @@ export function hueFor(name: string): string {
 }
 
 export function AppCard({ app }: { app: AppInfo }) {
-  const open = () => {
-    // An app with an entry opens its FOLDER in the claude_split view — the
-    // app rendered beside a Claude chat; a manifest without one falls back to
-    // the plain folder listing so the card is never dead.
-    if (app.entry_html) navigate(app.path, { isDir: true, mode: "claude_split" });
-    else navigate(app.path, { isDir: true });
-  };
   const title = app.title || app.name;
+  // An anchor, not a button, so middle-click / Cmd-click / "Open in new tab"
+  // work; the open rule itself lives in appEntry so all three card surfaces
+  // share it. The tooltip names what will actually open.
   return (
-    <button type="button" className="home-app" onClick={open} title={app.path}>
+    <a
+      className="home-app"
+      href={hrefFor(app)}
+      onClick={(e) => onAppCardClick(e, app)}
+      title={openTargetFor(app).path}
+    >
       <span className="home-app-monogram" aria-hidden="true" style={{ color: hueFor(app.name) }}>
         {title.charAt(0).toUpperCase()}
       </span>
@@ -44,6 +45,6 @@ export function AppCard({ app }: { app: AppInfo }) {
         {title !== app.name && <span className="home-app-sub">{app.name}</span>}
       </span>
       <span className="home-app-tag">{app.tag}</span>
-    </button>
+    </a>
   );
 }

--- a/frontend/src/apps/builder/AppPreviewCard.tsx
+++ b/frontend/src/apps/builder/AppPreviewCard.tsx
@@ -6,7 +6,7 @@
 // blank. Iframes are lazy so a big workspace doesn't render everything at
 // once.
 import type { AppInfo } from "@platform/lib/api";
-import { navigate } from "@platform/lib/router";
+import { hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
 import { hueFor } from "@apps/builder/AppCard";
 
 // "3d ago" style stamp for the card meta line; null when the backend didn't
@@ -32,16 +32,17 @@ export function timeAgo(epochSeconds: number | null | undefined): string | null 
 const PREVIEW_SCALE = 0.25;
 
 export function AppPreviewCard({ app }: { app: AppInfo }) {
-  const open = () => {
-    // Folder-first: an app with an entry opens in the claude_split view (app
-    // beside a Claude chat); without one, the plain folder listing.
-    if (app.entry_html) navigate(app.path, { isDir: true, mode: "claude_split" });
-    else navigate(app.path, { isDir: true });
-  };
   const title = app.title || app.name;
   const ago = timeAgo(app.updated_at);
+  // An anchor, not a button — see AppCard. The href is what makes middle-click
+  // and "Open in new tab" land on the same place a left click does.
   return (
-    <button type="button" className="app-pcard" onClick={open} title={app.path}>
+    <a
+      className="app-pcard"
+      href={hrefFor(app)}
+      onClick={(e) => onAppCardClick(e, app)}
+      title={openTargetFor(app).path}
+    >
       <span className="app-pcard-thumb" aria-hidden="true">
         {app.entry_html ? (
           <>
@@ -58,7 +59,8 @@ export function AppPreviewCard({ app }: { app: AppInfo }) {
               title=""
             />
             {/* Shield: the preview is display-only — every pointer event lands
-                on the card button, never inside the app. */}
+                on the card's link, never inside the app — which is also what
+                keeps middle-click over the preview a new tab for the app. */}
             <span className="app-pcard-shield" />
           </>
         ) : (
@@ -75,6 +77,6 @@ export function AppPreviewCard({ app }: { app: AppInfo }) {
           {ago && <span className="app-pcard-ago">{ago}</span>}
         </span>
       </span>
-    </button>
+    </a>
   );
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1432,6 +1432,12 @@ export interface AppInfo {
   tag: string;
   path: string;
   entry_html: string | null;
+  // The file a card opens and previews — the entry HTML for an app of the
+  // folder-with-a-page shape. Reported separately from `entry_html`, which is
+  // the narrower claim that the entry is a renderable page and so the only one
+  // the HTML-only /render iframe may be pointed at. Optional for older backends
+  // that predate the key — read it through entryOf(), never directly.
+  entry?: string | null;
   title: string | null;
   // Last-modified time, epoch seconds. Optional/null for servers that don't
   // report it (older backends) — those sort last in the Home grid.

--- a/frontend/src/platform/lib/appEntry.test.ts
+++ b/frontend/src/platform/lib/appEntry.test.ts
@@ -1,0 +1,149 @@
+// Entry resolution for app cards. The rules that matter here are the ones no
+// typecheck can check: where a click lands, and whether the browser's own
+// new-tab gestures still reach the anchor. A wrong answer is either a card that
+// navigates somewhere unexpected or a middle-click that does nothing.
+import { expect, test } from "bun:test";
+
+import type { AppInfo } from "./api";
+
+// appEntry pulls `navigate`/`urlForFsPath` from router.ts, which reads
+// `location` at MODULE scope (IS_EMBED) — and bun's test runtime has no DOM. A
+// static import is hoisted above any shim, so `location` is stubbed first and
+// the module comes in dynamically after it. The stub is on globalThis, which
+// every file shares — hence `??=`, and hence a shape real enough for router to
+// read rather than an empty object.
+(globalThis as { location?: unknown }).location ??= {
+  pathname: "/",
+  search: "",
+  href: "http://localhost/",
+};
+// `openApp` really does call navigate(), which pushes history and fires the nav
+// event. Stubbed rather than avoided: the assertion below is about whether the
+// shell CLAIMED the click, and swapping in a fake openApp would test the fake.
+// Where navigate() then lands is router.ts's business, not this module's.
+(globalThis as { history?: unknown }).history ??= {
+  state: null,
+  pushState() {},
+  replaceState() {},
+};
+(globalThis as { window?: unknown }).window ??= { dispatchEvent() {} };
+
+const { entryOf, hrefFor, isBrowserHandledClick, onAppCardClick, openTargetFor } =
+  await import("./appEntry");
+
+function app(over: Partial<AppInfo> = {}): AppInfo {
+  return {
+    name: "demo",
+    tag: "local",
+    path: "/w/local/demo",
+    entry_html: "/w/local/demo/index.html",
+    title: null,
+    ...over,
+  };
+}
+
+// A React MouseEvent, reduced to what the handler reads. `preventDefault`
+// records rather than mocks — the assertion is whether the shell claimed the
+// click, and that IS the preventDefault call.
+function click(over: Record<string, unknown> = {}) {
+  let prevented = false;
+  return {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+    },
+    get prevented() {
+      return prevented;
+    },
+    ...over,
+  };
+}
+
+test("entryOf prefers entry and falls back to entry_html", () => {
+  expect(entryOf(app({ entry: "/w/e.png", entry_html: null }))).toBe("/w/e.png");
+  // An older backend sends no `entry` at all; the page must not read undefined.
+  expect(entryOf(app({ entry: undefined }))).toBe("/w/local/demo/index.html");
+  expect(entryOf(app({ entry: null, entry_html: null }))).toBe(null);
+});
+
+// ------------------------------------------------------- where a click lands
+
+test("an app with a page entry opens its folder beside a Claude chat", () => {
+  expect(openTargetFor(app())).toEqual({
+    path: "/w/local/demo",
+    opts: { isDir: true, mode: "claude_split" },
+  });
+});
+
+test("an entry that is not a page opens the file itself", () => {
+  // No workspace app is shaped this way today, but `entry` exists for exactly
+  // this case and the fallback below must keep meaning "nothing to open".
+  expect(openTargetFor(app({ entry: "/w/local/demo/table.csv", entry_html: null })))
+    .toEqual({ path: "/w/local/demo/table.csv" });
+});
+
+test("an app with no entry at all opens its folder", () => {
+  expect(openTargetFor(app({ entry: null, entry_html: null }))).toEqual({
+    path: "/w/local/demo",
+    opts: { isDir: true },
+  });
+});
+
+// -------------------------------------------------------------- the new tab
+
+test("href points at the same target a left click opens", () => {
+  // The whole point of building both from openTargetFor: a new tab and an
+  // in-app click cannot land in different places.
+  expect(hrefFor(app())).toBe("/view/w/local/demo?_mode=claude_split");
+  expect(hrefFor(app({ entry: "/w/local/demo/t.csv", entry_html: null }))).toBe(
+    "/view/w/local/demo/t.csv",
+  );
+});
+
+test("href encodes a path the URL codec would otherwise break on", () => {
+  // A space, a `#` and a non-ASCII name all have to survive into the href —
+  // an unencoded `#` would truncate the URL at the fragment.
+  expect(hrefFor(app({ path: "/w/local/my app #2", entry_html: null, entry: null }))).toBe(
+    "/view/w/local/my%20app%20%232",
+  );
+  expect(hrefFor(app({ path: "/w/local/日本", entry_html: null, entry: null }))).toBe(
+    "/view/w/local/%E6%97%A5%E6%9C%AC",
+  );
+});
+
+test("the browser keeps every gesture that means 'not this tab'", () => {
+  // Middle-click (and any non-primary button) plus every modifier: Cmd/Ctrl for
+  // a new tab, Shift for a new window, Alt for download. Intercepting any of
+  // them would make the card fight the browser.
+  expect(isBrowserHandledClick(click({ button: 1 }))).toBe(true);
+  expect(isBrowserHandledClick(click({ button: 2 }))).toBe(true);
+  expect(isBrowserHandledClick(click({ metaKey: true }))).toBe(true);
+  expect(isBrowserHandledClick(click({ ctrlKey: true }))).toBe(true);
+  expect(isBrowserHandledClick(click({ shiftKey: true }))).toBe(true);
+  expect(isBrowserHandledClick(click({ altKey: true }))).toBe(true);
+  // A plain left click is the shell's.
+  expect(isBrowserHandledClick(click())).toBe(false);
+});
+
+test("a plain left click is intercepted; a modified one is left alone", () => {
+  const plain = click();
+  onAppCardClick(plain, app());
+  expect(plain.prevented).toBe(true); // in-app navigation, no page reload
+
+  for (const modified of [click({ button: 1 }), click({ metaKey: true }),
+                          click({ ctrlKey: true }), click({ shiftKey: true })]) {
+    onAppCardClick(modified, app());
+    expect(modified.prevented).toBe(false); // the href does the work
+  }
+});
+
+test("a click something else already handled is not hijacked", () => {
+  const handled = click({ defaultPrevented: true });
+  onAppCardClick(handled, app());
+  expect(handled.prevented).toBe(false);
+});

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -1,0 +1,112 @@
+// How an app card resolves, links to and opens its app — shared by the three
+// places that render one (Home's Recent rows, Home's app tiles, the /apps hub's
+// preview cards) so they can never disagree about what clicking a card does.
+//
+// They did disagree. Each carried its own inline copy of the rule, and Home's
+// Recent row had already drifted from the hub's card. The rule itself is
+// unchanged: an app with a page entry opens its FOLDER in the claude_split view
+// (the app beside a Claude chat) — that is what an app is for — and one without
+// a resolvable entry falls back to the plain folder listing so a card is never
+// dead.
+//
+// The cards are ANCHORS, not buttons, so the browser's own "open in a new tab"
+// gestures work on them: middle-click, Cmd/Ctrl-click, and the context menu's
+// Open in New Tab. That needs two things to stay in lockstep — the href and the
+// click handler — which is the second reason this module exists: `hrefFor` and
+// `openTargetFor` resolve the same target, so a new tab and a left click can't
+// land in different places.
+import type { AppInfo } from "./api";
+import { navigate, urlForFsPath } from "./router";
+
+// The file this card is about, tolerating a backend that predates `entry`.
+// `entry` is "the file a card opens and previews"; `entry_html` is the narrower
+// "that entry is a renderable page". They are the same file for a workspace app.
+export function entryOf(app: AppInfo): string | null {
+  return app.entry ?? app.entry_html;
+}
+
+// Whether opening this app means opening its folder beside a Claude chat, which
+// is what a page entry earns: claude_split rediscovers the entry from the folder
+// and wants exactly one top-level .html there.
+function opensAsProject(app: AppInfo): boolean {
+  return Boolean(app.entry_html);
+}
+
+export interface OpenTarget {
+  path: string;
+  opts?: { isDir?: boolean; mode?: string };
+}
+
+// Where a card goes when activated, AS A VALUE. Split out from openApp so the
+// rule can be tested without touching `navigate`: mocking a module that half
+// the shell imports is process-wide in bun, and it leaks into whichever suite
+// runs next. A pure function needs no mock at all.
+export function openTargetFor(app: AppInfo): OpenTarget {
+  if (opensAsProject(app)) {
+    return { path: app.path, opts: { isDir: true, mode: "claude_split" } };
+  }
+  // A single file entry that isn't a page opens as the file. No workspace app
+  // reaches this today (its entry is its .html or it has none), but the branch
+  // is the contract `entry` exists for, and it keeps the fallback below meaning
+  // only "nothing to open".
+  const entry = entryOf(app);
+  if (entry) return { path: entry };
+  return { path: app.path, opts: { isDir: true } };
+}
+
+// The URL for that target — what the anchor's href carries, so the browser can
+// open it in a new tab without the shell's help.
+//
+// `_mode` rides along because it selects the destination's template (the
+// claude_split split view); the `preview` param navigate() keeps sticky across
+// folder navigation deliberately does NOT, since it is in-session layout the
+// user toggled and a new tab is a fresh session. Built through the router's own
+// codec, so an app path with a space, a `#` or a non-ASCII name encodes exactly
+// as in-app navigation encodes it.
+export function hrefFor(app: AppInfo): string {
+  const { path, opts } = openTargetFor(app);
+  const search = opts?.mode ? "?_mode=" + encodeURIComponent(opts.mode) : "";
+  return urlForFsPath(path, search);
+}
+
+export function openApp(app: AppInfo): void {
+  const { path, opts } = openTargetFor(app);
+  navigate(path, opts);
+}
+
+// Structural, like platform.ts's ModifierEvent: a React MouseEvent satisfies it,
+// and so does a plain object in a test.
+export interface CardClickEvent {
+  button: number;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  defaultPrevented: boolean;
+  preventDefault(): void;
+}
+
+// Whether the BROWSER should handle this click on a card, rather than the shell
+// intercepting it for an in-app navigation. True for every gesture that means
+// "somewhere other than this tab": middle (or any non-primary) button, and any
+// modifier — Cmd/Ctrl for a new tab, Shift for a new window, Alt for download.
+//
+// Deliberately NOT `isMod()`, the one exception to platform.ts's rule that
+// modifier tests go through it. `isMod` is exclusive by design (Meta on macOS,
+// Ctrl elsewhere) because a SHORTCUT must not fire on the wrong platform's
+// chord. This is not a shortcut: it asks whether the browser has already
+// claimed the click, and the browser's own rule is any-modifier. Gating on
+// `isMod` would swallow Shift-click everywhere and Ctrl-click on macOS — where
+// it opens the context menu — and the card would fight the browser.
+export function isBrowserHandledClick(e: CardClickEvent): boolean {
+  return e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey;
+}
+
+// The click handler every app card shares. Left click with no modifier is an
+// in-app navigation (no page reload, no lost state); everything else is left to
+// the href, which is why the anchor must always carry one.
+export function onAppCardClick(e: CardClickEvent, app: AppInfo): void {
+  if (e.defaultPrevented || isBrowserHandledClick(e)) return;
+  e.preventDefault();
+  openApp(app);
+}

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -6130,6 +6130,9 @@ select.field-control:has(option[value=""]:checked) {
   gap: 2px;
 }
 
+/* An <a> so middle-click / Cmd-click / "Open in new tab" work on it (appEntry).
+   `text-decoration: none` is what an anchor needs and a button did not; the
+   colour was already pinned, so a link never paints as one here. */
 .home-recent {
   display: flex;
   align-items: center;
@@ -6140,6 +6143,7 @@ select.field-control:has(option[value=""]:checked) {
   text-align: left;
   background: none;
   color: var(--fg);
+  text-decoration: none;
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -6182,6 +6186,7 @@ select.field-control:has(option[value=""]:checked) {
   }
 }
 
+/* An <a>, like .home-recent — see the note there. */
 .home-app {
   display: flex;
   align-items: center;
@@ -6192,6 +6197,7 @@ select.field-control:has(option[value=""]:checked) {
   text-align: left;
   background: none;
   color: var(--fg);
+  text-decoration: none;
   border: none;
   border-radius: 8px;
   cursor: pointer;
@@ -6743,6 +6749,7 @@ select.field-control:has(option[value=""]:checked) {
   gap: 18px;
 }
 
+/* An <a>, like .home-recent — see the note there. */
 .app-pcard {
   display: flex;
   flex-direction: column;
@@ -6751,6 +6758,7 @@ select.field-control:has(option[value=""]:checked) {
   font: inherit;
   text-align: left;
   color: var(--fg);
+  text-decoration: none;
   background: var(--bg-alt);
   border: 1px solid var(--border);
   border-radius: 12px;

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -12,6 +12,7 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { getApps } from "@platform/lib/api";
 import type { AppInfo, Config } from "@platform/lib/api";
+import { hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
 import { navigate, navigateUrl } from "@platform/lib/router";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { basename } from "@platform/lib/format";
@@ -94,21 +95,23 @@ function Doorway({
   );
 }
 
-// One row in the Recent list: name, tag, last-used — no icon. Same open
-// behavior as the /apps cards: the app FOLDER in the claude_split view when
-// an entry exists, else the plain folder.
+// One row in the Recent list: name, tag, last-used — no icon. Opens through the
+// same shared rule as the /apps cards (appEntry.openTargetFor), rather than the
+// inline copy it used to carry: that copy had already drifted from the hub's,
+// and a row and a card for the same app must not open different things.
 function RecentRow({ app }: { app: AppInfo }) {
-  const open = () => {
-    if (app.entry_html) navigate(app.path, { isDir: true, mode: "claude_split" });
-    else navigate(app.path, { isDir: true });
-  };
   const title = app.title || app.name;
   return (
-    <button type="button" className="home-recent" onClick={open} title={app.path}>
+    <a
+      className="home-recent"
+      href={hrefFor(app)}
+      onClick={(e) => onAppCardClick(e, app)}
+      title={openTargetFor(app).path}
+    >
       <span className="home-recent-name">{title}</span>
       <span className="home-app-tag">{app.tag}</span>
       <span className="home-recent-when">{timeAgo(app.updated_at) ?? "—"}</span>
-    </button>
+    </a>
   );
 }
 

--- a/fused_render/app_listing.py
+++ b/fused_render/app_listing.py
@@ -1,0 +1,140 @@
+"""The entry contract behind `GET /api/apps`, extracted from its router.
+
+An app is a folder with a single entry page: `<workspace>/<tag>/<name>/`, whose
+entry is its one non-hidden direct-child `.html`. The walk that finds them, and
+the two facts reported about each one — a title read out of the entry, and when
+the folder was last touched — live here rather than inside the route handler, so
+they can be tested and reused without a `TestClient`.
+
+Nothing in this module raises for a directory it cannot read: a listing degrades
+to what it could see. The one deliberate exception is `app_entry`, which lets
+its `OSError` out so the CALLER can tell "unreadable, skip it" from "no entry,
+list it as a folder" — see `app_dict`.
+"""
+import html
+import os
+import re
+
+_TITLE_RE = re.compile(rb"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+
+
+def app_entry(dir_path: str) -> str | None:
+    """An app folder's entry: the single non-hidden direct-child `.html`, or None
+    when the folder has zero or several (ambiguous — the UI opens the folder).
+    Raises OSError when the dir can't be listed; every caller skips those."""
+    children = os.listdir(dir_path)
+    htmls = [
+        c for c in sorted(children)
+        if not c.startswith(".")
+        and c.lower().endswith(".html")
+        and os.path.isfile(os.path.join(dir_path, c))
+    ]
+    if len(htmls) != 1:
+        return None
+    return os.path.abspath(os.path.join(dir_path, htmls[0]))
+
+
+def app_dict(path: str, name: str, tag: str, entry_html: str | None) -> dict:
+    """One app's listing entry — the single place the shape is built.
+
+    `entry_html` is resolved by the CALLER, deliberately. Resolving it in here
+    would mean swallowing `app_entry`'s `OSError`, which quietly turns "this
+    directory cannot be read, skip it" into "this directory has no entry, list
+    it as a folder" — an unreadable app comes back as a card. The caller is the
+    only one that knows which of those it wants, so it decides.
+    """
+    return {
+        "name": name,
+        "tag": tag,
+        "path": os.path.abspath(path),
+        # `entry` is the file a card opens and previews. For an app of this
+        # shape that is exactly its entry HTML; it is reported under its own key
+        # because "the file to open" and "this entry is a renderable page" are
+        # different claims, and only the second one may be handed to the
+        # HTML-only /render iframe. The shell reads `entry` (see the frontend's
+        # entryOf) and falls back to `entry_html` against an older server.
+        "entry": entry_html,
+        "entry_html": entry_html,
+        "title": entry_title(entry_html) if entry_html else None,
+        "updated_at": dir_updated_at(path),
+    }
+
+
+def two_level_apps(root: str) -> list[dict]:
+    """Every app in a Fused-shaped folder: `<root>/<tag>/<name>/`.
+
+    A "tag" is any non-hidden top-level directory, an "app" any non-hidden
+    directory directly inside one — no registry, so a new tag is just a new
+    folder.
+
+    Skips whatever it cannot read at every level and returns [] for a root that
+    isn't listable (no workspace yet, on a first run) — a listing degrades, it
+    never fails. Sorted at both levels so a partial result is still stable.
+    """
+    apps: list[dict] = []
+    try:
+        tag_names = os.listdir(root)
+    except OSError:
+        return apps
+    for tag in sorted(tag_names):
+        if tag.startswith("."):
+            continue
+        tag_path = os.path.join(root, tag)
+        try:
+            if not os.path.isdir(tag_path):
+                continue
+            names = os.listdir(tag_path)
+        except OSError:
+            continue  # unreadable/racing tag dir: skip, never fail the listing
+        for name in sorted(names):
+            if name.startswith("."):
+                continue
+            path = os.path.join(tag_path, name)
+            try:
+                if not os.path.isdir(path):
+                    continue
+                entry_html = app_entry(path)
+            except OSError:
+                # Unreadable or racing: SKIPPED, not listed as an entry-less
+                # card. Resolving the entry inside this guard is what makes
+                # that distinction — see `app_dict`.
+                continue
+            apps.append(app_dict(path, name, tag, entry_html))
+    return apps
+
+
+def entry_title(entry_html: str) -> str | None:
+    """The <title> of an entry file, from its first 4 KiB — cheap enough to run
+    per app on every listing. None when absent, empty, or unreadable."""
+    try:
+        with open(entry_html, "rb") as fh:
+            head = fh.read(4096)
+    except OSError:
+        return None
+    match = _TITLE_RE.search(head)
+    if not match:
+        return None
+    title = html.unescape(match.group(1).decode("utf-8", "replace"))
+    return " ".join(title.split()) or None
+
+
+def dir_updated_at(dir_path: str) -> float | None:
+    """When a folder-shaped app was last touched, as an epoch float (st_mtime).
+
+    Max of the dir's own mtime and its DIRECT children's — the dir mtime alone
+    only moves on add/remove/rename, so editing index.html in place wouldn't
+    register; a deep walk is unbounded work per listing for marginal gain (edits
+    in an app land overwhelmingly in top-level files). One extra stat per child,
+    no recursion. None when nothing stats (racing delete)."""
+    latest = None
+    try:
+        latest = os.stat(dir_path).st_mtime
+        with os.scandir(dir_path) as it:
+            for child in it:
+                try:
+                    latest = max(latest, child.stat().st_mtime)
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    return latest

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -10,6 +10,12 @@ direct-child ``.html`` file when there is exactly one — zero or several means
 the folder still lists, but opens as a directory instead of a view
 (``entry_html: null``).
 
+The walk itself lives in ``fused_render/app_listing.py``, which also defines
+what one listed app looks like. Each app reports its entry twice: ``entry`` is
+the file a card opens and previews, ``entry_html`` the narrower claim that the
+entry is a renderable page (the only one the HTML-only ``/render`` iframe may be
+pointed at). For an app of this shape they are the same file.
+
 POST /api/apps/new scaffolds ``<workspace>/local/<name>/`` from the packaged
 app starter kit (``fused_render/app_starter/`` — an ``index.html`` entry view
 plus a ``CLAUDE.md``) and — when the request carries a prompt — starts a
@@ -24,10 +30,8 @@ are synced to Claude Code's user-level skills dir instead (user_skills.py) —
 once per machine, refreshed at server startup and again here at create time —
 and the starter ``CLAUDE.md`` references them by name.
 """
-import html
 import json
 import os
-import re
 import shutil
 import subprocess
 import sys
@@ -36,6 +40,7 @@ import time
 
 from fastapi import APIRouter, Body, Header
 
+from fused_render import app_listing
 from fused_render.server.common import _error, _require_fused
 from fused_render.shell.seed import fused_dir
 
@@ -50,99 +55,14 @@ _APP_STARTER_DIR = os.path.join(
 
 # ------------------------------------------------------------------- listing
 
-_TITLE_RE = re.compile(rb"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
-
-
-def _entry_title(entry_html: str) -> str | None:
-    """The <title> of an entry file, from its first 4 KiB — cheap enough to run
-    per app on every listing. None when absent, empty, or unreadable."""
-    try:
-        with open(entry_html, "rb") as fh:
-            head = fh.read(4096)
-    except OSError:
-        return None
-    match = _TITLE_RE.search(head)
-    if not match:
-        return None
-    title = html.unescape(match.group(1).decode("utf-8", "replace"))
-    return " ".join(title.split()) or None
-
-
-def _updated_at(dir_path: str) -> float | None:
-    """When the app was last touched, as an epoch float (st_mtime).
-
-    Max of the dir's own mtime and its DIRECT children's — the dir mtime alone
-    only moves on add/remove/rename, so editing index.html in place wouldn't
-    register; a deep walk is unbounded work per listing for marginal gain
-    (edits in an app land overwhelmingly in top-level files). One extra stat
-    per child, no recursion. None when nothing stats (racing delete)."""
-    latest = None
-    try:
-        latest = os.stat(dir_path).st_mtime
-        with os.scandir(dir_path) as it:
-            for child in it:
-                try:
-                    latest = max(latest, child.stat().st_mtime)
-                except OSError:
-                    continue
-    except OSError:
-        pass
-    return latest
-
-
-def _app_entry(dir_path: str) -> str | None:
-    """The app's entry file: the single non-hidden direct-child .html, or None
-    when the folder has zero or several (ambiguous — the UI opens the folder).
-    Raises OSError when the dir can't be listed — the caller skips those."""
-    children = os.listdir(dir_path)
-    htmls = [
-        c for c in sorted(children)
-        if not c.startswith(".")
-        and c.lower().endswith(".html")
-        and os.path.isfile(os.path.join(dir_path, c))
-    ]
-    if len(htmls) != 1:
-        return None
-    return os.path.abspath(os.path.join(dir_path, htmls[0]))
+# The walk and the entry contract live in `app_listing` rather than in this
+# handler: they are the part worth testing directly (and reusing) — a route is
+# not the right place for the rules about what an app IS. See that module.
 
 
 @router.get("/api/apps")
 def api_apps():
-    root = fused_dir()
-    apps = []
-    try:
-        tag_names = os.listdir(root)
-    except OSError:
-        # No workspace yet (first run before seeding) — an empty Home, not a 500.
-        return {"apps": []}
-    for tag in tag_names:
-        if tag.startswith("."):
-            continue
-        tag_path = os.path.join(root, tag)
-        try:
-            if not os.path.isdir(tag_path):
-                continue
-            names = os.listdir(tag_path)
-        except OSError:
-            continue  # unreadable/racing tag dir: skip, never fail the listing
-        for name in names:
-            if name.startswith("."):
-                continue
-            path = os.path.join(tag_path, name)
-            try:
-                if not os.path.isdir(path):
-                    continue
-                entry_html = _app_entry(path)
-            except OSError:
-                continue  # unreadable/racing entry: skip, never fail the listing
-            apps.append({
-                "name": name,
-                "tag": tag,
-                "path": os.path.abspath(path),
-                "entry_html": entry_html,
-                "title": _entry_title(entry_html) if entry_html else None,
-                "updated_at": _updated_at(path),
-            })
+    apps = app_listing.two_level_apps(fused_dir())
     apps.sort(key=lambda a: (a["tag"].lower(), a["name"].lower()))
     return {"apps": apps}
 

--- a/fused_render/templates/claude_split/app.py
+++ b/fused_render/templates/claude_split/app.py
@@ -12,7 +12,7 @@ def main(dir: str = ""):
         names = os.listdir(dir)
     except OSError:
         return {"entry": None}
-    # Same filter as the apps API's `_app_entry` (server/routers/apps.py):
+    # Same filter as the listing's `app_entry` (fused_render/app_listing.py):
     # non-hidden direct children, `.html` only — a hidden html or a sibling
     # `.htm` must not change which folders count as apps.
     htmls = [n for n in sorted(names)

--- a/tests/_thread_scoped.py
+++ b/tests/_thread_scoped.py
@@ -1,0 +1,41 @@
+"""Thread-scoped filesystem traps for the "this code must not enumerate" tests.
+
+Several suites assert that a code path never issues `os.scandir`/`os.listdir`/
+`os.walk`/`glob` — the mount tests (a stray readdir drops an rclone mount), the
+condition-gate tests (CT-12), the pathops tests. They do it the only way one
+can: by patching the function on the `os` module, which is **process-wide**.
+
+That is fine until something else in the process has a background thread. Under
+the `fused-engine` CI job it does: the `fused` package starts an
+`openfused-invoke-dispatcher` thread that polls its own request directory with
+`pathlib.glob`, i.e. `os.scandir`. It ticks on its own schedule, so it lands
+inside the patched window at random — and the trap blames the code under test
+for a directory it never touched. Observed as both a hard failure
+(`test_load_meta_consolidated_does_not_scandir_at_all` recording
+`/tmp/openfused-invoke-*/requests`) and, in an earlier run, a
+`PytestUnhandledThreadExceptionWarning` raised inside that thread.
+
+Widening the trap's allow-list would be the wrong fix: it would have to name
+another package's private temp paths, and it would go stale. What every one of
+these assertions actually means is "**this** call must not enumerate" — a
+property of one thread's work, not of the process. So the trap applies to the
+thread that installed it and delegates everything else straight through.
+"""
+import threading
+
+
+def this_thread_only(real, guard):
+    """`guard`, but only for the installing thread; other threads get `real`.
+
+    Capture happens at call time, so the owner is whichever thread builds the
+    trap — which is the test thread, since these are installed by fixtures and
+    test bodies rather than by imports.
+    """
+    owner = threading.get_ident()
+
+    def wrapper(*args, **kwargs):
+        if threading.get_ident() != owner:
+            return real(*args, **kwargs)
+        return guard(*args, **kwargs)
+
+    return wrapper

--- a/tests/test_app_listing.py
+++ b/tests/test_app_listing.py
@@ -1,0 +1,132 @@
+"""The listing's rules, exercised directly rather than through /api/apps.
+
+These four cases are the reason `app_listing` is a module and not a section of
+`server/routers/apps.py`: every one of them is a filesystem condition — a stray
+file where an app folder is expected, an entry that cannot be read, a directory
+that vanishes mid-scan — and reaching them through a `TestClient` means building
+a whole app to observe one `except OSError`. They were uncovered while the code
+lived in the route handler, for exactly that reason.
+"""
+import os
+
+from fused_render import app_listing
+
+
+def _app(tag_dir, name, entry="index.html", body="<html><body>hi</body></html>"):
+    d = tag_dir / name
+    d.mkdir(parents=True)
+    if entry:
+        (d / entry).write_text(body, encoding="utf-8")
+    return d
+
+
+# ------------------------------------------------------------------- the walk
+
+
+def test_a_loose_file_in_a_tag_folder_is_not_an_app(tmp_path):
+    """A workspace is a folder a user drops things into, so a stray file lands
+    beside the app folders sooner or later (`notes.txt` in `local/`). Only
+    DIRECTORIES are apps; a file must not become a card whose path opens
+    nothing."""
+    tag = tmp_path / "local"
+    _app(tag, "real")
+    (tag / "notes.txt").write_text("scratch", encoding="utf-8")
+    (tag / "index.html").write_text("<html></html>", encoding="utf-8")
+
+    assert [a["name"] for a in app_listing.two_level_apps(tmp_path)] == ["real"]
+
+
+def test_a_loose_file_at_the_top_level_is_not_a_tag(tmp_path):
+    """The mirror of the above one level up: a file in the workspace root is not
+    a tag folder to walk into."""
+    _app(tmp_path / "local", "real")
+    (tmp_path / "README.md").write_text("hi", encoding="utf-8")
+
+    assert [a["tag"] for a in app_listing.two_level_apps(tmp_path)] == ["local"]
+
+
+# ------------------------------------------------------------------ the title
+
+
+def test_an_unreadable_entry_has_no_title_rather_than_failing(tmp_path):
+    """A title is a nicety; the app still lists without one.
+
+    Uses a DIRECTORY at the entry's path to make the read fail for every uid —
+    a chmod would be vacuous as root, the trap `test_apps_api` documents.
+    """
+    entry = tmp_path / "index.html"
+    entry.mkdir()  # opening a directory raises OSError (IsADirectoryError)
+
+    assert app_listing.entry_title(str(entry)) is None
+    assert app_listing.entry_title(str(tmp_path / "absent.html")) is None
+
+
+def test_a_directory_named_index_html_is_not_an_entry(tmp_path):
+    """An entry has to be a FILE — `app_entry` checks `isfile`, not just the
+    suffix. A folder called `index.html` leaves the app entry-less (it opens as a
+    folder) rather than producing an `entry` the shell would hand to /render and
+    fail to read.
+
+    There is no end-to-end test here for an entry that is a real file the server
+    cannot open: as root every file is readable, so the only way to stage one is
+    a chmod that does nothing for uid 0 — the vacuous-test trap `test_apps_api`
+    documents. `entry_title`'s failure path is covered directly above instead.
+    """
+    app_dir = _app(tmp_path / "local", "odd", entry=None)
+    (app_dir / "index.html").mkdir()
+
+    (listed,) = app_listing.two_level_apps(tmp_path)
+    assert listed["name"] == "odd"
+    assert listed["entry"] is None and listed["entry_html"] is None
+    assert listed["title"] is None
+
+
+# --------------------------------------------------------------- the recency
+
+
+def test_recency_of_a_directory_that_is_not_there_is_none(tmp_path):
+    """`None`, not an exception and not 0 — the listing sorts these last instead
+    of showing a folder as last touched at the epoch."""
+    assert app_listing.dir_updated_at(str(tmp_path / "gone")) is None
+
+
+def test_a_child_that_vanishes_mid_scan_does_not_lose_the_folder(tmp_path,
+                                                                monkeypatch):
+    """The documented racing-delete case: a file listed by scandir is gone by the
+    time it is stat'd. That child contributes nothing and the folder still
+    reports the newest time among what survived — the alternative, letting the
+    OSError out, would drop the app from the listing entirely."""
+    (tmp_path / "keep.html").write_text("<html></html>", encoding="utf-8")
+    (tmp_path / "racing.html").write_text("<html></html>", encoding="utf-8")
+    os.utime(tmp_path / "keep.html", (10_000, 10_000))
+
+    real_scandir = os.scandir
+
+    class _Vanishing:
+        def __init__(self, entry):
+            self._entry = entry
+            self.name = entry.name
+
+        def stat(self, *args, **kwargs):
+            if self.name == "racing.html":
+                raise FileNotFoundError(2, "No such file or directory", self.name)
+            return self._entry.stat(*args, **kwargs)
+
+    class _Scandir:
+        def __init__(self, path):
+            self._it = real_scandir(path)
+
+        def __enter__(self):
+            return (_Vanishing(e) for e in self._it.__enter__())
+
+        def __exit__(self, *exc):
+            return self._it.__exit__(*exc)
+
+    monkeypatch.setattr(os, "scandir", _Scandir)
+
+    updated = app_listing.dir_updated_at(str(tmp_path))
+
+    assert updated is not None
+    # The surviving child's mtime is in the running, and the vanished one did not
+    # take the answer down with it.
+    assert updated >= 10_000

--- a/tests/test_app_listing.py
+++ b/tests/test_app_listing.py
@@ -8,6 +8,9 @@ a whole app to observe one `except OSError`. They were uncovered while the code
 lived in the route handler, for exactly that reason.
 """
 import os
+import time
+
+import pytest
 
 from fused_render import app_listing
 
@@ -93,16 +96,36 @@ def test_recency_of_a_directory_that_is_not_there_is_none(tmp_path):
 def test_a_child_that_vanishes_mid_scan_does_not_lose_the_folder(tmp_path,
                                                                 monkeypatch):
     """The documented racing-delete case: a file listed by scandir is gone by the
-    time it is stat'd. That child contributes nothing and the folder still
-    reports the newest time among what survived — the alternative, letting the
-    OSError out, would drop the app from the listing entirely."""
-    (tmp_path / "keep.html").write_text("<html></html>", encoding="utf-8")
+    time it is stat'd. That child contributes nothing, and the scan CONTINUES —
+    letting the OSError out instead would abandon the remaining children and
+    report the folder as last touched whenever its own mtime says.
+
+    Two details are what keep this from asserting nothing, both learned the hard
+    way (the first version of this test passed with the per-child handler
+    deleted):
+
+    * `keep.html` is stamped in the FUTURE, so it is strictly newer than the
+      directory's own mtime. Against a sentinel older than the directory, the
+      assertion is satisfied by the directory alone — which is precisely what
+      the outer handler falls back to, so removing the inner one changes
+      nothing.
+    * the vanishing child is scanned FIRST. `os.scandir` order is arbitrary; if
+      the survivor came first its mtime would already be in `latest` when the
+      exception escaped, and the outer handler would return the right answer for
+      the wrong reason.
+    """
+    keep = tmp_path / "keep.html"
+    keep.write_text("<html></html>", encoding="utf-8")
     (tmp_path / "racing.html").write_text("<html></html>", encoding="utf-8")
-    os.utime(tmp_path / "keep.html", (10_000, 10_000))
+    future = time.time() + 10_000
+    os.utime(keep, (future, future))
 
     real_scandir = os.scandir
 
     class _Vanishing:
+        """A DirEntry whose stat fails, standing in for a file deleted between
+        the readdir that listed it and the stat that reads it."""
+
         def __init__(self, entry):
             self._entry = entry
             self.name = entry.name
@@ -117,7 +140,10 @@ def test_a_child_that_vanishes_mid_scan_does_not_lose_the_folder(tmp_path,
             self._it = real_scandir(path)
 
         def __enter__(self):
-            return (_Vanishing(e) for e in self._it.__enter__())
+            entries = [_Vanishing(e) for e in self._it.__enter__()]
+            # Vanished first, survivors after — see the docstring.
+            entries.sort(key=lambda e: e.name != "racing.html")
+            return iter(entries)
 
         def __exit__(self, *exc):
             return self._it.__exit__(*exc)
@@ -126,7 +152,5 @@ def test_a_child_that_vanishes_mid_scan_does_not_lose_the_folder(tmp_path,
 
     updated = app_listing.dir_updated_at(str(tmp_path))
 
-    assert updated is not None
-    # The surviving child's mtime is in the running, and the vanished one did not
-    # take the answer down with it.
-    assert updated >= 10_000
+    # The survivor's mtime, reached only by continuing past the vanished child.
+    assert updated == pytest.approx(future, abs=1)

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -18,6 +18,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+from fused_render import app_listing
 from fused_render.server import create_app
 from fused_render.server.routers import apps as apps_mod
 
@@ -156,9 +157,56 @@ def test_unreadable_project_dir_is_skipped_not_fatal(client, workspace):
     assert [a["name"] for a in apps] == ["ok"]  # unreadable project dir skipped, no 500
 
 
+def test_an_unreadable_project_dir_is_skipped_at_any_uid(client, workspace,
+                                                         monkeypatch):
+    """The same contract as above, without depending on file permissions.
+
+    The chmod test is VACUOUS FOR ROOT — mode 0 does not stop uid 0 reading the
+    directory, so it is skipped there and a developer (or a container) running
+    as root gets no coverage of this path at all. That is how a regression
+    shipped once: `app_entry` was called from inside `app_dict`, which swallowed
+    the `OSError` and turned "skip this directory" into "list it with no entry".
+
+    Raising from `app_entry` itself reproduces the condition deterministically,
+    for every uid and on Windows too, and is what the listing actually has to
+    survive.
+    """
+    _app_dir(workspace, "ok")
+    (workspace / "local" / "locked").mkdir()
+
+    real = app_listing.app_entry
+
+    def refuse(path):
+        if os.path.basename(path) == "locked":
+            raise PermissionError(13, "Permission denied", path)
+        return real(path)
+
+    monkeypatch.setattr(app_listing, "app_entry", refuse)
+    apps = client.get("/api/apps").json()["apps"]
+
+    assert [a["name"] for a in apps] == ["ok"]
+
+
 def test_missing_workspace_lists_empty(client, workspace):
     os.rmdir(workspace)
     assert client.get("/api/apps").json() == {"apps": []}
+
+
+def test_entry_is_reported_alongside_entry_html(client, workspace):
+    """Both keys, same file — the shell reads `entry` and needs it to be there.
+
+    `entry` is "the file a card opens"; `entry_html` is the narrower "this entry
+    is a renderable page". They coincide for a workspace app, and an entry-less
+    folder reports null under both rather than omitting either key.
+    """
+    _app_dir(workspace, "withentry")
+    (workspace / "local" / "bare").mkdir()
+
+    apps = {a["name"]: a for a in client.get("/api/apps").json()["apps"]}
+
+    assert apps["withentry"]["entry"] == apps["withentry"]["entry_html"]
+    assert apps["withentry"]["entry"].endswith("index.html")
+    assert apps["bare"]["entry"] is None and apps["bare"]["entry_html"] is None
 
 
 # ------------------------------------------------------------------- creation

--- a/tests/test_browse_mount.py
+++ b/tests/test_browse_mount.py
@@ -22,6 +22,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+from _thread_scoped import this_thread_only
+
 from fused_render.templates.geotiff import browse as br
 from fused_render.templates.zarr_aoi import browse as zbr
 
@@ -129,10 +131,12 @@ def no_kernel_list(monkeypatch):
     def boom(*a, **k):
         raise AssertionError("kernel filesystem access on a remote path")
 
-    monkeypatch.setattr(os, "listdir", boom)
-    monkeypatch.setattr(os, "scandir", boom)
-    monkeypatch.setattr(os.path, "isdir", boom)
-    monkeypatch.setattr(os.path, "getsize", boom)
+    # Thread-scoped — these are process-wide patches and another package's
+    # background thread must not be blamed for them (tests/_thread_scoped.py).
+    for target, name in ((os, "listdir"), (os, "scandir"),
+                         (os.path, "isdir"), (os.path, "getsize")):
+        monkeypatch.setattr(target, name,
+                            this_thread_only(getattr(target, name), boom))
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_graph_condition.py
+++ b/tests/test_graph_condition.py
@@ -20,6 +20,8 @@ from unittest import mock
 
 import pytest
 
+from _thread_scoped import this_thread_only
+
 CONDITION = os.path.join(
     os.path.dirname(__file__), "..", "fused_render", "templates", "graph", "condition.py")
 
@@ -45,11 +47,16 @@ def _no_enumeration():
     def forbidden(*args, **kwargs):
         raise AssertionError("the gate must never enumerate a directory (CT-12)")
 
-    with mock.patch.object(os, "listdir", forbidden), \
-            mock.patch.object(os, "scandir", forbidden), \
-            mock.patch.object(os, "walk", forbidden), \
-            mock.patch.object(glob_mod, "glob", forbidden), \
-            mock.patch.object(glob_mod, "iglob", forbidden):
+    # Thread-scoped: these patches are process-wide, and under the
+    # fused-engine job another package's background thread polls its own
+    # directory with glob — it would trip a gate assertion about code it never
+    # ran. See tests/_thread_scoped.py.
+    def guard(target, name):
+        real = getattr(target, name)
+        return mock.patch.object(target, name, this_thread_only(real, forbidden))
+
+    with guard(os, "listdir"), guard(os, "scandir"), guard(os, "walk"), \
+            guard(glob_mod, "glob"), guard(glob_mod, "iglob"):
         yield
 
 

--- a/tests/test_netcdf_zarr_mount.py
+++ b/tests/test_netcdf_zarr_mount.py
@@ -26,6 +26,8 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import pytest
 
+from _thread_scoped import this_thread_only
+
 NETCDF_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
     "fused_render", "templates", "netcdf")
@@ -156,7 +158,12 @@ class _ScandirTrap:
                     f"scandir on chunk dir {ap} — would drop the mount")
             return self._real(path)
 
-        monkeypatch.setattr(Z.os, "scandir", fake)
+        # Thread-scoped: `Z.os` is the real `os` module, so this patch is
+        # process-wide, and under the fused-engine job another package's
+        # background thread polls its own directory with glob (see
+        # _thread_scoped.py). Recording ITS scandir made `scanned` a list of
+        # paths this code never touched.
+        monkeypatch.setattr(Z.os, "scandir", this_thread_only(self._real, fake))
 
 
 # --------------------------------------------------------------------------
@@ -221,7 +228,7 @@ def test_chunk_stats_remote_skips_scandir(tmp_path, monkeypatch):
     def boom(path):
         raise AssertionError("os.scandir called for a remote chunk_stats")
 
-    monkeypatch.setattr(Z.os, "scandir", boom)
+    monkeypatch.setattr(Z.os, "scandir", this_thread_only(os.scandir, boom))
     za = {"shape": [100, 100], "chunks": [10, 10]}
     present, total = Z._chunk_stats(store, "temperature", za, remote=True)
     assert present is None

--- a/tests/test_notebook_kernel.py
+++ b/tests/test_notebook_kernel.py
@@ -179,8 +179,27 @@ def test_output_truncation(kernel):
 
 
 def test_interrupt_aborts_queued_cells(kernel):
-    kernel.send({"op": "execute", "id": "e1", "code": "import time\ntime.sleep(60)"})
+    # Wait until e1 is provably INSIDE the sleep, not merely `started`.
+    #
+    # `started` is emitted at the top of kernel_body.execute — before the flush
+    # ticker starts, before the stdio swap, before ast.parse and before a line
+    # of the cell runs. Interrupting on that event alone races the cell's own
+    # progress toward `time.sleep`, and this test's whole subject is what an
+    # interrupt does to a cell that IS running. It failed exactly that way on a
+    # loaded CI runner: e2 and e3 were aborted off the queue as expected, but
+    # e1 never produced `done`, so the wait below timed out after 15s.
+    #
+    # The printed marker closes the window deterministically: once its stream
+    # event has arrived (StreamWriter.flush emits synchronously), the next
+    # statement executed is the sleep. The short settle covers the handful of
+    # bytecodes between the two — the sibling test_interrupt_running_cell buys
+    # the same guarantee with a bare 0.5s wait and no marker.
+    kernel.send({"op": "execute", "id": "e1",
+                 "code": "import time\nprint('sleeping', flush=True)\ntime.sleep(60)"})
     kernel.wait_for(lambda e: e.get("type") == "started" and e.get("id") == "e1")
+    kernel.wait_for(lambda e: e.get("type") == "stream"
+                    and "sleeping" in (e.get("text") or ""))
+    time.sleep(0.2)
     # e2/e3 sit on the queue behind the sleeping cell; the stdin pipe is FIFO,
     # so they are queued before the interrupt is processed
     kernel.send({"op": "execute", "id": "e2", "code": "x = 'ran'"})

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,6 +7,8 @@ import os
 
 import pytest
 
+from _thread_scoped import this_thread_only
+
 from fused_render.server import templates as server
 
 
@@ -789,8 +791,9 @@ def test_zarr_condition_never_lists_directory(tmp_path, monkeypatch):
     def boom(*a, **k):
         raise AssertionError("zarr_aoi condition must not list the directory")
 
-    monkeypatch.setattr(os, "listdir", boom)
-    monkeypatch.setattr(os, "scandir", boom)
+    # Thread-scoped (tests/_thread_scoped.py) — see test_browse_mount.
+    monkeypatch.setattr(os, "listdir", this_thread_only(os.listdir, boom))
+    monkeypatch.setattr(os, "scandir", this_thread_only(os.scandir, boom))
 
     named = tmp_path / "s.zarr"
     named.mkdir()


### PR DESCRIPTION
## Summary

The separable parts of #369 — the listing refactor and two CI-flake fixes — plus a new fix: **app cards support middle-click and "Open in new tab"**.

Nothing from the Claude Science or Claude Code artifact-discovery features lands here. No `claude_science.py`, no `claude_projects.py`, no Preferences → App discovery section, no source badges, no new env vars. #369 keeps all of it and gets smaller by this much.

## What's here

**Test-infra flake fixes** (cherry-picked from #369, test-only)

- `tests/_thread_scoped.py` — the "this code must not enumerate a directory" traps (mount tests, condition gates, zarr/geotiff browse) patch `os.scandir`/`listdir`/`walk`/`glob`, which is process-wide. Under the `fused-engine` job the `fused` package runs an `openfused-invoke-dispatcher` thread polling its own request dir with `pathlib.glob`, so the trap intermittently blamed the code under test for a directory it never touched. The trap is now scoped to the installing thread; other threads pass through to the real function.
- `test_interrupt_aborts_queued_cells` interrupted on the `started` event, which is emitted before `ast.parse` and before any of the cell runs — so it raced the cell's own progress toward `time.sleep`, and timed out at 15s on a loaded runner. It now waits for a printed marker whose stream event flushes synchronously.

**`app_listing.py` — the apps walk moves out of its router**

The rules about what an app *is* (the two-level walk, entry resolution, the `<title>` read, the recency stat) lived inside the `GET /api/apps` handler, where reaching them at all meant a `TestClient`. Moved verbatim; the handler is now the walk plus the sort.

- `app_dict` takes an already-resolved `entry_html` rather than calling `app_entry` itself. Resolving it in there means swallowing the `OSError`, which turns *"this directory cannot be read, skip it"* into *"this directory has no entry, list it as a folder"* — an unreadable app comes back as a card.
- That distinction had no honest test. The existing coverage is chmod-based and so **vacuous for root** — mode 0 does not stop uid 0 reading a directory, so it skips there and a container running as root gets no coverage of the path at all. Added one that raises from `app_entry` directly: deterministic, every uid, Windows included.
- Each app now also reports `entry` beside `entry_html`. Same file for an app of this shape; separate keys because "the file a card opens" and "the entry is a renderable page" are different claims, and only the second may be handed to the HTML-only `/render` iframe.

**App cards open in a new tab** (new here, not from #369)

Home's Recent rows, Home's app tiles and the /apps hub's preview cards each carried their own inline copy of the open rule, and they had already drifted — Home's row and the hub's card disagreed. The rule now lives once in `platform/lib/appEntry.ts`, resolved as a value (`openTargetFor`) so it is testable without mocking the router (bun's module mocks are process-wide and a stubbed router leaks into the next suite). The rule itself is unchanged.

The cards were `<button>`s, so the browser's own gestures did nothing: no middle-click, no Cmd/Ctrl-click, and a context menu with no Open in New Tab. They are anchors now, with an href built from the same `openTargetFor` the click handler uses — a new tab and a left click cannot land in different places. `_mode` rides along in the href because it selects the destination template; `preview` does not, since that is in-session layout and a new tab is a fresh session.

`isBrowserHandledClick` deliberately does **not** go through `platform.ts`'s `isMod()` — the one place that rule is broken, with a comment saying why. `isMod` is exclusive by design (Meta on macOS, Ctrl elsewhere) because a *shortcut* must not fire on the wrong platform's chord. This is not a shortcut: it asks whether the browser has already claimed the click, and the browser's rule is any-modifier. Gating on `isMod` would swallow Shift-click everywhere and Ctrl-click on macOS, where it opens the context menu.

## Deliberately left out

- **The `__pycache__` work (D207).** Its prevention mechanism — `sys.dont_write_bytecode = True` in both engines — is process-wide, so it also stops caching for everything a call imports from site-packages. User venvs are built by `uv`, which does not compile bytecode (measured: 0 `.pyc` after `uv pip install pandas`), and PY-6 spawns a fresh process per call, so the cost recurs on every call rather than being paid once. Measured for `import pandas` in such a venv: **~1.7s every call** vs **~0.4–0.6s** after the first with caching allowed. `sys.pycache_prefix` gets the same clean app folder (verified: 0 `__pycache__` in the app folder) while keeping the cache at ~0.35s. Being reworked separately.
- **`IGNORED_CHILDREN`** (`__pycache__`/`.git` excluded from cards and from recency) is the listing-side half of that same decision, so it stayed with it. It is a small follow-up on top of `app_listing.py` whenever D207 lands.

## Testing

- `pytest`: 4225 passed, 165 skipped. Six failures in this container are pre-existing on clean `main` (five `test_engine.py` PYTHONHOME/fake-bundle stand-in tests, `test_server_ai.py::test_relay_happy_path`) — verified by stashing the branch and re-running.
- `bun test`: 91 passed, including 9 new `appEntry` tests covering the open rule, href/click agreement, path encoding (space, `#`, non-ASCII), and every modified-click case.
- `npm run build`: boundaries OK (93 files), `tsc --noEmit` clean, vite build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019LhLUzYR9vRFxTVtSNvp4u

---
_Generated by [Claude Code](https://claude.ai/code/session_019LhLUzYR9vRFxTVtSNvp4u)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes primary navigation for app discovery surfaces and refactors apps listing with subtle OSError/skip semantics; mitigated by new unit tests and backward-compatible `entryOf` fallback for older backends.
> 
> **Overview**
> **App cards** on Home (Recent rows and tiles) and the `/apps` hub preview grid are now **`<a>` links** with a real `href`, so middle-click, Cmd/Ctrl-click, and “Open in new tab” work. Left-click still uses in-app `navigate` via a shared handler that leaves modified clicks to the browser.
> 
> Open behavior is centralized in **`platform/lib/appEntry.ts`** (`openTargetFor`, `hrefFor`, `onAppCardClick`) so those surfaces no longer carry duplicated rules—Home Recent had already drifted from the hub cards. `href` and click targets are built from the same resolver so new tabs and normal clicks land in the same place (`_mode=claude_split` in the URL when applicable).
> 
> **`GET /api/apps`** listing logic moves into **`fused_render/app_listing.py`**; the route handler only walks and sorts. Each app now reports **`entry`** alongside **`entry_html`** (same file today; `entry` is what cards open, `entry_html` is the renderable-page claim for `/render`). Unreadable app dirs stay **skipped** rather than listed as entry-less folders—`app_dict` no longer swallows `app_entry` errors.
> 
> **Test-only CI fixes:** **`tests/_thread_scoped.py`** scopes `os`/`glob` enumeration traps to the installing thread so background `openfused-invoke-dispatcher` polling does not flake mount/condition tests; **`test_interrupt_aborts_queued_cells`** waits for a stream marker before interrupting so it does not race `started` vs `time.sleep`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7e7dbf415050cd58a1c74f7137a1c1444ec968. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->