### PR TITLE
explorer: default the preview pane on, persist an explicit close

### DIFF
--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -43,6 +43,7 @@ import { MenuIcons } from "@platform/ui/MenuIcons";
 import { PromptDialog, ConfirmDialog, nameError } from "@apps/explorer/FsDialogs";
 import DeployModal from "@platform/cloud/DeployModal";
 import Listing from "@apps/explorer/Listing";
+import { paneIsOpen } from "@apps/explorer/listing/pane";
 
 interface HeaderProps {
   fsPath: string;
@@ -432,18 +433,21 @@ function TemplatePreview({
   // replaceSearch, which fires fused:urlchange) so the switcher-hide below
   // tracks the pane live.
   useUrlVersion();
-  // When the listing's right preview pane is open (`?preview=true`), the pane
-  // header carries its own mode switcher — showing the top-bar one too is
-  // duplicate chrome, so it hides. Top-bar variant only; the in-body header
-  // (non-explorer hosts) never coexists with the pane.
-  const paneOpen =
-    !!actionsInTopbar && new URLSearchParams(location.search).get("preview") === "true";
   // `_listing` sentinel (D81): the shell's built-in directory listing, mounted
   // in place of the preview iframe — no iframe, no `_file`. Every directory
   // renders through this same header + body chrome (even a plain folder's
   // single `_listing` mode), so the preview header is uniform across files and
   // dirs.
   const isListing = entry.mode === "_listing";
+  // When the listing's right preview pane is open (default ON — see
+  // listing/pane.ts paneIsOpen), the pane header carries its own mode
+  // switcher — showing the top-bar one too is duplicate chrome, so it hides.
+  // Top-bar variant only; the in-body header (non-explorer hosts) never
+  // coexists with the pane. Gated on `isListing`: a FILE view's fsPath never
+  // carries pane viewstate (the pane belongs to directories) and `preview`
+  // never rides onto file URLs (router.ts navigate), so paneIsOpen would
+  // otherwise read the now-default-on value and hide every file's switcher.
+  const paneOpen = !!actionsInTopbar && isListing && paneIsOpen(fsPath);
   // Path of the directory's lone top-level HTML file, reported by Listing
   // (null when there isn't exactly one) — drives the "Open as app" button
   // between the directory name and the mode switcher.

--- a/frontend/src/apps/explorer/listing/pane.ts
+++ b/frontend/src/apps/explorer/listing/pane.ts
@@ -8,10 +8,11 @@
 // viewstate-only — a pixel width isn't something a shared link should impose.
 // A folder with no saved width opens the pane at HALF the split container
 // (width null until the measuring effect resolves it; PANE_FALLBACK_W covers
-// the pre-paint frame and the unmeasurable edge). Default off — a folder never
-// toggled shows the plain listing exactly as before. `pane` and `panew` are
-// independent: turning the pane off keeps a dragged width, so re-opening the
-// folder restores it.
+// the pre-paint frame and the unmeasurable edge). Default ON — no `preview`
+// param and no saved viewstate shows the pane; closing it writes an explicit
+// `pane=0` (viewstate) / `preview=false` (URL) so the closed choice sticks.
+// `pane` and `panew` are independent: turning the pane off keeps a dragged
+// width, so re-opening the folder restores it.
 import { useLayoutEffect, useRef, useState } from "react";
 import { replaceSearch } from "@platform/lib/router";
 import { getViewState, setViewState } from "@platform/lib/viewstate";
@@ -36,14 +37,22 @@ function clampPaneWidth(containerW: number, width: number): number {
   return Math.max(PANE_MIN_W, Math.min(containerW - LIST_MIN_W, width));
 }
 
+// Shared by resolvePane and any other view (Preview.tsx's topbar-hiding
+// check) that needs to know whether the pane is showing for a path without
+// wanting its width too. `preview=true`/`preview=false` — the owner's literal
+// format (any other value reads as absent, falling back to the saved state).
+// No saved state means ON by default; only an explicit `pane=0` (a prior
+// close) turns it off.
+export function paneIsOpen(fsPath: string): boolean {
+  const urlPreview = new URLSearchParams(location.search).get("preview");
+  if (urlPreview !== null) return urlPreview === "true";
+  return new URLSearchParams(getViewState(fsPath)).get("pane") !== "0";
+}
+
 function resolvePane(fsPath: string): { on: boolean; width: number | null } {
   const s = new URLSearchParams(getViewState(fsPath));
-  const url = new URLSearchParams(location.search);
-  // `preview=true` exactly — the owner's literal format (any other value
-  // reads as absent, falling back to the saved state).
-  const on = url.get("preview") !== null ? url.get("preview") === "true" : s.get("pane") === "1";
   const w = parseInt(s.get("panew") || "", 10);
-  return { on, width: Number.isFinite(w) && w >= PANE_MIN_W ? w : null };
+  return { on: paneIsOpen(fsPath), width: Number.isFinite(w) && w >= PANE_MIN_W ? w : null };
 }
 
 // Merge the pane keys into this folder's saved state without touching a saved
@@ -52,10 +61,15 @@ function resolvePane(fsPath: string): { on: boolean; width: number | null } {
 // choice worth remembering. The two keys are INDEPENDENT: `panew` outlives a
 // toggle-off, so closing the pane and coming back to the folder re-opens at
 // the width that was dragged rather than re-measuring the default.
+//
+// `pane` only ever stores the OFF choice (`"0"`) — on is the default, so
+// nothing needs persisting for it; a stale `pane=1` from before the default
+// flipped is just as good as no key at all (resolvePane treats anything but
+// `"0"` as on).
 function savePaneState(fsPath: string, on: boolean, width: number | null): void {
   const s = new URLSearchParams(getViewState(fsPath));
-  if (on) s.set("pane", "1");
-  else s.delete("pane");
+  if (on) s.delete("pane");
+  else s.set("pane", "0");
   if (width !== null) s.set("panew", String(Math.round(width)));
   else s.delete("panew");
   const qs = s.toString();
@@ -101,7 +115,9 @@ export function usePreviewPane(fsPath: string, enabled = true) {
       const params = new URLSearchParams(location.search);
       if (next.on) params.set("preview", "true");
       else {
-        params.delete("preview");
+        // Explicit `false`, not a deleted param — on is the default now, so
+        // an absent param would reopen the pane on the next load/nav.
+        params.set("preview", "false");
         // The pane's mode param has no pane to describe once it's closed.
         params.delete("_panelMode");
       }
@@ -142,7 +158,8 @@ export function usePreviewPane(fsPath: string, enabled = true) {
       // keeping the pre-drag width so re-opening restores it.
       if (moved && raw < PANE_CLOSE_W) {
         const params = new URLSearchParams(location.search);
-        params.delete("preview");
+        // Explicit `false` — see togglePane: on is the default now.
+        params.set("preview", "false");
         params.delete("_panelMode");
         const qs = params.toString();
         replaceSearch(location.pathname + (qs ? "?" + qs : ""));
@@ -163,16 +180,17 @@ export function usePreviewPane(fsPath: string, enabled = true) {
   return { pane, splitRef, togglePane, onDividerPointerDown };
 }
 
-// Same URL reflection Listing does for a saved sort: a pane restored from
-// saved viewstate (URL carried no `preview`) puts `preview=true` on the
+// Same URL reflection Listing does for a saved sort: a pane restored CLOSED
+// from saved viewstate (URL carried no `preview`) puts `preview=false` on the
 // address bar so refresh, bookmarks and onward navigation (which carries the
 // param) all see the shown state. Only ever ADDS the param — a URL without it
-// and a folder without saved pane state keep the clean URL, and an explicit
-// `?preview=false` stays authoritative (resolvePane already read it as off).
+// and a folder with no saved close (on is the default) keep the clean URL,
+// and an explicit `?preview=` value stays authoritative (resolvePane already
+// read it).
 export function reflectPaneInUrl(fsPath: string): void {
   if (new URLSearchParams(location.search).get("preview") !== null) return; // URL is authoritative
-  if (!new URLSearchParams(getViewState(fsPath)).get("pane")) return;
+  if (new URLSearchParams(getViewState(fsPath)).get("pane") !== "0") return; // on is the default
   const params = new URLSearchParams(location.search);
-  params.set("preview", "true");
+  params.set("preview", "false");
   replaceSearch(location.pathname + "?" + params.toString());
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -551,6 +551,8 @@ table.pane-mini-list td.status-message {
   width: 30px;
   height: 30px;
   padding: 0;
+  margin-left: 8px;
+  margin-right: -8px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: transparent;


### PR DESCRIPTION
## Summary
- Directory listing pages now show the preview pane by default when the URL carries no `preview` param and the folder has no saved viewstate — previously default-off.
- Closing the pane persists that explicit choice: `pane=0` in the folder's viewstate and `preview=false` on the URL (mirroring the existing sticky-open behavior via `router.ts`'s directory-nav carry-through).
- Fixed a regression the flip introduced: `Preview.tsx`'s topbar mode-switcher hide is now gated on `isListing` — a file view's path never carries pane viewstate, so the new default-on `paneIsOpen()` would otherwise hide every file's switcher.

## Test plan
- [x] `npm run typecheck` / `npm run check:boundaries` pass
- [x] Manually verified via a CDP-attached Chrome against the local dev server:
  - Fresh/never-visited folder opens with the pane on, no `preview` param
  - Closing the pane writes `?preview=false` to the address bar
  - Reloading the clean directory URL restores the closed pane and re-adds `preview=false`
  - A file view (README.md) still renders its top-bar mode switcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default UX and URL/viewstate semantics for directory navigation; the `isListing` gate fixes a regression that would hide mode switchers on all file views.
> 
> **Overview**
> Directory listings now **open with the right preview pane visible** when there is no `preview` query param and no per-folder viewstate—previously the pane defaulted off.
> 
> **Closing** the pane is persisted explicitly: viewstate stores `pane=0` (only the off state is saved; on needs no key), and the URL uses `preview=false` instead of removing the param, so a bare URL no longer reopens the pane after the user closed it. Toggle and drag-to-close paths were updated accordingly; `reflectPaneInUrl` now adds `preview=false` when restoring a saved closed state.
> 
> A shared **`paneIsOpen(fsPath)`** helper centralizes URL + viewstate resolution for `resolvePane` and **Preview** top-bar mode-switcher hiding. That hide is now limited to **`isListing`** directory views so file previews still show their top-bar switcher under the new default-on behavior.
> 
> Minor **CSS** tweak for the listing pane toggle margins in the search row.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c4c60a506d64abc460d61abe195ee455b67c17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->