### PR TITLE
Preview pane: template-driven folder previews, full-height split, and directory support for the claude template

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -733,75 +733,87 @@ export default function Listing({
     <div className="listing">
       <div className="listing-split" ref={splitRef}>
         <div className="listing-main">
-          <div className="listing-search">
-            {/* The box wraps input + pinned chips so the pane toggle can sit to
+          {/* Embedded (preview pane): no search row — the pane is a glance,
+              and the host listing's search/toggle already own that chrome. */}
+          {!embedded && (
+            <div className="listing-search">
+              {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin. */}
-            <div className="listing-search-box">
-              <input
-                ref={searchInputRef}
-                type="search"
-                className="listing-search-input"
-                placeholder="Start typing to search…"
-                value={query}
-                onFocus={prefetchWalk}
-                onChange={(e) => setQuery(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    e.preventDefault();
-                    setQuery("");
-                    e.currentTarget.blur();
-                  }
-                }}
-              />
-              {searching &&
-                (validWalk.status === "idle" ||
-                  validWalk.status === "streaming") && (
-                  <span className="listing-search-spinner" aria-hidden="true" />
+              <div className="listing-search-box">
+                <input
+                  ref={searchInputRef}
+                  type="search"
+                  className="listing-search-input"
+                  placeholder="Start typing to search…"
+                  value={query}
+                  onFocus={prefetchWalk}
+                  onChange={(e) => setQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Escape") {
+                      e.preventDefault();
+                      setQuery("");
+                      e.currentTarget.blur();
+                    }
+                  }}
+                />
+                {searching &&
+                  (validWalk.status === "idle" ||
+                    validWalk.status === "streaming") && (
+                    <span
+                      className="listing-search-spinner"
+                      aria-hidden="true"
+                    />
+                  )}
+                {searchCount !== null && (
+                  <span
+                    className="listing-search-count"
+                    title={searchCountTitle}
+                  >
+                    {searchCount}
+                  </span>
                 )}
-              {searchCount !== null && (
-                <span className="listing-search-count" title={searchCountTitle}>
-                  {searchCount}
-                </span>
-              )}
-              {/* Multi-selection readout — a single selected row needs no count. */}
-              {sel.paths.length > 1 && (
-                <span className="listing-search-count">
-                  {sel.paths.length} selected
-                </span>
-              )}
-            </div>
-            {/* Current result ordering, and the way back to relevance. Without it
+                {/* Multi-selection readout — a single selected row needs no count. */}
+                {sel.paths.length > 1 && (
+                  <span className="listing-search-count">
+                    {sel.paths.length} selected
+                  </span>
+                )}
+              </div>
+              {/* Current result ordering, and the way back to relevance. Without it
             "no arrow anywhere" was the only signal that results were in fuzzy
             rank order, and a column sort had no explicit escape. */}
-            {searching && (
-              <button
-                type="button"
-                className={"listing-sort-chip" + (searchSort ? " sorted" : "")}
-                disabled={!searchSort}
-                title={
-                  searchSort
-                    ? "Results are column-sorted — click for relevance order"
-                    : "Results are in relevance order (best match first)"
-                }
-                onClick={() => setSearchSort(null)}
-              >
-                {searchSort
-                  ? `${SORT_KEYS[searchSort.sort].toLowerCase()} ${searchSort.order}`
-                  : "relevance"}
-              </button>
-            )}
-            {!embedded && (
-              <button
-                type="button"
-                className={"listing-pane-toggle" + (pane.on ? " active" : "")}
-                title={pane.on ? "Hide preview pane" : "Show preview pane"}
-                aria-pressed={pane.on}
-                onClick={togglePane}
-              >
-                <SplitRightIcon />
-              </button>
-            )}
-          </div>
+              {searching && (
+                <button
+                  type="button"
+                  className={
+                    "listing-sort-chip" + (searchSort ? " sorted" : "")
+                  }
+                  disabled={!searchSort}
+                  title={
+                    searchSort
+                      ? "Results are column-sorted — click for relevance order"
+                      : "Results are in relevance order (best match first)"
+                  }
+                  onClick={() => setSearchSort(null)}
+                >
+                  {searchSort
+                    ? `${SORT_KEYS[searchSort.sort].toLowerCase()} ${searchSort.order}`
+                    : "relevance"}
+                </button>
+              )}
+              {!embedded && (
+                <button
+                  type="button"
+                  className={"listing-pane-toggle" + (pane.on ? " active" : "")}
+                  title={pane.on ? "Hide preview pane" : "Show preview pane"}
+                  aria-pressed={pane.on}
+                  onClick={togglePane}
+                >
+                  <SplitRightIcon />
+                </button>
+              )}
+            </div>
+          )}
           <div
             ref={scrollRef}
             /* Dimmed both when the deferred render lags a keystroke and while
@@ -811,7 +823,7 @@ export default function Listing({
               (isStale || showingHeld ? " listing-stale" : "")
             }
             onClick={onBackgroundClick}
-          onContextMenu={openBackgroundMenu}
+            onContextMenu={openBackgroundMenu}
           >
             <table className="listing-table">
               <thead>
@@ -894,10 +906,31 @@ export default function Listing({
             >
               {/* Keyed on the previewed path: switching rows remounts the pane,
                   so a stale iframe never lingers a frame while the new row's
-                  stat/list resolves. */}
+                  stat/list resolves. Nothing selected → the pane previews THIS
+                  folder itself (self: its template or lone app — never its
+                  listing, which is already on the left). */}
               <ListingPreviewPane
