### PR TITLE
Explorer chrome pass (no Up button, crumb-selects-origin, folder-owned bar) + a default-model preference

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1520,16 +1520,32 @@ never imports server).
 ### 20.1 Store & endpoints
 
 - **PF-1** `GET /api/prefs` → `{engine: {selected, effective, forced_by,
-  fused_available}, deploy: {enabled}, reader: {enabled}, calls: {…}}` — and no
+  fused_available}, deploy: {enabled}, reader: {enabled}, model: {default,
+  choices}, calls: {…}}` — and no
   `log` block (PF-5). `PUT /api/prefs`
   (X-Fused) applies a **partial** update — any of `engine`, `deploy_enabled`,
-  `reader_enabled`, `calls_enabled`, `calls_params` or `calls_retention_days`
-  present, so each control PUTs only its own field — and
+  `reader_enabled`, `default_model`, `calls_enabled`, `calls_params` or
+  `calls_retention_days` present, so each control PUTs only its own field — and
   returns the same shape. An unknown engine value, a non-boolean
   `deploy_enabled`, or a body naming no known preference → 400; the file merges
   (future prefs are new keys, not new files).
+- **PF-1b** `default_model` is the user's preferred Claude model as a **short
+  name** — `""` (unset), `fable`, `opus`, `sonnet` or `haiku`, the claude
+  template's own selector vocabulary; anything else → 400, and a hand-edited
+  unknown value in the file reads as unset. Two consumers rank it identically:
+  an **explicit** choice always wins, the preference is next, and each keeps its
+  own hardcoded fallback beneath it. For the fused.ai relay (`server/ai.py`)
+  that is a caller-supplied `model` > the pref > `claude-haiku-4-5-20251001`,
+  with the short→full-id mapping (`fable`→`claude-fable-5`,
+  `opus`→`claude-opus-5`, `sonnet`→`claude-sonnet-5`,
+  `haiku`→`claude-haiku-4-5`) living in that one module. For the claude chat
+  template it is the `model` pane param > the config detected from the
+  project's sessions/settings > the pref > `sonnet`; the template reads it with
+  a plain `GET /api/prefs`, like its other `/api/…` reads. Read per request, so
+  a change applies without a restart.
 - **PF-1a** The page renders its sections in this order: **Appearance**,
-  **Call log**, **Deploy to Fused account**, **Accessibility**, and last
+  **Default model**, **Call log**, **Deploy to Fused account**,
+  **Accessibility**, and last
   **Execution engine** — last because it is the setting a user is least likely
   to have come here to change (builtin suits almost everyone, and an env var
   pins it where it matters). There is **no Tour button**: the tour still runs

--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -24,6 +24,8 @@
 // fourth.
 import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { modeTitle } from "@platform/lib/mode-name";
+import { copyToClipboard } from "@platform/lib/clipboard";
+import { pushToast } from "@platform/lib/toast";
 
 // Keep the popup on screen: it is right-aligned to the trigger in spirit, but
 // clamping the LEFT edge is what actually matters near the window's edge.
@@ -237,6 +239,40 @@ export function ModeMenu({ entries, active, busy, onSelect }: ModeMenuProps) {
 export interface OverflowItem {
   label: string;
   onClick: () => void;
+}
+
+// The path `···`: the two low-frequency one-shots every view OF A PATH offers.
+// It lives here rather than in the bar that used to own it because it now has
+// two homes — the crumb bar's layout zone for a file/preview, and the
+// listing's own search row for a folder (Listing.tsx; the handover is
+// listing/folder-chrome.ts) — and one definition is what makes "the same
+// items, wherever it sits" true rather than merely intended.
+const FILE_MANAGER = navigator.userAgent.includes("Windows") ? "File Explorer" : "Finder";
+
+// Browsers block file:// navigation from http pages, so revealing in the OS
+// file manager goes through the server (POST /api/fs/reveal). X-Fused forces
+// a CORS preflight so a foreign page can't fire this blind (D3 guard).
+function revealInFileManager(path: string): void {
+  fetch("/api/fs/reveal", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "X-Fused": "1" },
+    body: JSON.stringify({ path }),
+  });
+}
+
+export function PathOverflow({ fsPath }: { fsPath: string }) {
+  const copyPath = async () => {
+    if (await copyToClipboard(fsPath)) pushToast({ msg: "Path copied", tone: "info" });
+    else pushToast({ msg: "Couldn't copy the path", tone: "error" });
+  };
+  return (
+    <OverflowMenu
+      items={[
+        { label: "Open in " + FILE_MANAGER, onClick: () => revealInFileManager(fsPath) },
+        { label: "Copy path", onClick: () => void copyPath() },
+      ]}
+    />
+  );
 }
 
 // `···` menu for the bars' layout zone. Renders nothing when it has no items,

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -12,7 +12,8 @@
 //
 // Rendered by every view: path crumbs for listing/preview, a static label for
 // the layout modes (LM-11 / TM-9 — ★/update still operate on currentUrl()).
-import React, { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
+import { createPortal } from "react-dom";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
 import { navigate, navigateUrl, currentUrl, IS_EMBED } from "@platform/lib/router";
 import { basename } from "@platform/lib/format";
@@ -40,8 +41,10 @@ import { springDisarms } from "@apps/explorer/listing/drag-drop";
 import { cameFromSelParam } from "@apps/explorer/listing/selection";
 import {
   folderChromeClaimed,
+  folderChromeSlot,
   subscribeFolderChrome,
 } from "@apps/explorer/listing/folder-chrome";
+import { publishTopbarSlot, retractTopbarSlot } from "@apps/explorer/topbar-slot";
 import { registerSpring, SPRING_ATTR } from "@apps/explorer/listing/row-drag";
 
 // How long a file drag has to hover a crumb before the listing follows it.
@@ -316,8 +319,16 @@ export function UpdateBookmarkButton() {
 // Portal target for the view's header actions (mode switcher, deploy, "Open as
 // app") — Preview renders into this via TopbarActions. Carries
 // .preview-actions so the existing switcher/button styling applies unchanged.
+// The node is published rather than looked up by id, because the bar relocates
+// under a folder view and the lookup would go stale (topbar-slot.ts).
 function TopbarActionsSlot() {
-  return <div id="topbar-mode-slot" className="crumb-actions preview-actions" />;
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) publishTopbarSlot(el);
+    return () => retractTopbarSlot(el);
+  }, []);
+  return <div ref={ref} id="topbar-mode-slot" className="crumb-actions preview-actions" />;
 }
 
 // Split entry (LM-10): two panes side by side (`dir` "row", `,` in the codec)
@@ -371,6 +382,33 @@ async function openUrl(url: string, scheme: string): Promise<void> {
     return;
   }
   pushToast({ msg: `Can't open ${scheme}:// URLs in the explorer`, tone: "error" });
