### PR TITLE
claude_split: annotation toggle switches, auto-send comments, send-as-stop

### DIFF
--- a/fused_render/templates/claude_split/agent.py
+++ b/fused_render/templates/claude_split/agent.py
@@ -1580,6 +1580,111 @@ def _poll(run_id: str) -> dict:
 
 # ------------------------------------------------------- sessions & history
 
+_MODEL_SHORT = ("fable", "opus", "sonnet", "haiku")
+_EFFORT_LEVELS = ("low", "medium", "high", "xhigh", "max")
+
+
+def _short_model(raw: str) -> str:
+    """Collapse any spelling of a model — full id ('claude-fable-5'), alias
+    ('opusplan'), or already-short name — to the selector's short names."""
+    raw = (raw or "").lower()
+    for name in _MODEL_SHORT:
+        if name in raw:
+            return name
+    return ""
+
+
+def _scan_transcript(path: str) -> tuple:
+    """(model, effort) of the newest main-loop rows in one session transcript.
+
+    Reads only the file's tail: the last rows are the last-used config, and a
+    long session's early history can't change the answer. Sidechain rows are
+    skipped — subagents pick their own model, and the user never chose it."""
+    try:
+        size = os.path.getsize(path)
+        with open(path, "rb") as f:
+            if size > 262144:
+                f.seek(size - 262144)
+            blob = f.read().decode("utf-8", "replace")
+    except OSError:
+        return "", ""
+    model = effort = ""
+    for line in reversed(blob.splitlines()):
+        if not line.startswith("{"):
+            continue
+        try:
+            row = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(row, dict) or row.get("isSidechain"):
+            continue
+        if not model:
+            msg = row.get("message")
+            if isinstance(msg, dict):
+                model = _short_model(str(msg.get("model", "")))
+        if not effort:
+            e = str(row.get("effort", "")).lower()
+            if e in _EFFORT_LEVELS:
+                effort = e
+        if model and effort:
+            break
+    return model, effort
+
+
+def _defaults(file: str) -> dict:
+    """The model/effort the user ACTUALLY last used with Claude Code for this
+    project — through this template or the CLI directly — so the selectors can
+    preselect a real config instead of a hardcoded guess.
+
+    Priority: newest session transcripts in this project's store (true
+    last-used, shared by CLI and template runs since both key sessions on the
+    same cwd munge), then settings files (project .claude/settings.local.json,
+    project .claude/settings.json, ~/.claude/settings.json — the `model` and
+    `effortLevel` keys). Empty fields mean nothing was detected; the page keeps
+    its own fallback."""
+    workdir = _workdir(os.path.abspath(file))
+    model = effort = source = ""
+    proj = os.path.join(PROJECTS, _munge(workdir))
+    try:
+        names = [n for n in os.listdir(proj) if n.endswith(".jsonl")]
+        paths = sorted((os.path.join(proj, n) for n in names),
+                       key=os.path.getmtime, reverse=True)
+    except OSError:
+        paths = []
+    # Newest few only: the newest transcript IS the answer when it has both
+    # fields, and one more file covers a fresh session that hasn't spoken yet.
+    for path in paths[:5]:
+        m, e = _scan_transcript(path)
+        model = model or m
+        effort = effort or e
+        if model or effort:
+            source = "session"
+        if model and effort:
+            break
+    if not (model and effort):
+        for p in (os.path.join(workdir, ".claude", "settings.local.json"),
+                  os.path.join(workdir, ".claude", "settings.json"),
+                  os.path.join(CLAUDE_DIR, "settings.json")):
+            try:
+                with open(p, encoding="utf-8") as f:
+                    data = json.load(f)
+            except (OSError, ValueError):
+                continue
+            if not isinstance(data, dict):
+                continue
+            if not model:
+                m = _short_model(str(data.get("model", "")))
+                if m:
+                    model, source = m, source or "settings"
+            if not effort:
+                e = str(data.get("effortLevel", "")).lower()
+                if e in _EFFORT_LEVELS:
+                    effort, source = e, source or "settings"
+            if model and effort:
+                break
+    return {"model": model, "effort": effort, "source": source}
+
+
 def _sessions(file: str) -> dict:
     """Sessions recorded in THIS file's sidecar, newest activity first."""
     file = os.path.abspath(file)