-                key={sel.paths.length === 1 && leadRow ? leadRow.path : "none"}
-                row={sel.paths.length === 1 && leadRow ? leadRow : null}
+                key={
+                  sel.paths.length === 1 && leadRow
+                    ? leadRow.path
+                    : sel.paths.length === 0
+                      ? "self:" + fsPath
+                      : "none"
+                }
+                row={
+                  sel.paths.length === 1 && leadRow
+                    ? leadRow
+                    : sel.paths.length === 0
+                      ? {
+                          path: fsPath,
+                          name:
+                            fsPath.replace(/\/+$/, "").split("/").pop() ||
+                            fsPath,
+                          isDir: true,
+                          self: true,
+                        }
+                      : null
+                }
                 selCount={sel.paths.length}
               />
             </div>

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -96,7 +96,7 @@ export default function Listing({
   const [{ sort, order }, setSortState] = useState<{
     sort: SortKey;
     order: SortOrder;
-  }>(() => resolveSort(fsPath));
+  }>(() => resolveSort(fsPath, !embedded));
   // When the sort was restored from saved state (URL carried none), reflect it
   // in the URL so the address bar, bookmarks, and Back-button history match
   // what's shown — as if the column had been clicked. Only syncs a genuinely

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -41,8 +41,17 @@ import {
   type SortOrder,
 } from "@apps/explorer/listing/types";
 import { resolveSort, sortEntries } from "@apps/explorer/listing/sorting";
-import { skeletonRows, ClipMark, renderHighlight, measureScrollAnchor } from "@apps/explorer/listing/bits";
-import { usePreviewPane, reflectPaneInUrl, PANE_DEFAULT_FRAC } from "@apps/explorer/listing/pane";
+import {
+  skeletonRows,
+  ClipMark,
+  renderHighlight,
+  measureScrollAnchor,
+} from "@apps/explorer/listing/bits";
+import {
+  usePreviewPane,
+  reflectPaneInUrl,
+  PANE_DEFAULT_FRAC,
+} from "@apps/explorer/listing/pane";
 import { useDirListing } from "@apps/explorer/listing/useDirListing";
 import { useWalkSearch } from "@apps/explorer/listing/useWalkSearch";
 import { useListingSelection } from "@apps/explorer/listing/useListingSelection";
@@ -71,13 +80,15 @@ export default function Listing({
   // plain (non-search) listing settles, so it tracks dir-watch refreshes too.
   onSingleApp?: (path: string | null) => void;
 }) {
-  const { state, refresh, refetch, loadMore, loadingMore, newNames } = useDirListing(fsPath);
+  const { state, refresh, refetch, loadMore, loadingMore, newNames } =
+    useDirListing(fsPath);
 
   // Sort lives in the URL; mirror it in state so clicks re-render without a
   // navigation (vanilla re-ran renderListing after its replaceState).
-  const [{ sort, order }, setSortState] = useState<{ sort: SortKey; order: SortOrder }>(() =>
-    resolveSort(fsPath)
-  );
+  const [{ sort, order }, setSortState] = useState<{
+    sort: SortKey;
+    order: SortOrder;
+  }>(() => resolveSort(fsPath));
   // When the sort was restored from saved state (URL carried none), reflect it
   // in the URL so the address bar, bookmarks, and Back-button history match
   // what's shown — as if the column had been clicked. Only syncs a genuinely
@@ -136,7 +147,8 @@ export default function Listing({
     setSearchSortKey,
   } = useWalkSearch(fsPath, refresh);
 
-  const { pane, splitRef, togglePane, onDividerPointerDown } = usePreviewPane(fsPath);
+  const { pane, splitRef, togglePane, onDividerPointerDown } =
+    usePreviewPane(fsPath);
 
   const clipboard = useClipboard();
 
@@ -158,8 +170,9 @@ export default function Listing({
   // this branch even displays) was pure waste when `state`/sort/order hadn't
   // changed.
   const sortedEntries = useMemo(
-    () => (state.status === "ok" ? sortEntries(state.entries, sort, order) : []),
-    [state, sort, order]
+    () =>
+      state.status === "ok" ? sortEntries(state.entries, sort, order) : [],
+    [state, sort, order],
   );
 
   const base = fsPath.replace(/\/$/, "");
@@ -194,7 +207,7 @@ export default function Listing({
       searching
         ? visibleHits.map(({ entry }) => base + "/" + entry.rel)
         : sortedEntries.map((entry) => base + "/" + entry.name),
-    [searching, visibleHits, sortedEntries, base]
+    [searching, visibleHits, sortedEntries, base],
   );
 
   // Whether navRows reflects a LOADED listing (not a transient empty while the
@@ -269,7 +282,11 @@ export default function Listing({
   // had. The anchor is re-measured on EVERY commit (it has to be current), but
   // the correction is applied only when the refresh generation changed: a sort
   // or a page reveal is the user's own gesture and must not be undone.
-  const anchorRef = useRef<{ key: string; top: number; scrollTop: number } | null>(null);
+  const anchorRef = useRef<{
+    key: string;
+    top: number;
+    scrollTop: number;
+  } | null>(null);
   const anchorGenRef = useRef(refresh);
   useLayoutEffect(() => {
     const scroller = scrollRef.current;
@@ -292,7 +309,7 @@ export default function Listing({
   // several paths, so this is a set rather than one path.
   const cutSet = useMemo(
     () => new Set(clipboard?.op === "cut" ? clipboard.paths : []),
-    [clipboard]
+    [clipboard],
   );
 
   // The copy counterpart: marked with an accent edge + wash rather than dimmed
@@ -300,7 +317,7 @@ export default function Listing({
   // one of cutSet/copiedSet is ever non-empty — the clipboard holds one op.
   const copiedSet = useMemo(
     () => new Set(clipboard?.op === "copy" ? clipboard.paths : []),
-    [clipboard]
+    [clipboard],
   );
 
   // Map every rendered row's path to its RowCtx, so a keyboard shortcut can
@@ -339,7 +356,10 @@ export default function Listing({
   // the user can actually see selected.
   const selectedRows = useMemo(() => {
     const chosen = new Set(sel.paths);
-    return navRows.filter((p) => chosen.has(p)).map((p) => rowCtxByPath.get(p)!).filter(Boolean);
+    return navRows
+      .filter((p) => chosen.has(p))
+      .map((p) => rowCtxByPath.get(p)!)
+      .filter(Boolean);
   }, [sel.paths, navRows, rowCtxByPath]);
   // The lead row, for the single-entry operations (Rename, paste target).
   const leadRow = sel.lead ? rowCtxByPath.get(sel.lead) : undefined;
@@ -446,64 +466,76 @@ export default function Listing({
       // query while a refresh-invalidated walk re-runs (showingHeld).
       body = (
         <>
-            {visibleHits.map(({ entry, positions }) => {
-              const childPath = base + "/" + entry.rel;
-              return (
-                <tr
-                  key={entry.rel}
-                  data-flip-key={childPath}
-                  className={
-                    "row" +
-                    (selectedSet.has(childPath) ? " selected" : "") +
-                    // Marker only (no styling of its own): the lead row is what
-                    // the scroll-into-view effect tracks.
-                    (childPath === selectedPath ? " lead" : "") +
-                    (cutSet.has(childPath) ? " cut" : "") +
-                    (copiedSet.has(childPath) ? " copied" : "")
-                  }
-                  onClick={(e) =>
-                    onRowClick(e, childPath, {
-                      path: childPath,
-                      name: entry.rel.split("/").pop() ?? entry.rel,
-                      isDir: entry.is_dir,
-                      parentDir: dirname(childPath),
-                    })
-                  }
-                  onDoubleClick={() =>
-                    onRowDoubleClick({
-                      path: childPath,
-                      name: entry.rel.split("/").pop() ?? entry.rel,
-                      isDir: entry.is_dir,
-                      parentDir: dirname(childPath),
-                    })
-                  }
-                  onMouseDown={onRowMouseDown}
-                  onContextMenu={(e) =>
-                    openRowMenu(e, {
-                      path: childPath,
-                      name: entry.rel.split("/").pop() ?? entry.rel,
-                      isDir: entry.is_dir,
-                      parentDir: dirname(childPath),
-                    })
-                  }
-                >
-                  <td className="name">
-                    <span className="icon">{iconForEntry(entry.rel.split("/").pop() ?? entry.rel, entry.is_dir)}</span>
-                    <span className="search-path">{renderHighlight(entry.rel, positions)}</span>
-                    <ClipMark cut={cutSet.has(childPath)} copied={copiedSet.has(childPath)} />
-                  </td>
-                  <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
-                  <td className="mtime">{formatMtime(entry.mtime)}</td>
-                </tr>
-              );
-            })}
-            {hasMore && (
-              <tr ref={sentinelRef}>
-                <td colSpan={3} className="status-message">
-                  Scroll for more…
+          {visibleHits.map(({ entry, positions }) => {
+            const childPath = base + "/" + entry.rel;
+            return (
+              <tr
+                key={entry.rel}
+                data-flip-key={childPath}
+                className={
+                  "row" +
+                  (selectedSet.has(childPath) ? " selected" : "") +
+                  // Marker only (no styling of its own): the lead row is what
+                  // the scroll-into-view effect tracks.
+                  (childPath === selectedPath ? " lead" : "") +
+                  (cutSet.has(childPath) ? " cut" : "") +
+                  (copiedSet.has(childPath) ? " copied" : "")
+                }
+                onClick={(e) =>
+                  onRowClick(e, childPath, {
+                    path: childPath,
+                    name: entry.rel.split("/").pop() ?? entry.rel,
+                    isDir: entry.is_dir,
+                    parentDir: dirname(childPath),
+                  })
+                }
+                onDoubleClick={() =>
+                  onRowDoubleClick({
+                    path: childPath,
+                    name: entry.rel.split("/").pop() ?? entry.rel,
+                    isDir: entry.is_dir,
+                    parentDir: dirname(childPath),
+                  })
+                }
+                onMouseDown={onRowMouseDown}
+                onContextMenu={(e) =>
+                  openRowMenu(e, {
+                    path: childPath,
+                    name: entry.rel.split("/").pop() ?? entry.rel,
+                    isDir: entry.is_dir,
+                    parentDir: dirname(childPath),
+                  })
+                }
+              >
+                <td className="name">
+                  <span className="icon">
+                    {iconForEntry(
+                      entry.rel.split("/").pop() ?? entry.rel,
+                      entry.is_dir,
+                    )}
+                  </span>
+                  <span className="search-path">
+                    {renderHighlight(entry.rel, positions)}
+                  </span>
+                  <ClipMark
+                    cut={cutSet.has(childPath)}
+                    copied={copiedSet.has(childPath)}
+                  />
                 </td>
+                <td className="size">
+                  {entry.is_dir ? "" : formatSize(entry.size)}
+                </td>
+                <td className="mtime">{formatMtime(entry.mtime)}</td>
               </tr>
-            )}
+            );
+          })}
+          {hasMore && (
+            <tr ref={sentinelRef}>
+              <td colSpan={3} className="status-message">
+                Scroll for more…
+              </td>
+            </tr>
+          )}
         </>
       );
     } else if (validWalk.status === "ok" || validWalk.status === "streaming") {
@@ -515,8 +547,8 @@ export default function Listing({
         validWalk.status === "streaming"
           ? `No matches yet — still searching (${validWalk.count.toLocaleString()} entries scanned)`
           : validWalk.truncated
-          ? `No matches in the first ${validWalk.total.toLocaleString()} entries — this folder tree is too large to search fully`
-          : "No matches";
+            ? `No matches in the first ${validWalk.total.toLocaleString()} entries — this folder tree is too large to search fully`
+            : "No matches";
       body = (
         <tr>
           <td colSpan={3} className="status-message">
@@ -592,9 +624,14 @@ export default function Listing({
           }
         >
           <td className="name">
-            <span className="icon">{iconForEntry(entry.name, entry.is_dir)}</span>
+            <span className="icon">
+              {iconForEntry(entry.name, entry.is_dir)}
+            </span>
             {entry.name}
-            <ClipMark cut={cutSet.has(childPath)} copied={copiedSet.has(childPath)} />
+            <ClipMark
+              cut={cutSet.has(childPath)}
+              copied={copiedSet.has(childPath)}
+            />
           </td>
           <td className="size">{entry.is_dir ? "" : formatSize(entry.size)}</td>
           <td className="mtime">{formatMtime(entry.mtime)}</td>
@@ -608,7 +645,8 @@ export default function Listing({
     const banner = state.truncated ? (
       <tr key="__truncated__" className="listing-truncated">
         <td colSpan={3} className="status-message">
-          Showing first {sortedEntries.length} entries — directory listing is partial.
+          Showing first {sortedEntries.length} entries — directory listing is
+          partial.
           {state.cursor && (
             <button
               type="button"
@@ -656,119 +694,148 @@ export default function Listing({
 
   return (
     <div className="listing">
-      <div className="listing-search">
-        {/* The box wraps input + pinned chips so the pane toggle can sit to
+      <div className="listing-split" ref={splitRef}>
+        <div className="listing-main">
+          <div className="listing-search">
+            {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin. */}
-        <div className="listing-search-box">
-          <input
-            ref={searchInputRef}
-            type="search"
-            className="listing-search-input"
-            placeholder="Start typing to search…"
-            value={query}
-            onFocus={prefetchWalk}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Escape") {
-                e.preventDefault();
-                setQuery("");
-                e.currentTarget.blur();
-              }
-            }}
-          />
-          {searching && (validWalk.status === "idle" || validWalk.status === "streaming") && (
-            <span className="listing-search-spinner" aria-hidden="true" />
-          )}
-          {searchCount !== null && (
-            <span className="listing-search-count" title={searchCountTitle}>
-              {searchCount}
-            </span>
-          )}
-          {/* Multi-selection readout — a single selected row needs no count. */}
-          {sel.paths.length > 1 && (
-            <span className="listing-search-count">{sel.paths.length} selected</span>
-          )}
-        </div>
-        {/* Current result ordering, and the way back to relevance. Without it
+            <div className="listing-search-box">
+              <input
+                ref={searchInputRef}
+                type="search"
+                className="listing-search-input"
+                placeholder="Start typing to search…"
+                value={query}
+                onFocus={prefetchWalk}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Escape") {
+                    e.preventDefault();
+                    setQuery("");
+                    e.currentTarget.blur();
+                  }
+                }}
+              />
+              {searching &&
+                (validWalk.status === "idle" ||
+                  validWalk.status === "streaming") && (
+                  <span className="listing-search-spinner" aria-hidden="true" />
+                )}
+              {searchCount !== null && (
+                <span className="listing-search-count" title={searchCountTitle}>
+                  {searchCount}
+                </span>
+              )}
+              {/* Multi-selection readout — a single selected row needs no count. */}
+              {sel.paths.length > 1 && (
+                <span className="listing-search-count">
+                  {sel.paths.length} selected
+                </span>
+              )}
+            </div>
+            {/* Current result ordering, and the way back to relevance. Without it
             "no arrow anywhere" was the only signal that results were in fuzzy
             rank order, and a column sort had no explicit escape. */}
-        {searching && (
-          <button
-            type="button"
-            className={"listing-sort-chip" + (searchSort ? " sorted" : "")}
-            disabled={!searchSort}
-            title={
-              searchSort
-                ? "Results are column-sorted — click for relevance order"
-                : "Results are in relevance order (best match first)"
-            }
-            onClick={() => setSearchSort(null)}
-          >
-            {searchSort
-              ? `${SORT_KEYS[searchSort.sort].toLowerCase()} ${searchSort.order}`
-              : "relevance"}
-          </button>
-        )}
-        <button
-          type="button"
-          className={"listing-pane-toggle" + (pane.on ? " active" : "")}
-          title={pane.on ? "Hide preview pane" : "Show preview pane"}
-          aria-pressed={pane.on}
-          onClick={togglePane}
-        >
-          <SplitRightIcon />
-        </button>
-      </div>
-      <div className="listing-split" ref={splitRef}>
-        <div
-          ref={scrollRef}
-          /* Dimmed both when the deferred render lags a keystroke and while
+            {searching && (
+              <button
+                type="button"
+                className={"listing-sort-chip" + (searchSort ? " sorted" : "")}
+                disabled={!searchSort}
+                title={
+                  searchSort
+                    ? "Results are column-sorted — click for relevance order"
+                    : "Results are in relevance order (best match first)"
+                }
+                onClick={() => setSearchSort(null)}
+              >
+                {searchSort
+                  ? `${SORT_KEYS[searchSort.sort].toLowerCase()} ${searchSort.order}`
+                  : "relevance"}
+              </button>
+            )}
+            <button
+              type="button"
+              className={"listing-pane-toggle" + (pane.on ? " active" : "")}
+              title={pane.on ? "Hide preview pane" : "Show preview pane"}
+              aria-pressed={pane.on}
+              onClick={togglePane}
+            >
+              <SplitRightIcon />
+            </button>
+          </div>
+          <div
+            ref={scrollRef}
+            /* Dimmed both when the deferred render lags a keystroke and while
              held (pre-refresh) results stand in for a re-running walk. */
-          className={"listing-scroll" + (isStale || showingHeld ? " listing-stale" : "")}
-          onContextMenu={openBackgroundMenu}
-        >
-          <table className="listing-table">
-            <thead>
-              <tr>
-                {(Object.entries(SORT_KEYS) as [SortKey, string][]).map(([key, label]) =>
-                  searching ? (
-                    // While searching, headers sort the results; no active arrow
-                    // means relevance (fuzzy-rank) order.
-                    <th
-                      key={key}
-                      className={"sortable" + (searchSort?.sort === key ? " sorted" : "")}
-                      title={
-                        searchSort?.sort === key && searchSort.order === "desc"
-                          ? `Back to relevance order`
-                          : `Sort results by ${label.toLowerCase()}`
-                      }
-                      onClick={() => setSearchSortKey(key)}
-                    >
-                      {label}
-                      {/* One glyph that ROTATES for desc (see .sort-arrow):
+            className={
+              "listing-scroll" +
+              (isStale || showingHeld ? " listing-stale" : "")
+            }
+            onContextMenu={openBackgroundMenu}
+          >
+            <table className="listing-table">
+              <thead>
+                <tr>
+                  {(Object.entries(SORT_KEYS) as [SortKey, string][]).map(
+                    ([key, label]) =>
+                      searching ? (
+                        // While searching, headers sort the results; no active arrow
+                        // means relevance (fuzzy-rank) order.
+                        <th
+                          key={key}
+                          className={
+                            "sortable" +
+                            (searchSort?.sort === key ? " sorted" : "")
+                          }
+                          title={
+                            searchSort?.sort === key &&
+                            searchSort.order === "desc"
+                              ? `Back to relevance order`
+                              : `Sort results by ${label.toLowerCase()}`
+                          }
+                          onClick={() => setSearchSortKey(key)}
+                        >
+                          {label}
+                          {/* One glyph that ROTATES for desc (see .sort-arrow):
                           swapping ▲ for ▼ replaced the element, so the change
                           could only ever pop. */}
-                      {searchSort?.sort === key && (
-                        <span className={"sort-arrow" + (searchSort.order === "desc" ? " desc" : "")}>▲</span>
-                      )}
-                    </th>
-                  ) : (
-                    <th
-                      key={key}
-                      className={"sortable" + (key === sort ? " sorted" : "")}
-                      onClick={() => setSort(key)}
-                    >
-                      {label}
-                      {key === sort && (
-                        <span className={"sort-arrow" + (order === "desc" ? " desc" : "")}>▲</span>
-                      )}
-                    </th>
-                  )
-                )}
-              </tr>
-            </thead>
-            <tbody>{body}</tbody>
-          </table>
+                          {searchSort?.sort === key && (
+                            <span
+                              className={
+                                "sort-arrow" +
+                                (searchSort.order === "desc" ? " desc" : "")
+                              }
+                            >
+                              ▲
+                            </span>
+                          )}
+                        </th>
+                      ) : (
+                        <th
+                          key={key}
+                          className={
+                            "sortable" + (key === sort ? " sorted" : "")
+                          }
+                          onClick={() => setSort(key)}
+                        >
+                          {label}
+                          {key === sort && (
+                            <span
+                              className={
+                                "sort-arrow" + (order === "desc" ? " desc" : "")
+                              }
+                            >
+                              ▲
+                            </span>
+                          )}
+                        </th>
+                      ),
+                  )}
+                </tr>
+              </thead>
+              <tbody>{body}</tbody>
+            </table>
+          </div>
         </div>
         {pane.on && (
           <>
@@ -799,7 +866,12 @@ export default function Listing({
       </div>
 
       {menu && (
-        <ContextMenu x={menu.x} y={menu.y} items={menu.items} onClose={() => setMenu(null)} />
+        <ContextMenu
+          x={menu.x}
+          y={menu.y}
+          items={menu.items}
+          onClose={() => setMenu(null)}
+        />
       )}
 
       {dialog?.kind === "prompt" && (
@@ -830,7 +902,6 @@ export default function Listing({
           onCancel={() => setDialog(null)}
         />
       )}
-
     </div>
   );
 }

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -261,6 +261,7 @@ export default function Listing({
     rowCtxByPathRef,
     overlayOpenRef,
     globalKeys: !embedded,
+    urlSync: !embedded,
   });
 
   const {

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -229,6 +229,7 @@ export default function Listing({
     selectOnly,
     toggleSelected,
     extendTo,
+    clearSelection,
     pendingSelectRef,
   } = useListingSelection({
     fsPath,
@@ -441,6 +442,15 @@ export default function Listing({
     const rows = inSelection && selectedRows.length > 1 ? selectedRows : [row];
     if (!inSelection) selectOnly(row.path);
     setMenu({ x: e.clientX, y: e.clientY, items: rowMenu(row, rows) });
+  };
+
+  // Clicking the listing background (the empty area below/beside the rows)
+  // deselects, like Finder. Row clicks land on tr.row, header/sort clicks on
+  // th, and Load more on a button — none of those should clear.
+  const onBackgroundClick = (e: React.MouseEvent) => {
+    const t = e.target as HTMLElement;
+    if (t.closest("tr.row, th, button, input")) return;
+    if (sel.paths.length) clearSelection();
   };
 
   // Fires only for the listing background (rows stopPropagation above).
@@ -771,7 +781,8 @@ export default function Listing({
               "listing-scroll" +
               (isStale || showingHeld ? " listing-stale" : "")
             }
-            onContextMenu={openBackgroundMenu}
+            onClick={onBackgroundClick}
+          onContextMenu={openBackgroundMenu}
           >
             <table className="listing-table">
               <thead>

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -61,6 +61,7 @@ import { useListingShortcuts } from "@apps/explorer/listing/useListingShortcuts"
 export default function Listing({
   fsPath,
   provisional = false,
+  embedded = false,
   onSingleApp,
 }: {
   fsPath: string;
@@ -74,6 +75,13 @@ export default function Listing({
   // let stat commit the real view. Absent/false (the committed post-stat
   // render), errors show normally.
   provisional?: boolean;
+  // `embedded`: this Listing renders INSIDE another view (the preview pane's
+  // `_listing` mode), not as the shell's main view. It must not touch the
+  // address bar (no sort/q/preview URL reflection), never opens its own
+  // preview pane (no nesting), and registers no document-level keyboard
+  // handlers — those belong to the host's Listing. Mouse interaction stays:
+  // clicks select/navigate, right-click menus and dialogs work as usual.
+  embedded?: boolean;
   // Reports the path of this directory's lone top-level HTML file (an
   // "app"), or null when there isn't exactly one — the caller (Preview's
   // header) uses this to surface an "Open as app" button. Fires whenever the
@@ -95,6 +103,7 @@ export default function Listing({
   // saved order; an unsorted folder keeps its clean, param-free URL. replaceState
   // (not navigate) so the view doesn't remount.
   useEffect(() => {
+    if (embedded) return; // the URL belongs to the host view
     if (new URLSearchParams(location.search).get("sort")) return; // URL is authoritative
     const s = new URLSearchParams(getViewState(fsPath));
     // No stored SORT → leave default sort + clean URL. (The stored string may
@@ -104,10 +113,13 @@ export default function Listing({
     params.set("sort", s.get("sort") || "name");
     params.set("order", s.get("order") === "desc" ? "desc" : "asc");
     replaceSearch(location.pathname + "?" + params.toString());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fsPath]);
   // Same URL reflection for a pane restored from saved viewstate.
   useEffect(() => {
+    if (embedded) return;
     reflectPaneInUrl(fsPath);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [fsPath]);
 
   const setSort = (key: SortKey) => {
@@ -115,6 +127,12 @@ export default function Listing({
       sort: key,
       order: key === sort && order === "asc" ? "desc" : "asc",
     };
+    if (embedded) {
+      // Pane-local: no URL write, no persisted per-folder choice — a glance
+      // in the preview must not re-sort the folder's real listing later.
+      setSortState(next);
+      return;
+    }
     const params = new URLSearchParams(location.search);
     params.set("sort", next.sort);
     params.set("order", next.order);
@@ -145,10 +163,17 @@ export default function Listing({
     searchSort,
     setSearchSort,
     setSearchSortKey,
-  } = useWalkSearch(fsPath, refresh);
+  } = useWalkSearch(fsPath, refresh, !embedded);
 
-  const { pane, splitRef, togglePane, onDividerPointerDown } =
-    usePreviewPane(fsPath);
+  const {
+    pane: paneResolved,
+    splitRef,
+    togglePane,
+    onDividerPointerDown,
+  } = usePreviewPane(fsPath);
+  // An embedded Listing never opens its own pane (no nesting), whatever the
+  // folder's saved viewstate says.
+  const pane = embedded ? { on: false, width: null } : paneResolved;
 
   const clipboard = useClipboard();
 
@@ -238,6 +263,7 @@ export default function Listing({
     searchInputRef,
     rowCtxByPathRef,
     overlayOpenRef,
+    globalKeys: !embedded,
   });
 
   const {
@@ -378,6 +404,7 @@ export default function Listing({
     doTrash,
     startRename,
     startNewFolder,
+    globalKeys: !embedded,
   });
 
   // Mouse selection on a row:
@@ -763,15 +790,17 @@ export default function Listing({
                   : "relevance"}
               </button>
             )}
-            <button
-              type="button"
-              className={"listing-pane-toggle" + (pane.on ? " active" : "")}
-              title={pane.on ? "Hide preview pane" : "Show preview pane"}
-              aria-pressed={pane.on}
-              onClick={togglePane}
-            >
-              <SplitRightIcon />
-            </button>
+            {!embedded && (
+              <button
+                type="button"
+                className={"listing-pane-toggle" + (pane.on ? " active" : "")}
+                title={pane.on ? "Hide preview pane" : "Show preview pane"}
+                aria-pressed={pane.on}
+                onClick={togglePane}
+              >
+                <SplitRightIcon />
+              </button>
+            )}
           </div>
           <div
             ref={scrollRef}

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -165,15 +165,12 @@ export default function Listing({
     setSearchSortKey,
   } = useWalkSearch(fsPath, refresh, !embedded);
 
-  const {
-    pane: paneResolved,
-    splitRef,
-    togglePane,
-    onDividerPointerDown,
-  } = usePreviewPane(fsPath);
-  // An embedded Listing never opens its own pane (no nesting), whatever the
-  // folder's saved viewstate says.
-  const pane = embedded ? { on: false, width: null } : paneResolved;
+  // An embedded Listing never opens its own pane (no nesting): the feature is
+  // disabled at the hook, whatever the folder's saved viewstate says.
+  const { pane, splitRef, togglePane, onDividerPointerDown } = usePreviewPane(
+    fsPath,
+    !embedded
+  );
 
   const clipboard = useClipboard();
 

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -277,12 +277,8 @@ export default function ListingPreviewPane({
     icon: templateModeIcon(e),
   }));
   if (row.isDir) {
-    modes.push({
-      mode: "_listing",
-      title: modeTitle("_listing"),
-      icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
-    });
-    // App detection is a MODE, not a default: it only ever shows when picked.
+    // The lone app outranks the listing: it leads the menu and wins the
+    // default below when the folder has no template of its own.
     if (app) {
       modes.push({
         mode: APP_MODE,
@@ -290,19 +286,36 @@ export default function ListingPreviewPane({
         icon: <span className="pane-header-icon">{iconForEntry(app.name, false)}</span>,
       });
     }
+    modes.push({
+      mode: "_listing",
+      title: modeTitle("_listing"),
+      icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
+    });
   }
 
   // Default mode: the folder's/file's own first eligible template (same
   // unconditional-first rule as Preview, CT-12); a folder without one falls
-  // back to `_listing`, a file to the metadata card (mode null).
+  // back to its lone app, then `_listing`; a file to the metadata card
+  // (mode null). While the app probe is still in flight the default is
+  // undecided — skeleton below, so the pane never flashes the listing and
+  // then swaps to the app.
   const defaultEntry = embeddable.find((e) => !e.conditional) ?? embeddable[0] ?? null;
+  if (row.isDir && !defaultEntry && modeOverride === null && app === undefined) {
+    return (
+      <div className="listing-pane">
+        <div className="pane-skel" />
+      </div>
+    );
+  }
   const activeMode =
     modeOverride !== null && modes.some((m) => m.mode === modeOverride)
       ? modeOverride
       : defaultEntry
         ? defaultEntry.mode
         : row.isDir
-          ? "_listing"
+          ? app
+            ? APP_MODE
+            : "_listing"
           : null;
   const activeEntry = embeddable.find((e) => e.mode === activeMode) ?? null;
 

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -201,49 +201,40 @@ export default function ListingPreviewPane({
 
   // --- the pane's mode list ---------------------------------------------------
 
-  // Registry templates the pane can embed as an iframe. `_listing` gets its
-  // own PaneMode below (folders — it mounts the embedded Listing, no iframe);
-  // on a FILE a `_listing` bind (rare registry rebind) is dropped entirely:
-  // the pane has no slot for a full listing of a file.
+  // Mode order = pane priority. The special `_app` mode leads when a lone
+  // app exists; after it the template system's own order stands untouched —
+  // `_listing` stays exactly where the registry ranks it (typically ahead of
+  // claude/git), rendered as the embedded Listing rather than an iframe. On a
+  // FILE a `_listing` bind (rare registry rebind) is dropped entirely: the
+  // pane has no slot for a full listing of a file. Same for a SELF target's
+  // `_listing` — that listing is already on the left.
   const allowed = (e: TemplateEntry) =>
     !e.conditional || (info.conditions !== null && info.conditions[e.mode] === true);
   const embeddable = info.templates.filter((e) => e.mode !== "_listing" && allowed(e));
 
-  const modes: PaneMode[] = embeddable.map((e) => ({
-    mode: e.mode,
-    icon: templateModeIcon(e),
-  }));
-  if (row.isDir) {
-    // The lone app outranks the listing: it leads the switcher and wins the
-    // default below when the folder has no template of its own.
-    if (app) {
-      modes.push({ mode: APP_MODE, icon: APP_MODE_ICON });
+  const modes: PaneMode[] = [];
+  if (row.isDir && app) modes.push({ mode: APP_MODE, icon: APP_MODE_ICON });
+  for (const e of info.templates) {
+    if (e.mode === "_listing") {
+      if (row.isDir && !row.self) modes.push({ mode: "_listing", icon: templateModeIcon(e) });
+      continue;
     }
-    if (!row.self) {
-      modes.push({
-        mode: "_listing",
-        icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
-      });
-    }
+    if (allowed(e)) modes.push({ mode: e.mode, icon: templateModeIcon(e) });
   }
 
-  // Default mode: the folder's/file's own first eligible template (same
-  // unconditional-first rule as Preview, CT-12); a folder without one falls
-  // back to its lone app, then `_listing`; a file to the metadata card
-  // (mode null). While the app probe is still in flight the default is
-  // undecided — skeleton below, so the pane never flashes the listing and
-  // then swaps to the app.
-  const defaultEntry = embeddable.find((e) => !e.conditional) ?? embeddable[0] ?? null;
-  if (row.isDir && !defaultEntry && modeOverride === null && app === undefined) {
+  // While the folder's app probe is still in flight the default is undecided
+  // (`_app` would lead the list) — skeleton, so the pane never flashes some
+  // other mode and then swaps to the app.
+  if (row.isDir && modeOverride === null && app === undefined) {
     return (
       <div className="listing-pane">
         <div className="pane-skel" />
       </div>
     );
   }
-  // A self target with nothing to show (no template, no lone app) gets the
+  // A self target with nothing to show (no app, no template) gets the
   // neutral hint — never its own listing, which is already on the left.
-  if (row.self && !defaultEntry && !app && modeOverride === null) {
+  if (row.self && modes.length === 0) {
     return (
       <div className="listing-pane">
         <div className="pane-center">
@@ -252,16 +243,12 @@ export default function ListingPreviewPane({
       </div>
     );
   }
+  // Default = the first mode in pane priority order; the menu override wins
+  // while it's still offered.
   const activeMode =
     modeOverride !== null && modes.some((m) => m.mode === modeOverride)
       ? modeOverride
-      : defaultEntry
-        ? defaultEntry.mode
-        : row.isDir
-          ? app
-            ? APP_MODE
-            : "_listing"
-          : null;
+      : (modes[0]?.mode ?? null);
   const activeEntry = embeddable.find((e) => e.mode === activeMode) ?? null;
 
   // All-conditional mode list, verdicts still in flight: keep the skeleton —

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -26,6 +26,10 @@ export interface PaneTarget {
   path: string;
   name: string;
   isDir: boolean;
+  // True when the target is the listing's OWN folder (nothing selected): the
+  // same mode logic runs, except `_listing` is never offered — that listing
+  // is already on the left side of the split.
+  self?: boolean;
 }
 
 // The pane-only sentinel for a folder's lone HTML app rendered in place. Not
@@ -286,11 +290,13 @@ export default function ListingPreviewPane({
         icon: <span className="pane-header-icon">{iconForEntry(app.name, false)}</span>,
       });
     }
-    modes.push({
-      mode: "_listing",
-      title: modeTitle("_listing"),
-      icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
-    });
+    if (!row.self) {
+      modes.push({
+        mode: "_listing",
+        title: modeTitle("_listing"),
+        icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
+      });
+    }
   }
 
   // Default mode: the folder's/file's own first eligible template (same
@@ -304,6 +310,17 @@ export default function ListingPreviewPane({
     return (
       <div className="listing-pane">
         <div className="pane-skel" />
+      </div>
+    );
+  }
+  // A self target with nothing to show (no template, no lone app) gets the
+  // neutral hint — never its own listing, which is already on the left.
+  if (row.self && !defaultEntry && !app && modeOverride === null) {
+    return (
+      <div className="listing-pane">
+        <div className="pane-center">
+          <div className="pane-hint">Select a file to preview.</div>
+        </div>
       </div>
     );
   }
@@ -355,7 +372,8 @@ export default function ListingPreviewPane({
         >
           Open app
         </button>
-      ) : (
+      ) : row.self ? null : (
+        // Self target: "Open" would navigate to the folder already open.
         <button
           type="button"
           className="pane-header-btn"

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -36,6 +36,25 @@ export interface PaneTarget {
 // a registry mode — it exists only in this menu, so the constant is local.
 const APP_MODE = "_app";
 
+// Monochrome switcher icon for the `_app` mode — currentColor like the other
+// mode icons, so it takes the switcher's muted/active tinting instead of the
+// colored file icon (which read as an odd yellow button in the strip).
+const APP_MODE_ICON = (
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="3" />
+    <path d="M10 8.5l6 3.5-6 3.5z" />
+  </svg>
+);
+
 // The stat'ed template picture for the selected row. `conditions` is null
 // while gated entries are still resolving (CT-12 deferred verdicts).
 interface PaneInfo {
@@ -212,10 +231,7 @@ export default function ListingPreviewPane({
     // The lone app outranks the listing: it leads the switcher and wins the
     // default below when the folder has no template of its own.
     if (app) {
-      modes.push({
-        mode: APP_MODE,
-        icon: <span className="pane-header-icon">{iconForEntry(app.name, false)}</span>,
-      });
+      modes.push({ mode: APP_MODE, icon: APP_MODE_ICON });
     }
     if (!row.self) {
       modes.push({

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useState } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
 import type { TemplateEntry } from "@platform/lib/api";
-import { navigate, VIEW_PREFIX } from "@platform/lib/router";
+import { navigate } from "@platform/lib/router";
 import { formatSize } from "@platform/lib/format";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
 import ModeSwitcher, { KNOWN_SENTINEL_MODES, templateModeIcon } from "@apps/explorer/ModeSwitcher";
@@ -81,20 +81,6 @@ interface AppTarget {
 interface PaneMode {
   mode: string;
   icon: React.ReactNode;
-}
-
-// Always the plain /view/ route, never /embed/ — an embed URL is meant to be
-// framed by a host page, so it would be the wrong thing to land in a fresh
-// tab. Same drive-letter normalization as lib/router's urlForFsPath.
-function viewUrlFor(fsPath: string): string {
-  const norm = /^[A-Za-z]:[\\/]/.test(fsPath) ? fsPath.replace(/\\/g, "/") : fsPath;
-  const encoded = norm
-    .replace(/^\/+/, "")
-    .split("/")
-    .filter((s) => s.length > 0)
-    .map(encodeURIComponent)
-    .join("/");
-  return VIEW_PREFIX + encoded;
 }
 
 export default function ListingPreviewPane({
@@ -304,16 +290,9 @@ export default function ListingPreviewPane({
       {/* Horizontal icon strip, same look as the shell preview header (PT-10):
           every available mode side by side, active one highlighted. */}
       <ModeSwitcher entries={modes} active={activeMode ?? ""} onSelect={(m) => setModeOverride(m)} />
-      {activeMode === APP_MODE && app ? (
-        <button
-          type="button"
-          className="pane-header-btn"
-          onClick={() => window.open(viewUrlFor(app.path), "_blank", "noopener")}
-        >
-          Open app
-        </button>
-      ) : row.self ? null : (
-        // Self target: "Open" would navigate to the folder already open.
+      {/* One label for every mode. Self target: "Open" would navigate to the
+          folder already open, so it hides. */}
+      {!row.self && (
         <button
           type="button"
           className="pane-header-btn"

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -222,10 +222,16 @@ export default function ListingPreviewPane({
     if (allowed(e)) modes.push({ mode: e.mode, icon: templateModeIcon(e) });
   }
 
-  // While the folder's app probe is still in flight the default is undecided
-  // (`_app` would lead the list) — skeleton, so the pane never flashes some
-  // other mode and then swaps to the app.
-  if (row.isDir && modeOverride === null && app === undefined) {
+  // While the default is still undecided, hold the skeleton — the pane must
+  // never settle on an interim mode and then jump. Undecided means: the
+  // folder's app probe is in flight (`_app` would lead the list), or any
+  // gated template's verdict is unresolved (a higher-ranked conditional mode
+  // may still enter the list — and for a self target, an all-conditional
+  // list must not flash the "no preview" hint while a gate may yet allow).
+  const gatesPending =
+    info.conditions === null &&
+    info.templates.some((e) => e.conditional && e.mode !== "_listing");
+  if (modeOverride === null && (gatesPending || (row.isDir && app === undefined))) {
     return (
       <div className="listing-pane">
         <div className="pane-skel" />
@@ -250,21 +256,6 @@ export default function ListingPreviewPane({
       ? modeOverride
       : (modes[0]?.mode ?? null);
   const activeEntry = embeddable.find((e) => e.mode === activeMode) ?? null;
-
-  // All-conditional mode list, verdicts still in flight: keep the skeleton —
-  // the pane must not claim "no preview" while a gate may still allow one.
-  if (
-    !row.isDir &&
-    activeEntry === null &&
-    info.conditions === null &&
-    info.templates.some((e) => e.mode !== "_listing" && e.conditional)
-  ) {
-    return (
-      <div className="listing-pane">
-        <div className="pane-skel" />
-      </div>
-    );
-  }
 
   // Header: name + mode menu + Open. Shown for every mode except the file
   // metadata card, which carries its own big-icon layout instead.

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -3,21 +3,22 @@
 // selected, and shows a neutral placeholder otherwise. Reuses the app's own
 // template pipeline for FILES AND FOLDERS alike: the selection is stat'ed to
 // discover its template modes and the default embeds as the normal /render
-// iframe. A folder whose default resolves to the `_listing` sentinel (no
-// custom directory template) falls back to the lightweight in-pane view: its
-// lone HTML "app" rendered in place, or a read-only mini list of children.
-// The header carries a PaneModeMenu so the previewed mode can be switched
-// (pane-local, transient — it never touches the URL or saved viewstate).
-// Wire-up state (pane visibility, width, the divider drag) stays in Listing —
-// this component only owns what the pane shows for a given selection.
-import { useEffect, useState } from "react";
+// iframe. A folder's `_listing` mode mounts the real shell Listing component
+// (embedded — no URL writes, no nested pane, no global keyboard); a folder
+// with a lone top-level HTML "app" additionally offers the pane-only `_app`
+// mode that renders that app in place. The header carries a mode menu so the
+// previewed mode can be switched (pane-local, transient — it never touches
+// the URL or saved viewstate). Wire-up state (pane visibility, width, the
+// divider drag) stays in Listing — this component only owns what the pane
+// shows for a given selection.
+import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
-import type { FsEntry, TemplateEntry } from "@platform/lib/api";
+import type { TemplateEntry } from "@platform/lib/api";
 import { navigate, VIEW_PREFIX } from "@platform/lib/router";
 import { formatSize } from "@platform/lib/format";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
-import { KNOWN_SENTINEL_MODES } from "@apps/explorer/ModeSwitcher";
-import PaneModeMenu from "@apps/explorer/PaneModeMenu";
+import { KNOWN_SENTINEL_MODES, modeTitle, templateModeIcon } from "@apps/explorer/ModeSwitcher";
+import Listing from "@apps/explorer/Listing";
 
 // The selected row, as the pane needs it. Structurally a subset of Listing's
 // RowCtx, so the lead row can be passed straight through.
@@ -27,10 +28,9 @@ export interface PaneTarget {
   isDir: boolean;
 }
 
-// A folder child with its absolute path attached (listDir returns bare names).
-interface PaneChild extends FsEntry {
-  path: string;
-}
+// The pane-only sentinel for a folder's lone HTML app rendered in place. Not
+// a registry mode — it exists only in this menu, so the constant is local.
+const APP_MODE = "_app";
 
 // The stat'ed template picture for the selected row. `conditions` is null
 // while gated entries are still resolving (CT-12 deferred verdicts).
@@ -46,12 +46,19 @@ type InfoState =
   | { status: "error"; message: string }
   | ({ status: "ok" } & PaneInfo);
 
-// The `_listing` fallback for a folder: lone-app iframe or child mini-list.
-type DirBody =
-  | { status: "loading" }
-  | { status: "error"; message: string }
-  | { status: "app"; src: string; app: PaneChild }
-  | { status: "children"; children: PaneChild[]; truncated: boolean };
+// Lone-app detection for a folder: null while loading or when the folder has
+// no single unambiguous app (a truncated listing never proves uniqueness).
+interface AppTarget {
+  name: string;
+  path: string;
+}
+
+// One entry of the pane's mode menu (template modes + the pane's sentinels).
+interface PaneMode {
+  mode: string;
+  title: string;
+  icon: React.ReactNode;
+}
 
 // Always the plain /view/ route, never /embed/ — an embed URL is meant to be
 // framed by a host page, so it would be the wrong thing to land in a fresh
@@ -67,16 +74,75 @@ function viewUrlFor(fsPath: string): string {
   return VIEW_PREFIX + encoded;
 }
 
-// Mini-list order: dot-entries last, dirs first within each, then name asc —
-// the pane is a glance, not a sortable table, so the order is fixed.
-function sortChildren(children: PaneChild[]): PaneChild[] {
-  return [...children].sort((a, b) => {
-    const aDot = a.name.startsWith(".");
-    const bDot = b.name.startsWith(".");
-    if (aDot !== bDot) return aDot ? 1 : -1;
-    if (a.is_dir !== b.is_dir) return a.is_dir ? -1 : 1;
-    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-  });
+// The pane's own mode dropdown. PaneModeMenu (Panel/Tabs chrome) stats its
+// path itself and only knows registry modes; the pane's list is richer (the
+// synthetic `_app` mode) and already stat'ed here, so this menu is fed the
+// finished list instead. Same look: pane-mode-* classes, fixed-position
+// dropdown, closes on outside pointerdown / window blur.
+function PaneModeSelect({
+  modes,
+  active,
+  onSelect,
+}: {
+  modes: PaneMode[];
+  active: string;
+  onSelect: (mode: string) => void;
+}) {
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const rootRef = useRef<HTMLSpanElement | null>(null);
+
+  useEffect(() => {
+    if (!pos) return;
+    const onDown = (e: PointerEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setPos(null);
+    };
+    const onBlur = () => setPos(null);
+    document.addEventListener("pointerdown", onDown);
+    window.addEventListener("blur", onBlur);
+    return () => {
+      document.removeEventListener("pointerdown", onDown);
+      window.removeEventListener("blur", onBlur);
+    };
+  }, [pos]);
+
+  if (modes.length < 2) return null;
+  const current = modes.find((m) => m.mode === active) ?? modes[0];
+
+  const toggle = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (pos) {
+      setPos(null);
+      return;
+    }
+    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+    setPos({ top: r.bottom + 4, left: Math.max(0, Math.min(r.left, window.innerWidth - 150)) });
+  };
+
+  return (
+    <span className="pane-mode-menu" ref={rootRef}>
+      <span className="pane-mode-btn" title={"Mode: " + current.title} onClick={toggle}>
+        {current.icon}
+      </span>
+      {pos && (
+        <span className="pane-mode-dropdown" style={{ top: pos.top, left: pos.left }}>
+          {modes.map((m) => (
+            <span
+              key={m.mode}
+              className={"pane-mode-item" + (m.mode === current.mode ? " active" : "")}
+              onClick={(e) => {
+                e.stopPropagation();
+                setPos(null);
+                onSelect(m.mode);
+              }}
+            >
+              {m.icon}
+              <span>{m.title}</span>
+            </span>
+          ))}
+        </span>
+      )}
+    </span>
+  );
 }
 
 export default function ListingPreviewPane({
@@ -89,17 +155,20 @@ export default function ListingPreviewPane({
   selCount: number;
 }) {
   const [info, setInfo] = useState<InfoState>({ status: "loading" });
+  // Lone-app probe result for a folder: undefined = still loading, null =
+  // no unambiguous app. Only drives the `_app` menu entry, never a default.
+  const [app, setApp] = useState<AppTarget | null | undefined>(undefined);
   // Pane-local mode override from the mode menu; null = the default mode.
   // The component is keyed on the previewed path (Listing), so this resets
   // with every new selection — deliberately transient.
   const [modeOverride, setModeOverride] = useState<string | null>(null);
-  const [dirBody, setDirBody] = useState<DirBody>({ status: "loading" });
 
   // Stat the selection — files and folders alike carry a template mode list
   // (folders at minimum the `_listing` sentinel). The cleanup flag is the
   // superseded-click guard: a stale async result for a row that's no longer
   // selected must not render.
   const path = row?.path;
+  const isDir = row?.isDir;
   useEffect(() => {
     if (!path) return;
     let alive = true;
@@ -135,66 +204,32 @@ export default function ListingPreviewPane({
     };
   }, [path]);
 
-  // --- choose the active mode ------------------------------------------------
-
-  // `_listing` mounts the shell's Listing component full-screen (Preview.tsx),
-  // not an iframe — the pane has no iframe slot for it. For folders it maps to
-  // the in-pane fallback below; on a file (a rare registry rebind) it is
-  // skipped when defaulting and shows the metadata card if picked explicitly.
-  let active: TemplateEntry | null = null; // entry to embed as an iframe
-  let activeMode: string | null = null; // includes "_listing" (no entry embed)
-  if (info.status === "ok") {
-    const embeddable = info.templates.filter((e) => e.mode !== "_listing");
-    const allowed = (e: TemplateEntry) =>
-      !e.conditional || (info.conditions !== null && info.conditions[e.mode] === true);
-    if (modeOverride !== null) {
-      activeMode = modeOverride;
-      active = embeddable.find((e) => e.mode === modeOverride && allowed(e)) ?? null;
-    } else {
-      // Same default-mode rule as Preview (CT-12): the first UNCONDITIONAL
-      // entry; an all-conditional list waits for verdicts and takes the first
-      // allowed one. No embeddable default → folders fall back to `_listing`,
-      // files to the metadata card.
-      const t = embeddable.find((e) => !e.conditional) ?? embeddable.find(allowed) ?? null;
-      active = t;
-      activeMode = t ? t.mode : row?.isDir ? "_listing" : null;
-    }
-  }
-
-  // --- the `_listing` folder fallback -----------------------------------------
-
-  const wantDirBody = info.status === "ok" && !!row?.isDir && activeMode === "_listing";
+  // Folder lone-app probe, for the `_app` mode. A truncated listing is only a
+  // partial page (server cap), so a lone HTML match in it doesn't prove it is
+  // the folder's ONLY one — offer no `_app` mode then (mirrors Listing's
+  // onSingleApp guard). Errors also just drop the mode; the embedded Listing
+  // surfaces the folder's real error itself.
   useEffect(() => {
-    if (!wantDirBody || !path) return;
+    if (!path || !isDir) return;
     let alive = true;
-    setDirBody({ status: "loading" });
+    setApp(undefined);
     listDir(path).then(
       (data) => {
         if (!alive) return;
         const dir = (data.path || path).replace(/\/+$/, "");
-        const children = data.entries.map((e) => ({ ...e, path: dir + "/" + e.name }));
-        // A truncated listing is only a partial page (server cap), so a lone
-        // HTML match in it doesn't prove it is the folder's ONLY one — fall
-        // through to the child list rather than render a maybe-wrong app
-        // (mirrors Listing's onSingleApp guard).
-        const apps = children.filter((e) => isAppEntry(e.name, e.is_dir));
-        if (!data.truncated && apps.length === 1) {
-          const app = apps[0];
-          setDirBody({ status: "app", src: `/render?path=${encodeURIComponent(app.path)}`, app });
-        } else {
-          setDirBody({
-            status: "children",
-            children: sortChildren(children),
-            truncated: !!data.truncated,
-          });
-        }
+        const apps = data.entries.filter((e) => isAppEntry(e.name, e.is_dir));
+        setApp(
+          !data.truncated && apps.length === 1
+            ? { name: apps[0].name, path: dir + "/" + apps[0].name }
+            : null
+        );
       },
-      (err: Error) => alive && setDirBody({ status: "error", message: err.message })
+      () => alive && setApp(null)
     );
     return () => {
       alive = false;
     };
-  }, [wantDirBody, path]);
+  }, [path, isDir]);
 
   // Placeholders need no fetch: nothing selected, or a multi-selection.
   if (!row) {
@@ -209,28 +244,113 @@ export default function ListingPreviewPane({
     );
   }
 
-  // Header: name + mode menu + Open. Shown for folders and for any templated
-  // view — the metadata card carries its own big-icon layout instead.
+  if (info.status === "loading") {
+    return (
+      <div className="listing-pane">
+        <div className="pane-skel" />
+      </div>
+    );
+  }
+  if (info.status === "error") {
+    return (
+      <div className="listing-pane">
+        <div className="pane-center">
+          <div className="status-message error">{info.message}</div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- the pane's mode list ---------------------------------------------------
+
+  // Registry templates the pane can embed as an iframe. `_listing` gets its
+  // own PaneMode below (folders — it mounts the embedded Listing, no iframe);
+  // on a FILE a `_listing` bind (rare registry rebind) is dropped entirely:
+  // the pane has no slot for a full listing of a file.
+  const allowed = (e: TemplateEntry) =>
+    !e.conditional || (info.conditions !== null && info.conditions[e.mode] === true);
+  const embeddable = info.templates.filter((e) => e.mode !== "_listing" && allowed(e));
+
+  const modes: PaneMode[] = embeddable.map((e) => ({
+    mode: e.mode,
+    title: modeTitle(e.mode),
+    icon: templateModeIcon(e),
+  }));
+  if (row.isDir) {
+    modes.push({
+      mode: "_listing",
+      title: modeTitle("_listing"),
+      icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
+    });
+    // App detection is a MODE, not a default: it only ever shows when picked.
+    if (app) {
+      modes.push({
+        mode: APP_MODE,
+        title: "App",
+        icon: <span className="pane-header-icon">{iconForEntry(app.name, false)}</span>,
+      });
+    }
+  }
+
+  // Default mode: the folder's/file's own first eligible template (same
+  // unconditional-first rule as Preview, CT-12); a folder without one falls
+  // back to `_listing`, a file to the metadata card (mode null).
+  const defaultEntry = embeddable.find((e) => !e.conditional) ?? embeddable[0] ?? null;
+  const activeMode =
+    modeOverride !== null && modes.some((m) => m.mode === modeOverride)
+      ? modeOverride
+      : defaultEntry
+        ? defaultEntry.mode
+        : row.isDir
+          ? "_listing"
+          : null;
+  const activeEntry = embeddable.find((e) => e.mode === activeMode) ?? null;
+
+  // All-conditional mode list, verdicts still in flight: keep the skeleton —
+  // the pane must not claim "no preview" while a gate may still allow one.
+  if (
+    !row.isDir &&
+    activeEntry === null &&
+    info.conditions === null &&
+    info.templates.some((e) => e.mode !== "_listing" && e.conditional)
+  ) {
+    return (
+      <div className="listing-pane">
+        <div className="pane-skel" />
+      </div>
+    );
+  }
+
+  // Header: name + mode menu + Open. Shown for every mode except the file
+  // metadata card, which carries its own big-icon layout instead.
   const header = (
     <div className="pane-header">
       <span className="pane-header-icon">{iconForEntry(row.name, row.isDir)}</span>
       <span className="pane-header-name" title={row.name}>
         {row.name}
       </span>
-      <PaneModeMenu
-        path={row.path}
-        query={modeOverride !== null ? `?_mode=${encodeURIComponent(modeOverride)}` : ""}
-        onNavigate={(q) =>
-          setModeOverride(new URLSearchParams(q.replace(/^\?/, "")).get("_mode"))
-        }
+      <PaneModeSelect
+        modes={modes}
+        active={activeMode ?? ""}
+        onSelect={(m) => setModeOverride(m)}
       />
-      <button
-        type="button"
-        className="pane-header-btn"
-        onClick={() => navigate(row.path, { isDir: row.isDir })}
-      >
-        Open
-      </button>
+      {activeMode === APP_MODE && app ? (
+        <button
+          type="button"
+          className="pane-header-btn"
+          onClick={() => window.open(viewUrlFor(app.path), "_blank", "noopener")}
+        >
+          Open app
+        </button>
+      ) : (
+        <button
+          type="button"
+          className="pane-header-btn"
+          onClick={() => navigate(row.path, { isDir: row.isDir })}
+        >
+          Open
+        </button>
+      )}
     </div>
   );
 
@@ -238,122 +358,47 @@ export default function ListingPreviewPane({
   // file itself (PT-12); a template mode renders the template against _file.
   const srcFor = (t: TemplateEntry): string => {
     if (t.mode === "_render") return `/render?path=${encodeURIComponent(row.path)}`;
-    const remote = info.status === "ok" && info.remote ? "&_remote=1" : "";
+    const remote = info.remote ? "&_remote=1" : "";
     return `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(row.path)}${remote}`;
   };
 
   let body: React.ReactNode;
-  if (info.status === "loading") {
-    body = <div className="pane-skel" />;
-  } else if (info.status === "error") {
-    body = (
-      <div className="pane-center">
-        <div className="status-message error">{info.message}</div>
-      </div>
-    );
-  } else if (active) {
+  if (activeEntry) {
     // Keyed on mode so switching modes replaces the iframe outright — never
     // reuse a live frame across different templates.
     body = (
       <>
         {header}
-        <iframe key={active.mode} className="pane-frame" src={srcFor(active)} title={row.name} />
+        <iframe
+          key={activeEntry.mode}
+          className="pane-frame"
+          src={srcFor(activeEntry)}
+          title={row.name}
+        />
       </>
     );
-  } else if (row.isDir && activeMode === "_listing") {
-    if (dirBody.status === "loading") {
-      body = (
-        <>
-          {header}
-          <div className="pane-skel" />
-        </>
-      );
-    } else if (dirBody.status === "error") {
-      body = (
-        <>
-          {header}
-          <div className="pane-center">
-            <div className="status-message error">{dirBody.message}</div>
-          </div>
-        </>
-      );
-    } else if (dirBody.status === "app") {
-      body = (
-        <>
-          <div className="pane-header">
-            <span className="pane-header-icon">{iconForEntry(dirBody.app.name, false)}</span>
-            <span className="pane-header-name" title={dirBody.app.name}>
-              {dirBody.app.name}
-            </span>
-            <PaneModeMenu
-              path={row.path}
-              query={modeOverride !== null ? `?_mode=${encodeURIComponent(modeOverride)}` : ""}
-              onNavigate={(q) =>
-                setModeOverride(new URLSearchParams(q.replace(/^\?/, "")).get("_mode"))
-              }
-            />
-            <button
-              type="button"
-              className="pane-header-btn"
-              onClick={() => window.open(viewUrlFor(dirBody.app.path), "_blank", "noopener")}
-            >
-              Open app
-            </button>
-          </div>
-          <iframe className="pane-frame" src={dirBody.src} title={row.name} />
-        </>
-      );
-    } else {
-      // Folder children. Clicking a child navigates the shell to it — the user
-      // is already one level in, so a click here means "go there".
-      body = (
-        <>
-          {header}
-          <div className="pane-mini-scroll">
-            <table className="pane-mini-list">
-              <tbody>
-                {dirBody.children.length === 0 ? (
-                  <tr>
-                    <td colSpan={2} className="status-message">
-                      Empty folder
-                    </td>
-                  </tr>
-                ) : (
-                  dirBody.children.map((c) => (
-                    <tr
-                      key={c.name}
-                      className={c.ignored ? "row ignored" : "row"}
-                      onClick={() => navigate(c.path, { isDir: c.is_dir })}
-                    >
-                      <td className="name">
-                        <span className="icon">{iconForEntry(c.name, c.is_dir)}</span>
-                        <span className="label">{c.name}</span>
-                      </td>
-                      <td className="size">{c.is_dir ? "" : formatSize(c.size)}</td>
-                    </tr>
-                  ))
-                )}
-                {dirBody.truncated && (
-                  <tr>
-                    <td colSpan={2} className="status-message">
-                      Showing first {dirBody.children.length} entries — folder listing is partial.
-                    </td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-        </>
-      );
-    }
-  } else if (
-    info.templates.some((e) => e.mode !== "_listing" && e.conditional) &&
-    info.conditions === null &&
-    modeOverride === null
-  ) {
-    // All-conditional mode list, verdicts still in flight: keep the skeleton —
-    // the pane must not claim "no preview" while a gate may still allow one.
-    body = <div className="pane-skel" />;
+  } else if (activeMode === APP_MODE && app) {
+    body = (
+      <>
+        {header}
+        <iframe
+          key={APP_MODE}
+          className="pane-frame"
+          src={`/render?path=${encodeURIComponent(app.path)}`}
+          title={app.name}
+        />
+      </>
+    );
+  } else if (activeMode === "_listing" && row.isDir) {
+    // The real shell Listing, embedded: full sorting/search/selection UI, but
+    // URL-silent, paneless and without document-level keyboard (see Listing's
+    // `embedded` prop).
+    body = (
+      <>
+        {header}
+        <Listing key={row.path} fsPath={row.path} embedded />
+      </>
+    );
   } else {
     // No embeddable template for a file: metadata card (icon, name, size, Open).
     body = (

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -1,12 +1,15 @@
 // Right-hand preview pane for the directory listing (views/Listing.tsx) —
 // selection-driven: previews the listing's lead row when exactly one row is
-// selected, and shows a neutral placeholder otherwise. Ported from the old
-// `preview` directory template so the pane reuses the app's own template
-// pipeline: a file is stat'ed to discover its default template and embedded
-// as the normal /render iframe; a folder shows its lone HTML "app" rendered
-// in place, or a read-only mini list of its children. Wire-up state (pane
-// visibility, width, the divider drag) stays in Listing — this component only
-// owns what the pane shows for a given selection.
+// selected, and shows a neutral placeholder otherwise. Reuses the app's own
+// template pipeline for FILES AND FOLDERS alike: the selection is stat'ed to
+// discover its template modes and the default embeds as the normal /render
+// iframe. A folder whose default resolves to the `_listing` sentinel (no
+// custom directory template) falls back to the lightweight in-pane view: its
+// lone HTML "app" rendered in place, or a read-only mini list of children.
+// The header carries a PaneModeMenu so the previewed mode can be switched
+// (pane-local, transient — it never touches the URL or saved viewstate).
+// Wire-up state (pane visibility, width, the divider drag) stays in Listing —
+// this component only owns what the pane shows for a given selection.
 import { useEffect, useState } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
 import type { FsEntry, TemplateEntry } from "@platform/lib/api";
@@ -14,6 +17,7 @@ import { navigate, VIEW_PREFIX } from "@platform/lib/router";
 import { formatSize } from "@platform/lib/format";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
 import { KNOWN_SENTINEL_MODES } from "@apps/explorer/ModeSwitcher";
+import PaneModeMenu from "@apps/explorer/PaneModeMenu";
 
 // The selected row, as the pane needs it. Structurally a subset of Listing's
 // RowCtx, so the lead row can be passed straight through.
@@ -28,19 +32,26 @@ interface PaneChild extends FsEntry {
   path: string;
 }
 
-// What the pane is currently showing for the selected row. Every async
-// resolution (stat for a file, listDir for a folder) lands in exactly one of
-// these; the loading skeleton covers the gap.
-type PaneState =
+// The stat'ed template picture for the selected row. `conditions` is null
+// while gated entries are still resolving (CT-12 deferred verdicts).
+interface PaneInfo {
+  templates: TemplateEntry[];
+  conditions: Record<string, boolean> | null;
+  size: number | null;
+  remote: boolean;
+}
+
+type InfoState =
   | { status: "loading" }
-  // A file with a bound template, or a folder's lone HTML app: an embedded
-  // /render iframe. The app case also carries a slim header (name + Open app).
-  | { status: "frame"; src: string; app: PaneChild | null }
-  // A file with no bound template: metadata card (icon, name, size, Open).
-  | { status: "meta"; size: number | null }
-  // A folder without a single app: its children, read-only.
-  | { status: "children"; children: PaneChild[]; truncated: boolean }
-  | { status: "error"; message: string };
+  | { status: "error"; message: string }
+  | ({ status: "ok" } & PaneInfo);
+
+// The `_listing` fallback for a folder: lone-app iframe or child mini-list.
+type DirBody =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "app"; src: string; app: PaneChild }
+  | { status: "children"; children: PaneChild[]; truncated: boolean };
 
 // Always the plain /view/ route, never /embed/ — an embed URL is meant to be
 // framed by a host page, so it would be the wrong thing to land in a fresh
@@ -77,99 +88,113 @@ export default function ListingPreviewPane({
   // Total selected rows, for the multi-selection placeholder.
   selCount: number;
 }) {
-  const [state, setState] = useState<PaneState>({ status: "loading" });
+  const [info, setInfo] = useState<InfoState>({ status: "loading" });
+  // Pane-local mode override from the mode menu; null = the default mode.
+  // The component is keyed on the previewed path (Listing), so this resets
+  // with every new selection — deliberately transient.
+  const [modeOverride, setModeOverride] = useState<string | null>(null);
+  const [dirBody, setDirBody] = useState<DirBody>({ status: "loading" });
 
-  // Resolve what the selected row previews as. The cleanup flag is the
+  // Stat the selection — files and folders alike carry a template mode list
+  // (folders at minimum the `_listing` sentinel). The cleanup flag is the
   // superseded-click guard: a stale async result for a row that's no longer
-  // selected must not render (the effect for the NEW row has already reset
-  // state to loading).
+  // selected must not render.
   const path = row?.path;
-  const isDir = row?.isDir;
   useEffect(() => {
     if (!path) return;
     let alive = true;
-    setState({ status: "loading" });
-    if (isDir) {
-      listDir(path).then(
-        (data) => {
-          if (!alive) return;
-          const dir = (data.path || path).replace(/\/+$/, "");
-          const children = data.entries.map((e) => ({ ...e, path: dir + "/" + e.name }));
-          // A truncated listing is only a partial page (server cap), so a lone
-          // HTML match in it doesn't prove it is the folder's ONLY one — fall
-          // through to the child list rather than render a maybe-wrong app
-          // (mirrors Listing's onSingleApp guard).
-          const apps = children.filter((e) => isAppEntry(e.name, e.is_dir));
-          if (!data.truncated && apps.length === 1) {
-            const app = apps[0];
-            setState({
-              status: "frame",
-              src: `/render?path=${encodeURIComponent(app.path)}`,
-              app,
-            });
-          } else {
-            setState({ status: "children", children: sortChildren(children), truncated: !!data.truncated });
-          }
-        },
-        (err: Error) => alive && setState({ status: "error", message: err.message })
-      );
-    } else {
-      statPath(path).then(
-        (st) => {
-          if (!alive) return;
-          const show = (t: TemplateEntry) => {
-            const remote = st.remote ? "&_remote=1" : "";
-            const src =
-              t.mode === "_render"
-                ? `/render?path=${encodeURIComponent(path)}`
-                : `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(path)}${remote}`;
-            setState({ status: "frame", src, app: null });
-          };
-          // Same defensive filter as Preview (SPEC PT-12): an entry with
-          // path===null whose mode isn't a recognized sentinel would build a
-          // `path=null` render URL, so drop it before choosing.
-          const templates = st.templates.filter(
-            (e) => e.path !== null || KNOWN_SENTINEL_MODES.has(e.mode)
-          );
-          // "_listing" mounts the shell's Listing component full-screen
-          // (Preview.tsx), not an iframe — the pane has no slot for that, so
-          // a registry bind putting "_listing" on a file (rare, but legal)
-          // must not fall into `show()` and build a `path=null` render URL.
-          // Skip it here; the pane still tries the file's other templates.
-          const embeddable = templates.filter((e) => e.mode !== "_listing");
-          // Same default-mode rule as Preview (CT-12): the first UNCONDITIONAL
-          // entry, which renders without waiting on any gate.
-          const t = embeddable.find((e) => !e.conditional);
-          if (t) {
-            show(t);
-            return;
-          }
-          // No unconditional entry. An ALL-conditional list still previews
-          // full-screen (Preview.defaultTemplate falls back to templates[0]
-          // once verdicts land), so the pane must not claim "no preview" —
-          // resolve the gates and show the first allowed one. Fail closed on
-          // an empty list or a broken gate: metadata card.
-          if (embeddable.length === 0) {
-            setState({ status: "meta", size: st.size });
-            return;
-          }
-          resolveConditions(path).then(
-            (r) => {
-              if (!alive) return;
-              const allowed = embeddable.find((e) => r.conditions[e.mode] === true);
-              if (allowed) show(allowed);
-              else setState({ status: "meta", size: st.size });
-            },
-            () => alive && setState({ status: "meta", size: st.size })
-          );
-        },
-        (err: Error) => alive && setState({ status: "error", message: err.message })
-      );
-    }
+    setInfo({ status: "loading" });
+    statPath(path).then(
+      (st) => {
+        if (!alive) return;
+        // Same defensive filter as Preview (SPEC PT-12): an entry with
+        // path===null whose mode isn't a recognized sentinel would build a
+        // `path=null` render URL, so drop it before choosing.
+        const templates = st.templates.filter(
+          (e) => e.path !== null || KNOWN_SENTINEL_MODES.has(e.mode)
+        );
+        const base: InfoState = {
+          status: "ok",
+          templates,
+          conditions: templates.some((e) => e.conditional) ? null : {},
+          size: st.size,
+          remote: !!st.remote,
+        };
+        setInfo(base);
+        if (base.conditions !== null) return;
+        resolveConditions(path).then(
+          (r) => alive && setInfo({ ...base, conditions: r.conditions }),
+          // Fail closed, like a broken gate: every gated entry reads denied.
+          () => alive && setInfo({ ...base, conditions: {} })
+        );
+      },
+      (err: Error) => alive && setInfo({ status: "error", message: err.message })
+    );
     return () => {
       alive = false;
     };
-  }, [path, isDir]);
+  }, [path]);
+
+  // --- choose the active mode ------------------------------------------------
+
+  // `_listing` mounts the shell's Listing component full-screen (Preview.tsx),
+  // not an iframe — the pane has no iframe slot for it. For folders it maps to
+  // the in-pane fallback below; on a file (a rare registry rebind) it is
+  // skipped when defaulting and shows the metadata card if picked explicitly.
+  let active: TemplateEntry | null = null; // entry to embed as an iframe
+  let activeMode: string | null = null; // includes "_listing" (no entry embed)
+  if (info.status === "ok") {
+    const embeddable = info.templates.filter((e) => e.mode !== "_listing");
+    const allowed = (e: TemplateEntry) =>
+      !e.conditional || (info.conditions !== null && info.conditions[e.mode] === true);
+    if (modeOverride !== null) {
+      activeMode = modeOverride;
+      active = embeddable.find((e) => e.mode === modeOverride && allowed(e)) ?? null;
+    } else {
+      // Same default-mode rule as Preview (CT-12): the first UNCONDITIONAL
+      // entry; an all-conditional list waits for verdicts and takes the first
+      // allowed one. No embeddable default → folders fall back to `_listing`,
+      // files to the metadata card.
+      const t = embeddable.find((e) => !e.conditional) ?? embeddable.find(allowed) ?? null;
+      active = t;
+      activeMode = t ? t.mode : row?.isDir ? "_listing" : null;
+    }
+  }
+
+  // --- the `_listing` folder fallback -----------------------------------------
+
+  const wantDirBody = info.status === "ok" && !!row?.isDir && activeMode === "_listing";
+  useEffect(() => {
+    if (!wantDirBody || !path) return;
+    let alive = true;
+    setDirBody({ status: "loading" });
+    listDir(path).then(
+      (data) => {
+        if (!alive) return;
+        const dir = (data.path || path).replace(/\/+$/, "");
+        const children = data.entries.map((e) => ({ ...e, path: dir + "/" + e.name }));
+        // A truncated listing is only a partial page (server cap), so a lone
+        // HTML match in it doesn't prove it is the folder's ONLY one — fall
+        // through to the child list rather than render a maybe-wrong app
+        // (mirrors Listing's onSingleApp guard).
+        const apps = children.filter((e) => isAppEntry(e.name, e.is_dir));
+        if (!data.truncated && apps.length === 1) {
+          const app = apps[0];
+          setDirBody({ status: "app", src: `/render?path=${encodeURIComponent(app.path)}`, app });
+        } else {
+          setDirBody({
+            status: "children",
+            children: sortChildren(children),
+            truncated: !!data.truncated,
+          });
+        }
+      },
+      (err: Error) => alive && setDirBody({ status: "error", message: err.message })
+    );
+    return () => {
+      alive = false;
+    };
+  }, [wantDirBody, path]);
 
   // Placeholders need no fetch: nothing selected, or a multi-selection.
   if (!row) {
@@ -184,102 +209,168 @@ export default function ListingPreviewPane({
     );
   }
 
+  // Header: name + mode menu + Open. Shown for folders and for any templated
+  // view — the metadata card carries its own big-icon layout instead.
+  const header = (
+    <div className="pane-header">
+      <span className="pane-header-icon">{iconForEntry(row.name, row.isDir)}</span>
+      <span className="pane-header-name" title={row.name}>
+        {row.name}
+      </span>
+      <PaneModeMenu
+        path={row.path}
+        query={modeOverride !== null ? `?_mode=${encodeURIComponent(modeOverride)}` : ""}
+        onNavigate={(q) =>
+          setModeOverride(new URLSearchParams(q.replace(/^\?/, "")).get("_mode"))
+        }
+      />
+      <button
+        type="button"
+        className="pane-header-btn"
+        onClick={() => navigate(row.path, { isDir: row.isDir })}
+      >
+        Open
+      </button>
+    </div>
+  );
+
+  // The /render embed URL for a chosen template entry. "_render" renders the
+  // file itself (PT-12); a template mode renders the template against _file.
+  const srcFor = (t: TemplateEntry): string => {
+    if (t.mode === "_render") return `/render?path=${encodeURIComponent(row.path)}`;
+    const remote = info.status === "ok" && info.remote ? "&_remote=1" : "";
+    return `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(row.path)}${remote}`;
+  };
+
   let body: React.ReactNode;
-  if (state.status === "loading") {
+  if (info.status === "loading") {
     body = <div className="pane-skel" />;
-  } else if (state.status === "error") {
+  } else if (info.status === "error") {
     body = (
       <div className="pane-center">
-        <div className="status-message error">{state.message}</div>
+        <div className="status-message error">{info.message}</div>
       </div>
     );
-  } else if (state.status === "frame") {
+  } else if (active) {
+    // Keyed on mode so switching modes replaces the iframe outright — never
+    // reuse a live frame across different templates.
     body = (
       <>
-        {state.app && (
+        {header}
+        <iframe key={active.mode} className="pane-frame" src={srcFor(active)} title={row.name} />
+      </>
+    );
+  } else if (row.isDir && activeMode === "_listing") {
+    if (dirBody.status === "loading") {
+      body = (
+        <>
+          {header}
+          <div className="pane-skel" />
+        </>
+      );
+    } else if (dirBody.status === "error") {
+      body = (
+        <>
+          {header}
+          <div className="pane-center">
+            <div className="status-message error">{dirBody.message}</div>
+          </div>
+        </>
+      );
+    } else if (dirBody.status === "app") {
+      body = (
+        <>
           <div className="pane-header">
-            <span className="pane-header-icon">{iconForEntry(state.app.name, false)}</span>
-            <span className="pane-header-name" title={state.app.name}>
-              {state.app.name}
+            <span className="pane-header-icon">{iconForEntry(dirBody.app.name, false)}</span>
+            <span className="pane-header-name" title={dirBody.app.name}>
+              {dirBody.app.name}
             </span>
+            <PaneModeMenu
+              path={row.path}
+              query={modeOverride !== null ? `?_mode=${encodeURIComponent(modeOverride)}` : ""}
+              onNavigate={(q) =>
+                setModeOverride(new URLSearchParams(q.replace(/^\?/, "")).get("_mode"))
+              }
+            />
             <button
               type="button"
               className="pane-header-btn"
-              onClick={() => window.open(viewUrlFor(state.app!.path), "_blank", "noopener")}
+              onClick={() => window.open(viewUrlFor(dirBody.app.path), "_blank", "noopener")}
             >
               Open app
             </button>
           </div>
-        )}
-        <iframe className="pane-frame" src={state.src} title={row.name} />
-      </>
-    );
-  } else if (state.status === "meta") {
+          <iframe className="pane-frame" src={dirBody.src} title={row.name} />
+        </>
+      );
+    } else {
+      // Folder children. Clicking a child navigates the shell to it — the user
+      // is already one level in, so a click here means "go there".
+      body = (
+        <>
+          {header}
+          <div className="pane-mini-scroll">
+            <table className="pane-mini-list">
+              <tbody>
+                {dirBody.children.length === 0 ? (
+                  <tr>
+                    <td colSpan={2} className="status-message">
+                      Empty folder
+                    </td>
+                  </tr>
+                ) : (
+                  dirBody.children.map((c) => (
+                    <tr
+                      key={c.name}
+                      className={c.ignored ? "row ignored" : "row"}
+                      onClick={() => navigate(c.path, { isDir: c.is_dir })}
+                    >
+                      <td className="name">
+                        <span className="icon">{iconForEntry(c.name, c.is_dir)}</span>
+                        <span className="label">{c.name}</span>
+                      </td>
+                      <td className="size">{c.is_dir ? "" : formatSize(c.size)}</td>
+                    </tr>
+                  ))
+                )}
+                {dirBody.truncated && (
+                  <tr>
+                    <td colSpan={2} className="status-message">
+                      Showing first {dirBody.children.length} entries — folder listing is partial.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      );
+    }
+  } else if (
+    info.templates.some((e) => e.mode !== "_listing" && e.conditional) &&
+    info.conditions === null &&
+    modeOverride === null
+  ) {
+    // All-conditional mode list, verdicts still in flight: keep the skeleton —
+    // the pane must not claim "no preview" while a gate may still allow one.
+    body = <div className="pane-skel" />;
+  } else {
+    // No embeddable template for a file: metadata card (icon, name, size, Open).
     body = (
       <div className="pane-center">
         <div className="pane-big-icon">{iconForEntry(row.name, false)}</div>
         <div className="pane-title">{row.name}</div>
         <div className="pane-hint">
-          No preview for this file type{state.size !== null ? ` — ${formatSize(state.size)}` : ""}.
+          No preview for this file type{info.size !== null ? ` — ${formatSize(info.size)}` : ""}.
         </div>
-        <button type="button" className="pane-open-btn" onClick={() => navigate(row.path, { isDir: false })}>
+        <button
+          type="button"
+          className="pane-open-btn"
+          onClick={() => navigate(row.path, { isDir: false })}
+        >
           Open
         </button>
       </div>
-    );
-  } else {
-    // Folder children. Clicking a child navigates the shell to it — the user
-    // is already one level in, so a click here means "go there".
-    body = (
-      <>
-        <div className="pane-header">
-          <span className="pane-header-icon">{iconForEntry(row.name, true)}</span>
-          <span className="pane-header-name" title={row.name}>
-            {row.name}
-          </span>
-          <button
-            type="button"
-            className="pane-header-btn"
-            onClick={() => navigate(row.path, { isDir: true })}
-          >
-            Open folder
-          </button>
-        </div>
-        <div className="pane-mini-scroll">
-          <table className="pane-mini-list">
-            <tbody>
-              {state.children.length === 0 ? (
-                <tr>
-                  <td colSpan={2} className="status-message">
-                    Empty folder
-                  </td>
-                </tr>
-              ) : (
-                state.children.map((c) => (
-                  <tr
-                    key={c.name}
-                    className={c.ignored ? "row ignored" : "row"}
-                    onClick={() => navigate(c.path, { isDir: c.is_dir })}
-                  >
-                    <td className="name">
-                      <span className="icon">{iconForEntry(c.name, c.is_dir)}</span>
-                      <span className="label">{c.name}</span>
-                    </td>
-                    <td className="size">{c.is_dir ? "" : formatSize(c.size)}</td>
-                  </tr>
-                ))
-              )}
-              {state.truncated && (
-                <tr>
-                  <td colSpan={2} className="status-message">
-                    Showing first {state.children.length} entries — folder listing is partial.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
-      </>
     );
   }
 

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -11,13 +11,13 @@
 // the URL or saved viewstate). Wire-up state (pane visibility, width, the
 // divider drag) stays in Listing — this component only owns what the pane
 // shows for a given selection.
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useEffect, useState } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
 import type { TemplateEntry } from "@platform/lib/api";
 import { navigate, VIEW_PREFIX } from "@platform/lib/router";
 import { formatSize } from "@platform/lib/format";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
-import { KNOWN_SENTINEL_MODES, modeTitle, templateModeIcon } from "@apps/explorer/ModeSwitcher";
+import ModeSwitcher, { KNOWN_SENTINEL_MODES, templateModeIcon } from "@apps/explorer/ModeSwitcher";
 import Listing from "@apps/explorer/Listing";
 
 // The selected row, as the pane needs it. Structurally a subset of Listing's
@@ -57,10 +57,10 @@ interface AppTarget {
   path: string;
 }
 
-// One entry of the pane's mode menu (template modes + the pane's sentinels).
+// One entry of the pane's mode switcher (template modes + pane sentinels) —
+// the shape ModeSwitcher takes.
 interface PaneMode {
   mode: string;
-  title: string;
   icon: React.ReactNode;
 }
 
@@ -76,77 +76,6 @@ function viewUrlFor(fsPath: string): string {
     .map(encodeURIComponent)
     .join("/");
   return VIEW_PREFIX + encoded;
-}
-
-// The pane's own mode dropdown. PaneModeMenu (Panel/Tabs chrome) stats its
-// path itself and only knows registry modes; the pane's list is richer (the
-// synthetic `_app` mode) and already stat'ed here, so this menu is fed the
-// finished list instead. Same look: pane-mode-* classes, fixed-position
-// dropdown, closes on outside pointerdown / window blur.
-function PaneModeSelect({
-  modes,
-  active,
-  onSelect,
-}: {
-  modes: PaneMode[];
-  active: string;
-  onSelect: (mode: string) => void;
-}) {
-  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
-  const rootRef = useRef<HTMLSpanElement | null>(null);
-
-  useEffect(() => {
-    if (!pos) return;
-    const onDown = (e: PointerEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setPos(null);
-    };
-    const onBlur = () => setPos(null);
-    document.addEventListener("pointerdown", onDown);
-    window.addEventListener("blur", onBlur);
-    return () => {
-      document.removeEventListener("pointerdown", onDown);
-      window.removeEventListener("blur", onBlur);
-    };
-  }, [pos]);
-
-  if (modes.length < 2) return null;
-  const current = modes.find((m) => m.mode === active) ?? modes[0];
-
-  const toggle = (e: MouseEvent) => {
-    e.stopPropagation();
-    if (pos) {
-      setPos(null);
-      return;
-    }
-    const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-    setPos({ top: r.bottom + 4, left: Math.max(0, Math.min(r.left, window.innerWidth - 150)) });
-  };
-
-  return (
-    <span className="pane-mode-menu" ref={rootRef}>
-      <span className="pane-mode-btn" title={"Mode: " + current.title} onClick={toggle}>
-        {current.icon}
-      </span>
-      {pos && (
-        <span className="pane-mode-dropdown" style={{ top: pos.top, left: pos.left }}>
-          {modes.map((m) => (
-            <span
-              key={m.mode}
-              className={"pane-mode-item" + (m.mode === current.mode ? " active" : "")}
-              onClick={(e) => {
-                e.stopPropagation();
-                setPos(null);
-                onSelect(m.mode);
-              }}
-            >
-              {m.icon}
-              <span>{m.title}</span>
-            </span>
-          ))}
-        </span>
-      )}
-    </span>
-  );
 }
 
 export default function ListingPreviewPane({
@@ -277,23 +206,20 @@ export default function ListingPreviewPane({
 
   const modes: PaneMode[] = embeddable.map((e) => ({
     mode: e.mode,
-    title: modeTitle(e.mode),
     icon: templateModeIcon(e),
   }));
   if (row.isDir) {
-    // The lone app outranks the listing: it leads the menu and wins the
+    // The lone app outranks the listing: it leads the switcher and wins the
     // default below when the folder has no template of its own.
     if (app) {
       modes.push({
         mode: APP_MODE,
-        title: "App",
         icon: <span className="pane-header-icon">{iconForEntry(app.name, false)}</span>,
       });
     }
     if (!row.self) {
       modes.push({
         mode: "_listing",
-        title: modeTitle("_listing"),
         icon: templateModeIcon({ mode: "_listing", path: null } as TemplateEntry),
       });
     }
@@ -359,11 +285,9 @@ export default function ListingPreviewPane({
       <span className="pane-header-name" title={row.name}>
         {row.name}
       </span>
-      <PaneModeSelect
-        modes={modes}
-        active={activeMode ?? ""}
-        onSelect={(m) => setModeOverride(m)}
-      />
+      {/* Horizontal icon strip, same look as the shell preview header (PT-10):
+          every available mode side by side, active one highlighted. */}
+      <ModeSwitcher entries={modes} active={activeMode ?? ""} onSelect={(m) => setModeOverride(m)} />
       {activeMode === APP_MODE && app ? (
         <button
           type="button"

--- a/frontend/src/apps/explorer/ModeSwitcher.tsx
+++ b/frontend/src/apps/explorer/ModeSwitcher.tsx
@@ -29,6 +29,7 @@ export interface ModeSwitcherEntry<M extends string> {
 export function modeTitle(mode: string): string {
   if (mode === "_render") return "Rendered";
   if (mode === "_listing") return "Listing";
+  if (mode === "_app") return "App"; // pane-only sentinel (ListingPreviewPane)
   return mode.charAt(0).toUpperCase() + mode.slice(1);
 }
 

--- a/frontend/src/apps/explorer/listing/pane.ts
+++ b/frontend/src/apps/explorer/listing/pane.ts
@@ -60,7 +60,10 @@ function savePaneState(fsPath: string, on: boolean, width: number | null): void 
   setViewState(fsPath, qs ? "?" + qs : "");
 }
 
-export function usePreviewPane(fsPath: string) {
+// `enabled=false` (an embedded Listing — the preview pane's own `_listing`
+// mode) turns the whole feature off at the source: the pane never resolves
+// from URL/viewstate, stays off, and the toggle is inert — no nesting.
+export function usePreviewPane(fsPath: string, enabled = true) {
   // Visibility restores URL-first (resolvePane: `?preview=true` wins, then the
   // folder's saved viewstate); width is viewstate-only. Toggling writes BOTH:
   // the URL (replaceSearch, like setSort — on sets `preview=true`, off deletes
@@ -68,7 +71,9 @@ export function usePreviewPane(fsPath: string) {
   // sticky) and the viewstate (so a folder re-opened from a clean URL
   // remembers). Width is clamped live during the divider drag; the max
   // fraction is enforced against the split container's current size.
-  const [pane, setPane] = useState<{ on: boolean; width: number | null }>(() => resolvePane(fsPath));
+  const [pane, setPane] = useState<{ on: boolean; width: number | null }>(() =>
+    enabled ? resolvePane(fsPath) : { on: false, width: null }
+  );
   const splitRef = useRef<HTMLDivElement>(null);
   // Is `pane.width` a width the USER chose (restored from `panew`, or dragged
   // this session), as opposed to the measured half-container default? Only a
@@ -88,6 +93,7 @@ export function usePreviewPane(fsPath: string) {
   }, [pane.on, pane.width]);
 
   const togglePane = () => {
+    if (!enabled) return;
     setPane((prev) => {
       const next = { ...prev, on: !prev.on };
       const params = new URLSearchParams(location.search);

--- a/frontend/src/apps/explorer/listing/sorting.ts
+++ b/frontend/src/apps/explorer/listing/sorting.ts
@@ -9,9 +9,16 @@ import { SORT_KEYS, type SortKey, type SortOrder } from "@apps/explorer/listing/
 // folder shows its own remembered order regardless of how it was reached
 // (clicked into, a breadcrumb, Back, or a fresh URL), and sibling folders keep
 // independent sorts.
-export function resolveSort(fsPath: string): { sort: SortKey; order: SortOrder } {
+// `urlWins=false` (an embedded Listing): the address bar belongs to the HOST
+// view, so its sort/order must not seed the previewed folder — only that
+// folder's own saved viewstate (or the default) applies.
+export function resolveSort(
+  fsPath: string,
+  urlWins = true
+): { sort: SortKey; order: SortOrder } {
   const url = new URLSearchParams(location.search);
-  const src = url.get("sort") ? url : new URLSearchParams(getViewState(fsPath));
+  const src =
+    urlWins && url.get("sort") ? url : new URLSearchParams(getViewState(fsPath));
   const key = src.get("sort");
   const sort: SortKey = key && key in SORT_KEYS ? (key as SortKey) : "name";
   const order: SortOrder = src.get("order") === "desc" ? "desc" : "asc";

--- a/frontend/src/apps/explorer/listing/useListingSelection.ts
+++ b/frontend/src/apps/explorer/listing/useListingSelection.ts
@@ -347,6 +347,7 @@ export function useListingSelection({
     selectOnly,
     toggleSelected,
     extendTo,
+    clearSelection,
     pendingSelectRef,
   };
 }

--- a/frontend/src/apps/explorer/listing/useListingSelection.ts
+++ b/frontend/src/apps/explorer/listing/useListingSelection.ts
@@ -23,6 +23,7 @@ export function useListingSelection({
   searchInputRef,
   rowCtxByPathRef,
   overlayOpenRef,
+  globalKeys = true,
 }: {
   fsPath: string;
   // Flat, ordered list of the paths the arrow keys step through (the rendered
@@ -39,6 +40,10 @@ export function useListingSelection({
   // document-level nav handler hard-guards on this so an open overlay owns the
   // keyboard — a stray Enter can't navigate a row behind the dialog.
   overlayOpenRef: React.MutableRefObject<boolean>;
+  // False for an EMBEDDED Listing (the preview pane's `_listing` mode): the
+  // document-level keyboard belongs to the host view's own Listing, so the
+  // embedded one keeps mouse selection but registers no global handlers.
+  globalKeys?: boolean;
 }) {
   // The selected rows (see Selection): one for a plain click / arrow move, many
   // for a Shift-range, Mod-click toggle or Select All. Seeded from the
@@ -143,6 +148,7 @@ export function useListingSelection({
   // are deliberately left to the shortcut handler (see Listing.tsx).
   // Bound to `document` so it also drives the plain listing with nothing focused.
   useEffect(() => {
+    if (!globalKeys) return;
     function onKeyDown(e: KeyboardEvent) {
       // While an IME is composing, Enter confirms a candidate and the arrows
       // move through the candidate list — never repurpose them for navigation.
@@ -245,7 +251,8 @@ export function useListingSelection({
     }
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, []);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [globalKeys]);
 
   // Keep the keyboard selection scrolled into view as it moves. Follows the LEAD
   // row (`.lead`), not merely the first selected one: extending a Shift-range

--- a/frontend/src/apps/explorer/listing/useListingSelection.ts
+++ b/frontend/src/apps/explorer/listing/useListingSelection.ts
@@ -2,7 +2,7 @@
 // selection model, the document-level arrow/Home/End/PageUp/Enter handler,
 // the post-mutation reconcile (re-anchor by path), and scroll-into-view.
 import { useEffect, useMemo, useRef, useState } from "react";
-import { navigate } from "@platform/lib/router";
+import { navigate, replaceSearch } from "@platform/lib/router";
 import { isMod } from "@platform/lib/platform";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import type { RowCtx } from "@apps/explorer/listing/types";
@@ -24,6 +24,7 @@ export function useListingSelection({
   rowCtxByPathRef,
   overlayOpenRef,
   globalKeys = true,
+  urlSync = true,
 }: {
   fsPath: string;
   // Flat, ordered list of the paths the arrow keys step through (the rendered
@@ -44,6 +45,9 @@ export function useListingSelection({
   // document-level keyboard belongs to the host view's own Listing, so the
   // embedded one keeps mouse selection but registers no global handlers.
   globalKeys?: boolean;
+  // False for an embedded Listing: the address bar belongs to the host view,
+  // so the lead row is never mirrored to (or seeded from) `?sel`.
+  urlSync?: boolean;
 }) {
   // The selected rows (see Selection): one for a plain click / arrow move, many
   // for a Shift-range, Mod-click toggle or Select All. Seeded from the
@@ -69,6 +73,39 @@ export function useListingSelection({
   useEffect(() => {
     rememberSelection(fsPath, sel);
   }, [fsPath, sel]);
+
+  // URL sync for the lead row (like `preview`/`sort`): `?sel=<path relative
+  // to this folder>` so a refreshed or shared URL restores the selection —
+  // and with it the preview pane's content. navigate() drops the param on
+  // folder navigation (only `preview` is sticky), so it never leaks.
+  //   • Seed ONCE, after the listing has loaded: a recalled (cross-remount)
+  //     selection outranks the URL, and a `sel` naming no current row is
+  //     simply ignored (no forced selection).
+  //   • Mirror only after the seed decision, so the initial no-selection
+  //     render can't wipe the param before it was read.
+  const urlSelSeededRef = useRef(false);
+  useEffect(() => {
+    if (!urlSync || urlSelSeededRef.current || !listingLoaded) return;
+    urlSelSeededRef.current = true;
+    const rel = new URLSearchParams(location.search).get("sel");
+    if (!rel || selRef.current.paths.length) return;
+    const abs = fsPath.replace(/\/+$/, "") + "/" + rel;
+    if (navRows.includes(abs)) setSel(oneSelected(abs));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlSync, listingLoaded, navRows, fsPath]);
+  useEffect(() => {
+    if (!urlSync || !urlSelSeededRef.current) return;
+    const base = fsPath.replace(/\/+$/, "");
+    const rel =
+      sel.lead && sel.lead.startsWith(base + "/") ? sel.lead.slice(base.length + 1) : null;
+    const params = new URLSearchParams(location.search);
+    if (params.get("sel") === rel) return; // already in step (incl. both absent)
+    if (rel !== null) params.set("sel", rel);
+    else params.delete("sel");
+    const qs = params.toString();
+    replaceSearch(location.pathname + (qs ? "?" + qs : ""));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlSync, sel.lead, fsPath]);
 
   // A path the selection should jump to once it appears in the reloaded rows
   // (a rename/duplicate target — its row doesn't exist until the refetch lands).

--- a/frontend/src/apps/explorer/listing/useListingShortcuts.ts
+++ b/frontend/src/apps/explorer/listing/useListingShortcuts.ts
@@ -28,6 +28,7 @@ export function useListingShortcuts({
   doTrash,
   startRename,
   startNewFolder,
+  globalKeys = true,
 }: {
   base: string;
   clipboard: Clipboard | null;
@@ -44,6 +45,9 @@ export function useListingShortcuts({
   doTrash: (rows: RowCtx[]) => void;
   startRename: (row: RowCtx) => void;
   startNewFolder: (dir: string) => void;
+  // False for an embedded Listing (preview pane): the document-level file-op
+  // chords belong to the host view's Listing.
+  globalKeys?: boolean;
 }) {
   const shortcutRef = useRef<(e: KeyboardEvent) => void>(() => {});
   shortcutRef.current = (e: KeyboardEvent) => {
@@ -146,8 +150,9 @@ export function useListingShortcuts({
     }
   };
   useEffect(() => {
+    if (!globalKeys) return;
     const h = (e: KeyboardEvent) => shortcutRef.current(e);
     document.addEventListener("keydown", h);
     return () => document.removeEventListener("keydown", h);
-  }, []);
+  }, [globalKeys]);
 }

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -30,8 +30,11 @@ function currentQuery(): string {
   return new URLSearchParams(location.search).get("q") || "";
 }
 
-export function useWalkSearch(fsPath: string, refresh: number) {
-  const [query, setQueryState] = useState<string>(currentQuery);
+// `urlSync=false` (an embedded Listing, e.g. the preview pane's `_listing`
+// mode) keeps the query fully local: it neither seeds from ?q nor mirrors
+// keystrokes back to the address bar — that URL belongs to the host view.
+export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
+  const [query, setQueryState] = useState<string>(() => (urlSync ? currentQuery() : ""));
   const [walk, setWalk] = useState<WalkState>(IDLE_WALK);
   // Which refresh generation of the walk has been REQUESTED (null = none).
   // The fetch effect keys on this, not on `refresh` itself: a dir-watch bump
@@ -39,7 +42,7 @@ export function useWalkSearch(fsPath: string, refresh: number) {
   // happens only while search is active (auto-request effect) or on the next
   // gesture — an idle listing must not re-walk the tree on every watch event.
   const [walkReq, setWalkReq] = useState<number | null>(() =>
-    currentQuery().trim() !== "" ? 0 : null
+    urlSync && currentQuery().trim() !== "" ? 0 : null
   );
   // Bumped to re-run the stream effect after an error, from a real user
   // gesture only (focus / typing) — an effect-driven retry would loop forever.
@@ -174,6 +177,7 @@ export function useWalkSearch(fsPath: string, refresh: number) {
       setWalkReq(refresh);
       setRetryNonce((n) => n + 1);
     }
+    if (!urlSync) return;
     if (urlTimer.current !== null) clearTimeout(urlTimer.current);
     urlTimer.current = setTimeout(() => {
       const params = new URLSearchParams(location.search);

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1301,6 +1301,42 @@ a.bookmark-name::after {
   display: inline-flex;
 }
 
+/* The pane header's mode switcher: same icon strip as the preview header
+   (PT-10) but compact and quiet, sized to the slim pane bar — borderless
+   ghost buttons, accent only on the active mode. */
+.listing-pane .pane-header .mode-switcher {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.listing-pane .pane-header .mode-switcher-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.listing-pane .pane-header .mode-switcher-btn:hover {
+  background: var(--bg);
+  border-color: var(--border);
+  color: var(--fg);
+}
+
+.listing-pane .pane-header .mode-switcher-btn.active {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--on-accent);
+}
+
 .listing-pane .pane-header-name {
   flex: 1 1 auto;
   overflow: hidden;

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1157,8 +1157,19 @@ a.bookmark-name::after {
    resize that narrows the container under an already-sized pane. Scoped to the
    split-with-pane case — a paneless listing in a narrow panel/tab keeps
    shrinking as it always did. */
-.listing-split:has(.listing-pane-slot) > .listing-scroll {
+.listing-split:has(.listing-pane-slot) > .listing-main {
   min-width: 220px;
+}
+
+/* Left column of the split: search header pinned above the scrolling table.
+   With the pane on, the pane spans the template's full height while search
+   and the split toggle stay in this column. */
+.listing-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 /* Split body when the preview pane is on: table on the left, a draggable

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -241,8 +241,27 @@ def _bad_id(value: str) -> bool:
     return not value or value.startswith(".") or any(c in value for c in "/\\:")
 
 
+def _cwd_of(file: str) -> str:
+    """Claude's working directory for a target: the file's parent directory,
+    or the directory ITSELF when the target is one (a directory registry key,
+    e.g. the universal "/" binding, D81). Every transcript project-dir lookup
+    is keyed off this, so all callers must agree."""
+    return file if os.path.isdir(file) else os.path.dirname(file)
+
+
 def _system_prompt(file: str) -> str:
-    name = os.path.basename(file)
+    name = os.path.basename(file.rstrip("/")) or file
+    if os.path.isdir(file):
+        return (
+            f"You are embedded in a local file explorer, opened on the "
+            f"folder {file}. The user is looking at {name} right now; treat "
+            "that folder as the subject of this conversation — answer "
+            "questions about its contents and make requested changes inside "
+            "it. Keep your work scoped to this folder unless the user "
+            "explicitly asks for something broader. This is guidance, not a "
+            "hard rule: follow explicit user instructions even when they go "
+            "beyond the folder."
+        )
     return (
         f"You are embedded in a local file viewer, opened on {file}. "
         f"The user is looking at {name} right now; treat that file as the "
@@ -313,7 +332,7 @@ def _record_session(file: str, session_id: str, message: str,
     """
     data = _load_sidecar(file)
     now = time.time()
-    cwd = os.path.dirname(file)
+    cwd = _cwd_of(file)
     for entry in data["claudeSessions"]:
         if entry.get("id") in (session_id, resumed_from):
             entry["id"] = session_id
@@ -349,7 +368,7 @@ def _migrate_session(file: str, session_id: str) -> None:
     means claude reports the session as not found."""
     if _bad_id(session_id):
         return
-    new_cwd = os.path.dirname(file)
+    new_cwd = _cwd_of(file)
     dest_dir = os.path.join(PROJECTS, _munge(new_cwd))
     dest = os.path.join(dest_dir, session_id + ".jsonl")
 
@@ -727,8 +746,10 @@ def _start(file: str, message: str, session_id: str, model: str,
            effort: str, permission_mode: str = "",
            message_via_stdin: bool = False) -> dict:
     file = os.path.abspath(file)
-    if not os.path.isfile(file):
-        return {"error": f"target file not found: {file}"}
+    # Directories are legal targets too (a directory registry key, e.g. the
+    # universal "/" binding) — claude then runs WITH the folder as its cwd.
+    if not os.path.exists(file):
+        return {"error": f"target not found: {file}"}
     if session_id:
         _migrate_session(file, session_id)
 
@@ -799,7 +820,7 @@ def _start(file: str, message: str, session_id: str, model: str,
         with _private_open(os.path.join(run_dir, "out.jsonl")) as out, \
              _private_open(os.path.join(run_dir, "err.log")) as err:
             proc = subprocess.Popen(cmd, stdout=out, stderr=err,
-                                    cwd=os.path.dirname(file),
+                                    cwd=_cwd_of(file),
                                     stdin=stdin_fh or subprocess.DEVNULL,
                                     **_DETACH)
     finally:
@@ -1060,7 +1081,7 @@ def _history(file: str, session_id: str) -> dict:
         return {"turns": []}
     file = os.path.abspath(file)
     _migrate_session(file, session_id)
-    path = os.path.join(PROJECTS, _munge(os.path.dirname(file)),
+    path = os.path.join(PROJECTS, _munge(_cwd_of(file)),
                         session_id + ".jsonl")
     if not os.path.isfile(path):
         return {"turns": []}

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -483,6 +483,7 @@
   "/": [
     "_listing",
     "claude_split",
+    "claude",
     "versions",
     "git",
     "graph",

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -175,7 +175,7 @@ def test_gated_directory_peers_follow_the_listing():
     # and the raw commit log sits one click further (#361).
     got, error = modes("/x/somedir", is_dir=True)
     assert error is None
-    assert got == ["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"]
+    assert got == ["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"]
 
 
 def test_git_ships_a_condition_gate_and_an_icon():
@@ -226,9 +226,9 @@ def test_unmapped_file_empty_and_plain_dir_lists():
     # `zarr_aoi` — for a plain folder, a dotted folder and the filesystem root
     # alike. Each gated mode is dropped unless its condition.py says otherwise;
     # see tests/test_graph_condition.py and the zarr_aoi tests below.
-    assert modes("/x/somedir", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
-    assert modes("/x/my.data", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
-    assert modes("/", is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/somedir", is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/my.data", is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes("/", is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
 
 
 # --------------------------------------------- text sniff for unmapped files
@@ -661,7 +661,7 @@ def test_registry_drops_zarr_template_and_sentinel_keys():
     assert server._resolve_name("zarr")[0] is None
     # zarr_aoi is the .zarr/ default and a gated candidate on every directory
     assert registry[".zarr/"] == ["zarr_aoi", "_listing"]
-    assert registry["/"] == ["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"]
+    assert registry["/"] == ["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"]
 
 
 def test_zarr_named_dir_gate_true_with_no_markers(tmp_path):
@@ -686,7 +686,7 @@ def test_plain_dir_with_store_marker_gates_true(tmp_path, marker):
     store = tmp_path / "data"
     store.mkdir()
     (store / marker).write_text("{}")
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
     assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
@@ -698,7 +698,7 @@ def test_v3_group_dir_offered(tmp_path):
     store = tmp_path / "grp"
     store.mkdir()
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "group"}')
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
     assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": True} and err is None
@@ -749,7 +749,7 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     store = tmp_path / "plain"
     store.mkdir()
     (store / "readme.txt").write_text("hi")
-    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "versions", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "claude_split", "claude", "versions", "git", "graph", "zarr_aoi"], None)
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
     assert cond == {"claude_split": False, "git": False, "versions": False, "graph": False, "zarr_aoi": False} and err is None
@@ -757,10 +757,11 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     entries, _ = server._templates_for(str(store), True)
     assert entries[0]["mode"] == "_listing" and "conditional" not in entries[0]
     assert entries[1]["mode"] == "claude_split" and entries[1].get("conditional") is True
-    assert entries[2]["mode"] == "versions" and entries[2].get("conditional") is True
-    assert entries[3]["mode"] == "git" and entries[3].get("conditional") is True
-    assert entries[4]["mode"] == "graph" and entries[4].get("conditional") is True
-    assert entries[5]["mode"] == "zarr_aoi" and entries[5].get("conditional") is True
+    assert entries[2]["mode"] == "claude" and "conditional" not in entries[2]
+    assert entries[3]["mode"] == "versions" and entries[3].get("conditional") is True
+    assert entries[4]["mode"] == "git" and entries[4].get("conditional") is True
+    assert entries[5]["mode"] == "graph" and entries[5].get("conditional") is True
+    assert entries[6]["mode"] == "zarr_aoi" and entries[6].get("conditional") is True
 
 
 def test_zarr_condition_fail_closed(tmp_path):


### PR DESCRIPTION
## Summary

Reworks the listing's right-side preview pane from a file-only iframe + folder mini-list into a full template-driven surface, and makes folders first-class targets for it.

### Layout & selection
- Search row and split toggle move into the left column of the split; the preview pane now spans the template's full height.
- Clicking empty listing background deselects (Escape already did).

### Preview pane
- Files AND folders are stat'ed through the template pipeline; the selection's default template embeds as the normal `/render` iframe.
- Folder `_listing` mode mounts the real `Listing` component via a new `embedded` prop: no URL writes (sort/q/preview), preview-pane feature disabled at the `usePreviewPane` hook, no document-level keyboard handlers, no search row — sorting/search stay pane-local.
- Lone-app detection becomes an explicit pane-only `_app` mode with a monochrome icon instead of an automatic fallback.
- Mode priority: `_app` first, then the template system's own registry order (`_listing` keeps its ranked position). Default = first in that order.
- Modes render as the shell's horizontal `ModeSwitcher` icon strip in the pane header (compact ghost-button styling), replacing a dropdown.
- Nothing selected → the pane previews the OPEN folder itself (template or lone app; never its own listing). One "Open" button for every mode.

### Claude on directories
- `agent.py` accepts directory targets: claude runs with cwd = the folder itself via a shared `_cwd_of` helper (Popen cwd, sidecar records, session migration, history lookup all agree), with folder-specific system-prompt wording.
- Built-in registry: `claude` added to the universal `/` directory key after `claude_split`.

## Testing
- Frontend: 166 bun tests, tsc, vite build, boundary check — all pass.
- Python: `test_templates.py` 67/67 (expectations updated for the new `/` mode list); full suite green except 3 pre-existing environment-dependent failures (deploy CLI checks, one calls merge test) untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core explorer navigation, URL state (`?sel`), and embedded listing keyboard isolation; Claude agent now runs with folder cwd, which expands blast radius for directory opens but is scoped to existing template/registry wiring.
> 
> **Overview**
> Reworks the directory listing **preview pane** from file-only iframes and a folder mini-list into a **template-driven** surface aligned with the main shell preview, plus layout and selection polish.
> 
> **Layout:** Search and the pane toggle sit in a new left **`listing-main`** column; the pane runs **full height** beside the table. Clicking empty listing background **clears selection** (Finder-style).
> 
> **`embedded` Listing:** Preview **`_listing`** mode mounts the real `Listing` with `embedded` — no URL sync for sort/`q`/`preview`/`sel`, no nested pane (`usePreviewPane(enabled)`), no global keyboard (selection/shortcuts hooks), and no search chrome in the pane.
> 
> **`ListingPreviewPane`:** Files and folders go through **stat + template modes**; default mode embeds `/render`. Adds pane-only **`_app`** for a lone HTML app, **`ModeSwitcher`** in the header, and gates/skeleton logic so defaults don’t jump. With **no selection**, the pane previews the **open folder** (`self`) via templates/app, not `_listing`. Drops the old folder children table.
> 
> **URL:** Lead row syncs to **`?sel`** (share/refresh restores pane content); disabled when embedded.
> 
> **Backend:** **`claude`** on universal `/` in registry; **`agent.py`** treats **directories** as targets via `_cwd_of` (cwd, sidecar, migration, history). CSS for split layout and compact pane mode switcher.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ab579e0531bd282df3efac85f2d55962e1c6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->