### PR TITLE
Fix Windows "server did not become ready": decouple readiness + builtin mount-readiness from live mount I/O

### DIFF
--- a/fused_render/desktop_probe.py
+++ b/fused_render/desktop_probe.py
@@ -4,10 +4,19 @@ A desktop launch must confirm that the server answering on its port is *the
 one it started* — not an unrelated process that happened to hold the port
 (a stale dev server, another app). Each launch publishes a per-launch 256-bit
 token plus the desktop instance id into the child/in-process server's
-environment; the server echoes them from `/api/config` (see
-`fused_render.paths.desktop_instance` and the `/api/config` handler). This
-module polls that endpoint with the token header and reports ready only when
-the echoed id + token match.
+environment; the server echoes them from `/api/desktop/ready` (see
+`fused_render.paths.desktop_instance` and the `/api/desktop/ready` handler).
+This module polls that endpoint with the token header and reports ready only
+when the echoed id + token match.
+
+`/api/desktop/ready` is a dedicated, dependency-free endpoint on purpose: the
+probe must reflect only "the HTTP server is up and is ours", never the health
+of an optional subsystem. It used to poll `/api/config`, whose
+`learn_mount_ready`/`sessions_mount_ready` fields do a live rcd/WinFsp check on
+every request; a slow cold-start mount attach then pushed each response past
+the 0.5s per-request timeout below for the whole readiness window, so the
+Windows supervisor declared "Python server did not become ready" and
+killed-and-retried a server that was in fact serving fine.
 
 Shared by both backends: the Windows supervisor (out-of-process child server)
 and the macOS app (in-process server thread). urllib + json only, so it stays
@@ -28,12 +37,12 @@ DESKTOP_INSTANCE_ID = "desktop-v1"
 
 
 def matching_server(port: int, token: str, instance_id: str = DESKTOP_INSTANCE_ID) -> bool:
