### PR TITLE
ui(claude): terminal handoff kebab, click-pinned highlight; History mode last

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -58,6 +58,7 @@ Actions:
 import json
 import os
 import re
+import shlex
 import shutil
 import signal
 import stat
@@ -600,6 +601,55 @@ def _migrate_session(file: str, session_id: str) -> None:
             _save_sidecar(file, data)
         except OSError:
             pass
+
+
+def _terminal_command(file: str, session_id: str = "") -> dict:
+    """The shell command that continues (or starts) this target's session in a
+    real terminal, for the page's "in terminal" menu item to put on the
+    clipboard.
+
+    Same session, same ground: the cwd is `_workdir` (the key everything else
+    here uses) and the fused-render skills ride along via the same
+    `--plugin-dir` the spawned runs get, so a session moved to the terminal
+    keeps the skills it was using. Deliberately NOT carried over: the headless
+    plumbing (-p, stream-json, the permission bridge, --append-system-prompt)
+    — that machinery exists because a browser page cannot be a terminal, and
+    an interactive `claude` brings its own. With a session id the transcript
+    is migrated first (the same copy-on-resume a browser resume does), so
+    `--resume` finds it from the cwd the command cd's into.
+
+    The binary is spelled `claude` when PATH resolves it — a command the user
+    reads and reuses should say what they would type — and falls back to the
+    located absolute path only when it doesn't."""
+    if not file:
+        return {"error": "missing target file (no _file param?)"}
+    workdir = _workdir(file)
+    if shutil.which("claude"):
+        binary = "claude"
+    else:
+        try:
+            binary = _claude_bin()
+        except RuntimeError:
+            # Not installed anywhere we know. Still hand over the command the
+            # user WOULD run — pasted, it produces the shell's own "command
+            # not found", which names the actual problem.
+            binary = "claude"
+    argv = [binary, *_plugin_argv()]
+    if session_id:
+        if _bad_id(session_id):
+            return {"error": "malformed session id"}
+        _migrate_session(file, session_id)
+        argv += ["--resume", session_id]
+    if os.name == "nt":
+        # cmd.exe quoting: bare when safe, double-quoted otherwise. shlex is
+        # POSIX-only and its output misleads on Windows.
+        def quote(s):
+            return '"' + s + '"' if (" " in s or not s) else s
+        command = "cd /d {} && {}".format(quote(workdir),
+                                          " ".join(quote(a) for a in argv))
+    else:
+        command = "cd {} && {}".format(shlex.quote(workdir), shlex.join(argv))
+    return {"command": command, "cwd": workdir}
 
 
 # ------------------------------------------------------------- tool approvals
