### PR TITLE
Simplify claude_split annotation controls

### DIFF
--- a/fused_render/templates/claude_split/template.html
+++ b/fused_render/templates/claude_split/template.html
@@ -101,56 +101,43 @@
   }
 
   /* ── annotation controls: a layout row at the top of the chat pane ─────── */
-  /* Two labelled left-right sliding switches — annotate mode (#annbtn) and pin
-     visibility (#annvis) — in a real flex ROW above the chat content, shown in
-     both views. A row, not an overlay: the floating versions (corner icon, then
-     margin pills) kept landing on top of whatever the chat pane drew underneath.
-     In a row the labels cost nothing, cover nothing, and say plainly what each
-     control governs. Idle tints (accent on panel); the annotate switch FILLS
-     when armed — annotate mode swallows the app's clicks, so its on-state is
-     the loudest of the two. */
+  /* One labelled left-right sliding switch — annotate mode (#annbtn) — in a
+     real flex ROW above the chat content, shown in both views. A row, not an
+     overlay: the floating versions (corner icon, then margin pills) kept
+     landing on top of whatever the chat pane drew underneath. Pin visibility
+     follows the mode (annotating shows the comment pins; leaving the mode
+     hides them), so a second switch has nothing left to govern. Deliberately
+     quiet: plain label text and a small track that tints accent when armed —
+     no filled pill, no border. */
   #anntools {
     flex-shrink: 0;
     display: flex;
     align-items: center;
-    justify-content: space-between;
     gap: 12px;
     padding: 8px 16px;
     border-bottom: 1px solid var(--border);
   }
   #annbtn {
     height: 26px;
-    padding: 0 8px 0 10px;
+    padding: 0;
     display: flex;
     align-items: center;
     gap: 7px;
     font: inherit;
     font-size: 12px;
-    font-weight: 600;
     line-height: 1;
     white-space: nowrap;
-    border: 1px solid var(--accent);
-    border-radius: 999px;
-    background: var(--panel);
-    color: var(--accent);
+    border: 0;
+    background: transparent;
+    color: var(--muted, var(--fg));
     cursor: pointer;
-    transition: color .12s, border-color .12s, background .12s, filter .12s;
+    transition: color .12s;
   }
-  /* The same hover-vs-active rule as `.pill` in the composer, stated the same way:
-     the neutral hover excludes the active state, and the active state hovers within
-     its accent. See the comment on `.pill:hover`. */
-  /* `display: block` kills the inline baseline gap that would push the glyph off
-     centre. Same rule as `.viewshot svg`. */
-  #annbtn svg { display: block; }
-  #annbtn:hover:not(.on) { background: var(--surface-2); }
-  #annbtn.on {
-    background: var(--accent);
-    color: var(--on-accent);
-  }
-  #annbtn.on:hover { filter: brightness(1.1); }
-  /* The slider: knob left = off, knob right = on. Drawn in currentColor so it
-     follows the pill's own idle/armed palette; the on-state inverts it so the
-     knob stays visible on the accent-filled pill. */
+  #annbtn:hover { color: var(--fg); }
+  #annbtn.on { color: var(--fg); }
+  /* The slider: knob left = off, knob right = on. Off is drawn in the quiet
+     currentColor; the on-state fills the track with the accent — the only
+     colour the control ever shows, and only while armed. */
   #annbtn .track {
     position: relative;
     width: 28px;
@@ -158,7 +145,7 @@
     border-radius: 999px;
     border: 1px solid currentColor;
     flex-shrink: 0;
-    transition: background .15s;
+    transition: background .15s, border-color .15s;
   }
   #annbtn .knob {
     position: absolute;
@@ -170,51 +157,8 @@
     background: currentColor;
     transition: left .15s, background .15s;
   }