+}
+
+// The crumb bar AND its box, in whichever column it belongs to.
+//
+// Normally that is shell level: `#breadcrumb` is a child of `#main`, above
+// `#content`, spanning the window. Over a FOLDER the listing publishes a slot
+// in its own left column (listing/folder-chrome.ts) and the whole bar portals
+// into it — so the bar ends at the split divider and the preview pane on the
+// right starts at the very top of the window, its own header the first thing
+// in the column. Nothing about the bar's markup or styling changes; only where
+// it hangs.
+//
+// A portal, not a prop, for the reason the claim store exists at all: whether
+// the content resolves to a listing is decided several levels below the bar,
+// after this component has rendered.
+export function BreadcrumbBar(props: {
+  fsPath: string;
+  home?: string;
+  renderedTitle?: string | null;
+}) {
+  const slot = useSyncExternalStore(subscribeFolderChrome, folderChromeSlot, () => null);
+  const bar = (
+    <div id="breadcrumb">
+      <Breadcrumb {...props} />
+    </div>
+  );
+  return slot ? createPortal(bar, slot) : bar;
 }
 
 export function Breadcrumb({

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -38,6 +38,7 @@ import { panelUrl } from "@apps/explorer/Panel";
 import { SplitRightIcon, SplitDownIcon } from "@platform/ui/SplitIcons";
 import { OverflowMenu } from "@apps/explorer/BarMenu";
 import { springDisarms } from "@apps/explorer/listing/drag-drop";
+import { cameFromSelParam } from "@apps/explorer/listing/selection";
 import { registerSpring, SPRING_ATTR } from "@apps/explorer/listing/row-drag";
 
 // How long a file drag has to hover a crumb before the listing follows it.
@@ -491,7 +492,12 @@ export function Breadcrumb({
         // `claude` view read as "nothing happened"). navigate() still carries
         // the sticky `preview` onto directory targets, so pane visibility
         // survives the hop. Breadcrumb targets are always dirs.
-        navigate(underHome ? home : "/", { isDir: true });
+        //
+        // `sel` lands the ancestor with the child we came out of highlighted
+        // and scrolled to — the file-manager rule, shared with the keyboard's
+        // go-up chord (listing/useListingShortcuts) through one pure decision.
+        const target = underHome ? (home as string) : "/";
+        navigate(target, { isDir: true, sel: cameFromSelParam(target, fsPath) });
       }}
     >
       {underHome ? "~" : "/"}
@@ -535,7 +541,9 @@ export function Breadcrumb({
           {...springProps(target)}
           onClick={(e) => {
             e.preventDefault();
-            navigate(target, { isDir: true }); // plain listing, no `_mode`
+            // Plain listing, no `_mode`; `sel` highlights the child we came
+            // out of (see the root crumb above).
+            navigate(target, { isDir: true, sel: cameFromSelParam(target, fsPath) });
           }}
         >
           {part}

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -12,7 +12,7 @@
 //
 // Rendered by every view: path crumbs for listing/preview, a static label for
 // the layout modes (LM-11 / TM-9 — ★/update still operate on currentUrl()).
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
 import { navigate, navigateUrl, currentUrl, IS_EMBED } from "@platform/lib/router";
 import { basename } from "@platform/lib/format";
@@ -32,13 +32,16 @@ import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "@pla
 import { urlScheme, isCloudScheme, fileUrlToPath } from "@platform/lib/path-url";
 import { resolveCloudUrl } from "@platform/lib/api";
 import { pushToast } from "@platform/lib/toast";
-import { copyToClipboard } from "@platform/lib/clipboard";
 import { encodePaneSegment, splitShellSearch } from "@platform/lib/layout-codec";
 import { panelUrl } from "@apps/explorer/Panel";
 import { SplitRightIcon, SplitDownIcon } from "@platform/ui/SplitIcons";
-import { OverflowMenu } from "@apps/explorer/BarMenu";
+import { PathOverflow } from "@apps/explorer/BarMenu";
 import { springDisarms } from "@apps/explorer/listing/drag-drop";
 import { cameFromSelParam } from "@apps/explorer/listing/selection";
+import {
+  folderChromeClaimed,
+  subscribeFolderChrome,
+} from "@apps/explorer/listing/folder-chrome";
 import { registerSpring, SPRING_ATTR } from "@apps/explorer/listing/row-drag";
 
 // How long a file drag has to hover a crumb before the listing follows it.
@@ -183,40 +186,17 @@ function StarIcon({ filled }: { filled: boolean }) {
   );
 }
 
-// Browsers block file:// navigation from http pages, so revealing in the OS
-// file manager goes through the server (POST /api/fs/reveal). X-Fused forces
-// a CORS preflight so a foreign page can't fire this blind (D3 guard).
-function revealInFileManager(path: string): void {
-  fetch("/api/fs/reveal", {
-    method: "POST",
-    headers: { "Content-Type": "application/json", "X-Fused": "1" },
-    body: JSON.stringify({ path }),
-  });
-}
-
-const FILE_MANAGER = navigator.userAgent.includes("Windows") ? "File Explorer" : "Finder";
-
-// The bar's low-frequency one-shot actions. Both used to be (or wanted to be)
-// glyphs in the crumb strip; neither is worth a permanent slot beside the
-// splits, which is exactly what an overflow menu is for.
-function LayoutOverflow({ fsPath }: { fsPath: string }) {
-  const copyPath = async () => {
-    if (await copyToClipboard(fsPath)) pushToast({ msg: "Path copied", tone: "info" });
-    else pushToast({ msg: "Couldn't copy the path", tone: "error" });
-  };
-  return (
-    <OverflowMenu
-      items={[
-        { label: "Open in " + FILE_MANAGER, onClick: () => revealInFileManager(fsPath) },
-        { label: "Copy path", onClick: () => void copyPath() },
-      ]}
-    />
-  );
-}
-
-// Split entry buttons + the overflow: the bar's layout zone, in the same
-// position in every state so the hand learns where layout lives.
+// Split entry buttons + the path overflow: the bar's layout zone, in the same
+// position in every state so the hand learns where layout lives — EXCEPT over
+// a folder, where the listing underneath claims the zone and renders the `···`
+// in its own search row instead (listing/folder-chrome.ts says which state we
+// are in; Listing.tsx renders the other half). Nothing here for a folder at
+// all: the splits are the pair that make least sense over a view that already
+// IS a split, and with them gone the rule and the hairline would be a zone
+// with nothing in it.
 function LayoutZone({ fsPath }: { fsPath: string }) {
+  const claimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
+  if (claimed) return null;
   return (
     <>
       <span className="bar-rule" aria-hidden="true" />
@@ -241,7 +221,7 @@ function LayoutZone({ fsPath }: { fsPath: string }) {
         >
           <SplitDownIcon />
         </button>
-        <LayoutOverflow fsPath={fsPath} />
+        <PathOverflow fsPath={fsPath} />
       </div>
     </>
   );

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -3,6 +3,8 @@
 //   path    ★ bookmark button, then the crumbs (or the editable path field)
 //   mode    the `#topbar-mode-slot` portal target — Preview renders the view's
 //           conditional primary action and the shared mode control into it
+//   search  over a FOLDER only: the listing's search row portals in here, so
+//           its column has one header strip instead of two (search-slot.ts)
 //   layout  a hairline rule, then split-right / split-down / `···`
 //
 // The Finder and split glyphs used to live INSIDE the crumb strip, welded to
@@ -45,6 +47,7 @@ import {
   subscribeFolderChrome,
 } from "@apps/explorer/listing/folder-chrome";
 import { publishTopbarSlot, retractTopbarSlot } from "@apps/explorer/topbar-slot";
+import { publishSearchSlot, retractSearchSlot } from "@apps/explorer/search-slot";
 import { registerSpring, SPRING_ATTR } from "@apps/explorer/listing/row-drag";
 
 // How long a file drag has to hover a crumb before the listing follows it.
@@ -189,14 +192,36 @@ function StarIcon({ filled }: { filled: boolean }) {
   );
 }
 
+// Portal target for the FOLDER view's search row, at the bar's right end.
+//
+// Rendered only while a folder holds the chrome claim: a file view's bar has
+// no search box, and an empty div would still eat the bar's `gap`. The listing
+// portals its own `.listing-search` in here — box, sort chip and the path
+// `···` — so the left column has ONE strip, matching the preview pane's one
+// strip across the divider (search-slot.ts).
+function FolderSearchSlot() {
+  const claimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
+  const ref = useRef<HTMLDivElement>(null);
+  // A layout effect, and the cleanup is identity-checked (node-slot.ts): the
+  // bar's own relocation into the listing column rebuilds this node, and the
+  // outgoing one is retracted after the incoming one has published.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) publishSearchSlot(el);
+    return () => retractSearchSlot(el);
+  }, [claimed]);
+  if (!claimed) return null;
+  return <div className="crumb-search-slot" ref={ref} />;
+}
+
 // Split entry buttons + the path overflow: the bar's layout zone, in the same
 // position in every state so the hand learns where layout lives — EXCEPT over
 // a folder, where the listing underneath claims the zone and renders the `···`
-// in its own search row instead (listing/folder-chrome.ts says which state we
-// are in; Listing.tsx renders the other half). Nothing here for a folder at
-// all: the splits are the pair that make least sense over a view that already
-// IS a split, and with them gone the rule and the hairline would be a zone
-// with nothing in it.
+// at the end of the search row that has just moved into this bar
+// (listing/folder-chrome.ts says which state we are in; Listing.tsx renders
+// the other half). Nothing here for a folder at all: the splits are the pair
+// that make least sense over a view that already IS a split, and with them
+// gone the rule and the hairline would be a zone with nothing in it.
 function LayoutZone({ fsPath }: { fsPath: string }) {
   const claimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
   if (claimed) return null;
@@ -612,6 +637,7 @@ export function Breadcrumb({
       )}
       <UpdateBookmarkButton />
       <TopbarActionsSlot />
+      <FolderSearchSlot />
       <LayoutZone fsPath={fsPath} />
     </>
   );

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -219,19 +219,9 @@ export default function Listing({
 
   const base = fsPath.replace(/\/$/, "");
 
-  // "Up" navigation for the button beside the search box: hop to the parent
-  // folder. It does NOT seed the parent's `?sel=` with the folder you came
-  // from: navigate() starts every folder on a fresh query string (router.ts),
-  // and the parent lands on its first entry like any other folder open — the
-  // param restores a selection, it does not carry one across. Disabled at
-  // the filesystem / drive root, where dirname collapses to the folder itself.
-  const here = normDir(base);
-  const parentDir = dirname(here);
-  const atRoot = parentDir === here;
-  const goUp = () => {
-    if (atRoot) return;
-    navigate(parentDir, { isDir: true });
-  };
+  // No "Up" BUTTON beside the search box any more: the crumb strip above is
+  // the same hop with a target the user can name, and the keyboard keeps its
+  // own (Mod+Up / bare Backspace — see listing/useListingShortcuts).
 
   // Tell the caller whether this folder's top level holds exactly one HTML
   // ("app") file. Keyed off the plain listing, not the search results — the
@@ -940,28 +930,6 @@ export default function Listing({
               and the host listing's search/toggle already own that chrome. */}
           {!embedded && (
             <div className="listing-search">
-              <button
-                type="button"
-                className="bar-ctl bar-ctl-icon"
-                title={atRoot ? "Already at the root" : "Up to parent folder"}
-                aria-label="Up to parent folder"
-                disabled={atRoot}
-                onClick={goUp}
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  width="16"
-                  height="16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <line x1="12" y1="19" x2="12" y2="5" />
-                  <polyline points="5 12 12 5 19 12" />
-                </svg>
-              </button>
               {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin.
             `has-pin` says a chip is actually pinned right now, so the input

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -1021,7 +1021,12 @@ export default function Listing({
                   ref={searchInputRef}
                   type="search"
                   className="listing-search-input"
-                  placeholder="Start typing to search…"
+                  // Just "Search…": the row shares the crumb bar now, and the
+                  // resting box is deliberately small (it grows to the whole
+                  // strip on the first keystroke), so the placeholder has to
+                  // fit that box rather than set its width. "Start typing to
+                  // search" was instructions for a control that needs none.
+                  placeholder="Search…"
                   value={query}
                   onFocus={prefetchWalk}
                   onChange={(e) => setQuery(e.target.value)}

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -25,7 +25,16 @@
 //   useRowDrag.ts          what a press picks up + who performs the drop
 //   shortcut-chord.ts       which chord means which action (pure)
 //   useListingShortcuts.ts file-op keyboard chords
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
 import { IS_SNAPSHOT, navigate, replaceSearch } from "@platform/lib/router";
 import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
@@ -40,6 +49,7 @@ import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
 import { PathOverflow } from "@apps/explorer/BarMenu";
 import { claimFolderChrome } from "@apps/explorer/listing/folder-chrome";
+import { searchSlot, subscribeSearchSlot } from "@apps/explorer/search-slot";
 import {
   FLIP_MAX_ROWS,
   SORT_KEYS,
@@ -68,6 +78,15 @@ import { useWalkSearch } from "@apps/explorer/listing/useWalkSearch";
 import { useListingSelection } from "@apps/explorer/listing/useListingSelection";
 import { useFileOps } from "@apps/explorer/listing/useFileOps";
 import { useListingShortcuts } from "@apps/explorer/listing/useListingShortcuts";
+
+// The search row hangs in the crumb bar when there is one to hang in, and
+// stays put otherwise. Either way it is the SAME React element — the query,
+// the walk's live counts and `searchInputRef` are Listing's state, and a
+// portal moves the DOM without touching any of that (a keystroke that focuses
+// the box from the listing below still reaches it).
+function inSearchSlot(slot: HTMLElement | null, row: ReactNode): ReactNode {
+  return slot ? createPortal(row, slot) : row;
+}
 
 export default function Listing({
   fsPath,
@@ -245,6 +264,13 @@ export default function Listing({
     if (!ownsBarChrome) return;
     return claimFolderChrome(crumbSlotRef.current);
   }, [ownsBarChrome]);
+
+  // …and the search row goes UP into that same bar, at its right end — one
+  // header strip in this column, matching the pane's one across the divider
+  // (search-slot.ts). Non-null only once the bar has rendered its target,
+  // which is only ever over a folder that claimed the chrome; a host with no
+  // crumb bar (the app builder) keeps the row in place as its own first strip.
+  const barSearchSlot = useSyncExternalStore(subscribeSearchSlot, searchSlot, () => null);
 
   // No "Up" BUTTON beside the search box any more: the crumb strip above is
   // the same hop with a target the user can name, and the keyboard keeps its
@@ -925,20 +951,35 @@ export default function Listing({
   }
 
   // --- search match count (inline in the search row) ------------------------
+  //
+  // Two strings per state: a TERSE one to show and the full sentence to say.
+  // The chip is pinned inside the input's right edge, so every character it
+  // spends is a character the query cannot use — and since the row moved up
+  // into the crumb bar (search-slot.ts) it is competing with the path as well.
+  // "1,204 matches · 45,110 scanned…" was most of a narrow box. The numbers are
+  // the whole message; "matches" and "scanned" are recoverable from context by
+  // anyone looking at a list of search results, and stay in the title and the
+  // aria-label for anyone who is not.
+  const compact = (n: number) =>
+    n.toLocaleString(undefined, { notation: "compact", maximumFractionDigits: 1 });
 
   let searchCount: string | null = null;
-  let searchCountTitle: string | undefined;
+  let searchCountFull: string | undefined;
   if (searching && validWalk.status === "streaming") {
     // Live progress while the walk streams: match count so far + how much of
-    // the tree has been scanned. Updates in place, no layout shift.
-    searchCount = `${hits.length.toLocaleString()} match${hits.length === 1 ? "" : "es"} · ${validWalk.count.toLocaleString()} scanned…`;
+    // the tree has been scanned. Updates in place, no layout shift. The scan
+    // total is the digit-hungry half and the one nobody reads precisely, so it
+    // is the half that goes compact ("45.1K").
+    searchCount = `${compact(hits.length)} · ${compact(validWalk.count)}…`;
+    searchCountFull = `${hits.length.toLocaleString()} match${hits.length === 1 ? "" : "es"} · ${validWalk.count.toLocaleString()} entries scanned so far`;
   } else if (searching && validWalk.status === "ok" && hits.length > 0) {
     // A truncated walk (server safety cap) means `hits` undercounts the real
     // tree. Signal that without new UI: a "+" on the number plus a tooltip.
     const suffix = validWalk.truncated ? "+" : "";
-    searchCount = `${hits.length.toLocaleString()}${suffix} match${hits.length === 1 ? "" : "es"}`;
+    searchCount = `${compact(hits.length)}${suffix}`;
+    searchCountFull = `${hits.length.toLocaleString()}${suffix} match${hits.length === 1 ? "" : "es"}`;
     if (validWalk.truncated)
-      searchCountTitle = `Search covers the first ${validWalk.total.toLocaleString()} entries of this folder tree`;
+      searchCountFull += ` — search covers the first ${validWalk.total.toLocaleString()} entries of this folder tree`;
   }
 
   // Is anything pinned inside the search input right now? Mirrors the three
@@ -954,15 +995,21 @@ export default function Listing({
       <div className="listing-split" ref={splitRef}>
         <div className="listing-main">
           {/* Where the crumb bar lands over a folder (the claim above). It sits
-              INSIDE the left column, above the search row, so the bar ends at
-              the divider and the pane keeps the whole right-hand column from
-              the top of the window down. `display: contents`, so the bar is a
-              flex item of .listing-main exactly as it was of #main. */}
+              INSIDE the left column, as its whole header — the search row
+              portals up into it — so the bar ends at the divider and the pane
+              keeps the whole right-hand column from the top of the window
+              down. `display: contents`, so the bar is a flex item of
+              .listing-main exactly as it was of #main. */}
           {ownsBarChrome && <div className="listing-crumb-slot" ref={crumbSlotRef} />}
           {/* Embedded (preview pane): no search row — the pane is a glance,
               and the host listing's search/toggle already own that chrome. */}
-          {!embedded && (
-            <div className="listing-search">
+          {!embedded && inSearchSlot(barSearchSlot,
+            /* `searching` (a non-empty query) is what tells the crumb bar to
+               stand the crumbs down and give the row its whole width — see
+               #breadcrumb:has(.listing-search.searching) in explorer.css.
+               Nothing to hand upward: the row is portaled INTO the bar, so a
+               class on the row is already inside the bar's subtree. */
+            <div className={"listing-search" + (searching ? " searching" : "")}>
               {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin.
             `has-pin` says a chip is actually pinned right now, so the input
@@ -997,7 +1044,8 @@ export default function Listing({
                 {searchCount !== null && (
                   <span
                     className="listing-search-count"
-                    title={searchCountTitle}
+                    title={searchCountFull}
+                    aria-label={searchCountFull}
                   >
                     {searchCount}
                   </span>
@@ -1036,11 +1084,12 @@ export default function Listing({
                   a button to flip — and a control that only ever restated what
                   the layout already showed was one more thing in a row that is
                   meant to be the search box. */}
-              {/* The path `···`, moved down out of the crumb bar for the
-                  folder view (see the claim above). Same control, same two
-                  items — "Open in Finder" and "Copy path" — now at the end of
-                  the row that already holds this folder's other control
-                  instead of at the far end of the bar. */}
+              {/* The path `···` for the folder view (see the claim above).
+                  Same control, same two items — "Open in Finder" and "Copy
+                  path" — rendered here, at the end of the row that holds this
+                  folder's other control, and carried into the crumb bar with
+                  it: the row is what portals, so the `···` ends up back at the
+                  bar's right end without the bar having to own it. */}
               {/* normDir, not the bare `base`: `base` has its trailing slash
                   stripped, which at the filesystem root leaves "" (and "C:" at
                   a Windows drive root). The crumb-bar copy of this control got

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -38,6 +38,8 @@ import { useClipboard } from "@apps/explorer/lib/fs-clipboard";
 import ContextMenu from "@platform/ui/ContextMenu";
 import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
+import { PathOverflow } from "@apps/explorer/BarMenu";
+import { claimFolderChrome } from "@apps/explorer/listing/folder-chrome";
 import {
   FLIP_MAX_ROWS,
   SORT_KEYS,
@@ -71,6 +73,7 @@ export default function Listing({
   fsPath,
   provisional = false,
   embedded = false,
+  barChrome = false,
   onSingleApp,
 }: {
   fsPath: string;
@@ -91,6 +94,14 @@ export default function Listing({
   // handlers — those belong to the host's Listing. Mouse interaction stays:
   // clicks select/navigate, right-click menus and dialogs work as usual.
   embedded?: boolean;
+  // `barChrome`: this Listing IS the explorer's folder view — the one under
+  // the crumb bar, whose layout zone it therefore claims (see
+  // listing/folder-chrome.ts). The splits go away and the path `···` renders
+  // in this listing's search row instead of at the far end of the bar. False
+  // for every other host: the app-builder and learn variants have no crumb bar
+  // to claim, and a panel pane's Listing sits under a pane bar that carries
+  // its own splits and its own `···`.
+  barChrome?: boolean;
   // Reports the path of this directory's lone top-level HTML file (an
   // "app"), or null when there isn't exactly one — the caller (Preview's
   // header) uses this to surface an "Open as app" button. Fires whenever the
@@ -218,6 +229,16 @@ export default function Listing({
   );
 
   const base = fsPath.replace(/\/$/, "");
+
+  // Claim the crumb bar's layout zone for as long as this folder view is
+  // mounted: the splits come off the bar and the path `···` renders in the
+  // search row below (see listing/folder-chrome.ts for why the claim is
+  // counted and why it is a store rather than a prop).
+  const ownsBarChrome = barChrome && !embedded;
+  useEffect(() => {
+    if (!ownsBarChrome) return;
+    return claimFolderChrome();
+  }, [ownsBarChrome]);
 
   // No "Up" BUTTON beside the search box any more: the crumb strip above is
   // the same hop with a target the user can name, and the keyboard keeps its
@@ -1003,6 +1024,12 @@ export default function Listing({
                   a button to flip — and a control that only ever restated what
                   the layout already showed was one more thing in a row that is
                   meant to be the search box. */}
+              {/* The path `···`, moved down out of the crumb bar for the
+                  folder view (see the claim above). Same control, same two
+                  items — "Open in Finder" and "Copy path" — now at the end of
+                  the row that already holds this folder's other control
+                  instead of at the far end of the bar. */}
+              {ownsBarChrome && <PathOverflow fsPath={base} />}
             </div>
           )}
           <div

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -230,14 +230,20 @@ export default function Listing({
 
   const base = fsPath.replace(/\/$/, "");
 
-  // Claim the crumb bar's layout zone for as long as this folder view is
-  // mounted: the splits come off the bar and the path `···` renders in the
-  // search row below (see listing/folder-chrome.ts for why the claim is
-  // counted and why it is a store rather than a prop).
+  // Claim the crumb bar for as long as this folder view is mounted: the splits
+  // come off it, the path `···` renders in the search row below, and the bar
+  // itself portals into `crumbSlotRef` — the top of THIS column — so the
+  // preview pane beside it runs the full height of the window (see
+  // listing/folder-chrome.ts).
+  //
+  // A layout effect: the claim moves the bar, and a passive effect would paint
+  // one frame with it still spanning the window before it dropped into place.
+  // Refs are attached before layout effects run, so the slot is there.
   const ownsBarChrome = barChrome && !embedded;
-  useEffect(() => {
+  const crumbSlotRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
     if (!ownsBarChrome) return;
-    return claimFolderChrome();
+    return claimFolderChrome(crumbSlotRef.current);
   }, [ownsBarChrome]);
 
   // No "Up" BUTTON beside the search box any more: the crumb strip above is
@@ -947,6 +953,12 @@ export default function Listing({
     <div className="listing">
       <div className="listing-split" ref={splitRef}>
         <div className="listing-main">
+          {/* Where the crumb bar lands over a folder (the claim above). It sits
+              INSIDE the left column, above the search row, so the bar ends at
+              the divider and the pane keeps the whole right-hand column from
+              the top of the window down. `display: contents`, so the bar is a
+              flex item of .listing-main exactly as it was of #main. */}
+          {ownsBarChrome && <div className="listing-crumb-slot" ref={crumbSlotRef} />}
           {/* Embedded (preview pane): no search row — the pane is a glance,
               and the host listing's search/toggle already own that chrome. */}
           {!embedded && (

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -1029,7 +1029,13 @@ export default function Listing({
                   items — "Open in Finder" and "Copy path" — now at the end of
                   the row that already holds this folder's other control
                   instead of at the far end of the bar. */}
-              {ownsBarChrome && <PathOverflow fsPath={base} />}
+              {/* normDir, not the bare `base`: `base` has its trailing slash
+                  stripped, which at the filesystem root leaves "" (and "C:" at
+                  a Windows drive root). The crumb-bar copy of this control got
+                  the un-stripped fsPath, so at "/" the menu's two items used to
+                  copy an empty string and POST an empty reveal path. Same
+                  normalisation the drop target below uses. */}
+              {ownsBarChrome && <PathOverflow fsPath={normDir(base)} />}
             </div>
           )}
           <div

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -13,7 +13,7 @@
 // see its branch below. Wire-up state (pane visibility, width, the divider
 // drag) stays in Listing — this component only owns what the pane shows for a
 // given selection.
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
 import type { TemplateEntry } from "@platform/lib/api";
 import { navigate, replaceSearch } from "@platform/lib/router";
@@ -25,6 +25,10 @@ import { ModeMenu } from "@apps/explorer/BarMenu";
 import { useAppButton } from "@apps/explorer/lib/app-button";
 import { withNoFocus } from "@apps/explorer/listing/frame-focus";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
+import {
+  publishPaneActionSlot,
+  retractPaneActionSlot,
+} from "@apps/explorer/pane-action-slot";
 import Listing from "@apps/explorer/Listing";
 import {
   PANE_APP_MODE,
@@ -94,6 +98,24 @@ interface AppTarget {
 interface PaneMode {
   mode: string;
   icon: React.ReactNode;
+}
+
+// Portal target for the open folder's primary action (pane-action-slot.ts).
+// Publishing the live node rather than letting Preview find it by id: the pane
+// unmounts whenever the split narrows past its threshold, and a stale
+// reference would leave the button portaled into a detached div — invisible,
+// with nothing in the title bar either.
+//
+// Collapses when empty so the header's `gap` does not open a hole beside the
+// mode chip for the folders that have no app to open (.pane-action-slot:empty).
+function PaneActionSlot() {
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) publishPaneActionSlot(el);
+    return () => retractPaneActionSlot(el);
+  }, []);
+  return <div className="pane-action-slot" ref={ref} />;
 }
 
 export default function ListingPreviewPane({
@@ -230,8 +252,17 @@ export default function ListingPreviewPane({
   //
   // `extra` is what the settled preview puts in it: the mode menu and the
   // open-full-screen button, at the strip's far end.
+  //
+  // It opens with the OPEN FOLDER's primary action, portaled down from
+  // Preview.tsx (pane-action-slot.ts) — see there for why it is not in the
+  // title bar. In `strip` itself, so it is present in every state: that button
+  // belongs to the folder on the left, not to whichever row the pane happens
+  // to be showing, and it must not blink out while a preview loads.
   const strip = (extra?: React.ReactNode) => (
-    <div className="pane-header">{extra}</div>
+    <div className="pane-header">
+      <PaneActionSlot />
+      {extra}
+    </div>
   );
 
   // Placeholders need no fetch: nothing selected, or a multi-selection. No

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -211,27 +211,27 @@ export default function ListingPreviewPane({
   const { rootRef, guardProps } = usePaneFocusGuard<HTMLDivElement>();
 
   // The pane's chrome strip, and EVERY state gets one — a loading skeleton, an
-  // error, the metadata card and the multi-selection placeholder alike. It
-  // keeps the strip's height agreeing with the search row beside it in every
-  // state rather than most of them (see .pane-header).
+  // error, the metadata card and the multi-selection placeholder alike. It is
+  // the TOP BAR of the right-hand column now that the pane runs the full height
+  // of the window, so it has to hold its height in every state or the seam it
+  // shares with the crumb bar on the left breaks (see .pane-header).
   //
   // It used to open with a COLLAPSE button, sitting on the seam it sent the
   // pane back to. That went with the toggle: the split is now decided by the
   // container's width (listing/pane.ts), so a closed pane would have had no
   // way back short of resizing the window.
   //
-  // `extra` is what the settled preview adds after the name, at the strip's
-  // far end: the mode menu and the open-full-screen button.
+  // It then carried the previewed row's ICON AND NAME. Those are gone too. The
+  // pane's subject is whichever row is selected, and that row is highlighted an
+  // inch to the left with its name in the same eyeline — restating it here put
+  // the loudest text in the strip on the one fact the layout already made
+  // obvious, and (unlike the crumb bar it now sits beside) it named a thing the
+  // bar's own controls do not act on.
+  //
+  // `extra` is what the settled preview puts in it: the mode menu and the
+  // open-full-screen button, at the strip's far end.
   const strip = (extra?: React.ReactNode) => (
-    <div className="pane-header">
-      {row && (
-        <span className="pane-header-icon">{iconForEntry(row.name, row.isDir)}</span>
-      )}
-      <span className="pane-header-name" title={row?.name}>
-        {row?.name ?? ""}
-      </span>
-      {extra}
-    </div>
+    <div className="pane-header">{extra}</div>
   );
 
   // Placeholders need no fetch: nothing selected, or a multi-selection. No

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -842,6 +842,10 @@ function TemplatePreview({
         ) : isListing ? (
           <Listing
             fsPath={fsPath}
+            /* Same condition as the header's: `actionsInTopbar` IS "this view
+               is the explorer's, and the crumb bar is its bar" — so this
+               listing is the one that claims the bar's layout zone. */
+            barChrome={actionsInTopbar}
             onSingleApp={setSingleAppPath}
           />
         ) : (

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -936,8 +936,16 @@ function TemplatePreview({
             listing, revealed only in embed — same pattern as
             preview-browse-chip. Opposite corner so the two can coexist (a
             directory can have both a browsable counterpart mode AND a lone
-            HTML file). */}
-        {appBtn && (
+            HTML file).
+
+            Not when there is a PANE, though: embed hides the two headers but
+            not the pane's strip, so the portaled button is on screen there and
+            the chip would be the same action twice, one of them lying on top
+            of the listing. Keyed on the slot rather than on `listingPaneOpen`
+            because the slot is the button's actual whereabouts — the two agree
+            almost always, and when they disagree it is the slot that is right.
+            .preview-browse-chip makes the same call one condition up. */}
+        {appBtn && !paneSlot && (
           <button type="button" className="open-as-app-chip" onClick={appBtn.onClick}>
             {appBtn.label}
           </button>

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -3,7 +3,7 @@
 //   2. else                      -> fallback metadata card
 // No file-type checks live in the shell — html arrives through stat.templates
 // like everything else, via the "_render" sentinel (SPEC PT-12).
-import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
   getDeployStatus,
@@ -42,6 +42,7 @@ import {
   effectiveActive,
 } from "@platform/lib/mode-visibility";
 import { ModeMenu, OverflowMenu } from "@apps/explorer/BarMenu";
+import { subscribeTopbarSlot, topbarSlot } from "@apps/explorer/topbar-slot";
 import ContextMenu, { type MenuEntry, type MenuItem } from "@platform/ui/ContextMenu";
 import { MenuIcons } from "@platform/ui/MenuIcons";
 import { PromptDialog, ConfirmDialog, nameError } from "@apps/explorer/FsDialogs";
@@ -76,14 +77,13 @@ function Header({ fsPath, stat, children, afterName, onContextMenu }: HeaderProp
 
 // Explorer variant: the second header bar is gone (the name is redundant with
 // the breadcrumb), so the view's actions render into the breadcrumb bar's
-// `#topbar-mode-slot` (Breadcrumb.tsx) via a portal. The slot is a sibling
-// rendered in the same commit as the preview, so it exists by the time this
-// effect runs; keyed remounts on navigation re-find it.
+// `#topbar-mode-slot` (Breadcrumb.tsx) via a portal. The slot node comes from
+// a store rather than a getElementById at mount: over a folder the crumb bar
+// itself portals down into the listing's left column, which rebuilds the slot
+// — and a node captured once would be a detached div from then on
+// (topbar-slot.ts).
 function TopbarActions({ children }: { children: ReactNode }) {
-  const [slot, setSlot] = useState<HTMLElement | null>(null);
-  useEffect(() => {
-    setSlot(document.getElementById("topbar-mode-slot"));
-  }, []);
+  const slot = useSyncExternalStore(subscribeTopbarSlot, topbarSlot, () => null);
   return slot ? createPortal(children, slot) : null;
 }
 

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -43,6 +43,7 @@ import {
 } from "@platform/lib/mode-visibility";
 import { ModeMenu, OverflowMenu } from "@apps/explorer/BarMenu";
 import { subscribeTopbarSlot, topbarSlot } from "@apps/explorer/topbar-slot";
+import { subscribePaneActionSlot, paneActionSlot } from "@apps/explorer/pane-action-slot";
 import ContextMenu, { type MenuEntry, type MenuItem } from "@platform/ui/ContextMenu";
 import { MenuIcons } from "@platform/ui/MenuIcons";
 import { PromptDialog, ConfirmDialog, nameError } from "@apps/explorer/FsDialogs";
@@ -85,6 +86,19 @@ function Header({ fsPath, stat, children, afterName, onContextMenu }: HeaderProp
 function TopbarActions({ children }: { children: ReactNode }) {
   const slot = useSyncExternalStore(subscribeTopbarSlot, topbarSlot, () => null);
   return slot ? createPortal(children, slot) : null;
+}
+
+// Where the open FOLDER's primary action goes. The preview pane's header when
+// there is one (pane-action-slot.ts): the title bar is crowded — crumbs,
+// search box, `···` — and a labelled pill among them squeezes the path down to
+// nothing, while the header across the divider has room to spare.
+//
+// Null when there is no pane. Below the split's width threshold it does not
+// render at all, and the button has to keep appearing SOMEWHERE — a narrow
+// window must not silently cost a folder its primary action — so the caller
+// falls back to the bar it came from.
+function usePaneActionSlot(): HTMLElement | null {
+  return useSyncExternalStore(subscribePaneActionSlot, paneActionSlot, () => null);
 }
 
 // One open modal for the preview file menu: a Rename prompt or a Delete confirm
@@ -719,17 +733,25 @@ function TemplatePreview({
   // render this one.
   const appBtn = useAppButton(isListing ? fsPath : null, singleAppPath);
 
-  // The folder's primary action, built once and rendered in exactly one place:
-  // the title bar, whenever the folder qualifies.
+  // The folder's primary action, built once and rendered in exactly one place
+  // — which of the two bars depends on whether there is a pane.
   //
-  // It spent a while riding down into the preview pane's header instead
-  // whenever the pane was open, on the theory that the pane's own row already
-  // had an empty primary slot for it. That slot belongs to the pane's SELF
-  // target (nothing selected) — and a qualifying folder is by definition
-  // non-empty (it holds a top-level HTML file), so FS-16's auto-select claims
-  // the selection the moment the folder opens. So the self row almost never
-  // shows, and the button had effectively disappeared from the default view of
-  // exactly the folders it exists for.
+  // It spent a while riding down into the preview pane's header whenever the
+  // pane was open, on the theory that the pane's own row already had an empty
+  // primary slot for it. That slot belonged to the pane's SELF target (nothing
+  // selected) — and a qualifying folder is by definition non-empty (it holds a
+  // top-level HTML file), so FS-16's auto-select claims the selection the
+  // moment the folder opens. The self row almost never showed, and the button
+  // had effectively disappeared from the default view of exactly the folders it
+  // exists for. It moved to the title bar for that reason.
+  //
+  // It is back in the pane header, but on a different footing: the slot is in
+  // `strip` now, so it is there in EVERY pane state rather than one that is
+  // almost never reached. The title bar meanwhile stopped having room — the
+  // search row moved into it, and the pill was pushing the folder's own name
+  // out of the crumbs. The bar is still the fallback when the window is too
+  // narrow for a pane (paneActionSlot is null then).
+  const paneSlot = usePaneActionSlot();
   const openAsAppBtn = appBtn ? (
     <button type="button" className="open-as-app-btn" onClick={appBtn.onClick}>
       {appBtn.label}
@@ -811,11 +833,16 @@ function TemplatePreview({
     </>
   );
 
+  // One or the other, never both.
+  const appBtnInPane = paneSlot ? openAsAppBtn : null;
+  const appBtnInBar = paneSlot ? null : openAsAppBtn;
+
   return (
     <>
+      {appBtnInPane && createPortal(appBtnInPane, paneSlot as HTMLElement)}
       {actionsInTopbar ? (
         <TopbarActions>
-          {openAsAppBtn}
+          {appBtnInBar}
           {headerActions}
         </TopbarActions>
       ) : (
@@ -824,7 +851,7 @@ function TemplatePreview({
             fsPath={fsPath}
             stat={stat}
             onContextMenu={fileMenu.onContextMenu}
-            afterName={openAsAppBtn}
+            afterName={appBtnInBar}
           >
             {headerActions}
           </Header>

--- a/frontend/src/apps/explorer/listing/folder-chrome.test.ts
+++ b/frontend/src/apps/explorer/listing/folder-chrome.test.ts
@@ -1,14 +1,19 @@
-// The bar-zone handover store. The counting is the whole of it, and the
-// counting is exactly what a boolean got wrong: React mounts the incoming view
-// before unmounting the outgoing one, so a folder→folder hop releases the old
-// claim AFTER the new one is made.
+// The crumb-bar handover store. The overlap handling is the whole of it, and
+// the overlap is exactly what a boolean got wrong: React can hold the incoming
+// view and the outgoing one at the same time, so a folder→folder hop may
+// release the old claim AFTER the new one is made.
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   claimFolderChrome,
   folderChromeClaimed,
+  folderChromeSlot,
   resetFolderChrome,
   subscribeFolderChrome,
 } from "./folder-chrome";
+
+// The store only ever holds and compares the node, so a stand-in is enough
+// here — these tests run without a DOM.
+const node = (name: string) => ({ name }) as unknown as HTMLElement;
 
 afterEach(() => resetFolderChrome());
 
@@ -41,6 +46,40 @@ describe("folder chrome claims", () => {
     const other = claimFolderChrome();
     expect(folderChromeClaimed()).toBe(true);
     other();
+  });
+
+  test("no slot until something claims one — the bar stays at shell level", () => {
+    expect(folderChromeSlot()).toBe(null);
+    const release = claimFolderChrome();
+    expect(folderChromeSlot()).toBe(null);
+    release();
+  });
+
+  test("the claim carries the slot the bar portals into", () => {
+    const el = node("left-column");
+    const release = claimFolderChrome(el);
+    expect(folderChromeSlot()).toBe(el);
+    release();
+    expect(folderChromeSlot()).toBe(null);
+  });
+
+  test("during an overlap the NEWEST slot wins, in either commit order", () => {
+    // Incoming mounts first, outgoing then unmounts (folder→folder hop).
+    const outgoing = claimFolderChrome(node("outgoing"));
+    const incomingEl = node("incoming");
+    const incoming = claimFolderChrome(incomingEl);
+    outgoing();
+    expect(folderChromeSlot()).toBe(incomingEl);
+    incoming();
+
+    // Outgoing unmounts first, incoming then mounts (scaffold→resolved swap).
+    const goneEl = node("gone");
+    const gone = claimFolderChrome(goneEl);
+    gone();
+    const nextEl = node("next");
+    const next = claimFolderChrome(nextEl);
+    expect(folderChromeSlot()).toBe(nextEl);
+    next();
   });
 
   test("subscribers hear every change, and unsubscribe stops them", () => {

--- a/frontend/src/apps/explorer/listing/folder-chrome.test.ts
+++ b/frontend/src/apps/explorer/listing/folder-chrome.test.ts
@@ -1,0 +1,59 @@
+// The bar-zone handover store. The counting is the whole of it, and the
+// counting is exactly what a boolean got wrong: React mounts the incoming view
+// before unmounting the outgoing one, so a folder→folder hop releases the old
+// claim AFTER the new one is made.
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  claimFolderChrome,
+  folderChromeClaimed,
+  resetFolderChrome,
+  subscribeFolderChrome,
+} from "./folder-chrome";
+
+afterEach(() => resetFolderChrome());
+
+describe("folder chrome claims", () => {
+  test("unclaimed by default — the crumb bar keeps its zone", () => {
+    expect(folderChromeClaimed()).toBe(false);
+  });
+
+  test("a claim moves the zone, its release moves it back", () => {
+    const release = claimFolderChrome();
+    expect(folderChromeClaimed()).toBe(true);
+    release();
+    expect(folderChromeClaimed()).toBe(false);
+  });
+
+  test("an overlapping mount/unmount never un-claims the live view", () => {
+    const first = claimFolderChrome();
+    const second = claimFolderChrome(); // the incoming folder mounts…
+    first(); // …and only then does the outgoing one unmount
+    expect(folderChromeClaimed()).toBe(true);
+    second();
+    expect(folderChromeClaimed()).toBe(false);
+  });
+
+  test("a release is idempotent — a double-invoked cleanup cannot go negative", () => {
+    const release = claimFolderChrome();
+    release();
+    release();
+    expect(folderChromeClaimed()).toBe(false);
+    const other = claimFolderChrome();
+    expect(folderChromeClaimed()).toBe(true);
+    other();
+  });
+
+  test("subscribers hear every change, and unsubscribe stops them", () => {
+    let seen = 0;
+    const off = subscribeFolderChrome(() => {
+      seen += 1;
+    });
+    const release = claimFolderChrome();
+    expect(seen).toBe(1);
+    release();
+    expect(seen).toBe(2);
+    off();
+    claimFolderChrome()();
+    expect(seen).toBe(2);
+  });
+});

--- a/frontend/src/apps/explorer/listing/folder-chrome.ts
+++ b/frontend/src/apps/explorer/listing/folder-chrome.ts
@@ -1,14 +1,21 @@
-// Who owns the explorer bar's LAYOUT ZONE right now — the crumb bar, or the
-// folder listing underneath it.
+// Who owns the explorer's CRUMB BAR right now — the shell, or the folder
+// listing underneath it.
 //
-// Over a FOLDER the zone's contents are wrong in two different ways. The split
-// buttons offer to tear the window in half at the moment the view is already a
-// split (list + preview pane), which is the one place a second one buys
-// nothing; and the `···` sits at the far end of a bar whose other end is the
-// path, three hundred pixels from the search box that is the folder's actual
-// control. So a folder view CLAIMS the zone: the splits go away and the `···`
-// re-renders inside the listing's search row, next to the thing it acts on
-// (Listing.tsx). A file/preview keeps the zone exactly as it was.
+// Over a FOLDER the bar is wrong in two different ways. Its layout zone offers
+// to tear the window in half at the moment the view is already a split (list +
+// preview pane), which is the one place a second one buys nothing; and the
+// `···` sits at the far end of a bar whose other end is the path, three
+// hundred pixels from the search box that is the folder's actual control. So a
+// folder view CLAIMS the bar: the splits go away and the `···` re-renders
+// inside the listing's search row, next to the thing it acts on (Listing.tsx).
+//
+// The claim also carries a SLOT — a node inside the listing's left column that
+// the whole bar portals into (Breadcrumb.tsx `BreadcrumbBar`). That is what
+// makes the preview pane full height: with the bar confined to the left
+// column, the pane's own header is the topmost thing on the right and the pane
+// runs from the top of the window to the bottom. A file/preview claims
+// nothing, and its bar renders at shell level spanning the full width, exactly
+// as before.
 //
 // A module store rather than a prop because the two components are SIBLINGS —
 // App renders <Breadcrumb> above <Listing>/<Preview>, and which of those the
@@ -17,32 +24,48 @@
 // same shape as lib/ui-overlay and fs-clipboard: state that lives just outside
 // a remount boundary, with a subscribe/snapshot pair for useSyncExternalStore.
 //
-// Counted, not a boolean: a claim is released on unmount, and React mounts the
-// incoming view before unmounting the outgoing one, so a straight `false` on
-// release would leave the zone hidden after a folder→folder hop or shown after
-// a scaffold swap. Claims are idempotent per caller (each returns its own
-// release, called at most once by the effect that made it).
-let claims = 0;
+// A STACK, not a boolean: a claim is released on unmount, and a swap can hold
+// two folder views at once (folder→folder hop, scaffold→resolved), so a
+// straight `false` on release would leave the bar hidden or doubly rendered
+// depending on which side of the swap ran last. The newest claim wins — during
+// a swap that is the incoming view, whichever order the commit runs in. Claims
+// are idempotent per caller (each returns its own release, called at most once
+// by the effect that made it).
+type Claim = { slot: HTMLElement | null };
+
+let claims: Claim[] = [];
 const subscribers = new Set<() => void>();
 
 function notify(): void {
   for (const fn of subscribers) fn();
 }
 
-export function claimFolderChrome(): () => void {
-  claims += 1;
+// `slot` is the node in the listing's left column the crumb bar portals into.
+// Optional: a caller that only wants the zone hidden (or a test) can claim
+// without one, and the bar then stays where it is.
+export function claimFolderChrome(slot: HTMLElement | null = null): () => void {
+  const claim: Claim = { slot };
+  claims.push(claim);
   notify();
   let released = false;
   return () => {
     if (released) return;
     released = true;
-    claims -= 1;
+    const i = claims.indexOf(claim);
+    if (i >= 0) claims.splice(i, 1);
     notify();
   };
 }
 
 export function folderChromeClaimed(): boolean {
-  return claims > 0;
+  return claims.length > 0;
+}
+
+// The newest claim's slot, or null when nothing is claimed (or the claim came
+// without one). Identity-stable, so it is safe as a useSyncExternalStore
+// snapshot.
+export function folderChromeSlot(): HTMLElement | null {
+  return claims.length > 0 ? claims[claims.length - 1].slot : null;
 }
 
 export function subscribeFolderChrome(fn: () => void): () => void {
@@ -55,6 +78,6 @@ export function subscribeFolderChrome(fn: () => void): () => void {
 // Test seam: the store outlives any component, so a test that claims must be
 // able to put it back.
 export function resetFolderChrome(): void {
-  claims = 0;
+  claims = [];
   notify();
 }

--- a/frontend/src/apps/explorer/listing/folder-chrome.ts
+++ b/frontend/src/apps/explorer/listing/folder-chrome.ts
@@ -1,0 +1,60 @@
+// Who owns the explorer bar's LAYOUT ZONE right now — the crumb bar, or the
+// folder listing underneath it.
+//
+// Over a FOLDER the zone's contents are wrong in two different ways. The split
+// buttons offer to tear the window in half at the moment the view is already a
+// split (list + preview pane), which is the one place a second one buys
+// nothing; and the `···` sits at the far end of a bar whose other end is the
+// path, three hundred pixels from the search box that is the folder's actual
+// control. So a folder view CLAIMS the zone: the splits go away and the `···`
+// re-renders inside the listing's search row, next to the thing it acts on
+// (Listing.tsx). A file/preview keeps the zone exactly as it was.
+//
+// A module store rather than a prop because the two components are SIBLINGS —
+// App renders <Breadcrumb> above <Listing>/<Preview>, and which of those the
+// content resolves to is decided several levels down (a directory's `_mode`
+// can leave the listing for `git`/`history` without remounting the bar). The
+// same shape as lib/ui-overlay and fs-clipboard: state that lives just outside
+// a remount boundary, with a subscribe/snapshot pair for useSyncExternalStore.
+//
+// Counted, not a boolean: a claim is released on unmount, and React mounts the
+// incoming view before unmounting the outgoing one, so a straight `false` on
+// release would leave the zone hidden after a folder→folder hop or shown after
+// a scaffold swap. Claims are idempotent per caller (each returns its own
+// release, called at most once by the effect that made it).
+let claims = 0;
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const fn of subscribers) fn();
+}
+
+export function claimFolderChrome(): () => void {
+  claims += 1;
+  notify();
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    claims -= 1;
+    notify();
+  };
+}
+
+export function folderChromeClaimed(): boolean {
+  return claims > 0;
+}
+
+export function subscribeFolderChrome(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+// Test seam: the store outlives any component, so a test that claims must be
+// able to put it back.
+export function resetFolderChrome(): void {
+  claims = 0;
+  notify();
+}

--- a/frontend/src/apps/explorer/listing/selection.test.ts
+++ b/frontend/src/apps/explorer/listing/selection.test.ts
@@ -10,6 +10,7 @@ import {
   firstEntryPath,
   oneSelected,
   pathFromSelParam,
+  cameFromSelParam,
   rangeBetween,
   rowPressAction,
   selParam,
@@ -244,6 +245,45 @@ describe("selParam / pathFromSelParam", () => {
   test("a dotfile is a normal name, not a traversal", () => {
     expect(pathFromSelParam("/d", ".gitignore")).toBe("/d/.gitignore");
     expect(pathFromSelParam("/d", "..hidden")).toBe("/d/..hidden");
+  });
+});
+
+describe("cameFromSelParam", () => {
+  test("an ancestor hop selects the child it came through", () => {
+    // The Finder rule: go up and the folder you left is highlighted.
+    expect(cameFromSelParam("/a/b", "/a/b/c")).toBe("c");
+    expect(cameFromSelParam("/a", "/a/b/c/d")).toBe("b");
+  });
+
+  test("the child, never the whole remainder", () => {
+    // A crumb several levels up still selects its OWN child — the only row it
+    // actually has — not the deep path the user came from.
+    expect(cameFromSelParam("/a", "/a/b/c")).toBe("b");
+  });
+
+  test("the fs root is an ancestor like any other", () => {
+    expect(cameFromSelParam("/", "/etc/hosts")).toBe("etc");
+    // Listing's `base` form: the trailing slash already stripped off.
+    expect(cameFromSelParam("", "/etc/hosts")).toBe("etc");
+  });
+
+  test("a windows drive root keeps its slash out of the name", () => {
+    expect(cameFromSelParam("C:/", "C:/Users/me")).toBe("Users");
+    expect(cameFromSelParam("C:/Users", "C:/Users/me")).toBe("me");
+  });
+
+  test("staying put selects nothing", () => {
+    expect(cameFromSelParam("/a/b", "/a/b")).toBeNull();
+    expect(cameFromSelParam("/a/b", "/a/b/")).toBeNull();
+  });
+
+  test("a target that is not an ancestor selects nothing", () => {
+    // A typed path, a bookmark, a sibling: there is no "came from" row there.
+    expect(cameFromSelParam("/x", "/a/b")).toBeNull();
+    // Prefix-of-the-string is not prefix-of-the-path.
+    expect(cameFromSelParam("/a/bb", "/a/bbb/c")).toBeNull();
+    // Downward is not an ancestor hop either.
+    expect(cameFromSelParam("/a/b/c", "/a/b")).toBeNull();
   });
 });
 

--- a/frontend/src/apps/explorer/listing/selection.ts
+++ b/frontend/src/apps/explorer/listing/selection.ts
@@ -136,6 +136,33 @@ export function pathFromSelParam(base: string, raw: string | null): string | nul
   return base + "/" + raw;
 }
 
+// The `?sel=` value an UPWARD hop should seed: the child of `dest` that the
+// user is coming out of, or null when there is no such child.
+//
+// Every file manager does this — go up (crumb click, Mod+Up, Backspace) and
+// the folder you just left is the highlighted row, so the eye finds where it
+// was and a second Up carries on from there. The explorer's `?sel=` param
+// already IS "which row this folder opens on" (seeded at mount by
+// useListingSelection, scrolled into view by its effect), so the whole feature
+// is deciding the value — hence a pure function, and hence ONE of them for
+// both the crumbs (Breadcrumb.tsx) and the keyboard (useListingShortcuts).
+//
+// The answer is the IMMEDIATE child, not the remainder: a crumb three levels
+// up owns only its own rows, and `sub/deep/leaf` there would name a row that
+// folder does not render. (`selParam`, the write side, keeps whole relative
+// paths because a SEARCH hit really is a row of the folder it was found from.)
+//
+// `dest` and `from` are fs paths in the shell's canonical form; a trailing
+// slash on either is tolerated (the fs root arrives as "/" from the crumbs and
+// as "" from Listing's `base`, and a Windows drive root is "C:/").
+export function cameFromSelParam(dest: string, from: string): string | null {
+  const root = dest.replace(/\/+$/, "");
+  const rest = from.replace(/\/+$/, "");
+  if (!rest.startsWith(root + "/")) return null;
+  const seg = rest.slice(root.length + 1).split("/")[0];
+  return seg.length > 0 ? seg : null;
+}
+
 // What a press on a row does TO THE SELECTION — and nothing else, which is the
 // point.
 //

--- a/frontend/src/apps/explorer/listing/useListingShortcuts.ts
+++ b/frontend/src/apps/explorer/listing/useListingShortcuts.ts
@@ -17,6 +17,7 @@ import { matchChord } from "@apps/explorer/listing/shortcut-chord";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
 import { setClipboard, type Clipboard } from "@apps/explorer/lib/fs-clipboard";
+import { cameFromSelParam } from "@apps/explorer/listing/selection";
 import type { RowCtx } from "@apps/explorer/listing/types";
 import { targetDirOf } from "@apps/explorer/listing/row-utils";
 
@@ -97,7 +98,9 @@ export function useListingShortcuts({
       navigate(row.path, { isDir: row.isDir });
     } else if (action === "parent") {
       e.preventDefault();
-      if (parent !== here) navigate(parent, { isDir: true });
+      // Land on the folder we came out of, highlighted — the same rule the
+      // crumb strip follows (Breadcrumb.tsx), through the same pure decision.
+      if (parent !== here) navigate(parent, { isDir: true, sel: cameFromSelParam(parent, here) });
     } else if (action === "back" || action === "forward") {
       // The router only ever pushes, so this drives the browser history
       // directly — popstate is what the shell listens to anyway (useNavEpoch),

--- a/frontend/src/apps/explorer/node-slot.test.ts
+++ b/frontend/src/apps/explorer/node-slot.test.ts
@@ -1,0 +1,69 @@
+// The published-node store behind the crumb bar's two portals. The relocation
+// case is the whole of it: when the bar moves, the incoming slot publishes
+// before the outgoing one is torn down, and an unconditional retract there
+// would blank a bar that is already live.
+import { describe, expect, test } from "bun:test";
+import { createNodeSlot } from "./node-slot";
+
+// The store only ever holds and compares the node, so a stand-in is enough
+// here — these tests run without a DOM.
+const node = (name: string) => ({ name }) as unknown as HTMLElement;
+
+describe("node slot", () => {
+  test("empty until something publishes", () => {
+    expect(createNodeSlot().get()).toBe(null);
+  });
+
+  test("publish then retract leaves it empty again", () => {
+    const slot = createNodeSlot();
+    const el = node("a");
+    slot.publish(el);
+    expect(slot.get()).toBe(el);
+    slot.retract(el);
+    expect(slot.get()).toBe(null);
+  });
+
+  test("a stale node's retract cannot blank the live slot", () => {
+    const slot = createNodeSlot();
+    const outgoing = node("outgoing");
+    const incoming = node("incoming");
+    slot.publish(outgoing);
+    // The relocation order: the new container's layout effect runs before the
+    // old one's cleanup.
+    slot.publish(incoming);
+    slot.retract(outgoing);
+    expect(slot.get()).toBe(incoming);
+  });
+
+  test("subscribers hear every change, and only real changes", () => {
+    const slot = createNodeSlot();
+    let calls = 0;
+    const off = slot.subscribe(() => calls++);
+    const el = node("a");
+    slot.publish(el);
+    expect(calls).toBe(1);
+    slot.publish(el); // same node re-published: no churn
+    expect(calls).toBe(1);
+    slot.retract(node("other")); // not the live node: no churn
+    expect(calls).toBe(1);
+    slot.retract(el);
+    expect(calls).toBe(2);
+    off();
+    slot.publish(el);
+    expect(calls).toBe(2);
+  });
+
+  test("reset empties the slot for the next test", () => {
+    const slot = createNodeSlot();
+    slot.publish(node("a"));
+    slot.reset();
+    expect(slot.get()).toBe(null);
+  });
+
+  test("two slots are independent", () => {
+    const a = createNodeSlot();
+    const b = createNodeSlot();
+    a.publish(node("a"));
+    expect(b.get()).toBe(null);
+  });
+});

--- a/frontend/src/apps/explorer/node-slot.ts
+++ b/frontend/src/apps/explorer/node-slot.ts
@@ -1,0 +1,60 @@
+// A published DOM node, as a store: "here is the live element to portal into".
+//
+// The explorer's crumb bar hosts two portals whose CONTENT is rendered by a
+// different component than the one that owns the container — the view's mode
+// control (topbar-slot.ts) and, over a folder, the listing's search row
+// (search-slot.ts). Both used to be `getElementById` in a mount effect, which
+// held only while container and content were siblings committed together.
+//
+// They aren't: over a folder the whole bar portals down into the listing's
+// left column (listing/folder-chrome.ts), and changing a portal's container
+// REBUILDS the subtree — a new slot node. A reference captured at mount would
+// then point at a detached div and the portaled content would simply vanish.
+// Publishing the live node makes the portal follow the bar wherever it goes,
+// with no assumption about which effect runs first.
+export type NodeSlot = {
+  publish: (el: HTMLElement) => void;
+  retract: (el: HTMLElement | null) => void;
+  get: () => HTMLElement | null;
+  subscribe: (fn: () => void) => () => void;
+  // Test seam: the store outlives any component.
+  reset: () => void;
+};
+
+export function createNodeSlot(): NodeSlot {
+  let slot: HTMLElement | null = null;
+  const subscribers = new Set<() => void>();
+
+  const notify = (): void => {
+    for (const fn of subscribers) fn();
+  };
+
+  return {
+    publish(el) {
+      if (slot === el) return;
+      slot = el;
+      notify();
+    },
+    // Identity-checked: during a relocation the outgoing slot may be torn down
+    // after the incoming one has already published, and an unconditional clear
+    // there would blank a live bar.
+    retract(el) {
+      if (slot !== el) return;
+      slot = null;
+      notify();
+    },
+    get() {
+      return slot;
+    },
+    subscribe(fn) {
+      subscribers.add(fn);
+      return () => {
+        subscribers.delete(fn);
+      };
+    },
+    reset() {
+      slot = null;
+      notify();
+    },
+  };
+}

--- a/frontend/src/apps/explorer/pane-action-slot.ts
+++ b/frontend/src/apps/explorer/pane-action-slot.ts
@@ -1,0 +1,28 @@
+// The preview pane header's PRIMARY-ACTION portal target, published as a store.
+//
+// The open folder's "Open as app" (lib/app-button) belongs to the whole view,
+// so Preview.tsx builds it — but the title bar is a bad place to show it. That
+// bar also holds the crumbs and, since the search row moved up into it
+// (search-slot.ts), the search box and the `···`; a labelled pill wedged among
+// them squeezed the path down to "create-a-…" on a folder whose name is the
+// one thing the bar is for.
+//
+// The pane header across the divider has room and almost nothing in it. So the
+// button renders there instead — same button, same action, no second copy.
+//
+// Preview.tsx owns the CONTENT and ListingPreviewPane owns the CONTAINER, with
+// a Listing between them, so this is the only sane channel: the container
+// publishes its node, the content portals into whatever is published. The pane
+// is not always there (below the split's width threshold it does not render at
+// all), and `null` is exactly the signal Preview needs to keep the button in
+// the title bar in that case — a folder must not lose its primary action just
+// because the window got narrow.
+import { createNodeSlot } from "@apps/explorer/node-slot";
+
+const slot = createNodeSlot();
+
+export const publishPaneActionSlot = slot.publish;
+export const retractPaneActionSlot = slot.retract;
+export const paneActionSlot = slot.get;
+export const subscribePaneActionSlot = slot.subscribe;
+export const resetPaneActionSlot = slot.reset;

--- a/frontend/src/apps/explorer/search-slot.ts
+++ b/frontend/src/apps/explorer/search-slot.ts
@@ -1,0 +1,26 @@
+// The crumb bar's SEARCH portal target, published as a store.
+//
+// Over a folder the left column used to carry two full-height strips: the
+// crumb bar, and a search row directly under it holding the box, the sort chip
+// and the path `···`. The pane on the other side of the divider has one. Two
+// against one read as a mistake, so the search row moved INTO the bar: crumbs
+// at the left, the box and the `···` at its right end, one strip per column.
+//
+// Breadcrumb.tsx renders the target div (only while a folder holds the chrome
+// claim — a file view's bar has no search); Listing.tsx portals its existing
+// `.listing-search` row into it, unchanged. A portal rather than moving the
+// markup, because the row is woven into the listing's state: the query, the
+// walk's live counts, the selection readout and `searchInputRef` (which the
+// keyboard focuses from anywhere in the listing) all belong to Listing.
+//
+// Hosts with no crumb bar — the app builder — publish nothing, and the row
+// renders where it always did, as the column's own first strip.
+import { createNodeSlot } from "@apps/explorer/node-slot";
+
+const slot = createNodeSlot();
+
+export const publishSearchSlot = slot.publish;
+export const retractSearchSlot = slot.retract;
+export const searchSlot = slot.get;
+export const subscribeSearchSlot = slot.subscribe;
+export const resetSearchSlot = slot.reset;

--- a/frontend/src/apps/explorer/topbar-slot.ts
+++ b/frontend/src/apps/explorer/topbar-slot.ts
@@ -1,52 +1,15 @@
 // The crumb bar's header-actions portal target, published as a store.
 //
 // Breadcrumb.tsx renders the `#topbar-mode-slot` div; Preview.tsx portals the
-// view's mode switcher and primary action into it. That used to be a
-// `getElementById` in a mount effect, which held only because the two were
-// siblings rendered in the same commit.
-//
-// They aren't any more: over a folder the whole crumb bar portals down into
-// the listing's left column (listing/folder-chrome.ts), and changing a
-// portal's container rebuilds the subtree — a new slot node. A reference
-// captured at mount would then point at a detached div and the mode switcher
-// would simply vanish. Publishing the live node instead makes the portal
-// follow the bar wherever it goes, with no assumption about which effect runs
-// first.
-let slot: HTMLElement | null = null;
-const subscribers = new Set<() => void>();
+// view's mode switcher and primary action into it. Why a published node rather
+// than a `getElementById` at mount — the bar relocates over a folder — is
+// written down once, in node-slot.ts.
+import { createNodeSlot } from "@apps/explorer/node-slot";
 
-function notify(): void {
-  for (const fn of subscribers) fn();
-}
+const slot = createNodeSlot();
 
-export function publishTopbarSlot(el: HTMLElement): void {
-  if (slot === el) return;
-  slot = el;
-  notify();
-}
-
-// Identity-checked: during a relocation the outgoing slot may be torn down
-// after the incoming one has already published, and an unconditional clear
-// there would blank a live bar.
-export function retractTopbarSlot(el: HTMLElement | null): void {
-  if (slot !== el) return;
-  slot = null;
-  notify();
-}
-
-export function topbarSlot(): HTMLElement | null {
-  return slot;
-}
-
-export function subscribeTopbarSlot(fn: () => void): () => void {
-  subscribers.add(fn);
-  return () => {
-    subscribers.delete(fn);
-  };
-}
-
-// Test seam: the store outlives any component.
-export function resetTopbarSlot(): void {
-  slot = null;
-  notify();
-}
+export const publishTopbarSlot = slot.publish;
+export const retractTopbarSlot = slot.retract;
+export const topbarSlot = slot.get;
+export const subscribeTopbarSlot = slot.subscribe;
+export const resetTopbarSlot = slot.reset;

--- a/frontend/src/apps/explorer/topbar-slot.ts
+++ b/frontend/src/apps/explorer/topbar-slot.ts
@@ -1,0 +1,52 @@
+// The crumb bar's header-actions portal target, published as a store.
+//
+// Breadcrumb.tsx renders the `#topbar-mode-slot` div; Preview.tsx portals the
+// view's mode switcher and primary action into it. That used to be a
+// `getElementById` in a mount effect, which held only because the two were
+// siblings rendered in the same commit.
+//
+// They aren't any more: over a folder the whole crumb bar portals down into
+// the listing's left column (listing/folder-chrome.ts), and changing a
+// portal's container rebuilds the subtree — a new slot node. A reference
+// captured at mount would then point at a detached div and the mode switcher
+// would simply vanish. Publishing the live node instead makes the portal
+// follow the bar wherever it goes, with no assumption about which effect runs
+// first.
+let slot: HTMLElement | null = null;
+const subscribers = new Set<() => void>();
+
+function notify(): void {
+  for (const fn of subscribers) fn();
+}
+
+export function publishTopbarSlot(el: HTMLElement): void {
+  if (slot === el) return;
+  slot = el;
+  notify();
+}
+
+// Identity-checked: during a relocation the outgoing slot may be torn down
+// after the incoming one has already published, and an unconditional clear
+// there would blank a live bar.
+export function retractTopbarSlot(el: HTMLElement | null): void {
+  if (slot !== el) return;
+  slot = null;
+  notify();
+}
+
+export function topbarSlot(): HTMLElement | null {
+  return slot;
+}
+
+export function subscribeTopbarSlot(fn: () => void): () => void {
+  subscribers.add(fn);
+  return () => {
+    subscribers.delete(fn);
+  };
+}
+
+// Test seam: the store outlives any component.
+export function resetTopbarSlot(): void {
+  slot = null;
+  notify();
+}

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -881,10 +881,20 @@ export interface Prefs {
   // Whether the Reader (listen-to-files) accessibility mode is offered (opt-in,
   // default off).
   reader: { enabled: boolean };
+  // The default Claude model, as one of the claude template's own short names
+  // — "" means unset, and each consumer keeps its own default (the fused.ai
+  // relay's haiku, the chat template's sonnet). `choices` is the server's own
+  // value set, shipped with the value so the page renders exactly what a PUT
+  // will accept rather than a second copy that can drift.
+  model: { default: DefaultModel; choices: DefaultModel[] };
   // The app call log (fused_render/calls.py): capture state, how much of a
   // run's params is kept, retention window, and where the store lives.
   calls: CallsPrefs;
 }
+
+// Short model names, matching shell/prefs.py's VALID_DEFAULT_MODELS. "" is the
+// unset member, not an absence — it is what the "Automatic" option writes.
+export type DefaultModel = "" | "fable" | "opus" | "sonnet" | "haiku";
 
 export type CallsParamsMode = "full" | "keys" | "off";
 
@@ -926,6 +936,10 @@ export function putDeployEnabled(enabled: boolean): Promise<Prefs> {
 
 export function putReaderEnabled(enabled: boolean): Promise<Prefs> {
   return putJson<Prefs>("/api/prefs", { reader_enabled: enabled });
+}
+
+export function putDefaultModel(model: DefaultModel): Promise<Prefs> {
+  return putJson<Prefs>("/api/prefs", { default_model: model });
 }
 
 export function putCallsEnabled(enabled: boolean): Promise<Prefs> {
@@ -1672,9 +1686,15 @@ export function getClaudeSessionFolders(): Promise<{ folders: ClaudeSessionFolde
 
 // -- AI completion (POST /api/ai) ---------------------------------------------
 // The fused.ai relay: one non-streaming completion through the server's warm
-// Claude Code CLI instance (server/ai.py). Model defaults to haiku server-side;
-// the shell uses this for small utility completions (e.g. naming a new app
-// from its prompt on Home), not for anything conversational.
+// Claude Code CLI instance (server/ai.py). The shell uses this for small
+// utility completions (e.g. naming a new app from its prompt on Home), not for
+// anything conversational.
+//
+// No `model` is sent, deliberately: the server resolves one from the user's
+// default-model preference and falls back to haiku when that is unset. A model
+// named here would outrank the preference (that is the relay's precedence
+// rule), so every one of these call sites must keep NOT naming one for the
+// preference to mean anything.
 export function aiComplete(prompt: string, system_prompt?: string): Promise<string> {
   return postJson<{ ok: boolean; result: { text: string } }>("/api/ai", {
     prompt,

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -169,7 +169,10 @@ export function urlForFsPath(fsPath: string, search?: string): string {
   return PREFIX + encoded + (search || "");
 }
 
-export function navigate(fsPath: string, opts?: { isDir?: boolean; mode?: string }): void {
+export function navigate(
+  fsPath: string,
+  opts?: { isDir?: boolean; mode?: string; sel?: string | null },
+): void {
   // Navigating between files/dirs drops old view params (fresh query string) —
   // EXCEPT the pane's chosen mode (`_panelMode`), which is sticky across
   // DIRECTORY navigation: a folder hop keeps previewing in the mode the user
@@ -181,9 +184,12 @@ export function navigate(fsPath: string, opts?: { isDir?: boolean; mode?: string
   // Its companion `preview` (the pane's on/off) is GONE, not merely unlisted:
   // the split is decided by the container's width now (listing/pane.ts), so
   // there is no visibility to carry between folders and nothing a stale param
-  // could contradict. The `?sel=` selection param is likewise not carried —
+  // could contradict. The `?sel=` selection param is likewise not CARRIED —
   // a name from the folder you LEFT names nothing in the folder you arrive in
-  // (see useListingSelection).
+  // (see useListingSelection) — but a caller may SET one for the destination
+  // via `opts.sel`, which is how an upward hop lands with the folder you came
+  // out of highlighted (listing/selection.ts cameFromSelParam). Relative to
+  // the destination, exactly like the value the listing writes back.
   //
   // `snapshot=1` is the exception to the fresh-query-string rule, and it is a
   // different KIND of param from the two below: it says what this PAGE is — a
@@ -207,6 +213,7 @@ export function navigate(fsPath: string, opts?: { isDir?: boolean; mode?: string
   // cards open a project folder straight into the plain app view (appEntry's
   // APP_OPEN_MODE) instead of the folder's file listing.
   if (opts?.mode) parts.push("_mode=" + encodeURIComponent(opts.mode));
+  if (opts?.sel) parts.push("sel=" + encodeURIComponent(opts.sel));
   const search = parts.length ? "?" + parts.join("&") : "";
   // `opts.isDir` is a nav hint (the clicked listing row / breadcrumb already
   // knows whether the target is a directory): it rides in history.state so the

--- a/frontend/src/platform/lib/tour.ts
+++ b/frontend/src/platform/lib/tour.ts
@@ -54,11 +54,19 @@ const STEPS: DriveStep[] = [
       description: "Every view lives in the URL — copy or bookmark it to return.",
     },
   },
+  // Targets the listing body, NOT `#split-right-btn`. The tour auto-starts on
+  // the explorer's first screen, which is always a folder — and over a folder
+  // the crumb bar's layout zone is claimed (listing/folder-chrome.ts), so the
+  // split buttons aren't in the DOM and this step was silently filtered out of
+  // every first run. `.listing-split` is always there, and the copy now covers
+  // both halves of the feature: the pane the folder view opens for itself, and
+  // the buttons that appear once a file is open.
   {
-    element: "#split-right-btn",
+    element: ".listing-split",
     popover: {
-      title: "Split view",
-      description: "Open two panes side by side — like code next to its render.",
+      title: "Side by side",
+      description:
+        "Pick a file and it previews right here, beside the list. Open one and the bar offers full split panes.",
     },
   },
   {

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -194,9 +194,12 @@ function LoadingScaffold({ fsPath, isDir, headerless }: { fsPath: string; isDir:
           // Listing's hard "Failed to list" error while stat resolves — a 404
           // here just means the hint was wrong; stat will paint the file view.
           // `barChrome` on the scaffold too (same condition as `headerless`):
-          // the folder view's claim on the bar's layout zone must be live from
-          // the first paint, or the splits flash in and out across the
-          // scaffold→resolved swap.
+          // whenever the nav hint already says "directory" this claims the
+          // bar's layout zone from the first paint, so the splits don't flash
+          // in and out across the scaffold→resolved swap. Only a hinted nav
+          // gets that — open a folder URL directly (or reload) and there is no
+          // `history.state` hint, so no Listing mounts here and the splits do
+          // still show for the length of the stat.
           <Listing fsPath={fsPath} provisional barChrome={headerless} />
         ) : (
           <div className="preview-resolving">

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -34,7 +34,7 @@ import { isMod } from "@platform/lib/platform";
 import { isOverlayOpen } from "@platform/lib/ui-overlay";
 import { getClipboard, setClipboard } from "@apps/explorer/lib/fs-clipboard";
 import { reconcileOsClipboard } from "@apps/explorer/lib/os-clipboard";
-import { Breadcrumb, StaticBreadcrumb } from "@apps/explorer/Breadcrumb";
+import { BreadcrumbBar, StaticBreadcrumb } from "@apps/explorer/Breadcrumb";
 import Listing from "@apps/explorer/Listing";
 import Preview from "@apps/explorer/Preview";
 import Panel from "@apps/explorer/Panel";
@@ -335,11 +335,12 @@ function StatView({
   return (
     <>
       {/* Only the explorer carries a breadcrumb bar — the app builder and
-          learn render their content directly (no path chrome). */}
+          learn render their content directly (no path chrome). BreadcrumbBar
+          owns the `#breadcrumb` box itself: over a folder it portals the whole
+          bar down into the listing's left column, so it can't be a wrapper
+          rendered here (Breadcrumb.tsx). */}
       {variant === "explorer" && (
-        <div id="breadcrumb">
-          <Breadcrumb fsPath={fsPath} home={home} renderedTitle={renderedTitle} />
-        </div>
+        <BreadcrumbBar fsPath={fsPath} home={home} renderedTitle={renderedTitle} />
       )}
       <div id="content">{content}</div>
     </>

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -193,7 +193,11 @@ function LoadingScaffold({ fsPath, isDir, headerless }: { fsPath: string; isDir:
           // provisional: the hint could be stale (file, not dir). Suppress
           // Listing's hard "Failed to list" error while stat resolves — a 404
           // here just means the hint was wrong; stat will paint the file view.
-          <Listing fsPath={fsPath} provisional />
+          // `barChrome` on the scaffold too (same condition as `headerless`):
+          // the folder view's claim on the bar's layout zone must be live from
+          // the first paint, or the splits flash in and out across the
+          // scaffold→resolved swap.
+          <Listing fsPath={fsPath} provisional barChrome={headerless} />
         ) : (
           <div className="preview-resolving">
             <span className="mode-icon-spinner" />
@@ -303,7 +307,7 @@ function StatView({
     // it then — a folder must always render something.
     const s = stat.stat;
     if (s.is_dir && s.templates.length === 0) {
-      content = <Listing fsPath={fsPath} />;
+      content = <Listing fsPath={fsPath} barChrome={variant === "explorer"} />;
     } else if (!ready) {
       // Brief; only for files opened with an empty query while the sidecar
       // read resolves. Directories and param/bookmark opens are ready

--- a/frontend/src/shell/Preferences.tsx
+++ b/frontend/src/shell/Preferences.tsx
@@ -1,6 +1,8 @@
 // Preferences page (SPEC §20) — the `/view/_prefs` sentinel route, entered
 // from the sidebar's bottom-left gear. Two tabs (D125):
-//   Render preferences — Appearance, Call log (capture/redaction/retention for
+//   Render preferences — Appearance, Default model (which Claude model the
+//     chat and fused.ai reach for when nothing else has said), Call log
+//     (capture/redaction/retention for
 //     fused_render/calls.py), Deploy to Fused account (the opt-in Deploy-button
 //     toggle), Accessibility, and last Execution engine. Always present; the
 //     default (clean URL). No Tour button — the tour still runs itself on a
@@ -22,6 +24,7 @@ import {
   putCallsEnabled,
   putCallsParamsMode,
   putCallsRetentionDays,
+  putDefaultModel,
   putDeployEnabled,
   putEnginePref,
   putReaderEnabled,
@@ -263,6 +266,62 @@ function AccessibilitySection({
   );
 }
 
+// Human labels for the short model names the server accepts. Keyed off the
+// server's `choices` list rather than hardcoding the options, so the page can
+// never offer a value a PUT would reject — an unknown name still renders (as
+// itself) instead of vanishing from a control the user has one of selected.
+const MODEL_LABELS: Record<string, string> = {
+  "": "Automatic",
+  fable: "Fable",
+  opus: "Opus",
+  sonnet: "Sonnet",
+  haiku: "Haiku (fastest)",
+};
+
+function ModelSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) => void }) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  return (
+    <section className="prefs-section">
+      <h2>Default model</h2>
+      <p className="deploy-muted">
+        Which Claude model this app reaches for when nothing else has said. It preselects the
+        chat's model chip and picks the model behind <code>fused.ai</code>. A model chosen in a
+        chat, or one a page passes to <code>fused.ai</code> itself, still wins — this only
+        answers when nobody asked. <b>Automatic</b> leaves each to its own default.
+      </p>
+      <div className="prefs-field">
+        <label>
+          Model{" "}
+          <select
+            value={prefs.model.default}
+            disabled={busy}
+            onChange={async (e) => {
+              const next = e.target.value as Prefs["model"]["default"];
+              setBusy(true);
+              setError(null);
+              try {
+                onChange(await putDefaultModel(next));
+              } catch (err) {
+                setError((err as Error).message);
+              } finally {
+                setBusy(false);
+              }
+            }}
+          >
+            {prefs.model.choices.map((m) => (
+              <option key={m} value={m}>
+                {MODEL_LABELS[m] ?? m}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+    </section>
+  );
+}
+
 // The retention window as the "Currently keeping ..." line says it, matching
 // the select's own option labels so the forced value reads like a choice.
 function describeRetention(days: number): string {
@@ -488,6 +547,7 @@ export default function Preferences() {
             {tab === "render" && (
               <>
                 <AppearanceSection />
+                <ModelSection prefs={prefs} onChange={setPrefs} />
                 <CallLogSection prefs={prefs} onChange={setPrefs} />
                 <DeploymentsSection
                   prefs={prefs}

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -542,9 +542,11 @@
   /* Route fade (App.tsx): routes hard-remount per navigation, so there is no
      old-and-new overlap to cross-fade — a short fade-in on the content area
      alone makes the cut read as intentional. Shorter than --dur-med on purpose:
-     it must not delay reading the page. The sidebar and breadcrumb chrome sit
-     OUTSIDE this element and never flash. Replays because App keys this node on
-     the nav epoch (an iframe's param write doesn't bump it). */
+     it must not delay reading the page. The sidebar sits OUTSIDE this element
+     and never flashes; so does the crumb bar for a file view — over a FOLDER
+     the bar portals into the listing's left column and fades in with the
+     content it now belongs to. Replays because App keys this node on the nav
+     epoch (an iframe's param write doesn't bump it). */
   animation: content-in 110ms var(--ease-out);
 }
 
@@ -581,9 +583,18 @@
   min-width: 60px;
 }
 
-/* Left column of the split: search header pinned above the scrolling table.
-   With the pane on, the pane spans the template's full height while search
-   and the split toggle stay in this column. */
+/* Where the crumb bar hangs over a folder view (Breadcrumb.tsx BreadcrumbBar
+   portals into it, Listing.tsx renders it). `display: contents` so the wrapper
+   itself is invisible to the flex layout and `#breadcrumb` is a direct flex
+   item of .listing-main, sized and spaced exactly as it was under #main. */
+.listing-crumb-slot {
+  display: contents;
+}
+
+/* Left column of the split: crumb bar, then the search header, then the
+   scrolling table. The crumb bar is IN this column, which is the whole point —
+   the pane beside it starts at the top of the window and runs to the bottom,
+   with its own header as the topmost thing on that side. */
 .listing-main {
   flex: 1 1 auto;
   min-width: 0;

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -739,9 +739,9 @@
    the metadata card): while the pane is open this strip is the only thing
    carrying a way to close it.
 
-   No gutter hang for the leading button (unlike .listing-search's Up control):
-   this strip pads 10px and the thing beside the button is the file icon, not a
-   column the glyph has to line up with.
+   No gutter hang for the leading button (unlike .listing-search's trailing
+   `···`): this strip pads 10px and the thing beside the button is the file
+   icon, not a column the glyph has to line up with.
 
    It sits directly beside .listing-search — they are one visual row split by
    the pane divider — so the two MUST agree on height, or the pane's bottom
@@ -895,15 +895,14 @@ table.listing-table tr.skel-row:hover {
   background: var(--bg);
 }
 
-/* Optical gutter alignment for the leading Up button. The row pads 16px like
-   the listing gutter below it, but a ghost icon button is a 28px square with a
-   16px glyph centred, so its ARROW started ~6px right of the gutter while the
-   NAME header and the row icons underneath start exactly on it — the row read
-   as over-indented. Hang the button back into the padding so the glyph, not
-   the box, lines up. The 28px hit area is unchanged, and this is scoped to
-   this row: the topbar's controls sit against a right edge and are fine. */
-.listing-search > .bar-ctl-icon:first-child {
-  margin-left: -6px;
+/* Optical gutter alignment for the trailing path `···` (the folder view's,
+   moved down out of the crumb bar). The row pads 16px like the listing gutter
+   below it, but a ghost icon button is a 28px square with a 16px glyph
+   centred, so its dots would stop ~6px short of the gutter the MODIFIED column
+   above them ends on. Hang the button into the padding so the glyph, not the
+   box, lines up; the 28px hit area is unchanged. */
+.listing-search > .bar-overflow:last-child {
+  margin-right: -6px;
 }
 
 /* Wraps the input plus its pinned chips (count / spinner), so the preview-pane

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1000,6 +1000,9 @@ table.listing-table tr.skel-row:hover {
      crumb was part of it, and now only the strip's own trailing padding is.
      Ctrl+L and the crumbs themselves are unaffected. */
   margin-left: auto;
+  /* And the row packs to its own right edge, so any leftover slack in it falls
+     on the crumb side rather than between the `···` and the corner. */
+  justify-content: flex-end;
   height: auto;
   padding: 0;
   border-bottom: none;
@@ -1025,7 +1028,14 @@ table.listing-table tr.skel-row:hover {
    the `.searching` rules below — so this width has to serve the empty state
    and nothing else. */
 .crumb-search-slot .listing-search-box {
-  flex: 0 1 150px;
+  /* `width`, not a flex-basis. The row is sized by its content, and a flex
+     item's contribution to that is its MAX-content — for a bare `type=search`
+     input that is the UA's intrinsic ~166px, not the 150px basis it then lays
+     out at. The row came out 16px wider than what was in it, and the slack sat
+     at the end, holding the `···` that far off the right edge. A width is
+     intrinsic, so the row measures what it actually shows. */
+  flex: 0 1 auto;
+  width: 150px;
   min-width: 96px;
 }
 

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1111,8 +1111,25 @@ table.listing-table tr.skel-row:hover {
   padding-right: 96px;
 }
 
-.crumb-search-slot .listing-search-count {
-  right: 10px;
+/* The whole pin group moves in with it — the spinner too, or a streaming walk
+   would leave it hanging 16px out over the count. */
+.crumb-search-slot .listing-search-box {
+  --pin-right: 10px;
+}
+
+/* A pin costs 96px of the input, and the resting box is only 150px — which
+   would leave a few dozen pixels of field, clipping the placeholder and
+   anything typed. So a box with something pinned in it grows to keep its text
+   area: the reservation comes out of the bar's free width instead of out of
+   the query.
+
+   This is the MULTI-SELECTION readout in practice ("12 selected"). The other
+   pins ride a non-empty query, and that already takes the whole strip. Capped,
+   so a wide window does not turn a selection into a full-width search box; the
+   crumbs are scrollable and give up the difference. */
+.crumb-search-slot .listing-search-box.has-pin {
+  flex: 0 1 auto;
+  width: 260px;
 }
 
 /* Wraps the input plus its pinned chips (count / spinner), so the preview-pane
@@ -1144,10 +1161,13 @@ table.listing-table tr.skel-row:hover {
   appearance: none;
 }
 
-/* Match count pinned inside the input's right edge (no layout shift). */
+/* Match count pinned inside the input's right edge (no layout shift).
+   `--pin-right` is where the pinned chips hang from, so the two hosts can move
+   the whole pin group without either chip being left behind (the crumb-bar row
+   pulls it in — see .crumb-search-slot). */
 .listing-search-count {
   position: absolute;
-  right: 26px;
+  right: var(--pin-right, 26px);
   top: 50%;
   transform: translateY(-50%);
   color: var(--fg-muted);
@@ -1156,12 +1176,22 @@ table.listing-table tr.skel-row:hover {
   pointer-events: none;
 }
 
+/* A streaming walk shows BOTH — the spinner and the live count — and they hung
+   from the same offset, so the spinner sat on top of the digits. They stack
+   instead: spinner outermost, count shifted in by its width plus a gap. The
+   sibling combinator works because that is the DOM order (Listing.tsx renders
+   the spinner first), and it costs nothing in the settled state, where the
+   spinner is gone and the count keeps the pin to itself. */
+.listing-search-spinner + .listing-search-count {
+  right: calc(var(--pin-right, 26px) + 17px);
+}
+
 /* Small spinner shown while the recursive walk is still in flight, so a
    search on a huge folder doesn't look stalled while the input stays
    fully interactive. */
 .listing-search-spinner {
   position: absolute;
-  right: 26px;
+  right: var(--pin-right, 26px);
   top: 50%;
   width: 11px;
   height: 11px;

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -615,8 +615,9 @@
   display: contents;
 }
 
-/* Left column of the split: crumb bar, then the search header, then the
-   scrolling table. The crumb bar is IN this column, which is the whole point —
+/* Left column of the split: the crumb bar (search box and `···` included —
+   see .crumb-search-slot), then the scrolling table, and nothing between them.
+   The crumb bar is IN this column, which is the whole point —
    the pane beside it starts at the top of the window and runs to the bottom,
    with its own header as the topmost thing on that side. */
 .listing-main {
@@ -691,6 +692,38 @@
   min-width: 220px;
   min-height: 0;
   display: flex;
+  /* Anchors the seam below. */
+  position: relative;
+}
+
+/* The seam between the two columns, and where it STOPS.
+
+   It used to be a `border-left` on .listing-pane, which ran the full height —
+   including across the header row, where it cut the two strips into two boxes.
+   They are the same height, the same background and the same hairline at the
+   bottom precisely so they read as one bar across the window; a rule down the
+   middle of that undid it. So the seam now starts where the content does.
+
+   On the SLOT rather than on .listing-pane, because the pane is the scroll
+   container: an absolutely-positioned line inside it is laid out against the
+   padding box and would scroll away with a tall preview. The slot does not
+   scroll, so the line stays put. `top` is the shared strip height — the same
+   token the three bars use, so the seam meets the header's own bottom hairline
+   at exactly the corner in every host (with a crumb bar or, in the app
+   builder, with the search row as the left column's first strip).
+
+   The DRAG target is untouched: .listing-divider is a separate 5px flex item
+   spanning the full height, transparent until hover, and it still is. Only the
+   painted line got shorter. */
+.listing-pane-slot::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: var(--topbar-h);
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  pointer-events: none;
 }
 
 /* The pane itself: header bar + iframe / mini list / placeholder card. */
@@ -702,7 +735,8 @@
   flex-direction: column;
   overflow: auto;
   background: var(--bg-alt);
-  border-left: 1px solid var(--border);
+  /* The seam is painted by .listing-pane-slot::before, not by a border here:
+     it has to stop at the bottom of the header row. */
 }
 
 /* Fills whatever the pane has left — the whole pane for a file preview, the
@@ -908,13 +942,13 @@ table.listing-table tr.skel-row:hover {
   animation: skel-shimmer 1.2s ease-in-out infinite;
 }
 
-/* Row 2 of the listing column, under the crumb bar — and row 1 in the hosts
-   that have no crumb bar (the app builder), where it is what the preview
-   pane's header sits across the divider from. Same --topbar-h as the other two
-   strips either way; only the background differs, because this row belongs to
-   the list below it rather than to the chrome above. Its 30px input is the
-   tallest thing in any of the three, and is what sets the shared height's
-   content budget. */
+/* Row 1 of the listing column in the hosts that have NO crumb bar (the app
+   builder), where this row is what the preview pane's header sits across the
+   divider from: same --topbar-h, so the seam under the two columns is one
+   line. Over a folder in the explorer the row is not a row at all — it portals
+   into the crumb bar and the rules further down strip this box off it. Its
+   30px input is the tallest thing in any of the strips, and is what sets the
+   shared height's content budget. */
 .listing-search {
   flex: 0 0 auto;
   display: flex;
@@ -935,6 +969,99 @@ table.listing-table tr.skel-row:hover {
    box, lines up; the 28px hit area is unchanged. */
 .listing-search > .bar-overflow:last-child {
   margin-right: -6px;
+}
+
+/* ---- …and the same row once it has moved INTO the crumb bar --------------
+   Over a folder the left column had two full-height strips stacked (crumbs,
+   then search) against the preview pane's one across the divider, which read
+   as a mistake in the layout rather than as two things. The row portals into
+   the bar instead (search-slot.ts): crumbs at the left, the box and the `···`
+   at the right end, ONE strip per column.
+
+   `display: contents` on the target so the row itself is the bar's flex item,
+   and the row then gives up everything that made it a strip — its height, its
+   padding, its border and its background all belong to the bar now. */
+.crumb-search-slot {
+  display: contents;
+}
+
+.crumb-search-slot > .listing-search {
+  flex: 0 1 auto;
+  min-width: 0;
+  height: auto;
+  padding: 0;
+  border-bottom: none;
+  background: none;
+}
+
+/* The gutter hang exists to line the dots up with the MODIFIED column below
+   them. In the bar the neighbour is the file view's own `···`, at the bar's
+   16px padding — same bar, same corner, so it must not sit 6px off it. */
+.crumb-search-slot > .listing-search > .bar-overflow:last-child {
+  margin-right: 0;
+}
+
+/* Crumbs and the search box now share one row, so the box needs a size of its
+   own. It GROWS — with the seam over the header gone (see .listing-pane-slot)
+   the strip reads as one wide bar, and the search box is the thing in it worth
+   making wide. 320px of basis, up to 460px so a maximised window does not hand
+   it half the screen, and never below 140px (about "Start typing…" plus a few
+   characters of what was typed).
+
+   The crumbs still grow too, so the whitespace right of the last crumb — the
+   click-to-edit target — does not vanish; they just yield the row's width
+   first when it runs short (the shrink weight below). Ellipsizing and then
+   scrolling is what a path bar is built to do (.path-crumb.shrink), whereas a
+   squeezed input is just broken. */
+.crumb-search-slot .listing-search-box {
+  flex: 1 1 320px;
+  max-width: 460px;
+  min-width: 140px;
+}
+
+#breadcrumb:has(.crumb-search-slot) .crumbs {
+  flex-shrink: 6;
+}
+
+/* …and once there is a query, the crumbs get out of the way entirely.
+   Sharing the row is a compromise that only pays while both halves are in
+   use, and the moment someone types, the path is the half they are not
+   looking at — the results below no longer belong to it anyway. So the
+   crumbs stand down and the box takes the whole strip (max-width off), which
+   is the state where a long query most needs the room.
+
+   Reversible on a keystroke: clearing the query (or Esc) brings the path
+   straight back, so nothing is lost, only deferred. The ★ and the `···` stay
+   — they act on the folder, which has not changed. */
+#breadcrumb:has(.listing-search.searching) .crumbs {
+  display: none;
+}
+
+/* Both halves of that: the ROW has to grow (idle it is `0 1 auto`, sized to
+   its box) and the box inside it has to be allowed past the resting cap. Only
+   then does the field actually span the strip rather than sitting at 460px
+   with the freed-up crumb width as dead space beside it. */
+#breadcrumb:has(.listing-search.searching) .listing-search {
+  flex: 1 1 auto;
+}
+
+#breadcrumb:has(.listing-search.searching) .listing-search-box {
+  max-width: none;
+}
+
+/* Terse now ("1.2K · 45.1K…" rather than the full sentence — Listing.tsx keeps
+   that in the title and the aria-label), so the room reserved for it inside
+   the input comes back to the query: 116px sized the old sentence, 96px sizes
+   the widest thing left (the multi-selection readout, "1,234 selected") once
+   the chip stops hanging 26px off the edge. Still a reservation and not a
+   reflow — the chip is absolutely positioned, so a digit more or less never
+   moves the box. */
+.crumb-search-slot > .listing-search .listing-search-box.has-pin .listing-search-input {
+  padding-right: 96px;
+}
+
+.crumb-search-slot .listing-search-count {
+  right: 10px;
 }
 
 /* Wraps the input plus its pinned chips (count / spinner), so the preview-pane

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -6,18 +6,42 @@
   flex-direction: column;
 }
 
+/* THE top-bar height, shared by every strip that can be the first row of a
+   column: the crumb bar, the listing's search row, and the preview pane's
+   header. Over a folder the crumb bar and the pane header are side by side
+   with only the divider between them, so a difference of even a pixel puts a
+   visible step in the line under them. One number, in one place, is the only
+   way that stays true — and the pane header keeps matching the search row in
+   the app-builder variant, which has no crumb bar and starts its columns with
+   those two instead.
+
+   An EXACT height, not a floor. A `min-height` still lets the taller content
+   win — the pane header holds a 28px mode chip and, with 10px of padding and
+   the 1px border under border-box, came out one pixel taller than the crumb
+   bar beside it, which holds only text. One pixel is exactly the step the eye
+   catches on a line that runs the width of the window.
+
+   The budget: 48px, minus the 1px bottom border, minus 8px of padding at each
+   end, leaves 31px of content box — enough for the tallest thing any of the
+   three holds (the search row's 30px input; the bars' 28px controls). Anything
+   taller than 31px needs this number raised, not a local override. */
+:root {
+  --topbar-h: 48px;
+  --topbar-pad-y: 8px;
+}
+
 #breadcrumb {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  padding: 10px 16px;
+  padding: var(--topbar-pad-y) 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
-  /* Pin to the tallest state (28px control + 10px×2 padding) so the bar can't
-     grow when the portaled mode control lands after stat resolves. */
-  min-height: 48px;
+  /* Exact, so the bar neither grows when the portaled mode control lands after
+     stat resolves nor drifts off the pane header beside it. */
+  height: var(--topbar-h);
   box-sizing: border-box;
 }
 
@@ -738,49 +762,40 @@
   background: var(--bg-alt);
 }
 
-/* The pane's chrome strip, above whatever the pane is showing. It LEADS with
-   the collapse control — the pane's left edge is the seam it collapses toward,
-   so the close affordance sits on the boundary rather than in the far corner —
-   then a .bar-rule zone divider, then the row's identity (icon + name) and
-   whatever the settled preview adds at the other end (the mode control,
-   open-full-screen). The rule is what separates the one control that acts on
-   the PANE from everything that is about the previewed ROW; without it the
-   collapse glyph sat flush against the file icon and neither read as chrome. Present in EVERY pane state, including
-   the ones that have nothing else to put in it (a loading skeleton, an error,
-   the metadata card): while the pane is open this strip is the only thing
-   carrying a way to close it.
+/* The pane's chrome strip: the RIGHT COLUMN'S TOP BAR, since the pane now runs
+   the full height of the window with nothing above it. Directly across the
+   divider from the crumb bar (over a folder) or the search row (the
+   app-builder variant, which has no crumb bar) — one continuous strip split by
+   the divider — so it must match them exactly: same --topbar-h, same vertical
+   padding, same border, same background. Anything else puts a step in the line
+   under the two columns.
 
-   No gutter hang for the leading button (unlike .listing-search's trailing
-   `···`): this strip pads 10px and the thing beside the button is the file
-   icon, not a column the glyph has to line up with.
+   Present in EVERY pane state, including the ones with nothing to put in it (a
+   loading skeleton, an error, the metadata card, no selection). It holds no
+   text of its own any more — the row's icon and name came out
+   (ListingPreviewPane.tsx) — so the explicit `height` is the ONLY thing
+   standing the bar up in those states. It is not a nicety; without it the
+   strip collapses to its border and the seam breaks.
 
-   It sits directly beside .listing-search — they are one visual row split by
-   the pane divider — so the two MUST agree on height, or the pane's bottom
-   border runs 7px above the listing's and the row reads as broken. The search
-   row's height is content-derived (8px padding + a 30px input); this pins to
-   the same number and centres whatever it holds. Keep the two in step. */
+   `justify-content: flex-end` for the same reason: the strip's contents are
+   the mode menu and the open-full-screen glyph, which belong at the far end
+   the way the crumb bar's own controls do. With the name gone there is no
+   leading item left to push them there.
+
+   Horizontal padding stays at the PANE's 10px gutter (the crumb bar keeps the
+   listing's 16px): each bar lines up with the column underneath it, and the
+   seam is the border, not the gutter. */
 .listing-pane .pane-header {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
   gap: 8px;
-  padding: 8px 10px;
-  min-height: 46px;
+  padding: var(--topbar-pad-y) 10px;
+  height: var(--topbar-h);
+  box-sizing: border-box;
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
-}
-
-.listing-pane .pane-header-icon {
-  flex: 0 0 auto;
-  display: inline-flex;
-}
-
-.listing-pane .pane-header-name {
-  flex: 1 1 auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--fg);
 }
 
 /* Folder preview fallback: the folder's own entries, read-only. Narrower
@@ -893,15 +908,21 @@ table.listing-table tr.skel-row:hover {
   animation: skel-shimmer 1.2s ease-in-out infinite;
 }
 
-/* Row 2, listing side. Its height is the reference the preview pane's header
-   pins itself to (.listing-pane .pane-header) — the two are one row. */
+/* Row 2 of the listing column, under the crumb bar — and row 1 in the hosts
+   that have no crumb bar (the app builder), where it is what the preview
+   pane's header sits across the divider from. Same --topbar-h as the other two
+   strips either way; only the background differs, because this row belongs to
+   the list below it rather than to the chrome above. Its 30px input is the
+   tallest thing in any of the three, and is what sets the shared height's
+   content budget. */
 .listing-search {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
   gap: 8px;
-  min-height: 46px;
-  padding: 8px 16px;
+  height: var(--topbar-h);
+  box-sizing: border-box;
+  padding: var(--topbar-pad-y) 16px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -832,6 +832,23 @@
   background: var(--bg-alt);
 }
 
+/* Portal target for the open folder's "Open as app" (pane-action-slot.ts).
+   `display: contents` so the button is a flex item of the header itself and
+   picks up its gap and alignment, and `margin-right: auto` so it sits at the
+   header's LEFT end while the mode chip and the expand glyph stay packed
+   right: it belongs to the folder on the other side of the divider, not to the
+   row the rest of this bar is about.
+
+   :empty and it disappears — most folders have no lone page to open, and an
+   empty item would still spend one of the header's 8px gaps. */
+.listing-pane .pane-action-slot {
+  display: contents;
+}
+
+.listing-pane .pane-action-slot > * {
+  margin-right: auto;
+}
+
 /* Folder preview fallback: the folder's own entries, read-only. Narrower
    padding than the main table since it lives in the smaller pane. */
 .listing-pane .pane-mini-scroll {

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1014,11 +1014,24 @@ table.listing-table tr.skel-row:hover {
    and nothing else. */
 .crumb-search-slot .listing-search-box {
   flex: 0 1 150px;
-  min-width: 110px;
+  min-width: 96px;
 }
 
+/* Who yields when the bar runs short, and in what order.
+   The crumbs go first and by a long way (shrink 6 against the box's 1):
+   ellipsizing and then scrolling is what a path bar is built to do, and the
+   tail — the folder you are actually in — is pinned into view, so a narrow
+   crumb strip still says where you are. A squeezed input just looks broken.
+
+   But they stop at 120px rather than at zero, because a path bar scrolled down
+   to nothing is no longer a path bar. Past that point the search box takes
+   over and gives up its own width, down to 96px — still the full "Search…"
+   placeholder, just with no slack around it. Between the two floors the strip
+   stays one line at any width the split allows, which is what keeps it the
+   same height as the pane header across the divider. */
 #breadcrumb:has(.crumb-search-slot) .crumbs {
   flex-shrink: 6;
+  min-width: 120px;
 }
 
 /* …and once there is a query, the crumbs get out of the way entirely.

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -988,6 +988,18 @@ table.listing-table tr.skel-row:hover {
 .crumb-search-slot > .listing-search {
   flex: 0 1 auto;
   min-width: 0;
+  /* Pinned to the bar's right end, whatever else is or isn't in the row: the
+     mode slot hides itself when empty, and the split buttons are gone over a
+     folder, so "after the last thing" is not a fixed place. An auto margin is
+     — it eats the free width, so the box and the `···` sit against the right
+     edge in every state, which is where the hand goes looking for them (a
+     file view keeps its own `···` in that same corner).
+
+     It works because the crumbs stop growing here (see .crumbs below). That
+     costs the click-to-edit target some reach — the whitespace past the last
+     crumb was part of it, and now only the strip's own trailing padding is.
+     Ctrl+L and the crumbs themselves are unaffected. */
+  margin-left: auto;
   height: auto;
   padding: 0;
   border-bottom: none;
@@ -1030,6 +1042,7 @@ table.listing-table tr.skel-row:hover {
    stays one line at any width the split allows, which is what keeps it the
    same height as the pane header across the divider. */
 #breadcrumb:has(.crumb-search-slot) .crumbs {
+  flex-grow: 0;
   flex-shrink: 6;
   min-width: 120px;
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1002,21 +1002,19 @@ table.listing-table tr.skel-row:hover {
 }
 
 /* Crumbs and the search box now share one row, so the box needs a size of its
-   own. It GROWS — with the seam over the header gone (see .listing-pane-slot)
-   the strip reads as one wide bar, and the search box is the thing in it worth
-   making wide. 320px of basis, up to 460px so a maximised window does not hand
-   it half the screen, and never below 140px (about "Start typing…" plus a few
-   characters of what was typed).
+   own — and at rest it is SMALL. An idle search box is a target to click, not
+   a field to read, and the bar's real subject is the path; a wide empty input
+   sitting in the middle of it was the loudest thing in the strip and the least
+   used. 150px is a little more than "Search…" needs, and it stops there: the
+   box does not grow, so the free width stays with the crumbs (whose trailing
+   whitespace is the click-to-edit target).
 
-   The crumbs still grow too, so the whitespace right of the last crumb — the
-   click-to-edit target — does not vanish; they just yield the row's width
-   first when it runs short (the shrink weight below). Ellipsizing and then
-   scrolling is what a path bar is built to do (.path-crumb.shrink), whereas a
-   squeezed input is just broken. */
+   It is only at rest. The first keystroke hands the box the whole strip — see
+   the `.searching` rules below — so this width has to serve the empty state
+   and nothing else. */
 .crumb-search-slot .listing-search-box {
-  flex: 1 1 320px;
-  max-width: 460px;
-  min-width: 140px;
+  flex: 0 1 150px;
+  min-width: 110px;
 }
 
 #breadcrumb:has(.crumb-search-slot) .crumbs {
@@ -1038,15 +1036,15 @@ table.listing-table tr.skel-row:hover {
 }
 
 /* Both halves of that: the ROW has to grow (idle it is `0 1 auto`, sized to
-   its box) and the box inside it has to be allowed past the resting cap. Only
-   then does the field actually span the strip rather than sitting at 460px
-   with the freed-up crumb width as dead space beside it. */
+   its box) and so does the BOX (idle `0 1 200px`). Only then does the field
+   actually span the strip rather than sitting at its resting width with the
+   freed-up crumb width as dead space beside it. */
 #breadcrumb:has(.listing-search.searching) .listing-search {
   flex: 1 1 auto;
 }
 
 #breadcrumb:has(.listing-search.searching) .listing-search-box {
-  max-width: none;
+  flex: 1 1 auto;
 }
 
 /* Terse now ("1.2K · 45.1K…" rather than the full sentence — Listing.tsx keeps

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -17,6 +17,7 @@ from fastapi.responses import (
 )
 
 from fused_render.server.common import _require_fused
+from fused_render.shell.prefs import default_model
 
 router = APIRouter()
 
@@ -59,6 +60,29 @@ router = APIRouter()
 # by default in stream-json mode). See _AiSession.configure.
 _AI_EFFORTS = ("low", "medium", "high", "xhigh")
 _AI_DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+# The default-model PREFERENCE (shell/prefs.py) speaks short names, because its
+# other consumer — the claude chat template's model chip — does: one preference
+# cannot have two vocabularies. This relay hands its value to the CLI, which is
+# happier with a full id, so the short→id mapping lives here, at the one call
+# site that needs it, rather than in the pref (which would make the store know
+# about a model catalogue it has no other reason to track).
+#
+# Ids are unsuffixed aliases, not dated snapshots: a dated id pins a model
+# version the user did not choose, and "opus" in the picker meaning last
+# quarter's opus is a worse surprise than the alias moving. The hardcoded
+# `_AI_DEFAULT_MODEL` above keeps its date because it is a DIFFERENT promise —
+# the cheap, fast model this relay has always used for its small utility
+# completions when nobody has expressed a preference at all.
+#
+# Keys must cover VALID_DEFAULT_MODELS minus its "" (unset) member; the values
+# are argv, so they live inside `_AI_MODEL_RE`'s charset boundary. Both are
+# asserted in tests/test_server_ai.py.
+_AI_SHORT_MODEL_IDS = {
+    "fable": "claude-fable-5",
+    "opus": "claude-opus-5",
+    "sonnet": "claude-sonnet-5",
+    "haiku": "claude-haiku-4-5",
+}
 _AI_DEFAULT_SYSTEM_PROMPT = "You are a helpful assistant."
 _AI_TIMEOUT_S = 600.0
 # A reconfiguration step (/clear, set_model, effort) is local work; one that
@@ -643,7 +667,13 @@ async def _ai_relay(body: dict):
             "bad_request",
             "'model' must be a model id or alias (letters, digits, . _ -)",
             status=400)
-    model = model or _AI_DEFAULT_MODEL
+    # Precedence: the caller's explicit model, then the user's preference, then
+    # this relay's own default. Read per request (like the engine pref), so a
+    # change on the Preferences page applies to the next call with no restart.
+    # `default_model` is module-level so the mapping is the only thing between
+    # the pref and argv — an unmapped value falls through to the default rather
+    # than being passed along.
+    model = model or _AI_SHORT_MODEL_IDS.get(default_model()) or _AI_DEFAULT_MODEL
     effort = body.get("effort")
     if effort is not None and effort not in _AI_EFFORTS:
         return _ai_error(

--- a/fused_render/shell/prefs.py
+++ b/fused_render/shell/prefs.py
@@ -10,11 +10,12 @@ desktop tray's "Open app logs" already covers that. Since the call store moved t
 ~/.fused-render/logs, a second "Logs" heading here read as the call log's
 settings rather than as a separate thing.
 
-Three preferences are persisted: **deploy_enabled** (whether the preview-header
+Four preferences are persisted: **deploy_enabled** (whether the preview-header
 Deploy affordance is shown — opt-in, default off; see ``deploy_enabled``),
 **reader_enabled** (whether the Reader listen-to-files accessibility mode is
-offered — opt-in, default off; see ``reader_enabled``), and the **execution
-engine** for /api/run:
+offered — opt-in, default off; see ``reader_enabled``), **default_model** (the
+preferred Claude model as a short name, unset by default; see
+``default_model``), and the **execution engine** for /api/run:
 
   * ``"fused"`` (default, D204) — the fused local compute backend (engine.py):
     a folder's ``pyproject.toml`` dependencies resolved into cached venvs,
@@ -55,6 +56,15 @@ router = APIRouter()
 
 VALID_ENGINES = ("builtin", "fused")
 VALID_CALLS_PARAMS = ("full", "keys", "off")
+# The default-model preference's value set. SHORT NAMES, not API model ids, and
+# `""` — unset — is a first-class member rather than an absence: it is what the
+# page's "Automatic" option writes, and it means "let each consumer keep its own
+# default" (see default_model). The names are the claude template's own selector
+# list (templates/claude/template.html MODELS) — the pref has to speak the same
+# vocabulary as the control it presets, and the CLI those names reach accepts
+# them as aliases. The relay (server/ai.py) wants a full API id instead, so the
+# short→id mapping lives THERE, in one place, next to the caller that needs it.
+VALID_DEFAULT_MODELS = ("", "fable", "opus", "sonnet", "haiku")
 DEFAULT_CALLS_RETENTION_DAYS = 14
 
 
@@ -113,6 +123,25 @@ def reader_enabled() -> bool:
     reads as off.
     """
     return read_prefs().get("reader_enabled") is True
+
+
+def default_model() -> str:
+    """The user's preferred Claude model, as a short name — `""` when unset.
+
+    One preference, two consumers, and neither is allowed to be the authority
+    on it: the fused.ai relay (server/ai.py, which maps the short name to the
+    full API id it hands the CLI) and the claude chat template (which uses it
+    to preselect its model chip). Both rank it the same way — an EXPLICIT
+    choice always wins, this is the next-best answer, and each keeps its own
+    hardcoded fallback beneath it — so the pref changes what happens when
+    nobody asked for a model, never what happens when somebody did.
+
+    An unknown value reads as unset, exactly like `selected_engine`'s: prefs.json
+    is a plain file a user may hand-edit, and the one thing that must not happen
+    is an arbitrary string reaching a subprocess argv.
+    """
+    value = read_prefs().get("default_model")
+    return value if value in VALID_DEFAULT_MODELS else ""
 
 
 def calls_enabled() -> bool:
@@ -210,6 +239,11 @@ def _prefs_response() -> dict:
         "deploy": {"enabled": deploy_enabled()},
         # Whether the Reader (listen-to-files) accessibility mode is offered (opt-in).
         "reader": {"enabled": reader_enabled()},
+        # The default Claude model, as a short name; "" = unset (each consumer
+        # keeps its own default). `choices` ships the value set with the value
+        # so the Preferences page renders the options the server will accept
+        # rather than a second copy of this list that can drift from it.
+        "model": {"default": default_model(), "choices": list(VALID_DEFAULT_MODELS)},
         # The app call log (calls.py): capture state, param redaction, retention.
         # `dir` lets the page reveal the store through the existing
         # /api/fs/reveal, exactly as `log.path` does.
@@ -326,6 +360,16 @@ def put_prefs(body: dict = Body(...), x_fused: str | None = Header(default=None)
             return JSONResponse({"error": "'reader_enabled' must be a boolean"}, status_code=400)
         prefs["reader_enabled"] = value
         changed = True
+    if "default_model" in body:
+        value = body.get("default_model")
+        if value not in VALID_DEFAULT_MODELS:
+            return JSONResponse(
+                {"error": "'default_model' must be one of: "
+                          + ", ".join(repr(v) for v in VALID_DEFAULT_MODELS)},
+                status_code=400,
+            )
+        prefs["default_model"] = value
+        changed = True
     if "calls_enabled" in body:
         value = body.get("calls_enabled")
         if not isinstance(value, bool):
@@ -353,8 +397,9 @@ def put_prefs(body: dict = Body(...), x_fused: str | None = Header(default=None)
     if not changed:
         return JSONResponse(
             {"error": "no known preference in request (expected 'engine', "
-                      "'deploy_enabled', 'reader_enabled', 'calls_enabled', "
-                      "'calls_params' and/or 'calls_retention_days')"},
+                      "'deploy_enabled', 'reader_enabled', 'default_model', "
+                      "'calls_enabled', 'calls_params' and/or "
+                      "'calls_retention_days')"},
             status_code=400,
         )
     storage.write_json(_path(), prefs)

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -3971,7 +3971,17 @@ const DEFAULT_EFFORT = "medium";
 // the last-resort fallback when nothing was detected.
 let detectedModel = "";
 let detectedEffort = "";
-const curModel = () => fused.params.get("model") || detectedModel || DEFAULT_MODEL;
+// The user's default-model preference (Preferences → Default model), a short
+// name from the same list as MODELS above — "" while unset or unread. It ranks
+// BELOW detection deliberately: detection is what this project is actually
+// being worked in, which is a stronger statement about this chat than a
+// global preference, and the preference is what fills the gap when there is
+// nothing to detect (a project Claude has never touched). Read straight off
+// GET /api/prefs like the other /api/… reads in this file — the pref is app
+// state, not a mount- or server-internal fact.
+let prefModel = "";
+const curModel = () =>
+  fused.params.get("model") || detectedModel || prefModel || DEFAULT_MODEL;
 const curEffort = () => fused.params.get("effort") || detectedEffort || DEFAULT_EFFORT;
 // The strictest mode is the default: more auto-approval is opted into, never
 // handed out by a missing param.
@@ -4019,6 +4029,16 @@ fused.runPython(AGENT, { action: "defaults", file: FILE }, { key: null }).then((
   if (d && d.model && MODELS.includes(d.model)) detectedModel = d.model;
   if (d && d.effort && EFFORTS.includes(d.effort)) detectedEffort = d.effort;
   if (detectedModel || detectedEffort) syncSelects();
+}).catch(() => {});
+
+// The default-model preference, on the same best-effort footing as detection:
+// it lands whenever it lands, and syncSelects() re-reads curModel() so
+// whichever of the two arrives second simply re-renders the same ranking.
+// Validated against MODELS for the same reason detection is — a name this
+// build's selector doesn't have can't be shown as selected.
+fetch("/api/prefs").then((r) => r.json()).then((p) => {
+  const m = p && p.model && p.model.default;
+  if (m && MODELS.includes(m)) { prefModel = m; syncSelects(); }
 }).catch(() => {});
 
 // The split param changes on drag too — applySplit on every change is cheap

--- a/tests/test_claude_defaults.py
+++ b/tests/test_claude_defaults.py
@@ -115,9 +115,19 @@ def test_the_page_asks_and_ranks_detection_below_an_explicit_choice():
     html = open(os.path.join("fused_render", "templates", "claude",
                              "template.html"), encoding="utf-8").read()
     assert '{ action: "defaults", file: FILE }' in html
-    # explicit pane param > detected config > hardcoded fallback
-    assert 'fused.params.get("model") || detectedModel || DEFAULT_MODEL' in html
+    # explicit pane param > detected config > user preference > hardcoded
+    # fallback. The preference sits BELOW detection on purpose: what this
+    # project is actually worked in says more about this chat than a global
+    # setting does, and the preference is what fills the gap when there is
+    # nothing to detect.
+    assert (
+        'fused.params.get("model") || detectedModel || prefModel || DEFAULT_MODEL' in html
+    )
     assert 'fused.params.get("effort") || detectedEffort || DEFAULT_EFFORT' in html
     # detected values are validated against the selector's own lists
     assert "MODELS.includes(d.model)" in html
     assert "EFFORTS.includes(d.effort)" in html
+    # …and so is the preference, for the same reason: a name this build's
+    # selector doesn't have cannot be shown as selected.
+    assert 'fetch("/api/prefs")' in html
+    assert "MODELS.includes(m)" in html

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -30,6 +30,18 @@ _STATIC = Path(fused_render.__file__).parent / "static"
 RUNTIME = (_STATIC / "runtime.js").read_text(encoding="utf-8")
 
 
+@pytest.fixture(autouse=True)
+def _isolated_prefs(tmp_path, monkeypatch):
+    """Never read the developer's own prefs.json.
+
+    The relay now resolves an unspecified model through the default-model
+    preference, so a machine that has one set would flip the model out from
+    under every test that asserts the hardcoded default — a pass/fail that
+    depends on whose laptop is running it.
+    """
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "prefs-home"))
+
+
 def _relay(body):
     return asyncio.run(_server_ai._ai_relay(body))
 
@@ -389,6 +401,61 @@ def test_relay_set_model_is_sent_on_every_request(monkeypatch):
                      "model": _server_ai._AI_DEFAULT_MODEL,
                      "system_prompt": _server_ai._AI_DEFAULT_SYSTEM_PROMPT}
                for c in set_models)
+
+
+def _set_models(proc):
+    return [c for c in proc.controls if c["subtype"] == "set_model"]
+
+
+def test_relay_uses_the_default_model_pref_when_the_call_names_none(monkeypatch):
+    # The pref is a SHORT name (shell/prefs.py); the CLI wants an id, and the
+    # mapping lives here so the two consumers of the pref can't disagree on it.
+    monkeypatch.setattr(_server_ai, "default_model", lambda: "opus")
+    fake = _cli_ok(monkeypatch, turns=[_result_lines()])
+    _relay({"prompt": "one"})
+    proc, = fake.procs
+    assert _set_models(proc)[0]["model"] == _server_ai._AI_SHORT_MODEL_IDS["opus"]
+
+
+def test_relay_falls_back_to_the_hardcoded_default_while_the_pref_is_unset(monkeypatch):
+    monkeypatch.setattr(_server_ai, "default_model", lambda: "")
+    fake = _cli_ok(monkeypatch, turns=[_result_lines()])
+    _relay({"prompt": "one"})
+    proc, = fake.procs
+    assert _set_models(proc)[0]["model"] == _server_ai._AI_DEFAULT_MODEL
+
+
+def test_relay_an_explicit_model_outranks_the_pref(monkeypatch):
+    # The pref changes what happens when nobody asked for a model, never what
+    # happens when somebody did — a caller that names one still gets it.
+    monkeypatch.setattr(_server_ai, "default_model", lambda: "haiku")
+    fake = _cli_ok(monkeypatch, turns=[_result_lines()])
+    _relay({"prompt": "one", "model": "claude-opus-4-8"})
+    proc, = fake.procs
+    assert _set_models(proc)[0]["model"] == "claude-opus-4-8"
+
+
+def test_relay_ignores_a_pref_value_it_has_no_id_for(monkeypatch):
+    # Belt-and-braces against the two lists drifting apart: a short name the
+    # mapping doesn't know falls through to the hardcoded default rather than
+    # reaching argv as an unmapped string.
+    monkeypatch.setattr(_server_ai, "default_model", lambda: "nonesuch")
+    fake = _cli_ok(monkeypatch, turns=[_result_lines()])
+    _relay({"prompt": "one"})
+    proc, = fake.procs
+    assert _set_models(proc)[0]["model"] == _server_ai._AI_DEFAULT_MODEL
+
+
+def test_every_valid_pref_short_name_maps_to_an_id(monkeypatch):
+    # The pref's value set and the relay's mapping are two lists that must
+    # cover each other; "" is the unset member and deliberately has no id.
+    from fused_render.shell.prefs import VALID_DEFAULT_MODELS
+
+    assert set(_server_ai._AI_SHORT_MODEL_IDS) == set(VALID_DEFAULT_MODELS) - {""}
+    for model_id in _server_ai._AI_SHORT_MODEL_IDS.values():
+        # Every mapped id must clear the argv charset guard — this mapping is
+        # a source of argv values, so it is inside that security boundary.
+        assert _server_ai._AI_MODEL_RE.fullmatch(model_id)
 
 
 def test_relay_effort_maps_to_thinking_budget_and_flag(monkeypatch):

--- a/tests/test_shell_prefs.py
+++ b/tests/test_shell_prefs.py
@@ -172,6 +172,70 @@ def test_put_rejects_bad_deploy_enabled_and_empty_body(tmp_path, monkeypatch):
     assert not (home / "prefs.json").exists()
 
 
+def test_default_model_defaults_to_unset_and_round_trips(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    # Unset is its own value — "" means "whatever each consumer's own default
+    # is", not a model. Every consumer treats it as no answer at all.
+    assert client.get("/api/prefs").json()["model"]["default"] == ""
+    body = client.put("/api/prefs", json={"default_model": "opus"}, headers=FUSED).json()
+    assert body["model"]["default"] == "opus"
+    stored = json.loads((home / "prefs.json").read_text(encoding="utf-8"))
+    assert stored["default_model"] == "opus"
+    assert client.get("/api/prefs").json()["model"]["default"] == "opus"
+    # And back to unset, which is a settable choice and not just an absence.
+    assert (
+        client.put("/api/prefs", json={"default_model": ""}, headers=FUSED).json()["model"][
+            "default"
+        ]
+        == ""
+    )
+
+
+def test_default_model_accepts_exactly_the_short_names(tmp_path, monkeypatch):
+    client, _ = _client(tmp_path, monkeypatch)
+    # The short names are the claude template's own selector list — the
+    # preference has to speak the same vocabulary as the control it presets.
+    for name in ("fable", "opus", "sonnet", "haiku"):
+        assert (
+            client.put("/api/prefs", json={"default_model": name}, headers=FUSED).json()["model"][
+                "default"
+            ]
+            == name
+        )
+
+
+def test_put_rejects_an_unknown_default_model(tmp_path, monkeypatch):
+    client, home = _client(tmp_path, monkeypatch)
+    # A full API id is NOT accepted: the pref is the short name, and the
+    # short→id mapping lives in exactly one place (server/ai.py).
+    for bad in ("claude-opus-5", "gpt-4", 3, None):
+        assert (
+            client.put("/api/prefs", json={"default_model": bad}, headers=FUSED).status_code == 400
+        )
+    assert not (home / "prefs.json").exists()
+
+
+def test_default_model_is_independent_of_the_other_prefs(tmp_path, monkeypatch):
+    client, _ = _client(tmp_path, monkeypatch)
+    monkeypatch.setattr(prefs_mod, "fused_engine_available", lambda: True)
+    client.put("/api/prefs", json={"engine": "fused"}, headers=FUSED)
+    client.put("/api/prefs", json={"reader_enabled": True}, headers=FUSED)
+    body = client.put("/api/prefs", json={"default_model": "haiku"}, headers=FUSED).json()
+    assert body["engine"]["selected"] == "fused"
+    assert body["reader"]["enabled"] is True
+    assert body["model"]["default"] == "haiku"
+
+
+def test_default_model_reader_ignores_a_hand_edited_junk_value(tmp_path, monkeypatch):
+    # prefs.json is a user-editable file; an unknown value reads as unset
+    # rather than reaching a consumer that would pass it to a CLI.
+    client, home = _client(tmp_path, monkeypatch)
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "prefs.json").write_text(json.dumps({"default_model": "wat"}), encoding="utf-8")
+    assert prefs_mod.default_model() == ""
+    assert client.get("/api/prefs").json()["model"]["default"] == ""
+
+
 def test_env_var_reports_as_forcing(tmp_path, monkeypatch):
     client, _ = _client(tmp_path, monkeypatch)
     monkeypatch.setenv("FUSED_RENDER_ENGINE", "builtin")


### PR DESCRIPTION
## Summary

- **The Up button is gone.** Going up is now the crumbs and the keyboard (Backspace / Mod+Up), not a third affordance wedged into the search row. The chord is untouched.
- **An upward hop lands on the folder you came out of.** Click a crumb (or press Backspace) and the folder you just left is the selected, scrolled-into-view row — the behaviour every file manager has. Crumbs and keyboard share one pure function.
- **A default Claude model is now a preference.** `~/.fused-render/prefs.json` grows `default_model`; the Preferences page offers it; the fused.ai relay and the claude template's model chip both respect it. An explicit model always still wins.
- **The folder view owns its own chrome.** Over a folder the split buttons disappear (the view is *already* a split — list + preview pane) and the `···` moves out of the far end of the crumb bar into the listing's search row, next to the control it acts on. File/preview views are unchanged.

## Visuals

Where a model comes from on a call with no explicit `model` — the new pref slots between detection and each consumer's hardcoded fallback, and never outranks an explicit choice.

```mermaid
flowchart TD
    A[Model requested] --> B{Explicit model?}
    B -->|yes| Z[Use it]
    B -->|no| C{Detected from session?}
    C -->|yes, template only| Z
    C -->|no| D{default_model pref set?}
    D -->|yes| E[Short name to id]
    D -->|no| F[Hardcoded fallback]
    E --> Z
    F --> Z
```

Short name → API id mapping lives in `server/ai.py` (`_AI_SHORT_MODEL_IDS`); the pref itself stores short names because the template's chip speaks short names too.

## Usage

**Set a default model** — Preferences → *Default model* → pick `Automatic` / Fable / Opus / Sonnet / Haiku. Or via the API:

```bash
curl -X PUT localhost:PORT/api/prefs -H 'content-type: application/json' \
     -d '{"default_model": "opus"}'
```

`"" ` (Automatic) means "each consumer keeps its own default" — the relay falls back to `claude-haiku-4-5-20251001`, the template to `sonnet`.

**Explorer** — open any folder: no Up button, no split buttons, `···` sits at the end of the search row. Click any breadcrumb segment and the folder you came from is highlighted.

## Test Plan

- [x] `tests/test_shell_prefs.py` — `default_model` validation, unknown-value-reads-as-unset, GET payload `choices`, PUT rejection.
- [x] `tests/test_server_ai.py` — relay precedence (explicit > pref > hardcoded); asserts `_AI_SHORT_MODEL_IDS` covers `VALID_DEFAULT_MODELS` and every mapped id clears the `_AI_MODEL_RE` argv guard. Autouse `_isolated_prefs` fixture so a developer's real pref can't flip these.
- [x] `tests/test_claude_defaults.py` — precedence source-guard updated for the new `prefModel` rank, plus guards on the `/api/prefs` fetch and `MODELS.includes(m)` validation.
- [x] `frontend/.../listing/selection.test.ts` (+8) — `cameFromSelParam`: root, Windows drive root, non-ancestor, prefix-of-string ≠ prefix-of-path.
- [x] `frontend/.../listing/folder-chrome.test.ts` (+5) — counted claim store (mount-before-unmount ordering, idempotent release).
- [x] Python suite: **4899 passed, 135 skipped**. One failure, `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, is pre-existing and environmental — it reads `/proc/self/fd`, which does not exist on macOS. Confirmed failing on a clean baseline before any change here.
- [x] `bun run typecheck` clean; `bun run check:boundaries` OK (163 files). `bun test`: 396 pass, 8 fail — all 8 in `listing/shortcut-chord.test.ts`, **verified to fail identically at the base commit with those files untouched** (Bun 1.3.13 now defines a `navigator` matching `/mac/i`, so `isMac` is true and the tests' non-Mac expectations break).
- [x] Browser-verified against a live dev server: crumb click lands on `…/fused-render?sel=core_apps` with the row highlighted; folder view has 0 split buttons and 1 search-row `···`, file view has 1 and 0; split-right still enters panel mode.

### Not verified — needs a human

- Native pointer interaction with the moved `···` (hover states, popup anchoring in the search row) — the webview can't fire real `:hover`.
- Drag-and-drop and marquee in the folder view after the search-row change (geometry-sensitive).
- The go-up **keyboard** path end-to-end — same pure function and same `navigate` option as the verified crumb path, but a real key event couldn't be delivered.
- The claude template's pref path in a live chat: this machine's `~/.claude/settings.json` sets `model`, so detection legitimately outranks the pref everywhere it could be tested. Worth one check on a machine without that.
- `/api/ai` against a real `claude` binary (unit tests cover the mocked subprocess only).

### Scope note

"Make the preview pane take full height" turned out to need no change: `.listing-pane-slot` already spans the entire content area (measured byte-identical to `#content`). Going "fuller" would mean hoisting the pane above the crumb bar into a shell-level slot, which breaks the width-driven split, divider drag, marquee and drop targets from #430 — judged out of proportion and left alone. Moving the `···` into the search row gives the intended unbroken-row read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
