### PR TITLE
Fix the two flaky test-python tests and the superseded-run false red

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -566,6 +566,13 @@ jobs:
     steps:
       - name: Check test status
         run: |
+          # A cancelled detect-changes means THIS RUN was superseded by
+          # concurrency-cancel (a newer push); failing here paints a red X on
+          # the history of a run nobody cares about. Neutral pass instead.
+          if [[ "${{ needs.detect-changes.result }}" == "cancelled" ]]; then
+            echo "Run superseded (detect-changes cancelled); nothing to verify."
+            exit 0
+          fi
           if [[ "${{ needs.detect-changes.result }}" != "success" ]]; then
             echo "detect-changes did not succeed (${{ needs.detect-changes.result }})"
             exit 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,6 +285,58 @@ def _pin_the_script_interpreter_resolution():
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _no_real_rcd_spawn():
+    """Make spawning a REAL rclone rcd from the suite impossible, loudly.
+
+    The flake this kills (PR #407's own CI run proved the mechanism): a
+    background mount thread leaked by an earlier test finishes its ensure_rcd
+    spawn-wait AFTER the FUSED_RENDER_HOME env var has moved on to a later
+    test's home, so write_rcd_state (rcd.py, post-liveness) lands a real
+    daemon's {port, pid} in THAT test's rcd.json — and its ensure_rcd then
+    "reuses" a foreign daemon (assert 55455 == 37291). Per-test patches can't
+    stop it: env vars and monkeypatches are process-global, so a leaked thread
+    always sees whatever the current test sees. The only sound boundary is the
+    spawn itself: no real daemon can ever exist, so no foreign state write can
+    ever land — and the leaked thread now raises, which pytest surfaces as an
+    unhandled-thread-exception warning NAMING the leaking thread.
+
+    Session-scoped and applied to rcd's module namespace only, so:
+      * tests that fake the spawn by patching `mounts_mod.subprocess.Popen`
+        (the stdlib module object — test_mounts_rcd_persist/_auth,
+        test_mount_nfs_handle_cache) still work: the shim delegates whenever
+        global Popen is not the real one;
+      * every other user of subprocess (StubRcd helpers, node runners, the
+        reaper's `ps` via subprocess.run) is untouched.
+    """
+    import subprocess as _sp
+
+    from fused_render.shell.mounts import rcd as _rcd
+
+    real_popen = _sp.Popen
+    real_module = _rcd.subprocess
+
+    class _NoRealSpawn:
+        def __getattr__(self, name):
+            return getattr(_sp, name)
+
+        @staticmethod
+        def Popen(*args, **kwargs):
+            popen = _sp.Popen
+            if popen is real_popen:
+                raise AssertionError(
+                    "test attempted to spawn a real rclone rcd daemon "
+                    "(patch subprocess.Popen or rclone_bin, or fix the "
+                    "leaked background thread this raised in)")
+            return popen(*args, **kwargs)
+
+    _rcd.subprocess = _NoRealSpawn()
+    try:
+        yield
+    finally:
+        _rcd.subprocess = real_module
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _reap_test_rcd_daemons():
     """Kill any REAL rclone rcd daemon a test spawned, on session teardown.
 

--- a/tests/test_shell_mounts.py
+++ b/tests/test_shell_mounts.py
@@ -190,8 +190,16 @@ def rcd(home, monkeypatch):
     exactly when the stub reports mount/mount success. A test that needs a
     different ismount view (stale/disconnected, adopt-an-existing-mount) still
     monkeypatches os.path.ismount itself in its body — that runs after this and
-    wins."""
+    wins.
+
+    rclone_bin is pinned to None so the ensure_rcd spawn path is IMPOSSIBLE
+    here: a transient core/pid probe failure (a loaded CI runner slipping the
+    3s deadline under xdist) otherwise falls through to spawning the REAL
+    rclone that CI installs — a cryptic port-mismatch assert plus a leaked
+    daemon. With the pin, that path fails loudly as "rclone is not installed"
+    instead."""
     stub = StubRcd()
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: None)
     mounts_mod.write_rcd_state(stub.port, 4242)
     monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p in stub.mounted)
     yield stub

--- a/tests/test_skill_plugin.py
+++ b/tests/test_skill_plugin.py
@@ -103,17 +103,22 @@ def test_two_syncs_at_once_do_not_stage_into_the_same_directory(home, sources):
     publish whichever fragment won."""
     seen = []
     real_build = skill_plugin._build
