### PR TITLE
Claude pane chrome + folder card polish from Sina's design review

### DIFF
--- a/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
+++ b/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
@@ -15,8 +15,8 @@ export default function ExplorerSidebar({ config }: { config: Config }) {
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-home-link" label="Home" icon={HOME_ICON} />
       </div>
-      <BookmarksSection />
       <RecentsSection />
+      <BookmarksSection />
     </SidebarFrame>
   );
 }

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -448,7 +448,9 @@
   flex-direction: column;
   min-width: 0;
   flex: 0 0 auto;
-  font-size: 12.5px;
+  /* A step below .fh-card-path (11.5px) — the sheet labels must read smaller
+     than the card's own path line. */
+  font-size: 10px;
   /* Lifted a step above --bg-panel so the sheets separate from the stack's
      --bg well; separation is carried by shadow, the hairline only stops
      same-value surfaces from fusing. */
@@ -481,13 +483,20 @@
 }
 
 .fhb-sheet-d1 {
-  margin: 0 10px -17px;
+  margin: 0 10px -20px;
   z-index: 2;
 }
 
 .fhb-sheet-d2 {
-  margin: 0 20px -17px;
+  margin: 0 20px -20px;
   z-index: 1;
+}
+
+/* Back-sheet title rows sit tighter than the front sheet's — at rest the
+   stack should read as slim page edges, not a column of full-height bars. */
+.fhb-sheet-d1 .fhb-sheet-row,
+.fhb-sheet-d2 .fhb-sheet-row {
+  padding: 4px 11px;
 }
 
 /* Back sheets are open pages, not closed pills: square bottom corners and no
@@ -500,14 +509,15 @@
 }
 
 /* The back sheet's page body: a blank strip a step off the sheet's own fill,
-   3px of which stays visible at rest (peek height minus the -17px overlap) —
-   the sliver of page edge that keeps stacked rows readable as separate
-   sheets; the hover fan slides the rest out. */
+   fully tucked away at rest (peek height equals the -20px overlap) — the
+   hover fan slides a 4px page edge out. */
 .fhb-sheet-peek {
   position: relative;
   flex: 0 0 auto;
   height: 20px;
-  background: rgba(var(--tint), 0.03);
+  /* A clear step lighter than the sheet's own fill so the page body reads
+     apart from the title row when the hover fan reveals it. */
+  background: color-mix(in srgb, var(--fg) 24%, var(--bg-panel));
   overflow: hidden;
 }
 
@@ -529,11 +539,15 @@
   border-color: color-mix(in srgb, var(--fg) 6%, var(--bg-alt));
 }
 
