### PR TITLE
ui: claude strip rearrange + terminal handoff; Artifacts tab; versions → History (last)

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -418,7 +418,7 @@ export default function FilesHome({ config }: { config: Config }) {
                 className={"fh-tab" + (tab === "sessions" ? " active" : "")}
                 onClick={() => setTab("sessions")}
               >
-                Claude sessions
+                Artifacts
               </button>
               <button
                 type="button"
@@ -488,7 +488,7 @@ export default function FilesHome({ config }: { config: Config }) {
                 <p className="fh-empty">Nothing opened yet. Files you view will show up here.</p>
               )
             ) : shownSessions === null ? (
-              <p className="fh-empty">Looking for Claude sessions…</p>
+              <p className="fh-empty">Looking for artifacts…</p>
             ) : sessionFolders && sessionFolders.length ? (
               <>
                 <div className="fhb-grid">

--- a/frontend/src/platform/lib/mode-name.test.ts
+++ b/frontend/src/platform/lib/mode-name.test.ts
@@ -32,3 +32,9 @@ test("keys with a conventional casing keep it", () => {
   expect(modeTitle("duckdb")).toBe("DuckDB");
   expect(modeTitle("geojson")).toBe("GeoJSON");
 });
+
+test("the versions mode is labelled History", () => {
+  // The standalone history mode is de-linked from the registry; the versions
+  // template carries the History name (and clock icon) in its place.
+  expect(modeTitle("versions")).toBe("History");
+});

--- a/frontend/src/platform/lib/mode-name.ts
+++ b/frontend/src/platform/lib/mode-name.ts
@@ -26,6 +26,11 @@ const NICE_NAMES: Record<string, string> = {
   // the registry, `?_mode=app`, APP_OPEN_MODE, and the "Open as app" /
   // "Add as app" buttons, which are about the app concept, not this view.
   app: "View",
+  // The `versions` template wears the History name (and the history template's
+  // clock icon) now that the standalone `history` mode is de-linked from the
+  // registry: one timeline surface, one name. The KEY stays `versions`
+  // (registry, `?_mode=versions`, bookmarks) — only the label changed.
+  versions: "History",
   duckdb: "DuckDB",
   geojson: "GeoJSON",
   json: "JSON",

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -135,6 +135,11 @@
   #annbtn {
     height: 26px;
     padding: 0;
+    /* The row's ONE auto margin, and the strip's right-hand anchor: everything
+       before it (#back) sits left, everything after it (the picker, the view
+       toggle) rides right with it. It was #viewbtn's, back when the switch led
+       the row — see #leftbar #leftmode for why a row gets exactly one. */
+    margin-left: auto;
     /* The elastic one. Its label is a mode name, and "Annot…" beside a visible
        accent track still reads — where half of "Back to chat" would not tell you
        it is the way back. See #viewbtn's flex-shrink. */
@@ -234,10 +239,10 @@
   #leftmode { position: relative; flex-shrink: 0; }
   /* THE RIGHT-HAND END of the pane's own bar. The bar exists to carry this one
      control, and a lone control hard against the left edge reads as a label for
-     the pane rather than as a switch on it — the same reason #viewbtn parks
+     the pane rather than as a switch on it — the same reason #annbtn parks
      itself at the end of the strip across the divider. Scoped to #leftbar: in
      the narrow layout the picker shares #anntools with the annotate switch and
-     the view toggle, where #viewbtn already owns the auto margin and a second
+     the view toggle, where #annbtn already owns the auto margin and a second
      one would split the free space between them and float the picker into the
      middle of the row. */
   #leftbar #leftmode { margin-left: auto; }
@@ -339,7 +344,6 @@
      because a truncated "Back to cha…" is the only way out of the preview. */
   #viewbtn {
     display: none;
-    margin-left: auto;
     flex-shrink: 0;
     height: 26px;
     padding: 0 8px;
@@ -468,6 +472,10 @@
     overflow: hidden;
   }
   #chat.home #topbar, #chat.home #logwrap, #chat.home #composer-chat { display: none; }
+  /* #back rides the #anntools strip (which BOTH views keep), so its home-view
+     hiding is its own rule — the landing page IS the chat list, and a "back to
+     where you already are" is a control for nothing. */
+  #chat.home #back { display: none; }
   #chat:not(.home) #home { display: none; }
 
   /* top bar */
@@ -1191,6 +1199,12 @@
            acts on the preview. Hiding them would hide part of the message. */
     body.view-chat #annbtn,
     body.view-chat #leftmode { display: none; }
+    /* The rule above also removes the row's ONE auto margin (#annbtn owns it,
+       see the wide styles), which would let the view toggle fall in next to
+       #back at the LEFT edge. The toggle takes the margin over only while the
+       switch is off screen, so the strip keeps its shape — way back at one end,
+       way forward at the other — in both views. */
+    body.view-chat #viewbtn { margin-left: auto; }
     /* The pin overlay (#annpins, #annhl, #annpop) needs no rule of its own: all
        three are children of #left, so parking the column takes them with it —
        `visibility: hidden` inherits (none of them sets `visibility: visible`)
@@ -1221,6 +1235,11 @@
     body.view-preview #left { flex: 1; min-height: 0; }
     body.view-preview #chat { flex: 0 0 auto; }
     body.view-preview #chat > *:not(#anntools) { display: none; }
+    /* #back survived the collapse above only because it moved into #anntools.
+       It stays hidden HERE for the same reason the rest of the chat column is:
+       the chat list it returns to is off screen in this view, so the button
+       would navigate to something the layout cannot show. */
+    body.view-preview #back { display: none; }
 
     #viewbtn { display: flex; align-items: center; }
   }