@@ -1704,6 +1809,10 @@ def main(action: str = "start", file: str = "", message: str = "",
         if not file:
             return {"error": "missing target file (no _file param?)"}
         return _sessions(file)
+    if action == "defaults":
+        if not file:
+            return {"error": "missing target file (no _file param?)"}
+        return _defaults(file)
     if action == "history":
         if not file:
             return {"error": "missing target file (no _file param?)"}

--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -2808,6 +2808,16 @@ const PERMISSION_LABELS = {
 };
 const DEFAULT_MODEL = "sonnet";
 const DEFAULT_EFFORT = "medium";
+// What the user ACTUALLY last used with Claude Code for this project — via this
+// template or the CLI directly — detected by the agent from the project's
+// session transcripts and settings files. A hardcoded "default" tells the user
+// nothing; the real config is worth preselecting. An explicit pane param (the
+// user touched the selector) always outranks detection; the constants above are
+// the last-resort fallback when nothing was detected.
+let detectedModel = "";
+let detectedEffort = "";
+const curModel = () => fused.params.get("model") || detectedModel || DEFAULT_MODEL;
+const curEffort = () => fused.params.get("effort") || detectedEffort || DEFAULT_EFFORT;
 // The strictest mode is the default: more auto-approval is opted into, never
 // handed out by a missing param.
 const DEFAULT_PERMISSION = "prompt";
@@ -2831,8 +2841,8 @@ document.querySelectorAll(".perm-sel").forEach((el) => {
 });
 
 function syncSelects() {
-  document.querySelectorAll(".model-sel").forEach((el) => { el.value = fused.params.get("model") || DEFAULT_MODEL; });
-  document.querySelectorAll(".effort-sel").forEach((el) => { el.value = fused.params.get("effort") || DEFAULT_EFFORT; });
+  document.querySelectorAll(".model-sel").forEach((el) => { el.value = curModel(); });
+  document.querySelectorAll(".effort-sel").forEach((el) => { el.value = curEffort(); });
   const perm = fused.params.get("permission");
   document.querySelectorAll(".perm-sel").forEach((el) => {
     el.value = PERMISSION_MODES.includes(perm) ? perm : DEFAULT_PERMISSION;
@@ -2845,6 +2855,16 @@ document.querySelectorAll(".effort-sel").forEach((el) =>
 document.querySelectorAll(".perm-sel").forEach((el) =>
   el.addEventListener("change", () => { fused.params.set("permission", el.value); syncSelects(); }));
 syncSelects();
+
+// Detection is async and best-effort: the selects show the fallback until it
+// lands, then snap to the real config — unless a pane param already pinned a
+// choice, which curModel/curEffort rank higher. Values are validated against
+// the selector's own lists so a config this build doesn't know stays fallback.
+fused.runPython(AGENT, { action: "defaults", file: FILE }, { key: null }).then((d) => {
+  if (d && d.model && MODELS.includes(d.model)) detectedModel = d.model;
+  if (d && d.effort && EFFORTS.includes(d.effort)) detectedEffort = d.effort;
+  if (detectedModel || detectedEffort) syncSelects();
+}).catch(() => {});
 
 // The split param changes on drag too — applySplit on every change is cheap
 // and idempotent.
@@ -3187,7 +3207,7 @@ function addWorking() {
                           stats.phase === "awaiting" ? "Waiting for your approval" :
                           stats.phase === "composing" ? "Composing" :
                           stats.phase === "tooling" ? "Working" : thinkVerb) + "…";
-    const effort = fused.params.get("effort") || DEFAULT_EFFORT;
+    const effort = curEffort();
     const parts = [secs + "s"];
     if (stats.tokens) parts.push("↓ " + stats.tokens + " tokens");
     if (stats.phase === "thinking" && effort) parts.push(effort + " effort");
@@ -3705,8 +3725,8 @@ async function sendMessage(message) {
       file: FILE,
       message: outgoing,
       session_id: fused.params.get("session_id") || "",
-      model: fused.params.get("model") || DEFAULT_MODEL,
-      effort: fused.params.get("effort") || DEFAULT_EFFORT,
+      model: curModel(),
+      effort: curEffort(),
       permission_mode: fused.params.get("permission") || DEFAULT_PERMISSION,
       // key:null — all agent calls opt out of default per-file cancellation
       // (D114): start/poll/history/sessions share one file, and superseding an

--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -100,31 +100,25 @@
     transition: background .15s;
   }
 
-  /* ── annotation layer over the left iframe ─────── */
-  /* Two labelled sliding switches, stacked outside the pane in the chat pane's
-     left header margin: annotate mode (#annbtn) and pin visibility (#annvis).
-     Outside the pane they cover zero pixels of the app, and the margin space is
-     otherwise empty — so a label and a switch track cost nothing and say plainly
-     what each control governs, where the previous 26px unlabelled circles had to
-     encode their state in a fill alone. Size and position are IDENTICAL in both
-     states of each switch: the active state may only repaint (plus the knob
-     sliding INSIDE its fixed track), so toggling can never reflow the iframe's
-     box — pins and `annStageRect` are in frame viewport coordinates and stay
-     put. */
-  /* A labelled sliding switch, not a bare icon: the control anchors by its LEFT
-     edge just past the divider (`left: calc(100% + 14px)`) and grows rightward
-     into the chat pane's empty header margin — so a label and a track cost the
-     app zero pixels, and the state ("Annotating" / "Annotate") is spelled out
-     instead of encoded in a fill an unlabelled 26px glyph had to carry alone.
-     Nothing clips it — neither `#left` nor `#leftview` sets `overflow`, and
-     `#chat`'s own `overflow: hidden` cannot clip a box that is not its
-     descendant. Idle tints (accent on panel), armed FILLS the whole pill —
-     annotate mode swallows the app's clicks, so its on-state is the loudest. */
+  /* ── annotation controls: a layout row at the top of the chat pane ─────── */
+  /* Two labelled left-right sliding switches — annotate mode (#annbtn) and pin
+     visibility (#annvis) — in a real flex ROW above the chat content, shown in
+     both views. A row, not an overlay: the floating versions (corner icon, then
+     margin pills) kept landing on top of whatever the chat pane drew underneath.
+     In a row the labels cost nothing, cover nothing, and say plainly what each
+     control governs. Idle tints (accent on panel); the annotate switch FILLS
+     when armed — annotate mode swallows the app's clicks, so its on-state is
+     the loudest of the two. */
+  #anntools {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 16px;
+    border-bottom: 1px solid var(--border);
+  }
   #annbtn {
-    position: absolute;
-    top: 10px;
-    left: calc(100% + 14px);
-    z-index: 4;
     height: 26px;
     padding: 0 8px 0 10px;
     display: flex;
@@ -140,7 +134,6 @@
     background: var(--panel);
     color: var(--accent);
     cursor: pointer;
-    box-shadow: 0 2px 8px var(--shadow);
     transition: color .12s, border-color .12s, background .12s, filter .12s;
   }
   /* The same hover-vs-active rule as `.pill` in the composer, stated the same way:
@@ -179,15 +172,9 @@
   }
   #annbtn.on .track { background: var(--on-accent); }
   #annbtn.on .knob { left: 14px; background: var(--accent); }
-  /* The pins-visibility switch: a labelled left-right sliding toggle under the
-     annotate icon. Anchored by its LEFT edge just past the divider (`left:
-     calc(100% + 14px)`) so growing wider extends into the chat pane's empty
-     header margin, never leftward over the app. On = knob right, accent track. */
+  /* The pins-visibility switch: same anatomy, quieter on-state — track fills,
+     pill stays panel. On = knob right, accent track. */
   #annvis {
-    position: absolute;
-    top: 44px;
-    left: calc(100% + 14px);
-    z-index: 4;
     height: 26px;
     padding: 0 10px 0 6px;
     display: flex;
@@ -826,33 +813,6 @@
          positioned in FRAME viewport coordinates (pins, highlight, composer). -->
     <div id="leftview">
       <iframe id="leftframe" title="File preview"></iframe>
-      <!-- One small floating icon in the bottom-right corner. A real <button>, so
-           Enter/Space work and `aria-pressed` announces the state to a screen
-           reader that cannot see the accent fill; `aria-label` names it because
-           there is no text to read. Inside #leftview so it floats over the app —
-           and therefore outside the iframe, so it can never land in a capture. -->
-      <!-- A comment bubble, not a pencil: a pencil means "edit this", which is what
-           CLAUDE does to the app — this button lets the user leave a note ON the app,
-           and the marks it produces are numbered comment pins. Inline SVG stroked in
-           `currentColor` like the composer's pane-shot icon, so it follows the accent
-           tint while idle and is knocked out to `--on-accent` when armed; a text
-           glyph could do neither and rendered at a different weight per platform. -->
-      <button id="annbtn" type="button" aria-pressed="false" aria-label="Annotate the app"
-              title="Annotate the app, then send the notes to Claude"><svg width="13" height="13"
-        viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.3" y="2.8" width="11.4"
-        height="8.4" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M5.6 11.2v2.6l3-2.6"
-        stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg><span
-        class="lbl">Annotate</span><span class="track" aria-hidden="true"><span class="knob"></span></span></button>
-      <!-- Visibility switch for the annotation pins, stacked under the annotate
-           button. A real sliding switch WITH a label — the margin under the 26px
-           icon column runs into the chat pane's empty header space, so the label
-           costs nothing and says exactly what the control governs. -->
-      <button id="annvis" type="button" role="switch" aria-checked="true"
-              aria-label="Show annotation comments on the app"
-              title="Show or hide the annotation comment pins over the app">
-        <span class="track" aria-hidden="true"><span class="knob"></span></span>
-        <span class="lbl">Comments shown</span>
-      </button>
       <div id="annhl"></div>
       <div id="annpins"></div>
       <div id="annpop">
@@ -866,6 +826,28 @@
   <div id="divider" role="separator" aria-orientation="vertical" aria-label="Resize panels"></div>
 
   <div id="chat" class="home">
+    <!-- Annotation controls: a real layout ROW above everything else in this
+         pane, in both views — never an overlay, so it can't land on top of the
+         topbar or the transcript. Both are real <button>s (Enter/Space work,
+         aria announces state) living in the parent document, a structural
+         guarantee they can never appear in a pane capture (shotPane rasterises
+         the framed document only). The bubble icon is a comment bubble, not a
+         pencil: a pencil means "edit this", which is what CLAUDE does — these
+         controls let the user leave notes ON the app. -->
+    <div id="anntools">
+      <button id="annbtn" type="button" aria-pressed="false" aria-label="Annotate the app"
+              title="Annotate the app, then send the notes to Claude"><svg width="13" height="13"
+        viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.3" y="2.8" width="11.4"
+        height="8.4" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M5.6 11.2v2.6l3-2.6"
+        stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg><span
+        class="lbl">Annotate</span><span class="track" aria-hidden="true"><span class="knob"></span></span></button>
+      <button id="annvis" type="button" role="switch" aria-checked="true"
+              aria-label="Show annotation comments on the app"
+              title="Show or hide the annotation comment pins over the app">
+        <span class="track" aria-hidden="true"><span class="knob"></span></span>
+        <span class="lbl">Comments shown</span>
+      </button>
+    </div>
     <!-- chat view -->
     <div id="topbar">
       <span class="spark">✻</span>

--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -101,59 +101,40 @@
   }
 
   /* ── annotation layer over the left iframe ─────── */
-  /* A small floating icon, NOT a strip or a banner. Annotating is an occasional
-     act, and a permanent row (or a full-width status bar) charged every project
-     that never annotates ~28px of app height plus a line of chrome the app did
-     not ask for. So the control floats over the app again — but it is a 26px
-     circle in ONE corner instead of the ~100px labelled pill whose active state
-     grew into a sentence, which is what made the old floating version cover the
-     app's top-right corner and get in the way of clicking.
-     And it is pushed OUTSIDE the pane (see `right`), so it covers none of the app
-     at all — the corner it used to sit on is annotatable again. Bottom edge,
-     deliberately: an app's headings, tabs and toolbars — the things people annotate
-     most — live along the TOP.
-     Size and position are IDENTICAL in both states: the active state may only
-     repaint. A control that grew when armed would cover more of the app at
-     exactly the moment the user is aiming at it, and being an overlay (not a
-     layout row) it cannot move the iframe's box at all, so pins and
-     `annStageRect` — which are in frame viewport coordinates — are untouched by
-     toggling.
-     No label in either state. Armed is signalled by the accent fill and by the
-     highlight box that tracks the pointer over the app; the full instruction and
-     both ways out live in the tooltip, where they cost no space. */
+  /* Two labelled sliding switches, stacked outside the pane in the chat pane's
+     left header margin: annotate mode (#annbtn) and pin visibility (#annvis).
+     Outside the pane they cover zero pixels of the app, and the margin space is
+     otherwise empty — so a label and a switch track cost nothing and say plainly
+     what each control governs, where the previous 26px unlabelled circles had to
+     encode their state in a fill alone. Size and position are IDENTICAL in both
+     states of each switch: the active state may only repaint (plus the knob
+     sliding INSIDE its fixed track), so toggling can never reflow the iframe's
+     box — pins and `annStageRect` are in frame viewport coordinates and stay
+     put. */
+  /* A labelled sliding switch, not a bare icon: the control anchors by its LEFT
+     edge just past the divider (`left: calc(100% + 14px)`) and grows rightward
+     into the chat pane's empty header margin — so a label and a track cost the
+     app zero pixels, and the state ("Annotating" / "Annotate") is spelled out
+     instead of encoded in a fill an unlabelled 26px glyph had to carry alone.
+     Nothing clips it — neither `#left` nor `#leftview` sets `overflow`, and
+     `#chat`'s own `overflow: hidden` cannot clip a box that is not its
+     descendant. Idle tints (accent on panel), armed FILLS the whole pill —
+     annotate mode swallows the app's clicks, so its on-state is the loudest. */
   #annbtn {
     position: absolute;
-    /* Top of the pane, with real space around it on both axes. The two offsets are
-       the same 10px, so the icon reads as inset from a corner rather than pinned to
-       one edge — a control jammed against the divider with no gap looked like it
-       had slid there, and the vertically-centred version was aligned to nothing
-       the eye could see. */
     top: 10px;
-    /* Pushed clear of the pane entirely, PLUS a gap: -40px = the button's own 26px,
-       the 4px divider, and 10px of air between the divider and the button. So it
-       covers zero of the app, none of the divider's drag strip, and does not touch
-       the seam. Nothing clips it — neither `#left` nor `#leftview` sets `overflow`,
-       and `#chat`'s own `overflow: hidden` cannot clip a box that is not its
-       descendant. It lands in the chat pane's left margin, which is empty
-       background: `#chat` has `min-width: 340px` and this layout never stacks
-       vertically, so those 40px always exist. */
-    right: -40px;
+    left: calc(100% + 14px);
     z-index: 4;
-    width: 26px;
     height: 26px;
-    padding: 0;
+    padding: 0 8px 0 10px;
     display: flex;
     align-items: center;
-    justify-content: center;
+    gap: 7px;
     font: inherit;
     font-size: 12px;
+    font-weight: 600;
     line-height: 1;
-    /* Accent while IDLE, on purpose: the control is now a 26px unlabelled glyph
-       parked outside the pane, which is easy to miss entirely — so the one thing it
-       still has to do is be noticed. Idle TINTS (accent glyph and ring on the panel
-       background), armed FILLS (solid accent disc, glyph knocked out). Both use the
-       accent, and the difference is which one is painted, so the two states stay
-       distinguishable without a label to tell them apart. */
+    white-space: nowrap;
     border: 1px solid var(--accent);
     border-radius: 999px;
     background: var(--panel);
@@ -166,7 +147,7 @@
      the neutral hover excludes the active state, and the active state hovers within
      its accent. See the comment on `.pill:hover`. */
   /* `display: block` kills the inline baseline gap that would push the glyph off
-     centre inside a fixed 26px circle. Same rule as `.viewshot svg`. */
+     centre. Same rule as `.viewshot svg`. */
   #annbtn svg { display: block; }
   #annbtn:hover:not(.on) { background: var(--surface-2); }
   #annbtn.on {
@@ -174,6 +155,79 @@
     color: var(--on-accent);
   }
   #annbtn.on:hover { filter: brightness(1.1); }
+  /* The slider: knob left = off, knob right = on. Drawn in currentColor so it
+     follows the pill's own idle/armed palette; the on-state inverts it so the
+     knob stays visible on the accent-filled pill. */
+  #annbtn .track {
+    position: relative;
+    width: 28px;
+    height: 16px;
+    border-radius: 999px;
+    border: 1px solid currentColor;
+    flex-shrink: 0;
+    transition: background .15s;
+  }
+  #annbtn .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: currentColor;
+    transition: left .15s, background .15s;
+  }
+  #annbtn.on .track { background: var(--on-accent); }
+  #annbtn.on .knob { left: 14px; background: var(--accent); }
+  /* The pins-visibility switch: a labelled left-right sliding toggle under the
+     annotate icon. Anchored by its LEFT edge just past the divider (`left:
+     calc(100% + 14px)`) so growing wider extends into the chat pane's empty
+     header margin, never leftward over the app. On = knob right, accent track. */
+  #annvis {
+    position: absolute;
+    top: 44px;
+    left: calc(100% + 14px);
+    z-index: 4;
+    height: 26px;
+    padding: 0 10px 0 6px;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    background: var(--panel);
+    color: var(--accent);
+    cursor: pointer;
+    box-shadow: 0 2px 8px var(--shadow);
+    transition: color .12s, border-color .12s, background .12s, filter .12s;
+  }
+  #annvis:hover { background: var(--surface-2); }
+  #annvis .track {
+    position: relative;
+    width: 28px;
+    height: 16px;
+    border-radius: 999px;
+    border: 1px solid var(--accent);
+    background: transparent;
+    transition: background .15s;
+    flex-shrink: 0;
+  }
+  #annvis .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent);
+    transition: left .15s, background .15s;
+  }
+  #annvis.on .track { background: var(--accent); }
+  #annvis.on .knob { left: 14px; background: var(--on-accent); }
   #annpins { position: absolute; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
   .annpin {
     position: absolute;
@@ -229,8 +283,18 @@
     outline: none;
   }
   #annpop .hint { color: var(--faint); font-size: 11px; margin-top: 5px; display: flex; align-items: center; }
