### PR TITLE
Upgrade GitHub Actions to latest stable versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       tag: ${{ steps.resolve.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # previous-tag lookup needs all tags
 
@@ -89,12 +89,12 @@ jobs:
       CDN_DOMAIN: d2ic19jpchjovp.cloudfront.net
       CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # build_dmg.sh's own version check needs `str | None` syntax (py>=3.10);
       # macOS runners' default `python3` can resolve to an older CLT/system
       # python that chokes on this (hit locally with Xcode's bundled 3.9).
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -103,7 +103,7 @@ jobs:
       # no other way to build a script venv there (D176). The Linux and Windows
       # build scripts already require uv on the host the same way; macOS runners
       # do not have it preinstalled, so the build fails loudly without this.
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - name: Import signing cert + notary credentials into ephemeral keychain
         env:
@@ -153,7 +153,7 @@ jobs:
         run: security delete-keychain "$KEYCHAIN_PATH" || true
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
           role-session-name: GithubFusedRenderRelease
@@ -229,7 +229,7 @@ jobs:
       CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
       WINDOWS_PREFIX: fused-render-windows
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Dropped from the windows-2025 runner image
       # (actions/runner-images#11644); the build script finds ISCC.exe where
@@ -238,14 +238,14 @@ jobs:
         shell: pwsh
         run: choco install innosetup --no-progress -y
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
       - name: Build installer
         shell: pwsh
         run: .\scripts\build_windows_installer.ps1
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
           role-session-name: GithubFusedRenderReleaseWindows
@@ -305,13 +305,13 @@ jobs:
       CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
       LINUX_PREFIX: fused-render-linux
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
       # desktop-file-utils provides desktop-file-validate, which appimagetool
       # runs against the bundled .desktop file — same prerequisite the CI smoke
@@ -326,7 +326,7 @@ jobs:
         run: bash scripts/build_linux_appimage.sh
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
           role-session-name: GithubFusedRenderReleaseLinux
@@ -380,14 +380,14 @@ jobs:
       CDN_DOMAIN: d2ic19jpchjovp.cloudfront.net
       CLOUDFRONT_DISTRIBUTION_ID: E393B7TS7Y3EDS
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::926411091187:role/github_fused_render_role
           role-session-name: GithubFusedRenderReleaseDownloadPage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       macos_desktop: ${{ steps.filter.outputs.macos_desktop }}
       macos_packaging: ${{ steps.filter.outputs.macos_packaging }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -106,7 +106,7 @@ jobs:
     if: needs.detect-changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v4
         with:
@@ -157,14 +157,14 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:
           name: shell-dist
           path: fused_render/static/shell-dist
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -239,7 +239,7 @@ jobs:
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # The suite starts the HTTP server (create_app), which serves the built
       # shell — same artifact dependency as test-python.
@@ -248,7 +248,7 @@ jobs:
           name: shell-dist
           path: fused_render/static/shell-dist
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # 3.11 is the extra's floor (the wheel's marker) and the version the
           # matrix job already reports coverage from.
@@ -263,7 +263,7 @@ jobs:
       # The backend builds each script's venv with `uv venv` + `uv pip install`
       # when uv is on PATH (it falls back to `python -m venv` + pip otherwise,
       # which works but is markedly slower). Same action the desktop jobs use.
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
       # tests/test_server_env_install.py runs the install loader's own JS under
       # node (the only way to assert which key gets polled and when the overlay
@@ -349,9 +349,9 @@ jobs:
     if: needs.detect-changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           # 3.12 is what all three desktop builds ship, so the markers this
           # resolves are the ones the bundle actually gets.
@@ -381,18 +381,18 @@ jobs:
     if: needs.detect-changes.outputs.app == 'true' && needs.frontend.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:
           name: shell-dist
           path: fused_render/static/shell-dist
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
       # desktop-file-utils provides desktop-file-validate, which appimagetool
       # runs against the bundled .desktop file during the AppImage build smoke.
@@ -459,9 +459,9 @@ jobs:
     if: needs.detect-changes.outputs.windows_desktop == 'true'
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -487,7 +487,7 @@ jobs:
         shell: pwsh
         run: choco install innosetup --no-progress -y
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
         if: needs.detect-changes.outputs.windows_packaging == 'true'
 
       - name: Build the Windows installer (smoke)
@@ -519,7 +519,7 @@ jobs:
     if: needs.detect-changes.outputs.macos_desktop == 'true' && needs.frontend.result == 'success'
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: actions/download-artifact@v4
         with:
@@ -531,9 +531,9 @@ jobs:
       # no other way to build a script venv there (D176). The Linux and Windows
       # build scripts already require uv on the host the same way; macOS runners
       # do not have it preinstalled, so the build fails loudly without this.
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v9.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions dependencies to their latest stable versions across both CI and release workflows to benefit from bug fixes, security patches, and performance improvements.

## Key Changes
- **actions/checkout**: v4 → v5
- **actions/setup-python**: v5 → v6
- **astral-sh/setup-uv**: v5 → v9.0.0
- **aws-actions/configure-aws-credentials**: v4 → v6

## Details
These upgrades are applied consistently across all workflow files:
- `.github/workflows/test.yml`: Updated in detect-changes, frontend, test-python, test-server, resolve-markers, linux-desktop, and macos-desktop jobs
- `.github/workflows/release.yml`: Updated in resolve-tag, macos-release, windows-release, linux-release, and download-page jobs

All action upgrades maintain backward compatibility with existing workflow configurations and do not require changes to job logic or parameters.

https://claude.ai/code/session_01FrXRejomfE8fYsHNLMK9Nc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only workflow dependency bumps with the same `with:` blocks; risk is limited to upstream action regressions, which is typical for maintenance upgrades.
> 
> **Overview**
> Bumps third-party GitHub Actions across **`.github/workflows/test.yml`** and **`.github/workflows/release.yml`** with no changes to job logic, inputs, or permissions.
> 
> **`actions/checkout`**: v4 → v5 on every job that checks out the repo. **`actions/setup-python`**: v5 → v6 wherever Python is provisioned. **`astral-sh/setup-uv`**: v5 → **v9.0.0** (pinned) on macOS/Linux/Windows build and test paths that need `uv`. **`aws-actions/configure-aws-credentials`**: v4 → v6 on release jobs that assume the fused-render IAM role via OIDC.
> 
> Other actions (e.g. `setup-node`, `upload-artifact`, `paths-filter`) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 774425a49660d7812914f383592186e43b5f5d66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->