### PR TITLE
Explorer: a Repos tab, and .git recorded in the index as a leaf directory

### DIFF
--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -380,11 +380,16 @@ export function RecentPreviewCard({
   );
 }
 
-// A folder holding Claude Code sessions, in the same card shell as a
-// bookmark — header (icon + name over path) over the same folder "stack"
-// preview a directory bookmark gets (FolderStack, above). Clicking opens the
-// folder itself in the Explorer, not the Sessions app.
-export function ClaudeSessionFolderCard({ path }: { path: string }) {
+// A plain folder, in the same card shell as a bookmark — header (icon + name
+// over path) over the same folder "stack" preview a directory bookmark gets
+// (FolderStack, above). Clicking opens the folder itself in the Explorer.
+//
+// Deliberately knows nothing about WHY the folder is being listed: the homepage's
+// Artifacts tab points it at Claude Code project folders and its Repos tab at
+// git repo roots, and both want exactly "the folder preview the other tabs
+// show". Any per-tab metadata (a branch, a session time) would belong in the
+// card's header, so it would have to arrive as a prop — none does, on purpose.
+export function FolderPreviewCard({ path }: { path: string }) {
   return (
     <a
       className="fhb-card"

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -21,6 +21,7 @@ import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@a
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
 import {
+  refreshIsPending,
   reposMessage,
   reposNeedsIndexPoll,
   reposStaleNote,
@@ -700,7 +701,10 @@ export default function FilesHome({ config }: { config: Config }) {
   // is precisely the scan-end flicker (the tab showing "go rebuild it" between the
   // poll going idle and the new list arriving). Triggered is not arrived, so the
   // view has to be able to see the gap rather than be told about it afterwards.
-  const refreshPending = fetchedKey !== indexKey;
+  //
+  // The rule itself (notably: the first poll reading is a BASELINE, not a change)
+  // lives in refreshIsPending so it is covered by the state-table walk.
+  const refreshPending = refreshIsPending(fetchedKey, indexKey);
   // One total function over all four inputs, so no impossible in-between state can
   // be rendered — see the state table in lib/repos.ts.
   const reposTab = reposView({

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -7,23 +7,24 @@ import { useEffect, useRef, useState } from "react";
 import { navigate, replaceSearch, urlForFsPath } from "@platform/lib/router";
 import { basename, formatMtime, formatMtimeFull, formatSize } from "@platform/lib/format";
 import { iconForEntry } from "@platform/ui/FileIcons";
-import type { Config, ClaudeSessionFolder } from "@platform/lib/api";
-import { getClaudeSessionFolders, statPath } from "@platform/lib/api";
+import type { Config, ClaudeSessionFolder, GitRepos } from "@platform/lib/api";
+import { getClaudeSessionFolders, getGitRepos, statPath } from "@platform/lib/api";
 import { allBookmarks, hydrateBookmarks, loadBookmarks } from "@platform/lib/bookmarks";
 import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
-import { BookmarkPreviewCard, RecentPreviewCard, ClaudeSessionFolderCard } from "@apps/explorer/BookmarkCards";
+import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
+import { emptyReposMessage } from "@apps/explorer/lib/repos";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
 
-// How many cards the Bookmarks/Recents tab shows before "Show more" — flat
-// count, not a row multiple, so it's the same rule for either tab regardless
-// of how many columns the grid happens to lay out at the current width.
+// How many cards a tab shows before "Show more" — flat count, not a row
+// multiple, so it's the same rule for every tab regardless of how many columns
+// the grid happens to lay out at the current width.
 // 9 fills a 3×3 grid at the layout's usual three columns.
 const MAX_CARDS = 9;
 
-type LaunchTab = "bookmarks" | "recents" | "sessions";
+type LaunchTab = "bookmarks" | "recents" | "sessions" | "repos";
 
 // -- AI search (the files-home composer) --------------------------------------
 
@@ -308,6 +309,7 @@ export default function FilesHome({ config }: { config: Config }) {
   const [expandedBookmarks, setExpandedBookmarks] = useState(false);
   const [expandedRecents, setExpandedRecents] = useState(false);
   const [expandedSessions, setExpandedSessions] = useState(false);
+  const [expandedRepos, setExpandedRepos] = useState(false);
   // Folders flattened: the homepage is a launcher, and a bookmark buried two
   // folders deep is still one the user cared enough to save. Saved-list order.
   const bookmarks = loadBookmarks().length ? allBookmarks() : [];
@@ -333,6 +335,26 @@ export default function FilesHome({ config }: { config: Config }) {
   }, []);
   const shownSessions =
     sessionFolders && (expandedSessions ? sessionFolders : sessionFolders.slice(0, MAX_CARDS));
+  // Git repos, same deal as the session folders: one cheap GET on mount whatever
+  // tab is showing. The whole response is kept, not just the list — the tab has
+  // to tell "no repos on this machine" apart from "the first index scan hasn't
+  // finished", and only `indexed`/`scanning` carry that. A failed request lands
+  // on a null response, which the tab renders as its own message rather than as
+  // an empty repo list.
+  const [repos, setRepos] = useState<GitRepos | null>(null);
+  const [reposFailed, setReposFailed] = useState(false);
+  useEffect(() => {
+    let alive = true;
+    getGitRepos().then(
+      (r) => alive && setRepos(r),
+      () => alive && setReposFailed(true),
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+  const repoList = repos?.repos ?? [];
+  const shownRepos = expandedRepos ? repoList : repoList.slice(0, MAX_CARDS);
   // With no ?tab= in the URL, land on Claude sessions — the leading tab.
   // Bookmark/recent caches still hydrate on mount (effect below) so the other
   // tabs are ready when clicked. An explicit ?tab= always wins.
@@ -342,7 +364,10 @@ export default function FilesHome({ config }: { config: Config }) {
     void hydrateRecents();
   }, []);
   const tab: LaunchTab =
-    tabParam === "recents" || tabParam === "sessions" || tabParam === "bookmarks"
+    tabParam === "recents" ||
+    tabParam === "sessions" ||
+    tabParam === "bookmarks" ||
+    tabParam === "repos"
       ? tabParam
       : "sessions";
   // A committed AI search result takes over the page body (bookmarks/recents
@@ -417,6 +442,15 @@ export default function FilesHome({ config }: { config: Config }) {
               >
                 Recents
               </button>
+              <button
+                type="button"
+                role="tab"
+                aria-selected={tab === "repos"}
+                className={"fh-tab" + (tab === "repos" ? " active" : "")}
+                onClick={() => setTab("repos")}
+              >
+                Repos
+              </button>
               </div>
               {/* Browse rides the tab strip's right edge — the one action in a
                   row of filters, so it sits opposite them rather than above
@@ -480,13 +514,39 @@ export default function FilesHome({ config }: { config: Config }) {
               ) : (
                 <p className="fh-empty">Nothing opened yet. Files you view will show up here.</p>
               )
+            ) : tab === "repos" ? (
+              reposFailed ? (
+                <p className="fh-empty">Couldn't read the list of repos.</p>
+              ) : repos === null ? (
+                <p className="fh-empty">Looking for repos…</p>
+              ) : repoList.length ? (
+                <>
+                  <div className="fhb-grid">
+                    {shownRepos.map((r) => (
+                      <FolderPreviewCard key={r.path} path={r.path} />
+                    ))}
+                  </div>
+                  {repoList.length > MAX_CARDS && (
+                    <ShowMoreButton
+                      expanded={expandedRepos}
+                      onClick={() => setExpandedRepos((v) => !v)}
+                    />
+                  )}
+                </>
+              ) : (
+                // The repo list is derived from the file index, so an empty list
+                // means two different things and the tab must not conflate them:
+                // "you have no repos" is an answer, "we haven't finished looking"
+                // is not.
+                <p className="fh-empty">{emptyReposMessage(repos)}</p>
+              )
             ) : shownSessions === null ? (
               <p className="fh-empty">Looking for artifacts…</p>
             ) : sessionFolders && sessionFolders.length ? (
               <>
                 <div className="fhb-grid">
                   {shownSessions.map((f) => (
-                    <ClaudeSessionFolderCard key={f.path} path={f.path} />
+                    <FolderPreviewCard key={f.path} path={f.path} />
                   ))}
                 </div>
                 {sessionFolders.length > MAX_CARDS && (

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -15,6 +15,7 @@ import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@a
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
 import { emptyReposMessage } from "@apps/explorer/lib/repos";
+import { useIndexStatus } from "@platform/lib/index-status";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
 
@@ -343,18 +344,41 @@ export default function FilesHome({ config }: { config: Config }) {
   // an empty repo list.
   const [repos, setRepos] = useState<GitRepos | null>(null);
   const [reposFailed, setReposFailed] = useState(false);
+  // ...but "one GET on mount" alone would strand the user, because the answer can
+  // arrive LATER: this list is derived from the file index, and a homepage opened
+  // while the first scan is running would sit on "Still building…" until something
+  // remounted the page — which switching tabs does not do (the tab is a URL param,
+  // not a route). That is not an edge case; it is every user's state right after an
+  // upgrade that changes the index rules and forces a rescan.
+  //
+  // So the existing index poller drives the refetch (useIndexStatus, shared with
+  // the listing's search indicator) rather than a poll of our own: it already
+  // knows both scan rates and already reports `last_completed_at`, which is the
+  // exact edge we need — a scan finished, so ask again. Gated on `!indexed`, so a
+  // page whose answer is already good polls nothing at all.
+  const indexScan = useIndexStatus(repos !== null && !repos.indexed);
+  const scanCompletedAt = indexScan?.last_completed_at ?? null;
   useEffect(() => {
     let alive = true;
     getGitRepos().then(
-      (r) => alive && setRepos(r),
+      (r) => {
+        if (!alive) return;
+        setReposFailed(false);
+        setRepos(r);
+      },
       () => alive && setReposFailed(true),
     );
     return () => {
       alive = false;
     };
-  }, []);
+  }, [scanCompletedAt]);
   const repoList = repos?.repos ?? [];
   const shownRepos = expandedRepos ? repoList : repoList.slice(0, MAX_CARDS);
+  // The live poll outranks the (possibly minutes-old) response for `scanning`
+  // alone, so the empty state moves from "no index — go rebuild it" to "still
+  // building" the moment a scan actually starts.
+  const reposState =
+    repos && indexScan ? { ...repos, scanning: indexScan.scanning } : repos;
   // With no ?tab= in the URL, land on Claude sessions — the leading tab.
   // Bookmark/recent caches still hydrate on mount (effect below) so the other
   // tabs are ready when clicked. An explicit ?tab= always wins.
@@ -538,7 +562,7 @@ export default function FilesHome({ config }: { config: Config }) {
                 // means two different things and the tab must not conflate them:
                 // "you have no repos" is an answer, "we haven't finished looking"
                 // is not.
-                <p className="fh-empty">{emptyReposMessage(repos)}</p>
+                <p className="fh-empty">{emptyReposMessage(reposState ?? repos)}</p>
               )
             ) : shownSessions === null ? (
               <p className="fh-empty">Looking for artifacts…</p>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -14,7 +14,12 @@ import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
-import { reposMessage, reposStaleNote, reposView } from "@apps/explorer/lib/repos";
+import {
+  reposMessage,
+  reposNeedsIndexPoll,
+  reposStaleNote,
+  reposView,
+} from "@apps/explorer/lib/repos";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
@@ -353,9 +358,14 @@ export default function FilesHome({ config }: { config: Config }) {
   //
   // So the existing index poller drives the refetch (useIndexStatus, shared with
   // the listing's search indicator) rather than a poll of our own: it already
-  // knows both scan rates. Gated on `!indexed`, so a page whose answer is already
-  // good polls nothing at all.
-  const indexScan = useIndexStatus(repos !== null && !repos.indexed);
+  // knows both scan rates.
+  //
+  // It runs until the answer is FINAL, not merely present (reposNeedsIndexPoll).
+  // Gating on `!indexed` stopped the poll the instant a stale-but-served list
+  // arrived — which froze `indexKey` below, so the cards and their "Reindexing"
+  // note stayed on screen forever, even after the scan that would have cleared
+  // them finished.
+  const indexScan = useIndexStatus(reposNeedsIndexPoll(repos));
   // Refetch whenever the index's OBSERVABLE STATE changes — not when a scan
   // "completes". Completion was the previous trigger and it was subtly wrong:
   // `last_completed_at` is read off the manifest, and a cancelled, failed or
@@ -372,23 +382,46 @@ export default function FilesHome({ config }: { config: Config }) {
   const indexKey = indexScan
     ? `${indexScan.scanning}|${indexScan.last_completed_at ?? ""}`
     : null;
+  // The key the response we are HOLDING was fetched under. `undefined` means
+  // nothing has been fetched yet, which no real key can equal.
+  const [fetchedKey, setFetchedKey] = useState<string | null | undefined>(undefined);
   useEffect(() => {
     let alive = true;
+    const key = indexKey;
     getGitRepos().then(
       (r) => {
         if (!alive) return;
         setReposFailed(false);
         setRepos(r);
+        setFetchedKey(key);
       },
-      () => alive && setReposFailed(true),
+      () => {
+        if (!alive) return;
+        setReposFailed(true);
+        // Stamped on failure too, or `refreshPending` would stay true forever and
+        // the tab would claim something is coming when nothing is.
+        setFetchedKey(key);
+      },
     );
     return () => {
       alive = false;
     };
   }, [indexKey]);
-  // One total function over both sources, so no impossible in-between state can be
-  // rendered (see lib/repos.ts on why this is enumerated rather than derived).
-  const reposTab = reposView(repos, reposFailed, indexScan?.scanning ?? null);
+  // DERIVED, not stored in an effect. The instant `indexKey` changes, this is
+  // already true in the very same render — which is the whole point: a
+  // `setRefreshPending(true)` in an effect lands one frame late, and that one frame
+  // is precisely the scan-end flicker (the tab showing "go rebuild it" between the
+  // poll going idle and the new list arriving). Triggered is not arrived, so the
+  // view has to be able to see the gap rather than be told about it afterwards.
+  const refreshPending = fetchedKey !== indexKey;
+  // One total function over all four inputs, so no impossible in-between state can
+  // be rendered — see the state table in lib/repos.ts.
+  const reposTab = reposView({
+    response: repos,
+    failed: reposFailed,
+    liveScanning: indexScan?.scanning ?? null,
+    refreshPending,
+  });
   const repoList = reposTab.kind === "ready" ? reposTab.repos : [];
   const shownRepos = expandedRepos ? repoList : repoList.slice(0, MAX_CARDS);
   // With no ?tab= in the URL, land on Claude sessions — the leading tab.

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -14,7 +14,7 @@ import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
-import { emptyReposMessage } from "@apps/explorer/lib/repos";
+import { emptyReposMessage, withLiveScanning } from "@apps/explorer/lib/repos";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
@@ -374,11 +374,9 @@ export default function FilesHome({ config }: { config: Config }) {
   }, [scanCompletedAt]);
   const repoList = repos?.repos ?? [];
   const shownRepos = expandedRepos ? repoList : repoList.slice(0, MAX_CARDS);
-  // The live poll outranks the (possibly minutes-old) response for `scanning`
-  // alone, so the empty state moves from "no index — go rebuild it" to "still
-  // building" the moment a scan actually starts.
-  const reposState =
-    repos && indexScan ? { ...repos, scanning: indexScan.scanning } : repos;
+  // The live poll may only RAISE `scanning`, never lower it — see
+  // withLiveScanning for why lowering renders the wrong instruction.
+  const reposState = repos && withLiveScanning(repos, indexScan?.scanning ?? null);
   // With no ?tab= in the URL, land on Claude sessions — the leading tab.
   // Bookmark/recent caches still hydrate on mount (effect below) so the other
   // tabs are ready when clicked. An explicit ?tab= always wins.

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -14,7 +14,7 @@ import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
-import { reposMessage, reposView } from "@apps/explorer/lib/repos";
+import { reposMessage, reposStaleNote, reposView } from "@apps/explorer/lib/repos";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
@@ -553,6 +553,12 @@ export default function FilesHome({ config }: { config: Config }) {
             ) : tab === "repos" ? (
               repoList.length ? (
                 <>
+                  {/* A stale list still shows every card; this is a footnote, not a
+                      warning. An index is always a little behind the filesystem,
+                      so alarming copy here would cry wolf permanently. */}
+                  {reposStaleNote(reposTab) && (
+                    <p className="fh-search-summary">{reposStaleNote(reposTab)}</p>
+                  )}
                   <div className="fhb-grid">
                     {shownRepos.map((r) => (
                       <FolderPreviewCard key={r.path} path={r.path} />

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -14,7 +14,7 @@ import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { BookmarkPreviewCard, RecentPreviewCard, FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
-import { emptyReposMessage, withLiveScanning } from "@apps/explorer/lib/repos";
+import { reposMessage, reposView } from "@apps/explorer/lib/repos";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { TextArea } from "@platform/ui/field/fields";
@@ -353,11 +353,25 @@ export default function FilesHome({ config }: { config: Config }) {
   //
   // So the existing index poller drives the refetch (useIndexStatus, shared with
   // the listing's search indicator) rather than a poll of our own: it already
-  // knows both scan rates and already reports `last_completed_at`, which is the
-  // exact edge we need — a scan finished, so ask again. Gated on `!indexed`, so a
-  // page whose answer is already good polls nothing at all.
+  // knows both scan rates. Gated on `!indexed`, so a page whose answer is already
+  // good polls nothing at all.
   const indexScan = useIndexStatus(repos !== null && !repos.indexed);
-  const scanCompletedAt = indexScan?.last_completed_at ?? null;
+  // Refetch whenever the index's OBSERVABLE STATE changes — not when a scan
+  // "completes". Completion was the previous trigger and it was subtly wrong:
+  // `last_completed_at` is read off the manifest, and a cancelled, failed or
+  // killed run stops without ever writing one (runner.derive_state sets running
+  // false on any run_end; _with_liveness does the same for an abandoned worker).
+  // So those runs moved `scanning` true -> false with `last_completed_at` frozen,
+  // no refetch fired, and the tab sat on "Still building…" with nothing running.
+  //
+  // Keying on the pair covers every way a scan can end — completed, cancelled,
+  // failed, killed — and also the start of one, with no transition bookkeeping to
+  // get wrong. Extra refetches are harmless (the request is a cheap read and the
+  // view is a pure function of its result), which is the point: this trigger is
+  // deliberately over-eager rather than clever.
+  const indexKey = indexScan
+    ? `${indexScan.scanning}|${indexScan.last_completed_at ?? ""}`
+    : null;
   useEffect(() => {
     let alive = true;
     getGitRepos().then(
@@ -371,12 +385,12 @@ export default function FilesHome({ config }: { config: Config }) {
     return () => {
       alive = false;
     };
-  }, [scanCompletedAt]);
-  const repoList = repos?.repos ?? [];
+  }, [indexKey]);
+  // One total function over both sources, so no impossible in-between state can be
+  // rendered (see lib/repos.ts on why this is enumerated rather than derived).
+  const reposTab = reposView(repos, reposFailed, indexScan?.scanning ?? null);
+  const repoList = reposTab.kind === "ready" ? reposTab.repos : [];
   const shownRepos = expandedRepos ? repoList : repoList.slice(0, MAX_CARDS);
-  // The live poll may only RAISE `scanning`, never lower it — see
-  // withLiveScanning for why lowering renders the wrong instruction.
-  const reposState = repos && withLiveScanning(repos, indexScan?.scanning ?? null);
   // With no ?tab= in the URL, land on Claude sessions — the leading tab.
   // Bookmark/recent caches still hydrate on mount (effect below) so the other
   // tabs are ready when clicked. An explicit ?tab= always wins.
@@ -537,11 +551,7 @@ export default function FilesHome({ config }: { config: Config }) {
                 <p className="fh-empty">Nothing opened yet. Files you view will show up here.</p>
               )
             ) : tab === "repos" ? (
-              reposFailed ? (
-                <p className="fh-empty">Couldn't read the list of repos.</p>
-              ) : repos === null ? (
-                <p className="fh-empty">Looking for repos…</p>
-              ) : repoList.length ? (
+              repoList.length ? (
                 <>
                   <div className="fhb-grid">
                     {shownRepos.map((r) => (
@@ -556,11 +566,11 @@ export default function FilesHome({ config }: { config: Config }) {
                   )}
                 </>
               ) : (
-                // The repo list is derived from the file index, so an empty list
-                // means two different things and the tab must not conflate them:
-                // "you have no repos" is an answer, "we haven't finished looking"
-                // is not.
-                <p className="fh-empty">{emptyReposMessage(reposState ?? repos)}</p>
+                // Every no-cards case routes through the same function, so "you
+                // have no repos" can never be shown for "we haven't finished
+                // looking" (or the reverse) — the distinction the index makes
+                // necessary, and the one three earlier versions of this got wrong.
+                <p className="fh-empty">{reposMessage(reposTab)}</p>
               )
             ) : shownSessions === null ? (
               <p className="fh-empty">Looking for artifacts…</p>

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  refreshIsPending,
   reposMessage,
   reposNeedsIndexPoll,
   reposStaleNote,
@@ -200,6 +201,93 @@ describe("reposNeedsIndexPoll", () => {
   });
 });
 
+// -- refreshIsPending: the mount corner --------------------------------------
+
+describe("refreshIsPending", () => {
+  it("is false before anything has been fetched", () => {
+    expect(refreshIsPending(undefined, null)).toBe(false);
+    expect(refreshIsPending(undefined, "false|1")).toBe(false);
+  });
+
+  it("treats the FIRST poll reading as a baseline, not a change", () => {
+    // The bug: at mount the held response is fetched before any poll, so
+    // fetchedKey is null; the first reading then flipped the key and claimed a
+    // pending refresh, flashing "Still building…" over an idle tab's CTA.
+    expect(refreshIsPending(null, "false|123")).toBe(false);
+    expect(refreshIsPending(null, null)).toBe(false);
+  });
+
+  it("is true for every later change, which is what fixes the scan-end flicker", () => {
+    expect(refreshIsPending("false|1", "true|1")).toBe(true);   // scan started
+    expect(refreshIsPending("true|1", "false|1")).toBe(true);   // cancelled/failed
+    expect(refreshIsPending("true|1", "false|2")).toBe(true);   // completed
+    expect(refreshIsPending("false|1", "false|1")).toBe(false); // nothing changed
+  });
+});
+
+describe("the mount sequence, step by step", () => {
+  // An IDLE machine with no index: the tab must reach its actionable CTA and stay
+  // there, never passing through "Still building…".
+  const idleNoIndex = res({ indexed: false, scanning: false, reason: "no-index" });
+
+  it("loading -> unavailable, with no building flash in between", () => {
+    // 1. mounted, nothing fetched, no poll yet
+    let key: string | null = null;
+    let fetched: string | null | undefined = undefined;
+    expect(
+      reposView({ response: null, failed: false, liveScanning: null,
+                  refreshPending: refreshIsPending(fetched, key) }).kind,
+    ).toBe("loading");
+
+    // 2. first response lands (fetched before any poll reading)
+    fetched = null;
+    expect(
+      reposView({ response: idleNoIndex, failed: false, liveScanning: null,
+                  refreshPending: refreshIsPending(fetched, key) }).kind,
+    ).toBe("unavailable");
+
+    // 3. the first poll reading arrives: idle, agreeing with the response. THIS is
+    //    the step that used to flash "building" for a redundant round trip.
+    key = "false|999";
+    const v = reposView({ response: idleNoIndex, failed: false, liveScanning: false,
+                          refreshPending: refreshIsPending(fetched, key) });
+    expect(v.kind).toBe("unavailable");
+    expect(msg(v)).toMatch(/Preferences/);
+
+    // 4. the redundant refetch lands with the same answer. Still settled.
+    fetched = key;
+    expect(
+      reposView({ response: idleNoIndex, failed: false, liveScanning: false,
+                  refreshPending: refreshIsPending(fetched, key) }).kind,
+    ).toBe("unavailable");
+  });
+
+  it("an outdated index reaches its own message without a building flash", () => {
+    const outdated = res({ indexed: false, scanning: false, reason: "outdated" });
+    const v = reposView({ response: outdated, failed: false, liveScanning: false,
+                          refreshPending: refreshIsPending(null, "false|1") });
+    expect(v.kind).toBe("outdated");
+  });
+
+  it("but a scan starting AFTER the baseline still reaches building, no CTA flash", () => {
+    // The case that needs `refreshPending`: the held response predates the scan
+    // entirely, so its own `scanning` is false and only pending covers the gap.
+    const fetched = "false|1";
+    // scan runs
+    expect(
+      reposView({ response: idleNoIndex, failed: false, liveScanning: true,
+                  refreshPending: refreshIsPending(fetched, "true|1") }).kind,
+    ).toBe("building");
+    // scan ends; poll idle again, refetch in flight -> must NOT show the CTA
+    const gap = reposView({
+      response: idleNoIndex, failed: false, liveScanning: false,
+      refreshPending: refreshIsPending(fetched, "false|2"),
+    });
+    expect(gap.kind).toBe("building");
+    expect(msg(gap)).not.toMatch(/Preferences/);
+  });
+});
+
 // -- the whole table, walked ------------------------------------------------
 //
 // Every input combination, checked against the two invariants and for total
@@ -215,12 +303,30 @@ describe("the complete input space", () => {
     LIST,
     STALE_LIST,
   ];
+  // refreshPending is walked as the KEY PAIR it is derived from, not as a free
+  // boolean: the mount corner (fetchedKey null + a first reading) is a specific
+  // pair, and enumerating the boolean alone is what let it through inspection.
+  const keyPairs: Array<[string | null | undefined, string | null]> = [
+    [undefined, null],      // mounted, nothing fetched, no poll
+    [undefined, "false|1"], // nothing fetched, poll already read
+    [null, null],           // response held, poll never read
+    [null, "false|1"],      // THE mount corner: first reading arrives
+    ["false|1", "false|1"], // settled
+    ["false|1", "true|1"],  // a scan started
+    ["true|1", "false|1"],  // cancelled or failed
+    ["true|1", "false|2"],  // completed
+  ];
   const cells: Array<{ input: ReposInputs; v: ReposView }> = [];
   for (const response of responses) {
     for (const failed of [false, true]) {
       for (const liveScanning of [null, false, true]) {
-        for (const refreshPending of [false, true]) {
-          const input = { response, failed, liveScanning, refreshPending };
+        for (const [fetchedKey, indexKey] of keyPairs) {
+          const input = {
+            response,
+            failed,
+            liveScanning,
+            refreshPending: refreshIsPending(fetchedKey, indexKey),
+          };
           cells.push({ input, v: reposView(input) });
         }
       }
@@ -248,6 +354,22 @@ describe("the complete input space", () => {
       const scanning = input.liveScanning ?? input.response?.scanning ?? false;
       if (scanning || input.refreshPending) {
         expect(msg(v)).not.toMatch(/Preferences/);
+      }
+    }
+  });
+
+  it("NO FALSE BUILDING: a settled idle load never claims a scan", () => {
+    // The #2 invariant, by construction. When the response itself reports idle,
+    // the live poll agrees, and the only key movement is the mount baseline, there
+    // is nothing in motion — so `building` would be a claim about nothing and
+    // would hide the CTA the user actually needs.
+    for (const [fetchedKey, indexKey] of keyPairs) {
+      if (refreshIsPending(fetchedKey, indexKey)) continue;
+      for (const response of responses) {
+        if (response === null || response.indexed || response.scanning) continue;
+        const v = reposView({ response, failed: false, liveScanning: false,
+                              refreshPending: false });
+        expect(v.kind).not.toBe("building");
       }
     }
   });

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { reposMessage, reposView, type ReposView } from "@apps/explorer/lib/repos";
+import {
+  reposMessage,
+  reposStaleNote,
+  reposView,
+  type ReposView,
+} from "@apps/explorer/lib/repos";
 import type { GitRepos } from "@platform/lib/api";
 
 const msg = (v: ReposView) => reposMessage(v);
 const res = (over: Partial<GitRepos> = {}): GitRepos => ({
   indexed: false,
   scanning: false,
+  stale: false,
   repos: [],
   ...over,
 });
@@ -24,15 +30,17 @@ describe("reposView", () => {
 
   it("an indexed answer is ready, empty list included", () => {
     const v = reposView(res({ indexed: true }), false, null);
-    expect(v).toEqual({ kind: "ready", repos: [] });
+    expect(v).toEqual({ kind: "ready", repos: [], stale: false });
     expect(msg(v)).toMatch(/No git repositories/);
   });
 
-  it("keeps serving a real answer while a RESCAN runs", () => {
+  it("keeps serving a real answer while a RESCAN runs, marked stale", () => {
     // A rescan over a usable index keeps serving the last completed generation
-    // (index-store.md §4), so scanning must not downgrade an answer to "wait".
+    // (index-store.md §4), so scanning must not downgrade an answer to "wait" —
+    // it becomes a note on a live list.
     const v = reposView(res({ indexed: true, repos: [{ path: "/a" }] }), false, true);
-    expect(v).toEqual({ kind: "ready", repos: [{ path: "/a" }] });
+    expect(v).toEqual({ kind: "ready", repos: [{ path: "/a" }], stale: true });
+    expect(reposStaleNote(v)).toMatch(/may be out of date/i);
   });
 
   it("the live poll outranks the response's older scanning flag", () => {
@@ -45,6 +53,59 @@ describe("reposView", () => {
   });
 });
 
+// The design rule: a stale index is still a useful index. Never hide a list we
+// hold; annotate it.
+describe("stale results are shown, not withheld", () => {
+  const repos = [{ path: "/a" }, { path: "/b" }];
+
+  it("renders every card when the server says stale", () => {
+    const v = reposView(res({ indexed: true, stale: true, repos }), false, false);
+    expect(v).toEqual({ kind: "ready", repos, stale: true });
+    // the note is a footnote, and nothing about it hides the list
+    expect(reposStaleNote(v)).not.toBeNull();
+  });
+
+  it("a fresh answer carries no note at all", () => {
+    const v = reposView(res({ indexed: true, repos }), false, false);
+    expect(reposStaleNote(v)).toBeNull();
+  });
+
+  it("never notes staleness on a state that has no list to be stale", () => {
+    for (const v of [
+      reposView(null, false, null),
+      reposView(null, true, null),
+      reposView(res({ scanning: true }), false, true),
+      reposView(res({ reason: "outdated" }), false, false),
+      reposView(res(), false, false),
+    ]) {
+      expect(reposStaleNote(v)).toBeNull();
+    }
+  });
+});
+
+describe("zero rows: missing data vs a real answer", () => {
+  it("an index predating repo detection is NOT 'no repositories'", () => {
+    // The original silent lie. Zero rows because the rule never ran.
+    const v = reposView(res({ indexed: false, reason: "outdated" }), false, false);
+    expect(v.kind).toBe("outdated");
+    expect(msg(v)).not.toMatch(/No git repositories/);
+    // and it is not the user's job to fix, unlike `unavailable`
+    expect(msg(v)).not.toMatch(/Preferences/);
+  });
+
+  it("a fresh index that found nothing IS 'no repositories'", () => {
+    const v = reposView(res({ indexed: true }), false, false);
+    expect(msg(v)).toMatch(/No git repositories/);
+  });
+
+  it("an outdated index still shows rows when it has them", () => {
+    // reason only accompanies indexed: false; if the server served rows they win.
+    const v = reposView(
+      res({ indexed: true, stale: true, repos: [{ path: "/a" }] }), false, false);
+    expect(v.kind).toBe("ready");
+  });
+});
+
 // The four ways a scan can end, from the tab's point of view. Only the first
 // updates the manifest, which is why "a scan completed" was the wrong refetch
 // trigger and the pair (scanning, last_completed_at) is the right one — see
@@ -53,7 +114,7 @@ describe("reposView", () => {
 describe("the four scan endings", () => {
   it("COMPLETED: the index can answer, so the list shows", () => {
     const v = reposView(res({ indexed: true, repos: [{ path: "/r" }] }), false, false);
-    expect(v).toEqual({ kind: "ready", repos: [{ path: "/r" }] });
+    expect(v).toEqual({ kind: "ready", repos: [{ path: "/r" }], stale: false });
   });
 
   it("CANCELLED: no index and nothing running — actionable, not 'building'", () => {
@@ -92,7 +153,8 @@ describe("reposMessage", () => {
       { kind: "failed" },
       { kind: "building" },
       { kind: "unavailable" },
-      { kind: "ready", repos: [] },
+      { kind: "outdated" },
+      { kind: "ready", repos: [], stale: false },
     ];
     const seen = kinds.map(msg);
     expect(seen.every((m) => m.length > 0)).toBe(true);

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { emptyReposMessage } from "@apps/explorer/lib/repos";
+
+describe("emptyReposMessage", () => {
+  it("says there are none only when the index has actually looked", () => {
+    const msg = emptyReposMessage({ indexed: true, scanning: false, repos: [] });
+    expect(msg).toMatch(/No git repositories/);
+  });
+
+  it("keeps saying 'none' during a RESCAN over an existing index", () => {
+    // scanning is independent of has_index (index-store.md §4: a rescan keeps
+    // serving the last completed generation), so a rescan must not turn a real
+    // answer into "still building".
+    const msg = emptyReposMessage({ indexed: true, scanning: true, repos: [] });
+    expect(msg).toMatch(/No git repositories/);
+  });
+
+  it("says the index is still building while the first scan runs", () => {
+    const msg = emptyReposMessage({ indexed: false, scanning: true, repos: [] });
+    expect(msg).toMatch(/Still building/);
+    expect(msg).not.toMatch(/No git repositories/);
+  });
+
+  it("points at the rebuild control when nothing has ever indexed", () => {
+    const msg = emptyReposMessage({ indexed: false, scanning: false, repos: [] });
+    expect(msg).toMatch(/Preferences → Indexing/);
+    expect(msg).not.toMatch(/No git repositories/);
+  });
+});

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from "bun:test";
 import {
   reposMessage,
+  reposNeedsIndexPoll,
   reposStaleNote,
   reposView,
+  type ReposInputs,
   type ReposView,
 } from "@apps/explorer/lib/repos";
 import type { GitRepos } from "@platform/lib/api";
 
 const msg = (v: ReposView) => reposMessage(v);
+
 const res = (over: Partial<GitRepos> = {}): GitRepos => ({
   indexed: false,
   scanning: false,
@@ -16,139 +19,53 @@ const res = (over: Partial<GitRepos> = {}): GitRepos => ({
   ...over,
 });
 
-describe("reposView", () => {
-  it("is loading until a response arrives, which is not the same as empty", () => {
-    expect(reposView(null, false, null)).toEqual({ kind: "loading" });
-    expect(msg(reposView(null, false, null))).toMatch(/Looking for repos/);
+/** The view, with every input defaulted to "nothing happening". */
+const view = (over: Partial<ReposInputs> = {}): ReposView =>
+  reposView({
+    response: null,
+    failed: false,
+    liveScanning: null,
+    refreshPending: false,
+    ...over,
   });
 
-  it("reports a failed request rather than an empty machine", () => {
-    expect(reposView(null, true, null)).toEqual({ kind: "failed" });
-    // even with a response in hand, a later failure is not "no repos"
-    expect(reposView(res({ indexed: true }), true, null).kind).toBe("failed");
+const REPOS = [{ path: "/a" }, { path: "/b" }];
+const LIST = res({ indexed: true, repos: REPOS });
+const STALE_LIST = res({ indexed: true, stale: true, repos: REPOS });
+
+// -- resting states ----------------------------------------------------------
+
+describe("reposView resting states", () => {
+  it("is loading until the first response, which is not the same as empty", () => {
+    expect(view()).toEqual({ kind: "loading" });
+    expect(msg(view())).toMatch(/Looking for repos/);
+  });
+
+  it("reports a failed FIRST fetch", () => {
+    expect(view({ failed: true })).toEqual({ kind: "failed" });
   });
 
   it("an indexed answer is ready, empty list included", () => {
-    const v = reposView(res({ indexed: true }), false, null);
+    const v = view({ response: res({ indexed: true }) });
     expect(v).toEqual({ kind: "ready", repos: [], stale: false });
     expect(msg(v)).toMatch(/No git repositories/);
   });
 
-  it("keeps serving a real answer while a RESCAN runs, marked stale", () => {
-    // A rescan over a usable index keeps serving the last completed generation
-    // (index-store.md §4), so scanning must not downgrade an answer to "wait" —
-    // it becomes a note on a live list.
-    const v = reposView(res({ indexed: true, repos: [{ path: "/a" }] }), false, true);
-    expect(v).toEqual({ kind: "ready", repos: [{ path: "/a" }], stale: true });
-    expect(reposStaleNote(v)).toMatch(/may be out of date/i);
-  });
-
-  it("the live poll outranks the response's older scanning flag", () => {
-    // response says idle, poll says a scan just started
-    expect(reposView(res(), false, true).kind).toBe("building");
-    // response says scanning, poll says it has stopped — see the four endings below
-    expect(reposView(res({ scanning: true }), false, false).kind).toBe("unavailable");
-    // ...and with nothing polled yet, the response's own flag is all there is
-    expect(reposView(res({ scanning: true }), false, null).kind).toBe("building");
-  });
-});
-
-// The design rule: a stale index is still a useful index. Never hide a list we
-// hold; annotate it.
-describe("stale results are shown, not withheld", () => {
-  const repos = [{ path: "/a" }, { path: "/b" }];
-
-  it("renders every card when the server says stale", () => {
-    const v = reposView(res({ indexed: true, stale: true, repos }), false, false);
-    expect(v).toEqual({ kind: "ready", repos, stale: true });
-    // the note is a footnote, and nothing about it hides the list
-    expect(reposStaleNote(v)).not.toBeNull();
-  });
-
-  it("a fresh answer carries no note at all", () => {
-    const v = reposView(res({ indexed: true, repos }), false, false);
-    expect(reposStaleNote(v)).toBeNull();
-  });
-
-  it("never notes staleness on a state that has no list to be stale", () => {
+  it("only 'unavailable' is actionable, and only when nothing is in motion", () => {
+    expect(view({ response: res({ reason: "no-index" }) }).kind).toBe("unavailable");
+    expect(msg(view({ response: res({ reason: "no-index" }) }))).toMatch(/Preferences/);
+    // the other no-list states must never send the user anywhere
     for (const v of [
-      reposView(null, false, null),
-      reposView(null, true, null),
-      reposView(res({ scanning: true }), false, true),
-      reposView(res({ reason: "outdated" }), false, false),
-      reposView(res(), false, false),
+      view({ response: res({ reason: "no-index" }), liveScanning: true }),
+      view({ response: res({ reason: "no-index" }), refreshPending: true }),
+      view({ response: res({ reason: "outdated" }) }),
     ]) {
-      expect(reposStaleNote(v)).toBeNull();
+      expect(msg(v)).not.toMatch(/Preferences/);
     }
   });
-});
 
-describe("zero rows: missing data vs a real answer", () => {
-  it("an index predating repo detection is NOT 'no repositories'", () => {
-    // The original silent lie. Zero rows because the rule never ran.
-    const v = reposView(res({ indexed: false, reason: "outdated" }), false, false);
-    expect(v.kind).toBe("outdated");
-    expect(msg(v)).not.toMatch(/No git repositories/);
-    // and it is not the user's job to fix, unlike `unavailable`
-    expect(msg(v)).not.toMatch(/Preferences/);
-  });
-
-  it("a fresh index that found nothing IS 'no repositories'", () => {
-    const v = reposView(res({ indexed: true }), false, false);
-    expect(msg(v)).toMatch(/No git repositories/);
-  });
-
-  it("an outdated index still shows rows when it has them", () => {
-    // reason only accompanies indexed: false; if the server served rows they win.
-    const v = reposView(
-      res({ indexed: true, stale: true, repos: [{ path: "/a" }] }), false, false);
-    expect(v.kind).toBe("ready");
-  });
-});
-
-// The four ways a scan can end, from the tab's point of view. Only the first
-// updates the manifest, which is why "a scan completed" was the wrong refetch
-// trigger and the pair (scanning, last_completed_at) is the right one — see
-// FilesHome. Here the contract is narrower and total: given a fresh response and
-// the live flag, the state is never "building" once nothing is scanning.
-describe("the four scan endings", () => {
-  it("COMPLETED: the index can answer, so the list shows", () => {
-    const v = reposView(res({ indexed: true, repos: [{ path: "/r" }] }), false, false);
-    expect(v).toEqual({ kind: "ready", repos: [{ path: "/r" }], stale: false });
-  });
-
-  it("CANCELLED: no index and nothing running — actionable, not 'building'", () => {
-    // The regression this replaced: scanning went true -> false with the manifest
-    // untouched, so the old clamp held "Still building…" forever.
-    const v = reposView(res({ indexed: false, scanning: false }), false, false);
-    expect(v.kind).toBe("unavailable");
-    expect(msg(v)).toMatch(/Preferences → Indexing/);
-    expect(msg(v)).not.toMatch(/Still building/);
-  });
-
-  it("FAILED: indistinguishable from cancelled here, and should be", () => {
-    // A failed run also stops without a manifest. The tab has no better advice
-    // than "rebuild it", so both endings share one honest message.
-    const v = reposView(res({ indexed: false, scanning: false }), false, false);
-    expect(v.kind).toBe("unavailable");
-  });
-
-  it("NEVER STARTED: same state, reached without any scan at all", () => {
-    const v = reposView(res(), false, null);
-    expect(v.kind).toBe("unavailable");
-    expect(msg(v)).toMatch(/hasn't been built yet/);
-  });
-
-  it("IN FLIGHT: only this one says 'building'", () => {
-    expect(msg(reposView(res({ scanning: true }), false, true))).toMatch(
-      /Still building/,
-    );
-  });
-});
-
-describe("reposMessage", () => {
-  it("gives every state its own copy, and no state falls through", () => {
-    const kinds: ReposView[] = [
+  it("gives every state distinct non-empty copy, so none falls through", () => {
+    const all: ReposView[] = [
       { kind: "loading" },
       { kind: "failed" },
       { kind: "building" },
@@ -156,8 +73,210 @@ describe("reposMessage", () => {
       { kind: "outdated" },
       { kind: "ready", repos: [], stale: false },
     ];
-    const seen = kinds.map(msg);
+    const seen = all.map(msg);
     expect(seen.every((m) => m.length > 0)).toBe(true);
-    expect(new Set(seen).size).toBe(kinds.length);
+    expect(new Set(seen).size).toBe(all.length);
+  });
+});
+
+// -- the two invariants ------------------------------------------------------
+
+describe("NEVER REGRESS: a list on screen is not taken away", () => {
+  it("survives a failed refresh", () => {
+    const v = view({ response: LIST, failed: true });
+    expect(v).toEqual({ kind: "ready", repos: REPOS, stale: false });
+  });
+
+  it("survives a rescan, gaining only a note", () => {
+    const v = view({ response: LIST, liveScanning: true });
+    expect(v).toEqual({ kind: "ready", repos: REPOS, stale: true });
+    expect(reposStaleNote(v)).toMatch(/may be out of date/i);
+  });
+
+  it("survives a pending refresh without flashing the note", () => {
+    // `refreshPending` deliberately does NOT set `stale`: it would blink a note on
+    // every refetch of a perfectly fresh list.
+    const v = view({ response: LIST, refreshPending: true });
+    expect(v).toEqual({ kind: "ready", repos: REPOS, stale: false });
+    expect(reposStaleNote(v)).toBeNull();
+  });
+});
+
+describe("NEVER ACTIONABLE while something is coming", () => {
+  it("a pending refresh holds 'building' instead of 'go rebuild it'", () => {
+    // Finding 7, twice over. When a first scan ends, the poll flips to idle before
+    // the keyed refetch lands; without `refreshPending` this cell rendered the
+    // actionable copy for one round trip.
+    const v = view({
+      response: res({ reason: "no-index", scanning: true }),
+      liveScanning: false,
+      refreshPending: true,
+    });
+    expect(v.kind).toBe("building");
+    expect(msg(v)).not.toMatch(/Preferences/);
+  });
+
+  it("only reaches 'unavailable' once the refresh has landed and nothing runs", () => {
+    const v = view({ response: res({ reason: "no-index" }), liveScanning: false });
+    expect(v.kind).toBe("unavailable");
+  });
+});
+
+// -- transitions: where all five bugs lived ----------------------------------
+
+describe("transitions", () => {
+  it("SCAN STARTS over an empty index: unavailable -> building", () => {
+    const before = view({ response: res({ reason: "no-index" }), liveScanning: false });
+    expect(before.kind).toBe("unavailable");
+    // the poll sees a scan; the response has not changed yet
+    const after = view({
+      response: res({ reason: "no-index" }),
+      liveScanning: true,
+      refreshPending: true,
+    });
+    expect(after.kind).toBe("building");
+  });
+
+  it("SCAN ENDS, refetch pending: stays 'building' for the whole gap", () => {
+    const during = view({
+      response: res({ reason: "no-index", scanning: true }),
+      liveScanning: true,
+    });
+    expect(during.kind).toBe("building");
+    // poll idle, new answer not yet applied -> must NOT become actionable
+    const gap = view({
+      response: res({ reason: "no-index", scanning: true }),
+      liveScanning: false,
+      refreshPending: true,
+    });
+    expect(gap.kind).toBe("building");
+  });
+
+  it("REFETCH LANDS FRESH: building -> ready, no note", () => {
+    const v = view({ response: LIST, liveScanning: false, refreshPending: false });
+    expect(v).toEqual({ kind: "ready", repos: REPOS, stale: false });
+    expect(reposStaleNote(v)).toBeNull();
+  });
+
+  it("REFETCH LANDS STILL-STALE (partial multi-root): ready + note, keeps polling", () => {
+    const v = view({ response: STALE_LIST, liveScanning: false });
+    expect(v).toEqual({ kind: "ready", repos: REPOS, stale: true });
+    expect(reposStaleNote(v)).not.toBeNull();
+    // Finding 8: this is the state that used to freeze the poll and strand the note.
+    expect(reposNeedsIndexPoll(STALE_LIST)).toBe(true);
+  });
+
+  it("SCAN CANCELLED with a usable list on screen: cards never disappear", () => {
+    const during = view({ response: STALE_LIST, liveScanning: true });
+    expect(during.kind).toBe("ready");
+    // cancelled: poll idle, manifest untouched, refetch in flight
+    const gap = view({ response: STALE_LIST, liveScanning: false, refreshPending: true });
+    expect(gap).toEqual({ kind: "ready", repos: REPOS, stale: true });
+    // ...and the refetch returns the same still-stale answer. Still a list.
+    const after = view({ response: STALE_LIST, liveScanning: false });
+    expect(after.kind).toBe("ready");
+    expect((after as { repos: unknown }).repos).toEqual(REPOS);
+  });
+
+  it("SCAN CANCELLED with NOTHING on screen: reaches the actionable state", () => {
+    // The counterpart that must still work: a cancelled first scan leaves no index,
+    // and now nothing is coming, so the user does need to be told.
+    const v = view({ response: res({ reason: "no-index" }), liveScanning: false });
+    expect(v.kind).toBe("unavailable");
+    expect(msg(v)).toMatch(/Preferences/);
+  });
+});
+
+// -- the poll gate -----------------------------------------------------------
+
+describe("reposNeedsIndexPoll", () => {
+  it("polls until the answer is FINAL, not merely present", () => {
+    expect(reposNeedsIndexPoll(null)).toBe(true);              // nothing yet
+    expect(reposNeedsIndexPoll(res({ reason: "no-index" }))).toBe(true);
+    expect(reposNeedsIndexPoll(STALE_LIST)).toBe(true);        // finding 8
+    expect(reposNeedsIndexPoll(res({ indexed: true, scanning: true, stale: true })))
+      .toBe(true);
+    expect(reposNeedsIndexPoll(LIST)).toBe(false);             // fresh: stop
+  });
+});
+
+// -- the whole table, walked ------------------------------------------------
+//
+// Every input combination, checked against the two invariants and for total
+// coverage. This is the test that replaces "I reasoned about the cells": five bugs
+// in this file were all a cell nobody enumerated.
+describe("the complete input space", () => {
+  const responses: Array<GitRepos | null> = [
+    null,
+    res({ reason: "no-index" }),
+    res({ reason: "no-index", scanning: true }),
+    res({ reason: "outdated" }),
+    res({ indexed: true }),
+    LIST,
+    STALE_LIST,
+  ];
+  const cells: Array<{ input: ReposInputs; v: ReposView }> = [];
+  for (const response of responses) {
+    for (const failed of [false, true]) {
+      for (const liveScanning of [null, false, true]) {
+        for (const refreshPending of [false, true]) {
+          const input = { response, failed, liveScanning, refreshPending };
+          cells.push({ input, v: reposView(input) });
+        }
+      }
+    }
+  }
+
+  it("is total: every cell yields one of the known kinds", () => {
+    const kinds = new Set([
+      "loading", "failed", "building", "unavailable", "outdated", "ready",
+    ]);
+    for (const { v } of cells) expect(kinds.has(v.kind)).toBe(true);
+  });
+
+  it("NEVER REGRESS holds in every cell: an answer is always shown", () => {
+    for (const { input, v } of cells) {
+      if (input.response?.indexed) {
+        expect(v.kind).toBe("ready");
+        expect((v as { repos: unknown }).repos).toEqual(input.response.repos);
+      }
+    }
+  });
+
+  it("NEVER ACTIONABLE holds in every cell where something is coming", () => {
+    for (const { input, v } of cells) {
+      const scanning = input.liveScanning ?? input.response?.scanning ?? false;
+      if (scanning || input.refreshPending) {
+        expect(msg(v)).not.toMatch(/Preferences/);
+      }
+    }
+  });
+
+  it("every state is reachable — no dead branch in the union", () => {
+    const reached = new Set(cells.map((c) => c.v.kind));
+    expect([...reached].sort()).toEqual([
+      "building", "failed", "loading", "outdated", "ready", "unavailable",
+    ]);
+  });
+
+  it("the poll stops in exactly one situation: a fresh, present answer", () => {
+    for (const response of responses) {
+      const shouldStop = response !== null && response.indexed && !response.stale;
+      expect(reposNeedsIndexPoll(response)).toBe(!shouldStop);
+    }
+  });
+});
+
+// -- zero rows: missing data vs a real answer --------------------------------
+
+describe("zero rows", () => {
+  it("an index predating repo detection is NOT 'no repositories'", () => {
+    const v = view({ response: res({ reason: "outdated" }), liveScanning: false });
+    expect(v.kind).toBe("outdated");
+    expect(msg(v)).not.toMatch(/No git repositories/);
+  });
+
+  it("a fresh index that found nothing IS 'no repositories'", () => {
+    expect(msg(view({ response: res({ indexed: true }) }))).toMatch(/No git repositories/);
   });
 });

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "bun:test";
-import { emptyReposMessage } from "@apps/explorer/lib/repos";
+import { emptyReposMessage, withLiveScanning } from "@apps/explorer/lib/repos";
+
+describe("withLiveScanning", () => {
+  const stale = { indexed: false, scanning: true, repos: [] };
+
+  it("does not lower scanning when a scan just finished", () => {
+    // The flicker: indexed is still false from the pre-scan response, so lowering
+    // scanning here renders "go rebuild the index" for as long as the refetch
+    // takes — telling the user to do the thing that just happened.
+    const merged = withLiveScanning(stale, false);
+    expect(merged.scanning).toBe(true);
+    expect(emptyReposMessage(merged)).toMatch(/Still building/);
+  });
+
+  it("raises scanning the moment a scan starts", () => {
+    const idle = { indexed: false, scanning: false, repos: [] };
+    expect(emptyReposMessage(idle)).toMatch(/Preferences → Indexing/);
+    expect(emptyReposMessage(withLiveScanning(idle, true))).toMatch(/Still building/);
+  });
+
+  it("is a no-op with no poll data yet", () => {
+    expect(withLiveScanning(stale, null)).toBe(stale);
+  });
+
+  it("defers to a fresh response: once refetched, the server's value stands", () => {
+    // The post-refetch state for an index that finished but is still unusable
+    // (e.g. another configured root is unreconciled) must reach the real message.
+    const fresh = { indexed: false, scanning: false, repos: [] };
+    expect(withLiveScanning(fresh, false).scanning).toBe(false);
+    expect(emptyReposMessage(withLiveScanning(fresh, false)))
+      .toMatch(/Preferences → Indexing/);
+  });
+});
 
 describe("emptyReposMessage", () => {
   it("says there are none only when the index has actually looked", () => {

--- a/frontend/src/apps/explorer/lib/repos.test.ts
+++ b/frontend/src/apps/explorer/lib/repos.test.ts
@@ -1,61 +1,101 @@
 import { describe, expect, it } from "bun:test";
-import { emptyReposMessage, withLiveScanning } from "@apps/explorer/lib/repos";
+import { reposMessage, reposView, type ReposView } from "@apps/explorer/lib/repos";
+import type { GitRepos } from "@platform/lib/api";
 
-describe("withLiveScanning", () => {
-  const stale = { indexed: false, scanning: true, repos: [] };
+const msg = (v: ReposView) => reposMessage(v);
+const res = (over: Partial<GitRepos> = {}): GitRepos => ({
+  indexed: false,
+  scanning: false,
+  repos: [],
+  ...over,
+});
 
-  it("does not lower scanning when a scan just finished", () => {
-    // The flicker: indexed is still false from the pre-scan response, so lowering
-    // scanning here renders "go rebuild the index" for as long as the refetch
-    // takes — telling the user to do the thing that just happened.
-    const merged = withLiveScanning(stale, false);
-    expect(merged.scanning).toBe(true);
-    expect(emptyReposMessage(merged)).toMatch(/Still building/);
+describe("reposView", () => {
+  it("is loading until a response arrives, which is not the same as empty", () => {
+    expect(reposView(null, false, null)).toEqual({ kind: "loading" });
+    expect(msg(reposView(null, false, null))).toMatch(/Looking for repos/);
   });
 
-  it("raises scanning the moment a scan starts", () => {
-    const idle = { indexed: false, scanning: false, repos: [] };
-    expect(emptyReposMessage(idle)).toMatch(/Preferences → Indexing/);
-    expect(emptyReposMessage(withLiveScanning(idle, true))).toMatch(/Still building/);
+  it("reports a failed request rather than an empty machine", () => {
+    expect(reposView(null, true, null)).toEqual({ kind: "failed" });
+    // even with a response in hand, a later failure is not "no repos"
+    expect(reposView(res({ indexed: true }), true, null).kind).toBe("failed");
   });
 
-  it("is a no-op with no poll data yet", () => {
-    expect(withLiveScanning(stale, null)).toBe(stale);
+  it("an indexed answer is ready, empty list included", () => {
+    const v = reposView(res({ indexed: true }), false, null);
+    expect(v).toEqual({ kind: "ready", repos: [] });
+    expect(msg(v)).toMatch(/No git repositories/);
   });
 
-  it("defers to a fresh response: once refetched, the server's value stands", () => {
-    // The post-refetch state for an index that finished but is still unusable
-    // (e.g. another configured root is unreconciled) must reach the real message.
-    const fresh = { indexed: false, scanning: false, repos: [] };
-    expect(withLiveScanning(fresh, false).scanning).toBe(false);
-    expect(emptyReposMessage(withLiveScanning(fresh, false)))
-      .toMatch(/Preferences → Indexing/);
+  it("keeps serving a real answer while a RESCAN runs", () => {
+    // A rescan over a usable index keeps serving the last completed generation
+    // (index-store.md §4), so scanning must not downgrade an answer to "wait".
+    const v = reposView(res({ indexed: true, repos: [{ path: "/a" }] }), false, true);
+    expect(v).toEqual({ kind: "ready", repos: [{ path: "/a" }] });
+  });
+
+  it("the live poll outranks the response's older scanning flag", () => {
+    // response says idle, poll says a scan just started
+    expect(reposView(res(), false, true).kind).toBe("building");
+    // response says scanning, poll says it has stopped — see the four endings below
+    expect(reposView(res({ scanning: true }), false, false).kind).toBe("unavailable");
+    // ...and with nothing polled yet, the response's own flag is all there is
+    expect(reposView(res({ scanning: true }), false, null).kind).toBe("building");
   });
 });
 
-describe("emptyReposMessage", () => {
-  it("says there are none only when the index has actually looked", () => {
-    const msg = emptyReposMessage({ indexed: true, scanning: false, repos: [] });
-    expect(msg).toMatch(/No git repositories/);
+// The four ways a scan can end, from the tab's point of view. Only the first
+// updates the manifest, which is why "a scan completed" was the wrong refetch
+// trigger and the pair (scanning, last_completed_at) is the right one — see
+// FilesHome. Here the contract is narrower and total: given a fresh response and
+// the live flag, the state is never "building" once nothing is scanning.
+describe("the four scan endings", () => {
+  it("COMPLETED: the index can answer, so the list shows", () => {
+    const v = reposView(res({ indexed: true, repos: [{ path: "/r" }] }), false, false);
+    expect(v).toEqual({ kind: "ready", repos: [{ path: "/r" }] });
   });
 
-  it("keeps saying 'none' during a RESCAN over an existing index", () => {
-    // scanning is independent of has_index (index-store.md §4: a rescan keeps
-    // serving the last completed generation), so a rescan must not turn a real
-    // answer into "still building".
-    const msg = emptyReposMessage({ indexed: true, scanning: true, repos: [] });
-    expect(msg).toMatch(/No git repositories/);
+  it("CANCELLED: no index and nothing running — actionable, not 'building'", () => {
+    // The regression this replaced: scanning went true -> false with the manifest
+    // untouched, so the old clamp held "Still building…" forever.
+    const v = reposView(res({ indexed: false, scanning: false }), false, false);
+    expect(v.kind).toBe("unavailable");
+    expect(msg(v)).toMatch(/Preferences → Indexing/);
+    expect(msg(v)).not.toMatch(/Still building/);
   });
 
-  it("says the index is still building while the first scan runs", () => {
-    const msg = emptyReposMessage({ indexed: false, scanning: true, repos: [] });
-    expect(msg).toMatch(/Still building/);
-    expect(msg).not.toMatch(/No git repositories/);
+  it("FAILED: indistinguishable from cancelled here, and should be", () => {
+    // A failed run also stops without a manifest. The tab has no better advice
+    // than "rebuild it", so both endings share one honest message.
+    const v = reposView(res({ indexed: false, scanning: false }), false, false);
+    expect(v.kind).toBe("unavailable");
   });
 
-  it("points at the rebuild control when nothing has ever indexed", () => {
-    const msg = emptyReposMessage({ indexed: false, scanning: false, repos: [] });
-    expect(msg).toMatch(/Preferences → Indexing/);
-    expect(msg).not.toMatch(/No git repositories/);
+  it("NEVER STARTED: same state, reached without any scan at all", () => {
+    const v = reposView(res(), false, null);
+    expect(v.kind).toBe("unavailable");
+    expect(msg(v)).toMatch(/hasn't been built yet/);
+  });
+
+  it("IN FLIGHT: only this one says 'building'", () => {
+    expect(msg(reposView(res({ scanning: true }), false, true))).toMatch(
+      /Still building/,
+    );
+  });
+});
+
+describe("reposMessage", () => {
+  it("gives every state its own copy, and no state falls through", () => {
+    const kinds: ReposView[] = [
+      { kind: "loading" },
+      { kind: "failed" },
+      { kind: "building" },
+      { kind: "unavailable" },
+      { kind: "ready", repos: [] },
+    ];
+    const seen = kinds.map(msg);
+    expect(seen.every((m) => m.length > 0)).toBe(true);
+    expect(new Set(seen).size).toBe(kinds.length);
   });
 });

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -25,13 +25,19 @@ export type ReposView =
   | { kind: "loading" }
   // The request itself failed; the index's state is unknown.
   | { kind: "failed" }
-  // The index cannot answer yet AND a scan is in flight — it is coming.
+  // Nothing to show AND a scan is in flight — a list is coming.
   | { kind: "building" }
-  // The index cannot answer and nothing is scanning: it was never built, or a
-  // scan ended without producing one (cancelled, failed). Needs the user.
+  // Nothing to show, nothing running: no index was ever built, or a scan ended
+  // without producing one (cancelled, failed). Needs the user.
   | { kind: "unavailable" }
+  // The index predates repo detection, so its zero rows are not an answer. A
+  // rebuild is forced on the next scan; nothing for the user to fix.
+  | { kind: "outdated" }
   // The index answered. `repos` may be empty, and that is a real answer.
-  | { kind: "ready"; repos: GitRepo[] };
+  // `stale` folds INTO this variant rather than sitting beside the union, so
+  // "showing a list" and "the list might be a little behind" cannot drift apart:
+  // a stale ready state still renders every card, just with a quiet note.
+  | { kind: "ready"; repos: GitRepo[]; stale: boolean };
 
 /**
  * `liveScanning` is the index poll's `scanning`, or null when nothing has polled
@@ -44,13 +50,26 @@ export function reposView(
 ): ReposView {
   if (failed) return { kind: "failed" };
   if (response === null) return { kind: "loading" };
-  // `indexed` is the only bit that decides whether there is an ANSWER. A rescan
-  // over a usable index keeps serving the last completed generation
-  // (index-store.md §4), so scanning never downgrades a real answer to "wait".
-  if (response.indexed) return { kind: "ready", repos: response.repos };
-  return (liveScanning ?? response.scanning)
-    ? { kind: "building" }
-    : { kind: "unavailable" };
+  const scanning = liveScanning ?? response.scanning;
+  // `indexed` is the only bit that decides whether there is an ANSWER, and a
+  // scan in flight never downgrades one: a rescan keeps serving the last completed
+  // generation (index-store.md §4), and the whole point of `stale` is that a list
+  // a generation behind beats no list. It only becomes a note on the cards.
+  if (response.indexed) {
+    return { kind: "ready", repos: response.repos, stale: response.stale || scanning };
+  }
+  // No answer available. `outdated` is its own state because the remedy differs:
+  // nothing has to be done, a rebuild is already forced — where `unavailable`
+  // genuinely needs the user to start one.
+  if (scanning) return { kind: "building" };
+  return response.reason === "outdated" ? { kind: "outdated" } : { kind: "unavailable" };
+}
+
+/** The quiet note shown above a stale list, or null when there is nothing to say. */
+export function reposStaleNote(view: ReposView): string | null {
+  return view.kind === "ready" && view.stale
+    ? "Reindexing — this list may be out of date."
+    : null;
 }
 
 export function reposMessage(view: ReposView): string {
@@ -61,6 +80,10 @@ export function reposMessage(view: ReposView): string {
       return "Couldn't read the list of repos.";
     case "building":
       return "Still building the file index — repos will appear when the first scan finishes.";
+    case "outdated":
+      // Not actionable on purpose: the rules change already forces a rescan, so
+      // sending the user to Preferences would be busywork.
+      return "The file index predates repo detection — repos will appear after the next scan.";
     case "unavailable":
       // Deliberately actionable: this is the state where nothing is going to
       // happen on its own, including after a scan was cancelled or failed.

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -8,6 +8,23 @@
 // three messages. Pure, so it can be tested without rendering the page.
 import type { GitRepos } from "@platform/lib/api";
 
+// Fold the live index poll's `scanning` into a (possibly stale) /api/git-repos
+// response. The poll may only RAISE the flag, never lower it.
+//
+// Raising is the useful half: the empty state moves from "no index — go rebuild
+// it" to "still building" the moment a scan starts, without waiting for a refetch.
+// Lowering would be actively wrong — the instant a scan finishes `scanning` goes
+// false while `indexed` is still false from the pre-scan response, so the tab would
+// render "go rebuild the index from Preferences" for as long as the refetch takes,
+// telling the user to do something that just happened. The refetch is already in
+// flight (FilesHome keys it on that same completion), so holding the previous
+// message until the real answer lands is both correct and shorter. Once it lands,
+// `scanning` comes fresh from the server and this is a no-op.
+export function withLiveScanning(r: GitRepos, liveScanning: boolean | null): GitRepos {
+  if (liveScanning === null) return r;
+  return { ...r, scanning: r.scanning || liveScanning };
+}
+
 export function emptyReposMessage(r: GitRepos): string {
   if (r.indexed) return "No git repositories found on this machine.";
   // Not indexed. `scanning` separates "wait, it's happening" from "nothing has

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -40,29 +40,97 @@ export type ReposView =
   | { kind: "ready"; repos: GitRepo[]; stale: boolean };
 
 /**
- * `liveScanning` is the index poll's `scanning`, or null when nothing has polled
- * yet. It wins over the response's own (older) copy whenever it exists.
+ * Everything the view depends on. A named object rather than positional booleans
+ * on purpose: "two independently-updating booleans read next to each other" is the
+ * literal shape of every bug this file has had, and at three of them a positional
+ * signature is a trap.
  */
-export function reposView(
-  response: GitRepos | null,
-  failed: boolean,
-  liveScanning: boolean | null,
-): ReposView {
-  if (failed) return { kind: "failed" };
-  if (response === null) return { kind: "loading" };
+export interface ReposInputs {
+  /** Last SUCCESSFUL /api/git-repos body, or null before the first one. */
+  response: GitRepos | null;
+  /** The most recent fetch rejected. */
+  failed: boolean;
+  /** The index poll's `scanning`, or null when nothing has polled yet. */
+  liveScanning: boolean | null;
+  /**
+   * A /api/git-repos request is in flight whose result has not been applied yet.
+   *
+   * This is the input whose absence caused the scan-end flicker twice. "A refetch
+   * is triggered" is not the same claim as "the new answer has arrived", and the
+   * whole gap between those two is a window where the response on hand describes a
+   * world that no longer exists. It must be derived during render (FilesHome
+   * compares the key the response was fetched under against the current one), not
+   * set from an effect — an effect lands one frame late, which is exactly the
+   * flicker in miniature.
+   */
+  refreshPending: boolean;
+}
+
+/**
+ * The complete state table. Rows are ordered by the priority the guards apply,
+ * every cell is reachable, and the two invariants that killed five bugs are:
+ *
+ *   NEVER REGRESS  — a state on screen is never replaced by a worse one just
+ *                    because a transient input flipped. A held list survives a
+ *                    failed refresh and an in-flight rescan.
+ *   NEVER ACTIONABLE WHILE SOMETHING IS COMING — the "go rebuild it" copy is
+ *                    unreachable while a scan runs OR a refresh is pending, so it
+ *                    can only appear when nothing is going to fix itself.
+ *
+ * | response | failed | scanning | pending | reason   | -> view            |
+ * |----------|--------|----------|---------|----------|--------------------|
+ * | null     | no     | any      | any     | -        | loading            |
+ * | null     | YES    | any      | any     | -        | failed             |
+ * | indexed  | any    | no       | any     | -        | ready (stale?)     |
+ * | indexed  | any    | YES      | any     | -        | ready + stale      |
+ * | no list  | any    | YES      | any     | any      | building           |
+ * | no list  | any    | no       | YES     | any      | building  <- #7    |
+ * | no list  | any    | no       | no      | outdated | outdated           |
+ * | no list  | any    | no       | no      | other    | unavailable        |
+ *
+ * `scanning` is `liveScanning ?? response.scanning`: the live poll wins when we
+ * have one, the response's own copy bridges the first render.
+ */
+export function reposView({
+  response,
+  failed,
+  liveScanning,
+  refreshPending,
+}: ReposInputs): ReposView {
+  // `failed` only decides the outcome when there is nothing else to show. Throwing
+  // away 21 good cards because one refresh timed out would be the never-regress
+  // rule violated at its most visible.
+  if (response === null) return failed ? { kind: "failed" } : { kind: "loading" };
   const scanning = liveScanning ?? response.scanning;
-  // `indexed` is the only bit that decides whether there is an ANSWER, and a
-  // scan in flight never downgrades one: a rescan keeps serving the last completed
-  // generation (index-store.md §4), and the whole point of `stale` is that a list
-  // a generation behind beats no list. It only becomes a note on the cards.
+  // `indexed` is the only bit that decides whether there is an ANSWER, and nothing
+  // downgrades one: a rescan keeps serving the last completed generation
+  // (index-store.md §4), and the point of `stale` is that a list a generation
+  // behind beats no list. Both only add a note to the cards.
   if (response.indexed) {
     return { kind: "ready", repos: response.repos, stale: response.stale || scanning };
   }
-  // No answer available. `outdated` is its own state because the remedy differs:
-  // nothing has to be done, a rebuild is already forced — where `unavailable`
-  // genuinely needs the user to start one.
-  if (scanning) return { kind: "building" };
+  // No answer to show. Anything in motion means one is coming, so the holding
+  // message is used and the actionable ones are out of reach.
+  if (scanning || refreshPending) return { kind: "building" };
+  // Nothing in motion. `outdated` is still distinct from `unavailable` because its
+  // remedy differs: a rebuild is already forced by the rules change, so telling the
+  // user to go start one would be busywork.
   return response.reason === "outdated" ? { kind: "outdated" } : { kind: "unavailable" };
+}
+
+/**
+ * Whether the tab should keep polling the index. True until the answer is FINAL —
+ * indexed and not stale. Gating on `!indexed` (the previous rule) stopped the poll
+ * the moment a stale-but-served list arrived, which froze the refetch key and left
+ * the cards and their "Reindexing" note on screen permanently.
+ *
+ * The cost, named: a `stale` that nothing will clear on its own — a configured root
+ * the user never rescans — keeps the poll on its 10s idle heartbeat for as long as
+ * the homepage is open. That is the same idle heartbeat the listing's search box
+ * pays, and it is the price of never being stuck.
+ */
+export function reposNeedsIndexPoll(response: GitRepos | null): boolean {
+  return !(response !== null && response.indexed && !response.stale);
 }
 
 /** The quiet note shown above a stale list, or null when there is nothing to say. */

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -119,6 +119,37 @@ export function reposView({
 }
 
 /**
+ * Whether a /api/git-repos refetch that COULD CHANGE THE ANSWER is in flight.
+ *
+ * `fetchedKey` is the index-state key the held response was fetched under;
+ * `indexKey` is the current one. Both are opaque strings (see FilesHome), and
+ * `null` means "no poll reading yet".
+ *
+ * Two cases are deliberately NOT pending, and both are about the mount sequence:
+ *
+ *   * nothing fetched yet (`undefined`) — the view is `loading` regardless, and
+ *     there is no held answer for a pending flag to protect.
+ *   * the held response was fetched before any poll reading (`fetchedKey` null)
+ *     and this is that FIRST reading arriving. That is a baseline adoption, not a
+ *     change: the response already carried the server's own `scanning` for the
+ *     same moment, so the refetch it triggers cannot change the answer. Calling
+ *     it pending made an idle no-index tab flash "Still building…" over its
+ *     Preferences CTA for one redundant round trip on every load.
+ *
+ * Every later transition IS pending, which is what keeps the scan-end flicker
+ * fixed — including the case where the held response predates the scan entirely
+ * (fetched idle, then a scan starts and ends), where the response's own
+ * `scanning` is false and nothing else would cover the gap.
+ */
+export function refreshIsPending(
+  fetchedKey: string | null | undefined,
+  indexKey: string | null,
+): boolean {
+  if (fetchedKey === undefined || fetchedKey === null) return false;
+  return fetchedKey !== indexKey;
+}
+
+/**
  * Whether the tab should keep polling the index. True until the answer is FINAL —
  * indexed and not stale. Gating on `!indexed` (the previous rule) stopped the poll
  * the moment a stale-but-served list arrived, which froze the refetch key and left

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -1,0 +1,18 @@
+// The Repos tab's empty-state copy (FilesHome.tsx).
+//
+// The repo list is DERIVED from the file index, so an empty list is ambiguous in
+// a way the other tabs' empty lists are not: bookmarks and recents are local
+// state that is simply empty, but "no repos" can mean the first index scan
+// hasn't finished. Saying "no repos found" then is a lie about the machine, and
+// the user has no way to tell it apart from the truth — so the three cases get
+// three messages. Pure, so it can be tested without rendering the page.
+import type { GitRepos } from "@platform/lib/api";
+
+export function emptyReposMessage(r: GitRepos): string {
+  if (r.indexed) return "No git repositories found on this machine.";
+  // Not indexed. `scanning` separates "wait, it's happening" from "nothing has
+  // ever indexed this machine", which needs the user to go start a scan.
+  return r.scanning
+    ? "Still building the file index — repos will appear when the first scan finishes."
+    : "The file index hasn't been built yet, so there's nothing to list repos from. Rebuild it from Preferences → Indexing.";
+}

--- a/frontend/src/apps/explorer/lib/repos.ts
+++ b/frontend/src/apps/explorer/lib/repos.ts
@@ -1,35 +1,71 @@
-// The Repos tab's empty-state copy (FilesHome.tsx).
+// What the Explorer homepage's Repos tab is currently showing, and the copy for
+// each state.
 //
-// The repo list is DERIVED from the file index, so an empty list is ambiguous in
-// a way the other tabs' empty lists are not: bookmarks and recents are local
-// state that is simply empty, but "no repos" can mean the first index scan
-// hasn't finished. Saying "no repos found" then is a lie about the machine, and
-// the user has no way to tell it apart from the truth — so the three cases get
-// three messages. Pure, so it can be tested without rendering the page.
-import type { GitRepos } from "@platform/lib/api";
+// This exists as ONE total function over the inputs because deriving the state ad
+// hoc did not work. The tab has two independently-updating sources — a
+// /api/git-repos response (which can be seconds old) and the live index poll — and
+// three rounds of bugs all came from the same shape: reading a boolean from one
+// source next to a boolean from the other produces intermediate combinations that
+// are not real states. "Still building" forever (no refetch), then the opposite
+// flicker ("go rebuild the index" for one frame right after a scan finished), then
+// "Still building" forever again for a CANCELLED scan. Each patch created the next
+// edge case.
+//
+// So the states are enumerated instead of derived, the impossible combinations are
+// not representable, and the freshness problem is solved where it belongs: the
+// caller refetches whenever the index's observable state changes AT ALL (see
+// FilesHome), so a scan that completes, is cancelled, fails, or is killed all end
+// with a fresh response. That is what lets `liveScanning` simply win here rather
+// than being clamped one way — the clamp was the previous fix, and it was a clamp
+// precisely because the refetch could not be trusted to happen.
+import type { GitRepo, GitRepos } from "@platform/lib/api";
 
-// Fold the live index poll's `scanning` into a (possibly stale) /api/git-repos
-// response. The poll may only RAISE the flag, never lower it.
-//
-// Raising is the useful half: the empty state moves from "no index — go rebuild
-// it" to "still building" the moment a scan starts, without waiting for a refetch.
-// Lowering would be actively wrong — the instant a scan finishes `scanning` goes
-// false while `indexed` is still false from the pre-scan response, so the tab would
-// render "go rebuild the index from Preferences" for as long as the refetch takes,
-// telling the user to do something that just happened. The refetch is already in
-// flight (FilesHome keys it on that same completion), so holding the previous
-// message until the real answer lands is both correct and shorter. Once it lands,
-// `scanning` comes fresh from the server and this is a no-op.
-export function withLiveScanning(r: GitRepos, liveScanning: boolean | null): GitRepos {
-  if (liveScanning === null) return r;
-  return { ...r, scanning: r.scanning || liveScanning };
+export type ReposView =
+  // No response yet. Distinct from "ready with nothing", which is an answer.
+  | { kind: "loading" }
+  // The request itself failed; the index's state is unknown.
+  | { kind: "failed" }
+  // The index cannot answer yet AND a scan is in flight — it is coming.
+  | { kind: "building" }
+  // The index cannot answer and nothing is scanning: it was never built, or a
+  // scan ended without producing one (cancelled, failed). Needs the user.
+  | { kind: "unavailable" }
+  // The index answered. `repos` may be empty, and that is a real answer.
+  | { kind: "ready"; repos: GitRepo[] };
+
+/**
+ * `liveScanning` is the index poll's `scanning`, or null when nothing has polled
+ * yet. It wins over the response's own (older) copy whenever it exists.
+ */
+export function reposView(
+  response: GitRepos | null,
+  failed: boolean,
+  liveScanning: boolean | null,
+): ReposView {
+  if (failed) return { kind: "failed" };
+  if (response === null) return { kind: "loading" };
+  // `indexed` is the only bit that decides whether there is an ANSWER. A rescan
+  // over a usable index keeps serving the last completed generation
+  // (index-store.md §4), so scanning never downgrades a real answer to "wait".
+  if (response.indexed) return { kind: "ready", repos: response.repos };
+  return (liveScanning ?? response.scanning)
+    ? { kind: "building" }
+    : { kind: "unavailable" };
 }
 
-export function emptyReposMessage(r: GitRepos): string {
-  if (r.indexed) return "No git repositories found on this machine.";
-  // Not indexed. `scanning` separates "wait, it's happening" from "nothing has
-  // ever indexed this machine", which needs the user to go start a scan.
-  return r.scanning
-    ? "Still building the file index — repos will appear when the first scan finishes."
-    : "The file index hasn't been built yet, so there's nothing to list repos from. Rebuild it from Preferences → Indexing.";
+export function reposMessage(view: ReposView): string {
+  switch (view.kind) {
+    case "loading":
+      return "Looking for repos…";
+    case "failed":
+      return "Couldn't read the list of repos.";
+    case "building":
+      return "Still building the file index — repos will appear when the first scan finishes.";
+    case "unavailable":
+      // Deliberately actionable: this is the state where nothing is going to
+      // happen on its own, including after a scan was cancelled or failed.
+      return "The file index hasn't been built yet, so there's nothing to list repos from. Rebuild it from Preferences → Indexing.";
+    case "ready":
+      return "No git repositories found on this machine.";
+  }
 }

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1881,6 +1881,14 @@ export function getClaudeSessionFolders(): Promise<{ folders: ClaudeSessionFolde
 // the file index, so a machine whose first scan has not finished yet is NOT the
 // same as a machine with no repos, and `scanning` says whether one is in flight.
 // Both come from the same vocabulary /api/index/status uses.
+//
+// `stale` means "this list may be out of date, reindexing" — a scan is running, or
+// the index was built under older rules. It is NOT an error and NOT a reason to
+// hide the list: an index is always slightly behind the filesystem, so a stale
+// answer is the normal one. The server serves rows whenever it has them and only
+// reports `indexed: false` when it genuinely cannot answer, in which case `reason`
+// says which way ("no-index": nothing has ever been built; "outdated": the index
+// predates repo detection, so its zero rows are not an answer).
 export interface GitRepo {
   path: string;
 }
@@ -1888,6 +1896,8 @@ export interface GitRepo {
 export interface GitRepos {
   indexed: boolean;
   scanning: boolean;
+  stale: boolean;
+  reason?: "no-index" | "outdated" | null;
   repos: GitRepo[];
 }
 

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1872,6 +1872,29 @@ export function getClaudeSessionFolders(): Promise<{ folders: ClaudeSessionFolde
   return getJson<{ folders: ClaudeSessionFolder[] }>("/api/claude-sessions");
 }
 
+// -- Git repos (GET /api/git-repos) -------------------------------------------
+// Git repositories on this machine, for the Explorer homepage's "Repos" tab.
+// One entry per repo root, in path order; `path` is ready to pass straight to
+// navigate(path, {isDir:true}).
+//
+// `indexed` is the state the tab has to distinguish: the list is derived from
+// the file index, so a machine whose first scan has not finished yet is NOT the
+// same as a machine with no repos, and `scanning` says whether one is in flight.
+// Both come from the same vocabulary /api/index/status uses.
+export interface GitRepo {
+  path: string;
+}
+
+export interface GitRepos {
+  indexed: boolean;
+  scanning: boolean;
+  repos: GitRepo[];
+}
+
+export function getGitRepos(): Promise<GitRepos> {
+  return getJson<GitRepos>("/api/git-repos");
+}
+
 // -- AI completion (POST /api/ai) ---------------------------------------------
 // The fused.ai relay: one non-streaming completion through the server's warm
 // Claude Code CLI instance (server/ai.py). The shell uses this for small

--- a/frontend/src/shell/ClaudeArtifacts.tsx
+++ b/frontend/src/shell/ClaudeArtifacts.tsx
@@ -1,6 +1,6 @@
 // /claude-artifacts: the Explorer homepage's "Artifacts" tab, promoted to a
 // page of its own under the sidebar's CLAUDE group. Same data and the same
-// card as the tab (GET /api/claude-sessions → ClaudeSessionFolderCard, one
+// card as the tab (GET /api/claude-sessions → FolderPreviewCard, one
 // entry per project folder that holds Claude Code transcripts, newest first);
 // the difference is that a page has room to list every folder instead of
 // folding at the tab's MAX_CARDS, so there is no "Show more" here.
@@ -9,7 +9,7 @@
 // list, for people who think of it as a Claude thing rather than a file thing.
 import { useEffect, useState } from "react";
 import { getClaudeSessionFolders, type ClaudeSessionFolder } from "@platform/lib/api";
-import { ClaudeSessionFolderCard } from "@apps/explorer/BookmarkCards";
+import { FolderPreviewCard } from "@apps/explorer/BookmarkCards";
 
 export default function ClaudeArtifacts() {
   // One cheap GET on mount — no client-side cache to reconcile, and the shell
@@ -42,7 +42,7 @@ export default function ClaudeArtifacts() {
         ) : folders.length ? (
           <div className="fhb-grid">
             {folders.map((f) => (
-              <ClaudeSessionFolderCard key={f.path} path={f.path} />
+              <FolderPreviewCard key={f.path} path={f.path} />
             ))}
           </div>
         ) : (

--- a/fused_render/index/ignore.py
+++ b/fused_render/index/ignore.py
@@ -9,6 +9,12 @@ Three layers, deliberately distinct:
     Dependency and build caches that are huge, machine-generated and useless
     to search. Pruning them is not a display filter: the walk never descends,
     so they cost no stat, no parquet row and no query time.
+  * the LEAF rules (`LEAF_DIR_SUFFIXES`, `LEAF_DIR_NAMES`) — recorded as one
+    opaque row and never listed. The middle ground between indexing a tree and
+    pretending it isn't there: a macOS package or a `.git` directory is worth
+    knowing about but never worth looking inside. Cheaper than an ignore rule,
+    too, since ignore rules prune subdirectories but not the files sitting
+    directly in the pruned directory.
   * `MountGuard` — remote buckets mounted by fused-render. `default_ignore()`
     already names the mounts dir, but that list is user-editable and a kernel
     `scandir`/`stat` on an rclone NFS mount path can wedge the mount
@@ -64,8 +70,15 @@ SKIP_DIRS = {
 # and kept by the other makes results flip between two sources that are meant
 # to be interchangeable — the same inconsistency server/index_gitignore.py
 # exists to prevent for gitignored entries.
+#
+# `.git` is deliberately NOT here — it is a LEAF dir (LEAF_DIR_NAMES below), so
+# it gets one row and no contents rather than vanishing. Ignoring it would be
+# strictly worse than the leaf rule even on cost grounds: ignore rules prune
+# SUBdirectories but not files, so a pruned-tree `.git` would still contribute
+# the ~15 loose files sitting directly in it (HEAD, config, index, …) and still
+# pay to list the directory. A leaf dir is never listed at all.
 SHARED_IGNORE_DIRS = (
-    "node_modules", ".venv", "venv", "__pycache__", ".git", "site-packages",
+    "node_modules", ".venv", "venv", "__pycache__", "site-packages",
 )
 # macOS package directories: ONE entry, never descended. Their internals are
 # implementation details (Finder hides them too) and one Electron .app alone is
@@ -79,15 +92,39 @@ SHARED_IGNORE_DIRS = (
 # and not the other flips results between two interchangeable sources. The
 # dependency direction is server -> index; do not invert it.
 LEAF_DIR_SUFFIXES = (".app", ".framework", ".bundle", ".photoslibrary")
+# Leaf directories matched by EXACT NAME rather than by suffix.
+#
+# `.git` is one: the explorer's homepage lists this machine's git repositories,
+# and making that a queryable index fact ("which dirs rows are named .git") beats
+# the alternative of stat-ing every one of ~71k indexed directories for a `.git`
+# child on every request. The leaf rule is what makes it nearly free — one row,
+# no descent, so a repo's object database (routinely 10k+ files) stays out.
+#
+# Name equality, NOT an extra LEAF_DIR_SUFFIXES entry: that tuple is matched with
+# `endswith`, and a bare repository is conventionally named `foo.git` — a suffix
+# rule would record those as opaque leaves and hide their entire contents, which
+# for a bare repo is the whole repository. `.git` as a NAME is unambiguous.
+#
+# Shared with server/walk.py (WALK_LEAF_DIR_NAMES) for the same reason
+# LEAF_DIR_SUFFIXES is, and it matters more here: `.git` moved OUT of
+# SHARED_IGNORE_DIRS to get this treatment, so a walk that kept pruning it would
+# disagree with the index about whether `.git` exists at all.
+LEAF_DIR_NAMES = (".git",)
 
 
 def is_leaf_dir(path: str) -> bool:
-    """Whether `path` is a package directory — recorded, but never descended."""
-    return path.lower().endswith(LEAF_DIR_SUFFIXES)
+    """Whether `path` is a leaf directory — recorded, but never descended.
+
+    A macOS package (LEAF_DIR_SUFFIXES) or a directory whose name is one of
+    LEAF_DIR_NAMES (`.git`). Both are opaque for the same reason: the contents
+    are machine-managed implementation detail nobody searches for, while the
+    directory's own existence is worth a row."""
+    tail = path.rpartition("/")[2].lower()
+    return tail in LEAF_DIR_NAMES or tail.endswith(LEAF_DIR_SUFFIXES)
 
 
 def is_inside_leaf_dir(path: str) -> bool:
-    """Whether any ANCESTOR of `path` is a package directory — i.e. whether the
+    """Whether any ANCESTOR of `path` is a leaf directory — i.e. whether the
     leaf rule means this path should not exist as a row at all.
 
     `is_leaf_dir` is enough wherever descent is what's being decided: a walk
@@ -95,14 +132,18 @@ def is_inside_leaf_dir(path: str) -> bool:
     are handed a path instead of descending to it — the FSEvents fast path
     (scan._run_fsevents), the coverage test in query.search_under — see package
     internals directly and need this test, because the final component of
-    `Foo.app/Contents/Resources` says nothing about the package above it.
+    `Foo.app/Contents/Resources` says nothing about the package above it. `.git`
+    makes this path hotter, not different: an active repo writes under
+    `.git/objects` constantly, so the journal names those directories on almost
+    every incremental run.
 
-    Ancestors ONLY: a final component that is itself a package is is_leaf_dir's
+    Ancestors ONLY: a final component that is itself a leaf is is_leaf_dir's
     business, and that one gets RECORDED where these get dropped. Pure string
     work on purpose — it runs once per journal-reported directory, so it must
     not stat anything. Paths are `norm`ed, so "/" is the only separator."""
     head, _, _ = path.rpartition("/")
-    return any(part.lower().endswith(LEAF_DIR_SUFFIXES)
+    return any(part.lower() in LEAF_DIR_NAMES
+               or part.lower().endswith(LEAF_DIR_SUFFIXES)
                for part in head.split("/"))
 
 
@@ -258,7 +299,23 @@ class IgnoreRules:
                 if s not in SKIP_DIRS and not self.is_ignored(s)]
 
     def sig(self) -> str:
-        return ignore_sig(self.patterns)
+        """The fingerprint of everything that decides WHAT LANDS IN THE INDEX,
+        which is what every caller actually means by this value: `scan.run_scan`
+        drops its incremental cache when it changes, and the router's
+        needs_rescan bit is the same comparison.
+
+        So it covers the leaf-dir rules as well as the user's patterns. That is
+        not decoration — `.git` moved from the ignore list to LEAF_DIR_NAMES,
+        which turns "no `.git` rows" from a fact into a rule change, and an index
+        built before it holds no `.git` rows at all. Without the leaf rules in
+        here, that index's sig would still match and nothing would ever rescan
+        it, so /api/git-repos would confidently report zero repositories forever.
+        Including them makes the first scan after the upgrade a full rescan for
+        everyone, and lets a reader detect a pre-rule index (routers/git_repos.py)
+        instead of trusting it."""
+        return ignore_sig([*self.patterns,
+                           "\x00leaf-names=" + ",".join(LEAF_DIR_NAMES),
+                           "\x00leaf-suffixes=" + ",".join(LEAF_DIR_SUFFIXES)])
 
 
 class MountGuard:

--- a/fused_render/index/ignore.py
+++ b/fused_render/index/ignore.py
@@ -123,6 +123,50 @@ def is_leaf_dir(path: str) -> bool:
     return tail in LEAF_DIR_NAMES or tail.endswith(LEAF_DIR_SUFFIXES)
 
 
+def ignored_for_index(rules: "IgnoreRules", path: str, *, tree: bool) -> bool:
+    """THE question every ignore gate asks: does the ignore list forbid a
+    `dirs.parquet` ROW for `path`?
+
+    This is the single definition, and it exists because there are THREE gates
+    that filter by the ignore list (specs/scan-ignore.md §3) and the leaf
+    exemption has to mean the same thing at all of them:
+
+      * `scan.keep_subdirs`     — subdirs handed on by a walk        (tree=False)
+      * `store.load_dir_cache`  — cached rows read back from parquet (tree=True)
+      * `scan._run_fsevents`    — paths named by the OS journal      (tree=True)
+
+    Applying it at only one of those is not a partial fix, it is a DATA LOSS bug:
+    `keep_subdirs` alone let a full rescan write `.git` rows for a config that
+    names `.git`, and then the next incremental pass — where the cache filter
+    decides what is carried forward and the journal gate decides what is
+    re-added — dropped every one of them. A user whose Repos tab worked lost it
+    on the next scan. Same shape as the walk/index parity bug and the
+    canonical_root drift: one rule, several implementations, silent disagreement.
+
+    `tree` is about what the CALLER knows, not about the rule:
+      * False — the path came from a walk that already vetted its ancestors, so
+        only its own name is in question. Deliberately NOT the tree test: a scan
+        root that itself sits inside a directory matching an ignore NAME (say
+        `~/venv/myproject`) would otherwise have every path under it forbidden.
+      * True — the path arrived without its ancestors being checked (a cached
+        row, a journal entry), so an ignored ANCESTOR forbids it too.
+
+    The leaf exemption is applied once, here: a leaf dir is never forbidden by a
+    verdict on its OWN name (see `keep_subdirs` for why — the ignore list can
+    only delete the row, never save any work), but ancestors keep their veto, so
+    `<repo>/.git` survives an entry naming `.git` while
+    `node_modules/pkg/.git` does not.
+    """
+    if is_leaf_dir(path):
+        if not tree:
+            # Its own name is the only thing in question, and a leaf is exempt
+            # from that.
+            return False
+        parent = path.rpartition("/")[0]
+        return bool(parent) and rules.is_ignored_tree(parent)
+    return rules.is_ignored_tree(path) if tree else rules.is_ignored(path)
+
+
 def is_inside_leaf_dir(path: str) -> bool:
     """Whether any ANCESTOR of `path` is a leaf directory — i.e. whether the
     leaf rule means this path should not exist as a row at all.

--- a/fused_render/index/runner.py
+++ b/fused_render/index/runner.py
@@ -27,6 +27,25 @@ from fused_render.shell import storage
 WORKER_MODULE = "fused_render.index.worker"
 
 
+def canonical_root(root: str) -> str:
+    """The canonical spelling of a scan root: expanded, absolute, forward slashes.
+
+    THE one form, because a root is a KEY, not just a path. It is what `start`
+    records in the run spec, so it is what `scan.run_scan` hands to
+    `save_applied_ignore` and `_record_scan` — meaning every fingerprint, debounce
+    entry and freshness comparison in the store is filed under this spelling. A
+    caller that looks one of those up with the user's raw spelling misses:
+    `~/proj` and `/Users/me/proj` are the same root, and on Windows
+    `os.path.expanduser("~")` hands back `C:\\Users\\me` while this stores
+    `C:/Users/me`, so EVERY lookup misses on that platform.
+
+    Exists as a function rather than a line inside `start` for exactly that
+    reason: the bug is two spellings drifting apart, so there is one definition
+    and callers that need to compare (`routers/index.scan_roots`) use it too.
+    Idempotent, so applying it to an already-canonical root is free and safe."""
+    return norm(os.path.abspath(os.path.expanduser((root or "~").strip())))
+
+
 def _mounts_dir() -> str:
     """Indirection so a test can point the mount guard somewhere harmless."""
     from fused_render.shell.mounts import mounts_dir
@@ -114,7 +133,7 @@ def start(cfg: IndexConfig, root: str, full: bool = False) -> dict:
     from its own spec — let a pre-edit run finish last and stamp the OLD rules
     over the post-edit run's, leaving the root stale indefinitely. The store
     lock serializes the two compactions; none of that is what it protects."""
-    root = norm(os.path.abspath(os.path.expanduser((root or "~").strip())))
+    root = canonical_root(root)
     # The guard runs BEFORE any kernel syscall on the caller's path: it is
     # pure string work against the mount records, while os.path.isdir on a
     # path under a wedged NFS mount blocks the request thread indefinitely

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -339,16 +339,30 @@ def run_scan(run_dir: str) -> None:
     _emit(ev, type="run_start", msg=root)
 
     try:
-        # A changed ignore list invalidates the cache: cached dirs carry subdir
+        # A changed rule set invalidates the cache: cached dirs carry subdir
         # counts computed under the old rules, so an incremental scan would keep
         # skipping folders that are no longer ignored.
+        #
+        # An ABSENT fingerprint counts as changed too, which it did not used to.
+        # That was safe while the only rules were ignore PATTERNS: removing a
+        # pattern is self-purging through the filtered cache (scan-ignore.md §3),
+        # so an unfingerprinted index could be reconciled incrementally. It is not
+        # safe for a rule that ADDS rows. `.git` becoming a leaf dir is exactly
+        # that: the new row can only appear by visiting the repo directory, and an
+        # incremental scan skips it precisely because its mtime has not changed —
+        # after which this scan would STAMP the new fingerprint over an index that
+        # never grew the rows, and every reader that trusts the stamp (notably
+        # /api/git-repos) would be confidently wrong, permanently. One full rescan
+        # of an unfingerprinted index is the cheap side of that trade.
         applied = applied_ignore_sig(cfg, root)
-        rules_changed = applied is not None and applied != rules.sig()
+        rules_changed = applied != rules.sig()
         cache = ({} if (spec.get("full") or rules_changed)
                  else load_dir_cache(cfg, root, pq))
         incremental = bool(cache)
         if rules_changed:
-            _emit(ev, type="phase", msg="ignore rules changed - full rescan")
+            _emit(ev, type="phase", msg=(
+                "ignore rules changed - full rescan" if applied is not None
+                else "no applied rules fingerprint - full rescan"))
 
         # Journal position captured BEFORE scanning: events during the scan get
         # replayed (harmlessly re-checked) next time instead of being missed.

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -23,6 +23,7 @@ from fused_render.index.ignore import (
     SKIP_DIRS,
     IgnoreRules,
     MountGuard,
+    ignored_for_index,
     is_inside_leaf_dir,
     is_leaf_dir,
     norm,
@@ -54,10 +55,14 @@ def keep_subdirs(subdirs, rules: IgnoreRules, guard: MountGuard):
 
     Narrow on purpose — this only overrides the verdict on the leaf dir ITSELF.
     A repo inside an ignored tree is still gone, because the walk never reaches
-    its parent to offer it here."""
+    its parent to offer it here.
+
+    The exemption is NOT spelled out here: it lives in `ignored_for_index`, which
+    every ignore gate routes through. It used to be inline, and that is exactly
+    how the other two gates went on purging the rows this one kept."""
     return [s for s in subdirs
             if s not in SKIP_DIRS and not guard.blocks(s)
-            and (is_leaf_dir(s) or not rules.is_ignored(s))]
+            and not ignored_for_index(rules, s, tree=False)]
 
 
 def _dir_sig(entries):
@@ -535,8 +540,14 @@ def _run_fsevents(cfg, rules, guard, root, hint, cache, sink, ev, cancel_flag,
         # below then carries those rows forward on every later run. The
         # package's own dirs row is unaffected: it is is_leaf_dir's, made when
         # the journal or the walk names the package.
-        if (d in scanned or rules.is_ignored_tree(d) or guard.blocks(d)
-                or is_inside_leaf_dir(d)):
+        # ignored_for_index, not rules.is_ignored_tree: a leaf dir the user's
+        # ignore list names must still be re-added here, or an incremental pass
+        # PURGES the rows the walk-driven scan wrote (the cache filter drops them
+        # from the keep list, this gate refuses to recreate them, and the
+        # compaction then has neither). tree=True because the journal hands over
+        # a path whose ancestors nobody checked.
+        if (d in scanned or ignored_for_index(rules, d, tree=True)
+                or guard.blocks(d) or is_inside_leaf_dir(d)):
             continue
         scanned.add(d)
         kind, payload, subdirs = scan_dir_once(

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -37,11 +37,27 @@ from fused_render.index.store import (
 
 
 def keep_subdirs(subdirs, rules: IgnoreRules, guard: MountGuard):
-    """The subdirectories a walk may descend into: not a hardcoded skip, not
-    ignored, and not mount-backed."""
+    """The subdirectories a walk may hand on: not a hardcoded skip, not
+    mount-backed, and not ignored — except that a LEAF dir survives the ignore
+    list.
+
+    "Hand on" rather than "descend into", because a leaf dir kept here is not
+    descended: scan_dir_once records it and returns no children. Which is exactly
+    why the ignore list does not get a veto over one. An ignore entry buys the
+    scan two things — no descent and no row — and for a leaf dir the first is
+    already true, so all it can still do is delete the row. For `.git` that row
+    IS the repo-detection fact /api/git-repos reads, and a user (or an old saved
+    config, from back when `.git` shipped in the default ignore list) still
+    naming `.git` there would silently empty the homepage's Repos tab while
+    saving one stat. SKIP_DIRS and the mount guard keep their veto: those are
+    hazards, not preferences.
+
+    Narrow on purpose — this only overrides the verdict on the leaf dir ITSELF.
+    A repo inside an ignored tree is still gone, because the walk never reaches
+    its parent to offer it here."""
     return [s for s in subdirs
-            if s not in SKIP_DIRS and not rules.is_ignored(s)
-            and not guard.blocks(s)]
+            if s not in SKIP_DIRS and not guard.blocks(s)
+            and (is_leaf_dir(s) or not rules.is_ignored(s))]
 
 
 def _dir_sig(entries):

--- a/fused_render/index/specs/scan-ignore.md
+++ b/fused_render/index/specs/scan-ignore.md
@@ -66,10 +66,11 @@ Filtering the cache is what makes newly-ignored folders **self-purging**: an ign
 directory is absent from the cache, so it is never added to the keep list, so
 compaction drops its file rows (`index-store.md §4`). No full rescan is needed.
 
-### Package leaves
+### Leaf directories
 
-`LEAF_DIR_SUFFIXES` (`.app`, `.framework`, `.bundle`, `.photoslibrary`) is a
-*fourth*, differently-shaped rule, and not an ignore pattern: a package is
+`LEAF_DIR_SUFFIXES` (`.app`, `.framework`, `.bundle`, `.photoslibrary`) and
+`LEAF_DIR_NAMES` (`.git`) are a
+*fourth*, differently-shaped rule, and not an ignore pattern: a leaf dir is
 **recorded and not descended**, where an ignored directory is neither. It is one
 `dirs.parquet` row with no file rows, produced by `scan_dir_once` returning before
 it lists the directory — so it costs the stat it had already taken and no scandir,
@@ -85,6 +86,26 @@ derived from this constant), so:
   relative path, out-ranking real hits;
 - **skipping** it would drop the package from the corpus entirely, and the walk
   does list it.
+
+`.git` is a leaf by NAME, and it is the reason the name half of the rule exists.
+It used to sit in `SHARED_IGNORE_DIRS`; it was moved here so the index carries one
+row per repository, which makes "is this directory a git repo" a queryable index
+fact — `/api/git-repos` (the Explorer homepage's Repos tab) selects the `.git`
+rows and takes each one's parent, instead of stat-ing every one of ~71 000 indexed
+directories on every request. Three consequences worth stating:
+
+- matching is **name equality, never a suffix**: `LEAF_DIR_SUFFIXES` is matched
+  with `endswith`, and a bare repository is conventionally named `foo.git` —
+  a suffix rule would make those opaque and hide the whole repository;
+- a leaf is strictly cheaper than an ignore pattern here, because ignore rules
+  prune *subdirectories* but not files: an ignored `.git` would still contribute
+  the ~15 loose files sitting directly in it (`HEAD`, `config`, `index`, …) and
+  still pay to list the directory. A leaf is never listed at all;
+- `keep_subdirs` lets a leaf dir survive the **user's** ignore list (`SKIP_DIRS`
+  and the mount guard keep their veto). An ignore entry buys a scan no-descent and
+  no-row; for a leaf the first is already true, so all it could still do is delete
+  the row that repo detection depends on — and `.git` shipped in the default list
+  once, so old saved configs really do name it.
 
 `is_leaf_dir` tests the path's own final component, which is all a descent needs:
 a walk that refuses to list `Foo.app` never reaches anything below it. Two callers
@@ -116,6 +137,14 @@ computed under the old rules (`scan-incremental.md §2`), so a re-included folde
 stay invisible while its parent's mtime is unchanged.
 
 - `ignore_sig` — sha1 of the newline-joined active pattern list.
+- `IgnoreRules.sig()` — what every caller actually compares: `ignore_sig` over the
+  patterns **plus the leaf rules** (§3). The leaf rules decide index content just as
+  the patterns do, so leaving them out would mean an index built before `.git`
+  became a leaf keeps matching, never rescans, and holds no `.git` rows — making
+  `/api/git-repos` report zero repositories forever. Including them makes the first
+  scan after that change a full rescan, and lets a reader detect a pre-rule index
+  (`applied_ignore_sig(cfg) != cfg.rules.sig()`) and report "not ready" instead of
+  trusting it.
 - `ignore_applied.json` in the index dir — the fingerprint the current index was
   **built** with, written by `save_applied_ignore` only after a *successful*
   compaction.

--- a/fused_render/index/specs/scan-ignore.md
+++ b/fused_render/index/specs/scan-ignore.md
@@ -54,13 +54,27 @@ stale rows survive a scan:
 
 | Route | Filter | Function |
 |---|---|---|
-| the walk's subdirectory list | `keep_subdirs` (also applies `SKIP_DIRS` and the mount guard) | `scan_dir_once`, both the unchanged and rescanned branches |
-| cached directories loaded from `dirs.parquet` | `is_ignored_tree` | `load_dir_cache` |
-| paths replayed from the FSEvents journal | `is_ignored_tree` + the mount guard | `_run_fsevents` |
+| the walk's subdirectory list | `ignored_for_index(…, tree=False)` (also applies `SKIP_DIRS` and the mount guard) | `scan_dir_once`, both the unchanged and rescanned branches |
+| cached directories loaded from `dirs.parquet` | `ignored_for_index(…, tree=True)` | `load_dir_cache` |
+| paths replayed from the FSEvents journal | `ignored_for_index(…, tree=True)` + the mount guard | `_run_fsevents` |
 
-`is_ignored` tests one directory (the walk already pruned its parents);
-`is_ignored_tree` also matches paths *inside* an ignored folder, for the two routes
-where a path arrives without its ancestors having been checked.
+All three go through **one predicate**, `ignore.ignored_for_index` — "does the
+ignore list forbid a row for this path?". `tree` says what the CALLER knows, not
+what the rule is: `tree=False` tests the directory's own name (the walk already
+pruned its parents), `tree=True` also matches paths *inside* an ignored folder, for
+the two routes where a path arrives without its ancestors having been checked.
+`tree=False` must NOT be widened to the tree test — a scan root that itself sits
+inside a directory matching an ignore *name* (`~/venv/myproject`) would then have
+its whole subtree forbidden.
+
+One predicate rather than three call sites spelling out the same rule, because the
+leaf exemption below is a rule about *what may exist as a row* and it was once
+applied at only the first of these three. The result was not a partial fix but
+DATA LOSS: a full rescan wrote the `.git` rows, and the next incremental pass —
+where the cache filter decides what is carried forward and the journal gate
+decides what is re-added — deleted every one of them, so a working Repos tab
+broke on the next scan. Same failure shape as the walk/index parity rule and
+`runner.canonical_root`: one rule, several implementations, silent disagreement.
 
 Filtering the cache is what makes newly-ignored folders **self-purging**: an ignored
 directory is absent from the cache, so it is never added to the keep list, so
@@ -101,11 +115,13 @@ directories on every request. Three consequences worth stating:
   prune *subdirectories* but not files: an ignored `.git` would still contribute
   the ~15 loose files sitting directly in it (`HEAD`, `config`, `index`, …) and
   still pay to list the directory. A leaf is never listed at all;
-- `keep_subdirs` lets a leaf dir survive the **user's** ignore list (`SKIP_DIRS`
-  and the mount guard keep their veto). An ignore entry buys a scan no-descent and
-  no-row; for a leaf the first is already true, so all it could still do is delete
-  the row that repo detection depends on — and `.git` shipped in the default list
-  once, so old saved configs really do name it.
+- a leaf dir survives the **user's** ignore list (`SKIP_DIRS` and the mount guard
+  keep their veto). An ignore entry buys a scan no-descent and no-row; for a leaf
+  the first is already true, so all it could still do is delete the row that repo
+  detection depends on — and `.git` shipped in the default list once, so old saved
+  configs really do name it. The exemption lives in `ignored_for_index` (§3) and so
+  applies at **all three** gates; ancestors keep their veto, so `<repo>/.git`
+  survives an entry naming `.git` while `node_modules/pkg/.git` does not.
 
 `is_leaf_dir` tests the path's own final component, which is all a descent needs:
 a walk that refuses to list `Foo.app` never reaches anything below it. Two callers

--- a/fused_render/index/specs/scan-ignore.md
+++ b/fused_render/index/specs/scan-ignore.md
@@ -149,8 +149,19 @@ stay invisible while its parent's mtime is unchanged.
   **built** with, written by `save_applied_ignore` only after a *successful*
   compaction.
 - `run_scan` compares the two: a mismatch discards the cache, emits the phase
-  `ignore rules changed - full rescan`, and rebuilds. An **absent** applied file is
-  *not* treated as a change — that case is safe incrementally, per §3.
+  `ignore rules changed - full rescan`, and rebuilds. An **absent** applied file
+  counts as a mismatch too (phase `no applied rules fingerprint - full rescan`).
+
+  That last point reverses the earlier rule ("absent is safe incrementally"), and
+  the reason is the leaf rules. Absent *was* safe while every rule only ever
+  *removed* rows: dropping a pattern is self-purging through the filtered cache
+  (§3), so an unfingerprinted index reconciled itself. A rule that **adds** rows
+  cannot work that way — a `.git` row appears only by visiting the repo directory,
+  and an incremental scan skips exactly that directory because its mtime has not
+  changed. The scan would then *stamp* the new fingerprint over an index that
+  never grew the rows, and every reader trusting the stamp (`/api/git-repos`)
+  would be permanently, confidently wrong. One full rescan is the cheap side of
+  that trade.
 
 ## 5. Storage and API
 

--- a/fused_render/index/store.py
+++ b/fused_render/index/store.py
@@ -16,6 +16,7 @@ import os
 import time
 
 from fused_render.index.config import IndexConfig
+from fused_render.index.ignore import ignored_for_index
 
 
 # How often the Windows lock re-tries. Short enough to hand the lock over
@@ -224,7 +225,14 @@ def load_dir_cache(cfg: IndexConfig, root: str, pq) -> dict:
     """dir -> (mtime_ns, n_files, n_subdirs) for cached dirs under `root`,
     from dirs.parquet. Returns {} when there is no usable cache (missing file
     or a pre-mtime index). Ignored subtrees are filtered out here, which is
-    what makes a newly-ignored folder self-purging (specs/scan-ignore.md §3)."""
+    what makes a newly-ignored folder self-purging (specs/scan-ignore.md §3).
+
+    Self-purging is why this filter is also the sharpest edge in the whole ignore
+    story: a row missing from this cache is a row the next compaction drops. So it
+    asks `ignored_for_index`, the one predicate all three gates share, rather than
+    the raw rules — otherwise a LEAF dir the user's ignore list names (a `.git`,
+    for every config saved before it left the default list) is written by a full
+    rescan and then deleted by the very next incremental one."""
     if not os.path.exists(cfg.dirs_parquet):
         return {}
     names = pq.read_schema(cfg.dirs_parquet).names
@@ -241,7 +249,8 @@ def load_dir_cache(cfg: IndexConfig, root: str, pq) -> dict:
     for d, m, n, ns in zip(t.column("dir").to_pylist(),
                            t.column("mtime_ns").to_pylist(),
                            t.column("n_files").to_pylist(), subs):
-        if (d == root or d.startswith(prefix)) and not rules.is_ignored_tree(d):
+        if ((d == root or d.startswith(prefix))
+                and not ignored_for_index(rules, d, tree=True)):
             cache[d] = (m, n, ns)
     return cache
 

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -48,6 +48,7 @@ from fused_render.server.routers.env import router as env_router
 from fused_render.server.routers.export import router as export_router
 from fused_render.server.fs_mutate import router as fs_mutate_router
 from fused_render.server.routers.fs_read import router as fs_read_router
+from fused_render.server.routers.git_repos import router as git_repos_router
 from fused_render.server.routers import index as index_routes
 from fused_render.server.routers.jobs import router as jobs_router
 from fused_render.server.routers.render import router as render_router
@@ -324,6 +325,10 @@ def create_app(start_dir: str) -> FastAPI:
     # Claude Code project folders for the Explorer homepage's "Claude
     # sessions" tab (routers/claude_sessions.py) — read-only, no auth guard.
     app.include_router(claude_sessions_router)
+    # Git repositories on this machine for the Explorer homepage's "Repos" tab
+    # (routers/git_repos.py) — candidates come from the file index, never a
+    # fresh walk, so it cannot touch a mount. Read-only, no auth guard.
+    app.include_router(git_repos_router)
     # Claude Code CONFIG editing for the Preferences page's "Claude config" tab
     # (routers/claude_config.py): one dispatch POST over the
     # fused_render/claude_config/ feature modules, plus a cheap availability

--- a/fused_render/server/routers/fs_read.py
+++ b/fused_render/server/routers/fs_read.py
@@ -332,10 +332,13 @@ async def api_fs_walk(request: Request, path: str, hidden: str = "0", stream: st
     # disconnect without stalling the event loop.
     #
     # `hidden=1` (explicit intent: the user typed a dot-leading query)
-    # includes dot-files and descends into dot-dirs. WALK_IGNORE_DIRS and
-    # gitignore pruning apply regardless — those trees are noise, not
-    # "hidden data", and letting hidden=1 descend into .git/node_modules
-    # would flood the results with machine-managed junk.
+    # includes dot-files and descends into dot-dirs. WALK_IGNORE_DIRS,
+    # the leaf rules and gitignore pruning apply regardless — those trees are
+    # noise, not "hidden data", and letting hidden=1 descend into
+    # node_modules or a repo's .git would flood the results with
+    # machine-managed junk. `.git` is emitted as ONE undescended entry (it is a
+    # leaf name, so the index has a row for it and the two corpora agree);
+    # everything under it stays out either way.
     #
     # `stream=1` returns NDJSON: zero or more `{"entries": [...]}` batch
     # lines (WALK_BATCH_SIZE each) followed by exactly one terminal

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -1,0 +1,138 @@
+"""GET /api/git-repos — git repositories on this machine, for the Explorer
+homepage's "Repos" tab.
+
+The candidate directory list comes from the app's own index (`dirs.parquet`),
+never from a fresh filesystem walk. That is not an optimisation, it is the
+safety property:
+
+  * `dirs.parquet` is a complete directory tree for the scanned roots that has
+    ALREADY had `node_modules`/`.venv`/`__pycache__`/… pruned, is confined to
+    the root's `st_dev` (`scan.scan_dir_once`), and is `MountGuard`-screened —
+    so sourcing candidates from it means this endpoint cannot walk into a
+    network mount, and a wedged mount cannot hang it.
+  * an `os.walk` of the home directory would re-cross all of that on every
+    request. There is deliberately no fallback to one: "the index is not built
+    yet" is a state the tab renders (`indexed: false`), not a cue to crawl.
+
+`.git` itself is NOT in the index — it is in `SHARED_IGNORE_DIRS` and
+`keep_subdirs` prunes it, so no row exists for any `.git` directory or anything
+inside one. So the repos cannot be queried out of the index directly; instead
+every indexed directory is confirmed with ONE `os.path.isdir(d + "/.git")`.
+That is ~1 cheap stat per indexed directory (~71k on a real home, tens of ms),
+and no subprocess: no `git rev-parse`, no `git` at all.
+
+A `.git` DIRECTORY is the test. A linked worktree and a modern submodule mark
+themselves with a `.git` FILE, so both are naturally excluded — normal repos
+only, which is the intent.
+
+Hidden and machine-managed paths are screened out with the explorer's one
+standard for rows that did not come from its walk (`walk.junk_path`, shared with
+/api/search/files): a dot-segment or a WALK_IGNORE_DIRS segment anywhere in the
+path drops the row. Without it this tab is mostly other people's checkouts —
+`~/.local/share/nvim/lazy/*`, `~/.oh-my-zsh/custom/plugins/*`,
+`~/.claude/plugins/cache/temp_git_*` — which outnumbered the user's own repos
+better than 2:1 on the first machine this ran on. The named cost: a repo you
+deliberately keep inside a dotted directory is not listed here.
+
+Order is the index's own row order, which is path order: the compaction writes
+dirs.parquet `ORDER BY dir` (`store._compact_locked`). Free, deterministic, and
+no extra stat or sort to get it. Nested repos therefore appear alongside their
+parent rather than being collapsed away — a repo inside a repo is still a repo
+you might want to open.
+"""
+import logging
+import os
+
+from fastapi import APIRouter
+from fastapi.concurrency import run_in_threadpool
+
+from fused_render._view_url_codec import canonical_fs_path
+from fused_render.index import runner
+from fused_render.index.config import load_config
+from fused_render.index.ignore import MountGuard
+from fused_render.index.query import dirs_src
+from fused_render.index.store import read_manifest
+from fused_render.server.common import _error
+from fused_render.server.walk import junk_path
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class IndexUnreadable(RuntimeError):
+    """The index is on disk but its dirs table could not be queried. Distinct
+    from "not built yet", which is a state the tab renders rather than an
+    error."""
+
+
+def _scanning(cfg) -> bool:
+    """Whether any scan is in flight — the same fact /api/index/status reports
+    under this name, so the tab can say "still building" while the first scan
+    runs. Best-effort: a run directory that cannot be read must not turn a
+    perfectly answerable repo list into an error."""
+    try:
+        return any(r["running"] for r in runner.list_runs(cfg, limit=20)["runs"])
+    except Exception:  # noqa: BLE001 - telemetry only, never the answer
+        logger.debug("could not read index run state", exc_info=True)
+        return False
+
+
+def _repos() -> dict:
+    cfg = load_config()
+    # BOTH are required, and neither implies the other: the manifest is written
+    # by a compaction that had file shards, while dirs.parquet is the table this
+    # endpoint actually reads. Missing either is "not indexed yet" — reported as
+    # such rather than as an empty list, because "no repos on this machine" and
+    # "we have not looked yet" are different answers.
+    if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
+        return {"indexed": False, "scanning": _scanning(cfg), "repos": []}
+    import duckdb
+
+    con = duckdb.connect()
+    # No ORDER BY: the rows are already in `dir` order on disk (see the module
+    # docstring), and sorting 70k+ strings again to reproduce that would be work
+    # bought with nothing.
+    try:
+        rows = con.execute(f"SELECT dir FROM {dirs_src(cfg)}").fetchall()
+    except Exception as e:  # noqa: BLE001 - duckdb's exception tree, flattened
+        # An index that exists but cannot be read is a FAILURE, not "not indexed
+        # yet": reporting it as the latter would have the tab promise a list that
+        # is never coming. Same split /api/search/files draws (503 vs 502).
+        logger.exception("the repo list query failed")
+        raise IndexUnreadable(type(e).__name__) from e
+    # Resolved once for the whole request; every `blocks()` call after that is
+    # pure string comparison, no syscall. The index is already guarded during the
+    # scan, so this is belt-and-braces — but it is the layer that keeps a stat
+    # from ever reaching a mount tree if an older index on disk holds rows a
+    # newer guard would have pruned.
+    guard = MountGuard()
+    repos = []
+    for (d,) in rows:
+        # `junk_path` before the stat, so the screened-out majority costs no
+        # syscall at all. On a real home this is the difference between 69 rows
+        # and 21: everything under ~/.local/share/nvim/lazy, ~/.oh-my-zsh and
+        # ~/.claude/plugins/cache is a package manager's checkout, not a repo
+        # anyone opens. It is the same standard /api/search/files and
+        # /api/fs/walk hold their results to — a hidden path never surfaces in
+        # the explorer, and a tab whose first cards are `temp_git_1786451303910`
+        # is not a list of your repos.
+        if not d or junk_path(d) or guard.blocks(d):
+            continue
+        # No try/except around the probe: os.path.isdir swallows OSError itself
+        # and answers False, which is exactly right here — a directory deleted or
+        # turned unreadable since the scan is dropped, the same way
+        # /api/claude-sessions drops a folder no longer on disk. This list exists
+        # to be opened.
+        if os.path.isdir(os.path.join(d, ".git")):
+            repos.append({"path": canonical_fs_path(d)})
+    return {"indexed": True, "scanning": _scanning(cfg), "repos": repos}
+
+
+@router.get("/api/git-repos")
+async def api_git_repos():
+    # duckdb plus tens of thousands of stats block, so it runs off the event
+    # loop — a homepage tab must not stall the whole server while it lists.
+    try:
+        return await run_in_threadpool(_repos)
+    except IndexUnreadable as e:
+        return _error(f"the file index could not be read: {e}", status=502)

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -37,16 +37,32 @@ THREE THINGS THAT LOOK WRONG AND ARE NOT
    guarded at scan time. It is the layer that holds if an index written by an
    older build carries rows a newer guard would have pruned, and it costs nothing
    — the roots resolve once per request and every check is string comparison.
-3. An index any of whose configured roots was built under a different ignore
-   signature is reported as NOT READY, not as an empty list. This is the migration
-   case and it is the one way this endpoint could ship a silent lie: `.git` moving
-   out of the ignore list and into the leaf rules changed `IgnoreRules.sig()`,
-   which forces a full rescan — but until that rescan finishes, an index already on
-   disk has no `.git` rows whatsoever. A pure query would then answer
-   `{indexed: true, repos: []}` and tell the user, with total confidence, that they
-   have no repositories. So EVERY root's signature is checked individually (see
-   `_usable` for why the rootless form is not enough) and a stale index is reported
-   exactly as a missing one.
+3. A STALE index still answers. If the dirs table yields `.git` rows they are
+   served — while a scan is in flight, while the applied ignore signature is a
+   generation behind, whatever has changed on disk since. An index is ALWAYS
+   slightly behind the filesystem, so treating "behind" as "unusable" would refuse
+   to answer approximately always; the response carries `stale: true` instead and
+   the tab shows the list with a quiet note. Staleness is the normal condition, not
+   an error.
+
+   The rules signature keeps exactly ONE job, and it is not a veto on results. It
+   separates two kinds of zero:
+
+     * zero rows because the RULE NEVER RAN — an index predating `.git` becoming a
+       leaf dir has no `.git` rows to find, and answering "no repositories on this
+       machine" from it is a confident falsehood. This is the original silent lie
+       and the reason any of this exists; it reports not-ready (`reason:
+       "outdated"`) so the tab can say a rebuild is coming.
+     * zero rows because the machine GENUINELY HAS NO REPOS — the rule ran and
+       found nothing. A real answer, served as `{indexed: true, repos: []}`.
+
+   The test is on RAW row count, before screening. Screening can legitimately take
+   real rows down to zero (every repo on the machine inside a dotted directory),
+   and that is a rule that DID run — so it is an answer, not a migration.
+
+   Signatures are still checked per configured ROOT (see `_fresh` on why the
+   rootless form is not enough); the consequence of a mismatch is now `stale`
+   rather than silence.
 
 Order is the index's own row order, which is path order: the compaction writes
 dirs.parquet `ORDER BY dir` (`store._compact_locked`), and stripping the trailing
@@ -97,17 +113,11 @@ def _scanning(cfg) -> bool:
         return False
 
 
-def _usable(cfg) -> bool:
-    """Whether the index on disk can answer this question at all.
-
-    Three ways it cannot, all reported identically to the caller:
-      * no manifest — nothing has ever compacted;
-      * no dirs.parquet — the table this endpoint reads is the one that matters,
-        and the manifest does not imply it;
-      * any CONFIGURED ROOT whose applied ignore signature is not the current one
-        — that root's slice of the index was built under different rules, so it
-        predates `.git` being recorded and holds no `.git` rows. See the module
-        docstring's point 3.
+def _fresh(cfg) -> bool:
+    """Whether every configured root's slice of the index was built under today's
+    rules. NOT a gate on serving results (module docstring point 3) — it decides
+    `stale`, and it separates "no rows because the leaf rule never ran" from "no
+    rows because there are no repos".
 
     Every root is checked INDIVIDUALLY, and the rootless `applied_ignore_sig(cfg)`
     is deliberately not used for this. That form compares only the values in the
@@ -123,8 +133,6 @@ def _usable(cfg) -> bool:
     current signature either — "predates the applied-ignore file" cannot be
     assumed to have been built under today's rules.
     """
-    if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
-        return False
     sig = cfg.rules.sig()
     # scan_roots is the definition of "what this index is supposed to cover"
     # (configured roots, else home) and lives with the scan scheduler that acts on
@@ -134,10 +142,19 @@ def _usable(cfg) -> bool:
     return all(applied_ignore_sig(cfg, r) == sig for r in scan_roots(cfg))
 
 
+def _not_ready(cfg, reason: str) -> dict:
+    """The index cannot answer. `stale` is False rather than True: there is no list,
+    so "the list may be out of date" would be a claim about nothing."""
+    return {"indexed": False, "reason": reason, "scanning": _scanning(cfg),
+            "stale": False, "repos": []}
+
+
 def _repos() -> dict:
     cfg = load_config()
-    if not _usable(cfg):
-        return {"indexed": False, "scanning": _scanning(cfg), "repos": []}
+    # The only genuinely unanswerable state: no store to read. Everything past here
+    # queries first and judges freshness second — rows win over signatures.
+    if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
+        return _not_ready(cfg, "no-index")
     import duckdb
 
     con = duckdb.connect()
@@ -158,6 +175,14 @@ def _repos() -> dict:
         # never coming. Same split /api/search/files draws (503 vs 502).
         logger.exception("the repo list query failed")
         raise IndexUnreadable(type(e).__name__) from e
+    fresh = _fresh(cfg)
+    # RAW row count, before screening — the one thing the signature still decides.
+    # No rows under old rules means the leaf rule never ran and the data does not
+    # exist yet; saying "no repositories" from that is the original silent lie.
+    # Rows screened down to zero is a different thing entirely: the rule DID run, so
+    # the empty answer is real (module docstring point 3).
+    if not rows and not fresh:
+        return _not_ready(cfg, "outdated")
     guard = MountGuard()
     repos = []
     for (git_dir,) in rows:
@@ -167,7 +192,15 @@ def _repos() -> dict:
         if not root or junk_path(root) or guard.blocks(root):
             continue
         repos.append({"path": canonical_fs_path(root)})
-    return {"indexed": True, "scanning": _scanning(cfg), "repos": repos}
+    scanning = _scanning(cfg)
+    # ONE flag for the user-facing question "might this list be out of date?", over
+    # two causes that have the same answer and the same remedy (wait). A caller that
+    # needs to tell them apart still has `scanning` on its own. Note what is NOT in
+    # here: files changed on disk since the scan. Nothing can know that without
+    # re-walking, which is the cost this endpoint exists to avoid — so `stale: false`
+    # means "as fresh as the index gets", never "identical to the filesystem".
+    return {"indexed": True, "reason": None, "scanning": scanning,
+            "stale": (not fresh) or scanning, "repos": repos}
 
 
 @router.get("/api/git-repos")

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -37,15 +37,16 @@ THREE THINGS THAT LOOK WRONG AND ARE NOT
    guarded at scan time. It is the layer that holds if an index written by an
    older build carries rows a newer guard would have pruned, and it costs nothing
    — the roots resolve once per request and every check is string comparison.
-3. An index whose applied ignore signature does not match the current one is
-   reported as NOT READY, not as an empty list. This is the migration case and it
-   is the one way this endpoint could ship a silent lie: `.git` moving out of the
-   ignore list and into the leaf rules changed `IgnoreRules.sig()`, which forces
-   a full rescan — but until that rescan finishes, an index already on disk has
-   no `.git` rows whatsoever. A pure query would then answer
-   `{indexed: true, repos: []}` and tell the user, with total confidence, that
-   they have no repositories. So the signature is checked and a stale index is
-   reported exactly as a missing one.
+3. An index any of whose configured roots was built under a different ignore
+   signature is reported as NOT READY, not as an empty list. This is the migration
+   case and it is the one way this endpoint could ship a silent lie: `.git` moving
+   out of the ignore list and into the leaf rules changed `IgnoreRules.sig()`,
+   which forces a full rescan — but until that rescan finishes, an index already on
+   disk has no `.git` rows whatsoever. A pure query would then answer
+   `{indexed: true, repos: []}` and tell the user, with total confidence, that they
+   have no repositories. So EVERY root's signature is checked individually (see
+   `_usable` for why the rootless form is not enough) and a stale index is reported
+   exactly as a missing one.
 
 Order is the index's own row order, which is path order: the compaction writes
 dirs.parquet `ORDER BY dir` (`store._compact_locked`), and stripping the trailing
@@ -103,20 +104,34 @@ def _usable(cfg) -> bool:
       * no manifest — nothing has ever compacted;
       * no dirs.parquet — the table this endpoint reads is the one that matters,
         and the manifest does not imply it;
-      * an applied ignore signature that is not the current one — the index was
-        built under different rules, so it predates `.git` being recorded and has
-        no `.git` rows to find. See the module docstring's point 3.
+      * any CONFIGURED ROOT whose applied ignore signature is not the current one
+        — that root's slice of the index was built under different rules, so it
+        predates `.git` being recorded and holds no `.git` rows. See the module
+        docstring's point 3.
 
-    `applied_ignore_sig(cfg)` with no root answers "do ALL recorded roots match
-    the current rules", which is the right question: a machine indexing two roots
-    where only one has been rescanned can still be missing every repo under the
-    other.
+    Every root is checked INDIVIDUALLY, and the rootless `applied_ignore_sig(cfg)`
+    is deliberately not used for this. That form compares only the values in the
+    file's `roots` map and never consults `legacy_sig` — so on a store migrated
+    from the pre-per-root format, the moment the FIRST root is rescanned and
+    stamped, `{"roots": {"/a": current}, "legacy_sig": old}` reads as "everything
+    matches" while `/b` is still described by nothing but the stale legacy sig and
+    still has no repo rows. The per-root form returns `legacy_sig` for exactly
+    those roots (`roots.get(root, data.get("legacy_sig"))`), which is the answer
+    that makes them visible as stale.
+
+    A root that has never been stamped at all answers None, which is not the
+    current signature either — "predates the applied-ignore file" cannot be
+    assumed to have been built under today's rules.
     """
     if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
         return False
-    # None means "an index predating the applied-ignore file", which cannot be
-    # assumed to have been built under the current rules either.
-    return applied_ignore_sig(cfg) == cfg.rules.sig()
+    sig = cfg.rules.sig()
+    # scan_roots is the definition of "what this index is supposed to cover"
+    # (configured roots, else home) and lives with the scan scheduler that acts on
+    # it; duplicating the fallback here is how the two would drift.
+    from fused_render.server.routers.index import scan_roots
+
+    return all(applied_ignore_sig(cfg, r) == sig for r in scan_roots(cfg))
 
 
 def _repos() -> dict:

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -1,44 +1,57 @@
 """GET /api/git-repos — git repositories on this machine, for the Explorer
 homepage's "Repos" tab.
 
-The candidate directory list comes from the app's own index (`dirs.parquet`),
-never from a fresh filesystem walk. That is not an optimisation, it is the
-safety property:
+Repo-ness is an INDEX FACT, not a filesystem probe. `.git` is a leaf directory
+(`ignore.LEAF_DIR_NAMES`): the scan records one dirs row for it and never lists
+its contents, so "which directories are repositories" is exactly "which dirs rows
+are named `.git`", and each repo root is that row's parent. One SQL query over
+`dirs.parquet`, zero stats, zero subprocesses — no `git rev-parse`, no `git` at
+all.
 
-  * `dirs.parquet` is a complete directory tree for the scanned roots that has
-    ALREADY had `node_modules`/`.venv`/`__pycache__`/… pruned, is confined to
-    the root's `st_dev` (`scan.scan_dir_once`), and is `MountGuard`-screened —
-    so sourcing candidates from it means this endpoint cannot walk into a
-    network mount, and a wedged mount cannot hang it.
-  * an `os.walk` of the home directory would re-cross all of that on every
-    request. There is deliberately no fallback to one: "the index is not built
-    yet" is a state the tab renders (`indexed: false`), not a cue to crawl.
+That replaces the first cut of this endpoint, which read every indexed directory
+out of the same table and asked `os.path.isdir(d + "/.git")` about each: ~71k
+stats per request on a real home. It also inherits the index's safety
+properties rather than re-earning them — the table is `st_dev`-confined
+(`scan.scan_dir_once`), `MountGuard`-screened and node_modules/.venv-pruned, so
+this endpoint cannot touch a network mount at all. There is deliberately no walk
+or stat fallback: "the index cannot answer yet" is a state the tab renders, not a
+cue to crawl.
 
-`.git` itself is NOT in the index — it is in `SHARED_IGNORE_DIRS` and
-`keep_subdirs` prunes it, so no row exists for any `.git` directory or anything
-inside one. So the repos cannot be queried out of the index directly; instead
-every indexed directory is confirmed with ONE `os.path.isdir(d + "/.git")`.
-That is ~1 cheap stat per indexed directory (~71k on a real home, tens of ms),
-and no subprocess: no `git rev-parse`, no `git` at all.
+A `.git` DIRECTORY is what gets a row, so linked worktrees and modern submodules
+— which mark themselves with a `.git` FILE — are absent from the dirs table and
+therefore naturally excluded. Normal repos only, which is the intent.
 
-A `.git` DIRECTORY is the test. A linked worktree and a modern submodule mark
-themselves with a `.git` FILE, so both are naturally excluded — normal repos
-only, which is the intent.
-
-Hidden and machine-managed paths are screened out with the explorer's one
-standard for rows that did not come from its walk (`walk.junk_path`, shared with
-/api/search/files): a dot-segment or a WALK_IGNORE_DIRS segment anywhere in the
-path drops the row. Without it this tab is mostly other people's checkouts —
-`~/.local/share/nvim/lazy/*`, `~/.oh-my-zsh/custom/plugins/*`,
-`~/.claude/plugins/cache/temp_git_*` — which outnumbered the user's own repos
-better than 2:1 on the first machine this ran on. The named cost: a repo you
-deliberately keep inside a dotted directory is not listed here.
+THREE THINGS THAT LOOK WRONG AND ARE NOT
+----------------------------------------
+1. `junk_path` is applied to the PARENT, never to the row. `.git` is itself a
+   dot-segment, so screening the raw row would reject every repository on the
+   machine. The parent is the path the user is offered, so the parent is what
+   gets held to the explorer's standard for rows that did not come from its walk
+   (`walk.junk_path`, shared with /api/search/files). Without it the tab is
+   mostly other people's checkouts — `~/.local/share/nvim/lazy/*`,
+   `~/.oh-my-zsh/custom/plugins/*`, `~/.claude/plugins/cache/temp_git_*`
+   outnumbered the user's own repos better than 2:1 on the first machine this ran
+   on. Named cost: a repo you deliberately keep inside a dotted directory is not
+   listed here.
+2. `MountGuard` still screens the parent, even though the index is already
+   guarded at scan time. It is the layer that holds if an index written by an
+   older build carries rows a newer guard would have pruned, and it costs nothing
+   — the roots resolve once per request and every check is string comparison.
+3. An index whose applied ignore signature does not match the current one is
+   reported as NOT READY, not as an empty list. This is the migration case and it
+   is the one way this endpoint could ship a silent lie: `.git` moving out of the
+   ignore list and into the leaf rules changed `IgnoreRules.sig()`, which forces
+   a full rescan — but until that rescan finishes, an index already on disk has
+   no `.git` rows whatsoever. A pure query would then answer
+   `{indexed: true, repos: []}` and tell the user, with total confidence, that
+   they have no repositories. So the signature is checked and a stale index is
+   reported exactly as a missing one.
 
 Order is the index's own row order, which is path order: the compaction writes
-dirs.parquet `ORDER BY dir` (`store._compact_locked`). Free, deterministic, and
-no extra stat or sort to get it. Nested repos therefore appear alongside their
-parent rather than being collapsed away — a repo inside a repo is still a repo
-you might want to open.
+dirs.parquet `ORDER BY dir` (`store._compact_locked`), and stripping the trailing
+`/.git` preserves that order. Free, deterministic, no sort. Nested repos appear
+alongside their parent rather than being collapsed away — a repo inside a repo is
+still a repo you might want to open.
 """
 import logging
 import os
@@ -51,18 +64,24 @@ from fused_render.index import runner
 from fused_render.index.config import load_config
 from fused_render.index.ignore import MountGuard
 from fused_render.index.query import dirs_src
-from fused_render.index.store import read_manifest
+from fused_render.index.store import applied_ignore_sig, read_manifest
 from fused_render.server.common import _error
 from fused_render.server.walk import junk_path
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
+# The leaf directory whose presence marks a repository. Deliberately spelled out
+# here rather than derived from LEAF_DIR_NAMES: that tuple is "directories the
+# scan records opaquely" and may grow to hold names that have nothing to do with
+# git, at which point iterating it here would start listing non-repositories.
+GIT_DIR = ".git"
+
 
 class IndexUnreadable(RuntimeError):
     """The index is on disk but its dirs table could not be queried. Distinct
-    from "not built yet", which is a state the tab renders rather than an
-    error."""
+    from "not built yet"/"stale", which are states the tab renders rather than
+    errors."""
 
 
 def _scanning(cfg) -> bool:
@@ -77,61 +96,69 @@ def _scanning(cfg) -> bool:
         return False
 
 
+def _usable(cfg) -> bool:
+    """Whether the index on disk can answer this question at all.
+
+    Three ways it cannot, all reported identically to the caller:
+      * no manifest — nothing has ever compacted;
+      * no dirs.parquet — the table this endpoint reads is the one that matters,
+        and the manifest does not imply it;
+      * an applied ignore signature that is not the current one — the index was
+        built under different rules, so it predates `.git` being recorded and has
+        no `.git` rows to find. See the module docstring's point 3.
+
+    `applied_ignore_sig(cfg)` with no root answers "do ALL recorded roots match
+    the current rules", which is the right question: a machine indexing two roots
+    where only one has been rescanned can still be missing every repo under the
+    other.
+    """
+    if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
+        return False
+    # None means "an index predating the applied-ignore file", which cannot be
+    # assumed to have been built under the current rules either.
+    return applied_ignore_sig(cfg) == cfg.rules.sig()
+
+
 def _repos() -> dict:
     cfg = load_config()
-    # BOTH are required, and neither implies the other: the manifest is written
-    # by a compaction that had file shards, while dirs.parquet is the table this
-    # endpoint actually reads. Missing either is "not indexed yet" — reported as
-    # such rather than as an empty list, because "no repos on this machine" and
-    # "we have not looked yet" are different answers.
-    if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):
+    if not _usable(cfg):
         return {"indexed": False, "scanning": _scanning(cfg), "repos": []}
     import duckdb
 
     con = duckdb.connect()
-    # No ORDER BY: the rows are already in `dir` order on disk (see the module
-    # docstring), and sorting 70k+ strings again to reproduce that would be work
-    # bought with nothing.
+    # `dir LIKE '%/.git'` would also match a directory literally named `x/.git`
+    # on a platform where that is possible, and would not match a `.git` at the
+    # filesystem root — neither matters, but comparing the final component is
+    # what is actually meant, and DuckDB evaluates it just as cheaply.
+    #
+    # No ORDER BY: rows are already in `dir` order on disk (see the module
+    # docstring) and dropping a constant-length suffix keeps that order.
     try:
-        rows = con.execute(f"SELECT dir FROM {dirs_src(cfg)}").fetchall()
+        rows = con.execute(
+            f"SELECT dir FROM {dirs_src(cfg)} "
+            f"WHERE regexp_extract(dir, '[^/]*$') = '{GIT_DIR}'").fetchall()
     except Exception as e:  # noqa: BLE001 - duckdb's exception tree, flattened
-        # An index that exists but cannot be read is a FAILURE, not "not indexed
-        # yet": reporting it as the latter would have the tab promise a list that
-        # is never coming. Same split /api/search/files draws (503 vs 502).
+        # An index that exists but cannot be read is a FAILURE, not "not ready":
+        # reporting it as the latter would have the tab promise a list that is
+        # never coming. Same split /api/search/files draws (503 vs 502).
         logger.exception("the repo list query failed")
         raise IndexUnreadable(type(e).__name__) from e
-    # Resolved once for the whole request; every `blocks()` call after that is
-    # pure string comparison, no syscall. The index is already guarded during the
-    # scan, so this is belt-and-braces — but it is the layer that keeps a stat
-    # from ever reaching a mount tree if an older index on disk holds rows a
-    # newer guard would have pruned.
     guard = MountGuard()
     repos = []
-    for (d,) in rows:
-        # `junk_path` before the stat, so the screened-out majority costs no
-        # syscall at all. On a real home this is the difference between 69 rows
-        # and 21: everything under ~/.local/share/nvim/lazy, ~/.oh-my-zsh and
-        # ~/.claude/plugins/cache is a package manager's checkout, not a repo
-        # anyone opens. It is the same standard /api/search/files and
-        # /api/fs/walk hold their results to — a hidden path never surfaces in
-        # the explorer, and a tab whose first cards are `temp_git_1786451303910`
-        # is not a list of your repos.
-        if not d or junk_path(d) or guard.blocks(d):
+    for (git_dir,) in rows:
+        root = git_dir.rpartition("/")[0]
+        # A `.git` at the filesystem root has no parent to offer; nothing else
+        # can produce an empty root here.
+        if not root or junk_path(root) or guard.blocks(root):
             continue
-        # No try/except around the probe: os.path.isdir swallows OSError itself
-        # and answers False, which is exactly right here — a directory deleted or
-        # turned unreadable since the scan is dropped, the same way
-        # /api/claude-sessions drops a folder no longer on disk. This list exists
-        # to be opened.
-        if os.path.isdir(os.path.join(d, ".git")):
-            repos.append({"path": canonical_fs_path(d)})
+        repos.append({"path": canonical_fs_path(root)})
     return {"indexed": True, "scanning": _scanning(cfg), "repos": repos}
 
 
 @router.get("/api/git-repos")
 async def api_git_repos():
-    # duckdb plus tens of thousands of stats block, so it runs off the event
-    # loop — a homepage tab must not stall the whole server while it lists.
+    # duckdb blocks, so it runs off the event loop — a homepage tab must not
+    # stall the whole server while it lists.
     try:
         return await run_in_threadpool(_repos)
     except IndexUnreadable as e:

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -68,10 +68,19 @@ def scan_roots(cfg: IndexConfig, start_dir: str | None = None) -> list:
     one project answers almost no search the explorer wants to ask. `start_dir`
     is accepted so a caller can express a narrower intent, but it is not used
     as a fallback — an index that silently follows whichever folder the app was
-    opened on would give different answers per window."""
+    opened on would give different answers per window.
+
+    Roots come back in `runner.canonical_root` form — the same spelling
+    `runner.start` files every store key under. This function's output is not only
+    started but COMPARED against those keys (the stale-fingerprint scan below,
+    freshness.note_folder_opened, routers/git_repos._usable), and the user's raw
+    configured spelling is not the stored one: `~/proj` never matches
+    `/Users/me/proj`, and on Windows `expanduser("~")` returns `C:\\Users\\me`
+    against a stored `C:/Users/me`, so every lookup misses on that platform and the
+    index reads as permanently unreconciled."""
     if cfg.roots:
-        return list(cfg.roots)
-    return [os.path.expanduser("~")]
+        return [runner.canonical_root(r) for r in cfg.roots]
+    return [runner.canonical_root("~")]
 
 
 def run_startup_scan(start_dir: str | None = None) -> None:

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -52,7 +52,11 @@ from fused_render.index.query import dirs_src, files_src
 from fused_render.index.store import depth_expr, like_literal, read_manifest
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle
-from fused_render.server.walk import WALK_IGNORE_DIRS
+# The one screening standard for rows that did not come out of the walk itself;
+# it lives next to WALK_IGNORE_DIRS so the two sources cannot disagree. Bound to
+# the pre-existing private name here because this module's callers (and its
+# tests) already know it as that.
+from fused_render.server.walk import junk_path as _junk_path
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -181,22 +185,6 @@ def _parse_spec(body: dict):
     for key, _end in _DATE_FIELDS:
         spec[key] = date_str(key)
     return spec
-
-
-# Path segments that mark a hit as machine-managed junk or hidden data. The
-# index's own ignore rules are a user-editable name list that says nothing about
-# hidden files, so hits are screened with the same standards the explorer's walk
-# enforces during traversal: WALK_IGNORE_DIRS segments and dot-segments never
-# surface (matching /api/fs/walk's default).
-def _junk_path(path: str) -> bool:
-    # Both separators: the index stores posix paths (index/ignore.norm) whatever
-    # the platform, and one screening standard has to cover both spellings.
-    for seg in re.split(r"[/\\]", path):
-        if seg in WALK_IGNORE_DIRS:
-            return True
-        if seg.startswith(".") and seg not in (".", ".."):
-            return True
-    return False
 
 
 def _nearest_repo(dirpath: str, memo: dict) -> str | None:

--- a/fused_render/server/walk.py
+++ b/fused_render/server/walk.py
@@ -5,7 +5,11 @@ import stat as stat_mod
 import sys
 from types import SimpleNamespace
 
-from fused_render.index.ignore import LEAF_DIR_SUFFIXES, SHARED_IGNORE_DIRS
+from fused_render.index.ignore import (
+    LEAF_DIR_NAMES,
+    LEAF_DIR_SUFFIXES,
+    SHARED_IGNORE_DIRS,
+)
 from fused_render.server.common import _error
 from fused_render.server.gitignore import _IgnoreOracle, _repo_toplevel
 
@@ -81,18 +85,23 @@ WALK_BATCH_SIZE = 500
 # descends, on mounts and locally alike. Checked between yielded entries
 # (best-effort — a single blocking listdir can't be interrupted mid-call).
 WALK_FLUSH_INTERVAL_S = 0.15
-# Directory names never descended into by the walk, checked against the bare
-# name so it also applies under hidden=1 (".git" is machine noise, not
-# "hidden data"). This is only the UNIVERSAL floor — inside a git repository
-# the walk additionally prunes whatever the repo's own .gitignore ignores
-# (see _IgnoreOracle), which is what actually catches dist/, build/, .next/,
-# target/ and friends without hardcoding every ecosystem's junk dir. The
-# floor still matters outside repos (a stray node_modules in ~/Downloads)
-# and for .git itself, which git never reports as ignored.
+# Directory names never emitted or descended into by the walk, checked against
+# the bare name so it also applies under hidden=1 (a node_modules is machine
+# noise, not "hidden data"). This is only the UNIVERSAL floor — inside a git
+# repository the walk additionally prunes whatever the repo's own .gitignore
+# ignores (see _IgnoreOracle), which is what actually catches dist/, build/,
+# .next/, target/ and friends without hardcoding every ecosystem's junk dir. The
+# floor still matters outside repos (a stray node_modules in ~/Downloads).
 # Defined once in index/ignore.py, because the index's default list has to
 # contain it: search is answered by this walk or by the index depending on
 # whether a scan has reached the folder, and a name pruned by one but kept by
 # the other flips results between two interchangeable sources.
+#
+# `.git` is NOT in here — it is a LEAF name (WALK_LEAF_DIR_NAMES below), emitted
+# as one entry and never descended. It has to be, in lockstep with the index:
+# the index records a `.git` dirs row now (that row is what /api/git-repos reads
+# instead of stat-ing 71k directories), and a walk that kept pruning the name
+# would be the exact disagreement this shared definition exists to prevent.
 WALK_IGNORE_DIRS = set(SHARED_IGNORE_DIRS)
 # Cap on concurrently open check-ignore co-processes during one walk (a home
 # walk crosses dozens of repos; each oracle holds a git subprocess).
@@ -105,6 +114,15 @@ WALK_MAX_ORACLES = 8
 # source but not the other flips results between two sources meant to be
 # interchangeable.
 WALK_LEAF_DIR_SUFFIXES = LEAF_DIR_SUFFIXES
+# The same treatment for directories matched by exact NAME rather than suffix —
+# `.git`. Emitted (so the corpus agrees with the index's `.git` dirs row) and
+# never descended (so a repo's object database stays out of a search that has a
+# 200k-entry budget). Under the walk's default hidden=0 a dot-name is dropped
+# before this rule is even consulted, so in practice only an explicitly
+# hidden-inclusive walk ever emits it. Suffix matching is wrong here: a bare
+# repository is conventionally `foo.git`, and treating those as opaque would hide
+# the entire repository — see LEAF_DIR_NAMES.
+WALK_LEAF_DIR_NAMES = LEAF_DIR_NAMES
 
 
 def junk_path(path: str) -> bool:
@@ -423,7 +441,10 @@ def _walk_bfs(path, include_hidden, max_entries=None, max_depth=None):
                         is_link = child.is_symlink()
                     except OSError:
                         is_link = True  # can't tell — safer not to descend
-                    if not is_link and not child.name.lower().endswith(WALK_LEAF_DIR_SUFFIXES):
+                    lowered = child.name.lower()
+                    is_leaf = (lowered in WALK_LEAF_DIR_NAMES
+                               or lowered.endswith(WALK_LEAF_DIR_SUFFIXES))
+                    if not is_link and not is_leaf:
                         if not can_descend:
                             depth_capped = True
                             continue  # at the depth cap — don't enqueue deeper

--- a/fused_render/server/walk.py
+++ b/fused_render/server/walk.py
@@ -1,5 +1,6 @@
 from collections import deque
 import os
+import re
 import stat as stat_mod
 import sys
 from types import SimpleNamespace
@@ -104,6 +105,31 @@ WALK_MAX_ORACLES = 8
 # source but not the other flips results between two sources meant to be
 # interchangeable.
 WALK_LEAF_DIR_SUFFIXES = LEAF_DIR_SUFFIXES
+
+
+def junk_path(path: str) -> bool:
+    """Whether `path` is machine-managed junk or hidden data that no explorer
+    surface may show.
+
+    The screening standard for results that did NOT come out of this walk — the
+    index-backed search (routers/search.py) and the homepage's repo list
+    (routers/git_repos.py) both answer from parquet rows, and the index's own
+    ignore rules are a user-editable NAME list that says nothing about hidden
+    files. So a row is held to what this walk enforces during traversal:
+    WALK_IGNORE_DIRS segments and dot-segments never surface.
+
+    It lives here, next to WALK_IGNORE_DIRS, for the reason that constant does:
+    one definition, so two interchangeable sources cannot disagree about which
+    paths exist.
+    """
+    # Both separators: the index stores posix paths (index/ignore.norm) whatever
+    # the platform, and one screening standard has to cover both spellings.
+    for seg in re.split(r"[/\\]", path):
+        if seg in WALK_IGNORE_DIRS:
+            return True
+        if seg.startswith(".") and seg not in (".", ".."):
+            return True
+    return False
 
 
 class _RcDirEntry:

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -227,6 +227,39 @@ def test_a_partially_rescanned_multi_root_index_is_not_indexed(home, tmp_path,
     assert [r["path"] for r in body["repos"]] == [str(repo)]
 
 
+def test_a_root_configured_in_a_NON_canonical_spelling_still_reads_usable(
+        home, tmp_path, client, monkeypatch):
+    """The fingerprint is stamped under runner.canonical_root(root), so looking it
+    up with the user's raw configured spelling misses and the tab would sit in the
+    not-indexed empty state forever — even after a successful scan. On Windows that
+    is EVERY root (`expanduser("~")` -> `C:\\Users\\me` vs a stored `C:/Users/me`),
+    which is strictly worse than the multi-root staleness the per-root check fixed.
+
+    Exercised through `~` rather than through separators: expansion is a
+    normalization every platform performs, so this fails on POSIX too if the
+    lookup key is raw."""
+    from fused_render.index import runner
+
+    real_expanduser = os.path.expanduser
+
+    def expand(p):
+        if p == "~":
+            return str(tmp_path)
+        if p.startswith("~/"):
+            return str(tmp_path) + p[1:]
+        return real_expanduser(p)
+
+    monkeypatch.setattr(os.path, "expanduser", expand)
+    repo = tmp_path / "proj" / "repo"
+    _set_roots(["~/proj"])                       # raw, un-expanded spelling
+    cfg = _write_dirs_index([_git(repo)], applied=False)
+    save_applied_ignore(cfg, runner.canonical_root("~/proj"))   # what a scan writes
+
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+
+
 def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
         home, tmp_path, client):
     """Bugbot's multi-root hole, pinned. On a store migrated from the pre-per-root

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -18,6 +18,7 @@ from fastapi.testclient import TestClient
 from fused_render.index.config import load_config
 from fused_render.index.store import save_applied_ignore
 from fused_render.server import create_app
+from fused_render.server.routers.index import scan_roots
 
 
 @pytest.fixture()
@@ -68,13 +69,27 @@ def _write_dirs_index(dirs, *, manifest=True, applied=True):
         with open(cfg.partitions_json, "w") as f:
             json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
     if applied:
-        save_applied_ignore(cfg, "/")
+        # The roots the endpoint checks are the CONFIGURED ones (scan_roots:
+        # cfg.roots, else home), each individually — so stamping some other path
+        # would leave the index reading as stale.
+        for r in scan_roots(cfg):
+            save_applied_ignore(cfg, r)
     return cfg
 
 
 def _git(path):
     """The dirs row a repo at `path` produces."""
     return str(path) + "/.git"
+
+
+def _set_roots(roots):
+    """Persist the configured scan roots, so scan_roots() reports them instead of
+    falling back to the real home directory."""
+    from fused_render.index.config import save_config
+
+    cfg = load_config()
+    cfg.roots = [str(r) for r in roots]
+    save_config(cfg)
 
 
 # -- the happy path ------------------------------------------------------------
@@ -197,16 +212,44 @@ def test_an_index_with_no_applied_signature_at_all_is_not_indexed(home, tmp_path
 
 
 def test_a_partially_rescanned_multi_root_index_is_not_indexed(home, tmp_path,
-                                                              client):
-    """Two roots, only one rescanned under the current rules: every repo under
-    the other is still missing, so the honest answer is "not ready"."""
-    repo = tmp_path / "repo"
-    cfg = _write_dirs_index([str(repo), _git(repo)])
-    with open(cfg.applied_ignore_json) as f:
-        data = json.load(f)
-    data["roots"]["/other"] = "a-stale-signature"
+                                                               client):
+    """Two configured roots, only one rescanned under the current rules: every
+    repo under the other is still missing, so the honest answer is "not ready"."""
+    a, b = tmp_path / "a", tmp_path / "b"
+    repo = a / "repo"
+    _set_roots([a, b])
+    cfg = _write_dirs_index([str(repo), _git(repo)], applied=False)
+    save_applied_ignore(cfg, str(a))   # only /a reconciled
+    assert client.get("/api/git-repos").json()["indexed"] is False
+    save_applied_ignore(cfg, str(b))
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+
+
+def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
+        home, tmp_path, client):
+    """Bugbot's multi-root hole, pinned. On a store migrated from the pre-per-root
+    applied-ignore format, stamping the FIRST root leaves
+    `{"roots": {a: current}, "legacy_sig": old}` — and the ROOTLESS
+    applied_ignore_sig() reads only the `roots` values, so it answers "everything
+    matches" while root `b` is still described by nothing but the stale legacy sig
+    and still holds no `.git` rows. Checking each root individually is what sees
+    it: the per-root form falls back to `legacy_sig` for `b`."""
+    from fused_render.index.store import applied_ignore_sig
+
+    a, b = tmp_path / "a", tmp_path / "b"
+    repo = a / "repo"
+    _set_roots([a, b])
+    cfg = _write_dirs_index([str(repo), _git(repo)], applied=False)
+    # the pre-per-root file, then one root migrated onto the new format
     with open(cfg.applied_ignore_json, "w") as f:
-        json.dump(data, f)
+        json.dump({"sig": "a-pre-leaf-rule-global-sig"}, f)
+    save_applied_ignore(cfg, str(a))
+
+    # the rootless form is exactly as misleading as reported...
+    assert applied_ignore_sig(cfg) == cfg.rules.sig()
+    # ...and the endpoint must not be fooled by it
     assert client.get("/api/git-repos").json()["indexed"] is False
 
 

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -1,0 +1,192 @@
+"""GET /api/git-repos (server/routers/git_repos.py): git repositories on this
+machine, for the Explorer homepage's "Repos" tab.
+
+The candidate directory list comes from the index's dirs.parquet (never a fresh
+filesystem walk — see the router's docstring), so these tests build a small
+dirs.parquet by hand rather than running a scan.
+"""
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render.index.config import load_config
+from fused_render.server import create_app
+
+
+@pytest.fixture()
+def home(tmp_path, monkeypatch):
+    """A throwaway shell home, so the index store lands under it."""
+    h = tmp_path / "home"
+    h.mkdir()
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(h))
+    return h
+
+
+@pytest.fixture()
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _write_dirs_index(dirs, *, manifest=True):
+    """A minimal index store holding exactly `dirs` in dirs.parquet.
+
+    Same schema the real compaction writes (index/store.schemas) and the same
+    `ORDER BY dir` row order, so the endpoint's "natural order is path order"
+    assumption is exercised as it is in production.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from fused_render.index.store import schemas
+
+    cfg = load_config()
+    os.makedirs(cfg.dir, exist_ok=True)
+    _files, dir_schema = schemas(pa)
+    rows = sorted(dirs)
+    pq.write_table(
+        pa.table({
+            "dir": rows,
+            "sig": ["" for _ in rows],
+            "n_files": [0 for _ in rows],
+            "total_size": [0 for _ in rows],
+            "mtime_ns": [0 for _ in rows],
+            "n_subdirs": [0 for _ in rows],
+            "depth": [d.count("/") for d in rows],
+        }, schema=dir_schema),
+        cfg.dirs_parquet,
+    )
+    if manifest:
+        with open(cfg.partitions_json, "w") as f:
+            json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
+    return cfg
+
+
+def _repo(root, name):
+    d = root / name
+    (d / ".git").mkdir(parents=True)
+    return d
+
+
+def test_lists_only_dirs_holding_a_dot_git_directory(home, tmp_path, client):
+    repo = _repo(tmp_path, "repo")
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    _write_dirs_index([str(tmp_path), str(repo), str(plain)])
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+
+
+def test_a_dot_git_FILE_is_not_a_repo(home, tmp_path, client):
+    """A linked worktree and a modern submodule both mark themselves with a
+    `.git` FILE, not a directory. Normal repos only — that is the point."""
+    wt = tmp_path / "worktree"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8")
+    _write_dirs_index([str(tmp_path), str(wt)])
+    body = client.get("/api/git-repos").json()
+    assert body["repos"] == []
+
+
+def test_nested_repos_are_both_listed_in_path_order(home, tmp_path, client):
+    outer = _repo(tmp_path, "outer")
+    inner = _repo(outer, "inner")
+    other = _repo(tmp_path, "aaa")
+    _write_dirs_index([str(tmp_path), str(outer), str(inner), str(other)])
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [
+        str(other), str(outer), str(inner),
+    ]
+
+
+def test_a_repo_deleted_since_the_scan_is_dropped(home, tmp_path, client):
+    gone = tmp_path / "gone"  # never created on disk
+    _write_dirs_index([str(tmp_path), str(gone)])
+    assert client.get("/api/git-repos").json()["repos"] == []
+
+
+def test_no_index_reports_not_indexed_rather_than_no_repos(home, tmp_path, client):
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is False
+    assert body["repos"] == []
+    # The tab has to be able to say "still building" instead of "none found".
+    assert "scanning" in body
+
+
+def test_a_manifest_with_no_dirs_parquet_is_not_indexed(home, tmp_path, client):
+    cfg = load_config()
+    os.makedirs(cfg.dir, exist_ok=True)
+    with open(cfg.partitions_json, "w") as f:
+        json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is False
+
+
+def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):
+    """An index that exists but cannot be queried is a failure. Reporting it as
+    "still building" would have the tab promise a list that is never coming."""
+    cfg = load_config()
+    os.makedirs(cfg.dir, exist_ok=True)
+    with open(cfg.partitions_json, "w") as f:
+        json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
+    with open(cfg.dirs_parquet, "wb") as f:
+        f.write(b"not a parquet file at all")
+    resp = client.get("/api/git-repos")
+    assert resp.status_code == 502
+    assert "index could not be read" in resp.json()["error"]
+
+
+def test_hidden_and_machine_managed_checkouts_are_screened_out(home, tmp_path,
+                                                               client):
+    """A package manager's checkouts (~/.oh-my-zsh, nvim's lazy dir, Claude
+    plugin caches) are repos by the .git test but not repos anyone opens. Same
+    standard /api/search/files holds its rows to (walk.junk_path)."""
+    mine = _repo(tmp_path, "mine")
+    hidden = _repo(tmp_path, ".oh-my-zsh")
+    nested = _repo(tmp_path / ".local" / "share", "plugin")
+    vendored = _repo(tmp_path / "proj" / "node_modules", "dep")
+    _write_dirs_index([str(tmp_path), str(mine), str(hidden), str(nested),
+                       str(vendored)])
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(mine)]
+
+
+def test_a_screened_out_row_is_never_statted(home, tmp_path, client, monkeypatch):
+    """The screen runs BEFORE the probe, so the majority of rows on a real home
+    cost no syscall at all."""
+    from fused_render.server.routers import git_repos as mod
+
+    hidden = _repo(tmp_path, ".cache")
+    _write_dirs_index([str(tmp_path), str(hidden)])
+    probed = []
+    real_isdir = os.path.isdir
+    monkeypatch.setattr(mod.os.path, "isdir",
+                        lambda p: (probed.append(p), real_isdir(p))[1])
+    client.get("/api/git-repos")
+    assert not any(str(hidden) in p for p in probed)
+
+
+def test_paths_inside_a_fused_render_home_are_never_probed(home, tmp_path, client,
+                                                           monkeypatch):
+    """MountGuard territory: a fused-render home holds the mount trees, and a
+    stat inside a wedged mount can hang the process forever. Such a candidate
+    must be dropped WITHOUT a filesystem probe."""
+    from fused_render.server.routers import git_repos as mod
+
+    inside = _repo(home, "mountish")
+    outside = _repo(tmp_path, "real")
+    _write_dirs_index([str(inside), str(outside)])
+
+    probed = []
+    real_isdir = os.path.isdir
+
+    def spy(path):
+        probed.append(path)
+        return real_isdir(path)
+
+    monkeypatch.setattr(mod.os.path, "isdir", spy)
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(outside)]
+    assert not any(str(inside) in p for p in probed)

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -183,15 +183,15 @@ def test_a_manifest_with_no_dirs_parquet_is_not_indexed(home, tmp_path, client):
     assert client.get("/api/git-repos").json()["indexed"] is False
 
 
-def test_an_index_built_under_OLD_ignore_rules_is_not_indexed(home, tmp_path,
-                                                              client):
+def test_an_index_built_under_OLD_rules_with_NO_rows_is_not_indexed(home, tmp_path,
+                                                                    client):
     """THE migration case, and the one way this endpoint could ship a silent lie.
 
     `.git` moving out of the ignore list and into the leaf rules changed
     IgnoreRules.sig(), which forces a full rescan — but an index already on disk
     has no `.git` rows until that rescan lands. Answering `indexed: true` with an
     empty list would tell the user, with total confidence, that they have no
-    repositories."""
+    repositories. Zero rows under OLD rules is missing data, not an answer."""
     repo = tmp_path / "repo"
     # A real index (rows, manifest) whose applied signature is a stale one.
     cfg = _write_dirs_index([str(tmp_path), str(repo)], applied=False)
@@ -199,31 +199,106 @@ def test_an_index_built_under_OLD_ignore_rules_is_not_indexed(home, tmp_path,
         json.dump({"roots": {"/": "a-signature-from-before-the-leaf-rule"}}, f)
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is False
+    assert body["reason"] == "outdated"
     assert body["repos"] == []
 
 
-def test_an_index_with_no_applied_signature_at_all_is_not_indexed(home, tmp_path,
-                                                                  client):
-    """None means "predates the applied-ignore file", which cannot be assumed to
-    have been built under the current rules either."""
+# -- a stale index still answers -----------------------------------------------
+
+def test_a_stale_index_WITH_rows_serves_them_marked_stale(home, tmp_path, client):
+    """The principle: a stale index is still a useful index. Rows that can answer
+    the question are served even though the rules signature is a generation behind
+    — refusing would hide a list that is almost certainly right, and an index is
+    ALWAYS somewhat behind the filesystem."""
+    repo = tmp_path / "repo"
+    cfg = _write_dirs_index([str(repo), _git(repo)], applied=False)
+    with open(cfg.applied_ignore_json, "w") as f:
+        json.dump({"roots": {"/": "an-older-signature"}}, f)
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert body["stale"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+
+
+def test_a_fresh_index_with_no_repos_is_a_real_empty_answer(home, tmp_path, client):
+    """The other side of the same coin: the rule DID run and found nothing, so the
+    empty list is an answer and must not be dressed up as "still building"."""
+    _write_dirs_index([str(tmp_path), str(tmp_path / "plain")])
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert body["stale"] is False
+    assert body["repos"] == []
+
+
+def test_rows_screened_down_to_zero_is_still_a_real_answer(home, tmp_path, client):
+    """The zero-row test is on RAW rows, before screening. A machine whose every
+    repo sits inside a dotted directory screens to an empty list — but the rule ran,
+    so that is an answer, not a migration. Getting this backwards would report
+    "outdated" forever on such a machine."""
+    hidden = tmp_path / ".oh-my-zsh"
+    cfg = _write_dirs_index([_git(hidden)], applied=False)
+    with open(cfg.applied_ignore_json, "w") as f:
+        json.dump({"roots": {"/": "an-older-signature"}}, f)
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True   # rows existed; screening emptied them
+    assert body["repos"] == []
+
+
+def test_a_scan_in_flight_over_a_usable_index_serves_it_marked_stale(
+        home, tmp_path, client, monkeypatch):
+    """A rescan keeps serving the last completed generation (index-store.md §4),
+    so a scan in flight is a `stale` note on a live list, never a reason to hide
+    it."""
+    from fused_render.server.routers import git_repos as mod
+
+    repo = tmp_path / "repo"
+    _write_dirs_index([str(repo), _git(repo)])
+    monkeypatch.setattr(mod, "_scanning", lambda cfg: True)
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert body["scanning"] is True
+    assert body["stale"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+
+
+def test_no_index_at_all_says_so_distinctly(home, tmp_path, client):
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is False
+    assert body["reason"] == "no-index"
+    assert body["stale"] is False
+
+
+def test_an_index_with_no_applied_signature_reads_stale_but_still_answers(
+        home, tmp_path, client):
+    """None means "predates the applied-ignore file", so the rows cannot be assumed
+    current — but they exist, and rows beat signatures. Served, marked stale."""
     repo = tmp_path / "repo"
     _write_dirs_index([str(tmp_path), str(repo), _git(repo)], applied=False)
-    assert client.get("/api/git-repos").json()["indexed"] is False
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert body["stale"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
 
 
-def test_a_partially_rescanned_multi_root_index_is_not_indexed(home, tmp_path,
-                                                               client):
-    """Two configured roots, only one rescanned under the current rules: every
-    repo under the other is still missing, so the honest answer is "not ready"."""
+def test_a_partially_rescanned_multi_root_index_serves_what_it_has(home, tmp_path,
+                                                                  client):
+    """Two configured roots, only one reconciled under the current rules. The repos
+    under the reconciled root are real and get served; `stale` says the picture is
+    incomplete. Hiding them would be the "refuse to answer while behind" mistake —
+    an index is essentially always behind on at least one root."""
     a, b = tmp_path / "a", tmp_path / "b"
     repo = a / "repo"
     _set_roots([a, b])
     cfg = _write_dirs_index([str(repo), _git(repo)], applied=False)
     save_applied_ignore(cfg, str(a))   # only /a reconciled
-    assert client.get("/api/git-repos").json()["indexed"] is False
+    body = client.get("/api/git-repos").json()
+    assert body["indexed"] is True
+    assert body["stale"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
     save_applied_ignore(cfg, str(b))
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
+    assert body["stale"] is False      # every root now reconciled
     assert [r["path"] for r in body["repos"]] == [str(repo)]
 
 
@@ -267,8 +342,13 @@ def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
     `{"roots": {a: current}, "legacy_sig": old}` — and the ROOTLESS
     applied_ignore_sig() reads only the `roots` values, so it answers "everything
     matches" while root `b` is still described by nothing but the stale legacy sig
-    and still holds no `.git` rows. Checking each root individually is what sees
-    it: the per-root form falls back to `legacy_sig` for `b`."""
+    and is unreconciled. Checking each root individually is what sees it: the
+    per-root form falls back to `legacy_sig` for `b`.
+
+    The CONSEQUENCE moved — a mismatch now marks the answer `stale` instead of
+    withholding it — but the detection must not: `stale: false` here would promise a
+    complete picture of a machine half of which was never scanned under these
+    rules."""
     from fused_render.index.store import applied_ignore_sig
 
     a, b = tmp_path / "a", tmp_path / "b"
@@ -282,8 +362,10 @@ def test_a_legacy_sig_root_is_stale_even_once_another_root_is_stamped(
 
     # the rootless form is exactly as misleading as reported...
     assert applied_ignore_sig(cfg) == cfg.rules.sig()
-    # ...and the endpoint must not be fooled by it
-    assert client.get("/api/git-repos").json()["indexed"] is False
+    # ...and the endpoint must not be fooled into claiming freshness
+    body = client.get("/api/git-repos").json()
+    assert body["stale"] is True
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
 
 
 def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -1,9 +1,13 @@
 """GET /api/git-repos (server/routers/git_repos.py): git repositories on this
 machine, for the Explorer homepage's "Repos" tab.
 
-The candidate directory list comes from the index's dirs.parquet (never a fresh
-filesystem walk — see the router's docstring), so these tests build a small
-dirs.parquet by hand rather than running a scan.
+Repo-ness is an INDEX FACT: `.git` is a leaf dir, so the scan records one dirs
+row for it and the endpoint's whole job is "find those rows, take the parent".
+These tests therefore build dirs.parquet by hand rather than running a scan, and
+mostly do not touch the filesystem at all — the endpoint never stats.
+
+The `.git`-is-recorded-and-not-descended half lives in tests/test_index_scan.py;
+the walk/index parity of the rule lives in tests/test_index_ignore.py.
 """
 import json
 import os
@@ -12,6 +16,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from fused_render.index.config import load_config
+from fused_render.index.store import save_applied_ignore
 from fused_render.server import create_app
 
 
@@ -29,12 +34,14 @@ def client(tmp_path):
     return TestClient(create_app(start_dir=str(tmp_path)))
 
 
-def _write_dirs_index(dirs, *, manifest=True):
+def _write_dirs_index(dirs, *, manifest=True, applied=True):
     """A minimal index store holding exactly `dirs` in dirs.parquet.
 
     Same schema the real compaction writes (index/store.schemas) and the same
     `ORDER BY dir` row order, so the endpoint's "natural order is path order"
-    assumption is exercised as it is in production.
+    assumption is exercised as it is in production. `applied` stamps the current
+    ignore signature — without it the endpoint (rightly) treats the index as
+    predating the `.git` leaf rule.
     """
     import pyarrow as pa
     import pyarrow.parquet as pq
@@ -60,52 +67,90 @@ def _write_dirs_index(dirs, *, manifest=True):
     if manifest:
         with open(cfg.partitions_json, "w") as f:
             json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
+    if applied:
+        save_applied_ignore(cfg, "/")
     return cfg
 
 
-def _repo(root, name):
-    d = root / name
-    (d / ".git").mkdir(parents=True)
-    return d
+def _git(path):
+    """The dirs row a repo at `path` produces."""
+    return str(path) + "/.git"
 
 
-def test_lists_only_dirs_holding_a_dot_git_directory(home, tmp_path, client):
-    repo = _repo(tmp_path, "repo")
-    plain = tmp_path / "plain"
-    plain.mkdir()
-    _write_dirs_index([str(tmp_path), str(repo), str(plain)])
+# -- the happy path ------------------------------------------------------------
+
+def test_a_repo_is_the_parent_of_a_dot_git_row(home, tmp_path, client):
+    repo = tmp_path / "repo"
+    _write_dirs_index([str(tmp_path), str(repo), _git(repo)])
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is True
     assert [r["path"] for r in body["repos"]] == [str(repo)]
 
 
-def test_a_dot_git_FILE_is_not_a_repo(home, tmp_path, client):
-    """A linked worktree and a modern submodule both mark themselves with a
-    `.git` FILE, not a directory. Normal repos only — that is the point."""
-    wt = tmp_path / "worktree"
-    wt.mkdir()
-    (wt / ".git").write_text("gitdir: /elsewhere/.git/worktrees/wt\n", encoding="utf-8")
-    _write_dirs_index([str(tmp_path), str(wt)])
-    body = client.get("/api/git-repos").json()
-    assert body["repos"] == []
+def test_a_dir_without_a_dot_git_row_is_not_a_repo(home, tmp_path, client):
+    """Which also covers linked worktrees and modern submodules: both mark
+    themselves with a `.git` FILE, and a file never produces a dirs row."""
+    plain = tmp_path / "plain"
+    _write_dirs_index([str(tmp_path), str(plain)])
+    assert client.get("/api/git-repos").json()["repos"] == []
 
 
 def test_nested_repos_are_both_listed_in_path_order(home, tmp_path, client):
-    outer = _repo(tmp_path, "outer")
-    inner = _repo(outer, "inner")
-    other = _repo(tmp_path, "aaa")
-    _write_dirs_index([str(tmp_path), str(outer), str(inner), str(other)])
+    outer = tmp_path / "outer"
+    inner = outer / "inner"
+    other = tmp_path / "aaa"
+    _write_dirs_index([str(tmp_path), str(outer), _git(outer), str(inner),
+                       _git(inner), str(other), _git(other)])
     body = client.get("/api/git-repos").json()
     assert [r["path"] for r in body["repos"]] == [
         str(other), str(outer), str(inner),
     ]
 
 
-def test_a_repo_deleted_since_the_scan_is_dropped(home, tmp_path, client):
-    gone = tmp_path / "gone"  # never created on disk
-    _write_dirs_index([str(tmp_path), str(gone)])
-    assert client.get("/api/git-repos").json()["repos"] == []
+def test_the_endpoint_does_not_stat_anything(home, tmp_path, client, monkeypatch):
+    """The point of sourcing repo-ness from the index: no filesystem syscall on
+    a candidate path, so a wedged mount cannot hang the request. None of these
+    paths exist on disk at all."""
+    from fused_render.server.routers import git_repos as mod
 
+    repo = tmp_path / "nowhere" / "repo"
+    _write_dirs_index([str(repo), _git(repo)])
+    probed = []
+    monkeypatch.setattr(mod.os.path, "isdir",
+                        lambda p: (probed.append(p), False)[1])
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    assert not any(str(repo) in p for p in probed)
+
+
+# -- screening -----------------------------------------------------------------
+
+def test_junk_path_screens_the_PARENT_not_the_dot_git_row(home, tmp_path, client):
+    """The trap this endpoint is built around. `.git` is itself a dot-segment, so
+    holding the ROW to the explorer's no-hidden-paths standard would reject every
+    repository on the machine. The parent is what the user is offered, so the
+    parent is what gets screened."""
+    mine = tmp_path / "mine"
+    hidden = tmp_path / ".oh-my-zsh"
+    nested = tmp_path / ".local" / "share" / "plugin"
+    vendored = tmp_path / "proj" / "node_modules" / "dep"
+    _write_dirs_index([_git(mine), _git(hidden), _git(nested), _git(vendored)])
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(mine)]
+
+
+def test_a_repo_inside_a_fused_render_home_is_excluded(home, tmp_path, client):
+    """MountGuard territory: a fused-render home holds the mount trees. The scan
+    already refuses them, so this is the layer that holds if an index written by
+    an older build carries such a row."""
+    inside = home / "mountish"
+    outside = tmp_path / "real"
+    _write_dirs_index([_git(inside), _git(outside)])
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(outside)]
+
+
+# -- states that are not an answer ---------------------------------------------
 
 def test_no_index_reports_not_indexed_rather_than_no_repos(home, tmp_path, client):
     body = client.get("/api/git-repos").json()
@@ -120,73 +165,58 @@ def test_a_manifest_with_no_dirs_parquet_is_not_indexed(home, tmp_path, client):
     os.makedirs(cfg.dir, exist_ok=True)
     with open(cfg.partitions_json, "w") as f:
         json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
+    assert client.get("/api/git-repos").json()["indexed"] is False
+
+
+def test_an_index_built_under_OLD_ignore_rules_is_not_indexed(home, tmp_path,
+                                                              client):
+    """THE migration case, and the one way this endpoint could ship a silent lie.
+
+    `.git` moving out of the ignore list and into the leaf rules changed
+    IgnoreRules.sig(), which forces a full rescan — but an index already on disk
+    has no `.git` rows until that rescan lands. Answering `indexed: true` with an
+    empty list would tell the user, with total confidence, that they have no
+    repositories."""
+    repo = tmp_path / "repo"
+    # A real index (rows, manifest) whose applied signature is a stale one.
+    cfg = _write_dirs_index([str(tmp_path), str(repo)], applied=False)
+    with open(cfg.applied_ignore_json, "w") as f:
+        json.dump({"roots": {"/": "a-signature-from-before-the-leaf-rule"}}, f)
     body = client.get("/api/git-repos").json()
     assert body["indexed"] is False
+    assert body["repos"] == []
+
+
+def test_an_index_with_no_applied_signature_at_all_is_not_indexed(home, tmp_path,
+                                                                  client):
+    """None means "predates the applied-ignore file", which cannot be assumed to
+    have been built under the current rules either."""
+    repo = tmp_path / "repo"
+    _write_dirs_index([str(tmp_path), str(repo), _git(repo)], applied=False)
+    assert client.get("/api/git-repos").json()["indexed"] is False
+
+
+def test_a_partially_rescanned_multi_root_index_is_not_indexed(home, tmp_path,
+                                                              client):
+    """Two roots, only one rescanned under the current rules: every repo under
+    the other is still missing, so the honest answer is "not ready"."""
+    repo = tmp_path / "repo"
+    cfg = _write_dirs_index([str(repo), _git(repo)])
+    with open(cfg.applied_ignore_json) as f:
+        data = json.load(f)
+    data["roots"]["/other"] = "a-stale-signature"
+    with open(cfg.applied_ignore_json, "w") as f:
+        json.dump(data, f)
+    assert client.get("/api/git-repos").json()["indexed"] is False
 
 
 def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):
     """An index that exists but cannot be queried is a failure. Reporting it as
     "still building" would have the tab promise a list that is never coming."""
+    _write_dirs_index([str(tmp_path)])
     cfg = load_config()
-    os.makedirs(cfg.dir, exist_ok=True)
-    with open(cfg.partitions_json, "w") as f:
-        json.dump({"partitions": [], "rows": 0, "updated": 0.0}, f)
     with open(cfg.dirs_parquet, "wb") as f:
         f.write(b"not a parquet file at all")
     resp = client.get("/api/git-repos")
     assert resp.status_code == 502
     assert "index could not be read" in resp.json()["error"]
-
-
-def test_hidden_and_machine_managed_checkouts_are_screened_out(home, tmp_path,
-                                                               client):
-    """A package manager's checkouts (~/.oh-my-zsh, nvim's lazy dir, Claude
-    plugin caches) are repos by the .git test but not repos anyone opens. Same
-    standard /api/search/files holds its rows to (walk.junk_path)."""
-    mine = _repo(tmp_path, "mine")
-    hidden = _repo(tmp_path, ".oh-my-zsh")
-    nested = _repo(tmp_path / ".local" / "share", "plugin")
-    vendored = _repo(tmp_path / "proj" / "node_modules", "dep")
-    _write_dirs_index([str(tmp_path), str(mine), str(hidden), str(nested),
-                       str(vendored)])
-    body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(mine)]
-
-
-def test_a_screened_out_row_is_never_statted(home, tmp_path, client, monkeypatch):
-    """The screen runs BEFORE the probe, so the majority of rows on a real home
-    cost no syscall at all."""
-    from fused_render.server.routers import git_repos as mod
-
-    hidden = _repo(tmp_path, ".cache")
-    _write_dirs_index([str(tmp_path), str(hidden)])
-    probed = []
-    real_isdir = os.path.isdir
-    monkeypatch.setattr(mod.os.path, "isdir",
-                        lambda p: (probed.append(p), real_isdir(p))[1])
-    client.get("/api/git-repos")
-    assert not any(str(hidden) in p for p in probed)
-
-
-def test_paths_inside_a_fused_render_home_are_never_probed(home, tmp_path, client,
-                                                           monkeypatch):
-    """MountGuard territory: a fused-render home holds the mount trees, and a
-    stat inside a wedged mount can hang the process forever. Such a candidate
-    must be dropped WITHOUT a filesystem probe."""
-    from fused_render.server.routers import git_repos as mod
-
-    inside = _repo(home, "mountish")
-    outside = _repo(tmp_path, "real")
-    _write_dirs_index([str(inside), str(outside)])
-
-    probed = []
-    real_isdir = os.path.isdir
-
-    def spy(path):
-        probed.append(path)
-        return real_isdir(path)
-
-    monkeypatch.setattr(mod.os.path, "isdir", spy)
-    body = client.get("/api/git-repos").json()
-    assert [r["path"] for r in body["repos"]] == [str(outside)]
-    assert not any(str(inside) in p for p in probed)

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -391,6 +391,41 @@ def test_configured_roots_win_over_the_default(home, tmp_path):
         str(tmp_path / "proj")]
 
 
+def test_scan_roots_are_canonical_so_store_lookups_hit(home, tmp_path, monkeypatch):
+    """Roots are KEYS, not just paths: runner.start files every fingerprint,
+    debounce entry and freshness record under runner.canonical_root(root), and
+    scan_roots' output is compared against those keys (the stale-fingerprint
+    rescan, routers/git_repos._usable). A raw configured spelling misses —
+    `~/proj` is not `/home/me/proj`, and on Windows `expanduser("~")` gives
+    `C:\\Users\\me` against a stored `C:/Users/me`, so every lookup misses there
+    and the index reads as permanently unreconciled.
+
+    Asserted as "identical to what runner.start would use", not against a
+    hand-written string: the whole bug is two spellings drifting, so the test has
+    to pin them together rather than restate one of them (and a separator
+    assertion would only ever fire on Windows, where this suite does not run)."""
+    real_expanduser = os.path.expanduser
+    fake_home = str(tmp_path / "userhome")
+
+    def expand(p):
+        if p == "~":
+            return fake_home
+        if p.startswith("~/"):
+            return fake_home + p[1:]
+        return real_expanduser(p)
+
+    monkeypatch.setattr(os.path, "expanduser", expand)
+    cfg = load_config()
+    cfg.roots = ["~/proj", str(tmp_path / "other") + "/"]
+    assert index_router.scan_roots(cfg) == [
+        runner.canonical_root(r) for r in cfg.roots]
+    # ~ really was expanded, so this is not a tautology over two no-ops
+    assert index_router.scan_roots(cfg)[0] == str(tmp_path / "userhome" / "proj")
+    # and the default root gets the same treatment
+    cfg.roots = []
+    assert index_router.scan_roots(cfg) == [runner.canonical_root("~")]
+
+
 # -- manual actions ------------------------------------------------------------
 
 def test_scan_passes_the_full_flag_through(home, tmp_path, monkeypatch):

--- a/tests/test_index_ignore.py
+++ b/tests/test_index_ignore.py
@@ -98,3 +98,62 @@ def test_the_walk_and_the_index_share_one_ignore_floor():
     # the index may prune MORE (a background crawl of the whole home), but
     # never less: everything the walk hides has to be hidden by the index too
     assert set(WALK_IGNORE_DIRS) <= set(DEFAULT_IGNORE_NAMES)
+
+
+def test_the_walk_and_the_index_share_one_leaf_rule():
+    """Same argument as the ignore floor, for the OTHER structural rule. It
+    matters more here: `.git` is a leaf rather than an ignore entry precisely so
+    the index carries a row for it, and a walk that kept pruning the name would
+    disagree with the index about whether `.git` exists."""
+    from fused_render.index.ignore import LEAF_DIR_NAMES, LEAF_DIR_SUFFIXES
+    from fused_render.server.walk import (
+        WALK_LEAF_DIR_NAMES,
+        WALK_LEAF_DIR_SUFFIXES,
+    )
+
+    assert WALK_LEAF_DIR_NAMES == LEAF_DIR_NAMES
+    assert WALK_LEAF_DIR_SUFFIXES == LEAF_DIR_SUFFIXES
+
+
+def test_dot_git_is_a_leaf_not_an_ignore_entry():
+    """It must be in EXACTLY one of the two mechanisms. In the ignore list it
+    would leave no row for /api/git-repos to read (and would still index the ~15
+    loose files sitting directly in `.git`, since ignore rules prune
+    subdirectories but not files)."""
+    from fused_render.index.ignore import (
+        DEFAULT_IGNORE_NAMES,
+        SHARED_IGNORE_DIRS,
+        is_leaf_dir,
+    )
+    from fused_render.server.walk import WALK_IGNORE_DIRS
+
+    assert ".git" not in SHARED_IGNORE_DIRS
+    assert ".git" not in DEFAULT_IGNORE_NAMES
+    assert ".git" not in WALK_IGNORE_DIRS
+    assert is_leaf_dir("/x/proj/.git")
+
+
+def test_a_bare_repo_named_foo_dot_git_is_NOT_a_leaf():
+    """Why `.git` is a NAME rule and not another LEAF_DIR_SUFFIXES entry: that
+    tuple is matched with endswith, and a bare repository is conventionally
+    `foo.git` — treating those as opaque would hide the whole repository."""
+    from fused_render.index.ignore import is_inside_leaf_dir, is_leaf_dir
+
+    assert not is_leaf_dir("/srv/git/foo.git")
+    assert not is_inside_leaf_dir("/srv/git/foo.git/refs")
+    # and the real thing still is one, at any depth
+    assert is_leaf_dir("/x/.git")
+    assert is_inside_leaf_dir("/x/.git/objects/ab")
+
+
+def test_leaf_rules_are_part_of_the_applied_signature():
+    """The signature means "the rules this index was built under", and the leaf
+    rules decide index content just as the patterns do. If they were left out, an
+    index predating the `.git` leaf rule would keep matching and never rescan, so
+    /api/git-repos would report zero repositories forever."""
+    from fused_render.index.ignore import IgnoreRules, ignore_sig
+
+    assert IgnoreRules(["a", "b"]).sig() != ignore_sig(["a", "b"])
+    # still a pure function of the rules: same patterns, same signature
+    assert IgnoreRules(["a", "b"]).sig() == IgnoreRules(["a", "b"]).sig()
+    assert IgnoreRules(["a"]).sig() != IgnoreRules(["b"]).sig()

--- a/tests/test_index_ignore.py
+++ b/tests/test_index_ignore.py
@@ -146,6 +146,37 @@ def test_a_bare_repo_named_foo_dot_git_is_NOT_a_leaf():
     assert is_inside_leaf_dir("/x/.git/objects/ab")
 
 
+def test_ignored_for_index_is_the_one_predicate_all_three_gates_share():
+    """The leaf exemption is a rule about what may EXIST as a row, and there are
+    three gates that filter by the ignore list. Applying it at one of them was a
+    data-loss bug (see test_index_scan's purge test), so it lives in exactly one
+    predicate and every gate routes through it."""
+    from fused_render.index.ignore import IgnoreRules, ignored_for_index
+
+    rules = IgnoreRules([".git", "node_modules"])
+
+    # the leaf's OWN name never forbids its row, under either flavour
+    assert not ignored_for_index(rules, "/w/proj/.git", tree=False)
+    assert not ignored_for_index(rules, "/w/proj/.git", tree=True)
+    # ...but an ignored ANCESTOR still does, and only the tree flavour sees it
+    assert ignored_for_index(rules, "/w/node_modules/pkg/.git", tree=True)
+    # ordinary dirs are unaffected in both flavours
+    assert ignored_for_index(rules, "/w/node_modules", tree=False)
+    assert ignored_for_index(rules, "/w/node_modules/pkg/lib", tree=True)
+    assert not ignored_for_index(rules, "/w/src", tree=True)
+
+
+def test_tree_false_does_not_judge_ancestors_so_a_root_inside_a_named_dir_works():
+    """Why keep_subdirs must NOT use the tree flavour: a scan root that itself sits
+    inside a directory matching an ignore NAME would otherwise have every path
+    under it forbidden, and the whole subtree would silently vanish."""
+    from fused_render.index.ignore import IgnoreRules, ignored_for_index
+
+    rules = IgnoreRules(["venv"])
+    assert not ignored_for_index(rules, "/home/me/venv/myproject/src", tree=False)
+    assert ignored_for_index(rules, "/home/me/venv/myproject/src", tree=True)
+
+
 def test_leaf_rules_are_part_of_the_applied_signature():
     """The signature means "the rules this index was built under", and the leaf
     rules decide index content just as the patterns do. If they were left out, an

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -349,7 +349,22 @@ def test_a_second_run_carries_unchanged_directories_forward(tmp_path):
                for e in _events(run_dir))
 
 
-def test_a_rescan_picks_up_a_new_file(tmp_path):
+def test_a_rescan_picks_up_a_new_file(tmp_path, monkeypatch):
+    """The mtime-driven incremental path: `sub`'s mtime moved, so it is rescanned
+    and the new file lands.
+
+    The FSEvents fast path is pinned OFF, and that is load-bearing rather than
+    tidiness. FSEvents is a machine-global, ASYNCHRONOUS journal: with the journal
+    live, run 2 takes the fast path and visits only what the OS has already
+    reported — so if the report for `sub` has not landed yet, every cached row is
+    carried forward and this assertion fails with no bug present. Measured: 4 runs
+    in 10 under `-n auto` once neighbouring tests in this file started writing
+    enough files to make the journal lag. The fsevents path has its own tests
+    (test_the_fsevents_path_does_not_walk_into_a_package), which pin `hint` for the
+    same reason in the other direction."""
+    from fused_render.index import fsevents
+
+    monkeypatch.setattr(fsevents, "hint", lambda *a, **k: None)
     src = tmp_path / "src"
     src.mkdir()
     _tree(src)
@@ -361,6 +376,35 @@ def test_a_rescan_picks_up_a_new_file(tmp_path):
     assert _summary(run_dir)["msg"] == "complete"
     part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
     assert str(src / "sub" / "new.txt") in pq.read_table(part).column("path").to_pylist()
+
+
+def test_a_missing_applied_fingerprint_forces_a_full_rescan(tmp_path):
+    """An index with no `ignore_applied.json` must NOT be reconciled
+    incrementally, and this is not a theoretical tidiness point.
+
+    Absent used to count as "no change", which was sound while every rule only
+    ever REMOVED rows: dropping an ignore pattern is self-purging through the
+    filtered cache. A rule that ADDS rows breaks it — a `.git` row appears only by
+    visiting the repo directory, and an incremental scan skips exactly that
+    directory because its mtime is unchanged. The run would then stamp the new
+    fingerprint over an index that never grew the rows, and /api/git-repos, which
+    trusts that stamp, would report zero repositories forever.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    cfg = _cfg(tmp_path, ignore=["node_modules"])
+    _run(cfg, str(src))
+    # a repo appears, and the fingerprint is lost (an index predating the file)
+    (src / "proj" / ".git").mkdir(parents=True)
+    os.remove(cfg.applied_ignore_json)
+
+    run_dir = _run(cfg, str(src), run_name="run2")
+    msgs = [e.get("msg") for e in _events(run_dir)]
+    assert "no applied rules fingerprint - full rescan" in msgs
+    assert "scanning (full)" in msgs
+    dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
+    assert str(src / "proj" / ".git") in dirs
 
 
 def test_changing_the_ignore_rules_forces_a_full_rescan(tmp_path):

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -159,6 +159,69 @@ def test_a_package_directory_is_recorded_but_not_descended(tmp_path):
     assert subs == []            # and nothing below it is queued
 
 
+def _repo(root, name="proj"):
+    """A repo whose .git holds the loose files git actually puts there plus a
+    subdirectory, so "recorded but not listed" is distinguishable from "pruned as
+    an ignored tree" (an ignore rule prunes the subdir but NOT the loose files)."""
+    proj = root / name
+    git = proj / ".git"
+    (git / "objects" / "ab").mkdir(parents=True)
+    (git / "objects" / "ab" / "cdef").write_text("blob", encoding="utf-8")
+    for loose in ("HEAD", "config", "index"):
+        (git / loose).write_text("x", encoding="utf-8")
+    (proj / "main.py").write_text("print()", encoding="utf-8")
+    return proj, git
+
+
+def test_dot_git_is_recorded_as_a_leaf_and_never_listed(tmp_path):
+    """Repo-ness has to be a queryable index fact (routers/git_repos.py reads
+    these rows instead of stat-ing every indexed directory), and it has to cost
+    one row: NOT the ~15 loose files directly inside `.git`, which is exactly what
+    an ignore rule would have left behind, and certainly not the object
+    database."""
+    proj, git = _repo(tmp_path)
+    rules, guard = IgnoreRules([]), _guard(tmp_path)
+
+    # the repo's own scan offers .git onward — that is how the row gets made
+    kind, payload, subs = scan_dir_once(str(proj), {}, rules, guard)
+    assert kind == "s"
+    assert str(git) in subs
+    assert [r[2] for r in payload[1]] == ["main.py"]
+
+    # and .git itself is one row with nothing in it and nothing below it
+    kind, payload, subs = scan_dir_once(str(git), {}, rules, guard)
+    assert kind == "s"           # recorded
+    assert payload[1] == []      # no HEAD/config/index rows
+    assert payload[4] == 0
+    assert subs == []            # objects/ never queued
+
+
+def test_a_user_ignore_entry_cannot_delete_the_dot_git_row(tmp_path):
+    """An ignore entry buys a scan two things: no descent and no row. For a leaf
+    dir the first is already true, so all it can still do is delete the row that
+    IS the repo-detection fact — silently emptying the homepage's Repos tab to
+    save one stat. `.git` shipped in the default ignore list once, so old saved
+    configs really do name it."""
+    proj, git = _repo(tmp_path)
+    rules, guard = IgnoreRules([".git"]), _guard(tmp_path)
+    assert str(git) in scan_dir_once(str(proj), {}, rules, guard)[2]
+    # ... and it is still opaque: kept, not descended
+    assert scan_dir_once(str(git), {}, rules, guard)[2] == []
+
+
+def test_keep_subdirs_still_honors_ignores_for_non_leaf_dirs(tmp_path):
+    """The leaf override is narrow — it decides the verdict on the leaf dir
+    ITSELF and changes nothing else, including for a repo sitting inside an
+    ignored tree (the walk never reaches its parent to offer it)."""
+    guard = _guard(tmp_path)
+    rules = IgnoreRules([".git", "node_modules"])
+    assert keep_subdirs([str(tmp_path / "node_modules")], rules, guard) == []
+    # SKIP_DIRS and the mount guard keep their veto over a leaf dir too
+    assert keep_subdirs(["/dev"], rules, guard) == []
+    blocked = MountGuard(mounts_dir=str(tmp_path / "m"))
+    assert keep_subdirs([str(tmp_path / "m" / "s3" / ".git")], rules, blocked) == []
+
+
 def test_keep_subdirs_drops_skip_dirs_ignored_and_mount_paths(tmp_path):
     guard = MountGuard(mounts_dir=str(tmp_path / "mounts"))
     subs = [str(tmp_path / "ok"), str(tmp_path / "mounts" / "s3"),

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -209,6 +209,51 @@ def test_a_user_ignore_entry_cannot_delete_the_dot_git_row(tmp_path):
     assert scan_dir_once(str(git), {}, rules, guard)[2] == []
 
 
+def test_an_ignored_dot_git_row_SURVIVES_an_incremental_rescan(tmp_path):
+    """The data-loss sequence, end to end: a full rescan writes the `.git` rows,
+    then an incremental pass over a config that NAMES `.git` must not purge them.
+
+    keep_subdirs alone was not enough. The cache filter (load_dir_cache) decides
+    what an incremental pass carries forward and the journal gate decides what it
+    re-adds; with the leaf exemption in only the walk gate, the rows the first scan
+    wrote were dropped by the second — so a user whose Repos tab worked lost it on
+    the next scan. Worse than a stale list: actively purged."""
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    _repo(src, "proj")
+    cfg = _cfg(tmp_path, ignore=["node_modules", ".git"])
+
+    _run(cfg, str(src))
+    git_dir = str(src / "proj" / ".git")
+    dirs = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
+    assert git_dir in dirs, "the full rescan should record the leaf row"
+
+    # ...and the incremental pass must keep it. Both gates are exercised: the
+    # cache filter (whether it is carried forward) and the journal/walk gate
+    # (whether it is re-added).
+    _run(cfg, str(src), run_name="run2")
+    dirs2 = pq.read_table(cfg.dirs_parquet).column("dir").to_pylist()
+    assert git_dir in dirs2, "an incremental pass purged the .git row"
+
+
+def test_load_dir_cache_keeps_an_ignored_leaf_but_drops_a_real_ignored_tree(tmp_path):
+    """The cache filter is the sharpest edge: a row missing here is a row the next
+    compaction deletes. Leaf exempt, ancestors still vetoing."""
+    import pyarrow.parquet as pqmod
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    _repo(src, "proj")
+    cfg = _cfg(tmp_path, ignore=["node_modules", ".git"])
+    _run(cfg, str(src))
+
+    cache = load_dir_cache(cfg, str(src), pqmod)
+    assert str(src / "proj" / ".git") in cache          # leaf: exempt
+    assert str(src / "node_modules") not in cache       # ordinary ignore: gone
+
+
 def test_keep_subdirs_still_honors_ignores_for_non_leaf_dirs(tmp_path):
     """The leaf override is narrow — it decides the verdict on the leaf dir
     ITSELF and changes nothing else, including for a repo sitting inside an

--- a/tests/test_server_walk.py
+++ b/tests/test_server_walk.py
@@ -155,13 +155,24 @@ def test_walk_app_bundle_is_leaf(tmp_path):
     assert not any(r.startswith("Cool.app/") for r in rels)
 
 
-def test_walk_hidden_still_prunes_git_and_venv(tmp_path):
-    # .git/.venv are machine-managed noise, pruned even under hidden=1 —
-    # otherwise a ".py" extension search floods with .git object files.
+def test_walk_hidden_never_yields_the_contents_of_git_or_venv(tmp_path):
+    """The invariant: under hidden=1, NOTHING inside .git or .venv surfaces —
+    otherwise a ".py" extension search floods with a repo's object files.
+
+    The two get there by different mechanisms, and the difference is deliberate.
+    `.venv` is on the shared ignore floor (WALK_IGNORE_DIRS): pruned outright, not
+    even its own name shows. `.git` is a LEAF (WALK_LEAF_DIR_NAMES): emitted as one
+    undescended entry, because the index records a `.git` dirs row for it — that
+    row is what /api/git-repos reads instead of stat-ing every indexed directory —
+    and the walk and the index must not disagree about what exists
+    (tests/test_index_ignore.py holds that parity directly). One entry per repo is
+    the entire cost; the tree below it stays out either way.
+    """
     for name in (".git", ".venv"):
         d = tmp_path / name
-        d.mkdir()
+        (d / "sub").mkdir(parents=True)
         (d / "junk.txt").write_text("x", encoding="utf-8")
+        (d / "sub" / "deep.py").write_text("x", encoding="utf-8")
     (tmp_path / ".env").write_text("x", encoding="utf-8")
     data = (
         _client(tmp_path)
@@ -170,8 +181,22 @@ def test_walk_hidden_still_prunes_git_and_venv(tmp_path):
     )
     rels = {e["rel"] for e in data["entries"]}
     assert ".env" in rels  # a real dotfile still shows
-    assert ".git" not in rels and ".venv" not in rels
+    # THE invariant: no descendant of either, at any depth.
     assert not any(r.startswith((".git/", ".venv/")) for r in rels)
+    assert ".venv" not in rels  # ignore floor: pruned, name and all
+    assert ".git" in rels       # leaf: recorded, matching the index's row
+
+
+def test_walk_default_hides_git_entirely(tmp_path):
+    """The leaf rule only decides what happens once a dot-name is in scope. With
+    the default hidden=0 — every walk the explorer makes except an explicitly
+    dot-leading query — `.git` is dropped as a dotfile before the rule is ever
+    consulted, so making it a leaf did not put it in front of anyone."""
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "keep.txt").write_text("x", encoding="utf-8")
+    data = _client(tmp_path).get("/api/fs/walk", params={"path": str(tmp_path)}).json()
+    rels = {e["rel"] for e in data["entries"]}
+    assert rels == {"keep.txt"}
 
 
 def test_walk_symlink_dir_not_descended(tmp_path):


### PR DESCRIPTION
## Summary

- **Adds a fourth tab, "Repos", to the Explorer homepage**, listing this machine's git repositories as folder-preview cards you can click into — same card, grid and "Show more" fold as the existing tabs.
- **Makes `.git` a leaf directory in the index instead of an ignored one.** It moves out of `SHARED_IGNORE_DIRS` into a new `LEAF_DIR_NAMES = (".git",)` — the "recorded as one opaque row, never listed" treatment `.app`/`.framework` already get. A repo's object database still stays out of the index entirely; only the `.git` row itself now exists.
- **Repo-ness becomes a queryable index fact.** `GET /api/git-repos` is one SQL query for `dirs` rows whose final component is `.git`, taking each parent as the repo root. **Zero filesystem syscalls, no `git` subprocess.** Measured live: **59ms**, down from **~210ms** for the first cut, which stat-ed all ~71k indexed directories per request.
- **Leaf rules beat an ignore rule here on cost, not just tidiness.** Ignore rules prune sub*directories* but not files, so an ignored-tree `.git` would still contribute the ~15 loose files sitting directly in it (`HEAD`, `config`, `index`…) and still pay to list the directory. A leaf dir is never listed at all.
- **A name, not a suffix** — `LEAF_DIR_SUFFIXES` is `endswith`-matched, and a bare repository is conventionally named `foo.git`; a suffix rule would record those as opaque leaves and hide the entire repository.
- Linked worktrees and modern submodules use a `.git` **file**, so they never appear in the `dirs` table and are excluded for free — normal repos only.
- Hidden/machine-managed paths are screened out, reusing the standard `/api/search/files` and `/api/fs/walk` already hold non-walk results to (`_junk_path` lifted from `routers/search.py` to `walk.junk_path`). Live: **69 raw `.git` rows → 21 repos**; the 48 dropped are package-manager checkouts under `~/.local/share/nvim/lazy`, `~/.oh-my-zsh` and `~/.claude/plugins/cache`. **Named cost: a repo kept inside a dotted directory is not listed.**

## A stale index is still served

The endpoint never refuses to answer when it holds rows that can answer. An index is always slightly behind the filesystem, and treating that as unusable would be wrong — so staleness is reported, not enforced: `stale = (not fresh) or scanning`, and the tab renders every card plus one quiet footnote ("Reindexing — this list may be out of date.").

The rules signature keeps exactly one job, the one nothing else can do: telling two kinds of zero apart. **Zero rows because the leaf rule never ran** (a pre-upgrade index — say "outdated", because claiming "no repositories on this machine" would be a confident lie) versus **zero rows because this machine genuinely has no repos** (a real, empty answer). It is no longer a veto on non-empty results.

The zero-row test is deliberately on **raw** rows, before screening: screening can legitimately take real rows to zero on a machine where every repo sits inside a dotted directory, and that is a rule which *did* run.

## Visuals

```mermaid
flowchart TD
    A[GET /api/git-repos] --> B{manifest + dirs.parquet?}
    B -->|no| C[not ready]
    B -->|yes| D["SELECT dir WHERE<br/>basename = '.git'"]
    D --> E{rows found?}
    E -->|yes| F["serve, stale = not fresh or scanning"]
    E -->|"no, rules stale"| G[outdated — rescan pending]
    E -->|"no, rules current"| H[ready, genuinely empty]
```

`junk_path`/`MountGuard` screen the **parent**, never the row — `.git` is itself a dot-segment, so screening the row would reject every repo on the machine.

Verified by screenshot against a live server: four tabs fit one row without wrapping, `?tab=repos` deep-links, and `FolderStack` previews render for repo roots including live iframe previews. The one-card-per-row/tall-card layout is **identical to the existing Artifacts tab**, i.e. inherited, not introduced here.

## Usage

```bash
curl -s http://127.0.0.1:8000/api/git-repos
# {"indexed":true,"scanning":false,"stale":false,"reason":null,
#  "repos":[{"path":"/Users/you/Work/project"}, ...]}
```

In the UI: Explorer homepage → **Repos**, or deep-link `/explorer?tab=repos`. Each card opens the repo root.

### ⚠️ Upgrade behavior: one forced reindex

`IgnoreRules.sig()` now fingerprints the leaf rules as well as the user's patterns, so every existing index mismatches and the next scan discards its incremental cache. Deliberate — and it closes three silent-failure modes found in review:

1. **Missing fingerprint ran incrementally.** `rules_changed` required `applied is not None`, so an absent `ignore_applied.json` meant "no rules change" → incremental scan → stamped the new leaf-aware signature over an index that never gained `.git` rows (a repo dir's mtime doesn't change, so the incremental pass skips exactly it). Permanently empty repo list. The old assumption held only while rules *removed* rows; it cannot hold for a rule that *adds* them.
2. **Multi-root staleness.** `applied_ignore_sig`'s rootless form reads only `roots` values and ignores `legacy_sig`, so once the first root migrated, a half-reconciled machine read as all-match. Now every configured root is checked individually.
3. **Path spellings drifted.** `runner.start` canonicalized (`expanduser` → `abspath` → `norm`) and wrote *that* into the store, while `scan_roots` returned raw config strings — so lookups missed for any `~`-configured root, and on Windows for every root, leaving a permanently dead tab. Canonicalization is now `runner.canonical_root()`, used by both sides. **This also fixes two pre-existing latent bugs on `main`:** `routers/index.py`'s post-edit rescan could skip its reconciling scan for a `~`-configured root, and `freshness.note_folder_opened` compared a canonical path against raw roots.

## Test Plan

- [x] **Live, end-to-end** — dev server on a freshly rescanned index: 69 `.git` rows in `dirs.parquet`, `GET /api/git-repos` → 200, 21 repos, `stale:false`, **59ms**. Count matches the old stat-based implementation exactly.
- [x] **Backend** — `tests/test_git_repos_api.py`, 19 tests: the staleness matrix (stale-with-rows, stale-without-rows, fresh-and-empty, scan-in-flight-over-usable-index), rows-screened-to-zero, partially-rescanned multi-root, `.git` file vs directory, junk/mount screening on the parent, ordering.
- [x] **Index rules** — `tests/test_index_ignore.py`, `test_index_scan.py`, `test_index_runner.py`, `test_index_freshness.py`, `test_index_api.py`: leaf-by-name, `foo.git` not swallowed, leaf survives a user ignore entry, sig covers leaf rules, root canonicalization.
- [x] **Walk contract** — `test_walk_hidden_still_prunes_git_and_venv` rewritten to the leaf rule (`.git` emitted undescended; nothing beneath it at any depth), plus `test_walk_default_hides_git_entirely` pinning that the default `hidden=0` drops dot-names *before* the leaf rule is consulted — so parity with the index costs one entry in one narrow case, not a visible regression.
- [x] **Frontend** — `repos.test.ts`, 17 tests over the `ReposView` union (`loading | failed | building | unavailable | outdated | ready`), incl. every scan ending: completed, cancelled, failed, never-started.
- [x] **Flake fixed, measured** — `test_index_scan.py::test_a_rescan_picks_up_a_new_file` failed **4/10** under `-n auto` alongside the new tests, **0/10** with them deselected. Cause: the new tests' `.git` trees added FSEvents churn, so the journal report hadn't landed when run 2 took the fast path. Pinned to the mtime path: **0/12**. Pre-existing fragility, exposed here.
- [x] **Full suite** — 1 failed / 5298 passed / 131 skipped. The failure is the pre-existing `tests/test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, unchanged from the pre-branch baseline and the only one. It passes in CI. Frontend `bun test` 570 pass / 8 fail, all 8 the pre-existing `shortcut-chord.test.ts` failures verified against stashed code.
- [x] **Specs** — `fused_render/index/specs/scan-ignore.md` §4 updated.
- [ ] **Not observed:** the five non-`ready` states and the stale footnote as *rendered* (unit-tested pure logic; the live index was fresh, so only `ready`/not-stale was seen in a browser). Keyboard/arrow nav across four tabs, "Show more" expanding 9 → 21, and refetch-on-scan-end firing in a real browser. The Windows canonicalization path is reasoned and unit-tested, never executed on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