-  #anndel {
+  #annauto {
+    display: flex;
+    align-items: center;
+    gap: 3px;
     margin-left: auto;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+  }
+  #annauto input { margin: 0; accent-color: var(--accent); cursor: pointer; }
+  #anndel {
+    margin-left: 8px;
     border: 0;
     background: transparent;
     color: var(--error);
@@ -608,6 +672,11 @@
   }
   .send:hover { filter: brightness(1.1); transform: translateY(-1px); }
   .send:active { transform: none; }
+  /* While a run is live the send buttons become stop buttons: the arrow hides and
+     a stop square shows. Clicking then kills the run (same as Escape). */
+  .send .ic-stop { display: none; }
+  body.running .send .ic-send { display: none; }
+  body.running .send .ic-stop { display: block; }
 
   #composer-chat {
     flex-shrink: 0;
@@ -772,12 +841,25 @@
               title="Annotate the app, then send the notes to Claude"><svg width="13" height="13"
         viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.3" y="2.8" width="11.4"
         height="8.4" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M5.6 11.2v2.6l3-2.6"
-        stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+        stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg><span
+        class="lbl">Annotate</span><span class="track" aria-hidden="true"><span class="knob"></span></span></button>
+      <!-- Visibility switch for the annotation pins, stacked under the annotate
+           button. A real sliding switch WITH a label — the margin under the 26px
+           icon column runs into the chat pane's empty header space, so the label
+           costs nothing and says exactly what the control governs. -->
+      <button id="annvis" type="button" role="switch" aria-checked="true"
+              aria-label="Show annotation comments on the app"
+              title="Show or hide the annotation comment pins over the app">
+        <span class="track" aria-hidden="true"><span class="knob"></span></span>
+        <span class="lbl">Comments shown</span>
+      </button>
       <div id="annhl"></div>
       <div id="annpins"></div>
       <div id="annpop">
         <textarea rows="2" placeholder="What about this element?" spellcheck="false"></textarea>
