### PR TITLE
feat(explorer): restyle folder cards as stacked-sheet previews

### DIFF
--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -22,7 +22,7 @@ import { bookmarkFsPath } from "@apps/explorer/sidebar/BookmarksSection";
 // same pure-CSS trick as AppPreviewCard.
 const PREVIEW_SCALE = 0.25;
 
-// How many stack chips a folder card fans out (the rest stays behind the count).
+// How many stacked sheets a folder card fans out (the rest stays behind the count).
 const MAX_CHIPS = 3;
 
 // A view url (bookmark or recent) re-prefixed onto the chrome-free embed
@@ -173,28 +173,45 @@ function FolderStack({ path }: { path: string }) {
   const peekPath = firstFile ? joinPath(path, firstFile.name) : (subPeek ?? null);
   // Settled: listDir landed AND the subfolder probe reached a verdict.
   const settled = entries !== null && subPeek !== undefined;
+  // The front sheet's body, under its title row: the peeked view, or (once
+  // settled with nothing to peek) a count so the card isn't a void.
+  const body = peekPath ? (
+    <LivePreview src={embedUrlForFsPath(peekPath)} />
+  ) : settled ? (
+    <span className="fhb-sheet-note">
+      {`${teaser.length} item${teaser.length === 1 ? "" : "s"}`}
+    </span>
+  ) : null;
   return (
     <span className="fhb-stack">
-      {/* Back chip first: natural stacking keeps the front chip on top. */}
-      {shown.map((e, i) => (
-        <span key={e.name} className={`fhb-chip fhb-chip-d${shown.length - 1 - i}`}>
-          <span className="fhb-chip-icon">{iconForEntry(e.name, e.is_dir)}</span>
-          <span className="fhb-chip-label">{e.name}</span>
-        </span>
-      ))}
-      {peekPath ? (
-        <LivePreview src={embedUrlForFsPath(peekPath)} />
-      ) : (
-        settled && (
-          // Nothing to peek at — fill the stack's leftover space with a
-          // count so a subfolder-only (or empty) folder card isn't a void.
-          <span className="fhb-note">
-            {shown.length === 0
-              ? "Empty folder"
-              : `${teaser.length} item${teaser.length === 1 ? "" : "s"}`}
+      {/* Back sheet first: natural stacking keeps the front sheet on top.
+          Each entry is ONE sheet — a title row whose card body slides down
+          behind the sheet in front of it; the front sheet carries the
+          preview inside itself (the ref design's titlebar-plus-page card,
+          not a bar floating over a separate panel). */}
+      {shown.map((e, i) => {
+        const depth = shown.length - 1 - i;
+        return (
+          <span key={e.name} className={`fhb-sheet fhb-sheet-d${depth}`}>
+            <span className="fhb-sheet-row">
+              <span className="fhb-sheet-icon">{iconForEntry(e.name, e.is_dir)}</span>
+              <span className="fhb-sheet-label">{e.name}</span>
+            </span>
+            {depth === 0 ? (
+              body
+            ) : (
+              // Back sheets carry their own page too: a strip of the entry's
+              // live view (a folder embeds as its listing) that stays tucked
+              // behind the sheet in front until the card's hover fan slides
+              // it out — a page edge with real content, not a blank lip.
+              <span className="fhb-sheet-peek">
+                <LivePreview src={embedUrlForFsPath(joinPath(path, e.name))} />
+              </span>
+            )}
           </span>
-        )
-      )}
+        );
+      })}
+      {shown.length === 0 && settled && <span className="fhb-note">Empty folder</span>}
     </span>
   );
 }

