### PR TITLE
Skip the venv when the app interpreter already satisfies a header, and give each install its own progress row

### DIFF
--- a/fused_render/_env_install_worker.py
+++ b/fused_render/_env_install_worker.py
@@ -28,7 +28,10 @@ Two deliberate choices:
 commands.** That function owns the ready marker, the half-built-directory
 rebuild and the disk-quota diagnostics; a second implementation here would be a
 second thing to keep correct, and — worse — could disagree with the venv key the
-run then looks for.
+run then looks for. It reaches that function by loading upstream's `venvs.py`
+straight off disk (`_venvs_module`) instead of importing it through the `fused`
+package, which drags pandas in for ~500ms; it is the same file either way, so the
+key stays identical.
 
 **Its error text is upstream's, unedited.** `venvs._run_step` raises
 `RuntimeError("Failed to <step>:\\n<stderr>")` with uv's or pip's own stderr in
@@ -135,11 +138,91 @@ def _acquire_python(version):
         )
 
 
+_VENVS_MODULE = "fused.agent_core.backends.local.venvs"
+_VENVS_RELPATH = ("agent_core", "backends", "local", "venvs.py")
+
+# Memoised so a retry inside one worker run does not re-exec the file. One worker
+# builds one venv, so this is thrift rather than necessity — but `_build` is also
+# what the tests call, and a second module object would mean a second identity for
+# `venv_key`, which is the one thing here that must be singular.
+_venvs_cache = []
+
+
+def _venvs_module():
+    """Upstream's `venvs.py`, loaded from its FILE rather than through `fused`.
+
+    Why not the obvious import: `from fused.agent_core.backends.local.venvs
+    import ...` imports every parent package on the way down, so `fused/__init__`
+    runs → `fused.api` → `fused._auth` → `fused.core._cache` →
+    `fused._optional_deps` → **pandas**. Measured with `-X importtime`: ~520ms of
+    the 543ms this worker spent installing one tiny pure-Python package was that
+    chain, to reach a module whose own import costs ~100µs. `venvs.py` imports
+    only stdlib (errno, hashlib, json, logging, os, shutil, subprocess, sys,
+    threading, pathlib), so nothing about it needs the package around it.
+
+    Why this is safe, and the crux of the whole change: it is **literally the same
+    file**, so `venv_key` / `requirements_venv_id` / `ensure_requirements_venv`
+    stay byte-identical to what the server's `envinstall.venv_key_for` composes
+    through the package import. A reimplementation of the key here would agree
+    until upstream changed the recipe and then build a venv `is_installed()` never
+    looks in — the page would install, retry, and be told to install again forever,
+    with a fully built venv sitting on disk.
+
+    An already-imported `venvs` wins: in a host that has `fused` loaded anyway (the
+    test session, or an embedding process) a second module object would be a second
+    set of module-level locks and caches guarding the same directories, and any
+    monkeypatch of the real module would silently not apply to the copy.
+    """
+    if _venvs_cache:
+        return _venvs_cache[0]
+    mod = sys.modules.get(_VENVS_MODULE)
+    if mod is None:
+        mod = _load_venvs_by_path()
+    _venvs_cache.append(mod)
+    return mod
+
+
+def _load_venvs_by_path():
+    """`venvs.py` off disk, having executed no `fused` module at all.
+
+    `find_spec("fused")` is the top-level name only, which resolves through the
+    meta path finders WITHOUT executing `fused/__init__`; asking for the dotted
+    submodule instead would import every parent and defeat the point, and so would
+    reading `fused.__file__`. The remaining path segments are joined literally.
+    """
+    import importlib.util
+
+    spec = importlib.util.find_spec("fused")
+    locations = list(getattr(spec, "submodule_search_locations", None) or [])
+    if not locations:
+        raise ImportError("cannot locate the `fused` package directory")
+    path = os.path.join(locations[0], *_VENVS_RELPATH)
+    # Loaded under a private name, not the real dotted one: registering
+    # `fused.agent_core.backends.local.venvs` in sys.modules with none of its
+    # parents there would make a later real `import fused...venvs` hand out this
+    # copy from a half-built package tree.
+    sub = importlib.util.spec_from_file_location("_fused_venvs_direct", path)
+    if sub is None or sub.loader is None:
+        raise ImportError("no loader for %s" % path)
+    mod = importlib.util.module_from_spec(sub)
+    sub.loader.exec_module(mod)
+    return mod
+
+
 def _build(venvs_path, requirements, python_executable):
-    """Upstream's builder, in one place (and imported at call time, not at module
+    """Upstream's builder, in one place (and resolved at call time, not at module
     import, so a missing `fused` surfaces as a progress error rather than an
     unexplained non-zero exit)."""
-    from fused.agent_core.backends.local.venvs import ensure_requirements_venv
+    try:
+        ensure_requirements_venv = _venvs_module().ensure_requirements_venv
+    except Exception as e:  # noqa: BLE001
+        # LOUD, not silent: an install that still works but has quietly gone back to
+        # paying ~500ms of pandas import per build is a regression with no symptom,
+        # and stderr here lands in `progress_dir/worker.log` where it can be found.
+        # Falling back rather than failing, because a slow install beats none.
+        print("env-install: could not load %s by path (%s: %s); falling back to the "
+              "package import" % (_VENVS_MODULE, type(e).__name__, e), file=sys.stderr)
+        from fused.agent_core.backends.local.venvs import ensure_requirements_venv
 
     return ensure_requirements_venv(venvs_path, list(requirements), python_executable)
 

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -379,6 +379,205 @@ def app_interpreter() -> str | None:
         return _app_interpreter
 
 
+# --- a header the app interpreter ALREADY satisfies ---------------------------
+#
+# D172 settled that a header is the script's COMPLETE dependency list: no baseline
+# is unioned into it. What nothing checked is the INVERSE question — whether the
+# list is already satisfied by the interpreter the app ships. `[bundled]` bakes
+# pandas/numpy/duckdb/pyarrow/geopandas/rasterio/zarr/pyproj/keyring/pyyaml/
+# cryptography into that interpreter, so a header naming `pandas` built a
+# multi-gigabyte venv beside the pandas already on disk, then downloaded it again
+# for the next header that differed by one package.
+#
+# Measured on one developer machine's venv store: 33 venvs / 4.9GB beside a 51GB uv
+# cache, in which the set ['duckdb>=1.5.0','keyring>=24','pandas>=2.0.0',
+# 'pyarrow>=14.0.0','pyyaml>=6.0.0'] — every member already present on the
+# interpreter — existed under FIVE distinct keys, and one thirteen-package science
+# stack under four.
+#
+# What makes skipping the venv expressible at all is upstream's precedence rule:
+# `_execute_sync` reads `interpreter` and, when it is set, never looks at
+# `requirements` (`compute_base.execute`'s docstring states it outright, and
+# tests/test_env_install.py pins it). So handing over an interpreter is a claim of
+# full ownership over what is installed — upstream will neither build nor verify
+# anything behind it. That is exactly why every branch below fails CLOSED: this
+# path may only be taken when every requirement is PROVEN present, because the
+# alternative to proof is not a slower run, it is a script that dies on its first
+# import with an error about the code rather than about the environment.
+#
+# The accepted trade: such a script now runs on the shared app interpreter and can
+# therefore see packages its header never declared, where a purpose-built venv
+# would have hidden them. PY-17 already runs every header-LESS script exactly this
+# way, so this widens an existing property rather than introducing a new one.
+_FORCE_VENV_ENV = "FUSED_RENDER_FORCE_SCRIPT_VENV"
+
+# Distribution names + versions, as the APP INTERPRETER sees them. It has to be
+# that interpreter and not this process: in the packaged macOS app they are
+# different pythons with different site-packages, and answering from ours would
+# clear a header the child cannot actually import.
+#
+# `importlib.metadata`, not an import attempt, because the question is a PEP 508
+# one — `pandas>=2.0.0` needs a VERSION, and importability cannot supply it — and
+# because distribution names are what a header spells: `python-pptx` imports as
+# `pptx`, so an import-based check would need a name map that metadata makes
+# unnecessary.
+_APP_PACKAGES_PROBE = (
+    "import json;"
+    "from importlib.metadata import distributions;"
+    "print(json.dumps({(d.metadata['Name'] or ''): d.version for d in distributions()}))"
+)
+
+_app_packages = _UNPROBED
+# Same reasoning as `_app_interpreter_lock`: `app_satisfies` is reached through
+# `asyncio.to_thread`, so two runs starting together genuinely race, and the cache
+# only ever goes _UNPROBED -> final.
+_app_packages_lock = threading.Lock()
+
+
+def reset_app_packages_cache() -> None:
+    """Forget the probed distribution list so the next call re-probes."""
+    global _app_packages
+    with _app_packages_lock:
+        _app_packages = _UNPROBED
+
+
+def _probe_app_packages(exe: str) -> dict | None:
+    """`{canonical distribution name: version}` for `exe`, or None if it wouldn't say.
+
+    None is "no evidence", never "nothing installed" — `app_satisfies` treats the
+    two completely differently, and collapsing them would send every satisfied
+    header to the venv path on one unlucky spawn (harmless) or, with the sense
+    inverted, clear a header on a probe that never ran (not harmless).
+
+    Under `_child_env()` and `_PROBE_TIMEOUT_S`, for the same reasons `_probe`
+    documents: the environment the backend will actually give the child, and a
+    budget small enough that a candidate which never answers cannot hang a request.
+    """
+    try:
+        proc = subprocess.run(
+            [exe, "-c", _APP_PACKAGES_PROBE],
+            capture_output=True, text=True, timeout=_PROBE_TIMEOUT_S, env=_child_env(),
+        )
+    except (OSError, subprocess.SubprocessError) as e:
+        logger.info("app package probe failed for %s: %s: %s", exe, type(e).__name__, e)
+        return None
+    if proc.returncode != 0:
+        logger.info("app package probe failed for %s: %s", exe,
+                    (proc.stderr or proc.stdout or "").strip() or f"exit {proc.returncode}")
+        return None
+    try:
+        raw = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError) as e:
+        logger.info("app package probe output unparseable for %s: %s: %s",
+                    exe, type(e).__name__, e)
+        return None
+    # Canonicalised HERE rather than in the probe: PEP 503 folding (case, and
+    # `_`/`.`/`-` all equivalent) is `packaging`'s job, and the probe must stay a
+    # one-liner that runs on an interpreter which may not have packaging at all.
+    from packaging.utils import canonicalize_name
+
+    return {canonicalize_name(name): version for name, version in raw.items() if name}
+
+
+def app_packages() -> dict | None:
+    """`_probe_app_packages` for the app interpreter, memoized per process.
+
+    The ceiling this guarantees, and the reason it exists: at most ONE subprocess
+    per server process, never one per `/api/run`. The probe enumerates every
+    distribution on the interpreter's path, and it is consulted on the request path
+    of every PEP 723 script — the exact per-request spawn this fast path was built
+    to remove, so paying it per request would be self-defeating.
+    """
+    global _app_packages
+    if _app_packages is not _UNPROBED:
+        return _app_packages
+    with _app_packages_lock:
+        if _app_packages is not _UNPROBED:
+            return _app_packages
+        exe = app_interpreter()
+        # No verified interpreter means nothing to probe AND nothing to run on, so
+        # there is no answer to cache-bust later: `app_interpreter` is itself
+        # per-process and terminal, so this cannot go stale while it stays None.
+        _app_packages = None if exe is None else _probe_app_packages(exe)
+        return _app_packages
+
+
+def app_satisfies(requirements: list[str]) -> bool:
+    """Does the app interpreter already meet EVERY one of `requirements`?
+
+    All-or-nothing, because a script runs on exactly one interpreter: "pandas from
+    the app, imagecodecs from a venv" is not a thing that can be arranged, so a
+    single unmet requirement sends the whole header down the venv path unchanged.
+
+    Every uncertain answer is False. The cases, and why each one is not a
+    judgement call:
+
+    * **no requirements** — that is PY-17's business, and the vacuous truth a
+      quantifier gives here would claim this path for a script that never asked.
+    * **`_FORCE_VENV_ENV` set** — the escape hatch, checked before any probe so it
+      also costs nothing.
+    * **the probe said nothing** (`app_packages() is None`) — no evidence is not
+      evidence, the same three-valued discipline `envinstall._venv_is_usable` and
+      `_probe` already follow.
+    * **extras** (`pandas[performance]`) — a version number vouches for the
+      distribution and says nothing whatsoever about an extra's transitive
+      dependencies, so this is unprovable by construction, not merely unproven.
+    * **unparseable requirement, or any exception at all** — "I could not read it"
+      must never arrive as "it is already there".
+
+    Environment markers are ignored on purpose: `script_requirements` has already
+    dropped the requirements whose markers do not hold and returns the survivors
+    verbatim, markers included, so re-evaluating one here would be a second
+    implementation of a decision that is already made.
+    """
+    if not requirements:
+        return False
+    if os.environ.get(_FORCE_VENV_ENV):
+        return False
+    installed = app_packages()
+    if installed is None:
+        return False
+    try:
+        from packaging.requirements import InvalidRequirement, Requirement
+        from packaging.utils import canonicalize_name
+
+        for spec in requirements:
+            try:
+                req = Requirement(spec)
+            except InvalidRequirement:
+                return False
+            if req.extras:
+                return False
+            version = installed.get(canonicalize_name(req.name))
+            if version is None:
+                return False
+            # prereleases=True so an app shipping `2.1.0rc1` counts against
+            # `>=2.0.0`. The default excludes pre-releases, which would send a
+            # header to the venv path over a version the interpreter genuinely
+            # has — and that venv would resolve the very same pre-release.
+            if str(req.specifier) and not req.specifier.contains(version, prereleases=True):
+                return False
+        return True
+    except Exception:  # noqa: BLE001
+        # Deliberately total: this function's contract is that it never turns an
+        # internal problem into a claim that packages are present. Logged rather
+        # than swallowed, because a persistent failure here is a silent, permanent
+        # loss of the fast path and nothing else would ever say so.
+        logger.exception("app_satisfies failed for %r; treating as unsatisfied",
+                         requirements)
+        return False
+
+
+def _app_interpreter_if_satisfies(requirements: list[str]) -> str | None:
+    """The app interpreter when it already meets `requirements`, else None.
+
+    Both probes behind ONE `asyncio.to_thread` hop from `run_python`: they are
+    subprocess-backed on first call, and two hops would be two chances to stall
+    the event loop for no gain.
+    """
+    return app_interpreter() if app_satisfies(requirements) else None
+
+
 def _resolve_app_interpreter() -> str | None:
     """Probe the rungs and answer with the interpreter to cache.
 
