### PR TITLE
UI polish: explorer-first navigation, neutral app buttons, session inbox tweaks

### DIFF
--- a/core_apps/sessions/inbox.html
+++ b/core_apps/sessions/inbox.html
@@ -233,6 +233,7 @@
       <span style="flex:1"></span>
       <button class="peek-btn" id="peek-analyze" title="Review this session with a fresh Claude run">Analyze session</button>
       <button class="peek-btn" id="peek-continue" title="Copy a terminal command that resumes this session">Continue with Claude ⧉</button>
+      <button class="peek-btn" id="peek-open-dir" title="Open the folder this session worked in, in Fused Explorer">Open in explorer</button>
     </div>
     <div class="peek-body" id="peek-body"></div>
   </div>
@@ -821,6 +822,19 @@ function renderPeek() {
   const cdPrefix = cwd ? `cd ${q(cwd)} && ` : "";
   $("peek-continue").onclick = copyCmd("peek-continue",
     `${cdPrefix}claude --resume ${id}`);
+
+  // open the session's working directory in Fused Explorer — same /view/
+  // codec the shell's router uses (segment-wise encode of the abs path).
+  // Navigates the TOP window: the inbox is an iframe inside the shell, and
+  // "open in explorer" means leaving the inbox for the explorer.
+  const openDirBtn = $("peek-open-dir");
+  openDirBtn.style.display = cwd ? "" : "none";
+  openDirBtn.onclick = () => {
+    const norm = /^[A-Za-z]:[\\/]/.test(cwd) ? cwd.replace(/\\/g, "/") : cwd;
+    const encoded = norm.replace(/^\/+/, "").split("/")
+      .filter(Boolean).map(encodeURIComponent).join("/");
+    window.open("/explorer/view/" + encoded, "_top");
+  };
 
   // launch a new detached Claude session that analyzes this one — it appears
   // in the inbox as its own session, so it's tracked there like any other

--- a/frontend/src/apps/builder/sidebar/BuilderSidebar.tsx
+++ b/frontend/src/apps/builder/sidebar/BuilderSidebar.tsx
@@ -10,7 +10,7 @@ export default function BuilderSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
   return (
-    <SidebarFrame title="App" version={config.version} homeHref="/apps">
+    <SidebarFrame title="App" homeHref="/apps">
       <div className="sidebar-section">
         <NavItem href="/apps" id="builder-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -332,30 +332,18 @@ export default function FilesHome({ config }: { config: Config }) {
   }, []);
   const shownSessions =
     sessionFolders && (expandedSessions ? sessionFolders : sessionFolders.slice(0, MAX_CARDS));
-  // With no ?tab= in the URL, land on the first tab that has anything to
-  // show: bookmarks, else recents, else Claude sessions. Latched ONCE after
-  // the bookmark/recent caches hydrate (they start empty at boot, so deriving
-  // per render would flash "sessions" on a cold load, and cross-tab polls
-  // could yank an unpinned tab later). Not written to the URL, so an explicit
-  // ?tab= always wins.
-  const [defaultTab, setDefaultTab] = useState<LaunchTab | null>(null);
+  // With no ?tab= in the URL, land on Claude sessions — the leading tab.
+  // Bookmark/recent caches still hydrate on mount (effect below) so the other
+  // tabs are ready when clicked. An explicit ?tab= always wins.
   useEffect(() => {
-    let alive = true;
     // Both are idempotent (enqueued; bookmarks no-ops when already hydrated).
-    Promise.all([hydrateBookmarks(), hydrateRecents()]).finally(() => {
-      if (!alive) return;
-      setDefaultTab(
-        loadBookmarks().length ? "bookmarks" : loadRecents().entries.length ? "recents" : "sessions",
-      );
-    });
-    return () => {
-      alive = false;
-    };
+    void hydrateBookmarks();
+    void hydrateRecents();
   }, []);
   const tab: LaunchTab =
     tabParam === "recents" || tabParam === "sessions" || tabParam === "bookmarks"
       ? tabParam