-  #annbtn.on .track { background: var(--on-accent); }
-  #annbtn.on .knob { left: 14px; background: var(--accent); }
-  /* The pins-visibility switch: same anatomy, quieter on-state — track fills,
-     pill stays panel. On = knob right, accent track. */
-  #annvis {
-    height: 26px;
-    padding: 0 10px 0 6px;
-    display: flex;
-    align-items: center;
-    gap: 7px;
-    font: inherit;
-    font-size: 12px;
-    line-height: 1;
-    white-space: nowrap;
-    border: 1px solid var(--accent);
-    border-radius: 999px;
-    background: var(--panel);
-    color: var(--accent);
-    cursor: pointer;
-    box-shadow: 0 2px 8px var(--shadow);
-    transition: color .12s, border-color .12s, background .12s, filter .12s;
-  }
-  #annvis:hover { background: var(--surface-2); }
-  #annvis .track {
-    position: relative;
-    width: 28px;
-    height: 16px;
-    border-radius: 999px;
-    border: 1px solid var(--accent);
-    background: transparent;
-    transition: background .15s;
-    flex-shrink: 0;
-  }
-  #annvis .knob {
-    position: absolute;
-    top: 2px;
-    left: 2px;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--accent);
-    transition: left .15s, background .15s;
-  }
-  #annvis.on .track { background: var(--accent); }
-  #annvis.on .knob { left: 14px; background: var(--on-accent); }
+  #annbtn.on .track { background: var(--accent); border-color: var(--accent); }
+  #annbtn.on .knob { left: 14px; background: var(--on-accent); }
   #annpins { position: absolute; inset: 0; z-index: 2; pointer-events: none; overflow: hidden; }
   .annpin {
     position: absolute;
@@ -270,16 +214,6 @@
     outline: none;
   }
   #annpop .hint { color: var(--faint); font-size: 11px; margin-top: 5px; display: flex; align-items: center; }
-  #annauto {
-    display: flex;
-    align-items: center;
-    gap: 3px;
-    margin-left: auto;
-    cursor: pointer;
-    user-select: none;
-    white-space: nowrap;
-  }
-  #annauto input { margin: 0; accent-color: var(--accent); cursor: pointer; }
   #anndel {
     margin-left: 8px;
     border: 0;
@@ -818,7 +752,6 @@
       <div id="annpop">
         <textarea rows="2" placeholder="What about this element?" spellcheck="false"></textarea>
         <div class="hint">Enter to save · Esc to cancel
-          <label id="annauto" title="Send the note to Claude immediately when saved"><input type="checkbox" checked> Auto-send</label>
           <button id="anndel" type="button" hidden>Delete</button></div>
       </div>
     </div><!-- /leftview -->
@@ -826,27 +759,17 @@
   <div id="divider" role="separator" aria-orientation="vertical" aria-label="Resize panels"></div>
 
   <div id="chat" class="home">
-    <!-- Annotation controls: a real layout ROW above everything else in this
+    <!-- Annotation control: a real layout ROW above everything else in this
          pane, in both views — never an overlay, so it can't land on top of the
-         topbar or the transcript. Both are real <button>s (Enter/Space work,
-         aria announces state) living in the parent document, a structural
-         guarantee they can never appear in a pane capture (shotPane rasterises
-         the framed document only). The bubble icon is a comment bubble, not a
-         pencil: a pencil means "edit this", which is what CLAUDE does — these
-         controls let the user leave notes ON the app. -->
+         topbar or the transcript. A real <button> (Enter/Space work, aria
+         announces state) living in the parent document, a structural guarantee
+         it can never appear in a pane capture (shotPane rasterises the framed
+         document only). One switch is enough: the comment pins over the app
+         show while annotating and hide when the mode is off. -->
     <div id="anntools">
       <button id="annbtn" type="button" aria-pressed="false" aria-label="Annotate the app"
-              title="Annotate the app, then send the notes to Claude"><svg width="13" height="13"
-        viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2.3" y="2.8" width="11.4"
-        height="8.4" rx="2.2" stroke="currentColor" stroke-width="1.4"/><path d="M5.6 11.2v2.6l3-2.6"
-        stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg><span
+              title="Annotate the app, then send the notes to Claude"><span
         class="lbl">Annotate</span><span class="track" aria-hidden="true"><span class="knob"></span></span></button>