@@ -906,6 +1105,13 @@ async def run_python(path: str, params: dict) -> dict:
     # `requirements` are mutually exclusive upstream (the interpreter branch
     # ignores requirements silently), so they are never both set here.
     interpreter = None
+    if requirements:
+        # A header the app interpreter already meets needs no venv, no download and
+        # no loader — see the `app_satisfies` block above for why this fails closed
+        # and what it trades. Off the event loop because both probes behind it are
+        # subprocess-backed on their first call, exactly as `app_interpreter` and
+        # `is_installed` below are.
+        interpreter = await asyncio.to_thread(_app_interpreter_if_satisfies, requirements)
     if not requirements:
         # Off the event loop: `app_interpreter` is sync (it is called from sync
         # contexts and tests) and its first call in a process runs up to two
@@ -959,7 +1165,12 @@ async def run_python(path: str, params: dict) -> dict:
         # full budget. `to_thread` re-raises in this frame, so the guard above still
         # contains the ImportError/RuntimeError pair (pinned by a test, because "the
         # exception now surfaces somewhere else" is exactly what a thread hop hides).
-        if requirements:
+        # `interpreter is None` and not merely `requirements`: a header the app
+        # interpreter already satisfies resolved one above, and it has nothing to
+        # install — asking `is_installed` about it would name a venv directory that
+        # is never going to be built and answer `needs_install`, putting the loader
+        # in front of a run that was ready to go.
+        if requirements and interpreter is None:
             from fused_render import envinstall
 
             if not await asyncio.to_thread(envinstall.is_installed, requirements):

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -537,10 +537,23 @@ def app_satisfies(requirements: list[str]) -> bool:
     installed = app_packages()
     if installed is None:
         return False
+    # Split out of the catch-all below, and NOT logged as an exception: a missing
+    # parser is a packaging fault, not a bug in this call, and it would otherwise
+    # write a full traceback on every run of every header while silently disabling
+    # the fast path — a permanent slowdown whose only evidence is a stack trace that
+    # looks like a crash. `packaging` is a declared dependency (pyproject.toml), so
+    # this is a broken install rather than a supported configuration.
     try:
         from packaging.requirements import InvalidRequirement, Requirement
         from packaging.utils import canonicalize_name
-
+    except ImportError as e:
+        logger.warning(
+            "cannot check whether the app interpreter satisfies %r: %s. Every "
+            "header will build its own venv until `packaging` is importable.",
+            requirements, e,
+        )
+        return False
+    try:
         for spec in requirements:
             try:
                 req = Requirement(spec)
@@ -566,6 +579,29 @@ def app_satisfies(requirements: list[str]) -> bool:
         logger.exception("app_satisfies failed for %r; treating as unsatisfied",
                          requirements)
         return False
+
+
+def _interpreter_path_available() -> bool:
+    """Can this backend run code on an interpreter WE choose?
+
+    `_execute_sync` is the only route to that (`execute()` derives an interpreter
+    only from a uv workflow project, which a standalone .py has none of), so
+    without it the fast path cannot be taken at all.
+
+    Asked before the pre-flight rather than discovered inside `_execute`, and that
+    ordering is the whole point: a header that declines the fast path must still
+    reach `is_installed`, so a missing venv comes back as `needs_install` and the
+    loader builds it off the request path. Discovering it later would leave
+    `execute(requirements=…)` to build the venv INLINE — a blocking download inside
+    /api/run, which is the exact failure PY-18 exists to remove.
+
+    Note this is a strictly weaker requirement than the header-LESS path's: there,
+    no `_execute_sync` is fatal (D175 — an empty venv has no data stack, so running
+    the script anyway would fail on `import numpy`), because there is nothing to
+    fall back TO. Here the venv path is a perfectly good fallback: slower, more
+    isolated, and exactly what this header did before the fast path existed.
+    """
+    return hasattr(get_backend(), "_execute_sync")
 
 
 def _app_interpreter_if_satisfies(requirements: list[str]) -> str | None:
@@ -1105,13 +1141,6 @@ async def run_python(path: str, params: dict) -> dict:
     # `requirements` are mutually exclusive upstream (the interpreter branch
     # ignores requirements silently), so they are never both set here.
     interpreter = None
-    if requirements:
-        # A header the app interpreter already meets needs no venv, no download and
-        # no loader — see the `app_satisfies` block above for why this fails closed
-        # and what it trades. Off the event loop because both probes behind it are
-        # subprocess-backed on their first call, exactly as `app_interpreter` and
-        # `is_installed` below are.
-        interpreter = await asyncio.to_thread(_app_interpreter_if_satisfies, requirements)
     if not requirements:
         # Off the event loop: `app_interpreter` is sync (it is called from sync
         # contexts and tests) and its first call in a process runs up to two
@@ -1165,11 +1194,30 @@ async def run_python(path: str, params: dict) -> dict:
         # full budget. `to_thread` re-raises in this frame, so the guard above still
         # contains the ImportError/RuntimeError pair (pinned by a test, because "the
         # exception now surfaces somewhere else" is exactly what a thread hop hides).
+        # The app-interpreter fast path: a header this interpreter already meets
+        # needs no venv, no download and no loader. See the `app_satisfies` block
+        # above for why it fails closed and what it trades.
+        #
+        # Inside the try and BEFORE the pre-flight, both deliberately.
+        # `_interpreter_path_available` calls `get_backend()`, which imports the
+        # backend and can raise — out here that would be an unhandled 500 rather
+        # than the house wire shape. And declining the fast path has to fall through
+        # to `is_installed` below, so a missing venv still becomes `needs_install`
+        # instead of an inline download inside this request.
+        #
+        # Off the event loop for the same reason `app_interpreter` and
+        # `is_installed` are: both probes behind it spawn a subprocess on their
+        # first call.
+        if requirements and _interpreter_path_available():
+            interpreter = await asyncio.to_thread(
+                _app_interpreter_if_satisfies, requirements
+            )
+
         # `interpreter is None` and not merely `requirements`: a header the app
