### PR TITLE
Right-click menu on app cards, and a plain view for using an app

### DIFF
--- a/frontend/src/apps/builder/AppPreviewCard.tsx
+++ b/frontend/src/apps/builder/AppPreviewCard.tsx
@@ -31,7 +31,15 @@ export function timeAgo(epochSeconds: number | null | undefined): string | null 
 // exactly the .app-pcard-thumb box, whatever the grid column resolves to.
 const PREVIEW_SCALE = 0.25;
 
-export function AppPreviewCard({ app }: { app: AppInfo }) {
+export function AppPreviewCard({
+  app,
+  onContextMenu,
+}: {
+  app: AppInfo;
+  // Right-click: the card only forwards the event and its own app — the menu
+  // state lives one level up (Apps.tsx), so the whole grid shares one portal.
+  onContextMenu?: (e: React.MouseEvent, app: AppInfo) => void;
+}) {
   const title = app.title || app.name;
   const ago = timeAgo(app.updated_at);
   // An anchor, not a button — see AppCard. The href is what makes middle-click
@@ -41,6 +49,10 @@ export function AppPreviewCard({ app }: { app: AppInfo }) {
       className="app-pcard"
       href={hrefFor(app)}
       onClick={(e) => onAppCardClick(e, app)}
+      // On the <a>, not on the body: the thumbnail's pointer-events shield sits
+      // INSIDE this element, so a right-click over the preview bubbles up here
+      // (the iframe itself never sees it) and one handler covers the whole card.
+      onContextMenu={onContextMenu && ((e) => onContextMenu(e, app))}
       title={openTargetFor(app).path}
     >
       <span className="app-pcard-body">

--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -9,8 +9,10 @@
 import { useEffect, useMemo, useState } from "react";
 import { getApps } from "@platform/lib/api";
 import type { AppInfo } from "@platform/lib/api";
+import { appCardMenu } from "@platform/lib/appCardMenu";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
 import { useDeployEnabled } from "@platform/lib/prefs";
+import ContextMenu, { type MenuEntry } from "@platform/ui/ContextMenu";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { AppPreviewCard } from "@apps/builder/AppPreviewCard";
 import { HomeHero } from "./HomeHero";
@@ -44,6 +46,15 @@ export default function Apps() {
   const deployEnabled = useDeployEnabled();
   // Bumped when the panel creates an app: refetches the grid without clearing it.
   const [nonce, setNonce] = useState(0);
+  // One context-menu portal for the whole grid, at the cursor coords — same
+  // shape as the explorer listing's (Listing.tsx openRowMenu).
+  const [menu, setMenu] = useState<{ x: number; y: number; items: MenuEntry[] } | null>(null);
+
+  const openCardMenu = (e: React.MouseEvent, app: AppInfo) => {
+    // The card is an anchor: without this the browser's own link menu wins.
+    e.preventDefault();
+    setMenu({ x: e.clientX, y: e.clientY, items: appCardMenu(app) });
+  };
 
   useEffect(() => {
     let alive = true;
@@ -164,13 +175,17 @@ export default function Apps() {
             ) : (
               <div className="apps-cards">
                 {shown.map((app) => (
-                  <AppPreviewCard key={app.path} app={app} />
+                  <AppPreviewCard key={app.path} app={app} onContextMenu={openCardMenu} />
                 ))}
               </div>
             )}
           </>
         )}
       </div>
+
+      {menu && (
+        <ContextMenu x={menu.x} y={menu.y} items={menu.items} onClose={() => setMenu(null)} />
+      )}
     </div>
   );
 }

--- a/frontend/src/apps/builder/sidebar/RecentsSection.tsx
+++ b/frontend/src/apps/builder/sidebar/RecentsSection.tsx
@@ -2,6 +2,7 @@
 // builder's own store (apps/builder/lib/recents.ts — independent of the
 // explorer's file recents). Rows reuse the bookmark row classes so the
 // section reads like the explorer's.
+import { APP_OPEN_MODE } from "@platform/lib/appEntry";
 import { APP_ROUTE_PREFIX, navigateUrl } from "@platform/lib/router";
 import { loadAppRecents, useAppRecentsVersion } from "@apps/builder/lib/recents";
 
@@ -19,7 +20,9 @@ export default function RecentsSection() {
           encodeURIComponent(r.tag) +
           "/" +
           encodeURIComponent(r.name) +
-          "?_mode=claude_split";
+          // Opening a recent app IS opening an app: same mode the hub's cards
+          // use (appEntry), never the create-a-new-app split view.
+          "?_mode=" + APP_OPEN_MODE;
         return (
           <a
             key={r.tag + "/" + r.name}

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -778,8 +778,9 @@ interface PreviewProps {
   // for every dispatch branch that isn't the "_render"-carrying TemplatePreview.
   onRenderedTitle?: (title: string | null) => void;
   // Sub-app mode allowlist: when set, only these modes from stat.templates are
-  // offered (the app-builder pins its views to claude_split/versions). The
-  // server keeps resolving the full list; this is a UI restriction only —
+  // offered (the app-builder pins its views to the app modes, App.tsx
+  // APP_MODES). The server keeps resolving the full list; this is a UI
+  // restriction only —
   // `_mode` semantics on the URL are unchanged.
   allowModes?: string[];
   // Chrome-free render (the /learn page): no preview header, no mode switcher —

--- a/frontend/src/apps/explorer/lib/fs-actions.ts
+++ b/frontend/src/apps/explorer/lib/fs-actions.ts
@@ -147,18 +147,11 @@ export function claudeDeepLink(path: string, isDir: boolean, name: string, paren
   return "claude-cli://open?cwd=" + encodeURIComponent(normDir(parentDir)) + "&q=" + encodeURIComponent(q);
 }
 
-// Write text to the system clipboard; resolves true on success, false when the
-// Clipboard API is missing or the write is denied. Callers decide whether to
-// toast (a failure stays silent — the path is still reachable via Reveal).
-export async function copyToClipboard(text: string): Promise<boolean> {
-  if (!navigator.clipboard) return false;
-  try {
-    await navigator.clipboard.writeText(text);
-    return true;
-  } catch {
-    return false;
-  }
-}
+// Re-exported, not defined here: the app-card context menu needs the same
+// clipboard write and lives in another app, which may not import this one, so
+// the implementation moved to @platform/lib/clipboard. Kept exported from here
+// so every existing `from "./fs-actions"` call site is untouched.
+export { copyToClipboard } from "@platform/lib/clipboard";
 
 // Drop every path that lives INSIDE another path of the same set, keeping the
 // outermost ancestors (input order preserved).

--- a/frontend/src/platform/lib/appCardMenu.test.ts
+++ b/frontend/src/platform/lib/appCardMenu.test.ts
@@ -1,0 +1,105 @@
+// The right-click menu on an app card. What matters here is what no typecheck
+// can check: which entries the menu offers, in which order, and — for the one
+// the menu exists for — that "Open in Explorer" really lands on the app FOLDER
+// in the internal explorer rather than opening the app or shelling out to the
+// OS file manager.
+import { expect, test } from "bun:test";
+
+import type { AppInfo } from "./api";
+
+// Same shim dance as appEntry.test.ts: router.ts reads `location`/`history` at
+// MODULE scope, and bun's test runtime has no DOM. `??=` because the stubs are
+// shared with every other suite in the run.
+(globalThis as { location?: unknown }).location ??= {
+  pathname: "/",
+  search: "",
+  href: "http://localhost/",
+};
+(globalThis as { history?: unknown }).history ??= {
+  state: null,
+  pushState() {},
+  replaceState() {},
+};
+(globalThis as { window?: unknown }).window ??= {
+  dispatchEvent() {},
+  setTimeout: globalThis.setTimeout.bind(globalThis),
+  clearTimeout: globalThis.clearTimeout.bind(globalThis),
+};
+
+const { appCardMenu } = await import("./appCardMenu");
+const { hrefFor } = await import("./appEntry");
+const { MenuIcons } = await import("@platform/ui/MenuIcons");
+import type { MenuEntry, MenuItem } from "@platform/ui/ContextMenu";
+
+function app(over: Partial<AppInfo> = {}): AppInfo {
+  return {
+    name: "demo",
+    tag: "local",
+    path: "/w/local/demo",
+    entry_html: "/w/local/demo/index.html",
+    title: null,
+    ...over,
+  };
+}
+
+function labels(items: MenuEntry[]): string[] {
+  return items.map((i) => (i === "separator" ? "separator" : i.label));
+}
+
+function itemNamed(items: MenuEntry[], label: string): MenuItem {
+  const hit = items.find((i) => i !== "separator" && i.label === label);
+  if (!hit || hit === "separator") throw new Error("no such item: " + label);
+  return hit;
+}
+
+// Records what navigate()/openApp() push, so the entries can be activated for
+// real instead of against a fake navigate. Restored after each use: the stub
+// object is shared with the rest of the run.
+function capturePushes<T>(body: () => T): { url: string; state: unknown }[] {
+  const h = globalThis.history as unknown as {
+    pushState: (s: unknown, t: string, u: string) => void;
+  };
+  const original = h.pushState;
+  const pushes: { url: string; state: unknown }[] = [];
+  h.pushState = (state, _title, url) => pushes.push({ url, state });
+  try {
+    body();
+  } finally {
+    h.pushState = original;
+  }
+  return pushes;
+}
+
+test("the card menu offers Finder-order entries, Open in Explorer second", () => {
+  expect(labels(appCardMenu(app()))).toEqual([
+    "Open",
+    "Open in Explorer",
+    "separator",
+    "Reveal in Finder",
+    "Copy Path",
+  ]);
+});
+
+test("every entry carries an icon", () => {
+  // The icon column is reserved for the whole group, so a single iconless row
+  // reads as a hole in the menu.
+  for (const item of appCardMenu(app())) {
+    if (item !== "separator") expect(item.icon).toBeDefined();
+  }
+  expect(itemNamed(appCardMenu(app()), "Copy Path").icon).toBe(MenuIcons.copyPath);
+});
+
+test("Open in Explorer opens the app FOLDER in the internal explorer", () => {
+  // Not the app (that is what "Open" does) and not the OS file manager (that is
+  // "Reveal in Finder"): the explorer listing of the app's own directory, with
+  // the isDir nav hint so the destination paints the listing scaffold at once.
+  const pushes = capturePushes(() => itemNamed(appCardMenu(app()), "Open in Explorer").onClick!());
+  expect(pushes).toEqual([{ url: "/explorer/view/w/local/demo", state: { fsDir: true } }]);
+});
+
+test("Open goes where a left click on the card goes", () => {
+  // Same target as hrefFor — the app folder in the builder namespace, in the
+  // plain-app mode.
+  const pushes = capturePushes(() => itemNamed(appCardMenu(app()), "Open").onClick!());
+  expect(pushes).toEqual([{ url: hrefFor(app()), state: { fsDir: true } }]);
+});

--- a/frontend/src/platform/lib/appCardMenu.ts
+++ b/frontend/src/platform/lib/appCardMenu.ts
@@ -1,0 +1,52 @@
+// The right-click menu on an app card, in macOS Finder order. Sibling of
+// appEntry.ts and for the same reason: every surface that renders an app card
+// should offer the same entries, and a builder that is a plain function of the
+// AppInfo can be tested without a DOM.
+//
+// The entry this menu exists for is "Open in Explorer" — the app's FOLDER in
+// fused-render's own explorer, which is a different destination from both
+// neighbours: "Open" opens the app itself (the builder route), and "Reveal in
+// Finder" hands the path to the OS file manager.
+import { revealPath, type AppInfo } from "./api";
+import { openApp } from "./appEntry";
+import { copyToClipboard } from "./clipboard";
+import { navigate } from "./router";
+import { pushToast } from "./toast";
+import { MenuIcons } from "@platform/ui/MenuIcons";
+import type { MenuEntry } from "@platform/ui/ContextMenu";
+
+export function appCardMenu(app: AppInfo): MenuEntry[] {
+  return [
+    { label: "Open", icon: MenuIcons.open, onClick: () => openApp(app) },
+    {
+      label: "Open in Explorer",
+      icon: MenuIcons.folder,
+      // isDir is the nav hint the explorer uses to paint a listing scaffold
+      // before the stat resolves — an app card always knows it has a folder.
+      onClick: () => navigate(app.path, { isDir: true }),
+    },
+    "separator",
+    // Same label and glyph as the explorer's own row menu (listing/useFileOps),
+    // so the two menus never name the same action differently.
+    {
+      label: "Reveal in Finder",
+      icon: MenuIcons.reveal,
+      onClick: () => {
+        revealPath(app.path).catch((e: Error) =>
+          pushToast({ msg: "Could not reveal " + app.name + ": " + e.message, tone: "error" }),
+        );
+      },
+    },
+    {
+      label: "Copy Path",
+      icon: MenuIcons.copyPath,
+      // Confirm with a non-error toast; a failed write stays silent, as in the
+      // explorer — the path is still reachable through Reveal in Finder.
+      onClick: () => {
+        copyToClipboard(app.path).then((ok) => {
+          if (ok) pushToast({ msg: "Path copied", tone: "info" });
+        });
+      },
+    },
+  ];
+}

--- a/frontend/src/platform/lib/appEntry.test.ts
+++ b/frontend/src/platform/lib/appEntry.test.ts
@@ -80,10 +80,10 @@ test("entryOf prefers entry and falls back to entry_html", () => {
 
 // ------------------------------------------------------- where a click lands
 
-test("an app with a page entry opens its folder beside a Claude chat", () => {
+test("an app with a page entry opens its folder in the plain app view", () => {
   expect(openTargetFor(app())).toEqual({
     path: "/w/local/demo",
-    opts: { isDir: true, mode: "claude_split" },
+    opts: { isDir: true, mode: "app" },
   });
 });
 
@@ -107,7 +107,7 @@ test("href points at the same target a left click opens", () => {
   // The whole point of building both from openTargetFor: a new tab and an
   // in-app click cannot land in different places. A project open lands in the
   // BUILDER namespace (/apps/<tag>/<name>); fallbacks stay explorer URLs.
-  expect(hrefFor(app())).toBe("/apps/local/demo?_mode=claude_split");
+  expect(hrefFor(app())).toBe("/apps/local/demo?_mode=app");
   expect(hrefFor(app({ entry: "/w/local/demo/t.csv", entry_html: null }))).toBe(
     "/explorer/view/w/local/demo/t.csv",
   );
@@ -124,7 +124,7 @@ test("href encodes a path the URL codec would otherwise break on", () => {
   );
   // Builder-route segments encode too — tag/name are path segments.
   expect(hrefFor(app({ tag: "my tag", name: "app#2" }))).toBe(
-    "/apps/my%20tag/app%232?_mode=claude_split",
+    "/apps/my%20tag/app%232?_mode=app",
   );
 });
 

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -3,11 +3,14 @@
 // sidebar's recents) so they can never disagree about what clicking a card does.
 //
 // They did disagree. Each carried its own inline copy of the rule, and Home's
-// Recent row had already drifted from the hub's card. The rule itself is
-// unchanged: an app with a page entry opens its FOLDER in the claude_split view
-// (the app beside a Claude chat) — that is what an app is for — and one without
-// a resolvable entry falls back to the plain folder listing so a card is never
-// dead.
+// Recent row had already drifted from the hub's card. The rule: an app with a
+// page entry opens its FOLDER in the `app` view — the app itself, full-bleed,
+// for USING it — and one without a resolvable entry falls back to the plain
+// folder listing so a card is never dead.
+//
+// OPENING an app is not BUILDING one: the `claude_split` view (the app beside a
+// Claude chat) is where a new app is created and iterated on, and the create
+// path still lands there (HomeHero). Everything in this module is the open path.
 //
 // The cards are ANCHORS, not buttons, so the browser's own "open in a new tab"
 // gestures work on them: middle-click, Cmd/Ctrl-click, and the context menu's
@@ -31,9 +34,9 @@ export function entryOf(app: AppInfo): string | null {
   return app.entry ?? app.entry_html;
 }
 
-// Whether opening this app means opening its folder beside a Claude chat, which
-// is what a page entry earns: claude_split rediscovers the entry from the folder
-// and wants exactly one top-level .html there.
+// Whether opening this app means opening its FOLDER in an app view, which is
+// what a page entry earns: those templates rediscover the entry from the folder
+// and want an index.html or exactly one top-level .html there.
 function opensAsProject(app: AppInfo): boolean {
   return Boolean(app.entry_html);
 }
@@ -43,13 +46,19 @@ export interface OpenTarget {
   opts?: { isDir?: boolean; mode?: string };
 }
 
+// The template an app folder opens in: the app itself, full-bleed
+// (fused_render/templates/app). Set EXPLICITLY rather than left to the default —
+// with `_mode` absent, Preview's defaultTemplate picks the first UNCONDITIONAL
+// entry, which for a directory is `_listing`, i.e. the folder's file list.
+export const APP_OPEN_MODE = "app";
+
 // Where a card goes when activated, AS A VALUE. Split out from openApp so the
 // rule can be tested without touching `navigate`: mocking a module that half
 // the shell imports is process-wide in bun, and it leaks into whichever suite
 // runs next. A pure function needs no mock at all.
 export function openTargetFor(app: AppInfo): OpenTarget {
   if (opensAsProject(app)) {
-    return { path: app.path, opts: { isDir: true, mode: "claude_split" } };
+    return { path: app.path, opts: { isDir: true, mode: APP_OPEN_MODE } };
   }
   // A single file entry that isn't a page opens as the file. No workspace app
   // reaches this today (its entry is its .html or it has none), but the branch
@@ -64,16 +73,16 @@ export function openTargetFor(app: AppInfo): OpenTarget {
 // open it in a new tab without the shell's help.
 //
 // `_mode` rides along because it selects the destination's template (the
-// claude_split split view); the `preview` param navigate() keeps sticky across
+// plain app view); the `preview` param navigate() keeps sticky across
 // folder navigation deliberately does NOT, since it is in-session layout the
 // user toggled and a new tab is a fresh session. Built through the router's own
 // codec, so an app path with a space, a `#` or a non-ASCII name encodes exactly
 // as in-app navigation encodes it.
 export function hrefFor(app: AppInfo): string {
   // A project open lands in the BUILDER namespace (/apps/<tag>/<name>) — the
-  // app rendered beside a Claude chat under the builder's own sidebar; the
-  // fallbacks stay explorer URLs (plain folder listing / single file).
-  if (opensAsProject(app)) return appRouteUrl(app) + "?_mode=claude_split";
+  // app under the builder's own sidebar, with the header's mode switcher pinned
+  // to the app modes; the fallbacks stay explorer URLs (folder / single file).
+  if (opensAsProject(app)) return appRouteUrl(app) + "?_mode=" + APP_OPEN_MODE;
   const { path, opts } = openTargetFor(app);
   const search = opts?.mode ? "?_mode=" + encodeURIComponent(opts.mode) : "";
   return urlForFsPath(path, search);

--- a/frontend/src/platform/lib/clipboard.ts
+++ b/frontend/src/platform/lib/clipboard.ts
@@ -1,0 +1,17 @@
+// System-clipboard write, shared by every surface that offers a "Copy …" menu
+// entry (the explorer's file ops, the preview header, the app cards' context
+// menu). Platform-level rather than explorer-level because the app-card menu
+// lives outside the explorer app and an app may not import another app.
+
+// Write text to the system clipboard; resolves true on success, false when the
+// Clipboard API is missing or the write is denied. Callers decide whether to
+// toast (a failure stays silent — the path is still reachable via Reveal).
+export async function copyToClipboard(text: string): Promise<boolean> {
+  if (!navigator.clipboard) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -134,7 +134,8 @@ export function navigate(fsPath: string, opts?: { isDir?: boolean; mode?: string
   const parts: string[] = [];
   if (opts?.isDir === true && preview !== null) parts.push("preview=" + encodeURIComponent(preview));
   // `opts.mode` picks the destination's template mode (`_mode`) — how the app
-  // cards open a project folder straight into the claude_split split view.
+  // cards open a project folder straight into the plain app view (appEntry's
+  // APP_OPEN_MODE) instead of the folder's file listing.
   if (opts?.mode) parts.push("_mode=" + encodeURIComponent(opts.mode));
   const search = parts.length ? "?" + parts.join("&") : "";
   // `opts.isDir` is a nav hint (the clicked listing row / breadcrumb already

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -40,6 +40,14 @@ export const MenuIcons: Record<string, ReactNode> = {
       <rect x="13" y="13" width="7" height="7" rx="1.5" />
     </svg>
   ),
+  // Open in Explorer — plain folder (newFolder's body without the plus): the
+  // internal explorer's listing of a directory, as opposed to `reveal`, which
+  // is the OS file manager.
+  folder: (
+    <svg {...svgProps}>
+      <path d="M4 8V6a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8z" />
+    </svg>
+  ),
   // Move to Bin — trash can with lid + two ribs.
   trash: (
     <svg {...svgProps}>

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -199,10 +199,13 @@ function LoadingScaffold({ fsPath, isDir }: { fsPath: string; isDir: boolean }) 
   );
 }
 
-// The mode list the app builder pins its views to — the two modes that make
-// sense over an app folder. The URL's `_mode` semantics are unchanged; this
-// only restricts what the switcher offers (Preview filters client-side).
-const APP_MODES = ["claude_split", "versions"];
+// The mode list the app builder pins its views to — the modes that make sense
+// over an app folder, in switcher order. `app` (the app itself, full-bleed) is
+// first because it is what opening an app lands on; `claude_split` is where an
+// app is built. A mode absent from this list is filtered out of the switcher
+// entirely (Preview's allowModes), so this is what makes the plain view
+// reachable. The URL's `_mode` semantics are unchanged.
+const APP_MODES = ["app", "claude_split", "versions"];
 
 // Stat-backed views (listing/preview): breadcrumb + content under one hook
 // component so useStat only runs when the pathname is a real fs path, not a
@@ -581,8 +584,8 @@ export default function App({ config }: { config: Config }) {
     // its own #content).
     main = <LearnView key={epoch} config={config} epoch={epoch} />;
   } else if (appFsPath) {
-    // App builder: the app folder rendered in claude_split/versions, no
-    // breadcrumb (StatView variant "app" carries its own #content).
+    // App builder: the app folder rendered in one of APP_MODES, no breadcrumb
+    // (StatView variant "app" carries its own #content).
     main = (
       <StatView
         key={epoch + ":" + appFsPath}

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -186,7 +186,8 @@ def _agent_path() -> str:
     (server.templates.TEMPLATES_DIR), the same file the split app view
     executes, so the runs dir, sidecar shape (.claude-split.json inside the
     app folder), and permission_server path stay in step with what the page
-    will poll. Apps open folder-first in claude_split, so the scaffolding
+    will poll. A newly CREATED app lands folder-first in claude_split (opening
+    an existing one lands in the plain `app` view instead), so the scaffolding
     session must be recorded at the folder level too."""
     from fused_render.server import templates as _server_templates
 

--- a/fused_render/templates/app/app.py
+++ b/fused_render/templates/app/app.py
@@ -1,0 +1,17 @@
+def main(dir: str = ""):
+    """Resolve the app folder's entry page — the html the view renders full-bleed.
+
+    The rule is shared with `claude_split/app.py` (../shared/app_entry.py) so the
+    plain view and the split view can never open different pages for the same
+    folder. Returns {"entry": <abs path> | None}."""
+    import os
+    import sys
+
+    shared = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared")
+    # Guarded insert: /api/run may exec this module repeatedly in one worker.
+    if shared not in sys.path:
+        sys.path.insert(0, shared)
+    from app_entry import entry_html
+
+    return {"entry": entry_html(dir)}

--- a/fused_render/templates/app/condition.py
+++ b/fused_render/templates/app/condition.py
@@ -1,0 +1,55 @@
+"""Gate for the `app` template (bound on the universal "/" directory key).
+
+`main(path)` offers the plain app view — the app itself, full-bleed, for USING
+it — ONLY for a project folder, i.e. a directory exactly two levels below the
+workspace root: <workspace>/<tag>/<project>. Anywhere else (the root itself, a
+tag folder, a nested subfolder, an unrelated directory) the mode stays hidden,
+and `_listing` remains what an ordinary directory opens on.
+
+Same rule, deliberately identical to `claude_split/condition.py`: the two modes
+are two ways of looking at the same thing, so a folder must never offer one
+without the other. Unlike `versions` there is no `.git` requirement — using an
+app has nothing to do with whether its history is tracked.
+
+CRITICAL: this never lists or walks the directory (`os.listdir`, `os.scandir`,
+`glob`, recursion) and never resolves symlinks — the gate runs for every
+directory the explorer stats, some on remote mounts, and pure path arithmetic on
+the already-known path is the only I/O-free answer. Mount-backed paths are
+refused outright: an app is by definition a local folder, and a mount path is
+itself shaped <mounts>/<remote>/<dir>, which would otherwise pass the rule.
+"""
+
+
+def main(path: str) -> bool:
+    import os
+    import sys
+
+    try:
+        shared = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared")
+        # Guarded insert: _run_condition re-execs this module on every stat.
+        if shared not in sys.path:
+            sys.path.insert(0, shared)
+        try:
+            from appenv import is_mount_backed, workspace_dir
+        except Exception:  # noqa: BLE001 — cannot tell -> refuse (CT-12)
+            return False
+        if is_mount_backed(path):
+            return False
+
+        root = workspace_dir()
+        try:
+            rel = os.path.relpath(os.path.abspath(path), root)
+        except ValueError:
+            # Windows: different drive letters -> not under the root.
+            return False
+        if rel == os.curdir or rel.split(os.sep, 1)[0] == os.pardir:
+            return False
+        # Exactly <tag>/<project>: two segments, no more, no fewer — and neither
+        # hidden. The apps API skips dot-prefixed tags and projects when listing
+        # Home cards; `tag/.venv` or `.hidden/project` must not sneak the mode in
+        # through the gate.
+        parts = [p for p in rel.split(os.sep) if p not in ("", ".")]
+        return len(parts) == 2 and not any(p.startswith(".") for p in parts)
+    except Exception:  # noqa: BLE001 — a broken gate must hide, never raise
+        return False

--- a/fused_render/templates/app/icon.svg
+++ b/fused_render/templates/app/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 5h16a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1z M3 9h18 M10.5 12.2v3.6l3.2-1.8z"/></svg>

--- a/fused_render/templates/app/template.html
+++ b/fused_render/templates/app/template.html
@@ -75,8 +75,10 @@ function notice(msg, isError) {
 
 async function load() {
   try {
+    // Rejects on a Python-side error (runtime.js turns the error payload into a
+    // thrown Error), so the catch below is the only failure path — app.py never
+    // returns an error key of its own.
     const res = await fused.runPython("./app.py", { dir: FILE }, { key: "entry" });
-    if (res.error) return notice(res.error, true);
     if (!res.entry) {
       return notice("No page to open here — an app needs an index.html, " +
                     "or exactly one .html file.");

--- a/fused_render/templates/app/template.html
+++ b/fused_render/templates/app/template.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html data-fused-theme="shell">
+<head>
+<meta charset="utf-8" />
+<title>App</title>
+<style>
+  /* Appearance (SPEC §30, D134). Dark block is the palette; light redefines
+     every token. `data-theme` is written onto <html> by the injected runtime
+     because this document opted in via `data-fused-theme` (runtime.js).
+
+     Deliberately tiny: this template paints nothing but a notice. The app fills
+     the frame and carries its own appearance, and the app NAME and the mode
+     switcher belong to the shell's preview header above this document — a bar
+     in here would be a second one. */
+  :root {
+    color-scheme: dark;
+    --bg: #131417;
+    --ink-2: #9aa0a6;
+    --danger: #ff7a7a;
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --bg: #ffffff;
+    --ink-2: #61656c;
+    --danger: #b3261e;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    background: var(--bg);
+  }
+  #frame {
+    display: block;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+  #notice {
+    position: absolute;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    text-align: center;
+    color: var(--ink-2);
+    background: var(--bg);
+  }
+  #notice.error { color: var(--danger); }
+  #notice.show { display: flex; }
+</style>
+</head>
+<body>
+  <iframe id="frame" title="App"></iframe>
+  <div id="notice"></div>
+
+<script>
+// The target arrives as the read-only _file param (template contract). The gate
+// (condition.py) only offers this mode for an app FOLDER, so _file is the app
+// directory and the entry page is resolved from it.
+const FILE = fused.params.get("_file") || "";
+
+const frameEl = document.getElementById("frame");
+const noticeEl = document.getElementById("notice");
+
+function notice(msg, isError) {
+  frameEl.removeAttribute("src");
+  noticeEl.textContent = msg;
+  noticeEl.className = "show" + (isError ? " error" : "");
+}
+
+async function load() {
+  try {
+    const res = await fused.runPython("./app.py", { dir: FILE }, { key: "entry" });
+    if (res.error) return notice(res.error, true);
+    if (!res.entry) {
+      return notice("No page to open here — an app needs an index.html, " +
+                    "or exactly one .html file.");
+    }
+    // `/render`, NOT `/embed`: /embed serves the React shell, which would nest
+    // this app inside a second copy of the chrome one iframe deeper (the same
+    // reason claude_split renders its left pane through /render).
+    frameEl.src = "/render?path=" + encodeURIComponent(res.entry);
+  } catch (err) {
+    notice("Could not open the app: " + err.message, true);
+  }
+}
+
+// The auto-reload opt-out the sidebar templates take is deliberately absent:
+// this mode is for USING the app while it is being edited, so a change on disk
+// should land in the frame.
+if (!FILE) {
+  notice("No app selected (missing _file param).", true);
+} else {
+  load();
+}
+</script>
+</body>
+</html>

--- a/fused_render/templates/claude_split/app.py
+++ b/fused_render/templates/claude_split/app.py
@@ -2,26 +2,18 @@ def main(dir: str = ""):
     """Resolve the project folder's app entry: the html file the left pane
     should render. Mirrors the shell's "Open as app" rule — index.html first,
     else the folder's single top-level .html — so the split view opens the
-    same page that button would. Returns {"entry": <abs path> | None}."""
+    same page the `app` mode and that button open. The rule itself lives in
+    ../shared/app_entry.py, shared with the `app` template so the two views can
+    never disagree about which page an app folder is.
+    Returns {"entry": <abs path> | None}."""
     import os
+    import sys
 
-    dir = os.path.abspath(dir)
-    if not os.path.isdir(dir):
-        return {"entry": None}
-    try:
-        names = os.listdir(dir)
-    except OSError:
-        return {"entry": None}
-    # Same filter as the listing's `app_entry` (fused_render/app_listing.py):
-    # non-hidden direct children, `.html` only — a hidden html or a sibling
-    # `.htm` must not change which folders count as apps.
-    htmls = [n for n in sorted(names)
-             if not n.startswith(".")
-             and n.lower().endswith(".html")
-             and os.path.isfile(os.path.join(dir, n))]
-    for n in htmls:
-        if n.lower() == "index.html":
-            return {"entry": os.path.join(dir, n)}
-    if len(htmls) == 1:
-        return {"entry": os.path.join(dir, htmls[0])}
-    return {"entry": None}
+    shared = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared")
+    # Guarded insert: /api/run may exec this module repeatedly in one worker.
+    if shared not in sys.path:
+        sys.path.insert(0, shared)
+    from app_entry import entry_html
+
+    return {"entry": entry_html(dir)}

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -482,6 +482,7 @@
   ],
   "/": [
     "_listing",
+    "app",
     "claude_split",
     "versions",
     "git",

--- a/fused_render/templates/shared/app_entry.py
+++ b/fused_render/templates/shared/app_entry.py
@@ -1,0 +1,56 @@
+"""Which html file IS an app folder — the one rule, in one place.
+
+An app is a folder with a single entry page. Two templates have to resolve that
+page from the folder alone: `claude_split` (the app beside a Claude chat) and
+`app` (the app plainly, full-bleed). They must never disagree — switching modes
+would silently swap which page you are looking at — so the rule lives here and
+both `app.py` backends delegate to it.
+
+The rule: `index.html` if the folder has one, else the folder's single
+non-hidden top-level `.html`. Zero or several (without an index) is ambiguous
+and resolves to None — the UI opens the plain folder listing instead of picking
+a page for the user.
+
+The server keeps its OWN copy in `fused_render/app_listing.py` (`app_entry`),
+deliberately: a template must not import `fused_render` (SPEC PY-15 / D166), and
+that copy answers a narrower question — which folders count as apps in the
+`GET /api/apps` listing, where an `index.html` beside other pages is not enough
+to call the folder a single-entry app.
+
+Imported by a template with the guarded `sys.path.insert` pattern the shared
+`appenv` uses:
+
+    shared = os.path.join(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))), "shared")
+    if shared not in sys.path:
+        sys.path.insert(0, shared)
+    from app_entry import entry_html
+"""
+import os
+
+
+def entry_html(dir: str) -> str | None:
+    """The app entry page inside `dir`, as an absolute path, or None.
+
+    Never raises: an unreadable or missing directory is "no entry", which is
+    what every caller wants to render as a notice.
+    """
+    dir = os.path.abspath(dir)
+    if not os.path.isdir(dir):
+        return None
+    try:
+        names = os.listdir(dir)
+    except OSError:
+        return None
+    # Non-hidden direct children, `.html` only — a hidden html or a sibling
+    # `.htm` must not change which page an app folder opens on.
+    htmls = [n for n in sorted(names)
+             if not n.startswith(".")
+             and n.lower().endswith(".html")
+             and os.path.isfile(os.path.join(dir, n))]
+    for n in htmls:
+        if n.lower() == "index.html":
+            return os.path.join(dir, n)
+    if len(htmls) == 1:
+        return os.path.join(dir, htmls[0])
+    return None

--- a/tests/_theme_sources.py
+++ b/tests/_theme_sources.py
@@ -29,6 +29,7 @@ OPT_IN_ATTR = "data-fused-theme"
 TIER_ONE_TEMPLATES = (
     "annotate",
     "api",
+    "app",
     "bundle",
     "claude",
     "claude_split",

--- a/tests/test_app_template.py
+++ b/tests/test_app_template.py
@@ -1,0 +1,216 @@
+"""The `app` template: an app folder rendered plainly, full-bleed, for USING it.
+
+Three things are tested here, all of them the parts no typecheck or manual
+click-through covers:
+
+  * the condition gate — the mode is bound to the universal "/" directory key,
+    so it is offered for every directory the explorer stats and the gate is the
+    only thing narrowing that to real app folders (<workspace>/<tag>/<name>);
+  * the shared entry rule (`shared/app_entry.py`) the template's `app.py` and
+    `claude_split/app.py` now both delegate to — index.html wins, else the
+    folder's single non-hidden top-level .html, else nothing;
+  * the template document itself: chromeless (the shell's preview header already
+    carries the app name and the mode switcher) and pointed at `/render`, not
+    `/embed`, which would nest the app inside a second React shell.
+
+The template modules are exec'd standalone, exactly as production does
+(conditions via server._run_condition, backends via /api/run), so nothing here
+goes through a package import.
+"""
+import importlib.util
+import os
+
+import pytest
+
+TEMPLATES_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates")
+TEMPLATE_DIR = os.path.join(TEMPLATES_DIR, "app")
+
+
+def _load(directory, name, alias):
+    path = os.path.join(directory, name + ".py")
+    spec = importlib.util.spec_from_file_location(alias, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def workspace(tmp_path, monkeypatch):
+    fdir = tmp_path / "Fused"
+    fdir.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_DIR", str(fdir))
+    monkeypatch.setenv("FUSED_RENDER_WORKSPACE_DIR", str(fdir))
+    monkeypatch.setenv("FUSED_RENDER_HOME_DIR", str(tmp_path / "home"))
+    monkeypatch.setenv("FUSED_RENDER_MOUNTS_DIR", str(tmp_path / "home" / "mounts"))
+    return fdir
+
+
+@pytest.fixture()
+def gate():
+    return _load(TEMPLATE_DIR, "condition", "test_app_template_condition").main
+
+
+# ------------------------------------------------------------------- the gate
+
+
+def test_an_app_folder_is_offered(workspace, gate):
+    app = workspace / "local" / "demo"
+    app.mkdir(parents=True)
+    assert gate(str(app)) is True
+    # Unlike `versions`, no git repo is required: using an app has nothing to do
+    # with whether its history is being tracked.
+    assert not (app / ".git").exists()
+
+
+def test_a_folder_that_does_not_exist_yet_is_still_offered(workspace, gate):
+    # Pure path arithmetic, by design (the gate runs for every directory the
+    # explorer stats, some of them on remote mounts) — so it never probes.
+    assert gate(str(workspace / "local" / "notyet")) is True
+
+
+@pytest.mark.parametrize("rel", [
+    "",                       # the workspace root itself
+    "local",                  # a tag folder — one level too shallow
+    "local/demo/src",         # inside an app — one level too deep
+    "local/demo/src/deeper",
+])
+def test_anything_other_than_exactly_two_levels_is_refused(workspace, gate, rel):
+    target = workspace if rel == "" else workspace / rel
+    assert gate(str(target)) is False
+
+
+def test_a_directory_outside_the_workspace_is_refused(workspace, gate, tmp_path):
+    assert gate(str(tmp_path / "elsewhere" / "a" / "b")) is False
+
+
+@pytest.mark.parametrize("rel", [".hidden/demo", "local/.venv"])
+def test_a_dot_prefixed_segment_is_refused(workspace, gate, rel):
+    # The apps API skips dot-prefixed tags and projects when listing cards;
+    # `tag/.venv` must not sneak the mode in through the gate either.
+    assert gate(str(workspace / rel)) is False
+
+
+def test_a_mount_backed_path_is_refused(workspace, gate, tmp_path, monkeypatch):
+    # An app is by definition a local folder, and the shape of a mount path
+    # (<mounts>/<remote>/<dir>) is exactly two levels down, so without this
+    # refusal every second-level directory on every remote would offer the mode.
+    mounts = tmp_path / "home" / "mounts"
+    monkeypatch.setenv("FUSED_RENDER_WORKSPACE_DIR", str(mounts))
+    target = mounts / "s3demo" / "project"
+    assert gate(str(target)) is False
+
+
+def test_the_gate_fails_closed(workspace, gate):
+    # Anything the gate cannot answer must hide the mode, never raise into the
+    # stat path — _run_condition calls this for every directory the user opens.
+    assert gate(None) is False
+    assert gate(b"/bytes/not/str") is False
+
+
+# ------------------------------------------------- the shared entry-html rule
+
+
+@pytest.fixture()
+def entry_of():
+    shared = _load(os.path.join(TEMPLATES_DIR, "shared"), "app_entry",
+                   "test_app_template_shared_entry")
+    return shared.entry_html
+
+
+def test_index_html_wins_over_its_siblings(tmp_path, entry_of):
+    for name in ("index.html", "about.html", "zzz.html"):
+        (tmp_path / name).write_text("<html></html>")
+    assert entry_of(str(tmp_path)) == str(tmp_path / "index.html")
+
+
+def test_a_single_html_is_the_entry_whatever_it_is_called(tmp_path, entry_of):
+    (tmp_path / "dashboard.html").write_text("<html></html>")
+    assert entry_of(str(tmp_path)) == str(tmp_path / "dashboard.html")
+
+
+def test_no_html_and_several_htmls_both_resolve_to_nothing(tmp_path, entry_of):
+    assert entry_of(str(tmp_path)) is None
+    (tmp_path / "data.csv").write_text("a,b\n")
+    assert entry_of(str(tmp_path)) is None
+    (tmp_path / "a.html").write_text("<html></html>")
+    (tmp_path / "b.html").write_text("<html></html>")
+    # Ambiguous without an index.html: the UI opens the folder instead.
+    assert entry_of(str(tmp_path)) is None
+
+
+def test_hidden_and_nested_html_files_are_ignored(tmp_path, entry_of):
+    (tmp_path / ".hidden.html").write_text("<html></html>")
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "index.html").write_text("<html></html>")
+    assert entry_of(str(tmp_path)) is None
+    # ...and a hidden index.html does not count as THE index either.
+    (tmp_path / ".index.html").write_text("<html></html>")
+    (tmp_path / "real.html").write_text("<html></html>")
+    assert entry_of(str(tmp_path)) == str(tmp_path / "real.html")
+
+
+def test_a_missing_or_unreadable_directory_resolves_to_nothing(tmp_path, entry_of):
+    assert entry_of(str(tmp_path / "nope")) is None
+    f = tmp_path / "a.html"
+    f.write_text("<html></html>")
+    assert entry_of(str(f)) is None  # a file, not a directory
+
+
+# --------------------------------------------------------------- the backends
+
+
+def test_the_template_backend_reports_the_resolved_entry(tmp_path):
+    backend = _load(TEMPLATE_DIR, "app", "test_app_template_backend")
+    (tmp_path / "index.html").write_text("<html></html>")
+    assert backend.main(dir=str(tmp_path)) == {"entry": str(tmp_path / "index.html")}
+    assert backend.main(dir=str(tmp_path / "nope")) == {"entry": None}
+    # No argument at all must not blow up in the /api/run worker: the template
+    # always passes _file, but a missing param must answer, not raise.
+    assert "entry" in backend.main()
+
+
+def test_claude_split_resolves_entries_the_same_way(tmp_path):
+    # The two backends answer the same question and now share one rule; a drift
+    # between them means the split view and the plain view open different pages.
+    plain = _load(TEMPLATE_DIR, "app", "test_app_template_backend_b")
+    split = _load(os.path.join(TEMPLATES_DIR, "claude_split"), "app",
+                  "test_app_template_claude_split_backend")
+    (tmp_path / "index.html").write_text("<html></html>")
+    (tmp_path / "other.html").write_text("<html></html>")
+    assert plain.main(dir=str(tmp_path)) == split.main(dir=str(tmp_path))
+
+
+# --------------------------------------------------------------- the document
+
+
+def _template_html():
+    with open(os.path.join(TEMPLATE_DIR, "template.html"), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_the_template_renders_the_app_through_render_not_embed():
+    html = _template_html()
+    assert '"/render?path="' in html
+    # /embed serves the React shell, which would nest the app one iframe deeper
+    # inside a second copy of the chrome. (Matched as a URL literal: the
+    # template's own comment explains the choice and names the route.)
+    assert '"/embed' not in html
+
+
+def test_the_template_adds_no_chrome_of_its_own():
+    html = _template_html()
+    # The shell's preview header already carries the app name and the pinned
+    # mode switcher; a bar in here would be a second one.
+    assert "<iframe" in html
+    assert html.count("<iframe") == 1
+    # Nothing of the sidebar templates' split machinery.
+    for absent in ("divider", "col-resize", 'params.get("split")'):
+        assert absent not in html, absent
+
+
+def test_the_template_keeps_live_reload():
+    # The point of this mode is using the app while editing it, so unlike the
+    # sidebar templates it must not switch auto-reload off.
+    assert "autoReload(" not in _template_html()

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -170,12 +170,14 @@ def test_git_is_absent_from_data_media_and_binary_keys():
 
 def test_gated_directory_peers_follow_the_listing():
     # `_listing` stays the default of the universal `/` key (D81); the gated
-    # peers follow it in switcher order (left to right), with `versions` ahead
-    # of `git` — for an app folder the version timeline is what you want first,
-    # and the raw commit log sits one click further (#361).
+    # peers follow it in switcher order (left to right). `app` (the app itself,
+    # full-bleed — what OPENING an app lands on) leads them, then the split
+    # build view, then `versions` ahead of `git` — for an app folder the version
+    # timeline is what you want first, and the raw commit log sits one click
+    # further (#361).
     got, error = modes("/x/somedir", is_dir=True)
     assert error is None
-    assert got == ["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"]
+    assert got == ["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"]
 
 
 def test_git_ships_a_condition_gate_and_an_icon():
@@ -226,9 +228,9 @@ def test_unmapped_file_empty_and_plain_dir_lists():
     # `zarr_aoi` — for a plain folder, a dotted folder and the filesystem root
     # alike. Each gated mode is dropped unless its condition.py says otherwise;
     # see tests/test_graph_condition.py and the zarr_aoi tests below.
-    assert modes("/x/somedir", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
-    assert modes("/x/my.data", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
-    assert modes("/", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/somedir", is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/my.data", is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/", is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
 
 
 # --------------------------------------------- text sniff for unmapped files
@@ -661,7 +663,7 @@ def test_registry_drops_zarr_template_and_sentinel_keys():
     assert server._resolve_name("zarr")[0] is None
     # zarr_aoi is the .zarr/ default and a gated candidate on every directory
     assert registry[".zarr/"] == ["zarr_aoi", "_listing"]
-    assert registry["/"] == ["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"]
+    assert registry["/"] == ["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"]
 
 
 def test_zarr_named_dir_gate_true_with_no_markers(tmp_path):
@@ -686,10 +688,10 @@ def test_plain_dir_with_store_marker_gates_true(tmp_path, marker):
     store = tmp_path / "data"
     store.mkdir()
     (store / marker).write_text("{}")
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
-    assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
+    assert cond == {"app": False, "claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
 
 
 def test_v3_group_dir_offered(tmp_path):
@@ -698,10 +700,10 @@ def test_v3_group_dir_offered(tmp_path):
     store = tmp_path / "grp"
     store.mkdir()
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "group"}')
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
-    assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
+    assert cond == {"app": False, "claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
 
 
 def test_bare_array_dir_not_offered(tmp_path):
@@ -714,7 +716,7 @@ def test_bare_array_dir_not_offered(tmp_path):
     (store / ".zarray").write_text("{}")
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"app": False, "claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
 
 def test_v3_bare_array_dir_not_offered(tmp_path):
@@ -726,7 +728,7 @@ def test_v3_bare_array_dir_not_offered(tmp_path):
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "array"}')
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"app": False, "claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
 
 def test_v3_zarr_json_without_node_type_not_offered(tmp_path):
@@ -749,18 +751,19 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     store = tmp_path / "plain"
     store.mkdir()
     (store / "readme.txt").write_text("hi")
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
-    assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
+    assert cond == {"app": False, "claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
 
     entries, _ = server._templates_for(str(store), True)
     assert entries[0]["mode"] == "_listing" and "conditional" not in entries[0]
-    assert entries[1]["mode"] == "claude_split" and entries[1].get("conditional") is True
-    assert entries[2]["mode"] == "versions" and entries[2].get("conditional") is True
-    assert entries[3]["mode"] == "git" and entries[3].get("conditional") is True
-    assert entries[4]["mode"] == "graph" and entries[4].get("conditional") is True
-    assert entries[5]["mode"] == "zarr_aoi" and entries[5].get("conditional") is True
+    assert entries[1]["mode"] == "app" and entries[1].get("conditional") is True
+    assert entries[2]["mode"] == "claude_split" and entries[2].get("conditional") is True
+    assert entries[3]["mode"] == "versions" and entries[3].get("conditional") is True
+    assert entries[4]["mode"] == "git" and entries[4].get("conditional") is True
+    assert entries[5]["mode"] == "graph" and entries[5].get("conditional") is True
+    assert entries[6]["mode"] == "zarr_aoi" and entries[6].get("conditional") is True
 
 
 def test_zarr_condition_fail_closed(tmp_path):


### PR DESCRIPTION
## Summary

- **App cards now have a right-click menu**, headlined by **Open in Explorer** — the app's folder in fused-render's own explorer. Previously app cards had no context menu at all, and there was no quick route from a card to the folder behind it.
- **Opening an app now lands on a new `app` template**: just the app, full-bleed, for *using* it. Until now `/apps/<tag>/<name>` only offered the two sidebar-heavy modes (`claude_split`, `versions`), so there was no way to simply use an app without a chat or commit spine taking a third of the window.
- **Opening an app and creating one are now separate destinations.** Opening (cards, recents) goes to the plain `app` view; **creating** a new app still lands in `claude_split`, where you build it. The switcher offers `app · claude_split · versions`.
- The app-entry resolution rule (`index.html`, else the single top-level `.html`) was duplicated in `claude_split/app.py`; it's now extracted to `templates/shared/app_entry.py` and shared by both templates.

## Visuals

The delta in what happens to an app card. Left-click's destination changed; right-click is new.

```mermaid
flowchart TD
    Card[App card on /apps]
    Card -->|left-click| Route["/apps/tag/name?_mode=app"]
    Card -->|right-click NEW| Menu[Context menu]
    Route --> Tpl[app template, full-bleed]
    Tpl --> Frame["iframe /render?path=entry"]
    Menu -->|Open in Explorer| Exp["/explorer/view/path"]
    Menu -->|Reveal in Finder| OS[OS file manager]
```

No new chrome was added to the template: the app route already renders a shell-level header carrying the pinned mode switcher, so the template stays bare and that existing header is the top bar. Adding a bar inside `template.html` would have stacked a second one under it.

## Usage

**Context menu** — right-click any card on `/apps`:

| Item | Destination |
|---|---|
| Open | the app itself (builder route) |
| Open in Explorer | the app **folder** in fused-render's explorer |
| Reveal in Finder | the OS file manager |
| Copy Path | clipboard |

**The plain app view** — click any app on `/apps`; it opens full-bleed. Switch modes from the header switcher, or by URL:

```
/apps/<tag>/<name>?_mode=app            # the app, full-bleed (new default when opening)
/apps/<tag>/<name>?_mode=claude_split   # app beside a Claude chat (still where new apps land)
/apps/<tag>/<name>?_mode=versions       # app at a revision, commit spine
```

`_mode=app` is set **explicitly** rather than omitted: with `_mode` absent, `Preview`'s `defaultTemplate` picks the first unconditional entry, which for a directory is `_listing` (the file list). The template is `condition.py`-gated to directories exactly two levels under the workspace, so it never appears for ordinary folders.

## Test Plan

- [x] **`tests/test_app_template.py`** (21 new tests) — template resolution offers `app` for an app folder and not elsewhere; the gate refuses dot-prefixed segments and mount-backed paths, and fails closed; the shared entry rule (`index.html` wins, single `.html`, zero/multiple → `None`, hidden files ignored); both template backends agree on the same folder.
- [x] **`frontend/src/platform/lib/appCardMenu.test.ts`** (4 new tests) — menu labels and order, every row has an icon, "Open in Explorer" pushes `/explorer/view/...` with nav state `{fsDir:true}`, "Open" agrees with `hrefFor`.
- [x] `tests/test_templates.py` and `frontend/.../appEntry.test.ts` updated for the new mode and switcher list.
- [x] Full suite: **4547 passed**, 106 skipped. `tsc --noEmit` clean, `check:boundaries` OK (129 files), `bun run build` succeeds.
- [x] Rebased onto current `main` (after the mounts/OAuth refactor landed) and re-verified — clean rebase, no conflicts.
- [ ] **Manual:** open `/apps`, right-click a card → confirm all four items work and that right-click passes through the card's preview-iframe shield. Click a card → confirm it opens full-bleed with the app name and switcher in the header. Create a new app → confirm it still lands in `claude_split`.

### Known pre-existing failures (not from this PR)

Two failures exist on the untouched base and are unrelated to this diff:

- `tests/test_browse_mount.py` — 6 failures (rclone/mount-backed browsing), reproduce identically at the merge base.
- `tests/test_skill_plugin.py::test_two_syncs_at_once_do_not_stage_into_the_same_directory` — an xdist parallelism flake; passes 5/5 in isolation and fails 2/3 under `-n auto` at the **pre-change** base as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
