### PR TITLE
Decompose the Listing god file into focused modules

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -3,480 +3,51 @@
 // sorted listing is refresh-proof and bookmarkable like any other view state;
 // the search query rides the URL the same way (?q=…). A non-empty query swaps
 // the listing for flat, rank-ordered results over a recursive walk of the
-// folder. The walk STREAMS (NDJSON batches, breadth-first from the server):
-// results paint from the first batch and refine while deeper levels are still
-// arriving, so feedback is instant even on huge trees. The walk starts lazily
-// on first focus (or a URL-seeded query) and is cached until the dir watch
-// fires.
-import { useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { navigate, navigateUrl, urlForFsPath, replaceSearch } from "@platform/lib/router";
-import {
-  listDir,
-  prefetchListDir,
-  walkDirStream,
-  revealPath,
-  writeFile,
-  mkdir,
-  deleteEntry,
-  renameEntry,
-  copyEntry,
-  compressEntry,
-  gitRepoInfo,
-  statPath,
-} from "@platform/lib/api";
-import type { ArchiveFormat, FsEntry, WalkEntry } from "@platform/lib/api";
-import {
-  dirname,
-  normDir,
-  join,
-  freeArchivePath,
-  freeDuplicatePath,
-  freePastePath,
-  copyToClipboard,
-  notePathDeleted,
-  remapClipboardPath,
-  pruneDescendantPaths,
-  trashEntry,
-  resolveOpenWithModes,
-  buildOpenWithItems,
-  buildCompressItems,
-  friendlyFsError,
-  claudeDeepLink,
-} from "@apps/explorer/lib/fs-actions";
-import { acquireOverlay, releaseOverlay, isOverlayOpen } from "@platform/lib/ui-overlay";
-import { isMac, isMod } from "@platform/lib/platform";
-import { formatSize, formatMtime, basename } from "@platform/lib/format";
-import { fuzzyMatch, highlightSegments } from "@platform/lib/fuzzy";
+// folder — see listing/useWalkSearch for the streaming/scoring pipeline.
+//
+// This file is the orchestrator: it wires the hooks together and renders the
+// table. The pieces live in listing/:
+//   types.ts               shared types + tuning constants
+//   sorting.ts             sort resolution + entry sorting
+//   search.ts              fuzzy scoring / ranking (pure)
+//   selection.ts           selection model + cross-remount stash (pure)
+//   pane.ts                preview-pane state (usePreviewPane)
+//   row-utils.ts           RowCtx batch helpers
+//   bits.tsx               skeleton rows, ClipMark, highlight, scroll anchor
+//   useDirListing.ts       /api/fs/list fetch, Load more, dir watch, new-row cue
+//   useWalkSearch.ts       streamed walk + scoring + throttles + result paging
+//   useListingSelection.ts selection state + keyboard nav + reconcile
+//   useFileOps.ts          file operations + context menus + dialogs
+//   useListingShortcuts.ts file-op keyboard chords
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { navigate, replaceSearch } from "@platform/lib/router";
+import { dirname } from "@apps/explorer/lib/fs-actions";
+import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
+import { isMod } from "@platform/lib/platform";
+import { formatSize, formatMtime } from "@platform/lib/format";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
 import { getViewState, setViewState } from "@platform/lib/viewstate";
-import { appearedKeys, useFlip, FLIP_KEY_ATTR } from "@platform/lib/flip";
-import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "@platform/lib/search-hold";
-import { getClipboard, setClipboard, useClipboard } from "@apps/explorer/lib/fs-clipboard";
-import { pushToast } from "@platform/lib/toast";
-import ContextMenu, { type MenuEntry, type MenuItem } from "@platform/ui/ContextMenu";
-import { MenuIcons } from "@platform/ui/MenuIcons";
-import { PromptDialog, ConfirmDialog, nameError } from "@apps/explorer/FsDialogs";
+import { useFlip, FLIP_KEY_ATTR } from "@platform/lib/flip";
+import { useClipboard } from "@apps/explorer/lib/fs-clipboard";
+import ContextMenu from "@platform/ui/ContextMenu";
+import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import { SplitRightIcon } from "@platform/ui/SplitIcons";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
-
-// A right-clicked row, normalized so both listing rows (name relative to the
-// listed folder) and search-result rows (a `rel` path into a subtree) drive the
-// same menu. `parentDir` is the containing folder; `path` is the entry itself.
-interface RowCtx {
-  path: string;
-  name: string;
-  isDir: boolean;
-  parentDir: string;
-}
-
-// Row-shaped pruneDescendantPaths, for the batch row ops (Trash, Delete): a
-// search selection can hold a folder row and rows from inside it, and removing
-// the folder already removes those. Same input order.
-function pruneDescendantRows(rows: RowCtx[]): RowCtx[] {
-  const kept = new Set(pruneDescendantPaths(rows.map((r) => r.path)));
-  return rows.filter((r) => kept.has(r.path));
-}
-
-// The target folder for a New File / Paste against a row: INTO a directory row,
-// or the PARENT of a file row (Finder's behaviour).
-function targetDirOf(row: RowCtx): string {
-  return normDir(row.isDir ? row.path : row.parentDir);
-}
-
-// One open modal: a text prompt (New File/Folder, Rename) or a confirm (Delete).
-type DialogState =
-  | {
-      kind: "prompt";
-      title: string;
-      initial: string;
-      confirmLabel: string;
-      selectStem?: boolean;
-      onConfirm: (value: string) => void;
-    }
-  | {
-      kind: "confirm";
-      title: string;
-      message: React.ReactNode;
-      confirmLabel: string;
-      danger?: boolean;
-      onConfirm: () => void;
-    };
-
-const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
-type SortKey = keyof typeof SORT_KEYS;
-type SortOrder = "asc" | "desc";
-
-// Search-result rows rendered per "page". Fuzzy-scoring can match thousands
-// of entries in a large tree; mounting them all as <tr>s at once is what jams
-// the main thread (scoring itself is comparatively cheap). Scrolling to the
-// bottom reveals the next page (see the sentinel row below); the full ranked
-// list always exists in memory for the count text.
-const PAGE_SIZE = 250;
-
-// Above this many rendered rows the FLIP reorder animation is dropped. Measuring
-// every row's offsetTop on each commit is one forced layout, but the per-row
-// transform (a compositing layer each) is not free — on a listing this long the
-// glide costs more than the snap it replaces.
-const FLIP_MAX_ROWS = 600;
-
-// Minimum gap between commits of the RENDERED search ranking while a walk
-// streams (see the throttle in the component). Longer than STREAM_FLUSH_MS on
-// purpose: that one bounds how often results are re-scored, this one bounds how
-// often the rows on screen are allowed to move.
-const RERANK_COMMIT_MS = 280;
-
-// How long a row that just appeared in the folder keeps its tint. Long enough to
-// catch the eye if you weren't looking at that part of the list, short enough
-// that it doesn't become part of the row's normal appearance.
-const ROW_NEW_MS = 1500;
-
-// Where the scroll position is pinned across a dir-watch refresh: the lead
-// (selected) row, or failing that the topmost row still in view. Returns null
-// when there is nothing to anchor to (empty or unmounted listing).
-function measureScrollAnchor(
-  scroller: HTMLElement,
-): { key: string; top: number; scrollTop: number } | null {
-  let el = scroller.querySelector<HTMLElement>("tr.row.lead");
-  if (!el) {
-    for (const row of scroller.querySelectorAll<HTMLElement>(`[${FLIP_KEY_ATTR}]`)) {
-      if (row.offsetTop + row.offsetHeight > scroller.scrollTop) {
-        el = row;
-        break;
-      }
-    }
-  }
-  const key = el?.getAttribute(FLIP_KEY_ATTR);
-  if (!el || !key) return null;
-  return { key, top: el.offsetTop, scrollTop: scroller.scrollTop };
-}
-
-// Debounce for mirroring the query into the URL. Safari rate-limits
-// history.replaceState (~100 calls / 30s, then it THROWS); per-keystroke
-// sync trips that on fast typing. State stays immediate — only the URL lags.
-const URL_SYNC_MS = 200;
-
-// Minimum gap between streaming state flushes. Network chunks can arrive many
-// times per second on localhost; committing (and re-scoring) on every one
-// saturates the main thread and starves interaction. The first batch still
-// flushes immediately (lastFlush starts at 0), so first paint isn't delayed.
-const STREAM_FLUSH_MS = 200;
-
-// Effective sort for a folder. An explicit `?sort` in the URL wins — a shared
-// or hand-typed link is authoritative — otherwise fall back to this folder's
-// own saved state (lib/viewstate), otherwise the default name/asc. So each
-// folder shows its own remembered order regardless of how it was reached
-// (clicked into, a breadcrumb, Back, or a fresh URL), and sibling folders keep
-// independent sorts.
-function resolveSort(fsPath: string): { sort: SortKey; order: SortOrder } {
-  const url = new URLSearchParams(location.search);
-  const src = url.get("sort") ? url : new URLSearchParams(getViewState(fsPath));
-  const key = src.get("sort");
-  const sort: SortKey = key && key in SORT_KEYS ? (key as SortKey) : "name";
-  const order: SortOrder = src.get("order") === "desc" ? "desc" : "asc";
-  return { sort, order };
-}
-
-// The preview pane's per-folder state. Visibility follows the sort's model:
-// an explicit `?preview` in the URL wins (and rides along on directory
-// navigation — see lib/router navigate, which carries it so the pane is
-// sticky between folders), otherwise this folder's saved viewstate (keys
-// `pane`/`panew` alongside `sort`/`order`). Width is viewstate-only — a pixel
-// width isn't something a shared link should impose. A folder with no saved
-// width opens the pane at HALF the split container (width null until the
-// measuring effect resolves it; PANE_FALLBACK_W covers the pre-paint frame
-// and the unmeasurable edge). Default off — a folder never toggled shows the
-// plain listing exactly as before. `pane` and `panew` are independent: turning
-// the pane off keeps a dragged width, so re-opening the folder restores it.
-const PANE_MIN_W = 220;
-const LIST_MIN_W = 220;
-const PANE_MAX_FRAC = 0.65;
-const PANE_DEFAULT_FRAC = 0.5;
-const PANE_FALLBACK_W = 420;
-
-// The one place the FS-12 clamps live, so the drag and the measured default
-// cannot disagree. Two independent ceilings: the 65 % fraction (the list stays
-// the primary surface) and the LIST_MIN_W floor the list needs in pixels — on
-// a narrow window 65 % of the container leaves the list well under 220 px, so
-// the pixel ceiling is the binding one there. PANE_MIN_W is applied last: in
-// the degenerate case (a container too small to satisfy both minimums) the
-// pane keeps its floor and the list scrolls, which is what the old template's
-// `min-width` did.
-function clampPaneWidth(containerW: number, width: number): number {
-  return Math.max(PANE_MIN_W, Math.min(containerW * PANE_MAX_FRAC, containerW - LIST_MIN_W, width));
-}
-
-function resolvePane(fsPath: string): { on: boolean; width: number | null } {
-  const s = new URLSearchParams(getViewState(fsPath));
-  const url = new URLSearchParams(location.search);
-  // `preview=true` exactly — the owner's literal format (any other value
-  // reads as absent, falling back to the saved state).
-  const on = url.get("preview") !== null ? url.get("preview") === "true" : s.get("pane") === "1";
-  const w = parseInt(s.get("panew") || "", 10);
-  return { on, width: Number.isFinite(w) && w >= PANE_MIN_W ? w : null };
-}
-
-// Merge the pane keys into this folder's saved state without touching a saved
-// sort (and vice versa — setSort merges the same way). A null width (still at
-// the measured-default half) isn't persisted — only a dragged width is a
-// choice worth remembering. The two keys are INDEPENDENT: `panew` outlives a
-// toggle-off, so closing the pane and coming back to the folder re-opens at
-// the width that was dragged rather than re-measuring the default.
-function savePaneState(fsPath: string, on: boolean, width: number | null): void {
-  const s = new URLSearchParams(getViewState(fsPath));
-  if (on) s.set("pane", "1");
-  else s.delete("pane");
-  if (width !== null) s.set("panew", String(Math.round(width)));
-  else s.delete("panew");
-  const qs = s.toString();
-  setViewState(fsPath, qs ? "?" + qs : "");
-}
-
-function currentQuery(): string {
-  return new URLSearchParams(location.search).get("q") || "";
-}
-
-// Shimmering placeholder rows shown while the listing fetch is in flight —
-// same column shape as the real rows (icon + name + size + mtime), just with
-// shimmer bars instead of text so the table never reads as "frozen". The
-// width cycles make the bars ragged like real filenames.
-const SKEL_NAME_W = [70, 45, 82, 38, 60, 50, 74, 42, 66, 34];
-const SKEL_SIZE_W = [34, 28, 40, 24, 36, 30, 26, 38, 32, 22];
-function skeletonRows(n: number): React.ReactNode {
-  return Array.from({ length: n }, (_, i) => (
-    <tr key={i} className="skel-row">
-      <td className="name">
-        <span className="skel-bar icon-skel" />
-        <span className="skel-bar" style={{ width: `${SKEL_NAME_W[i % SKEL_NAME_W.length]}%` }} />
-      </td>
-      <td className="size">
-        <span className="skel-bar" style={{ width: SKEL_SIZE_W[i % SKEL_SIZE_W.length] }} />
-      </td>
-      <td className="mtime">
-        <span className="skel-bar" style={{ width: 84 }} />
-      </td>
-    </tr>
-  ));
-}
-
-// The pending-clipboard mark on a row: a small "Cut" / "Copied" pill in the name
-// cell, alongside the row-level styling (dim for cut, accent edge + wash for
-// copy). This IS the whole pending-clipboard UI — there is no chrome-level chip
-// (see Breadcrumb.tsx) — so the pill carries the Esc affordance in its tooltip.
-// `cut` and `copied` are never both true: the clipboard holds a single op.
-function ClipMark({ cut, copied }: { cut: boolean; copied: boolean }) {
-  if (!cut && !copied) return null;
-  return (
-    <span className={"clip-mark" + (cut ? " cut" : " copied")} title="Press Esc to cancel">
-      {cut ? "Cut" : "Copied"}
-    </span>
-  );
-}
-
-// A dot-leading query segment is explicit intent to SEE hidden entries.
-// The walk itself always includes hidden entries (one dataset — the server
-// prunes the actually-heavy machine trees like .git/node_modules, so hidden
-// files are cheap to carry); this only gates whether dot-entries are shown.
-// That makes ".py" work as an extension search (dotfiles like .pylintrc may
-// match too — fine, they're real matches) without a second walk, and "env"
-// deliberately not surface ".env".
-function queryWantsHidden(rawQuery: string): boolean {
-  const q = rawQuery.trim();
-  return q.startsWith(".") || q.includes("/.");
-}
-
-// An entry is hidden when any path segment is dot-leading.
-function isHiddenRel(rel: string): boolean {
-  return rel.startsWith(".") || rel.includes("/.");
-}
-
-function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEntry[] {
-  const flip = order === "desc" ? -1 : 1;
-  // Case-insensitive primary order, then an exact (case-sensitive) tiebreak so
-  // names differing only by case/accent get a stable, deterministic order.
-  // Without the tiebreak such names compare equal and the sort falls back to
-  // the arbitrary os.listdir() arrival order, which changes between refreshes.
-  const byName = (a: FsEntry, b: FsEntry) => {
-    const c = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-    return c !== 0 ? c : a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
-  };
-  return [...entries].sort((a, b) => {
-    const aDot = a.name.startsWith(".");
-    const bDot = b.name.startsWith(".");
-    if (aDot !== bDot) return aDot ? 1 : -1; // dot entries always group last
-    // Name sort is purely alphabetical — folders and files interleave. The
-    // size/mtime sorts still group dirs first: a dir has no size and its mtime
-    // means something different from a file's, so mixing them there is noise.
-    if (sort !== "name" && a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
-    let cmp: number;
-    if (sort === "size") cmp = (a.size ?? -1) - (b.size ?? -1);
-    else if (sort === "mtime") cmp = (a.mtime ?? 0) - (b.mtime ?? 0);
-    else cmp = byName(a, b);
-    if (cmp === 0) cmp = byName(a, b);
-    return cmp * flip;
-  });
-}
-
-// Ranking: longest consecutive matched run first (a contiguous substring hit
-// always beats a scattered subsequence one), then higher fuzzy score, then
-// fewer path segments (shallower = closer to hand), then alphabetical for a
-// stable order. Hits keep their score fields so partial result sets can be
-// merged and re-sorted incrementally as the walk streams in.
-interface SearchHit {
-  entry: WalkEntry;
-  positions: number[];
-  score: number;
-  longestRun: number;
-}
-
-function rankCompare(a: SearchHit, b: SearchHit): number {
-  if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
-  if (b.score !== a.score) return b.score - a.score;
-  const ad = a.entry.rel.split("/").length;
-  const bd = b.entry.rel.split("/").length;
-  if (ad !== bd) return ad - bd;
-  return a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
-}
-
-// Score `entries[from..]` against the query (unsorted — callers sort with
-// rankCompare after merging). `showHidden=false` skips dot-entries before
-// scoring (see queryWantsHidden). The `from` offset is what makes streaming
-// cheap: each flush scores only the entries that arrived since the last one.
-//
-// On top of the fuzzy score, the entry NAME (last path segment) gets intent
-// bonuses: an exact name match outranks everything ("Downloads" must beat
-// "DownloadStage", whose extra camel-hump bonus otherwise wins), and a name
-// starting with the query beats an interior hit. Char-level heuristics can't
-// express "this IS the thing you typed", so it's layered here, not in fuzzy.ts.
-function scoreEntries(query: string, entries: WalkEntry[], from: number, showHidden: boolean): SearchHit[] {
-  const q = query.toLowerCase();
-  const hits: SearchHit[] = [];
-  for (let i = from; i < entries.length; i++) {
-    const entry = entries[i];
-    if (!showHidden && isHiddenRel(entry.rel)) continue;
-    const m = fuzzyMatch(query, entry.rel);
-    if (!m) continue;
-    let score = m.score;
-    const name = entry.rel.slice(entry.rel.lastIndexOf("/") + 1).toLowerCase();
-    if (name === q) score += 100;
-    else if (name.startsWith(q)) score += 25;
-    hits.push({ entry, positions: m.positions, score, longestRun: m.longestRun });
-  }
-  return hits;
-}
-
-function renderHighlight(text: string, positions: number[]) {
-  return highlightSegments(text, positions).map((seg, i) =>
-    seg.match ? (
-      <mark key={i} className="search-mark">
-        {seg.text}
-      </mark>
-    ) : (
-      <span key={i}>{seg.text}</span>
-    )
-  );
-}
-
-type ListingState =
-  | { status: "loading" }
-  // `truncated`: the directory has more entries than the server cap, so this
-  // listing is a partial page. `cursor`: an opaque continuation token to fetch
-  // the next page (non-null only on the resumable S3-direct route); null means
-  // "no more can be fetched" — the banner then just states the listing is
-  // partial without a Load more button.
-  | { status: "ok"; entries: FsEntry[]; truncated: boolean; cursor: string | null }
-  | { status: "error"; message: string };
-
-// Streamed walk state. `entries` is one append-only array shared across the
-// streaming updates (each batch pushes into it); every update still creates a
-// NEW state object, so React re-renders and memos keyed on the walk recompute
-// against the grown array. `count` is the running total (doubles as the
-// version stamp that makes successive streaming states distinguishable).
-// Non-idle states are tagged with the `refresh` generation they were fetched
-// for; `validWalk` in the component treats a stale tag as idle, so a dir-watch
-// bump invalidates the cache synchronously WITHOUT itself triggering a
-// re-fetch (fetching is driven by `walkReq` — see below). The component
-// remounts per folder (keyed on fsPath in App), so no path tagging is needed.
-type WalkState =
-  | { status: "idle" }
-  | { status: "streaming"; entries: WalkEntry[]; count: number; forRefresh: number }
-  | { status: "ok"; entries: WalkEntry[]; truncated: boolean; total: number; forRefresh: number }
-  | { status: "error"; message: string; forRefresh: number };
-
-const IDLE_WALK: WalkState = { status: "idle" };
-
-// `provisional`: this Listing is rendering inside the pre-stat loading scaffold
-// (App LoadingScaffold), mounted off a directory NAV HINT rather than a
-// confirmed stat. The hint is authoritative in practice but can be stale — if
-// the path is actually a file, /api/fs/list 404s. In that provisional phase a
-// failed listing must NOT paint the hard "Failed to list" error: stat is still
-// resolving and will drive the correct final view (a file <Preview>) a beat
-// later, so we show the neutral loading body and let stat commit the real view.
-// Absent/false (the committed post-stat render), errors show normally.
-// Keyboard selection (the arrow-key row highlight) survives this component's
-// per-folder remount. Opening a folder first paints App's pre-stat scaffold
-// with a PROVISIONAL Listing, then swaps it for the resolved one when stat
-// lands ~1s later — a remount that would otherwise wipe an in-progress arrow
-// selection mid-keystroke (press Down during the open → the highlight vanishes).
-// Like fs-clipboard, the state lives just outside the remount boundary. A single
-// entry keyed by fsPath is enough (only one Listing is mounted at a time): it
-// bridges the scaffold→resolved swap and restores the highlight if you browse
-// back to the same folder.
-//
-// The stash carries the WHOLE multi-selection (see Selection below), not just
-// one path, so a Shift-range built in the provisional Listing survives too.
-interface Selection {
-  // Selected row paths, in the order they entered the selection (a Shift-range
-  // enters in rendered row order). Empty = nothing selected.
-  paths: string[];
-  // Where a Shift-range extends FROM: the last row selected by a plain or
-  // Mod-click / plain arrow move. null when nothing has been selected yet.
-  anchor: string | null;
-  // The focused row: what arrows move from, what Enter opens, what F2 renames,
-  // and what a paste/new-file targets. null = no selection.
-  lead: string | null;
-}
-
-const EMPTY_SELECTION: Selection = { paths: [], anchor: null, lead: null };
-
-// Collapse to exactly one row — the plain-click / plain-arrow / re-anchor case.
-function oneSelected(path: string): Selection {
-  return { paths: [path], anchor: path, lead: path };
-}
-
-let lastSelection: { fsPath: string; sel: Selection } | null = null;
-function recallSelection(fsPath: string): Selection {
-  return lastSelection && lastSelection.fsPath === fsPath ? lastSelection.sel : EMPTY_SELECTION;
-}
-function rememberSelection(fsPath: string, sel: Selection): void {
-  lastSelection = { fsPath, sel };
-}
-
-// A contiguous range of rendered rows, inclusive, in row order. `rows` is the
-// live navRows order (the SORTED/rendered order, never the raw fs order).
-function rangeBetween(rows: string[], from: string, to: string): string[] {
-  const a = rows.indexOf(from);
-  const b = rows.indexOf(to);
-  if (a === -1 || b === -1) return b === -1 ? [] : [to];
-  return a <= b ? rows.slice(a, b + 1) : rows.slice(b, a + 1);
-}
-
-// How many rows a PageUp/PageDown moves: one viewport of rows minus one, so the
-// row you were on stays visible as context. Measured from the live DOM (scroller
-// height / row height) and falls back to a sane constant before first paint.
-const PAGE_ROWS_FALLBACK = 12;
-function pageRows(): number {
-  const scroller = document.querySelector(".listing-scroll") as HTMLElement | null;
-  const row = document.querySelector("table.listing-table tr.row") as HTMLElement | null;
-  const rowH = row?.offsetHeight ?? 0;
-  if (!scroller || rowH <= 0) return PAGE_ROWS_FALLBACK;
-  return Math.max(1, Math.floor(scroller.clientHeight / rowH) - 1);
-}
-
-// Plural-friendly name for a batch of rows, used both in menu labels and as the
-// `name` in a friendlyFsError context ("Couldn't duplicate \"3 items\"").
-function batchLabel(rows: { name: string }[]): string {
-  return rows.length === 1 ? rows[0].name : `${rows.length} items`;
-}
+import {
+  FLIP_MAX_ROWS,
+  SORT_KEYS,
+  type RowCtx,
+  type SortKey,
+  type SortOrder,
+} from "@apps/explorer/listing/types";
+import { resolveSort, sortEntries } from "@apps/explorer/listing/sorting";
+import { skeletonRows, ClipMark, renderHighlight, measureScrollAnchor } from "@apps/explorer/listing/bits";
+import { usePreviewPane, reflectPaneInUrl, PANE_DEFAULT_FRAC } from "@apps/explorer/listing/pane";
+import { useDirListing } from "@apps/explorer/listing/useDirListing";
+import { useWalkSearch } from "@apps/explorer/listing/useWalkSearch";
+import { useListingSelection } from "@apps/explorer/listing/useListingSelection";
+import { useFileOps } from "@apps/explorer/listing/useFileOps";
+import { useListingShortcuts } from "@apps/explorer/listing/useListingShortcuts";
 
 export default function Listing({
   fsPath,
@@ -484,6 +55,15 @@ export default function Listing({
   onSingleApp,
 }: {
   fsPath: string;
+  // `provisional`: this Listing is rendering inside the pre-stat loading
+  // scaffold (App LoadingScaffold), mounted off a directory NAV HINT rather
+  // than a confirmed stat. The hint is authoritative in practice but can be
+  // stale — if the path is actually a file, /api/fs/list 404s. In that
+  // provisional phase a failed listing must NOT paint the hard "Failed to
+  // list" error: stat is still resolving and will drive the correct final view
+  // (a file <Preview>) a beat later, so we show the neutral loading body and
+  // let stat commit the real view. Absent/false (the committed post-stat
+  // render), errors show normally.
   provisional?: boolean;
   // Reports the path of this directory's lone top-level HTML file (an
   // "app"), or null when there isn't exactly one — the caller (Preview's
@@ -491,7 +71,8 @@ export default function Listing({
   // plain (non-search) listing settles, so it tracks dir-watch refreshes too.
   onSingleApp?: (path: string | null) => void;
 }) {
-  const [state, setState] = useState<ListingState>({ status: "loading" });
+  const { state, refresh, refetch, loadMore, loadingMore, newNames } = useDirListing(fsPath);
+
   // Sort lives in the URL; mirror it in state so clicks re-render without a
   // navigation (vanilla re-ran renderListing after its replaceState).
   const [{ sort, order }, setSortState] = useState<{ sort: SortKey; order: SortOrder }>(() =>
@@ -513,598 +94,10 @@ export default function Listing({
     params.set("order", s.get("order") === "desc" ? "desc" : "asc");
     replaceSearch(location.pathname + "?" + params.toString());
   }, [fsPath]);
-  // Same URL reflection for a pane restored from saved viewstate (URL carried
-  // no `preview`): put `preview=true` on the address bar so refresh, bookmarks
-  // and onward navigation (which carries the param) all see the shown state.
-  // Only ever ADDS the param — a URL without it and a folder without saved
-  // pane state keep the clean URL, and an explicit `?preview=false` stays
-  // authoritative (resolvePane already read it as off).
+  // Same URL reflection for a pane restored from saved viewstate.
   useEffect(() => {
-    if (new URLSearchParams(location.search).get("preview") !== null) return; // URL is authoritative
-    if (!new URLSearchParams(getViewState(fsPath)).get("pane")) return;
-    const params = new URLSearchParams(location.search);
-    params.set("preview", "true");
-    replaceSearch(location.pathname + "?" + params.toString());
+    reflectPaneInUrl(fsPath);
   }, [fsPath]);
-  const [refresh, setRefresh] = useState(0); // bumped by the dir watch socket
-  // loadMore captures the refresh generation it started in; a dir-watch refresh
-  // on the SAME path (App keys StatView on epoch+fsPath, so cross-directory
-  // merges can't happen, but a same-path re-fetch can) resets the listing while
-  // a cursored fetch is pending — the stale page must be discarded, not merged
-  // into the refreshed listing. Ref so the async callback reads the LATEST
-  // generation, not the one captured when loadMore was defined.
-  const refreshRef = useRef(refresh);
-  refreshRef.current = refresh;
-  const [query, setQueryState] = useState<string>(currentQuery);
-  const [walk, setWalk] = useState<WalkState>(IDLE_WALK);
-  // Which refresh generation of the walk has been REQUESTED (null = none).
-  // The fetch effect keys on this, not on `refresh` itself: a dir-watch bump
-  // only invalidates the cache (via the forRefresh tag) and a new fetch
-  // happens only while search is active (auto-request effect) or on the next
-  // gesture — an idle listing must not re-walk the tree on every watch event.
-  const [walkReq, setWalkReq] = useState<number | null>(() =>
-    currentQuery().trim() !== "" ? 0 : null
-  );
-  // Bumped to re-run the stream effect after an error, from a real user
-  // gesture only (focus / typing) — an effect-driven retry would loop forever.
-  const [retryNonce, setRetryNonce] = useState(0);
-  // Sort applied to search results. null = relevance (fuzzy rank). Deliberately
-  // NOT URL-synced (unlike the normal-mode sort) — it resets on every query
-  // change, so persisting it would fight that reset.
-  const [searchSort, setSearchSort] = useState<{ sort: SortKey; order: SortOrder } | null>(null);
-  // How many result rows are revealed; grows by PAGE_SIZE when the sentinel
-  // row scrolls into view, resets on every query change.
-  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
-  // The selected rows (see Selection): one for a plain click / arrow move, many
-  // for a Shift-range, Mod-click toggle or Select All. Seeded from the
-  // cross-remount store so a selection made in the pre-stat provisional Listing
-  // survives the swap to the resolved one (see recallSelection / lastSelection).
-  const [sel, setSel] = useState<Selection>(() => recallSelection(fsPath));
-  // The lead row — every place that used to read `selectedPath` (scroll-into-
-  // view, reconcile, Enter/F2 targets) still works off this single path.
-  const selectedPath = sel.lead;
-  // A Load more fetch (next page of a truncated listing) is in flight.
-  const [loadingMore, setLoadingMore] = useState(false);
-
-  // --- Preview pane (right-hand split) ---------------------------------------
-  // Visibility restores URL-first (resolvePane: `?preview=true` wins, then the
-  // folder's saved viewstate); width is viewstate-only. Toggling writes BOTH:
-  // the URL (replaceSearch, like setSort — on sets `preview=true`, off deletes
-  // it; navigate() then carries the param between folders, making the pane
-  // sticky) and the viewstate (so a folder re-opened from a clean URL
-  // remembers). Width is clamped live during the divider drag; the max
-  // fraction is enforced against the split container's current size.
-  const [pane, setPane] = useState<{ on: boolean; width: number | null }>(() => resolvePane(fsPath));
-  const splitRef = useRef<HTMLDivElement>(null);
-  // Is `pane.width` a width the USER chose (restored from `panew`, or dragged
-  // this session), as opposed to the measured half-container default? Only a
-  // chosen width is persisted — the measuring effect below fills `pane.width`
-  // in, which would otherwise make the default indistinguishable from a drag
-  // and let a later toggle write it to `panew`.
-  const paneSized = useRef(pane.width !== null);
-  // No saved width: default to half the split container, measured at first
-  // open (layout effect — before paint, so the pane never flashes another
-  // width). The clamps still apply; the fallback constant only covers the
-  // unmeasurable edge (ref not mounted yet).
-  useLayoutEffect(() => {
-    if (!pane.on || pane.width !== null) return;
-    const w = splitRef.current?.getBoundingClientRect().width;
-    const half = w ? clampPaneWidth(w, w * PANE_DEFAULT_FRAC) : PANE_FALLBACK_W;
-    setPane((prev) => (prev.width === null ? { ...prev, width: half } : prev));
-  }, [pane.on, pane.width]);
-  const togglePane = () => {
-    setPane((prev) => {
-      const next = { ...prev, on: !prev.on };
-      const params = new URLSearchParams(location.search);
-      if (next.on) params.set("preview", "true");
-      else params.delete("preview");
-      const qs = params.toString();
-      replaceSearch(location.pathname + (qs ? "?" + qs : ""));
-      savePaneState(fsPath, next.on, paneSized.current ? next.width : null);
-      return next;
-    });
-  };
-  // The divider drag: pointer capture keeps the drag alive when the cursor
-  // crosses into the pane's iframe (which would otherwise swallow mousemove).
-  const onDividerPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const divider = e.currentTarget;
-    divider.setPointerCapture(e.pointerId);
-    divider.classList.add("dragging");
-    let width = pane.width;
-    let moved = false;
-    const onMove = (ev: PointerEvent) => {
-      const rect = splitRef.current?.getBoundingClientRect();
-      if (!rect) return;
-      moved = true;
-      // The pane is the right side: its width is the distance from the cursor
-      // to the container's right edge, run through the shared FS-12 clamps.
-      width = clampPaneWidth(rect.width, rect.right - ev.clientX);
-      setPane((prev) => (prev.width === width ? prev : { ...prev, width }));
-    };
-    const onUp = () => {
-      divider.classList.remove("dragging");
-      divider.removeEventListener("pointermove", onMove);
-      divider.removeEventListener("pointerup", onUp);
-      divider.removeEventListener("pointercancel", onUp);
-      // Only a drag that actually moved the divider is a chosen width; a bare
-      // click on it leaves the measured default unpersisted.
-      if (moved) paneSized.current = true;
-      savePaneState(fsPath, true, paneSized.current ? width : null);
-    };
-    divider.addEventListener("pointermove", onMove);
-    divider.addEventListener("pointerup", onUp);
-    divider.addEventListener("pointercancel", onUp);
-  };
-
-  // --- Context-menu / file-operation state ----------------------------------
-  // The open context menu (position + items) and the open modal, both local to
-  // this folder view. Toasts are NOT local: they go to the global store
-  // (lib/toast), which owns the queue, the auto-dismiss timer and the single
-  // bottom-right stack every notification shares. In panel/tab mode each pane
-  // is its own document, so a pane's toast still lands in that pane's corner.
-  // The cut/copy clipboard is likewise a module-level store (lib/fs-clipboard)
-  // so it survives this component's per-folder remount (see there).
-  const clipboard = useClipboard();
-  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuEntry[] } | null>(null);
-  const [dialog, setDialog] = useState<DialogState | null>(null);
-
-  // Search input, so a keystroke anywhere in the listing can focus it.
-  const searchInputRef = useRef<HTMLInputElement>(null);
-  // Latest ordered list of navigable row paths + the current selection, read by
-  // the document keydown handler (registered once, so it can't close over them).
-  const navRowsRef = useRef<string[]>([]);
-  // Same mirroring pattern as before, widened to the whole selection: the
-  // document handlers are registered ONCE (empty deps), so they read current
-  // selection through this ref instead of re-registering per change.
-  const selRef = useRef<Selection>(sel);
-  selRef.current = sel;
-  // Fast membership test for the row renderer (a Select All can hold thousands).
-  const selectedSet = useMemo(() => new Set(sel.paths), [sel.paths]);
-  // Mirror the selection into the cross-remount store so it's already there
-  // when the resolved Listing mounts (the provisional one has no unmount step
-  // that would clear it). Keyed by fsPath, so a real nav to another folder
-  // starts fresh.
-  useEffect(() => {
-    rememberSelection(fsPath, sel);
-  }, [fsPath, sel]);
-  // Path -> RowCtx for the rendered rows, read by the once-registered keydown
-  // handler so Enter can pass the row's is_dir as a nav hint (see rowCtxByPath
-  // below, which assigns this each render).
-  const rowCtxByPathRef = useRef<Map<string, RowCtx>>(new Map());
-  // True while a context menu or a modal dialog is open. The document-level nav
-  // and shortcut handlers (registered once, reading refs) hard-guard on this so
-  // an open overlay owns the keyboard — a stray Enter can't navigate a row and
-  // Cmd+Backspace can't trash one behind the dialog, regardless of where focus
-  // sits (the dialog's own containment covers focus; this covers the rest).
-  const overlayOpenRef = useRef(false);
-  overlayOpenRef.current = menu !== null || dialog !== null;
-  // Also publish this view's overlay state to the shared registry (lib/
-  // ui-overlay) so OTHER views back off. When a directory is opened in Preview,
-  // that Preview's header menu/dialogs live in separate state; this embedded
-  // Listing's document-level handlers must not fire behind them (and vice
-  // versa). acquire on open, release on close — and on unmount, so a nav-away
-  // while the menu is open can't leak a held count.
-  // Layout effect so the hold registers before paint — no one-frame window
-  // where another view's handlers still see isOverlayOpen() === false.
-  useLayoutEffect(() => {
-    if (!overlayOpenRef.current) return;
-    acquireOverlay();
-    return () => releaseOverlay();
-  }, [menu, dialog]);
-  // A path the selection should jump to once it appears in the reloaded rows
-  // (a rename/duplicate target — its row doesn't exist until the refetch lands).
-  const pendingSelectRef = useRef<string | null>(null);
-  // Last known index of the selection within navRows. When the selected path
-  // vanishes (delete / move to bin / rename with no re-anchor) the reconcile
-  // effect clamps to this slot so selection lands on the nearest surviving row.
-  const lastSelIndexRef = useRef<number>(-1);
-
-  // --- selection mutators ---------------------------------------------------
-  // Every one of these closes over nothing but setSel and navRowsRef (both
-  // stable for the component's life), so the once-registered document handlers
-  // below can safely capture them from the first render.
-
-  const selectOnly = (path: string) => setSel(oneSelected(path));
-
-  const clearSelection = () => setSel(EMPTY_SELECTION);
-
-  // Mod-click: add/remove one row, and make it the anchor a later Shift-range
-  // pivots on (Finder/Explorer both re-anchor on the toggled row).
-  const toggleSelected = (path: string) =>
-    setSel((prev) => {
-      if (!prev.paths.includes(path)) {
-        return { paths: [...prev.paths, path], anchor: path, lead: path };
-      }
-      const paths = prev.paths.filter((p) => p !== path);
-      // Deselecting the lead hands focus to whatever is left of the selection.
-      return { paths, anchor: path, lead: paths.length ? paths[paths.length - 1] : null };
-    });
-
-  // Shift-click / Shift+arrow: the selection becomes anchor..path over the
-  // RENDERED row order (navRows — the active sort or search ranking), with the
-  // anchor left in place so further extension keeps pivoting on it.
-  const extendTo = (path: string) =>
-    setSel((prev) => {
-      const anchor = prev.anchor ?? prev.lead;
-      if (anchor === null) return oneSelected(path);
-      const paths = rangeBetween(navRowsRef.current, anchor, path);
-      if (!paths.length) return prev;
-      return { paths, anchor, lead: path };
-    });
-
-  const selectAllRows = () =>
-    setSel((prev) => {
-      const rows = navRowsRef.current;
-      if (!rows.length) return prev;
-      return {
-        paths: [...rows],
-        anchor: prev.lead ?? rows[0],
-        lead: prev.lead ?? rows[rows.length - 1],
-      };
-    });
-
-  // Move the lead to `index` (clamped into the row range), either collapsing the
-  // selection onto that row or extending the range from the anchor.
-  const moveLeadTo = (index: number, extend: boolean) =>
-    setSel((prev) => {
-      const rows = navRowsRef.current;
-      if (!rows.length) return prev;
-      const next = rows[Math.max(0, Math.min(rows.length - 1, index))];
-      if (!extend) return oneSelected(next);
-      const anchor = prev.anchor ?? prev.lead ?? next;
-      return { paths: rangeBetween(rows, anchor, next), anchor, lead: next };
-    });
-
-  // Keyboard navigation for the listing, whether focus is in the search box or
-  // nowhere in particular:
-  //   • a plain printable key focuses the search box so the character lands there;
-  //   • Up/Down move the selection through the rendered rows — in the search box
-  //     too, since a single-line input doesn't need them for the caret — and
-  //     Shift+Up/Down extend the range from the anchor instead;
-  //   • Home/End jump to the first/last row, PageUp/PageDown move a viewport
-  //     (both extend with Shift, like every list widget);
-  //   • Mod+A selects every rendered row, Escape clears the selection;
-  //   • Enter opens the lead row, or the top row when nothing is selected yet.
-  // Modifier chords that are NOT selection movement (Mod+Up/Down = parent/open)
-  // are deliberately left to the shortcut handler further down.
-  // Bound to `document` so it also drives the plain listing with nothing focused.
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      // While an IME is composing, Enter confirms a candidate and the arrows
-      // move through the candidate list — never repurpose them for navigation.
-      if (e.isComposing) return;
-      // An open context menu / dialog owns the keyboard: don't let Enter open a
-      // row behind it (the dialog handles its own Enter/Escape). isOverlayOpen()
-      // also covers an overlay owned by a HOSTING view (Preview's header menu
-      // when this Listing is embedded), which overlayOpenRef alone can't see.
-      if (overlayOpenRef.current || isOverlayOpen()) return;
-      const el = document.activeElement as HTMLElement | null;
-      const inSearch = el === searchInputRef.current;
-      // Only drive navigation from the search box or when nothing in particular
-      // is focused (body). If focus is on a chrome control — a breadcrumb link,
-      // the bookmark/mode-switch buttons, another input — leave its keys alone
-      // (otherwise Enter would open a file instead of activating that control).
-      const navActive =
-        inSearch || !el || el === document.body || el === document.documentElement;
-
-      const rows = navRowsRef.current;
-      const leadIdx = rows.indexOf(selRef.current.lead ?? "");
-
-      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        if (!navActive) return;
-        // Mod+Up/Down are navigation chords (parent folder / open), owned by the
-        // shortcut handler — they must not also move the selection.
-        if (isMod(e) || e.altKey) return;
-        if (!rows.length) return;
-        e.preventDefault();
-        const down = e.key === "ArrowDown";
-        // Nothing selected yet: Down starts at the top, Up at the bottom.
-        const next = leadIdx === -1 ? (down ? 0 : rows.length - 1) : leadIdx + (down ? 1 : -1);
-        moveLeadTo(next, e.shiftKey);
-        return;
-      }
-      if (e.key === "Home" || e.key === "End") {
-        // Unlike Up/Down, Home/End are real caret navigation in a text field, so
-        // the search box keeps them (same carve-out as Mod+A and Escape below).
-        if (!navActive || inSearch || isMod(e) || !rows.length) return;
-        e.preventDefault();
-        moveLeadTo(e.key === "Home" ? 0 : rows.length - 1, e.shiftKey);
-        return;
-      }
-      if (e.key === "PageDown" || e.key === "PageUp") {
-        if (!navActive || isMod(e) || !rows.length) return;
-        e.preventDefault();
-        const step = pageRows();
-        const down = e.key === "PageDown";
-        const next = leadIdx === -1 ? (down ? 0 : rows.length - 1) : leadIdx + (down ? step : -step);
-        moveLeadTo(next, e.shiftKey);
-        return;
-      }
-      if (isMod(e) && e.key.toLowerCase() === "a") {
-        // Select All. In the search box it must keep meaning "select the text",
-        // otherwise clearing a typed query becomes impossible.
-        if (!navActive || inSearch || !rows.length) return;
-        e.preventDefault();
-        selectAllRows();
-        return;
-      }
-      if (e.key === "Escape") {
-        // Clear the selection. The search input owns Escape while focused (it
-        // clears the query — see its onKeyDown), and the overlay/dialog guards
-        // above already stopped us if anything modal is up.
-        //
-        // A pending copy/cut outranks the selection: App's capture-phase Escape
-        // handler cancels the clipboard and calls preventDefault(), so one press
-        // never does both. Reading defaultPrevented keeps that precedence here
-        // without a second copy of the clipboard logic (which would also be
-        // wrong — the cancel has to work from Preview, where no Listing exists).
-        if (e.defaultPrevented) return;
-        if (!navActive || inSearch) return;
-        if (!selRef.current.paths.length) return;
-        e.preventDefault();
-        clearSelection();
-        return;
-      }
-      if (e.key === "Enter") {
-        // Already consumed by a chrome control that unmounted itself on the
-        // way (the breadcrumb's path input commits and closes on Enter, which
-        // hands focus back to <body> before this listener runs — navActive
-        // alone can't see that the key was spoken for).
-        if (e.defaultPrevented) return;
-        if (!navActive) return;
-        if (!rows.length) return;
-        e.preventDefault();
-        const target = leadIdx === -1 ? rows[0] : rows[leadIdx];
-        navigate(target, { isDir: rowCtxByPathRef.current.get(target)?.isDir });
-        return;
-      }
-      // Start typing → focus the search box so the character lands there. Only
-      // when nothing else is focused (not the search box already, not a chrome
-      // control) and only plain printable keys (no modifiers), so Space on a
-      // focused button and app shortcuts keep working.
-      if (
-        navActive && !inSearch &&
-        e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey
-      ) {
-        searchInputRef.current?.focus(); // keystroke falls through into the input
-      }
-    }
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, []);
-
-  // The input echoes `query` (immediate) so keystrokes never wait on the
-  // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
-  // load — React commits a cheap render with the old deferred value first
-  // (echoing the keystroke), then a low-priority render picks up the new
-  // value and redoes the expensive work, interruptible by further typing.
-  const deferredQuery = useDeferredValue(query);
-  const q = deferredQuery.trim();
-  const searching = q !== "";
-  const isStale = query.trim() !== q;
-
-  useEffect(() => {
-    let alive = true;
-    // A fresh fetch (navigation or dir-watch refresh) resets any accumulated
-    // Load more pages: the new listing replaces the array wholesale.
-    setLoadingMore(false);
-    // Initial mount goes through the prefetch cache so a listing kicked off by
-    // the loading scaffold (in parallel with stat) is reused when the real
-    // preview remounts this component for the same path — no duplicate request.
-    // A dir-watch refresh (refresh > 0) must see live data, so it bypasses.
-    (refresh === 0 ? prefetchListDir(fsPath) : listDir(fsPath)).then(
-      (data) =>
-        alive &&
-        setState({
-          status: "ok",
-          entries: data.entries,
-          truncated: !!data.truncated,
-          cursor: data.cursor ?? null,
-        }),
-      (err: Error) => alive && setState({ status: "error", message: err.message })
-    );
-    return () => {
-      alive = false;
-    };
-  }, [fsPath, refresh]);
-
-  // Fetch the next page of a truncated S3-direct listing and APPEND it (dedupe
-  // by name). The accumulated set is still sorted by the active column below —
-  // honest because the banner states the listing is partial; a global sort over
-  // the WHOLE directory is impossible (we only ever hold fetched pages).
-  const loadMore = () => {
-    if (state.status !== "ok" || !state.cursor || loadingMore) return;
-    const cursor = state.cursor;
-    const gen = refresh; // discard the response if a refresh supersedes it
-    setLoadingMore(true);
-    skipNewCue.current = true; // an appended page isn't a dir-watch change
-    listDir(fsPath, cursor).then(
-      (data) => {
-        if (refreshRef.current !== gen) return; // stale: a refresh replaced the listing
-        setLoadingMore(false);
-        setState((prev) => {
-          if (prev.status !== "ok") return prev;
-          const seen = new Set(prev.entries.map((e) => e.name));
-          const merged = prev.entries.concat(
-            data.entries.filter((e) => !seen.has(e.name))
-          );
-          return {
-            status: "ok",
-            entries: merged,
-            truncated: !!data.truncated,
-            cursor: data.cursor ?? null,
-          };
-        });
-      },
-      (err: Error) => {
-        if (refreshRef.current !== gen) return; // stale: the fetch effect reset state
-        setLoadingMore(false);
-        pushToast({ msg: err.message, tone: "error" });
-      }
-    );
-  };
-
-  // WebSocket watch on the listed directory (LS-1); WS not SSE per D74 (SSE
-  // pinned one of Chrome's 6 HTTP/1.1 sockets per view). A directory's mtime
-  // changes on create/delete/rename of entries (not on child content changes
-  // — LS-2, accepted). Closed on unmount = navigating away (LS-3). On change,
-  // debounce 300 ms then re-fetch; sort params live in URL + state, so a
-  // refetch preserves them.
-  useEffect(() => {
-    let sock: WebSocket | null = null;
-    let retry: ReturnType<typeof setTimeout> | null = null;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-    let closed = false;
-    const connect = () => {
-      const proto = location.protocol === "https:" ? "wss://" : "ws://";
-      sock = new WebSocket(proto + location.host + "/api/fs/events?path=" + encodeURIComponent(fsPath));
-      sock.onmessage = (ev) => {
-        let data;
-        try {
-          data = JSON.parse(ev.data);
-        } catch {
-          return;
-        }
-        if (data.keepalive) return;
-        if (timer !== null) clearTimeout(timer);
-        timer = setTimeout(() => setRefresh((n) => n + 1), 300);
-      };
-      // WebSockets don't auto-reconnect the way EventSource did.
-      sock.onclose = () => {
-        if (!closed) retry = setTimeout(connect, 1000);
-      };
-    };
-    connect();
-    return () => {
-      closed = true;
-      if (retry !== null) clearTimeout(retry);
-      if (timer !== null) clearTimeout(timer);
-      sock?.close();
-    };
-  }, [fsPath]);
-
-  // Synchronous cache validity: a non-idle walk fetched for a previous
-  // refresh generation reads as idle, immediately on the render where
-  // `refresh` bumps — no effect ordering to wait on, and no render ever
-  // scores search results against the pre-refresh tree.
-  const validWalk: WalkState =
-    walk.status === "idle" || walk.forRefresh === refresh ? walk : IDLE_WALK;
-
-  // Active search must always have a walk for the CURRENT tree. Covers a
-  // URL-seeded query on mount racing ahead of focus, typing after an
-  // invalidation, and the dir watch bumping `refresh` mid-search (the stale
-  // tag makes validWalk idle, this re-requests). Keyed on validWalk being
-  // IDLE so an errored walk never auto-retries (that would loop:
-  // request -> error -> request -> ...); error retries hang off real
-  // gestures (focus / typing) below. The immediate `query` (not deferred)
-  // drives this — the fetch should start on the first keystroke.
-  useEffect(() => {
-    if (query.trim() !== "" && validWalk.status === "idle" && walkReq !== refresh) {
-      setWalkReq(refresh);
-    }
-  }, [query, validWalk.status, walkReq, refresh]);
-
-  // The streamed validWalk. One effect owns the whole fetch lifecycle: it runs
-  // when a walk generation is requested (walkReq) or a gesture bumps
-  // `retryNonce` after an error, and ABORTS the in-flight stream on cleanup
-  // — which also cancels the server-side walk (the generator is closed on
-  // disconnect). Batches push into one append-only array; see WalkState.
-  useEffect(() => {
-    if (walkReq === null) return;
-    const forRefresh = walkReq;
-    const ctrl = new AbortController();
-    let alive = true;
-    const entries: WalkEntry[] = [];
-    // Flush throttle (STREAM_FLUSH_MS): entries accumulate in `pending`
-    // between commits so the scoring/render work runs a few times a second,
-    // not once per network chunk. A trailing timer guarantees the last
-    // partial interval still commits.
-    let pending: WalkEntry[] = [];
-    let lastFlush = 0;
-    let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    const flush = () => {
-      if (flushTimer !== null) {
-        clearTimeout(flushTimer);
-        flushTimer = null;
-      }
-      for (const e of pending) entries.push(e); // no spread: a big chunk would blow the arg limit
-      pending = [];
-      lastFlush = Date.now();
-      setWalk({ status: "streaming", entries, count: entries.length, forRefresh });
-    };
-    setWalk({ status: "streaming", entries, count: 0, forRefresh });
-    walkDirStream(fsPath, {
-      hidden: true,
-      signal: ctrl.signal,
-      onBatch: (batch) => {
-        if (!alive) return;
-        for (const e of batch) pending.push(e);
-        const wait = STREAM_FLUSH_MS - (Date.now() - lastFlush);
-        if (wait <= 0) flush();
-        else if (flushTimer === null) flushTimer = setTimeout(() => alive && flush(), wait);
-      },
-    }).then(
-      (end) => {
-        if (!alive) return;
-        if (flushTimer !== null) clearTimeout(flushTimer);
-        for (const e of pending) entries.push(e);
-        setWalk({ status: "ok", entries, truncated: end.truncated, total: end.total, forRefresh });
-      },
-      (err: Error) => {
-        if (!alive || err.name === "AbortError") return;
-        if (flushTimer !== null) clearTimeout(flushTimer);
-        setWalk({ status: "error", message: err.message, forRefresh });
-      }
-    );
-    return () => {
-      alive = false;
-      if (flushTimer !== null) clearTimeout(flushTimer);
-      ctrl.abort();
-    };
-  }, [fsPath, walkReq, retryNonce]);
-
-  // First focus starts the walk warming in the background; focus (like
-  // typing below) is also the retry gesture when a previous stream failed.
-  const prefetchWalk = () => {
-    if (validWalk.status === "idle") setWalkReq(refresh);
-    else if (validWalk.status === "error") {
-      setWalkReq(refresh);
-      setRetryNonce((n) => n + 1);
-    }
-  };
-
-  // Debounced URL mirror for the query (see URL_SYNC_MS). Pending sync is
-  // dropped on unmount — a navigation has already replaced the URL by then.
-  const urlTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  useEffect(
-    () => () => {
-      if (urlTimer.current !== null) clearTimeout(urlTimer.current);
-    },
-    []
-  );
-
-  const setQuery = (value: string) => {
-    setQueryState(value);
-    setSearchSort(null); // a new query drops back to relevance order
-    setVisibleCount(PAGE_SIZE);
-    // Editing the query is also a user gesture: if the last walk attempt
-    // failed, give it another shot instead of leaving search dead forever.
-    // (An idle walk needs no handling here — the auto-request effect fires
-    // as soon as the non-empty query state lands.)
-    if (validWalk.status === "error") {
-      setWalkReq(refresh);
-      setRetryNonce((n) => n + 1);
-    }
-    if (urlTimer.current !== null) clearTimeout(urlTimer.current);
-    urlTimer.current = setTimeout(() => {
-      const params = new URLSearchParams(location.search);
-      if (value) params.set("q", value);
-      else params.delete("q");
-      const qs = params.toString();
-      replaceSearch(location.pathname + (qs ? "?" + qs : ""));
-    }, URL_SYNC_MS);
-  };
 
   const setSort = (key: SortKey) => {
     const next: { sort: SortKey; order: SortOrder } = {
@@ -1125,170 +118,45 @@ export default function Listing({
     setViewState(fsPath, "?" + saved.toString());
   };
 
-  // Search headers cycle asc → desc → relevance. Relevance (the fuzzy rank) is
-  // the mode search results are actually FOR, and before this there was no way
-  // back to it short of retyping the query — the toggle only ever flipped
-  // between two column orders.
-  const setSearchSortKey = (key: SortKey) => {
-    setSearchSort((prev) => {
-      if (!prev || prev.sort !== key) return { sort: key, order: "asc" };
-      if (prev.order === "asc") return { sort: key, order: "desc" };
-      return null;
-    });
-  };
-
-  // Incremental-scoring cache for the streamed validWalk. As long as the query,
-  // hidden-intent and entries array are unchanged, only entries appended
-  // since `scored` get fuzzy-matched, then merged into the previous ranked
-  // list — so a stream flush near the tail of a 200k walk costs one small
-  // scan + a sort of the hits, not a full re-scan of everything (which is
-  // exactly what saturated the main thread and made the UI unresponsive
-  // while the walk loaded). Any change to query/hidden/array falls back to a
-  // full scan. A ref (not state): it's a pure memo accelerator, and the
-  // update below is idempotent, so double-invoked renders are harmless.
-  const scoreCache = useRef<{
-    q: string;
-    showHidden: boolean;
-    entries: WalkEntry[] | null;
-    scored: number; // how many of `entries` have been scored already
-    ranked: SearchHit[];
-  }>({ q: "", showHidden: false, entries: null, scored: 0, ranked: [] });
-
-  // Keyed on `q`/`searching` (both deferred) so full fuzzy scans run on
-  // React's low-priority schedule, not synchronously on every keystroke.
-  // While the walk streams, each flush produces a new `walk` state and this
-  // extends the ranked list with just the newly arrived entries (see
-  // scoreCache above).
-  const hits = useMemo(() => {
-    if (!searching || (validWalk.status !== "ok" && validWalk.status !== "streaming")) return [];
-    const showHidden = queryWantsHidden(q);
-    const cache = scoreCache.current;
-    let ranked: SearchHit[];
-    if (cache.entries === validWalk.entries && cache.q === q && cache.showHidden === showHidden) {
-      const fresh = scoreEntries(q, validWalk.entries, cache.scored, showHidden);
-      ranked = fresh.length ? cache.ranked.concat(fresh).sort(rankCompare) : cache.ranked;
-    } else {
-      ranked = scoreEntries(q, validWalk.entries, 0, showHidden).sort(rankCompare);
-    }
-    scoreCache.current = { q, showHidden, entries: validWalk.entries, scored: validWalk.entries.length, ranked };
-    if (!searchSort) return ranked; // relevance order
-    const { sort, order } = searchSort;
-    const flip = order === "desc" ? -1 : 1;
-    const byName = (a: SearchHit, b: SearchHit) =>
-      a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
-    return [...ranked].sort((a, b) => {
-      let cmp: number;
-      if (sort === "size") cmp = (a.entry.size ?? -1) - (b.entry.size ?? -1);
-      else if (sort === "mtime") cmp = (a.entry.mtime ?? 0) - (b.entry.mtime ?? 0);
-      else cmp = byName(a, b);
-      if (cmp === 0) cmp = byName(a, b);
-      return cmp * flip;
-    });
-  }, [searching, q, validWalk, searchSort]);
-
-  // --- Streaming re-rank throttle (B4) --------------------------------------
-  // Every stream flush re-scores the newly arrived entries and merges them into
-  // the ranked list, which reshuffles the visible rows several times a second —
-  // unreadable on its own, and worse now that the rows animate. The RENDERED
-  // ranking is therefore committed at most once per RERANK_COMMIT_MS. The
-  // accumulation underneath and the live "N matches · M scanned…" counter both
-  // keep running at full speed: they cost nothing and they are the honest
-  // progress signal.
-  //
-  // The committed ranking carries the QUERY it was computed for. That tag is
-  // load-bearing for the hold below and it has to be committed WITH the data:
-  // on the first render after `q` changes this state still holds the previous
-  // query's rows (this effect hasn't run yet), so anything that tags it at
-  // render time labels the old query's rows with the new query. See
-  // lib/search-hold.
-  const [rankedForRender, setRankedForRender] = useState<QueryTagged<SearchHit>>(() => ({
-    q,
-    items: hits,
-  }));
-  const lastRankCommit = useRef(0);
-  // Declared BEFORE the commit effect so it runs first in the same flush: a
-  // query change (or a sort change) is a direct response to a gesture and must
-  // paint immediately, never wait out a throttle window opened by the stream.
-  useEffect(() => {
-    lastRankCommit.current = 0;
-  }, [q, searchSort]);
-  useEffect(() => {
-    // Only a streaming walk churns. Anything else (settled, errored, or
-    // invalidated to idle) commits at once — there is nothing left to smooth
-    // and the final ranking must not be held back.
-    if (validWalk.status !== "streaming") {
-      lastRankCommit.current = 0;
-      setRankedForRender({ q, items: hits });
-      return;
-    }
-    const wait = RERANK_COMMIT_MS - (Date.now() - lastRankCommit.current);
-    const commit = () => {
-      lastRankCommit.current = Date.now();
-      setRankedForRender({ q, items: hits });
-    };
-    if (wait <= 0) {
-      commit(); // includes the first flush of a stream — first paint isn't delayed
-      return;
-    }
-    const id = window.setTimeout(commit, wait);
-    return () => window.clearTimeout(id);
-  }, [hits, q, validWalk.status]);
-
-  // --- Stale-while-revalidate for search results (B3) -----------------------
-  // A dir-watch event bumps `refresh`, which makes validWalk read idle for the
-  // stale generation, which collapses `hits` to [] — so the entire visible
-  // result list used to blank to "Searching…" while the tree re-walked, for as
-  // long as that takes on a big folder. Hold the last ranked answer and keep
-  // rendering it (dimmed, with the spinner) until the fresh one is ready.
-  //
-  // This changes only what is DISPLAYED. The invalidation machinery is
-  // untouched: a stale walk is still never scored against a new tree — `hits`
-  // remains derived from validWalk alone, and these held rows are not fed back
-  // into scoring.
-  //
-  // Both halves of the decision — what to retain, and what to render — live in
-  // lib/search-hold, pure and query-tagged: rows are only ever shown under the
-  // query they were computed for, so the ONE thing this must never do (show the
-  // previous query's matches under a new query) is structurally impossible
-  // rather than a condition someone has to remember. A query change falls
-  // through to "Searching…" exactly as before; only a same-query invalidation
-  // holds. The hold applies only while the current-generation walk is unsettled
-  // — a COMPLETED walk with no hits is a real "no matches" answer (the file was
-  // just deleted, say) and replaces the held rows.
-  const heldHits = useRef<QueryTagged<SearchHit> | null>(null);
-  heldHits.current = nextHeldHits(searching, q, rankedForRender, heldHits.current);
-  const walkUnsettled = validWalk.status === "idle" || validWalk.status === "streaming";
-  const { hits: displayHits, showingHeld } = resolveDisplayedHits(
+  const {
+    query,
+    setQuery,
     searching,
-    q,
-    rankedForRender,
-    heldHits.current,
-    walkUnsettled,
-  );
+    isStale,
+    validWalk,
+    prefetchWalk,
+    hits,
+    displayHits,
+    visibleHits,
+    showingHeld,
+    hasMore,
+    sentinelRef,
+    searchSort,
+    setSearchSort,
+    setSearchSortKey,
+  } = useWalkSearch(fsPath, refresh);
 
-  const visibleHits = useMemo(() => displayHits.slice(0, visibleCount), [displayHits, visibleCount]);
+  const { pane, splitRef, togglePane, onDividerPointerDown } = usePreviewPane(fsPath);
 
-  // Reveal the next page when the sentinel row (rendered only while more rows
-  // exist) scrolls into view. rootMargin pre-triggers a bit before the bottom
-  // so the next page is usually mounted by the time the user reaches it.
-  const sentinelRef = useRef<HTMLTableRowElement | null>(null);
-  const hasMore = searching && displayHits.length > visibleCount;
-  useEffect(() => {
-    const el = sentinelRef.current;
-    if (!el || !hasMore) return;
-    const io = new IntersectionObserver(
-      (obsEntries) => {
-        if (obsEntries.some((e) => e.isIntersecting)) setVisibleCount((c) => c + PAGE_SIZE);
-      },
-      { root: el.closest(".listing-scroll"), rootMargin: "200px" }
-    );
-    io.observe(el);
-    return () => io.disconnect();
-  }, [hasMore, visibleCount]);
+  const clipboard = useClipboard();
 
-  // Same idea for the plain (non-search) listing: re-sorting on every render
-  // (e.g. a keystroke that flips `searching` before this branch even
-  // displays) was pure waste when `state`/sort/order hadn't changed.
+  // Search input, so a keystroke anywhere in the listing can focus it.
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  // Path -> RowCtx for the rendered rows, read by the once-registered keydown
+  // handler so Enter can pass the row's is_dir as a nav hint (assigned each
+  // render from the rowCtxByPath memo below).
+  const rowCtxByPathRef = useRef<Map<string, RowCtx>>(new Map());
+  // True while a context menu or a modal dialog is open. The document-level nav
+  // and shortcut handlers (registered once, reading refs) hard-guard on this so
+  // an open overlay owns the keyboard — a stray Enter can't navigate a row and
+  // Cmd+Backspace can't trash one behind the dialog, regardless of where focus
+  // sits (the dialog's own containment covers focus; this covers the rest).
+  const overlayOpenRef = useRef(false);
+
+  // Same idea for the plain (non-search) listing as visibleHits' memo:
+  // re-sorting on every render (e.g. a keystroke that flips `searching` before
+  // this branch even displays) was pure waste when `state`/sort/order hadn't
+  // changed.
   const sortedEntries = useMemo(
     () => (state.status === "ok" ? sortEntries(state.entries, sort, order) : []),
     [state, sort, order]
@@ -1328,7 +196,6 @@ export default function Listing({
         : sortedEntries.map((entry) => base + "/" + entry.name),
     [searching, visibleHits, sortedEntries, base]
   );
-  navRowsRef.current = navRows;
 
   // Whether navRows reflects a LOADED listing (not a transient empty while the
   // fetch is in flight). Only the non-search listing can be mid-load with rows
@@ -1338,9 +205,55 @@ export default function Listing({
   // its prior behavior (results stream in). Used by the reconcile effect so a
   // real, still-valid selection is never cleared as "vanished" during a reload.
   // "Settled" = not mid-fetch: an ok listing OR a terminal error (rows are
-  // then genuinely empty, so the reconcile below should clear/reclamp a stale
+  // then genuinely empty, so the reconcile should clear/reclamp a stale
   // selection). Only the transient `loading` status suppresses reconcile.
   const listingLoaded = searching ? true : state.status !== "loading";
+
+  const {
+    sel,
+    selectedPath,
+    selectedSet,
+    selectOnly,
+    toggleSelected,
+    extendTo,
+    pendingSelectRef,
+  } = useListingSelection({
+    fsPath,
+    navRows,
+    listingLoaded,
+    searchInputRef,
+    rowCtxByPathRef,
+    overlayOpenRef,
+  });
+
+  const {
+    menu,
+    setMenu,
+    dialog,
+    setDialog,
+    doPaste,
+    doDuplicate,
+    doTrash,
+    startRename,
+    startNewFolder,
+    rowMenu,
+    backgroundMenu,
+  } = useFileOps({ base, clipboard, refetch, pendingSelectRef });
+
+  overlayOpenRef.current = menu !== null || dialog !== null;
+  // Also publish this view's overlay state to the shared registry (lib/
+  // ui-overlay) so OTHER views back off. When a directory is opened in Preview,
+  // that Preview's header menu/dialogs live in separate state; this embedded
+  // Listing's document-level handlers must not fire behind them (and vice
+  // versa). acquire on open, release on close — and on unmount, so a nav-away
+  // while the menu is open can't leak a held count.
+  // Layout effect so the hold registers before paint — no one-frame window
+  // where another view's handlers still see isOverlayOpen() === false.
+  useLayoutEffect(() => {
+    if (!overlayOpenRef.current) return;
+    acquireOverlay();
+    return () => releaseOverlay();
+  }, [menu, dialog]);
 
   // FLIP the rows to their new slots whenever the rendered set changes: a column
   // sort, a dir-watch refresh of the plain listing, or a streaming search
@@ -1349,29 +262,6 @@ export default function Listing({
   // moves nothing already on screen, so paging animates nothing.
   const scrollRef = useRef<HTMLDivElement>(null);
   useFlip(scrollRef, navRows, navRows.length <= FLIP_MAX_ROWS);
-
-  // Dir-watch change cue (B5). A refresh that adds entries used to slot them in
-  // silently — a file that just landed in the folder was indistinguishable from
-  // one that had been there all along. Newly appeared rows carry `.row-new` for
-  // ROW_NEW_MS (a tint that fades out; removals need no cue beyond the FLIP).
-  // Names are the plain listing's row identity. The FIRST listing of a folder is
-  // never "new" — appearedKeys returns nothing for a null previous list.
-  const prevNamesRef = useRef<string[] | null>(null);
-  const [newNames, setNewNames] = useState<Set<string>>(() => new Set());
-  // Set by loadMore: an appended page is the user's own gesture, and tinting
-  // 250 rows they just asked for is noise, not a cue.
-  const skipNewCue = useRef(false);
-  useEffect(() => {
-    if (state.status !== "ok") return;
-    const names = state.entries.map((e) => e.name);
-    const fresh = skipNewCue.current ? new Set<string>() : appearedKeys(prevNamesRef.current, names);
-    skipNewCue.current = false;
-    prevNamesRef.current = names;
-    if (fresh.size === 0) return;
-    setNewNames(fresh);
-    const id = window.setTimeout(() => setNewNames(new Set()), ROW_NEW_MS);
-    return () => window.clearTimeout(id);
-  }, [state]);
 
   // Scroll anchoring (B5). A dir-watch refresh that inserts or removes rows
   // ABOVE the viewport shifts everything below it, so the rows the user was
@@ -1397,101 +287,6 @@ export default function Listing({
     anchorGenRef.current = refresh;
     anchorRef.current = measureScrollAnchor(scroller);
   }, [navRows, refresh]);
-
-  // Keep the keyboard selection scrolled into view as it moves. Follows the LEAD
-  // row (`.lead`), not merely the first selected one: extending a Shift-range
-  // downward must keep the moving end visible, and the top of the range is
-  // usually the one that would otherwise win a `.selected` query.
-  // row. This is also what keeps the selection in view across a SORT: navRows is
-  // a dependency, and a sort click produces a new navRows.
-  useEffect(() => {
-    if (!selectedPath) return;
-    (
-      document.querySelector("table.listing-table tr.row.lead") ??
-      document.querySelector("table.listing-table tr.row.selected")
-    )?.scrollIntoView({ block: "nearest" });
-  }, [selectedPath, navRows]);
-
-  // Re-anchor the selection by PATH whenever the rows change (a refetch after
-  // rename / duplicate / delete / move-to-bin) or the selection moves. Without
-  // this the selected index kept pointing at the OLD name after a rename, so
-  // pressing Enter opened a path that no longer existed.
-  //   • A pending re-anchor (rename/duplicate target) is adopted the moment its
-  //     row appears in the reloaded listing.
-  //   • A still-present selection just refreshes its remembered slot index.
-  //   • A vanished selection (deleted / trashed / moved) clamps to the nearest
-  //     surviving row (or clears when the folder is now empty).
-  // The pending wait is BOUNDED, not open-ended: it only holds while the current
-  // selection is itself a live row. Renaming a search hit whose new path isn't a
-  // search match leaves the pending target absent from navRows forever while the
-  // old selected path also disappears — waiting unconditionally there would
-  // strand the selection on a dead row (broken Enter). So once the old selection
-  // is gone too, the pending target is abandoned and the normal clamp runs. The
-  // pending path still lands the moment it does appear (e.g. search results
-  // refetching to include the renamed file), so the happy path is unchanged.
-  //   • Rows of a MULTI-selection that vanished are pruned while the lead
-  //     survives, so a batch op that partly failed doesn't leave dead paths in
-  //     the selection (and a later Cmd+C can't copy them).
-  useEffect(() => {
-    const rows = navRows;
-    const pend = pendingSelectRef.current;
-    let clampFallback = false;
-    if (pend !== null) {
-      const pi = rows.indexOf(pend);
-      if (pi !== -1) {
-        pendingSelectRef.current = null;
-        lastSelIndexRef.current = pi;
-        if (selectedPath !== pend || sel.paths.length !== 1) setSel(oneSelected(pend));
-        return;
-      }
-      // Target not here yet. Keep waiting ONLY while the current selection is
-      // still a real row (nothing's broken, the target may still arrive). If it
-      // has also vanished, give up on the pending target and clamp below.
-      if (selectedPath !== null && rows.indexOf(selectedPath) !== -1) return;
-      pendingSelectRef.current = null;
-      clampFallback = true;
-    }
-    if (selectedPath === null) {
-      // No selection to reconcile. Only force one when a pending target was just
-      // abandoned (so selection never stays dead); otherwise leave it unset.
-      if (!clampFallback || rows.length === 0) return;
-      const clamped = Math.min(Math.max(lastSelIndexRef.current, 0), rows.length - 1);
-      setSel(oneSelected(rows[clamped]));
-      return;
-    }
-    const i = rows.indexOf(selectedPath);
-    if (i !== -1) {
-      lastSelIndexRef.current = i; // lead still valid; remember its slot
-      // Drop any other selected rows that are gone (deleted/moved/renamed).
-      if (sel.paths.length > 1) {
-        const live = new Set(rows);
-        const kept = sel.paths.filter((p) => live.has(p));
-        if (kept.length !== sel.paths.length) {
-          setSel({
-            paths: kept,
-            anchor: sel.anchor !== null && live.has(sel.anchor) ? sel.anchor : selectedPath,
-            lead: selectedPath,
-          });
-        }
-      }
-      return;
-    }
-    // Selection isn't in the current rows. While the listing is still LOADING
-    // (rows transiently empty during a fetch — notably the pre-stat provisional
-    // Listing being swapped for the resolved one right after a folder opens),
-    // don't treat it as vanished: keep it and rerun once rows arrive. Clearing
-    // here is what dropped an arrow-key selection made just after opening a
-    // folder, even with the selection carried across the remount.
-    if (!listingLoaded) return;
-    if (rows.length === 0) {
-      setSel(EMPTY_SELECTION);
-      return;
-    }
-    const clamped = Math.min(Math.max(lastSelIndexRef.current, 0), rows.length - 1);
-    setSel(oneSelected(rows[clamped]));
-  }, [navRows, selectedPath, sel, listingLoaded]);
-
-  // --- file operations ------------------------------------------------------
 
   // Which visible entries are cut sources — dimmed in the table. A cut can hold
   // several paths, so this is a set rather than one path.
@@ -1549,444 +344,20 @@ export default function Listing({
   // The lead row, for the single-entry operations (Rename, paste target).
   const leadRow = sel.lead ? rowCtxByPath.get(sel.lead) : undefined;
 
-  const refetch = () => setRefresh((n) => n + 1);
-
-  // Run a mutating fs call, then refetch on success or surface its error as a
-  // toast. The dir-watch socket also refetches, but that lags 300 ms and only
-  // fires for the listed dir — an explicit refetch keeps the UI immediate.
-  // `ctx` ({verb, name}) is optional but supplied by every menu action, so the
-  // caught wire string is humanized (friendlyFsError) instead of leaking bare.
-  const run = async (fn: () => Promise<unknown>, ctx?: { verb: string; name: string }) => {
-    try {
-      await fn();
-      refetch();
-    } catch (e) {
-      pushToast({ msg: ctx ? friendlyFsError(e, ctx) : (e as Error).message, tone: "error" });
-    }
-  };
-
-  // Belt-and-braces name guard for the New File / New Folder / Rename handlers:
-  // the dialog already blocks invalid names, but re-check here (and toast) before
-  // building a path so a "." / ".." / separator can never escape the folder.
-  // Returns true when the name is rejected (caller should bail).
-  const rejectName = (name: string): boolean => {
-    const err = nameError(name);
-    if (err) pushToast({ msg: err, tone: "error" });
-    return err !== null;
-  };
-
-  // Guards a paste that's still running so a second Paste gesture (a rapid
-  // Cmd+V×2) can't fire a parallel op on the same source — for a cut that
-  // second call would renameEntry an already-moved src and 404 with a jarring
-  // toast. Reset in the flight's .finally, so sequential copy-pastes stay fine.
-  const pasteInFlight = useRef(false);
-
-  // Paste into `dir`: a cut moves (rename) and clears the clipboard; a copy
-  // duplicates and keeps it. Same basename in the target folder either way.
-  // The TARGET is always a single folder; the SOURCE may be several paths (a
-  // multi-row cut/copy), which are processed in order — sequentially, because
-  // freePastePath resolves a name against a listing and parallel calls would
-  // both pick the same free "… copy" name.
-  // Reads the clipboard synchronously (getClipboard) and consumes a cut BEFORE
-  // the await, so re-entry sees an empty clipboard and no-ops.
-  const doPaste = (dir: string) => {
-    const clip = getClipboard();
-    if (!clip || clip.paths.length === 0 || pasteInFlight.current) return;
-    const target = normDir(dir); // "" (root) → "/", and join avoids "//name"
-    const { op } = clip;
-    // A clipboard filled from search results can hold a folder AND entries
-    // inside it (the hit list is a flat recursive walk). Paste the outermost
-    // ancestors only: the folder's move/copy carries its contents, so a
-    // descendant entry would either 404 on a source the parent already moved
-    // (killing the rest of the batch) or, for a copy, drop a stray second copy
-    // of the inner entry at the top of the target.
-    const paths = pruneDescendantPaths(clip.paths);
-    const label = paths.length === 1 ? basename(paths[0]) : `${paths.length} items`;
-    if (op === "cut") setClipboard(null); // consume atomically, before any await
-    pasteInFlight.current = true;
-    run(async () => {
-      const pasted: string[] = [];
-      let last: string | null = null;
-      try {
-        for (const src of paths) {
-          // Same-folder paste (dst would collide with the source), matching Finder:
-          //   • CUT into its own folder is a no-op — the backend rename would 409
-          //     on dst === src, so skip it (the clipboard is already cleared).
-          //   • COPY into its own folder makes a deduped "… copy" instead of
-          //     colliding (freeDuplicatePath, same as Duplicate).
-          const sameFolder = join(target, basename(src)) === src;
-          if (sameFolder && op === "cut") {
-            pasted.push(src);
-            continue;
-          }
-          // Both ops keep the name when free and dedupe to "… copy" when taken
-          // (Finder keep-both), instead of surfacing a 409.
-          const { is_dir } = await statPath(src);
-          const dst = sameFolder
-            ? await freeDuplicatePath(target, basename(src), is_dir)
-            : await freePastePath(target, basename(src), is_dir);
-          if (op === "cut") await renameEntry(src, dst);
-          else await copyEntry(src, dst);
-          pasted.push(src);
-          last = dst;
-        }
-      } catch (e) {
-        // The paste failed (e.g. a 403, or the source vanished); for a cut the
-        // pre-clear above dropped the clipboard, so re-set the cut for whatever
-        // hasn't moved yet and let run() toast the error — without this the user
-        // would have to re-cut before retrying. Skip the restore if the user
-        // cut/copied something newer mid-flight.
-        // Restoring from the PRUNED list (not clip.paths) is what keeps the
-        // retry viable: a descendant of an already-moved folder is gone from
-        // its old location, so putting it back on the clipboard would make
-        // every retry fail on the same dead source.
-        if (op === "cut" && getClipboard() === null) {
-          const left = paths.filter((p) => !pasted.includes(p));
-          if (left.length) setClipboard({ paths: left, op: "cut" });
-        }
-        // A multi-path paste can move/copy some entries before throwing. run()
-        // only refetches when the whole callback resolves, so refresh here or
-        // the listing keeps showing rows that are already gone (or misses the
-        // ones already written) until the 300 ms dir-watch catches up. The
-        // rethrow is preserved so run() still toasts the failure.
-        if (pasted.length) refetch();
-        throw e;
-      }
-      // Re-anchor onto the last thing written, if it lands in this view.
-      if (last !== null) pendingSelectRef.current = last;
-    }, { verb: "paste", name: label }).finally(() => {
-      pasteInFlight.current = false;
-    });
-  };
-
-  // Duplicate into the same folder, picking the first free "… copy[/ n]" name
-  // (freeDuplicatePath lists the folder so the copy never 409s on an existing
-  // name).
-  // In-flight guard, same idea as pasteInFlight: a rapid double Cmd+D would
-  // race both calls to the same free "… copy" name and 409 the second.
-  // Acts on the whole selection; the rows are duplicated one at a time for the
-  // same reason paste is sequential (each freeDuplicatePath re-reads the folder,
-  // so parallel calls would pick colliding names).
-  const duplicateInFlight = useRef(false);
-  const doDuplicate = (rows: RowCtx[]) => {
-    if (!rows.length || duplicateInFlight.current) return;
-    duplicateInFlight.current = true;
-    run(async () => {
-      let last: string | null = null;
-      try {
-        for (const row of rows) {
-          const dst = await freeDuplicatePath(row.parentDir, row.name, row.isDir);
-          await copyEntry(row.path, dst);
-          last = dst;
-        }
-      } catch (e) {
-        // Same partial-batch refresh as doPaste: run() refetches only on full
-        // success, so copies already written would stay invisible here until
-        // the dir-watch update. Rethrown so the error toast still shows.
-        if (last !== null) refetch();
-        throw e;
-      }
-      if (last !== null) pendingSelectRef.current = last; // select the new copy
-    }, { verb: "duplicate", name: batchLabel(rows) }).finally(() => {
-      duplicateInFlight.current = false;
-    });
-  };
-
-  // Compress a folder into a sibling archive. In-flight guard for the same
-  // reason Duplicate has one: two quick picks would race freeArchivePath to the
-  // same free name and 409 the second. The new archive is selected on success,
-  // matching what Duplicate does with its copy.
-  const compressInFlight = useRef(false);
-  const doCompress = (row: RowCtx, format: ArchiveFormat, ext: string) => {
-    if (compressInFlight.current) return;
-    compressInFlight.current = true;
-    run(async () => {
-      const dst = await freeArchivePath(row.parentDir, row.name, ext);
-      await compressEntry(row.path, format, dst);
-      pendingSelectRef.current = dst;
-    }, { verb: "compress", name: row.name }).finally(() => {
-      compressInFlight.current = false;
-    });
-  };
-
-  // Lazy loader for the Compress submenu. The git-repo probe is a subprocess on
-  // the server, so it runs here — once, on hover — rather than on every
-  // right-click; a failed probe just drops the git entries (fail closed, like
-  // the Open With condition gate).
-  const loadCompress = (row: RowCtx) => async (): Promise<MenuEntry[]> => {
-    let isRepoRoot = false;
-    try {
-      isRepoRoot = (await gitRepoInfo(row.path)).is_repo_root;
-    } catch {
-      isRepoRoot = false;
-    }
-    return buildCompressItems(isRepoRoot, (format, ext) => doCompress(row, format, ext));
-  };
-
-  const doReveal = (path: string) => {
-    revealPath(path).catch((e) =>
-      pushToast({ msg: friendlyFsError(e, { verb: "reveal", name: basename(path) }), tone: "error" })
-    );
-  };
-
-  const doCopyPath = (path: string) => {
-    // Confirm with a non-error "info" toast; a failure (clipboard unavailable
-    // or permission denied) stays silent — the path is still reachable via
-    // Reveal in Finder.
-    copyToClipboard(path).then((ok) => {
-      if (ok) pushToast({ msg: "Path copied", tone: "info" });
-    });
-  };
-
-  // Several paths go to the system clipboard newline-separated (what every file
-  // manager writes for a multi-selection paste into a terminal or editor).
-  const doCopyPaths = (paths: string[]) => {
-    copyToClipboard(paths.join("\n")).then((ok) => {
-      if (ok) pushToast({ msg: `${paths.length} paths copied`, tone: "info" });
-    });
-  };
-
-  // Open Claude Code via its claude-cli:// scheme handler — a dir cwd's into
-  // itself, a file cwd's into its parent and pre-fills an @-mention prompt.
-  // Setting location.href to a custom scheme does not navigate the SPA away.
-  const doOpenInClaude = (path: string, isDir: boolean, name: string, parentDir: string) => {
-    window.location.href = claudeDeepLink(path, isDir, name, parentDir);
-  };
-
-  const startNewFile = (dir: string) =>
-    setDialog({
-      kind: "prompt",
-      title: "New File",
-      initial: "untitled.txt",
-      confirmLabel: "Create",
-      onConfirm: (name) => {
-        if (rejectName(name)) return;
-        // create=true: refuse (409 "conflict", surfaced as an error toast) if a
-        // file with this name already exists, so New File never clobbers it.
-        run(() => writeFile(join(normDir(dir), name), "", true), { verb: "create", name });
-      },
-    });
-
-  const startNewFolder = (dir: string) =>
-    setDialog({
-      kind: "prompt",
-      title: "New Folder",
-      initial: "untitled folder",
-      confirmLabel: "Create",
-      onConfirm: (name) => {
-        if (rejectName(name)) return;
-        run(() => mkdir(join(normDir(dir), name)), { verb: "create", name });
-      },
-    });
-
-  const startRename = (row: RowCtx) =>
-    setDialog({
-      kind: "prompt",
-      title: "Rename",
-      initial: row.name,
-      confirmLabel: "Rename",
-      selectStem: true,
-      onConfirm: (name) => {
-        if (name === row.name) return;
-        if (rejectName(name)) return;
-        const dst = join(normDir(row.parentDir), name);
-        run(async () => {
-          await renameEntry(row.path, dst);
-          // Re-anchor onto the new name so the reloaded listing keeps this row
-          // selected (and Enter opens the renamed file, not the dead old path).
-          pendingSelectRef.current = dst;
-          // The clipboard may still be pointing at the old path (or inside it,
-          // if a renamed folder held the cut/copied entry) — repoint it so a
-          // later Paste doesn't target a source that's now gone.
-          remapClipboardPath(row.path, dst);
-        }, { verb: "rename", name: row.name });
-      },
-    });
-
-  // Hard delete, confirmed. Plural-aware: one row still names it (and says
-  // whether it's a folder), several are counted.
-  const startDelete = (allRows: RowCtx[]) => {
-    // Drop rows contained by another selected folder before anything else, so
-    // the confirm dialog counts what will actually be deleted and the loop below
-    // never calls deleteEntry on a path the parent's recursive delete just took
-    // (that 404 would abort the batch and toast a failure for a delete that in
-    // fact removed everything asked for).
-    const rows = pruneDescendantRows(allRows);
-    if (!rows.length) return;
-    const many = rows.length > 1;
-    setDialog({
-      kind: "confirm",
-      title: many ? `Delete ${rows.length} items` : "Delete",
-      message: many
-        ? `Delete these ${rows.length} items? Any folders among them are deleted with everything inside. This can't be undone.`
-        : rows[0].isDir
-        ? `Delete the folder "${rows[0].name}" and everything inside it? This can't be undone.`
-        : `Delete "${rows[0].name}"? This can't be undone.`,
-      confirmLabel: many ? `Delete ${rows.length} items` : "Delete",
-      danger: true,
-      // recursive=true for a directory (its contents were named in the message).
-      onConfirm: () =>
-        run(async () => {
-          let deleted = 0;
-          try {
-            for (const row of rows) {
-              await deleteEntry(row.path, row.isDir);
-              notePathDeleted(row.path);
-              deleted++;
-            }
-          } catch (e) {
-            // Partial batch: run() refetches only on full success, so without
-            // this the already-deleted rows linger in the listing until the
-            // dir-watch update. Rethrown so run() still toasts the failure.
-            if (deleted) refetch();
-            throw e;
-          }
-        }, { verb: "delete", name: batchLabel(rows) }),
-    });
-  };
-
-  // Move to Bin: a recoverable delete (macOS Trash), so no confirm dialog.
-  // Acts on every row passed in (the whole selection). Where the server can't
-  // trash (non-macOS → "unsupported") those rows fall back to the existing
-  // confirm-then-hard-delete flow, which IS irreversible and so keeps its
-  // warning. Success shows a low-key, count-aware info toast.
-  const doTrash = (allRows: RowCtx[]) => {
-    // As in startDelete: trashing a folder takes everything inside it, so a
-    // selection that also holds rows from within that folder must not trash them
-    // individually — the second call would hit a vanished path and be counted as
-    // a real failure, replacing the "Moved to Bin" toast with a bogus error.
-    const rows = pruneDescendantRows(allRows);
-    if (!rows.length) return;
-    void (async () => {
-      const trashed: RowCtx[] = [];
-      const unsupported: RowCtx[] = [];
-      let failed: { row: RowCtx; message: string } | null = null;
-      for (const row of rows) {
-        const r = await trashEntry(row.path, row.isDir);
-        if (r.status === "trashed") {
-          trashed.push(row);
-          notePathDeleted(row.path);
-        } else if (r.status === "unsupported") {
-          unsupported.push(row);
-        } else if (failed === null) {
-          failed = { row, message: r.message };
-        }
-      }
-      if (trashed.length) {
-        pushToast({
-          msg: trashed.length === 1 ? "Moved to Bin" : `Moved ${trashed.length} items to Bin`,
-          tone: "info",
-        });
-        refetch();
-      }
-      // A real failure raises its own toast. It used to REPLACE the info one
-      // above (one local slot, last write wins), which hid the fact that the
-      // other rows did move; the shared stack shows both, which is what a
-      // partial success actually is. The unsupported fallback only runs when
-      // nothing errored.
-      if (failed !== null) {
-        pushToast({
-          msg: friendlyFsError(failed.message, { verb: "move to Bin", name: failed.row.name }),
-          tone: "error",
-        });
-      } else if (unsupported.length) {
-        startDelete(unsupported);
-      }
-    })();
-  };
-
-  // Lazy loader for the Open With submenu: resolves the entry's template modes
-  // (resolveOpenWithModes mirrors Preview's filter + condition-gate handling).
-  // Selecting a mode navigates to the entry with `_mode` set; the default mode
-  // deletes the param.
-  const loadOpenWith = (path: string) => async (): Promise<MenuItem[]> => {
-    const modes = await resolveOpenWithModes(path);
-    return buildOpenWithItems(modes, (mode, isDefault) => {
-      const search = isDefault ? "" : "?_mode=" + encodeURIComponent(mode);
-      navigateUrl(urlForFsPath(path, search));
-    });
-  };
-
-  // Menu for a right-clicked row (file or dir), in macOS Finder order. Paste
-  // target follows Finder: into a dir, or the parent of a file. New File/Folder
-  // live only on the background menu (Finder shows them there, not on a row).
-  // `rows` is what the menu ACTS on: just the right-clicked row normally, or the
-  // whole selection when the right-click landed inside a multi-row selection
-  // (see openRowMenu). With several rows the entries that only make sense for
-  // one — Open / Open With / Rename / Reveal / Open in Claude Code — are
-  // dropped, and the batch entries count what they'll affect.
-  const rowMenu = (row: RowCtx, rows: RowCtx[]): MenuEntry[] => {
-    const dir = targetDirOf(row);
-    const n = rows.length;
-    if (n > 1) {
-      return [
-        { label: `Move ${n} items to Bin`, icon: MenuIcons.trash, onClick: () => doTrash(rows) },
-        "separator",
-        { label: `Duplicate ${n} items`, icon: MenuIcons.duplicate, onClick: () => doDuplicate(rows) },
-        "separator",
-        {
-          label: `Cut ${n} items`,
-          icon: MenuIcons.cut,
-          onClick: () => setClipboard({ paths: rows.map((r) => r.path), op: "cut" }),
-        },
-        {
-          label: `Copy ${n} items`,
-          icon: MenuIcons.copy,
-          onClick: () => setClipboard({ paths: rows.map((r) => r.path), op: "copy" }),
-        },
-        { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(dir) },
-        "separator",
-        {
-          label: `Copy ${n} Paths`,
-          icon: MenuIcons.copyPath,
-          onClick: () => doCopyPaths(rows.map((r) => r.path)),
-        },
-      ];
-    }
-    return [
-      { label: isAppEntry(row.name, row.isDir) ? "Open App" : "Open", icon: MenuIcons.open, onClick: () => navigate(row.path, { isDir: row.isDir }) },
-      { label: "Open With", icon: MenuIcons.openWith, submenu: loadOpenWith(row.path) },
-      "separator",
-      { label: "Move to Bin", icon: MenuIcons.trash, onClick: () => doTrash([row]) },
-      "separator",
-      { label: "Rename…", icon: MenuIcons.rename, onClick: () => startRename(row) },
-      { label: "Duplicate", icon: MenuIcons.duplicate, onClick: () => doDuplicate([row]) },
-      // Folders only, in Finder's position (after Duplicate, before Cut/Copy).
-      // Not on the multi-select or background menus: one archive per folder.
-      ...(row.isDir
-        ? [{ label: "Compress", icon: MenuIcons.compress, submenu: loadCompress(row) } as MenuEntry]
-        : []),
-      "separator",
-      { label: "Cut", icon: MenuIcons.cut, onClick: () => setClipboard({ paths: [row.path], op: "cut" }) },
-      { label: "Copy", icon: MenuIcons.copy, onClick: () => setClipboard({ paths: [row.path], op: "copy" }) },
-      { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(dir) },
-      "separator",
-      { label: "Copy Path", icon: MenuIcons.copyPath, onClick: () => doCopyPath(row.path) },
-      { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(row.path) },
-      {
-        label: "Open in Claude Code",
-        icon: MenuIcons.openWith,
-        onClick: () => doOpenInClaude(row.path, row.isDir, row.name, row.parentDir),
-      },
-    ];
-  };
-
-  // Menu for the empty listing background — operates on the current folder.
-  // Finder order: New Folder before New File.
-  const backgroundMenu = (): MenuEntry[] => [
-    { label: "New Folder…", icon: MenuIcons.newFolder, onClick: () => startNewFolder(base) },
-    { label: "New File…", icon: MenuIcons.newFile, onClick: () => startNewFile(base) },
-    "separator",
-    { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(base) },
-    "separator",
-    { label: "Refresh", icon: MenuIcons.refresh, onClick: refetch },
-    { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(normDir(base)) },
-    {
-      label: "Open in Claude Code",
-      icon: MenuIcons.openWith,
-      onClick: () => doOpenInClaude(normDir(base), true, "", normDir(base)),
-    },
-  ];
+  useListingShortcuts({
+    base,
+    clipboard,
+    selectedRows,
+    leadRow,
+    searchInputRef,
+    overlayOpenRef,
+    refetch,
+    doPaste,
+    doDuplicate,
+    doTrash,
+    startRename,
+    startNewFolder,
+  });
 
   // Mouse selection on a row:
   //   • Shift+click  — select the contiguous range anchor..row (rendered order);
@@ -2036,8 +407,8 @@ export default function Listing({
   const onRowMouseDown = (e: React.MouseEvent) => {
     if (!e.shiftKey && !isMod(e)) return;
     e.preventDefault();
-    const sel = window.getSelection();
-    if (sel && !sel.isCollapsed) sel.removeAllRanges();
+    const winSel = window.getSelection();
+    if (winSel && !winSel.isCollapsed) winSel.removeAllRanges();
   };
 
   // Right-clicking INSIDE an existing multi-row selection keeps it and acts on
@@ -2057,121 +428,6 @@ export default function Listing({
     e.preventDefault();
     setMenu({ x: e.clientX, y: e.clientY, items: backgroundMenu() });
   };
-
-  // Keyboard shortcuts scoped to the listing: file operations on the selection
-  // plus the folder-level navigation chords. Registered once (empty deps); the
-  // handler is re-assigned each render so it always reads fresh state/closures.
-  // Separate from the nav handler above, and non-overlapping with it by
-  // construction: everything here carries the primary modifier or is a key that
-  // handler ignores (F2, Delete, Backspace — its printable-key branch only fires
-  // for single-character keys, and its arrow branch bails when isMod(e)).
-  const shortcutRef = useRef<(e: KeyboardEvent) => void>(() => {});
-  shortcutRef.current = (e: KeyboardEvent) => {
-    if (e.isComposing) return;
-    // Same hard guard as the nav handler: while a context menu or dialog is
-    // open (in this view OR a hosting one, e.g. Preview's header menu with this
-    // Listing embedded), file-op shortcuts (Cmd+Backspace trash, Cmd+X cut, …)
-    // must not fire on the row behind it.
-    if (overlayOpenRef.current || isOverlayOpen()) return;
-    const el = document.activeElement as HTMLElement | null;
-    const inSearch = el === searchInputRef.current;
-    const navActive = inSearch || !el || el === document.body || el === document.documentElement;
-    if (!navActive) return;
-    // Every file operation acts on the WHOLE selection; the single-entry ones
-    // (Rename, and the paste target) use the lead row.
-    const rows = selectedRows;
-    const row = leadRow;
-    const mod = isMod(e);
-    const key = e.key.toLowerCase();
-    // The parent folder, for Mod+Up / bare Backspace. Equal to the current
-    // folder at the filesystem (or drive) root, where there's nowhere to go.
-    const here = normDir(base);
-    const parent = dirname(here);
-    const goParent = () => {
-      if (parent !== here) navigate(parent, { isDir: true });
-    };
-    // With focus in the search box, Cmd+C/X/V must keep their native text
-    // clipboard meaning — only the non-text shortcuts stay live there.
-    if (inSearch && mod && (key === "c" || key === "x" || key === "v")) return;
-    if (mod && key === "c") {
-      if (!rows.length) return;
-      e.preventDefault();
-      setClipboard({ paths: rows.map((r) => r.path), op: "copy" });
-    } else if (mod && key === "x") {
-      if (!rows.length) return;
-      e.preventDefault();
-      setClipboard({ paths: rows.map((r) => r.path), op: "cut" });
-    } else if (mod && key === "v") {
-      if (!clipboard) return;
-      e.preventDefault();
-      // Paste is single-TARGET: into the lead row's folder (or itself, if it's a
-      // directory), else the folder being listed.
-      doPaste(row ? targetDirOf(row) : base);
-    } else if (mod && key === "d") {
-      if (!rows.length) return;
-      e.preventDefault();
-      doDuplicate(rows);
-    } else if (mod && e.key === "ArrowDown") {
-      // Open the lead row — the same gesture as Enter (macOS Cmd+Down).
-      if (!row) return;
-      e.preventDefault();
-      navigate(row.path, { isDir: row.isDir });
-    } else if (mod && e.key === "ArrowUp") {
-      e.preventDefault();
-      goParent();
-    } else if (mod && (e.key === "[" || e.key === "]")) {
-      // Back / forward. The router only ever pushes, so this drives the browser
-      // history directly — popstate is what the shell listens to anyway
-      // (useNavEpoch), so the view remounts exactly as it does for a Back click.
-      e.preventDefault();
-      if (e.key === "[") history.back();
-      else history.forward();
-    } else if (mod && e.shiftKey && key === "n") {
-      e.preventDefault();
-      startNewFolder(base);
-    } else if (mod && key === "r") {
-      // The app's own listing refresh, not a page reload — preventDefault is
-      // what stops the browser from throwing the whole SPA away.
-      e.preventDefault();
-      refetch();
-    } else if (mod && e.key === "Backspace") {
-      // macOS trash chord. Windows/Linux use the Delete key below instead.
-      // Never while typing in the search box: Cmd+Delete is the standard macOS
-      // "clear to start of line" chord, so trashing there would be a foot-gun.
-      if (!isMac || inSearch || !rows.length) return;
-      e.preventDefault();
-      doTrash(rows);
-      // Bare key only: because isMod() is exclusive, `!mod` alone is still true
-      // when the OTHER modifier is held (Super+Backspace on Linux), so test the
-      // raw flags instead.
-    } else if (e.key === "Backspace" && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
-      // Windows/Linux: bare Backspace goes up a folder. On macOS it must stay
-      // inert — Cmd+Backspace is trash there and a bare Backspace navigating
-      // away would be a foot-gun. Never while typing in the search box.
-      if (isMac || inSearch) return;
-      e.preventDefault();
-      goParent();
-    } else if (e.key === "Delete" && !e.metaKey && !e.ctrlKey) {
-      // Windows/Linux trash key. On macOS the Delete (⌦) key is not the trash
-      // gesture — Cmd+Backspace above is. Raw-flag test rather than `!mod` so a
-      // held Super key can't slip a destructive key through (see Backspace).
-      if (isMac || inSearch || !rows.length) return;
-      e.preventDefault();
-      doTrash(rows);
-    } else if (e.key === "F2") {
-      // Rename is single-entry: with several rows selected it renames the LEAD
-      // row (what Windows Explorer does — F2 edits the focused item), not a
-      // no-op and never a batch rename.
-      if (!row) return;
-      e.preventDefault();
-      startRename(row);
-    }
-  };
-  useEffect(() => {
-    const h = (e: KeyboardEvent) => shortcutRef.current(e);
-    document.addEventListener("keydown", h);
-    return () => document.removeEventListener("keydown", h);
-  }, []);
 
   // --- table body -----------------------------------------------------------
 

--- a/frontend/src/apps/explorer/listing/bits.tsx
+++ b/frontend/src/apps/explorer/listing/bits.tsx
@@ -1,0 +1,73 @@
+// Small presentational pieces of the listing: skeleton rows, the clipboard
+// pill, and search-match highlighting.
+import { highlightSegments } from "@platform/lib/fuzzy";
+import { FLIP_KEY_ATTR } from "@platform/lib/flip";
+
+// Shimmering placeholder rows shown while the listing fetch is in flight —
+// same column shape as the real rows (icon + name + size + mtime), just with
+// shimmer bars instead of text so the table never reads as "frozen". The
+// width cycles make the bars ragged like real filenames.
+const SKEL_NAME_W = [70, 45, 82, 38, 60, 50, 74, 42, 66, 34];
+const SKEL_SIZE_W = [34, 28, 40, 24, 36, 30, 26, 38, 32, 22];
+export function skeletonRows(n: number): React.ReactNode {
+  return Array.from({ length: n }, (_, i) => (
+    <tr key={i} className="skel-row">
+      <td className="name">
+        <span className="skel-bar icon-skel" />
+        <span className="skel-bar" style={{ width: `${SKEL_NAME_W[i % SKEL_NAME_W.length]}%` }} />
+      </td>
+      <td className="size">
+        <span className="skel-bar" style={{ width: SKEL_SIZE_W[i % SKEL_SIZE_W.length] }} />
+      </td>
+      <td className="mtime">
+        <span className="skel-bar" style={{ width: 84 }} />
+      </td>
+    </tr>
+  ));
+}
+
+// The pending-clipboard mark on a row: a small "Cut" / "Copied" pill in the name
+// cell, alongside the row-level styling (dim for cut, accent edge + wash for
+// copy). This IS the whole pending-clipboard UI — there is no chrome-level chip
+// (see Breadcrumb.tsx) — so the pill carries the Esc affordance in its tooltip.
+// `cut` and `copied` are never both true: the clipboard holds a single op.
+export function ClipMark({ cut, copied }: { cut: boolean; copied: boolean }) {
+  if (!cut && !copied) return null;
+  return (
+    <span className={"clip-mark" + (cut ? " cut" : " copied")} title="Press Esc to cancel">
+      {cut ? "Cut" : "Copied"}
+    </span>
+  );
+}
+
+export function renderHighlight(text: string, positions: number[]) {
+  return highlightSegments(text, positions).map((seg, i) =>
+    seg.match ? (
+      <mark key={i} className="search-mark">
+        {seg.text}
+      </mark>
+    ) : (
+      <span key={i}>{seg.text}</span>
+    )
+  );
+}
+
+// Where the scroll position is pinned across a dir-watch refresh: the lead
+// (selected) row, or failing that the topmost row still in view. Returns null
+// when there is nothing to anchor to (empty or unmounted listing).
+export function measureScrollAnchor(
+  scroller: HTMLElement,
+): { key: string; top: number; scrollTop: number } | null {
+  let el = scroller.querySelector<HTMLElement>("tr.row.lead");
+  if (!el) {
+    for (const row of scroller.querySelectorAll<HTMLElement>(`[${FLIP_KEY_ATTR}]`)) {
+      if (row.offsetTop + row.offsetHeight > scroller.scrollTop) {
+        el = row;
+        break;
+      }
+    }
+  }
+  const key = el?.getAttribute(FLIP_KEY_ATTR);
+  if (!el || !key) return null;
+  return { key, top: el.offsetTop, scrollTop: scroller.scrollTop };
+}

--- a/frontend/src/apps/explorer/listing/pane.ts
+++ b/frontend/src/apps/explorer/listing/pane.ts
@@ -1,0 +1,151 @@
+// The preview pane (right-hand split): per-folder visibility/width state and
+// the usePreviewPane hook that owns the toggle + divider drag.
+//
+// Visibility follows the sort's model: an explicit `?preview` in the URL wins
+// (and rides along on directory navigation — see lib/router navigate, which
+// carries it so the pane is sticky between folders), otherwise this folder's
+// saved viewstate (keys `pane`/`panew` alongside `sort`/`order`). Width is
+// viewstate-only — a pixel width isn't something a shared link should impose.
+// A folder with no saved width opens the pane at HALF the split container
+// (width null until the measuring effect resolves it; PANE_FALLBACK_W covers
+// the pre-paint frame and the unmeasurable edge). Default off — a folder never
+// toggled shows the plain listing exactly as before. `pane` and `panew` are
+// independent: turning the pane off keeps a dragged width, so re-opening the
+// folder restores it.
+import { useLayoutEffect, useRef, useState } from "react";
+import { replaceSearch } from "@platform/lib/router";
+import { getViewState, setViewState } from "@platform/lib/viewstate";
+
+const PANE_MIN_W = 220;
+const LIST_MIN_W = 220;
+const PANE_MAX_FRAC = 0.65;
+export const PANE_DEFAULT_FRAC = 0.5;
+const PANE_FALLBACK_W = 420;
+
+// The one place the FS-12 clamps live, so the drag and the measured default
+// cannot disagree. Two independent ceilings: the 65 % fraction (the list stays
+// the primary surface) and the LIST_MIN_W floor the list needs in pixels — on
+// a narrow window 65 % of the container leaves the list well under 220 px, so
+// the pixel ceiling is the binding one there. PANE_MIN_W is applied last: in
+// the degenerate case (a container too small to satisfy both minimums) the
+// pane keeps its floor and the list scrolls, which is what the old template's
+// `min-width` did.
+function clampPaneWidth(containerW: number, width: number): number {
+  return Math.max(PANE_MIN_W, Math.min(containerW * PANE_MAX_FRAC, containerW - LIST_MIN_W, width));
+}
+
+function resolvePane(fsPath: string): { on: boolean; width: number | null } {
+  const s = new URLSearchParams(getViewState(fsPath));
+  const url = new URLSearchParams(location.search);
+  // `preview=true` exactly — the owner's literal format (any other value
+  // reads as absent, falling back to the saved state).
+  const on = url.get("preview") !== null ? url.get("preview") === "true" : s.get("pane") === "1";
+  const w = parseInt(s.get("panew") || "", 10);
+  return { on, width: Number.isFinite(w) && w >= PANE_MIN_W ? w : null };
+}
+
+// Merge the pane keys into this folder's saved state without touching a saved
+// sort (and vice versa — setSort merges the same way). A null width (still at
+// the measured-default half) isn't persisted — only a dragged width is a
+// choice worth remembering. The two keys are INDEPENDENT: `panew` outlives a
+// toggle-off, so closing the pane and coming back to the folder re-opens at
+// the width that was dragged rather than re-measuring the default.
+function savePaneState(fsPath: string, on: boolean, width: number | null): void {
+  const s = new URLSearchParams(getViewState(fsPath));
+  if (on) s.set("pane", "1");
+  else s.delete("pane");
+  if (width !== null) s.set("panew", String(Math.round(width)));
+  else s.delete("panew");
+  const qs = s.toString();
+  setViewState(fsPath, qs ? "?" + qs : "");
+}
+
+export function usePreviewPane(fsPath: string) {
+  // Visibility restores URL-first (resolvePane: `?preview=true` wins, then the
+  // folder's saved viewstate); width is viewstate-only. Toggling writes BOTH:
+  // the URL (replaceSearch, like setSort — on sets `preview=true`, off deletes
+  // it; navigate() then carries the param between folders, making the pane
+  // sticky) and the viewstate (so a folder re-opened from a clean URL
+  // remembers). Width is clamped live during the divider drag; the max
+  // fraction is enforced against the split container's current size.
+  const [pane, setPane] = useState<{ on: boolean; width: number | null }>(() => resolvePane(fsPath));
+  const splitRef = useRef<HTMLDivElement>(null);
+  // Is `pane.width` a width the USER chose (restored from `panew`, or dragged
+  // this session), as opposed to the measured half-container default? Only a
+  // chosen width is persisted — the measuring effect below fills `pane.width`
+  // in, which would otherwise make the default indistinguishable from a drag
+  // and let a later toggle write it to `panew`.
+  const paneSized = useRef(pane.width !== null);
+  // No saved width: default to half the split container, measured at first
+  // open (layout effect — before paint, so the pane never flashes another
+  // width). The clamps still apply; the fallback constant only covers the
+  // unmeasurable edge (ref not mounted yet).
+  useLayoutEffect(() => {
+    if (!pane.on || pane.width !== null) return;
+    const w = splitRef.current?.getBoundingClientRect().width;
+    const half = w ? clampPaneWidth(w, w * PANE_DEFAULT_FRAC) : PANE_FALLBACK_W;
+    setPane((prev) => (prev.width === null ? { ...prev, width: half } : prev));
+  }, [pane.on, pane.width]);
+
+  const togglePane = () => {
+    setPane((prev) => {
+      const next = { ...prev, on: !prev.on };
+      const params = new URLSearchParams(location.search);
+      if (next.on) params.set("preview", "true");
+      else params.delete("preview");
+      const qs = params.toString();
+      replaceSearch(location.pathname + (qs ? "?" + qs : ""));
+      savePaneState(fsPath, next.on, paneSized.current ? next.width : null);
+      return next;
+    });
+  };
+
+  // The divider drag: pointer capture keeps the drag alive when the cursor
+  // crosses into the pane's iframe (which would otherwise swallow mousemove).
+  const onDividerPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const divider = e.currentTarget;
+    divider.setPointerCapture(e.pointerId);
+    divider.classList.add("dragging");
+    let width = pane.width;
+    let moved = false;
+    const onMove = (ev: PointerEvent) => {
+      const rect = splitRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      moved = true;
+      // The pane is the right side: its width is the distance from the cursor
+      // to the container's right edge, run through the shared FS-12 clamps.
+      width = clampPaneWidth(rect.width, rect.right - ev.clientX);
+      setPane((prev) => (prev.width === width ? prev : { ...prev, width }));
+    };
+    const onUp = () => {
+      divider.classList.remove("dragging");
+      divider.removeEventListener("pointermove", onMove);
+      divider.removeEventListener("pointerup", onUp);
+      divider.removeEventListener("pointercancel", onUp);
+      // Only a drag that actually moved the divider is a chosen width; a bare
+      // click on it leaves the measured default unpersisted.
+      if (moved) paneSized.current = true;
+      savePaneState(fsPath, true, paneSized.current ? width : null);
+    };
+    divider.addEventListener("pointermove", onMove);
+    divider.addEventListener("pointerup", onUp);
+    divider.addEventListener("pointercancel", onUp);
+  };
+
+  return { pane, splitRef, togglePane, onDividerPointerDown };
+}
+
+// Same URL reflection Listing does for a saved sort: a pane restored from
+// saved viewstate (URL carried no `preview`) puts `preview=true` on the
+// address bar so refresh, bookmarks and onward navigation (which carries the
+// param) all see the shown state. Only ever ADDS the param — a URL without it
+// and a folder without saved pane state keep the clean URL, and an explicit
+// `?preview=false` stays authoritative (resolvePane already read it as off).
+export function reflectPaneInUrl(fsPath: string): void {
+  if (new URLSearchParams(location.search).get("preview") !== null) return; // URL is authoritative
+  if (!new URLSearchParams(getViewState(fsPath)).get("pane")) return;
+  const params = new URLSearchParams(location.search);
+  params.set("preview", "true");
+  replaceSearch(location.pathname + "?" + params.toString());
+}

--- a/frontend/src/apps/explorer/listing/row-utils.ts
+++ b/frontend/src/apps/explorer/listing/row-utils.ts
@@ -1,0 +1,24 @@
+// Small pure helpers over RowCtx batches, shared by the file operations and
+// the context menus.
+import { normDir, pruneDescendantPaths } from "@apps/explorer/lib/fs-actions";
+import type { RowCtx } from "@apps/explorer/listing/types";
+
+// Row-shaped pruneDescendantPaths, for the batch row ops (Trash, Delete): a
+// search selection can hold a folder row and rows from inside it, and removing
+// the folder already removes those. Same input order.
+export function pruneDescendantRows(rows: RowCtx[]): RowCtx[] {
+  const kept = new Set(pruneDescendantPaths(rows.map((r) => r.path)));
+  return rows.filter((r) => kept.has(r.path));
+}
+
+// The target folder for a New File / Paste against a row: INTO a directory row,
+// or the PARENT of a file row (Finder's behaviour).
+export function targetDirOf(row: RowCtx): string {
+  return normDir(row.isDir ? row.path : row.parentDir);
+}
+
+// Plural-friendly name for a batch of rows, used both in menu labels and as the
+// `name` in a friendlyFsError context ("Couldn't duplicate \"3 items\"").
+export function batchLabel(rows: { name: string }[]): string {
+  return rows.length === 1 ? rows[0].name : `${rows.length} items`;
+}

--- a/frontend/src/apps/explorer/listing/search.ts
+++ b/frontend/src/apps/explorer/listing/search.ts
@@ -1,0 +1,78 @@
+// Fuzzy scoring and ranking for the in-folder search (over the streamed walk).
+import type { WalkEntry } from "@platform/lib/api";
+import { fuzzyMatch } from "@platform/lib/fuzzy";
+import type { SearchHit, SortKey, SortOrder } from "@apps/explorer/listing/types";
+
+// A dot-leading query segment is explicit intent to SEE hidden entries.
+// The walk itself always includes hidden entries (one dataset — the server
+// prunes the actually-heavy machine trees like .git/node_modules, so hidden
+// files are cheap to carry); this only gates whether dot-entries are shown.
+// That makes ".py" work as an extension search (dotfiles like .pylintrc may
+// match too — fine, they're real matches) without a second walk, and "env"
+// deliberately not surface ".env".
+export function queryWantsHidden(rawQuery: string): boolean {
+  const q = rawQuery.trim();
+  return q.startsWith(".") || q.includes("/.");
+}
+
+// An entry is hidden when any path segment is dot-leading.
+export function isHiddenRel(rel: string): boolean {
+  return rel.startsWith(".") || rel.includes("/.");
+}
+
+export function rankCompare(a: SearchHit, b: SearchHit): number {
+  if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
+  if (b.score !== a.score) return b.score - a.score;
+  const ad = a.entry.rel.split("/").length;
+  const bd = b.entry.rel.split("/").length;
+  if (ad !== bd) return ad - bd;
+  return a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
+}
+
+// Score `entries[from..]` against the query (unsorted — callers sort with
+// rankCompare after merging). `showHidden=false` skips dot-entries before
+// scoring (see queryWantsHidden). The `from` offset is what makes streaming
+// cheap: each flush scores only the entries that arrived since the last one.
+//
+// On top of the fuzzy score, the entry NAME (last path segment) gets intent
+// bonuses: an exact name match outranks everything ("Downloads" must beat
+// "DownloadStage", whose extra camel-hump bonus otherwise wins), and a name
+// starting with the query beats an interior hit. Char-level heuristics can't
+// express "this IS the thing you typed", so it's layered here, not in fuzzy.ts.
+export function scoreEntries(
+  query: string,
+  entries: WalkEntry[],
+  from: number,
+  showHidden: boolean,
+): SearchHit[] {
+  const q = query.toLowerCase();
+  const hits: SearchHit[] = [];
+  for (let i = from; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!showHidden && isHiddenRel(entry.rel)) continue;
+    const m = fuzzyMatch(query, entry.rel);
+    if (!m) continue;
+    let score = m.score;
+    const name = entry.rel.slice(entry.rel.lastIndexOf("/") + 1).toLowerCase();
+    if (name === q) score += 100;
+    else if (name.startsWith(q)) score += 25;
+    hits.push({ entry, positions: m.positions, score, longestRun: m.longestRun });
+  }
+  return hits;
+}
+
+// Column-sort a ranked result set (the search headers' asc/desc modes; null
+// searchSort — relevance — leaves the rankCompare order untouched upstream).
+export function sortHits(hits: SearchHit[], sort: SortKey, order: SortOrder): SearchHit[] {
+  const flip = order === "desc" ? -1 : 1;
+  const byName = (a: SearchHit, b: SearchHit) =>
+    a.entry.rel.localeCompare(b.entry.rel, undefined, { sensitivity: "base" });
+  return [...hits].sort((a, b) => {
+    let cmp: number;
+    if (sort === "size") cmp = (a.entry.size ?? -1) - (b.entry.size ?? -1);
+    else if (sort === "mtime") cmp = (a.entry.mtime ?? 0) - (b.entry.mtime ?? 0);
+    else cmp = byName(a, b);
+    if (cmp === 0) cmp = byName(a, b);
+    return cmp * flip;
+  });
+}

--- a/frontend/src/apps/explorer/listing/selection.ts
+++ b/frontend/src/apps/explorer/listing/selection.ts
@@ -1,0 +1,62 @@
+// Selection model + cross-remount stash for the listing's keyboard/mouse
+// selection.
+//
+// Keyboard selection (the arrow-key row highlight) survives the Listing
+// component's per-folder remount. Opening a folder first paints App's pre-stat
+// scaffold with a PROVISIONAL Listing, then swaps it for the resolved one when
+// stat lands ~1s later — a remount that would otherwise wipe an in-progress
+// arrow selection mid-keystroke (press Down during the open → the highlight
+// vanishes). Like fs-clipboard, the state lives just outside the remount
+// boundary. A single entry keyed by fsPath is enough (only one Listing is
+// mounted at a time): it bridges the scaffold→resolved swap and restores the
+// highlight if you browse back to the same folder.
+//
+// The stash carries the WHOLE multi-selection, not just one path, so a
+// Shift-range built in the provisional Listing survives too.
+export interface Selection {
+  // Selected row paths, in the order they entered the selection (a Shift-range
+  // enters in rendered row order). Empty = nothing selected.
+  paths: string[];
+  // Where a Shift-range extends FROM: the last row selected by a plain or
+  // Mod-click / plain arrow move. null when nothing has been selected yet.
+  anchor: string | null;
+  // The focused row: what arrows move from, what Enter opens, what F2 renames,
+  // and what a paste/new-file targets. null = no selection.
+  lead: string | null;
+}
+
+export const EMPTY_SELECTION: Selection = { paths: [], anchor: null, lead: null };
+
+// Collapse to exactly one row — the plain-click / plain-arrow / re-anchor case.
+export function oneSelected(path: string): Selection {
+  return { paths: [path], anchor: path, lead: path };
+}
+
+let lastSelection: { fsPath: string; sel: Selection } | null = null;
+export function recallSelection(fsPath: string): Selection {
+  return lastSelection && lastSelection.fsPath === fsPath ? lastSelection.sel : EMPTY_SELECTION;
+}
+export function rememberSelection(fsPath: string, sel: Selection): void {
+  lastSelection = { fsPath, sel };
+}
+
+// A contiguous range of rendered rows, inclusive, in row order. `rows` is the
+// live navRows order (the SORTED/rendered order, never the raw fs order).
+export function rangeBetween(rows: string[], from: string, to: string): string[] {
+  const a = rows.indexOf(from);
+  const b = rows.indexOf(to);
+  if (a === -1 || b === -1) return b === -1 ? [] : [to];
+  return a <= b ? rows.slice(a, b + 1) : rows.slice(b, a + 1);
+}
+
+// How many rows a PageUp/PageDown moves: one viewport of rows minus one, so the
+// row you were on stays visible as context. Measured from the live DOM (scroller
+// height / row height) and falls back to a sane constant before first paint.
+const PAGE_ROWS_FALLBACK = 12;
+export function pageRows(): number {
+  const scroller = document.querySelector(".listing-scroll") as HTMLElement | null;
+  const row = document.querySelector("table.listing-table tr.row") as HTMLElement | null;
+  const rowH = row?.offsetHeight ?? 0;
+  if (!scroller || rowH <= 0) return PAGE_ROWS_FALLBACK;
+  return Math.max(1, Math.floor(scroller.clientHeight / rowH) - 1);
+}

--- a/frontend/src/apps/explorer/listing/sorting.ts
+++ b/frontend/src/apps/explorer/listing/sorting.ts
@@ -1,0 +1,46 @@
+// Sort resolution and entry sorting for the plain (non-search) listing.
+import type { FsEntry } from "@platform/lib/api";
+import { getViewState } from "@platform/lib/viewstate";
+import { SORT_KEYS, type SortKey, type SortOrder } from "@apps/explorer/listing/types";
+
+// Effective sort for a folder. An explicit `?sort` in the URL wins — a shared
+// or hand-typed link is authoritative — otherwise fall back to this folder's
+// own saved state (lib/viewstate), otherwise the default name/asc. So each
+// folder shows its own remembered order regardless of how it was reached
+// (clicked into, a breadcrumb, Back, or a fresh URL), and sibling folders keep
+// independent sorts.
+export function resolveSort(fsPath: string): { sort: SortKey; order: SortOrder } {
+  const url = new URLSearchParams(location.search);
+  const src = url.get("sort") ? url : new URLSearchParams(getViewState(fsPath));
+  const key = src.get("sort");
+  const sort: SortKey = key && key in SORT_KEYS ? (key as SortKey) : "name";
+  const order: SortOrder = src.get("order") === "desc" ? "desc" : "asc";
+  return { sort, order };
+}
+
+export function sortEntries(entries: FsEntry[], sort: SortKey, order: SortOrder): FsEntry[] {
+  const flip = order === "desc" ? -1 : 1;
+  // Case-insensitive primary order, then an exact (case-sensitive) tiebreak so
+  // names differing only by case/accent get a stable, deterministic order.
+  // Without the tiebreak such names compare equal and the sort falls back to
+  // the arbitrary os.listdir() arrival order, which changes between refreshes.
+  const byName = (a: FsEntry, b: FsEntry) => {
+    const c = a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    return c !== 0 ? c : a.name < b.name ? -1 : a.name > b.name ? 1 : 0;
+  };
+  return [...entries].sort((a, b) => {
+    const aDot = a.name.startsWith(".");
+    const bDot = b.name.startsWith(".");
+    if (aDot !== bDot) return aDot ? 1 : -1; // dot entries always group last
+    // Name sort is purely alphabetical — folders and files interleave. The
+    // size/mtime sorts still group dirs first: a dir has no size and its mtime
+    // means something different from a file's, so mixing them there is noise.
+    if (sort !== "name" && a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
+    let cmp: number;
+    if (sort === "size") cmp = (a.size ?? -1) - (b.size ?? -1);
+    else if (sort === "mtime") cmp = (a.mtime ?? 0) - (b.mtime ?? 0);
+    else cmp = byName(a, b);
+    if (cmp === 0) cmp = byName(a, b);
+    return cmp * flip;
+  });
+}

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -1,0 +1,112 @@
+// Shared types and tuning constants for the directory listing view.
+// See Listing.tsx for the top-level architecture notes.
+import type { FsEntry, WalkEntry } from "@platform/lib/api";
+
+// A right-clicked row, normalized so both listing rows (name relative to the
+// listed folder) and search-result rows (a `rel` path into a subtree) drive the
+// same menu. `parentDir` is the containing folder; `path` is the entry itself.
+export interface RowCtx {
+  path: string;
+  name: string;
+  isDir: boolean;
+  parentDir: string;
+}
+
+// One open modal: a text prompt (New File/Folder, Rename) or a confirm (Delete).
+export type DialogState =
+  | {
+      kind: "prompt";
+      title: string;
+      initial: string;
+      confirmLabel: string;
+      selectStem?: boolean;
+      onConfirm: (value: string) => void;
+    }
+  | {
+      kind: "confirm";
+      title: string;
+      message: React.ReactNode;
+      confirmLabel: string;
+      danger?: boolean;
+      onConfirm: () => void;
+    };
+
+export const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
+export type SortKey = keyof typeof SORT_KEYS;
+export type SortOrder = "asc" | "desc";
+
+// Search-result rows rendered per "page". Fuzzy-scoring can match thousands
+// of entries in a large tree; mounting them all as <tr>s at once is what jams
+// the main thread (scoring itself is comparatively cheap). Scrolling to the
+// bottom reveals the next page (see the sentinel row in Listing.tsx); the full
+// ranked list always exists in memory for the count text.
+export const PAGE_SIZE = 250;
+
+// Above this many rendered rows the FLIP reorder animation is dropped. Measuring
+// every row's offsetTop on each commit is one forced layout, but the per-row
+// transform (a compositing layer each) is not free — on a listing this long the
+// glide costs more than the snap it replaces.
+export const FLIP_MAX_ROWS = 600;
+
+// Minimum gap between commits of the RENDERED search ranking while a walk
+// streams (see the throttle in useWalkSearch). Longer than STREAM_FLUSH_MS on
+// purpose: that one bounds how often results are re-scored, this one bounds how
+// often the rows on screen are allowed to move.
+export const RERANK_COMMIT_MS = 280;
+
+// How long a row that just appeared in the folder keeps its tint. Long enough to
+// catch the eye if you weren't looking at that part of the list, short enough
+// that it doesn't become part of the row's normal appearance.
+export const ROW_NEW_MS = 1500;
+
+// Debounce for mirroring the query into the URL. Safari rate-limits
+// history.replaceState (~100 calls / 30s, then it THROWS); per-keystroke
+// sync trips that on fast typing. State stays immediate — only the URL lags.
+export const URL_SYNC_MS = 200;
+
+// Minimum gap between streaming state flushes. Network chunks can arrive many
+// times per second on localhost; committing (and re-scoring) on every one
+// saturates the main thread and starves interaction. The first batch still
+// flushes immediately (lastFlush starts at 0), so first paint isn't delayed.
+export const STREAM_FLUSH_MS = 200;
+
+export type ListingState =
+  | { status: "loading" }
+  // `truncated`: the directory has more entries than the server cap, so this
+  // listing is a partial page. `cursor`: an opaque continuation token to fetch
+  // the next page (non-null only on the resumable S3-direct route); null means
+  // "no more can be fetched" — the banner then just states the listing is
+  // partial without a Load more button.
+  | { status: "ok"; entries: FsEntry[]; truncated: boolean; cursor: string | null }
+  | { status: "error"; message: string };
+
+// Streamed walk state. `entries` is one append-only array shared across the
+// streaming updates (each batch pushes into it); every update still creates a
+// NEW state object, so React re-renders and memos keyed on the walk recompute
+// against the grown array. `count` is the running total (doubles as the
+// version stamp that makes successive streaming states distinguishable).
+// Non-idle states are tagged with the `refresh` generation they were fetched
+// for; `validWalk` in useWalkSearch treats a stale tag as idle, so a dir-watch
+// bump invalidates the cache synchronously WITHOUT itself triggering a
+// re-fetch (fetching is driven by `walkReq` — see useWalkSearch). The
+// component remounts per folder (keyed on fsPath in App), so no path tagging
+// is needed.
+export type WalkState =
+  | { status: "idle" }
+  | { status: "streaming"; entries: WalkEntry[]; count: number; forRefresh: number }
+  | { status: "ok"; entries: WalkEntry[]; truncated: boolean; total: number; forRefresh: number }
+  | { status: "error"; message: string; forRefresh: number };
+
+export const IDLE_WALK: WalkState = { status: "idle" };
+
+// Ranking: longest consecutive matched run first (a contiguous substring hit
+// always beats a scattered subsequence one), then higher fuzzy score, then
+// fewer path segments (shallower = closer to hand), then alphabetical for a
+// stable order. Hits keep their score fields so partial result sets can be
+// merged and re-sorted incrementally as the walk streams in.
+export interface SearchHit {
+  entry: WalkEntry;
+  positions: number[];
+  score: number;
+  longestRun: number;
+}

--- a/frontend/src/apps/explorer/listing/useDirListing.ts
+++ b/frontend/src/apps/explorer/listing/useDirListing.ts
@@ -1,0 +1,150 @@
+// The plain (non-search) directory listing: the /api/fs/list fetch, the
+// Load-more pagination for truncated listings, the WebSocket dir watch that
+// drives refreshes, and the "new row" tint cue.
+import { useEffect, useRef, useState } from "react";
+import { listDir, prefetchListDir } from "@platform/lib/api";
+import { appearedKeys } from "@platform/lib/flip";
+import { pushToast } from "@platform/lib/toast";
+import { ROW_NEW_MS, type ListingState } from "@apps/explorer/listing/types";
+
+export function useDirListing(fsPath: string) {
+  const [state, setState] = useState<ListingState>({ status: "loading" });
+  const [refresh, setRefresh] = useState(0); // bumped by the dir watch socket
+  // loadMore captures the refresh generation it started in; a dir-watch refresh
+  // on the SAME path (App keys StatView on epoch+fsPath, so cross-directory
+  // merges can't happen, but a same-path re-fetch can) resets the listing while
+  // a cursored fetch is pending — the stale page must be discarded, not merged
+  // into the refreshed listing. Ref so the async callback reads the LATEST
+  // generation, not the one captured when loadMore was defined.
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  // A Load more fetch (next page of a truncated listing) is in flight.
+  const [loadingMore, setLoadingMore] = useState(false);
+  // Set by loadMore: an appended page is the user's own gesture, and tinting
+  // 250 rows they just asked for is noise, not a cue.
+  const skipNewCue = useRef(false);
+
+  useEffect(() => {
+    let alive = true;
+    // A fresh fetch (navigation or dir-watch refresh) resets any accumulated
+    // Load more pages: the new listing replaces the array wholesale.
+    setLoadingMore(false);
+    // Initial mount goes through the prefetch cache so a listing kicked off by
+    // the loading scaffold (in parallel with stat) is reused when the real
+    // preview remounts this component for the same path — no duplicate request.
+    // A dir-watch refresh (refresh > 0) must see live data, so it bypasses.
+    (refresh === 0 ? prefetchListDir(fsPath) : listDir(fsPath)).then(
+      (data) =>
+        alive &&
+        setState({
+          status: "ok",
+          entries: data.entries,
+          truncated: !!data.truncated,
+          cursor: data.cursor ?? null,
+        }),
+      (err: Error) => alive && setState({ status: "error", message: err.message })
+    );
+    return () => {
+      alive = false;
+    };
+  }, [fsPath, refresh]);
+
+  // Fetch the next page of a truncated S3-direct listing and APPEND it (dedupe
+  // by name). The accumulated set is still sorted by the active column —
+  // honest because the banner states the listing is partial; a global sort over
+  // the WHOLE directory is impossible (we only ever hold fetched pages).
+  const loadMore = () => {
+    if (state.status !== "ok" || !state.cursor || loadingMore) return;
+    const cursor = state.cursor;
+    const gen = refresh; // discard the response if a refresh supersedes it
+    setLoadingMore(true);
+    skipNewCue.current = true; // an appended page isn't a dir-watch change
+    listDir(fsPath, cursor).then(
+      (data) => {
+        if (refreshRef.current !== gen) return; // stale: a refresh replaced the listing
+        setLoadingMore(false);
+        setState((prev) => {
+          if (prev.status !== "ok") return prev;
+          const seen = new Set(prev.entries.map((e) => e.name));
+          const merged = prev.entries.concat(
+            data.entries.filter((e) => !seen.has(e.name))
+          );
+          return {
+            status: "ok",
+            entries: merged,
+            truncated: !!data.truncated,
+            cursor: data.cursor ?? null,
+          };
+        });
+      },
+      (err: Error) => {
+        if (refreshRef.current !== gen) return; // stale: the fetch effect reset state
+        setLoadingMore(false);
+        pushToast({ msg: err.message, tone: "error" });
+      }
+    );
+  };
+
+  // WebSocket watch on the listed directory (LS-1); WS not SSE per D74 (SSE
+  // pinned one of Chrome's 6 HTTP/1.1 sockets per view). A directory's mtime
+  // changes on create/delete/rename of entries (not on child content changes
+  // — LS-2, accepted). Closed on unmount = navigating away (LS-3). On change,
+  // debounce 300 ms then re-fetch; sort params live in URL + state, so a
+  // refetch preserves them.
+  useEffect(() => {
+    let sock: WebSocket | null = null;
+    let retry: ReturnType<typeof setTimeout> | null = null;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let closed = false;
+    const connect = () => {
+      const proto = location.protocol === "https:" ? "wss://" : "ws://";
+      sock = new WebSocket(proto + location.host + "/api/fs/events?path=" + encodeURIComponent(fsPath));
+      sock.onmessage = (ev) => {
+        let data;
+        try {
+          data = JSON.parse(ev.data);
+        } catch {
+          return;
+        }
+        if (data.keepalive) return;
+        if (timer !== null) clearTimeout(timer);
+        timer = setTimeout(() => setRefresh((n) => n + 1), 300);
+      };
+      // WebSockets don't auto-reconnect the way EventSource did.
+      sock.onclose = () => {
+        if (!closed) retry = setTimeout(connect, 1000);
+      };
+    };
+    connect();
+    return () => {
+      closed = true;
+      if (retry !== null) clearTimeout(retry);
+      if (timer !== null) clearTimeout(timer);
+      sock?.close();
+    };
+  }, [fsPath]);
+
+  // Dir-watch change cue (B5). A refresh that adds entries used to slot them in
+  // silently — a file that just landed in the folder was indistinguishable from
+  // one that had been there all along. Newly appeared rows carry `.row-new` for
+  // ROW_NEW_MS (a tint that fades out; removals need no cue beyond the FLIP).
+  // Names are the plain listing's row identity. The FIRST listing of a folder is
+  // never "new" — appearedKeys returns nothing for a null previous list.
+  const prevNamesRef = useRef<string[] | null>(null);
+  const [newNames, setNewNames] = useState<Set<string>>(() => new Set());
+  useEffect(() => {
+    if (state.status !== "ok") return;
+    const names = state.entries.map((e) => e.name);
+    const fresh = skipNewCue.current ? new Set<string>() : appearedKeys(prevNamesRef.current, names);
+    skipNewCue.current = false;
+    prevNamesRef.current = names;
+    if (fresh.size === 0) return;
+    setNewNames(fresh);
+    const id = window.setTimeout(() => setNewNames(new Set()), ROW_NEW_MS);
+    return () => window.clearTimeout(id);
+  }, [state]);
+
+  const refetch = () => setRefresh((n) => n + 1);
+
+  return { state, refresh, refetch, loadMore, loadingMore, newNames };
+}

--- a/frontend/src/apps/explorer/listing/useFileOps.ts
+++ b/frontend/src/apps/explorer/listing/useFileOps.ts
@@ -1,0 +1,515 @@
+// File operations on listing rows (paste, duplicate, compress, trash, delete,
+// rename, new file/folder, reveal, copy-path, open-in-Claude) plus the context
+// menus built from them. Owns the dialog + context-menu state; toasts go to
+// the global store (lib/toast) and the cut/copy clipboard is the module-level
+// store in lib/fs-clipboard (both survive this component's per-folder remount).
+import { useRef, useState } from "react";
+import { navigate, navigateUrl, urlForFsPath } from "@platform/lib/router";
+import {
+  writeFile,
+  mkdir,
+  deleteEntry,
+  renameEntry,
+  copyEntry,
+  compressEntry,
+  gitRepoInfo,
+  statPath,
+  revealPath,
+} from "@platform/lib/api";
+import type { ArchiveFormat } from "@platform/lib/api";
+import {
+  normDir,
+  join,
+  freeArchivePath,
+  freeDuplicatePath,
+  freePastePath,
+  copyToClipboard,
+  notePathDeleted,
+  remapClipboardPath,
+  pruneDescendantPaths,
+  trashEntry,
+  resolveOpenWithModes,
+  buildOpenWithItems,
+  buildCompressItems,
+  friendlyFsError,
+  claudeDeepLink,
+} from "@apps/explorer/lib/fs-actions";
+import { basename } from "@platform/lib/format";
+import { isAppEntry } from "@platform/ui/FileIcons";
+import { getClipboard, setClipboard, type Clipboard } from "@apps/explorer/lib/fs-clipboard";
+import { pushToast } from "@platform/lib/toast";
+import type { MenuEntry, MenuItem } from "@platform/ui/ContextMenu";
+import { MenuIcons } from "@platform/ui/MenuIcons";
+import { nameError } from "@apps/explorer/FsDialogs";
+import type { DialogState, RowCtx } from "@apps/explorer/listing/types";
+import { pruneDescendantRows, targetDirOf, batchLabel } from "@apps/explorer/listing/row-utils";
+
+export function useFileOps({
+  base,
+  clipboard,
+  refetch,
+  pendingSelectRef,
+}: {
+  base: string;
+  clipboard: Clipboard | null;
+  refetch: () => void;
+  // A path the selection should jump to once it appears in the reloaded rows
+  // (a rename/duplicate target — its row doesn't exist until the refetch lands).
+  pendingSelectRef: React.MutableRefObject<string | null>;
+}) {
+  // The open context menu (position + items) and the open modal, both local to
+  // this folder view.
+  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuEntry[] } | null>(null);
+  const [dialog, setDialog] = useState<DialogState | null>(null);
+
+  // Run a mutating fs call, then refetch on success or surface its error as a
+  // toast. The dir-watch socket also refetches, but that lags 300 ms and only
+  // fires for the listed dir — an explicit refetch keeps the UI immediate.
+  // `ctx` ({verb, name}) is optional but supplied by every menu action, so the
+  // caught wire string is humanized (friendlyFsError) instead of leaking bare.
+  const run = async (fn: () => Promise<unknown>, ctx?: { verb: string; name: string }) => {
+    try {
+      await fn();
+      refetch();
+    } catch (e) {
+      pushToast({ msg: ctx ? friendlyFsError(e, ctx) : (e as Error).message, tone: "error" });
+    }
+  };
+
+  // Belt-and-braces name guard for the New File / New Folder / Rename handlers:
+  // the dialog already blocks invalid names, but re-check here (and toast) before
+  // building a path so a "." / ".." / separator can never escape the folder.
+  // Returns true when the name is rejected (caller should bail).
+  const rejectName = (name: string): boolean => {
+    const err = nameError(name);
+    if (err) pushToast({ msg: err, tone: "error" });
+    return err !== null;
+  };
+
+  // Guards a paste that's still running so a second Paste gesture (a rapid
+  // Cmd+V×2) can't fire a parallel op on the same source — for a cut that
+  // second call would renameEntry an already-moved src and 404 with a jarring
+  // toast. Reset in the flight's .finally, so sequential copy-pastes stay fine.
+  const pasteInFlight = useRef(false);
+
+  // Paste into `dir`: a cut moves (rename) and clears the clipboard; a copy
+  // duplicates and keeps it. Same basename in the target folder either way.
+  // The TARGET is always a single folder; the SOURCE may be several paths (a
+  // multi-row cut/copy), which are processed in order — sequentially, because
+  // freePastePath resolves a name against a listing and parallel calls would
+  // both pick the same free "… copy" name.
+  // Reads the clipboard synchronously (getClipboard) and consumes a cut BEFORE
+  // the await, so re-entry sees an empty clipboard and no-ops.
+  const doPaste = (dir: string) => {
+    const clip = getClipboard();
+    if (!clip || clip.paths.length === 0 || pasteInFlight.current) return;
+    const target = normDir(dir); // "" (root) → "/", and join avoids "//name"
+    const { op } = clip;
+    // A clipboard filled from search results can hold a folder AND entries
+    // inside it (the hit list is a flat recursive walk). Paste the outermost
+    // ancestors only: the folder's move/copy carries its contents, so a
+    // descendant entry would either 404 on a source the parent already moved
+    // (killing the rest of the batch) or, for a copy, drop a stray second copy
+    // of the inner entry at the top of the target.
+    const paths = pruneDescendantPaths(clip.paths);
+    const label = paths.length === 1 ? basename(paths[0]) : `${paths.length} items`;
+    if (op === "cut") setClipboard(null); // consume atomically, before any await
+    pasteInFlight.current = true;
+    run(async () => {
+      const pasted: string[] = [];
+      let last: string | null = null;
+      try {
+        for (const src of paths) {
+          // Same-folder paste (dst would collide with the source), matching Finder:
+          //   • CUT into its own folder is a no-op — the backend rename would 409
+          //     on dst === src, so skip it (the clipboard is already cleared).
+          //   • COPY into its own folder makes a deduped "… copy" instead of
+          //     colliding (freeDuplicatePath, same as Duplicate).
+          const sameFolder = join(target, basename(src)) === src;
+          if (sameFolder && op === "cut") {
+            pasted.push(src);
+            continue;
+          }
+          // Both ops keep the name when free and dedupe to "… copy" when taken
+          // (Finder keep-both), instead of surfacing a 409.
+          const { is_dir } = await statPath(src);
+          const dst = sameFolder
+            ? await freeDuplicatePath(target, basename(src), is_dir)
+            : await freePastePath(target, basename(src), is_dir);
+          if (op === "cut") await renameEntry(src, dst);
+          else await copyEntry(src, dst);
+          pasted.push(src);
+          last = dst;
+        }
+      } catch (e) {
+        // The paste failed (e.g. a 403, or the source vanished); for a cut the
+        // pre-clear above dropped the clipboard, so re-set the cut for whatever
+        // hasn't moved yet and let run() toast the error — without this the user
+        // would have to re-cut before retrying. Skip the restore if the user
+        // cut/copied something newer mid-flight.
+        // Restoring from the PRUNED list (not clip.paths) is what keeps the
+        // retry viable: a descendant of an already-moved folder is gone from
+        // its old location, so putting it back on the clipboard would make
+        // every retry fail on the same dead source.
+        if (op === "cut" && getClipboard() === null) {
+          const left = paths.filter((p) => !pasted.includes(p));
+          if (left.length) setClipboard({ paths: left, op: "cut" });
+        }
+        // A multi-path paste can move/copy some entries before throwing. run()
+        // only refetches when the whole callback resolves, so refresh here or
+        // the listing keeps showing rows that are already gone (or misses the
+        // ones already written) until the 300 ms dir-watch catches up. The
+        // rethrow is preserved so run() still toasts the failure.
+        if (pasted.length) refetch();
+        throw e;
+      }
+      // Re-anchor onto the last thing written, if it lands in this view.
+      if (last !== null) pendingSelectRef.current = last;
+    }, { verb: "paste", name: label }).finally(() => {
+      pasteInFlight.current = false;
+    });
+  };
+
+  // Duplicate into the same folder, picking the first free "… copy[/ n]" name
+  // (freeDuplicatePath lists the folder so the copy never 409s on an existing
+  // name).
+  // In-flight guard, same idea as pasteInFlight: a rapid double Cmd+D would
+  // race both calls to the same free "… copy" name and 409 the second.
+  // Acts on the whole selection; the rows are duplicated one at a time for the
+  // same reason paste is sequential (each freeDuplicatePath re-reads the folder,
+  // so parallel calls would pick colliding names).
+  const duplicateInFlight = useRef(false);
+  const doDuplicate = (rows: RowCtx[]) => {
+    if (!rows.length || duplicateInFlight.current) return;
+    duplicateInFlight.current = true;
+    run(async () => {
+      let last: string | null = null;
+      try {
+        for (const row of rows) {
+          const dst = await freeDuplicatePath(row.parentDir, row.name, row.isDir);
+          await copyEntry(row.path, dst);
+          last = dst;
+        }
+      } catch (e) {
+        // Same partial-batch refresh as doPaste: run() refetches only on full
+        // success, so copies already written would stay invisible here until
+        // the dir-watch update. Rethrown so the error toast still shows.
+        if (last !== null) refetch();
+        throw e;
+      }
+      if (last !== null) pendingSelectRef.current = last; // select the new copy
+    }, { verb: "duplicate", name: batchLabel(rows) }).finally(() => {
+      duplicateInFlight.current = false;
+    });
+  };
+
+  // Compress a folder into a sibling archive. In-flight guard for the same
+  // reason Duplicate has one: two quick picks would race freeArchivePath to the
+  // same free name and 409 the second. The new archive is selected on success,
+  // matching what Duplicate does with its copy.
+  const compressInFlight = useRef(false);
+  const doCompress = (row: RowCtx, format: ArchiveFormat, ext: string) => {
+    if (compressInFlight.current) return;
+    compressInFlight.current = true;
+    run(async () => {
+      const dst = await freeArchivePath(row.parentDir, row.name, ext);
+      await compressEntry(row.path, format, dst);
+      pendingSelectRef.current = dst;
+    }, { verb: "compress", name: row.name }).finally(() => {
+      compressInFlight.current = false;
+    });
+  };
+
+  // Lazy loader for the Compress submenu. The git-repo probe is a subprocess on
+  // the server, so it runs here — once, on hover — rather than on every
+  // right-click; a failed probe just drops the git entries (fail closed, like
+  // the Open With condition gate).
+  const loadCompress = (row: RowCtx) => async (): Promise<MenuEntry[]> => {
+    let isRepoRoot = false;
+    try {
+      isRepoRoot = (await gitRepoInfo(row.path)).is_repo_root;
+    } catch {
+      isRepoRoot = false;
+    }
+    return buildCompressItems(isRepoRoot, (format, ext) => doCompress(row, format, ext));
+  };
+
+  const doReveal = (path: string) => {
+    revealPath(path).catch((e) =>
+      pushToast({ msg: friendlyFsError(e, { verb: "reveal", name: basename(path) }), tone: "error" })
+    );
+  };
+
+  const doCopyPath = (path: string) => {
+    // Confirm with a non-error "info" toast; a failure (clipboard unavailable
+    // or permission denied) stays silent — the path is still reachable via
+    // Reveal in Finder.
+    copyToClipboard(path).then((ok) => {
+      if (ok) pushToast({ msg: "Path copied", tone: "info" });
+    });
+  };
+
+  // Several paths go to the system clipboard newline-separated (what every file
+  // manager writes for a multi-selection paste into a terminal or editor).
+  const doCopyPaths = (paths: string[]) => {
+    copyToClipboard(paths.join("\n")).then((ok) => {
+      if (ok) pushToast({ msg: `${paths.length} paths copied`, tone: "info" });
+    });
+  };
+
+  // Open Claude Code via its claude-cli:// scheme handler — a dir cwd's into
+  // itself, a file cwd's into its parent and pre-fills an @-mention prompt.
+  // Setting location.href to a custom scheme does not navigate the SPA away.
+  const doOpenInClaude = (path: string, isDir: boolean, name: string, parentDir: string) => {
+    window.location.href = claudeDeepLink(path, isDir, name, parentDir);
+  };
+
+  const startNewFile = (dir: string) =>
+    setDialog({
+      kind: "prompt",
+      title: "New File",
+      initial: "untitled.txt",
+      confirmLabel: "Create",
+      onConfirm: (name) => {
+        if (rejectName(name)) return;
+        // create=true: refuse (409 "conflict", surfaced as an error toast) if a
+        // file with this name already exists, so New File never clobbers it.
+        run(() => writeFile(join(normDir(dir), name), "", true), { verb: "create", name });
+      },
+    });
+
+  const startNewFolder = (dir: string) =>
+    setDialog({
+      kind: "prompt",
+      title: "New Folder",
+      initial: "untitled folder",
+      confirmLabel: "Create",
+      onConfirm: (name) => {
+        if (rejectName(name)) return;
+        run(() => mkdir(join(normDir(dir), name)), { verb: "create", name });
+      },
+    });
+
+  const startRename = (row: RowCtx) =>
+    setDialog({
+      kind: "prompt",
+      title: "Rename",
+      initial: row.name,
+      confirmLabel: "Rename",
+      selectStem: true,
+      onConfirm: (name) => {
+        if (name === row.name) return;
+        if (rejectName(name)) return;
+        const dst = join(normDir(row.parentDir), name);
+        run(async () => {
+          await renameEntry(row.path, dst);
+          // Re-anchor onto the new name so the reloaded listing keeps this row
+          // selected (and Enter opens the renamed file, not the dead old path).
+          pendingSelectRef.current = dst;
+          // The clipboard may still be pointing at the old path (or inside it,
+          // if a renamed folder held the cut/copied entry) — repoint it so a
+          // later Paste doesn't target a source that's now gone.
+          remapClipboardPath(row.path, dst);
+        }, { verb: "rename", name: row.name });
+      },
+    });
+
+  // Hard delete, confirmed. Plural-aware: one row still names it (and says
+  // whether it's a folder), several are counted.
+  const startDelete = (allRows: RowCtx[]) => {
+    // Drop rows contained by another selected folder before anything else, so
+    // the confirm dialog counts what will actually be deleted and the loop below
+    // never calls deleteEntry on a path the parent's recursive delete just took
+    // (that 404 would abort the batch and toast a failure for a delete that in
+    // fact removed everything asked for).
+    const rows = pruneDescendantRows(allRows);
+    if (!rows.length) return;
+    const many = rows.length > 1;
+    setDialog({
+      kind: "confirm",
+      title: many ? `Delete ${rows.length} items` : "Delete",
+      message: many
+        ? `Delete these ${rows.length} items? Any folders among them are deleted with everything inside. This can't be undone.`
+        : rows[0].isDir
+        ? `Delete the folder "${rows[0].name}" and everything inside it? This can't be undone.`
+        : `Delete "${rows[0].name}"? This can't be undone.`,
+      confirmLabel: many ? `Delete ${rows.length} items` : "Delete",
+      danger: true,
+      // recursive=true for a directory (its contents were named in the message).
+      onConfirm: () =>
+        run(async () => {
+          let deleted = 0;
+          try {
+            for (const row of rows) {
+              await deleteEntry(row.path, row.isDir);
+              notePathDeleted(row.path);
+              deleted++;
+            }
+          } catch (e) {
+            // Partial batch: run() refetches only on full success, so without
+            // this the already-deleted rows linger in the listing until the
+            // dir-watch update. Rethrown so run() still toasts the failure.
+            if (deleted) refetch();
+            throw e;
+          }
+        }, { verb: "delete", name: batchLabel(rows) }),
+    });
+  };
+
+  // Move to Bin: a recoverable delete (macOS Trash), so no confirm dialog.
+  // Acts on every row passed in (the whole selection). Where the server can't
+  // trash (non-macOS → "unsupported") those rows fall back to the existing
+  // confirm-then-hard-delete flow, which IS irreversible and so keeps its
+  // warning. Success shows a low-key, count-aware info toast.
+  const doTrash = (allRows: RowCtx[]) => {
+    // As in startDelete: trashing a folder takes everything inside it, so a
+    // selection that also holds rows from within that folder must not trash them
+    // individually — the second call would hit a vanished path and be counted as
+    // a real failure, replacing the "Moved to Bin" toast with a bogus error.
+    const rows = pruneDescendantRows(allRows);
+    if (!rows.length) return;
+    void (async () => {
+      const trashed: RowCtx[] = [];
+      const unsupported: RowCtx[] = [];
+      let failed: { row: RowCtx; message: string } | null = null;
+      for (const row of rows) {
+        const r = await trashEntry(row.path, row.isDir);
+        if (r.status === "trashed") {
+          trashed.push(row);
+          notePathDeleted(row.path);
+        } else if (r.status === "unsupported") {
+          unsupported.push(row);
+        } else if (failed === null) {
+          failed = { row, message: r.message };
+        }
+      }
+      if (trashed.length) {
+        pushToast({
+          msg: trashed.length === 1 ? "Moved to Bin" : `Moved ${trashed.length} items to Bin`,
+          tone: "info",
+        });
+        refetch();
+      }
+      // A real failure raises its own toast. It used to REPLACE the info one
+      // above (one local slot, last write wins), which hid the fact that the
+      // other rows did move; the shared stack shows both, which is what a
+      // partial success actually is. The unsupported fallback only runs when
+      // nothing errored.
+      if (failed !== null) {
+        pushToast({
+          msg: friendlyFsError(failed.message, { verb: "move to Bin", name: failed.row.name }),
+          tone: "error",
+        });
+      } else if (unsupported.length) {
+        startDelete(unsupported);
+      }
+    })();
+  };
+
+  // Lazy loader for the Open With submenu: resolves the entry's template modes
+  // (resolveOpenWithModes mirrors Preview's filter + condition-gate handling).
+  // Selecting a mode navigates to the entry with `_mode` set; the default mode
+  // deletes the param.
+  const loadOpenWith = (path: string) => async (): Promise<MenuItem[]> => {
+    const modes = await resolveOpenWithModes(path);
+    return buildOpenWithItems(modes, (mode, isDefault) => {
+      const search = isDefault ? "" : "?_mode=" + encodeURIComponent(mode);
+      navigateUrl(urlForFsPath(path, search));
+    });
+  };
+
+  // Menu for a right-clicked row (file or dir), in macOS Finder order. Paste
+  // target follows Finder: into a dir, or the parent of a file. New File/Folder
+  // live only on the background menu (Finder shows them there, not on a row).
+  // `rows` is what the menu ACTS on: just the right-clicked row normally, or the
+  // whole selection when the right-click landed inside a multi-row selection
+  // (see openRowMenu in Listing.tsx). With several rows the entries that only
+  // make sense for one — Open / Open With / Rename / Reveal / Open in Claude
+  // Code — are dropped, and the batch entries count what they'll affect.
+  const rowMenu = (row: RowCtx, rows: RowCtx[]): MenuEntry[] => {
+    const dir = targetDirOf(row);
+    const n = rows.length;
+    if (n > 1) {
+      return [
+        { label: `Move ${n} items to Bin`, icon: MenuIcons.trash, onClick: () => doTrash(rows) },
+        "separator",
+        { label: `Duplicate ${n} items`, icon: MenuIcons.duplicate, onClick: () => doDuplicate(rows) },
+        "separator",
+        {
+          label: `Cut ${n} items`,
+          icon: MenuIcons.cut,
+          onClick: () => setClipboard({ paths: rows.map((r) => r.path), op: "cut" }),
+        },
+        {
+          label: `Copy ${n} items`,
+          icon: MenuIcons.copy,
+          onClick: () => setClipboard({ paths: rows.map((r) => r.path), op: "copy" }),
+        },
+        { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(dir) },
+        "separator",
+        {
+          label: `Copy ${n} Paths`,
+          icon: MenuIcons.copyPath,
+          onClick: () => doCopyPaths(rows.map((r) => r.path)),
+        },
+      ];
+    }
+    return [
+      { label: isAppEntry(row.name, row.isDir) ? "Open App" : "Open", icon: MenuIcons.open, onClick: () => navigate(row.path, { isDir: row.isDir }) },
+      { label: "Open With", icon: MenuIcons.openWith, submenu: loadOpenWith(row.path) },
+      "separator",
+      { label: "Move to Bin", icon: MenuIcons.trash, onClick: () => doTrash([row]) },
+      "separator",
+      { label: "Rename…", icon: MenuIcons.rename, onClick: () => startRename(row) },
+      { label: "Duplicate", icon: MenuIcons.duplicate, onClick: () => doDuplicate([row]) },
+      // Folders only, in Finder's position (after Duplicate, before Cut/Copy).
+      // Not on the multi-select or background menus: one archive per folder.
+      ...(row.isDir
+        ? [{ label: "Compress", icon: MenuIcons.compress, submenu: loadCompress(row) } as MenuEntry]
+        : []),
+      "separator",
+      { label: "Cut", icon: MenuIcons.cut, onClick: () => setClipboard({ paths: [row.path], op: "cut" }) },
+      { label: "Copy", icon: MenuIcons.copy, onClick: () => setClipboard({ paths: [row.path], op: "copy" }) },
+      { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(dir) },
+      "separator",
+      { label: "Copy Path", icon: MenuIcons.copyPath, onClick: () => doCopyPath(row.path) },
+      { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(row.path) },
+      {
+        label: "Open in Claude Code",
+        icon: MenuIcons.openWith,
+        onClick: () => doOpenInClaude(row.path, row.isDir, row.name, row.parentDir),
+      },
+    ];
+  };
+
+  // Menu for the empty listing background — operates on the current folder.
+  // Finder order: New Folder before New File.
+  const backgroundMenu = (): MenuEntry[] => [
+    { label: "New Folder…", icon: MenuIcons.newFolder, onClick: () => startNewFolder(base) },
+    { label: "New File…", icon: MenuIcons.newFile, onClick: () => startNewFile(base) },
+    "separator",
+    { label: "Paste", icon: MenuIcons.paste, disabled: !clipboard, onClick: () => doPaste(base) },
+    "separator",
+    { label: "Refresh", icon: MenuIcons.refresh, onClick: refetch },
+    { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(normDir(base)) },
+    {
+      label: "Open in Claude Code",
+      icon: MenuIcons.openWith,
+      onClick: () => doOpenInClaude(normDir(base), true, "", normDir(base)),
+    },
+  ];
+
+  return {
+    menu,
+    setMenu,
+    dialog,
+    setDialog,
+    doPaste,
+    doDuplicate,
+    doTrash,
+    startRename,
+    startNewFolder,
+    rowMenu,
+    backgroundMenu,
+  };
+}

--- a/frontend/src/apps/explorer/listing/useListingSelection.ts
+++ b/frontend/src/apps/explorer/listing/useListingSelection.ts
@@ -1,0 +1,352 @@
+// Selection state + keyboard navigation for the listing: the multi-row
+// selection model, the document-level arrow/Home/End/PageUp/Enter handler,
+// the post-mutation reconcile (re-anchor by path), and scroll-into-view.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { navigate } from "@platform/lib/router";
+import { isMod } from "@platform/lib/platform";
+import { isOverlayOpen } from "@platform/lib/ui-overlay";
+import type { RowCtx } from "@apps/explorer/listing/types";
+import {
+  EMPTY_SELECTION,
+  oneSelected,
+  pageRows,
+  rangeBetween,
+  recallSelection,
+  rememberSelection,
+  type Selection,
+} from "@apps/explorer/listing/selection";
+
+export function useListingSelection({
+  fsPath,
+  navRows,
+  listingLoaded,
+  searchInputRef,
+  rowCtxByPathRef,
+  overlayOpenRef,
+}: {
+  fsPath: string;
+  // Flat, ordered list of the paths the arrow keys step through (the rendered
+  // order — the active sort or search ranking).
+  navRows: string[];
+  // Whether navRows reflects a LOADED listing (not a transient empty while the
+  // fetch is in flight) — see Listing.tsx, where this is derived.
+  listingLoaded: boolean;
+  searchInputRef: React.RefObject<HTMLInputElement>;
+  // Path -> RowCtx for the rendered rows, read by the once-registered keydown
+  // handler so Enter can pass the row's is_dir as a nav hint.
+  rowCtxByPathRef: React.MutableRefObject<Map<string, RowCtx>>;
+  // True while a context menu or a modal dialog is open in this view. The
+  // document-level nav handler hard-guards on this so an open overlay owns the
+  // keyboard — a stray Enter can't navigate a row behind the dialog.
+  overlayOpenRef: React.MutableRefObject<boolean>;
+}) {
+  // The selected rows (see Selection): one for a plain click / arrow move, many
+  // for a Shift-range, Mod-click toggle or Select All. Seeded from the
+  // cross-remount store so a selection made in the pre-stat provisional Listing
+  // survives the swap to the resolved one (see recallSelection).
+  const [sel, setSel] = useState<Selection>(() => recallSelection(fsPath));
+  // The lead row — every place that used to read `selectedPath` (scroll-into-
+  // view, reconcile, Enter/F2 targets) still works off this single path.
+  const selectedPath = sel.lead;
+
+  // Latest ordered list of navigable row paths + the current selection, read by
+  // the document keydown handler (registered once, so it can't close over them).
+  const navRowsRef = useRef<string[]>([]);
+  navRowsRef.current = navRows;
+  const selRef = useRef<Selection>(sel);
+  selRef.current = sel;
+  // Fast membership test for the row renderer (a Select All can hold thousands).
+  const selectedSet = useMemo(() => new Set(sel.paths), [sel.paths]);
+  // Mirror the selection into the cross-remount store so it's already there
+  // when the resolved Listing mounts (the provisional one has no unmount step
+  // that would clear it). Keyed by fsPath, so a real nav to another folder
+  // starts fresh.
+  useEffect(() => {
+    rememberSelection(fsPath, sel);
+  }, [fsPath, sel]);
+
+  // A path the selection should jump to once it appears in the reloaded rows
+  // (a rename/duplicate target — its row doesn't exist until the refetch lands).
+  const pendingSelectRef = useRef<string | null>(null);
+  // Last known index of the selection within navRows. When the selected path
+  // vanishes (delete / move to bin / rename with no re-anchor) the reconcile
+  // effect clamps to this slot so selection lands on the nearest surviving row.
+  const lastSelIndexRef = useRef<number>(-1);
+
+  // --- selection mutators ---------------------------------------------------
+  // Every one of these closes over nothing but setSel and navRowsRef (both
+  // stable for the component's life), so the once-registered document handlers
+  // below can safely capture them from the first render.
+
+  const selectOnly = (path: string) => setSel(oneSelected(path));
+
+  const clearSelection = () => setSel(EMPTY_SELECTION);
+
+  // Mod-click: add/remove one row, and make it the anchor a later Shift-range
+  // pivots on (Finder/Explorer both re-anchor on the toggled row).
+  const toggleSelected = (path: string) =>
+    setSel((prev) => {
+      if (!prev.paths.includes(path)) {
+        return { paths: [...prev.paths, path], anchor: path, lead: path };
+      }
+      const paths = prev.paths.filter((p) => p !== path);
+      // Deselecting the lead hands focus to whatever is left of the selection.
+      return { paths, anchor: path, lead: paths.length ? paths[paths.length - 1] : null };
+    });
+
+  // Shift-click / Shift+arrow: the selection becomes anchor..path over the
+  // RENDERED row order (navRows — the active sort or search ranking), with the
+  // anchor left in place so further extension keeps pivoting on it.
+  const extendTo = (path: string) =>
+    setSel((prev) => {
+      const anchor = prev.anchor ?? prev.lead;
+      if (anchor === null) return oneSelected(path);
+      const paths = rangeBetween(navRowsRef.current, anchor, path);
+      if (!paths.length) return prev;
+      return { paths, anchor, lead: path };
+    });
+
+  const selectAllRows = () =>
+    setSel((prev) => {
+      const rows = navRowsRef.current;
+      if (!rows.length) return prev;
+      return {
+        paths: [...rows],
+        anchor: prev.lead ?? rows[0],
+        lead: prev.lead ?? rows[rows.length - 1],
+      };
+    });
+
+  // Move the lead to `index` (clamped into the row range), either collapsing the
+  // selection onto that row or extending the range from the anchor.
+  const moveLeadTo = (index: number, extend: boolean) =>
+    setSel((prev) => {
+      const rows = navRowsRef.current;
+      if (!rows.length) return prev;
+      const next = rows[Math.max(0, Math.min(rows.length - 1, index))];
+      if (!extend) return oneSelected(next);
+      const anchor = prev.anchor ?? prev.lead ?? next;
+      return { paths: rangeBetween(rows, anchor, next), anchor, lead: next };
+    });
+
+  // Keyboard navigation for the listing, whether focus is in the search box or
+  // nowhere in particular:
+  //   • a plain printable key focuses the search box so the character lands there;
+  //   • Up/Down move the selection through the rendered rows — in the search box
+  //     too, since a single-line input doesn't need them for the caret — and
+  //     Shift+Up/Down extend the range from the anchor instead;
+  //   • Home/End jump to the first/last row, PageUp/PageDown move a viewport
+  //     (both extend with Shift, like every list widget);
+  //   • Mod+A selects every rendered row, Escape clears the selection;
+  //   • Enter opens the lead row, or the top row when nothing is selected yet.
+  // Modifier chords that are NOT selection movement (Mod+Up/Down = parent/open)
+  // are deliberately left to the shortcut handler (see Listing.tsx).
+  // Bound to `document` so it also drives the plain listing with nothing focused.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      // While an IME is composing, Enter confirms a candidate and the arrows
+      // move through the candidate list — never repurpose them for navigation.
+      if (e.isComposing) return;
+      // An open context menu / dialog owns the keyboard: don't let Enter open a
+      // row behind it (the dialog handles its own Enter/Escape). isOverlayOpen()
+      // also covers an overlay owned by a HOSTING view (Preview's header menu
+      // when this Listing is embedded), which overlayOpenRef alone can't see.
+      if (overlayOpenRef.current || isOverlayOpen()) return;
+      const el = document.activeElement as HTMLElement | null;
+      const inSearch = el === searchInputRef.current;
+      // Only drive navigation from the search box or when nothing in particular
+      // is focused (body). If focus is on a chrome control — a breadcrumb link,
+      // the bookmark/mode-switch buttons, another input — leave its keys alone
+      // (otherwise Enter would open a file instead of activating that control).
+      const navActive =
+        inSearch || !el || el === document.body || el === document.documentElement;
+
+      const rows = navRowsRef.current;
+      const leadIdx = rows.indexOf(selRef.current.lead ?? "");
+
+      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        if (!navActive) return;
+        // Mod+Up/Down are navigation chords (parent folder / open), owned by the
+        // shortcut handler — they must not also move the selection.
+        if (isMod(e) || e.altKey) return;
+        if (!rows.length) return;
+        e.preventDefault();
+        const down = e.key === "ArrowDown";
+        // Nothing selected yet: Down starts at the top, Up at the bottom.
+        const next = leadIdx === -1 ? (down ? 0 : rows.length - 1) : leadIdx + (down ? 1 : -1);
+        moveLeadTo(next, e.shiftKey);
+        return;
+      }
+      if (e.key === "Home" || e.key === "End") {
+        // Unlike Up/Down, Home/End are real caret navigation in a text field, so
+        // the search box keeps them (same carve-out as Mod+A and Escape below).
+        if (!navActive || inSearch || isMod(e) || !rows.length) return;
+        e.preventDefault();
+        moveLeadTo(e.key === "Home" ? 0 : rows.length - 1, e.shiftKey);
+        return;
+      }
+      if (e.key === "PageDown" || e.key === "PageUp") {
+        if (!navActive || isMod(e) || !rows.length) return;
+        e.preventDefault();
+        const step = pageRows();
+        const down = e.key === "PageDown";
+        const next = leadIdx === -1 ? (down ? 0 : rows.length - 1) : leadIdx + (down ? step : -step);
+        moveLeadTo(next, e.shiftKey);
+        return;
+      }
+      if (isMod(e) && e.key.toLowerCase() === "a") {
+        // Select All. In the search box it must keep meaning "select the text",
+        // otherwise clearing a typed query becomes impossible.
+        if (!navActive || inSearch || !rows.length) return;
+        e.preventDefault();
+        selectAllRows();
+        return;
+      }
+      if (e.key === "Escape") {
+        // Clear the selection. The search input owns Escape while focused (it
+        // clears the query — see its onKeyDown), and the overlay/dialog guards
+        // above already stopped us if anything modal is up.
+        //
+        // A pending copy/cut outranks the selection: App's capture-phase Escape
+        // handler cancels the clipboard and calls preventDefault(), so one press
+        // never does both. Reading defaultPrevented keeps that precedence here
+        // without a second copy of the clipboard logic (which would also be
+        // wrong — the cancel has to work from Preview, where no Listing exists).
+        if (e.defaultPrevented) return;
+        if (!navActive || inSearch) return;
+        if (!selRef.current.paths.length) return;
+        e.preventDefault();
+        clearSelection();
+        return;
+      }
+      if (e.key === "Enter") {
+        // Already consumed by a chrome control that unmounted itself on the
+        // way (the breadcrumb's path input commits and closes on Enter, which
+        // hands focus back to <body> before this listener runs — navActive
+        // alone can't see that the key was spoken for).
+        if (e.defaultPrevented) return;
+        if (!navActive) return;
+        if (!rows.length) return;
+        e.preventDefault();
+        const target = leadIdx === -1 ? rows[0] : rows[leadIdx];
+        navigate(target, { isDir: rowCtxByPathRef.current.get(target)?.isDir });
+        return;
+      }
+      // Start typing → focus the search box so the character lands there. Only
+      // when nothing else is focused (not the search box already, not a chrome
+      // control) and only plain printable keys (no modifiers), so Space on a
+      // focused button and app shortcuts keep working.
+      if (
+        navActive && !inSearch &&
+        e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey
+      ) {
+        searchInputRef.current?.focus(); // keystroke falls through into the input
+      }
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Keep the keyboard selection scrolled into view as it moves. Follows the LEAD
+  // row (`.lead`), not merely the first selected one: extending a Shift-range
+  // downward must keep the moving end visible, and the top of the range is
+  // usually the one that would otherwise win a `.selected` query.
+  // This is also what keeps the selection in view across a SORT: navRows is
+  // a dependency, and a sort click produces a new navRows.
+  useEffect(() => {
+    if (!selectedPath) return;
+    (
+      document.querySelector("table.listing-table tr.row.lead") ??
+      document.querySelector("table.listing-table tr.row.selected")
+    )?.scrollIntoView({ block: "nearest" });
+  }, [selectedPath, navRows]);
+
+  // Re-anchor the selection by PATH whenever the rows change (a refetch after
+  // rename / duplicate / delete / move-to-bin) or the selection moves. Without
+  // this the selected index kept pointing at the OLD name after a rename, so
+  // pressing Enter opened a path that no longer existed.
+  //   • A pending re-anchor (rename/duplicate target) is adopted the moment its
+  //     row appears in the reloaded listing.
+  //   • A still-present selection just refreshes its remembered slot index.
+  //   • A vanished selection (deleted / trashed / moved) clamps to the nearest
+  //     surviving row (or clears when the folder is now empty).
+  // The pending wait is BOUNDED, not open-ended: it only holds while the current
+  // selection is itself a live row. Renaming a search hit whose new path isn't a
+  // search match leaves the pending target absent from navRows forever while the
+  // old selected path also disappears — waiting unconditionally there would
+  // strand the selection on a dead row (broken Enter). So once the old selection
+  // is gone too, the pending target is abandoned and the normal clamp runs. The
+  // pending path still lands the moment it does appear (e.g. search results
+  // refetching to include the renamed file), so the happy path is unchanged.
+  //   • Rows of a MULTI-selection that vanished are pruned while the lead
+  //     survives, so a batch op that partly failed doesn't leave dead paths in
+  //     the selection (and a later Cmd+C can't copy them).
+  useEffect(() => {
+    const rows = navRows;
+    const pend = pendingSelectRef.current;
+    let clampFallback = false;
+    if (pend !== null) {
+      const pi = rows.indexOf(pend);
+      if (pi !== -1) {
+        pendingSelectRef.current = null;
+        lastSelIndexRef.current = pi;
+        if (selectedPath !== pend || sel.paths.length !== 1) setSel(oneSelected(pend));
+        return;
+      }
+      // Target not here yet. Keep waiting ONLY while the current selection is
+      // still a real row (nothing's broken, the target may still arrive). If it
+      // has also vanished, give up on the pending target and clamp below.
+      if (selectedPath !== null && rows.indexOf(selectedPath) !== -1) return;
+      pendingSelectRef.current = null;
+      clampFallback = true;
+    }
+    if (selectedPath === null) {
+      // No selection to reconcile. Only force one when a pending target was just
+      // abandoned (so selection never stays dead); otherwise leave it unset.
+      if (!clampFallback || rows.length === 0) return;
+      const clamped = Math.min(Math.max(lastSelIndexRef.current, 0), rows.length - 1);
+      setSel(oneSelected(rows[clamped]));
+      return;
+    }
+    const i = rows.indexOf(selectedPath);
+    if (i !== -1) {
+      lastSelIndexRef.current = i; // lead still valid; remember its slot
+      // Drop any other selected rows that are gone (deleted/moved/renamed).
+      if (sel.paths.length > 1) {
+        const live = new Set(rows);
+        const kept = sel.paths.filter((p) => live.has(p));
+        if (kept.length !== sel.paths.length) {
+          setSel({
+            paths: kept,
+            anchor: sel.anchor !== null && live.has(sel.anchor) ? sel.anchor : selectedPath,
+            lead: selectedPath,
+          });
+        }
+      }
+      return;
+    }
+    // Selection isn't in the current rows. While the listing is still LOADING
+    // (rows transiently empty during a fetch — notably the pre-stat provisional
+    // Listing being swapped for the resolved one right after a folder opens),
+    // don't treat it as vanished: keep it and rerun once rows arrive. Clearing
+    // here is what dropped an arrow-key selection made just after opening a
+    // folder, even with the selection carried across the remount.
+    if (!listingLoaded) return;
+    if (rows.length === 0) {
+      setSel(EMPTY_SELECTION);
+      return;
+    }
+    const clamped = Math.min(Math.max(lastSelIndexRef.current, 0), rows.length - 1);
+    setSel(oneSelected(rows[clamped]));
+  }, [navRows, selectedPath, sel, listingLoaded]);
+
+  return {
+    sel,
+    selectedPath,
+    selectedSet,
+    selectOnly,
+    toggleSelected,
+    extendTo,
+    pendingSelectRef,
+  };
+}

--- a/frontend/src/apps/explorer/listing/useListingShortcuts.ts
+++ b/frontend/src/apps/explorer/listing/useListingShortcuts.ts
@@ -1,0 +1,153 @@
+// Keyboard shortcuts scoped to the listing: file operations on the selection
+// plus the folder-level navigation chords. Registered once (empty deps); the
+// handler is re-assigned each render so it always reads fresh state/closures.
+// Separate from the nav handler (useListingSelection), and non-overlapping
+// with it by construction: everything here carries the primary modifier or is
+// a key that handler ignores (F2, Delete, Backspace — its printable-key branch
+// only fires for single-character keys, and its arrow branch bails when
+// isMod(e)).
+import { useEffect, useRef } from "react";
+import { navigate } from "@platform/lib/router";
+import { isMac, isMod } from "@platform/lib/platform";
+import { isOverlayOpen } from "@platform/lib/ui-overlay";
+import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
+import { setClipboard, type Clipboard } from "@apps/explorer/lib/fs-clipboard";
+import type { RowCtx } from "@apps/explorer/listing/types";
+import { targetDirOf } from "@apps/explorer/listing/row-utils";
+
+export function useListingShortcuts({
+  base,
+  clipboard,
+  selectedRows,
+  leadRow,
+  searchInputRef,
+  overlayOpenRef,
+  refetch,
+  doPaste,
+  doDuplicate,
+  doTrash,
+  startRename,
+  startNewFolder,
+}: {
+  base: string;
+  clipboard: Clipboard | null;
+  // The selection as full rows, in rendered order; every file operation acts on
+  // the whole selection.
+  selectedRows: RowCtx[];
+  // The lead row, for the single-entry operations (Rename, paste target).
+  leadRow: RowCtx | undefined;
+  searchInputRef: React.RefObject<HTMLInputElement>;
+  overlayOpenRef: React.MutableRefObject<boolean>;
+  refetch: () => void;
+  doPaste: (dir: string) => void;
+  doDuplicate: (rows: RowCtx[]) => void;
+  doTrash: (rows: RowCtx[]) => void;
+  startRename: (row: RowCtx) => void;
+  startNewFolder: (dir: string) => void;
+}) {
+  const shortcutRef = useRef<(e: KeyboardEvent) => void>(() => {});
+  shortcutRef.current = (e: KeyboardEvent) => {
+    if (e.isComposing) return;
+    // Same hard guard as the nav handler: while a context menu or dialog is
+    // open (in this view OR a hosting one, e.g. Preview's header menu with this
+    // Listing embedded), file-op shortcuts (Cmd+Backspace trash, Cmd+X cut, …)
+    // must not fire on the row behind it.
+    if (overlayOpenRef.current || isOverlayOpen()) return;
+    const el = document.activeElement as HTMLElement | null;
+    const inSearch = el === searchInputRef.current;
+    const navActive = inSearch || !el || el === document.body || el === document.documentElement;
+    if (!navActive) return;
+    const rows = selectedRows;
+    const row = leadRow;
+    const mod = isMod(e);
+    const key = e.key.toLowerCase();
+    // The parent folder, for Mod+Up / bare Backspace. Equal to the current
+    // folder at the filesystem (or drive) root, where there's nowhere to go.
+    const here = normDir(base);
+    const parent = dirname(here);
+    const goParent = () => {
+      if (parent !== here) navigate(parent, { isDir: true });
+    };
+    // With focus in the search box, Cmd+C/X/V must keep their native text
+    // clipboard meaning — only the non-text shortcuts stay live there.
+    if (inSearch && mod && (key === "c" || key === "x" || key === "v")) return;
+    if (mod && key === "c") {
+      if (!rows.length) return;
+      e.preventDefault();
+      setClipboard({ paths: rows.map((r) => r.path), op: "copy" });
+    } else if (mod && key === "x") {
+      if (!rows.length) return;
+      e.preventDefault();
+      setClipboard({ paths: rows.map((r) => r.path), op: "cut" });
+    } else if (mod && key === "v") {
+      if (!clipboard) return;
+      e.preventDefault();
+      // Paste is single-TARGET: into the lead row's folder (or itself, if it's a
+      // directory), else the folder being listed.
+      doPaste(row ? targetDirOf(row) : base);
+    } else if (mod && key === "d") {
+      if (!rows.length) return;
+      e.preventDefault();
+      doDuplicate(rows);
+    } else if (mod && e.key === "ArrowDown") {
+      // Open the lead row — the same gesture as Enter (macOS Cmd+Down).
+      if (!row) return;
+      e.preventDefault();
+      navigate(row.path, { isDir: row.isDir });
+    } else if (mod && e.key === "ArrowUp") {
+      e.preventDefault();
+      goParent();
+    } else if (mod && (e.key === "[" || e.key === "]")) {
+      // Back / forward. The router only ever pushes, so this drives the browser
+      // history directly — popstate is what the shell listens to anyway
+      // (useNavEpoch), so the view remounts exactly as it does for a Back click.
+      e.preventDefault();
+      if (e.key === "[") history.back();
+      else history.forward();
+    } else if (mod && e.shiftKey && key === "n") {
+      e.preventDefault();
+      startNewFolder(base);
+    } else if (mod && key === "r") {
+      // The app's own listing refresh, not a page reload — preventDefault is
+      // what stops the browser from throwing the whole SPA away.
+      e.preventDefault();
+      refetch();
+    } else if (mod && e.key === "Backspace") {
+      // macOS trash chord. Windows/Linux use the Delete key below instead.
+      // Never while typing in the search box: Cmd+Delete is the standard macOS
+      // "clear to start of line" chord, so trashing there would be a foot-gun.
+      if (!isMac || inSearch || !rows.length) return;
+      e.preventDefault();
+      doTrash(rows);
+      // Bare key only: because isMod() is exclusive, `!mod` alone is still true
+      // when the OTHER modifier is held (Super+Backspace on Linux), so test the
+      // raw flags instead.
+    } else if (e.key === "Backspace" && !e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey) {
+      // Windows/Linux: bare Backspace goes up a folder. On macOS it must stay
+      // inert — Cmd+Backspace is trash there and a bare Backspace navigating
+      // away would be a foot-gun. Never while typing in the search box.
+      if (isMac || inSearch) return;
+      e.preventDefault();
+      goParent();
+    } else if (e.key === "Delete" && !e.metaKey && !e.ctrlKey) {
+      // Windows/Linux trash key. On macOS the Delete (⌦) key is not the trash
+      // gesture — Cmd+Backspace above is. Raw-flag test rather than `!mod` so a
+      // held Super key can't slip a destructive key through (see Backspace).
+      if (isMac || inSearch || !rows.length) return;
+      e.preventDefault();
+      doTrash(rows);
+    } else if (e.key === "F2") {
+      // Rename is single-entry: with several rows selected it renames the LEAD
+      // row (what Windows Explorer does — F2 edits the focused item), not a
+      // no-op and never a batch rename.
+      if (!row) return;
+      e.preventDefault();
+      startRename(row);
+    }
+  };
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => shortcutRef.current(e);
+    document.addEventListener("keydown", h);
+    return () => document.removeEventListener("keydown", h);
+  }, []);
+}

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -1,0 +1,355 @@
+// The in-folder search: query state (URL-synced), the streamed recursive walk,
+// incremental fuzzy scoring, the render-side re-rank throttle, the
+// stale-while-revalidate hold across dir-watch refreshes, and result paging.
+//
+// A non-empty query swaps the listing for flat, rank-ordered results over a
+// recursive walk of the folder. The walk STREAMS (NDJSON batches,
+// breadth-first from the server): results paint from the first batch and
+// refine while deeper levels are still arriving, so feedback is instant even
+// on huge trees. The walk starts lazily on first focus (or a URL-seeded
+// query) and is cached until the dir watch fires.
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { walkDirStream } from "@platform/lib/api";
+import type { WalkEntry } from "@platform/lib/api";
+import { replaceSearch } from "@platform/lib/router";
+import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "@platform/lib/search-hold";
+import {
+  IDLE_WALK,
+  PAGE_SIZE,
+  RERANK_COMMIT_MS,
+  STREAM_FLUSH_MS,
+  URL_SYNC_MS,
+  type SearchHit,
+  type SortKey,
+  type SortOrder,
+  type WalkState,
+} from "@apps/explorer/listing/types";
+import { queryWantsHidden, rankCompare, scoreEntries, sortHits } from "@apps/explorer/listing/search";
+
+function currentQuery(): string {
+  return new URLSearchParams(location.search).get("q") || "";
+}
+
+export function useWalkSearch(fsPath: string, refresh: number) {
+  const [query, setQueryState] = useState<string>(currentQuery);
+  const [walk, setWalk] = useState<WalkState>(IDLE_WALK);
+  // Which refresh generation of the walk has been REQUESTED (null = none).
+  // The fetch effect keys on this, not on `refresh` itself: a dir-watch bump
+  // only invalidates the cache (via the forRefresh tag) and a new fetch
+  // happens only while search is active (auto-request effect) or on the next
+  // gesture — an idle listing must not re-walk the tree on every watch event.
+  const [walkReq, setWalkReq] = useState<number | null>(() =>
+    currentQuery().trim() !== "" ? 0 : null
+  );
+  // Bumped to re-run the stream effect after an error, from a real user
+  // gesture only (focus / typing) — an effect-driven retry would loop forever.
+  const [retryNonce, setRetryNonce] = useState(0);
+  // Sort applied to search results. null = relevance (fuzzy rank). Deliberately
+  // NOT URL-synced (unlike the normal-mode sort) — it resets on every query
+  // change, so persisting it would fight that reset.
+  const [searchSort, setSearchSort] = useState<{ sort: SortKey; order: SortOrder } | null>(null);
+  // How many result rows are revealed; grows by PAGE_SIZE when the sentinel
+  // row scrolls into view, resets on every query change.
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  // The input echoes `query` (immediate) so keystrokes never wait on the
+  // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
+  // load — React commits a cheap render with the old deferred value first
+  // (echoing the keystroke), then a low-priority render picks up the new
+  // value and redoes the expensive work, interruptible by further typing.
+  const deferredQuery = useDeferredValue(query);
+  const q = deferredQuery.trim();
+  const searching = q !== "";
+  const isStale = query.trim() !== q;
+
+  // Synchronous cache validity: a non-idle walk fetched for a previous
+  // refresh generation reads as idle, immediately on the render where
+  // `refresh` bumps — no effect ordering to wait on, and no render ever
+  // scores search results against the pre-refresh tree.
+  const validWalk: WalkState =
+    walk.status === "idle" || walk.forRefresh === refresh ? walk : IDLE_WALK;
+
+  // Active search must always have a walk for the CURRENT tree. Covers a
+  // URL-seeded query on mount racing ahead of focus, typing after an
+  // invalidation, and the dir watch bumping `refresh` mid-search (the stale
+  // tag makes validWalk idle, this re-requests). Keyed on validWalk being
+  // IDLE so an errored walk never auto-retries (that would loop:
+  // request -> error -> request -> ...); error retries hang off real
+  // gestures (focus / typing) below. The immediate `query` (not deferred)
+  // drives this — the fetch should start on the first keystroke.
+  useEffect(() => {
+    if (query.trim() !== "" && validWalk.status === "idle" && walkReq !== refresh) {
+      setWalkReq(refresh);
+    }
+  }, [query, validWalk.status, walkReq, refresh]);
+
+  // The streamed validWalk. One effect owns the whole fetch lifecycle: it runs
+  // when a walk generation is requested (walkReq) or a gesture bumps
+  // `retryNonce` after an error, and ABORTS the in-flight stream on cleanup
+  // — which also cancels the server-side walk (the generator is closed on
+  // disconnect). Batches push into one append-only array; see WalkState.
+  useEffect(() => {
+    if (walkReq === null) return;
+    const forRefresh = walkReq;
+    const ctrl = new AbortController();
+    let alive = true;
+    const entries: WalkEntry[] = [];
+    // Flush throttle (STREAM_FLUSH_MS): entries accumulate in `pending`
+    // between commits so the scoring/render work runs a few times a second,
+    // not once per network chunk. A trailing timer guarantees the last
+    // partial interval still commits.
+    let pending: WalkEntry[] = [];
+    let lastFlush = 0;
+    let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    const flush = () => {
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      for (const e of pending) entries.push(e); // no spread: a big chunk would blow the arg limit
+      pending = [];
+      lastFlush = Date.now();
+      setWalk({ status: "streaming", entries, count: entries.length, forRefresh });
+    };
+    setWalk({ status: "streaming", entries, count: 0, forRefresh });
+    walkDirStream(fsPath, {
+      hidden: true,
+      signal: ctrl.signal,
+      onBatch: (batch) => {
+        if (!alive) return;
+        for (const e of batch) pending.push(e);
+        const wait = STREAM_FLUSH_MS - (Date.now() - lastFlush);
+        if (wait <= 0) flush();
+        else if (flushTimer === null) flushTimer = setTimeout(() => alive && flush(), wait);
+      },
+    }).then(
+      (end) => {
+        if (!alive) return;
+        if (flushTimer !== null) clearTimeout(flushTimer);
+        for (const e of pending) entries.push(e);
+        setWalk({ status: "ok", entries, truncated: end.truncated, total: end.total, forRefresh });
+      },
+      (err: Error) => {
+        if (!alive || err.name === "AbortError") return;
+        if (flushTimer !== null) clearTimeout(flushTimer);
+        setWalk({ status: "error", message: err.message, forRefresh });
+      }
+    );
+    return () => {
+      alive = false;
+      if (flushTimer !== null) clearTimeout(flushTimer);
+      ctrl.abort();
+    };
+  }, [fsPath, walkReq, retryNonce]);
+
+  // First focus starts the walk warming in the background; focus (like
+  // typing below) is also the retry gesture when a previous stream failed.
+  const prefetchWalk = () => {
+    if (validWalk.status === "idle") setWalkReq(refresh);
+    else if (validWalk.status === "error") {
+      setWalkReq(refresh);
+      setRetryNonce((n) => n + 1);
+    }
+  };
+
+  // Debounced URL mirror for the query (see URL_SYNC_MS). Pending sync is
+  // dropped on unmount — a navigation has already replaced the URL by then.
+  const urlTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (urlTimer.current !== null) clearTimeout(urlTimer.current);
+    },
+    []
+  );
+
+  const setQuery = (value: string) => {
+    setQueryState(value);
+    setSearchSort(null); // a new query drops back to relevance order
+    setVisibleCount(PAGE_SIZE);
+    // Editing the query is also a user gesture: if the last walk attempt
+    // failed, give it another shot instead of leaving search dead forever.
+    // (An idle walk needs no handling here — the auto-request effect fires
+    // as soon as the non-empty query state lands.)
+    if (validWalk.status === "error") {
+      setWalkReq(refresh);
+      setRetryNonce((n) => n + 1);
+    }
+    if (urlTimer.current !== null) clearTimeout(urlTimer.current);
+    urlTimer.current = setTimeout(() => {
+      const params = new URLSearchParams(location.search);
+      if (value) params.set("q", value);
+      else params.delete("q");
+      const qs = params.toString();
+      replaceSearch(location.pathname + (qs ? "?" + qs : ""));
+    }, URL_SYNC_MS);
+  };
+
+  // Search headers cycle asc → desc → relevance. Relevance (the fuzzy rank) is
+  // the mode search results are actually FOR, and before this there was no way
+  // back to it short of retyping the query — the toggle only ever flipped
+  // between two column orders.
+  const setSearchSortKey = (key: SortKey) => {
+    setSearchSort((prev) => {
+      if (!prev || prev.sort !== key) return { sort: key, order: "asc" };
+      if (prev.order === "asc") return { sort: key, order: "desc" };
+      return null;
+    });
+  };
+
+  // Incremental-scoring cache for the streamed validWalk. As long as the query,
+  // hidden-intent and entries array are unchanged, only entries appended
+  // since `scored` get fuzzy-matched, then merged into the previous ranked
+  // list — so a stream flush near the tail of a 200k walk costs one small
+  // scan + a sort of the hits, not a full re-scan of everything (which is
+  // exactly what saturated the main thread and made the UI unresponsive
+  // while the walk loaded). Any change to query/hidden/array falls back to a
+  // full scan. A ref (not state): it's a pure memo accelerator, and the
+  // update below is idempotent, so double-invoked renders are harmless.
+  const scoreCache = useRef<{
+    q: string;
+    showHidden: boolean;
+    entries: WalkEntry[] | null;
+    scored: number; // how many of `entries` have been scored already
+    ranked: SearchHit[];
+  }>({ q: "", showHidden: false, entries: null, scored: 0, ranked: [] });
+
+  // Keyed on `q`/`searching` (both deferred) so full fuzzy scans run on
+  // React's low-priority schedule, not synchronously on every keystroke.
+  // While the walk streams, each flush produces a new `walk` state and this
+  // extends the ranked list with just the newly arrived entries (see
+  // scoreCache above).
+  const hits = useMemo(() => {
+    if (!searching || (validWalk.status !== "ok" && validWalk.status !== "streaming")) return [];
+    const showHidden = queryWantsHidden(q);
+    const cache = scoreCache.current;
+    let ranked: SearchHit[];
+    if (cache.entries === validWalk.entries && cache.q === q && cache.showHidden === showHidden) {
+      const fresh = scoreEntries(q, validWalk.entries, cache.scored, showHidden);
+      ranked = fresh.length ? cache.ranked.concat(fresh).sort(rankCompare) : cache.ranked;
+    } else {
+      ranked = scoreEntries(q, validWalk.entries, 0, showHidden).sort(rankCompare);
+    }
+    scoreCache.current = { q, showHidden, entries: validWalk.entries, scored: validWalk.entries.length, ranked };
+    if (!searchSort) return ranked; // relevance order
+    return sortHits(ranked, searchSort.sort, searchSort.order);
+  }, [searching, q, validWalk, searchSort]);
+
+  // --- Streaming re-rank throttle (B4) --------------------------------------
+  // Every stream flush re-scores the newly arrived entries and merges them into
+  // the ranked list, which reshuffles the visible rows several times a second —
+  // unreadable on its own, and worse now that the rows animate. The RENDERED
+  // ranking is therefore committed at most once per RERANK_COMMIT_MS. The
+  // accumulation underneath and the live "N matches · M scanned…" counter both
+  // keep running at full speed: they cost nothing and they are the honest
+  // progress signal.
+  //
+  // The committed ranking carries the QUERY it was computed for. That tag is
+  // load-bearing for the hold below and it has to be committed WITH the data:
+  // on the first render after `q` changes this state still holds the previous
+  // query's rows (this effect hasn't run yet), so anything that tags it at
+  // render time labels the old query's rows with the new query. See
+  // lib/search-hold.
+  const [rankedForRender, setRankedForRender] = useState<QueryTagged<SearchHit>>(() => ({
+    q,
+    items: hits,
+  }));
+  const lastRankCommit = useRef(0);
+  // Declared BEFORE the commit effect so it runs first in the same flush: a
+  // query change (or a sort change) is a direct response to a gesture and must
+  // paint immediately, never wait out a throttle window opened by the stream.
+  useEffect(() => {
+    lastRankCommit.current = 0;
+  }, [q, searchSort]);
+  useEffect(() => {
+    // Only a streaming walk churns. Anything else (settled, errored, or
+    // invalidated to idle) commits at once — there is nothing left to smooth
+    // and the final ranking must not be held back.
+    if (validWalk.status !== "streaming") {
+      lastRankCommit.current = 0;
+      setRankedForRender({ q, items: hits });
+      return;
+    }
+    const wait = RERANK_COMMIT_MS - (Date.now() - lastRankCommit.current);
+    const commit = () => {
+      lastRankCommit.current = Date.now();
+      setRankedForRender({ q, items: hits });
+    };
+    if (wait <= 0) {
+      commit(); // includes the first flush of a stream — first paint isn't delayed
+      return;
+    }
+    const id = window.setTimeout(commit, wait);
+    return () => window.clearTimeout(id);
+  }, [hits, q, validWalk.status]);
+
+  // --- Stale-while-revalidate for search results (B3) -----------------------
+  // A dir-watch event bumps `refresh`, which makes validWalk read idle for the
+  // stale generation, which collapses `hits` to [] — so the entire visible
+  // result list used to blank to "Searching…" while the tree re-walked, for as
+  // long as that takes on a big folder. Hold the last ranked answer and keep
+  // rendering it (dimmed, with the spinner) until the fresh one is ready.
+  //
+  // This changes only what is DISPLAYED. The invalidation machinery is
+  // untouched: a stale walk is still never scored against a new tree — `hits`
+  // remains derived from validWalk alone, and these held rows are not fed back
+  // into scoring.
+  //
+  // Both halves of the decision — what to retain, and what to render — live in
+  // lib/search-hold, pure and query-tagged: rows are only ever shown under the
+  // query they were computed for, so the ONE thing this must never do (show the
+  // previous query's matches under a new query) is structurally impossible
+  // rather than a condition someone has to remember. A query change falls
+  // through to "Searching…" exactly as before; only a same-query invalidation
+  // holds. The hold applies only while the current-generation walk is unsettled
+  // — a COMPLETED walk with no hits is a real "no matches" answer (the file was
+  // just deleted, say) and replaces the held rows.
+  const heldHits = useRef<QueryTagged<SearchHit> | null>(null);
+  heldHits.current = nextHeldHits(searching, q, rankedForRender, heldHits.current);
+  const walkUnsettled = validWalk.status === "idle" || validWalk.status === "streaming";
+  const { hits: displayHits, showingHeld } = resolveDisplayedHits(
+    searching,
+    q,
+    rankedForRender,
+    heldHits.current,
+    walkUnsettled,
+  );
+
+  const visibleHits = useMemo(() => displayHits.slice(0, visibleCount), [displayHits, visibleCount]);
+
+  // Reveal the next page when the sentinel row (rendered only while more rows
+  // exist) scrolls into view. rootMargin pre-triggers a bit before the bottom
+  // so the next page is usually mounted by the time the user reaches it.
+  const sentinelRef = useRef<HTMLTableRowElement | null>(null);
+  const hasMore = searching && displayHits.length > visibleCount;
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el || !hasMore) return;
+    const io = new IntersectionObserver(
+      (obsEntries) => {
+        if (obsEntries.some((e) => e.isIntersecting)) setVisibleCount((c) => c + PAGE_SIZE);
+      },
+      { root: el.closest(".listing-scroll"), rootMargin: "200px" }
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, [hasMore, visibleCount]);
+
+  return {
+    query,
+    setQuery,
+    q,
+    searching,
+    isStale,
+    validWalk,
+    prefetchWalk,
+    hits,
+    displayHits,
+    visibleHits,
+    showingHeld,
+    hasMore,
+    sentinelRef,
+    searchSort,
+    setSearchSort,
+    setSearchSortKey,
+  };
+}


### PR DESCRIPTION
## Summary

`frontend/src/apps/explorer/Listing.tsx` had grown to 2580 lines — one component holding the directory fetch, the streamed search walk, the selection model, the preview pane, file operations, context menus, and two document-level keyboard handlers. This splits it into 12 focused modules under `apps/explorer/listing/`, leaving `Listing.tsx` as an 836-line orchestrator that wires the hooks together and renders the table.

| Module | Owns |
|---|---|
| `types.ts` | shared types + tuning constants |
| `sorting.ts` | sort resolution + entry sorting (pure) |
| `search.ts` | fuzzy scoring / ranking (pure) |
| `selection.ts` | selection model + cross-remount stash (pure) |
| `pane.ts` | preview pane state (`usePreviewPane`) |
| `row-utils.ts` | RowCtx batch helpers |
| `bits.tsx` | skeleton rows, ClipMark, highlight, scroll anchor |
| `useDirListing.ts` | list fetch, Load more, dir watch, new-row cue |
| `useWalkSearch.ts` | streamed walk + scoring + throttles + result paging |
| `useListingSelection.ts` | selection state + keyboard nav + reconcile |
| `useFileOps.ts` | file operations + context menus + dialogs |
| `useListingShortcuts.ts` | file-op keyboard chords |

Behavior is unchanged: code moved verbatim, with two mechanical exceptions — the inline searchSort comparator extracted as `sortHits()`, and a local `sel` renamed `winSel` in `onRowMouseDown` to avoid shadowing the selection state. The default export path is untouched, so the two importers (`App.tsx`, `Preview.tsx`) need no changes.

## Test plan

- `tsc --noEmit` clean
- `node scripts/check-boundaries.mjs` OK (113 files)
- `bun test` 94/94 pass
- `vite build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large structural move across selection, search streaming, and file operations; regressions are possible despite the stated no-behavior-change goal, but there is no new product surface—only module boundaries.
> 
> **Overview**
> **Splits** the explorer directory listing out of one ~2.5k-line `Listing.tsx` into **`frontend/src/apps/explorer/listing/`**, leaving `Listing.tsx` as an orchestrator that composes hooks and renders the table. The default export path is unchanged (`App.tsx` / `Preview.tsx` keep importing `@apps/explorer/Listing`).
> 
> **New layout:** shared **`types`**, pure **`sorting`**, **`search`**, **`selection`**, **`row-utils`**, UI **`bits`**, **`pane`** (`usePreviewPane` + `reflectPaneInUrl`), and hooks **`useDirListing`**, **`useWalkSearch`**, **`useListingSelection`**, **`useFileOps`**, **`useListingShortcuts`**.
> 
> **Mechanical tweaks only:** search column sorting extracted as **`sortHits()`**; **`onRowMouseDown`** renames the window selection local to **`winSel`** so it does not shadow listing selection state. Logic is otherwise moved verbatim—fetch, dir watch, streamed walk/search, selection, preview pane, file ops, menus, and keyboard handlers should behave the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 905ce51212c29ec0e4292ecb55cdfe77bdbbe700. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->