### PR TITLE
Bundle rio-tiler so the Map Viewer raster path works in packaged apps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,12 @@ bundled = [
     "fpdf2>=2.8.7",
     "msgpack>=1.0",
     "rasterio",
+    # The Map Viewer's raster XYZ tile reader (templates/map/raster_engine.py).
+    # Imported lazily, so its absence does not fail the build — it surfaces at
+    # runtime as an "install rio-tiler" hint (templates/map/optional_runtime.py)
+    # that packaged-app users cannot act on, which is exactly what shipping it
+    # here fixes. ~4 MB installed: numpy/rasterio/pyproj are already above.
+    "rio-tiler",
     # Matches zarr_aoi/tile_server.py's header (and its DAEMON_DEPS): it reads
     # v3 stores through the 3.x API, so a bare pin could resolve to 2.x here.
     # Marked 3.11+ like the `fused` pins below: every zarr 3.x requires

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,11 +121,6 @@ bundled = [
     "fpdf2>=2.8.7",
     "msgpack>=1.0",
     "rasterio",
-    # The Map Viewer's raster XYZ tile reader (templates/map/raster_engine.py).
-    # Imported lazily, so its absence does not fail the build — it surfaces at
-    # runtime as an "install rio-tiler" hint (templates/map/optional_runtime.py)
-    # that packaged-app users cannot act on, which is exactly what shipping it
-    # here fixes. ~4 MB installed: numpy/rasterio/pyproj are already above.
     "rio-tiler",
     # Matches zarr_aoi/tile_server.py's header (and its DAEMON_DEPS): it reads
     # v3 stores through the 3.x API, so a bare pin could resolve to 2.x here.

--- a/tests/test_engine_requirements.py
+++ b/tests/test_engine_requirements.py
@@ -88,6 +88,7 @@ _IMPORT_TO_DIST = {
     "fpdf": "fpdf2",
     "msgpack": "msgpack",
     "rasterio": "rasterio",
+    "rio_tiler": "rio-tiler",
     "zarr": "zarr",
     "fitz": "pymupdf",
     "pymupdf": "pymupdf",

--- a/tests/test_map_runtime_contract.py
+++ b/tests/test_map_runtime_contract.py
@@ -110,7 +110,6 @@ def test_map_runtime_dependencies_stay_out_of_project_and_platform_packaging():
     project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     bundled = project["project"]["optional-dependencies"]["bundled"]
 
-    assert not any(item.startswith("rio-tiler") for item in bundled)
     assert not any(item.startswith("mapbox-vector-tile") for item in bundled)
     assert not any(item.startswith("xlrd") for item in bundled)
 
@@ -122,7 +121,7 @@ def test_map_runtime_dependencies_stay_out_of_project_and_platform_packaging():
     assert not (MAP / "pyproject.toml").exists()
 
     setup = (ROOT / "scripts" / "setup_py2app.py").read_text(encoding="utf-8")
-    for package in ("rio_tiler", "mapbox_vector_tile", "xlrd", "pyclipper"):
+    for package in ("mapbox_vector_tile", "xlrd", "pyclipper"):
         assert f'"{package}"' not in setup
 
 


### PR DESCRIPTION
## What

Adds `rio-tiler` to the `[bundled]` extra in `pyproject.toml`.

## Why

Opening a GeoTIFF in the **Map Viewer** template renders raster XYZ tiles through `rio-tiler` (`templates/map/raster_engine.py`). The import is lazy, and when the package is absent the template surfaces an install hint via `templates/map/optional_runtime.py`:

> Optional support for Raster layers requires Python packages that are not installed: rio-tiler. … `uv pip install rio-tiler`

That hint is actionable for a `pip install` dev environment but **not for packaged desktop-app users**, who cannot pip-install into the bundled interpreter. On the shipped app, `numpy`, `rasterio` and `geopandas` are bundled but `rio-tiler` is not — so opening a `.tif` in the Map Viewer dead-ends on the hint instead of rendering.

The template's design already assumes rio-tiler lives in the bundled geo runtime (`templates/map/geo_classify.py` docstring lists it), so this closes a packaging gap rather than changing behavior.

## Why bundle (vs. a PEP 723 header)

A header on `map_render.py` would build an isolated venv, and per the engine's D172 rule a header is the script's *complete* dependency list — no bundled baseline is unioned in (`engine.py`). Since the template lazily imports the whole geo stack, the header would have to redeclare all of it, and because rio-tiler is unmet by the app interpreter the *entire* header diverts to a fresh venv — re-downloading the numpy/rasterio/geopandas already in the bundle (~250 MB+) on first map open. Bundling avoids that: rio-tiler's heavy deps are already present, so the incremental cost is only **~4 MB** (rio-tiler + morecantile + color-operations + numexpr + pystac).

## Packaging

No other change needed: `scripts/setup_py2app.py`'s force-list derives from installed distributions and `BUNDLED_EXCLUDED` is empty, so the reconciliation in `tests/test_bundle_contents.py` picks rio-tiler up automatically. The Windows/Linux builds install the `[bundled]` extra directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with small incremental bundle size; behavior matches what dev installs already expected from the map template.
> 
> **Overview**
> **Adds `rio-tiler` to the `[bundled]` extra** so the Map Viewer’s in-process raster path (`raster_engine.py`) can import it in packaged desktop builds instead of showing a `uv pip install rio-tiler` hint users cannot act on.
> 
> Test updates align with that packaging choice: **`rio_tiler` → `rio-tiler`** in the PEP 723 import map, and the map runtime contract **no longer treats `rio-tiler` as a daemon-only / py2app-excluded** dependency (unlike `mapbox-vector-tile`, `xlrd`, `pyclipper`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13ead9e19d017078e1befd67907687fd1da5ba13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->