### PR TITLE
fix(explorer): make bookmark star a toggle

### DIFF
--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -12,15 +12,15 @@ import { isMod } from "@platform/lib/platform";
 import {
   addBookmark,
   allBookmarks,
+  deleteBookmark,
   updateBookmarkUrl,
   armBookmark,
   disarmBookmark,
   getArmedBookmark,
-  getArmedBookmarkFor,
   sameSearch,
   splitBookmarkUrl,
 } from "@platform/lib/bookmarks";
-import { useUrlVersion, useBookmarksVersion, useArmedVersion, notifyBookmarksChanged } from "@platform/lib/hooks";
+import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "@platform/lib/hooks";
 import { urlScheme, isCloudScheme, fileUrlToPath } from "@platform/lib/path-url";
 import { resolveCloudUrl } from "@platform/lib/api";
 import { pushToast } from "@platform/lib/toast";
@@ -112,31 +112,40 @@ function RevealButton({ fsPath }: { fsPath: string }) {
 // the row marking is where the user is already looking.
 
 // ★ bookmark button, leftmost in the bar. Highlighted (accent-yellow, filled)
-// when the current view is bookmarked or an armed bookmark is live. `name` is
-// the default bookmark name.
+// only when a bookmark matches the current view exactly (same pathname AND
+// same params, via sameSearch) — a param change empties the star, so the user
+// can save the changed view as a new bookmark. Clicking a filled star deletes
+// the matching bookmark (toggle), disarming it if it was armed. `name` is the
+// default bookmark name.
 function BookmarkStar({ name }: { name: string }) {
   useUrlVersion();
   useBookmarksVersion();
-  useArmedVersion();
-  const starred = allBookmarks().some((b) => b.url === currentUrl());
-  // Pathname-gated (getArmedBookmarkFor): an armed bookmark lights the star
-  // only on ITS view, and useArmedVersion re-renders this when a disarm fires.
-  const armed = !IS_EMBED && getArmedBookmarkFor(location.pathname) !== null;
-  const active = starred || armed;
+  const matchesCurrent = (b: { url: string }) => {
+    const { pathname, search } = splitBookmarkUrl(b.url);
+    return pathname === location.pathname && sameSearch(search, location.search);
+  };
+  const existing = allBookmarks().find(matchesCurrent);
+  const starred = existing !== undefined;
 
   const onBookmark = async () => {
-    await addBookmark(name, currentUrl());
+    if (existing) {
+      await deleteBookmark(existing.id);
+      const armed = getArmedBookmark();
+      if (armed && armed.id === existing.id) disarmBookmark();
+    } else {
+      await addBookmark(name, currentUrl());
+    }
     notifyBookmarksChanged();
   };
 
   return (
     <button
       id="bookmark-btn"
-      className={"bookmark-star-btn" + (active ? " active" : "")}
-      title={starred ? "View is bookmarked (★ adds another)" : "Bookmark this view"}
+      className={"bookmark-star-btn" + (starred ? " active" : "")}
+      title={starred ? "Remove bookmark" : "Bookmark this view"}
       onClick={onBookmark}
     >
-      <StarIcon filled={active} />
+      <StarIcon filled={starred} />
     </button>
   );
 }


### PR DESCRIPTION
## What

Star icon in breadcrumb now behaves as a toggle:

- Click empty star → creates bookmark, star fills yellow (unchanged).
- Click filled star → deletes that bookmark (previously it created a duplicate).
- Star fills only when a bookmark matches the current view exactly (same pathname and same params, compared via `sameSearch`). Changing any param empties the star, letting the user bookmark the changed view as a new bookmark.
- Deleting an armed bookmark via the star also disarms it, so the Update-bookmark button can't reference a deleted bookmark.

## Notes

- Armed state no longer fills the star — previously an armed bookmark kept the star yellow even after params drifted. The Update-bookmark flow itself is untouched.
- Typecheck clean; `bun test` 170 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in `BookmarkStar` with existing bookmark APIs; no auth, data, or routing changes.
> 
> **Overview**
> The explorer breadcrumb **bookmark star** is now a **toggle**: a filled star **removes** the matching bookmark instead of adding a duplicate, and an empty star still **adds** one.
> 
> **Highlighting** uses **pathname + query** (`sameSearch`), not a raw full URL string. Any param drift clears the star so the user can save the new view as a separate bookmark. **Armed** bookmarks no longer keep the star yellow when params have drifted—the **Update bookmark** flow is unchanged.
> 
> Removing a bookmark via the star also **disarms** it when that bookmark was armed, so the update button cannot reference a deleted entry. Tooltips and imports were updated (`deleteBookmark`; dropped `useArmedVersion` / `getArmedBookmarkFor` from this component only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3cc3ff360a429b5924f8c9880902146535f6e16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->