@@ -1263,6 +1282,14 @@
          document only). One switch is enough: the comment pins over the app
          show while annotating and hide when the mode is off. -->
     <div id="anntools">
+      <!-- The way back to the chat list, at the strip's left end. It lived at
+           the right end of #topbar; it sits HERE so the strip reads
+           [← Chats … Annotate] on one line, with the topbar below carrying only
+           the session's identity. Hidden on the home view (there is no chat to
+           leave) and in the narrow preview view (the view it returns to is off
+           screen there) — both rules are in the stylesheet, where the topbar's
+           own home-view hiding already lives. -->
+      <button id="back" type="button" aria-label="Back to chats">← Chats</button>
       <!-- Kind-free wording, and rewritten by applyPaneNoun once stat says what
            the pane is: "the app" for an app folder, "the preview" for a file. It
            said "the app" unconditionally, so a screen-reader user on `notes.md`
@@ -1305,7 +1332,6 @@
       <span class="tb-title">Claude</span>
       <span class="tb-file" id="banner-sub"></span>
       <span id="session" class="mono"></span>
-      <button id="back" type="button" aria-label="Back to chats">← Chats</button>
     </div>
     <div id="logwrap"><div id="log"></div><div id="queue"></div></div>
     <!-- `display: contents` is in the stylesheet, deliberately not here: an inline