+:root[data-theme="light"] .fhb-sheet-peek {
+  background: color-mix(in srgb, var(--fg) 14%, var(--bg));
+}
+
 /* Hovering the card slides the back sheets out a little — more of each page
    edge shows, the ref design's "contents fan". */
 .fhb-card:hover .fhb-sheet-d1,
 .fhb-card:hover .fhb-sheet-d2 {
-  margin-bottom: -10px;
+  margin-bottom: -16px;
 }
 
 .fhb-sheet-icon {

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -3120,6 +3120,10 @@ const viewBtn = document.getElementById("viewbtn");
 // (params.onChange fires for every param, `split` and `model` included). null
 // until the first call: boot is not a flip.
 let narrowShown = null;
+// The breakpoint crossing's transient view default ("preview" after a live
+// wide→narrow crossing, else null): consulted only while `paneview` is absent,
+// never persisted — see the NARROW_MQ change handler for why it is not a param.
+let narrowCrossView = null;
 function applyNarrowView() {
   // No pane, no two views to be one of: the toggle and its strip are out of the
   // document (enterNoPane) and `paneview` describes a collapse this target never
@@ -3130,7 +3134,9 @@ function applyNarrowView() {
   // Default CHAT: an unset param reads as the chat, so a narrow pane opens on
   // the conversation — the reason the mode exists — and the preview is one click
   // away. Pane-local like `split`, so a reload keeps the view the user was on.
-  const preview = fused.params.get("paneview") === "preview";
+  // `narrowCrossView` sits between the param and that default: a live crossing
+  // keeps the preview on screen without spending a history entry on a resize.
+  const preview = (fused.params.get("paneview") || narrowCrossView || "chat") === "preview";
   document.body.classList.toggle("view-preview", preview);
   document.body.classList.toggle("view-chat", !preview);
   // The button names its DESTINATION, and names what the destination is FOR: the
@@ -3202,8 +3208,12 @@ function applyNarrowView() {
 }
 viewBtn.addEventListener("click", () => {
   // Writes the param only — applyNarrowView runs from params.onChange, the same
-  // one-way flow `split` and `leftmode` use.
-  fused.params.set("paneview", fused.params.get("paneview") === "preview" ? "chat" : "preview");
+  // one-way flow `split` and `leftmode` use. The opposite of the view ON SCREEN
+  // (narrowShown), not of the raw param: after a breakpoint crossing the preview
+  // can be showing on `narrowCrossView` with the param still absent, and reading
+  // the param there would write "preview" over a visible preview — a toggle
+  // whose first click does nothing.
+  fused.params.set("paneview", narrowShown ? "chat" : "preview");
 });
 applyNarrowView();
 // Crossing the breakpoint, in EITHER direction, without a reload. Two things
@@ -3223,12 +3233,15 @@ NARROW_MQ.addEventListener("change", () => {
   // Crossing DOWN with `paneview` unset: both halves were on screen, and the
   // narrow default (chat — the right call for a FRESH narrow open, see
   // applyNarrowView) would here hide the preview the user was just looking
-  // at, mid-resize, with no click. Record "preview" so the collapse keeps the
-  // half that would otherwise vanish. Written only over an ABSENT param: a
-  // view the user chose with the toggle stays chosen, in both directions —
-  // and enterNoPane's posture holds, this never runs on a no-pane target.
+  // at, mid-resize, with no click. Remember "preview" so the collapse keeps
+  // the half that would otherwise vanish. A VARIABLE, deliberately not a
+  // `fused.params.set` — a resize is not a navigation, and the bridge's
+  // first-change-push would mint a history entry for it, so Back from a
+  // pristine visit would clear the param and jump the layout to chat
+  // (Bugbot, PR #447). The toggle still writes the param, and a param, once
+  // present, wins over this default in both directions — see applyNarrowView.
   if (NARROW_MQ.matches && !noPane && !fused.params.get("paneview")) {
-    fused.params.set("paneview", "preview");
+    narrowCrossView = "preview";
   }
   placeLeftPicker();
   applySplit();

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -4569,11 +4569,16 @@ function buildPermCard(p, run_id, liveMode) {
 //
 // Writes the param rather than calling applyNarrowView, the same one-way flow
 // #viewbtn uses. No-op in the wide layout (nothing is hidden) and for the no-pane
-// target (`paneview` describes a collapse it never does).
+// target (`paneview` describes a collapse it never does). The Preview test is
+// `narrowShown` — the view ON SCREEN — not the raw param: after a breakpoint
+// crossing the preview shows on `narrowCrossView` with the param still absent,
+// and the raw read left the card in the collapsed #log, a hard block with no
+// visible way to answer it (Bugbot, PR #447). Same reason #viewbtn toggles off
+// narrowShown.
 function showPermissionCard(card, working) {
   if (working && working.el && working.el.isConnected) log.insertBefore(card.el, working.el);
   else log.appendChild(card.el);
-  if (!noPane && NARROW_MQ.matches && fused.params.get("paneview") === "preview") {
+  if (!noPane && NARROW_MQ.matches && narrowShown) {
     fused.params.set("paneview", "chat");
   }
   scrollBottom();

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -339,6 +339,10 @@
      #leftmodepop — same box, same shadow — because to the user they are the
      same kind of thing: a small menu hanging off the strip. */
   #kebab { position: relative; flex-shrink: 0; }
+  /* The no-pane strip (an ordinary folder, D239): #annbtn — the row's usual
+     auto-margin owner — is out of the document, so the kebab, the one control
+     the teardown keeps, anchors the right-hand end itself. */
+  body.nopane #kebab { margin-left: auto; }
   #kebabbtn {
     display: flex;
     align-items: center;
@@ -1256,11 +1260,24 @@
     body.view-chat #annbtn,
     body.view-chat #leftmode { display: none; }
     /* The rule above also removes the row's ONE auto margin (#annbtn owns it,
-       see the wide styles), which would let the view toggle fall in next to
-       #back at the LEFT edge. The toggle takes the margin over only while the
-       switch is off screen, so the strip keeps its shape — way back at one end,
-       way forward at the other — in both views. */
+       see the wide styles), which would let everything after it fall in next
+       to #back at the LEFT edge. The view toggle takes the margin over while
+       the switch is off screen, and the kebab is pushed to the row's LAST
+       seat (see the #kebab order rule below): navigation reads left, actions
+       read right, ⋮ closes the row — the same order every other view keeps. */
     body.view-chat #viewbtn { margin-left: auto; }
+    /* THE STRIP'S GRAMMAR, in both narrow views: the way OUT of the view sits
+       at the left edge, the controls that act on it sit right, and the kebab
+       is always the row's last word — the one seat it holds in every layout,
+       wide, narrow and no-pane alike, so it can never teleport across the row
+       when the layout flips (it used to sit hard left in the chat view: the
+       breakpoint crossing moved it end to end, and its right-anchored popup,
+       suddenly against the viewport's left edge, clipped to a blank sliver).
+       Flex `order` rather than moving DOM nodes: #back and #viewbtn ship in
+       the position the WIDE layout wants, and these two rules are the whole
+       narrow rearrangement. */
+    #kebab { order: 10; }
+    body.view-preview #viewbtn { order: -1; }
     /* The pin overlay (#annpins, #annhl, #annpop) needs no rule of its own: all
        three are children of #left, so parking the column takes them with it —
        `visibility: hidden` inherits (none of them sets `visibility: visible`)
@@ -1289,7 +1306,13 @@
        from the stylesheet (see the #inputbox rule), and
        tests/test_claude_narrow.py fails on any inline `display` in the column. */
     body.view-preview #left { flex: 1; min-height: 0; }
-    body.view-preview #chat { flex: 0 0 auto; }
+    /* `overflow: visible`, overriding the column's base `hidden`: here #chat
+       IS the strip — a 43px box — and the kebab's popup hangs below it, over
+       the preview. The base clip (sane for a full-height transcript column)
+       cut that popup to a 3px sliver and left the menu painting under the
+       frame. Safe to lift exactly here because every other child of #chat is
+       display:none'd by the rule below — there is nothing else to spill. */
+    body.view-preview #chat { flex: 0 0 auto; overflow: visible; }
     body.view-preview #chat > *:not(#anntools) { display: none; }
     /* #back survived the collapse above only because it moved into #anntools.
        It stays hidden HERE for the same reason the rest of the chat column is:
@@ -2476,14 +2499,17 @@ function applyLeftMode() {
 // Removed rather than hidden, because there is no state in which any of it is
 // wanted again: the target's kind does not change mid-session (a folder that
 // grows an index.html gets its pane on the next open, which is where the
-// predicate is read). Three subtrees go:
+// predicate is read). Two subtrees go whole:
 //   * #left — the frame, the pins, the highlight and the note popover;
 //   * #divider — no two columns, no ratio to drag;
-//   * #anntools — the annotate switch, the view toggle, and the `leftmode`
-//     picker when the narrow layout is what put it there (in the split layout
-//     the picker sits in #leftbar and goes with #left above). It is a child of
-//     #chat, so it survives removing #left, and would otherwise sit there as an
-//     empty bordered row of controls for a pane that is not there.
+// and #anntools is SLIMMED, not removed: every control in it that acts on the
+// pane goes — the annotate switch, the view toggle, and the `leftmode` picker
+// when the narrow layout is what put it there (in the split layout the picker
+// sits in #leftbar and goes with #left above) — but the kebab STAYS, because
+// its one item ("New session in terminal") acts on the TARGET, and a folder
+// with no preview is still a thing to open a terminal session on. The strip is
+// a child of #chat, so it survives removing #left; with the kebab in it, it is
+// no longer the empty bordered row that used to justify taking it too.
 //
 // What this deliberately does NOT do is tidy the URL. `split`, `paneview`,
 // `leftmode`, `annmode` and `annotations` left by an old bookmark are IGNORED,
@@ -2517,15 +2543,13 @@ function enterNoPane() {
   //    rendered a blank page. applyNarrowView returns early from here on, so
   //    nothing puts either class back.
   document.body.classList.remove("view-preview", "view-chat");
-  // 4. Rescue #back before its host goes: the button lives in #anntools (the
-  //    strip earns its place as the [← Chats … Annotate] row), but the way back
-  //    to the chat list must outlive the pane. The topbar takes it — the row
-  //    that held it before the strip existed, and the one piece of chat chrome
-  //    this teardown keeps.
-  const backBtn = document.getElementById("back");
-  const topBar = document.getElementById("topbar");
-  if (backBtn && topBar) topBar.appendChild(backBtn);
-  for (const id of ["left", "divider", "anntools"]) {
+  // 4. Slim the strip to the two controls that outlive the pane: #back (the
+  //    way back to the chat list; the home view hides it by CSS, same as ever)
+  //    and the kebab. The `nopane` class hands the kebab the row's auto margin
+  //    — #annbtn, the usual owner, is about to leave the document — so the ⋮
+  //    keeps the right-hand seat it has in every other layout.
+  document.body.classList.add("nopane");
+  for (const id of ["annbtn", "leftmode", "viewbtn", "left", "divider"]) {
     const el = document.getElementById(id);
     if (el) el.remove();
   }
@@ -3196,6 +3220,16 @@ applyNarrowView();
 // pins — so doing it first means that measurement is taken against the layout
 // that is actually going to be on screen.
 NARROW_MQ.addEventListener("change", () => {
+  // Crossing DOWN with `paneview` unset: both halves were on screen, and the
+  // narrow default (chat — the right call for a FRESH narrow open, see
+  // applyNarrowView) would here hide the preview the user was just looking
+  // at, mid-resize, with no click. Record "preview" so the collapse keeps the
+  // half that would otherwise vanish. Written only over an ABSENT param: a
+  // view the user chose with the toggle stays chosen, in both directions —
+  // and enterNoPane's posture holds, this never runs on a no-pane target.
+  if (NARROW_MQ.matches && !noPane && !fused.params.get("paneview")) {
+    fused.params.set("paneview", "preview");
+  }
   placeLeftPicker();
   applySplit();
   applyNarrowView();
@@ -4199,7 +4233,12 @@ function kebabOpen() {
   terminalOpt.disabled = false;
   kebabPop.hidden = false;
   kebabBtn.setAttribute("aria-expanded", "true");
-  terminalOpt.focus();
+  // preventScroll, and it is load-bearing: the popup hangs BELOW the strip,
+  // and in the narrow Preview view the strip is all of #chat — a plain focus
+  // asks the browser to bring the item into #chat's 43px box, which cannot
+  // hold it, so #chat scrolled to its limit and took every strip control off
+  // screen: an open menu floating under an empty white row.
+  terminalOpt.focus({ preventScroll: true });
 }
 kebabBtn.addEventListener("click", () => {
   if (kebabPop.hidden) kebabOpen(); else kebabClose();

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -285,7 +285,7 @@ def test_the_dead_framing_params_are_gone_from_their_consumers_too():
         assert 'get("preview")' not in code, f"{rel[-1]} still reads the dead param"
 
 
-def test_the_no_pane_state_removes_the_column_the_divider_and_the_strip():
+def test_the_no_pane_state_removes_the_column_the_divider_and_the_pane_controls():
     """The no-pane case is a DESIGNED state, not a missing element — and the
     difference is load-bearing.
 
@@ -300,17 +300,23 @@ def test_the_no_pane_state_removes_the_column_the_divider_and_the_strip():
     script has finished: every declaration is initialised before anything is
     taken away.
 
-    Three things go, and each one is chrome that acts on the pane: `#left` (the
-    frame, the pins, the highlight, the popover), `#divider` (no ratio to drag)
-    and `#anntools` (the annotate switch, the `leftmode` picker and the view
-    toggle all live in that strip, which is a child of `#chat` and would
-    otherwise stay behind as an empty bordered row).
+    What goes is exactly the chrome that acts on the pane: `#left` (the frame,
+    the pins, the highlight, the popover), `#divider` (no ratio to drag), and —
+    out of the `#anntools` strip — the annotate switch, the `leftmode` picker
+    and the view toggle. The strip itself STAYS, because the kebab stays: its
+    "New session in terminal" acts on the TARGET, not on the pane, and a folder
+    with no preview is still a thing to hand to a terminal. The `nopane` body
+    class is the styling half of that survival — it hands the kebab the row's
+    auto margin, whose usual owner (#annbtn) just left the document.
     """
     code = _pane_code()
     i = code.index("function enterNoPane()")
     body = code[i:code.index("\n}", i)]
-    assert 'for (const id of ["left", "divider", "anntools"]) {' in body
+    assert 'for (const id of ["annbtn", "leftmode", "viewbtn", "left", "divider"]) {' in body
     assert "if (el) el.remove();" in body
+    assert '"anntools"' not in body, "the strip survives — the kebab lives there"
+    assert 'document.body.classList.add("nopane");' in body
+    assert "body.nopane #kebab { margin-left: auto; }" in _pane_source()
 
 
 def test_the_no_pane_state_undoes_what_boot_did_from_a_stale_param():

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -897,8 +897,12 @@ def test_the_narrow_layout_keeps_the_view_toggle_reachable_from_both_views():
     assert "body.view-preview #chat > *:not(#anntools) { display: none; }" in block
     assert "#viewbtn { display: flex" in block
     # Default Chat: an unset param is the conversation, the reason the mode
-    # exists, with the preview one click away.
-    assert 'fused.params.get("paneview") === "preview"' in _pane_source()
+    # exists, with the preview one click away — with one carve-out between the
+    # param and the default: a live wide→narrow crossing keeps the preview via
+    # the transient `narrowCrossView` (a variable, not a param write — a resize
+    # is not a navigation and must not mint a history entry).
+    assert ('(fused.params.get("paneview") || narrowCrossView || "chat") === "preview"'
+            in _pane_source())
 
 
 def test_no_control_for_the_hidden_half_is_reachable_in_the_chat_only_view():


### PR DESCRIPTION
## What

Fixes from Sina's design-review DMs (2026-08-11):

**Claude pane (`templates/claude/template.html`)**
- Resizing the pane under 800px hid the preview: `paneview` unset defaults to the chat view, so the collapse parked the preview the user was looking at. A downward crossing now records `paneview=preview`; an explicit toggle choice still wins.
- The kebab (⋮) now holds the row's **last** seat in every layout (wide, narrow chat, narrow preview, no-pane). It used to jump end-to-end across the 800px crossing, and its right-anchored popup clipped to a blank sliver at the viewport's left edge.
- Opening the kebab no longer blanks the strip: the menu-item focus scrolled `#chat` (a 43px box in the narrow preview view) to its limit — `focus({preventScroll})` — and the column's base `overflow: hidden` cut the popup to a 3px sliver — lifted to `visible` for `body.view-preview` only.
- Narrow strips now share one grammar: way out on the left (`Back to chat` / `← Chats`), actions on the right (`Annotate`, `Rendered`), ⋮ last. Done with flex `order`, no DOM moves.
- Ordinary folders (no preview pane) keep the kebab: "New session in terminal" acts on the target, not the pane. `enterNoPane()` now slims the strip instead of removing it.

**Folder cards (`preferences.css`)**
- Back-sheet stack much tighter at rest (page edge fully tucked, slimmer title rows); hover reveals a 4px edge (≈ the old resting state).
- Page-edge strip is a clear step lighter than the sheet fill in both themes (body vs title contrast).
- Sheet labels 12.5px → 10px, below the card's path line.

**Explorer sidebar (`ExplorerSidebar.tsx`)**
- Recents section above Bookmarks.

## Test plan

- Playwright against the dev server: strip order in all three layouts, kebab open leaves the strip intact (`#chat` scrollTop stays 0), popup fully visible over the preview, no-pane folder shows the working kebab, card stack rest/hover in dark + light.
- `pytest` full suite: 5165 passed (1 pre-existing macOS-only failure in `test_calls.py`, `/proc/self/fd`, fails identically on main).
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches responsive layout, URL/history-adjacent narrow view logic, and no-pane teardown in a large chat template; regressions would show as broken narrow preview, kebab menus, or folder chats missing terminal actions.
> 
> **Overview**
> Design-review follow-ups across **Claude pane chrome**, **folder home cards**, and the **Explorer sidebar**.
> 
> **Claude (`template.html`)** — Narrow layouts now keep a consistent strip grammar (exit left, actions right, **⋮ last**) via flex `order`, including after the 800px breakpoint so the kebab menu no longer clips at the viewport edge. Resizing below 800px with no `paneview` param uses transient `narrowCrossView` (not a history write) so the preview you were viewing stays visible; toggles and permission cards key off **what’s on screen** (`narrowShown`) instead of the raw param. **No-pane folders** slim `#anntools` instead of removing it: pane-only controls go away but the kebab stays for terminal actions, with `body.nopane` right-aligning ⋮. Kebab open uses `focus({ preventScroll: true })` and preview mode sets `#chat { overflow: visible }` so the menu isn’t scrolled away or clipped.
> 
> **Folder cards (`preferences.css`)** — Tighter back-sheet stack at rest, lighter peek strip, smaller sheet labels (10px), and adjusted hover fan margins.
> 
> **Explorer** — `RecentsSection` renders above `BookmarksSection`.
> 
> Tests in `test_claude_kind.py` updated for the new no-pane strip behavior and `narrowCrossView` preview default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e394ed60e79ad85fa2fabd6132fa3c6493109db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->