### PR TITLE
perf(core-templates): hash the packaged tree once per process, not twice

### DIFF
--- a/fused_render/core_templates.py
+++ b/fused_render/core_templates.py
@@ -99,9 +99,38 @@ def _tree_digest(root: str) -> str:
     return h.hexdigest()
 
 
+# The packaged tree can't change under a running process, so its sha256 — the one
+# expensive part of the gate — is computed at most ONCE per process and reused.
+# ensure_core_templates() runs at import time from BOTH server.templates and
+# executor during a single `import fused_render.server`; without this memo each
+# paid a full, independent hash of the identical ~15.6MB tree. Keyed on
+# PACKAGE_TEMPLATES_DIR so it is self-correcting rather than needing a reset: the
+# suite repoints that constant at a fresh fake tree per test, so a prior test's
+# digest is never reused, and production — one stable path — keeps one entry. The
+# gate stays honest: ensure_core_templates still reads and compares the on-disk
+# marker every call, so a stale STAGED copy is caught exactly as before. Only a
+# test that edits the packaged tree in place (modelling a second app launch — the
+# one time those bytes change) drops the memo via _reset_expected_marker_cache().
+_EXPECTED_MARKER_MEMO: tuple[str, str] | None = None
+
+
+def _reset_expected_marker_cache() -> None:
+    """Drop the process-lifetime digest memo (tests only — see _expected_marker)."""
+    global _EXPECTED_MARKER_MEMO
+    _EXPECTED_MARKER_MEMO = None
+
+
 def _expected_marker() -> str:
-    """The marker a correctly staged copy of the current package would hold."""
-    return f"{__version__} {_tree_digest(PACKAGE_TEMPLATES_DIR)}"
+    """The marker a correctly staged copy of the current package would hold:
+    `<app version> <sha256 of the packaged tree>`. Memoized per process on
+    PACKAGE_TEMPLATES_DIR — the tree is immutable within a process and both
+    import-time callers would otherwise hash all of it independently."""
+    global _EXPECTED_MARKER_MEMO
+    if _EXPECTED_MARKER_MEMO is not None and _EXPECTED_MARKER_MEMO[0] == PACKAGE_TEMPLATES_DIR:
+        return _EXPECTED_MARKER_MEMO[1]
+    marker = f"{__version__} {_tree_digest(PACKAGE_TEMPLATES_DIR)}"
+    _EXPECTED_MARKER_MEMO = (PACKAGE_TEMPLATES_DIR, marker)
+    return marker
 
 
 def ensure_core_templates() -> str:

--- a/fused_render/core_templates.py
+++ b/fused_render/core_templates.py
@@ -99,32 +99,19 @@ def _tree_digest(root: str) -> str:
     return h.hexdigest()
 
 
-# The packaged tree can't change under a running process, so its sha256 — the one
-# expensive part of the gate — is computed at most ONCE per process and reused.
-# ensure_core_templates() runs at import time from BOTH server.templates and
-# executor during a single `import fused_render.server`; without this memo each
-# paid a full, independent hash of the identical ~15.6MB tree. Keyed on
-# PACKAGE_TEMPLATES_DIR so it is self-correcting rather than needing a reset: the
-# suite repoints that constant at a fresh fake tree per test, so a prior test's
-# digest is never reused, and production — one stable path — keeps one entry. The
-# gate stays honest: ensure_core_templates still reads and compares the on-disk
-# marker every call, so a stale STAGED copy is caught exactly as before. Only a
-# test that edits the packaged tree in place (modelling a second app launch — the
-# one time those bytes change) drops the memo via _reset_expected_marker_cache().
+# Process-lifetime memo of the packaged-tree digest, keyed on PACKAGE_TEMPLATES_DIR
+# so it self-corrects across the suite's per-test fake trees.
 _EXPECTED_MARKER_MEMO: tuple[str, str] | None = None
 
 
 def _reset_expected_marker_cache() -> None:
-    """Drop the process-lifetime digest memo (tests only — see _expected_marker)."""
+    """Drop the digest memo (tests only)."""
     global _EXPECTED_MARKER_MEMO
     _EXPECTED_MARKER_MEMO = None
 
 
 def _expected_marker() -> str:
-    """The marker a correctly staged copy of the current package would hold:
-    `<app version> <sha256 of the packaged tree>`. Memoized per process on
-    PACKAGE_TEMPLATES_DIR — the tree is immutable within a process and both
-    import-time callers would otherwise hash all of it independently."""
+    """The marker a correctly staged copy of the current package would hold."""
     global _EXPECTED_MARKER_MEMO
     if _EXPECTED_MARKER_MEMO is not None and _EXPECTED_MARKER_MEMO[0] == PACKAGE_TEMPLATES_DIR:
         return _EXPECTED_MARKER_MEMO[1]

--- a/tests/test_core_templates.py
+++ b/tests/test_core_templates.py
@@ -60,9 +60,7 @@ def test_editing_a_packaged_template_restages_without_a_version_bump(staged):
     (staged.package / "csv" / "template.html").write_text(
         '<html data-fused-theme>light + dark</html>', encoding="utf-8"
     )
-    # A packaged-template edit only ever happens across two app launches; the
-    # digest memo is per process, so drop it to model the second launch (within
-    # one real process the packaged bytes cannot change under a running server).
+    # Per-process memo; drop it to model the second app launch.
     core_templates._reset_expected_marker_cache()
     ensure_core_templates()
     assert staged.served() == '<html data-fused-theme>light + dark</html>'
@@ -98,13 +96,8 @@ def test_an_unchanged_tree_does_not_recopy(staged, monkeypatch):
 
 
 def test_the_packaged_tree_is_hashed_once_per_process(staged, monkeypatch):