-      <button id="annvis" type="button" role="switch" aria-checked="true"
-              aria-label="Show annotation comments on the app"
-              title="Show or hide the annotation comment pins over the app">
-        <span class="track" aria-hidden="true"><span class="knob"></span></span>
-        <span class="lbl">Comments shown</span>
-      </button>
     </div>
     <!-- chat view -->
     <div id="topbar">
@@ -1189,7 +1112,7 @@ function searchParamsOf(search) {
 // user's notes, already sent in their own block.
 const CHAT_PARAMS = new Set(["_file", "_mode", "session_id", "run", "split",
                              "model", "effort", "permission", "annotations",
-                             "annmode", "annshow", "annautosend",
+                             "annmode",
                              "path"]);
 
 function appParamsOf(all) {
@@ -1469,10 +1392,9 @@ const annFrame = document.getElementById("leftframe");
 let annOn = false;
 let annDraft = null;    // anchor of a NEW note being composed
 let annEditing = null;  // id of an existing pending note being edited
-// Pins visible over the app. Default ON: an unset param means shown, and only an
-// explicit "0" (the user toggled it off) hides them. Chips above the composer are
-// the send payload and stay visible either way.
-let annShow = fused.params.get("annshow") !== "0";
+// Pins follow the mode: annotating shows the comment pins over the app, leaving
+// the mode hides them. Chips above the composer are the send payload and stay
+// visible either way.
 
 function annLoad() {
   try {
@@ -1559,8 +1481,8 @@ function annLabelFor(i) {
 function renderAnn() {
   // pins over the frame
   annPins.innerHTML = "";
-  annPins.style.display = annShow ? "" : "none";
-  const doc = annShow ? annFrame.contentDocument : null;
+  annPins.style.display = annOn ? "" : "none";
+  const doc = annOn ? annFrame.contentDocument : null;
   // #leftview, not #left: pins are placed in FRAME viewport coordinates, so their
   // host must be the box the iframe fills — #left also holds the control strip,
   // and measuring that would put every pin the strip's height too high.
@@ -1667,15 +1589,15 @@ function annCloseComposer() {
 }
 // A fresh note usually precedes a "go apply it" message: seed the visible
 // composer so sending is one keypress. Only when it's empty — never clobber
-// typed text. Auto-send (the popover's checkbox, default on) then submits it.
+// typed text. Auto-send (always on) then submits it.
 const ANN_PREFILL = "apply the comments";
 function annPrefillComposer() {
   const home = chatEl.classList.contains("home");
   const el = home ? homebox : box;
   // A typed draft is the user's — hands off. But the composer holding exactly
   // the canonical prefill is OUR text (a previous note left it, e.g. one saved
-  // with auto-send off), not a draft: it still counts as fillable, so the next
-  // note's auto-send can fire and carry every pending note with it.
+  // while a turn was in flight), not a draft: it still counts as fillable, so
+  // the next note's auto-send can fire and carry every pending note with it.
   const v = el.value.trim();
   if (v && v !== ANN_PREFILL) return false;
   el.value = ANN_PREFILL;
@@ -1722,7 +1644,7 @@ annTa.addEventListener("keydown", (e) => {
     // rides the next message) and when the composer holds a typed draft — the
     // prefill refused to touch it, and sending a half-typed message is worse
     // than leaving the note as a chip.
-    if (isNew && filled && annAutoEl.checked && !sending) annAutoSubmit();
+    if (isNew && filled && !sending) annAutoSubmit();
   }
 });
 
@@ -1735,6 +1657,9 @@ function annSetMode(on) {
   annBtn.classList.toggle("on", annOn);
   annBtn.setAttribute("aria-pressed", String(annOn));
   annBtn.querySelector(".lbl").textContent = annOn ? "Annotating" : "Annotate";
+  // Pins follow the mode, so a toggle must repaint them (show on arm, hide on
+  // disarm) — renderAnn gates on `annOn` now.
+  renderAnn();
   // No label in either state — the icon never changes size or position, so nothing
   // here can cover more of the app than the idle button already does. The tooltip
   // is where the instruction and BOTH ways out live, because it has no width limit
@@ -1751,28 +1676,8 @@ annBtn.addEventListener("click", () => annSetMode(!annOn));
 // explicit "0" (the user slid it off, or pressed Escape) starts it disarmed.
 annSetMode(fused.params.get("annmode") !== "0");
 
-// Pins-visibility toggle: pressed (filled) = pins shown, which is the default.
-const annVisBtn = document.getElementById("annvis");
-function annSetShow(on) {
-  annShow = on;
-  fused.params.set("annshow", on ? "1" : "0");
-  annVisBtn.classList.toggle("on", on);
-  annVisBtn.setAttribute("aria-checked", String(on));
-  annVisBtn.querySelector(".lbl").textContent = on ? "Comments shown" : "Comments hidden";
-  annVisBtn.title = on ? "Annotation comment pins are shown over the app — click to hide them"
-                       : "Annotation comment pins are hidden — click to show them";
-  renderAnn();
-}
-annSetShow(annShow);
-annVisBtn.addEventListener("click", () => annSetShow(!annShow));
-
-// Auto-send: a saved NEW note goes to Claude immediately (default on). The
-// checkbox lives in the note popover and persists like the pins toggle.
-const annAutoEl = document.querySelector("#annauto input");
-annAutoEl.checked = fused.params.get("annautosend") !== "0";
-annAutoEl.addEventListener("change", () => {
-  fused.params.set("annautosend", annAutoEl.checked ? "1" : "0");
-});
+// Auto-send: a saved NEW note goes to Claude immediately, always — there is no
+// off switch. The `filled`/`sending` guards below are the only gates.
 function annAutoSubmit() {
   if (chatEl.classList.contains("home")) document.getElementById("card").requestSubmit();
   else submitChat();

--- a/tests/test_claude_split_shots.py
+++ b/tests/test_claude_split_shots.py
@@ -1974,8 +1974,7 @@ def test_hover_never_eats_an_active_state_in_either_control(html):
     within its accent. Asserted for both, because a comment saying they agree is not
     a test that they do."""
     pairs = [('.pill:hover:not([aria-pressed="true"])',
-              '.pill[aria-pressed="true"]:hover'),
-             ("#annbtn:hover:not(.on)", "#annbtn.on:hover")]
+              '.pill[aria-pressed="true"]:hover')]
     for neutral, active in pairs:
         assert neutral + " {" in html, neutral
         assert active + " {" in html, active
@@ -1983,6 +1982,10 @@ def test_hover_never_eats_an_active_state_in_either_control(html):
         assert "filter: brightness" in _between(html, active + " {", "}")
         # ...and it is not bodged in with !important
         assert "!important" not in _between(html, neutral + " {", "}")
+    # #annbtn no longer carries an accent fill at all (the subtle restyle), so it
+    # has no hover-vs-active collision left to guard: both states paint the same
+    # quiet foreground colour.
+    assert "#annbtn.on:hover" not in html
     assert "!important" not in html, "specificity, not force"
 
 
@@ -2078,68 +2081,66 @@ def test_both_composers_draw_the_toggle_identically(html):
 
 
 def test_the_annotate_control_is_a_labelled_switch(html):
-    """The annotate control is a labelled left-right sliding switch, not a bare
-    icon: it sits OUTSIDE the pane in the chat pane's empty header margin, where a
-    label costs the app zero pixels — so the state is spelled out ("Annotating" /
-    "Annotate") instead of encoded in a fill an unlabelled 26px glyph had to carry
-    alone. Both switches (#annbtn, #annvis) follow the shape: track + knob + text,
-    fixed height, absolute overlay."""
-    for sel in ("#annbtn {", "#annvis {"):
-        btn = _between(html, sel, "}")
-        assert "height: 26px" in btn, btn
-        assert "border-radius: 999px" in btn, btn
-        assert "white-space: nowrap" in btn, btn
-        # the switch anatomy exists in CSS for both controls
-        root = sel.split(" ")[0]
-        assert root + " .track {" in html, root
-        assert root + " .knob {" in html, root
-        # the knob SLIDES on toggle: the on-state moves it inside its fixed track
-        assert "left: 14px" in _between(html, root + ".on .knob {", "}"), root
-    # idle tints, armed fills the whole pill — annotate mode swallows the app's
-    # clicks, so its on-state must be the loudest of the two switches
+    """The annotate control is ONE labelled left-right sliding switch — plain
+    label text plus track + knob, no icon, no filled pill, no accent border. The
+    state is spelled out ("Annotating" / "Annotate") and the only colour it ever
+    shows is the accent-filled track while armed. The old second switch (#annvis,
+    pin visibility) is gone: pins follow the mode."""
     btn = _between(html, "#annbtn {", "}")
-    assert "color: var(--accent)" in btn and "background: var(--panel)" in btn, btn
+    assert "height: 26px" in btn, btn
+    assert "white-space: nowrap" in btn, btn
+    # quiet by construction: no border, no fill, no accent on the idle control
+    assert "border: 0" in btn, btn
+    assert "background: transparent" in btn, btn
+    assert "var(--accent)" not in btn, "idle control carries no accent: " + btn
+    # the switch anatomy: track + knob, and the knob SLIDES on toggle
+    assert "#annbtn .track {" in html
+    assert "#annbtn .knob {" in html
+    assert "left: 14px" in _between(html, "#annbtn.on .knob {", "}")
+    # armed state repaints only the small track with the accent — never the pill
     on = _between(html, "#annbtn.on {", "}")
-    assert "background: var(--accent)" in on, on
-    assert "color: var(--on-accent)" in on, on
-    # named, announced, and labelled in the markup
+    assert "background" not in on, "no filled pill when armed: " + on
+    assert "background: var(--accent)" in _between(html, "#annbtn.on .track {", "}")
+    # named, announced, and labelled in the markup — text only, no icon
     view = _between(html, '<div id="anntools">', "</div>")
     assert 'id="annbtn"' in view and 'aria-label="' in view, view
     assert 'class="lbl"' in view, view
-    for root in ("annBtn", "annVisBtn"):
-        assert root + '.querySelector(".lbl").textContent' in html, root
-    # the comment-bubble icon survives, stroked in currentColor so it follows the
-    # accent tint and is knocked out to --on-accent when armed
-    icon = _between(view, 'id="annbtn"', "</button>")
-    assert "<svg" in icon and 'stroke="currentColor"' in icon, icon
-    assert 'fill="none"' in icon and 'aria-hidden="true"' in icon, icon
+    assert "<svg" not in view, "simple text + switch, no glyph: " + view
+    assert 'annBtn.querySelector(".lbl").textContent' in html
+    # the second switch is gone entirely
+    assert "annvis" not in html and "annVisBtn" not in html
     assert "✎" not in html, "the pencil glyph is gone from the template"
 
 
-def test_annotate_mode_and_pin_visibility_default_on(html):
-    """Both switches start ON: an unset param means enabled, and only an explicit
-    "0" — the user sliding it off — disables. Encoded as `!== "0"` rather than
-    `=== "1"` so a first visit (no params at all) gets the default."""
+def test_annotate_mode_defaults_on_and_owns_pin_visibility(html):
+    """The one switch starts ON: an unset param means enabled, and only an
+    explicit "0" — the user sliding it off — disables. Encoded as `!== "0"`
+    rather than `=== "1"` so a first visit (no params at all) gets the default.
+    Pin visibility and auto-send have no params of their own any more: pins
+    follow the mode, and a saved new note always auto-sends."""
     assert 'annSetMode(fused.params.get("annmode") !== "0")' in html
-    assert 'fused.params.get("annshow") !== "0"' in html
-    assert 'fused.params.get("annautosend") !== "0"' in html
+    assert "annshow" not in html
+    assert "annautosend" not in html
+    # pins gate on the mode itself, and toggling the mode repaints them
+    assert 'annPins.style.display = annOn ? "" : "none"' in html
+    assert "renderAnn()" in _between(html, "function annSetMode(", "\n}")
+    # auto-send is unconditional (bar the in-flight / typed-draft guards)
+    assert "if (isNew && filled && !sending) annAutoSubmit();" in html
+    assert "annAutoEl" not in html and 'id="annauto"' not in html
 
 
-def test_the_annotation_switches_are_a_layout_row_not_an_overlay(html):
-    """Every floating version of these controls — corner icon, then margin pills —
+def test_the_annotation_switch_is_a_layout_row_not_an_overlay(html):
+    """Every floating version of this control — corner icon, then margin pills —
     eventually landed on top of something (the app's corner, the chat topbar, an
     open transcript). A real flex ROW at the top of the chat pane cannot: layout
-    reserves its height, so it covers nothing in either pane and in either view.
-    Horizontal, with real space between the two switches."""
+    reserves its height, so it covers nothing in either pane and in either view."""
     row = _between(html, "#anntools {", "}")
     assert "display: flex" in row, row
-    assert "justify-content: space-between" in row, row
     assert "flex-shrink: 0" in row, row
-    # the switches themselves are plain flow children — no absolute anchoring left
-    for sel in ("#annbtn {", "#annvis {"):
-        btn = _between(html, sel, "}")
-        assert "position" not in btn, btn
-        assert "top:" not in btn and "left:" not in btn and "right:" not in btn, btn
+    # the switch itself is a plain flow child — no absolute anchoring left
+    btn = _between(html, "#annbtn {", "}")
+    assert "position" not in btn, btn
+    assert "top:" not in btn and "right:" not in btn, btn
     # the row is a child of the chat pane, above the topbar, and hidden in
     # NEITHER view — the home-view hide list must not grow to include it
     chat = _between(html, '<div id="chat"', '<div id="topbar">')


### PR DESCRIPTION
## What

In the `claude_split` template:

- **One switch instead of two.** The pin-visibility switch (`#annvis`, "Comments shown") is gone — annotation comment pins over the app now show while annotate mode is on and hide when it's off. `renderAnn` gates on `annOn`, and toggling the mode repaints the pins.
- **Auto-send always on.** The popover's Auto-send checkbox and the `annautosend` param are removed; a saved new note always submits (still guarded by in-flight turn / typed-draft rules). `annshow` param removed too.
- **Subtle annotate toggle.** Plain label text ("Annotate" / "Annotating") plus a small track/knob switch. No icon, no accent border, no filled pill — the only colour is the accent track while armed.

Tests in `test_claude_split_shots.py` updated to assert the new design. All 294 claude_split/template tests pass; verified live on the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Template UI and annotation UX only; no auth or backend changes. Users lose independent pin visibility and optional auto-send, which is intentional product simplification.
> 
> **Overview**
> **Simplifies** the `claude_split` annotation bar to **one control** instead of two: the separate “comments shown” switch (`#annvis`) is removed, and overlay pins now **follow annotate mode** (`renderAnn` gates on `annOn`; `annSetMode` repaints pins).
> 
> The annotate toggle is **restyled** to plain “Annotate” / “Annotating” text plus a small track/knob (no icon, border, or filled pill; accent only on the track when armed). **Auto-send** is always on for new notes—the popover checkbox and `annautosend` / `annshow` URL params are dropped; `CHAT_PARAMS` keeps only `annmode`.
> 
> `test_claude_split_shots.py` is updated to assert the single-switch layout, pin gating, and unconditional auto-send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee02544b24bd9bc0a8c757e8be44c567eb5ffc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->