-    """True iff 127.0.0.1:<port>/api/config answers 200 and echoes our
+    """True iff 127.0.0.1:<port>/api/desktop/ready answers 200 and echoes our
     desktop instance id AND token. Any failure (refused, timeout, non-200,
     bad JSON, mismatched id/token) is a plain False — the caller keeps
     polling until its own deadline."""
     req = urllib.request.Request(
-        f"http://127.0.0.1:{port}/api/config",
+        f"http://127.0.0.1:{port}/api/desktop/ready",
         headers={"X-Fused-Desktop-Token": token},
     )
     try:

--- a/fused_render/desktop_probe.py
+++ b/fused_render/desktop_probe.py
@@ -9,10 +9,7 @@ environment; the server echoes them from `/api/desktop/ready` (see
 This module polls that endpoint with the token header and reports ready only
 when the echoed id + token match.
 
-`/api/desktop/ready` is dedicated and dependency-free on purpose: it reflects
-only "the HTTP server is up and is ours". The probe used to poll `/api/config`,
-whose live mount-readiness check pushed cold-start responses past the timeout
-below and made the Windows supervisor kill a healthy server.
+`/api/desktop/ready` is dependency-free on purpose: it once polled `/api/config`, whose live mount check timed out on Windows cold start and made the supervisor kill a healthy server.
 
 Shared by both backends: the Windows supervisor (out-of-process child server)
 and the macOS app (in-process server thread). urllib + json only, so it stays

--- a/fused_render/desktop_probe.py
+++ b/fused_render/desktop_probe.py
@@ -9,16 +9,10 @@ environment; the server echoes them from `/api/desktop/ready` (see
 This module polls that endpoint with the token header and reports ready only
 when the echoed id + token match.
 
-`/api/desktop/ready` is a dedicated, dependency-free endpoint on purpose: the
-probe must reflect only "the HTTP server is up and is ours", never the health
-of an optional subsystem. It used to poll `/api/config`, whose
-`learn_mount_ready`/`sessions_mount_ready` fields then did a live rcd/WinFsp
-check on every request (since made cached — see `builtin_mount_ready`); a slow
-cold-start mount attach pushed each response past the 0.5s per-request timeout
-below for the whole readiness window, so the Windows supervisor declared
-"Python server did not become ready" and killed-and-retried a server that was
-in fact serving fine. A dedicated endpoint keeps readiness immune to that class
-of regression whatever `/api/config` grows to do.
+`/api/desktop/ready` is dedicated and dependency-free on purpose: it reflects
+only "the HTTP server is up and is ours". The probe used to poll `/api/config`,
+whose live mount-readiness check pushed cold-start responses past the timeout
+below and made the Windows supervisor kill a healthy server.
 
 Shared by both backends: the Windows supervisor (out-of-process child server)
 and the macOS app (in-process server thread). urllib + json only, so it stays

--- a/fused_render/desktop_probe.py
+++ b/fused_render/desktop_probe.py
@@ -12,11 +12,13 @@ when the echoed id + token match.
 `/api/desktop/ready` is a dedicated, dependency-free endpoint on purpose: the
 probe must reflect only "the HTTP server is up and is ours", never the health
 of an optional subsystem. It used to poll `/api/config`, whose
-`learn_mount_ready`/`sessions_mount_ready` fields do a live rcd/WinFsp check on
-every request; a slow cold-start mount attach then pushed each response past
-the 0.5s per-request timeout below for the whole readiness window, so the
-Windows supervisor declared "Python server did not become ready" and
-killed-and-retried a server that was in fact serving fine.
+`learn_mount_ready`/`sessions_mount_ready` fields then did a live rcd/WinFsp
+check on every request (since made cached — see `builtin_mount_ready`); a slow
+cold-start mount attach pushed each response past the 0.5s per-request timeout
+below for the whole readiness window, so the Windows supervisor declared
+"Python server did not become ready" and killed-and-retried a server that was
+in fact serving fine. A dedicated endpoint keeps readiness immune to that class
+of regression whatever `/api/config` grows to do.
 
 Shared by both backends: the Windows supervisor (out-of-process child server)
 and the macOS app (in-process server thread). urllib + json only, so it stays

--- a/fused_render/server/routers/config.py
+++ b/fused_render/server/routers/config.py
@@ -102,10 +102,7 @@ def api_config(
 def api_desktop_ready(
     token: str | None = Header(default=None, alias="X-Fused-Desktop-Token"),
 ):
-    # Readiness probe (desktop_probe.matching_server): echoes only the launch
-    # token — no mounts, rcd, or dir picker — so a slow cold-start subsystem
-    # can't make the supervisor kill a healthy server. Same echo shape as
-    # /api/config so the probe reads desktop_instance.
+    # Readiness probe (desktop_probe.matching_server): echoes only the launch token, touching no mounts/rcd, so a slow cold-start subsystem can't make the supervisor kill a healthy server.
     from fused_render.paths import desktop_instance
 
     instance = desktop_instance()

--- a/fused_render/server/routers/config.py
+++ b/fused_render/server/routers/config.py
@@ -107,11 +107,12 @@ def api_desktop_ready(
     # touches NOTHING but the launch token echo — no mounts, no rcd, no dir
     # picker. Readiness means "the HTTP server is up and is ours", never "every
     # optional subsystem is warm". The probe used to poll /api/config, whose
-    # learn_mount_ready/sessions_mount_ready do a live rcd/WinFsp check on every
-    # call; a slow cold-start mount attach then dragged each response past the
-    # probe's per-request timeout, so the supervisor declared the server "did
-    # not become ready" and killed-and-retried it. Same echo shape as
-    # /api/config so the probe reads desktop_instance either way.
+    # learn_mount_ready/sessions_mount_ready then did a live rcd/WinFsp check on
+    # every call (since made cached); a slow cold-start mount attach dragged
+    # each response past the probe's per-request timeout, so the supervisor
+    # declared the server "did not become ready" and killed-and-retried it. A
+    # dedicated endpoint keeps readiness immune whatever /api/config grows to
+    # do. Same echo shape as /api/config so the probe reads desktop_instance.
     from fused_render.paths import desktop_instance
 
     instance = desktop_instance()

--- a/fused_render/server/routers/config.py
+++ b/fused_render/server/routers/config.py
@@ -102,17 +102,10 @@ def api_config(
 def api_desktop_ready(
     token: str | None = Header(default=None, alias="X-Fused-Desktop-Token"),
 ):
-    # The desktop startup probe (desktop_probe.matching_server) polls this to
-    # confirm the server answering the port is the instance it launched. It
-    # touches NOTHING but the launch token echo — no mounts, no rcd, no dir
-    # picker. Readiness means "the HTTP server is up and is ours", never "every
-    # optional subsystem is warm". The probe used to poll /api/config, whose
-    # learn_mount_ready/sessions_mount_ready then did a live rcd/WinFsp check on
-    # every call (since made cached); a slow cold-start mount attach dragged
-    # each response past the probe's per-request timeout, so the supervisor
-    # declared the server "did not become ready" and killed-and-retried it. A
-    # dedicated endpoint keeps readiness immune whatever /api/config grows to
-    # do. Same echo shape as /api/config so the probe reads desktop_instance.
+    # Readiness probe (desktop_probe.matching_server): echoes only the launch
+    # token — no mounts, rcd, or dir picker — so a slow cold-start subsystem
+    # can't make the supervisor kill a healthy server. Same echo shape as
+    # /api/config so the probe reads desktop_instance.
     from fused_render.paths import desktop_instance
 
     instance = desktop_instance()

--- a/fused_render/server/routers/config.py
+++ b/fused_render/server/routers/config.py
@@ -98,6 +98,30 @@ def api_config(
             config["desktop_instance"]["token"] = instance[1]
     return config
 
+@router.get("/api/desktop/ready")
+def api_desktop_ready(
+    token: str | None = Header(default=None, alias="X-Fused-Desktop-Token"),
+):
+    # The desktop startup probe (desktop_probe.matching_server) polls this to
+    # confirm the server answering the port is the instance it launched. It
+    # touches NOTHING but the launch token echo — no mounts, no rcd, no dir
+    # picker. Readiness means "the HTTP server is up and is ours", never "every
+    # optional subsystem is warm". The probe used to poll /api/config, whose
+    # learn_mount_ready/sessions_mount_ready do a live rcd/WinFsp check on every
+    # call; a slow cold-start mount attach then dragged each response past the
+    # probe's per-request timeout, so the supervisor declared the server "did
+    # not become ready" and killed-and-retried it. Same echo shape as
+    # /api/config so the probe reads desktop_instance either way.
+    from fused_render.paths import desktop_instance
+
+    instance = desktop_instance()
+    if instance is None:
+        return {}
+    echo = {"id": instance[0]}
+    if token == instance[1]:
+        echo["token"] = instance[1]
+    return {"desktop_instance": echo}
+
 @router.post("/api/desktop/shutdown")
 def api_desktop_shutdown(
     request: Request,

--- a/fused_render/shell/mounts/__init__.py
+++ b/fused_render/shell/mounts/__init__.py
@@ -359,6 +359,7 @@ from .automount import (
     learn_mount_ready,
     learn_zip_path,
     sessions_mount_ready,
+    set_builtin_ready,
 )
 from .health import (
     HEALTH_POLL_INTERVAL,

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -28,14 +28,10 @@ BUILTIN_MOUNTS = {
 }
 
 
-# Whether each builtin mount is attached RIGHT NOW, tracked across the automount
-# lifecycle rather than probed live on the request path (builtin_mount_ready).
-# run_automount is the sole writer: it clears every builtin to False before its
-# force-detach+remount pass, then flips one True the moment its own attach_mount
-# succeeds. The invariant that matters: this is True only for a mount THIS run
-# attached — never one that merely survived from a previous run — because the
-# frontend sticky-caches the first True it sees (platform/lib/hooks.ts), so a
-# stale True would pin Learn/Sessions over an empty mountpoint for the session.
+# Whether each builtin is attached right now, tracked across the automount
+# lifecycle (see builtin_mount_ready). True only for a mount THIS run attached,
+# never one that survived a previous run — the frontend sticky-caches the first
+# True it sees (platform/lib/hooks.ts), so a stale True would pin a dead entry.
 _builtin_ready_lock = threading.Lock()
 _builtin_ready: dict[str, bool] = {name: False for name in BUILTIN_MOUNTS}
 
@@ -197,37 +193,11 @@ def sessions_mount_ready() -> bool:
 
 
 def builtin_mount_ready(name: str) -> bool:
-    """True when run_automount has attached this builtin THIS run — an I/O-free
-    read of the lifecycle-tracked _builtin_ready flag, never a live probe.
-
-    The sidebar's Learn entry (Sidebar.tsx) uses this, surfaced through
-    /api/config, to decide whether to render at all.
-
-    Why not a live probe: the old check was `mp in mounted_paths()` plus
-    `_ismount(mp)`, and on Windows `_ismount()` (os.path.ismount/os.lstat on the
-    WinFsp reparse point) BLOCKS for ~the rc timeout while run_automount is
-    mid-attach of the mountpoint. /api/config embeds this for BOTH builtins, so
-    a cold start dragged /api/config to ~60s and the browser window couldn't
-    paint. macOS (nfsmount) and Linux (FUSE) attach fast enough to hide it; the
-    flag read fixes it on every platform.
-
-    Why not the health monitor's cached state: that cache can hold "mounted"
-    from a mount a PREVIOUS run left behind, before ensure_builtin_mount
-    force-detaches it on startup — and since the frontend sticky-caches the
-    first True (platform/lib/hooks.ts), a single stale True pins Learn over an
-    empty mountpoint for the whole session. run_automount instead drops the flag
-    to False before its force-detach and only sets it True once its own
-    attach_mount has re-attached the mount this run, so True always means a
-    mount that is live now. The frontend polls until it sees that True, so the
-    seconds run_automount takes to attach cost only a briefly-absent sidebar
-    entry, never a wrong one. True is written only by an operation that
-    SUCCESSFULLY attached the mount this run — run_automount's own attach, or a
-    manual reconnect_mount after the split-brain `continue` — and reset to False
-    by run_automount at the start of each pass. It is never inferred from an
-    observed "mounted": a mount lingering from a failed force-detach reads
-    mounted while serving stale content, and a transient post-attach snapshot
-    can read not-mounted, so the health monitor deliberately leaves this flag
-    alone."""
+    """True once run_automount has attached this builtin this run — an I/O-free
+    read of the attach-owned _builtin_ready flag (surfaced via /api/config for
+    the sidebar's Learn entry). Not a live probe: an _ismount on the WinFsp
+    mountpoint blocks ~the rc timeout mid-attach, which dragged /api/config to
+    ~60s on a Windows cold start."""
     with _builtin_ready_lock:
         return _builtin_ready.get(name, False)
 

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -220,10 +220,12 @@ def builtin_mount_ready(name: str) -> bool:
     attach_mount has re-attached the mount this run, so True always means a
     mount that is live now. The frontend polls until it sees that True, so the
     seconds run_automount takes to attach cost only a briefly-absent sidebar
-    entry, never a wrong one. Once run_automount's startup pass is done the
-    health monitor (poll_once) keeps this flag in sync with the observed state,
-    so a builtin brought online out-of-band — a manual Reconnect after the
-    split-brain path, say — still turns ready without a restart."""
+    entry, never a wrong one. True is written only by an operation that
+    SUCCESSFULLY attached the mount this run — run_automount's own attach, or a
+    manual reconnect_mount after the split-brain `continue` — never inferred
+    from an observed "mounted" (a mount lingering from a failed force-detach
+    would read mounted while serving stale content). The health monitor only
+    ever CLEARS the flag, when a mount is observed no longer live."""
     with _builtin_ready_lock:
         return _builtin_ready.get(name, False)
 

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -220,7 +220,10 @@ def builtin_mount_ready(name: str) -> bool:
     attach_mount has re-attached the mount this run, so True always means a
     mount that is live now. The frontend polls until it sees that True, so the
     seconds run_automount takes to attach cost only a briefly-absent sidebar
-    entry, never a wrong one."""
+    entry, never a wrong one. Once run_automount's startup pass is done the
+    health monitor (poll_once) keeps this flag in sync with the observed state,
+    so a builtin brought online out-of-band — a manual Reconnect after the
+    split-brain path, say — still turns ready without a restart."""
     with _builtin_ready_lock:
         return _builtin_ready.get(name, False)
 

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -28,10 +28,7 @@ BUILTIN_MOUNTS = {
 }
 
 
-# Whether each builtin is attached right now, tracked across the automount
-# lifecycle (see builtin_mount_ready). True only for a mount THIS run attached,
-# never one that survived a previous run — the frontend sticky-caches the first
-# True it sees (platform/lib/hooks.ts), so a stale True would pin a dead entry.
+# Attach-owned readiness per builtin (see builtin_mount_ready); True only for a mount THIS run attached, since the frontend sticky-caches the first True it sees.
 _builtin_ready_lock = threading.Lock()
 _builtin_ready: dict[str, bool] = {name: False for name in BUILTIN_MOUNTS}
 
@@ -193,11 +190,7 @@ def sessions_mount_ready() -> bool:
 
 
 def builtin_mount_ready(name: str) -> bool:
-    """True once run_automount has attached this builtin this run — an I/O-free
-    read of the attach-owned _builtin_ready flag (surfaced via /api/config for
-    the sidebar's Learn entry). Not a live probe: an _ismount on the WinFsp
-    mountpoint blocks ~the rc timeout mid-attach, which dragged /api/config to
-    ~60s on a Windows cold start."""
+    """I/O-free read of the attach-owned _builtin_ready flag (a live _ismount here blocked /api/config ~60s mid-attach on a Windows cold start)."""
     with _builtin_ready_lock:
         return _builtin_ready.get(name, False)
 

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -7,6 +7,7 @@ import os
 import re
 import signal
 import sys
+import threading
 import time
 import uuid
 
@@ -25,6 +26,23 @@ BUILTIN_MOUNTS = {
     LEARN_MOUNT_NAME: ("learn.zip", "FUSED_RENDER_LEARN_ZIP"),
     SESSIONS_MOUNT_NAME: ("sessions.zip", "FUSED_RENDER_SESSIONS_ZIP"),
 }
+
+
+# Whether each builtin mount is attached RIGHT NOW, tracked across the automount
+# lifecycle rather than probed live on the request path (builtin_mount_ready).
+# run_automount is the sole writer: it clears every builtin to False before its
+# force-detach+remount pass, then flips one True the moment its own attach_mount
+# succeeds. The invariant that matters: this is True only for a mount THIS run
+# attached — never one that merely survived from a previous run — because the
+# frontend sticky-caches the first True it sees (platform/lib/hooks.ts), so a
+# stale True would pin Learn/Sessions over an empty mountpoint for the session.
+_builtin_ready_lock = threading.Lock()
+_builtin_ready: dict[str, bool] = {name: False for name in BUILTIN_MOUNTS}
+
+
+def set_builtin_ready(name: str, ready: bool) -> None:
+    with _builtin_ready_lock:
+        _builtin_ready[name] = ready
 
 
 def builtin_zip_path(name: str) -> str | None:
@@ -179,35 +197,32 @@ def sessions_mount_ready() -> bool:
 
 
 def builtin_mount_ready(name: str) -> bool:
-    """True when the health monitor has observed a builtin mount actually
-    attached ("mounted") — not merely that its record exists in mounts.json.
+    """True when run_automount has attached this builtin THIS run — an I/O-free
+    read of the lifecycle-tracked _builtin_ready flag, never a live probe.
 
     The sidebar's Learn entry (Sidebar.tsx) uses this, surfaced through
     /api/config, to decide whether to render at all.
 
-    Reads the health monitor's CACHED per-mount state (_health_episodes, the
-    same I/O-free source /api/mounts/health serves) rather than probing rcd +
-    the kernel live. That live probe — `mp in mounted_paths()` plus
-    `_ismount(mp)` — is the reason this must not run on the request path: on
-    Windows, `_ismount()` (an os.path.ismount/os.lstat on the WinFsp reparse
-    point) BLOCKS for ~the rc timeout while run_automount is mid-attach of the
-    mountpoint, and /api/config embeds this for BOTH builtins, so a cold start
-    dragged /api/config to ~60s and the browser window couldn't paint. macOS
-    (nfsmount) and Linux (FUSE) attach fast enough to hide it; the cached read
-    fixes it on every platform. The health monitor pays the ismount cost on its
-    own background thread (poll_once, probe_io=False) and this just reads the
-    result, so it is still never eager — it reads False until a poll has
-    confirmed the mount is genuinely "mounted", which self-heals within one
-    poll interval of the attach completing (the concern the old live check and
-    its force-detach-every-startup BUGBOT were guarding against)."""
-    from fused_render.shell.mounts import _health_episodes, list_mounts
-    builtin = next(
-        (m for m in list_mounts() if m.get("builtin") == name), None
-    )
-    if builtin is None:
-        return False
-    episode = _health_episodes.get(builtin["id"])
-    return bool(episode) and episode.get("state") == "mounted"
+    Why not a live probe: the old check was `mp in mounted_paths()` plus
+    `_ismount(mp)`, and on Windows `_ismount()` (os.path.ismount/os.lstat on the
+    WinFsp reparse point) BLOCKS for ~the rc timeout while run_automount is
+    mid-attach of the mountpoint. /api/config embeds this for BOTH builtins, so
+    a cold start dragged /api/config to ~60s and the browser window couldn't
+    paint. macOS (nfsmount) and Linux (FUSE) attach fast enough to hide it; the
+    flag read fixes it on every platform.
+
+    Why not the health monitor's cached state: that cache can hold "mounted"
+    from a mount a PREVIOUS run left behind, before ensure_builtin_mount
+    force-detaches it on startup — and since the frontend sticky-caches the
+    first True (platform/lib/hooks.ts), a single stale True pins Learn over an
+    empty mountpoint for the whole session. run_automount instead drops the flag
+    to False before its force-detach and only sets it True once its own
+    attach_mount has re-attached the mount this run, so True always means a
+    mount that is live now. The frontend polls until it sees that True, so the
+    seconds run_automount takes to attach cost only a briefly-absent sidebar
+    entry, never a wrong one."""
+    with _builtin_ready_lock:
+        return _builtin_ready.get(name, False)
 
 
 def _force_detach_builtin_mount(builtin: dict, old_remote: str) -> None:

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -179,33 +179,35 @@ def sessions_mount_ready() -> bool:
 
 
 def builtin_mount_ready(name: str) -> bool:
-    """True when a builtin mount is actually attached — both rcd and
-    the kernel agree the mountpoint is live — not merely when its record
-    exists in mounts.json.
+    """True when the health monitor has observed a builtin mount actually
+    attached ("mounted") — not merely that its record exists in mounts.json.
 
     The sidebar's Learn entry (Sidebar.tsx) uses this, surfaced through
     /api/config, to decide whether to render at all.
 
-    BUGBOT (record-presence was not enough): ensure_learn_mount now
-    force-detaches and remounts the learn mountpoint on EVERY startup (see
-    its docstring) — including the common case where the record already
-    existed on disk from a prior run. A presence-only check would read
-    "ready" the instant that record is read off disk, well before
-    run_automount's attach_mount loop (which runs after ensure_learn_mount
-    returns, on the same background automount thread) has remounted it —
-    an early click would hit an empty mountpoint whose HTTP serve was just
-    stopped. Checking BOTH mounted_paths() (rcd's own bookkeeping) and
-    os.path.ismount() (the kernel mount table) is exactly attach_mount's own
-    signal for "there is nothing left to attach" (see its `os.path.ismount`
-    check), so this reads true only once that loop has actually succeeded."""
-    from fused_render.shell.mounts import list_mounts, mounted_paths
+    Reads the health monitor's CACHED per-mount state (_health_episodes, the
+    same I/O-free source /api/mounts/health serves) rather than probing rcd +
+    the kernel live. That live probe — `mp in mounted_paths()` plus
+    `_ismount(mp)` — is the reason this must not run on the request path: on
+    Windows, `_ismount()` (an os.path.ismount/os.lstat on the WinFsp reparse
+    point) BLOCKS for ~the rc timeout while run_automount is mid-attach of the
+    mountpoint, and /api/config embeds this for BOTH builtins, so a cold start
+    dragged /api/config to ~60s and the browser window couldn't paint. macOS
+    (nfsmount) and Linux (FUSE) attach fast enough to hide it; the cached read
+    fixes it on every platform. The health monitor pays the ismount cost on its
+    own background thread (poll_once, probe_io=False) and this just reads the
+    result, so it is still never eager — it reads False until a poll has
+    confirmed the mount is genuinely "mounted", which self-heals within one
+    poll interval of the attach completing (the concern the old live check and
+    its force-detach-every-startup BUGBOT were guarding against)."""
+    from fused_render.shell.mounts import _health_episodes, list_mounts
     builtin = next(
         (m for m in list_mounts() if m.get("builtin") == name), None
     )
     if builtin is None:
         return False
-    mp = mountpoint(builtin)
-    return mp in mounted_paths() and _ismount(mp)
+    episode = _health_episodes.get(builtin["id"])
+    return bool(episode) and episode.get("state") == "mounted"
 
 
 def _force_detach_builtin_mount(builtin: dict, old_remote: str) -> None:

--- a/fused_render/shell/mounts/automount.py
+++ b/fused_render/shell/mounts/automount.py
@@ -222,10 +222,12 @@ def builtin_mount_ready(name: str) -> bool:
     seconds run_automount takes to attach cost only a briefly-absent sidebar
     entry, never a wrong one. True is written only by an operation that
     SUCCESSFULLY attached the mount this run — run_automount's own attach, or a
-    manual reconnect_mount after the split-brain `continue` — never inferred
-    from an observed "mounted" (a mount lingering from a failed force-detach
-    would read mounted while serving stale content). The health monitor only
-    ever CLEARS the flag, when a mount is observed no longer live."""
+    manual reconnect_mount after the split-brain `continue` — and reset to False
+    by run_automount at the start of each pass. It is never inferred from an
+    observed "mounted": a mount lingering from a failed force-detach reads
+    mounted while serving stale content, and a transient post-attach snapshot
+    can read not-mounted, so the health monitor deliberately leaves this flag
+    alone."""
     with _builtin_ready_lock:
         return _builtin_ready.get(name, False)
 

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -79,6 +79,17 @@ _health_thread: "threading.Thread | None" = None
 _health_started = threading.Lock()  # guards start_health_monitor idempotency
 
 
+# Set once run_automount has completed its first force-detach+remount pass this
+# process. Until then poll_once must NOT sync builtin readiness from observed
+# state: a mount that survived a previous run still shows "mounted" before the
+# force-detach tears it down, and letting that reach _builtin_ready would pin a
+# stale-ready Learn/Sessions the frontend sticky-caches. After the pass, syncing
+# is safe and desirable — it self-heals a builtin brought online out-of-band
+# (reconnect_mount, the mount endpoint), which run_automount's one-shot True
+# would otherwise leave stuck off.
+_automount_completed = threading.Event()
+
+
 _NEEDS_RECONNECT = ("disconnected", "stale")
 
 
@@ -129,6 +140,13 @@ def poll_once() -> None:
     for m in list_mounts():
         mid = m["id"]
         state = mount_state(m, live, probe_io=False)
+        # Keep builtin readiness in sync with the observed state — but only once
+        # run_automount has done its startup force-detach+remount, so a prior
+        # run's surviving mount can't flip it True before the detach (see
+        # _automount_completed). This is what self-heals a builtin that came
+        # online via reconnect_mount rather than run_automount's own attach.
+        if m.get("builtin") and _automount_completed.is_set():
+            set_builtin_ready(m["builtin"], state == "mounted")
         ep = _health_episodes.setdefault(mid, {"state": None, "notified": False})
         prev = ep["state"]
         ep["state"] = state
@@ -259,6 +277,10 @@ def run_automount() -> None:
         # the two cases apart: a serves.json only exists once some earlier
         # run actually had something to serve.
         sync_serves()
+    # The startup force-detach+remount is done: from here poll_once may sync
+    # builtin readiness from observed state without risking a prior run's
+    # surviving mount reading as ready.
+    _automount_completed.set()
 
 
 def startup() -> None:

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -11,7 +11,7 @@ import threading
 import time
 
 from .access import serves_path
-from .automount import ensure_builtin_mounts
+from .automount import BUILTIN_MOUNTS, ensure_builtin_mounts, set_builtin_ready
 from .lifecycle import attach_mount, sync_serves
 from .rcd import _copytruncate_rcd_log, _rcd_lock
 from .store import _ismount, mountpoint
@@ -214,6 +214,13 @@ def run_automount() -> None:
     # fresh install has zero user mounts, and skipping the attach loop below
     # would otherwise skip the builtins' very first mount too.
     from fused_render.shell.mounts import list_mounts, mounted_paths
+    # Drop builtin readiness before the force-detach+remount below: a mount that
+    # survived from a previous run must not read as ready during the empty
+    # window between detach and re-attach (builtin_mount_ready). Re-set True
+    # per builtin only once its own attach_mount succeeds, so True always means
+    # a mount THIS run attached.
+    for name in BUILTIN_MOUNTS:
+        set_builtin_ready(name, False)
     ensure_builtin_mounts()
     mounts = list_mounts()
     if mounts:
@@ -233,6 +240,8 @@ def run_automount() -> None:
             err = attach_mount(m)
             if err:
                 logger.warning("automount of %r failed: %s", m["name"], err)
+            elif m.get("builtin"):
+                set_builtin_ready(m["builtin"], True)
         # Mounts that survived a server restart skip attach_mount above, so
         # their HTTP serves (lost with any rcd restart) get re-ensured here.
         sync_serves()

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -214,11 +214,8 @@ def run_automount() -> None:
     # fresh install has zero user mounts, and skipping the attach loop below
     # would otherwise skip the builtins' very first mount too.
     from fused_render.shell.mounts import list_mounts, mounted_paths
-    # Drop builtin readiness before the force-detach+remount below: a mount that
-    # survived from a previous run must not read as ready during the empty
-    # window between detach and re-attach (builtin_mount_ready). Re-set True
-    # per builtin only once its own attach_mount succeeds, so True always means
-    # a mount THIS run attached.
+    # Clear builtin readiness before the force-detach+remount below; each is
+    # re-set True only once its own attach_mount succeeds this run.
     for name in BUILTIN_MOUNTS:
         set_builtin_ready(name, False)
     ensure_builtin_mounts()

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -129,13 +129,6 @@ def poll_once() -> None:
     for m in list_mounts():
         mid = m["id"]
         state = mount_state(m, live, probe_io=False)
-        # Clear builtin readiness when the mount is no longer live, so a later
-        # drop hides the sidebar entry. Never SET it True here: True is only ever
-        # a successful attach THIS run (run_automount / reconnect_mount), so a
-        # mount lingering from a failed force-detach or surviving a previous run
-        # can't read as ready off an ambiguous "mounted" observation.
-        if m.get("builtin") and state != "mounted":
-            set_builtin_ready(m["builtin"], False)
         ep = _health_episodes.setdefault(mid, {"state": None, "notified": False})
         prev = ep["state"]
         ep["state"] = state

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -214,8 +214,7 @@ def run_automount() -> None:
     # fresh install has zero user mounts, and skipping the attach loop below
     # would otherwise skip the builtins' very first mount too.
     from fused_render.shell.mounts import list_mounts, mounted_paths
-    # Clear builtin readiness before the force-detach+remount below; each is
-    # re-set True only once its own attach_mount succeeds this run.
+    # Clear builtin readiness before the force-detach+remount; each is re-set True only once its own attach_mount succeeds this run.
     for name in BUILTIN_MOUNTS:
         set_builtin_ready(name, False)
     ensure_builtin_mounts()

--- a/fused_render/shell/mounts/health.py
+++ b/fused_render/shell/mounts/health.py
@@ -79,17 +79,6 @@ _health_thread: "threading.Thread | None" = None
 _health_started = threading.Lock()  # guards start_health_monitor idempotency
 
 
-# Set once run_automount has completed its first force-detach+remount pass this
-# process. Until then poll_once must NOT sync builtin readiness from observed
-# state: a mount that survived a previous run still shows "mounted" before the
-# force-detach tears it down, and letting that reach _builtin_ready would pin a
-# stale-ready Learn/Sessions the frontend sticky-caches. After the pass, syncing
-# is safe and desirable — it self-heals a builtin brought online out-of-band
-# (reconnect_mount, the mount endpoint), which run_automount's one-shot True
-# would otherwise leave stuck off.
-_automount_completed = threading.Event()
-
-
 _NEEDS_RECONNECT = ("disconnected", "stale")
 
 
@@ -140,13 +129,13 @@ def poll_once() -> None:
     for m in list_mounts():
         mid = m["id"]
         state = mount_state(m, live, probe_io=False)
-        # Keep builtin readiness in sync with the observed state — but only once
-        # run_automount has done its startup force-detach+remount, so a prior
-        # run's surviving mount can't flip it True before the detach (see
-        # _automount_completed). This is what self-heals a builtin that came
-        # online via reconnect_mount rather than run_automount's own attach.
-        if m.get("builtin") and _automount_completed.is_set():
-            set_builtin_ready(m["builtin"], state == "mounted")
+        # Clear builtin readiness when the mount is no longer live, so a later
+        # drop hides the sidebar entry. Never SET it True here: True is only ever
+        # a successful attach THIS run (run_automount / reconnect_mount), so a
+        # mount lingering from a failed force-detach or surviving a previous run
+        # can't read as ready off an ambiguous "mounted" observation.
+        if m.get("builtin") and state != "mounted":
+            set_builtin_ready(m["builtin"], False)
         ep = _health_episodes.setdefault(mid, {"state": None, "notified": False})
         prev = ep["state"]
         ep["state"] = state
@@ -277,10 +266,6 @@ def run_automount() -> None:
         # the two cases apart: a serves.json only exists once some earlier
         # run actually had something to serve.
         sync_serves()
-    # The startup force-detach+remount is done: from here poll_once may sync
-    # builtin readiness from observed state without risking a prior run's
-    # surviving mount reading as ready.
-    _automount_completed.set()
 
 
 def startup() -> None:

--- a/fused_render/shell/mounts/lifecycle.py
+++ b/fused_render/shell/mounts/lifecycle.py
@@ -823,7 +823,15 @@ def reconnect_mount(m: dict) -> str | None:
                 pass  # "mount not found" once the kernel mount is gone — fine
     if port is not None:
         _stop_serve_for(port, m["remote"])
-    return attach_mount(m)
+    err = attach_mount(m)
+    # A builtin repaired out-of-band (this is the manual Reconnect the
+    # run_automount split-brain `continue` defers to) must flip its readiness
+    # flag, or Learn/Sessions stay hidden despite a now-live mount. Only on a
+    # genuine success — a failed reconnect leaves it whatever it was.
+    if err is None and m.get("builtin"):
+        from .automount import set_builtin_ready
+        set_builtin_ready(m["builtin"], True)
+    return err
 
 
 PROBE_TIMEOUT = 3.0

--- a/fused_render/shell/mounts/lifecycle.py
+++ b/fused_render/shell/mounts/lifecycle.py
@@ -824,8 +824,7 @@ def reconnect_mount(m: dict) -> str | None:
     if port is not None:
         _stop_serve_for(port, m["remote"])
     err = attach_mount(m)
-    # A manual reconnect that repairs a builtin (the split-brain path automount
-    # defers to) must flip its readiness flag — only on success.
+    # A manual reconnect that repairs a builtin must flip its readiness flag — only on success.
     if err is None and m.get("builtin"):
         from .automount import set_builtin_ready
         set_builtin_ready(m["builtin"], True)

--- a/fused_render/shell/mounts/lifecycle.py
+++ b/fused_render/shell/mounts/lifecycle.py
@@ -824,10 +824,8 @@ def reconnect_mount(m: dict) -> str | None:
     if port is not None:
         _stop_serve_for(port, m["remote"])
     err = attach_mount(m)
-    # A builtin repaired out-of-band (this is the manual Reconnect the
-    # run_automount split-brain `continue` defers to) must flip its readiness
-    # flag, or Learn/Sessions stay hidden despite a now-live mount. Only on a
-    # genuine success — a failed reconnect leaves it whatever it was.
+    # A manual reconnect that repairs a builtin (the split-brain path automount
+    # defers to) must flip its readiness flag — only on success.
     if err is None and m.get("builtin"):
         from .automount import set_builtin_ready
         set_builtin_ready(m["builtin"], True)

--- a/tests/test_desktop_probe.py
+++ b/tests/test_desktop_probe.py
@@ -1,11 +1,18 @@
 """Token-verified desktop readiness probe (desktop_probe.py) and the server
-side it checks against (/api/config's desktop_instance echo).
+side it checks against (/api/desktop/ready's desktop_instance echo).
 
 The contract: a launch publishes its instance id + a per-launch token into the
-env, the server echoes them from /api/config, and the probe reports ready only
-when the echo matches — so a decoy server holding the port cannot satisfy
-startup. Pure stdlib + a real local uvicorn instance; no pywin32, so this runs
-on every platform.
+env, the server echoes them from /api/desktop/ready, and the probe reports
+ready only when the echo matches — so a decoy server holding the port cannot
+satisfy startup. Pure stdlib + a real local uvicorn instance; no pywin32, so
+this runs on every platform.
+
+/api/desktop/ready is deliberately dependency-free: readiness must not depend
+on any optional subsystem. The probe formerly polled /api/config, whose
+learn_mount_ready/sessions_mount_ready do a live rcd/WinFsp check per request,
+so a slow cold-start mount attach blew the readiness budget and the supervisor
+killed a healthy server ("Python server did not become ready"). The last test
+here pins that decoupling.
 """
 import contextlib
 import socket
@@ -76,6 +83,54 @@ def test_config_has_no_desktop_instance_without_env(tmp_path, monkeypatch):
     monkeypatch.delenv("FUSED_RENDER_DESKTOP_INSTANCE_TOKEN", raising=False)
     client = TestClient(create_app(start_dir=str(tmp_path)))
     assert "desktop_instance" not in client.get("/api/config").json()
+
+
+# ---- server-side /api/desktop/ready echo (what the probe actually polls) ----
+
+
+def test_ready_echoes_token_when_header_matches(tmp_path, desktop_env):
+    client = TestClient(create_app(start_dir=str(tmp_path)))
+    body = client.get("/api/desktop/ready", headers={"X-Fused-Desktop-Token": desktop_env}).json()
+    assert body["desktop_instance"] == {
+        "id": desktop_probe.DESKTOP_INSTANCE_ID,
+        "token": desktop_env,
+    }
+
+
+def test_ready_hides_token_when_header_absent_or_wrong(tmp_path, desktop_env):
+    client = TestClient(create_app(start_dir=str(tmp_path)))
+    assert client.get("/api/desktop/ready").json()["desktop_instance"] == {
+        "id": desktop_probe.DESKTOP_INSTANCE_ID
+    }
+    body = client.get("/api/desktop/ready", headers={"X-Fused-Desktop-Token": "wrong"}).json()
+    assert body["desktop_instance"] == {"id": desktop_probe.DESKTOP_INSTANCE_ID}
+
+
+def test_ready_has_no_desktop_instance_without_env(tmp_path, monkeypatch):
+    monkeypatch.delenv("FUSED_RENDER_DESKTOP_INSTANCE_ID", raising=False)
+    monkeypatch.delenv("FUSED_RENDER_DESKTOP_INSTANCE_TOKEN", raising=False)
+    client = TestClient(create_app(start_dir=str(tmp_path)))
+    assert "desktop_instance" not in client.get("/api/desktop/ready").json()
+
+
+def test_readiness_is_independent_of_mount_health(tmp_path, desktop_env, monkeypatch):
+    # The regression this whole endpoint exists for: a broken/slow mount
+    # subsystem (rcd down, WinFsp remount mid-flight) must not gate readiness.
+    # mounted_paths is the live rcd call learn_mount_ready/sessions_mount_ready
+    # make on the /api/config path; make it explode and confirm the probe's
+    # endpoint is unaffected while /api/config itself is dragged down by it.
+    import fused_render.shell.mounts as shell_mounts
+
+    def boom(*_a, **_k):
+        raise RuntimeError("rcd is down / mount wedged")
+
+    monkeypatch.setattr(shell_mounts, "mounted_paths", boom)
+    client = TestClient(create_app(start_dir=str(tmp_path)))
+    body = client.get("/api/desktop/ready", headers={"X-Fused-Desktop-Token": desktop_env}).json()
+    assert body["desktop_instance"] == {
+        "id": desktop_probe.DESKTOP_INSTANCE_ID,
+        "token": desktop_env,
+    }
 
 
 # ---- the probe against a real local port -----------------------------------

--- a/tests/test_desktop_probe.py
+++ b/tests/test_desktop_probe.py
@@ -7,12 +7,7 @@ ready only when the echo matches — so a decoy server holding the port cannot
 satisfy startup. Pure stdlib + a real local uvicorn instance; no pywin32, so
 this runs on every platform.
 
-/api/desktop/ready is deliberately dependency-free: readiness must not depend
-on any optional subsystem. The probe formerly polled /api/config, whose
-learn_mount_ready/sessions_mount_ready do a live rcd/WinFsp check per request,
-so a slow cold-start mount attach blew the readiness budget and the supervisor
-killed a healthy server ("Python server did not become ready"). The last test
-here pins that decoupling.
+/api/desktop/ready is deliberately dependency-free (the probe formerly polled /api/config, whose live mount check blew the readiness budget on Windows cold start); the last test here pins that decoupling.
 """
 import contextlib
 import socket
@@ -114,11 +109,7 @@ def test_ready_has_no_desktop_instance_without_env(tmp_path, monkeypatch):
 
 
 def test_readiness_is_independent_of_mount_health(tmp_path, desktop_env, monkeypatch):
-    # The regression this whole endpoint exists for: a broken/slow mount
-    # subsystem (rcd down, WinFsp remount mid-flight) must not gate readiness.
-    # mounted_paths is the live rcd call learn_mount_ready/sessions_mount_ready
-    # make on the /api/config path; make it explode and confirm the probe's
-    # endpoint is unaffected while /api/config itself is dragged down by it.
+    # A broken mount subsystem must not gate readiness: make the live rcd call /api/config depends on explode, and confirm /api/desktop/ready is unaffected.
     import fused_render.shell.mounts as shell_mounts
 
     def boom(*_a, **_k):

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -29,14 +29,12 @@ def learn_zip(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _reset_builtin_ready():
-    # _builtin_ready and the automount-completed gate are process-global; reset
-    # them so state set by one test never leaks into the next.
+    # _builtin_ready is process-global; reset it so readiness set by one test
+    # never leaks into the next.
     import fused_render.shell.mounts.automount as _am
-    import fused_render.shell.mounts.health as _health
     with _am._builtin_ready_lock:
         for name in list(_am._builtin_ready):
             _am._builtin_ready[name] = False
-    _health._automount_completed.clear()
     yield
 
 
@@ -444,34 +442,51 @@ def test_run_automount_leaves_builtin_not_ready_on_attach_failure(home, learn_zi
     assert mounts_mod.learn_mount_ready() is False
 
 
-def test_poll_once_self_heals_builtin_after_out_of_band_reconnect(home, learn_zip, monkeypatch):
-    # A builtin left False by run_automount's split-brain `continue` and then
-    # brought online by a manual Reconnect (which doesn't touch the flag) must
-    # still turn ready — the health monitor syncs it, once automount has run.
-    import fused_render.shell.mounts.health as health_mod
+def test_poll_once_never_marks_builtin_ready_from_observation(home, learn_zip, monkeypatch):
+    # poll_once must NEVER flip readiness True off an observed "mounted": a mount
+    # surviving a previous run (before the startup force-detach) or lingering
+    # from a failed force-detach both read "mounted" while serving stale/absent
+    # content, and the frontend sticky-caches the first True. True is only ever
+    # a successful attach this run.
     mounts_mod.ensure_learn_mount()
     monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
     monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "mounted")
-
-    health_mod._automount_completed.set()
-    assert mounts_mod.learn_mount_ready() is False  # not attached by automount
-    mounts_mod.poll_once()
-    assert mounts_mod.learn_mount_ready() is True    # health observed it live
-
-
-def test_poll_once_ignores_surviving_mount_before_automount(home, learn_zip, monkeypatch):
-    # The other side of the gate: before run_automount's startup force-detach,
-    # a mount that survived a previous run still reads "mounted" — poll_once must
-    # NOT let that reach _builtin_ready (the frontend sticky-caches the first
-    # True), or it reintroduces the stale-ready race.
-    import fused_render.shell.mounts.health as health_mod
-    mounts_mod.ensure_learn_mount()
-    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
-    monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "mounted")
-
-    health_mod._automount_completed.clear()  # startup pass not done yet
     mounts_mod.poll_once()
     assert mounts_mod.learn_mount_ready() is False
+
+
+def test_poll_once_clears_builtin_ready_on_drop(home, learn_zip, monkeypatch):
+    # It does the opposite direction though: a builtin that was ready and later
+    # drops is cleared, so the sidebar entry hides.
+    mounts_mod.ensure_learn_mount()
+    mounts_mod.set_builtin_ready("learn", True)
+    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
+    monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "disconnected")
+    mounts_mod.poll_once()
+    assert mounts_mod.learn_mount_ready() is False
+
+
+def test_reconnect_marks_builtin_ready_on_success(home, learn_zip, monkeypatch):
+    # The out-of-band repair path Bugbot flagged: run_automount's split-brain
+    # `continue` leaves a builtin False, and a manual Reconnect brings it online.
+    # reconnect_mount must flip the flag on success (and only on success).
+    import fused_render.shell.mounts.lifecycle as lifecycle_mod
+    mounts_mod.ensure_learn_mount()
+    m = _learn_records()[0]
+
+    # reconnect_mount lazily imports these from the package; _is_mounted and
+    # attach_mount are lifecycle module-level names.
+    monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda: None)
+    monkeypatch.setattr(lifecycle_mod, "_is_mounted", lambda mp: False)
+    monkeypatch.setattr(lifecycle_mod, "attach_mount", lambda mm: None)  # success
+    assert lifecycle_mod.reconnect_mount(m) is None
+    assert mounts_mod.learn_mount_ready() is True
+
+    mounts_mod.set_builtin_ready("learn", False)
+    monkeypatch.setattr(lifecycle_mod, "attach_mount", lambda mm: "still broken")
+    assert lifecycle_mod.reconnect_mount(m) == "still broken"
+    assert mounts_mod.learn_mount_ready() is False  # failed reconnect: unchanged
 
 
 def test_learn_mount_ready_false_for_user_mount_named_learn(home):

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -99,6 +99,32 @@ def test_idempotent(home, learn_zip):
     assert mounts_mod.list_mounts() == before
 
 
+def test_builtin_mount_ready_reads_cached_state_not_live_probe(home, learn_zip, monkeypatch):
+    # /api/config embeds learn_mount_ready; it must NEVER do a live rcd/WinFsp
+    # probe on the request path — a cold-start _ismount on the WinFsp mountpoint
+    # blocked /api/config ~60s (×2 builtins). Blow up if the live probe runs,
+    # and drive readiness purely off the health monitor's cached state.
+    mounts_mod.ensure_learn_mount()
+    mid = _learn_records()[0]["id"]
+
+    def _boom(*_a, **_k):
+        raise AssertionError("live mount probe must not run on the readiness path")
+
+    monkeypatch.setattr(mounts_mod, "mounted_paths", _boom)
+    monkeypatch.setattr(mounts_mod, "_health_episodes", {}, raising=False)
+
+    # Cold start: no health observation yet -> not ready (conservative), fast.
+    assert mounts_mod.learn_mount_ready() is False
+
+    # Health monitor has since observed the mount live.
+    mounts_mod._health_episodes[mid] = {"state": "mounted", "notified": False}
+    assert mounts_mod.learn_mount_ready() is True
+
+    # A later disconnect flips it back — still no live probe.
+    mounts_mod._health_episodes[mid] = {"state": "disconnected", "notified": True}
+    assert mounts_mod.learn_mount_ready() is False
+
+
 def test_updates_stale_remote(home, learn_zip, tmp_path, monkeypatch):
     mounts_mod.ensure_learn_mount()
     old_id = _learn_records()[0]["id"]
@@ -354,22 +380,23 @@ def test_force_detach_runs_outside_store_lock(home, learn_zip, monkeypatch):
 
 
 def test_learn_mount_ready_false_until_actually_mounted(home, learn_zip, monkeypatch):
-    # BUGBOT: record presence alone isn't "ready" — ensure_learn_mount
-    # force-detaches on every startup, so a record can exist while the
-    # mountpoint is momentarily empty (between the detach and the
-    # subsequent attach_mount in run_automount's loop).
+    # Record presence alone isn't "ready": until the health monitor has
+    # observed the mountpoint actually attached ("mounted"), this stays False —
+    # ensure_learn_mount force-detaches on every startup, so a record can exist
+    # while the mountpoint is momentarily empty between detach and re-attach.
     assert mounts_mod.learn_mount_ready() is False
     mounts_mod.ensure_learn_mount()
-    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
-    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: False)
+    mid = _learn_records()[0]["id"]
+    monkeypatch.setattr(mounts_mod, "_health_episodes",
+                        {mid: {"state": "unmounted", "notified": False}}, raising=False)
     assert mounts_mod.learn_mount_ready() is False  # record exists, not attached
 
 
 def test_learn_mount_ready_true_once_actually_mounted(home, learn_zip, monkeypatch):
     mounts_mod.ensure_learn_mount()