-        <div class="hint">Enter to save · Esc to cancel <button id="anndel" type="button" hidden>Delete</button></div>
+        <div class="hint">Enter to save · Esc to cancel
+          <label id="annauto" title="Send the note to Claude immediately when saved"><input type="checkbox" checked> Auto-send</label>
+          <button id="anndel" type="button" hidden>Delete</button></div>
       </div>
     </div><!-- /leftview -->
   </div>
@@ -808,8 +890,11 @@
                     title="Attach a screenshot of the whole app pane to this message (for layout problems that are not about one element)"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.2" y="3.2" width="11.6" height="9.6" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M2.9 11.4 6 8.3a1.2 1.2 0 0 1 1.7 0l3 3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="10.6" cy="6.3" r="1.1" fill="currentColor"/></svg></button>
             <span class="spacer"></span>
             <button class="send" type="submit" aria-label="Send">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <svg class="ic-send" width="14" height="14" viewBox="0 0 16 16" fill="none">
                 <path d="M8 13V3M8 3L3.5 7.5M8 3l4.5 4.5" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg class="ic-stop" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor"/>
               </svg>
             </button>
           </div>
@@ -836,8 +921,11 @@
                     title="Attach a screenshot of the whole app pane to this message (for layout problems that are not about one element)"><svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.2" y="3.2" width="11.6" height="9.6" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M2.9 11.4 6 8.3a1.2 1.2 0 0 1 1.7 0l3 3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/><circle cx="10.6" cy="6.3" r="1.1" fill="currentColor"/></svg></button>
             <span class="spacer"></span>
             <button class="send" type="submit" aria-label="Send">
-              <svg width="14" height="14" viewBox="0 0 16 16" fill="none">
+              <svg class="ic-send" width="14" height="14" viewBox="0 0 16 16" fill="none">
                 <path d="M8 13V3M8 3L3.5 7.5M8 3l4.5 4.5" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg class="ic-stop" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <rect x="4" y="4" width="8" height="8" rx="1.5" fill="currentColor"/>
               </svg>
             </button>
           </div>
@@ -1398,6 +1486,10 @@ const annFrame = document.getElementById("leftframe");
 let annOn = false;
 let annDraft = null;    // anchor of a NEW note being composed
 let annEditing = null;  // id of an existing pending note being edited