+    # The barrier lives INSIDE the spy so both threads must be inside _build
+    # before either finishes: without it, the first sync could publish + stamp
+    # before the second even checked loadability, and the second would take the
+    # legitimate short-circuit — one _build call, spurious failure. It can't
+    # deadlock: the first thread blocked here has published nothing, so the
+    # second's stamp check must fail and bring it into _build too.
+    barrier = threading.Barrier(2, timeout=30)
 
     def spy(staging, sources_map):
         seen.append(staging)
+        barrier.wait()
         return real_build(staging, sources_map)
 
     skill_plugin._build = spy
     try:
-        barrier = threading.Barrier(2)
-
         def run():
-            barrier.wait()
             skill_plugin.sync_skill_plugin()
 
         threads = [threading.Thread(target=run) for _ in range(2)]


### PR DESCRIPTION
## Why

`test-python` has been intermittently red for reasons unrelated to the code under test. Audit of the last 30 runs found two genuinely flaky tests plus one cosmetic false red.

## Changes

1. **`test_two_syncs_at_once_do_not_stage_into_the_same_directory`** (failed on 3.10 and 3.11 runs): the barrier only synchronized thread *start*. If thread A built, published, and stamped before B reached the loadable/stamp check, B took the legitimate short-circuit and the `len(seen) == 2` assert failed. The barrier now lives inside the `_build` spy, so both threads must be mid-build before either can publish — structurally guaranteeing two builds. Cannot deadlock: a thread blocked in the spy has published nothing, so the other's stamp check must fail and bring it into `_build` too.

2. **`test_ensure_rcd_reuses_live_daemon`** — the interesting one. This PR's own first CI run disproved the initial "probe timeout" theory: with the test thread unable to spawn (`rclone_bin` pinned to `None`), the test still failed with `assert 55455 == 37291` — a *live foreign daemon*. The real mechanism: **a background mount thread leaked by an earlier test** finishes its `ensure_rcd` spawn-wait after `FUSED_RENDER_HOME` has moved on to a later test's home, and `write_rcd_state` (which runs post-liveness-check) lands a real rclone daemon's `{port, pid}` in *that* test's `rcd.json` — whose `ensure_rcd` then "reuses" a daemon it never started. Per-test patches cannot stop this (env vars and monkeypatches are process-global; a leaked thread sees whatever the current test sees), so the fix is a **session-scoped autouse conftest guard** that makes spawning a real rcd impossible, loudly: a shim on `rcd`'s module namespace whose `Popen` raises unless a test has faked global `subprocess.Popen` (the existing spawn-path tests — `test_mounts_rcd_persist`, `test_mounts_rcd_auth`, `test_mount_nfs_handle_cache` — keep working). No real daemon can ever exist ⇒ no foreign state write can ever land, the leaked thread surfaces as a *named* unhandled-thread-exception warning instead of silently corrupting a victim test, and CI runners stop accumulating orphaned rclone daemons. The `rclone_bin` pin in the `rcd` fixture stays as defense-in-depth.

3. **`test-status` false red** (e.g. run 31118018474 on main): concurrency-cancel on a newer push cancels `detect-changes`, and test-status treated any non-success as failure — a red X on the history of a superseded run. Cancelled `detect-changes` now exits 0.

## Testing

- Full suite locally with the guard: 4581 passed, 127 skipped (1 pre-existing failure of a Linux-only `/proc` test on macOS, unrelated).
- Spawn-faking tests (`test_mounts_rcd_persist`, `test_mounts_rcd_auth`, `test_mount_nfs_handle_cache`) pass under the guard.
- `tests/test_skill_plugin.py`: 35 passed × 5 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures, one concurrency test, and CI status logic; no production runtime behavior is modified.
> 
> **Overview**
> Addresses intermittent **`test-python`** failures and a misleading red **Test Status** on superseded workflow runs.
> 
> **CI:** When **`detect-changes`** is **cancelled** (concurrency from a newer push), **`test-status`** now exits successfully instead of failing—so old runs don’t show a false red X.
> 
> **Mount / rcd tests:** A session-scoped autouse fixture on **`rcd`’s `subprocess`** blocks spawning a real **rclone rcd** unless tests patch **`Popen`** (delegates to the patch). That stops leaked background threads from writing another test’s **`rcd.json`** after **`FUSED_RENDER_HOME`** moves. The shared **`rcd`** fixture also pins **`rclone_bin`** to **`None`** so a flaky liveness probe can’t fall through to the real **rclone** on CI.
> 
> **Skill plugin concurrency test:** The **`threading.Barrier`** moved from thread start into the **`_build`** spy so both threads must enter **`_build`** before either finishes—avoiding a race where one sync publishes and the second short-circuits with only one staged directory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41d8bf8d6baa2941b42ec48bada77e7515db8e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->