-    mp = mounts_mod.mountpoint(_learn_records()[0])
-    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: {mp})
-    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: p == mp)
+    mid = _learn_records()[0]["id"]
+    monkeypatch.setattr(mounts_mod, "_health_episodes",
+                        {mid: {"state": "mounted", "notified": False}}, raising=False)
     assert mounts_mod.learn_mount_ready() is True
 
 
@@ -378,10 +405,11 @@ def test_learn_mount_ready_false_without_zip(home):
 
 
 def test_learn_mount_ready_false_for_user_mount_named_learn(home, monkeypatch):
-    mounts_mod.add_mount("learn", "s3remote:my-learn-bucket")
-    monkeypatch.setattr(mounts_mod, "mounted_paths",
-                        lambda: {mounts_mod.mountpoint({"name": "learn"})})
-    monkeypatch.setattr(mounts_mod.os.path, "ismount", lambda p: True)
+    # A user mount named "learn" has no builtin marker, so even a "mounted"
+    # health observation for it must not read as the builtin being ready.
+    user = mounts_mod.add_mount("learn", "s3remote:my-learn-bucket")
+    monkeypatch.setattr(mounts_mod, "_health_episodes",
+                        {user["id"]: {"state": "mounted", "notified": False}}, raising=False)
     assert mounts_mod.learn_mount_ready() is False
 
 

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -455,15 +455,16 @@ def test_poll_once_never_marks_builtin_ready_from_observation(home, learn_zip, m
     assert mounts_mod.learn_mount_ready() is False
 
 
-def test_poll_once_clears_builtin_ready_on_drop(home, learn_zip, monkeypatch):
-    # It does the opposite direction though: a builtin that was ready and later
-    # drops is cleared, so the sidebar entry hides.
+def test_poll_once_leaves_ready_flag_untouched(home, learn_zip, monkeypatch):
+    # The health monitor must not disturb a readiness set by a real attach: a
+    # transient post-attach snapshot can read not-mounted, and clearing off that
+    # would strand the flag (nothing restores it). Readiness is attach-owned.
     mounts_mod.ensure_learn_mount()
     mounts_mod.set_builtin_ready("learn", True)
     monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
     monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "disconnected")
     mounts_mod.poll_once()