@@ -2302,6 +2352,8 @@ def main(action: str = "start", file: str = "", message: str = "",
         # Asked for by the page BEFORE it composes a message, because that is
         # when it has crops to upload — see SHOTS for why this is not a run dir.
         return _shots_dir()
+    if action == "terminal_command":
+        return _terminal_command(file, session_id)
     if action == "cancel":
         return _cancel(run_id)
     return {"error": f"unknown action: {action}"}

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -629,7 +629,7 @@ def _terminal_command(file: str, session_id: str = "") -> dict:
     else:
         try:
             binary = _claude_bin()
-        except RuntimeError:
+        except FileNotFoundError:
             # Not installed anywhere we know. Still hand over the command the
             # user WOULD run — pasted, it produces the shell's own "command
             # not found", which names the actual problem.

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -334,6 +334,62 @@
   .mode-opt:hover, .mode-opt:focus-visible { background: var(--surface-2); }
   .mode-opt[aria-selected="true"] { color: var(--accent); }
 
+  /* More options (⋮) beside the annotate switch: trigger drawn as quiet as
+     #annbtn and #leftmodebtn (borderless, muted ink), popup drawn exactly like
+     #leftmodepop — same box, same shadow — because to the user they are the
+     same kind of thing: a small menu hanging off the strip. */
+  #kebab { position: relative; flex-shrink: 0; }
+  #kebabbtn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 22px;
+    height: 26px;
+    padding: 0;
+    font: inherit;
+    font-size: 14px;
+    line-height: 1;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--dim);
+    cursor: pointer;
+    transition: color .12s, background .12s;
+  }
+  #kebabbtn:hover, #kebabbtn[aria-expanded="true"] { color: var(--fg); background: var(--surface); }
+  #kebabpop {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    z-index: 30;
+    min-width: 196px;
+    padding: 4px;
+    background: var(--panel);
+    border: 1px solid var(--border-strong);
+    border-radius: 10px;
+    box-shadow: 0 6px 24px var(--shadow);
+  }
+  /* Same story as #leftmodepop: `position: absolute` outranks the UA's
+     `[hidden]` rule, so the hide needs a rule of its own. */
+  #kebabpop[hidden] { display: none; }
+  .kebab-opt {
+    display: block;
+    width: 100%;
+    padding: 7px 9px;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1;
+    white-space: nowrap;
+    border: 0;
+    border-radius: 7px;
+    background: none;
+    color: var(--fg);
+    cursor: pointer;
+    text-align: left;
+  }
+  .kebab-opt:hover, .kebab-opt:focus-visible { background: var(--surface-2); }
+  .kebab-opt[disabled] { color: var(--dim); cursor: default; }
+
   /* "Annotate preview" ⇄ "Back to chat" toggle. Exists for the NARROW layout only
      (see the 800px block at the end of this stylesheet): while both columns are on
      screen there is nothing to toggle, so it is display:none here and the media
@@ -1298,6 +1354,19 @@
       <button id="annbtn" type="button" aria-pressed="false" aria-label="Annotate the preview"
               title="Annotate the preview, then send the notes to Claude"><span
         class="lbl">Annotate</span><span class="track" aria-hidden="true"><span class="knob"></span></span></button>
+      <!-- More options (⋮), beside the annotate switch. One item today: hand
+           this session to a real terminal. The LABEL is decided at open time
+           (kebabOpen) because it names what the copied command will do —
+           "Continue in terminal" when a session id is on the URL, "New session
+           in terminal" from the landing page — and the id is a param that
+           changes without a reload. -->
+      <div id="kebab">
+        <button id="kebabbtn" type="button" aria-haspopup="menu" aria-expanded="false"
+                aria-label="More options" title="More options">⋮</button>
+        <div id="kebabpop" role="menu" aria-label="More options" hidden>
+          <button id="terminalopt" type="button" role="menuitem" class="kebab-opt"></button>
+        </div>
+      </div>
       <!-- Which view the LEFT pane frames. The popup ships EMPTY and the whole
            control `hidden`: the options are the target's own preview modes,
            which only the stat call in paneURL() knows, and there is no picker to
@@ -2937,6 +3006,13 @@ annFrame.addEventListener("load", () => {
   }, true);
   doc.addEventListener("mousemove", (e) => {
     if (!annOn) return;
+    // An open composer means the user CLICKED an element and is writing about
+    // it: the highlight is that element's, and a hover that drags it away
+    // makes the popover describe one box while the orange ring shows another.
+    // Frozen, not re-anchored — the composer doesn't follow scroll either, so
+    // the pair moves (and closes) together. Any close path (Esc, outside
+    // mousedown, save) lets this handler resume on the next move.
+    if (annPop.style.display === "block") return;
     const el = elementOf(e.target);
     if (!el || el === doc.body || el === doc.documentElement) {
       annHl.style.display = "none";
@@ -4068,6 +4144,68 @@ function enterChat() {
   chatEl.classList.remove("home");
   focusBox(box);
 }
+
+// ── more options (⋮): hand the session to a real terminal ──────────────
+// One menu item that copies a paste-ready shell command: `claude --resume
+// <id>` from the target's workdir when a session is on the URL, a fresh
+// `claude` from the same ground when there isn't. The command comes from
+// agent.py (action "terminal_command") because only it knows the workdir
+// rule, the plugin dir and the copy-on-resume transcript move — the page
+// just puts the string on the clipboard.
+const kebabBtn = document.getElementById("kebabbtn");
+const kebabPop = document.getElementById("kebabpop");
+const terminalOpt = document.getElementById("terminalopt");
+function kebabClose() {
+  kebabPop.hidden = true;
+  kebabBtn.setAttribute("aria-expanded", "false");
+}
+function kebabOpen() {
+  // Named at open time: the session param changes without a reload (back
+  // button, first turn of a new chat), so a label written once would lie.
+  terminalOpt.textContent = fused.params.get("session_id")
+    ? "Continue in terminal" : "New session in terminal";
+  terminalOpt.disabled = false;
+  kebabPop.hidden = false;
+  kebabBtn.setAttribute("aria-expanded", "true");
+  terminalOpt.focus();
+}
+kebabBtn.addEventListener("click", () => {
+  if (kebabPop.hidden) kebabOpen(); else kebabClose();
+});
+// Same dismissal contract as the view picker: outside click or Escape. The
+// frame's own mousedown can't bubble here, but entering the frame means
+// leaving the menu, and the pane sits outside this subtree, so the document
+// listener covers it.
+document.addEventListener("mousedown", (e) => {
+  if (!kebabPop.hidden && !e.composedPath().includes(document.getElementById("kebab"))) {
+    kebabClose();
+  }
+});
+kebabPop.addEventListener("keydown", (e) => {
+  if (e.key === "Escape") { e.stopPropagation(); kebabClose(); kebabBtn.focus(); }
+});
+terminalOpt.addEventListener("click", async () => {
+  const label = terminalOpt.textContent;
+  terminalOpt.disabled = true;
+  try {
+    const out = await fused.runPython(AGENT, {
+      action: "terminal_command",
+      file: FILE,
+      session_id: fused.params.get("session_id") || "",
+    }, { key: null });
+    if (out.error) throw new Error(out.error);
+    await navigator.clipboard.writeText(out.command);
+    // The copied state shows INSIDE the item, then the menu goes away on its
+    // own: the click's whole job was the clipboard, there is nothing further
+    // to do in an open menu.
+    terminalOpt.textContent = "Copied — paste in your terminal";
+    setTimeout(() => { kebabClose(); terminalOpt.textContent = label; }, 900);
+  } catch (err) {
+    terminalOpt.disabled = false;
+    terminalOpt.textContent = "Copy failed — " + (err && err.message || err);
+    setTimeout(() => { terminalOpt.textContent = label; }, 2500);
+  }
+});
 
 // ── log rendering ──
 function addUser(text) {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -3004,6 +3004,19 @@ annFrame.addEventListener("load", () => {
   doc.addEventListener("mousedown", () => {
     if (annPop.style.display === "block") annCloseComposer();
   }, true);
+  // One placement path for both writers: the hover follow below and the click
+  // handler's re-anchor. The click MUST place, not trust the last hover — on
+  // the "move the popover" flow the ring was frozen on the PREVIOUS element
+  // for the whole trip over (see the composer guard in mousemove), so at
+  // click time it shows the box the user just left.
+  const annPlaceHl = (el) => {
+    const r = annStageRect(el);
+    annHl.style.display = "block";
+    annHl.style.left = r.left + "px";
+    annHl.style.top = r.top + "px";
+    annHl.style.width = r.width + "px";
+    annHl.style.height = r.height + "px";
+  };
   doc.addEventListener("mousemove", (e) => {
     if (!annOn) return;
     // An open composer means the user CLICKED an element and is writing about
@@ -3018,12 +3031,7 @@ annFrame.addEventListener("load", () => {
       annHl.style.display = "none";
       return;
     }
-    const r = annStageRect(el);
-    annHl.style.display = "block";
-    annHl.style.left = r.left + "px";
-    annHl.style.top = r.top + "px";
-    annHl.style.width = r.width + "px";
-    annHl.style.height = r.height + "px";
+    annPlaceHl(el);
   });
   // Capture phase, everything swallowed while annotating — buttons and links
   // included: annotate mode exists precisely to point at controls without
@@ -3048,6 +3056,10 @@ annFrame.addEventListener("load", () => {
     anchor.tag = el.tagName.toLowerCase();
     const t = (el.textContent || "").trim().replace(/\s+/g, " ");
     if (t) anchor.text = t.slice(0, 80);
+    // Re-anchor the ring to what was CLICKED before freezing on it: the hover
+    // follow stops while a composer is open, so on a click that moves the
+    // popover the last-painted ring belongs to the previous element.
+    annPlaceHl(el);
     annOpenComposer(e.clientX, e.clientY, anchor);
   }, true);
   // Scroll and mutation storms coalesce to one re-render per frame.

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -4,23 +4,23 @@
     "structure",
     "h3",
     "claude",
-    "history",
-    "geometry_editor"
+    "geometry_editor",
+    "history"
   ],
   ".csv": [
     "duckdb",
     "excel",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".tsv": [
     "duckdb",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".xlsx": [
     "xlsx",
@@ -44,15 +44,15 @@
     "code",
     "duckdb",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".jsonl": [
     "code",
     "duckdb",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".ipynb": [
     "notebook",
@@ -75,8 +75,8 @@
     "code",
     "duckdb",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".csv.gz": [
     "duckdb",
@@ -124,43 +124,43 @@
     "tree",
     "code",
     "claude",
-    "history",
-    "geometry_editor"
+    "geometry_editor",
+    "history"
   ],
   ".md": [
     "markdown",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".markdown": [
     "markdown",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".tex": [
     "latex",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".ltx": [
     "latex",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".latex": [
     "latex",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".svg": [
     "image",
@@ -249,180 +249,180 @@
     "code",
     "api",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".js": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".ts": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".tsx": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".jsx": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".cjs": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".mjs": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".cts": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".mts": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".sh": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".zsh": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".fish": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".ps1": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".csh": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".zsh-theme": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".vim": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".yaml": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".yml": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".toml": [
     "canvas",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".ini": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".cfg": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".conf": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".tf": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".hcl": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".css": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".txt": [
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".log": [
     "log_studio",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".html": [
     "_render",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".htm": [
     "_render",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ],
   ".tif": [
     "geotiff",
@@ -447,10 +447,10 @@
     "_listing",
     "app",
     "claude",
-    "history",
     "git",
     "graph",
-    "zarr_aoi"
+    "zarr_aoi",
+    "history"
   ],
   ".zarr/": [
     "zarr_aoi",
@@ -611,7 +611,7 @@
     "plist",
     "code",
     "claude",
-    "history",
-    "reader"
+    "reader",
+    "history"
   ]
 }

--- a/tests/test_canvas_template.py
+++ b/tests/test_canvas_template.py
@@ -108,7 +108,7 @@ def _write_canvas(dir_path, name="canvas.toml", body=CANVAS_TOML):
 def test_canvas_toml_gets_canvas_mode_first(tmp_path):
     p = _write_canvas(tmp_path / "cv")
     m, error = modes(str(p))
-    assert m == ["canvas", "code", "claude", "history", "reader"]
+    assert m == ["canvas", "code", "claude", "reader", "history"]
     assert error is None
     entries, _ = _server_templates._templates_for(str(p), False)
     assert entries[0]["path"].endswith("canvas/template.html")
@@ -134,7 +134,7 @@ def test_plain_toml_denied_canvas_mode(tmp_path):
     p.write_text("[tool.black]\nline-length = 88\n")
     m, error = modes(str(p))
     # stat still lists canvas (marked conditional, gate not run at stat time)
-    assert m == ["canvas", "code", "claude", "history", "reader"]
+    assert m == ["canvas", "code", "claude", "reader", "history"]
     assert error is None
     allowed, err = canvas_verdict(str(p))
     assert allowed is False  # basename pre-check denies it

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -1118,14 +1118,16 @@ def test_the_registry_binds_the_split_view_to_files_and_keeps_the_directory_key(
     # mode needed a display name of its own.
     assert registry["/"].count("claude") == 1
 
-    # Chat then history, adjacent, on every FILE key that has them. The `/` key
-    # is excluded deliberately: its order is the directory story (`_listing`,
-    # then the app modes, then the chat and the two history views).
+    # Chat before history on every FILE key that has them — no longer adjacent:
+    # `history` trails every list it is bound to
+    # (test_templates.py::test_history_is_the_last_mode_wherever_bound). The
+    # `/` key is excluded deliberately: its order is the directory story
+    # (`_listing`, then the app modes, then the chat and the history views).
     for key, names in registry.items():
         if key.endswith("/") or not isinstance(names, list):
             continue
         if "claude" in names and "history" in names:
-            assert names.index("claude") + 1 == names.index("history"), key
+            assert names.index("claude") < names.index("history"), key
 
 
 def test_the_gates_docstring_does_not_justify_itself_with_the_deleted_pane():

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -79,9 +79,11 @@ def test_builtin_html_default_is_render_sentinel():
     assert error is None
     # One timeline mode, and it is called `history`: the old standalone history
     # view is gone and `versions` was renamed into its name, icon and slot
-    # (D243). No `git` either — that is folder-only now (GT-2).
+    # (D243). No `git` either — that is folder-only now (GT-2). It sits LAST in
+    # every list it is bound to: a timeline is a view about the file, not a way
+    # to read it.
     assert [e["mode"] for e in entries] == [
-        "_render", "code", "claude", "history", "reader"]
+        "_render", "code", "claude", "reader", "history"]
     assert entries[0]["path"] is None and entries[0]["icon"] is None
     assert entries[1]["path"].endswith("code/template.html")
     assert entries[2]["path"].endswith("claude/template.html")
@@ -90,36 +92,39 @@ def test_builtin_html_default_is_render_sentinel():
 def test_builtin_parquet_default_is_duckdb():
     entries, error = server._templates_for("/x/data.parquet", False)
     assert error is None
-    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude", "history",
-            "geometry_editor"]
+    assert [e["mode"] for e in entries] == ["duckdb", "structure", "h3", "claude",
+            "geometry_editor", "history"]
     assert entries[0]["path"].endswith("duckdb/template.html")
 
 
 # ------------------------------------------------------------ reader mode (RD)
 #
-# `reader` (listen/TTS mode, templates/reader/) is the LAST mode on text-bearing
-# keys — it used to sit immediately before `annotate`, which is deregistered as of
-# D235 (the annotation tools live in the claude pane now, not in a mode of
-# their own). It is deliberately absent from binary/visual keys (images, 3D, geo,
-# media, archives, parquet data).
+# `reader` (listen/TTS mode, templates/reader/) is the LAST content-facing mode
+# on text-bearing keys — it used to sit immediately before `annotate`, which is
+# deregistered as of D235 (the annotation tools live in the claude pane now,
+# not in a mode of their own). It is deliberately absent from binary/visual
+# keys (images, 3D, geo, media, archives, parquet data). Only `history` — a
+# view ABOUT the file rather than of it — sits after it.
 
 
 def test_reader_is_the_last_mode_on_text_keys():
     # Reader trails every real view on representative text formats, and is never
     # the default (first entry stays the content view).
     cases = {
-        "/x/notes.md": ["markdown", "code", "claude", "history", "reader"],
-        "/x/data.csv": ["duckdb", "excel", "code", "claude", "history",
-                        "reader"],
+        "/x/notes.md": ["markdown", "code", "claude", "reader", "history"],
+        "/x/data.csv": ["duckdb", "excel", "code", "claude", "reader",
+                        "history"],
         "/x/paper.pdf": ["pdf", "pdf_studio", "reader"],
-        "/x/log.txt": ["code", "claude", "history", "reader"],
+        "/x/log.txt": ["code", "claude", "reader", "history"],
     }
     for path, expected in cases.items():
         got, error = modes(path)
         assert error is None, path
         assert got == expected, path
         assert got[0] != "reader", path       # never the default
-        assert got[-1] == "reader", path      # always last
+        # last among the CONTENT views: only the history timeline may follow
+        rest = [m for m in got if m != "history"]
+        assert rest[-1] == "reader", path
 
 
 def test_no_builtin_key_binds_text():
@@ -193,17 +198,33 @@ def test_history_survives_on_every_key_git_left():
         assert "history" in got, path
 
 
-def test_git_follows_history_immediately_on_the_directory_key():
-    # The one list that still holds both: the working tree and its history sit
-    # together in switcher order.
+def test_history_trails_git_on_the_directory_key():
+    # The one list that still holds both. They used to sit together with the
+    # timeline first; `history` now trails the whole list like it does on every
+    # key (history-last, below), so the working tree reads first.
     got, _ = modes("/x/somedir", is_dir=True)
-    assert got.index("history") + 1 == got.index("git")
+    assert got.index("git") < got.index("history")
+    assert got[-1] == "history"
+
+
+def test_history_is_the_last_mode_wherever_bound():
+    # The history timeline is a view ABOUT the target, not of it, so it trails
+    # everything: content views, the chat, the working tree, reader. Derived
+    # from the registry rather than a hand-picked path list, so a key bound
+    # later is covered.
+    with open(os.path.join(server.TEMPLATES_DIR, "registry.json"),
+              encoding="utf-8") as f:
+        registry = json.load(f)
+    offenders = [k for k, v in registry.items()
+                 if isinstance(v, list) and "history" in v and v[-1] != "history"]
+    assert offenders == []
 
 
 def test_the_file_side_history_and_chat_are_history_and_claude():
     # The other half of the same split: what `git` and `claude` stopped offering
-    # on a file, `history` and `claude` now do — and in that order, chat
-    # then history, on every key that has them.
+    # on a file, `history` and `claude` now do — chat ahead of the timeline,
+    # which trails the whole list (history-last, above), on every key that has
+    # them.
     for path in ["/x/mod.py", "/x/app.tsx", "/x/deploy.sh", "/x/site.css",
                  "/x/config.yaml", "/x/pyproject.toml", "/x/tsconfig.json",
                  "/x/main.tf", "/x/notes.md", "/x/paper.tex",
@@ -213,7 +234,8 @@ def test_the_file_side_history_and_chat_are_history_and_claude():
         assert error is None, path
         assert "claude" in got, path
         assert "history" in got, path
-        assert got.index("claude") + 1 == got.index("history"), path
+        assert got.index("claude") < got.index("history"), path
+        assert got[-1] == "history", path
         assert got[0] not in ("claude", "history"), path  # never default
 
 
@@ -253,12 +275,13 @@ def test_git_is_never_the_default_mode():
 
 
 def test_the_file_side_pair_sits_before_the_trailing_meta_mode():
-    # `reader` trails everything (RD); the chat/history pair slots in ahead of it
-    # rather than after, so the content views and then the companion views read
-    # left to right.
+    # The chat slots in ahead of `reader` (RD) so the content views and then
+    # the companion views read left to right; the history timeline is the one
+    # thing meta enough to sit after reader (history-last, above).
     for path in ["/x/mod.py", "/x/notes.md", "/x/readme.txt"]:
         got, _ = modes(path)
-        assert got.index("history") < got.index("reader"), path
+        assert got.index("claude") < got.index("reader"), path
+        assert got.index("reader") < got.index("history"), path
 
 
 def test_the_file_side_pair_is_absent_from_media_and_binary_keys():
@@ -279,12 +302,12 @@ def test_gated_directory_peers_follow_the_listing():
     # `_listing` stays the default of the universal `/` key (D81); the gated
     # peers follow it in switcher order (left to right). `app` (the app itself,
     # full-bleed — what OPENING an app lands on) leads them, then the split
-    # build view, then `history` ahead of `git` — for an app folder the version
-    # timeline is what you want first, and the raw commit log sits one click
-    # further (#361).
+    # build view and the working tree; `history` trails the whole list like it
+    # does on every key (history-last, above), which supersedes #361's
+    # timeline-ahead-of-git ordering.
     got, error = modes("/x/somedir", is_dir=True)
     assert error is None
-    assert got == ["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"]
+    assert got == ["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"]
 
 
 def test_git_ships_a_condition_gate_and_an_icon():
@@ -335,9 +358,9 @@ def test_unmapped_file_empty_and_plain_dir_lists():
     # `zarr_aoi` — for a plain folder, a dotted folder and the filesystem root
     # alike. Each gated mode is dropped unless its condition.py says otherwise;
     # see tests/test_graph_condition.py and the zarr_aoi tests below.
-    assert modes("/x/somedir", is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
-    assert modes("/x/my.data", is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
-    assert modes("/", is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
+    assert modes("/x/somedir", is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
+    assert modes("/x/my.data", is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
+    assert modes("/", is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
 
 
 # --------------------------------------------- text sniff for unmapped files
@@ -776,7 +799,7 @@ def test_registry_drops_zarr_template_and_sentinel_keys():
     assert server._resolve_name("zarr")[0] is None
     # zarr_aoi is the .zarr/ default and a gated candidate on every directory
     assert registry[".zarr/"] == ["zarr_aoi", "_listing"]
-    assert registry["/"] == ["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"]
+    assert registry["/"] == ["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"]
 
 
 def test_zarr_named_dir_gate_true_with_no_markers(tmp_path):
@@ -807,7 +830,7 @@ def test_plain_dir_with_store_marker_gates_true(tmp_path, marker):
     store = tmp_path / "data"
     store.mkdir()
     (store / marker).write_text("{}")
-    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
     assert cond == {"app": False, "claude": True, "git": False, "history": False, "graph": False, "zarr_aoi": True} and err is None
@@ -819,7 +842,7 @@ def test_v3_group_dir_offered(tmp_path):
     store = tmp_path / "grp"
     store.mkdir()
     (store / "zarr.json").write_text('{"zarr_format": 3, "node_type": "group"}')
-    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
     assert _zarr_condition_main()(str(store)) is True
     cond, err = conditions(str(store))
     assert cond == {"app": False, "claude": True, "git": False, "history": False, "graph": False, "zarr_aoi": True} and err is None
@@ -870,7 +893,7 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     store = tmp_path / "plain"
     store.mkdir()
     (store / "readme.txt").write_text("hi")
-    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "history", "git", "graph", "zarr_aoi"], None)
+    assert modes(str(store), is_dir=True) == (["_listing", "app", "claude", "git", "graph", "zarr_aoi", "history"], None)
     assert _zarr_condition_main()(str(store)) is False
     cond, err = conditions(str(store))
     assert cond == {"app": False, "claude": True, "git": False, "history": False, "graph": False, "zarr_aoi": False} and err is None
@@ -879,10 +902,10 @@ def test_plain_dir_without_markers_gates_false(tmp_path):
     assert entries[0]["mode"] == "_listing" and "conditional" not in entries[0]
     assert entries[1]["mode"] == "app" and entries[1].get("conditional") is True
     assert entries[2]["mode"] == "claude" and entries[2].get("conditional") is True
-    assert entries[3]["mode"] == "history" and entries[3].get("conditional") is True
-    assert entries[4]["mode"] == "git" and entries[4].get("conditional") is True
-    assert entries[5]["mode"] == "graph" and entries[5].get("conditional") is True
-    assert entries[6]["mode"] == "zarr_aoi" and entries[6].get("conditional") is True
+    assert entries[3]["mode"] == "git" and entries[3].get("conditional") is True
+    assert entries[4]["mode"] == "graph" and entries[4].get("conditional") is True
+    assert entries[5]["mode"] == "zarr_aoi" and entries[5].get("conditional") is True
+    assert entries[6]["mode"] == "history" and entries[6].get("conditional") is True
     # `claude` used to sit at index 3 as the one UNCONDITIONAL entry after
     # `_listing` — the "no condition.py at all" case this list also covered. It is
     # deleted; `_listing` at index 0 still covers it.


### PR DESCRIPTION
Follow-up to #429 (merged mid-flight — this carries the third round, rebased onto the post-#430 rename where the mode key is `history`).

## What

1. **Terminal handoff (⋮ kebab)** beside the Annotating switch, in both views. One menu item copies a paste-ready shell command:
   - **"Continue in terminal"** when a session is on the URL → `cd <workdir> && claude --plugin-dir … --resume <session_id>`
   - **"New session in terminal"** from the landing page → same ground, fresh `claude`
   agent.py builds the command (new action `terminal_command`): same workdir rule, same `--plugin-dir` skills, copy-on-resume transcript migration — none of the headless plumbing (`-p`, stream-json, the permission bridge), which an interactive `claude` brings itself.
2. **Annotate highlight pins on click.** The orange ring follows the cursor only while nothing is clicked; once an element is clicked and the note composer opens, the highlight sticks to that element until the composer closes (Esc, outside click, save), then hover-follow resumes.
3. **History is the last mode everywhere.** `history` moves to the end of every registry list it is bound to (43 keys) — a timeline is a view about the file, not a way to read it. Pinned as a registry-wide rule by `test_history_is_the_last_mode_wherever_bound`; ordering tests updated across `test_templates.py`, `test_canvas_template.py`, `test_claude_kind.py` (chat-before-history stays, adjacency is gone; #361's timeline-ahead-of-git on `/` is superseded).

## Screenshots

| Kebab — Continue in terminal | Kebab — New session in terminal (home) |
|---|---|
| ![kebab continue](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/kebab-continue.png) | ![kebab new](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/kebab-new.png) |

| Mode menu — History last | Highlight pinned while composer open |
|---|---|
| ![mode menu](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/mode-menu.png) | ![highlight stick](https://raw.githubusercontent.com/fusedio/fused-render/assets/20260810-button-rearrange/.pr-assets/highlight-stick.png) |

(Screenshots on the throwaway `assets/20260810-button-rearrange` branch — delete after merge.)

## Testing

- `pytest tests/` — 4664 passed; 3 failures are environment-only on macOS (`/proc/self/fd`, pip-installable probe), untouched.
- Verified live with Playwright against a dev server on this branch: menu order `Rendered / Code / Claude / Reader / History`, kebab labels + actual clipboard contents for both states, highlight rect identical before/after mousemove with the composer open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly UI and registry ordering; `terminal_command` reuses existing workdir, plugin, and session-migration logic without altering in-browser chat runs.
> 
> **Overview**
> **Terminal handoff:** A **⋮** menu next to Annotate offers **Continue in terminal** or **New session in terminal** (label depends on `session_id` on the URL). Choosing it calls agent action **`terminal_command`**, which builds `cd <workdir> && claude …` with the same **`--plugin-dir`** skills and optional **`--resume`** after **`_migrate_session`**—without headless flags (`-p`, stream-json, permission bridge, appended system prompt). The page copies the command to the clipboard and shows brief success/error feedback.
> 
> **Annotate UX:** While the note composer is open, the orange highlight **stops following the mouse** and stays on the clicked element; on click, the ring is **re-anchored** to that element before opening the composer (fixes mismatch when moving the popover).
> 
> **Mode switcher order:** **`history`** is moved to the **last** slot on every registry list that includes it (content views and **`reader`** precede it; directory lists put **`git`** before **`history`**). Tests enforce **`test_history_is_the_last_mode_wherever_bound`** and related ordering expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 860d0d9a5ba33a79bc9d02b6414f2095b7a79c58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->