### PR TITLE
Rebrand sidebar/hero naming and compact explorer search

### DIFF
--- a/frontend/src/apps/builder/HomeHero.tsx
+++ b/frontend/src/apps/builder/HomeHero.tsx
@@ -322,11 +322,15 @@ function HeroComposer({ onCreated }: { onCreated: () => void }) {
 export function HomeHero({ onCreated }: { onCreated: () => void }) {
   return (
     <header className="home-hero">
-      {/* Fused mark + "Fused App" wordmark row, centered above the title. */}
-      <HeroBrand name="App" />
-      <h1 className="home-hero-title">
-        Build your next <span className="home-hero-accent">local app</span>
-      </h1>
+      {/* Fused mark + "App" wordmark with the tagline on the same line. */}
+      <HeroBrand
+        name="App"
+        tagline={
+          <>
+            Build your next <span className="home-hero-accent">local app</span>
+          </>
+        }
+      />
       {/* The hero's only verb, prompt-first: describe the app right here
           and a named, scaffolded folder + claude session comes back. */}
       <HeroComposer onCreated={onCreated} />

--- a/frontend/src/apps/builder/HomeHero.tsx
+++ b/frontend/src/apps/builder/HomeHero.tsx
@@ -323,7 +323,7 @@ export function HomeHero({ onCreated }: { onCreated: () => void }) {
   return (
     <header className="home-hero">
       {/* Fused mark + "Fused App" wordmark row, centered above the title. */}
-      <HeroBrand name="Fused App" />
+      <HeroBrand name="App" />
       <h1 className="home-hero-title">
         Build your next <span className="home-hero-accent">local app</span>
       </h1>

--- a/frontend/src/apps/builder/sidebar/BuilderSidebar.tsx
+++ b/frontend/src/apps/builder/sidebar/BuilderSidebar.tsx
@@ -10,7 +10,7 @@ export default function BuilderSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
   return (
-    <SidebarFrame title="Fused App" version={config.version} homeHref="/apps">
+    <SidebarFrame title="App" version={config.version} homeHref="/apps">
       <div className="sidebar-section">
         <NavItem href="/apps" id="builder-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -378,10 +378,14 @@ export default function FilesHome({ config }: { config: Config }) {
             the hero's only verb is the search prompt, mirroring how /apps
             leads with its build prompt. */}
         <header className="home-hero files-hero">
-          <HeroBrand name="Explorer" />
-          <h1 className="home-hero-title">
-            Find and preview <span className="home-hero-accent">your files</span>
-          </h1>
+          <HeroBrand
+            name="Explorer"
+            tagline={
+              <>
+                Find and preview <span className="home-hero-accent">your files</span>
+              </>
+            }
+          />
           <AiSearchComposer
             home={home}
             initialQuery={initialQuery}

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -378,7 +378,7 @@ export default function FilesHome({ config }: { config: Config }) {
             the hero's only verb is the search prompt, mirroring how /apps
             leads with its build prompt. */}
         <header className="home-hero files-hero">
-          <HeroBrand name="Fused Explorer" />
+          <HeroBrand name="Explorer" />
           <h1 className="home-hero-title">
             Find and preview <span className="home-hero-accent">your files</span>
           </h1>

--- a/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
+++ b/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
@@ -11,7 +11,7 @@ export default function ExplorerSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
   return (
-    <SidebarFrame title="Fused Explorer" version={config.version} homeHref="/explorer">
+    <SidebarFrame title="Explorer" version={config.version} homeHref="/explorer">
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/platform/ui/HeroBrand.tsx
+++ b/frontend/src/platform/ui/HeroBrand.tsx
@@ -12,12 +12,12 @@ import logoMarkLight from "@assets/logo-white-bg-transparent.png";
 export function HeroBrand({ name, tagline }: { name: string; tagline?: ReactNode }) {
   return (
     <h1 className="home-hero-brand">
-      <img className="home-hero-logo home-hero-logo-dark" src={logoMarkDark} alt="" aria-hidden="true" />
-      <img className="home-hero-logo home-hero-logo-light" src={logoMarkLight} alt="" aria-hidden="true" />
-      <span className="home-hero-brand-text">
+      <span className="home-hero-brand-mark">
+        <img className="home-hero-logo home-hero-logo-dark" src={logoMarkDark} alt="" aria-hidden="true" />
+        <img className="home-hero-logo home-hero-logo-light" src={logoMarkLight} alt="" aria-hidden="true" />
         <span className="home-hero-brand-name">{name}</span>
-        {tagline && <span className="home-hero-tagline">{tagline}</span>}
       </span>
+      {tagline && <span className="home-hero-tagline">{tagline}</span>}
     </h1>
   );
 }

--- a/frontend/src/platform/ui/HeroBrand.tsx
+++ b/frontend/src/platform/ui/HeroBrand.tsx
@@ -2,17 +2,20 @@
 // theme renders of the mark are in the DOM; CSS shows the one matching
 // data-theme (dark is the :root default, light takes over under
 // [data-theme="light"] — see .home-hero-logo-* in shell.css). Lives in
-// platform because two apps wear it: the builder ("Fused App") and the
-// explorer ("Fused Explorer").
+// platform because two apps wear it: the builder ("App") and the
+// explorer ("Explorer"). An optional tagline sits on the same line, smaller
+// and dimmer than the name so the name stays the visual anchor.
+import type { ReactNode } from "react";
 import logoMarkDark from "@assets/logo-black-bg-transparent.png";
 import logoMarkLight from "@assets/logo-white-bg-transparent.png";
 
-export function HeroBrand({ name }: { name: string }) {
+export function HeroBrand({ name, tagline }: { name: string; tagline?: ReactNode }) {
   return (
-    <div className="home-hero-brand">
+    <h1 className="home-hero-brand">
       <img className="home-hero-logo home-hero-logo-dark" src={logoMarkDark} alt="" aria-hidden="true" />
       <img className="home-hero-logo home-hero-logo-light" src={logoMarkLight} alt="" aria-hidden="true" />
       <span className="home-hero-brand-name">{name}</span>
-    </div>
+      {tagline && <span className="home-hero-tagline">{tagline}</span>}
+    </h1>
   );
 }

--- a/frontend/src/platform/ui/HeroBrand.tsx
+++ b/frontend/src/platform/ui/HeroBrand.tsx
@@ -14,8 +14,10 @@ export function HeroBrand({ name, tagline }: { name: string; tagline?: ReactNode
     <h1 className="home-hero-brand">
       <img className="home-hero-logo home-hero-logo-dark" src={logoMarkDark} alt="" aria-hidden="true" />
       <img className="home-hero-logo home-hero-logo-light" src={logoMarkLight} alt="" aria-hidden="true" />
-      <span className="home-hero-brand-name">{name}</span>
-      {tagline && <span className="home-hero-tagline">{tagline}</span>}
+      <span className="home-hero-brand-text">
+        <span className="home-hero-brand-name">{name}</span>
+        {tagline && <span className="home-hero-tagline">{tagline}</span>}
+      </span>
     </h1>
   );
 }

--- a/frontend/src/shell/ShellSidebar.tsx
+++ b/frontend/src/shell/ShellSidebar.tsx
@@ -42,12 +42,12 @@ export default function ShellSidebar({ config }: { config: Config }) {
   const sessionsMountReady = useSessionsMountReady(config.sessions_mount_ready);
 
   return (
-    <SidebarFrame title="Fused Render" version={config.version}>
+    <SidebarFrame title="Render" version={config.version}>
       <div className="sidebar-section">
-        <NavItem href="/apps" id="apps-link" label="Apps" icon={APPS_ICON} />
-        <NavItem href="/explorer" id="explorer-link" label="File Explorer" icon={<FolderIcon />} />
-        {sessionsMountReady && <NavItem href="/sessions" id="sessions-link" label="Sessions" icon={SESSIONS_ICON} />}
-        {learnMountReady && <NavItem href="/learn" id="learn-link" label="Learn" icon={<LearnIcon />} />}
+        <NavItem href="/apps" id="apps-link" label="Fused App" icon={APPS_ICON} />
+        <NavItem href="/explorer" id="explorer-link" label="Fused Explorer" icon={<FolderIcon />} />
+        {sessionsMountReady && <NavItem href="/sessions" id="sessions-link" label="Claude Sessions" icon={SESSIONS_ICON} />}
+        {learnMountReady && <NavItem href="/learn" id="learn-link" label="Learn More" icon={<LearnIcon />} />}
       </div>
       {/* Settings — pinned to the bottom edge (margin-top: auto), the same
           list treatment as the sub-app list above. */}

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -62,6 +62,17 @@
   margin: 0 0 18px;
 }
 
+/* Name + tagline as their own wrapping row, nested inside the brand row —
+   this is what re-centers cleanly if the tagline wraps onto its own line,
+   instead of a fixed margin-left dragging it off-center (bugbot 36e6acdd). */
+.home-hero-brand-text {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+}
+
 .home-hero-logo {
   display: block;
   height: 48px;
@@ -87,7 +98,6 @@
 /* Tagline shares the brand line but reads secondary: smaller, lighter weight,
    dimmer color, set off from the name by a little extra space. */
 .home-hero-tagline {
-  margin-left: 18px;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -139,6 +139,17 @@
   line-height: 1.5;
 }
 
+/* Explorer's search composer is a one-line query box, not a build prompt —
+   trim the vertical padding so it reads shorter than the /apps composer. */
+.files-search .home-composer-input,
+.files-search .home-composer-input:focus {
+  padding: 9px 16px 2px;
+}
+
+.files-search .home-composer-bar {
+  padding: 2px 8px 6px 16px;
+}
+
 .home-composer-bar {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -139,17 +139,6 @@
   line-height: 1.5;
 }
 
-/* Explorer's search composer is a one-line query box, not a build prompt —
-   trim the vertical padding so it reads shorter than the /apps composer. */
-.files-search .home-composer-input,
-.files-search .home-composer-input:focus {
-  padding: 9px 16px 2px;
-}
-
-.files-search .home-composer-bar {
-  padding: 2px 8px 6px 16px;
-}
-
 .home-composer-bar {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -58,7 +58,7 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 4px;
+  gap: 0;
   margin: 0 0 18px;
 }
 
@@ -87,7 +87,7 @@
 /* Tagline shares the brand line but reads secondary: smaller, lighter weight,
    dimmer color, set off from the name by a little extra space. */
 .home-hero-tagline {
-  margin-left: 10px;
+  margin-left: 18px;
   font-size: 16px;
   font-weight: 500;
   letter-spacing: -0.01em;

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -58,19 +58,16 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: 0;
+  /* Row gap keeps a wrapped tagline off the logo row; the 18px column gap is
+     the name-to-tagline spacing (logo and name are one tight .home-hero-brand-mark
+     group, so it stays centered when the tagline wraps). */
+  gap: 4px 18px;
   margin: 0 0 18px;
 }
 
-/* Name + tagline as their own wrapping row, nested inside the brand row —
-   this is what re-centers cleanly if the tagline wraps onto its own line,
-   instead of a fixed margin-left dragging it off-center (bugbot 36e6acdd). */
-.home-hero-brand-text {
-  display: flex;
-  align-items: baseline;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 4px 18px;
+.home-hero-brand-mark {
+  display: inline-flex;
+  align-items: center;
 }
 
 .home-hero-logo {

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -57,8 +57,9 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
   gap: 4px;
-  margin: 0 0 10px;
+  margin: 0 0 18px;
 }
 
 .home-hero-logo {
@@ -83,13 +84,14 @@
   letter-spacing: -0.02em;
 }
 
-.home-hero-title {
-  margin: 0 0 18px;
-  text-align: center;
-  font-size: 24px;
-  font-weight: 700;
-  letter-spacing: -0.025em;
-  line-height: 1.08;
+/* Tagline shares the brand line but reads secondary: smaller, lighter weight,
+   dimmer color, set off from the name by a little extra space. */
+.home-hero-tagline {
+  margin-left: 10px;
+  font-size: 16px;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--fg-muted);
 }
 
 .home-hero-accent {


### PR DESCRIPTION
## Summary
- Shell sidebar: title "Render"; entries renamed to Fused App, Fused Explorer, Claude Sessions, Learn More
- Sub-app sidebar titles: "App" (builder), "Explorer" (explorer)
- Homepage heroes: brand name is now just "App" / "Explorer", with the former headline folded onto the same line as an inline muted tagline
- Hero spacing: tighter logo-name gap, wider name-tagline gap
- Explorer search composer trimmed vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentational markup/CSS only; no auth, data, or routing logic changes.
> 
> **Overview**
> **Rebrands navigation and hero copy** so the shell reads as **Render** with **Fused App**, **Fused Explorer**, **Claude Sessions**, and **Learn More** in the top-level sidebar, while builder/explorer sub-app sidebars show **App** and **Explorer**.
> 
> **Homepage heroes** on `/apps` and `/explorer` drop the separate `<h1>` headline and pass the old title text into **`HeroBrand`** as an optional muted **tagline** on the same line as the logo + short name (**App** / **Explorer**). **`HeroBrand`** is now a single `<h1>` wrapping a tight logo+name group and optional tagline.
> 
> **`home.css`** updates hero layout for wrapping (flex-wrap, name–tagline gap) and adds **`.home-hero-tagline`** styling in place of **`.home-hero-title`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97727a47e7dd9d4059f2277ef6172f735ae8a7bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->