### PR TITLE
Explorer search: sane results, path-only hits, and a queryable index

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -30,7 +30,7 @@ type LaunchTab = "bookmarks" | "recents" | "sessions";
 type SearchPhase = "idle" | "searching";
 
 // The hero's search box, styled after the /apps hero composer: one line of
-// natural language in, one haiku call to interpret it, one bounded walk to
+// natural language in, one haiku call to interpret it, one indexed SQL query to
 // answer it (see lib/ai-search.ts). While a result is showing, the homepage's
 // bookmark/recent grids yield to the result grid; Clear (or emptying the box)
 // brings them back.
@@ -210,7 +210,6 @@ function SearchResults({
           : summary
             ? `Understood as: ${summary}`
             : "No filters — showing closest matches."}
-        {result.engine === "walk" && " · Searched your home folder."}
         {result.truncated && " · Broad query: showing the first slice of matches."}
       </p>
       {result.hits.length ? (

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -53,6 +53,7 @@ import { searchSlot, subscribeSearchSlot } from "@apps/explorer/search-slot";
 import {
   FLIP_MAX_ROWS,
   SORT_KEYS,
+  columnCount,
   type RowCtx,
   type SortKey,
   type SortOrder,
@@ -196,8 +197,6 @@ export default function Listing({
     visibleHits,
     showingHeld,
     cappedAway,
-    searchSort,
-    setSearchSortKey,
   } = useWalkSearch(fsPath, refresh, !embedded);
 
   // Scan state for the search box's "indexing…" caveat. Gated on `searching`
@@ -757,11 +756,14 @@ export default function Listing({
   // the preview pane, where NAME/SIZE/MODIFIED sat above one line of text).
   // Set by the empty branch below, read by the <thead> render.
   let emptyDir = false;
+  // Every row that spans the table, in the mode it is being rendered for
+  // (listing/types columnCount): three columns normally, one while searching.
+  const cols = columnCount(searching);
   if (searching) {
     if (validWalk.status === "error") {
       body = (
         <tr>
-          <td colSpan={3} className="status-message error">
+          <td colSpan={cols} className="status-message error">
             Search failed: {validWalk.message}
           </td>
         </tr>
@@ -831,12 +833,9 @@ export default function Listing({
                     copied={copiedSet.has(childPath)}
                   />
                 </td>
-                <td className="size">
-                  {entry.is_dir ? "" : formatSize(entry.size)}
-                </td>
-                <td className="mtime" title={formatMtimeFull(entry.mtime)}>
-                  {formatMtime(entry.mtime)}
-                </td>
+                {/* No size/modified cells: a hit's cell holds a whole rel
+                    path, and the two fixed-width columns were spending a
+                    third of the table on values nobody searches by. */}
               </tr>
             );
           })}
@@ -845,7 +844,7 @@ export default function Listing({
                rank stops being useful, so the answer is a better query. The
                count in the search chip carries the real total. */
             <tr>
-              <td colSpan={3} className="status-message">
+              <td colSpan={cols} className="status-message">
                 {cappedAway.toLocaleString()} more match
                 {cappedAway === 1 ? "" : "es"} not shown
               </td>
@@ -861,7 +860,7 @@ export default function Listing({
       // every keystroke.
       body = (
         <tr>
-          <td colSpan={3} className="status-message">
+          <td colSpan={cols} className="status-message">
             Searching…
           </td>
         </tr>
@@ -887,7 +886,7 @@ export default function Listing({
             : "No matches";
       body = (
         <tr>
-          <td colSpan={3} className="status-message">
+          <td colSpan={cols} className="status-message">
             {message}
           </td>
         </tr>
@@ -895,7 +894,7 @@ export default function Listing({
     } else {
       body = (
         <tr>
-          <td colSpan={3} className="status-message">
+          <td colSpan={cols} className="status-message">
             Searching…
           </td>
         </tr>
@@ -913,7 +912,7 @@ export default function Listing({
       skeletonRows(8)
     ) : (
       <tr>
-        <td colSpan={3} className="status-message error">
+        <td colSpan={cols} className="status-message error">
           Failed to list {fsPath}: {state.message}
         </td>
       </tr>
@@ -982,7 +981,7 @@ export default function Listing({
     // page; otherwise it just states the listing is partial.
     const banner = state.truncated ? (
       <tr key="__truncated__" className="listing-truncated">
-        <td colSpan={3} className="status-message">
+        <td colSpan={cols} className="status-message">
           Showing first {sortedEntries.length} entries — directory listing is
           partial.
           {state.cursor && (
@@ -1001,7 +1000,7 @@ export default function Listing({
     emptyDir = !rows.length && !banner;
     body = emptyDir ? (
       <tr>
-        <td colSpan={3} className="status-message">
+        <td colSpan={cols} className="status-message">
           Empty directory
         </td>
       </tr>
@@ -1198,41 +1197,17 @@ export default function Listing({
                   `emptyDir`. */}
               <thead className={emptyDir ? "listing-head-empty" : undefined}>
                 <tr>
-                  {(Object.entries(SORT_KEYS) as [SortKey, string][]).map(
-                    ([key, label]) =>
-                      searching ? (
-                        // While searching, headers sort the results; no active arrow
-                        // means relevance (fuzzy-rank) order.
-                        <th
-                          key={key}
-                          className={
-                            `sortable col-${key}` +
-                            (searchSort?.sort === key ? " sorted" : "")
-                          }
-                          title={
-                            searchSort?.sort === key &&
-                            searchSort.order === "desc"
-                              ? `Back to relevance order`
-                              : `Sort results by ${label.toLowerCase()}`
-                          }
-                          onClick={() => setSearchSortKey(key)}
-                        >
-                          {label}
-                          {/* One glyph that ROTATES for desc (see .sort-arrow):
-                          swapping ▲ for ▼ replaced the element, so the change
-                          could only ever pop. */}
-                          {searchSort?.sort === key && (
-                            <span
-                              className={
-                                "sort-arrow" +
-                                (searchSort.order === "desc" ? " desc" : "")
-                              }
-                            >
-                              ▲
-                            </span>
-                          )}
-                        </th>
-                      ) : (
+                  {searching ? (
+                    // One column, and NOT a sort control. Results are in
+                    // relevance (fuzzy-rank) order, full stop: the hit set is
+                    // capped and, while the walk streams, partial — ordering
+                    // that by name or date presents it as an answer it isn't,
+                    // and the search box already says the coverage is
+                    // approximate (listing/index-caveat).
+                    <th className="col-name">Path</th>
+                  ) : (
+                    (Object.entries(SORT_KEYS) as [SortKey, string][]).map(
+                      ([key, label]) => (
                         <th
                           key={key}
                           className={
@@ -1242,6 +1217,9 @@ export default function Listing({
                           onClick={() => setSort(key)}
                         >
                           {label}
+                          {/* One glyph that ROTATES for desc (see .sort-arrow):
+                          swapping ▲ for ▼ replaced the element, so the change
+                          could only ever pop. */}
                           {key === sort && (
                             <span
                               className={
@@ -1253,6 +1231,7 @@ export default function Listing({
                           )}
                         </th>
                       ),
+                    )
                   )}
                 </tr>
               </thead>

--- a/frontend/src/apps/explorer/lib/ai-search.test.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.test.ts
@@ -24,7 +24,6 @@ describe("parseAiSearchSpec", () => {
         kind: "file",
         modified_after: "2026-08-01",
         modified_before: "2026-08-05",
-        created_after: "2026-07-01",
         min_size_bytes: null,
         max_size_bytes: null,
         path_hints: ["data"],
@@ -35,8 +34,6 @@ describe("parseAiSearchSpec", () => {
     expect(spec!.kind).toBe("file");
     expect(spec!.modified_after).toBe("2026-08-01");
     expect(spec!.modified_before).toBe("2026-08-05");
-    expect(spec!.created_after).toBe("2026-07-01");
-    expect(spec!.created_before).toBeNull();
   });
 
   it("peels code fences the model adds despite instructions", () => {
@@ -58,7 +55,6 @@ describe("parseAiSearchSpec", () => {
         kind: "everything",
         modified_after: "last week", // not a date
         modified_before: "2026-02-31", // shape of a date, not a real one
-        created_after: 20260801,
         min_size_bytes: "big",
       }),
     );
@@ -67,7 +63,6 @@ describe("parseAiSearchSpec", () => {
     expect(spec!.kind).toBe("any");
     expect(spec!.modified_after).toBeNull();
     expect(spec!.modified_before).toBeNull();
-    expect(spec!.created_after).toBeNull();
     expect(spec!.min_size_bytes).toBeNull();
   });
 });
@@ -77,7 +72,7 @@ describe("hasNonNameFilters", () => {
     expect(hasNonNameFilters(fallbackSpec("weather"))).toBe(false);
     expect(hasNonNameFilters({ ...fallbackSpec(""), extensions: ["mov"] })).toBe(true);
     expect(hasNonNameFilters({ ...fallbackSpec(""), modified_after: "2026-08-04" })).toBe(true);
-    expect(hasNonNameFilters({ ...fallbackSpec(""), created_before: "2026-08-04" })).toBe(true);
+    expect(hasNonNameFilters({ ...fallbackSpec(""), max_size_bytes: 100 })).toBe(true);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/ai-search.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.ts
@@ -1,10 +1,11 @@
 // AI-assisted file search (pattern "query understanding"): one haiku call
 // through /api/ai translates a natural-language query into a strict, tiny
-// filter spec; the spec then runs SYSTEM-WIDE through /api/search/files (the
-// app's own SQL index first, then Spotlight on macOS for anything the index
-// cannot answer or does not cover, then a bounded home walk), and the hits are
-// ranked client-side with the shared fuzzy matcher. The model never sees the
-// filesystem and never returns anything executable — its output is data,
+// filter spec; the spec then runs through /api/search/files, which executes it
+// as one SQL query against the app's own file index (the only engine — it covers
+// the indexed roots, home by default, and reports a missing index as an error
+// rather than as an empty disk), and the hits are ranked client-side with the
+// shared fuzzy matcher. The model never sees the filesystem and never returns
+// anything executable — its output is data,
 // validated field by field on BOTH sides of the wire (here at the parse
 // boundary, and again in the server's _parse_spec), and a garbage reply
 // degrades to a plain term search on the user's own words.
@@ -20,12 +21,12 @@ export interface AiSearchSpec {
   // extension-filtered; a dir hit passes regardless.
   extensions: string[];
   kind: "file" | "dir" | "any";
-  // Inclusive YYYY-MM-DD date ranges; either end may be open (null).
-  // Modified = last content change; created = filesystem birth time.
+  // Inclusive YYYY-MM-DD range over the last content change; either end may be
+  // open (null). There is no creation-date filter: the index records mtime and
+  // no birth time, so the server refuses one outright rather than silently
+  // answering a different question (see search.py).
   modified_after: string | null;
   modified_before: string | null;
-  created_after: string | null;
-  created_before: string | null;
   min_size_bytes: number | null;
   max_size_bytes: number | null;
   // Directory-name hints ("in my photos folder", "downloaded" → downloads) —
@@ -42,7 +43,6 @@ export interface AiSearchResult {
   hits: AiSearchHit[];
   truncated: boolean; // the engine hit its result cap
   usedFallback: boolean; // the model reply was unusable; plain term search ran
-  engine: string; // "index" | "spotlight" | "walk" — the server says which ran
   spec: AiSearchSpec;
 }
 
@@ -61,8 +61,6 @@ export function aiSearchSystemPrompt(): string {
     ' "kind": "file" | "dir" | "any",\n' +
     ' "modified_after": "YYYY-MM-DD" or null,\n' +
     ' "modified_before": "YYYY-MM-DD" or null,\n' +
-    ' "created_after": "YYYY-MM-DD" or null,\n' +
-    ' "created_before": "YYYY-MM-DD" or null,\n' +
     ' "min_size_bytes": number or null,\n' +
     ' "max_size_bytes": number or null,\n' +
     ' "path_hints": [folder-name words the query implies, empty if none]}\n' +
@@ -79,10 +77,9 @@ export function aiSearchSystemPrompt(): string {
     "leave an end null when the query only bounds one side. today→" +
     "modified_after today; yesterday→after yesterday, before yesterday; " +
     "'in June'→after 06-01, before 06-30; last week / recently→after " +
-    "(today-7d); 'before March'→modified_before 02-28 only. Phrases about " +
-    "when a file was made/added/downloaded ('created', 'made', 'saved', " +
-    "'downloaded') use the created_* fields instead; when unsure, use " +
-    "modified_*.\n" +
+    "(today-7d); 'before March'→modified_before 02-28 only. There is no " +
+    "creation-date field, so phrases about when a file was made, added, saved " +
+    "or downloaded use the modified_* range too.\n" +
     "- Sizes: big/large→min_size_bytes 10000000; huge→100000000; " +
     "small/tiny→max_size_bytes 100000.\n" +
     "- 'folder'/'directory'→kind \"dir\".\n" +
@@ -130,8 +127,6 @@ export function parseAiSearchSpec(text: string): AiSearchSpec | null {
     kind,
     modified_after: dateStr(o.modified_after),
     modified_before: dateStr(o.modified_before),
-    created_after: dateStr(o.created_after),
-    created_before: dateStr(o.created_before),
     min_size_bytes: posNum(o.min_size_bytes),
     max_size_bytes: posNum(o.max_size_bytes),
     path_hints: strings(o.path_hints).slice(0, 4),
@@ -147,8 +142,6 @@ export function fallbackSpec(query: string): AiSearchSpec {
     kind: "any",
     modified_after: null,
     modified_before: null,
-    created_after: null,
-    created_before: null,
     min_size_bytes: null,
     max_size_bytes: null,
     path_hints: [],
@@ -171,8 +164,6 @@ export function describeSpec(spec: AiSearchSpec): string {
   if (spec.kind !== "any") parts.push(spec.kind === "dir" ? "folders" : "files");
   if (spec.modified_after !== null || spec.modified_before !== null)
     parts.push(`modified ${fmtRange(spec.modified_after, spec.modified_before)}`);
-  if (spec.created_after !== null || spec.created_before !== null)
-    parts.push(`created ${fmtRange(spec.created_after, spec.created_before)}`);
   if (spec.min_size_bytes !== null) parts.push(`≥${fmtBytes(spec.min_size_bytes)}`);
   if (spec.max_size_bytes !== null) parts.push(`≤${fmtBytes(spec.max_size_bytes)}`);
   if (spec.path_hints.length) parts.push("near " + spec.path_hints.join(", "));
@@ -195,8 +186,6 @@ export function hasNonNameFilters(spec: AiSearchSpec): boolean {
     spec.extensions.length > 0 ||
     spec.modified_after !== null ||
     spec.modified_before !== null ||
-    spec.created_after !== null ||
-    spec.created_before !== null ||
     spec.min_size_bytes !== null ||
     spec.max_size_bytes !== null
   );
@@ -215,9 +204,8 @@ export function hasEngineNarrowing(spec: AiSearchSpec): boolean {
 // Rank the engine's hits: fuzzy name-term score + path-hint boost, recency
 // tie-break (and the whole order when the spec has no name terms). The
 // engine already applied the HARD filters (ext/kind/date/size); name terms
-// are re-scored here because Spotlight matched them with a dumb *term* glob
-// (as does the index engine, with a case-insensitive substring) and neither
-// can rank, and the walk fallback didn't match them at all.
+// are re-scored here because the engine matches them with a dumb
+// case-insensitive substring (SQL ILIKE) and cannot rank.
 export function rankHits(
   entries: SearchFileEntry[],
   spec: AiSearchSpec,
@@ -253,9 +241,13 @@ export function rankHits(
   return hits.slice(0, MAX_HITS);
 }
 
-// The engine treats name terms as a hard glob, so a spec that ALSO carries
-// real filters retries without the terms when the first pass comes up empty
-// — same rationale as the soft-term ranking above.
+// Name terms are a hard WHERE in the engine too (an OR of ILIKE substrings), so
+// a spec that ALSO carries real filters retries without them when the first pass
+// comes up empty — same rationale as the soft-term ranking above: "video
+// downloaded today" has its extension and date pinned, and IMG_1234.mov must not
+// be lost to a filename that never says "video". The retry therefore still earns
+// its keep against the index engine, and now costs one more SQL query rather
+// than one more Spotlight run.
 async function queryEngine(spec: AiSearchSpec, signal?: AbortSignal) {
   const first = await searchFiles(spec, signal);
   if (first.entries.length || !spec.name_terms.length || !hasNonNameFilters(spec))
@@ -263,7 +255,7 @@ async function queryEngine(spec: AiSearchSpec, signal?: AbortSignal) {
   return searchFiles({ ...spec, name_terms: [] }, signal);
 }
 
-// The full pipeline: model → spec → system-wide engine → rank.
+// The full pipeline: model → spec → the index engine → rank.
 export async function runAiSearch(
   home: string,
   query: string,
@@ -290,7 +282,6 @@ export async function runAiSearch(
     hits: rankHits(res.entries, spec, home),
     truncated: res.truncated,
     usedFallback,
-    engine: res.engine,
     spec,
   };
 }

--- a/frontend/src/apps/explorer/lib/ai-search.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.ts
@@ -1,7 +1,8 @@
 // AI-assisted file search (pattern "query understanding"): one haiku call
 // through /api/ai translates a natural-language query into a strict, tiny
-// filter spec; the spec then runs SYSTEM-WIDE through /api/search/files
-// (Spotlight on macOS, a bounded home walk elsewhere), and the hits are
+// filter spec; the spec then runs SYSTEM-WIDE through /api/search/files (the
+// app's own SQL index first, then Spotlight on macOS for anything the index
+// cannot answer or does not cover, then a bounded home walk), and the hits are
 // ranked client-side with the shared fuzzy matcher. The model never sees the
 // filesystem and never returns anything executable — its output is data,
 // validated field by field on BOTH sides of the wire (here at the parse
@@ -41,7 +42,7 @@ export interface AiSearchResult {
   hits: AiSearchHit[];
   truncated: boolean; // the engine hit its result cap
   usedFallback: boolean; // the model reply was unusable; plain term search ran
-  engine: string; // "spotlight" | "walk" — the server says which ran
+  engine: string; // "index" | "spotlight" | "walk" — the server says which ran
   spec: AiSearchSpec;
 }
 
@@ -215,7 +216,8 @@ export function hasEngineNarrowing(spec: AiSearchSpec): boolean {
 // tie-break (and the whole order when the spec has no name terms). The
 // engine already applied the HARD filters (ext/kind/date/size); name terms
 // are re-scored here because Spotlight matched them with a dumb *term* glob
-// and can't rank, and the walk fallback didn't match them at all.
+// (as does the index engine, with a case-insensitive substring) and neither
+// can rank, and the walk fallback didn't match them at all.
 export function rankHits(
   entries: SearchFileEntry[],
   spec: AiSearchSpec,

--- a/frontend/src/apps/explorer/listing/column-shedding.test.ts
+++ b/frontend/src/apps/explorer/listing/column-shedding.test.ts
@@ -5,9 +5,9 @@
 // because both have already been got wrong once:
 //
 //   1. `display: none` on the shed HEADER left two width-less columns (the
-//      column survives either way — the status rows span all three via
-//      colSpan={3}), and WebKit splits the remainder evenly between them. NAME
-//      took half; the shed column kept the rest as a dead strip.
+//      column survives either way — the status rows span the whole table), and
+//      WebKit splits the remainder evenly between them. NAME took half; the
+//      shed column kept the rest as a dead strip.
 //   2. Pinning NAME with `calc(100% - 96px)` reads correctly and is silently
 //      DISCARDED by WKWebKit for table cells under table-layout:fixed. It
 //      passed a source check that asserted the calc string while the shipped
@@ -16,6 +16,10 @@
 // So the invariant is: a shed column stays a RENDERED zero-width column, sized
 // in px, leaving NAME as the only width-less column. Real geometry still needs
 // a browser (see the report).
+//
+// This is about the PLAIN listing. Search mode never mounts SIZE/MODIFIED at
+// all (listing/search-columns), so these rules simply have nothing to match
+// there — and the one-width-less-column invariant holds trivially.
 import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";

--- a/frontend/src/apps/explorer/listing/result-cap.test.ts
+++ b/frontend/src/apps/explorer/listing/result-cap.test.ts
@@ -21,6 +21,7 @@ function hits(n: number): SearchHit[] {
       // descending score, so index order IS rank order
       score: n - i,
       longestRun: 1,
+      tier: 1,
       depth: 1,
     });
   }

--- a/frontend/src/apps/explorer/listing/scan-job.test.ts
+++ b/frontend/src/apps/explorer/listing/scan-job.test.ts
@@ -21,7 +21,7 @@ function corpus(n: number): WalkEntry[] {
 }
 
 function hit(entry: WalkEntry): SearchHit {
-  return { entry, positions: [], score: 1, longestRun: 1, depth: 1 };
+  return { entry, positions: [], score: 1, longestRun: 1, tier: 1, depth: 1 };
 }
 
 /** A fake event loop: nothing runs until the test drains it. */

--- a/frontend/src/apps/explorer/listing/search-bar-expand.test.ts
+++ b/frontend/src/apps/explorer/listing/search-bar-expand.test.ts
@@ -1,0 +1,116 @@
+// What the crumb bar gives up while a folder search is running, guarded at the
+// SOURCE. There is no DOM in this suite, so what is testable is the mechanism,
+// not the geometry (real layout still needs a browser — see the report).
+//
+// The bar is a flex row and its `searching` state is already expressed purely in
+// CSS (`#breadcrumb:has(.listing-search.searching)`, set by Listing.tsx from a
+// non-empty query), so everything here hangs off that one selector. Two things
+// are worth pinning down:
+//
+//   1. HOW the star is removed. `visibility: hidden` or `opacity: 0` keeps the
+//      element's box — and the star's box is 24px plus a deliberate -11px
+//      negative margin (explorer.css) — so the input would stop 13px short of
+//      where the star was, i.e. a hole. In a flex row `display: none` takes the
+//      item out of the layout entirely, gap included, which is what "expand
+//      completely" needs. This is NOT the column-shedding case
+//      (column-shedding.test.ts): there the shed element had to STAY rendered
+//      because a table column under `table-layout: fixed` survives its header
+//      being hidden and WebKit then split the remainder between two width-less
+//      columns. A flex item has no such ghost.
+//   2. That the star is HIDDEN, not unmounted. `useUpdateButton` in
+//      Breadcrumb.tsx has deliberate side-effect semantics — an armed bookmark
+//      disarms permanently on certain changes — and BookmarkStar deletes the
+//      matching bookmark on click. Unmounting the subtree on the first keystroke
+//      and remounting it on Esc is a state change nobody asked for; CSS is not.
+//
+// Reversibility comes free from the same fact: the query going empty drops the
+// `.searching` class, so every rule here stops applying. Nothing is set from JS,
+// so there is no stale state to restore.
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const CSS = readFileSync(join(import.meta.dir, "../../../styles/explorer.css"), "utf8")
+  // Comments quote these selectors verbatim; a rule scan that kept them would
+  // "find" rules that do not exist.
+  .replace(/\/\*[\s\S]*?\*\//g, "");
+const BREADCRUMB = readFileSync(join(import.meta.dir, "../Breadcrumb.tsx"), "utf8");
+
+const SEARCHING = ".listing-search.searching";
+
+/** Every declaration block whose selector is the searching state. */
+function searchingRules(): { selector: string; decls: string }[] {
+  const out: { selector: string; decls: string }[] = [];
+  const re = /([^{}]+)\{([^{}]*)\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(CSS)) !== null) {
+    const selector = m[1].trim();
+    if (selector.includes(SEARCHING)) out.push({ selector, decls: m[2] });
+  }
+  return out;
+}
+
+const rules = searchingRules();
+
+function ruleFor(fragment: string): { selector: string; decls: string } | undefined {
+  return rules.find((r) => r.selector.includes(fragment));
+}
+
+test("the searching state is expressed in CSS at all", () => {
+  // If this fails the rest of the file is asserting nothing.
+  expect(rules.length).toBeGreaterThanOrEqual(4);
+});
+
+test("the bar stands down everything to the left of the search box", () => {
+  // The crumbs and the path `···` were already given up; the ★ is what was
+  // still holding the box off the left edge.
+  for (const target of [".crumbs", "> .bar-overflow", ".bookmark-star-btn"]) {
+    const rule = ruleFor(target);
+    expect(rule, `no searching rule for ${target}`).toBeDefined();
+    expect(rule!.decls).toMatch(/display:\s*none/);
+  }
+});
+
+test("the star is removed from the layout, not merely made invisible", () => {
+  // Its box is 24px wide and carries a -11px right margin to pull the first
+  // crumb close (explorer.css). visibility/opacity keep both, so the input
+  // would start 13px in from where the star was.
+  const decls = ruleFor(".bookmark-star-btn")!.decls;
+  expect(decls).not.toMatch(/visibility:\s*hidden/);
+  expect(decls).not.toMatch(/opacity:\s*0/);
+});
+
+test("hiding the star is scoped to the main crumb bar", () => {
+  // Panel mode renders one star per pane out of the same component
+  // (Breadcrumb.tsx `BookmarkStar`), and those bars have no search row — an
+  // unscoped `.bookmark-star-btn { display: none }` would be a live grenade the
+  // day one gains one.
+  const selector = ruleFor(".bookmark-star-btn")!.selector;
+  expect(selector).toMatch(/#breadcrumb/);
+});
+
+test("both the row and the box are told to grow, or the field cannot span the bar", () => {
+  // Idle they are `0 1 auto` / a 150px width, so freeing the crumb width is only
+  // half of it: without grow on BOTH the input sits at its resting size with the
+  // freed space dead beside it.
+  for (const target of [".listing-search", ".listing-search-box"]) {
+    const rule = rules.find(
+      (r) => r.selector.endsWith(target) && /flex:\s*1\s+1/.test(r.decls),
+    );
+    expect(rule, `no grow rule for ${target}`).toBeDefined();
+  }
+});
+
+test("the star is rendered unconditionally, so search cannot disarm a bookmark", () => {
+  // An armed bookmark disarms permanently on certain changes (useUpdateButton),
+  // and the star owns the delete-on-click toggle. Mounting it on the state of a
+  // search query would tie both to a keystroke.
+  const uses = BREADCRUMB.match(/<BookmarkStar\b[^/]*\/>/g) || [];
+  expect(uses.length).toBeGreaterThanOrEqual(2); // the bar and the static bar
+  for (const use of uses) {
+    // No `{searching && …}` / ternary guard wrapped around the element.
+    const at = BREADCRUMB.indexOf(use);
+    const before = BREADCRUMB.slice(Math.max(0, at - 40), at);
+    expect(before).not.toMatch(/[&?]\s*$|\{\s*!?\w+\s*&&\s*$/);
+  }
+});

--- a/frontend/src/apps/explorer/listing/search-columns.test.ts
+++ b/frontend/src/apps/explorer/listing/search-columns.test.ts
@@ -1,0 +1,100 @@
+// Search mode renders ONE column — the path — and everything the table does
+// per-column has to follow the mode. Guarded at the SOURCE for the same reason
+// column-shedding.test.ts is: this is table layout, and the frontend suite has
+// no DOM, so what is testable here is the mechanism.
+//
+// Why it needs guarding at all:
+//
+//   1. A status row spanning colSpan={3} under a one-column <thead> declares
+//      two columns nothing else mentions. Under table-layout:fixed the engine
+//      then has width-less columns to distribute the remainder to — the exact
+//      dead-strip failure column-shedding.test.ts documents, arrived at from
+//      the other direction. Every colSpan therefore goes through columnCount().
+//   2. The Size/Modified headers were the only control for sorting search
+//      results, and search-result sorting is gone with them: a capped,
+//      partially-streamed hit set sorted by size or date is a confident answer
+//      to a question the data cannot answer. Relevance order, full stop — so
+//      the surviving header must not look or behave like a sort control, and
+//      no searchSort machinery may survive to re-order hits invisibly.
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { columnCount } from "@apps/explorer/listing/types";
+import * as search from "@apps/explorer/listing/search";
+
+const LISTING = readFileSync(join(import.meta.dir, "../Listing.tsx"), "utf8");
+const HOOK = readFileSync(join(import.meta.dir, "useWalkSearch.ts"), "utf8");
+const CSS = readFileSync(join(import.meta.dir, "../../../styles/explorer.css"), "utf8");
+
+/** The `if (searching) { … }` arm of the table-body builder. */
+function searchBody(): string {
+  const start = LISTING.indexOf("\n  if (searching) {");
+  const end = LISTING.indexOf('\n  } else if (state.status === "loading") {', start);
+  expect(start).toBeGreaterThan(0);
+  expect(end).toBeGreaterThan(start);
+  return LISTING.slice(start, end);
+}
+
+/** Everything else in the builder — the plain listing's rows and status rows. */
+function listingBody(): string {
+  const body = searchBody();
+  return LISTING.replace(body, "");
+}
+
+function thead(): string {
+  const start = LISTING.indexOf("<thead className=");
+  const end = LISTING.indexOf("</thead>", start);
+  expect(start).toBeGreaterThan(0);
+  return LISTING.slice(start, end);
+}
+
+test("the search listing is one column and the plain listing is three", () => {
+  expect(columnCount(true)).toBe(1);
+  expect(columnCount(false)).toBe(3);
+});
+
+test("no status or banner row hardcodes a column count", () => {
+  // A literal survives a mode change silently; columnCount cannot.
+  expect(LISTING).not.toMatch(/colSpan=\{\s*\d/);
+  expect(LISTING).toMatch(/colSpan=\{cols\}/);
+});
+
+test("search-hit rows render no size or modified cell", () => {
+  const body = searchBody();
+  expect(body).toMatch(/className="search-path"/); // the path IS the row
+  expect(body).not.toMatch(/<td className="size"/);
+  expect(body).not.toMatch(/<td className="mtime"/);
+});
+
+test("the plain listing keeps all three cells", () => {
+  const body = listingBody();
+  expect(body).toMatch(/<td className="size"/);
+  expect(body).toMatch(/<td className="mtime"/);
+});
+
+test("the search header is not a sort control", () => {
+  // No click target, no arrow, no `sortable` — there is nothing to sort by.
+  const head = thead();
+  const searchArm = head.slice(head.indexOf("searching ?"), head.indexOf(") : ("));
+  expect(searchArm.length).toBeGreaterThan(0);
+  expect(searchArm).not.toMatch(/sortable/);
+  expect(searchArm).not.toMatch(/onClick/);
+  expect(searchArm).not.toMatch(/sort-arrow/);
+  expect(searchArm).toMatch(/col-name/); // still the width-less NAME column
+});
+
+test("no searchSort machinery survives anywhere", () => {
+  expect(LISTING).not.toMatch(/searchSort/);
+  expect(HOOK).not.toMatch(/searchSort/);
+  // sortHits existed only to apply it; an unused export invites a caller back.
+  expect("sortHits" in search).toBe(false);
+});
+
+test("only a sortable header advertises itself as clickable", () => {
+  // `cursor: pointer` on the bare `th` promised a sort the search header does
+  // not perform. The rule has to be scoped to the sortable ones.
+  const bare = CSS.match(/table\.listing-table th \{([^}]*)\}/);
+  expect(bare).not.toBeNull();
+  expect(bare![1]).not.toMatch(/cursor:\s*pointer/);
+  expect(CSS).toMatch(/th\.sortable[^{]*\{[^}]*cursor:\s*pointer/s);
+});

--- a/frontend/src/apps/explorer/listing/search.test.ts
+++ b/frontend/src/apps/explorer/listing/search.test.ts
@@ -5,7 +5,7 @@
 // every re-score. Anything per-COMPARISON in here is multiplied by ~3.5M.
 import { expect, test } from "bun:test";
 import type { WalkEntry } from "@platform/lib/api";
-import { rankCompare, scoreEntries, sortHits } from "@apps/explorer/listing/search";
+import { rankCompare, scoreEntries } from "@apps/explorer/listing/search";
 
 function entry(rel: string): WalkEntry {
   return { rel, is_dir: false, size: 1, mtime: 1 } as WalkEntry;
@@ -69,18 +69,6 @@ test("the comparator does no per-comparison string splitting", () => {
   // it inside the comparator meant two split("/") allocations per comparison.
   const hits = scoreEntries("c", [entry("a/b/c.ts"), entry("c.ts")], 0, true);
   expect(hits.map((h) => h.depth)).toEqual([3, 1]);
-});
-
-test("sortHits stays case-insensitive too", () => {
-  // "a-x" and "Á-x" collate EQUAL at base sensitivity, so their relative
-  // order is just the stable sort's — the property under test is that both
-  // sort before "b-x" rather than after "z".
-  const hits = scoreEntries("x", ["b-x", "Á-x", "a-x"].map(entry), 0, true);
-  expect(sortHits(hits, "name", "asc").map((h) => h.entry.rel)).toEqual([
-    "Á-x",
-    "a-x",
-    "b-x",
-  ]);
 });
 
 test("ranking a large hit set stays well under a frame budget", () => {

--- a/frontend/src/apps/explorer/listing/search.test.ts
+++ b/frontend/src/apps/explorer/listing/search.test.ts
@@ -48,6 +48,22 @@ test("a substring match still outranks a fuzzy one", () => {
   );
 });
 
+test("a whole-path smear is not a hit at all", () => {
+  // The span bound (lib/fuzzy `maxSpan`). `storepy` over this path is a valid
+  // subsequence spread across 37 characters — s from `fused`, t from
+  // `templates`, and so on — and it used to rank among the real store.py hits.
+  //
+  // The tier is deliberately NOT tested alongside it: tightening cannot move the
+  // LAST matched position (the end is fixed by the forward pass), and
+  // `nameTier`'s ancestors-only rule reads exactly that position, so tier
+  // semantics are unchanged by construction.
+  const smear = "fused_render/templates/autocad_viewer/tests/test_browse.py";
+  expect(scoreEntries("storepy", [entry(smear)], 0, true)).toEqual([]);
+  expect(ranked("storepy", [smear, "fused_render/index/store.py"])).toEqual([
+    "fused_render/index/store.py",
+  ]);
+});
+
 test("shallower paths win ties", () => {
   expect(ranked("readme", ["a/b/c/readme.md", "readme.md"])[0]).toBe("readme.md");
 });

--- a/frontend/src/apps/explorer/listing/search.test.ts
+++ b/frontend/src/apps/explorer/listing/search.test.ts
@@ -21,6 +21,33 @@ test("an exact name match outranks a longer name containing it", () => {
   expect(ranked("downloads", ["a/DownloadStage.ts", "a/Downloads"])[0]).toBe("a/Downloads");
 });
 
+test("an entry whose own name matches beats one that only inherits an ancestor", () => {
+  // scoreEntries matches the whole rel path, so a matching ANCESTOR DIRECTORY
+  // donated its score to every descendant: "render" scored
+  // render/a/b/c/d/e/f/deep-thing.bin at 26 and myrender.ts at 21, and depth is
+  // only reachable on an exact score tie, so the deep file won. The name-match
+  // tier sits above score and settles it.
+  expect(ranked("render", ["render/a/b/c/d/junk.bin", "myrender.ts"])[0]).toBe(
+    "myrender.ts",
+  );
+});
+
+test("a fuzzy name match still beats an ancestor-only match", () => {
+  // Tier 2 vs tier 3: neither name contains "cfg" as a substring, but one has
+  // the matched characters inside its own name.
+  expect(ranked("cfg", ["c/f/g/notes.txt", "mycxfxg.txt"])[0]).toBe("mycxfxg.txt");
+});
+
+test("a substring match still outranks a fuzzy one", () => {
+  // Structural, and it must stay that way: fuzzyMatch's substring branch sets
+  // longestRun = q.length (the maximum), which the subsequence branch can never
+  // reach, so longestRun as the PRIMARY key decides this before the tier or the
+  // score is looked at. Here the fuzzy hit has more than twice the score.
+  expect(ranked("cfg", ["c/f/g/notes.txt", "mycfgfile.txt"])[0]).toBe(
+    "mycfgfile.txt",
+  );
+});
+
 test("shallower paths win ties", () => {
   expect(ranked("readme", ["a/b/c/readme.md", "readme.md"])[0]).toBe("readme.md");
 });

--- a/frontend/src/apps/explorer/listing/search.ts
+++ b/frontend/src/apps/explorer/listing/search.ts
@@ -1,7 +1,7 @@
 // Fuzzy scoring and ranking for the in-folder search (over the streamed walk).
 import type { WalkEntry } from "@platform/lib/api";
 import { fuzzyMatch } from "@platform/lib/fuzzy";
-import type { SearchHit, SortKey, SortOrder } from "@apps/explorer/listing/types";
+import type { SearchHit } from "@apps/explorer/listing/types";
 
 // A dot-leading query segment is explicit intent to SEE hidden entries.
 // The walk itself always includes hidden entries (one dataset — the server
@@ -110,19 +110,4 @@ export function scoreEntries(
                 depth: depthOf(entry.rel) });
   }
   return hits;
-}
-
-// Column-sort a ranked result set (the search headers' asc/desc modes; null
-// searchSort — relevance — leaves the rankCompare order untouched upstream).
-export function sortHits(hits: SearchHit[], sort: SortKey, order: SortOrder): SearchHit[] {
-  const flip = order === "desc" ? -1 : 1;
-  const byName = (a: SearchHit, b: SearchHit) => byRel(a.entry.rel, b.entry.rel);
-  return [...hits].sort((a, b) => {
-    let cmp: number;
-    if (sort === "size") cmp = (a.entry.size ?? -1) - (b.entry.size ?? -1);
-    else if (sort === "mtime") cmp = (a.entry.mtime ?? 0) - (b.entry.mtime ?? 0);
-    else cmp = byName(a, b);
-    if (cmp === 0) cmp = byName(a, b);
-    return cmp * flip;
-  });
 }

--- a/frontend/src/apps/explorer/listing/search.ts
+++ b/frontend/src/apps/explorer/listing/search.ts
@@ -40,8 +40,33 @@ function depthOf(rel: string): number {
   return depth;
 }
 
+// How much of the match landed on the entry's OWN name: 1 = the query is a
+// substring of the name, 2 = the name matched only fuzzily, 3 = only ancestor
+// directories matched. Derived from what the matcher already returned plus the
+// lowercased name scoreEntries already slices for its exact/prefix bonuses —
+// calling fuzzyMatch a second time (against the name alone) would double the
+// cost of the hot path, and the 150k-hit budget in search.test.ts does not have
+// room for that.
+function nameTier(name: string, nameStart: number, q: string,
+                  positions: number[]): 1 | 2 | 3 {
+  if (name.includes(q)) return 1;
+  // Every matched char sits before the name: the hit is entirely in ancestors.
+  if (positions.length && positions[positions.length - 1] < nameStart) return 3;
+  return 2;
+}
+
 export function rankCompare(a: SearchHit, b: SearchHit): number {
   if (b.longestRun !== a.longestRun) return b.longestRun - a.longestRun;
+  // Above `score`, because scoring runs over the whole rel path and a matching
+  // ancestor directory therefore donates its score to every descendant: query
+  // "render" scored render/a/b/c/d/e/f/deep-thing.bin at 26 and myrender.ts at
+  // 21, and `depth` below is only reachable on an exact score tie.
+  //
+  // BELOW `longestRun`, which is what already guarantees substring-over-fuzzy:
+  // fuzzyMatch's substring branch sets longestRun = q.length (the maximum the
+  // subsequence branch can never reach), so mycfgfile.txt beats c/f/g/notes.txt
+  // before the tier is consulted. That invariant must survive any change here.
+  if (a.tier !== b.tier) return a.tier - b.tier;
   if (b.score !== a.score) return b.score - a.score;
   if (a.depth !== b.depth) return a.depth - b.depth;
   return byRel(a.entry.rel, b.entry.rel);
@@ -76,10 +101,12 @@ export function scoreEntries(
     const m = fuzzyMatch(query, entry.rel);
     if (!m) continue;
     let score = m.score;
-    const name = entry.rel.slice(entry.rel.lastIndexOf("/") + 1).toLowerCase();
+    const nameStart = entry.rel.lastIndexOf("/") + 1;
+    const name = entry.rel.slice(nameStart).toLowerCase();
     if (name === q) score += 100;
     else if (name.startsWith(q)) score += 25;
     hits.push({ entry, positions: m.positions, score, longestRun: m.longestRun,
+                tier: nameTier(name, nameStart, q, m.positions),
                 depth: depthOf(entry.rel) });
   }
   return hits;

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -134,6 +134,11 @@ export interface SearchHit {
   positions: number[];
   score: number;
   longestRun: number;
+  // 1 = the query is a substring of this entry's own NAME, 2 = the name matched
+  // only fuzzily, 3 = only ancestor directories matched. Lower wins. Ranked
+  // above `score` because scoring runs over the whole rel path, so a matching
+  // ancestor directory donates its score to every descendant (see search.ts).
+  tier: 1 | 2 | 3;
   // Path depth, precomputed at score time. The rank comparator runs n·log n
   // times over a hit list that can be the whole corpus, so it must not derive
   // anything per comparison (see search.ts).

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -35,6 +35,16 @@ export const SORT_KEYS = { name: "Name", size: "Size", mtime: "Modified" };
 export type SortKey = keyof typeof SORT_KEYS;
 export type SortOrder = "asc" | "desc";
 
+// Columns the listing table renders. Search mode shows the matched PATH alone:
+// a hit's row is already a full rel path, and it needs every pixel the table
+// has. Status, banner and sentinel rows span the table, so their colSpan must
+// follow the mode — a hardcoded 3 under a one-column head declares two columns
+// nothing else mentions, and table-layout:fixed hands them width (the dead
+// strip in listing/column-shedding).
+export function columnCount(searching: boolean): number {
+  return searching ? 1 : 3;
+}
+
 // Search-result rows rendered per "page". Fuzzy-scoring can match thousands
 // of entries in a large tree; mounting them all as <tr>s at once is what jams
 // the main thread (scoring itself is comparatively cheap). Scrolling to the

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -33,11 +33,9 @@ import {
   STREAM_FLUSH_MS,
   URL_SYNC_MS,
   type SearchHit,
-  type SortKey,
-  type SortOrder,
   type WalkState,
 } from "@apps/explorer/listing/types";
-import { queryWantsHidden, rankCompare, scoreEntries, sortHits } from "@apps/explorer/listing/search";
+import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
 
 function currentQuery(): string {
   return new URLSearchParams(location.search).get("q") || "";
@@ -60,10 +58,6 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // Bumped to re-run the stream effect after an error, from a real user
   // gesture only (focus / typing) — an effect-driven retry would loop forever.
   const [retryNonce, setRetryNonce] = useState(0);
-  // Sort applied to search results. null = relevance (fuzzy rank). Deliberately
-  // NOT URL-synced (unlike the normal-mode sort) — it resets on every query
-  // change, so persisting it would fight that reset.
-  const [searchSort, setSearchSort] = useState<{ sort: SortKey; order: SortOrder } | null>(null);
 
   // The input echoes `query` (immediate) so keystrokes never wait on the
   // fuzzy-scoring/rendering work below. `deferredQuery` trails behind under
@@ -277,7 +271,6 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     // A query change is a boundary: the rows are being replaced anyway, so a
     // generation deferred during the previous query lands here for free.
     reconcile();
-    setSearchSort(null); // a new query drops back to relevance order
     // Editing the query is also a user gesture: if the last walk attempt
     // failed, give it another shot instead of leaving search dead forever.
     // (An idle walk needs no handling here — the auto-request effect fires
@@ -297,18 +290,6 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
       const qs = params.toString();
       replaceSearch(location.pathname + (qs ? "?" + qs : ""));
     }, URL_SYNC_MS);
-  };
-
-  // Search headers cycle asc → desc → relevance. Relevance (the fuzzy rank) is
-  // the mode search results are actually FOR, and before this there was no way
-  // back to it short of retyping the query — the toggle only ever flipped
-  // between two column orders.
-  const setSearchSortKey = (key: SortKey) => {
-    setSearchSort((prev) => {
-      if (!prev || prev.sort !== key) return { sort: key, order: "asc" };
-      if (prev.order === "asc") return { sort: key, order: "desc" };
-      return null;
-    });
   };
 
   // Incremental-scoring cache for the corpus. As long as the query,
@@ -401,11 +382,15 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // computed for the CURRENT query, so a scan still catching up never shows
   // the previous query's matches — the same rule search-hold enforces
   // downstream, applied at the source.
+  // Relevance (the fuzzy rank) is the only order search results have. Column
+  // sorting used to be offered here and was withdrawn with the Size/Modified
+  // headers: the hit set is capped and, mid-walk, partial — a by-date or
+  // by-size ordering over it reads as an answer to a question the data cannot
+  // answer, and the search UI already warns the coverage is approximate.
   const hits = useMemo(() => {
     if (!searching || scanned.q !== q) return [];
-    if (!searchSort) return scanned.items; // relevance order
-    return sortHits(scanned.items, searchSort.sort, searchSort.order);
-  }, [searching, scanned, q, searchSort]);
+    return scanned.items;
+  }, [searching, scanned, q]);
 
   // True while the scan for the current query has not published yet — the
   // spinner and the dimmed-rows treatment key off this, so it has to mean
@@ -436,11 +421,11 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   }));
   const lastRankCommit = useRef(0);
   // Declared BEFORE the commit effect so it runs first in the same flush: a
-  // query change (or a sort change) is a direct response to a gesture and must
-  // paint immediately, never wait out a throttle window opened by the stream.
+  // query change is a direct response to a gesture and must paint immediately,
+  // never wait out a throttle window opened by the stream.
   useEffect(() => {
     lastRankCommit.current = 0;
-  }, [q, searchSort]);
+  }, [q]);
   useEffect(() => {
     // Only a streaming walk churns. Anything else (settled, errored, or
     // invalidated to idle) commits at once — there is nothing left to smooth
@@ -519,8 +504,5 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     visibleHits,
     showingHeld,
     cappedAway,
-    searchSort,
-    setSearchSort,
-    setSearchSortKey,
   };
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -396,8 +396,9 @@ export function deleteIndex(): Promise<{ deleted: boolean }> {
   });
 }
 
-// One hit from POST /api/search/files (the AI search's execution engine —
-// Spotlight on macOS, a bounded home walk elsewhere). `path` is absolute.
+// One hit from POST /api/search/files (the AI search's execution engine — the
+// app's SQL index first, then Spotlight on macOS, then a bounded home walk).
+// `path` is absolute.
 export interface SearchFileEntry {
   path: string;
   is_dir: boolean;
@@ -408,12 +409,14 @@ export interface SearchFileEntry {
 export interface SearchFilesResult {
   entries: SearchFileEntry[];
   truncated: boolean;
-  engine: string; // "spotlight" | "walk"
+  engine: string; // "index" | "spotlight" | "walk" — which engine answered
 }
 
 // System-wide file search from a filter spec (see apps/explorer/lib/ai-search).
 // Takes a signal because a new search must be able to abandon the previous
-// engine run mid-flight (Spotlight on a broad query can take seconds).
+// engine run mid-flight (Spotlight on a broad query can take seconds; the
+// index engine answers in one SQL query, but it is not always the one that
+// runs — see the server's search.py for the fallback order).
 export async function searchFiles(
   spec: unknown,
   signal?: AbortSignal,

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1,5 +1,7 @@
 // Server API wrappers. Non-ok responses throw with the server's error message.
 import { noteFsMutation, noteIndexLifecycle } from "@platform/lib/index-freshness";
+import { outcomeFrom } from "@platform/lib/index-query";
+import type { IndexQueryOutcome } from "@platform/lib/index-query";
 
 export interface Config {
   start_dir: string;
@@ -339,6 +341,49 @@ export function startIndexScan(opts: { root?: string; full?: boolean } = {}): Pr
   runs: { run_id: string; root: string }[];
 }> {
   return mutateJson("POST", "/api/index/scan", opts);
+}
+
+// POST /api/index/query and /api/index/ask — read-only SQL over the index, and
+// the same thing from a question in English (index/specs/query.md §5).
+//
+// NOT through mutateJson, for two reasons: it throws on a non-2xx, and a
+// refused `ask` returns a 400 whose body carries the compiled `sql` the user
+// needs to see — throwing would drop it. And deliberately NOT through
+// noteAfter/noteFsMutation: a query changes nothing, so marking a folder dirty
+// would drop it to a live walk for the rest of the session for no reason.
+// The X-Fused header is still required (both routes execute a caller-shaped
+// statement, so both are guarded).
+export async function runIndexQuery(
+  body: { sql: string; limit?: number },
+): Promise<IndexQueryOutcome> {
+  return indexQueryPost("/api/index/query", body);
+}
+
+export async function askIndex(
+  body: { prompt: string; limit?: number },
+): Promise<IndexQueryOutcome> {
+  return indexQueryPost("/api/index/ask", body);
+}
+
+async function indexQueryPost(url: string, body: unknown): Promise<IndexQueryOutcome> {
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Fused": "1" },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    return { ok: false, sql: null, error: (e as Error).message };
+  }
+  let data: unknown = null;
+  try {
+    data = await res.json();
+  } catch {
+    // outcomeFrom turns a null body into `HTTP <status>`, which is the honest
+    // message when the server did not answer JSON at all.
+  }
+  return outcomeFrom(res.status, data);
 }
 
 export function deleteIndex(): Promise<{ deleted: boolean }> {

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -396,9 +396,8 @@ export function deleteIndex(): Promise<{ deleted: boolean }> {
   });
 }
 
-// One hit from POST /api/search/files (the AI search's execution engine — the
-// app's SQL index first, then Spotlight on macOS, then a bounded home walk).
-// `path` is absolute.
+// One hit from POST /api/search/files (the AI search's execution engine — one
+// SQL query against the app's file index, the only engine). `path` is absolute.
 export interface SearchFileEntry {
   path: string;
   is_dir: boolean;
@@ -409,14 +408,17 @@ export interface SearchFileEntry {
 export interface SearchFilesResult {
   entries: SearchFileEntry[];
   truncated: boolean;
-  engine: string; // "index" | "spotlight" | "walk" — which engine answered
+  // Always "index" now that the index is the only engine; kept in the response
+  // for older clients and because "what answered this" is the first support
+  // question about a surprising result.
+  engine: string;
 }
 
-// System-wide file search from a filter spec (see apps/explorer/lib/ai-search).
-// Takes a signal because a new search must be able to abandon the previous
-// engine run mid-flight (Spotlight on a broad query can take seconds; the
-// index engine answers in one SQL query, but it is not always the one that
-// runs — see the server's search.py for the fallback order).
+// File search from a filter spec (see apps/explorer/lib/ai-search), scoped to
+// whatever the index has scanned — home by default. Takes a signal because a new
+// search must be able to abandon the previous one mid-flight. A missing or
+// unreadable index is an ERROR here (503/502), never an empty result: see the
+// server's search.py.
 export async function searchFiles(
   spec: unknown,
   signal?: AbortSignal,

--- a/frontend/src/platform/lib/fuzzy.test.ts
+++ b/frontend/src/platform/lib/fuzzy.test.ts
@@ -118,6 +118,19 @@ describe("the span bound", () => {
     }
   });
 
+  test("the named cost: a 3-char initialism over a long prose title is refused", () => {
+    // Not a bug — a measured trade, recorded so it is not rediscovered as one.
+    // The bookmark search matches against page titles, and word-initials over a
+    // long one spread further than a short query's bound allows. The obvious fix
+    // (an allowance per segment-start hit) re-admits the whole-path smear this
+    // bound exists for — see maxSpan's comment for the numbers. One more typed
+    // character brings it back.
+    const title = "Zarr v3 multiscale pyramid budget notes";
+    expect(fuzzyMatch("zmp", title)).toBeNull();
+    // Typing more of the first word buys the span back.
+    expect(fuzzyMatch("zarrmp", title)).not.toBeNull();
+  });
+
   test("the bound is on the whole span, not on each gap", () => {
     // Two tight halves separated by one long gap is a GOOD match ("index" then
     // ".md" across a directory name), so a per-gap cap has to be loose — and

--- a/frontend/src/platform/lib/fuzzy.test.ts
+++ b/frontend/src/platform/lib/fuzzy.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+import { fuzzyMatch, highlightSegments, maxSpan } from "./fuzzy";
+
+// The reported case: greedy-earliest alignment bound `i` to `iamsdas`, `n` to
+// `render` and so on, smearing an 8-char query across the whole path while a
+// near-perfect match sat in the last segment.
+const REL = "fused_render/index/specs/index-store.md";
+const ABS = "/Users/iamsdas/Work/fused-render/" + REL;
+
+describe("tightening", () => {
+  test("the match snaps onto the tail segment, not the earliest letters", () => {
+    const m = fuzzyMatch("index.md", REL)!;
+    expect(m).not.toBeNull();
+    // `index` of index-store.md, then `.md` — not one letter each from
+    // fused_render / index / specs.
+    expect(m.positions).toEqual([25, 26, 27, 28, 29, 36, 37, 38]);
+    expect(REL.slice(25, 30)).toBe("index");
+  });
+
+  test("score and longestRun are recomputed from the tightened alignment", () => {
+    // Greedy binds `a` to index 0 and gets a run of 2 (`bc`); packing leftwards
+    // from the same end finds the `abc` at index 2 and a run of 3. Judging the
+    // greedy numbers would have under-scored a better match.
+    const m = fuzzyMatch("abcd", "aXabcYd")!;
+    expect(m.positions).toEqual([2, 3, 4, 6]);
+    expect(m.longestRun).toBe(3);
+    expect(fuzzyMatch("index.md", REL)!.longestRun).toBe(5);
+  });
+
+  test("the highlight no longer scatters across the leading path", () => {
+    const m = fuzzyMatch("index.md", ABS)!;
+    const marked = highlightSegments(ABS, m.positions)
+      .filter((s) => s.match)
+      .map((s) => s.text);
+    expect(marked).toEqual(["index", ".md"]);
+    // Every marked char is inside the final segment; none is in the leading
+    // /Users/iamsdas/Work/… that used to donate letters.
+    const lastSlash = ABS.lastIndexOf("/");
+    expect(Math.min(...m.positions)).toBeGreaterThan(lastSlash);
+  });
+
+  test("tightening cannot lose a match the greedy pass found", () => {
+    // The forward pass proves feasibility and fixes the end; the backward pass
+    // is then always satisfiable from it.
+    for (const [q, t] of [
+      ["abc", "a-b-c"],
+      ["abc", "aabbcc"],
+      ["aaa", "aaaa"],
+      ["ab", "ba-ab"],
+    ] as const) {
+      const m = fuzzyMatch(q, t);
+      expect(m, `${q} in ${t}`).not.toBeNull();
+      expect(m!.positions.length).toBe(q.length);
+    }
+  });
+
+  test("positions stay ascending and one per query char", () => {
+    const m = fuzzyMatch("aaa", "aXaYaZa")!;
+    expect(m.positions.length).toBe(3);
+    for (let i = 1; i < m.positions.length; i++) {
+      expect(m.positions[i]).toBeGreaterThan(m.positions[i - 1]);
+    }
+  });
+
+  test("the last query char binds as late as the earliest end allows", () => {
+    // "ab" over "a-b-b": the end is fixed at the FIRST reachable b, so the
+    // second b is not chased — tightening packs leftwards from a fixed end, it
+    // does not hunt for the tail of the string.
+    //
+    // Worth stating because a consumer depends on it: listing/search.ts's
+    // `nameTier` grades a hit ancestors-only from the LAST position, and that
+    // position is the one thing tightening never moves. Tier semantics are
+    // therefore unchanged by construction, not by luck.
+    expect(fuzzyMatch("ab", "a-b-b")!.positions).toEqual([0, 2]);
+  });
+});
+
+describe("the span bound", () => {
+  test("it grows with the query, so a long query may legitimately spread", () => {
+    expect(maxSpan(2)).toBe(14);
+    expect(maxSpan(8)).toBe(32);
+    expect(maxSpan(14)).toBe(50);
+  });
+
+  test("a match exactly at the bound is kept and one char wider is not", () => {
+    const at = "a" + "z".repeat(maxSpan(2) - 2) + "b";
+    const over = "a" + "z".repeat(maxSpan(2) - 1) + "b";
+    expect(fuzzyMatch("ab", at)).not.toBeNull();
+    expect(fuzzyMatch("ab", over)).toBeNull();
+  });
+
+  test("the reported scatter is refused outright", () => {
+    // Real repo paths where the ONLY alignment for `index.md` is a whole-path
+    // smear: nothing named index, nothing ending index-ish.
+    for (const t of [
+      "/Users/iamsdas/Work/fused-render/docs/EXPORT.md",
+      "/Users/iamsdas/Work/fused-render/docs/LINUX_DESKTOP_SPEC.md",
+    ]) {
+      expect(fuzzyMatch("index.md", t), t).toBeNull();
+    }
+  });
+
+  test("multi-segment queries a user really types keep matching", () => {
+    // Each of these spans several path segments and is exactly the intent the
+    // matcher exists for; a per-gap cap tight enough to catch the scatter above
+    // would have killed them.
+    for (const [q, t] of [
+      ["index.md", REL],
+      ["explorersearch", "frontend/src/apps/explorer/listing/useWalkSearch.ts"],
+      ["fusedindex", "fused_render/index/freshness.py"],
+      ["indexstore", "fused_render/index/specs/index-store.md"],
+      ["storepy", "fused_render/shell/mounts/store.py"],
+      ["srcstyles", "frontend/src/styles/account.css"],
+      ["fris", "frontend/src/platform/ui/Skeleton.tsx"],
+      ["specsscanmd", "fused_render/index/specs/scan-incremental.md"],
+    ] as const) {
+      expect(fuzzyMatch(q, t), `${q} in ${t}`).not.toBeNull();
+    }
+  });
+
+  test("the bound is on the whole span, not on each gap", () => {
+    // Two tight halves separated by one long gap is a GOOD match ("index" then
+    // ".md" across a directory name), so a per-gap cap has to be loose — and
+    // once it is loose enough for that it no longer catches the scatter.
+    expect(fuzzyMatch("indexmd", "index/a-fairly-long-folder-name/x.md")).not
+      .toBeNull();
+  });
+});
+
+describe("the substring fast path is untouched", () => {
+  test("a substring sets longestRun to the query length", () => {
+    // rankCompare orders on longestRun FIRST, and this is the invariant that
+    // guarantees substring-over-fuzzy (listing/search.ts).
+    const m = fuzzyMatch("index", REL)!;
+    expect(m.longestRun).toBe(5);
+    expect(m.positions).toEqual([13, 14, 15, 16, 17]);
+  });
+
+  test("a substring is never refused for its span", () => {
+    // Spans are irrelevant here — a substring's span IS the query length — but
+    // the branch must also stay ahead of the bound check.
+    const long = "a".repeat(200) + "needle";
+    expect(fuzzyMatch("needle", long)!.longestRun).toBe(6);
+  });
+
+  test("a whole-text match still works", () => {
+    expect(fuzzyMatch("abc", "abc")!.positions).toEqual([0, 1, 2]);
+  });
+});
+
+describe("unchanged contracts", () => {
+  test("an empty query is a zero match, not a miss", () => {
+    expect(fuzzyMatch("", "anything")).toEqual({
+      score: 0,
+      positions: [],
+      longestRun: 0,
+    });
+  });
+
+  test("a char that is not there at all is still null", () => {
+    expect(fuzzyMatch("xyz", "abc")).toBeNull();
+    expect(fuzzyMatch("abcd", "abc")).toBeNull();
+  });
+
+  test("matching is case-insensitive and highlights the original case", () => {
+    // And the tighten shows up here too: greedy took the leading `D`, leaving
+    // two islands; packing leftwards lands on `dM`, the camel-hump seam a human
+    // typing "dm" meant.
+    const m = fuzzyMatch("dm", "DownloadManager.tsx")!;
+    expect(m.positions).toEqual([7, 8]);
+    expect(highlightSegments("DownloadManager.tsx", m.positions)
+      .filter((s) => s.match)
+      .map((s) => s.text)).toEqual(["dM"]);
+  });
+});

--- a/frontend/src/platform/lib/fuzzy.ts
+++ b/frontend/src/platform/lib/fuzzy.ts
@@ -64,6 +64,16 @@ function isSegmentStart(text: string, i: number): boolean {
  * query in fuzzy.test.ts and refuses `index.md` against
  * `docs/LINUX_DESKTOP_SPEC.md`. The `+ 8` is what keeps very short queries
  * usable, where a proportional bound alone would be a couple of characters.
+ *
+ * NAMED COST: a very short query used as word initials over a long prose string
+ * — `zmp` for the bookmark titled "Zarr v3 multiscale pyramid budget notes",
+ * span 20 against a bound of 17 — stops matching. The obvious fix, an extra
+ * allowance per matched char that lands on a segment start, was measured and is
+ * WORSE: at `+4` per start it rescues that case and re-admits `index.md`
+ * against `/Users/…/docs/EXPORT.md` (span 40, four segment starts, bound 48),
+ * which is the very smear this exists to refuse. A short query over prose is
+ * low-signal either way, and one more character typed fixes it; a whole-path
+ * smear ranked among real hits is what the user actually reported.
  */
 export function maxSpan(queryLength: number): number {
   return queryLength * 3 + 8;

--- a/frontend/src/platform/lib/fuzzy.ts
+++ b/frontend/src/platform/lib/fuzzy.ts
@@ -1,8 +1,34 @@
 // Dependency-free, case-insensitive fuzzy subsequence matcher shared by the
-// explorer and bookmark searches. Greedy left-to-right matching finds a
-// subsequence whenever one exists (taking the earliest occurrence of each
-// query char never blocks a later one); the score is a heuristic, not an
-// optimum. Returns null when the query's chars don't all appear in order.
+// explorer and bookmark searches. Returns null when the query's chars don't all
+// appear in order, or when the alignment is too spread out to mean anything.
+//
+// TWO passes, not one, and the second is what makes the result usable:
+//
+//   1. FORWARD, greedy-earliest. This decides only two things — whether a
+//      subsequence exists at all (taking the earliest occurrence of each query
+//      char never blocks a later one) and the earliest index the match can END
+//      at.
+//   2. BACKWARD from that end, binding each query char as LATE as possible.
+//
+// Pass 1 alone was the bug. Query `index.md` over
+// `/Users/iamsdas/…/index/specs/index-store.md` bound `i` to `iamsdas`, `n` to
+// `render` and so on, smearing eight chars across the whole path while a
+// near-perfect match sat in the last segment — a bad score, a worse
+// `longestRun`, and a highlight of scattered letters. Packing leftwards from a
+// fixed end snaps the whole thing onto `index-store.md`. This is the standard
+// fzf-style tighten; it is still a heuristic, not an optimum (the end stays the
+// earliest feasible one), but it is the alignment a human reading the path
+// would pick. `positions`, `score` and `longestRun` all come from pass 2.
+//
+// Then the SPAN bound: a match whose tightened alignment still stretches further
+// than `maxSpan(query.length)` is refused. Bounding the total span rather than
+// each gap is deliberate — a good match is often two tight halves either side of
+// one long gap (`index` … `.md` across a folder name), so a per-gap cap has to
+// be loose enough for that, and once it is, it no longer catches the smear.
+//
+// Both passes are O(text length) and allocate one positions array. This runs
+// over a 150k-entry corpus on every keystroke (listing/scan-job), so nothing
+// here may become a dynamic-programming alignment.
 export interface FuzzyResult {
   score: number;
   positions: number[]; // indices in `text` of the matched chars, ascending
@@ -27,12 +53,33 @@ function isSegmentStart(text: string, i: number): boolean {
   return isUpper(text[i]) && !isUpper(prev);
 }
 
+/**
+ * How far a `queryLength`-char match may stretch, first matched char to last.
+ *
+ * Tuned against this repo's real paths, not derived: for the queries a person
+ * actually types the tightened span sits at the query length plus a handful
+ * (`indexstore` → 11 over 10, `explorersearch` → 15-30 over 14, `fusedindex` →
+ * 18 over 10), while the smears that prompted this are 40-78. `3n + 8` sits
+ * between the two everywhere it was measured — it keeps every multi-segment
+ * query in fuzzy.test.ts and refuses `index.md` against
+ * `docs/LINUX_DESKTOP_SPEC.md`. The `+ 8` is what keeps very short queries
+ * usable, where a proportional bound alone would be a couple of characters.
+ */
+export function maxSpan(queryLength: number): number {
+  return queryLength * 3 + 8;
+}
+
 export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
   if (query === "") return { score: 0, positions: [], longestRun: 0 };
   const q = query.toLowerCase();
   const t = text.toLowerCase();
   const sub = t.indexOf(q);
   if (sub !== -1) {
+    // The substring branch is untouched, and stays AHEAD of everything below.
+    // `longestRun = q.length` is the maximum the subsequence branch can never
+    // reach, and rankCompare orders on longestRun first — that is what
+    // guarantees substring-over-fuzzy (listing/search.ts). Its span is the query
+    // length by construction, so the bound cannot apply to it.
     const positions: number[] = [];
     let score = 0;
     for (let ti = sub; ti < sub + q.length; ti++) {
@@ -43,24 +90,39 @@ export function fuzzyMatch(query: string, text: string): FuzzyResult | null {
     }
     return { score, positions, longestRun: q.length };
   }
-  const positions: number[] = [];
+  // Pass 1: does a subsequence exist, and where is the earliest it can end?
   let qi = 0;
-  let score = 0;
-  let prev = -2; // index of the previously matched char, for the consecutive test
-  let run = 0; // length of the current consecutive matched stretch
-  let longestRun = 0;
+  let end = -1;
   for (let ti = 0; ti < t.length && qi < q.length; ti++) {
-    if (t[ti] !== q[qi]) continue;
-    positions.push(ti);
+    if (t[ti] === q[qi]) {
+      end = ti;
+      qi++;
+    }
+  }
+  if (qi < q.length) return null; // ran out of text before matching every char
+  // Pass 2: the same match, packed as far right as `end` allows. Guaranteed to
+  // complete — pass 1's alignment is itself a witness that ends at `end`, and
+  // binding later can only ever be easier.
+  const positions = new Array<number>(q.length);
+  let qj = q.length - 1;
+  for (let ti = end; ti >= 0 && qj >= 0; ti--) {
+    if (t[ti] === q[qj]) positions[qj--] = ti;
+  }
+  if (end - positions[0] + 1 > maxSpan(q.length)) return null;
+  // Scored over the TIGHTENED positions. Scoring pass 1's would have judged a
+  // match nobody is going to see.
+  let score = 0;
+  let run = 0;
+  let longestRun = 0;
+  let prev = -2;
+  for (const ti of positions) {
     score += 1;
     run = ti === prev + 1 ? run + 1 : 1;
     if (run > longestRun) longestRun = run;
     if (ti === prev + 1) score += 3; // consecutive run
     if (isSegmentStart(text, ti)) score += 5; // landed on a word boundary
     prev = ti;
-    qi++;
   }
-  if (qi < q.length) return null; // ran out of text before matching every char
   return { score, positions, longestRun };
 }
 

--- a/frontend/src/platform/lib/index-freshness.ts
+++ b/frontend/src/platform/lib/index-freshness.ts
@@ -4,8 +4,11 @@
 // There is no filesystem watcher (index/specs/scan.md), so the index is a
 // snapshot: rename a file and the corpus keeps offering the old name and
 // cannot offer the new one until the next scan. For out-of-band edits that
-// is the documented trade — the index is rebuilt at startup and a scan says
-// "indexing…" while it runs. For edits the explorer itself just made it is
+// is the documented trade — the index is rebuilt at startup, opening a folder
+// whose own mtime is ahead of the index rescans its root in the background
+// (index/specs/scan-incremental.md §5), and a scan says "indexing…" while it
+// runs. None of that is instant, and a change deeper than the folder being
+// viewed does not move its mtime at all. For edits the explorer itself just made it is
 // not a trade, it is a visible lie: the user renamed the file in this window
 // and search still can't find it.
 //

--- a/frontend/src/platform/lib/index-query.test.ts
+++ b/frontend/src/platform/lib/index-query.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+import { cellText, outcomeFrom } from "./index-query";
+
+describe("cellText", () => {
+  test("null is spelled out, because an empty cell is a different fact", () => {
+    expect(cellText(null)).toBe("NULL");
+    expect(cellText(undefined)).toBe("NULL");
+    expect(cellText("")).toBe("");
+  });
+
+  test("numbers and booleans render, 0 and false included", () => {
+    expect(cellText(0)).toBe("0");
+    expect(cellText(false)).toBe("false");
+    expect(cellText(1.5)).toBe("1.5");
+  });
+
+  test("a structured value is shown as JSON rather than [object Object]", () => {
+    expect(cellText({ a: 1 })).toBe('{"a":1}');
+    expect(cellText([1, 2])).toBe("[1,2]");
+  });
+});
+
+describe("outcomeFrom", () => {
+  test("a successful query becomes a table", () => {
+    const out = outcomeFrom(200, {
+      ok: true,
+      columns: ["ext", "n"],
+      rows: [
+        ["ts", 12],
+        ["md", 3],
+      ],
+      truncated: false,
+    });
+    expect(out).toEqual({
+      ok: true,
+      sql: null,
+      table: {
+        columns: ["ext", "n"],
+        rows: [
+          ["ts", "12"],
+          ["md", "3"],
+        ],
+        truncated: false,
+      },
+    });
+  });
+
+  test("the compiled SQL travels with an ask result", () => {
+    const out = outcomeFrom(200, {
+      ok: true,
+      sql: "SELECT 1",
+      columns: ["a"],
+      rows: [[1]],
+      truncated: true,
+    });
+    expect(out.ok && out.sql).toBe("SELECT 1");
+    expect(out.ok && out.table.truncated).toBe(true);
+  });
+
+  test("a short row is padded to the column count", () => {
+    // The table renders one <td> per column; a ragged row would shift the rest
+    // of its cells one column left.
+    const out = outcomeFrom(200, { ok: true, columns: ["a", "b", "c"], rows: [[1]] });
+    expect(out.ok && out.table.rows).toEqual([["1", "NULL", "NULL"]]);
+  });
+
+  test("a plain server error carries its message verbatim", () => {
+    // The server sends duckdb's own text ("no such column: nope"), which is the
+    // whole point of not rewording it.
+    const out = outcomeFrom(400, { error: "Binder Error: no such column: nope" });
+    expect(out).toEqual({
+      ok: false,
+      sql: null,
+      error: "Binder Error: no such column: nope",
+    });
+  });
+
+  test("a refused ask still reports the SQL that was refused", () => {
+    const out = outcomeFrom(400, {
+      error: "only read-only statements are allowed here",
+      sql: "DELETE FROM files",
+    });
+    expect(out.ok).toBe(false);
+    expect(out.sql).toBe("DELETE FROM files");
+  });
+
+  test("the AI relay's typed envelope is unwrapped to its message", () => {
+    // /api/index/ask passes a relay failure straight through, so the error is
+    // an OBJECT here, not a string — read as-is it rendered "[object Object]".
+    const out = outcomeFrom(502, {
+      ok: false,
+      error: { type: "ai_unavailable", message: "claude binary not found on PATH" },
+    });
+    expect(out.ok).toBe(false);
+    expect(!out.ok && out.error).toBe("claude binary not found on PATH");
+  });
+
+  test("an unreadable response is still an error and never a crash", () => {
+    for (const data of [null, undefined, "nope", 5, []]) {
+      const out = outcomeFrom(500, data);
+      expect(out.ok).toBe(false);
+      expect(!out.ok && out.error.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("a 200 that is not ok:true is an error, not an empty table", () => {
+    const out = outcomeFrom(200, { ok: false, error: "nope" });
+    expect(out.ok).toBe(false);
+  });
+
+  test("a result with no rows is a table, not an error", () => {
+    const out = outcomeFrom(200, { ok: true, columns: ["a"], rows: [] });
+    expect(out.ok).toBe(true);
+    expect(out.ok && out.table.rows).toEqual([]);
+  });
+});

--- a/frontend/src/platform/lib/index-query.ts
+++ b/frontend/src/platform/lib/index-query.ts
@@ -1,0 +1,85 @@
+// Turning a /api/index/query or /api/index/ask response into something a table
+// can render, and every failure into one string.
+//
+// Pure and separate from the panel because the response shapes are three, not
+// one: the happy `{ok, columns, rows, truncated}`, a plain `{error}` 400 (which
+// for `ask` also carries the `sql` that was refused), and the AI relay's typed
+// `{error: {type, message}}` envelope passed straight through by /ask. Read
+// naively, that last one renders as "[object Object]".
+//
+// Nothing here rewords a server message. The whole point of the server mapping
+// duckdb's own text to a 400 is that "Binder Error: no such column: nope" tells
+// the user exactly what to fix; a friendlier wrapper would throw that away.
+
+export interface IndexQueryTable {
+  columns: string[];
+  // Pre-stringified. The table renders text, and doing the conversion here is
+  // what keeps a BLOB or a struct from reaching React as an object.
+  rows: string[][];
+  truncated: boolean;
+}
+
+export type IndexQueryOutcome =
+  // `sql` is what the SERVER compiled — non-null only for /ask, where the user
+  // needs to see the statement their question turned into.
+  | { ok: true; sql: string | null; table: IndexQueryTable }
+  | { ok: false; sql: string | null; error: string };
+
+/** One cell as text. */
+export function cellText(v: unknown): string {
+  // Spelled out, not blank: a NULL and an empty string are different answers,
+  // and a column of blanks is unreadable either way.
+  if (v === null || v === undefined) return "NULL";
+  if (typeof v === "object") {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  }
+  return String(v);
+}
+
+function stringOrNull(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function messageFrom(data: Record<string, unknown>, status: number): string {
+  const err = data.error;
+  if (typeof err === "string" && err) return err;
+  // The relay envelope. `type` is for programs; `message` is the sentence.
+  if (err && typeof err === "object") {
+    const msg = (err as Record<string, unknown>).message;
+    if (typeof msg === "string" && msg) return msg;
+  }
+  return `HTTP ${status}`;
+}
+
+/** The response, as either a table or a message. Never throws. */
+export function outcomeFrom(status: number, data: unknown): IndexQueryOutcome {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    return { ok: false, sql: null, error: `HTTP ${status}` };
+  }
+  const body = data as Record<string, unknown>;
+  const sql = stringOrNull(body.sql);
+  if (status < 400 && body.ok === true) {
+    const columns = Array.isArray(body.columns) ? body.columns.map(cellText) : [];
+    const raw = Array.isArray(body.rows) ? body.rows : [];
+    return {
+      ok: true,
+      sql,
+      table: {
+        columns,
+        // Padded to the column count: the table renders one cell per column, so
+        // a ragged row would shift every cell after the gap one column left.
+        rows: raw.map((row) => {
+          const cells = Array.isArray(row) ? row.map(cellText) : [cellText(row)];
+          while (cells.length < columns.length) cells.push(cellText(null));
+          return cells.slice(0, Math.max(columns.length, cells.length));
+        }),
+        truncated: body.truncated === true,
+      },
+    };
+  }
+  return { ok: false, sql, error: messageFrom(body, status) };
+}

--- a/frontend/src/shell/Indexing.tsx
+++ b/frontend/src/shell/Indexing.tsx
@@ -7,12 +7,15 @@
 // hatches, not the normal path.
 import { useEffect, useState } from "react";
 import {
+  askIndex,
   deleteIndex,
   getIndexConfig,
   putIndexConfig,
+  runIndexQuery,
   startIndexScan,
 } from "@platform/lib/api";
 import type { IndexConfig } from "@platform/lib/api";
+import type { IndexQueryOutcome } from "@platform/lib/index-query";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { formatMtimeFull } from "@platform/lib/format";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
@@ -221,6 +224,134 @@ export function IndexingPanel() {
           </>
         )}
       </section>
+
+      <QuerySection />
+    </>
+  );
+}
+
+// Rows a query asks for. Enough to see a shape, short enough that the table
+// stays scrollable rather than becoming the page; the server's own cap is far
+// higher for a caller that means it.
+const QUERY_LIMIT = 200;
+
+const EXAMPLE_SQL =
+  "SELECT ext, count(*) AS files, sum(size) AS bytes\nFROM files\nGROUP BY ext\nORDER BY files DESC\nLIMIT 20";
+
+// Preferences > Indexing > Query — read-only SQL over the index.
+//
+// The index is two parquet tables and the interesting questions about it
+// ("what is eating my disk", "what did I touch last week") are aggregate ones
+// that no search box can express. Statements run confined: read-only, and unable
+// to reach a path outside the index directory (index/specs/query.md §5). Ask
+// mode sends the question to the AI relay instead and shows the SQL it compiled,
+// which goes through exactly the same guard.
+function QuerySection() {
+  const [text, setText] = useState("");
+  const [ask, setAsk] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [outcome, setOutcome] = useState<IndexQueryOutcome | null>(null);
+
+  const run = async () => {
+    const body = text.trim();
+    if (!body || busy) return;
+    setBusy(true);
+    // The previous result is dropped before the request, not after: leaving a
+    // stale table under a running query reads as the answer to the new one.
+    setOutcome(null);
+    try {
+      setOutcome(
+        ask
+          ? await askIndex({ prompt: body, limit: QUERY_LIMIT })
+          : await runIndexQuery({ sql: body, limit: QUERY_LIMIT }),
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <section className="prefs-section">
+      <h2>Query</h2>
+      <p className="deploy-muted">
+        Read-only SQL over the index. Two tables: <code>files</code>(path, dir, name, ext,
+        size, mtime, depth) and <code>dirs</code>(dir, n_files, total_size, mtime_ns,
+        n_subdirs, depth). <code>size</code> is bytes and <code>mtime</code> is epoch
+        seconds. Nothing here can write, and nothing can read a file outside the index.
+      </p>
+      <label className="prefs-radio">
+        <input type="checkbox" checked={ask} onChange={(e) => setAsk(e.target.checked)} />
+        <span>
+          <b>Ask in plain English.</b> The question goes to Claude, which writes the SQL;
+          the statement it produced is shown with the results and runs under the same
+          guard as one you typed.
+        </span>
+      </label>
+      <textarea
+        className="prefs-textarea index-query-input"
+        rows={ask ? 3 : 6}
+        spellCheck={false}
+        value={text}
+        placeholder={ask ? "Which folders are using the most space?" : EXAMPLE_SQL}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          // ⌘↵ / Ctrl+↵ runs, because Enter has to stay a newline in a
+          // multi-line statement.
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            void run();
+          }
+        }}
+        aria-label={ask ? "Question about the index" : "SQL to run against the index"}
+      />
+      <div className="prefs-actions">
+        <button type="button" disabled={busy || !text.trim()} onClick={() => void run()}>
+          {busy ? "Running…" : ask ? "Ask" : "Run"}
+        </button>
+        <span className="deploy-muted">⌘↵</span>
+      </div>
+      {outcome?.sql && (
+        <pre className="index-query-sql">
+          <code>{outcome.sql}</code>
+        </pre>
+      )}
+      {outcome && !outcome.ok && <ErrorBanner>{outcome.error}</ErrorBanner>}
+      {outcome?.ok && <QueryTable outcome={outcome} />}
+    </section>
+  );
+}
+
+function QueryTable({ outcome }: { outcome: IndexQueryOutcome & { ok: true } }) {
+  const { columns, rows, truncated } = outcome.table;
+  if (rows.length === 0) {
+    return <p className="deploy-muted">No rows.</p>;
+  }
+  return (
+    <>
+      <div className="index-query-results">
+        <table>
+          <thead>
+            <tr>
+              {columns.map((c, i) => (
+                <th key={i}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, i) => (
+              <tr key={i}>
+                {row.map((cell, j) => (
+                  <td key={j}>{cell}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="deploy-muted">
+        {rows.length.toLocaleString()} {rows.length === 1 ? "row" : "rows"}
+        {truncated ? ` — stopped at ${QUERY_LIMIT}; add a LIMIT or an aggregate.` : "."}
+      </p>
     </>
   );
 }

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -661,8 +661,8 @@
 
    A shed column is COLLAPSED, not removed. `display: none` on the header
    looks like the obvious way and is the wrong one: the column survives
-   regardless — the status and sentinel rows span all three (colSpan={3} in
-   Listing.tsx) — and a display:none header contributes no width to
+   regardless — the status and sentinel rows span the whole table (columnCount
+   in listing/types) — and a display:none header contributes no width to
    table-layout:fixed, which left NAME and the shed column BOTH width-less.
    WebKit splits the remainder evenly between width-less columns, so NAME took
    half and the hidden column kept the other half as blank space running to
@@ -1391,8 +1391,14 @@ table.listing-table th {
      it, leaving a 1px bleed gap — paint the divider as an inset shadow so it
      rides with the header instead. */
   box-shadow: inset 0 -1px 0 var(--border);
-  cursor: pointer;
   user-select: none;
+}
+
+/* Only a header that sorts something gets the affordance. Search mode's single
+   PATH header does not sort (relevance order only — Listing.tsx's thead), and
+   a pointer cursor over it promised a click that does nothing. */
+table.listing-table th.sortable {
+  cursor: pointer;
 }
 
 table.listing-table th.sortable:hover {

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1142,9 +1142,29 @@ table.listing-table tr.skel-row:hover {
    is the state where a long query most needs the room.
 
    Reversible on a keystroke: clearing the query (or Esc) brings the path
-   straight back, so nothing is lost, only deferred. The ★ and the `···` stay
-   — they act on the folder, which has not changed. */
+   straight back, so nothing is lost, only deferred. */
 #breadcrumb:has(.listing-search.searching) .crumbs {
+  display: none;
+}
+
+/* …and so does the ★, for the same reason the path did. It acts on the folder,
+   which has not changed — but it was the last thing holding the field off the
+   left edge, and a search box that spans the whole bar is what someone typing a
+   query is asking for. Bookmarking is still one keystroke away (Esc).
+
+   `display: none`, not visibility/opacity: the star's box is 24px plus the
+   deliberate -11px right margin above, and hiding it while keeping the box would
+   leave the field starting 13px in from a gap. A flex item removed this way
+   takes its `gap` share with it, so there is nothing left behind. (This is the
+   opposite of the table-column case in listing/column-shedding.test.ts, where
+   the shed element had to stay rendered — a table column under
+   `table-layout: fixed` outlives its hidden header.)
+
+   Hidden, never unmounted: React keeps the button mounted, so an armed bookmark
+   is not disarmed by a keystroke (see useUpdateButton in Breadcrumb.tsx).
+   Scoped under #breadcrumb because panel mode renders one star per pane from the
+   same component. */
+#breadcrumb:has(.listing-search.searching) .bookmark-star-btn {
   display: none;
 }
 

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -836,3 +836,79 @@
   padding: 7px 10px;
 }
 
+/* ---- the index Query panel (shell/Indexing.tsx) ------------------------- */
+
+/* A statement is wider than a skip rule and wrapping one mid-identifier is
+   unreadable, so this box does not wrap — it scrolls, like an editor. */
+.index-query-input {
+  width: 100%;
+  box-sizing: border-box;
+  white-space: pre;
+  overflow-wrap: normal;
+  overflow-x: auto;
+}
+
+/* The SQL a question compiled to. Shown above the results so the user can see
+   what actually ran, and read-only text rather than a second editable box —
+   editing it means putting it in the box above and re-running. */
+.index-query-sql {
+  margin: 10px 0 0;
+  padding: 8px 10px;
+  background: var(--bg-alt);
+  border: 1px solid var(--border);
+  border-left: 2px solid var(--accent);
+  border-radius: 6px;
+  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+  /* A compiled statement can be one long line; it scrolls rather than reflowing
+     the panel, which is the same trade the input above makes. */
+  overflow-x: auto;
+  white-space: pre;
+}
+
+/* The result table scrolls INSIDE this box, in both axes: the column set is
+   whatever the query selected, so neither its width nor its height can be
+   predicted, and letting it size the panel would push the rest of Preferences
+   sideways. */
+.index-query-results {
+  margin-top: 10px;
+  max-height: 420px;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.index-query-results table {
+  border-collapse: collapse;
+  /* Not 100%: a wide result should overflow into the scroll above rather than
+     squeezing every column to fit. */
+  width: max-content;
+  min-width: 100%;
+  font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+}
+
+.index-query-results th,
+.index-query-results td {
+  padding: 4px 10px;
+  text-align: left;
+  white-space: nowrap;
+  border-bottom: 1px solid var(--border);
+}
+
+.index-query-results th {
+  /* Sticky, so the column names survive scrolling a few hundred rows. The
+     background is opaque on purpose — rows scroll underneath it. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-alt);
+  color: var(--fg-muted);
+  font-weight: 600;
+}
+
+.index-query-results tr:last-child td {
+  border-bottom: none;
+}
+

--- a/fused_render/index/freshness.py
+++ b/fused_render/index/freshness.py
@@ -1,0 +1,134 @@
+"""Noticing that the folder someone just opened is newer than the index, and
+refreshing it in the background.
+
+The index is a snapshot taken at startup and on demand, so a folder changed
+out of band since the last scan answers search from stale rows. This module is
+the whole fix: one mtime comparison, then the ORDINARY incremental scan of the
+enclosing configured root. There is no new scanning path — `run_scan(...,
+incremental=True)` already consults the FSEvents journal and rescans only what
+moved, so a triggered run is seconds of work, and adding a second mechanism
+would mean a second set of bookkeeping keyed on a root string
+(`scans.json`, the applied-ignore map, the fsevents state) to get wrong.
+
+Detection is a stat, not a walk: `dirs.parquet` already stores `mtime_ns` per
+directory, so "is this folder newer than the index thinks?" is one indexed row
+lookup against one `os.stat`. That also catches folders which changed while
+nothing at all was watching — which a watcher tap on the pane-watch registry
+would have missed.
+
+KNOWN BOUND, by design: a directory's mtime moves only when entries are added,
+removed or renamed IN THAT DIRECTORY. An edit five levels down does not flip
+the mtime of the folder being viewed, so this makes the index fresher, it does
+not make it correct. See specs/scan-incremental.md §5.
+
+See specs/scan-incremental.md §5.
+"""
+import os
+import time
+
+from fused_render.index import runner
+from fused_render.index.config import IndexConfig
+from fused_render.index.ignore import MountGuard, norm
+
+# How long a directory must have been settled before its staleness is acted on.
+# A churny directory (a build tree, a cache) has a mtime that moves
+# continuously, so it is never quiet and never triggers — which is what stops
+# it queueing scan after scan. It costs nothing: the next open after the churn
+# stops still fires.
+QUIET_S = 30.0
+
+# Floor between scans of one root STARTED by this path. Read off `scans.json`
+# via runner.last_scan, which the startup scheduler and the manual buttons also
+# stamp — so a scan that just ran for any reason suppresses a trigger, and the
+# trigger needs no state file of its own. Much lower than the startup
+# debounce (routers/index.SCAN_DEBOUNCE_S, 15 min) on purpose: that one exists
+# to stop a reload loop, this one to stop a browsing session from queueing.
+MIN_INTERVAL_S = 120.0
+
+
+def enclosing_root(roots, path: str):
+    """The configured scan root that contains `path`, deepest first, or None.
+
+    Deepest, because roots may nest and the narrower scan answers for the
+    folder sooner — firing the outer one as well would walk the subtree twice.
+    Compared segment-wise so `/x/proj-old` is not read as living inside
+    `/x/proj`."""
+    p = norm(os.path.abspath(path))
+    best = None
+    for raw in roots or []:
+        r = norm(os.path.abspath(os.path.expanduser(str(raw)))).rstrip("/") or "/"
+        pfx = "/" if r == "/" else r + "/"
+        if p == r or p.startswith(pfx):
+            if best is None or len(r) > len(best):
+                best = r
+    return best
+
+
+def indexed_mtime_ns(cfg: IndexConfig, path: str):
+    """The `mtime_ns` the last scan recorded for `path`, or None.
+
+    None covers three cases the caller treats identically — no index yet, this
+    directory was never visited, and a stored 0 (the placeholder a partition
+    predating the column compacts to, store._compact_locked). All three mean
+    "nothing to compare against", and reading 0 as a real mtime would make the
+    folder permanently stale and fire on every open.
+
+    duckdb is imported inside the function, as everywhere else in this package:
+    this runs off the folder-open path, and a call against a missing index must
+    not pay the import."""
+    if not os.path.exists(cfg.dirs_parquet):
+        return None
+    from fused_render.index.query import _q, dirs_src
+    import duckdb
+
+    try:
+        row = duckdb.connect().execute(
+            f"SELECT mtime_ns FROM {dirs_src(cfg)} "
+            f"WHERE dir = '{_q(norm(os.path.abspath(path)))}' LIMIT 1").fetchone()
+    except duckdb.Error:
+        # A dirs.parquet without the column, or a generation being replaced
+        # underneath us. Neither is worth an error on a housekeeping path.
+        return None
+    if row is None or not row[0]:
+        return None
+    return int(row[0])
+
+
+def note_folder_opened(cfg: IndexConfig, path: str, roots, now: float | None = None):
+    """The explorer opened `path`; start a rescan if the index is behind.
+
+    Returns the root a scan was started for, or None. Every gate is ordered
+    cheapest-first, so the duckdb lookup is unreachable for the common cases:
+    outside the roots, mount-backed, recently scanned, still churning.
+
+    Never raises — a listing must not fail because index housekeeping did."""
+    now = time.time() if now is None else now
+    root = enclosing_root(roots, path)
+    if root is None:
+        return None
+    # BEFORE any kernel syscall on the caller's path, and pure string work
+    # against the mount records: os.stat under a wedged rclone mount blocks the
+    # calling thread indefinitely (this repo's documented mount-wedge class),
+    # and this runs on the thread serving a listing request.
+    if MountGuard(mounts_dir=runner._mounts_dir()).blocks(path):
+        return None
+    last = runner.last_scan(cfg, root)
+    if last is not None and (now - last) < MIN_INTERVAL_S:
+        return None
+    try:
+        disk_ns = os.stat(path).st_mtime_ns
+    except OSError:
+        return None  # deleted between the open and this check
+    if (now - disk_ns / 1e9) < QUIET_S:
+        return None
+    indexed = indexed_mtime_ns(cfg, path)
+    if indexed is None or disk_ns <= indexed:
+        return None
+    # runner.start would JOIN a live run of this root — but only on an EXACT
+    # root-string match, and a triggered scan must not be the thing that
+    # discovers a mismatch. Refuse outright: the run in flight is already going
+    # to pick this folder up.
+    if runner.active_run(cfg, root) is not None:
+        return None
+    runner.start(cfg, root)
+    return root

--- a/fused_render/index/guarded_query.py
+++ b/fused_render/index/guarded_query.py
@@ -1,0 +1,184 @@
+"""User SQL against the index, confined to reading it.
+
+`query.py` builds its SQL from escaped literals and a fixed allowlist. This
+module does the opposite — it runs the caller's own statement — so the whole
+file is the two guards that make that safe, and they are independent:
+
+1. **The statement-type gate**, before anything executes. This is load-bearing,
+   not defence in depth: behind a fully locked configuration an in-memory
+   `INSERT` / `CREATE TABLE` / `DELETE` still succeeds, so the only place a
+   write can be refused is before it runs. `duckdb.extract_statements` gives
+   the type — and note that `PRAGMA database_list` parses as
+   `StatementType.SELECT`, so a naive "SELECT only" gate would admit PRAGMA and
+   CALL anyway while claiming not to. They are therefore admitted explicitly,
+   alongside DESCRIBE and EXPLAIN; everything else is refused.
+
+2. **The DuckDB lockdown**, in this exact order, once per connection:
+   `allowed_directories` → `enable_external_access=false` →
+   `lock_configuration=true`. The order matters and so does all three:
+   `allowed_directories` ALONE CONFINES NOTHING — it is a carve-out from
+   `enable_external_access=false`, not a restriction — and without the lock a
+   statement can simply widen the allowlist again. Afterwards the lazy
+   `read_parquet` views over the index still resolve (they are inside the
+   allowed directory) and every path outside it is a permission error.
+
+Deliberately NOT a function blocklist. There are ~40 file-touching functions
+among ~2 900 built-ins and that ratio moves every release; a list would be
+stale on the next upgrade, while the confinement covers the ones nobody
+enumerated.
+
+The scope of what this can reach is the same scope `/api/run` already has (it
+executes arbitrary local Python), so this is not a new capability — it is a
+narrower one, and the guards exist so a mistyped or model-written statement
+cannot write to the index or read outside it.
+
+See specs/query.md §5.
+"""
+import os
+import threading
+
+from fused_render.index.config import IndexConfig
+from fused_render.index.store import parquet_src, partition_files
+
+# Rows a single query may return, whatever the caller asks for — the same cap
+# `query.lookup` uses, so the two read surfaces cannot disagree about how much
+# a client is handed.
+MAX_LIMIT = 5_000
+
+# Wall clock a statement gets before `con.interrupt()` stops it. A cross join
+# over 600k rows is trivial to type and impossible to bound by inspection, and
+# the panel that calls this is a text box, so a timeout is the only backstop.
+TIMEOUT_S = 10.0
+
+
+def _statement_types():
+    """The read-only statement types, resolved at call time.
+
+    Named off `duckdb.StatementType` rather than written as integers: the
+    numeric values are DuckDB internals, and a release that renumbered them
+    would silently turn this allowlist into a different one."""
+    import duckdb
+
+    t = duckdb.StatementType
+    # SELECT covers WITH, DESCRIBE and PRAGMA as duckdb parses them. CALL and
+    # EXPLAIN are their own types. Everything absent here — INSERT, UPDATE,
+    # DELETE, CREATE, DROP, ALTER, COPY, ATTACH, DETACH, LOAD, SET, TRANSACTION
+    # — is refused.
+    return {t.SELECT, t.CALL, t.EXPLAIN}
+
+
+# The typed empty stand-ins used when the index has no partitions yet, so a
+# query written against a built index fails on nothing but its own logic.
+# MIRRORS store.schemas — int32 → INTEGER, int64 → BIGINT, float64 → DOUBLE —
+# and tests/test_index_guarded_query.py DESCRIBEs both views against it, which
+# is what stops the two drifting.
+_EMPTY_FILES = ("SELECT CAST(NULL AS VARCHAR) AS path, CAST(NULL AS VARCHAR) AS dir, "
+                "CAST(NULL AS VARCHAR) AS name, CAST(NULL AS VARCHAR) AS ext, "
+                "CAST(NULL AS BIGINT) AS size, CAST(NULL AS DOUBLE) AS mtime, "
+                "CAST(NULL AS INTEGER) AS depth WHERE false")
+_EMPTY_DIRS = ("SELECT CAST(NULL AS VARCHAR) AS dir, CAST(NULL AS VARCHAR) AS sig, "
+               "CAST(NULL AS INTEGER) AS n_files, CAST(NULL AS BIGINT) AS total_size, "
+               "CAST(NULL AS BIGINT) AS mtime_ns, CAST(NULL AS INTEGER) AS n_subdirs, "
+               "CAST(NULL AS INTEGER) AS depth WHERE false")
+
+
+def _one_read_statement(sql: str) -> str:
+    """`sql` stripped of its trailing semicolon, or ValueError.
+
+    Refuses an empty input, more than one statement, anything that does not
+    parse, and any statement type that is not a read."""
+    import duckdb
+
+    body = (sql or "").strip().rstrip(";").strip()
+    if not body:
+        raise ValueError("no SQL statement was given")
+    try:
+        statements = duckdb.extract_statements(body)
+    except duckdb.Error as e:
+        raise ValueError(str(e)) from e
+    if len(statements) != 1:
+        # One statement only. A batch is how a read-looking prefix smuggles a
+        # write past a reader skimming the box, and there is no result shape for
+        # more than one anyway.
+        raise ValueError("send exactly one statement")
+    allowed = _statement_types()
+    if statements[0].type not in allowed:
+        raise ValueError(
+            "only read-only statements are allowed here "
+            "(SELECT, WITH, PRAGMA, CALL, DESCRIBE, EXPLAIN)")
+    return body
+
+
+def _connect(cfg: IndexConfig):
+    """An in-memory connection holding `files` and `dirs`, then locked down."""
+    import duckdb
+
+    con = duckdb.connect()
+    files = parquet_src(partition_files(cfg)) or _EMPTY_FILES
+    dirs = (parquet_src([cfg.dirs_parquet])
+            if os.path.exists(cfg.dirs_parquet) else None) or _EMPTY_DIRS
+    # LAZY views, not tables. Copying the rows in first was the obvious shape
+    # and is strictly slower: measured at 300k rows, 14.9ms to materialise a
+    # table against 6.8ms for the view — the parquet is already columnar and
+    # already the format DuckDB wants.
+    con.execute(f"CREATE VIEW files AS SELECT * FROM {files}"
+                if files.startswith("read_parquet")
+                else f"CREATE VIEW files AS {files}")
+    con.execute(f"CREATE VIEW dirs AS SELECT * FROM {dirs}"
+                if dirs.startswith("read_parquet")
+                else f"CREATE VIEW dirs AS {dirs}")
+    # The order is the guard (see the module docstring). Set while external
+    # access is still on, then withdraw it, then lock so nothing can restore it.
+    quoted = cfg.dir.replace("'", "''")
+    con.execute(f"SET allowed_directories=['{quoted}']")
+    con.execute("SET enable_external_access=false")
+    con.execute("SET lock_configuration=true")
+    return con
+
+
+def _jsonable(v):
+    """A cell as JSON can carry it. The user picks the columns, so anything
+    duckdb can produce may arrive — dates, decimals, blobs, intervals."""
+    if v is None or isinstance(v, (bool, int, float, str)):
+        return v
+    if isinstance(v, (bytes, bytearray, memoryview)):
+        return bytes(v).decode("utf-8", "replace")
+    if isinstance(v, (list, tuple)):
+        return [_jsonable(x) for x in v]
+    if isinstance(v, dict):
+        return {str(k): _jsonable(x) for k, x in v.items()}
+    return str(v)
+
+
+def run_guarded(cfg: IndexConfig, sql: str, limit: int = 200) -> dict:
+    """Run one read-only statement against the index; `{columns, rows, truncated}`.
+
+    Raises ValueError for anything the statement-type gate refuses (the caller
+    turns that into a 400). A statement that parses but cannot run — a bad
+    column, a path outside the index — surfaces duckdb's own exception."""
+    body = _one_read_statement(sql)
+    cap = max(0, min(int(limit), MAX_LIMIT))
+    con = _connect(cfg)
+    # A statement that would return the whole index must not be MATERIALISED in
+    # full just to be trimmed afterwards, so the cap goes into the SQL. PRAGMA
+    # parses as SELECT but is not a subquery-able expression, so a wrap that
+    # does not parse falls back to the bare statement and the fetch cap — those
+    # statements answer in tens of rows by nature.
+    import duckdb
+
+    timer = threading.Timer(TIMEOUT_S, con.interrupt)
+    timer.start()
+    try:
+        try:
+            cur = con.execute(
+                f"SELECT * FROM ({body}) AS _guarded LIMIT {cap + 1}")
+        except (duckdb.ParserException, duckdb.BinderException):
+            cur = con.execute(body)
+        rows = cur.fetchmany(cap + 1)
+        columns = [d[0] for d in (cur.description or [])]
+    finally:
+        timer.cancel()
+        con.close()
+    return {"columns": columns,
+            "rows": [[_jsonable(v) for v in r] for r in rows[:cap]],
+            "truncated": len(rows) > cap}

--- a/fused_render/index/ignore.py
+++ b/fused_render/index/ignore.py
@@ -86,6 +86,26 @@ def is_leaf_dir(path: str) -> bool:
     return path.lower().endswith(LEAF_DIR_SUFFIXES)
 
 
+def is_inside_leaf_dir(path: str) -> bool:
+    """Whether any ANCESTOR of `path` is a package directory — i.e. whether the
+    leaf rule means this path should not exist as a row at all.
+
+    `is_leaf_dir` is enough wherever descent is what's being decided: a walk
+    that refuses to list `Foo.app` never reaches anything below it. Callers that
+    are handed a path instead of descending to it — the FSEvents fast path
+    (scan._run_fsevents), the coverage test in query.search_under — see package
+    internals directly and need this test, because the final component of
+    `Foo.app/Contents/Resources` says nothing about the package above it.
+
+    Ancestors ONLY: a final component that is itself a package is is_leaf_dir's
+    business, and that one gets RECORDED where these get dropped. Pure string
+    work on purpose — it runs once per journal-reported directory, so it must
+    not stat anything. Paths are `norm`ed, so "/" is the only separator."""
+    head, _, _ = path.rpartition("/")
+    return any(part.lower().endswith(LEAF_DIR_SUFFIXES)
+               for part in head.split("/"))
+
+
 # The index prunes MORE than the floor, and may: a scan is a background crawl
 # of the whole home, where these caches are pure cost. The walk cannot use the
 # same list, because inside a repo it defers to the repo's own .gitignore

--- a/fused_render/index/ignore.py
+++ b/fused_render/index/ignore.py
@@ -67,6 +67,25 @@ SKIP_DIRS = {
 SHARED_IGNORE_DIRS = (
     "node_modules", ".venv", "venv", "__pycache__", ".git", "site-packages",
 )
+# macOS package directories: ONE entry, never descended. Their internals are
+# implementation details (Finder hides them too) and one Electron .app alone is
+# thousands of files, which on a 200k-capped corpus is budget spent on rows
+# nobody searches for — and, because search scores the whole relative path, on
+# rows a matching package name would then rank ahead of real hits.
+#
+# Shared with server/walk.py (WALK_LEAF_DIR_SUFFIXES) for the same reason
+# SHARED_IGNORE_DIRS is: search is answered by the live walk or by the index
+# depending on whether a scan has reached the folder, so a rule applied by one
+# and not the other flips results between two interchangeable sources. The
+# dependency direction is server -> index; do not invert it.
+LEAF_DIR_SUFFIXES = (".app", ".framework", ".bundle", ".photoslibrary")
+
+
+def is_leaf_dir(path: str) -> bool:
+    """Whether `path` is a package directory — recorded, but never descended."""
+    return path.lower().endswith(LEAF_DIR_SUFFIXES)
+
+
 # The index prunes MORE than the floor, and may: a scan is a background crawl
 # of the whole home, where these caches are pure cost. The walk cannot use the
 # same list, because inside a repo it defers to the repo's own .gitignore

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -48,8 +48,10 @@ MAX_CORPUS = 200_000
 # live walk, since offering the pre-rename name back to the user who just
 # renamed it is not a trade (frontend lib/index-freshness.ts).
 #
-# There is no watcher (`scan.md`), so this is the honest bound on how wrong an
-# unflagged corpus can be. It is a trade, not a
+# There is no watcher (`scan.md`) — opening a folder whose own mtime is ahead of
+# the index rescans its root (`scan-incremental.md §5`), but a change deeper than
+# the folder being viewed does not move that mtime — so this is still the honest
+# bound on how wrong an unflagged corpus can be. It is a trade, not a
 # fact about the data — long enough that the index is actually used during a
 # working session, short enough that a morning's edits don't answer an
 # afternoon's search.

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -259,39 +259,49 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     limit = max(0, min(int(limit), MAX_CORPUS))
     hit = prune(m["partitions"], prefix)
     qlit = like_literal(q.strip()) if q and q.strip() else ""
-    like = f" AND path ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
-    # Shallow entries first (fewer slashes), path order within a depth: when
+    # Files and directories compete in ONE depth-ordered query, not two.
+    #
+    # Two queries meant the files branch was served first and directories got
+    # only `limit - len(files)` rows — so on any tree big enough to truncate the
+    # corpus, `room` was 0 and folder search was DEAD, not degraded: a query
+    # naming a folder returned the files inside it and never the folder. The
+    # live walk never had this bug because BFS interleaves both kinds.
+    #
+    # Shallow entries first (smaller `depth`), path order within a depth: when
     # the cap bites on a >limit tree, the capped corpus keeps the same
     # breadth-first character as the walk it replaces — plain ORDER BY path
     # would starve everything after the first deep subtree.
-    depth = "(length(path) - length(replace(path, '/', '')))"
+    #
+    # The trade: directories now spend part of the budget files used to have,
+    # so a very large tree carries slightly fewer files. A corpus with no
+    # folders in it at all is strictly worse.
+    fdepth = "(length(path) - length(replace(path, '/', '')))"
+    ddepth = "(length(dir) - length(replace(dir, '/', '')))"
+    branches = []
+    if hit:
+        like = f" AND path ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
+        branches.append(
+            f"SELECT path, size, mtime, false AS is_dir, {fdepth} AS depth "
+            f"FROM {_sources(cfg, hit)} "
+            f"WHERE path LIKE '{prefix_like}%' ESCAPE '\\'{like}")
+    if include_dirs:
+        dlike = f" AND dir ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
+        branches.append(
+            f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, "
+            f"nullif(mtime_ns, 0) / 1e9 AS mtime, true AS is_dir, "
+            f"{ddepth} AS depth FROM {dirs_src(cfg)} "
+            f"WHERE dir LIKE '{prefix_like}%' ESCAPE '\\'{dlike}")
     entries, truncated = [], False
-    if hit and limit:
+    if branches:
         # One row past the cap, so "there was more" is known without a count.
         rows = con.execute(
-            f"SELECT path, size, mtime FROM {_sources(cfg, hit)} "
-            f"WHERE path LIKE '{prefix_like}%' ESCAPE '\\'{like} "
-            f"ORDER BY {depth}, path LIMIT {limit + 1}").fetchall()
-        for path, size, mtime in rows[:limit]:
-            entries.append({"rel": path[len(prefix):], "is_dir": False,
+            " UNION ALL ".join(branches)
+            + f" ORDER BY depth, path LIMIT {limit + 1}").fetchall()
+        for path, size, mtime, is_dir, _depth in rows[:limit]:
+            entries.append({"rel": path[len(prefix):], "is_dir": bool(is_dir),
                             "size": int(size) if size is not None else None,
                             "mtime": float(mtime) if mtime is not None else None})
         truncated = len(rows) > limit
-    if include_dirs:
-        dlike = f" AND dir ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
-        # Even with no room left, one probe row decides `truncated`: file rows
-        # exactly filling the cap must not silently drop every directory while
-        # claiming the corpus is complete.
-        room = limit - len(entries)
-        ddepth = "(length(dir) - length(replace(dir, '/', '')))"
-        drows = con.execute(
-            f"SELECT dir, mtime_ns FROM {dirs_src(cfg)} "
-            f"WHERE dir LIKE '{prefix_like}%' ESCAPE '\\'{dlike} "
-            f"ORDER BY {ddepth}, dir LIMIT {room + 1}").fetchall()
-        for d, mtime_ns in drows[:room]:
-            entries.append({"rel": d[len(prefix):], "is_dir": True, "size": None,
-                            "mtime": (mtime_ns / 1e9) if mtime_ns else None})
-        truncated = truncated or len(drows) > room
     return {"covered": True, "fresh": fresh, "updated": updated, "age_s": age,
             "root": root, "scanned_partitions": len(hit),
             "of_partitions": len(m["partitions"]), "entries": entries,

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -18,7 +18,12 @@ import re
 
 from fused_render.index.config import IndexConfig
 from fused_render.index.ignore import norm
-from fused_render.index.store import like_literal, parquet_src, read_manifest
+from fused_render.index.store import (
+    depth_expr,
+    like_literal,
+    parquet_src,
+    read_manifest,
+)
 
 _DRIVE = re.compile(r"^[A-Za-z]:/")
 
@@ -125,6 +130,20 @@ def _sources(cfg: IndexConfig, parts) -> str:
     manifest."""
     files = [_q(os.path.join(cfg.files_dir, p["file"])) for p in parts]
     return "read_parquet([" + ",".join(f"'{f}'" for f in files) + "])"
+
+
+def _depth_col(con, src: str, path_col: str) -> str:
+    """`depth` when the parquet behind `src` carries it, else the slash-count
+    expression over `path_col`.
+
+    DESCRIBE reads footers only, so this costs no rows. Deciding per SOURCE
+    rather than per file is exact: every partition a manifest names was written
+    by one compaction, so a generation's schema is uniform (and DuckDB would
+    refuse a mixed-schema read_parquet list anyway). An index predating the
+    column keeps answering; migrating it is a full rescan."""
+    cols = {r[0] for r in con.execute(
+        f"DESCRIBE SELECT * FROM {src} LIMIT 0").fetchall()}
+    return "depth" if "depth" in cols else depth_expr(path_col)
 
 
 def lookup(cfg: IndexConfig, query: str = "", limit: int = 100, offset: int = 0,
@@ -275,21 +294,21 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     # The trade: directories now spend part of the budget files used to have,
     # so a very large tree carries slightly fewer files. A corpus with no
     # folders in it at all is strictly worse.
-    fdepth = "(length(path) - length(replace(path, '/', '')))"
-    ddepth = "(length(dir) - length(replace(dir, '/', '')))"
     branches = []
     if hit:
+        fsrc = _sources(cfg, hit)
         like = f" AND path ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
         branches.append(
-            f"SELECT path, size, mtime, false AS is_dir, {fdepth} AS depth "
-            f"FROM {_sources(cfg, hit)} "
+            f"SELECT path, size, mtime, false AS is_dir, "
+            f"{_depth_col(con, fsrc, 'path')} AS depth FROM {fsrc} "
             f"WHERE path LIKE '{prefix_like}%' ESCAPE '\\'{like}")
     if include_dirs:
+        dsrc = dirs_src(cfg)
         dlike = f" AND dir ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
         branches.append(
             f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, "
             f"nullif(mtime_ns, 0) / 1e9 AS mtime, true AS is_dir, "
-            f"{ddepth} AS depth FROM {dirs_src(cfg)} "
+            f"{_depth_col(con, dsrc, 'dir')} AS depth FROM {dsrc} "
             f"WHERE dir LIKE '{prefix_like}%' ESCAPE '\\'{dlike}")
     entries, truncated = [], False
     if branches:

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -122,7 +122,7 @@ def pattern_for(q: str):
     return pat, prune_prefix
 
 
-def _sources(cfg: IndexConfig, parts) -> str:
+def files_src(cfg: IndexConfig, parts) -> str:
     """A duckdb source over exactly the partitions the MANIFEST names.
 
     Never a `files/*.parquet` glob: a compaction writes the next generation
@@ -172,7 +172,7 @@ def lookup(cfg: IndexConfig, query: str = "", limit: int = 100, offset: int = 0,
     order = SORTS.get(sort, SORTS["mtime"])
     limit = max(0, min(int(limit), MAX_LIMIT))
     offset = max(0, int(offset))
-    src = _sources(cfg, hit)
+    src = files_src(cfg, hit)
     con = duckdb.connect()
     total = con.execute(f"SELECT count(*) FROM {src} {where}").fetchone()[0]
     rows = con.execute(
@@ -212,7 +212,7 @@ def stats(cfg: IndexConfig, root: str = "") -> dict:
         by_ext = con.execute(
             f"SELECT coalesce(nullif(ext, ''), 'no ext') e, count(*) n, "
             f"coalesce(sum(size), 0) s "
-            f"FROM {_sources(cfg, m['partitions'])} "
+            f"FROM {files_src(cfg, m['partitions'])} "
             f"WHERE {inside} "
             f"GROUP BY 1 ORDER BY s DESC").fetchall()
         n_rows = sum(r[1] for r in by_ext)
@@ -312,7 +312,7 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     # folders in it at all is strictly worse.
     branches = []
     if hit:
-        fsrc = _sources(cfg, hit)
+        fsrc = files_src(cfg, hit)
         like = f" AND path ILIKE '%{qlit}%' ESCAPE '\\'" if qlit else ""
         branches.append(
             f"SELECT path, size, mtime, false AS is_dir, "

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -1,11 +1,11 @@
 """Reading the index — strictly read-only, and strictly parameterized.
 
-Ported from OpenIndex's `query.py` MINUS its `sql` action. Inside a local
-trusted page, handing duckdb a user's statement was consistent with runPython
-executing arbitrary local Python anyway; behind an HTTP route it is an
-arbitrary read/write surface with no allowlist and no read-only flag, so it is
-gone rather than guarded. What remains — `stats` and `lookup` — builds SQL only
-from escaped literals, an int-cast limit/offset and a fixed sort allowlist.
+Ported from OpenIndex's `query.py` MINUS its `sql` action, which was an
+arbitrary read/write surface with no allowlist and no read-only flag. User SQL
+lives in `guarded_query.py` instead, where the confinement is the whole point of
+the module (specs/query.md §5); nothing here takes a caller's statement.
+`stats` and `lookup` build SQL only from escaped literals, an int-cast
+limit/offset and a fixed sort allowlist.
 
 duckdb is imported inside each function, not at module top: this module is
 imported by the server's router, and a call against a missing index should not

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -17,7 +17,7 @@ import os
 import re
 
 from fused_render.index.config import IndexConfig
-from fused_render.index.ignore import is_leaf_dir, norm
+from fused_render.index.ignore import is_inside_leaf_dir, is_leaf_dir, norm
 from fused_render.index.store import (
     depth_expr,
     like_literal,
@@ -276,7 +276,13 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     # leaf CHILDREN, not a leaf it was pointed at) — so hand it over, exactly as
     # for any other uncovered folder, instead of reporting an empty corpus as
     # complete.
-    covered = not is_leaf_dir(root) and con.execute(
+    # The test is is_inside_leaf_dir as well, not just the root's own final
+    # component: any index written before the leaf rule still holds real dirs
+    # rows for paths INSIDE a package, and answering `/x/Foo.app/Contents` from
+    # that partial set while `/x/Foo.app` one level up goes to the walk is the
+    # two-interchangeable-sources-disagree bug in miniature.
+    inside_pkg = is_leaf_dir(root) or is_inside_leaf_dir(root)
+    covered = not inside_pkg and con.execute(
         f"SELECT count(*) FROM {dirs_src(cfg)} "
         f"WHERE dir = '{_q(root)}'").fetchone()[0] > 0
     if not covered:

--- a/fused_render/index/query.py
+++ b/fused_render/index/query.py
@@ -17,7 +17,7 @@ import os
 import re
 
 from fused_render.index.config import IndexConfig
-from fused_render.index.ignore import norm
+from fused_render.index.ignore import is_leaf_dir, norm
 from fused_render.index.store import (
     depth_expr,
     like_literal,
@@ -268,7 +268,15 @@ def search_under(cfg: IndexConfig, root: str, q: str = "", limit: int = MAX_CORP
     # Coverage is "the scan visited this exact directory", which is what keeps
     # a partial index honest: a root whose parent was scanned but which was
     # itself pruned (ignored, or below a cancelled run's frontier) has no row.
-    covered = con.execute(
+    #
+    # A package directory is the exception: the scan records it as ONE opaque
+    # row and never lists it (scan.scan_dir_once), so its dirs row means "this
+    # is a leaf", not "we know what is inside". The explorer can still navigate
+    # into a .app, and the live walk answers that (it only refuses to descend
+    # leaf CHILDREN, not a leaf it was pointed at) — so hand it over, exactly as
+    # for any other uncovered folder, instead of reporting an empty corpus as
+    # complete.
+    covered = not is_leaf_dir(root) and con.execute(
         f"SELECT count(*) FROM {dirs_src(cfg)} "
         f"WHERE dir = '{_q(root)}'").fetchone()[0] > 0
     if not covered:

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -23,6 +23,7 @@ from fused_render.index.ignore import (
     SKIP_DIRS,
     IgnoreRules,
     MountGuard,
+    is_inside_leaf_dir,
     is_leaf_dir,
     norm,
 )
@@ -494,7 +495,18 @@ def _run_fsevents(cfg, rules, guard, root, hint, cache, sink, ev, cancel_flag,
             cancelled = True
             break
         d, force = stack.pop()
-        if d in scanned or rules.is_ignored_tree(d) or guard.blocks(d):
+        # is_inside_leaf_dir, and not the is_leaf_dir test scan_dir_once makes:
+        # this loop does not descend to `d`, the journal hands it over, and what
+        # the journal names inside a package is always a descendant (an app
+        # update writes Foo.app/Contents/Resources, Photos writes
+        # Foo.photoslibrary/database) — never the package itself. A
+        # final-component test therefore lets every package internal in through
+        # this path while the walk-driven one drops them, and the tail loop
+        # below then carries those rows forward on every later run. The
+        # package's own dirs row is unaffected: it is is_leaf_dir's, made when
+        # the journal or the walk names the package.
+        if (d in scanned or rules.is_ignored_tree(d) or guard.blocks(d)
+                or is_inside_leaf_dir(d)):
             continue
         scanned.add(d)
         kind, payload, subdirs = scan_dir_once(

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -19,7 +19,13 @@ import time
 
 from fused_render.index import fsevents
 from fused_render.index.config import IndexConfig
-from fused_render.index.ignore import SKIP_DIRS, IgnoreRules, MountGuard, norm
+from fused_render.index.ignore import (
+    SKIP_DIRS,
+    IgnoreRules,
+    MountGuard,
+    is_leaf_dir,
+    norm,
+)
 from fused_render.index.store import (
     Sink,
     applied_ignore_sig,
@@ -73,6 +79,14 @@ def scan_dir_once(d, cache, rules, guard, devs=None, root_dev=None):
             devs.add(dst.st_dev)
     except OSError:
         return None, None, []
+    if is_leaf_dir(d):
+        # A macOS package: RECORDED as one dirs row (this return), never listed.
+        # The walk emits `Foo.app` itself as a single leaf entry and nothing
+        # inside it, so the index has to do both halves — dropping the package
+        # from its parent's descent list instead would leave no dirs row for it
+        # at all, and break the same parity in the other direction. Costs the
+        # stat above and no scandir, whatever the package holds.
+        return "s", (_dir_sig([]), [], 0, d_mtime_ns, 0), []
     cached = cache.get(d)
     subdirs = []
     # cached[2] == -1 means a pre-upgrade row with unknown subdir count:

--- a/fused_render/index/specs/index-store.md
+++ b/fused_render/index/specs/index-store.md
@@ -42,6 +42,7 @@ second answer to "where is my data".
 | `ext` | string | lowercased, leading `.` stripped; `""` when none |
 | `size` | int64 | bytes |
 | `mtime` | float64 | epoch seconds |
+| `depth` | int32 | slashes in `path` (absolute, not relative to any root) — the corpus sort key (`query.md §6`) |
 
 **`dirs`** — one row per directory:
 
@@ -53,10 +54,22 @@ second answer to "where is my data".
 | `total_size` | int64 | bytes of those files |
 | `mtime_ns` | int64 | reuse decision input |
 | `n_subdirs` | int32 | post-prune count; `-1` = pre-upgrade unknown |
+| `depth` | int32 | slashes in `dir`; present on both tables because `search_under` UNIONs them |
+
+`name`, `ext`, `dir` and `depth` are all denormalised out of `path`. That is sound
+only because rows are never mutated in place — a scan writes a row once, and a
+compaction copies whole partitions and swaps the manifest — so no update path can
+leave a derived column disagreeing with its source. `depth` is *stored* rather than
+derived at read time because every query opens a fresh in-memory DuckDB over
+`read_parquet` (`query.md`): there is no persistent catalog to hold a generated
+column and parquet has no computed-column concept. It measures 92 ms vs 148 ms on
+300k rows at the real `LIMIT 200_001`, for +0.10% on disk.
 
 Readers tolerate older files: `load_dir_cache` treats a `dirs.parquet` without
 `mtime_ns` as no cache at all, and `compact` synthesizes missing `mtime_ns` /
-`n_subdirs` columns so an old index can still be merged forward.
+`n_subdirs` / `depth` columns so an old index can still be merged forward.
+`search_under` falls back to the slash-count expression for a partition set
+written before `depth` existed. Migration is a full rescan.
 
 ## 3. Shards (worker output)
 

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -101,7 +101,9 @@ Two flags travel with it:
   `root`), not merely some ancestor. A folder that was pruned, ignored, or left below a
   cancelled run's frontier therefore reports honestly instead of answering with a
   partial corpus. **This is the gate**: covered means the index answers, uncovered means
-  the live walk does.
+  the live walk does. A package directory (`scan-ignore.md §3`) is the one row that does
+  *not* count: it is recorded as an opaque leaf, so its row means "this is a leaf", not
+  "we know what is inside", and a search rooted at one hands over to the walk.
 - **`fresh`** — the last compaction is within `FRESH_MAX_AGE_S` (1 h). Reported, not
   enforced. Age does not decide anything because the index is rescanned at every
   startup, a rescan keeps serving its last completed generation

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -103,7 +103,10 @@ Two flags travel with it:
   partial corpus. **This is the gate**: covered means the index answers, uncovered means
   the live walk does. A package directory (`scan-ignore.md §3`) is the one row that does
   *not* count: it is recorded as an opaque leaf, so its row means "this is a leaf", not
-  "we know what is inside", and a search rooted at one hands over to the walk.
+  "we know what is inside", and a search rooted at one hands over to the walk. So does a
+  search rooted *inside* one: an index written before that rule holds real dirs rows for
+  package internals, and answering from that partial set while the folder one level up is
+  answered by the walk is the same disagreement the shared constant exists to prevent.
 - **`fresh`** — the last compaction is within `FRESH_MAX_AGE_S` (1 h). Reported, not
   enforced. Age does not decide anything because the index is rescanned at every
   startup, a rescan keeps serving its last completed generation

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -87,6 +87,14 @@ are indifferent to which source produced them. Files come from the partitions, f
 from `dirs.parquet`; the corpus is capped at `MAX_CORPUS` (200 000), the same cap the
 walk uses, and flags `truncated` the same way.
 
+The two sources are **one** query — a `UNION ALL` under a single
+`ORDER BY depth, path LIMIT limit + 1`, so files and folders compete for the same
+budget by depth and the capped corpus keeps the breadth-first character of the walk
+it replaces. Serving files first and giving folders the leftover meant that on any
+tree big enough to truncate there was no leftover, and folder search was dead rather
+than degraded. The named cost of the fix: folders now spend budget files used to have,
+so a very large tree carries slightly fewer files.
+
 Two flags travel with it:
 
 - **`covered`** — the scan visited *this exact directory* (a `dirs.parquet` row for

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -204,15 +204,18 @@ wants the hits.
 two views in SQL, and they are public because a **second reader** now uses them: the AI
 file search's index engine (`server/routers/search.py`, `POST /api/search/files`), which
 compiles its validated filter spec into one query over these views and returns rows
-without statting anything. Its own filters, refusals and fallbacks belong to that module
-— what belongs here is the invariant every reader must obey: the views are named from the
-**manifest**, never from a glob of the files dir, because a compaction leaves the
-previous generation's partitions on disk for readers still holding the old manifest
-(`index-store.md §4`) and a glob would count both generations.
+without statting anything. It is that endpoint's **only** engine — Spotlight and the
+bounded home walk that used to sit behind it are gone — so the index's coverage is now
+the search's coverage: the configured roots, home by default, and a missing index is
+reported to the user as an error instead of as an empty disk. Those filters and refusals
+belong to that module; what belongs here is the invariant every reader must obey: the
+views are named from the **manifest**, never from a glob of the files dir, because a
+compaction leaves the previous generation's partitions on disk for readers still holding
+the old manifest (`index-store.md §4`) and a glob would count both generations.
 
-The schema is what decides which spec fields an index query can honour: the files table
-carries `mtime` and **no birth time**, so a creation-date filter is not answerable here
-and its caller has to hand the query to an engine that stats.
+The schema is what decides which spec fields a search can offer at all: the files table
+carries `mtime` and **no birth time**, so there is no creation-date filter anywhere in
+the feature — the endpoint refuses one rather than answering it with modification time.
 
 ## Non-goals
 

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -65,17 +65,79 @@ queries; an unanchored substring query can match anywhere and therefore scans ev
 partition. Each response reports `scanned_partitions` / `of_partitions` plus the
 partition filenames.
 
-## 5. No user SQL
+## 5. Guarded user SQL
+
+> Implementing module: `guarded_query.py` (`run_guarded`, `MAX_LIMIT`, `TIMEOUT_S`);
+> routes in `server-api.md §1`. Deliberately NOT in `query.py`, and nothing here is
+> named `sql`: `tests/test_index_query.py` still asserts `query.py` has no `sql`
+> attribute, so the unrestricted action cannot come back by accident.
 
 OpenIndex exposed a third action that ran the caller's duckdb statement against views
-over the index — deliberately unrestricted: no allowlist, no read-only flag, able to
-attach files, write, or read anything the user's account can. That was consistent with
-a trusted local page where `runPython` already executes arbitrary local Python.
+over the index, unrestricted: no allowlist, no read-only flag, able to attach files,
+write, or read anything the user's account can. That was consistent with a trusted local
+page where `runPython` already executes arbitrary local Python — and behind an HTTP route
+it was not the same surface, so it was dropped rather than guarded.
 
-Behind an HTTP route it is not the same surface, so **it is not ported**. Any future
-AI-query feature must compile to a guarded, read-only view rather than reintroducing
-it. `tests/test_index_query.py` asserts the module has no `sql` attribute, so it cannot
-come back by accident.
+It is now back, **guarded**. The bar is set by what the app already is: `/api/run`
+executes arbitrary local Python for the same caller, so confined read-only SQL adds no
+capability. What the guard buys is that a mistyped — or model-written — statement cannot
+write to the index or read a file outside it.
+
+`run_guarded(cfg, sql, limit)` returns `{columns, rows, truncated}` over two views,
+`files` and `dirs`, whose columns are exactly the stored schemas (`index-store.md §2`).
+Two independent guards, and **both** are necessary:
+
+**The statement-type gate**, before anything executes. `duckdb.extract_statements` must
+yield exactly one statement, of type `SELECT`, `CALL` or `EXPLAIN`. This is
+load-bearing, not defence in depth: behind a fully locked configuration an in-memory
+`INSERT` / `CREATE TABLE` / `DELETE` **still succeeds**, so the only place a write can be
+refused is before it runs. It also cannot be "SELECT only" — duckdb parses
+`PRAGMA database_list` and `DESCRIBE …` as `StatementType.SELECT`, so PRAGMA, DESCRIBE
+and (via `CALL`) the table-function pragmas are reachable regardless; they are read-only
+and are therefore admitted *explicitly*, rather than smuggled in by a gate that claims
+to admit only SELECT. Everything else — INSERT, UPDATE, DELETE, CREATE, DROP, ALTER,
+`COPY … TO`, ATTACH, INSTALL/LOAD, SET/RESET — is refused, as is a batch.
+
+**The DuckDB lockdown**, once per connection, in this order:
+
+1. `SET allowed_directories=[<index dir>]`
+2. `SET enable_external_access=false`
+3. `SET lock_configuration=true`
+
+All three, in that order. `allowed_directories` **alone confines nothing** — it is a
+carve-out from `enable_external_access=false`, not a restriction — and without the lock a
+statement simply widens the allowlist again. Afterwards the lazy `read_parquet` views
+still resolve (they are inside the allowed directory) and every path outside it is a
+permission error, whichever function reaches for it.
+
+There is deliberately **no function blocklist**. Around 40 of ~2 900 built-ins touch the
+filesystem and that ratio moves every release, so a list would be stale on the next
+upgrade while the confinement covers the ones nobody enumerated.
+
+The views are **lazy `read_parquet`, not materialized tables** — measured at 300k rows,
+6.8 ms for the view against 14.9 ms to copy the rows in first; the parquet is already
+the columnar format DuckDB wants. Their file list comes from the manifest via
+`store.partition_files`, never a glob: the store leaves the previous generation on disk
+for readers still holding the old manifest (`index-store.md §4`), so a glob would read
+two generations and silently double every count. An index with no partitions yet gets
+typed empty stand-ins, so a query written against a built index fails on nothing but its
+own logic.
+
+Two limits: the row cap is pushed into the SQL as an outer `LIMIT limit + 1` (so a
+whole-index query is never materialized just to be trimmed), clamped server-side to
+`MAX_LIMIT` whatever the client asks, and one row past the cap is what sets `truncated`.
+A PRAGMA is not a subquery-able expression, so a wrap that fails to parse falls back to
+the bare statement and a fetch cap — those answer in tens of rows by nature. And
+`TIMEOUT_S` (10 s) arms a `con.interrupt()`: a cross join is trivial to type and
+impossible to bound by inspection, and the caller is a text box.
+
+**Natural language** (`POST /api/index/ask`) is a thin hop on top: the question goes to
+the existing AI relay with a system prompt carrying the two schemas and the units, the
+reply is stripped of code fencing, and the result runs through `run_guarded` unchanged.
+Nothing trusts the model — the prompt asking for a SELECT is a hint, the gate is the
+boundary — and the compiled statement is returned to the caller whatever happens to it,
+including when it is refused, because a wrong answer with the SQL visible is debuggable
+and a bare error is not.
 
 ## 6. `search_under` — the explorer's in-folder corpus
 

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -198,6 +198,22 @@ pass it: its client-side matching is subsequence-based, so pre-narrowing to subs
 server-side would silently drop legitimate matches. It exists for a caller that only
 wants the hits.
 
+## 7. The source helpers are public — `files_src` / `dirs_src`
+
+`files_src(cfg, partitions)` and `dirs_src(cfg)` are the only sanctioned way to name the
+two views in SQL, and they are public because a **second reader** now uses them: the AI
+file search's index engine (`server/routers/search.py`, `POST /api/search/files`), which
+compiles its validated filter spec into one query over these views and returns rows
+without statting anything. Its own filters, refusals and fallbacks belong to that module
+— what belongs here is the invariant every reader must obey: the views are named from the
+**manifest**, never from a glob of the files dir, because a compaction leaves the
+previous generation's partitions on disk for readers still holding the old manifest
+(`index-store.md §4`) and a glob would count both generations.
+
+The schema is what decides which spec fields an index query can honour: the files table
+carries `mtime` and **no birth time**, so a creation-date filter is not answerable here
+and its caller has to hand the query to an engine that stats.
+
 ## Non-goals
 
 - **Writing or repairing the index** — `scan.md` / `index-store.md`.

--- a/fused_render/index/specs/query.md
+++ b/fused_render/index/specs/query.md
@@ -213,6 +213,13 @@ views are named from the **manifest**, never from a glob of the files dir, becau
 compaction leaves the previous generation's partitions on disk for readers still holding
 the old manifest (`index-store.md §4`) and a glob would count both generations.
 
+It also inherits §6's lesson the hard way: two views under ONE ordered budget starve one
+of them. There it was files served before folders; there it was a folder losing a shared
+recency cap to the files inside it, which match the same name term and are newer. Any
+reader of both views owes them **separate budgets or an order that cannot starve either
+kind** — folders in that engine get a reserved share of the result cap and are ordered
+shallowest-first, since a dirs row's `mtime_ns` may be 0 (unknown) and would sort last.
+
 The schema is what decides which spec fields a search can offer at all: the files table
 carries `mtime` and **no birth time**, so there is no creation-date filter anywhere in
 the feature — the endpoint refuses one rather than answering it with modification time.

--- a/fused_render/index/specs/scan-ignore.md
+++ b/fused_render/index/specs/scan-ignore.md
@@ -66,6 +66,32 @@ Filtering the cache is what makes newly-ignored folders **self-purging**: an ign
 directory is absent from the cache, so it is never added to the keep list, so
 compaction drops its file rows (`index-store.md §4`). No full rescan is needed.
 
+### Package leaves
+
+`LEAF_DIR_SUFFIXES` (`.app`, `.framework`, `.bundle`, `.photoslibrary`) is a
+*fourth*, differently-shaped rule, and not an ignore pattern: a package is
+**recorded and not descended**, where an ignored directory is neither. It is one
+`dirs.parquet` row with no file rows, produced by `scan_dir_once` returning before
+it lists the directory — so it costs the stat it had already taken and no scandir,
+whatever the package holds.
+
+Both halves matter, and each fixes parity in the opposite direction from the other.
+`/api/fs/walk` emits `Foo.app` as a single leaf entry (`WALK_LEAF_DIR_SUFFIXES`,
+derived from this constant), so:
+
+- **descending** it filled the index with `Foo.app/Contents/...` paths the walk
+  never emits — thousands of rows per Electron app, spending a 200 000-row corpus
+  budget on entries nobody searches for and, because ranking scores the whole
+  relative path, out-ranking real hits;
+- **skipping** it would drop the package from the corpus entirely, and the walk
+  does list it.
+
+One consequence, handled in `query.search_under`: a package's dirs row means "this
+is a leaf", not "we know what is inside", so a search whose *root* is a package
+reports `covered: false` and falls back to the live walk — which does list a leaf
+it was pointed at. Migration for an index that already descended packages is a
+full rescan.
+
 ## 4. Rules-changed fingerprint
 
 Removing a pattern cannot be handled incrementally: cached `n_subdirs` values were

--- a/fused_render/index/specs/scan-ignore.md
+++ b/fused_render/index/specs/scan-ignore.md
@@ -86,11 +86,28 @@ derived from this constant), so:
 - **skipping** it would drop the package from the corpus entirely, and the walk
   does list it.
 
-One consequence, handled in `query.search_under`: a package's dirs row means "this
-is a leaf", not "we know what is inside", so a search whose *root* is a package
-reports `covered: false` and falls back to the live walk — which does list a leaf
-it was pointed at. Migration for an index that already descended packages is a
-full rescan.
+`is_leaf_dir` tests the path's own final component, which is all a descent needs:
+a walk that refuses to list `Foo.app` never reaches anything below it. Two callers
+are *handed* a path rather than descending to it, and use `is_inside_leaf_dir`
+(any ancestor is a package) instead:
+
+- the **FSEvents fast path** (`scan-incremental.md §1`) visits whatever directories
+  the OS journal names, and what the journal names inside a package is always a
+  descendant — an app update writes `Foo.app/Contents/Resources`, Photos writes
+  `Foo.photoslibrary/database`, never the package itself. A final-component test
+  passes those straight through, so package internals entered the index by this
+  path even though the walk-driven path excluded them, and the keep list then
+  carried the rows forward on every later run.
+- **`query.search_under`'s coverage test**: a package's dirs row means "this is a
+  leaf", not "we know what is inside", so a search rooted at a package reports
+  `covered: false` and falls back to the live walk — which does list a leaf it was
+  pointed at. The same has to hold one level down, because an index written before
+  this rule holds real dirs rows *inside* packages; answering
+  `Foo.app/Contents` from that partial set while `Foo.app` goes to the walk is the
+  two-interchangeable-sources-disagree bug again.
+
+Neither test purges rows an older index already has: they stop packages entering.
+Migration for an index that already descended packages is a full rescan.
 
 ## 4. Rules-changed fingerprint
 

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -92,6 +92,51 @@ existing index without a full rescan (`scan-ignore.md §4`). Mount-backed paths 
 refused here too, by the same `MountGuard` the walk uses: a journal replay is exactly
 the route by which a path can arrive without its ancestors having been checked.
 
+## 5. Open-folder freshness
+
+> Implementing module: `freshness.py` (`enclosing_root`, `indexed_mtime_ns`,
+> `note_folder_opened`); the server glue is `routers/index.py`
+> (`note_folder_opened`, `_run_freshness_check`), called from `GET /api/fs/list`.
+
+Between scans the index is a snapshot, so a folder changed out of band answers search
+from stale rows. Opening a folder is the signal that its slice has to be fresh, so the
+listing request checks it and, when it is behind, starts the **ordinary incremental
+scan** of its enclosing configured root. Deliberately not a new scanning path: §2 and §3
+already narrow a rescan to what moved, and a subtree-scoped run would need its own copy
+of every root-keyed store (`scans.json`, the applied-ignore map, the FSEvents position).
+
+Detection is the §2 rule read backwards: `dirs.parquet` already stores `mtime_ns` per
+directory, so it is one indexed row lookup against one `os.stat` — no walk. Three
+values read as "nothing to compare against" and trigger nothing: no index, no row for
+this directory (an uncovered folder already falls back to the live walk, `query.md §6`,
+so a scan buys its search nothing), and a stored `0` (the placeholder a partition
+predating the column compacts to — reading it as a real mtime would make the folder
+stale forever and fire on every open).
+
+Four gates, cheapest first, because `/api/fs/list` fires for every folder opened **and
+again on every watch tick of a folder on screen**:
+
+1. The path is inside a configured root (segment-wise), else nothing. The scan started
+   is always that **configured root** — a per-folder root would pollute `scans.json`
+   and defeat `runner.start`'s exact-match join.
+2. Not mount-backed. This is checked before any syscall on the path, by the same pure
+   string `MountGuard` §4 uses: `os.stat` under a wedged rclone mount blocks its thread
+   indefinitely, and this one is serving a listing.
+3. `MIN_INTERVAL_S` (120 s) since any scan of that root, read off `scans.json` — so no
+   state file of its own, and a scan that just ran for any reason suppresses a trigger.
+4. `QUIET_S` (30 s) since the directory's own mtime moved. A build tree's mtime never
+   stops moving, so it is never quiet and never triggers; the open after the churn stops
+   still does.
+
+A live run of the root is refused rather than joined, the check runs on a background
+thread throttled to one at a time, and nothing about the listing waits on it or fails
+with it.
+
+**Bound, by design:** a directory's mtime moves only when entries are added, removed or
+renamed *in that directory*. An edit five levels down does not flip the mtime of the
+folder being viewed. This makes the index fresher; it does not make it correct, and the
+`fresh`/`covered` flags of `query.md §6` still describe the honest state.
+
 ## Non-goals
 
 - **Choosing strategies / emitting phases** — `scan.md §1`, `§4`.

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -122,7 +122,11 @@ developer's real home. The scheduler's own tests call `run_startup_scan()` direc
 ## Non-goals
 
 - **Watching the filesystem** — there is no daemon. Freshness comes from the startup
-  scan plus on-demand scans; a watcher is a later project.
+  scan, on-demand scans, and the open-folder check `GET /api/fs/list` performs
+  (`scan-incremental.md §5`): a folder whose own mtime is ahead of the index gets its
+  root rescanned in the background. A folder nobody opens still waits for a startup or
+  manual scan, and a change deeper than the folder being viewed does not move its
+  mtime — an ambient watcher remains a later project.
 - **Indexing remote mounts** — refused structurally (`scan-ignore.md §7`).
 - **AI/SQL access to the index** — `query.md §5`.
 

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -38,6 +38,13 @@ duckdb's own ("no such column" is the caller's typo, not a server fault), and `a
 returns the compiled `sql` even when the guard refuses it. What makes them safe is
 `query.md §5`, not the header.
 
+Both also run their statement **off the event loop**: a guarded query is duckdb plus
+disk, bounded only by `TIMEOUT_S` (10 s), and a handler that blocks that long freezes
+every other request the app is making — including the status polling the same panel
+does. `query` gets that for free by being a plain `def` handler (FastAPI threadpools
+those); `ask` must be `async` for the AI relay hop, so it asks for a threadpool
+explicitly.
+
 ## 2. Status, and the first-boot window
 
 `GET /api/index/status` answers flat, render-ready state: `running`, `phase`, `dirs`,

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -20,6 +20,8 @@ unguarded like every other read endpoint and none of them can write.
 | `GET /api/index/stats?root=` | — | totals + per-extension breakdown (`query.md §2`) |
 | `GET /api/index/lookup?q=&limit=&offset=&sort=` | — | path lookup (`query.md §3`) |
 | `GET /api/index/search?root=&q=&limit=` | — | the explorer's in-folder corpus (`query.md §6`) |
+| `POST /api/index/query` `{sql, limit?}` | X-Fused | run ONE read-only statement over `files`/`dirs`; `{columns, rows, truncated}` (`query.md §5`) |
+| `POST /api/index/ask` `{prompt, limit?}` | X-Fused | compile a question to SQL through the AI relay, run it under the same guard, echo the `sql` (`query.md §5`) |
 | `GET /api/index/config` · `POST /api/index/config` | X-Fused on write | scan roots + ignore list (§3) |
 | `POST /api/index/delete` | X-Fused | drop the whole store (§5) |
 
@@ -28,7 +30,13 @@ de-globalizing the engine bought: an ignore-list edit applies to the next scan w
 restart, and a test's redirected home is honoured by the same process that served the
 previous test.
 
-**There is no route that runs SQL against the index** — see `query.md §5`.
+`query` and `ask` are the two routes that are **guarded despite being reads**. They
+write nothing, but they execute a statement the caller (or a model) wrote, and that is
+not something a foreign page should be able to fire blind — so they are POST-only and
+carry the header. Both map every refusal to a 400 with the message verbatim, including
+duckdb's own ("no such column" is the caller's typo, not a server fault), and `ask`
+returns the compiled `sql` even when the guard refuses it. What makes them safe is
+`query.md §5`, not the header.
 
 ## 2. Status, and the first-boot window
 
@@ -128,7 +136,8 @@ developer's real home. The scheduler's own tests call `run_startup_scan()` direc
   manual scan, and a change deeper than the folder being viewed does not move its
   mtime — an ambient watcher remains a later project.
 - **Indexing remote mounts** — refused structurally (`scan-ignore.md §7`).
-- **AI/SQL access to the index** — `query.md §5`.
+- **Deciding what SQL is safe** — the guard is `query.md §5`; these routes only adapt it
+  to HTTP.
 
 ## See also
 

--- a/fused_render/index/store.py
+++ b/fused_render/index/store.py
@@ -115,17 +115,47 @@ def like_literal(s: str) -> str:
 
 
 def schemas(pa):
-    """The single definition of both tables (specs/index-store.md §2)."""
+    """The single definition of both tables (specs/index-store.md §2).
+
+    `name`, `ext`, `dir` and `depth` are all DENORMALISED out of `path`. That is
+    correct only because rows are never mutated in place: a scan writes a row
+    once, and a compaction copies whole partitions and swaps the manifest, so
+    there is no update path that could leave a derived column disagreeing with
+    the path it was derived from. `depth` joins that existing family; it is not
+    a new anomaly.
+
+    It is a STORED int32 rather than a derived or generated column because
+    there is nowhere to put a generated one: every query opens a fresh
+    in-memory duckdb over `read_parquet` (query.py), so no catalog survives
+    between calls, and parquet has no computed-column concept. Measured on 300k
+    rows at the real LIMIT 200_001: 92.2ms stored vs 147.6ms for the
+    slash-counting expression, for +0.10% on disk.
+
+    `depth` is the ABSOLUTE slash count of the full path, not a count relative
+    to any search root — a stored column cannot know which root will read it.
+    Both tables carry it because query.search_under UNIONs them and a UNION
+    needs uniform columns. Appended last in both schemas: the compaction's
+    `UNION ALL` of old partitions with new shards is positional."""
     file_schema = pa.schema([
         ("path", pa.string()), ("dir", pa.string()), ("name", pa.string()),
         ("ext", pa.string()), ("size", pa.int64()), ("mtime", pa.float64()),
+        ("depth", pa.int32()),
     ])
     dir_schema = pa.schema([
         ("dir", pa.string()), ("sig", pa.string()),
         ("n_files", pa.int32()), ("total_size", pa.int64()),
         ("mtime_ns", pa.int64()), ("n_subdirs", pa.int32()),
+        ("depth", pa.int32()),
     ])
     return file_schema, dir_schema
+
+
+# The slash-count expression a pre-`depth` partition falls back to, so an index
+# already on disk keeps reading instead of hard-failing (the same additive
+# evolution load_dir_cache and _compact_locked already do for mtime_ns /
+# n_subdirs). Migration is a full rescan.
+def depth_expr(col: str) -> str:
+    return f"CAST(length({col}) - length(replace({col}, '/', '')) AS INTEGER)"
 
 
 class Sink:
@@ -155,12 +185,14 @@ class Sink:
             r["path"].append(fr[0]); r["dir"].append(fr[1])
             r["name"].append(fr[2]); r["ext"].append(fr[3])
             r["size"].append(fr[4]); r["mtime"].append(fr[5])
+            r["depth"].append(fr[0].count("/"))
         self.files += len(frows)
         dr = self.dir_rows
         dr["dir"].append(d); dr["sig"].append(sig)
         dr["n_files"].append(len(frows)); dr["total_size"].append(dtotal)
         dr["mtime_ns"].append(mtime_ns)
         dr["n_subdirs"].append(n_subdirs)
+        dr["depth"].append(d.count("/"))
         if len(r["path"]) >= self.shard_rows:
             self._flush_files()
 
@@ -383,7 +415,9 @@ def _compact_locked(cfg: IndexConfig, root, shards_dir, pa, pq, emit=None):
         mt = "mtime_ns" if "mtime_ns" in cols else "CAST(0 AS BIGINT) AS mtime_ns"
         ns = ("n_subdirs" if "n_subdirs" in cols
               else "CAST(-1 AS INTEGER) AS n_subdirs")
-        old_dirs_src = (f"SELECT dir, sig, n_files, total_size, {mt}, {ns} "
+        dp = ("depth" if "depth" in cols
+              else f"{depth_expr('dir')} AS depth")
+        old_dirs_src = (f"SELECT dir, sig, n_files, total_size, {mt}, {ns}, {dp} "
                         f"FROM {dirs_src}")
         old_in = f"SELECT dir, sig FROM ({old_dirs_src}) WHERE NOT {outside}"
         changed = con.execute(
@@ -431,7 +465,14 @@ def _compact_locked(cfg: IndexConfig, root, shards_dir, pa, pq, emit=None):
 
     srcs = []
     if has_old:
-        srcs.append(f"SELECT * FROM {old_src} WHERE {outside} OR {kept}")
+        # Column list spelled out, not `SELECT *`: a partition written before
+        # `depth` existed has one fewer column than the shards it is unioned
+        # with, and a positional UNION ALL would fail outright rather than
+        # merge. Backfill it from the path instead (see depth_expr).
+        fcols = pq.read_schema(old_files[0]).names
+        fdp = "depth" if "depth" in fcols else f"{depth_expr('path')} AS depth"
+        srcs.append(f"SELECT path, dir, name, ext, size, mtime, {fdp} "
+                    f"FROM {old_src} WHERE {outside} OR {kept}")
     if has_shards:
         srcs.append(f"SELECT * FROM {shard_src}")
     src = " UNION ALL ".join(srcs) or None

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -236,6 +236,17 @@ def api_fs_list(path: str, cursor: str | None = None):
         return _list_response(path, entries[:_server_walk.LIST_MAX_ENTRIES], truncated, None)
     if not os.path.isdir(path):
         return _error(f"not a directory: {path}", status=400)
+    # Opening a folder is the signal that its slice of the index has to be
+    # fresh, and this is the only request that says so on every platform. The
+    # check is thrown onto a background thread and throttled to one at a time
+    # (routers/index.note_folder_opened) — nothing about this listing waits on
+    # it. Imported lazily and looked up through the module so the seam stays
+    # patchable, and so a listing does not pull the index package in.
+    try:
+        from fused_render.server.routers import index as _index_router
+        _index_router.note_folder_opened(path)
+    except Exception:  # noqa: BLE001 - a listing must not fail on housekeeping
+        logger.exception("could not note %s for the index freshness check", path)
     entries = []
     # scandir over listdir+per-entry stat/isdir: the readdir already carries
     # each entry's type, so is_dir() is free and stat() is a single call —

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -25,6 +25,7 @@ import re
 import threading
 
 from fastapi import APIRouter, Body, Header, Query
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from fused_render.index import freshness, runner
@@ -425,7 +426,13 @@ async def api_index_ask(body: dict = Body(default={}),
     sql = _sql_from_answer((answered.get("result") or {}).get("text") or "")
     if not sql:
         return _error("the model answered with no SQL", status=502)
-    out = _guarded(load_config(), sql, body.get("limit"))
+    # In a threadpool, unlike `query` next door: that one is a plain `def`
+    # handler, so FastAPI already threadpools it, while this handler must be
+    # `async` for the relay `await` above — and a duckdb query bounded only by
+    # guarded_query.TIMEOUT_S (10s) run inline would block the event loop, and
+    # with it every other request the app is making meanwhile.
+    out = await run_in_threadpool(
+        lambda: _guarded(load_config(), sql, body.get("limit")))
     if not isinstance(out, dict):
         # Same 400, plus the statement that earned it.
         return JSONResponse({**json.loads(bytes(out.body)), "sql": sql},

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -10,18 +10,26 @@ Mutating routes carry the usual X-Fused guard. Reads are unguarded like the
 other read endpoints — a foreign page cannot read our responses anyway — and
 none of them can write.
 
-There is deliberately no route that runs SQL against the index (`index/specs/
-query.md §5`).
+User SQL against the index goes through POST /api/index/query, which executes it
+in a confined read-only DuckDB session (`index/guarded_query.py`,
+`index/specs/query.md §5`), and POST /api/index/ask, which compiles a question
+into one of those statements through the existing AI relay. Both are POST and
+X-Fused-guarded despite being reads: they execute a caller-shaped statement, so
+neither should be reachable from a crafted link.
 """
 import asyncio
+import json
 import logging
 import os
+import re
 import threading
 
 from fastapi import APIRouter, Body, Header, Query
+from fastapi.responses import JSONResponse
 
 from fused_render.index import freshness, runner
 from fused_render.index.config import IndexConfig, load_config, save_config
+from fused_render.index.guarded_query import MAX_LIMIT, run_guarded
 from fused_render.index.ignore import default_ignore, norm
 from fused_render.index.query import MAX_CORPUS
 from fused_render.index.query import lookup as index_lookup
@@ -33,6 +41,7 @@ from fused_render.index.store import (
     read_manifest,
     save_applied_ignore,
 )
+from fused_render.server import ai as _server_ai
 from fused_render.server.common import _error, _require_fused
 from fused_render.server.index_gitignore import filter_corpus
 
@@ -293,6 +302,135 @@ def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
     # everyone else on that generation.
     out = filter_corpus(out, cacheable=not q.strip() and limit >= MAX_CORPUS)
     return {"ok": True, **out}
+
+
+# ------------------------------------------------------------------ user SQL
+
+# Rows a query answers with when the caller names no limit. Small: this fills a
+# table in a preferences panel, and MAX_LIMIT is there for a caller that means
+# it.
+DEFAULT_QUERY_LIMIT = 200
+
+
+def _guarded(cfg: IndexConfig, sql: str, limit) -> dict | object:
+    """`run_guarded` with both failure modes mapped to a 400.
+
+    duckdb's own exceptions are 400s too, not 500s: "no such column" is the
+    caller's mistake, and the panel shows the message verbatim so a typo is
+    self-explanatory. Only the message travels — no traceback."""
+    try:
+        n = int(limit) if limit is not None else DEFAULT_QUERY_LIMIT
+    except (TypeError, ValueError):
+        return _error("'limit' must be a number")
+    try:
+        return run_guarded(cfg, sql, limit=min(max(n, 0), MAX_LIMIT))
+    except ValueError as e:
+        return _error(str(e))
+    except Exception as e:  # noqa: BLE001 - duckdb's exception tree, flattened
+        return _error(f"{type(e).__name__}: {e}")
+
+
+@router.post("/api/index/query")
+def api_index_query(body: dict = Body(default={}),
+                    x_fused: str | None = Header(default=None)):
+    """Run one read-only statement against `files` / `dirs`.
+
+    Guarded like the mutating routes even though it writes nothing: it executes
+    a statement the caller wrote, which is not something a foreign page should
+    be able to fire blind."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    sql = body.get("sql")
+    if not isinstance(sql, str) or not sql.strip():
+        return _error("'sql' must be a non-empty string")
+    out = _guarded(load_config(), sql, body.get("limit"))
+    if not isinstance(out, dict):
+        return out
+    return {"ok": True, **out}
+
+
+# What the model needs to write a valid statement, and nothing more: the two
+# schemas, the units, and the shape of an acceptable answer. Kept here rather
+# than derived from store.schemas because it is prose for a reader, not a
+# contract — a column list is only half of what makes `size` mean bytes.
+_ASK_SYSTEM_PROMPT = """\
+You translate a question about a filesystem index into ONE DuckDB SQL statement.
+
+Two views are available and nothing else:
+
+  files(path VARCHAR, dir VARCHAR, name VARCHAR, ext VARCHAR, size BIGINT,
+        mtime DOUBLE, depth INTEGER)
+  dirs(dir VARCHAR, sig VARCHAR, n_files INTEGER, total_size BIGINT,
+       mtime_ns BIGINT, n_subdirs INTEGER, depth INTEGER)
+
+- `path` and `dir` are absolute, POSIX-separated. `name` is the basename.
+- `ext` is lowercase and has no leading dot; it is '' for a file with no
+  extension.
+- `size` is bytes. `mtime` is epoch SECONDS (a float); `dirs.mtime_ns` is epoch
+  NANOSECONDS, and 0 there means unknown.
+- `depth` is the absolute count of '/' in the path.
+
+Rules: answer with ONE statement, a SELECT (a WITH is fine). No INSERT, UPDATE,
+DELETE, CREATE, COPY, ATTACH, SET or PRAGMA — they are refused. Do not read any
+file or table other than these two views. Give the columns readable aliases, and
+add an ORDER BY and a LIMIT when the question implies a top-N.
+
+Reply with the SQL and nothing else: no prose, no explanation, no code fence.\
+"""
+
+_FENCE = re.compile(r"```[a-zA-Z]*\s*(.*?)```", re.S)
+
+
+def _sql_from_answer(text: str) -> str:
+    """The SQL out of a model's reply.
+
+    Asked for bare SQL, models still fence it and still add a sentence either
+    side often enough that stripping is cheaper than a retry. The FIRST fenced
+    block wins; with no fence the whole reply is the statement."""
+    m = _FENCE.search(text or "")
+    return (m.group(1) if m else (text or "")).strip()
+
+
+@router.post("/api/index/ask")
+async def api_index_ask(body: dict = Body(default={}),
+                        x_fused: str | None = Header(default=None)):
+    """A question in English, answered from the index.
+
+    The compiled SQL is returned WHATEVER happens to it — including when the
+    guard refuses it — because a wrong answer with the statement visible is
+    debuggable and a bare error is not.
+
+    Nothing here trusts the model: its statement goes through exactly the same
+    guard a hand-typed one does (`index/guarded_query.py`). The prompt asking
+    for a SELECT is a hint, not the boundary."""
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    prompt = body.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        return _error("'prompt' must be a non-empty string")
+    # The relay owns the claude hop, the model preference, the timeout and the
+    # typed error envelope; a failure passes straight through it unchanged
+    # rather than being re-described here.
+    resp = await _server_ai._ai_relay({"prompt": prompt.strip(),
+                                       "system_prompt": _ASK_SYSTEM_PROMPT,
+                                       "stream": False})
+    try:
+        answered = json.loads(bytes(resp.body))
+    except ValueError:
+        return _error("the AI relay returned an unreadable response", status=502)
+    if not answered.get("ok"):
+        return resp
+    sql = _sql_from_answer((answered.get("result") or {}).get("text") or "")
+    if not sql:
+        return _error("the model answered with no SQL", status=502)
+    out = _guarded(load_config(), sql, body.get("limit"))
+    if not isinstance(out, dict):
+        # Same 400, plus the statement that earned it.
+        return JSONResponse({**json.loads(bytes(out.body)), "sql": sql},
+                            status_code=out.status_code)
+    return {"ok": True, "sql": sql, **out}
 
 
 # --------------------------------------------------------------------- config

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -16,10 +16,11 @@ query.md §5`).
 import asyncio
 import logging
 import os
+import threading
 
 from fastapi import APIRouter, Body, Header, Query
 
-from fused_render.index import runner
+from fused_render.index import freshness, runner
 from fused_render.index.config import IndexConfig, load_config, save_config
 from fused_render.index.ignore import default_ignore, norm
 from fused_render.index.query import MAX_CORPUS
@@ -103,6 +104,49 @@ def run_startup_scan(start_dir: str | None = None) -> None:
 async def startup_scan(start_dir: str | None = None) -> None:
     """The create_app hook. Off the event loop because it touches the disk."""
     await asyncio.to_thread(run_startup_scan, start_dir)
+
+
+# ------------------------------------------------------ open-folder freshness
+
+# At most one check in flight. /api/fs/list fires for every folder the explorer
+# opens AND again on every watch tick of a folder being displayed, so the hook
+# is called far more often than a check costs — and a check opens duckdb over
+# dirs.parquet. A plain non-reentrant lock, acquired by the request thread and
+# released by the worker, is the whole throttle.
+_freshness_slot = threading.Lock()
+
+
+def _run_freshness_check(path: str) -> None:
+    """The check itself, off the request thread. Never raises: a listing must
+    not fail, or slow down, because index housekeeping did."""
+    try:
+        cfg = load_config()
+        root = freshness.note_folder_opened(cfg, path, scan_roots(cfg))
+        if root:
+            logger.info("index: %s changed since the last scan; rescanning %s",
+                        path, root)
+    except Exception:  # noqa: BLE001 - housekeeping must never surface
+        logger.exception("could not check index freshness for %s", path)
+    finally:
+        if _freshness_slot.locked():
+            _freshness_slot.release()
+
+
+def note_folder_opened(path: str) -> bool:
+    """The explorer opened `path`: check the index against it in the background.
+
+    Returns whether a check was started. Called from /api/fs/list — the folder
+    the user is looking at is the one whose search must not be stale, and the
+    listing request is the only signal that says so on every platform."""
+    if not _freshness_slot.acquire(blocking=False):
+        return False
+    try:
+        threading.Thread(target=_run_freshness_check, args=(path,),
+                         daemon=True, name="index-freshness").start()
+    except RuntimeError:  # interpreter shutting down
+        _freshness_slot.release()
+        return False
+    return True
 
 
 # ------------------------------------------------------------------- scanning

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -49,7 +49,7 @@ from fastapi.concurrency import run_in_threadpool
 
 from fused_render.index.config import load_config
 from fused_render.index.query import dirs_src, files_src
-from fused_render.index.store import like_literal, read_manifest
+from fused_render.index.store import depth_expr, like_literal, read_manifest
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle
 from fused_render.server.walk import WALK_IGNORE_DIRS
@@ -60,6 +60,16 @@ router = APIRouter()
 # Rows a search may return. A broad query can match tens of thousands of index
 # rows; the client shows ~60, so 400 leaves plenty of ranking headroom.
 SEARCH_MAX_RESULTS = 400
+# Of that cap, the share DIRECTORY hits may claim. Folders are queried on their
+# own budget rather than competing with files for one ordered cap: a folder and
+# the files inside it match the same name term, the files are almost always the
+# newer rows, and under a shared recency budget a folder with more than `cap`
+# recent files in it could never surface — "where is my reports folder" answered
+# with the reports and never the folder. That is the files-starve-folders failure
+# query.search_under fixed for the in-folder corpus, in a different disguise.
+# The named cost: on a query matching both kinds heavily, up to this many file
+# rows give way to folders. Unused folder budget goes back to files.
+SEARCH_DIRS_RESERVE = 100
 
 _EXT_ALLOWED = set("abcdefghijklmnopqrstuvwxyz0123456789")
 
@@ -303,42 +313,92 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
     return " AND ".join(pieces)
 
 
-def _index_rows(cfg, spec, limit, *, parts=None, dirs=False):
-    """The spec as ONE query over the requested index views, newest first.
+def _files_query(cfg, parts, spec, now_s) -> str:
+    """The files view, newest first. Ordering only decides WHICH rows survive
+    the budget (the client re-ranks every hit), and recency is the best sample
+    of a file corpus. `path` breaks ties so paging is deterministic."""
+    return (
+        f"SELECT path, size, mtime, false AS is_dir FROM {files_src(cfg, parts)} "
+        f"WHERE " + _index_where(spec, path_expr="path", name_expr="name",
+                                 mtime_expr="mtime", ext_expr="ext",
+                                 size_expr="size", now_s=now_s)
+        + " ORDER BY mtime DESC, path")
 
-    Both views are named through the MANIFEST (query.files_src / dirs_src),
-    never a glob of the files dir: a compaction leaves the previous generation's
-    partitions on disk for readers still holding the old manifest
-    (index-store.md §4), so a glob would return every row twice."""
+
+def _dirs_query(cfg, spec, now_s) -> str:
+    """The dirs view, SHALLOWEST first.
+
+    Not by mtime, unlike files: a dirs row's mtime_ns can be 0 ("unknown" — a
+    row written before the column existed, or a directory whose stat failed),
+    which reads as NULL and sorts last under `mtime DESC`, so a recency order
+    dropped exactly those folders first. Shallow-first is immune to that, is
+    deterministic, and keeps the breadth-first character search_under's corpus
+    has — a folder near the top of the tree is the likelier answer to "where is
+    my X folder". `depth` is computed from the path rather than read from the
+    column so an index written before that column still orders correctly.
+
+    A dirs row carries no name column, so the final path component is the name.
+    """
+    dmtime = "nullif(mtime_ns, 0) / 1e9"
+    return (
+        f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, {dmtime} AS mtime, "
+        f"true AS is_dir FROM {dirs_src(cfg)} "
+        f"WHERE " + _index_where(spec, path_expr="dir",
+                                 name_expr="regexp_extract(dir, '[^/]*$')",
+                                 mtime_expr=dmtime, now_s=now_s)
+        + f" ORDER BY {depth_expr('dir')}, dir")
+
+
+def _row_entry(row) -> dict:
+    path, size, mtime, is_dir = row
+    return {"path": path, "is_dir": bool(is_dir),
+            "size": None if is_dir or size is None else int(size),
+            "mtime": None if mtime is None else float(mtime)}
+
+
+def _screen(rows) -> list:
+    """Response entries for `rows`, minus the hits no search may surface.
+
+    The index's own ignore rules are a user-editable name list; git is a server
+    concern (server/index_gitignore.py makes the same move for the in-folder
+    corpus, for the same reason: a gitignored build directory's 100k generated
+    files must not flood a search)."""
+    return _drop_gitignored([_row_entry(r) for r in rows if not _junk_path(r[0])])
+
+
+def _collect(con, sql, budget: int):
+    """Up to `budget` screened entries for one branch, plus whether the branch
+    had more rows than it was allowed to contribute. One row past the budget is
+    fetched, so "there was more" is known without a count."""
+    rows = con.execute(f"{sql} LIMIT {budget + 1}").fetchall()
+    return _screen(rows[:budget]), len(rows) > budget
+
+
+def _index_entries(cfg, spec, cap, *, parts=None, dirs=False):
+    """Screened entries for the spec, and whether anything was left behind.
+
+    Each view is its own query with its own budget — see SEARCH_DIRS_RESERVE for
+    why folders are not made to compete with files for one ordered cap. Both are
+    named through the MANIFEST (query.files_src / dirs_src), never a glob of the
+    files dir: a compaction leaves the previous generation's partitions on disk
+    for readers still holding the old manifest (index-store.md §4), so a glob
+    would return every row twice."""
     import duckdb
 
     now_s = time.time()
-    branches = []
-    if parts:
-        fsrc = files_src(cfg, parts)
-        branches.append(
-            f"SELECT path, size, mtime, false AS is_dir FROM {fsrc} WHERE "
-            + _index_where(spec, path_expr="path", name_expr="name",
-                           mtime_expr="mtime", ext_expr="ext",
-                           size_expr="size", now_s=now_s))
-    if dirs:
-        dsrc = dirs_src(cfg)
-        # A dirs row carries no name column, so the final path component is the
-        # name; mtime_ns of 0 means "unknown" and becomes NULL, which fails
-        # every mtime comparison rather than passing it.
-        dmtime = "nullif(mtime_ns, 0) / 1e9"
-        branches.append(
-            f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, "
-            f"{dmtime} AS mtime, true AS is_dir FROM {dsrc} WHERE "
-            + _index_where(spec, path_expr="dir",
-                           name_expr="regexp_extract(dir, '[^/]*$')",
-                           mtime_expr=dmtime, now_s=now_s))
-    # One row past the cap, so "there was more" is known without a count.
-    # Newest first: the client re-ranks every hit anyway, so ordering only
-    # decides WHICH rows survive the cap, and recency is the best sample.
-    return duckdb.connect().execute(
-        " UNION ALL ".join(branches)
-        + f" ORDER BY mtime DESC LIMIT {int(limit)}").fetchall()
+    con = duckdb.connect()
+    dir_entries, dirs_more = (
+        _collect(con, _dirs_query(cfg, spec, now_s), min(SEARCH_DIRS_RESERVE, cap))
+        if dirs else ([], False))
+    # Files ask for the WHOLE cap and give back whatever the folders took, so an
+    # unused folder reserve costs nothing.
+    file_entries, files_more = (
+        _collect(con, _files_query(cfg, parts, spec, now_s), cap)
+        if parts else ([], False))
+    room = cap - len(dir_entries)
+    entries = dir_entries + file_entries[:room]
+    truncated = dirs_more or files_more or len(file_entries) > room
+    return entries, truncated
 
 
 def _search_index(spec, cfg=None):
@@ -380,26 +440,14 @@ def _search_index(spec, cfg=None):
         raise IndexUnavailable(
             "the file index holds nothing this search could match yet — it may "
             "still be scanning")
-    cap = SEARCH_MAX_RESULTS
     try:
-        rows = _index_rows(cfg, spec, cap + 1, parts=parts, dirs=dirs)
+        entries, truncated = _index_entries(
+            cfg, spec, SEARCH_MAX_RESULTS, parts=parts, dirs=dirs)
     except Exception as e:  # noqa: BLE001 - duckdb's exception tree, flattened
         logger.exception("the index search query failed")
         raise RuntimeError(
             f"the file index could not be searched: {type(e).__name__}") from e
-    truncated = len(rows) > cap
-    entries = [
-        {"path": path, "is_dir": bool(is_dir),
-         "size": None if is_dir or size is None else int(size),
-         "mtime": None if mtime is None else float(mtime)}
-        for path, size, mtime, is_dir in rows[:cap]
-        if not _junk_path(path)
-    ]
-    # The index knows nothing about git (its ignore rules are name patterns), so
-    # gitignored hits are screened here — the same oracle the explorer's walk
-    # uses, and the same reason server/index_gitignore.py filters the in-folder
-    # corpus: a build directory's 100k generated files must not flood a search.
-    return {"entries": _drop_gitignored(entries), "truncated": truncated,
+    return {"entries": entries, "truncated": truncated,
             # Constant now that the index is the only engine. Kept in the
             # response because old clients read it, and because a support
             # question about a surprising result starts with "what answered it".

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -70,6 +70,13 @@ SEARCH_MAX_RESULTS = 400
 # The named cost: on a query matching both kinds heavily, up to this many file
 # rows give way to folders. Unused folder budget goes back to files.
 SEARCH_DIRS_RESERVE = 100
+# Pages a branch may read while filling its budget. Gitignored rows can only be
+# recognised OUTSIDE SQL, so a page that screens down to nothing has to be
+# followed by another or a gitignored build directory answers the whole query;
+# each extra page costs one duckdb query plus its check-ignore batch, and the
+# common case (few ignored hits) is one page. A bound rather than "until the cap
+# is full" because a query can match more ignored rows than any budget.
+SEARCH_MAX_PAGES = 5
 
 _EXT_ALLOWED = set("abcdefghijklmnopqrstuvwxyz0123456789")
 
@@ -368,10 +375,29 @@ def _screen(rows) -> list:
 
 def _collect(con, sql, budget: int):
     """Up to `budget` screened entries for one branch, plus whether the branch
-    had more rows than it was allowed to contribute. One row past the budget is
-    fetched, so "there was more" is known without a count."""
-    rows = con.execute(f"{sql} LIMIT {budget + 1}").fetchall()
-    return _screen(rows[:budget]), len(rows) > budget
+    had more rows than it was allowed to contribute.
+
+    Paged, because the cap is a budget for hits the user can SEE and screening
+    happens outside SQL: taking `budget` rows once and screening afterwards let
+    a page of gitignored rows answer the query with an empty list while real
+    matches sat one row past the cap. Each page asks for exactly the shortfall
+    plus one probe row, so the common case is a single query."""
+    kept: list = []
+    offset = 0
+    more = False
+    for _page in range(SEARCH_MAX_PAGES):
+        want = budget - len(kept)
+        if want <= 0:
+            break
+        rows = con.execute(
+            f"{sql} LIMIT {want + 1} OFFSET {offset}").fetchall()
+        more = len(rows) > want
+        page = rows[:want]
+        offset += len(page)
+        kept.extend(_screen(page))
+        if not more:
+            break
+    return kept[:budget], more
 
 
 def _index_entries(cfg, spec, cap, *, parts=None, dirs=False):

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -68,7 +68,9 @@ SEARCH_MAX_RESULTS = 400
 # with the reports and never the folder. That is the files-starve-folders failure
 # query.search_under fixed for the in-folder corpus, in a different disguise.
 # The named cost: on a query matching both kinds heavily, up to this many file
-# rows give way to folders. Unused folder budget goes back to files.
+# rows give way to folders. Unused folder budget goes back to files — and this is
+# a rule for SHARING the cap, not a ceiling on folders, so a search with no files
+# in it (kind "dir", or an index with no file partitions yet) gets the whole cap.
 SEARCH_DIRS_RESERVE = 100
 # Pages a branch may read while filling its budget. Gitignored rows can only be
 # recognised OUTSIDE SQL, so a page that screens down to nothing has to be
@@ -413,8 +415,13 @@ def _index_entries(cfg, spec, cap, *, parts=None, dirs=False):
 
     now_s = time.time()
     con = duckdb.connect()
+    # The reserve is a rule for SHARING the cap, so it only applies while both
+    # branches are live. A folder-only search — `kind: "dir"`, or an index whose
+    # file partitions are not there yet — has nothing competing with it and gets
+    # the whole cap, the same deal files get.
+    dirs_budget = min(SEARCH_DIRS_RESERVE, cap) if parts else cap
     dir_entries, dirs_more = (
-        _collect(con, _dirs_query(cfg, spec, now_s), min(SEARCH_DIRS_RESERVE, cap))
+        _collect(con, _dirs_query(cfg, spec, now_s), dirs_budget)
         if dirs else ([], False))
     # Files ask for the WHOLE cap and give back whatever the folders took, so an
     # unused folder reserve costs nothing.

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -1,75 +1,81 @@
 """POST /api/search/files — system-wide file search from a validated filter spec.
 
-The AI search on the explorer homepage translates a natural-language query
-into a small filter spec CLIENT-side (one /api/ai call); this endpoint is the
-execution half. Three engines answer it, in order, each labeled through
-`engine` in the response:
+The AI search on the explorer homepage translates a natural-language query into
+a small filter spec CLIENT-side (one /api/ai call); this endpoint is the
+execution half, and the app's own DuckDB/parquet index (`fused_render/index`) is
+the ONE engine that answers it. The index holds every fact the spec filters on —
+name, ext, size, mtime — so the whole spec becomes one SQL query over the `files`
+and `dirs` views and rows come back straight from parquet: no `stat`, no walk, no
+subprocess, and therefore no syscall a wedged mount could swallow.
 
-  * `index` — the app's own DuckDB/parquet index (fused_render/index). It holds
-    the same facts the spec filters on (name, ext, size, mtime), so the whole
-    spec becomes ONE SQL query and NOTHING is statted: no filesystem touch at
-    all, which also means no kernel syscall can be aimed at a wedged mount.
-  * `spotlight` — `mdfind` on macOS. Still the only whole-DISK engine, so it
-    covers what the index does not (the index scans the configured roots,
-    home by default) and answers anything the index declines.
-  * `walk` — the bounded home-dir walk (_walk_bfs), the last resort and the
-    only engine off macOS.
+There is deliberately NO fallback. Spotlight (`mdfind`) and the bounded home walk
+both used to sit behind this endpoint, and both are gone: two engines that answer
+the same query differently make the search box's results depend on which one ran,
+and the walk in particular re-statted the filesystem on every keystroke-driven
+query. The consequences are owned rather than papered over:
 
-SECURITY: the spec arrives from the client but ORIGINATES from a model, so
-every field is re-validated here as if hostile. The mdfind query string is
-assembled only from validated values — extensions/kind against closed
-charsets, numbers coerced, and name terms stripped of the two characters
-(backslash, double-quote) that could break out of an mdfind string literal.
-mdfind runs argv-style (no shell), and an empty spec is rejected rather than
-becoming a match-everything query. The index engine's SQL is assembled the same
-way: numbers are cast in Python, name terms go through `like_literal`, and the
-extension allowlist is re-checked at the point of interpolation.
+  * the index covers the CONFIGURED ROOTS (home by default), so this search is
+    no longer whole-disk. A path outside the roots is not findable here.
+  * a query that finds nothing returns an empty result — an honest miss, not a
+    cue to consult something wider.
+  * no index yet, or an index that cannot be read, is an ERROR (503 / 502) with
+    a message a search box can show. Reporting it as "no matches" would blame
+    the user's files for the app's state.
+  * `created_after` / `created_before` are REFUSED: the index stores `mtime` and
+    no birth time, and no engine is left that could stat for one. Only a stale
+    client can still send them; quietly searching by modification date instead
+    would answer a different question than the one asked.
+
+Freshness is deliberately not a gate — a scan in flight keeps serving its last
+completed generation, exactly as `query.FRESH_MAX_AGE_S` is informational for the
+explorer's in-folder corpus.
+
+SECURITY: the spec arrives from the client but ORIGINATES from a model, so every
+field is re-validated here as if hostile, and the SQL is assembled only from
+validated values — numbers cast in Python, name terms escaped with
+`like_literal`, extensions re-checked against a closed charset at the point of
+interpolation. An empty spec is rejected rather than becoming a
+match-everything query.
 """
 
 import logging
 import os
 import re
-import subprocess
-import sys
 import time
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Body
 from fastapi.concurrency import run_in_threadpool
 
-from fused_render._view_url_codec import canonical_fs_path
 from fused_render.index.config import load_config
 from fused_render.index.query import dirs_src, files_src
 from fused_render.index.store import like_literal, read_manifest
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle
-from fused_render.server.walk import _WALK_TRUNCATED, _walk_bfs, WALK_IGNORE_DIRS
+from fused_render.server.walk import WALK_IGNORE_DIRS
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
-# Result and runtime bounds. Spotlight can return tens of thousands of paths
-# for a broad query; the client shows ~60, so 400 leaves plenty of ranking
-# headroom without stat()ing the world.
+# Rows a search may return. A broad query can match tens of thousands of index
+# rows; the client shows ~60, so 400 leaves plenty of ranking headroom.
 SEARCH_MAX_RESULTS = 400
-SEARCH_MDFIND_TIMEOUT_S = 15.0
-# Fallback walk caps: the home dir is bigger than a workspace, so the walk
-# uses the same entry cap as /api/fs/walk but a shallower depth — deep hits
-# are unlikely search targets and shallow-first coverage matters more.
-SEARCH_WALK_MAX_ENTRIES = 200_000
-SEARCH_WALK_MAX_DEPTH = 12
 
 _EXT_ALLOWED = set("abcdefghijklmnopqrstuvwxyz0123456789")
 
-# Date-range spec fields: (key, mdfind attribute, is_range_end). Modified uses
-# the fs content-change date, created the fs creation date (birthtime).
-_DATE_FIELDS = (
-    ("modified_after", "kMDItemFSContentChangeDate", False),
-    ("modified_before", "kMDItemFSContentChangeDate", True),
-    ("created_after", "kMDItemFSCreationDate", False),
-    ("created_before", "kMDItemFSCreationDate", True),
-)
+# Date-range spec fields: (key, is_range_end). Modified only — see the module
+# docstring on created_*.
+_DATE_FIELDS = (("modified_after", False), ("modified_before", True))
+# Creation-date fields a stale client may still send. Named so they can be
+# refused explicitly instead of ignored.
+_REFUSED_DATE_FIELDS = ("created_after", "created_before")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class IndexUnavailable(RuntimeError):
+    """There is no index to search — no manifest, or nothing in it this spec
+    could be matched against. Distinct from a query FAILURE so the endpoint can
+    say "not ready yet" (503) rather than "broken" (502)."""
 
 
 def _day_bound_epoch(date_str: str, end: bool) -> float:
@@ -82,14 +88,13 @@ def _day_bound_epoch(date_str: str, end: bool) -> float:
     return datetime(d.year, d.month, d.day).astimezone().timestamp()
 
 
-def _time_iso(epoch: float) -> str:
-    """The mdfind $time.iso(...) literal for an epoch, in local offset form
-    (probed: mdfind accepts 2026-08-05T00:00:00+05:30)."""
-    return datetime.fromtimestamp(epoch).astimezone().isoformat()
-
-
 def _parse_spec(body: dict):
-    """Coerce the request body into a clean spec dict, or an error string."""
+    """Coerce the request body into a clean spec dict, or raise ValueError.
+
+    Fields the engine does not implement are IGNORED (`path_hints` is
+    client-side ranking only), with one exception: the creation-date fields are
+    refused outright, because dropping a date filter silently would answer a
+    different question than the caller asked."""
 
     def strings(key, limit, clean):
         raw = body.get(key)
@@ -114,8 +119,9 @@ def _parse_spec(body: dict):
             raise ValueError(f"'{key}' must be a positive number or null")
         return float(v)
 
-    # An mdfind string literal is "..."; only backslash and the quote itself
-    # can escape it, so stripping those two makes any term safe to embed.
+    # Backslash and double-quote are stripped rather than escaped: neither is
+    # meaningful to a substring match on a file name, and removing them keeps
+    # every term trivially safe to embed in whatever the engine builds.
     def clean_term(v):
         return v.replace("\\", "").replace('"', "").strip()
 
@@ -135,6 +141,11 @@ def _parse_spec(body: dict):
             raise ValueError(f"'{key}' is not a real date")
         return v
 
+    for key in _REFUSED_DATE_FIELDS:
+        if body.get(key) is not None:
+            raise ValueError(
+                f"'{key}' is not supported: the file index records modification "
+                f"time only. Use 'modified_after'/'modified_before'.")
     kind = body.get("kind", "any")
     if kind not in ("file", "dir", "any"):
         raise ValueError("'kind' must be 'file', 'dir', or 'any'")
@@ -148,74 +159,19 @@ def _parse_spec(body: dict):
         "min_size_bytes": pos_num("min_size_bytes"),
         "max_size_bytes": pos_num("max_size_bytes"),
     }
-    for key, _attr, _end in _DATE_FIELDS:
+    for key, _end in _DATE_FIELDS:
         spec[key] = date_str(key)
     return spec
 
 
-def _mdfind_query(spec) -> str | None:
-    """The Spotlight query for a spec, or None when the spec has no
-    constraints at all (a match-everything query is never intended)."""
-    pieces = []
-    if spec["name_terms"]:
-        # cd = case- and diacritic-insensitive. OR across terms: the model
-        # lists synonyms, and requiring all of them would over-filter.
-        terms = " || ".join(
-            f'kMDItemFSName = "*{t}*"cd' for t in spec["name_terms"]
-        )
-        pieces.append(f"({terms})")
-    if spec["extensions"]:
-        exts = " || ".join(
-            f'kMDItemFSName = "*.{e}"cd' for e in spec["extensions"]
-        )
-        pieces.append(f"({exts})")
-    if spec["kind"] == "dir":
-        pieces.append('kMDItemContentType == "public.folder"')
-    elif spec["kind"] == "file":
-        pieces.append('kMDItemContentType != "public.folder"')
-    if spec["modified_within_days"] is not None:
-        secs = int(spec["modified_within_days"] * 86400)
-        pieces.append(f"kMDItemFSContentChangeDate >= $time.now(-{secs})")
-    for key, attr, end in _DATE_FIELDS:
-        if spec[key] is not None:
-            epoch = _day_bound_epoch(spec[key], end)
-            op = "<" if end else ">="
-            pieces.append(f"{attr} {op} $time.iso({_time_iso(epoch)})")
-    if spec["min_size_bytes"] is not None:
-        pieces.append(f"kMDItemFSSize >= {int(spec['min_size_bytes'])}")
-    if spec["max_size_bytes"] is not None:
-        pieces.append(f"kMDItemFSSize <= {int(spec['max_size_bytes'])}")
-    # A kind-only query ("folders") still matches half the disk; require at
-    # least one NARROWING constraint beyond kind.
-    narrowing = [p for p in pieces if not p.startswith("kMDItemContentType")]
-    if not narrowing:
-        return None
-    return " && ".join(pieces)
-
-
-def _stat_entry(path):
-    """The response entry for one hit, or None when it can't be statted
-    (Spotlight's index can be ahead of the filesystem)."""
-    try:
-        st = os.stat(path)
-    except OSError:
-        return None
-    is_dir = os.path.isdir(path)
-    return {
-        "path": path,
-        "is_dir": is_dir,
-        "size": None if is_dir else st.st_size,
-        "mtime": st.st_mtime,
-    }
-
-
-# Path segments that mark a hit as machine-managed junk or hidden data.
-# Spotlight has no gitignore/hidden notion, so its hits are re-screened with
-# the same standards the walk enforces during traversal: WALK_IGNORE_DIRS
-# segments and dot-segments never surface (matching /api/fs/walk's default).
+# Path segments that mark a hit as machine-managed junk or hidden data. The
+# index's own ignore rules are a user-editable name list that says nothing about
+# hidden files, so hits are screened with the same standards the explorer's walk
+# enforces during traversal: WALK_IGNORE_DIRS segments and dot-segments never
+# surface (matching /api/fs/walk's default).
 def _junk_path(path: str) -> bool:
-    # Both separators: Spotlight hands back native paths, the index posix ones
-    # (index/ignore.norm), and one screening standard has to cover both.
+    # Both separators: the index stores posix paths (index/ignore.norm) whatever
+    # the platform, and one screening standard has to cover both spellings.
     for seg in re.split(r"[/\\]", path):
         if seg in WALK_IGNORE_DIRS:
             return True
@@ -272,14 +228,13 @@ def _drop_gitignored(entries):
     return [e for i, e in enumerate(entries) if i not in dropped]
 
 
-# ------------------------------------------------------------ index engine
+# ------------------------------------------------------------ the index engine
 
 # Spec fields that NARROW a query. `kind` is deliberately absent: "folders"
-# still matches half the disk, so it is not enough on its own (the same rule
-# _mdfind_query enforces by refusing a kind-only query).
+# still matches half the disk, so it is not enough on its own.
 _NARROWING_KEYS = (
     "modified_within_days", "modified_after", "modified_before",
-    "created_after", "created_before", "min_size_bytes", "max_size_bytes",
+    "min_size_bytes", "max_size_bytes",
 )
 
 
@@ -293,10 +248,8 @@ def _dir_narrowing(spec) -> bool:
 
     Extension and size are file facts a dirs row cannot answer, so an
     extensions-only spec ("find my mp4s") narrows the files view and nothing
-    else — and a dirs branch with no predicate left would return every folder
-    in the index, spending the result cap on rows that answer nothing. The
-    walk engine lets those dirs past too (_match_walk_entry), but it only ever
-    yields what it happens to reach; here it would be the whole index."""
+    else — and a dirs branch with no predicate left would return every folder in
+    the index, spending the result cap on rows that answer nothing."""
     return bool(spec["name_terms"]) or any(
         spec[k] is not None for k in
         ("modified_within_days", "modified_after", "modified_before"))
@@ -305,23 +258,22 @@ def _dir_narrowing(spec) -> bool:
 def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
                  ext_expr=None, size_expr=None) -> str:
     """The WHERE clause for one index view. `ext_expr`/`size_expr` are None for
-    the dirs view: extension and size are FILE facts, and _match_walk_entry
-    already lets a directory hit past both (the dirs table has no size column
-    at all).
+    the dirs view: extension and size are FILE facts, and the dirs table has no
+    size column at all.
 
-    Every value reaching SQL here is either a number cast in Python or a
-    name term escaped with `like_literal` (quotes doubled, LIKE metachars
-    escaped) — the model-originated half of the spec never lands in the
-    statement raw. See the module docstring's SECURITY note."""
-    # Dot segments never surface (parity with _junk_path and the walk). Applied
-    # in SQL as well as in _junk_path so the result cap is not spent on rows
-    # from ~/.cache that would be dropped a moment later; _junk_path stays the
-    # single standard, this is only a budget prefilter.
+    Every value reaching SQL here is either a number cast in Python or a name
+    term escaped with `like_literal` (quotes doubled, LIKE metachars escaped) —
+    the model-originated half of the spec never lands in the statement raw. See
+    the module docstring's SECURITY note."""
+    # Dot segments never surface (parity with _junk_path and the explorer's
+    # walk). Applied in SQL as well as in _junk_path so the result cap is not
+    # spent on rows from ~/.cache that would be dropped a moment later;
+    # _junk_path stays the single standard, this is only a budget prefilter.
     pieces = [f"{path_expr} NOT LIKE '%/.%'"]
     if spec["name_terms"]:
-        # Substring, case-insensitive, OR'd across terms — mirroring mdfind's
-        # `kMDItemFSName = "*term*"cd`. Recall matters more than precision:
-        # the client ranks these hits fuzzily anyway.
+        # Substring, case-insensitive, OR'd across terms: the model lists
+        # synonyms, and requiring all of them would over-filter. Recall matters
+        # more than precision — the client re-ranks these hits fuzzily.
         pieces.append("(" + " OR ".join(
             f"{name_expr} ILIKE '%{like_literal(t)}%' ESCAPE '\\'"
             for t in spec["name_terms"]) + ")")
@@ -335,8 +287,8 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
     if spec["modified_within_days"] is not None:
         cutoff = now_s - spec["modified_within_days"] * 86400
         pieces.append(f"{mtime_expr} >= {float(cutoff)!r}")
-    # The same local-day bounds the other two engines use: inclusive on both
-    # ends, so `before 2026-08-05` runs to the midnight AFTER the 5th.
+    # Local-day bounds, inclusive on both ends: `before 2026-08-05` runs to the
+    # midnight AFTER the 5th.
     if spec["modified_after"] is not None:
         pieces.append(f"{mtime_expr} >= "
                       f"{_day_bound_epoch(spec['modified_after'], False)!r}")
@@ -351,33 +303,29 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
     return " AND ".join(pieces)
 
 
-def _index_rows(cfg, manifest, spec, limit):
-    """The spec as ONE query over the index views, newest first, or None when
-    the index holds no view this `kind` could be answered from.
+def _index_rows(cfg, spec, limit, *, parts=None, dirs=False):
+    """The spec as ONE query over the requested index views, newest first.
 
-    Both views are read through the MANIFEST (query.files_src / dirs_src),
-    never a glob of the files dir: a compaction leaves the previous
-    generation's partitions on disk for readers still holding the old manifest
+    Both views are named through the MANIFEST (query.files_src / dirs_src),
+    never a glob of the files dir: a compaction leaves the previous generation's
+    partitions on disk for readers still holding the old manifest
     (index-store.md §4), so a glob would return every row twice."""
     import duckdb
 
     now_s = time.time()
     branches = []
-    parts = manifest.get("partitions") or []
-    if spec["kind"] in ("file", "any") and parts:
+    if parts:
         fsrc = files_src(cfg, parts)
         branches.append(
             f"SELECT path, size, mtime, false AS is_dir FROM {fsrc} WHERE "
             + _index_where(spec, path_expr="path", name_expr="name",
                            mtime_expr="mtime", ext_expr="ext",
                            size_expr="size", now_s=now_s))
-    if (spec["kind"] in ("dir", "any") and _dir_narrowing(spec)
-            and os.path.exists(cfg.dirs_parquet)):
+    if dirs:
         dsrc = dirs_src(cfg)
         # A dirs row carries no name column, so the final path component is the
         # name; mtime_ns of 0 means "unknown" and becomes NULL, which fails
-        # every mtime comparison — the same verdict _match_walk_entry gives a
-        # walk entry with no mtime.
+        # every mtime comparison rather than passing it.
         dmtime = "nullif(mtime_ns, 0) / 1e9"
         branches.append(
             f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, "
@@ -385,8 +333,6 @@ def _index_rows(cfg, manifest, spec, limit):
             + _index_where(spec, path_expr="dir",
                            name_expr="regexp_extract(dir, '[^/]*$')",
                            mtime_expr=dmtime, now_s=now_s))
-    if not branches:
-        return None
     # One row past the cap, so "there was more" is known without a count.
     # Newest first: the client re-ranks every hit anyway, so ordering only
     # decides WHICH rows survive the cap, and recency is the best sample.
@@ -396,49 +342,51 @@ def _index_rows(cfg, manifest, spec, limit):
 
 
 def _search_index(spec, cfg=None):
-    """The spec executed against the SQL index, or None when the index cannot
-    (or should not) answer it and the query belongs to Spotlight/the walk.
+    """The spec executed against the SQL index — the only engine.
 
-    Rows are returned straight from parquet — deliberately NOT re-statted the
-    way Spotlight hits are. That is the point of this engine: zero filesystem
-    syscalls, so a search can never touch (or wedge) a mount. The cost is that
-    a file deleted since the last scan can still appear, which is the same
-    staleness the index-backed in-folder search already accepts.
+    Rows are returned straight from parquet, deliberately NOT re-statted: that
+    is the point of this engine (zero filesystem syscalls, so a search can never
+    touch a mount). The cost is that a file deleted since the last scan can
+    still appear, the same staleness the index-backed in-folder search accepts.
 
-    Declines (returns None) when:
-      * there is no index yet, or the query errors (a corrupt/half-deleted
-        store must degrade to another engine, not to a 502);
-      * the spec carries created_after/created_before — the files table has
-        `mtime` and no birth time (index/store.schemas), and quietly dropping
-        the filter would answer a different question than the user asked;
-      * the spec asks only for directories but narrows nothing a dirs row can
-        answer (see _dir_narrowing);
-      * nothing matched. The index covers the CONFIGURED ROOTS (home by
-        default) while Spotlight covers the whole disk, so an empty result is
-        "ask the wider engine", not "no such file". A local miss costs one
-        extra mdfind; not doing this would make a query for something outside
-        home simply fail.
-
-    Freshness is deliberately NOT a gate: a scan in flight keeps serving its
-    last completed generation, exactly as query.FRESH_MAX_AGE_S is
-    informational for the in-folder corpus.
+    Raises, rather than quietly answering something narrower:
+      * `ValueError` — the spec narrows nothing (a match-everything query is
+        never intended), or it asks only for directories while narrowing only
+        file facts (see _dir_narrowing).
+      * `IndexUnavailable` — no manifest, or no view this `kind` could be
+        answered from. "Not ready", not "no matches".
+      * `RuntimeError` — the index is there but could not be read.
     """
     if not _has_narrowing(spec):
         raise ValueError("spec has no narrowing constraints")
-    if spec["created_after"] is not None or spec["created_before"] is not None:
-        return None
     cfg = load_config() if cfg is None else cfg
     manifest = read_manifest(cfg)
     if manifest is None:
-        return None
+        raise IndexUnavailable(
+            "the file index has not been built yet — search works once the "
+            "first scan finishes")
+    parts = (manifest.get("partitions") or []) if spec["kind"] != "dir" else []
+    dirs = spec["kind"] in ("dir", "any") and os.path.exists(cfg.dirs_parquet)
+    if dirs and not _dir_narrowing(spec):
+        # kind "any" simply drops the dirs half; a folder-only search with
+        # nothing a folder can be matched by has no answer to give, and there is
+        # no wider engine to pass it to.
+        if spec["kind"] == "dir":
+            raise ValueError(
+                "searching for folders needs a name or a date — extension and "
+                "size only narrow files")
+        dirs = False
+    if not parts and not dirs:
+        raise IndexUnavailable(
+            "the file index holds nothing this search could match yet — it may "
+            "still be scanning")
     cap = SEARCH_MAX_RESULTS
     try:
-        rows = _index_rows(cfg, manifest, spec, cap + 1)
-    except Exception:  # noqa: BLE001 - any index failure is a fallback, not a 502
-        logger.exception("index search failed; falling back to another engine")
-        return None
-    if rows is None:
-        return None
+        rows = _index_rows(cfg, spec, cap + 1, parts=parts, dirs=dirs)
+    except Exception as e:  # noqa: BLE001 - duckdb's exception tree, flattened
+        logger.exception("the index search query failed")
+        raise RuntimeError(
+            f"the file index could not be searched: {type(e).__name__}") from e
     truncated = len(rows) > cap
     entries = [
         {"path": path, "is_dir": bool(is_dir),
@@ -447,150 +395,15 @@ def _search_index(spec, cfg=None):
         for path, size, mtime, is_dir in rows[:cap]
         if not _junk_path(path)
     ]
-    # The index knows nothing about git (its ignore rules are name patterns),
-    # so gitignored hits are screened here — the same oracle the walk and
-    # Spotlight use, and the same reason server/index_gitignore.py filters the
-    # in-folder corpus: two interchangeable sources must not disagree.
-    entries = _drop_gitignored(entries)
-    if not entries:
-        return None
-    return {"entries": entries, "truncated": truncated, "engine": "index"}
-
-
-def _search_mdfind(spec):
-    query = _mdfind_query(spec)
-    if query is None:
-        raise ValueError("spec has no narrowing constraints")
-    # mdfind has been seen to die with SIGSEGV depending on the launch
-    # context; a signal death (negative returncode) gets one retry before
-    # the caller falls back to the walk engine.
-    for attempt in (1, 2):
-        try:
-            proc = subprocess.run(
-                ["mdfind", "-0", query],
-                capture_output=True,
-                timeout=SEARCH_MDFIND_TIMEOUT_S,
-            )
-        except subprocess.TimeoutExpired:
-            raise RuntimeError("Spotlight search timed out")
-        except FileNotFoundError:
-            raise RuntimeError("mdfind not available")
-        if proc.returncode >= 0 or attempt == 2:
-            break
-    if proc.returncode != 0:
-        err = proc.stderr.decode("utf-8", "replace").strip()
-        raise RuntimeError(f"mdfind failed: {err or proc.returncode}")
-    paths = [p for p in proc.stdout.decode("utf-8", "replace").split("\0") if p]
-    kept = [p for p in paths if not _junk_path(p)]
-    truncated = len(kept) > SEARCH_MAX_RESULTS
-    entries = []
-    for p in kept[:SEARCH_MAX_RESULTS]:
-        e = _stat_entry(p)
-        if e is not None:
-            entries.append(e)
-    entries = _drop_gitignored(entries)
-    return {"entries": entries, "truncated": truncated, "engine": "spotlight"}
-
-
-def _match_walk_entry(entry, spec, now_s):
-    """The fallback walk applies the spec's HARD filters server-side; name
-    terms stay client-side (the client ranks fuzzily either way)."""
-    if spec["kind"] == "file" and entry["is_dir"]:
-        return False
-    if spec["kind"] == "dir" and not entry["is_dir"]:
-        return False
-    if not entry["is_dir"] and spec["extensions"]:
-        ext = entry["rel"].rsplit(".", 1)
-        if len(ext) != 2 or ext[1].lower() not in spec["extensions"]:
-            return False
-    if spec["modified_within_days"] is not None:
-        cutoff = now_s - spec["modified_within_days"] * 86400
-        if entry["mtime"] is None or entry["mtime"] < cutoff:
-            return False
-    if spec["modified_after"] is not None:
-        if entry["mtime"] is None or entry["mtime"] < _day_bound_epoch(spec["modified_after"], False):
-            return False
-    if spec["modified_before"] is not None:
-        if entry["mtime"] is None or entry["mtime"] >= _day_bound_epoch(spec["modified_before"], True):
-            return False
-    if not entry["is_dir"]:
-        size = entry["size"] or 0
-        if spec["min_size_bytes"] is not None and size < spec["min_size_bytes"]:
-            return False
-        if spec["max_size_bytes"] is not None and size > spec["max_size_bytes"]:
-            return False
-    return True
-
-
-def _created_epoch(path: str) -> float | None:
-    """Best-effort creation time: st_birthtime where the OS has one (macOS,
-    some BSDs), st_ctime on Windows (creation there), else None."""
-    try:
-        st = os.stat(path)
-    except OSError:
-        return None
-    birth = getattr(st, "st_birthtime", None)
-    if birth is not None:
-        return birth
-    return st.st_ctime if sys.platform == "win32" else None
-
-
-def _match_created_range(path: str, spec) -> bool:
-    """Created-range check for the walk engine (walk entries carry no
-    creation time, so it costs a stat — only paid when the spec asks). On a
-    platform with no creation time the filter is skipped rather than
-    silently emptying every search."""
-    if spec["created_after"] is None and spec["created_before"] is None:
-        return True
-    created = _created_epoch(path)
-    if created is None:
-        return True
-    if spec["created_after"] is not None:
-        if created < _day_bound_epoch(spec["created_after"], False):
-            return False
-    if spec["created_before"] is not None:
-        if created >= _day_bound_epoch(spec["created_before"], True):
-            return False
-    return True
-
-
-def _search_walk_home(spec):
-    home = os.path.expanduser("~")
-    now_s = time.time()
-    entries = []
-    truncated = False
-    walker = _walk_bfs(
-        home,
-        False,
-        max_entries=SEARCH_WALK_MAX_ENTRIES,
-        max_depth=SEARCH_WALK_MAX_DEPTH,
-    )
-    for entry in walker:
-        if entry is _WALK_TRUNCATED:
-            truncated = True
-            continue
-        if not _match_walk_entry(entry, spec, now_s):
-            continue
-        abs_path = os.path.join(home, entry["rel"].replace("/", os.sep))
-        if not _match_created_range(abs_path, spec):
-            continue
-        entries.append(
-            {
-                # Canonicalized (forward slashes) for the response: the
-                # client strips `home` with a "/" join and its path helpers
-                # are forward-slash-only, matching every other fs path the
-                # runtime hands them. `abs_path` above stays native for the
-                # stat call.
-                "path": canonical_fs_path(abs_path),
-                "is_dir": entry["is_dir"],
-                "size": entry["size"],
-                "mtime": entry["mtime"],
-            }
-        )
-        if len(entries) >= SEARCH_MAX_RESULTS:
-            truncated = True
-            break
-    return {"entries": entries, "truncated": truncated, "engine": "walk"}
+    # The index knows nothing about git (its ignore rules are name patterns), so
+    # gitignored hits are screened here — the same oracle the explorer's walk
+    # uses, and the same reason server/index_gitignore.py filters the in-folder
+    # corpus: a build directory's 100k generated files must not flood a search.
+    return {"entries": _drop_gitignored(entries), "truncated": truncated,
+            # Constant now that the index is the only engine. Kept in the
+            # response because old clients read it, and because a support
+            # question about a surprising result starts with "what answered it".
+            "engine": "index"}
 
 
 @router.post("/api/search/files")
@@ -599,24 +412,15 @@ async def api_search_files(body: dict = Body(...)):
         spec = _parse_spec(body)
     except ValueError as e:
         return _error(str(e))
-    # Every engine blocks (duckdb / subprocess / disk walk); keep the event loop
-    # free. The index answers first when it can; anything it declines (no index,
-    # a created_* filter, zero hits — see _search_index) falls through to
-    # Spotlight, and a Spotlight failure (crash, timeout, missing mdfind)
-    # degrades to the home walk rather than a 502 — narrower coverage, labeled
-    # via `engine`, beats a dead search box.
+    # duckdb blocks, so it runs off the event loop. Every failure is REPORTED:
+    # there is no second engine to degrade to, and a search box that says
+    # "no matches" when the index is missing would be lying about the disk.
     try:
         result = await run_in_threadpool(_search_index, spec)
-        if result is None:
-            if sys.platform == "darwin":
-                try:
-                    result = await run_in_threadpool(_search_mdfind, spec)
-                except RuntimeError:
-                    result = await run_in_threadpool(_search_walk_home, spec)
-            else:
-                result = await run_in_threadpool(_search_walk_home, spec)
     except ValueError as e:
         return _error(str(e))
+    except IndexUnavailable as e:
+        return _error(str(e), status=503)
     except RuntimeError as e:
         return _error(str(e), status=502)
     return {"ok": True, **result}

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -2,11 +2,18 @@
 
 The AI search on the explorer homepage translates a natural-language query
 into a small filter spec CLIENT-side (one /api/ai call); this endpoint is the
-execution half. On macOS it queries Spotlight (`mdfind`) — the only engine
-with a whole-disk index, so "video downloaded today" can find ~/Downloads
-without walking the filesystem. Elsewhere it falls back to the bounded
-home-dir walk (_walk_bfs), which is honest about its narrower coverage via
-`engine` in the response.
+execution half. Three engines answer it, in order, each labeled through
+`engine` in the response:
+
+  * `index` — the app's own DuckDB/parquet index (fused_render/index). It holds
+    the same facts the spec filters on (name, ext, size, mtime), so the whole
+    spec becomes ONE SQL query and NOTHING is statted: no filesystem touch at
+    all, which also means no kernel syscall can be aimed at a wedged mount.
+  * `spotlight` — `mdfind` on macOS. Still the only whole-DISK engine, so it
+    covers what the index does not (the index scans the configured roots,
+    home by default) and answers anything the index declines.
+  * `walk` — the bounded home-dir walk (_walk_bfs), the last resort and the
+    only engine off macOS.
 
 SECURITY: the spec arrives from the client but ORIGINATES from a model, so
 every field is re-validated here as if hostile. The mdfind query string is
@@ -14,9 +21,12 @@ assembled only from validated values — extensions/kind against closed
 charsets, numbers coerced, and name terms stripped of the two characters
 (backslash, double-quote) that could break out of an mdfind string literal.
 mdfind runs argv-style (no shell), and an empty spec is rejected rather than
-becoming a match-everything query.
+becoming a match-everything query. The index engine's SQL is assembled the same
+way: numbers are cast in Python, name terms go through `like_literal`, and the
+extension allowlist is re-checked at the point of interpolation.
 """
 
+import logging
 import os
 import re
 import subprocess
@@ -28,10 +38,14 @@ from fastapi import APIRouter, Body
 from fastapi.concurrency import run_in_threadpool
 
 from fused_render._view_url_codec import canonical_fs_path
+from fused_render.index.config import load_config
+from fused_render.index.query import dirs_src, files_src
+from fused_render.index.store import like_literal, read_manifest
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle
 from fused_render.server.walk import _WALK_TRUNCATED, _walk_bfs, WALK_IGNORE_DIRS
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Result and runtime bounds. Spotlight can return tens of thousands of paths
@@ -200,7 +214,9 @@ def _stat_entry(path):
 # the same standards the walk enforces during traversal: WALK_IGNORE_DIRS
 # segments and dot-segments never surface (matching /api/fs/walk's default).
 def _junk_path(path: str) -> bool:
-    for seg in path.split(os.sep):
+    # Both separators: Spotlight hands back native paths, the index posix ones
+    # (index/ignore.norm), and one screening standard has to cover both.
+    for seg in re.split(r"[/\\]", path):
         if seg in WALK_IGNORE_DIRS:
             return True
         if seg.startswith(".") and seg not in (".", ".."):
@@ -254,6 +270,191 @@ def _drop_gitignored(entries):
         finally:
             oracle.close()
     return [e for i, e in enumerate(entries) if i not in dropped]
+
+
+# ------------------------------------------------------------ index engine
+
+# Spec fields that NARROW a query. `kind` is deliberately absent: "folders"
+# still matches half the disk, so it is not enough on its own (the same rule
+# _mdfind_query enforces by refusing a kind-only query).
+_NARROWING_KEYS = (
+    "modified_within_days", "modified_after", "modified_before",
+    "created_after", "created_before", "min_size_bytes", "max_size_bytes",
+)
+
+
+def _has_narrowing(spec) -> bool:
+    return bool(spec["name_terms"] or spec["extensions"]) or any(
+        spec[k] is not None for k in _NARROWING_KEYS)
+
+
+def _dir_narrowing(spec) -> bool:
+    """Whether anything in the spec narrows DIRECTORIES.
+
+    Extension and size are file facts a dirs row cannot answer, so an
+    extensions-only spec ("find my mp4s") narrows the files view and nothing
+    else — and a dirs branch with no predicate left would return every folder
+    in the index, spending the result cap on rows that answer nothing. The
+    walk engine lets those dirs past too (_match_walk_entry), but it only ever
+    yields what it happens to reach; here it would be the whole index."""
+    return bool(spec["name_terms"]) or any(
+        spec[k] is not None for k in
+        ("modified_within_days", "modified_after", "modified_before"))
+
+
+def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
+                 ext_expr=None, size_expr=None) -> str:
+    """The WHERE clause for one index view. `ext_expr`/`size_expr` are None for
+    the dirs view: extension and size are FILE facts, and _match_walk_entry
+    already lets a directory hit past both (the dirs table has no size column
+    at all).
+
+    Every value reaching SQL here is either a number cast in Python or a
+    name term escaped with `like_literal` (quotes doubled, LIKE metachars
+    escaped) — the model-originated half of the spec never lands in the
+    statement raw. See the module docstring's SECURITY note."""
+    # Dot segments never surface (parity with _junk_path and the walk). Applied
+    # in SQL as well as in _junk_path so the result cap is not spent on rows
+    # from ~/.cache that would be dropped a moment later; _junk_path stays the
+    # single standard, this is only a budget prefilter.
+    pieces = [f"{path_expr} NOT LIKE '%/.%'"]
+    if spec["name_terms"]:
+        # Substring, case-insensitive, OR'd across terms — mirroring mdfind's
+        # `kMDItemFSName = "*term*"cd`. Recall matters more than precision:
+        # the client ranks these hits fuzzily anyway.
+        pieces.append("(" + " OR ".join(
+            f"{name_expr} ILIKE '%{like_literal(t)}%' ESCAPE '\\'"
+            for t in spec["name_terms"]) + ")")
+    if ext_expr is not None and spec["extensions"]:
+        # clean_ext restricts these to [a-z0-9]{1,12}; re-checked here so the
+        # literal is provably quote-free however this spec was built.
+        exts = [e for e in spec["extensions"] if set(e) <= _EXT_ALLOWED]
+        if exts:
+            pieces.append(f"lower({ext_expr}) IN ("
+                          + ",".join(f"'{e}'" for e in exts) + ")")
+    if spec["modified_within_days"] is not None:
+        cutoff = now_s - spec["modified_within_days"] * 86400
+        pieces.append(f"{mtime_expr} >= {float(cutoff)!r}")
+    # The same local-day bounds the other two engines use: inclusive on both
+    # ends, so `before 2026-08-05` runs to the midnight AFTER the 5th.
+    if spec["modified_after"] is not None:
+        pieces.append(f"{mtime_expr} >= "
+                      f"{_day_bound_epoch(spec['modified_after'], False)!r}")
+    if spec["modified_before"] is not None:
+        pieces.append(f"{mtime_expr} < "
+                      f"{_day_bound_epoch(spec['modified_before'], True)!r}")
+    if size_expr is not None:
+        if spec["min_size_bytes"] is not None:
+            pieces.append(f"{size_expr} >= {int(spec['min_size_bytes'])}")
+        if spec["max_size_bytes"] is not None:
+            pieces.append(f"{size_expr} <= {int(spec['max_size_bytes'])}")
+    return " AND ".join(pieces)
+
+
+def _index_rows(cfg, manifest, spec, limit):
+    """The spec as ONE query over the index views, newest first, or None when
+    the index holds no view this `kind` could be answered from.
+
+    Both views are read through the MANIFEST (query.files_src / dirs_src),
+    never a glob of the files dir: a compaction leaves the previous
+    generation's partitions on disk for readers still holding the old manifest
+    (index-store.md §4), so a glob would return every row twice."""
+    import duckdb
+
+    now_s = time.time()
+    branches = []
+    parts = manifest.get("partitions") or []
+    if spec["kind"] in ("file", "any") and parts:
+        fsrc = files_src(cfg, parts)
+        branches.append(
+            f"SELECT path, size, mtime, false AS is_dir FROM {fsrc} WHERE "
+            + _index_where(spec, path_expr="path", name_expr="name",
+                           mtime_expr="mtime", ext_expr="ext",
+                           size_expr="size", now_s=now_s))
+    if (spec["kind"] in ("dir", "any") and _dir_narrowing(spec)
+            and os.path.exists(cfg.dirs_parquet)):
+        dsrc = dirs_src(cfg)
+        # A dirs row carries no name column, so the final path component is the
+        # name; mtime_ns of 0 means "unknown" and becomes NULL, which fails
+        # every mtime comparison — the same verdict _match_walk_entry gives a
+        # walk entry with no mtime.
+        dmtime = "nullif(mtime_ns, 0) / 1e9"
+        branches.append(
+            f"SELECT dir AS path, CAST(NULL AS BIGINT) AS size, "
+            f"{dmtime} AS mtime, true AS is_dir FROM {dsrc} WHERE "
+            + _index_where(spec, path_expr="dir",
+                           name_expr="regexp_extract(dir, '[^/]*$')",
+                           mtime_expr=dmtime, now_s=now_s))
+    if not branches:
+        return None
+    # One row past the cap, so "there was more" is known without a count.
+    # Newest first: the client re-ranks every hit anyway, so ordering only
+    # decides WHICH rows survive the cap, and recency is the best sample.
+    return duckdb.connect().execute(
+        " UNION ALL ".join(branches)
+        + f" ORDER BY mtime DESC LIMIT {int(limit)}").fetchall()
+
+
+def _search_index(spec, cfg=None):
+    """The spec executed against the SQL index, or None when the index cannot
+    (or should not) answer it and the query belongs to Spotlight/the walk.
+
+    Rows are returned straight from parquet — deliberately NOT re-statted the
+    way Spotlight hits are. That is the point of this engine: zero filesystem
+    syscalls, so a search can never touch (or wedge) a mount. The cost is that
+    a file deleted since the last scan can still appear, which is the same
+    staleness the index-backed in-folder search already accepts.
+
+    Declines (returns None) when:
+      * there is no index yet, or the query errors (a corrupt/half-deleted
+        store must degrade to another engine, not to a 502);
+      * the spec carries created_after/created_before — the files table has
+        `mtime` and no birth time (index/store.schemas), and quietly dropping
+        the filter would answer a different question than the user asked;
+      * the spec asks only for directories but narrows nothing a dirs row can
+        answer (see _dir_narrowing);
+      * nothing matched. The index covers the CONFIGURED ROOTS (home by
+        default) while Spotlight covers the whole disk, so an empty result is
+        "ask the wider engine", not "no such file". A local miss costs one
+        extra mdfind; not doing this would make a query for something outside
+        home simply fail.
+
+    Freshness is deliberately NOT a gate: a scan in flight keeps serving its
+    last completed generation, exactly as query.FRESH_MAX_AGE_S is
+    informational for the in-folder corpus.
+    """
+    if not _has_narrowing(spec):
+        raise ValueError("spec has no narrowing constraints")
+    if spec["created_after"] is not None or spec["created_before"] is not None:
+        return None
+    cfg = load_config() if cfg is None else cfg
+    manifest = read_manifest(cfg)
+    if manifest is None:
+        return None
+    cap = SEARCH_MAX_RESULTS
+    try:
+        rows = _index_rows(cfg, manifest, spec, cap + 1)
+    except Exception:  # noqa: BLE001 - any index failure is a fallback, not a 502
+        logger.exception("index search failed; falling back to another engine")
+        return None
+    if rows is None:
+        return None
+    truncated = len(rows) > cap
+    entries = [
+        {"path": path, "is_dir": bool(is_dir),
+         "size": None if is_dir or size is None else int(size),
+         "mtime": None if mtime is None else float(mtime)}
+        for path, size, mtime, is_dir in rows[:cap]
+        if not _junk_path(path)
+    ]
+    # The index knows nothing about git (its ignore rules are name patterns),
+    # so gitignored hits are screened here — the same oracle the walk and
+    # Spotlight use, and the same reason server/index_gitignore.py filters the
+    # in-folder corpus: two interchangeable sources must not disagree.
+    entries = _drop_gitignored(entries)
+    if not entries:
+        return None
+    return {"entries": entries, "truncated": truncated, "engine": "index"}
 
 
 def _search_mdfind(spec):
@@ -398,18 +599,22 @@ async def api_search_files(body: dict = Body(...)):
         spec = _parse_spec(body)
     except ValueError as e:
         return _error(str(e))
-    # Both engines block (subprocess / disk walk); keep the event loop free.
-    # A Spotlight failure (crash, timeout, missing mdfind) degrades to the
-    # home-walk engine rather than a 502 — narrower coverage, labeled via
-    # `engine`, beats a dead search box.
+    # Every engine blocks (duckdb / subprocess / disk walk); keep the event loop
+    # free. The index answers first when it can; anything it declines (no index,
+    # a created_* filter, zero hits — see _search_index) falls through to
+    # Spotlight, and a Spotlight failure (crash, timeout, missing mdfind)
+    # degrades to the home walk rather than a 502 — narrower coverage, labeled
+    # via `engine`, beats a dead search box.
     try:
-        if sys.platform == "darwin":
-            try:
-                result = await run_in_threadpool(_search_mdfind, spec)
-            except RuntimeError:
+        result = await run_in_threadpool(_search_index, spec)
+        if result is None:
+            if sys.platform == "darwin":
+                try:
+                    result = await run_in_threadpool(_search_mdfind, spec)
+                except RuntimeError:
+                    result = await run_in_threadpool(_search_walk_home, spec)
+            else:
                 result = await run_in_threadpool(_search_walk_home, spec)
-        else:
-            result = await run_in_threadpool(_search_walk_home, spec)
     except ValueError as e:
         return _error(str(e))
     except RuntimeError as e:

--- a/fused_render/server/walk.py
+++ b/fused_render/server/walk.py
@@ -4,7 +4,7 @@ import stat as stat_mod
 import sys
 from types import SimpleNamespace
 
-from fused_render.index.ignore import SHARED_IGNORE_DIRS
+from fused_render.index.ignore import LEAF_DIR_SUFFIXES, SHARED_IGNORE_DIRS
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle, _repo_toplevel
 
@@ -99,7 +99,11 @@ WALK_MAX_ORACLES = 8
 # macOS package directories: emitted as a single (dir) entry but never
 # descended — their internals are implementation details (Finder hides them
 # too), and one Electron .app alone can be thousands of files.
-WALK_LEAF_DIR_SUFFIXES = (".app", ".framework", ".bundle", ".photoslibrary")
+# Defined once in index/ignore.py for the same reason WALK_IGNORE_DIRS is: the
+# index applies the identical leaf rule, and a package descended by one corpus
+# source but not the other flips results between two sources meant to be
+# interchangeable.
+WALK_LEAF_DIR_SUFFIXES = LEAF_DIR_SUFFIXES
 
 
 class _RcDirEntry:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,17 @@ def _no_startup_index_scan(monkeypatch):
         return None
 
     monkeypatch.setattr(index_routes, "startup_scan", _skip)
+    # Same hazard by a second door: GET /api/fs/list notes the folder for the
+    # index freshness check (scan-incremental.md §5), which runs on a background
+    # thread and can call runner.start. A test listing any path under the
+    # developer's real home would therefore spawn a detached whole-home scan —
+    # a leaked thread that outlives the test and reads whatever
+    # FUSED_RENDER_HOME has moved on to, exactly as above.
+    #
+    # The tests that are ABOUT the check call `_run_freshness_check` /
+    # `freshness.note_folder_opened` directly with their own config
+    # (tests/test_index_api.py, tests/test_index_freshness.py).
+    monkeypatch.setattr(index_routes, "note_folder_opened", lambda path: False)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -724,6 +724,158 @@ def test_a_stale_open_folder_gets_its_configured_root_rescanned(
     assert started == [str(src)]
 
 
+# -- guarded SQL ---------------------------------------------------------------
+
+def _indexed_client(tmp_path, dirs=None):
+    """A client whose index holds one real dirs row, so SQL has something to
+    read."""
+    cfg = load_config()
+    _write_dirs_index(cfg, dirs or {str(tmp_path): 1})
+    return _client(tmp_path)
+
+
+@pytest.mark.parametrize("path,body", [
+    ("/api/index/query", {"sql": "SELECT 1"}),
+    ("/api/index/ask", {"prompt": "how many files"}),
+])
+def test_the_query_routes_require_the_fused_header(home, tmp_path, path, body):
+    """Read-only, but they execute a caller-shaped statement — so they are
+    POST-only and guarded, unlike GET /search."""
+    resp = _client(tmp_path).post(path, json=body)
+    assert resp.status_code == 403
+
+
+def test_query_answers_a_select_over_the_index(home, tmp_path):
+    client = _indexed_client(tmp_path)
+    body = client.post("/api/index/query",
+                       json={"sql": "SELECT count(*) AS n FROM dirs"},
+                       headers={"X-Fused": "1"}).json()
+    assert body["ok"] is True
+    assert body["columns"] == ["n"]
+    assert body["rows"] == [[1]]
+    assert body["truncated"] is False
+
+
+def test_query_rejects_a_mutation_with_a_400(home, tmp_path):
+    resp = _indexed_client(tmp_path).post(
+        "/api/index/query", json={"sql": "DELETE FROM files"},
+        headers={"X-Fused": "1"})
+    assert resp.status_code == 400
+    assert "read-only" in resp.json()["error"]
+
+
+def test_query_rejects_a_missing_or_non_string_sql(home, tmp_path):
+    client = _indexed_client(tmp_path)
+    for body in ({}, {"sql": 5}, {"sql": "   "}):
+        resp = client.post("/api/index/query", json=body,
+                           headers={"X-Fused": "1"})
+        assert resp.status_code == 400
+
+
+def test_query_enforces_the_row_cap_server_side(home, tmp_path):
+    """The client's `limit` is a request, not an instruction."""
+    client = _indexed_client(tmp_path)
+    body = client.post("/api/index/query",
+                       json={"sql": "SELECT * FROM range(50) t(i)",
+                             "limit": 10 ** 9},
+                       headers={"X-Fused": "1"}).json()
+    assert len(body["rows"]) == 50  # answered, and under the server cap
+    body = client.post("/api/index/query",
+                       json={"sql": "SELECT * FROM range(50) t(i)",
+                             "limit": 3},
+                       headers={"X-Fused": "1"}).json()
+    assert len(body["rows"]) == 3
+    assert body["truncated"] is True
+
+
+def test_a_duckdb_runtime_error_is_a_400_not_a_500(home, tmp_path):
+    resp = _indexed_client(tmp_path).post(
+        "/api/index/query", json={"sql": "SELECT nope FROM dirs"},
+        headers={"X-Fused": "1"})
+    assert resp.status_code == 400
+    assert "nope" in resp.json()["error"]
+
+
+# -- natural language ----------------------------------------------------------
+
+def _fake_relay(answer, seen=None):
+    """Stands in for server.ai._ai_relay: one non-streaming completion."""
+    from fastapi.responses import JSONResponse
+
+    async def relay(body):
+        if seen is not None:
+            seen.append(body)
+        return JSONResponse({"ok": True, "result": {"text": answer,
+                                                    "model": "m", "usage": {}}})
+
+    return relay
+
+
+def test_ask_runs_the_sql_the_model_returned_and_echoes_it(home, tmp_path,
+                                                           monkeypatch):
+    seen = []
+    monkeypatch.setattr(index_router._server_ai, "_ai_relay",
+                        _fake_relay("```sql\nSELECT count(*) AS n FROM dirs;\n```",
+                                    seen))
+    body = _indexed_client(tmp_path).post(
+        "/api/index/ask", json={"prompt": "how many folders"},
+        headers={"X-Fused": "1"}).json()
+    assert body["ok"] is True
+    assert body["sql"] == "SELECT count(*) AS n FROM dirs;"
+    assert body["rows"] == [[1]]
+    # The schemas have to reach the model, or it cannot write a valid statement.
+    assert "files" in seen[0]["system_prompt"]
+    assert "mtime_ns" in seen[0]["system_prompt"]
+    assert seen[0]["stream"] is False
+
+
+def test_ask_does_not_execute_a_mutation_the_model_wrote(home, tmp_path,
+                                                        monkeypatch):
+    """The guard is the boundary, not the prompt: a model that answers with a
+    DELETE is refused by the same gate a user's DELETE hits."""
+    monkeypatch.setattr(index_router._server_ai, "_ai_relay",
+                        _fake_relay("DELETE FROM files"))
+    resp = _indexed_client(tmp_path).post(
+        "/api/index/ask", json={"prompt": "delete everything"},
+        headers={"X-Fused": "1"})
+    assert resp.status_code == 400
+    assert "read-only" in resp.json()["error"]
+    # The SQL is echoed even when refused, so the user can see what was tried.
+    assert resp.json()["sql"] == "DELETE FROM files"
+
+
+def test_ask_passes_an_ai_failure_through_unchanged(home, tmp_path, monkeypatch):
+    from fastapi.responses import JSONResponse
+
+    async def broken(_body):
+        return JSONResponse({"ok": False, "error": {"type": "ai_unavailable",
+                                                    "message": "no claude"}},
+                            status_code=502)
+
+    monkeypatch.setattr(index_router._server_ai, "_ai_relay", broken)
+    resp = _indexed_client(tmp_path).post(
+        "/api/index/ask", json={"prompt": "anything"},
+        headers={"X-Fused": "1"})
+    assert resp.status_code == 502
+    assert resp.json()["error"]["type"] == "ai_unavailable"
+
+
+def test_ask_rejects_an_empty_prompt(home, tmp_path):
+    resp = _indexed_client(tmp_path).post(
+        "/api/index/ask", json={"prompt": "  "}, headers={"X-Fused": "1"})
+    assert resp.status_code == 400
+
+
+@pytest.mark.parametrize("answer,expected", [
+    ("```sql\nSELECT 1\n```", "SELECT 1"),
+    ("```\nSELECT 1\n```", "SELECT 1"),
+    ("SELECT 1", "SELECT 1"),
+    ("Here you go:\n```sql\nSELECT 1\n```\nHope that helps.", "SELECT 1"),
+])
+def test_the_models_fencing_is_stripped(answer, expected):
+    assert index_router._sql_from_answer(answer) == expected
+
+
 def _write_dirs_index(cfg, dirs):
     """A minimal real index whose dirs.parquet holds {dir: mtime_ns}."""
     import pyarrow as pa

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -866,6 +866,36 @@ def test_ask_passes_an_ai_failure_through_unchanged(home, tmp_path, monkeypatch)
     assert resp.json()["error"]["type"] == "ai_unavailable"
 
 
+def test_ask_runs_the_guarded_query_off_the_event_loop(home, tmp_path, monkeypatch):
+    """`ask` is an async handler, so anything it calls directly runs ON the
+    event loop — and the guarded query is duckdb plus disk, bounded only by
+    TIMEOUT_S (10s). Blocking there freezes every other request in the server,
+    including the scan-status polling the same panel is doing. `query` next
+    door is safe only because it is a plain `def` handler, which FastAPI runs
+    in a threadpool; this one has to ask for that explicitly."""
+    import asyncio
+
+    seen = {}
+    real = index_router.run_guarded
+
+    def spy(*a, **kw):
+        try:
+            asyncio.get_running_loop()
+            seen["on_loop"] = True
+        except RuntimeError:
+            seen["on_loop"] = False
+        return real(*a, **kw)
+
+    monkeypatch.setattr(index_router, "run_guarded", spy)
+    monkeypatch.setattr(index_router._server_ai, "_ai_relay",
+                        _fake_relay("SELECT count(*) AS n FROM dirs"))
+    body = _indexed_client(tmp_path).post(
+        "/api/index/ask", json={"prompt": "how many folders"},
+        headers={"X-Fused": "1"}).json()
+    assert body["ok"] is True
+    assert seen["on_loop"] is False
+
+
 def test_ask_rejects_an_empty_prompt(home, tmp_path):
     resp = _indexed_client(tmp_path).post(
         "/api/index/ask", json={"prompt": "  "}, headers={"X-Fused": "1"})

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -13,6 +13,9 @@ from fused_render.index import runner
 from fused_render.index.config import IndexConfig, load_config
 from fused_render.server import create_app
 from fused_render.server.routers import index as index_router
+from fused_render.server.routers.index import (
+    note_folder_opened as _real_note_folder_opened,
+)
 
 
 class _FakePopen:
@@ -690,12 +693,15 @@ def test_the_freshness_check_runs_at_most_one_at_a_time(home, tmp_path,
     threads = []
     monkeypatch.setattr(index_router.threading, "Thread",
                         lambda **kw: threads.append(kw) or _FakeThread())
-    assert index_router.note_folder_opened(str(tmp_path)) is True
-    assert index_router.note_folder_opened(str(tmp_path)) is False
+    # The REAL function, bound at import: conftest's _no_startup_index_scan
+    # replaces the module attribute for every test, so that this hook cannot
+    # spawn a home scan from a suite that merely lists a directory.
+    assert _real_note_folder_opened(str(tmp_path)) is True
+    assert _real_note_folder_opened(str(tmp_path)) is False
     assert len(threads) == 1
     # The slot frees once the check finishes, so the next open is checked again.
     threads[0]["target"](*threads[0]["args"])
-    assert index_router.note_folder_opened(str(tmp_path)) is True
+    assert _real_note_folder_opened(str(tmp_path)) is True
 
 
 class _FakeThread:

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -665,3 +665,75 @@ def test_a_rules_edit_rescans_every_stale_root_not_just_the_first(home, tmp_path
     assert body["needs_rescan"] is True
     assert started == [str(a), str(b)]
     assert body["rescan_run_ids"] == ["r1", "r2"]
+
+
+# -- open-folder freshness -----------------------------------------------------
+
+def test_listing_a_folder_notes_it_for_the_freshness_check(home, tmp_path,
+                                                           monkeypatch):
+    """The hook is on /api/fs/list because that is what "opened a folder"
+    actually is; the check itself must never run on the request thread."""
+    seen = []
+    monkeypatch.setattr(index_router, "note_folder_opened",
+                        lambda p: seen.append(p) or True)
+    src = _tree(tmp_path)
+    resp = _client(tmp_path).get("/api/fs/list", params={"path": str(src)})
+    assert resp.status_code == 200
+    assert seen == [str(src)]
+
+
+def test_the_freshness_check_runs_at_most_one_at_a_time(home, tmp_path,
+                                                        monkeypatch):
+    """A folder being watched re-lists on every mtime tick, so the hook fires
+    far more often than a check costs. Overlapping checks would each open
+    duckdb over dirs.parquet for nothing."""
+    threads = []
+    monkeypatch.setattr(index_router.threading, "Thread",
+                        lambda **kw: threads.append(kw) or _FakeThread())
+    assert index_router.note_folder_opened(str(tmp_path)) is True
+    assert index_router.note_folder_opened(str(tmp_path)) is False
+    assert len(threads) == 1
+    # The slot frees once the check finishes, so the next open is checked again.
+    threads[0]["target"](*threads[0]["args"])
+    assert index_router.note_folder_opened(str(tmp_path)) is True
+
+
+class _FakeThread:
+    def start(self):
+        pass
+
+
+def test_a_stale_open_folder_gets_its_configured_root_rescanned(
+        home, tmp_path, monkeypatch):
+    """The glue end to end, synchronously: the persisted config supplies the
+    roots and the check fires the ordinary incremental scan of the enclosing
+    one."""
+    started = []
+    monkeypatch.setattr(index_router.runner, "start",
+                        lambda cfg, root, full=False: started.append(root)
+                        or {"run_id": "r1", "root": root})
+    src = _tree(tmp_path)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    sub = src / "sub"
+    # An index that recorded `sub` long before its current mtime.
+    _write_dirs_index(load_config(), {str(src): 1, str(sub): 1})
+    monkeypatch.setattr(index_router.freshness, "QUIET_S", 0.0)
+    index_router._run_freshness_check(str(sub))
+    assert started == [str(src)]
+
+
+def _write_dirs_index(cfg, dirs):
+    """A minimal real index whose dirs.parquet holds {dir: mtime_ns}."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from fused_render.index.store import Sink, compact
+    shards = os.path.join(cfg.dir, "shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    for d, mtime_ns in dirs.items():
+        sink.add(d, "s", ("sig", [], 0, mtime_ns, 0))
+    sink.close()
+    compact(cfg, next(iter(dirs)), shards, pa, pq)

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -1,0 +1,240 @@
+"""Keeping the open folder's slice of the index fresh.
+
+See fused_render/index/specs/scan-incremental.md §5. The whole feature is one
+mtime comparison plus pacing: the trigger reuses the ordinary incremental scan,
+so what is worth guarding here is the decision to fire it — every gate that
+must refuse, in the order that makes the expensive ones unreachable.
+"""
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from fused_render.index import freshness, runner
+from fused_render.index.config import IndexConfig
+from fused_render.index.freshness import (
+    MIN_INTERVAL_S,
+    QUIET_S,
+    enclosing_root,
+    indexed_mtime_ns,
+    note_folder_opened,
+)
+from fused_render.index.store import Sink, compact
+
+NS = 1_000_000_000
+
+
+def _index(tmp_path, root, dirs):
+    """A real index whose dirs.parquet holds `dirs` = {abs dir: mtime_ns}."""
+    cfg = IndexConfig(dir=str(tmp_path / "ix"))
+    shards = str(tmp_path / "run" / "shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    for d, mtime_ns in dirs.items():
+        sink.add(d, "s", ("sig", [], 0, mtime_ns, 0))
+    sink.close()
+    compact(cfg, root, shards, pa, pq)
+    return cfg
+
+
+@pytest.fixture()
+def spawned(monkeypatch):
+    """runner.start recorded instead of spawning a worker."""
+    calls = []
+
+    def fake_start(cfg, root, full=False):
+        calls.append({"root": root, "full": full})
+        return {"run_id": "r1", "root": root}
+
+    monkeypatch.setattr(runner, "start", fake_start)
+    # No mounts records anywhere near tmp_path, so the guard is a no-op here
+    # except in the test that points it at one.
+    monkeypatch.setattr(runner, "_mounts_dir", lambda: "/nonexistent-mounts")
+    return calls
+
+
+def _tree(tmp_path, rel):
+    d = tmp_path / rel
+    d.mkdir(parents=True, exist_ok=True)
+    return str(d)
+
+
+# -- the staleness check -------------------------------------------------------
+
+def test_the_indexed_mtime_of_a_recorded_directory_is_read_back(tmp_path):
+    cfg = _index(tmp_path, "/r", {"/r": 500 * NS, "/r/sub": 700 * NS})
+    assert indexed_mtime_ns(cfg, "/r/sub") == 700 * NS
+
+
+def test_a_directory_the_index_never_recorded_reads_as_unknown(tmp_path):
+    cfg = _index(tmp_path, "/r", {"/r": 500 * NS})
+    assert indexed_mtime_ns(cfg, "/r/never-scanned") is None
+
+
+def test_an_index_that_was_never_built_reads_as_unknown(tmp_path):
+    assert indexed_mtime_ns(IndexConfig(dir=str(tmp_path / "ix")), "/r") is None
+
+
+# -- which root a folder belongs to -------------------------------------------
+
+@pytest.mark.parametrize("path,expected", [
+    ("/home/me/code/app", "/home/me/code"),
+    ("/home/me/code", "/home/me/code"),
+    ("/home/me/other", None),
+    # segment-wise, so a sibling with the root as a name prefix is not inside it
+    ("/home/me/code-old/app", None),
+])
+def test_enclosing_root_is_matched_segment_wise(path, expected):
+    assert enclosing_root(["/home/me/code"], path) == expected
+
+
+def test_the_deepest_configured_root_wins():
+    """Roots may nest. The scan that answers for the folder soonest is the
+    narrower one, and firing the outer root as well would scan its subtree
+    twice."""
+    roots = ["/a", "/a/b"]
+    assert enclosing_root(roots, "/a/b/c") == "/a/b"
+
+
+# -- the trigger --------------------------------------------------------------
+
+def test_a_folder_whose_mtime_moved_since_the_scan_triggers_a_rescan(
+        tmp_path, spawned):
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) == root
+    assert spawned == [{"root": root, "full": False}]
+
+
+def test_an_unchanged_folder_triggers_nothing(tmp_path, spawned):
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS,
+                                 sub: os.stat(sub).st_mtime_ns})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) is None
+    assert spawned == []
+
+
+def test_a_folder_the_index_never_recorded_triggers_nothing(tmp_path, spawned):
+    """An uncovered folder already falls back to the live walk (query.md §6),
+    so a scan buys its search nothing — and treating "absent" as stale would
+    make every folder outside the index a trigger."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) is None
+    assert spawned == []
+
+
+def test_an_unknown_recorded_mtime_triggers_nothing(tmp_path, spawned):
+    """A partition written before mtime_ns existed reads 0 (store._compact_locked).
+    Comparing against 0 would read as "stale forever" and fire on every open."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 0})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) is None
+    assert spawned == []
+
+
+def test_a_folder_that_changed_moments_ago_is_left_to_settle(tmp_path, spawned):
+    """The quiet period. A build directory's mtime moves continuously, so it is
+    never quiet and never triggers — which is what stops it queueing scan after
+    scan."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    now = os.stat(sub).st_mtime + QUIET_S - 1
+    assert note_folder_opened(cfg, sub, [root], now=now) is None
+    assert spawned == []
+
+
+def test_a_root_scanned_within_the_floor_is_not_rescanned(tmp_path, spawned):
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    runner._record_scan(cfg, root)
+    assert runner.last_scan(cfg, root) is not None
+    # `now` is in the future relative to the record just written, so express the
+    # floor from the record itself.
+    at = runner.last_scan(cfg, root) + MIN_INTERVAL_S - 1
+    assert note_folder_opened(cfg, sub, [root], now=max(now, at)) is None
+    assert spawned == []
+
+
+def test_a_folder_outside_every_configured_root_triggers_nothing(
+        tmp_path, spawned):
+    root = _tree(tmp_path, "root")
+    outside = _tree(tmp_path, "elsewhere")
+    cfg = _index(tmp_path, root, {root: 1 * NS, outside: 1 * NS})
+    now = os.stat(outside).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, outside, [root], now=now) is None
+    assert spawned == []
+
+
+def test_a_live_scan_of_the_root_is_not_joined_by_a_second_one(
+        tmp_path, spawned, monkeypatch):
+    """runner.start would join it, but only for an EXACT root-string match, and
+    a triggered scan must not be the thing that discovers that. Refuse here."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    monkeypatch.setattr(runner, "active_run",
+                        lambda cfg, r: {"run_id": "live", "root": r})
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) is None
+    assert spawned == []
+
+
+def test_the_scan_it_starts_is_of_the_configured_root_not_the_open_folder(
+        tmp_path, monkeypatch):
+    """`scans.json` is keyed by root string and read by the startup debounce,
+    so a per-folder root would both pollute it and defeat runner.start's
+    exact-match join. Let the real runner.start record, and check the key."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    monkeypatch.setattr(runner, "_mounts_dir", lambda: "/nonexistent-mounts")
+    monkeypatch.setattr(runner.subprocess, "Popen", lambda *a, **k: _Spawned())
+    now = os.stat(sub).st_mtime + QUIET_S + 1
+    assert note_folder_opened(cfg, sub, [root], now=now) == root
+    assert runner.last_scan(cfg, root) is not None
+    assert runner.last_scan(cfg, sub) is None
+
+
+class _Spawned:
+    pid = 4242
+
+
+def test_a_mount_backed_folder_is_refused_without_touching_the_kernel(
+        tmp_path, spawned, monkeypatch):
+    """os.stat on a wedged rclone mount blocks the request thread forever (this
+    repo's documented mount-wedge class), so the guard has to come first — and
+    it is pure string work against the mount records."""
+    mounts = _tree(tmp_path, "home/mounts")
+    root = _tree(tmp_path, "home")
+    under = _tree(tmp_path, "home/mounts/bucket/data")
+    cfg = _index(tmp_path, root, {root: 1 * NS, under: 1 * NS})
+    monkeypatch.setattr(runner, "_mounts_dir", lambda: mounts)
+
+    def boom(_p):
+        raise AssertionError("stat reached a mount-backed path")
+
+    monkeypatch.setattr(freshness.os, "stat", boom)
+    now = 10 ** 10
+    assert note_folder_opened(cfg, under, [root], now=now) is None
+    assert spawned == []
+
+
+def test_a_vanished_folder_is_not_an_error(tmp_path, spawned):
+    root = _tree(tmp_path, "root")
+    gone = os.path.join(root, "gone")
+    cfg = _index(tmp_path, root, {root: 1 * NS, gone: 1 * NS})
+    assert note_folder_opened(cfg, gone, [root], now=10 ** 10) is None
+    assert spawned == []

--- a/tests/test_index_guarded_query.py
+++ b/tests/test_index_guarded_query.py
@@ -1,0 +1,223 @@
+"""User SQL against the index, confined. See index/specs/query.md §5.
+
+Two independent guards, and the tests are split along them because they fail
+differently: the statement-type gate refuses before anything executes, and the
+DuckDB lockdown refuses paths at execution. Neither is belt-and-braces — after
+`lock_configuration=true` an in-memory INSERT still succeeds, and
+`allowed_directories` on its own confines nothing at all.
+"""
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+
+from fused_render.index import guarded_query
+from fused_render.index.config import IndexConfig
+from fused_render.index.guarded_query import MAX_LIMIT, run_guarded
+from fused_render.index.store import Sink, compact, schemas
+
+
+def _cfg(tmp_path):
+    return IndexConfig(dir=str(tmp_path / "ix"))
+
+
+def _index(tmp_path, root="/r", paths=("/r/a.txt", "/r/b.md"), sizes=None):
+    cfg = _cfg(tmp_path)
+    shards = str(tmp_path / "run" / "shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    by_dir = {}
+    for i, p in enumerate(paths):
+        d, name = p.rsplit("/", 1)
+        ext = name.rsplit(".", 1)[1].lower() if "." in name else ""
+        size = (sizes or {}).get(p, 10)
+        by_dir.setdefault(d, []).append((p, d, name, ext, size, 100.0 + i))
+    for d, rows in by_dir.items():
+        sink.add(d, "s", ("sig", rows, sum(r[4] for r in rows), 1, 0))
+    sink.close()
+    compact(cfg, root, shards, pa, pq)
+    return cfg
+
+
+# -- the read path works -------------------------------------------------------
+
+def test_a_select_over_files_answers(tmp_path):
+    out = run_guarded(_index(tmp_path), "SELECT name, size FROM files ORDER BY name")
+    assert out["columns"] == ["name", "size"]
+    assert out["rows"] == [["a.txt", 10], ["b.md", 10]]
+    assert out["truncated"] is False
+
+
+def test_a_select_over_dirs_answers(tmp_path):
+    out = run_guarded(_index(tmp_path), "SELECT dir FROM dirs")
+    assert out["rows"] == [["/r"]]
+
+
+def test_the_two_views_carry_the_stored_schemas(tmp_path):
+    """The empty-index views are written out by hand, so they can drift from
+    store.schemas. DESCRIBE is the check that they haven't."""
+    file_schema, dir_schema = schemas(pa)
+    cfg = _index(tmp_path)
+    for table, schema in (("files", file_schema), ("dirs", dir_schema)):
+        got = [r[0] for r in run_guarded(cfg, f"DESCRIBE {table}")["rows"]]
+        assert got == list(schema.names)
+
+
+def test_an_empty_index_answers_with_no_rows_rather_than_an_error(tmp_path):
+    cfg = _cfg(tmp_path)
+    assert run_guarded(cfg, "SELECT count(*) FROM files")["rows"] == [[0]]
+    assert run_guarded(cfg, "SELECT count(*) FROM dirs")["rows"] == [[0]]
+    # …and the empty views still carry the real column names, so a query
+    # written against a built index does not fail differently on an empty one.
+    file_schema, dir_schema = schemas(pa)
+    for table, schema in (("files", file_schema), ("dirs", dir_schema)):
+        got = [r[0] for r in run_guarded(cfg, f"DESCRIBE {table}")["rows"]]
+        assert got == list(schema.names)
+
+
+def test_the_files_view_reads_only_the_manifests_partitions(tmp_path):
+    """A glob of the files dir would read the PREVIOUS generation too — the
+    store leaves it on disk for readers still holding the old manifest — and
+    silently double every count."""
+    cfg = _index(tmp_path, paths=("/r/a.txt",))
+    _index(tmp_path, paths=("/r/a.txt", "/r/b.txt"))  # second generation
+    on_disk = len([f for f in os.listdir(cfg.files_dir) if f.endswith(".parquet")])
+    assert on_disk > 1  # the previous generation is still there
+    assert run_guarded(cfg, "SELECT count(*) FROM files")["rows"] == [[2]]
+
+
+# -- the statement-type gate ---------------------------------------------------
+
+@pytest.mark.parametrize("sql", [
+    "INSERT INTO files VALUES ('/x', '/', 'x', '', 1, 1.0, 1)",
+    "DELETE FROM files",
+    "UPDATE files SET size = 0",
+    "CREATE TABLE t AS SELECT 1",
+    "CREATE VIEW v AS SELECT 1",
+    "DROP VIEW files",
+    "COPY files TO '/tmp/fused-guarded-should-not-exist.csv'",
+    "ATTACH '/tmp/fused-guarded.db' AS other",
+    "INSTALL httpfs",
+    "LOAD httpfs",
+    "SET enable_external_access=true",
+    "RESET allowed_directories",
+])
+def test_a_non_read_statement_is_refused_before_it_runs(tmp_path, sql):
+    """The gate is LOAD-BEARING, not defence in depth: `lock_configuration`
+    stops the settings changing, and stops nothing else — an in-memory INSERT
+    or CREATE TABLE still succeeds behind it."""
+    with pytest.raises(ValueError, match="read-only"):
+        run_guarded(_index(tmp_path), sql)
+
+
+def test_a_copy_that_was_refused_wrote_nothing(tmp_path):
+    out = tmp_path / "out.csv"
+    with pytest.raises(ValueError):
+        run_guarded(_index(tmp_path), f"COPY files TO '{out}'")
+    assert not out.exists()
+
+
+def test_more_than_one_statement_is_refused(tmp_path):
+    with pytest.raises(ValueError, match="one statement"):
+        run_guarded(_index(tmp_path), "SELECT 1; DROP VIEW files")
+
+
+def test_an_empty_statement_is_refused(tmp_path):
+    for sql in ("", "   ", "-- nothing\n"):
+        with pytest.raises(ValueError):
+            run_guarded(_index(tmp_path), sql)
+
+
+def test_unparseable_sql_is_an_error_not_a_crash(tmp_path):
+    with pytest.raises(ValueError):
+        run_guarded(_index(tmp_path), "SELEKT * FROM files")
+
+
+def test_the_read_only_statement_types_are_allowed(tmp_path):
+    """PRAGMA and CALL are named explicitly because they are already reachable:
+    duckdb parses `PRAGMA database_list` as StatementType.SELECT, so a gate that
+    admitted only SELECT would admit them anyway while claiming not to."""
+    cfg = _index(tmp_path)
+    for sql in ("PRAGMA database_list",
+                "CALL pragma_version()",
+                "DESCRIBE SELECT 1",
+                "EXPLAIN SELECT 1",
+                "WITH x AS (SELECT 1 c) SELECT c FROM x"):
+        assert isinstance(run_guarded(cfg, sql)["rows"], list)
+
+
+# -- the lockdown --------------------------------------------------------------
+
+@pytest.mark.parametrize("fn", ["read_csv", "read_parquet", "read_text",
+                                "read_blob"])
+def test_a_file_outside_the_index_directory_cannot_be_read(tmp_path, fn):
+    """`allowed_directories` alone confines NOTHING — it is a carve-out from
+    `enable_external_access=false`, not a restriction — so this only holds
+    because external access is off and the configuration is locked."""
+    secret = tmp_path / "secret.csv"
+    secret.write_text("a\n1\n", encoding="utf-8")
+    with pytest.raises(Exception) as exc:
+        run_guarded(_index(tmp_path), f"SELECT * FROM {fn}('{secret}')")
+    assert "Permission Error" in str(exc.value)
+
+
+def test_the_allowlist_cannot_be_widened_from_inside_a_query(tmp_path):
+    with pytest.raises(ValueError, match="read-only"):
+        run_guarded(_index(tmp_path), "SET allowed_directories=['/']")
+
+
+def test_a_glob_outside_the_index_directory_is_refused(tmp_path):
+    (tmp_path / "leak.parquet").write_bytes(b"not really")
+    with pytest.raises(Exception):
+        run_guarded(_index(tmp_path),
+                    f"SELECT * FROM glob('{tmp_path}/*')")
+
+
+# -- the row cap --------------------------------------------------------------
+
+def test_the_row_cap_is_enforced_and_flagged(tmp_path):
+    cfg = _index(tmp_path, paths=[f"/r/f{i}.txt" for i in range(20)])
+    out = run_guarded(cfg, "SELECT path FROM files ORDER BY path", limit=5)
+    assert len(out["rows"]) == 5
+    assert out["truncated"] is True
+
+
+def test_a_result_that_fits_is_not_flagged(tmp_path):
+    cfg = _index(tmp_path, paths=[f"/r/f{i}.txt" for i in range(3)])
+    out = run_guarded(cfg, "SELECT path FROM files", limit=5)
+    assert len(out["rows"]) == 3
+    assert out["truncated"] is False
+
+
+def test_the_callers_limit_cannot_exceed_the_server_cap(tmp_path):
+    cfg = _index(tmp_path, paths=[f"/r/f{i}.txt" for i in range(3)])
+    out = run_guarded(cfg, "SELECT path FROM files", limit=MAX_LIMIT * 100)
+    assert len(out["rows"]) == 3  # clamped, not honoured
+    assert run_guarded(cfg, "SELECT path FROM files", limit=0)["rows"] == []
+
+
+def test_the_users_own_limit_still_applies(tmp_path):
+    cfg = _index(tmp_path, paths=[f"/r/f{i}.txt" for i in range(20)])
+    out = run_guarded(cfg, "SELECT path FROM files LIMIT 2", limit=10)
+    assert len(out["rows"]) == 2
+    assert out["truncated"] is False
+
+
+# -- the shape that leaves the process ----------------------------------------
+
+def test_a_runaway_statement_is_interrupted(tmp_path, monkeypatch):
+    """A cross join is trivial to type and impossible to bound by inspection,
+    and the caller is a text box — so the timeout is the only backstop there is."""
+    monkeypatch.setattr(guarded_query, "TIMEOUT_S", 0.05)
+    with pytest.raises(Exception) as exc:
+        run_guarded(_index(tmp_path),
+                    "SELECT count(*) FROM range(100000000) a, range(1000) b")
+    assert "interrupt" in str(exc.value).lower()
+
+
+def test_values_that_json_cannot_hold_leave_as_strings(tmp_path):
+    out = run_guarded(_index(tmp_path),
+                      "SELECT DATE '2020-01-01' d, CAST(1 AS HUGEINT) h, "
+                      "'x'::BLOB b")
+    assert out["rows"] == [["2020-01-01", 1, "x"]]

--- a/tests/test_index_query.py
+++ b/tests/test_index_query.py
@@ -1,8 +1,10 @@
 """Reading the index: the lookup pattern grammar, partition pruning, and
 stats. See fused_render/index/specs/query.md.
 
-The raw `sql` action OpenIndex exposed is deliberately absent — arbitrary
-duckdb from a client is an arbitrary read/write surface behind an HTTP route.
+The raw `sql` action OpenIndex exposed is deliberately absent from THIS module —
+arbitrary duckdb from a client is an arbitrary read/write surface. The confined
+one lives in `guarded_query.py` (tests/test_index_guarded_query.py), which is
+why the assertion below is about `query.py` specifically.
 """
 import os
 
@@ -192,7 +194,8 @@ def test_stats_on_an_empty_index(tmp_path):
 def test_there_is_no_raw_sql_surface():
     """The `sql` action was fine inside a trusted local page and is not fine
     behind an HTTP route: duckdb with unrestricted SQL reads and writes
-    anything the user's account can."""
+    anything the user's account can. The guarded replacement is a separate
+    module on purpose, so this assertion keeps meaning what it meant."""
     assert not hasattr(index_query, "sql")
     assert "sql" not in dir(index_query)
 

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -129,6 +129,32 @@ def test_unreadable_directory_is_skipped_not_fatal(tmp_path):
     assert (kind, payload, subs) == (None, None, [])
 
 
+def _package(root):
+    app = root / "Cool.app"
+    (app / "Contents").mkdir(parents=True)
+    (app / "Contents" / "Info.plist").write_text("x", encoding="utf-8")
+    return app
+
+
+def test_a_package_directory_is_recorded_but_not_descended(tmp_path):
+    """The walk treats macOS packages as opaque leaves — one entry, no contents
+    (WALK_LEAF_DIR_SUFFIXES) — and the scan had no counterpart, so the index was
+    full of Cool.app/Contents/... paths the walk would never emit.
+
+    Dropping the package from the descent list is not the fix on its own: a
+    dirs.parquet row exists only for a SCANNED directory, so the package would
+    vanish from the corpus entirely and break parity the other way. It is
+    recorded, with no file rows, and not listed."""
+    app = _package(tmp_path)
+    rules, guard = IgnoreRules([]), _guard(tmp_path)
+    assert scan_dir_once(str(tmp_path), {}, rules, guard)[2] == [str(app)]
+    kind, payload, subs = scan_dir_once(str(app), {}, rules, guard)
+    assert kind == "s"           # recorded: one dirs row
+    assert payload[1] == []      # no file rows from inside the package
+    assert payload[4] == 0
+    assert subs == []            # and nothing below it is queued
+
+
 def test_keep_subdirs_drops_skip_dirs_ignored_and_mount_paths(tmp_path):
     guard = MountGuard(mounts_dir=str(tmp_path / "mounts"))
     subs = [str(tmp_path / "ok"), str(tmp_path / "mounts" / "s3"),
@@ -172,6 +198,31 @@ def test_a_run_indexes_the_tree_and_skips_ignored_folders(tmp_path):
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
     names = pq.read_table(part).column("path").to_pylist()
     assert names == [str(src / "a.txt"), str(src / "sub" / "b.md")]
+
+
+def test_a_run_and_the_walk_agree_about_a_package_directory(tmp_path):
+    """Corpus/walk parity: the two sources are meant to be interchangeable, so
+    the package appears in both as exactly one leaf entry."""
+    from fused_render.index.query import search_under
+    from fused_render.server.walk import _walk_bfs
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("a", encoding="utf-8")
+    app = _package(src)
+    cfg = _cfg(tmp_path)
+    run_dir = _run(cfg, str(src))
+    assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
+
+    dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
+    assert str(app) in dirs
+    assert not any(d.startswith(str(app) + "/") for d in dirs)
+    part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
+    assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
+
+    corpus = {e["rel"] for e in search_under(cfg, str(src))["entries"]}
+    walked = {e["rel"] for e in _walk_bfs(str(src), True) if isinstance(e, dict)}
+    assert corpus == walked == {"a.txt", "Cool.app"}
 
 
 def test_a_second_run_carries_unchanged_directories_forward(tmp_path):

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -13,7 +13,11 @@ import pytest
 from fused_render.index.config import IndexConfig
 from fused_render.index.ignore import IgnoreRules, MountGuard
 from fused_render.index.scan import keep_subdirs, run_scan, scan_dir_once
-from fused_render.index.store import load_dir_cache, read_manifest
+from fused_render.index.store import (
+    load_dir_cache,
+    partition_files,
+    read_manifest,
+)
 
 
 def _cfg(tmp_path, **over):
@@ -223,6 +227,48 @@ def test_a_run_and_the_walk_agree_about_a_package_directory(tmp_path):
     corpus = {e["rel"] for e in search_under(cfg, str(src))["entries"]}
     walked = {e["rel"] for e in _walk_bfs(str(src), True) if isinstance(e, dict)}
     assert corpus == walked == {"a.txt", "Cool.app"}
+
+
+def test_the_fsevents_path_does_not_walk_into_a_package(tmp_path, monkeypatch):
+    """The leaf rule has to hold on BOTH scan paths, and the journal one does not
+    arrive by descent: it visits whatever directories the OS names, and what the
+    OS names inside a package is always a descendant (an app update writes
+    Cool.app/Contents/..., Photos writes Foo.photoslibrary/database) — never the
+    package itself. A final-component test therefore passes those straight
+    through and re-fills the index with the very rows the walk-driven path
+    excludes. They are not self-correcting either: _run_fsevents keeps every
+    cached dir it did not visit, so once present they survive every later run.
+
+    The hint here is exactly what the journal reports after something writes
+    inside the package."""
+    from fused_render.index import fsevents
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "a.txt").write_text("a", encoding="utf-8")
+    app = _package(src)
+    cfg = _cfg(tmp_path)
+    assert _summary(_run(cfg, str(src)))["msg"] == "complete"
+
+    # Second run takes the journal fast path, with the package's INNER dir
+    # reported as changed.
+    monkeypatch.setattr(
+        fsevents, "hint",
+        lambda _cfg, _root: ([], [str(app / "Contents")]))
+    run_dir = _run(cfg, str(src), run_name="run2")
+    assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
+    # the run really took the journal path — otherwise this proves nothing
+    assert any(e.get("msg", "").startswith("scanning (fsevents")
+               for e in _events(run_dir))
+
+    dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
+    assert str(app) in dirs                                    # still recorded
+    assert not any(d.startswith(str(app) + "/") for d in dirs)  # nothing below
+    paths = []
+    for part in partition_files(cfg):
+        paths += pq.read_table(part).column("path").to_pylist()
+    assert not any(p.startswith(str(app) + "/") for p in paths), \
+        "package internals entered the index through the fsevents path"
 
 
 def test_a_second_run_carries_unchanged_directories_forward(tmp_path):

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -13,7 +13,7 @@ from fastapi.testclient import TestClient
 
 from fused_render.index.config import IndexConfig, load_config
 from fused_render.index.query import search_under
-from fused_render.index.store import Sink, compact
+from fused_render.index.store import Sink, compact, partition_files
 from fused_render.server import create_app
 
 
@@ -196,19 +196,68 @@ def test_search_under_ignores_a_lookalike_underscore_sibling(tmp_path):
 
 
 def test_dirs_are_not_silently_dropped_when_files_fill_the_cap(tmp_path):
-    """File rows exactly filling `limit` used to skip the dirs query entirely
-    and report truncated: false — a corpus claiming completeness while every
-    directory entry is missing."""
-    cfg = _index(tmp_path, "/r", ["/r/a.txt", "/r/b.txt"], dirs=["/r/sub"])
+    """Directories used to get only the budget the FILES branch left over, so
+    on any truncated corpus (`room == 0`) folder search was dead, not degraded.
+    Both kinds of entry compete in ONE depth-ordered query now, so a shallow
+    directory survives a cap that deep files would otherwise have filled."""
+    cfg = _index(tmp_path, "/r",
+                 [f"/r/deep/a/b/x{i}.txt" for i in range(5)],
+                 dirs=["/r/sub", "/r/deep", "/r/deep/a", "/r/deep/a/b"])
     out = search_under(cfg, "/r", limit=2)
-    assert len(out["entries"]) == 2
+    assert "sub" in [e["rel"] for e in out["entries"]]
     assert out["truncated"] is True
 
 
+def test_a_matching_folder_survives_a_cap_full_of_matching_files(tmp_path):
+    """The reported symptom: a query naming a folder returned 100 files from
+    inside it and not the folder itself."""
+    cfg = _index(tmp_path, "/r",
+                 [f"/r/target-thing/f{i}.txt" for i in range(5)],
+                 dirs=["/r/target-thing"])
+    out = search_under(cfg, "/r", q="target-thing", limit=2)
+    assert "target-thing" in [e["rel"] for e in out["entries"]]
+
+
 def test_a_capped_corpus_prefers_shallow_entries(tmp_path):
-    """The walk streams breadth-first, so its cap keeps shallow files; plain
+    """The walk streams breadth-first, so its cap keeps shallow entries; plain
     ORDER BY path would fill the whole cap with the first deep subtree."""
     cfg = _index(tmp_path, "/r",
-                 ["/r/deep/a/b/x1.txt", "/r/deep/a/b/x2.txt", "/r/top.txt"])
-    out = search_under(cfg, "/r", limit=1, include_dirs=False)
-    assert [e["rel"] for e in out["entries"]] == ["top.txt"]
+                 ["/r/deep/a/b/x1.txt", "/r/deep/a/b/x2.txt", "/r/top.txt"],
+                 dirs=["/r/deep", "/r/deep/a", "/r/deep/a/b"])
+    out = search_under(cfg, "/r", limit=2)
+    assert sorted(e["rel"] for e in out["entries"]) == ["deep", "top.txt"]
+
+
+def test_the_corpus_is_ordered_by_the_stored_depth_column(tmp_path):
+    """Depth is a materialised int32, not a slash-counting expression: every
+    query opens a fresh in-memory duckdb over parquet, so there is no catalog
+    to hold a generated column (see store.schemas)."""
+    cfg = _index(tmp_path, "/r", ["/r/a/b/deep.txt", "/r/top.txt"],
+                 dirs=["/r/a", "/r/a/b"])
+    t = pq.read_table(partition_files(cfg)[0])
+    assert dict(zip(t.column("path").to_pylist(),
+                    t.column("depth").to_pylist())) == {
+        "/r/a/b/deep.txt": 4, "/r/top.txt": 2}
+    d = pq.read_table(cfg.dirs_parquet)
+    assert dict(zip(d.column("dir").to_pylist(),
+                    d.column("depth").to_pylist())) == {
+        "/r": 1, "/r/a": 2, "/r/a/b": 3}
+
+
+def _drop_depth(cfg):
+    """Rewrite the index as a pre-`depth` one would have been written."""
+    for fp in partition_files(cfg) + [cfg.dirs_parquet]:
+        t = pq.read_table(fp)
+        pq.write_table(t.drop([c for c in ["depth"] if c in t.column_names]), fp)
+
+
+def test_an_index_written_without_a_depth_column_still_reads(tmp_path):
+    """Additive schema evolution: an index on disk from before `depth` existed
+    falls back to the slash-count expression rather than hard-failing (the same
+    defensive read load_dir_cache and the compaction already do)."""
+    cfg = _index(tmp_path, "/r", ["/r/a/b/deep.txt", "/r/top.txt"],
+                 dirs=["/r/a", "/r/a/b"])
+    _drop_depth(cfg)
+    out = search_under(cfg, "/r", limit=2)
+    assert out["covered"] is True
+    assert sorted(e["rel"] for e in out["entries"]) == ["a", "top.txt"]

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -104,6 +104,26 @@ def test_searching_inside_a_package_falls_back_to_the_walk(tmp_path):
     assert "Cool.app" in [e["rel"] for e in search_under(cfg, "/r")["entries"]]
 
 
+def test_searching_BELOW_a_package_root_also_falls_back_to_the_walk(tmp_path):
+    """Testing only the root's final component was not enough. An index written
+    before the leaf rule holds real dirs rows for paths INSIDE a package, and
+    those rows do describe a scanned directory — so the coverage query says yes
+    and the index answers from whatever partial set of package rows happens to
+    be on disk, while the folder one level up is answered by the live walk. Two
+    sources meant to be interchangeable then disagree, which is the whole reason
+    LEAF_DIR_SUFFIXES is shared between them.
+
+    The rows here are exactly what such an index looks like: the package's inner
+    directories present and populated."""
+    cfg = _index(tmp_path, "/r",
+                 ["/r/a.txt", "/r/Cool.app/Contents/Info.plist"],
+                 dirs=["/r/Cool.app", "/r/Cool.app/Contents"])
+    for root in ("/r/Cool.app", "/r/Cool.app/Contents"):
+        out = search_under(cfg, root)
+        assert out["covered"] is False, f"{root} answered from the index"
+        assert out["entries"] == []
+
+
 def test_search_under_reports_no_coverage_on_an_empty_index(tmp_path):
     out = search_under(IndexConfig(dir=str(tmp_path / "ix")), "/r")
     assert out["covered"] is False

--- a/tests/test_index_search.py
+++ b/tests/test_index_search.py
@@ -91,6 +91,19 @@ def test_search_under_reports_no_coverage_for_an_unindexed_root(tmp_path):
     assert out["entries"] == []
 
 
+def test_searching_inside_a_package_falls_back_to_the_walk(tmp_path):
+    """The scan records a .app as ONE opaque row and never lists it, so its dirs
+    row says "this is a leaf", not "we know what is inside". Answering `covered`
+    for it would report an empty corpus as complete; the live walk, which does
+    list a leaf it was pointed at, has the real answer."""
+    cfg = _index(tmp_path, "/r", ["/r/a.txt"], dirs=["/r/Cool.app"])
+    out = search_under(cfg, "/r/Cool.app")
+    assert out["covered"] is False
+    assert out["entries"] == []
+    # the package itself is still an entry of its PARENT's corpus
+    assert "Cool.app" in [e["rel"] for e in search_under(cfg, "/r")["entries"]]
+
+
 def test_search_under_reports_no_coverage_on_an_empty_index(tmp_path):
     out = search_under(IndexConfig(dir=str(tmp_path / "ix")), "/r")
     assert out["covered"] is False

--- a/tests/test_index_store.py
+++ b/tests/test_index_store.py
@@ -144,6 +144,44 @@ def test_compact_writes_sorted_partitions_and_a_manifest(tmp_path):
     assert not os.path.isdir(shards)
 
 
+def test_compact_stores_the_absolute_path_depth_on_both_tables(tmp_path):
+    """`depth` is denormalised out of the path so the corpus query can order by
+    a stored int32 instead of counting slashes per row (store.schemas)."""
+    cfg = _cfg(tmp_path)
+    compact(cfg, "/r", _shard(tmp_path, cfg, [
+        ("/r/b", _scanned("s", [_row("/r/b/1.txt")], 10, 2, 0)),
+        ("/r", _scanned("s", [_row("/r/a.txt")], 10, 1, 1)),
+    ]), pa, pq)
+    part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
+    t = pq.read_table(part)
+    assert dict(zip(t.column("path").to_pylist(),
+                    t.column("depth").to_pylist())) == {
+        "/r/a.txt": 2, "/r/b/1.txt": 3}
+    d = pq.read_table(cfg.dirs_parquet)
+    assert dict(zip(d.column("dir").to_pylist(),
+                    d.column("depth").to_pylist())) == {"/r": 1, "/r/b": 2}
+
+
+def test_compact_backfills_depth_onto_a_pre_depth_index(tmp_path):
+    """Additive schema evolution, like mtime_ns and n_subdirs before it: an
+    index already on disk has one fewer column than the shards it is unioned
+    with, and a positional UNION ALL would fail rather than merge."""
+    cfg = _cfg(tmp_path)
+    compact(cfg, "/one", _shard(tmp_path, cfg, [
+        ("/one", _scanned("s", [_row("/one/a.txt")], 10, 1, 0))]), pa, pq)
+    for fp in [os.path.join(cfg.files_dir, p["file"])
+               for p in read_manifest(cfg)["partitions"]] + [cfg.dirs_parquet]:
+        pq.write_table(pq.read_table(fp).drop(["depth"]), fp)
+    compact(cfg, "/two", _shard(tmp_path, cfg, [
+        ("/two", _scanned("s", [_row("/two/b/c.txt")], 10, 1, 0))]), pa, pq)
+    part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
+    t = pq.read_table(part)
+    assert dict(zip(t.column("path").to_pylist(),
+                    t.column("depth").to_pylist())) == {
+        "/one/a.txt": 2, "/two/b/c.txt": 3}
+    assert sorted(pq.read_table(cfg.dirs_parquet).column("depth").to_pylist()) == [1, 1]
+
+
 @pytest.mark.parametrize("awkward", ["Dave's stuff", "brack[et]s", "star*dir"])
 def test_compact_survives_a_store_path_with_sql_or_glob_metachars(tmp_path, awkward):
     """The store dir is the USER's path (FUSED_RENDER_HOME under their home),
@@ -290,7 +328,8 @@ def test_compact_reads_the_previous_index_through_the_manifest(tmp_path):
     stray = os.path.join(cfg.files_dir, "part-99999-99999.parquet")
     file_schema, _ = __import__("fused_render.index.store", fromlist=["schemas"]).schemas(pa)
     pq.write_table(pa.table({k: [v] for k, v in zip(
-        file_schema.names, ["/one/ghost.txt", "/one", "ghost.txt", "txt", 1, 1.0])},
+        file_schema.names,
+        ["/one/ghost.txt", "/one", "ghost.txt", "txt", 1, 1.0, 2])},
         schema=file_schema), stray)
     compact(cfg, "/two", _shard(tmp_path, cfg, [
         ("/two", _scanned("s", [_row("/two/b.txt")], 10, 1, 0))]), pa, pq)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,37 +1,20 @@
-"""Unit tests for /api/search/files' spec validation and query building.
+"""Unit tests for /api/search/files' spec validation and hit screening.
 
-The mdfind query string is a security boundary (model-originated values are
-embedded in it), so the escaping and allowlist tests here are the load-bearing
-ones — see search.py's module docstring.
+The spec is model-originated, so it reaches the endpoint as untrusted input and
+every field is re-validated here — the allowlist tests are the load-bearing
+ones (see search.py's module docstring). The engine that executes a validated
+spec is the SQL index, covered in test_search_index.py.
 """
 
 import pytest
 
 from fused_render.server.routers.search import (
+    _day_bound_epoch,
     _drop_gitignored,
     _junk_path,
-    _match_walk_entry,
-    _mdfind_query,
     _nearest_repo,
     _parse_spec,
 )
-
-
-def spec(**over):
-    base = {
-        "name_terms": [],
-        "extensions": [],
-        "kind": "any",
-        "modified_within_days": None,
-        "modified_after": None,
-        "modified_before": None,
-        "created_after": None,
-        "created_before": None,
-        "min_size_bytes": None,
-        "max_size_bytes": None,
-    }
-    base.update(over)
-    return base
 
 
 # -- _parse_spec ---------------------------------------------------------------
@@ -46,7 +29,7 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
             "min_size_bytes": 10,
         }
     )
-    # quote/backslash stripped (mdfind string-literal escape chars), blanks dropped
+    # quote/backslash stripped, blanks dropped
     assert parsed["name_terms"] == ["weather", "ok"]
     # dot peeled + lowercased; anything outside [a-z0-9]{1,12} dropped
     assert parsed["extensions"] == ["mov", "mp4"]
@@ -64,7 +47,7 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
         {"modified_within_days": -1},
         {"min_size_bytes": True},
         {"modified_after": "last week"},
-        {"created_before": "2026-02-31"},
+        {"modified_before": "2026-02-31"},
         {"modified_before": 20260805},
     ],
 )
@@ -73,89 +56,26 @@ def test_parse_spec_rejects_malformed_bodies(body):
         _parse_spec(body)
 
 
-# -- _mdfind_query -------------------------------------------------------------
-
-def test_mdfind_query_composes_all_constraints():
-    q = _mdfind_query(
-        spec(
-            name_terms=["report"],
-            extensions=["mov", "mp4"],
-            kind="file",
-            modified_within_days=1,
-            min_size_bytes=100,
-        )
-    )
-    assert '(kMDItemFSName = "*report*"cd)' in q
-    assert '(kMDItemFSName = "*.mov"cd || kMDItemFSName = "*.mp4"cd)' in q
-    assert 'kMDItemContentType != "public.folder"' in q
-    assert "kMDItemFSContentChangeDate >= $time.now(-86400)" in q
-    assert "kMDItemFSSize >= 100" in q
-    assert " && " in q
+@pytest.mark.parametrize("key", ["created_after", "created_before"])
+def test_parse_spec_refuses_a_creation_date_filter(key):
+    """The index stores `mtime` and no birth time, and it is the only engine —
+    so a created_* filter is unanswerable. It is REFUSED rather than dropped:
+    silently searching by modification date instead would answer a different
+    question than the caller asked. Only a stale client can still send one."""
+    with pytest.raises(ValueError, match="created"):
+        _parse_spec({"name_terms": ["x"], key: "2026-06-01"})
+    # ...and the key is not in the parsed spec at all
+    assert key not in _parse_spec({"name_terms": ["x"]})
 
 
-def test_mdfind_query_date_ranges_are_inclusive_local_days():
-    from fused_render.server.routers.search import _day_bound_epoch, _time_iso
-
-    q = _mdfind_query(
-        spec(modified_after="2026-06-01", modified_before="2026-06-30",
-             created_after="2026-05-01")
-    )
-    # after → >= that day's local midnight; before → < the NEXT day's
-    # midnight, so the whole named day is included.
-    assert (
-        f"kMDItemFSContentChangeDate >= $time.iso({_time_iso(_day_bound_epoch('2026-06-01', False))})"
-        in q
-    )
-    assert (
-        f"kMDItemFSContentChangeDate < $time.iso({_time_iso(_day_bound_epoch('2026-06-30', True))})"
-        in q
-    )
-    assert "kMDItemFSCreationDate >= " in q
-    assert _day_bound_epoch("2026-06-30", True) - _day_bound_epoch("2026-06-30", False) == 86400.0
+def test_day_bounds_are_inclusive_local_days():
+    """`after` is that day's local midnight, `before` the midnight AFTER the
+    named day — so both ends of a range include the day the user named."""
+    assert (_day_bound_epoch("2026-06-30", True)
+            - _day_bound_epoch("2026-06-30", False)) == 86400.0
 
 
-def test_match_walk_entry_modified_range():
-    from fused_render.server.routers.search import _day_bound_epoch
-
-    s = spec(modified_after="2026-06-01", modified_before="2026-06-30")
-    inside = _day_bound_epoch("2026-06-15", False)
-    before = _day_bound_epoch("2026-06-01", False) - 1
-    after = _day_bound_epoch("2026-06-30", True) + 1
-    now = after + 86400
-    assert _match_walk_entry(walk_entry("a.txt", mtime=inside), s, now)
-    assert not _match_walk_entry(walk_entry("a.txt", mtime=before), s, now)
-    assert not _match_walk_entry(walk_entry("a.txt", mtime=after), s, now)
-
-
-def test_mdfind_query_requires_a_narrowing_constraint():
-    # Nothing at all, and kind-only, would both match half the disk.
-    assert _mdfind_query(spec()) is None
-    assert _mdfind_query(spec(kind="dir")) is None
-    assert _mdfind_query(spec(kind="dir", name_terms=["x"])) is not None
-
-
-# -- _match_walk_entry (non-darwin fallback filters) ----------------------------
-
-def walk_entry(rel, is_dir=False, size=1000, mtime=1000.0):
-    return {"rel": rel, "is_dir": is_dir, "size": None if is_dir else size, "mtime": mtime}
-
-
-def test_match_walk_entry_enforces_hard_filters():
-    s = spec(extensions=["csv"], kind="file", modified_within_days=1, min_size_bytes=500)
-    now = 1000.0 + 3600
-    assert _match_walk_entry(walk_entry("data/report.csv"), s, now)
-    assert not _match_walk_entry(walk_entry("data/report.txt"), s, now)
-    assert not _match_walk_entry(walk_entry("data", is_dir=True), s, now)
-    assert not _match_walk_entry(walk_entry("old.csv", mtime=now - 90000), s, now)
-    assert not _match_walk_entry(walk_entry("tiny.csv", size=10), s, now)
-
-
-def test_match_walk_entry_dirs_skip_extension_and_size():
-    s = spec(extensions=["csv"], min_size_bytes=500)
-    assert _match_walk_entry(walk_entry("data", is_dir=True), s, 2000.0)
-
-
-# -- Spotlight hit screening (junk, hidden, gitignored) --------------------------
+# -- hit screening (junk, hidden, gitignored) ----------------------------------
 
 def test_junk_path_drops_ignore_dirs_and_hidden_segments():
     assert _junk_path("/Users/me/proj/node_modules/a/b.mov")

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -1,11 +1,12 @@
-"""/api/search/files answered from the SQL index, with the old engines behind it.
+"""/api/search/files, answered from the SQL index — the only engine.
 
-The AI search's filter spec used to execute against Spotlight (or a home walk).
-The index holds the same facts in parquet — name, ext, size, mtime — so the spec
-translates into ONE SQL query with no filesystem touch at all. These tests pin
-the translation (dates inclusive both ends, kind routing, ext/size only on
-files), the truncation flag, and every condition that must hand the query back
-to Spotlight instead of answering wrongly.
+The AI search's filter spec used to execute against Spotlight (or a bounded home
+walk). The index holds the same facts in parquet — name, ext, size, mtime — so
+the spec translates into ONE SQL query with no filesystem touch at all, and both
+of the old engines are gone. These tests pin the translation (dates inclusive
+both ends, kind routing, ext/size only on files), the truncation flag, and the
+contract when the index cannot answer: an honest empty result for a miss, and a
+plain error — never a silently narrower answer — when there is no index to read.
 """
 import os
 
@@ -18,7 +19,11 @@ from fused_render.index.config import IndexConfig
 from fused_render.index.store import Sink, compact
 from fused_render.server import create_app
 from fused_render.server.routers import search as search_mod
-from fused_render.server.routers.search import _day_bound_epoch, _search_index
+from fused_render.server.routers.search import (
+    IndexUnavailable,
+    _day_bound_epoch,
+    _search_index,
+)
 
 
 def spec(**over):
@@ -29,8 +34,6 @@ def spec(**over):
         "modified_within_days": None,
         "modified_after": None,
         "modified_before": None,
-        "created_after": None,
-        "created_before": None,
         "min_size_bytes": None,
         "max_size_bytes": None,
     }
@@ -111,8 +114,9 @@ def test_index_engine_kind_routes_which_views_are_queried(tmp_path):
 
 
 def test_index_engine_matches_name_terms_against_the_name_not_the_path(tmp_path):
-    """mdfind matches kMDItemFSName, so a term that only appears in an ANCESTOR
-    directory is not a file hit — the two engines must agree on that."""
+    """Terms match the NAME column: a term that only appears in an ancestor
+    directory is a hit on that directory, not on the files inside it (the
+    client scores the whole relative path afterwards)."""
     cfg = _index(tmp_path, "/r", [("/r/report/data.csv", 10, 100.0)],
                  dirs=["/r/report"])
     assert _paths(_search_index(spec(name_terms=["report"]), cfg)) == ["/r/report"]
@@ -125,13 +129,15 @@ def test_index_engine_skips_the_dirs_view_when_nothing_narrows_a_directory(tmp_p
     cfg = _index(tmp_path, "/r", [("/r/clip.mp4", 10, 100.0)],
                  dirs=["/r/movies"])
     assert _paths(_search_index(spec(extensions=["mp4"]), cfg)) == ["/r/clip.mp4"]
-    # dir-only, with nothing a dirs row can answer: handed to the next engine
-    assert _search_index(spec(extensions=["mp4"], kind="dir"), cfg) is None
+    # dir-only, with nothing a dirs row can answer: refused, not answered with
+    # every folder there is — there is no wider engine to hand it to.
+    with pytest.raises(ValueError, match="folder"):
+        _search_index(spec(extensions=["mp4"], kind="dir"), cfg)
 
 
 def test_index_engine_lets_dirs_past_extension_and_size_filters(tmp_path):
-    """_match_walk_entry's rule: extension and size are FILE facts, so a dir
-    hit passes them (the index has no size for a directory at all)."""
+    """Extension and size are FILE facts, so a dir hit passes them (the index
+    has no size for a directory at all)."""
     cfg = _index(tmp_path, "/r", [], dirs=["/r/reports"])
     out = _search_index(
         spec(name_terms=["report"], extensions=["csv"], min_size_bytes=10_000), cfg)
@@ -148,8 +154,7 @@ def test_index_engine_size_bounds_apply_to_files(tmp_path):
 
 def test_index_engine_date_ranges_are_inclusive_local_days(tmp_path):
     """`modified_after: 06-01` includes everything from that local midnight and
-    `modified_before: 06-30` includes all of the 30th — the same bounds
-    _day_bound_epoch gives the other two engines."""
+    `modified_before: 06-30` includes all of the 30th."""
     first = _day_bound_epoch("2026-06-01", False)
     last_end = _day_bound_epoch("2026-06-30", True)
     cfg = _index(tmp_path, "/r", [
@@ -232,28 +237,23 @@ def test_index_engine_drops_gitignored_hits(tmp_path):
     assert _paths(out) == [f"{root}/keep.mov"]
 
 
-# -- when the index hands the query back --------------------------------------
+# -- when the index cannot answer ---------------------------------------------
 
-def test_index_engine_declines_a_never_built_index(tmp_path):
+def test_a_never_built_index_is_an_error_not_an_empty_disk(tmp_path):
+    """With no engine behind it, "no index" cannot be reported as "no matches":
+    the box has to say the index is not ready, not imply the file is not there.
+    The client shows the message it gets, so the failure is visible."""
     cfg = IndexConfig(dir=str(tmp_path / "empty"))
-    assert _search_index(spec(name_terms=["x"]), cfg) is None
+    with pytest.raises(IndexUnavailable):
+        _search_index(spec(name_terms=["x"]), cfg)
 
 
-def test_index_engine_declines_a_created_range(tmp_path):
-    """The files table has mtime and no birth time, so a created_* filter can
-    only be honored by an engine that stats — silently ignoring it would answer
-    a different question than the user asked."""
+def test_a_zero_hit_query_is_an_honest_empty_result(tmp_path):
+    """A miss is a miss. There is no wider engine to consult, so an empty
+    result set is the answer — reported as one, with `engine` still set."""
     cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
-    assert _search_index(spec(name_terms=["a"], created_after="2026-06-01"), cfg) is None
-    assert _search_index(spec(name_terms=["a"], created_before="2026-06-01"), cfg) is None
-
-
-def test_index_engine_declines_a_zero_hit_query(tmp_path):
-    """The index covers the configured roots (home by default); Spotlight
-    covers the whole disk. So no hits means "ask the wider engine", not "no
-    such file"."""
-    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
-    assert _search_index(spec(name_terms=["nothing-like-this"]), cfg) is None
+    out = _search_index(spec(name_terms=["nothing-like-this"]), cfg)
+    assert out == {"entries": [], "truncated": False, "engine": "index"}
 
 
 def test_index_engine_refuses_a_spec_with_no_narrowing_constraint(tmp_path):
@@ -264,13 +264,15 @@ def test_index_engine_refuses_a_spec_with_no_narrowing_constraint(tmp_path):
         _search_index(spec(kind="dir"), cfg)
 
 
-def test_index_engine_declines_when_the_query_errors(tmp_path, monkeypatch):
-    """A corrupt or half-deleted store must degrade to Spotlight, not 502."""
+def test_a_query_failure_is_reported_not_swallowed(tmp_path):
+    """A corrupt or half-deleted store used to degrade to Spotlight; with
+    nothing to degrade to, it has to surface."""
     cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
     for name in os.listdir(cfg.files_dir):
         with open(os.path.join(cfg.files_dir, name), "wb") as f:
             f.write(b"not parquet")
-    assert _search_index(spec(name_terms=["a"]), cfg) is None
+    with pytest.raises(RuntimeError):
+        _search_index(spec(name_terms=["a"]), cfg)
 
 
 # -- the endpoint --------------------------------------------------------------
@@ -280,16 +282,13 @@ def client(tmp_path):
     return TestClient(create_app(start_dir=str(tmp_path)))
 
 
-def test_endpoint_answers_from_the_index_without_touching_spotlight(
-        client, tmp_path, monkeypatch):
+def test_the_endpoint_has_no_engine_but_the_index(client, tmp_path, monkeypatch):
+    """Spotlight and the home walk are gone, not merely deprioritized."""
+    for gone in ("_search_mdfind", "_search_walk_home", "_mdfind_query",
+                 "_match_walk_entry", "_stat_entry"):
+        assert not hasattr(search_mod, gone), gone
     cfg = _index(tmp_path, "/r", [("/r/quarterly.csv", 10, 100.0)])
     monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
-
-    def boom(spec):
-        raise AssertionError("the index answered; no engine below it should run")
-
-    monkeypatch.setattr(search_mod, "_search_mdfind", boom)
-    monkeypatch.setattr(search_mod, "_search_walk_home", boom)
     res = client.post("/api/search/files", json={"name_terms": ["quarterly"]})
     assert res.status_code == 200
     body = res.json()
@@ -297,15 +296,28 @@ def test_endpoint_answers_from_the_index_without_touching_spotlight(
     assert [e["path"] for e in body["entries"]] == ["/r/quarterly.csv"]
 
 
-def test_endpoint_falls_back_when_there_is_no_index(client, tmp_path, monkeypatch):
+def test_the_endpoint_reports_a_missing_index_as_a_503(client, tmp_path, monkeypatch):
     cfg = IndexConfig(dir=str(tmp_path / "empty"))
     monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
-    monkeypatch.setattr(
-        search_mod, "_search_mdfind",
-        lambda spec: {"entries": [], "truncated": False, "engine": "spotlight"})
-    monkeypatch.setattr(
-        search_mod, "_search_walk_home",
-        lambda spec: {"entries": [], "truncated": False, "engine": "walk"})
     res = client.post("/api/search/files", json={"name_terms": ["quarterly"]})
+    assert res.status_code == 503
+    # A message a search box can show verbatim, not a traceback.
+    assert "index" in res.json()["error"]
+
+
+def test_the_endpoint_returns_an_empty_ok_for_a_miss(client, tmp_path, monkeypatch):
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
+    res = client.post("/api/search/files", json={"name_terms": ["zzzz"]})
     assert res.status_code == 200
-    assert res.json()["engine"] in ("spotlight", "walk")
+    assert res.json() == {"ok": True, "entries": [], "truncated": False,
+                          "engine": "index"}
+
+
+def test_the_endpoint_rejects_a_creation_date_filter(client, tmp_path, monkeypatch):
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
+    res = client.post("/api/search/files",
+                      json={"name_terms": ["a"], "created_after": "2026-06-01"})
+    assert res.status_code == 400
+    assert "created" in res.json()["error"]

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -41,8 +41,13 @@ def spec(**over):
     return base
 
 
-def _index(tmp_path, root, files, dirs=(), dir_mtime_ns=1_000_000_000, name="ix"):
-    """An index over `files` — (path, size, mtime) triples — plus `dirs`."""
+def _index(tmp_path, root, files, dirs=(), dir_mtime_ns=1_000_000_000, name="ix",
+           dir_mtimes=None):
+    """An index over `files` — (path, size, mtime) triples — plus `dirs`.
+
+    `dir_mtimes` overrides the mtime_ns of individual directories; 0 there is
+    the index's "unknown" (a dirs row written before the column existed, or a
+    directory whose stat failed)."""
     cfg = IndexConfig(dir=str(tmp_path / name))
     shards = str(tmp_path / name / "run" / "shards")
     os.makedirs(shards, exist_ok=True)
@@ -54,7 +59,8 @@ def _index(tmp_path, root, files, dirs=(), dir_mtime_ns=1_000_000_000, name="ix"
         ext = fname.rsplit(".", 1)[1].lower() if "." in fname else ""
         by_dir.setdefault(d, []).append((path, d, fname, ext, size, mtime))
     for d, rows in by_dir.items():
-        sink.add(d, "s", ("sig", rows, sum(r[4] for r in rows), dir_mtime_ns, 0))
+        mt = (dir_mtimes or {}).get(d, dir_mtime_ns)
+        sink.add(d, "s", ("sig", rows, sum(r[4] for r in rows), mt, 0))
     sink.close()
     compact(cfg, root, shards, pa, pq)
     return cfg
@@ -200,6 +206,50 @@ def test_index_engine_marks_a_capped_result_set_truncated(tmp_path, monkeypatch)
     assert out["truncated"] is True
     monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 5)
     assert _search_index(spec(name_terms=["hit"]), cfg)["truncated"] is False
+
+
+def test_a_matching_folder_survives_a_flood_of_newer_files(tmp_path, monkeypatch):
+    """Folders get their OWN budget, not a share of one recency-ordered cap.
+
+    Under a single `ORDER BY mtime DESC LIMIT cap` over the union of both views,
+    any query matching more recent files than the cap buried the folder
+    entirely: "where is my reports folder" answered with the files inside it and
+    never the folder. That is the files-starve-folders failure
+    query.search_under exists to prevent for in-folder search, and a shared
+    recency budget reintroduced it here."""
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 8)
+    monkeypatch.setattr(search_mod, "SEARCH_DIRS_RESERVE", 2)
+    cfg = _index(
+        tmp_path, "/r",
+        # 20 files, every one NEWER than the folder that shares their name
+        [(f"/r/reports/report-{i}.csv", 10, 10_000.0 + i) for i in range(20)],
+        dirs=["/r/reports"],
+        dir_mtimes={"/r/reports": 1_000_000_000},  # 1.0s epoch: older than all
+    )
+    out = _search_index(spec(name_terms=["report"]), cfg)
+    paths = [e["path"] for e in out["entries"]]
+    assert "/r/reports" in paths
+    assert len(paths) == 8            # still exactly the cap
+    assert sum(1 for p in paths if p.endswith(".csv")) == 7
+    assert out["truncated"] is True
+
+
+def test_a_folder_with_no_recorded_mtime_is_not_starved(tmp_path, monkeypatch):
+    """mtime_ns 0 means "unknown" and reads as NULL, which sorts LAST under
+    `mtime DESC` — so the shared budget dropped these folders first of all.
+    Folders are ordered shallowest-first instead, which no mtime can affect."""
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 4)
+    monkeypatch.setattr(search_mod, "SEARCH_DIRS_RESERVE", 1)
+    cfg = _index(
+        tmp_path, "/r",
+        [(f"/r/photos/pic-{i}.png", 10, 10_000.0 + i) for i in range(10)],
+        dirs=["/r/photos"],
+        dir_mtimes={"/r/photos": 0},
+    )
+    out = _search_index(spec(name_terms=["photo"]), cfg)
+    entries = {e["path"]: e for e in out["entries"]}
+    assert "/r/photos" in entries
+    assert entries["/r/photos"]["mtime"] is None  # unknown, reported as such
 
 
 def test_index_engine_reads_through_the_manifest_not_a_glob(tmp_path):

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -1,0 +1,311 @@
+"""/api/search/files answered from the SQL index, with the old engines behind it.
+
+The AI search's filter spec used to execute against Spotlight (or a home walk).
+The index holds the same facts in parquet — name, ext, size, mtime — so the spec
+translates into ONE SQL query with no filesystem touch at all. These tests pin
+the translation (dates inclusive both ends, kind routing, ext/size only on
+files), the truncation flag, and every condition that must hand the query back
+to Spotlight instead of answering wrongly.
+"""
+import os
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render.index.config import IndexConfig
+from fused_render.index.store import Sink, compact
+from fused_render.server import create_app
+from fused_render.server.routers import search as search_mod
+from fused_render.server.routers.search import _day_bound_epoch, _search_index
+
+
+def spec(**over):
+    base = {
+        "name_terms": [],
+        "extensions": [],
+        "kind": "any",
+        "modified_within_days": None,
+        "modified_after": None,
+        "modified_before": None,
+        "created_after": None,
+        "created_before": None,
+        "min_size_bytes": None,
+        "max_size_bytes": None,
+    }
+    base.update(over)
+    return base
+
+
+def _index(tmp_path, root, files, dirs=(), dir_mtime_ns=1_000_000_000, name="ix"):
+    """An index over `files` — (path, size, mtime) triples — plus `dirs`."""
+    cfg = IndexConfig(dir=str(tmp_path / name))
+    shards = str(tmp_path / name / "run" / "shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t", pa, pq, cfg.shard_rows)
+    by_dir = {d: [] for d in dirs}
+    by_dir.setdefault(root, [])
+    for path, size, mtime in files:
+        d, fname = path.rsplit("/", 1)
+        ext = fname.rsplit(".", 1)[1].lower() if "." in fname else ""
+        by_dir.setdefault(d, []).append((path, d, fname, ext, size, mtime))
+    for d, rows in by_dir.items():
+        sink.add(d, "s", ("sig", rows, sum(r[4] for r in rows), dir_mtime_ns, 0))
+    sink.close()
+    compact(cfg, root, shards, pa, pq)
+    return cfg
+
+
+def _paths(out):
+    return sorted(e["path"] for e in out["entries"])
+
+
+# -- what the index engine returns ---------------------------------------------
+
+def test_index_engine_matches_name_terms_case_insensitively(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/Weather Report.csv", 10, 100.0),
+                                  ("/r/notes.txt", 20, 200.0)])
+    out = _search_index(spec(name_terms=["weather"]), cfg)
+    assert _paths(out) == ["/r/Weather Report.csv"]
+    assert out["engine"] == "index"
+    assert out["truncated"] is False
+
+
+def test_index_engine_ors_name_terms(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/a-cat.txt", 10, 100.0),
+                                  ("/r/a-dog.txt", 10, 100.0),
+                                  ("/r/a-fish.txt", 10, 100.0)])
+    out = _search_index(spec(name_terms=["cat", "dog"]), cfg)
+    assert _paths(out) == ["/r/a-cat.txt", "/r/a-dog.txt"]
+
+
+def test_index_engine_returns_entries_in_the_response_shape(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/clip.mov", 4096, 1234.5)], dirs=["/r/sub"])
+    out = _search_index(spec(extensions=["mov"]), cfg)
+    assert out["entries"] == [
+        {"path": "/r/clip.mov", "is_dir": False, "size": 4096, "mtime": 1234.5},
+    ]
+    dirs = _search_index(spec(name_terms=["sub"], kind="dir"), cfg)
+    assert dirs["entries"] == [
+        {"path": "/r/sub", "is_dir": True, "size": None, "mtime": 1.0},
+    ]
+
+
+def test_index_engine_filters_by_extension(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/a.MOV", 10, 100.0), ("/r/b.mp4", 10, 100.0),
+                                  ("/r/c.txt", 10, 100.0)])
+    out = _search_index(spec(extensions=["mov", "mp4"]), cfg)
+    assert _paths(out) == ["/r/a.MOV", "/r/b.mp4"]
+
+
+def test_index_engine_kind_routes_which_views_are_queried(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/report/report.csv", 10, 100.0)],
+                 dirs=["/r/report"])
+    both = _search_index(spec(name_terms=["report"]), cfg)
+    assert _paths(both) == ["/r/report", "/r/report/report.csv"]
+    assert _paths(_search_index(spec(name_terms=["report"], kind="file"), cfg)) == [
+        "/r/report/report.csv"]
+    assert _paths(_search_index(spec(name_terms=["report"], kind="dir"), cfg)) == [
+        "/r/report"]
+
+
+def test_index_engine_matches_name_terms_against_the_name_not_the_path(tmp_path):
+    """mdfind matches kMDItemFSName, so a term that only appears in an ANCESTOR
+    directory is not a file hit — the two engines must agree on that."""
+    cfg = _index(tmp_path, "/r", [("/r/report/data.csv", 10, 100.0)],
+                 dirs=["/r/report"])
+    assert _paths(_search_index(spec(name_terms=["report"]), cfg)) == ["/r/report"]
+
+
+def test_index_engine_skips_the_dirs_view_when_nothing_narrows_a_directory(tmp_path):
+    """An extensions-only spec ("find my mp4s") narrows files and nothing else;
+    an unpredicated dirs branch would return every folder in the index and
+    spend the result cap on rows that answer nothing."""
+    cfg = _index(tmp_path, "/r", [("/r/clip.mp4", 10, 100.0)],
+                 dirs=["/r/movies"])
+    assert _paths(_search_index(spec(extensions=["mp4"]), cfg)) == ["/r/clip.mp4"]
+    # dir-only, with nothing a dirs row can answer: handed to the next engine
+    assert _search_index(spec(extensions=["mp4"], kind="dir"), cfg) is None
+
+
+def test_index_engine_lets_dirs_past_extension_and_size_filters(tmp_path):
+    """_match_walk_entry's rule: extension and size are FILE facts, so a dir
+    hit passes them (the index has no size for a directory at all)."""
+    cfg = _index(tmp_path, "/r", [], dirs=["/r/reports"])
+    out = _search_index(
+        spec(name_terms=["report"], extensions=["csv"], min_size_bytes=10_000), cfg)
+    assert _paths(out) == ["/r/reports"]
+
+
+def test_index_engine_size_bounds_apply_to_files(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/tiny.bin", 10, 100.0),
+                                  ("/r/mid.bin", 5_000, 100.0),
+                                  ("/r/huge.bin", 10_000_000, 100.0)])
+    out = _search_index(spec(min_size_bytes=1_000, max_size_bytes=1_000_000), cfg)
+    assert _paths(out) == ["/r/mid.bin"]
+
+
+def test_index_engine_date_ranges_are_inclusive_local_days(tmp_path):
+    """`modified_after: 06-01` includes everything from that local midnight and
+    `modified_before: 06-30` includes all of the 30th — the same bounds
+    _day_bound_epoch gives the other two engines."""
+    first = _day_bound_epoch("2026-06-01", False)
+    last_end = _day_bound_epoch("2026-06-30", True)
+    cfg = _index(tmp_path, "/r", [
+        ("/r/before.txt", 10, first - 1),
+        ("/r/first-instant.txt", 10, first),
+        ("/r/last-instant.txt", 10, last_end - 1),
+        ("/r/after.txt", 10, last_end),
+    ])
+    out = _search_index(
+        spec(modified_after="2026-06-01", modified_before="2026-06-30"), cfg)
+    assert _paths(out) == ["/r/first-instant.txt", "/r/last-instant.txt"]
+
+
+def test_index_engine_honors_modified_within_days(tmp_path):
+    import time
+
+    now = time.time()
+    cfg = _index(tmp_path, "/r", [("/r/fresh.txt", 10, now - 3600),
+                                  ("/r/stale.txt", 10, now - 10 * 86400)])
+    out = _search_index(spec(modified_within_days=2), cfg)
+    assert _paths(out) == ["/r/fresh.txt"]
+
+
+def test_index_engine_screens_hidden_and_junk_paths(tmp_path):
+    """Parity with the other two engines: dot segments and machine-managed
+    directories never surface, whatever the index happens to hold."""
+    cfg = _index(
+        tmp_path, "/r",
+        [("/r/.config/keep.txt", 10, 100.0),
+         ("/r/node_modules/pkg/keep.txt", 10, 100.0),
+         ("/r/keep.txt", 10, 100.0)],
+        dirs=["/r/.config", "/r/node_modules", "/r/node_modules/pkg"])
+    out = _search_index(spec(name_terms=["keep"]), cfg)
+    assert _paths(out) == ["/r/keep.txt"]
+
+
+def test_index_engine_marks_a_capped_result_set_truncated(tmp_path, monkeypatch):
+    cfg = _index(tmp_path, "/r", [(f"/r/hit-{i}.txt", 10, 100.0 + i)
+                                  for i in range(5)])
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 3)
+    out = _search_index(spec(name_terms=["hit"]), cfg)
+    assert len(out["entries"]) == 3
+    assert out["truncated"] is True
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 5)
+    assert _search_index(spec(name_terms=["hit"]), cfg)["truncated"] is False
+
+
+def test_index_engine_reads_through_the_manifest_not_a_glob(tmp_path):
+    """A compaction leaves the PREVIOUS generation's partitions on disk for
+    readers still holding the old manifest (index-store.md §4). Globbing the
+    files dir would count both generations and return every row twice."""
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    shards = str(tmp_path / "ix" / "run2" / "shards")
+    os.makedirs(shards, exist_ok=True)
+    sink = Sink(shards, "t2", pa, pq, cfg.shard_rows)
+    sink.add("/r", "s", ("sig2", [("/r/a.txt", "/r", "a.txt", "txt", 10, 100.0)],
+                         10, 2_000_000_000, 0))
+    sink.close()
+    compact(cfg, "/r", shards, pa, pq)
+    assert len(os.listdir(cfg.files_dir)) > 1  # both generations on disk
+    out = _search_index(spec(name_terms=["a"]), cfg)
+    assert [e["path"] for e in out["entries"]] == ["/r/a.txt"]
+
+
+def test_index_engine_drops_gitignored_hits(tmp_path):
+    import subprocess as sp
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sp.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / ".gitignore").write_text("out/\n")
+    (repo / "out").mkdir()
+    (repo / "out" / "junk.mov").write_bytes(b"x")
+    (repo / "keep.mov").write_bytes(b"x")
+    root = str(repo).replace(os.sep, "/")
+    cfg = _index(tmp_path, root,
+                 [(f"{root}/out/junk.mov", 1, 100.0), (f"{root}/keep.mov", 1, 100.0)],
+                 dirs=[f"{root}/out"])
+    out = _search_index(spec(extensions=["mov"]), cfg)
+    assert _paths(out) == [f"{root}/keep.mov"]
+
+
+# -- when the index hands the query back --------------------------------------
+
+def test_index_engine_declines_a_never_built_index(tmp_path):
+    cfg = IndexConfig(dir=str(tmp_path / "empty"))
+    assert _search_index(spec(name_terms=["x"]), cfg) is None
+
+
+def test_index_engine_declines_a_created_range(tmp_path):
+    """The files table has mtime and no birth time, so a created_* filter can
+    only be honored by an engine that stats — silently ignoring it would answer
+    a different question than the user asked."""
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    assert _search_index(spec(name_terms=["a"], created_after="2026-06-01"), cfg) is None
+    assert _search_index(spec(name_terms=["a"], created_before="2026-06-01"), cfg) is None
+
+
+def test_index_engine_declines_a_zero_hit_query(tmp_path):
+    """The index covers the configured roots (home by default); Spotlight
+    covers the whole disk. So no hits means "ask the wider engine", not "no
+    such file"."""
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    assert _search_index(spec(name_terms=["nothing-like-this"]), cfg) is None
+
+
+def test_index_engine_refuses_a_spec_with_no_narrowing_constraint(tmp_path):
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    with pytest.raises(ValueError):
+        _search_index(spec(), cfg)
+    with pytest.raises(ValueError):
+        _search_index(spec(kind="dir"), cfg)
+
+
+def test_index_engine_declines_when_the_query_errors(tmp_path, monkeypatch):
+    """A corrupt or half-deleted store must degrade to Spotlight, not 502."""
+    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
+    for name in os.listdir(cfg.files_dir):
+        with open(os.path.join(cfg.files_dir, name), "wb") as f:
+            f.write(b"not parquet")
+    assert _search_index(spec(name_terms=["a"]), cfg) is None
+
+
+# -- the endpoint --------------------------------------------------------------
+
+@pytest.fixture
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def test_endpoint_answers_from_the_index_without_touching_spotlight(
+        client, tmp_path, monkeypatch):
+    cfg = _index(tmp_path, "/r", [("/r/quarterly.csv", 10, 100.0)])
+    monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
+
+    def boom(spec):
+        raise AssertionError("the index answered; no engine below it should run")
+
+    monkeypatch.setattr(search_mod, "_search_mdfind", boom)
+    monkeypatch.setattr(search_mod, "_search_walk_home", boom)
+    res = client.post("/api/search/files", json={"name_terms": ["quarterly"]})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["engine"] == "index"
+    assert [e["path"] for e in body["entries"]] == ["/r/quarterly.csv"]
+
+
+def test_endpoint_falls_back_when_there_is_no_index(client, tmp_path, monkeypatch):
+    cfg = IndexConfig(dir=str(tmp_path / "empty"))
+    monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
+    monkeypatch.setattr(
+        search_mod, "_search_mdfind",
+        lambda spec: {"entries": [], "truncated": False, "engine": "spotlight"})
+    monkeypatch.setattr(
+        search_mod, "_search_walk_home",
+        lambda spec: {"entries": [], "truncated": False, "engine": "walk"})
+    res = client.post("/api/search/files", json={"name_terms": ["quarterly"]})
+    assert res.status_code == 200
+    assert res.json()["engine"] in ("spotlight", "walk")

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -252,6 +252,52 @@ def test_a_folder_with_no_recorded_mtime_is_not_starved(tmp_path, monkeypatch):
     assert entries["/r/photos"]["mtime"] is None  # unknown, reported as such
 
 
+def test_a_folder_only_search_gets_the_whole_cap(tmp_path):
+    """The folder reserve is a rule for SHARING the cap, not a ceiling on
+    folders.
+
+    With `kind: "dir"` the files branch never runs, so nothing is competing for
+    the budget — and capping folders at the reserve truncated a folder search at
+    a quarter of the result cap, handing the client a fraction of the ranking
+    headroom every other search gets. Files already ask for the whole cap and
+    give back what folders took; folders do the same when files are not playing.
+    Deliberately run at the REAL constants, since the bug was the relationship
+    between them."""
+    dirs = [f"/r/reports-{i:03d}" for i in range(150)]
+    cfg = _index(tmp_path, "/r", [], dirs=dirs)
+    out = _search_index(spec(name_terms=["report"], kind="dir"), cfg)
+    assert search_mod.SEARCH_DIRS_RESERVE < 150 <= search_mod.SEARCH_MAX_RESULTS
+    assert len(out["entries"]) == 150
+    assert out["truncated"] is False
+
+
+def test_folders_get_the_whole_cap_when_the_index_holds_no_files(tmp_path):
+    """Same rule from the other direction: `kind: "any"` against an index whose
+    file partitions are absent (a scan that has only written dirs so far) is a
+    folder-only search in practice, and must not be capped as if files were
+    competing for the budget."""
+    dirs = [f"/r/reports-{i:03d}" for i in range(150)]
+    cfg = _index(tmp_path, "/r", [], dirs=dirs)
+    out = _search_index(spec(name_terms=["report"]), cfg)
+    assert len(out["entries"]) == 150
+    assert out["truncated"] is False
+
+
+def test_the_folder_reserve_still_bounds_folders_when_files_compete(tmp_path,
+                                                                   monkeypatch):
+    """The other half of the rule: with both branches live, folders are held to
+    the reserve so a folder-heavy query cannot spend the whole cap on dirs."""
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 8)
+    monkeypatch.setattr(search_mod, "SEARCH_DIRS_RESERVE", 2)
+    cfg = _index(tmp_path, "/r",
+                 [(f"/r/report-{i}.csv", 10, 100.0 + i) for i in range(10)],
+                 dirs=[f"/r/reports-{i}" for i in range(10)])
+    out = _search_index(spec(name_terms=["report"]), cfg)
+    assert len(out["entries"]) == 8
+    assert sum(1 for e in out["entries"] if e["is_dir"]) == 2
+    assert out["truncated"] is True
+
+
 def test_gitignored_hits_do_not_spend_the_result_cap(tmp_path, monkeypatch):
     """The cap is a budget for hits the user can SEE.
 

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -252,6 +252,55 @@ def test_a_folder_with_no_recorded_mtime_is_not_starved(tmp_path, monkeypatch):
     assert entries["/r/photos"]["mtime"] is None  # unknown, reported as such
 
 
+def test_gitignored_hits_do_not_spend_the_result_cap(tmp_path, monkeypatch):
+    """The cap is a budget for hits the user can SEE.
+
+    Gitignored rows can only be recognised outside SQL (git is not a duckdb
+    function), so a page that filters down to nothing has to be followed by
+    another — otherwise a build directory's 100k generated files answer the
+    whole query with an empty list, and with no engine behind this one that is a
+    hard false miss, not a degraded result."""
+    import subprocess as sp
+
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 3)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sp.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / ".gitignore").write_text("dist/\n")
+    (repo / "dist").mkdir()
+    root = str(repo).replace(os.sep, "/")
+    # The four NEWEST matches are all gitignored; the two real ones are oldest.
+    files = [(f"{root}/dist/bundle-{i}.js", 10, 10_000.0 + i) for i in range(4)]
+    files += [(f"{root}/app.js", 10, 100.0), (f"{root}/main.js", 10, 101.0)]
+    cfg = _index(tmp_path, root, files, dirs=[f"{root}/dist"])
+    out = _search_index(spec(extensions=["js"]), cfg)
+    assert _paths(out) == [f"{root}/app.js", f"{root}/main.js"]
+    # Everything that matched was either returned or filtered — nothing is being
+    # withheld, so the client must not be told there is more.
+    assert out["truncated"] is False
+
+
+def test_the_cap_still_bounds_a_result_set_with_ignored_hits(tmp_path, monkeypatch):
+    """The refill fills the cap; it does not lift it, and `truncated` still says
+    when rows were left behind."""
+    import subprocess as sp
+
+    monkeypatch.setattr(search_mod, "SEARCH_MAX_RESULTS", 3)
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sp.run(["git", "init", "-q", str(repo)], check=True)
+    (repo / ".gitignore").write_text("dist/\n")
+    (repo / "dist").mkdir()
+    root = str(repo).replace(os.sep, "/")
+    files = [(f"{root}/dist/bundle-{i}.js", 10, 10_000.0 + i) for i in range(3)]
+    files += [(f"{root}/keep-{i}.js", 10, 100.0 + i) for i in range(6)]
+    cfg = _index(tmp_path, root, files, dirs=[f"{root}/dist"])
+    out = _search_index(spec(extensions=["js"]), cfg)
+    assert len(out["entries"]) == 3
+    assert all("/dist/" not in e["path"] for e in out["entries"])
+    assert out["truncated"] is True
+
+
 def test_index_engine_reads_through_the_manifest_not_a_glob(tmp_path):
     """A compaction leaves the PREVIOUS generation's partitions on disk for
     readers still holding the old manifest (index-store.md §4). Globbing the


### PR DESCRIPTION
## Summary

Explorer search was returning nonsense: folders never appeared, a deep file could outrank an exact name match by inheriting its ancestors' score, and macOS bundles were walked as directory trees. That is fixed, and — folded into the same landing at the author's request — the index gained two features and the search UI two changes.

- **Search results are now sane.** Directories and files come from one depth-ordered corpus query; `depth` is a stored `int32` on both tables; an own-name match ranks above an inherited one; `.app`/`.framework`/… are recorded as leaves instead of descended (on the FSEvents path too, not just the full scan).
- **Search shows the path alone, in relevance order.** The Size and Modified columns are dropped while searching — they gave up width to say nothing useful about a hit — and search-result sorting is gone entirely rather than shipping an ordering we already knew was wrong. The search box now takes the whole crumb bar and the ★ hides while it is open.
- **The fuzzy matcher no longer smears.** A greedy earliest-char alignment let `index.md` match `…/index/specs/index-store.md` across the whole path; there is now an fzf-style backward tightening pass and a bound on how far a match may spread relative to query length. **This module is shared with the bookmark sidebar, so highlights and match acceptance shift there too** — see *Known costs* below.
- **The open folder is rescanned when it has gone stale** (`index/freshness.py`): opening a directory whose own `mtime_ns` is newer than the indexed one triggers the existing incremental scan, paced by `MIN_INTERVAL_S=120` and a quiet-period gate.
- **Read-only SQL over the index** (`index/guarded_query.py`, `POST /api/index/query`, `POST /api/index/ask`), plus a Query panel. Scope note: the app already executes arbitrary local Python via `/api/run`, so this adds no capability — it is a strictly narrower one, guarded so a mistyped or model-written statement cannot write to the index or read outside it.
- **The home page AI search now answers from the SQL index — and only the index. Spotlight and the home-walk engine are deleted** (−250 lines of engine). `/api/search/files` compiles the validated filter spec into one query over the `files`/`dirs` parquet views; hits come straight from parquet with **no stat per hit** (the mount-wedge rule). There is no fallback: zero hits is an honest empty result, no-index-yet is a 503 with a message the search box shows verbatim, a corrupt store is a 502, and `created_*` filters are removed end to end (the index stores no birthtime; the model prompt now maps "created/saved/downloaded" phrasing to `modified_*`, and a stale client sending `created_*` gets a 400 rather than a silently different answer). **Coverage consequence, stated plainly: search reach shrinks from whole-disk to the configured index roots (home by default).** Name terms match the *name* column, mirroring the old `kMDItemFSName` semantics.
- **Review fixes:** `/api/index/ask` ran its guarded DuckDB query (bounded only by the 10s timeout) on the asyncio event loop — now `run_in_threadpool`, with a test asserting the call happens off-loop. Two more confirmed findings on the index engine: folders now get their own reserved budget (100 of the 400) ordered shallowest-first instead of losing a recency-ordered union to newer files (`5cc145f2`) — and that reserve is a rule for *sharing* the cap, not a ceiling: a folder-only search (`kind:"dir"`, or an index with no file partitions yet) gets the whole 400 instead of being cut at 100 with a false `truncated` (`dc3f5a08`) — and the result cap is now a budget for *visible* hits — each branch pages past gitignored rows until the budget fills, so a `dist/` of recent generated files can no longer answer a query with a false empty (`7b622d16`). One finding (FSEvents descending package interiors) was a false positive against HEAD: fixed earlier on this branch in `d3c7cf82` with the exact guard and test.

## Visuals

The search path, end to end — every stage in it changed:

```mermaid
flowchart TD
    Q[Query keystroke] --> C[One depth-ordered corpus<br/>dirs + files interleaved]
    C --> F[fuzzyMatch<br/>tighten, then bound the span]
    F --> R[rankCompare<br/>run, tier, score, depth]
    R --> V[Path-only rows<br/>relevance order, no sorting]
```

`tier` is what fixes the inherited-score bug: 1 = query is a substring of the entry's own name, 2 = the name matched fuzzily, 3 = ancestors only. `longestRun` sorts ahead of it and structurally guarantees a substring hit beats a fuzzy one.

## Usage

Search behaves the same — type in the crumb bar — it just returns the right rows in the right order.

The SQL surface is new:

```bash
curl -sX POST localhost:8000/api/index/query \
  -H 'X-Fused: 1' -H 'Content-Type: application/json' \
  -d '{"sql":"SELECT ext, count(*) n FROM files GROUP BY 1 ORDER BY n DESC","limit":20}'

# English in, SQL + rows out (the compiled SQL comes back even when it fails)
curl -sX POST localhost:8000/api/index/ask \
  -H 'X-Fused: 1' -H 'Content-Type: application/json' \
  -d '{"question":"largest 10 parquet files"}'
```

The home page AI search is unchanged to use — type a natural-language query — but it is answered entirely by the SQL index now (`engine` is always `"index"`; the field stays in the response for old clients). Before the first scan completes it says so (503 with a human message) instead of searching some other way.

Two views, `files` and `dirs`. `SELECT`/`WITH`/`PRAGMA`/`CALL`/`DESCRIBE`/`EXPLAIN` are admitted; DDL, DML, `COPY`, `ATTACH`, `SET` and multi-statement input are refused before anything executes. 5 000-row cap, 10s timeout. In the UI: the Query panel under Indexing.

## Test Plan

- [x] **Python: `5273 passed, 2 failed, 131 skipped`** (`-n auto`). One failure is the known macOS-impossible `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`. The other, `test_index_scan.py::test_a_rescan_picks_up_a_new_file`, has now flaked on 2 of ~5 full-suite runs and never in isolation — and the mechanism is **diagnosed, deterministically reproduced**: the second scan sometimes takes the FSEvents-journal path, and if the journal hasn't yet delivered the changed directory (async, load-dependent), the new file is missed. A sibling test already tolerates either scan path; this one's assertion only holds on the incremental path. Not touched here (no scan code in this diff, and the fix is a decision: pin the test to the incremental path, or make journal-path scans reconcile directory mtimes). Worth its own issue.
- [x] **Frontend: `553 pass, 8 fail`** (baseline `516 pass, 8 fail`). All 8 failures are the pre-existing `shortcut-chord.test.ts` ones. `bunx tsc --noEmit` clean; `bun run build` clean apart from the pre-existing >500 kB warning.
- [x] New suites: `test_index_freshness.py` (19), `test_index_guarded_query.py` (34), `test_index_api.py` (+14 query/ask, + freshness, + off-loop ask), `test_search_index.py` (spec→SQL bounds inclusive both ends, kind routing, junk/gitignore screening, truncation, previous-generation-on-disk not doubling rows, the no-index 503 / corrupt 502 / zero-hit-empty contract, and a test asserting the deleted engine functions are *absent* so a reintroduced fallback fails loudly), `fuzzy.test.ts`, `index-query.test.ts`, `search-columns.test.ts`, `search-bar-expand.test.ts`. `test_search.py` rewritten to spec validation + hit screening (mdfind/walk tests deleted with their engines). New tests re-run 3× under `-n auto`, no flake.
- [x] Every new test was run against the pre-change bytes first and shown to fail. Three drafts that passed both ways were rewritten into discriminating cases rather than kept as coverage theatre.
- [x] Guarded-query confinement verified empirically on DuckDB 1.5.5: `allowed_directories` alone confines nothing (it is a carve-out from `enable_external_access=false`), and `PRAGMA database_list` parses as `StatementType.SELECT` — both are why the gate is ordered and typed the way it is.
- [x] Partition resolution goes through the manifest, never a glob — with a test proving a retained previous generation on disk does not double the row count.
- [ ] **Browser pass, not yet done — geometry is untestable in this suite (no DOM):** search input actually fills the bar with no leftover gap where the ★ was; no jump entering/leaving search; the Path column claiming full width with no dead strip in WKWebView; the same in the narrow `_listing` preview-pane host; Query panel results scrolling in both axes with sticky headers over ~200 rows; `index.md` underlining `index` and `.md` inside `index-store.md` and nothing in the leading path, **in the bookmark sidebar as well as the listing**.
- [ ] **Feature A end to end:** open a folder, `touch` a file in it from a terminal, wait >30s, reopen — index status should show a scan.
- [ ] **AI search against a real home index:** every test uses a synthetic parquet store. Unmeasured on a multi-hundred-thousand-row index: query latency as felt in the UI, how often a genuine miss now happens (previously masked by Spotlight), how often the gitignore refill actually pages, and whether `SEARCH_DIRS_RESERVE=100` / `SEARCH_MAX_PAGES=5` are the right numbers (documented judgment calls, not tuned on real data). Also unverified visually: the 503 "index not built yet" message in the homepage error banner, and the empty-result copy.

### Known costs, stated rather than buried

1. **A triggered rescan is a full store rewrite.** `store.compact()` rebuilds *all* partitions on every merge regardless of scan scope, so each trigger costs ~6.5s of CPU and a full parquet rewrite on a 611k-file index — at most one per 120s while browsing changed folders. Root-scoped scans were chosen deliberately (a subtree scan keeps the bookkeeping honest but rewrites just as much), so this is the accepted price.
2. **The span bound loses one legitimate case.** A short query as word initials over long prose — `zmp` for a bookmark titled "Zarr v3 multiscale pyramid budget notes" — now falls outside the bound. The obvious fix (allowance per segment-start hit) was measured and is worse: it re-admits the exact path smears the bound exists for. Recorded as a test and a comment. If bookmark-title initialisms matter more than path smears, the bound wants revisiting.
3. **`fuzzy.ts` is shared and there are no bookmark-search tests in the repo at all.** That surface was unguarded before this PR and still is; the two measured behaviour changes there are the `zmp` loss above and `prefs` correctly ceasing to match an unrelated 60-char title.
4. **`QUIET_S` was reinterpreted.** The design said "root quiet for 30s since the last watch event"; mtime detection has no event stream, so it is now stateless — the directory's own mtime must be ≥30s old. Same anti-storm intent (a build tree's mtime never stops moving, so it never triggers), no state. Documented in code and in `specs/scan-incremental.md`.
5. **`abf33146` fixes a defect introduced here:** the `/api/fs/list` freshness hook was not neutralised in `conftest.py`, so a test listing a path under a real home directory would have spawned a detached whole-home scan outliving the test. Nothing was spawned during the runs — only because no test happens to list such a path. Now patched out the same way the startup scan is.
6. **The AI search's reach is narrower than before, deliberately.** Whole-disk coverage went with Spotlight: the search now sees exactly what the index scans (configured roots, home by default), and something outside them gets an honest empty result where Spotlight used to find it. Name terms match the entry's *name* only (mirroring `kMDItemFSName`), so `/r/report/data.csv` is no longer a hit for "report" while `/r/report` still is. A `kind:"dir"` spec whose only other constraint is extensions/size is a 400 ("searching for folders needs a name or a date") rather than every folder in the index. All pinned by tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
