### PR TITLE
Fix the white flash between embedded documents in dark mode

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,8 +48,16 @@
        just stamped, so the placeholder can't flash the wrong appearance.
        Honours prefers-reduced-motion like everything in shell.css does. -->
   <style>
-    body { margin: 0; background: #131417; }
-    html[data-theme="light"] body { background: #ffffff; }
+    /* On <html>, not just <body>: the canvas takes its colour from the root
+       element until <body> is parsed, so a rule on body alone leaves the
+       browser's white base painting the first frames of every load — the
+       white flash a preview iframe showed on each navigation. `color-scheme`
+       is here for the same reason, one step earlier still: it is what the
+       browser's own default surfaces (and any document that never sets a
+       background) resolve against. */
+    html { color-scheme: dark; background: #131417; }
+    html[data-theme="light"] { color-scheme: light; background: #ffffff; }
+    body { margin: 0; background: inherit; }
     #boot {
       position: fixed;
       inset: 0;

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -83,3 +83,20 @@ body {
   height: 100vh;
 }
 
+/* Every embedded document renders on the shell's own backdrop. Two reasons,
+   both about what shows through:
+     * WHILE A FRAME LOADS there is no document to paint, and the browser's
+       default canvas is white — the flash you got switching files in a preview
+       pane, since each switch is a fresh navigation;
+     * ONCE IT HAS, a template that sets no background of its own is
+       transparent, and the same white shows through for good.
+   `background` covers both. `color-scheme` is inherited from :root
+   (styles/tokens.css) and rides along to the embedded document, so the browser
+   paints ITS default surfaces (scrollbars, form controls) in the shell's
+   appearance rather than a light-mode set inside a dark page.
+   A template that wants a different surface just sets one — its own opaque
+   background paints over this. */
+iframe {
+  background: var(--bg);
+}
+

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -53,8 +53,10 @@
  * cross-origin ancestor) it falls back to reading/writing its own URL, treating
  * the `path` query key as reserved alongside any `_`-prefixed key.
  *
- * It also carries the appearance theme into OPTED-IN view documents — see the
- * theme block at the top of the IIFE (SPEC §30, D134).
+ * It also carries the appearance theme into view documents — as `data-theme`
+ * for the ones that opt in, and as `color-scheme` (browser defaults only) for
+ * the ones that don't — see the theme block at the top of the IIFE
+ * (SPEC §30, D134).
  */
 (function () {
   "use strict";
@@ -104,9 +106,35 @@
 
   function startTheme() {
     var root = document.documentElement;
-    if (!root || !root.hasAttribute("data-fused-theme")) return;
+    if (!root) return;
+    // Two kinds of document, one resolved theme:
+    //
+    //   OPTED IN (`data-fused-theme`) — the attribute goes on, its own
+    //   `:root[data-theme="light"]` block does the rest. Its CSS owns every
+    //   colour it paints.
+    //
+    //   NOT OPTED IN — a user-authored view, or a built-in not yet converted.
+    //   Its CSS still stays entirely its own; what it gets is `color-scheme`,
+    //   which changes no author colour at all — it only tells the browser
+    //   which set of DEFAULTS to use. That matters because the shell paints
+    //   its frames on its own backdrop (styles/base.css), so a document that
+    //   sets no background of its own is transparent over a dark surface while
+    //   its unstyled text stays UA black. Canvas and default text colour are a
+    //   pair and have to flip together: with color-scheme set, the browser
+    //   supplies a dark canvas AND light text, and the page reads exactly as
+    //   it does standalone in a dark-mode browser. A page that DOES set its
+    //   own background is unaffected — author colours always win.
+    // `color-scheme` goes on EVERY document, opted in or not. It changes no
+    // author colour — it only picks which set of browser defaults applies —
+    // and it is the only thing that can paint the canvas correctly before the
+    // document's own stylesheet has been parsed, which is exactly the window
+    // the white flash lived in. (This script is parser-blocking at the top of
+    // <head>, so "before" here means before anything else in the document.)
+    var optedIn = root.hasAttribute("data-fused-theme");
     var apply = function () {
-      root.setAttribute("data-theme", resolvedTheme());
+      var theme = resolvedTheme();
+      root.style.colorScheme = theme;
+      if (optedIn) root.setAttribute("data-theme", theme);
     };
     apply();
     // Another window changed the setting (a `clear()` reports key === null).


### PR DESCRIPTION
Switching files in a preview pane flashed white in dark mode — reported in Firefox, and absent in Chrome, which holds the outgoing document until the new one paints.

## What was happening

The preview is three documents deep: the pane's frame → the shell's `/explorer/embed/...` → the template. Two separate sources of white:

1. **While a frame navigates** there is no document to paint. The incoming document's base canvas takes its colour from the **root** element, and our boot styles only ever set `body` — so until `<body>` is parsed, the canvas is the browser's white.
2. **Once loaded**, a template that sets no background of its own is transparent, and the same white shows through for good.

Painting the iframe *element* doesn't help: the incoming document's own canvas paints over it. The fix has to be one layer up, in the embedded document, and earlier than any stylesheet can reach.

## The fix

- `index.html` moves the boot background onto `<html>` (not just `body`) and adds `color-scheme`. That's the canvas the browser paints from frame zero.
- `runtime.js` stamps `color-scheme` on **every** rendered document, opted into theming or not. It is parser-blocking at the top of `<head>`, so it lands before the document's own stylesheet.
- `iframe { background: var(--bg) }` in `base.css` covers the element layer for the same reason.

`color-scheme` is deliberate rather than more backgrounds: it changes no author colour, only which set of browser defaults applies. A page that sets no background is transparent over the shell's dark surface while its unstyled text stays UA black — canvas and default text colour are a pair, and overriding one alone gives you black-on-black. This flips both, so a theme-unaware view reads exactly as it would standalone in a dark-mode browser. A page that does set its own background is unaffected; author colours always win.

## Testing

Verified in Chrome that the root canvas and every nesting level resolve to the dark palette and that embedded templates report `color-scheme: dark`. **The flash itself is Firefox-only, so the cure still needs a check there.**

Split out of #440.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The changes are limited to first-paint styling and theme propagation in the shell and render runtime, with no auth, data, or API behavior changes; remaining risk is mainly visual regressions across browsers and theme opt-in edge cases.
> 
> **Overview**
> Fixes the **white flash when switching files in the preview pane** (especially in Firefox) by addressing both the empty-navigation gap and theme-unaware embedded templates.
> 
> **Shell boot (`index.html`)** moves the first-paint background and **`color-scheme`** onto `<html>` (with `body` inheriting), so the root canvas is dark from frame zero instead of staying on the browser default until `<body>` parses.
> 
> **Embedded views (`runtime.js`)** now sets **`document.documentElement.style.colorScheme`** for every injected page from the parser-blocking theme block, while **`data-theme`** is still applied only when `data-fused-theme` is present. Non–opt-in views get matching UA canvas and default text without overriding author CSS.
> 
> **Preview iframes (`base.css`)** use **`iframe { background: var(--bg) }`** so the shell backdrop shows through during load and behind transparent templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42292dc4eca62ba4e4991f8910ca7c801f7403fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->