### PR TITLE
Consolidate explorer top bar: star bookmark, inline split icons, mode switcher in breadcrumb bar

### DIFF
--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -16,10 +16,11 @@ import {
   armBookmark,
   disarmBookmark,
   getArmedBookmark,
+  getArmedBookmarkFor,
   sameSearch,
   splitBookmarkUrl,
 } from "@platform/lib/bookmarks";
-import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "@platform/lib/hooks";
+import { useUrlVersion, useBookmarksVersion, useArmedVersion, notifyBookmarksChanged } from "@platform/lib/hooks";
 import { urlScheme, isCloudScheme, fileUrlToPath } from "@platform/lib/path-url";
 import { resolveCloudUrl } from "@platform/lib/api";
 import { pushToast } from "@platform/lib/toast";
@@ -116,8 +117,11 @@ function RevealButton({ fsPath }: { fsPath: string }) {
 function BookmarkStar({ name }: { name: string }) {
   useUrlVersion();
   useBookmarksVersion();
+  useArmedVersion();
   const starred = allBookmarks().some((b) => b.url === currentUrl());
-  const armed = !IS_EMBED && getArmedBookmark() !== null;
+  // Pathname-gated (getArmedBookmarkFor): an armed bookmark lights the star
+  // only on ITS view, and useArmedVersion re-renders this when a disarm fires.
+  const armed = !IS_EMBED && getArmedBookmarkFor(location.pathname) !== null;
   const active = starred || armed;
 
   const onBookmark = async () => {

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -1,6 +1,9 @@
-// Crumb bar + "+ Bookmark" / "Update bookmark" / split right/down buttons.
-// Rendered by every view: path crumbs for listing/preview, a static label for
-// the layout modes (LM-11 / TM-9 — ★/update still operate on currentUrl()).
+// Crumb bar: ★ bookmark button on the left, path crumbs, split right/down +
+// reveal-in-Finder icons at the crumbs' tail, and the `#topbar-mode-slot`
+// portal target on the right (Preview portals its mode switcher/deploy actions
+// there). Rendered by every view: path crumbs for listing/preview, a static
+// label for the layout modes (LM-11 / TM-9 — ★/update still operate on
+// currentUrl()).
 import React, { useEffect, useRef, useState } from "react";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
 import { navigate, navigateUrl, urlForFsPath, currentUrl, IS_EMBED } from "@platform/lib/router";
@@ -60,12 +63,20 @@ function useUpdateButton(urlVersion: number, bookmarksVersion: number): boolean 
   return visible;
 }
 
-// Shared action block (present on every view). `name` is the default bookmark
-// name; `onSplit` present adds the panel-mode entry points (the layout modes
-// themselves pass none).
-interface CrumbActionsProps {
-  name: string;
-  onSplit?: (dir: "row" | "col") => void;
+function StarIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      width="15"
+      height="15"
+      viewBox="0 0 16 16"
+      fill={filled ? "currentColor" : "none"}
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    >
+      <path d="M8 1.8l1.9 3.9 4.3.6-3.1 3 .7 4.3L8 11.6l-3.8 2 .7-4.3-3.1-3 4.3-.6z" />
+    </svg>
+  );
 }
 
 // Browsers block file:// navigation from http pages, so revealing in the OS
@@ -99,16 +110,42 @@ function RevealButton({ fsPath }: { fsPath: string }) {
 // chrome-level readout lingered in the corner with no way to dismiss it, and
 // the row marking is where the user is already looking.
 
-function CrumbActions({ name, onSplit }: CrumbActionsProps) {
-  const urlVersion = useUrlVersion();
-  const bookmarksVersion = useBookmarksVersion();
-  const showUpdate = useUpdateButton(urlVersion, bookmarksVersion);
+// ★ bookmark button, leftmost in the bar. Highlighted (accent-yellow, filled)
+// when the current view is bookmarked or an armed bookmark is live. `name` is
+// the default bookmark name.
+function BookmarkStar({ name }: { name: string }) {
+  useUrlVersion();
+  useBookmarksVersion();
   const starred = allBookmarks().some((b) => b.url === currentUrl());
+  const armed = !IS_EMBED && getArmedBookmark() !== null;
+  const active = starred || armed;
 
   const onBookmark = async () => {
     await addBookmark(name, currentUrl());
     notifyBookmarksChanged();
   };
+
+  return (
+    <button
+      id="bookmark-btn"
+      className={"bookmark-star-btn" + (active ? " active" : "")}
+      title={starred ? "View is bookmarked (★ adds another)" : "Bookmark this view"}
+      onClick={onBookmark}
+    >
+      <StarIcon filled={active} />
+    </button>
+  );
+}
+
+// "Update bookmark" text button, after the crumbs strip (and its finder/split
+// icons), before the actions slot. Visible only when the armed bookmark's
+// params have drifted (D38).
+function UpdateBookmarkButton() {
+  const urlVersion = useUrlVersion();
+  const bookmarksVersion = useBookmarksVersion();
+  const showUpdate = useUpdateButton(urlVersion, bookmarksVersion);
+  if (!showUpdate) return null;
+
   const onUpdate = async () => {
     const armed = getArmedBookmark();
     if (!armed) return;
@@ -119,47 +156,22 @@ function CrumbActions({ name, onSplit }: CrumbActionsProps) {
   };
 
   return (
-    <div className="crumb-actions">
-      {showUpdate && (
-        <button
-          id="update-bookmark-btn"
-          className="star-btn starred"
-          title="Update bookmark to current params"
-          onClick={onUpdate}
-        >
-          Update bookmark
-        </button>
-      )}
-      {onSplit && (
-        <>
-          <button
-            id="split-right-btn"
-            className="star-btn split-dir"
-            title="Open this view in panel mode, split right"
-            onClick={() => onSplit("row")}
-          >
-            <SplitRightIcon />
-          </button>
-          <button
-            id="split-down-btn"
-            className="star-btn split-dir"
-            title="Open this view in panel mode, split down"
-            onClick={() => onSplit("col")}
-          >
-            <SplitDownIcon />
-          </button>
-        </>
-      )}
-      <button
-        id="bookmark-btn"
-        className={"star-btn" + (starred ? " starred" : "")}
-        title={starred ? "View is bookmarked (★ adds another)" : "Bookmark this view"}
-        onClick={onBookmark}
-      >
-        + Bookmark
-      </button>
-    </div>
+    <button
+      id="update-bookmark-btn"
+      className="star-btn starred"
+      title="Update bookmark to current params"
+      onClick={onUpdate}
+    >
+      Update bookmark
+    </button>
   );
+}
+
+// Portal target for the view's header actions (mode switcher, deploy, "Open as
+// app") — Preview renders into this via TopbarActions. Carries
+// .preview-actions so the existing switcher/button styling applies unchanged.
+function TopbarActionsSlot() {
+  return <div id="topbar-mode-slot" className="crumb-actions preview-actions" />;
 }
 
 // Split entry (LM-10): two panes side by side (`dir` "row", `,` in the codec)
@@ -377,6 +389,7 @@ export function Breadcrumb({
 
   return (
     <>
+      <BookmarkStar name={renderedTitle || basename(fsPath)} />
       {editing ? (
         <input
           className="crumb-edit"
@@ -413,9 +426,26 @@ export function Breadcrumb({
         >
           {pieces}
           <RevealButton fsPath={fsPath} />
+          <button
+            id="split-right-btn"
+            className="reveal-btn split-dir"
+            title="Open this view in panel mode, split right"
+            onClick={() => enterPanel(fsPath, "row")}
+          >
+            <SplitRightIcon />
+          </button>
+          <button
+            id="split-down-btn"
+            className="reveal-btn split-dir"
+            title="Open this view in panel mode, split down"
+            onClick={() => enterPanel(fsPath, "col")}
+          >
+            <SplitDownIcon />
+          </button>
         </div>
       )}
-      <CrumbActions name={renderedTitle || basename(fsPath)} onSplit={(dir) => enterPanel(fsPath, dir)} />
+      <UpdateBookmarkButton />
+      <TopbarActionsSlot />
     </>
   );
 }
@@ -423,10 +453,12 @@ export function Breadcrumb({
 export function StaticBreadcrumb({ label }: { label: string }) {
   return (
     <>
+      <BookmarkStar name={label} />
       <div className="crumbs">
         <span className="current">{label}</span>
       </div>
-      <CrumbActions name={label} />
+      <UpdateBookmarkButton />
+      <TopbarActionsSlot />
     </>
   );
 }

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -4,6 +4,7 @@
 // No file-type checks live in the shell — html arrives through stat.templates
 // like everything else, via the "_render" sentinel (SPEC PT-12).
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import {
   getDeployStatus,
   rawUrl,
@@ -62,6 +63,19 @@ function Header({ fsPath, stat, children, afterName, onContextMenu }: HeaderProp
       <div className="preview-actions">{children}</div>
     </div>
   );
+}
+
+// Explorer variant: the second header bar is gone (the name is redundant with
+// the breadcrumb), so the view's actions render into the breadcrumb bar's
+// `#topbar-mode-slot` (Breadcrumb.tsx) via a portal. The slot is a sibling
+// rendered in the same commit as the preview, so it exists by the time this
+// effect runs; keyed remounts on navigation re-find it.
+function TopbarActions({ children }: { children: ReactNode }) {
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  useEffect(() => {
+    setSlot(document.getElementById("topbar-mode-slot"));
+  }, []);
+  return slot ? createPortal(children, slot) : null;
 }
 
 // One open modal for the preview file menu: a Rename prompt or a Delete confirm
@@ -381,6 +395,7 @@ function TemplatePreview({
   conditions,
   onRenderedTitle,
   hideHeader,
+  actionsInTopbar,
 }: {
   fsPath: string;
   stat: StatResult;
@@ -388,6 +403,7 @@ function TemplatePreview({
   conditions: Record<string, boolean> | null;
   onRenderedTitle?: (title: string | null) => void;
   hideHeader?: boolean;
+  actionsInTopbar?: boolean;
 }) {
   // Caller only renders this when `templates` (already sentinel-filtered by
   // Preview's dispatch, SPEC PT-12) is non-empty. Entries whose condition.py
@@ -633,48 +649,62 @@ function TemplatePreview({
     Promise.resolve(buildOpenWithItems(templates, (m) => void setMode(m)));
   const fileMenu = usePreviewFileMenu(fsPath, stat, loadOpenWith);
 
+  const openAsAppBtn =
+    isListing && singleAppPath ? (
+      <button
+        type="button"
+        className="open-as-app-btn"
+        onClick={() => navigate(singleAppPath, { isDir: false })}
+      >
+        Open as app
+      </button>
+    ) : null;
+
+  const headerActions = (
+    <>
+      {/* Deployable = the mode list carries the "_render" sentinel AND the
+          file is .html/.htm — the exporter's actual contract. The extension
+          check matters because a registry rebind can put "_render" on any
+          type (D73), but /api/export and /api/deploy/preview accept only
+          .html/.htm — the button must not open a modal that can't deploy.
+          Directories never deploy (no _render binding exists for one today;
+          the guard keeps that true even if a registry ever says otherwise).
+          Gated on the opt-in Deploy pref (Preferences → Deployments): hidden
+          entirely unless the user has turned Deploy on. */}
+      {!stat.is_dir &&
+        deployEnabled &&
+        templates.some((t) => t.mode === "_render") &&
+        /\.html?$/i.test(fsPath) && <DeployButton fsPath={fsPath} />}
+      <ModeSwitcher
+        entries={templates.map((t) => ({ mode: t.mode, icon: templateModeIcon(t), pending: isPending(t) }))}
+        active={entry.mode}
+        /* Spinner from the click until the incoming frame has actually taken
+           over — the flush wait AND the new document's load are both time the
+           user is waiting on that button. */
+        busy={switchingTo ?? (shown !== mode ? mode : null)}
+        onSelect={setMode}
+      />
+    </>
+  );
+
   return (
     <>
-      {!hideHeader && (
-      <Header
-        fsPath={fsPath}
-        stat={stat}
-        onContextMenu={fileMenu.onContextMenu}
-        afterName={
-          isListing && singleAppPath ? (
-            <button
-              type="button"
-              className="open-as-app-btn"
-              onClick={() => navigate(singleAppPath, { isDir: false })}
-            >
-              Open as app
-            </button>
-          ) : null
-        }
-      >
-        {/* Deployable = the mode list carries the "_render" sentinel AND the
-            file is .html/.htm — the exporter's actual contract. The extension
-            check matters because a registry rebind can put "_render" on any
-            type (D73), but /api/export and /api/deploy/preview accept only
-            .html/.htm — the button must not open a modal that can't deploy.
-            Directories never deploy (no _render binding exists for one today;
-            the guard keeps that true even if a registry ever says otherwise).
-            Gated on the opt-in Deploy pref (Preferences → Deployments): hidden
-            entirely unless the user has turned Deploy on. */}
-        {!stat.is_dir &&
-          deployEnabled &&
-          templates.some((t) => t.mode === "_render") &&
-          /\.html?$/i.test(fsPath) && <DeployButton fsPath={fsPath} />}
-        <ModeSwitcher
-          entries={templates.map((t) => ({ mode: t.mode, icon: templateModeIcon(t), pending: isPending(t) }))}
-          active={entry.mode}
-          /* Spinner from the click until the incoming frame has actually taken
-             over — the flush wait AND the new document's load are both time the
-             user is waiting on that button. */
-          busy={switchingTo ?? (shown !== mode ? mode : null)}
-          onSelect={setMode}
-        />
-      </Header>
+      {actionsInTopbar ? (
+        <TopbarActions>
+          {openAsAppBtn}
+          {headerActions}
+        </TopbarActions>
+      ) : (
+        !hideHeader && (
+          <Header
+            fsPath={fsPath}
+            stat={stat}
+            onContextMenu={fileMenu.onContextMenu}
+            afterName={openAsAppBtn}
+          >
+            {headerActions}
+          </Header>
+        )
       )}
       <div className="preview-body">
         {isPending(entry) ? (
@@ -740,14 +770,14 @@ function TemplatePreview({
   );
 }
 
-function FallbackPreview({ fsPath, stat }: { fsPath: string; stat: StatResult }) {
+function FallbackPreview({ fsPath, stat, actionsInTopbar }: { fsPath: string; stat: StatResult; actionsInTopbar?: boolean }) {
   // No renderable views back this file (that's why it's the fallback), so Open
   // With resolves to the empty "No views available" list without a re-stat.
   const loadOpenWith = () => Promise.resolve(buildOpenWithItems([], () => {}));
   const fileMenu = usePreviewFileMenu(fsPath, stat, loadOpenWith);
   return (
     <>
-      <Header fsPath={fsPath} stat={stat} onContextMenu={fileMenu.onContextMenu} />
+      {!actionsInTopbar && <Header fsPath={fsPath} stat={stat} onContextMenu={fileMenu.onContextMenu} />}
       <div className="preview-body">
         <div className="metadata-card">
           <dl>
@@ -786,9 +816,12 @@ interface PreviewProps {
   // Chrome-free render (the /learn page): no preview header, no mode switcher —
   // the content fills the body directly.
   hideHeader?: boolean;
+  // Explorer variant: no preview header bar; the mode switcher/deploy actions
+  // portal into the breadcrumb bar's #topbar-mode-slot instead.
+  actionsInTopbar?: boolean;
 }
 
-export default function Preview({ fsPath, stat, onRenderedTitle, allowModes, hideHeader }: PreviewProps) {
+export default function Preview({ fsPath, stat, onRenderedTitle, allowModes, hideHeader, actionsInTopbar }: PreviewProps) {
   // Defensive filter (SPEC PT-12): an entry with path===null whose mode isn't
   // a recognized sentinel (`_render`, `_listing`) is dropped. Filtering here
   // keeps the non-empty dispatch check honest (an all-unknown list falls back
@@ -809,7 +842,7 @@ export default function Preview({ fsPath, stat, onRenderedTitle, allowModes, hid
   if (resolving && templates.length > 0 && templates.every((t) => t.conditional)) {
     return (
       <>
-        <Header fsPath={fsPath} stat={stat} />
+        {!actionsInTopbar && <Header fsPath={fsPath} stat={stat} />}
         <div className="preview-body">
           <div className="preview-resolving">
             <span className="mode-icon-spinner" />
@@ -828,7 +861,8 @@ export default function Preview({ fsPath, stat, onRenderedTitle, allowModes, hid
         conditions={conditions}
         onRenderedTitle={onRenderedTitle}
         hideHeader={hideHeader}
+        actionsInTopbar={actionsInTopbar}
       />
     );
-  return <FallbackPreview fsPath={fsPath} stat={stat} />;
+  return <FallbackPreview fsPath={fsPath} stat={stat} actionsInTopbar={actionsInTopbar} />;
 }

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -928,10 +928,40 @@ a.bookmark-name::after {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
+  gap: 10px;
   padding: 10px 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
+  /* Pin to the tallest state (28px mode-switcher button + 10px×2 padding) so
+     the bar can't grow when the portaled switcher lands after stat resolves. */
+  min-height: 48px;
+  box-sizing: border-box;
+}
+
+/* ★ bookmark button, leftmost in the bar. Subtle: bare glyph, no box —
+   muted until hovered; accent-yellow (filled star) when the view is
+   bookmarked or an armed bookmark is live. */
+.bookmark-star-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color var(--dur-fast) var(--ease-out);
+}
+
+.bookmark-star-btn:hover {
+  color: var(--fg);
+}
+
+.bookmark-star-btn.active,
+.bookmark-star-btn.active:hover {
+  color: var(--accent);
 }
 
 /* Shared with the panel path bar (.panel-crumbs/.panel-crumb*, Panel.tsx):
@@ -1068,6 +1098,12 @@ a.bookmark-name::after {
   gap: 8px;
 }
 
+/* The portal target collapses entirely when no view has filled it (loading,
+   fallback card, static pages) — no stray gap at the bar's right edge. */
+#topbar-mode-slot:empty {
+  display: none;
+}
+
 .star-btn {
   flex: 0 0 auto;
   font: inherit;
@@ -1081,25 +1117,10 @@ a.bookmark-name::after {
   cursor: pointer;
 }
 
-/* Icon-only split buttons: same chrome as .star-btn, tighter padding so the
-   14px glyph sits centred at the text buttons' height. The pair sits closer
-   together than the 8px crumb-actions gap, with matching extra room on both
-   sides; hover is a quiet light-grey lift, not the accent of text buttons. */
-.star-btn.split-dir {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 7px;
-  margin-left: 6px;
-}
-
-.star-btn.split-dir + .star-btn.split-dir {
-  margin-left: -5px;
-  margin-right: 6px;
-}
-
-.star-btn.split-dir:hover {
-  color: var(--fg);
-  border-color: var(--fg-muted);
+/* Icon-only split buttons at the crumbs' tail, after the Finder glyph — same
+   boxless .reveal-btn chrome, sitting slightly tighter as a pair. */
+.reveal-btn.split-dir {
+  margin-left: 2px;
 }
 
 .star-btn:hover {

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -1937,6 +1937,22 @@ table.listing-table td.mtime {
   color: var(--accent);
 }
 
+/* In the explorer the button portals into the breadcrumb's actions slot
+   (.preview-actions): re-assert the accent chrome over the slot's generic
+   `.preview-actions button` rules, which otherwise outrank the class above. */
+.preview-actions .open-as-app-btn {
+  font-size: 12px;
+  border: 1px solid rgba(var(--accent-rgb), 0.35);
+  background: rgba(var(--accent-rgb), 0.08);
+  color: var(--accent-soft);
+}
+
+.preview-actions .open-as-app-btn:hover {
+  background: rgba(var(--accent-rgb), 0.16);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .preview-actions {
   display: flex;
   align-items: center;

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -164,24 +164,28 @@ function StatErrorView({
 // (api.prefetchListDir) when stat resolves and the preview remounts the
 // listing. Without a directory hint we can't safely show a listing (a file's
 // list would 404), so only the header + a neutral loading body paint.
-function LoadingScaffold({ fsPath, isDir }: { fsPath: string; isDir: boolean }) {
+function LoadingScaffold({ fsPath, isDir, headerless }: { fsPath: string; isDir: boolean; headerless?: boolean }) {
   return (
     <>
       {/* Mirror the loaded Header exactly (Preview.tsx `Header`): the name in a
           `.preview-title` group, and a `.mode-switcher-placeholder` that reserves
           the mode switcher's button height in the actions slot. Without this the
           header grows (spinner → 28px buttons) when stat resolves, dropping the
-          name and the whole body — a visible layout shift on every navigation. */}
-      <div className="preview-header">
-        <div className="preview-title">
-          <h1 title={fsPath}>{basename(fsPath)}</h1>
+          name and the whole body — a visible layout shift on every navigation.
+          Skipped for the explorer (`headerless`): its actions live in the
+          breadcrumb bar's slot, and there is no second header bar at all. */}
+      {!headerless && (
+        <div className="preview-header">
+          <div className="preview-title">
+            <h1 title={fsPath}>{basename(fsPath)}</h1>
+          </div>
+          <div className="preview-actions">
+            <span className="mode-switcher-placeholder" aria-label="Loading">
+              <span className="mode-icon-spinner" />
+            </span>
+          </div>
         </div>
-        <div className="preview-actions">
-          <span className="mode-switcher-placeholder" aria-label="Loading">
-            <span className="mode-icon-spinner" />
-          </span>
-        </div>
-      </div>
+      )}
       <div className="preview-body">
         {isDir ? (
           // provisional: the hint could be stale (file, not dir). Suppress
@@ -272,7 +276,7 @@ function StatView({
   if (stat.status === "loading") {
     // Not a blank screen: paint the scaffold immediately (Fix #1). A directory
     // nav also starts its listing fetch now, parallel with stat (Fix #2).
-    content = <LoadingScaffold fsPath={fsPath} isDir={navIsDir === true} />;
+    content = <LoadingScaffold fsPath={fsPath} isDir={navIsDir === true} headerless={variant === "explorer"} />;
   } else if (stat.status === "error") {
     content = (
       <StatErrorView
@@ -299,7 +303,7 @@ function StatView({
       // the same file scaffold as the stat-loading branch (header + spinner in
       // the file's chrome) rather than a bare centered "Loading…" — on a cold
       // mount this wait is ~2s and must never read as a blank/black screen.
-      content = <LoadingScaffold fsPath={fsPath} isDir={false} />;
+      content = <LoadingScaffold fsPath={fsPath} isDir={false} headerless={variant === "explorer"} />;
     } else {
       content = (
         <Preview
@@ -308,6 +312,7 @@ function StatView({
           onRenderedTitle={setRenderedTitle}
           allowModes={variant === "app" ? APP_MODES : undefined}
           hideHeader={variant === "learn"}
+          actionsInTopbar={variant === "explorer"}
         />
       );
     }


### PR DESCRIPTION
## Summary
- Replace the "+ Bookmark" text button with a boxless ★ icon at the far left of the breadcrumb bar — filled + accent-yellow when the view is bookmarked or a bookmark is armed
- Move the split right/down buttons into the crumbs strip after the Finder glyph, restyled as plain icon buttons matching it
- "Update bookmark" (armed bookmark with drifted params, D38) renders after the strip, before the actions slot
- Portal the mode switcher / Deploy / "Open as app" actions into a new `#topbar-mode-slot` on the bar's right (explorer variant only; app builder and learn chrome unchanged)
- Remove the now-redundant second header bar (it only held the file name, duplicated by the last crumb); LoadingScaffold and fallback/resolving branches skip it too, and the bar is height-pinned so the switcher landing doesn't shift layout

Final bar order: ★ star · breadcrumbs (… Finder · split icons) · Update bookmark · mode switcher/deploy.

Trade-off: the header chrome's right-click file menu loses its trigger in the explorer (listing rows keep theirs).

## Test plan
- `npx tsc --noEmit` and `npm run build` pass
- Manual: browse folders/files — star toggles yellow on bookmark/arm; split buttons open panel mode; mode switcher works from the top bar; app builder and learn views unchanged; embed still hides all chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Explorer-only UI/layout refactor with no API or auth changes; main regression risk is lost preview-header context menu and portal timing for topbar actions.
> 
> **Overview**
> The **explorer** breadcrumb bar is the single chrome row: **★** bookmark (left), path crumbs with Finder + **split right/down** icons, **Update bookmark**, then **`#topbar-mode-slot`** on the right.
> 
> **Bookmarking** drops the "+ Bookmark" text control for a left **star** (accent when bookmarked or pathname-gated armed via `getArmedBookmarkFor` / `useArmedVersion`). Split controls move from the old right action cluster into the crumb strip as **`.reveal-btn`**-style icons.
> 
> **Preview** gains `actionsInTopbar` (explorer only from `App.tsx`): mode switcher, Deploy, and Open as app **portal** into the breadcrumb slot via `TopbarActions`; the redundant **preview header** (duplicate filename) is omitted in that mode. Loading scaffold skips the fake header when `headerless`.
> 
> **CSS** pins breadcrumb `min-height`, styles `.bookmark-star-btn`, hides empty `#topbar-mode-slot`, and retargets split button styling.
> 
> **Trade-off:** right-click file menu on the preview header chrome is gone in explorer (listing rows still have context menus). App builder and learn variants are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 921fa78719d0a69f6f5002aad68812d8e95106e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->