-      : defaultTab ?? "bookmarks";
+      : "sessions";
   // A committed AI search result takes over the page body (bookmarks/recents
   // hide behind it) until cleared — the homepage becomes the result page.
   const [search, setSearch] = useState<{ query: string; result: AiSearchResult } | null>(null);

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -424,6 +424,15 @@ export default function FilesHome({ config }: { config: Config }) {
               <button
                 type="button"
                 role="tab"
+                aria-selected={tab === "sessions"}
+                className={"fh-tab" + (tab === "sessions" ? " active" : "")}
+                onClick={() => setTab("sessions")}
+              >
+                Claude sessions
+              </button>
+              <button
+                type="button"
+                role="tab"
                 aria-selected={tab === "bookmarks"}
                 className={"fh-tab" + (tab === "bookmarks" ? " active" : "")}
                 onClick={() => setTab("bookmarks")}
@@ -438,15 +447,6 @@ export default function FilesHome({ config }: { config: Config }) {
                 onClick={() => setTab("recents")}
               >
                 Recents
-              </button>
-              <button
-                type="button"
-                role="tab"
-                aria-selected={tab === "sessions"}
-                className={"fh-tab" + (tab === "sessions" ? " active" : "")}
-                onClick={() => setTab("sessions")}
-              >
-                Claude sessions
               </button>
             </div>
 

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -673,7 +673,7 @@ function TemplatePreview({
 
   // How the listed folder relates to the app system, for the button below:
   // "workspace"/"linked" folders open as an app, an "unlinked" one offers
-  // "Convert to app" (registers it in the linked-apps registry — it then shows
+  // "Add as app" (registers it in the linked-apps registry — it then shows
   // up on the Home grid under the "linked" tag). Fetched per folder, only when
   // the single-HTML button would show at all; a fetch failure (older backend)
   // falls back to "workspace" so the button degrades to plain "Open as app".
@@ -713,7 +713,7 @@ function TemplatePreview({
       navigate(singleAppPath as string, { isDir: false });
     }
   };
-  const appBtnLabel = linkStatus?.status === "unlinked" ? "Convert to app" : "Open as app";
+  const appBtnLabel = linkStatus?.status === "unlinked" ? "Add as app" : "Open as app";
   const appBtnAction = linkStatus?.status === "unlinked" ? convertToApp : openAsApp;
 
   const openAsAppBtn =

--- a/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
+++ b/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
@@ -11,7 +11,7 @@ export default function ExplorerSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
   return (
-    <SidebarFrame title="Explorer" version={config.version} homeHref="/explorer">
+    <SidebarFrame title="Explorer" homeHref="/explorer">
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -16,7 +16,8 @@ import {
 export interface SidebarFrameProps {
   /** Brand text next to the cube mark — names the owning context. */
   title: string;
-  version: string;
+  /** Version chip after the title — shown only by the shell ("Render"). */
+  version?: string;
   /** Where the brand click lands; the front door of the owning app. */
   homeHref?: string;
   children: React.ReactNode;
@@ -186,7 +187,7 @@ export function SidebarFrame({ title, version, homeHref = "/apps", children }: S
           </span>{" "}
           <span className="brand-title">{title}</span>
         </a>
-        <span className="brand-version">v{version}</span>
+        {version && <span className="brand-version">v{version}</span>}
         <button
           type="button"
           className="icon-btn sidebar-collapse-btn"

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -1,5 +1,5 @@
 // Route dispatch (super-app step 2 — shell + three sub-apps):
-//   "/"                      -> redirect (replaceState) to /apps
+//   "/"                      -> redirect (replaceState) to /explorer
 //   "/apps"                  -> apps homepage (the app home)
 //   "/apps/<tag>/<name>"     -> app builder (StatView variant "app")
 //   "/explorer"              -> file-explorer homepage (FilesHome)
@@ -461,12 +461,12 @@ export default function App({ config }: { config: Config }) {
     return () => document.removeEventListener("keydown", onKey, true);
   }, []);
 
-  // The app home lives at /apps — "/" is just its front door. Render-time
+  // The explorer home is the front door — "/" lands there. Render-time
   // write is safe — it changes pathname, so the re-render (via fused:urlchange)
   // derives the real route. (Legacy /view/_home, /view/_account, and the whole
   // /view//embed namespaces are rewritten at boot by router.ts.)
   if (location.pathname === "/") {
-    history.replaceState(null, "", "/apps");
+    history.replaceState(null, "", "/explorer");
   }
 
   const pathname = location.pathname;

--- a/frontend/src/shell/ShellSidebar.tsx
+++ b/frontend/src/shell/ShellSidebar.tsx
@@ -46,7 +46,7 @@ export default function ShellSidebar({ config }: { config: Config }) {
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-link" label="Fused Explorer" icon={<FolderIcon />} />
         <NavItem href="/apps" id="apps-link" label="Fused App" icon={APPS_ICON} />
-        {sessionsMountReady && <NavItem href="/sessions" id="sessions-link" label="Claude Sessions" icon={SESSIONS_ICON} />}
+        {sessionsMountReady && <NavItem href="/sessions" id="sessions-link" label="Session Inbox" icon={SESSIONS_ICON} />}
         {learnMountReady && <NavItem href="/learn" id="learn-link" label="Learn More" icon={<LearnIcon />} />}
       </div>
       {/* Settings — pinned to the bottom edge (margin-top: auto), the same

--- a/frontend/src/shell/ShellSidebar.tsx
+++ b/frontend/src/shell/ShellSidebar.tsx
@@ -44,8 +44,8 @@ export default function ShellSidebar({ config }: { config: Config }) {
   return (
     <SidebarFrame title="Render" version={config.version}>
       <div className="sidebar-section">
-        <NavItem href="/apps" id="apps-link" label="Fused App" icon={APPS_ICON} />
         <NavItem href="/explorer" id="explorer-link" label="Fused Explorer" icon={<FolderIcon />} />
+        <NavItem href="/apps" id="apps-link" label="Fused App" icon={APPS_ICON} />
         {sessionsMountReady && <NavItem href="/sessions" id="sessions-link" label="Claude Sessions" icon={SESSIONS_ICON} />}
         {learnMountReady && <NavItem href="/learn" id="learn-link" label="Learn More" icon={<LearnIcon />} />}
       </div>

--- a/frontend/src/styles/home.css
+++ b/frontend/src/styles/home.css
@@ -63,6 +63,7 @@
      group, so it stays centered when the tagline wraps). */
   gap: 4px 18px;
   margin: 0 0 18px;
+  text-align: center;
 }
 
 .home-hero-brand-mark {
@@ -92,17 +93,23 @@
   letter-spacing: -0.02em;
 }
 
-/* Tagline shares the brand line but reads secondary: smaller, lighter weight,
-   dimmer color, set off from the name by a little extra space. */
+/* Tagline shares the brand line at the name's size; it reads secondary
+   through weight and the muted grey alone. */
 .home-hero-tagline {
-  font-size: 16px;
+  font-size: 22px;
   font-weight: 500;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
   color: var(--fg-muted);
 }
 
 .home-hero-accent {
   color: var(--accent);
+}
+
+/* Inside the subtle grey tagline the accent words go quiet too — one step
+   brighter than the muted body so they still read as the emphasis. */
+.home-hero-tagline .home-hero-accent {
+  color: var(--fg);
 }
 
 /* The hero's prompt composer — the claude.ai/v0 "what do you want to build?"

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -51,17 +51,17 @@
   font: inherit;
   font-size: 12px;
   padding: 5px 10px;
-  border: 1px solid rgba(var(--accent-rgb), 0.35);
+  border: 1px solid rgba(var(--fg-muted-rgb), 0.35);
   border-radius: 6px;
-  background: rgba(var(--accent-rgb), 0.08);
-  color: var(--accent-soft);
+  background: rgba(var(--fg-muted-rgb), 0.08);
+  color: var(--fg-muted);
   cursor: pointer;
 }
 
 .open-as-app-btn:hover {
-  background: rgba(var(--accent-rgb), 0.16);
-  border-color: var(--accent);
-  color: var(--accent);
+  background: rgba(var(--fg-muted-rgb), 0.16);
+  border-color: var(--fg-muted);
+  color: var(--fg);
 }
 
 /* In the explorer the button portals into the breadcrumb's actions slot
@@ -69,15 +69,15 @@
    `.preview-actions button` rules, which otherwise outrank the class above. */
 .preview-actions .open-as-app-btn {
   font-size: 12px;
-  border: 1px solid rgba(var(--accent-rgb), 0.35);
-  background: rgba(var(--accent-rgb), 0.08);
-  color: var(--accent-soft);
+  border: 1px solid rgba(var(--fg-muted-rgb), 0.35);
+  background: rgba(var(--fg-muted-rgb), 0.08);
+  color: var(--fg-muted);
 }
 
 .preview-actions .open-as-app-btn:hover {
-  background: rgba(var(--accent-rgb), 0.16);
-  border-color: var(--accent);
-  color: var(--accent);
+  background: rgba(var(--fg-muted-rgb), 0.16);
+  border-color: var(--fg-muted);
+  color: var(--fg);
 }
 
 .preview-actions {


### PR DESCRIPTION
## Changes

**Explorer-first navigation**
- `/` now redirects to `/explorer` instead of `/apps`
- Shell sidebar: Fused Explorer listed above Fused App
- Explorer homepage: Claude sessions is the first tab and the default when no `?tab=` is set
- Shell sidebar: "Claude Sessions" renamed to "Session Inbox"

**App header buttons**
- "Convert to app" renamed to "Add as app"
- "Add as app" / "Open as app" / "Open in explorer" buttons switch from the yellow accent to the muted grey palette

**Homepage hero**
- Tagline now matches the name's size (22px), muted grey, with accent words one step brighter instead of yellow; brand row text centered

**Sidebar**
- Version chip shown only on the shell (Render) sidebar; removed from App and Explorer sidebars

**Session inbox**
- New "Open in explorer" button on the session peek — opens the session's working directory in Fused Explorer (hidden when the session has no cwd)

🤖 Generated with [Claude Code](https://claude.com/claude-code)