-        # interpreter already satisfies resolved one above, and it has nothing to
-        # install — asking `is_installed` about it would name a venv directory that
-        # is never going to be built and answer `needs_install`, putting the loader
-        # in front of a run that was ready to go.
+        # interpreter already satisfies resolved one just above, and it has nothing
+        # to install — asking `is_installed` about it would name a venv directory
+        # that is never going to be built and answer `needs_install`, putting the
+        # loader in front of a run that was ready to go.
         if requirements and interpreter is None:
             from fused_render import envinstall
 

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -561,6 +561,18 @@ def app_satisfies(requirements: list[str]) -> bool:
                 return False
             if req.extras:
                 return False
+            # A direct reference (`pandas @ https://…/pandas-9.9.9.whl`, or a local
+            # path / VCS URL) names a SOURCE, and an installed version number is no
+            # evidence at all about whether the thing installed came from it. Left
+            # unchecked this was the extras hole in a second shape: the app happens
+            # to have a `pandas`, so the header cleared and the wheel the author
+            # deliberately pinned was never fetched — a script silently running
+            # against different code than it asked for. Not hypothetical here,
+            # either: this repo pins its own `fused` as a direct-URL wheel
+            # (pyproject.toml's `[fused]` extra), so the idiom is one a template
+            # author has every reason to copy.
+            if req.url:
+                return False
             version = installed.get(canonicalize_name(req.name))
             if version is None:
                 return False

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -534,9 +534,12 @@ def app_satisfies(requirements: list[str]) -> bool:
         return False
     if os.environ.get(_FORCE_VENV_ENV):
         return False
-    installed = app_packages()
-    if installed is None:
-        return False
+    # Imported BEFORE `app_packages()`, not just before the loop: `_probe_app_packages`
+    # canonicalises with `packaging` too, so probing first would let the very
+    # ImportError this handler exists for escape from underneath it — turning a
+    # missing parser into an EngineError on every header instead of one warning and
+    # the venv path.
+    #
     # Split out of the catch-all below, and NOT logged as an exception: a missing
     # parser is a packaging fault, not a bug in this call, and it would otherwise
     # write a full traceback on every run of every header while silently disabling
@@ -552,6 +555,9 @@ def app_satisfies(requirements: list[str]) -> bool:
             "header will build its own venv until `packaging` is importable.",
             requirements, e,
         )
+        return False
+    installed = app_packages()
+    if installed is None:
         return False
     try:
         for spec in requirements:
@@ -612,8 +618,18 @@ def _interpreter_path_available() -> bool:
     the script anyway would fail on `import numpy`), because there is nothing to
     fall back TO. Here the venv path is a perfectly good fallback: slower, more
     isolated, and exactly what this header did before the fast path existed.