--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -202,29 +202,32 @@ function FolderStack({ path }: { path: string }) {
           Each entry is ONE sheet — a title row whose card body slides down
           behind the sheet in front of it; the front sheet carries the
           preview inside itself (the ref design's titlebar-plus-page card,
-          not a bar floating over a separate panel). */}
-      {shown.map((e, i) => {
-        const depth = shown.length - 1 - i;
-        return (
-          <span key={e.name} className={`fhb-sheet fhb-sheet-d${depth}`}>
-            <span className="fhb-sheet-row">
-              <span className="fhb-sheet-icon">{iconForEntry(e.name, e.is_dir)}</span>
-              <span className="fhb-sheet-label">{e.name}</span>
-            </span>
-            {depth === 0 ? (
-              body
-            ) : (
-              // Back sheets carry their own page too: a strip of the entry's
-              // live view (a folder embeds as its listing) that stays tucked
-              // behind the sheet in front until the card's hover fan slides
-              // it out — a page edge with real content, not a blank lip.
-              <span className="fhb-sheet-peek">
-                <LivePreview src={embedUrlForFsPath(joinPath(path, e.name))} />
+          not a bar floating over a separate panel). The whole stack waits
+          for settled: painting an alphabetical stack mid-probe would let
+          the front sheet reorder under the user once subPeek names it. */}
+      {settled &&
+        shown.map((e, i) => {
+          const depth = shown.length - 1 - i;
+          return (
+            <span key={e.name} className={`fhb-sheet fhb-sheet-d${depth}`}>
+              <span className="fhb-sheet-row">
+                <span className="fhb-sheet-icon">{iconForEntry(e.name, e.is_dir)}</span>
+                <span className="fhb-sheet-label">{e.name}</span>
               </span>
-            )}
-          </span>
-        );
-      })}
+              {depth === 0 ? (
+                body
+              ) : (
+                // Back sheets carry their own page too: a strip of the entry's
+                // live view (a folder embeds as its listing) that stays tucked
+                // behind the sheet in front until the card's hover fan slides
+                // it out — a page edge with real content, not a blank lip.
+                <span className="fhb-sheet-peek">
+                  <LivePreview src={embedUrlForFsPath(joinPath(path, e.name))} />
+                </span>
+              )}
+            </span>
+          );
+        })}
       {shown.length === 0 && settled && <span className="fhb-note">Empty folder</span>}
     </span>
   );

--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -121,11 +121,15 @@ function bestPeekFile(entries: FsEntry[]): FsEntry | null {
 // app) wins the probe outright.
 function FolderStack({ path }: { path: string }) {
   const [entries, setEntries] = useState<FsEntry[] | null>(null);
-  // Absolute fs path of a probed subfolder's best file — the fallback peek.
+  // A probed subfolder's best file — the fallback peek: the file's absolute
+  // fs path plus the name of the subfolder it came from (that subfolder
+  // becomes the front sheet, so the sheet's title owns the page it shows).
   // undefined = probe not settled yet, null = settled with nothing to peek;
   // the note body waits for settled so it doesn't flash a count and then
   // swap to a preview mid-probe.
-  const [subPeek, setSubPeek] = useState<string | null | undefined>(undefined);
+  const [subPeek, setSubPeek] = useState<{ path: string; dir: string } | null | undefined>(
+    undefined,
+  );
   useEffect(() => {
     let alive = true;
     setEntries(null);
@@ -144,7 +148,7 @@ function FolderStack({ path }: { path: string }) {
         setSubPeek(null); // a direct file child wins — no probe needed
         return;
       }
-      let best: { path: string; rank: number } | null = null;
+      let best: { path: string; rank: number; dir: string } | null = null;
       for (const d of teaser.filter((e) => e.is_dir).slice(0, APP_PROBE_LIMIT)) {
         const subPath = joinPath(path, d.name);
         let sub: FsEntry[];
@@ -157,10 +161,11 @@ function FolderStack({ path }: { path: string }) {
         const f = bestPeekFile(teaserEntries(sub));
         if (!f) continue;
         const rank = peekRank(f.name);
-        if (!best || rank < best.rank) best = { path: joinPath(subPath, f.name), rank };
+        if (!best || rank < best.rank)
+          best = { path: joinPath(subPath, f.name), rank, dir: d.name };
         if (rank === 0) break; // an html — nothing can outrank it
       }
-      setSubPeek(best ? best.path : null);
+      setSubPeek(best ? { path: best.path, dir: best.dir } : null);
     })();
     return () => {
       alive = false;
@@ -168,11 +173,20 @@ function FolderStack({ path }: { path: string }) {
   }, [path]);
 
   const teaser = teaserEntries(entries ?? []);
-  const shown = teaser.slice(0, MAX_CHIPS);
   const firstFile = bestPeekFile(teaser);
-  const peekPath = firstFile ? joinPath(path, firstFile.name) : (subPeek ?? null);
+  const peekPath = firstFile ? joinPath(path, firstFile.name) : (subPeek?.path ?? null);
   // Settled: listDir landed AND the subfolder probe reached a verdict.
   const settled = entries !== null && subPeek !== undefined;
+  // The front sheet must be the entry whose page it shows: the peeked file
+  // itself, or the probed subfolder the fallback peek came from — never an
+  // alphabetical bystander wearing another entry's preview.
+  const frontName = firstFile?.name ?? subPeek?.dir ?? null;
+  const front = frontName ? teaser.find((e) => e.name === frontName) : undefined;
+  let shown = teaser.slice(0, MAX_CHIPS);
+  if (front) {
+    shown = shown.filter((e) => e.name !== front.name).slice(0, MAX_CHIPS - 1);
+    shown.push(front);
+  }
   // The front sheet's body, under its title row: the peeked view, or (once
   // settled with nothing to peek) a count so the card isn't a void.
   const body = peekPath ? (

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -334,7 +334,7 @@
 .fhb-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 14px;
+  gap: 16px;
 }
 
 .fhb-card {
@@ -345,7 +345,12 @@
   text-decoration: none;
   background: var(--bg-alt);
   border: 1px solid var(--border);
-  border-radius: 12px;
+  border-radius: 16px;
+  /* The card carries the padding and the body well brings its own radius, so
+     the body reads as an inset floating panel (the ref design) rather than a
+     full-bleed border-top split. */
+  padding: 6px;
+  box-shadow: 0 1px 2px var(--shadow-sm);
   overflow: hidden;
   transition:
     border-color 0.15s ease,
@@ -354,17 +359,31 @@
 }
 
 .fhb-card:hover {
-  border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  box-shadow: 0 6px 22px var(--shadow-sm);
+  border-color: color-mix(in srgb, var(--fg) 16%, var(--border));
+  box-shadow: 0 8px 24px var(--shadow-sm);
   transform: translateY(-2px);
 }
 
 .fhb-card-head {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 12px 14px;
+  gap: 10px;
+  padding: 7px 8px 11px;
   min-width: 0;
+}
+
+/* Header pieces sized up inside the preview cards only — the flat launcher
+   rows keep the shared .fh-card-* base look. */
+.fhb-card .fh-card-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--fg) 7%, transparent);
+}
+
+.fhb-card .fh-card-name {
+  font-size: 14px;
+  font-weight: 650;
 }
 
 .fhb-card-head .bookmark-missing-badge {
@@ -378,7 +397,8 @@
   display: block;
   aspect-ratio: 16 / 10;
   background: var(--bg);
-  border-top: 1px solid var(--border);
+  border: 1px solid var(--border);
+  border-radius: 10px;
   overflow: hidden;
 }
 
