### PR TITLE
fix(theme): kill the dark-mode white flash in Firefox

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,8 +48,16 @@
        just stamped, so the placeholder can't flash the wrong appearance.
        Honours prefers-reduced-motion like everything in shell.css does. -->
   <style>
-    body { margin: 0; background: #131417; }
-    html[data-theme="light"] body { background: #ffffff; }
+    /* On <html>, not just <body>: the canvas takes its colour from the root
+       element until <body> is parsed, so a rule on body alone leaves the
+       browser's white base painting the first frames of every load — the
+       white flash a preview iframe showed on each navigation. `color-scheme`
+       is here for the same reason, one step earlier still: it is what the
+       browser's own default surfaces (and any document that never sets a
+       background) resolve against. */
+    html { color-scheme: dark; background: #131417; }
+    html[data-theme="light"] { color-scheme: light; background: #ffffff; }
+    body { margin: 0; background: inherit; }
     #boot {
       position: fixed;
       inset: 0;

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -83,3 +83,20 @@ body {
   height: 100vh;
 }
 
+/* Every embedded document renders on the shell's own backdrop. Two reasons,
+   both about what shows through:
+     * WHILE A FRAME LOADS there is no document to paint, and the browser's
+       default canvas is white — the flash you got switching files in a preview
+       pane, since each switch is a fresh navigation;
+     * ONCE IT HAS, a template that sets no background of its own is
+       transparent, and the same white shows through for good.
+   `background` covers both. `color-scheme` is inherited from :root
+   (styles/tokens.css) and rides along to the embedded document, so the browser
+   paints ITS default surfaces (scrollbars, form controls) in the shell's
+   appearance rather than a light-mode set inside a dark page.
+   A template that wants a different surface just sets one — its own opaque
+   background paints over this. */
+iframe {
+  background: var(--bg);
+}
+

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -53,8 +53,10 @@
  * cross-origin ancestor) it falls back to reading/writing its own URL, treating
  * the `path` query key as reserved alongside any `_`-prefixed key.
  *
- * It also carries the appearance theme into OPTED-IN view documents — see the
- * theme block at the top of the IIFE (SPEC §30, D134).
+ * It also carries the appearance theme into view documents — as `data-theme`
+ * for the ones that opt in, and as `color-scheme` (browser defaults only) for
+ * the ones that don't — see the theme block at the top of the IIFE
+ * (SPEC §30, D134).
  */
 (function () {
   "use strict";
@@ -104,9 +106,35 @@
 
   function startTheme() {
     var root = document.documentElement;
-    if (!root || !root.hasAttribute("data-fused-theme")) return;
+    if (!root) return;
+    // Two kinds of document, one resolved theme:
+    //
+    //   OPTED IN (`data-fused-theme`) — the attribute goes on, its own
+    //   `:root[data-theme="light"]` block does the rest. Its CSS owns every
+    //   colour it paints.
+    //
+    //   NOT OPTED IN — a user-authored view, or a built-in not yet converted.
+    //   Its CSS still stays entirely its own; what it gets is `color-scheme`,
+    //   which changes no author colour at all — it only tells the browser
+    //   which set of DEFAULTS to use. That matters because the shell paints
+    //   its frames on its own backdrop (styles/base.css), so a document that
+    //   sets no background of its own is transparent over a dark surface while
+    //   its unstyled text stays UA black. Canvas and default text colour are a
+    //   pair and have to flip together: with color-scheme set, the browser
+    //   supplies a dark canvas AND light text, and the page reads exactly as
+    //   it does standalone in a dark-mode browser. A page that DOES set its
+    //   own background is unaffected — author colours always win.
+    // `color-scheme` goes on EVERY document, opted in or not. It changes no
+    // author colour — it only picks which set of browser defaults applies —
+    // and it is the only thing that can paint the canvas correctly before the
+    // document's own stylesheet has been parsed, which is exactly the window
+    // the white flash lived in. (This script is parser-blocking at the top of
+    // <head>, so "before" here means before anything else in the document.)
+    var optedIn = root.hasAttribute("data-fused-theme");
     var apply = function () {
-      root.setAttribute("data-theme", resolvedTheme());
+      var theme = resolvedTheme();
+      root.style.colorScheme = theme;
+      if (optedIn) root.setAttribute("data-theme", theme);
     };
     apply();
     // Another window changed the setting (a `clear()` reports key === null).


### PR DESCRIPTION
Extracted from #440 — just the dark-mode flash fixes, nothing else from that branch.

Three places where a white frame could show before author CSS applies:

- **`frontend/index.html`** — `color-scheme` and `background` go on `<html>`, not just `<body>`: the canvas takes its colour from the root element until `<body>` is parsed, so a rule on `body` alone leaves the browser's white base painting the first frames of every load.
- **`frontend/src/styles/base.css`** — iframes paint on the shell backdrop (`var(--bg)`). Covers both the load window (no document yet → white canvas) and templates that set no background of their own (transparent → white shows through for good).
- **`fused_render/static/runtime.js`** — `color-scheme` now goes on *every* embedded document, not only the `data-fused-theme` opt-ins. It changes no author colour, only which set of browser defaults applies, and it's the one thing that can paint the canvas correctly before the document's own stylesheet is parsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/theming-only changes at first paint and iframe backdrop; no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **white flashes** when loading the shell or navigating preview iframes in dark mode, by setting theme-colored surfaces before author CSS runs.
> 
> **`frontend/index.html`** moves **`color-scheme`** and **`background`** from `body` to **`html`**, with `body` inheriting the background. The root element paints the canvas until `body` exists; **`color-scheme`** aligns browser default surfaces with the palette.
> 
> **`frontend/src/styles/base.css`** gives preview **`iframe`** elements **`background: var(--bg)`** so the gap while a frame loads and transparent templates no longer show the default white canvas.
> 
> **`fused_render/static/runtime.js`** runs theme sync for **every** rendered document: **`root.style.colorScheme`** is always set from the resolved theme; **`data-theme`** still applies only to **`data-fused-theme`** opt-ins. That paints the embedded document canvas early via parser-blocking script without overriding author colors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d333b34215054d3c9a80a896453d38b5f3e38ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->