-    assert mounts_mod.learn_mount_ready() is False
+    assert mounts_mod.learn_mount_ready() is True
 
 
 def test_reconnect_marks_builtin_ready_on_success(home, learn_zip, monkeypatch):

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -29,12 +29,14 @@ def learn_zip(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _reset_builtin_ready():
-    # _builtin_ready is process-global; reset it so readiness set by one test
-    # never leaks into the next.
+    # _builtin_ready and the automount-completed gate are process-global; reset
+    # them so state set by one test never leaks into the next.
     import fused_render.shell.mounts.automount as _am
+    import fused_render.shell.mounts.health as _health
     with _am._builtin_ready_lock:
         for name in list(_am._builtin_ready):
             _am._builtin_ready[name] = False
+    _health._automount_completed.clear()
     yield
 
 
@@ -439,6 +441,36 @@ def test_run_automount_leaves_builtin_not_ready_on_attach_failure(home, learn_zi
     monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
 
     mounts_mod.run_automount()
+    assert mounts_mod.learn_mount_ready() is False
+
+
+def test_poll_once_self_heals_builtin_after_out_of_band_reconnect(home, learn_zip, monkeypatch):
+    # A builtin left False by run_automount's split-brain `continue` and then
+    # brought online by a manual Reconnect (which doesn't touch the flag) must
+    # still turn ready — the health monitor syncs it, once automount has run.
+    import fused_render.shell.mounts.health as health_mod
+    mounts_mod.ensure_learn_mount()
+    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
+    monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "mounted")
+
+    health_mod._automount_completed.set()
+    assert mounts_mod.learn_mount_ready() is False  # not attached by automount
+    mounts_mod.poll_once()
+    assert mounts_mod.learn_mount_ready() is True    # health observed it live
+
+
+def test_poll_once_ignores_surviving_mount_before_automount(home, learn_zip, monkeypatch):
+    # The other side of the gate: before run_automount's startup force-detach,
+    # a mount that survived a previous run still reads "mounted" — poll_once must
+    # NOT let that reach _builtin_ready (the frontend sticky-caches the first
+    # True), or it reintroduces the stale-ready race.
+    import fused_render.shell.mounts.health as health_mod
+    mounts_mod.ensure_learn_mount()
+    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
+    monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "mounted")
+
+    health_mod._automount_completed.clear()  # startup pass not done yet
+    mounts_mod.poll_once()
     assert mounts_mod.learn_mount_ready() is False
 
 

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -29,8 +29,7 @@ def learn_zip(tmp_path, monkeypatch):
 
 @pytest.fixture(autouse=True)
 def _reset_builtin_ready():