+
+    `get_backend()` raising is one of those "no" answers, not an error to propagate.
+    It raises when `fused` is absent entirely, and this gate is the FIRST thing
+    /api/run touches — so letting it through would make every failure downstream
+    (the pre-flight's `RuntimeError`, `needs_install`, D175) unreachable, replacing
+    each one's specific diagnosis with a bare ModuleNotFoundError from a fast-path
+    probe that was only ever asking an optional question.
     """
-    return hasattr(get_backend(), "_execute_sync")
+    try:
+        return hasattr(get_backend(), "_execute_sync")
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _app_interpreter_if_satisfies(requirements: list[str]) -> str | None:

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -567,14 +567,44 @@
   // Shape follows the docs template's typst install (a detached worker writing
   // progress.json, polled) — one pattern in this app, not two.
   const INSTALL_POLL_MS = 500;
+  // The first second is polled faster. A fixed 500ms grid is invisible next to a
+  // four-minute download but dominates a short one: a ~540ms install lands
+  // mid-grid, so it is not noticed until the SECOND poll, turning ~0.5s of work
+  // into ~1.5s of blocked page. The window is bounded rather than adaptive because
+  // the only installs it can help are the ones that finish inside it, and a long
+  // download must not end up polled harder than it was before.
+  const INSTALL_POLL_FAST_MS = 100;
+  const INSTALL_FAST_POLL_WINDOW_MS = 1000;
+
+  // How long an install may run before the overlay appears at all.
+  //
+  // The overlay used to mount synchronously, before anything was known about how
+  // long the install would take — so an install that finishes in tens of
+  // milliseconds still threw a full-screen modal over the page and tore it down
+  // again, which reads as a flicker/flash rather than as progress. Now that a
+  // header the app interpreter already satisfies installs NOTHING (see engine.py's
+  // `app_satisfies`), the installs that remain are either genuinely long (a real
+  // download, where 600ms of delay is imperceptible) or genuinely short (a warm uv
+  // cache, where the modal was pure noise). Delay separates the two without having
+  // to predict which one this is.
+  const INSTALL_MOUNT_DELAY_MS = 600;
+
   let installUi = null;
-  // Live installs, as key -> how many calls are waiting on it. A page can call
-  // two different .py files, each with its own header, so the overlay is shared
-  // by more than one install and has to stay up until the LAST one finishes, or
-  // the first to end tears the loader out from under the others and the page sits
-  // blank with no cancel button. Ref-COUNTED, not a Set of keys: two .py files
-  // with identical requirement sets share one venv key, so a Set would hold a
-  // single entry that the first call to settle deletes.
+  // Live installs, as key -> { row, count }.
+  //
+  // A page can call several .py files, each with its OWN header, so N installs
+  // with N DISTINCT keys run at once. Each therefore gets its own ROW — its own
+  // title, detail, bar and Cancel — because one shared set of nodes made N
+  // installs illegible: the title named whichever install started last, N pollers
+  // rewrote one detail line at 2Hz, and one Cancel button carried N listeners, so
+  // a single click cancelled every install while each chain's message overwrote
+  // the others'.
+  //
+  // Still ref-COUNTED per key, which is a different case and remains real: two .py
+  // files with IDENTICAL requirement sets share one venv key, so they share one
+  // row, and the row may only go when the LAST of them settles. The count lives
+  // inside the entry so both facts — which row, how many waiters — are one piece of
+  // state that cannot disagree with itself.
   const installing = new Map();
 
   // The indeterminate bar (D213). The worker parks at pct 25 for the WHOLE download
@@ -602,9 +632,11 @@
   }
 
   // `dataset.indeterminate` is the DOM-observable contract: the tests assert on it,
-  // because no headless test can see whether an animation LOOKS right.
-  function installBarIndeterminate(ui, on) {
-    const bar = ui.bar;
+  // because no headless test can see whether an animation LOOKS right. Takes a ROW
+  // (one install's nodes), not the overlay: with several installs live, "the bar" is
+  // not a thing there is one of.
+  function installBarIndeterminate(row, on) {
+    const bar = row.bar;
     if (on) {
       if (bar.dataset.indeterminate === "1") return; // never restart the sweep
       ensureInstallBarStyle();
@@ -626,9 +658,9 @@
   // stage-to-bar rule has exactly one definition and can be driven directly by a
   // test; `notice` is installEnv's sticky message, which must outrank the record's
   // own detail (see the `notice` comment there).
-  function paintInstall(ui, prog, notice) {
+  function paintInstall(row, prog, notice) {
     if (!prog) return;
-    ui.detail.textContent = notice || prog.detail || prog.stage || "";
+    row.detail.textContent = notice || prog.detail || prog.stage || "";
     // Both long steps are indeterminate, for the same reason: `install` runs uv
     // behind captured output, and `python` (D214, the interpreter download) captures
     // it too, so neither has a percentage to report. Listed rather than inferred from
@@ -636,11 +668,11 @@
     // indeterminate bar is for — and a stage added later without a decision here
     // should render as a plain bar, not silently inherit the sweep.
     if ((prog.stage === "install" || prog.stage === "python") && !prog.done) {
-      installBarIndeterminate(ui, true);
+      installBarIndeterminate(row, true);
       return;
     }
-    installBarIndeterminate(ui, false);
-    if (typeof prog.pct === "number") ui.bar.style.width = prog.pct + "%";
+    installBarIndeterminate(row, false);
+    if (typeof prog.pct === "number") row.bar.style.width = prog.pct + "%";
   }
 
   // Act on this needs_install, or fail? The rule is PROGRESS, not a count: a key we
@@ -659,6 +691,9 @@
     return Boolean(need && need.key) && !installed.has(need.key);
   }
 
+  // The backdrop, and the container every install's row is appended to. It owns no
+  // title/detail/bar of its own any more — those belong to a row, because there is
+  // no longer one install to describe.
   function installOverlay() {
     if (installUi) return installUi;
     const el = document.createElement("div");
@@ -669,6 +704,30 @@
       "font-size:14px", "padding:32px", "box-sizing:border-box",
       "display:flex", "flex-direction:column", "gap:14px",
       "align-items:center", "justify-content:center", "text-align:center",
+    ].join(";");
+    const rows = document.createElement("div");
+    rows.style.cssText = [
+      "display:flex", "flex-direction:column", "gap:26px",
+      "align-items:center", "width:100%",
+    ].join(";");
+    el.appendChild(rows);
+    // `mountTimer` is part of the state, not a local in `showInstall`: the delay has
+    // to be cancellable from `hideInstall` (an install that finishes inside the
+    // window must not mount an overlay afterwards) and must not be restarted by a
+    // second install arriving while it is still pending.
+    installUi = { el, rows, mounted: false, mountTimer: null };
+    return installUi;
+  }
+
+  // One install's nodes. Built per key, and — deliberately — built SYNCHRONOUSLY in
+  // `showInstall` even though mounting is delayed: `installEnv` registers its cancel
+  // handler and paints its first record immediately, so the nodes have to exist
+  // before the overlay does. A row that is never mounted is simply never seen.
+  function installRow() {
+    const el = document.createElement("div");
+    el.style.cssText = [
+      "display:flex", "flex-direction:column", "gap:10px",
+      "align-items:center", "text-align:center",
     ].join(";");
     const title = document.createElement("div");
     title.style.cssText = "font-size:17px;font-weight:600;";
@@ -691,22 +750,41 @@
       "font-size:13px", "cursor:pointer",
     ].join(";");
     el.append(title, track, detail, cancel);
-    installUi = { el, title, detail, bar, cancel, mounted: false };
-    return installUi;
+    return { el, title, detail, bar, cancel };
+  }
+
+  // Mount after INSTALL_MOUNT_DELAY_MS, at most one timer at a time.
+  //
+  // The `installing.size` re-check inside the callback is the point of the whole
+  // mechanism, not a precaution: between scheduling and firing, every install can
+  // have finished and called `hideInstall`, and mounting then would put a modal over
+  // the page with nothing running behind it and no live Cancel to dismiss it.
+  function mountInstallSoon(ui) {
+    if (ui.mounted || ui.mountTimer !== null) return;
+    ui.mountTimer = setTimeout(function () {
+      ui.mountTimer = null;
+      if (!installing.size) return;
+      document.body.appendChild(ui.el);
+      ui.mounted = true;
+    }, INSTALL_MOUNT_DELAY_MS);
   }
 
   function showInstall(need) {
     const ui = installOverlay();
-    installing.set(need.key, (installing.get(need.key) || 0) + 1);
-    if (!ui.mounted) {
-      document.body.appendChild(ui.el);
-      ui.mounted = true;
+    let entry = installing.get(need.key);
+    if (!entry) {
+      entry = { row: installRow(), count: 0 };
+      installing.set(need.key, entry);
+      ui.rows.appendChild(entry.row.el);
     }
+    entry.count += 1;
+    mountInstallSoon(ui);
+    const row = entry.row;
     // Name what is actually being fetched. On the interpreter round (D214) the
     // packages are NOT downloading yet, and titling that round with their names is
     // the kind of small lie that makes a four-minute wait feel broken — the user
     // watches "Installing tensorflow" and nothing about tensorflow is happening.
-    ui.title.textContent = need.python
+    row.title.textContent = need.python
       ? "Installing Python " + need.python
       : "Installing " + (need.requirements || []).join(", ");
     // Deliberately NOT "starting…" at 0%. `/api/env/install` JOINS an install
@@ -717,19 +795,34 @@
     // state therefore asserts no percentage at all: indeterminate until the
     // server's own record arrives (installEnv paints the POST response, which
     // carries it), so the first honest paint is the only paint.
-    ui.detail.textContent = "contacting the installer…";
-    installBarIndeterminate(ui, true);
-    return ui;
+    row.detail.textContent = "contacting the installer…";
+    installBarIndeterminate(row, true);
+    return row;
   }
 
   function hideInstall(key) {
-    const left = (installing.get(key) || 0) - 1;
-    if (left > 0) installing.set(key, left);
-    else installing.delete(key);
+    const entry = installing.get(key);
+    if (entry) {
+      entry.count -= 1;
+      if (entry.count > 0) return; // another call is still waiting on this key
+      entry.row.el.remove();
+      installing.delete(key);
+    }
     if (installing.size) return; // another install is still running
-    if (installUi && installUi.mounted) {
-      installUi.el.remove();
-      installUi.mounted = false;
+    const ui = installUi;
+    if (!ui) return;
+    // A pending mount is cancelled, not left to fire: this is the path a fast
+    // install takes, and without the clear the overlay would appear ~600ms AFTER
+    // everything finished and stay there (the callback's own size check would also
+    // catch it, but leaving a timer armed to do nothing is how the next person
+    // reading this concludes the delay is unreliable).
+    if (ui.mountTimer !== null) {
+      clearTimeout(ui.mountTimer);
+      ui.mountTimer = null;
+    }
+    if (ui.mounted) {
+      ui.el.remove();
+      ui.mounted = false;
     }
   }
 
@@ -747,7 +840,7 @@
   // needs, and rewriting it into something friendlier is what made this opaque
   // in the first place.
   function installEnv(need, pyPath, ownPath) {
-    const ui = showInstall(need);
+    const row = showInstall(need);
     let cancelled = false;
     // The key to poll and to cancel is the INSTALLER's, not the pre-flight's.
     // /api/env/install re-derives the requirements from the .py on disk and
@@ -770,7 +863,7 @@
     const onCancel = () => {
       cancelled = true;
       notice = "";
-      ui.detail.textContent = "cancelling…";
+      row.detail.textContent = "cancelling…";
       envPost("/api/env/cancel", { key: activeKey })
         .then(({ data }) => {
           if (data && data.cancelled === false) {
@@ -781,14 +874,24 @@
             notice =
               "the installer could not be stopped — it had not started yet, or " +
               "had already finished. Press Cancel again if it is still running.";
-            ui.detail.textContent = notice;
+            row.detail.textContent = notice;
           }
         })
         .catch(() => {});
     };
-    ui.cancel.addEventListener("click", onCancel);
+    row.cancel.addEventListener("click", onCancel);
 
-    const paint = (prog) => paintInstall(ui, prog, notice);
+    const paint = (prog) => paintInstall(row, prog, notice);
+
+    // Measured from the click, not from the previous poll, so the fast window is a
+    // property of the INSTALL's age rather than of how many times we happened to
+    // poll — a slow first response would otherwise stretch the fast phase
+    // arbitrarily.
+    const startedAt = Date.now();
+    const pollDelay = () =>
+      Date.now() - startedAt < INSTALL_FAST_POLL_WINDOW_MS
+        ? INSTALL_POLL_FAST_MS
+        : INSTALL_POLL_MS;
 
     const poll = () =>
       fetch("/api/env/progress?key=" + encodeURIComponent(activeKey), {
@@ -805,7 +908,7 @@
             throw new Error("the installer left no progress record");
           }
           if (!prog.done) {
-            return new Promise((r) => setTimeout(r, INSTALL_POLL_MS)).then(poll);
+            return new Promise((r) => setTimeout(r, pollDelay())).then(poll);
           }
           if (prog.error) throw new Error(prog.error);
           return prog;
@@ -823,7 +926,7 @@
       })
       .then(
         (prog) => {
-          ui.cancel.removeEventListener("click", onCancel);
+          row.cancel.removeEventListener("click", onCancel);
           hideInstall(need.key);
           if (cancelled) {
             // The install finished anyway — a cancel the server could not honour,
@@ -838,7 +941,7 @@
           return prog;
         },
         (err) => {
-          ui.cancel.removeEventListener("click", onCancel);
+          row.cancel.removeEventListener("click", onCancel);
           hideInstall(need.key);
           if (cancelled) {
             const e = new Error("the install was cancelled");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,15 @@ dependencies = [
     # main path, not a corner. Core rather than an extra: the parser runs on
     # every /api/run under either engine.
     "tomli>=2.0; python_version < '3.11'",
+    # PEP 508 requirement/specifier parsing, for deciding whether the app
+    # interpreter already satisfies a script's PEP 723 header (engine.app_satisfies
+    # — a header it already meets runs with no venv at all). Core rather than an
+    # extra, and declared rather than borrowed: it arrives transitively from
+    # geopandas/matplotlib/rasterio/zarr today, so a plain `pip install
+    # fused-render` had it by luck. Without it every header silently falls back to
+    # building its own venv — a permanent slowdown with no failing test, which is
+    # exactly the shape of the `httpx`/`tomli` mistakes above.
+    "packaging>=22",
     # AppKit, for the macOS half of the OS clipboard bridge
     # (shell/pasteboard/_darwin.py reads and writes NSPasteboard file URLs).
     # Core rather than an extra, and marked rather than optional, because the

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1122,6 +1122,41 @@ def test_an_empty_requirement_list_is_not_the_fast_path(monkeypatch):
     assert engine.app_satisfies([]) is False
 
 
+def test_a_backend_that_cannot_be_resolved_is_not_an_interpreter_path(monkeypatch):
+    """`get_backend()` raising is a "no", not an error to propagate.
+
+    The gate is the FIRST thing /api/run touches for a header, and `get_backend`
+    raises outright when `fused` is absent — so letting that through made every
+    more specific failure downstream unreachable. CI caught it: the plain
+    `test-python` jobs install no `fused`, and
+    `test_a_preflight_that_cannot_answer_returns_the_house_error_shape` saw a bare
+    ModuleNotFoundError from this probe instead of the pre-flight's own diagnosis.
+    """
+    def _no_fused():
+        raise ModuleNotFoundError("No module named 'fused'")
+
+    monkeypatch.setattr(engine, "get_backend", _no_fused)
+    assert engine._interpreter_path_available() is False
+
+
+def test_a_missing_packaging_warns_instead_of_probing(monkeypatch):
+    """The ImportError handler must be reachable — it sits above the probe.
+
+    `_probe_app_packages` canonicalises with `packaging` too, so probing first let
+    the very ImportError this handler exists for escape from underneath it. What
+    the user got was not "the fast path is off" but an EngineError on every header
+    script, for a dependency problem that has a graceful answer.
+    """
+    probed = []
+    monkeypatch.setattr(engine, "app_packages",
+                        lambda: probed.append(True) or {"pandas": "2.3.3"})
+    # A None entry in sys.modules is what the import system treats as "this module
+    # is not importable" — closer to a broken install than deleting the real one.
+    monkeypatch.setitem(sys.modules, "packaging.requirements", None)
+    assert engine.app_satisfies(["pandas"]) is False
+    assert probed == [], "the probe ran, so it would have raised first"
+
+
 # --- the PYTHONHOME wrapper: making the packaged macOS app work ---------------
 #
 # Measured against a real DMG (FusedRender-0.3.12), because every earlier guess

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1078,6 +1078,27 @@ def test_the_fast_path_is_not_taken_when_the_backend_cannot_run_on_an_interprete
 
 
 @requires_fused
+def test_a_direct_url_requirement_is_never_treated_as_satisfied(monkeypatch):
+    """`pandas @ https://…` names a SOURCE, which a version cannot vouch for.
+
+    The extras hole in a second shape, and the more dangerous one: the app happens
+    to have a `pandas`, so the header cleared and the wheel the author deliberately
+    pinned was never fetched — the script ran against different code than it asked
+    for, silently. Local paths and VCS URLs are the same case (`req.url` covers all
+    three). This repo pins its own `fused` as a direct-URL wheel, so it is an idiom
+    a template author has every reason to copy.
+    """
+    monkeypatch.setattr(engine, "app_packages", lambda: {"pandas": "2.3.3"})
+    assert engine.app_satisfies(["pandas"]) is True, "control: the plain name is met"
+    for spec in (
+        "pandas @ https://example.com/pandas-9.9.9-py3-none-any.whl",
+        "pandas @ file:///tmp/pandas-9.9.9-py3-none-any.whl",
+        "pandas @ git+https://github.com/pandas-dev/pandas@main",
+    ):
+        assert engine.app_satisfies([spec]) is False, spec
+
+
+@requires_fused
 def test_an_unparseable_requirement_is_not_satisfied():
     """"I could not read it" must never read as "it is already there"."""
     assert engine.app_satisfies(["not a requirement at all!!"]) is False

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1019,6 +1019,64 @@ def test_the_app_package_probe_runs_at_most_once_per_process(monkeypatch):
     assert "pandas" in first, first
 
 
+class _NoSyncBackend:
+    """A backend with only the async half — a `fused` lacking `_execute_sync`."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    async def execute(self, **kw):
+        self.calls.append({"via": "execute", **kw})
+        return self._result
+
+
+@requires_tomllib
+@requires_fused
+def test_a_satisfied_header_falls_back_to_the_venv_without_execute_sync(
+    monkeypatch, tmp_path
+):
+    """No `_execute_sync` must cost speed, never the run.
+
+    `_execute_sync` is the only way to run on an interpreter WE pick, so without it
+    the fast path is impossible. The header-less path treats that as fatal (D175:
+    an empty venv has no data stack, so there is nothing to fall back to) — and
+    applying the same rule here regressed a header that worked perfectly well before
+    the fast path existed, turning a `pandas` script into an EngineError whose
+    message claimed it had "no dependencies of its own".
+
+    The fallback must also be the FULL venv path, pre-flight included: dropping
+    straight into `execute(requirements=…)` would build the venv inline, a blocking
+    download inside /api/run, which is the exact thing PY-18 moved out of it.
+    """
+    target = tmp_path / "declared.py"
+    target.write_text(_satisfied_header(["pandas>=2.0.0"]) + "def main():\n    return 1\n")
+    backend = _NoSyncBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    out = asyncio.run(engine.run_python(str(target), {}))
+    assert out["ok"] is True, out
+    assert seen == [["pandas>=2.0.0"]], (
+        "the pre-flight was skipped, so a missing venv would be built inline"
+    )
+    assert backend.calls[0]["via"] == "execute"
+    assert backend.calls[0]["requirements"] == ["pandas>=2.0.0"]
+
+
+@requires_fused
+def test_the_fast_path_is_not_taken_when_the_backend_cannot_run_on_an_interpreter(
+    monkeypatch,
+):
+    """The gate itself, independent of any script."""
+    monkeypatch.setattr(engine, "get_backend",
+                        lambda: _NoSyncBackend(_FakeResult(return_value="1")))
+    assert engine._interpreter_path_available() is False
+    monkeypatch.setattr(engine, "get_backend",
+                        lambda: _FakeBackend(_FakeResult(return_value="1")))
+    assert engine._interpreter_path_available() is True
+
+
 @requires_fused
 def test_an_unparseable_requirement_is_not_satisfied():
     """"I could not read it" must never read as "it is already there"."""

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -686,7 +686,24 @@ def test_a_headerless_script_sees_the_app_s_own_packages(monkeypatch, tmp_path):
 def test_a_declared_header_still_gets_its_own_venv(
     monkeypatch, tmp_path, warm_fused_backend_venv
 ):
-    """A header keeps today's venv path — it must NOT land on the app python."""
+    """The venv path, end to end: a real venv is built and the script runs IN it.
+
+    `_FORCE_VENV_ENV` is set because this test's header would otherwise no longer
+    reach the venv path at all, and for an honest reason rather than a convenient
+    one: `conftest.WARM_HEADER` declares `pip`, chosen because it is the cheapest
+    possible warm venv, and `pip` is present on the app interpreter (the dev-env
+    setup seeds it into `.venv` on purpose, so `test_deploy.py` can exercise a real
+    `_pip_available()`). A header every member of which is already installed is
+    precisely what `app_satisfies` now claims, so leaving the fast path enabled here
+    would silently convert this into a second header-less test.
+
+    The hatch keeps the assertion this test is FOR — build a venv, run the script
+    inside it, land under `venvs` — rather than trading it for a weaker one. Which
+    header routes where is covered separately, on the fake backend, by
+    `test_one_missing_package_sends_the_whole_header_to_the_venv_path` and
+    `test_a_header_the_app_already_satisfies_builds_no_venv`.
+    """
+    monkeypatch.setenv(engine._FORCE_VENV_ENV, "1")
     monkeypatch.setattr(engine, "_backend", None)
     target = tmp_path / "declared.py"
     target.write_text(
@@ -844,6 +861,186 @@ def test_a_missing_execute_sync_is_loud_too(monkeypatch, tmp_path):
     assert out["error"]["type"] == "EngineError"
     assert "_execute_sync" in out["error"]["traceback"]
     assert backend.calls == []
+
+
+# --- a header the app interpreter ALREADY satisfies ----------------------------
+#
+# The `[bundled]` extra puts pandas/duckdb/pyarrow/numpy/geopandas/rasterio/zarr/
+# pyproj/keyring/yaml/cryptography on the app interpreter, and D172 stops a header
+# being EXTENDED with a baseline — but nothing checked whether a header was already
+# SATISFIED. So a header naming `pandas` built a multi-GB venv beside the pandas the
+# app already ships. Measured on one machine's venv store: the set
+# ['duckdb>=1.5.0','keyring>=24','pandas>=2.0.0','pyarrow>=14.0.0','pyyaml>=6.0.0']
+# — every one already present — under FIVE different keys; 33 venvs, 4.9GB.
+#
+# These tests pin both directions: the fast path when every requirement is met, and
+# an unchanged venv path the moment anything cannot be PROVEN met.
+
+
+def _satisfied_header(deps):
+    return "# /// script\n# dependencies = %r\n# ///\n" % (list(deps),)
+
+
+def _preflight_spy(monkeypatch):
+    """Records whether the venv pre-flight was consulted at all."""
+    seen = []
+    monkeypatch.setattr("fused_render.envinstall.is_installed",
+                        lambda reqs: seen.append(list(reqs)) or True)
+    return seen
+
+
+@requires_tomllib
+@requires_fused
+def test_a_header_the_app_already_satisfies_builds_no_venv(monkeypatch, tmp_path):
+    """pandas is on the app interpreter, so a header naming it needs no venv."""
+    target = tmp_path / "declared.py"
+    target.write_text(_satisfied_header(["pandas>=2.0.0"]) + "def main():\n    return 1\n")
+    backend = _FakeBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    out = asyncio.run(engine.run_python(str(target), {}))
+    assert out["ok"] is True, out
+    assert "needs_install" not in out
+    assert seen == [], "the venv pre-flight ran for a header nothing needs to install"
+    call = backend.calls[0]
+    assert call["via"] == "_execute_sync"
+    assert call["interpreter"] == engine.app_interpreter()
+    assert "requirements" not in call, (
+        "upstream ignores requirements once interpreter is set; passing both misleads"
+    )
+
+
+@requires_tomllib
+@requires_fused
+def test_one_missing_package_sends_the_whole_header_to_the_venv_path(
+    monkeypatch, tmp_path
+):
+    """All-or-nothing: the venv is what makes the MISSING one importable.
+
+    Splitting the set — interpreter for the satisfied part, venv for the rest — is
+    not expressible: one script runs on one interpreter. So one miss means the
+    header goes to the venv exactly as before, pandas rebuilt and all.
+    """
+    target = tmp_path / "declared.py"
+    target.write_text(
+        _satisfied_header(["pandas>=2.0.0", "imagecodecs"])
+        + "def main():\n    return 1\n"
+    )
+    backend = _FakeBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    out = asyncio.run(engine.run_python(str(target), {}))
+    assert out["ok"] is True, out
+    assert seen == [["imagecodecs", "pandas>=2.0.0"]]
+    assert backend.calls[0]["via"] == "execute"
+    assert backend.calls[0]["requirements"] == ["imagecodecs", "pandas>=2.0.0"]
+
+
+@requires_tomllib
+@requires_fused
+def test_a_version_the_app_cannot_meet_is_not_treated_as_satisfied(
+    monkeypatch, tmp_path
+):
+    """The check is on the SPECIFIER, not on importability.
+
+    "pandas is importable" would have said yes to `pandas>=99`, run the script on
+    an interpreter with 2.x, and produced whatever error a version-sensitive script
+    produces — an error about the code, for a dependency problem.
+    """
+    target = tmp_path / "declared.py"
+    target.write_text(_satisfied_header(["pandas>=99"]) + "def main():\n    return 1\n")
+    backend = _FakeBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    asyncio.run(engine.run_python(str(target), {}))
+    assert seen == [["pandas>=99"]], "an unmeetable pin must still get its own venv"
+    assert backend.calls[0]["via"] == "execute"
+
+
+@requires_tomllib
+@requires_fused
+def test_extras_are_never_treated_as_satisfied(monkeypatch, tmp_path):
+    """`pandas[performance]` asks for packages a version number cannot vouch for.
+
+    `importlib.metadata.version` says nothing about whether an extra's transitive
+    dependencies are installed, so "cannot tell" has to mean "not satisfied" —
+    otherwise the script runs and fails on the first import of the extra's package.
+    """
+    target = tmp_path / "declared.py"
+    target.write_text(
+        _satisfied_header(["pandas[performance]>=2.0.0"]) + "def main():\n    return 1\n"
+    )
+    backend = _FakeBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    asyncio.run(engine.run_python(str(target), {}))
+    assert seen == [["pandas[performance]>=2.0.0"]]
+    assert backend.calls[0]["via"] == "execute"
+
+
+@requires_tomllib
+@requires_fused
+def test_the_escape_hatch_forces_the_venv_path(monkeypatch, tmp_path):
+    """One env var puts a satisfied header back on the old, isolated venv path."""
+    monkeypatch.setenv(engine._FORCE_VENV_ENV, "1")
+    target = tmp_path / "declared.py"
+    target.write_text(_satisfied_header(["pandas>=2.0.0"]) + "def main():\n    return 1\n")
+    backend = _FakeBackend(_FakeResult(return_value="1"))
+    monkeypatch.setattr(engine, "get_backend", lambda: backend)
+    seen = _preflight_spy(monkeypatch)
+
+    asyncio.run(engine.run_python(str(target), {}))
+    assert seen == [["pandas>=2.0.0"]]
+    assert backend.calls[0]["via"] == "execute"
+
+
+@requires_fused
+def test_the_app_package_probe_runs_at_most_once_per_process(monkeypatch):
+    """One subprocess per server process, not one per /api/run.
+
+    The probe spawns the app interpreter and imports importlib.metadata over every
+    distribution on its path — tens of milliseconds, and it is asked on the request
+    path. Uncached it would be paid by every run of every header, which is the cost
+    this whole fast path exists to remove.
+    """
+    engine.reset_app_packages_cache()
+    spawns = []
+    real = engine._probe_app_packages
+    monkeypatch.setattr(engine, "_probe_app_packages",
+                        lambda exe: spawns.append(exe) or real(exe))
+    first = engine.app_packages()
+    assert engine.app_packages() is first
+    assert engine.app_packages() is first
+    assert len(spawns) == 1, spawns
+    assert "pandas" in first, first
+
+
+@requires_fused
+def test_an_unparseable_requirement_is_not_satisfied():
+    """"I could not read it" must never read as "it is already there"."""
+    assert engine.app_satisfies(["not a requirement at all!!"]) is False
+
+
+def test_a_failed_probe_means_not_satisfied(monkeypatch):
+    """A probe that could not answer leaves the venv path in charge.
+
+    Same discipline as `envinstall._venv_is_usable` and `engine._probe`: a timeout
+    or a spawn failure is not evidence about what is installed, and acting on it as
+    if it were would run a script against an interpreter we know nothing about.
+    """
+    monkeypatch.setattr(engine, "app_packages", lambda: None)
+    assert engine.app_satisfies(["pandas"]) is False
+
+
+def test_an_empty_requirement_list_is_not_the_fast_path(monkeypatch):
+    """No header is PY-17's business, not this check's — and vacuous truth here
+    would make `app_satisfies([])` answer True for a script that never asked."""
+    monkeypatch.setattr(engine, "app_packages", lambda: {"pandas": "2.3.3"})
+    assert engine.app_satisfies([]) is False
 
 
 # --- the PYTHONHOME wrapper: making the packaged macOS app work ---------------

--- a/tests/test_engine_requirements.py
+++ b/tests/test_engine_requirements.py
@@ -109,6 +109,10 @@ _IMPORT_TO_DIST = {
     # it maps a name nothing provides — harmless, and listing it is what keeps
     # `test_the_import_map_covers_everything_the_app_ships` honest either way.
     "tomli": "tomli",
+    # PEP 508 parsing for `engine.app_satisfies`, which decides whether the app
+    # interpreter already meets a script's header (and so whether a venv is needed
+    # at all). Import name and distribution name coincide.
+    "packaging": "packaging",
     # AppKit, for the macOS clipboard bridge (shell/pasteboard/_darwin.py).
     # Only installed on darwin, so on Linux and Windows these map names nothing
     # provides — the same harmless shape as `tomli` above, and listing them is

--- a/tests/test_env_install.py
+++ b/tests/test_env_install.py
@@ -168,6 +168,115 @@ def test_the_stripped_env_vars_are_read_off_fused_not_guessed():
     assert set(engine._stripped_env_vars()) == set(python_compute._STRIPPED_ENV_VARS)
 
 
+# --- the precedence `run_python`'s interpreter fast path rests on --------------
+#
+# `run_python` skips the venv entirely when the app interpreter already satisfies
+# every requirement in a header, and it does that by passing `interpreter=` and NO
+# requirements. That is only correct because upstream reads `interpreter` FIRST and
+# never looks at `requirements` once it is set (`_execute_sync`, and stated in
+# `compute_base.py`: "`interpreter`, when set … wins over `requirements`"). Nothing
+# tested that precedence. If upstream ever flipped it to union the two, every
+# fast-path run would silently start building the multi-GB venv the fast path
+# exists to avoid — no error, just the old bill back. These two tests fail loudly
+# instead.
+#
+# Related hazard, deliberately NOT exercised here because we never trigger it:
+# `compute_base.execute()` sets `resolved_interpreter` from a uv workflow venv when
+# `project`/`project_dir` is passed, AND swaps the cache `env_component` to
+# `wv.env_component` — so with a project, requirements drop out of both the venv
+# and the cache identity. `engine._execute` passes neither argument; were it ever
+# to, "requirements were honoured" would stop being true on the venv path too.
+
+
+class _StopBeforeSpawn(BaseException):
+    """Aborts `_execute_sync` at the child spawn.
+
+    A `BaseException`, so the broad `except` blocks inside `_execute_sync` cannot
+    swallow it and turn a failed assertion into a plausible-looking result.
+    """
+
+
+@requires_fused
+def test_upstream_still_lets_the_interpreter_win_over_requirements(monkeypatch):
+    """Both arguments given: the interpreter runs the child, no venv is built."""
+    from fused.agent_core.backends.local import python_compute as pc
+
+    built = []
+    monkeypatch.setattr(
+        pc, "ensure_requirements_venv",
+        lambda *a, **k: built.append(a) or "/nonexistent/venv/bin/python",
+    )
+
+    backend = engine.get_backend()
+    monkeypatch.setattr(type(backend), "_ensure_dispatcher",
+                        lambda self: type("D", (), {"host_dir": "/tmp"})(),
+                        raising=True)
+    monkeypatch.setattr(type(backend), "_ensure_venv",
+                        lambda self: pytest.fail("built the bare venv"),
+                        raising=True)
+
+    spawned = []
+
+    def _run(cmd, **kw):
+        spawned.append(cmd)
+        raise _StopBeforeSpawn()
+
+    monkeypatch.setattr(pc.subprocess, "run", _run)
+
+    with pytest.raises(_StopBeforeSpawn):
+        backend._execute_sync(
+            code="print(1)",
+            interpreter="/the/app/interpreter",
+            requirements=["pandas>=2.0.0"],
+        )
+
+    assert not built, (
+        "upstream built a requirements venv despite `interpreter` being set; the "
+        "app-interpreter fast path in run_python is no longer safe"
+    )
+    assert spawned and spawned[0][0] == "/the/app/interpreter", (
+        f"the child ran on {spawned[0][0] if spawned else None}, not the interpreter"
+    )
+
+
+@requires_fused
+def test_engine_never_hands_the_backend_both_interpreter_and_requirements(monkeypatch):
+    """Our side of the same contract: the two are mutually exclusive at the call.
+
+    Passing both would read as "install these INTO that interpreter", which is not
+    what upstream does with it — and on the fast path the requirements are exactly
+    the set we have just proven is already present.
+    """
+    import asyncio
+
+    calls = {}
+
+    class _Backend:
+        def _execute_sync(self, **kw):
+            calls["sync"] = kw
+            return "ok"
+
+        async def execute(self, **kw):
+            calls["execute"] = kw
+            return "ok"
+
+    monkeypatch.setattr(engine, "get_backend", lambda: _Backend())
+
+    asyncio.run(engine._execute("code", ["pandas>=2.0.0"], "/the/app/interpreter", {}))
+    assert calls["sync"]["interpreter"] == "/the/app/interpreter"
+    assert "requirements" not in calls["sync"], (
+        "requirements travelled alongside interpreter; upstream would ignore them, "
+        "so passing them can only mislead a future reader"
+    )
+
+    calls.clear()
+    asyncio.run(engine._execute("code", ["pandas>=2.0.0"], None, {}))
+    assert calls["execute"]["requirements"] == ["pandas>=2.0.0"]
+    assert not calls["execute"].get("interpreter"), (
+        "the venv path must not pin an interpreter, or requirements stop mattering"
+    )
+
+
 def test_the_bundled_uv_is_found_beside_the_interpreter(tmp_path, monkeypatch):
     """The macOS bundle has no `venv`/`ensurepip`/`pip`, so uv is not optional.
 

--- a/tests/test_env_install.py
+++ b/tests/test_env_install.py
@@ -1605,6 +1605,79 @@ def test_the_worker_builds_the_venv_the_server_will_look_for(tmp_path, monkeypat
     )
 
 
+# --- the worker's builder is loaded by FILE, not through the `fused` package ---
+#
+# `from fused.agent_core.backends.local.venvs import ...` imports every parent,
+# so `fused/__init__` runs → `fused.api` → `fused._auth` → `fused._optional_deps`
+# → pandas. Measured: ~520ms of the 543ms it took this worker to install one tiny
+# pure-Python package was that import chain, to reach a module whose own import
+# costs microseconds. `venvs.py` is stdlib-only, so it can be loaded straight off
+# disk — and being the SAME FILE is what keeps `venv_key` identical to the key
+# `envinstall.venv_key_for` computes. These two tests protect both halves.
+
+
+@requires_fused
+def test_the_worker_loads_venvs_without_importing_the_fused_package(tmp_path):
+    """A fresh process must reach `ensure_requirements_venv` with no `fused` import.
+
+    Asserted in a SUBPROCESS because this test session has `fused` (and pandas)
+    imported already — in-process the absence could never be observed, which is
+    precisely why the cost went unnoticed.
+    """
+    worker_path = os.path.join(os.path.dirname(envinstall.__file__),
+                               "_env_install_worker.py")
+    probe = tmp_path / "probe.py"
+    probe.write_text(
+        "import importlib.util, json, sys\n"
+        f"spec = importlib.util.spec_from_file_location('_w', {worker_path!r})\n"
+        "w = importlib.util.module_from_spec(spec)\n"
+        "spec.loader.exec_module(w)\n"
+        "mod = w._venvs_module()\n"
+        "print(json.dumps({\n"
+        "    'has_builder': hasattr(mod, 'ensure_requirements_venv'),\n"
+        "    'has_key': hasattr(mod, 'venv_key'),\n"
+        "    'fused': 'fused' in sys.modules,\n"
+        "    'pandas': 'pandas' in sys.modules,\n"
+        "}))\n",
+        encoding="utf-8",
+    )
+    proc = subprocess.run([sys.executable, str(probe)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr
+    got = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert got["has_builder"] and got["has_key"], "the loaded module is not venvs.py"
+    assert got["fused"] is False, (
+        "loading venvs.py executed fused/__init__ — the ~500ms this avoids is back"
+    )
+    assert got["pandas"] is False, "pandas was imported to install a package"
+
+
+@requires_fused
+def test_the_directly_loaded_venvs_keys_a_venv_exactly_like_the_server_does():
+    """The invariant that makes the file load safe: same file, same key.
+
+    `envinstall.venv_key_for` composes upstream's `requirements_venv_id`/`venv_key`
+    through the package import; the worker now composes them from a module loaded
+    off disk. If those two ever disagreed the worker would fill a directory
+    `is_installed()` never looks in — the page would install, retry, and be told to
+    install again forever, with a fully built venv on disk (the same failure the
+    argv-borne `python_executable` exists to prevent).
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "_env_install_worker_keycheck",
+        os.path.join(os.path.dirname(envinstall.__file__), "_env_install_worker.py"),
+    )
+    worker = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(worker)
+
+    mod = worker._venvs_module()
+    reqs = ["pandas>=2.0.0", "pyarrow>=14.0.0"]
+    assert mod.venv_key(
+        mod.requirements_venv_id(list(reqs), envinstall._python_executable())
+    ) == envinstall.venv_key_for(reqs)
+
+
 # --- the worker's heartbeat (D213) --------------------------------------------
 #
 # `ensure_requirements_venv` runs uv behind `capture_output=True`, so between the

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -424,6 +424,9 @@ def test_cancelling_cancels_the_install_that_is_actually_running():
     result = _run_loader("""
 const cancelled = [];
 let polls = 0;
+// Assigned when the row exists; `showInstall` runs synchronously inside
+// `installEnv`, so it is there from the first poll onwards.
+let row = null;
 globalThis.fetch = (url, opts) => {
   if (url === "/api/env/install")
     return Promise.resolve({ ok: true, json: () => Promise.resolve(
@@ -431,8 +434,11 @@ globalThis.fetch = (url, opts) => {
   if (url.startsWith("/api/env/progress")) {
     polls += 1;
     if (polls === 1) {
-      // The user clicks Cancel while the install is genuinely in flight.
-      installUi.cancel._h.click[0]();
+      // The user clicks Cancel while the install is genuinely in flight. Reached
+      // through the ROW for this key: each install owns its own button now, so
+      // there is no single `installUi.cancel` to press.
+      row = installing.get("%(a)s").row;
+      row.cancel._h.click[0]();
       return Promise.resolve({ json: () => Promise.resolve({ ok: true,
         progress: { stage: "install", pct: 25, done: false } })});
     }
@@ -469,6 +475,7 @@ def test_a_cancel_the_server_could_not_honour_is_never_silent():
     """
     result = _run_loader("""
 let polls = 0;
+let row = null;
 globalThis.fetch = (url, opts) => {
   if (url === "/api/env/install")
     return Promise.resolve({ ok: true, json: () => Promise.resolve(
@@ -476,8 +483,10 @@ globalThis.fetch = (url, opts) => {
   if (url.startsWith("/api/env/progress")) {
     polls += 1;
     if (polls === 1) {
-      // Cancel lands inside the spawn window: nothing to kill yet.
-      installUi.cancel._h.click[0]();
+      // Cancel lands inside the spawn window: nothing to kill yet. Reached through
+      // the ROW for this key, since each install owns its own button now.
+      row = installing.get("%(a)s").row;
+      row.cancel._h.click[0]();
       return Promise.resolve({ json: () => Promise.resolve({ ok: true,
         progress: { stage: "install", pct: 25, detail: "downloading", done: false } })});
     }
@@ -490,8 +499,8 @@ globalThis.fetch = (url, opts) => {
     { ok: true, cancelled: false }) });
 };
 installEnv({ key: "%(a)s", requirements: ["x"] }, "a.py", "a.html").then(
-  () => console.log(JSON.stringify({ resolved: true, detail: installUi.detail.textContent })),
-  (e) => console.log(JSON.stringify({ type: e.type, detail: installUi.detail.textContent })));
+  () => console.log(JSON.stringify({ resolved: true, detail: row.detail.textContent })),
+  (e) => console.log(JSON.stringify({ type: e.type, detail: row.detail.textContent })));
 """ % {"a": _KEY_A, "b": _KEY_B})
     assert result.get("type") == "EnvInstallCancelled", (
         "the install resolved after the user cancelled it, so the script ran"
@@ -506,20 +515,36 @@ def test_one_finished_install_does_not_tear_the_overlay_off_another():
     """Two .py files with identical requirement sets share one venv key, so both
     calls track the SAME entry. A plain Set means the first to settle deletes it,
     `installing.size` hits 0, and the second install polls on with no UI and no
-    cancel button."""
+    cancel button.
+
+    Asserted across the mount delay rather than synchronously, because the overlay
+    no longer appears the instant an install starts: it is scheduled and mounts only
+    if something is still running when the timer fires. So the sequence checked here
+    is the whole lifecycle — the entry survives the first settle, the overlay does
+    appear while a waiter is live, and it goes on the LAST settle.
+    """
     result = _run_loader("""
 const need = { key: "%(a)s", requirements: ["x"] };
 showInstall(need);
 showInstall(need);
 hideInstall(need.key);
-const afterFirst = installUi.mounted;
-hideInstall(need.key);
-console.log(JSON.stringify({ afterFirst, afterSecond: installUi.mounted }));
+const afterFirst = installing.has(need.key);
+setTimeout(() => {
+  const mountedWhileLive = installUi.mounted;
+  hideInstall(need.key);
+  console.log(JSON.stringify({ afterFirst, mountedWhileLive,
+                               afterSecond: installUi.mounted,
+                               live: installing.size }));
+}, 900);
 """ % {"a": _KEY_A})
     assert result["afterFirst"] is True, (
-        "the overlay was removed while a second install with the same key was live"
+        "the shared entry was dropped while a second install with the same key was live"
+    )
+    assert result["mountedWhileLive"] is True, (
+        "the overlay never appeared for an install that outlived the mount delay"
     )
     assert result["afterSecond"] is False, "the overlay must go once the last one ends"
+    assert result["live"] == 0, "the entry outlived its last waiter"
 
 
 # --- the install stage has no percentage, so the bar must not claim one (D213) --
@@ -540,7 +565,7 @@ def test_the_install_stage_paints_an_indeterminate_bar():
     width, or a finished install would animate forever.
     """
     result = _run_loader("""
-const ui = installOverlay();
+const ui = installRow();
 const seen = [];
 const snap = (label) => seen.push([label, ui.bar.dataset.indeterminate || null,
                                    ui.bar.style.width]);
@@ -572,7 +597,7 @@ def test_the_python_stage_paints_an_indeterminate_bar_too():
     sweep.
     """
     result = _run_loader("""
-const ui = installOverlay();
+const ui = installRow();
 const seen = [];
 const snap = (label) => seen.push([label, ui.bar.dataset.indeterminate || null,
                                    ui.bar.style.width]);
@@ -684,12 +709,17 @@ def test_an_install_that_is_already_running_is_not_painted_as_zero_percent():
     percentage at all, and the first real paint comes from the server's own record.
     """
     result = _run_loader("""
-// installOverlay is memoised, so grabbing it first hands us the very bar the
-// loader will paint — and a recording setter then sees every width it assigns.
+// The row for this key is registered BEFORE installEnv runs, so the recording
+// setter is in place for `showInstall`'s own paints — which is where the
+// zero-percent bug lived. Attaching it afterwards would still pass while leaving
+// that exact regression invisible. `showInstall` reuses an existing entry for the key rather
+// than building a second row, so the loader paints into this very bar.
 const ui = installOverlay();
+const row = installRow();
+installing.set("%(a)s", { row, count: 0 });
 const widths = [];
-let w = ui.bar.style.width;
-Object.defineProperty(ui.bar.style, "width", {
+let w = row.bar.style.width;
+Object.defineProperty(row.bar.style, "width", {
   get: () => w,
   set: (v) => { w = v; widths.push(v); },
 });
@@ -719,6 +749,170 @@ installEnv({ key: "%(a)s", requirements: ["a", "b"] }, "a.py", "a.html").then(
         f"a joined install was painted as 0% first: {result['widths']}"
     )
     assert result["widths"][-1] == "100%", result["widths"]
+
+
+# --- several installs at once, each with its own row --------------------------
+#
+# The gap that let the shared-overlay bug ship: the only multi-install test above
+# passes the SAME key twice, because two .py files with identical requirement sets
+# share one venv key. That is a real case and it is covered. The case nobody
+# covered is the one users actually hit — an HTML view calling several .py files
+# with DIFFERENT headers, so N installs with N distinct keys run concurrently
+# against what used to be one title, one detail line and one Cancel button.
+
+
+def test_two_distinct_installs_get_their_own_rows():
+    """Distinct keys must not share nodes.
+
+    With one shared set, the title named whichever install started last and the
+    detail line flipped between N pollers at 2Hz. This asserts the structural fix:
+    two entries, two rows, two bars, both attached to the overlay.
+    """
+    result = _run_loader("""
+const ui = installOverlay();
+const a = showInstall({ key: "%(a)s", requirements: ["imagecodecs"] });
+const b = showInstall({ key: "%(b)s", requirements: ["s3fs"] });
+console.log(JSON.stringify({
+  live: installing.size,
+  rows: ui.rows.children.length,
+  sameRow: a === b,
+  sameBar: a.bar === b.bar,
+  sameCancel: a.cancel === b.cancel,
+  titleA: a.title.textContent,
+  titleB: b.title.textContent,
+}));
+""" % {"a": _KEY_A, "b": _KEY_B})
+    assert result["live"] == 2, result
+    assert result["rows"] == 2, "both installs must be visible at once"
+    assert result["sameRow"] is False
+    assert result["sameBar"] is False
+    assert result["sameCancel"] is False, (
+        "one shared Cancel button means a single click cancels every install"
+    )
+    assert result["titleA"] == "Installing imagecodecs"
+    assert result["titleB"] == "Installing s3fs", (
+        "the second install overwrote the first install's title"
+    )
+
+
+def test_painting_one_install_does_not_touch_another():
+    """Each poller writes only its own row.
+
+    Two pollers on one detail line is what made a legitimate pair of installs read
+    as a single flickering one, so this pins the isolation directly rather than
+    through the DOM shape alone.
+    """
+    result = _run_loader("""
+const a = showInstall({ key: "%(a)s", requirements: ["imagecodecs"] });
+const b = showInstall({ key: "%(b)s", requirements: ["s3fs"] });
+paintInstall(a, { stage: "install", pct: 25, detail: "fetching imagecodecs",
+                  done: false });
+paintInstall(b, { stage: "create", pct: 10, detail: "preparing s3fs", done: false });
+console.log(JSON.stringify({
+  detailA: a.detail.textContent, detailB: b.detail.textContent,
+  indetA: a.bar.dataset.indeterminate || null,
+  indetB: b.bar.dataset.indeterminate || null,
+  widthB: b.bar.style.width,
+}));
+""" % {"a": _KEY_A, "b": _KEY_B})
+    assert result["detailA"] == "fetching imagecodecs"
+    assert result["detailB"] == "preparing s3fs", "one poller overwrote the other's detail"
+    assert result["indetA"] == "1", "the install stage must stay indeterminate"
+    assert result["indetB"] is None, "a stage with a real pct must not animate"
+    assert result["widthB"] == "10%"
+
+
+def test_finishing_one_install_leaves_the_other_row_alone():
+    """The row goes with its own key, and only that key."""
+    result = _run_loader("""
+const ui = installOverlay();
+showInstall({ key: "%(a)s", requirements: ["imagecodecs"] });
+const b = showInstall({ key: "%(b)s", requirements: ["s3fs"] });
+paintInstall(b, { stage: "install", pct: 25, detail: "fetching s3fs", done: false });
+hideInstall("%(a)s");
+console.log(JSON.stringify({
+  live: installing.size,
+  stillB: installing.has("%(b)s"),
+  detailB: b.detail.textContent,
+  removedB: b.el.removed || false,
+}));
+""" % {"a": _KEY_A, "b": _KEY_B})
+    assert result["live"] == 1
+    assert result["stillB"] is True
+    assert result["removedB"] is False, "the surviving install's row was torn out"
+    assert result["detailB"] == "fetching s3fs", (
+        "the finished install wiped the running one's detail"
+    )
+
+
+def test_a_fast_install_never_mounts_the_overlay():
+    """An install that beats the mount delay must not flash a modal.
+
+    The overlay used to mount synchronously, before anything was known about
+    duration, so a warm-cache install measured in tens of milliseconds still threw a
+    full-screen modal over the page and pulled it down again.
+    """
+    result = _run_loader("""
+const need = { key: "%(a)s", requirements: ["x"] };
+showInstall(need);
+const duringInstall = installUi.mounted;
+hideInstall(need.key);
+// Past the delay: the cancelled timer must not mount an overlay after the fact.
+setTimeout(() => {
+  console.log(JSON.stringify({ duringInstall, afterDelay: installUi.mounted,
+                               timer: installUi.mountTimer }));
+}, 900);
+""" % {"a": _KEY_A})
+    assert result["duringInstall"] is False, "the overlay mounted before the delay"
+    assert result["afterDelay"] is False, (
+        "a finished install mounted the overlay after the fact"
+    )
+    assert result["timer"] is None, "the pending mount timer was left armed"
+
+
+def test_the_poll_interval_ramps_then_backs_off():
+    """The first second is polled fast, then it settles to the slow grid.
+
+    A fixed 500ms grid meant a ~540ms install was not noticed until its second
+    poll. What is asserted is the observable SCHEDULE — the gaps the loader asks
+    for — because wall-clock timing in a test would be measuring the machine.
+
+    Both the timer and the clock are stubbed, and the clock is the important one:
+    the ramp is keyed on the INSTALL's age rather than on a poll count, so with
+    real time frozen by an instant-firing timer it would stay in its fast phase
+    forever and this test would assert nothing about the back-off.
+    """
+    result = _run_loader("""
+const gaps = [];
+const realSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = (fn, ms) => { gaps.push(ms); return realSetTimeout(fn, 0); };
+// A controllable clock: 200ms of install age per poll, so the 1000ms fast window
+// is crossed on the fifth one.
+let now = 0;
+Date.now = () => now;
+let polls = 0;
+globalThis.fetch = (url) => {
+  if (url === "/api/env/install")
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(
+      { ok: true, key: "%(b)s", progress: { stage: "install", pct: 25, done: false } })});
+  polls += 1;
+  now += 200;
+  // Twelve unfinished polls, so the ramp has to cross its window and back off.
+  return Promise.resolve({ json: () => Promise.resolve({ ok: true,
+    progress: polls < 12
+      ? { stage: "install", pct: 25, done: false }
+      : { stage: "done", pct: 100, done: true, error: null } })});
+};
+installEnv({ key: "%(a)s", requirements: ["x"] }, "a.py", "a.html").then(
+  () => console.log(JSON.stringify({ gaps })),
+  (e) => console.log(JSON.stringify({ error: e.message, gaps })));
+""" % {"a": _KEY_A, "b": _KEY_B})
+    gaps = [g for g in result.get("gaps", []) if g in (100, 500)]
+    assert gaps, result
+    assert gaps[0] == 100, f"the first poll waited the full grid: {gaps}"
+    assert 500 in gaps, f"the interval never backed off: {gaps}"
+    # Monotonic: fast first, slow after — never back to fast.
+    assert gaps == sorted(gaps), f"the ramp went backwards: {gaps}"
 
 
 def test_the_runtime_drives_the_loader():


### PR DESCRIPTION
## Summary

Reported: an HTML view calling several `.py` files, each with its own PEP 723 header, shows **one** progress screen for all of them — and venv setup is slow.

- **Most of those venvs never needed to exist.** `[bundled]` already ships pandas/numpy/duckdb/pyarrow/geopandas/rasterio/zarr/pyproj/keyring/pyyaml/cryptography on the app interpreter. D172 stops a header being *extended* with a baseline; nothing checked whether one was already *satisfied*. Such a header now runs with no venv, no download and no loader. (One machine's store: 33 venvs / 4.9 GB, in which a five-package set whose every member was already present existed under **five** keys.)
- **Installs that remain start ~500 ms sooner.** The worker reached `ensure_requirements_venv` through the `fused` package, so `fused/__init__` pulled in pandas — ~520 ms of the 543 ms spent installing one tiny package. It now loads that stdlib-only file directly; same file, so the venv key is unchanged.
- **Concurrent installs are legible.** One row per install — own title, detail, bar, Cancel. Previously one shared set of nodes meant the title named whichever install started last, N pollers rewrote one line at 2 Hz, and one Cancel carried N listeners, so a single click cancelled everything.
- **Short installs no longer flash a modal.** The overlay mounts only if something is still running 600 ms later, and polling ramps (100 ms for the first second, then 500 ms).

Deliberate trade: a satisfied header now runs on the shared app interpreter and can see packages it never declared. PY-17 already does this for header-*less* scripts, so it widens an existing property. `FUSED_RENDER_FORCE_SCRIPT_VENV` opts out.

## Visuals

The delta is one new branch in `/api/run` — the "already satisfied" exit that skips the venv, the download and the loader.

```mermaid
flowchart TD
    A["run a .py"] --> B{"PEP 723 header?"}
    B -->|no| C["app interpreter, no venv"]
    B -->|yes| D{"app already satisfies it?"}
    D -->|"yes (new)"| C
    D -->|no| E{"venv ready?"}
    E -->|yes| F["run inside the venv"]
    E -->|no| G["needs_install, show loader"]
```

## Usage

Nothing new to invoke — existing views get this automatically.

- `FUSED_RENDER_FORCE_SCRIPT_VENV=1` forces every header back onto the venv path (isolation over speed).
- `engine.app_satisfies([...])` / `engine.app_packages()` answer "would this header need a venv?" directly.

`dependencies = ["pandas>=2.0.0", "duckdb", "pyarrow"]` now runs immediately; `imagecodecs` or `s3fs` still installs, as before.

## Test Plan

- [x] **Fast path** (`test_engine.py`): satisfied header builds no venv and returns no `needs_install`; one missing package sends the whole header to the venv path; `pandas>=99` is not satisfied (specifier, not importability); extras and direct URLs are never satisfied; escape hatch forces the venv path; probe runs at most once per process; unparseable specs and failed probes mean "not satisfied".
- [x] **Fallback**: with no `_execute_sync`, a satisfied header still runs via the venv path **with the pre-flight intact** — so a missing venv becomes `needs_install` rather than an inline download inside the request.
- [x] **Worker** (`test_env_install.py`): `venvs.py` loads without executing `fused/__init__`, and its `venv_key` equals `envinstall.venv_key_for` — the invariant keeping the worker on the directory the server reads.
- [x] **Overlay** (`test_server_env_install.py`): two distinct keys get their own rows/bars/Cancel; painting one leaves the other untouched; finishing one leaves the other's row alone; a fast install never mounts; the poll interval ramps then backs off.
- [x] **Upstream contract** (`test_env_install.py`): `interpreter` still wins over `requirements`, and `engine._execute` never passes both.
- [x] **Gates fail closed** (`test_engine.py`): a `get_backend()` that raises is not an interpreter path; a missing `packaging` warns *without* probing (asserting the ordering, not just the answer).
- [x] Full suite: **4571 passed**, 106 skipped. The 6 `test_remote_*` failures in `test_browse_mount.py` are pre-existing and fail identically on `origin/main`.
- [x] By hand: a `pandas`/`duckdb`/`pyarrow` header ran on the app interpreter with no `needs_install`; an `imagecodecs` header still routed to the installer.
- [ ] Worth a human glance: the multi-row overlay with two real concurrent installs (one `.py` needing `s3fs`, another `imagecodecs`). No headless test can see whether it *looks* right.

### Review follow-ups (already applied)

| Finding | Fix |
|---|---|
| Satisfied header hard-failed on a backend without `_execute_sync` — a regression, with a message claiming the script had "no dependencies of its own" | Gate moved into `run_python` **before** the pre-flight, so declining falls through to `is_installed` instead of an inline build |
| `packaging` imported but undeclared, and its absence swallowed into a per-run traceback that silently disabled the fast path | Declared core (matching pyproject's own `httpx`/`tomli` reasoning); `ImportError` split out and warned once |
| Direct-reference requirements treated as satisfied (Cursor Bugbot) — `pandas @ https://…` cleared whenever any `pandas` was installed, so the pinned wheel was never fetched | `req.url` now fails closed, like extras; covers URLs, local paths and VCS refs |
| **CI red:** `_interpreter_path_available` let `get_backend()` raise. It runs first, so on a build without `fused` a bare `ModuleNotFoundError` from an optional probe replaced the pre-flight's own diagnosis | Answers `False` — no backend is no interpreter path |
| `packaging`'s `ImportError` handler was unreachable (Cursor Bugbot) — the probe canonicalises with `packaging` too, so a missing parser escaped as an `EngineError` per header instead of one warning | Guarded import moved above the probe |

**Note on a changed test.** `test_a_declared_header_still_gets_its_own_venv` now sets the escape hatch: its header is `["pip"]` (the cheapest warm venv) and the dev-env setup seeds `pip` on purpose, so the fast path legitimately claims it and the test would otherwise have become a second header-less test. The hatch keeps what it is *for* — build a real venv, run the script inside it. Routing is covered separately on the fake backend.
