### PR TITLE
explorer: Up button in listing search row

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -771,7 +771,8 @@ export default function Listing({
                   strokeLinecap="round"
                   strokeLinejoin="round"
                 >
-                  <polyline points="6 15 12 9 18 15" />
+                  <line x1="12" y1="19" x2="12" y2="5" />
+                  <polyline points="5 12 12 5 19 12" />
                 </svg>
               </button>
               {/* The box wraps input + pinned chips so the pane toggle can sit to

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -21,7 +21,7 @@
 //   useListingShortcuts.ts file-op keyboard chords
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { navigate, replaceSearch } from "@platform/lib/router";
-import { dirname } from "@apps/explorer/lib/fs-actions";
+import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
 import { isMod } from "@platform/lib/platform";
 import { formatSize, formatMtime } from "@platform/lib/format";
@@ -197,6 +197,26 @@ export default function Listing({
   );
 
   const base = fsPath.replace(/\/$/, "");
+
+  // "Up" navigation for the button beside the search box: hop to the parent
+  // folder with THIS folder selected there (`?sel=<name>`), so the row you
+  // came from is highlighted — the same seed path a shared ?sel URL takes
+  // (useListingSelection). navigate() first (it carries the sticky pane
+  // params and the isDir scaffold hint), then the sel param is appended onto
+  // that same history entry via replaceSearch. Disabled at the filesystem /
+  // drive root, where dirname collapses to the folder itself.
+  const here = normDir(base);
+  const parentDir = dirname(here);
+  const atRoot = parentDir === here;
+  const goUp = () => {
+    if (atRoot) return;
+    const name = here.replace(/\/+$/, "").split("/").pop();
+    navigate(parentDir, { isDir: true });
+    if (!name) return;
+    const params = new URLSearchParams(location.search);
+    params.set("sel", name);
+    replaceSearch(location.pathname + "?" + params.toString());
+  };
 
   // Tell the caller whether this folder's top level holds exactly one HTML
   // ("app") file. Keyed off the plain listing, not the search results — the
@@ -734,6 +754,26 @@ export default function Listing({
               and the host listing's search/toggle already own that chrome. */}
           {!embedded && (
             <div className="listing-search">
+              <button
+                type="button"
+                className="listing-up-button"
+                title={atRoot ? "Already at the root" : "Up to parent folder"}
+                disabled={atRoot}
+                onClick={goUp}
+              >
+                <svg
+                  viewBox="0 0 24 24"
+                  width="14"
+                  height="14"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="6 15 12 9 18 15" />
+                </svg>
+              </button>
               {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin. */}
               <div className="listing-search-box">

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -40,6 +40,7 @@ table.listing-table th.sortable,
 .toast-action,
 .panel-btn,
 .listing-pane-toggle,
+.listing-up-button,
 .listing-load-more {
   transition:
     background-color var(--dur-fast) var(--ease-out),
@@ -58,6 +59,7 @@ table.listing-table th.sortable,
 .tab-add:active,
 .toast-action:active:not(:disabled),
 .listing-pane-toggle:active,
+.listing-up-button:active:not(:disabled),
 .listing-load-more:active:not(:disabled) {
   transform: translateY(1px);
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -565,6 +565,33 @@ table.pane-mini-list td.status-message {
   border-color: var(--fg-muted);
 }
 
+/* "Up to parent" button at the left edge of the listing's search row — same
+   quiet chrome as the pane toggle on the row's other end. */
+.listing-up-button {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+
+.listing-up-button:hover:not(:disabled) {
+  color: var(--fg);
+  border-color: var(--fg-muted);
+}
+
+.listing-up-button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 /* Skeleton loading state: shimmering bars shaped like the real listing rows
    (icon + name + size + mtime), plus a full-pane placeholder while a preview
    loads. Token-derived (--bg-alt/--border) so it reads as part of the UI. */


### PR DESCRIPTION
Adds an "Up" button at the left of the in-folder search box. Clicking it navigates to the parent folder and selects the folder you came from there (rides the existing `?sel` URL-seed path in `useListingSelection`, so preview-pane stickiness and the isDir scaffold hint are preserved). Disabled at the filesystem / drive root.

Follow-up candidate (not in this PR): make Cmd+Up / Backspace parent navigation also select the source folder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation in the explorer listing; no auth, data, or API changes.
> 
> **Overview**
> Adds an **Up** control at the left of the in-folder search row (non-embedded listings only). Clicking it goes to the parent directory and sets **`?sel`** to the current folder’s name so that row is highlighted in the parent view, reusing the same URL-seeding path as shared selection links. Navigation uses **`navigate(parentDir, { isDir: true })`** first so preview-pane sticky params and the directory scaffold stay intact, then **`replaceSearch`** appends **`sel`** on the same history entry.
> 
> Root detection uses **`normDir`** and **`dirname`**: the button is disabled when **`parentDir === here`** (filesystem or drive root). Styling matches the existing pane toggle, including shared hover/press transitions in **`base.css`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fef3f844654eeced9a9e4906fed0870eefc37328. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->