-    # _builtin_ready is process-global; reset it so readiness set by one test
-    # never leaks into the next.
+    # _builtin_ready is process-global; reset it so readiness doesn't leak between tests.
     import fused_render.shell.mounts.automount as _am
     with _am._builtin_ready_lock:
         for name in list(_am._builtin_ready):
@@ -111,10 +110,7 @@ def test_idempotent(home, learn_zip):
 
 
 def test_builtin_mount_ready_reads_flag_not_live_probe(home, learn_zip, monkeypatch):
-    # /api/config embeds learn_mount_ready; it must NEVER do a live rcd/WinFsp
-    # probe on the request path — a cold-start _ismount on the WinFsp mountpoint
-    # blocked /api/config ~60s (×2 builtins). Blow up if the live probe runs,
-    # and drive readiness purely off the lifecycle-tracked flag.
+    # learn_mount_ready must never do a live mount probe (a cold-start _ismount blocked /api/config ~60s); blow up if it does and drive readiness off the flag.
     mounts_mod.ensure_learn_mount()
 
     def _boom(*_a, **_k):
@@ -122,8 +118,7 @@ def test_builtin_mount_ready_reads_flag_not_live_probe(home, learn_zip, monkeypa
 
     monkeypatch.setattr(mounts_mod, "mounted_paths", _boom)
 
-    # Before automount attaches it this run -> not ready (conservative), fast.
-    assert mounts_mod.learn_mount_ready() is False
+    assert mounts_mod.learn_mount_ready() is False  # not attached this run yet
 
     mounts_mod.set_builtin_ready("learn", True)
     assert mounts_mod.learn_mount_ready() is True
@@ -387,9 +382,7 @@ def test_force_detach_runs_outside_store_lock(home, learn_zip, monkeypatch):
 
 
 def test_learn_mount_ready_false_until_actually_mounted(home, learn_zip):
-    # Record presence alone isn't "ready": until run_automount attaches it this
-    # run, the flag stays False — ensure_learn_mount force-detaches on every
-    # startup, so a record can exist while the mountpoint is momentarily empty.
+    # Record presence alone isn't "ready" — the flag stays False until run_automount attaches it this run.
     assert mounts_mod.learn_mount_ready() is False
     mounts_mod.ensure_learn_mount()
     assert mounts_mod.learn_mount_ready() is False  # record exists, not attached
@@ -406,17 +399,13 @@ def test_learn_mount_ready_false_without_zip(home):
 
 
 def test_run_automount_marks_builtin_ready_only_after_attach(home, learn_zip, monkeypatch):
-    # The stale-mount race Bugbot flagged: a mount that survived a previous run
-    # must not read as ready during the force-detach+remount window. Seed a
-    # stale True, then run_automount must clear it and only re-set True once its
-    # own attach_mount succeeds (the frontend sticky-caches the first True).
+    # A stale True from a previous run must be cleared before the remount and re-set only after this run's attach succeeds.
     import fused_render.shell.mounts.health as health_mod
 
     mounts_mod.set_builtin_ready("learn", True)  # stale, from a "previous run"
     seen_during_attach = []
 
     def fake_attach(m):
-        # At the moment automount is (re)attaching, readiness must read False.
         seen_during_attach.append(mounts_mod.learn_mount_ready())
         return None  # success
 
@@ -443,11 +432,7 @@ def test_run_automount_leaves_builtin_not_ready_on_attach_failure(home, learn_zi
 
 
 def test_poll_once_never_marks_builtin_ready_from_observation(home, learn_zip, monkeypatch):
-    # poll_once must NEVER flip readiness True off an observed "mounted": a mount
-    # surviving a previous run (before the startup force-detach) or lingering
-    # from a failed force-detach both read "mounted" while serving stale/absent
-    # content, and the frontend sticky-caches the first True. True is only ever
-    # a successful attach this run.
+    # poll_once must never set readiness True off an observed "mounted" (a lingering/prior-run mount reads mounted while stale); True is only ever a real attach this run.
     mounts_mod.ensure_learn_mount()
     monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
     monkeypatch.setattr(mounts_mod, "mount_state", lambda m, live, **k: "mounted")
@@ -456,9 +441,7 @@ def test_poll_once_never_marks_builtin_ready_from_observation(home, learn_zip, m
 
 
 def test_poll_once_leaves_ready_flag_untouched(home, learn_zip, monkeypatch):
-    # The health monitor must not disturb a readiness set by a real attach: a
-    # transient post-attach snapshot can read not-mounted, and clearing off that
-    # would strand the flag (nothing restores it). Readiness is attach-owned.
+    # The health monitor must not clear a readiness set by a real attach off a transient not-mounted snapshot (nothing would restore it).
     mounts_mod.ensure_learn_mount()
     mounts_mod.set_builtin_ready("learn", True)
     monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
@@ -468,15 +451,11 @@ def test_poll_once_leaves_ready_flag_untouched(home, learn_zip, monkeypatch):
 
 
 def test_reconnect_marks_builtin_ready_on_success(home, learn_zip, monkeypatch):
-    # The out-of-band repair path Bugbot flagged: run_automount's split-brain
-    # `continue` leaves a builtin False, and a manual Reconnect brings it online.
-    # reconnect_mount must flip the flag on success (and only on success).
+    # A manual Reconnect (the out-of-band repair automount defers to) must flip the flag on success, and only on success.
     import fused_render.shell.mounts.lifecycle as lifecycle_mod
     mounts_mod.ensure_learn_mount()
     m = _learn_records()[0]
 
-    # reconnect_mount lazily imports these from the package; _is_mounted and
-    # attach_mount are lifecycle module-level names.
     monkeypatch.setattr(mounts_mod, "_winfsp_available", lambda: True)
     monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda: None)
     monkeypatch.setattr(lifecycle_mod, "_is_mounted", lambda mp: False)
@@ -491,8 +470,7 @@ def test_reconnect_marks_builtin_ready_on_success(home, learn_zip, monkeypatch):
 
 
 def test_learn_mount_ready_false_for_user_mount_named_learn(home):
-    # A user mount named "learn" has no builtin marker; run_automount only sets
-    # the builtin flag for records marked builtin, so it never reads as ready.
+    # A user mount named "learn" has no builtin marker, so the flag is never set for it.
     mounts_mod.add_mount("learn", "s3remote:my-learn-bucket")
     mounts_mod.set_builtin_ready("learn", False)
     assert mounts_mod.learn_mount_ready() is False

--- a/tests/test_learn_mount.py
+++ b/tests/test_learn_mount.py
@@ -27,6 +27,17 @@ def learn_zip(tmp_path, monkeypatch):
     return zp
 
 
+@pytest.fixture(autouse=True)
+def _reset_builtin_ready():
+    # _builtin_ready is process-global; reset it so readiness set by one test
+    # never leaks into the next.
+    import fused_render.shell.mounts.automount as _am
+    with _am._builtin_ready_lock:
+        for name in list(_am._builtin_ready):
+            _am._builtin_ready[name] = False
+    yield
+
+
 def _learn_records():
     return [m for m in mounts_mod.list_mounts()
             if m.get("builtin") == mounts_mod.LEARN_MOUNT_NAME]
@@ -99,29 +110,25 @@ def test_idempotent(home, learn_zip):
     assert mounts_mod.list_mounts() == before
 
 
-def test_builtin_mount_ready_reads_cached_state_not_live_probe(home, learn_zip, monkeypatch):
+def test_builtin_mount_ready_reads_flag_not_live_probe(home, learn_zip, monkeypatch):
     # /api/config embeds learn_mount_ready; it must NEVER do a live rcd/WinFsp
     # probe on the request path — a cold-start _ismount on the WinFsp mountpoint
     # blocked /api/config ~60s (×2 builtins). Blow up if the live probe runs,
-    # and drive readiness purely off the health monitor's cached state.
+    # and drive readiness purely off the lifecycle-tracked flag.
     mounts_mod.ensure_learn_mount()
-    mid = _learn_records()[0]["id"]
 
     def _boom(*_a, **_k):
         raise AssertionError("live mount probe must not run on the readiness path")
 
     monkeypatch.setattr(mounts_mod, "mounted_paths", _boom)
-    monkeypatch.setattr(mounts_mod, "_health_episodes", {}, raising=False)
 
-    # Cold start: no health observation yet -> not ready (conservative), fast.
+    # Before automount attaches it this run -> not ready (conservative), fast.
     assert mounts_mod.learn_mount_ready() is False
 
-    # Health monitor has since observed the mount live.
-    mounts_mod._health_episodes[mid] = {"state": "mounted", "notified": False}
+    mounts_mod.set_builtin_ready("learn", True)
     assert mounts_mod.learn_mount_ready() is True
 
-    # A later disconnect flips it back — still no live probe.
-    mounts_mod._health_episodes[mid] = {"state": "disconnected", "notified": True}
+    mounts_mod.set_builtin_ready("learn", False)
     assert mounts_mod.learn_mount_ready() is False
 
 
@@ -379,24 +386,18 @@ def test_force_detach_runs_outside_store_lock(home, learn_zip, monkeypatch):
 # -- learn_mount_ready --------------------------------------------------------
 
 
-def test_learn_mount_ready_false_until_actually_mounted(home, learn_zip, monkeypatch):
-    # Record presence alone isn't "ready": until the health monitor has
-    # observed the mountpoint actually attached ("mounted"), this stays False —
-    # ensure_learn_mount force-detaches on every startup, so a record can exist
-    # while the mountpoint is momentarily empty between detach and re-attach.
+def test_learn_mount_ready_false_until_actually_mounted(home, learn_zip):
+    # Record presence alone isn't "ready": until run_automount attaches it this
+    # run, the flag stays False — ensure_learn_mount force-detaches on every
+    # startup, so a record can exist while the mountpoint is momentarily empty.
     assert mounts_mod.learn_mount_ready() is False
     mounts_mod.ensure_learn_mount()
-    mid = _learn_records()[0]["id"]
-    monkeypatch.setattr(mounts_mod, "_health_episodes",
-                        {mid: {"state": "unmounted", "notified": False}}, raising=False)
     assert mounts_mod.learn_mount_ready() is False  # record exists, not attached
 
 
-def test_learn_mount_ready_true_once_actually_mounted(home, learn_zip, monkeypatch):
+def test_learn_mount_ready_true_once_attached_this_run(home, learn_zip):
     mounts_mod.ensure_learn_mount()
-    mid = _learn_records()[0]["id"]
-    monkeypatch.setattr(mounts_mod, "_health_episodes",
-                        {mid: {"state": "mounted", "notified": False}}, raising=False)
+    mounts_mod.set_builtin_ready("learn", True)  # what run_automount does on a successful attach
     assert mounts_mod.learn_mount_ready() is True
 
 
@@ -404,12 +405,48 @@ def test_learn_mount_ready_false_without_zip(home):
     assert mounts_mod.learn_mount_ready() is False
 
 
-def test_learn_mount_ready_false_for_user_mount_named_learn(home, monkeypatch):
-    # A user mount named "learn" has no builtin marker, so even a "mounted"
-    # health observation for it must not read as the builtin being ready.
-    user = mounts_mod.add_mount("learn", "s3remote:my-learn-bucket")
-    monkeypatch.setattr(mounts_mod, "_health_episodes",
-                        {user["id"]: {"state": "mounted", "notified": False}}, raising=False)
+def test_run_automount_marks_builtin_ready_only_after_attach(home, learn_zip, monkeypatch):
+    # The stale-mount race Bugbot flagged: a mount that survived a previous run
+    # must not read as ready during the force-detach+remount window. Seed a
+    # stale True, then run_automount must clear it and only re-set True once its
+    # own attach_mount succeeds (the frontend sticky-caches the first True).
+    import fused_render.shell.mounts.health as health_mod
+
+    mounts_mod.set_builtin_ready("learn", True)  # stale, from a "previous run"
+    seen_during_attach = []
+
+    def fake_attach(m):
+        # At the moment automount is (re)attaching, readiness must read False.
+        seen_during_attach.append(mounts_mod.learn_mount_ready())
+        return None  # success
+
+    monkeypatch.setattr(health_mod, "attach_mount", fake_attach)
+    monkeypatch.setattr(health_mod, "sync_serves", lambda: None)
+    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
+
+    mounts_mod.run_automount()
+
+    assert seen_during_attach == [False]              # cleared before the attach
+    assert mounts_mod.learn_mount_ready() is True      # set only after it succeeded
+
+
+def test_run_automount_leaves_builtin_not_ready_on_attach_failure(home, learn_zip, monkeypatch):
+    import fused_render.shell.mounts.health as health_mod
+
+    mounts_mod.set_builtin_ready("learn", True)  # stale
+    monkeypatch.setattr(health_mod, "attach_mount", lambda m: "mount failed")
+    monkeypatch.setattr(health_mod, "sync_serves", lambda: None)
+    monkeypatch.setattr(mounts_mod, "mounted_paths", lambda: set())
+
+    mounts_mod.run_automount()
+    assert mounts_mod.learn_mount_ready() is False
+
+
+def test_learn_mount_ready_false_for_user_mount_named_learn(home):
+    # A user mount named "learn" has no builtin marker; run_automount only sets
+    # the builtin flag for records marked builtin, so it never reads as ready.
+    mounts_mod.add_mount("learn", "s3remote:my-learn-bucket")
+    mounts_mod.set_builtin_ready("learn", False)
     assert mounts_mod.learn_mount_ready() is False
 
 


### PR DESCRIPTION
Fixes the Windows **"Python server did not become ready"** dialog, and the related cold-start slowness, both rooted in the same mount↔request-path coupling.

## 1. Readiness probe decoupled from `/api/config`

The desktop supervisor's readiness probe polled **`/api/config`**, whose `learn_mount_ready()`/`sessions_mount_ready()` did a **live rcd + WinFsp check on every request**. During cold startup (automount respawning rcd + remounting the builtin `learn`/`sessions` mounts), every `/api/config` response exceeded the probe's 0.5 s timeout for the whole 20 s budget → the supervisor killed the child and retried 3× → the dialog.

**Fix:** a dedicated, dependency-free **`GET /api/desktop/ready`** that echoes only the launch token — no mounts, no rcd, no dir picker — and `desktop_probe` now polls it. Readiness = "the HTTP server is up and is the instance we launched", never "every optional subsystem is warm".

## 2. `/api/config` no longer blocks on mount attach

Even with the probe moved, `/api/config` itself took **62 s** on a cold start (the browser window couldn't paint). Root cause: `builtin_mount_ready` did `mp in mounted_paths()` + **`_ismount(mp)`**, and on Windows `_ismount()` on the WinFsp reparse point blocks for ~the rc timeout while the mountpoint is mid-attach — ×2 builtins. macOS (nfsmount) and Linux (FUSE) attach fast enough to hide it.

**Fix:** `builtin_mount_ready` is now an **I/O-free read of an attach-owned `_builtin_ready` flag** instead of a live probe. `run_automount` is the sole writer: it resets every builtin to **False** before its force-detach+remount pass, then flips one **True** only once its own `attach_mount` succeeds; a manual `reconnect_mount` also sets it on a successful builtin repair. So **True always means a mount this run attached** — never one that merely survived a previous run, which matters because the frontend sticky-caches the first True it sees. The health monitor (`poll_once`) never touches the flag: it must not infer readiness from an observed "mounted" (a mount lingering from a failed detach reads mounted while stale; a transient post-attach snapshot reads not-mounted), so readiness stays deterministic and attach-owned.

## Why Windows-only
`/api/config` is identical cross-platform; the difference is purely mount-backend latency — WinFsp attach/`ismount` is slow, nfsmount/FUSE are fast. Both fixes make the paths robust on every platform.

## Tests / e2e
`test_desktop_probe` (incl. `test_readiness_is_independent_of_mount_health`) and the learn/sessions suites are green (49 targeted tests). New lifecycle coverage in `test_learn_mount`: `builtin_mount_ready` reads the flag not a live probe; `run_automount` marks a builtin ready only after a successful attach and leaves it not-ready on failure; `poll_once` never sets or clears the flag from observation; `reconnect_mount` marks it ready only on success.

Built the installer from this branch and installed it end-to-end on real Windows: **build ~19.6 min, install ~4.6 min, supervisor readiness ~1.4 s** (server log: boot → `GET /api/desktop/ready -> 200`), supervisor + child both alive, **no dialog**. Cold `/api/config` worst-case dropped from **62 437 ms → 63 ms**. (3 pre-existing `test_shell_mounts` failures on Windows also fail on `main`.)

> [!NOTE]
> The browser window can still paint slowly on a *first* cold start — py-spy shows that's the first-run Fused engine bootstrapping the showcase UDFs' project venvs via `uv` subprocesses (plus the WinFsp mount attach), a separate first-run cost. It is not the readiness/mount-probe path fixed here (the supervisor probe runs before the browser opens and stays ~1.4 s).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches desktop startup gating and when Learn/Sessions sidebar links appear; logic is well-tested but wrong flag timing could hide links or show them before attach completes.
> 
> **Overview**
> Fixes Windows **"server did not become ready"** and multi‑second `/api/config` stalls on cold start by separating **supervisor readiness** from **sidebar mount readiness**.
> 
> **Readiness probe:** `desktop_probe` now polls **`GET /api/desktop/ready`**, which only echoes the desktop instance id and token (no mounts, rcd, or dir picker). The supervisor can confirm the launched HTTP server within its timeout instead of failing while builtins are still attaching.
> 
> **Builtin “ready” for `/api/config`:** `learn_mount_ready` / `sessions_mount_ready` no longer call **`mounted_paths()`** or **`_ismount()`** (WinFsp could block ~60s mid-attach). They read an in-memory **`_builtin_ready`** flag set only when **`run_automount`** or a successful **`reconnect_mount`** actually attaches that builtin this run—cleared at automount start so stale mounts from a prior run don’t satisfy the UI’s sticky cache.
> 
> Tests cover `/api/desktop/ready` decoupling from mount health and the attach-owned readiness lifecycle (`poll_once` never infers readiness from observation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 549d8bf64396bbc396843d76d9ce3fd51ff54aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