+// Pins visible over the app. Default ON: an unset param means shown, and only an
+// explicit "0" (the user toggled it off) hides them. Chips above the composer are
+// the send payload and stay visible either way.
+let annShow = fused.params.get("annshow") !== "0";
 
 function annLoad() {
   try {
@@ -1484,7 +1576,8 @@ function annLabelFor(i) {
 function renderAnn() {
   // pins over the frame
   annPins.innerHTML = "";
-  const doc = annFrame.contentDocument;
+  annPins.style.display = annShow ? "" : "none";
+  const doc = annShow ? annFrame.contentDocument : null;
   // #leftview, not #left: pins are placed in FRAME viewport coordinates, so their
   // host must be the box the iframe fills — #left also holds the control strip,
   // and measuring that would put every pin the strip's height too high.
@@ -1591,13 +1684,14 @@ function annCloseComposer() {
 }
 // A fresh note usually precedes a "go apply it" message: seed the visible
 // composer so sending is one keypress. Only when it's empty — never clobber
-// typed text — and never auto-send.
+// typed text. Auto-send (the popover's checkbox, default on) then submits it.
 function annPrefillComposer() {
   const home = chatEl.classList.contains("home");
   const el = home ? homebox : box;
-  if (el.value.trim()) return;
+  if (el.value.trim()) return false;  // a typed draft is the user's — hands off
   el.value = "apply the comments";
   (home ? growHome : growBox)();
+  return true;
 }
 // Click anywhere outside the popover dismisses it. mousedown, not click, so
 // it fires before the target's own handlers; pins and chips are exempt — their
@@ -1623,15 +1717,23 @@ annTa.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
     const content = annTa.value.trim();
-    if (content && annDraft) {
+    const isNew = !!(content && annDraft);
+    let filled = false;
+    if (isNew) {
       annotations.push({ id: crypto.randomUUID(), content, createdAt: Date.now(), ...annDraft });
       annSave();
-      annPrefillComposer();
+      filled = annPrefillComposer();
     } else if (content && annEditing) {
       const c = annotations.find((a) => a.id === annEditing);
       if (c && !c.sent) { c.content = content; annSave(); }
     }
     annCloseComposer();
+    // Auto-send fires for NEW notes only — editing an existing pending note must
+    // not send. Skipped while a turn is in flight (the note stays pending and
+    // rides the next message) and when the composer holds a typed draft — the
+    // prefill refused to touch it, and sending a half-typed message is worse
+    // than leaving the note as a chip.
+    if (isNew && filled && annAutoEl.checked && !sending) annAutoSubmit();
   }
 });
 
@@ -1640,8 +1742,10 @@ annTa.addEventListener("keydown", (e) => {
 // text to disagree with `annOn`.
 function annSetMode(on) {
   annOn = on;
+  fused.params.set("annmode", annOn ? "1" : "0");
   annBtn.classList.toggle("on", annOn);
   annBtn.setAttribute("aria-pressed", String(annOn));
+  annBtn.querySelector(".lbl").textContent = annOn ? "Annotating" : "Annotate";
   // No label in either state — the icon never changes size or position, so nothing
   // here can cover more of the app than the idle button already does. The tooltip
   // is where the instruction and BOTH ways out live, because it has no width limit
@@ -1654,6 +1758,36 @@ function annSetMode(on) {
 }
 
 annBtn.addEventListener("click", () => annSetMode(!annOn));
+// Annotate mode is ON by default: an unset param means armed, and only an
+// explicit "0" (the user slid it off, or pressed Escape) starts it disarmed.
+annSetMode(fused.params.get("annmode") !== "0");
+
+// Pins-visibility toggle: pressed (filled) = pins shown, which is the default.
+const annVisBtn = document.getElementById("annvis");
+function annSetShow(on) {
+  annShow = on;
+  fused.params.set("annshow", on ? "1" : "0");
+  annVisBtn.classList.toggle("on", on);
+  annVisBtn.setAttribute("aria-checked", String(on));
+  annVisBtn.querySelector(".lbl").textContent = on ? "Comments shown" : "Comments hidden";
+  annVisBtn.title = on ? "Annotation comment pins are shown over the app — click to hide them"
+                       : "Annotation comment pins are hidden — click to show them";
+  renderAnn();
+}
+annSetShow(annShow);
+annVisBtn.addEventListener("click", () => annSetShow(!annShow));
+
+// Auto-send: a saved NEW note goes to Claude immediately (default on). The
+// checkbox lives in the note popover and persists like the pins toggle.
+const annAutoEl = document.querySelector("#annauto input");
+annAutoEl.checked = fused.params.get("annautosend") !== "0";
+annAutoEl.addEventListener("change", () => {
+  fused.params.set("annautosend", annAutoEl.checked ? "1" : "0");
+});
+function annAutoSubmit() {
+  if (chatEl.classList.contains("home")) document.getElementById("card").requestSubmit();
+  else submitChat();
+}
 
 // Wire the framed app on every load (the app live-reloads on Claude's edits;
 // pins re-resolve against the fresh DOM). Handlers stay attached and gate on
@@ -3368,6 +3502,7 @@ async function pollLoop(run_id) {
   // place a run is ever in flight, which covers a re-attached run for free.
   activeRun = run_id;
   activeWorking = w;
+  setRunningUi(true);
   let reply = null;
   let typer = null;
   try {
@@ -3429,7 +3564,19 @@ async function pollLoop(run_id) {
     // the NEXT turn's ending as a stop.
     activeRun = null;
     activeWorking = null;
+    setRunningUi(false);
   }
+}
+
+// The composer's send buttons double as stop buttons while a run is live: the
+// arrow swaps for a stop square (CSS on body.running) and a click aims at the
+// run, same as Escape. Labels follow so a screen reader hears the real action.
+function setRunningUi(on) {
+  document.body.classList.toggle("running", on);
+  document.querySelectorAll(".send").forEach((b) => {
+    b.setAttribute("aria-label", on ? "Stop" : "Send");
+    b.title = on ? "Stop this turn (Esc)" : "";
+  });
 }
 
 async function sendMessage(message) {
@@ -3682,14 +3829,24 @@ function submitChat() {
   growBox();
   sendMessage(message);
 }
-document.getElementById("inputbox").onsubmit = (e) => { e.preventDefault(); submitChat(); };
+// The submit event is the send BUTTON's path (Enter in the box is handled below
+// and never reaches here): while a run is live the button is a stop button.
+document.getElementById("inputbox").onsubmit = (e) => {
+  e.preventDefault();
+  if (activeRun) { stopRun(); return; }
+  submitChat();
+};
 box.addEventListener("keydown", (e) => {
+  // Enter never stops a run — a user drafting the next message mid-run must not
+  // kill the turn with a keystroke meant to queue text. Only the button (now a
+  // stop square) and Escape do.
   if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submitChat(); }
 });
 
 // ── home: big input + this file's sidecar sessions ──
 document.getElementById("card").onsubmit = (e) => {
   e.preventDefault();
+  if (activeRun) { stopRun(); return; }
   if (sending) return;
   const message = homebox.value.trim();
   // notes alone are sendable, and so is a bare request for a picture of the pane

--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -1667,11 +1667,17 @@ function annCloseComposer() {
 // A fresh note usually precedes a "go apply it" message: seed the visible
 // composer so sending is one keypress. Only when it's empty — never clobber
 // typed text. Auto-send (the popover's checkbox, default on) then submits it.
+const ANN_PREFILL = "apply the comments";
 function annPrefillComposer() {
   const home = chatEl.classList.contains("home");
   const el = home ? homebox : box;
-  if (el.value.trim()) return false;  // a typed draft is the user's — hands off
-  el.value = "apply the comments";
+  // A typed draft is the user's — hands off. But the composer holding exactly
+  // the canonical prefill is OUR text (a previous note left it, e.g. one saved
+  // with auto-send off), not a draft: it still counts as fillable, so the next
+  // note's auto-send can fire and carry every pending note with it.
+  const v = el.value.trim();
+  if (v && v !== ANN_PREFILL) return false;
+  el.value = ANN_PREFILL;
   (home ? growHome : growBox)();
   return true;
 }

--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -1189,6 +1189,7 @@ function searchParamsOf(search) {
 // user's notes, already sent in their own block.
 const CHAT_PARAMS = new Set(["_file", "_mode", "session_id", "run", "split",
                              "model", "effort", "permission", "annotations",
+                             "annmode", "annshow", "annautosend",
                              "path"]);
 
 function appParamsOf(all) {
@@ -3583,7 +3584,12 @@ function setRunningUi(on) {
   document.body.classList.toggle("running", on);
   document.querySelectorAll(".send").forEach((b) => {
     b.setAttribute("aria-label", on ? "Stop" : "Send");
-    b.title = on ? "Stop this turn (Esc)" : "";
+    // No "(Esc)" hint: Escape's first claim is the annotation composer, then
+    // annotate mode (default ON) — during a normal run it disarms annotating,
+    // not the turn. Advertising it here would teach a keystroke that usually
+    // does something else; the working line's own stop control stays the
+    // keyboard-adjacent path.
+    b.title = on ? "Stop this turn" : "";
   });
 }
 

--- a/tests/test_claude_split_defaults.py
+++ b/tests/test_claude_split_defaults.py
@@ -1,0 +1,123 @@
+"""The `defaults` action: preselecting the model/effort the user ACTUALLY last
+used with Claude Code for this project — read from the project's session
+transcripts (shared by the CLI and this template, both key sessions on the same
+cwd munge) and, failing that, from settings files. A hardcoded "default" in the
+selector tells the user nothing; the real config does.
+"""
+import importlib.util
+import json
+import os
+
+import pytest
+
+
+def _load_agent():
+    path = os.path.join("fused_render", "templates", "claude_split", "agent.py")
+    spec = importlib.util.spec_from_file_location("claude_split_agent", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
+def _agent_in(tmp_path, monkeypatch):
+    agent = _load_agent()
+    claude_dir = tmp_path / "claude"
+    projects = claude_dir / "projects"
+    projects.mkdir(parents=True)
+    monkeypatch.setattr(agent, "CLAUDE_DIR", str(claude_dir))
+    monkeypatch.setattr(agent, "PROJECTS", str(projects))
+    return agent
+
+
+def _target(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    f = d / "index.html"
+    f.write_text("<html></html>")
+    return str(f), str(d)
+
+
+def _write_transcript(agent, workdir, rows, name="s1.jsonl"):
+    proj = os.path.join(agent.PROJECTS, agent._munge(workdir))
+    os.makedirs(proj, exist_ok=True)
+    path = os.path.join(proj, name)
+    with open(path, "w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+    return path
+
+
+def test_last_used_comes_from_the_newest_transcript_rows(tmp_path, monkeypatch):
+    agent = _agent_in(tmp_path, monkeypatch)
+    file, workdir = _target(tmp_path)
+    _write_transcript(agent, workdir, [
+        {"effort": "medium", "message": {"model": "claude-sonnet-5"}},
+        # sidechain rows are subagents — the user never chose their model
+        {"isSidechain": True, "message": {"model": "claude-haiku-4-5-20251001"}},
+        {"effort": "xhigh", "message": {"model": "claude-fable-5"}},
+    ])
+    out = agent.main(action="defaults", file=file)
+    assert out == {"model": "fable", "effort": "xhigh", "source": "session"}
+
+
+def test_settings_fill_in_when_no_transcript_speaks(tmp_path, monkeypatch):
+    agent = _agent_in(tmp_path, monkeypatch)
+    file, workdir = _target(tmp_path)
+    # project settings outrank the global file, most-specific first
+    proj_cfg = os.path.join(workdir, ".claude")
+    os.makedirs(proj_cfg)
+    with open(os.path.join(proj_cfg, "settings.json"), "w") as f:
+        json.dump({"model": "opusplan"}, f)
+    os.makedirs(agent.CLAUDE_DIR, exist_ok=True)
+    with open(os.path.join(agent.CLAUDE_DIR, "settings.json"), "w") as f:
+        json.dump({"model": "sonnet", "effortLevel": "low"}, f)
+    out = agent.main(action="defaults", file=file)
+    assert out["model"] == "opus"      # project wins, alias collapsed
+    assert out["effort"] == "low"      # global fills what the project omits
+    assert out["source"] == "settings"
+
+
+def test_nothing_detected_returns_empty_not_a_guess(tmp_path, monkeypatch):
+    """The page owns the fallback; the agent must not invent one — an empty
+    field is the honest answer when there is no history and no settings."""
+    agent = _agent_in(tmp_path, monkeypatch)
+    file, _ = _target(tmp_path)
+    out = agent.main(action="defaults", file=file)
+    assert out == {"model": "", "effort": "", "source": ""}
+
+
+def test_unknown_values_never_leak_into_the_answer(tmp_path, monkeypatch):
+    agent = _agent_in(tmp_path, monkeypatch)
+    file, workdir = _target(tmp_path)
+    _write_transcript(agent, workdir, [
+        {"effort": "turbo", "message": {"model": "gpt-42"}},
+    ])
+    out = agent.main(action="defaults", file=file)
+    assert out["model"] == "" and out["effort"] == ""
+
+
+def test_short_model_collapses_every_spelling(tmp_path, monkeypatch):
+    agent = _agent_in(tmp_path, monkeypatch)
+    assert agent._short_model("claude-fable-5") == "fable"
+    assert agent._short_model("opusplan") == "opus"
+    assert agent._short_model("SONNET") == "sonnet"
+    assert agent._short_model("claude-haiku-4-5-20251001") == "haiku"
+    assert agent._short_model("gpt-42") == ""
+    assert agent._short_model("") == ""
+
+
+def test_the_page_asks_and_ranks_detection_below_an_explicit_choice():
+    html = open(os.path.join("fused_render", "templates", "claude_split",
+                             "template.html"), encoding="utf-8").read()
+    assert '{ action: "defaults", file: FILE }' in html
+    # explicit pane param > detected config > hardcoded fallback
+    assert 'fused.params.get("model") || detectedModel || DEFAULT_MODEL' in html
+    assert 'fused.params.get("effort") || detectedEffort || DEFAULT_EFFORT' in html
+    # detected values are validated against the selector's own lists
+    assert "MODELS.includes(d.model)" in html
+    assert "EFFORTS.includes(d.effort)" in html

--- a/tests/test_claude_split_shots.py
+++ b/tests/test_claude_split_shots.py
@@ -2103,7 +2103,7 @@ def test_the_annotate_control_is_a_labelled_switch(html):
     assert "background: var(--accent)" in on, on
     assert "color: var(--on-accent)" in on, on
     # named, announced, and labelled in the markup
-    view = _between(html, '<div id="leftview"', "<!-- /leftview -->")
+    view = _between(html, '<div id="anntools">', "</div>")
     assert 'id="annbtn"' in view and 'aria-label="' in view, view
     assert 'class="lbl"' in view, view
     for root in ("annBtn", "annVisBtn"):
@@ -2125,35 +2125,38 @@ def test_annotate_mode_and_pin_visibility_default_on(html):
     assert 'fused.params.get("annautosend") !== "0"' in html
 
 
-def test_the_annotate_switch_covers_none_of_the_app(html):
-    """A control over the app blocks annotating whatever sits under it. Both
-    switches anchor by their LEFT edge past the divider (`left: calc(100% + …)`)
-    and grow RIGHTWARD into the chat pane's margin — wider labels extend away from
-    the app, never over it.
-
-    Safe because nothing clips them (neither `#left` nor `#leftview` sets
-    `overflow`, and `#chat`'s `overflow: hidden` cannot clip a non-descendant) and
-    because the space exists: `#chat` has `min-width: 340px` and this layout never
-    stacks vertically."""
+def test_the_annotation_switches_are_a_layout_row_not_an_overlay(html):
+    """Every floating version of these controls — corner icon, then margin pills —
+    eventually landed on top of something (the app's corner, the chat topbar, an
+    open transcript). A real flex ROW at the top of the chat pane cannot: layout
+    reserves its height, so it covers nothing in either pane and in either view.
+    Horizontal, with real space between the two switches."""
+    row = _between(html, "#anntools {", "}")
+    assert "display: flex" in row, row
+    assert "justify-content: space-between" in row, row
+    assert "flex-shrink: 0" in row, row
+    # the switches themselves are plain flow children — no absolute anchoring left
     for sel in ("#annbtn {", "#annvis {"):
         btn = _between(html, sel, "}")
-        assert "position: absolute" in btn, btn
-        # left-anchored past the pane's own width, so growth is rightward
-        assert "left: calc(100% + " in btn, btn
-        assert "right:" not in btn, btn
-    for clipper in ("#left {", "#leftview {"):
-        assert "overflow" not in _between(html, clipper, "}"), clipper
-    assert "min-width: 340px" in _between(html, "#chat {", "}")
+        assert "position" not in btn, btn
+        assert "top:" not in btn and "left:" not in btn and "right:" not in btn, btn
+    # the row is a child of the chat pane, above the topbar, and hidden in
+    # NEITHER view — the home-view hide list must not grow to include it
+    chat = _between(html, '<div id="chat"', '<div id="topbar">')
+    assert 'id="anntools"' in chat, "the row sits above the topbar in the chat pane"
+    assert "#anntools" not in _between(html, "#chat.home #topbar", ";"), \
+        "visible on the home view too"
 
 
-def test_the_annotate_icon_sits_outside_the_frame_so_it_cannot_be_captured(html):
-    """The button must not appear in a crop or the pane shot. Structural, not
+def test_the_annotation_controls_sit_outside_the_frame_so_they_cannot_be_captured(html):
+    """The switches must not appear in a crop or the pane shot. Structural, not
     hopeful: `shotPane` rasterises `appWindow().document.body` — the FRAMED
     document — so anything in the parent document is unreachable by construction.
-    This pins the arrangement that makes that argument true: the button is a
-    SIBLING of the iframe in the parent document, never inside it."""
+    They live in the chat pane's #anntools row, nowhere near the iframe."""
     view = _between(html, '<div id="leftview"', "<!-- /leftview -->")
-    assert 'id="leftframe"' in view and 'id="annbtn"' in view
+    assert 'id="leftframe"' in view
+    assert 'id="annbtn"' not in view, "the controls left the app pane entirely"
+    assert 'id="annbtn"' in _between(html, '<div id="anntools">', "</div>")
     # and the capture still reads the frame, not the pane
     assert "appWindow()" in _between(html, "async function shotPane(", "\n}\n")
 

--- a/tests/test_claude_split_shots.py
+++ b/tests/test_claude_split_shots.py
@@ -2077,66 +2077,70 @@ def test_both_composers_draw_the_toggle_identically(html):
     assert chat.replace('id="viewshot"', "ID") == home.replace('id="hviewshot"', "ID")
 
 
-def test_the_annotate_control_is_a_small_unlabelled_icon(html):
-    """Annotating is occasional, so its control must not charge every project that
-    never uses it. A permanent strip cost ~28px of app height plus a line of chrome
-    the app never asked for, and the labelled pill before it grew into a whole
-    sentence when armed — covering MORE of the app at the moment the user was
-    aiming at it. A fixed 26px icon has neither cost: no layout row, and nothing
-    that can change size."""
+def test_the_annotate_control_is_a_labelled_switch(html):
+    """The annotate control is a labelled left-right sliding switch, not a bare
+    icon: it sits OUTSIDE the pane in the chat pane's empty header margin, where a
+    label costs the app zero pixels — so the state is spelled out ("Annotating" /
+    "Annotate") instead of encoded in a fill an unlabelled 26px glyph had to carry
+    alone. Both switches (#annbtn, #annvis) follow the shape: track + knob + text,
+    fixed height, absolute overlay."""
+    for sel in ("#annbtn {", "#annvis {"):
+        btn = _between(html, sel, "}")
+        assert "height: 26px" in btn, btn
+        assert "border-radius: 999px" in btn, btn
+        assert "white-space: nowrap" in btn, btn
+        # the switch anatomy exists in CSS for both controls
+        root = sel.split(" ")[0]
+        assert root + " .track {" in html, root
+        assert root + " .knob {" in html, root
+        # the knob SLIDES on toggle: the on-state moves it inside its fixed track
+        assert "left: 14px" in _between(html, root + ".on .knob {", "}"), root
+    # idle tints, armed fills the whole pill — annotate mode swallows the app's
+    # clicks, so its on-state must be the loudest of the two switches
     btn = _between(html, "#annbtn {", "}")
-    assert "width: 26px" in btn and "height: 26px" in btn, btn
-    assert "border-radius: 999px" in btn, btn
-    # no label text in either state, so nothing to ellipsize and nothing to grow
-    assert "#annbtn .lbl {" not in html
-    assert "#annbtn .stop {" not in html
-    assert "annLbl" not in html and "annStop" not in html
-    assert "textContent" not in _between(html, "function annSetMode(", "\n}")
-    # Accent while idle, because a 26px unlabelled glyph outside the pane is easy
-    # to miss — but then idle and armed both use the accent, so the ONE thing that
-    # still separates them must hold: idle tints (accent glyph, panel background),
-    # armed fills (accent background, glyph knocked out). Without this the control
-    # has no visible state at all, and there is no label to fall back on.
     assert "color: var(--accent)" in btn and "background: var(--panel)" in btn, btn
     on = _between(html, "#annbtn.on {", "}")
     assert "background: var(--accent)" in on, on
     assert "color: var(--on-accent)" in on, on
-    # an icon-only control still has to have a name and announce its state
+    # named, announced, and labelled in the markup
     view = _between(html, '<div id="leftview"', "<!-- /leftview -->")
     assert 'id="annbtn"' in view and 'aria-label="' in view, view
-    assert 'aria-pressed="false"' in view, view
-    # An inline SVG stroked in currentColor, like the composer's pane-shot icon —
-    # that is what lets one glyph follow the accent tint AND be knocked out to
-    # --on-accent when armed. A text/emoji glyph can do neither, and renders at a
-    # different weight on every platform.
+    assert 'class="lbl"' in view, view
+    for root in ("annBtn", "annVisBtn"):
+        assert root + '.querySelector(".lbl").textContent' in html, root
+    # the comment-bubble icon survives, stroked in currentColor so it follows the
+    # accent tint and is knocked out to --on-accent when armed
     icon = _between(view, 'id="annbtn"', "</button>")
     assert "<svg" in icon and 'stroke="currentColor"' in icon, icon
     assert 'fill="none"' in icon and 'aria-hidden="true"' in icon, icon
     assert "✎" not in html, "the pencil glyph is gone from the template"
 
 
-def test_the_annotate_icon_covers_none_of_the_app(html):
-    """The original floating button sat on the app's own top-right corner, and you
-    cannot click through a control — whatever was under it could not be annotated.
-    Fixed by moving it OUT of the pane rather than by shrinking it: a negative
-    offset puts it past the divider, in the chat pane's left margin, so the overlap
-    with the app is zero rather than merely small.
+def test_annotate_mode_and_pin_visibility_default_on(html):
+    """Both switches start ON: an unset param means enabled, and only an explicit
+    "0" — the user sliding it off — disables. Encoded as `!== "0"` rather than
+    `=== "1"` so a first visit (no params at all) gets the default."""
+    assert 'annSetMode(fused.params.get("annmode") !== "0")' in html
+    assert 'fused.params.get("annshow") !== "0"' in html
+    assert 'fused.params.get("annautosend") !== "0"' in html
 
-    Safe because nothing clips it (neither `#left` nor `#leftview` sets `overflow`,
-    and `#chat`'s `overflow: hidden` cannot clip a non-descendant) and because the
-    space always exists: `#chat` has `min-width: 340px` and this layout never
+
+def test_the_annotate_switch_covers_none_of_the_app(html):
+    """A control over the app blocks annotating whatever sits under it. Both
+    switches anchor by their LEFT edge past the divider (`left: calc(100% + …)`)
+    and grow RIGHTWARD into the chat pane's margin — wider labels extend away from
+    the app, never over it.
+
+    Safe because nothing clips them (neither `#left` nor `#leftview` sets
+    `overflow`, and `#chat`'s `overflow: hidden` cannot clip a non-descendant) and
+    because the space exists: `#chat` has `min-width: 340px` and this layout never
     stacks vertically."""
-    btn = _between(html, "#annbtn {", "}")
-    assert "position: absolute" in btn, btn
-    # negative, i.e. outside the pane — clear of the 4px divider's drag strip AND
-    # not jammed against it: 26px button + 4px divider + a real gap. Flush against
-    # the seam read as having slid there rather than being placed.
-    off = btn[btn.index("right:"):].split(";")[0]
-    px = int(off.split(":")[1].strip().rstrip("px"))
-    assert px <= -34, "26px button + 4px divider + a gap: " + off
-    # inset from the corner on both axes by the same amount, so it reads as placed
-    top = btn[btn.index("top:"):].split(";")[0]
-    assert top.split(":")[1].strip() == "%dpx" % (-px - 30), (top, off)
+    for sel in ("#annbtn {", "#annvis {"):
+        btn = _between(html, sel, "}")
+        assert "position: absolute" in btn, btn
+        # left-anchored past the pane's own width, so growth is rightward
+        assert "left: calc(100% + " in btn, btn
+        assert "right:" not in btn, btn
     for clipper in ("#left {", "#leftview {"):
         assert "overflow" not in _between(html, clipper, "}"), clipper
     assert "min-width: 340px" in _between(html, "#chat {", "}")


### PR DESCRIPTION
## Summary
- Annotate mode and comment-pin visibility are now labelled left-right sliding toggle switches in a dedicated row (`#anntools`) at the top of the chat pane (space-between layout, visible in both home and chat views). Both default **ON**; state persists in pane params.
- New comments **auto-send** to Claude on save (checkbox in the note popover, default on, right-aligned). Skipped when a turn is in flight or the composer holds a real user draft — but the canonical "apply the comments" prefill left by an earlier note counts as ours, so a later auto-send carries all pending notes.
- The composer's **send button becomes a stop button** while a run is live (arrow swaps to a stop square via `body.running`), killing the run same as Escape. Enter never stops a run.

## Test plan
- `pytest tests/test_claude_split_*.py tests/test_templates.py tests/test_claude_stop_run.py` — 303 pass.
- Structural tests updated/added: switch anatomy + labels, layout row above topbar (not an overlay, not hidden on home view), controls outside the captured frame, default-on param encoding.
- Manual: annotate flow, pin hide/show, auto-send with toggle off→on across two comments, stop via send button mid-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run lifecycle (send-as-stop) and automatic message submission after annotations, which can cancel or trigger turns unexpectedly; defaults reads local Claude config/transcripts but does not widen trust boundaries.
> 
> **Overview**
> **Annotation UX** moves out of the app pane: **Annotate** and **Comments shown** are labelled toggle switches in a top **`#anntools`** row (home and chat), with state in pane params (`annmode`, `annshow`, `annautosend`). Both default **on** (`!== "0"`). Saving a new note can **auto-send** via a popover checkbox (default on): it prefills **apply the comments** and submits when safe—not while a turn is running and not over a real user draft (the canonical prefill still counts as ours).
> 
> **While a run is live**, composer **Send** becomes **Stop** (`body.running`, icon swap); submit clicks call `stopRun()`. **Enter** still only sends text, not stop.
> 
> **Model/effort** selectors no longer guess only hardcoded fallbacks: the agent adds a **`defaults`** action that reads the newest session transcripts (skipping sidechains) and `.claude` / global settings, exposed as short model names; the page loads it async with **explicit param > detected > default**, validated against `MODELS`/`EFFORTS`. New **`tests/test_claude_split_defaults.py`**; shot/annotation structural tests updated for the row layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a164547a644fbe541855524ee03ff0b59a99fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->