@@ -405,107 +425,159 @@
   inset: 0;
 }
 
-/* Folder body: inset panel holding the fanned chip stack. Chips overlap
-   upward (front chip on top via z-index by depth) and spread apart while the
-   card is hovered — the ref design's "contents fan". */
+/* Folder body: inset well holding the sheet stack. Every entry is one SHEET
+   — a rounded card whose title row is all that shows, its body sliding down
+   behind the sheet in front of it (extra bottom padding pulled back by the
+   same negative margin). The front sheet is the full card: title row plus
+   the preview inside the same rounded unit — the ref design's stacked pages,
+   not bars floating over a separate panel. */
 .fhb-stack {
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   aspect-ratio: 16 / 10;
-  padding: 12px 12px 0;
-  /* The base --bg (a step darker than the card's --bg-alt) so the chips —
+  padding: 10px 10px 0;
+  /* The base --bg (a step darker than the card's --bg-alt) so the sheets —
      lifted toward --fg below — read clearly against the well they sit in. */
   background: var(--bg);
-  border-top: 1px solid var(--border);
+  border-radius: 10px;
   overflow: hidden;
 }
 
-.fhb-chip {
+.fhb-sheet {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 0 0 auto;
+  font-size: 12.5px;
+  /* Lifted a step above --bg-panel so the sheets separate from the stack's
+     --bg well; separation is carried by shadow, the hairline only stops
+     same-value surfaces from fusing. */
+  background: color-mix(in srgb, var(--fg) 7%, var(--bg-panel));
+  border: 1px solid color-mix(in srgb, var(--fg) 8%, var(--bg-panel));
+  border-radius: 12px;
+  box-shadow: 0 1px 2px var(--shadow-sm), 0 4px 12px var(--shadow-sm);
+  transition: margin 0.18s ease;
+}
+
+.fhb-sheet-row {
   display: flex;
   align-items: center;
   gap: 8px;
   min-width: 0;
-  flex: 0 0 auto;
-  padding: 6px 10px;
-  font-size: 12px;
-  /* Lifted a step above --bg-panel so the chips separate from the stack's
-     --bg well. */
-  background: color-mix(in srgb, var(--fg) 6%, var(--bg-panel));
-  border: 1px solid color-mix(in srgb, var(--fg) 14%, var(--border));
-  border-radius: 9px;
-  box-shadow: 0 1px 3px var(--shadow-sm);
-  transition: margin 0.18s ease;
+  padding: 8px 12px;
 }
 
-/* Depth fan: the front chip (d0) is full width; each step back is narrower
-   and tucked under the one in front of it. */
-.fhb-chip-d0 {
-  width: 100%;
+/* Depth cascade: the front sheet (d0) is full width and holds the body; each
+   step back is inset further from the left (a touch from the right), with
+   its card body tucked behind the sheet in front — extra bottom padding
+   pulled back under the next sheet by the matching negative margin, so what
+   peeks out reads as a page edge, not a closed pill. */
+.fhb-sheet-d0 {
+  flex: 1 1 auto;
+  min-height: 0;
   z-index: 3;
+  border-bottom: none;
+  border-radius: 12px 12px 0 0;
+  overflow: hidden;
 }
 
-.fhb-chip-d1 {
-  width: 90%;
-  margin-bottom: -7px;
+.fhb-sheet-d1 {
+  margin: 0 4px -20px 20px;
   z-index: 2;
 }
 
-.fhb-chip-d2 {
-  width: 80%;
-  margin-bottom: -7px;
+.fhb-sheet-d2 {
+  margin: 0 8px -20px 40px;
   z-index: 1;
 }
 
-/* In light theme --bg and --bg-panel are both white, so the dark-theme
-   "darker well, lighter chips" collapses; invert it — grey well (--bg-alt),
-   plain white chips. */
+/* Back sheets are open pages, not closed pills: square bottom corners and no
+   bottom hairline, so the edge the hover fan reveals reads as a page
+   continuing down behind the sheet in front — never a pill's bottom radius. */
+.fhb-sheet-d1,
+.fhb-sheet-d2 {
+  border-bottom: none;
+  border-radius: 12px 12px 0 0;
+}
+
+/* The back sheet's page body: a strip of the entry's live view, exactly as
+   tall as the overlap that hides it, so at rest only the title row shows. */
+.fhb-sheet-peek {
+  position: relative;
+  flex: 0 0 auto;
+  height: 20px;
+  overflow: hidden;
+}
+
+/* In light theme the card lifts to plain white and the dark-theme "darker
+   well, lighter sheets" collapses (--bg and --bg-panel are both white);
+   invert it — white card, grey well (--bg-alt), plain white sheets. */
+:root[data-theme="light"] .fhb-card {
+  background: var(--bg);
+}
+
 :root[data-theme="light"] .fhb-stack {
   background: var(--bg-alt);
 }
 
-:root[data-theme="light"] .fhb-chip {
+:root[data-theme="light"] .fhb-sheet {
   background: var(--bg);
+  border-color: color-mix(in srgb, var(--fg) 6%, var(--bg-alt));
 }
 
-.fhb-card:hover .fhb-chip-d1,
-.fhb-card:hover .fhb-chip-d2 {
-  margin-bottom: 2px;
+/* Hovering the card slides the back sheets out a little — more of each page
+   edge shows, the ref design's "contents fan". */
+.fhb-card:hover .fhb-sheet-d1,
+.fhb-card:hover .fhb-sheet-d2 {
+  margin-bottom: -2px;
 }
 
-.fhb-chip-icon {
+.fhb-sheet-icon {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   color: var(--fg-muted);
 }
 
-.fhb-chip-icon svg {
-  width: 13px;
-  height: 13px;
+.fhb-sheet-icon svg {
+  width: 14px;
+  height: 14px;
 }
 
-.fhb-chip-label {
+.fhb-sheet-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* The first file child's view peeking out underneath the front chip. */
-.fhb-stack .fhb-preview {
+/* The peeked view INSIDE the front sheet, right under its title row — one
+   card, no seam; the sheet's overflow clip rounds the top corners and the
+   well's bottom edge cuts it off. (Front sheet only — a back sheet's strip
+   keeps the base absolute-fill .fhb-preview inside its .fhb-sheet-peek.) */
+.fhb-sheet-d0 .fhb-preview {
   position: relative;
   inset: auto;
   flex: 1 1 auto;
-  width: calc(100% - 8px);
-  margin-top: -3px;
+  width: 100%;
   min-height: 60px;
   background: var(--bg-panel);
-  border: 1px solid var(--border);
-  border-bottom: none;
-  border-radius: 9px 9px 0 0;
   z-index: 0;
+}
+
+/* The front sheet's no-preview body: the folder's item count where the
+   peeked view would be. */
+.fhb-sheet-note {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60px;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--fg-muted);
 }
 
 /* Placeholder body: missing target, stat in flight, or an empty folder. */
@@ -518,7 +590,7 @@
   font-size: 12px;
   color: var(--fg-muted);
   background: rgba(var(--tint), 0.04);
-  border-top: 1px solid var(--border);
+  border-radius: 10px;
   text-align: center;
 }
 

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -513,12 +513,14 @@
 
 /* In light theme the card lifts to plain white and the dark-theme "darker
    well, lighter sheets" collapses (--bg and --bg-panel are both white);
-   invert it — white card, grey well (--bg-alt), plain white sheets. */
+   invert it — white card, grey wells (--bg-alt, the file thumb included),
+   plain white sheets. */
 :root[data-theme="light"] .fhb-card {
   background: var(--bg);
 }
 
-:root[data-theme="light"] .fhb-stack {
+:root[data-theme="light"] .fhb-stack,
+:root[data-theme="light"] .fhb-thumb {
   background: var(--bg-alt);
 }
 


### PR DESCRIPTION
## What

Rebuilds the explorer homepage folder-card stack to match the reference design: every entry is one **sheet card** (title row + page body), not a pill bar floating over a separate preview panel.

- Front sheet holds the peeked live view **inside itself** — one titlebar-plus-page unit, no seam; the front sheet is always the entry the preview belongs to
- Back sheets cascade diagonally (staggered left insets), bodies tucked behind the sheet in front; square bottom corners so the revealed edge reads as a page, never a closed pill
- Card hover fans the stack out, revealing a 20px live-preview strip of each back entry's own page (folders embed as their chrome-free listing)
- Card body sits in an inset rounded well (card carries the padding); separation carried by shadows instead of borders
- Light mode inverts: white card / grey wells / white sheets; all colors via theme tokens

## Before / after

| | Before | After |
|---|---|---|
| **Dark** | ![before dark](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/before-dark.png) | ![after dark](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/after-dark.png) |
| **Light** | ![before light](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/before-light.png) | ![after light](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/after-light.png) |

### Hover fan (after)

| Dark | Light |
|---|---|
| ![after dark hover](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/after-dark-hover.png) | ![after light hover](https://raw.githubusercontent.com/fusedio/fused-render/assets/pr-432-screenshots/after-light-hover.png) |

Screenshots live on the throwaway `assets/pr-432-screenshots` branch — delete it after merge.

## Testing

- `tsc --noEmit` clean
- `tests/test_theme.py` 128 passed (token-only colors enforced)
- Full pytest: 2042 passed; 2 `test_deploy.py` fails are pre-existing on clean origin/main (env-dependent)
- `bun test`: 8 `shortcut-chord.test.ts` fails also pre-existing on clean origin/main (platform-dependent); frontend CI is green
- Bugbot round 1 findings (front-sheet title/preview mismatch, light-mode thumb well) fixed in 4cb320ff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only explorer bookmark card layout and CSS; embed URLs and navigation behavior are unchanged aside from fixing front-sheet title/preview alignment.
> 
> **Overview**
> Redesigns explorer **folder bookmark** card bodies from overlapping **chip bars** plus a separate peek iframe to **stacked sheet cards** (title row + page body in one unit), with matching **`.fhb-sheet*`** styling in `preferences.css`.
> 
> **`FolderStack`** now pins the **front sheet** to the entry that owns the peek (direct best file or the probed subfolder via `subPeek.dir`), reorders `shown` so that entry is on top, and **defers rendering** until `settled` to avoid mid-probe reorder flicker. The main preview lives **inside** the front sheet; back sheets get **20px `LivePreview` strips** that fan on card hover. Item counts move into **`.fhb-sheet-note`** on the front sheet when there is nothing to peek.
> 
> Card chrome shifts to **inset rounded wells** (padding on `.fhb-card`, rounded thumbs/stack), **shadow-first** separation, larger header icons, and **light-theme** inversion (white card, grey wells, white sheets).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74775907f9d920aada2d8e507362fba1ab2cdf20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->