@@ -2274,8 +2300,8 @@ function placeLeftPicker() {
   // Looked up rather than closed over: `viewbtn` has a const of its own further
   // down (viewBtn), and a second `const` of the same name here would be a
   // redeclaration. In the shared strip the picker belongs BETWEEN the annotate
-  // switch and the view toggle — appending would put it after #viewbtn, whose
-  // `margin-left: auto` pins it to the row's right end.
+  // switch and the view toggle — appending would put it after #viewbtn, and the
+  // toggle must stay the row's last word (it is the way out of the preview).
   const host = wide ? leftBar : document.getElementById("anntools");
   if (leftSel.parentElement !== host) {
     host.insertBefore(leftSel, wide ? null : document.getElementById("viewbtn"));
@@ -2391,6 +2417,14 @@ function enterNoPane() {
   //    rendered a blank page. applyNarrowView returns early from here on, so
   //    nothing puts either class back.
   document.body.classList.remove("view-preview", "view-chat");
+  // 4. Rescue #back before its host goes: the button lives in #anntools (the
+  //    strip earns its place as the [← Chats … Annotate] row), but the way back
+  //    to the chat list must outlive the pane. The topbar takes it — the row
+  //    that held it before the strip existed, and the one piece of chat chrome
+  //    this teardown keeps.
+  const backBtn = document.getElementById("back");
+  const topBar = document.getElementById("topbar");
+  if (backBtn && topBar) topBar.appendChild(backBtn);
   for (const id of ["left", "divider", "anntools"]) {
     const el = document.getElementById(id);
     if (el) el.remove();

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -6,7 +6,6 @@
     "claude",
     "versions",
     "git",
-    "history",
     "geometry_editor"
   ],
   ".csv": [
@@ -40,7 +39,6 @@
     "slides"
   ],
   ".*.json": [
-    "history",
     "tree",
     "code"
   ],
@@ -462,8 +460,7 @@
     "claude",
     "versions",
     "git",
-    "reader",
-    "history"
+    "reader"
   ],
   ".htm": [
     "_render",

--- a/fused_render/templates/versions/icon.svg
+++ b/fused_render/templates/versions/icon.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 6v12"/><path d="M18 9a9 9 0 0 1-9 9"/><circle cx="6" cy="4" r="2.6"/><circle cx="18" cy="6" r="2.6"/><circle cx="6" cy="20" r="2.6"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7L3.5 7.5"/><path d="M3.5 3.5v4h4"/><path d="M12 7.5V12l3 2"/></svg>

--- a/fused_render/templates/versions/template.html
+++ b/fused_render/templates/versions/template.html
@@ -2,7 +2,11 @@
 <html data-fused-theme="shell">
 <head>
 <meta charset="utf-8" />
-<title>Versions</title>
+<!-- "History", not "Versions": the mode wears the History name everywhere it
+     shows one (mode-name.ts NICE_NAMES, the claude template's paneModeLabel)
+     since the standalone history mode was de-linked, and the tab title must
+     not disagree with the row that opened it. The KEY stays `versions`. -->
+<title>History</title>
 <style>
   /* Appearance (SPEC §30, D134). Dark block is the palette; light redefines
      every token. `data-theme` is written onto <html> by the injected runtime

--- a/tests/test_history_template.py
+++ b/tests/test_history_template.py
@@ -10,11 +10,10 @@ import re
 
 from fused_render.server import templates as _server_templates
 
-# The two file extensions that bind `history` directly, so the view can be
-# opened ON them and `targetPath` is the file itself. (`.*.json` also binds
-# `history`, but there the view is on the SIDECAR and targetPath resolves back
-# to the target file — never to the sidecar, so the sidecar's own mode list is
-# not what the outbound links must satisfy.)
+# The two file extensions the history view's outbound links target. `history`
+# itself is de-linked from the registry for now, but the template still ships
+# and every row it wires up navigates to `targetPath` — a file of one of these
+# kinds — so its hardcoded `_mode=` links must still resolve against them.
 HISTORY_TARGET_FILES = ("/x/table.parquet", "/x/sine.html")
 
 
@@ -42,13 +41,15 @@ def hardcoded_nav_modes():
     return set(re.findall(r'"_mode=([a-z_]+)', history_template_text()))
 
 
-def test_sidecar_default_mode_is_history():
-    # `.html.json` (2 segments) beats the wildcard `.*.json` (also 2, but a
-    # literal beats `*` at equal length — CT-3), which beats bare `.json` (1).
+def test_sidecar_default_mode_is_tree():
+    # The standalone `history` mode is de-linked from the registry for now
+    # (the `versions` template wears its name and icon — see mode-name.ts),
+    # so a sidecar's own list falls back to tree-first. The wildcard `.*.json`
+    # still beats bare `.json` (2 segments vs 1 — CT-3).
     entries, error = _server_templates._templates_for("/x/sine.html.json", False)
     assert error is None
-    assert [e["mode"] for e in entries] == ["history", "tree", "code"]
-    assert entries[0]["path"].endswith("history/template.html")
+    assert [e["mode"] for e in entries] == ["tree", "code"]
+    assert entries[0]["path"].endswith("tree/template.html")
     assert entries[0]["icon"] is not None
 
 
@@ -58,10 +59,10 @@ def test_sidecar_wildcard_matches_any_extension():
     # doesn't make sense (comments belong on the target file, HV-8).
     entries, error = _server_templates._templates_for("/x/table.parquet.json", False)
     assert error is None
-    assert [e["mode"] for e in entries] == ["history", "tree", "code"]
+    assert [e["mode"] for e in entries] == ["tree", "code"]
 
 
-# .html and .parquet gaining "history" as their last mode is covered by
+# .html and .parquet no longer offering "history" is covered by
 # test_templates.py::test_builtin_html_default_is_render_sentinel and
 # test_builtin_parquet_default_is_duckdb, which already assert the full
 # resolved mode list for those keys.

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -77,18 +77,20 @@ def test_builtin_registry_parses_and_all_names_resolve():
 def test_builtin_html_default_is_render_sentinel():
     entries, error = server._templates_for("/x/page.html", False)
     assert error is None
+    # No `history`: the standalone history view is de-linked from the registry
+    # for now — `versions` wears its name and icon (see mode-name.ts).
     assert [e["mode"] for e in entries] == [
-        "_render", "code", "claude", "versions", "git", "reader", "history"]
+        "_render", "code", "claude", "versions", "git", "reader"]
     assert entries[0]["path"] is None and entries[0]["icon"] is None
     assert entries[1]["path"].endswith("code/template.html")
     assert entries[2]["path"].endswith("claude/template.html")
 
 
 def test_builtin_parquet_default_is_duckdb():
-    # `history` (HV-2) is bound here too — not `.html`-only.
+    # No `history` here either — de-linked from every key it was bound to.
     entries, error = server._templates_for("/x/data.parquet", False)
     assert error is None
-    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude", "versions", "git", "history",
+    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude", "versions", "git",
             "geometry_editor"]
     assert entries[0]["path"].endswith("duckdb/template.html")
 


### PR DESCRIPTION
## What

Three UI changes (as merged):

1. **Claude template top strip rearranged.** The chat pane led with the Annotate switch on its own row and parked "← Chats" at the right end of the topbar below. The strip now reads **[← Chats … Annotating]** on one line — back button at the left end, annotate switch anchored right — and the topbar below carries only the session's identity (`✻ Claude <file> <session>`).
2. **Explorer homepage tab renamed** from "Claude sessions" to **"Artifacts"** (loading copy follows: "Looking for artifacts…").
3. **`history` mode de-linked; `versions` becomes "History".** The mode menu offered both "Versions" and "History" — two timeline surfaces. The standalone history template was removed from the registry, and the versions mode took over the History identity: clock icon, "History" label, page title. A stale `?_mode=history` deep link falls back to the default view (PT-9).

Follow-up round (terminal-handoff kebab, click-pinned annotate highlight, History-last ordering) landed separately in #434 — it was pushed to this branch after the merge, so it is not part of this PR's merge commit.

## Screenshots

| Wide — chat view | Wide — home view |
|---|---|
| ![wide chat](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/wide-chat.png) | ![wide home](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/wide-home.png) |

| Narrow — chat view | Narrow — preview view |
|---|---|
| ![narrow chat](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/narrow-chat.png) | ![narrow preview](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/narrow-preview.png) |

| Explorer — Artifacts tab | History mode open |
|---|---|
| ![artifacts tab](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/artifacts-tab.png) | ![history mode](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/history-mode.png) |

## Testing

- `pytest tests/` green apart from 3 environment-only macOS failures; `bun test` + `tsc --noEmit` + boundaries clean.
- Verified live with Playwright: all strip layouts, Artifacts tab, mode menu, stale-mode fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)