### PR TITLE
Explorer home: fix folder-stack thumbnail contrast, simplify recents to a list

### DIFF
--- a/frontend/src/apps/builder/AppPreviewCard.tsx
+++ b/frontend/src/apps/builder/AppPreviewCard.tsx
@@ -9,22 +9,7 @@ import type { AppInfo } from "@platform/lib/api";
 import { hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
 import { hueFor } from "@apps/builder/AppCard";
 
-// "3d ago" style stamp for the card meta line; null when the backend didn't
-// report a modified time.
-export function timeAgo(epochSeconds: number | null | undefined): string | null {
-  if (!epochSeconds) return null;
-  const s = Math.max(0, Date.now() / 1000 - epochSeconds);
-  if (s < 60) return "just now";
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  if (d < 30) return `${d}d ago`;
-  const mo = Math.floor(d / 30);
-  if (mo < 12) return `${mo}mo ago`;
-  return `${Math.floor(mo / 12)}y ago`;
-}
+import { timeAgo } from "@platform/lib/format";
 
 // The iframe renders at a fixed desktop width and is scaled to the card by a
 // pure-CSS trick: 400% width/height + scale(0.25) means the visual size is

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -4,10 +4,8 @@
 // bookmarks and recent files. Entering any target navigates into
 // /explorer/view/... (the explorer proper).
 import { useLayoutEffect, useRef, useState } from "react";
-import type { ReactNode } from "react";
 import { navigate, navigateUrl } from "@platform/lib/router";
-import { basename } from "@platform/lib/format";
-import { iconForEntry } from "@platform/ui/FileIcons";
+import { basename, timeAgo } from "@platform/lib/format";
 import type { Config } from "@platform/lib/api";
 import { allBookmarks, loadBookmarks } from "@platform/lib/bookmarks";
 import { useBookmarksVersion } from "@platform/lib/hooks";
@@ -15,9 +13,9 @@ import { loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib
 import { BookmarkPreviewCard } from "@apps/explorer/BookmarkCards";
 import { HeroBrand } from "@platform/ui/HeroBrand";
 
-// How many recent files earn a card. The sidebar shows a tight top-3; the
-// homepage has room to be a real jump-off point.
-const MAX_RECENT_CARDS = 8;
+// How many recent files the list shows. The sidebar shows a tight top-3; the
+// homepage list stays short too — a jump-off point, not a history browser.
+const MAX_RECENTS = 5;
 
 // How many bookmark-grid rows show before the "Show more" fold.
 const BOOKMARK_ROWS = 2;
@@ -42,25 +40,25 @@ function useGridColumns(ref: React.RefObject<HTMLDivElement | null>, mounted: bo
   return cols;
 }
 
-// A launcher card: icon tile + name + path. Shared shape for bookmarks,
-// recents, and the workspace root so the grids read as one system. An anchor
-// so middle-click / Cmd-click open a new tab (same rationale as app cards).
-function LaunchCard({
+// One recents row: name, path, last-opened stamp. An anchor so middle-click /
+// Cmd-click open a new tab (same rationale as app cards).
+function RecentRow({
   href,
-  icon,
   name,
   path,
+  openedAt,
   onOpen,
 }: {
   href: string;
-  icon: ReactNode;
   name: string;
   path: string;
+  openedAt: string;
   onOpen: () => void;
 }) {
+  const when = timeAgo(Date.parse(openedAt) / 1000);
   return (
     <a
-      className="fh-card"
+      className="fh-recent"
       href={href}
       title={path}
       onClick={(e) => {
@@ -70,13 +68,9 @@ function LaunchCard({
         onOpen();
       }}
     >
-      <span className="fh-card-icon" aria-hidden="true">
-        {icon}
-      </span>
-      <span className="fh-card-text">
-        <span className="fh-card-name">{name}</span>
-        <span className="fh-card-path">{path}</span>
-      </span>
+      <span className="fh-recent-name">{name}</span>
+      <span className="fh-recent-path">{path}</span>
+      {when && <span className="fh-recent-when">{when}</span>}
     </a>
   );
 }
@@ -96,7 +90,7 @@ export default function FilesHome({ config }: { config: Config }) {
   const shownBookmarks = expanded ? bookmarks : bookmarks.slice(0, fold);
   // Raw MRU, not the sidebar's stable-slot top-3 — a full page doesn't jump
   // under the pointer the way a always-visible sidebar section does.
-  const recents = loadRecents().entries.slice(0, MAX_RECENT_CARDS);
+  const recents = loadRecents().entries.slice(0, MAX_RECENTS);
 
   return (
     <div className="files-home">
@@ -165,17 +159,17 @@ export default function FilesHome({ config }: { config: Config }) {
         <section className="fh-section">
           <h2 className="fh-heading">Recent files</h2>
           {recents.length ? (
-            <div className="fh-grid">
+            <div className="fh-recents">
               {recents.map((r) => {
                 const fsPath = recentFsPath(r.url);
                 const name = r.title || basename(fsPath);
                 return (
-                  <LaunchCard
+                  <RecentRow
                     key={fsPath}
                     href={r.url}
-                    icon={iconForEntry(basename(fsPath), false)}
                     name={name}
                     path={fsPath}
+                    openedAt={r.openedAt}
                     onOpen={() => navigateUrl(r.url)}
                   />
                 );

--- a/frontend/src/platform/lib/format.ts
+++ b/frontend/src/platform/lib/format.ts
@@ -18,6 +18,22 @@ export function formatMtime(epochSeconds: number | null | undefined): string {
   return new Date(epochSeconds * 1000).toLocaleString();
 }
 
+// "3d ago" style stamp; null when no time is known.
+export function timeAgo(epochSeconds: number | null | undefined): string | null {
+  if (!epochSeconds) return null;
+  const s = Math.max(0, Date.now() / 1000 - epochSeconds);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  const mo = Math.floor(d / 30);
+  if (mo < 12) return `${mo}mo ago`;
+  return `${Math.floor(mo / 12)}y ago`;
+}
+
 export function basename(fsPath: string): string {
   const parts = fsPath.split("/").filter((s) => s.length > 0);
   return parts.length ? parts[parts.length - 1] : "/";

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -323,8 +323,8 @@
   flex: 0 0 auto;
   padding: 6px 10px;
   font-size: 12px;
-  /* Lifted a step above --bg-panel (and greyed off white in light mode) so
-     the chips separate from the stack's --bg well in both themes. */
+  /* Lifted a step above --bg-panel so the chips separate from the stack's
+     --bg well. */
   background: color-mix(in srgb, var(--fg) 6%, var(--bg-panel));
   border: 1px solid color-mix(in srgb, var(--fg) 14%, var(--border));
   border-radius: 9px;
@@ -349,6 +349,17 @@
   width: 80%;
   margin-bottom: -7px;
   z-index: 1;
+}
+
+/* In light theme --bg and --bg-panel are both white, so the dark-theme
+   "darker well, lighter chips" collapses; invert it — grey well (--bg-alt),
+   plain white chips. */
+:root[data-theme="light"] .fhb-stack {
+  background: var(--bg-alt);
+}
+
+:root[data-theme="light"] .fhb-chip {
+  background: var(--bg);
 }
 
 .fhb-card:hover .fhb-chip-d1,

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -127,32 +127,57 @@
   color: var(--fg-muted);
 }
 
-.fh-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 12px;
-}
-
-/* One launcher card: icon tile on the left, name over path on the right. */
-.fh-card {
+/* Recents: a plain list — name, path, last-opened stamp per row. */
+.fh-recents {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.fh-recent {
+  display: flex;
+  align-items: baseline;
   gap: 12px;
-  padding: 12px 14px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  text-decoration: none;
-  color: var(--fg);
+  padding: 7px 10px;
   min-width: 0;
-  transition: border-color 120ms ease, background 120ms ease;
+  color: var(--fg);
+  text-decoration: none;
+  border-radius: 8px;
 }
 
-.fh-card:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: color-mix(in srgb, var(--accent) 4%, var(--bg-alt));
+.fh-recent:hover {
+  background: rgba(var(--tint), 0.05);
 }
 
+.fh-recent-name {
+  flex: 0 1 auto;
+  font-size: 13.5px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fh-recent-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fh-recent-when {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-family: ui-monospace, Menlo, Consolas, monospace;
+  font-size: 11px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+/* Icon tile + name-over-path text block, shared by the bookmark card heads. */
 .fh-card-icon {
   flex: 0 0 auto;
   display: flex;
@@ -283,7 +308,9 @@
   align-items: center;
   aspect-ratio: 16 / 10;
   padding: 12px 12px 0;
-  background: rgba(var(--tint), 0.04);
+  /* The base --bg (a step darker than the card's --bg-alt) so the chips —
+     lifted toward --fg below — read clearly against the well they sit in. */
+  background: var(--bg);
   border-top: 1px solid var(--border);
   overflow: hidden;
 }
@@ -296,8 +323,10 @@
   flex: 0 0 auto;
   padding: 6px 10px;
   font-size: 12px;
-  background: var(--bg-panel);
-  border: 1px solid var(--border);
+  /* Lifted a step above --bg-panel (and greyed off white in light mode) so
+     the chips separate from the stack's --bg well in both themes. */
+  background: color-mix(in srgb, var(--fg) 6%, var(--bg-panel));
+  border: 1px solid color-mix(in srgb, var(--fg) 14%, var(--border));
   border-radius: 9px;
   box-shadow: 0 1px 3px var(--shadow-sm);
   transition: margin 0.18s ease;


### PR DESCRIPTION
## Summary
- Folder bookmark card thumbnails: the fanned chip stack sat on a background nearly identical to the chip fill. The stack well now uses the darker base `--bg`, and chips are lifted toward `--fg` (fill via `color-mix` + stronger border) so they read clearly in both themes.
- Recent files on the explorer homepage: replaced the launcher-card grid with a plain list capped at 5 rows — name, file path, and a "3d ago" last-opened stamp.
- Moved `timeAgo` from the builder's `AppPreviewCard` into shared `platform/lib/format.ts`; removed the now-unused `.fh-grid` / `.fh-card` styles (icon/text pieces kept — bookmark card heads use them).

## Test plan
- [ ] Open `/explorer` home with a folder bookmark — chips inside the thumbnail visibly separate from the background (dark and light themes)
- [ ] Recents section shows at most 5 rows with name, path, and relative last-opened time
- [ ] Middle-click / Cmd-click on a recents row still opens in a new tab
- [ ] `/apps` hub cards still show the "ago" stamp

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only explorer homepage and CSS tweaks plus a pure refactor of timeAgo; no auth, APIs, or data handling changes.
> 
> **Overview**
> **Explorer home recents** switches from an 8-item launcher-card grid to a **5-row list** (`RecentRow`) showing name, path, and a relative **last-opened** stamp via shared `timeAgo`. Unused `.fh-grid` / `.fh-card` styles are removed; bookmark card heads still use `.fh-card-*`.
> 
> **`timeAgo`** moves from `AppPreviewCard` into **`@platform/lib/format`** so `/apps` preview cards and explorer recents share the same helper.
> 
> **Folder bookmark thumbnails** get stronger stack contrast: darker `--bg` well, chips lifted with `color-mix` and stronger borders, plus **light-theme overrides** so the well/chip separation doesn’t collapse when `--bg` and `--bg-panel` match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aee5fd6b728353a1add3cb5345991d725f896ea4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->