-    """The two module-level ensure_core_templates() calls — server/templates.py:16
-    and executor.py:41, both fired by a single `import fused_render.server` — must
-    hash the packaged tree ONCE between them, not twice. The tree can't change
-    under a running process, so the second full-tree sha256 was pure waste (~180ms)
-    on every launch. `staged` gives this test its own fresh fake package path, so
-    the first ensure always misses the memo and the assertion is exactly one pass.
-    """
+    """Both import-time ensure_core_templates() callers must hash the packaged
+    tree once between them, not twice."""
     hashed = []
     real = core_templates._tree_digest
     monkeypatch.setattr(core_templates, "_tree_digest",

--- a/tests/test_core_templates.py
+++ b/tests/test_core_templates.py
@@ -60,6 +60,10 @@ def test_editing_a_packaged_template_restages_without_a_version_bump(staged):
     (staged.package / "csv" / "template.html").write_text(
         '<html data-fused-theme>light + dark</html>', encoding="utf-8"
     )
+    # A packaged-template edit only ever happens across two app launches; the
+    # digest memo is per process, so drop it to model the second launch (within
+    # one real process the packaged bytes cannot change under a running server).
+    core_templates._reset_expected_marker_cache()
     ensure_core_templates()
     assert staged.served() == '<html data-fused-theme>light + dark</html>'
 
@@ -91,6 +95,24 @@ def test_an_unchanged_tree_does_not_recopy(staged, monkeypatch):
     monkeypatch.setattr(core_templates.shutil, "copytree", boom)
     monkeypatch.setattr(core_templates.shutil, "rmtree", boom)
     assert ensure_core_templates() == staged.core
+
+
+def test_the_packaged_tree_is_hashed_once_per_process(staged, monkeypatch):
+    """The two module-level ensure_core_templates() calls — server/templates.py:16
+    and executor.py:41, both fired by a single `import fused_render.server` — must
+    hash the packaged tree ONCE between them, not twice. The tree can't change
+    under a running process, so the second full-tree sha256 was pure waste (~180ms)
+    on every launch. `staged` gives this test its own fresh fake package path, so
+    the first ensure always misses the memo and the assertion is exactly one pass.
+    """
+    hashed = []
+    real = core_templates._tree_digest
+    monkeypatch.setattr(core_templates, "_tree_digest",
+                        lambda root: hashed.append(root) or real(root))
+
+    ensure_core_templates()  # server/templates.py:16
+    ensure_core_templates()  # executor.py:41
+    assert hashed == [str(staged.package)], hashed
 
 
 def test_the_tree_digest_is_stable_and_order_independent(tmp_path):


### PR DESCRIPTION
## What

`ensure_core_templates()` sha256-hashes the entire packaged templates tree (~15.6 MB / 243 files) to check its reset-on-release content gate. It runs at **module-import time from two places** during a single `import fused_render.server`:

- `fused_render/server/templates.py:16` — `TEMPLATES_DIR = ensure_core_templates()`
- `fused_render/executor.py:41` — `_TEMPLATES_DIR = os.path.realpath(ensure_core_templates())`

So every launch paid **two** full-tree hashes. The packaged tree is immutable within a process, so the second pass was pure waste (~180 ms, warm and cold).

This memoizes `_expected_marker()` per process, keyed on `PACKAGE_TEMPLATES_DIR`, so the two callers share one hash.

## Why it's safe — zero change to the gate

- Memoized `_expected_marker()`, **not** `_tree_digest` (driven directly by the order-independence test) and **not** `ensure_core_templates`.
- `ensure_core_templates()` still reads the on-disk `.version` marker and compares on **every** call — the staleness gate that makes releases ship pristine templates is untouched. Only the recomputation of the immutable packaged digest is skipped.
- `executor.py` is unchanged, so there is no import-order or `INPROCESS_HELPERS` allowlist risk, and the `FUSED_RENDER_CORE_TEMPLATES` override still short-circuits before any hashing.
- Keying the memo on the package path makes it self-correcting across the test suite's per-test fake trees (each a fresh path). The one test that edits the packaged tree in place (`test_editing_a_packaged_template_restages_without_a_version_bump`) clears the memo via `_reset_expected_marker_cache()` to model a second app launch — the only time those bytes actually change.

## Verification

- **New test** `test_the_packaged_tree_is_hashed_once_per_process` asserts two back-to-back `ensure_core_templates()` calls hash the tree exactly once.
- **`-X importtime`** on `import fused_render.server`, warm home:

  | module | before | after |
  |---|---|---|
  | `fused_render.server.templates` | 136 ms | 95 ms (the one real hash) |
  | `fused_render.executor` | **168 ms** | **3.6 ms** (memo hit) |

  The second-importing module drops ~165 ms; exactly one full-tree pass remains (confirmed 2 → 1 by in-process instrumentation).

## Tests

- `tests/test_core_templates.py`: **9/9 pass** (8 existing + the new invariant test).
- `tests/test_engine.py`: 44 pass, 25 skip. The only 3 failures are pre-existing POSIX shell-wrapper tests (`%1 is not a valid Win32 application`, `/usr/bin/python3`) that fail identically on unmodified `main` under Windows — unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only caching around digest computation; staging and staleness checks are unchanged, with test-only cache reset for in-place package edits.
> 
> **Overview**
> **Startup cost:** `ensure_core_templates()` runs at import from both `server/templates.py` and `executor.py`, and each call previously recomputed the full packaged-tree SHA256 (~15 MB). This adds a **process-lifetime memo** on `_expected_marker()` keyed by `PACKAGE_TEMPLATES_DIR`, so the second caller reuses the same expected marker string without walking the tree again.
> 
> **Behavior unchanged:** `ensure_core_templates()` still reads the on-disk `.version` marker and compares on every call; only the immutable packaged digest is cached. Tests that mutate the fake package tree in place call `_reset_expected_marker_cache()` to simulate a fresh launch. A new test asserts two back-to-back `ensure_core_templates()` invocations trigger exactly one `_tree_digest` pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff9617c3c44434c89acedd6d7970053437d8f56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->