### PR TITLE
Explorer home: an instant index-backed search bar, with AI search as a result row

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -27,6 +27,7 @@ import {
   homeHitsFrom,
   isAiRow,
   pathShortcut,
+  redirectsToSearch,
   stepHighlight,
   type CorpusState,
   type HomeHit,
@@ -323,6 +324,38 @@ function FilesSearch({
   const hits = useMemo(() => homeHitsFrom(ranked, home), [ranked, home]);
   const scanning = active && (scanned.q !== q || !scanned.done);
 
+  // -- the box is where typing goes ------------------------------------------
+  //
+  // This page exists to be typed into, so the caret starts here and STAYS
+  // reachable: a stray click on the background, or arriving with the hands
+  // already moving, must not cost a click on the input to recover. Any printable
+  // keystroke aimed at nothing else focuses the box and lands in it.
+  const inputEl = useRef<HTMLInputElement | null>(null);
+  useEffect(() => {
+    inputEl.current?.focus();
+  }, []);
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const el = e.target as HTMLElement | null;
+      const claim = redirectsToSearch({
+        key: e.key,
+        ctrlKey: e.ctrlKey,
+        altKey: e.altKey,
+        metaKey: e.metaKey,
+        tagName: el?.tagName,
+        isContentEditable: el?.isContentEditable === true,
+        isSearchInput: el === inputEl.current,
+      });
+      // Focus, then let the event through UNHANDLED: the browser delivers this
+      // same keystroke to the newly focused input, so the character is neither
+      // dropped nor inserted twice (preventDefault + appending by hand would
+      // fight the controlled value and lose the caret).
+      if (claim) inputEl.current?.focus();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, []);
+
   // -- AI search -------------------------------------------------------------
   const aiCtl = useRef<AbortController | null>(null);
   useEffect(() => () => aiCtl.current?.abort(), []);
@@ -419,6 +452,7 @@ function FilesSearch({
           <MagnifierIcon />
         </span>
         <input
+          ref={inputEl}
           type="search"
           className="files-search-input"
           placeholder="Search your files — or paste a path like ~/Downloads"

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -12,8 +12,9 @@ import { getClaudeSessionFolders, indexSearch, statPath } from "@platform/lib/ap
 import { allBookmarks, hydrateBookmarks, loadBookmarks } from "@platform/lib/bookmarks";
 import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
 import {
+  fsMutationCount,
   indexLifecycleCount,
-  indexMayAnswer,
+  subscribeFsMutations,
   subscribeIndexLifecycle,
 } from "@platform/lib/index-freshness";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
@@ -27,8 +28,10 @@ import {
   homeHitsFrom,
   isAiRow,
   pathShortcut,
+  rankingSettled,
   redirectsToSearch,
   stepHighlight,
+  submitRow,
   type CorpusState,
   type HomeHit,
 } from "@apps/explorer/lib/home-search";
@@ -145,19 +148,22 @@ function FileRow({
 // The last row: an ACTION, not a hit. Deliberately unlike the file rows above
 // it (accent glyph, no path, no size) because activating it costs a model call
 // and a wait, and because on a zero-hit query it is the only thing on screen.
+//
+// Deliberately NOT hoverable, unlike the file rows: setting the highlight on
+// mousemove meant nudging the pointer across the list armed Enter to spend a
+// model call. A pointer merely crossing a row must not arm a paid action —
+// reaching this one takes an arrow key or a click.
 function AiActionRow({
   query,
   active,
   running,
   id,
-  onHover,
   onRun,
 }: {
   query: string;
   active: boolean;
   running: boolean;
   id: string;
-  onHover: () => void;
   onRun: () => void;
 }) {
   return (
@@ -166,7 +172,6 @@ function AiActionRow({
         type="button"
         className={"fh-result fh-ai-row" + (active ? " is-active" : "")}
         disabled={running}
-        onMouseMove={onHover}
         onClick={onRun}
       >
         <span className="fh-result-icon fh-ai-glyph" aria-hidden="true">
@@ -249,6 +254,21 @@ function FilesSearch({
   // lib/index-freshness.
   const [lifecycle, setLifecycle] = useState(indexLifecycleCount);
   useEffect(() => subscribeIndexLifecycle(() => setLifecycle(indexLifecycleCount())), []);
+  // An in-app rename/delete moves paths the fetched corpus already holds, so
+  // search would find the old name and the click would 404. It is a REFETCH
+  // trigger, not a gate: `indexMayAnswer(home)` used to disable instant search
+  // outright, and since `touched` is session-scoped and home is an ancestor of
+  // every mutation, one rename anywhere pinned this page to "still building"
+  // for the rest of the session — while the index was in fact built. The home
+  // page has no live walk to fall back on, so switching search OFF is the worst
+  // available outcome: a corpus one rename stale beats no corpus at all.
+  // (useWalkSearch keeps the gate because it HAS a live walk to prefer.)
+  const [mutations, setMutations] = useState(fsMutationCount);
+  useEffect(() => subscribeFsMutations(() => setMutations(fsMutationCount())), []);
+  // Bumped by a real gesture (typing) to re-run a failed fetch. Without it a
+  // `setCorpus({status:"error"})` was terminal: none of the other deps is
+  // something a user can move, so search stayed dead until a reload.
+  const [retryNonce, setRetryNonce] = useState(0);
   // Requested on the first keystroke and never unrequested: dropping the
   // corpus when the box is cleared would re-fetch it on the next letter typed.
   const [wanted, setWanted] = useState(active);
@@ -257,13 +277,6 @@ function FilesSearch({
   }, [active]);
   useEffect(() => {
     if (!wanted) return;
-    // A folder this app changed since the last scan is not the index's to
-    // answer for; the home page has no live walk to fall back on, so it says
-    // so rather than serving pre-change paths.
-    if (!indexMayAnswer(home)) {
-      setCorpus({ status: "cold" });
-      return;
-    }
     const ctl = new AbortController();
     setCorpus((prev) => (prev.status === "ok" ? prev : { status: "loading" }));
     indexSearch(home, { signal: ctl.signal }).then(
@@ -276,7 +289,7 @@ function FilesSearch({
       },
     );
     return () => ctl.abort();
-  }, [home, wanted, lifecycle]);
+  }, [home, wanted, lifecycle, mutations, retryNonce]);
 
   // -- ranking ---------------------------------------------------------------
   // The same sliced, cancellable scan the in-folder search runs: a covered home
@@ -368,6 +381,12 @@ function FilesSearch({
   };
   const runAi = (target: string) => {
     if (!target) return;
+    // Re-entry guard, the keyboard's half of the `disabled` that already
+    // protects the mouse path: Enter on the AI row while a search is in flight
+    // aborted and re-issued it, so three impatient presses were three billed
+    // model calls. Editing the query is the way to change what is running (it
+    // resets the phase), so a running search is never for a stale query.
+    if (ai.status === "running") return;
     aiCtl.current?.abort();
     const ctl = new AbortController();
     aiCtl.current = ctl;
@@ -400,6 +419,9 @@ function FilesSearch({
   const edit = (value: string) => {
     setQuery(value);
     setHighlight(null);
+    // Typing is a user gesture, so it is also the retry for a failed corpus
+    // fetch — the same way useWalkSearch re-arms its stream from setQuery.
+    if (corpus.status === "error") setRetryNonce((n) => n + 1);
     // Editing the query is how the user gets back from AI results to instant
     // ones, so it drops the AI phase — and the ?q= that a committed search set.
     if (ai.status !== "off") {
@@ -419,7 +441,11 @@ function FilesSearch({
   }, []);
 
   const showingAi = ai.status === "done" && ai.query === q;
-  const current = activeRow(highlight, hits.length);
+  // Whether the instant list is a finished answer. Gates the AI row's
+  // pre-selection, so Enter during the corpus load or the scan debounce cannot
+  // spend a model call on a query that was about to answer itself.
+  const settled = rankingSettled(corpus.status, scanning);
+  const current = activeRow(highlight, hits.length, settled);
 
   const openRow = (row: number) => {
     if (isAiRow(row, hits.length)) runAi(q);
@@ -427,8 +453,8 @@ function FilesSearch({
   };
 
   // Enter with no row chosen: a query that is really an ADDRESS goes straight
-  // there (a pasted ~/Downloads is not a search), and a query with no index
-  // matches runs the AI search, because that row is the only content.
+  // there (a pasted ~/Downloads is not a search); otherwise it commits the top
+  // hit, or — only once ranking has settled on nothing — the AI row.
   const submit = async () => {
     if (highlight === null) {
       const target = pathShortcut(q, home);
@@ -442,7 +468,8 @@ function FilesSearch({
         }
       }
     }
-    if (current !== null) openRow(current);
+    const row = submitRow(highlight, hits.length, settled);
+    if (row !== null) openRow(row);
   };
 
   return (
@@ -530,7 +557,6 @@ function FilesSearch({
               active={current === hits.length}
               running={ai.status === "running"}
               id={"fh-row-" + hits.length}
-              onHover={() => setHighlight(hits.length)}
               onRun={() => runAi(q)}
             />
           </ul>

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -205,11 +205,7 @@ function SearchResults({
     <section className="fh-section">
       <h2 className="fh-heading">Results for “{query}”</h2>
       <p className="fh-search-summary">
-        {result.usedFallback
-          ? "AI unavailable — matched your words directly."
-          : summary
-            ? `Understood as: ${summary}`
-            : "No filters — showing closest matches."}
+        {summary ? `Understood as: ${summary}` : "No filters — showing closest matches."}
         {result.truncated && " · Broad query: showing the first slice of matches."}
       </p>
       {result.hits.length ? (

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -35,14 +35,7 @@ import {
   type CorpusState,
   type HomeHit,
 } from "@apps/explorer/lib/home-search";
-import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
-import { startScanJob } from "@apps/explorer/listing/scan-job";
-import {
-  RERANK_COMMIT_MS,
-  SCAN_IMMEDIATE_MAX,
-  SCAN_SLICE,
-  type SearchHit,
-} from "@apps/explorer/listing/types";
+import { useRankedScan } from "@apps/explorer/listing/useRankedScan";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 
 // How many cards the Bookmarks/Recents tab shows before "Show more" — flat
@@ -292,50 +285,14 @@ function FilesSearch({
   }, [home, wanted, lifecycle, mutations, retryNonce]);
 
   // -- ranking ---------------------------------------------------------------
-  // The same sliced, cancellable scan the in-folder search runs: a covered home
-  // root can be 200k entries, and scoring that synchronously on a keystroke is
-  // the typing freeze listing/scan-job exists to prevent.
+  // The same sliced, cancellable scan the in-folder search runs — literally the
+  // same hook (listing/useRankedScan): a covered home root can be 200k entries,
+  // and scoring that synchronously on a keystroke is the typing freeze
+  // listing/scan-job exists to prevent.
   const entries = corpus.status === "ok" ? corpus.entries : null;
-  const [scanned, setScanned] = useState<{ q: string; items: SearchHit[]; done: boolean }>({
-    q: "",
-    items: [],
-    done: true,
-  });
-  useEffect(() => {
-    if (entries === null || q === "") {
-      setScanned((prev) =>
-        prev.q === q && prev.items.length === 0 && prev.done ? prev : { q, items: [], done: true },
-      );
-      return;
-    }
-    return startScanJob(
-      {
-        q,
-        showHidden: queryWantsHidden(q),
-        entries,
-        from: 0,
-        ranked: [],
-        sliceSize: SCAN_SLICE,
-        immediateMax: SCAN_IMMEDIATE_MAX,
-        debounceMs: INSTANT_DEBOUNCE_MS,
-        commitMs: RERANK_COMMIT_MS,
-      },
-      {
-        score: scoreEntries,
-        sort: (hitsToSort) => hitsToSort.sort(rankCompare),
-        now: Date.now,
-        setTimer: (fn, ms) => window.setTimeout(fn, ms),
-        clearTimer: (id) => window.clearTimeout(id),
-        onPublish: (result, done) => setScanned({ ...result, done }),
-        onProgress: () => {},
-      },
-    );
-  }, [q, entries]);
-
-  // Rows are only ever shown under the query they were scored for.
-  const ranked = scanned.q === q ? scanned.items : [];
+  const { ranked, pending } = useRankedScan(entries, q, INSTANT_DEBOUNCE_MS);
   const hits = useMemo(() => homeHitsFrom(ranked, home), [ranked, home]);
-  const scanning = active && (scanned.q !== q || !scanned.done);
+  const scanning = active && pending;
 
   // -- the box is where typing goes ------------------------------------------
   //

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -328,7 +328,16 @@ function FilesSearch({
 
   // -- AI search -------------------------------------------------------------
   const aiCtl = useRef<AbortController | null>(null);
-  useEffect(() => () => aiCtl.current?.abort(), []);
+  // The path shortcut's stat, cancellable for the same reason: both outlive the
+  // gesture that started them, and both act on the app when they land.
+  const statCtl = useRef<AbortController | null>(null);
+  useEffect(
+    () => () => {
+      aiCtl.current?.abort();
+      statCtl.current?.abort();
+    },
+    [],
+  );
   const syncQueryParam = (value: string | null) => {
     const params = new URLSearchParams(location.search);
     if (value) params.set("q", value);
@@ -367,6 +376,7 @@ function FilesSearch({
 
   const clear = () => {
     aiCtl.current?.abort();
+    statCtl.current?.abort();
     setQuery("");
     setAi(AI_OFF);
     setHighlight(null);
@@ -376,6 +386,9 @@ function FilesSearch({
   const edit = (value: string) => {
     setQuery(value);
     setHighlight(null);
+    // Editing the query retracts the address that was submitted from it, so a
+    // stat still in flight for the old one must not navigate when it lands.
+    statCtl.current?.abort();
     // Typing is a user gesture, so it is also the retry for a failed corpus
     // fetch — the same way useWalkSearch re-arms its stream from setQuery.
     if (corpus.status === "error") setRetryNonce((n) => n + 1);
@@ -416,11 +429,21 @@ function FilesSearch({
     if (highlight === null) {
       const target = pathShortcut(q, home);
       if (target !== null) {
+        // A stat on a slow or network mount can outlive the intent behind it, and
+        // navigating on a stale answer is the worst kind of wrong: it yanks the
+        // user out of wherever they went next. Superseded by the next submit,
+        // cancelled by clear()/unmount, and re-checked after the await — a
+        // resolved-but-abandoned stat must not move anyone.
+        statCtl.current?.abort();
+        const ctl = new AbortController();
+        statCtl.current = ctl;
         try {
-          const st = await statPath(target);
+          const st = await statPath(target, ctl.signal);
+          if (ctl.signal.aborted) return;
           navigate(st.path, { isDir: st.is_dir });
           return;
         } catch {
+          if (ctl.signal.aborted) return;
           // not a real path — treat it as a search query
         }
       }

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -3,19 +3,43 @@
 // one accent moment) over card grids for the two things worth jumping to:
 // bookmarks and recent files. Entering any target navigates into
 // /explorer/view/... (the explorer proper).
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { navigate, replaceSearch, urlForFsPath } from "@platform/lib/router";
 import { basename, formatMtime, formatMtimeFull, formatSize } from "@platform/lib/format";
 import { iconForEntry } from "@platform/ui/FileIcons";
 import type { Config, ClaudeSessionFolder } from "@platform/lib/api";
-import { getClaudeSessionFolders, statPath } from "@platform/lib/api";
+import { getClaudeSessionFolders, indexSearch, statPath } from "@platform/lib/api";
 import { allBookmarks, hydrateBookmarks, loadBookmarks } from "@platform/lib/bookmarks";
 import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
+import {
+  indexLifecycleCount,
+  indexMayAnswer,
+  subscribeIndexLifecycle,
+} from "@platform/lib/index-freshness";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { BookmarkPreviewCard, RecentPreviewCard, ClaudeSessionFolderCard } from "@apps/explorer/BookmarkCards";
 import { describeSpec, runAiSearch, type AiSearchResult } from "@apps/explorer/lib/ai-search";
+import {
+  INSTANT_DEBOUNCE_MS,
+  activeRow,
+  corpusFrom,
+  homeCountNote,
+  homeHitsFrom,
+  isAiRow,
+  pathShortcut,
+  stepHighlight,
+  type CorpusState,
+  type HomeHit,
+} from "@apps/explorer/lib/home-search";
+import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
+import { startScanJob } from "@apps/explorer/listing/scan-job";
+import {
+  RERANK_COMMIT_MS,
+  SCAN_IMMEDIATE_MAX,
+  SCAN_SLICE,
+  type SearchHit,
+} from "@apps/explorer/listing/types";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
-import { TextArea } from "@platform/ui/field/fields";
 
 // How many cards the Bookmarks/Recents tab shows before "Show more" — flat
 // count, not a row multiple, so it's the same rule for either tab regardless
@@ -25,233 +49,460 @@ const MAX_CARDS = 9;
 
 type LaunchTab = "bookmarks" | "recents" | "sessions";
 
-// -- AI search (the files-home composer) --------------------------------------
+// -- The home search bar ------------------------------------------------------
+//
+// A plain file search that answers while you type, with AI search as one row
+// at the bottom of the results rather than the only way in. Typing ranks the
+// home root's index corpus locally (lib/home-search); picking the last row —
+// "Search with AI" — spends the model call the old composer spent on every
+// Enter, including on queries that were just a filename.
+//
+// The two modes never blur into each other: AI results REPLACE the instant
+// list (with the spec echo that makes a wrong interpretation visible), and
+// editing the query drops back to instant results. Only a committed AI search
+// touches the URL — mirroring every keystroke into ?q= would fill the history
+// with half-typed words and re-run a model call on reload.
 
-type SearchPhase = "idle" | "searching";
+// What the AI half of the box is doing. `off` is the normal state: the results
+// are the index's, and the AI row is an offer.
+type AiPhase =
+  | { status: "off" }
+  | { status: "running"; query: string }
+  | { status: "done"; query: string; result: AiSearchResult }
+  | { status: "failed"; query: string; message: string };
 
-// The hero's search box, styled after the /apps hero composer: one line of
-// natural language in, one haiku call to interpret it, one indexed SQL query to
-// answer it (see lib/ai-search.ts). While a result is showing, the homepage's
-// bookmark/recent grids yield to the result grid; Clear (or emptying the box)
-// brings them back.
-function AiSearchComposer({
-  home,
-  initialQuery,
-  onResult,
-  onClear,
-  active,
-}: {
-  home: string;
-  initialQuery: string;
-  onResult: (query: string, r: AiSearchResult) => void;
-  onClear: () => void;
-  active: boolean;
-}) {
-  const [query, setQuery] = useState(initialQuery);
-  const [phase, setPhase] = useState<SearchPhase>("idle");
-  const [error, setError] = useState<string | null>(null);
-  // One in-flight search at a time: a new submit aborts the previous walk.
-  const abortRef = useRef<AbortController | null>(null);
-  useEffect(() => () => abortRef.current?.abort(), []);
+const AI_OFF: AiPhase = { status: "off" };
 
-  const clear = () => {
-    abortRef.current?.abort();
-    setQuery("");
-    setPhase("idle");
-    setError(null);
-    onClear();
-  };
-
-  const submit = async () => {
-    const q = query.trim();
-    if (!q || phase === "searching") return;
-    abortRef.current?.abort();
-    const ctl = new AbortController();
-    abortRef.current = ctl;
-    setError(null);
-    setPhase("searching");
-    try {
-      // A pasted absolute path (/, ~/, or C:/) that actually exists opens
-      // directly — no reason to run an AI search over an exact address. A
-      // non-existent one falls through to the normal search.
-      if (/^(\/|~\/|~$|[A-Za-z]:[\\/])/.test(q)) {
-        let fsPath = q === "~" || q.startsWith("~/") ? home + q.slice(1) : q;
-        // Backslashes are only separators in drive-letter paths (same rule
-        // as the shell's path codec) — on POSIX "\" is a legal filename char.
-        if (/^[A-Za-z]:[\\/]/.test(fsPath)) fsPath = fsPath.replace(/\\/g, "/");
-        // Strip a trailing slash but keep roots whole: "/" stays "/", and a
-        // drive root keeps its slash (bare "C:" reads as cwd-relative).
-        fsPath = fsPath.replace(/\/+$/, "") || "/";
-        if (/^[A-Za-z]:$/.test(fsPath)) fsPath += "/";
-        try {
-          const st = await statPath(fsPath);
-          if (ctl.signal.aborted) return;
-          navigate(st.path, { isDir: st.is_dir });
-          return;
-        } catch {
-          if (ctl.signal.aborted) return;
-          // not a real path — treat it as a search query
-        }
-      }
-      const res = await runAiSearch(home, q, ctl.signal);
-      if (ctl.signal.aborted) return;
-      setPhase("idle");
-      onResult(q, res);
-    } catch (e) {
-      if (ctl.signal.aborted) return;
-      setPhase("idle");
-      setError((e as Error).message);
-    }
-  };
-
-  // A URL-restored query (?q=…) runs on mount: the URL is the state of
-  // record (same ethos as the listing's ?q=), so landing on a search URL
-  // must reproduce the search, not just prefill the box.
-  const ranInitial = useRef(false);
-  useEffect(() => {
-    if (ranInitial.current) return;
-    ranInitial.current = true;
-    if (initialQuery.trim()) void submit();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const busy = phase === "searching";
+function MagnifierIcon() {
   return (
-    <div className="home-composer-wrap files-search-wrap">
-      <div className={"home-composer files-search" + (busy ? " is-busy" : "")}>
-        {/* The clear ✕ floats at the input's right edge (not in the footer
-            bar) so wiping the query reads as an input affordance. */}
-        <div className="files-search-field">
-          <TextArea
-            className="home-composer-input"
-            placeholder="Search your files — “big csv from last week” — or paste a path like ~/Downloads"
-            aria-label="Search your files"
-            value={query}
-            rows={1}
-            disabled={busy}
-            onChange={(e) => setQuery(e.target.value)}
-            onKeyDown={(e) => {
-              // Enter submits (a search is a one-shot prompt); Shift+Enter
-              // keeps the newline — same contract as the /apps composer.
-              if (e.key === "Enter" && !e.shiftKey) {
-                e.preventDefault();
-                submit();
-              } else if (e.key === "Escape" && active) {
-                e.preventDefault();
-                clear();
-              }
-            }}
-          />
-          {(active || query !== "") && !busy && (
-            <button
-              type="button"
-              className="files-search-clear"
-              title="Clear search (esc)"
-              onClick={clear}
-            >
-              Clear
-            </button>
-          )}
-        </div>
-        <div className="home-composer-bar">
-          <span className="home-composer-hint">
-            {busy ? (
-              "Searching…"
-            ) : (
-              <>
-                <kbd>↵</kbd> to search · <kbd>⇧↵</kbd> for a new line
-                {active && (
-                  <>
-                    {" · "}
-                    <kbd>esc</kbd> to clear
-                  </>
-                )}
-              </>
-            )}
-          </span>
-          <button
-            type="button"
-            className="home-composer-send"
-            aria-label="Search"
-            title="Search"
-            disabled={!query.trim() || busy}
-            onClick={submit}
-          >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <circle cx="11" cy="11" r="7" />
-              <path d="M21 21l-4.3-4.3" />
-            </svg>
-          </button>
-        </div>
-      </div>
-      {error && <ErrorBanner>{error}</ErrorBanner>}
-    </div>
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="11" cy="11" r="7" />
+      <path d="M21 21l-4.3-4.3" />
+    </svg>
   );
 }
 
-// Result list: a flat scannable list (relevance order), not the launcher card
-// grid, so hits get room for path and dates.
-function SearchResults({
+function SparkIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+         strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M12 3l1.8 4.9L18.7 9.7l-4.9 1.8L12 16.4l-1.8-4.9L5.3 9.7l4.9-1.8L12 3z" />
+      <path d="M18 16.5l.7 1.8 1.8.7-1.8.7-.7 1.8-.7-1.8-1.8-.7 1.8-.7.7-1.8z" />
+    </svg>
+  );
+}
+
+// One file hit. An <a> (not a button) so cmd/ctrl-click opens it the way every
+// other path in this app does.
+function FileRow({
+  hit,
   home,
-  query,
-  result,
+  active,
+  id,
+  onHover,
 }: {
+  hit: HomeHit;
   home: string;
-  query: string;
-  result: AiSearchResult;
+  active: boolean;
+  id: string;
+  onHover: () => void;
 }) {
+  const display = hit.path.startsWith(home + "/") ? "~/" + hit.rel : hit.path;
+  return (
+    <li role="option" id={id} aria-selected={active}>
+      <a
+        className={"fh-result" + (active ? " is-active" : "")}
+        href={urlForFsPath(hit.path)}
+        title={hit.path}
+        onMouseMove={onHover}
+        onClick={(e) => {
+          if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
+            return;
+          e.preventDefault();
+          navigate(hit.path, { isDir: hit.is_dir });
+        }}
+      >
+        <span className="fh-result-icon" aria-hidden="true">
+          {iconForEntry(basename(hit.path), hit.is_dir)}
+        </span>
+        <span className="fh-result-name">{basename(hit.path)}</span>
+        <span className="fh-result-path">{display}</span>
+        <span className="fh-result-meta">
+          {hit.is_dir ? "" : formatSize(hit.size)}
+          {hit.mtime !== null && (
+            <span className="fh-result-date" title={formatMtimeFull(hit.mtime)}>
+              {formatMtime(hit.mtime)}
+            </span>
+          )}
+        </span>
+      </a>
+    </li>
+  );
+}
+
+// The last row: an ACTION, not a hit. Deliberately unlike the file rows above
+// it (accent glyph, no path, no size) because activating it costs a model call
+// and a wait, and because on a zero-hit query it is the only thing on screen.
+function AiActionRow({
+  query,
+  active,
+  running,
+  id,
+  onHover,
+  onRun,
+}: {
+  query: string;
+  active: boolean;
+  running: boolean;
+  id: string;
+  onHover: () => void;
+  onRun: () => void;
+}) {
+  return (
+    <li role="option" id={id} aria-selected={active}>
+      <button
+        type="button"
+        className={"fh-result fh-ai-row" + (active ? " is-active" : "")}
+        disabled={running}
+        onMouseMove={onHover}
+        onClick={onRun}
+      >
+        <span className="fh-result-icon fh-ai-glyph" aria-hidden="true">
+          <SparkIcon />
+        </span>
+        <span className="fh-result-name">Search with AI</span>
+        <span className="fh-result-path">“{query}”</span>
+        <span className="fh-result-meta">
+          {running ? "Asking…" : <kbd>↵</kbd>}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+// The "Understood as: …" echo above AI results — the one place a wrong
+// interpretation becomes visible instead of silently shaping the list.
+function AiResults({ home, query, result }: { home: string; query: string; result: AiSearchResult }) {
   const summary = describeSpec(result.spec);
   return (
-    <section className="fh-section">
-      <h2 className="fh-heading">Results for “{query}”</h2>
+    <div className="fh-panel">
       <p className="fh-search-summary">
+        <span className="fh-ai-badge">
+          <SparkIcon /> AI
+        </span>
         {summary ? `Understood as: ${summary}` : "No filters — showing closest matches."}
         {result.truncated && " · Broad query: showing the first slice of matches."}
       </p>
       {result.hits.length ? (
-        // A flat list, not the launcher card grid: results are scanned
-        // top-to-bottom by relevance, and a row gives the path and dates
-        // room the cards don't have.
-        <ul className="fh-results">
-          {result.hits.map((h) => {
-            const display = h.path.startsWith(home + "/")
-              ? "~/" + h.path.slice(home.length + 1)
-              : h.path;
-            return (
-              <li key={h.path}>
-                <a
-                  className="fh-result"
-                  href={urlForFsPath(h.path)}
-                  title={h.path}
-                  onClick={(e) => {
-                    if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
-                      return;
-                    e.preventDefault();
-                    navigate(h.path, { isDir: h.is_dir });
-                  }}
-                >
-                  <span className="fh-result-icon" aria-hidden="true">
-                    {iconForEntry(basename(h.path), h.is_dir)}
-                  </span>
-                  <span className="fh-result-name">{basename(h.path)}</span>
-                  <span className="fh-result-path">{display}</span>
-                  <span className="fh-result-meta">
-                    {h.is_dir ? "" : formatSize(h.size)}
-                    {h.mtime !== null && (
-                      <span className="fh-result-date" title={formatMtimeFull(h.mtime)}>
-                        {formatMtime(h.mtime)}
-                      </span>
-                    )}
-                  </span>
-                </a>
-              </li>
-            );
-          })}
+        <ul className="fh-results" role="listbox" aria-label="AI search results">
+          {result.hits.map((h) => (
+            <FileRow
+              key={h.path}
+              home={home}
+              active={false}
+              id={"fh-ai-hit-" + h.path}
+              onHover={() => {}}
+              hit={{
+                path: h.path,
+                rel: h.path.startsWith(home + "/") ? h.path.slice(home.length + 1) : h.path,
+                is_dir: h.is_dir,
+                size: h.size,
+                mtime: h.mtime,
+              }}
+            />
+          ))}
         </ul>
       ) : (
-        <p className="fh-empty">Nothing matched. Try different words, or fewer of them.</p>
+        <p className="fh-empty">
+          AI search found nothing for “{query}”. Try different words, or fewer of them.
+        </p>
       )}
-    </section>
+    </div>
+  );
+}
+
+function FilesSearch({
+  home,
+  initialQuery,
+  onActiveChange,
+}: {
+  home: string;
+  initialQuery: string;
+  onActiveChange: (active: boolean) => void;
+}) {
+  const [query, setQuery] = useState(initialQuery);
+  const [ai, setAi] = useState<AiPhase>(AI_OFF);
+  const [highlight, setHighlight] = useState<number | null>(null);
+  const q = query.trim();
+  const active = q !== "";
+  useEffect(() => onActiveChange(active), [active, onActiveChange]);
+
+  // -- the corpus ------------------------------------------------------------
+  // Fetched ONCE per index generation, not per keystroke: the index answers
+  // with the whole covered subtree, so re-asking on every letter would spend a
+  // round trip to receive the same rows. Ranking is what runs per query.
+  const [corpus, setCorpus] = useState<CorpusState>({ status: "idle" });
+  // A scan finishing or the index being deleted changes what the corpus IS,
+  // and no other signal reports it (the filesystem did not change) — see
+  // lib/index-freshness.
+  const [lifecycle, setLifecycle] = useState(indexLifecycleCount);
+  useEffect(() => subscribeIndexLifecycle(() => setLifecycle(indexLifecycleCount())), []);
+  // Requested on the first keystroke and never unrequested: dropping the
+  // corpus when the box is cleared would re-fetch it on the next letter typed.
+  const [wanted, setWanted] = useState(active);
+  useEffect(() => {
+    if (active) setWanted(true);
+  }, [active]);
+  useEffect(() => {
+    if (!wanted) return;
+    // A folder this app changed since the last scan is not the index's to
+    // answer for; the home page has no live walk to fall back on, so it says
+    // so rather than serving pre-change paths.
+    if (!indexMayAnswer(home)) {
+      setCorpus({ status: "cold" });
+      return;
+    }
+    const ctl = new AbortController();
+    setCorpus((prev) => (prev.status === "ok" ? prev : { status: "loading" }));
+    indexSearch(home, { signal: ctl.signal }).then(
+      (res) => {
+        if (!ctl.signal.aborted) setCorpus(corpusFrom(res));
+      },
+      (err: Error) => {
+        if (ctl.signal.aborted || err.name === "AbortError") return;
+        setCorpus({ status: "error", message: err.message });
+      },
+    );
+    return () => ctl.abort();
+  }, [home, wanted, lifecycle]);
+
+  // -- ranking ---------------------------------------------------------------
+  // The same sliced, cancellable scan the in-folder search runs: a covered home
+  // root can be 200k entries, and scoring that synchronously on a keystroke is
+  // the typing freeze listing/scan-job exists to prevent.
+  const entries = corpus.status === "ok" ? corpus.entries : null;
+  const [scanned, setScanned] = useState<{ q: string; items: SearchHit[]; done: boolean }>({
+    q: "",
+    items: [],
+    done: true,
+  });
+  useEffect(() => {
+    if (entries === null || q === "") {
+      setScanned((prev) =>
+        prev.q === q && prev.items.length === 0 && prev.done ? prev : { q, items: [], done: true },
+      );
+      return;
+    }
+    return startScanJob(
+      {
+        q,
+        showHidden: queryWantsHidden(q),
+        entries,
+        from: 0,
+        ranked: [],
+        sliceSize: SCAN_SLICE,
+        immediateMax: SCAN_IMMEDIATE_MAX,
+        debounceMs: INSTANT_DEBOUNCE_MS,
+        commitMs: RERANK_COMMIT_MS,
+      },
+      {
+        score: scoreEntries,
+        sort: (hitsToSort) => hitsToSort.sort(rankCompare),
+        now: Date.now,
+        setTimer: (fn, ms) => window.setTimeout(fn, ms),
+        clearTimer: (id) => window.clearTimeout(id),
+        onPublish: (result, done) => setScanned({ ...result, done }),
+        onProgress: () => {},
+      },
+    );
+  }, [q, entries]);
+
+  // Rows are only ever shown under the query they were scored for.
+  const ranked = scanned.q === q ? scanned.items : [];
+  const hits = useMemo(() => homeHitsFrom(ranked, home), [ranked, home]);
+  const scanning = active && (scanned.q !== q || !scanned.done);
+
+  // -- AI search -------------------------------------------------------------
+  const aiCtl = useRef<AbortController | null>(null);
+  useEffect(() => () => aiCtl.current?.abort(), []);
+  const syncQueryParam = (value: string | null) => {
+    const params = new URLSearchParams(location.search);
+    if (value) params.set("q", value);
+    else params.delete("q");
+    const qs = params.toString();
+    replaceSearch(location.pathname + (qs ? "?" + qs : ""));
+  };
+  const runAi = (target: string) => {
+    if (!target) return;
+    aiCtl.current?.abort();
+    const ctl = new AbortController();
+    aiCtl.current = ctl;
+    setAi({ status: "running", query: target });
+    runAiSearch(home, target, ctl.signal).then(
+      (result) => {
+        if (ctl.signal.aborted) return;
+        setAi({ status: "done", query: target, result });
+        // Only a committed AI search rides the URL, so a reload reproduces the
+        // search the user paid for — instant results need no restoring.
+        syncQueryParam(target);
+      },
+      (err: Error) => {
+        if (ctl.signal.aborted || err.name === "AbortError") return;
+        // No substituted keyword search: the index results underneath are
+        // still on screen, and they are the honest fallback (lib/ai-search).
+        setAi({ status: "failed", query: target, message: err.message });
+      },
+    );
+  };
+
+  const clear = () => {
+    aiCtl.current?.abort();
+    setQuery("");
+    setAi(AI_OFF);
+    setHighlight(null);
+    syncQueryParam(null);
+  };
+
+  const edit = (value: string) => {
+    setQuery(value);
+    setHighlight(null);
+    // Editing the query is how the user gets back from AI results to instant
+    // ones, so it drops the AI phase — and the ?q= that a committed search set.
+    if (ai.status !== "off") {
+      aiCtl.current?.abort();
+      setAi(AI_OFF);
+      syncQueryParam(null);
+    }
+  };
+
+  // A ?q= restored from the URL was a committed AI search, so it re-runs one.
+  const ranInitial = useRef(false);
+  useEffect(() => {
+    if (ranInitial.current) return;
+    ranInitial.current = true;
+    if (initialQuery.trim()) runAi(initialQuery.trim());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const showingAi = ai.status === "done" && ai.query === q;
+  const current = activeRow(highlight, hits.length);
+
+  const openRow = (row: number) => {
+    if (isAiRow(row, hits.length)) runAi(q);
+    else navigate(hits[row].path, { isDir: hits[row].is_dir });
+  };
+
+  // Enter with no row chosen: a query that is really an ADDRESS goes straight
+  // there (a pasted ~/Downloads is not a search), and a query with no index
+  // matches runs the AI search, because that row is the only content.
+  const submit = async () => {
+    if (highlight === null) {
+      const target = pathShortcut(q, home);
+      if (target !== null) {
+        try {
+          const st = await statPath(target);
+          navigate(st.path, { isDir: st.is_dir });
+          return;
+        } catch {
+          // not a real path — treat it as a search query
+        }
+      }
+    }
+    if (current !== null) openRow(current);
+  };
+
+  return (
+    <div className="files-search-wrap">
+      <div className="files-search">
+        <span className="files-search-icon" aria-hidden="true">
+          <MagnifierIcon />
+        </span>
+        <input
+          type="search"
+          className="files-search-input"
+          placeholder="Search your files — or paste a path like ~/Downloads"
+          aria-label="Search your files"
+          role="combobox"
+          aria-expanded={active && !showingAi}
+          aria-controls="fh-result-list"
+          aria-activedescendant={
+            active && !showingAi && current !== null ? "fh-row-" + current : undefined
+          }
+          autoComplete="off"
+          spellCheck={false}
+          value={query}
+          onChange={(e) => edit(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+              if (!active || showingAi) return;
+              e.preventDefault();
+              setHighlight((h) => stepHighlight(h, hits.length, e.key === "ArrowDown" ? 1 : -1));
+            } else if (e.key === "Enter") {
+              e.preventDefault();
+              void submit();
+            } else if (e.key === "Escape" && active) {
+              e.preventDefault();
+              clear();
+            }
+          }}
+        />
+        {active && (
+          <button type="button" className="files-search-clear" title="Clear search (esc)" onClick={clear}>
+            Clear
+          </button>
+        )}
+      </div>
+
+      {ai.status === "failed" && <ErrorBanner>{ai.message}</ErrorBanner>}
+
+      {!active ? null : showingAi ? (
+        <AiResults home={home} query={ai.query} result={ai.result} />
+      ) : (
+        <div className="fh-panel">
+          <p className="fh-result-note">
+            {corpus.status === "cold" ? (
+              // Never "no matches" for an index that has not been built: that
+              // would blame the user's files for the app's state.
+              "The file index is still building — AI search can answer in the meantime."
+            ) : corpus.status === "error" ? (
+              `The file index could not be searched: ${corpus.message}`
+            ) : corpus.status !== "ok" || scanning ? (
+              "Searching…"
+            ) : ranked.length === 0 ? (
+              `No file name matched “${q}” — AI search can look at dates, types and sizes.`
+            ) : (
+              <>
+                {homeCountNote(ranked.length, corpus.truncated)}
+                {" · "}
+                <kbd>↑</kbd>
+                <kbd>↓</kbd> to pick · <kbd>esc</kbd> to clear
+              </>
+            )}
+          </p>
+          <ul className="fh-results" id="fh-result-list" role="listbox" aria-label="Search results">
+            {hits.map((hit, i) => (
+              <FileRow
+                key={hit.path}
+                hit={hit}
+                home={home}
+                active={current === i}
+                id={"fh-row-" + i}
+                onHover={() => setHighlight(i)}
+              />
+            ))}
+            <AiActionRow
+              query={q}
+              active={current === hits.length}
+              running={ai.status === "running"}
+              id={"fh-row-" + hits.length}
+              onHover={() => setHighlight(hits.length)}
+              onRun={() => runAi(q)}
+            />
+          </ul>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -341,20 +592,12 @@ export default function FilesHome({ config }: { config: Config }) {
     tabParam === "recents" || tabParam === "sessions" || tabParam === "bookmarks"
       ? tabParam
       : "sessions";
-  // A committed AI search result takes over the page body (bookmarks/recents
-  // hide behind it) until cleared — the homepage becomes the result page.
-  const [search, setSearch] = useState<{ query: string; result: AiSearchResult } | null>(null);
-  // The committed query rides the URL (?q=…, same ethos as the listing
-  // search): submit writes it, Clear removes it, and a load with ?q= present
-  // re-runs the search via the composer's initialQuery.
+  // Search takes over the page body (bookmarks/recents hide behind it) for as
+  // long as there is a query — instant results appear while typing, so the
+  // grids yield from the first keystroke rather than on a submit.
+  const [searching, setSearching] = useState(false);
+  // A ?q= present at load was a committed AI search; FilesSearch re-runs it.
   const initialQuery = useRef(new URLSearchParams(location.search).get("q") || "").current;
-  const syncQueryParam = (q: string | null) => {
-    const params = new URLSearchParams(location.search);
-    if (q) params.set("q", q);
-    else params.delete("q");
-    const qs = params.toString();
-    replaceSearch(location.pathname + (qs ? "?" + qs : ""));
-  };
 
   return (
     <div className="files-home">
@@ -364,24 +607,10 @@ export default function FilesHome({ config }: { config: Config }) {
             "Find and preview your files" restatement above the box only
             pushed the one thing you came to use further down. */}
         <header className="home-hero files-hero">
-          <AiSearchComposer
-            home={home}
-            initialQuery={initialQuery}
-            active={search !== null}
-            onResult={(query, result) => {
-              setSearch({ query, result });
-              syncQueryParam(query);
-            }}
-            onClear={() => {
-              setSearch(null);
-              syncQueryParam(null);
-            }}
-          />
+          <FilesSearch home={home} initialQuery={initialQuery} onActiveChange={setSearching} />
         </header>
 
-        {search ? (
-          <SearchResults home={home} query={search.query} result={search.result} />
-        ) : (
+        {searching ? null : (
           <>
           <section className="fh-section">
             <div className="fh-tabs">

--- a/frontend/src/apps/explorer/lib/ai-search.test.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
+  engineSpec,
   hasNonNameFilters,
   parseAiSearchSpec,
   rankHits,
@@ -119,28 +120,18 @@ describe("rankHits", () => {
     expect(hits[0].path).toBe(`${HOME}/Movies/video-final.mp4`);
   });
 
-  it("boosts path hints and orders term-less specs by recency", () => {
-    const withHints = spec({ extensions: ["mov"], path_hints: ["downloads"] });
-    const hits = rankHits(
-      [
-        entry("Movies/a.mov", { mtime: NOW - 10 }),
-        entry("Downloads/b.mov", { mtime: NOW - 9999 }),
-      ],
-      withHints,
-      HOME,
-    );
-    // The hint boost outweighs recency; without hints recency would win.
-    expect(hits[0].path).toBe(`${HOME}/Downloads/b.mov`);
-
-    const noHints = rankHits(
-      [
-        entry("Movies/a.mov", { mtime: NOW - 10 }),
-        entry("Downloads/b.mov", { mtime: NOW - 9999 }),
-      ],
-      { ...withHints, path_hints: [] },
-      HOME,
-    );
-    expect(noHints[0].path).toBe(`${HOME}/Movies/a.mov`);
+  it("orders term-less specs by recency, path hints or not", () => {
+    // path_hints is an ENGINE constraint now (search.py), so every row that
+    // comes back already matches one — a ranking boost for it would score the
+    // whole result set identically and only add noise.
+    const rows = [
+      entry("Movies/a.mov", { mtime: NOW - 10 }),
+      entry("Downloads/b.mov", { mtime: NOW - 9999 }),
+    ];
+    for (const hints of [["downloads"], []]) {
+      const hits = rankHits(rows, spec({ extensions: ["mov"], path_hints: hints }), HOME);
+      expect(hits[0].path).toBe(`${HOME}/Movies/a.mov`);
+    }
   });
 
   it("scores against the home-relative path, not /Users/<name>", () => {
@@ -168,16 +159,22 @@ function jsonResponse(body: unknown, status = 200): Response {
   });
 }
 
-/** Stub /api/ai and /api/search/files; records every request URL in order. */
+/**
+ * Stub /api/ai and /api/search/files; records every request URL in order, and
+ * the spec bodies the engine was actually asked for (`sent`).
+ */
 function stubApi(opts: {
   aiText?: string;
   aiStatus?: number;
   entries?: SearchFileEntry[];
-}): string[] {
-  const calls: string[] = [];
-  globalThis.fetch = mock(async (url: string | URL | Request) => {
+}): string[] & { sent: AiSearchSpec[] } {
+  const calls = [] as unknown as string[] & { sent: AiSearchSpec[] };
+  calls.sent = [];
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
     calls.push(u);
+    if (u === "/api/search/files" && typeof init?.body === "string")
+      calls.sent.push(JSON.parse(init.body) as AiSearchSpec);
     if (u === "/api/ai") {
       if (opts.aiStatus && opts.aiStatus !== 200)
         return jsonResponse({ error: "claude is not installed" }, opts.aiStatus);
@@ -224,11 +221,73 @@ describe("runAiSearch", () => {
   });
 
   it("reports a spec that narrows nothing the engine understands", async () => {
-    // "in downloads" parses fine but only sets path_hints, which is
-    // client-side ranking and never reaches the engine.
-    const calls = stubApi({ aiText: JSON.stringify({ path_hints: ["downloads"] }) });
-    await expect(runAiSearch(HOME, "stuff in downloads")).rejects.toThrow(/narrow/i);
+    // "show me folders" parses fine but sets only `kind`, which still matches
+    // half the disk — the endpoint would refuse it a round trip later.
+    const calls = stubApi({ aiText: JSON.stringify({ kind: "dir" }) });
+    await expect(runAiSearch(HOME, "show me folders")).rejects.toThrow(/narrow/i);
     expect(calls).toEqual(["/api/ai"]);
+  });
+
+  it("answers a path-hints-only query — a place IS something to narrow by", async () => {
+    // "in downloads" was refused while path_hints was documented as ranking
+    // only. It is a WHERE clause now (search.py), so the query is answerable.
+    const calls = stubApi({
+      aiText: JSON.stringify({ path_hints: ["downloads"] }),
+      entries: [entry("Downloads/a.csv")],
+    });
+    const res = await runAiSearch(HOME, "stuff in downloads");
+    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(calls.sent[0].path_hints).toEqual(["downloads"]);
+    expect(res.hits.map((h) => h.path)).toEqual([`${HOME}/Downloads/a.csv`]);
+  });
+});
+
+// -- name terms: hard predicate only when they are the only narrowing ---------
+
+describe("engineSpec", () => {
+  it("drops name_terms when the spec has other real narrowing", () => {
+    // "videos I downloaded last week": ext+date already pin the query, so a
+    // hard name filter would reject IMG_1234.mov for not saying "video".
+    const sent = engineSpec(
+      spec({ name_terms: ["video"], extensions: ["mov"], modified_after: "2026-08-04" }),
+    );
+    expect(sent.name_terms).toEqual([]);
+    expect(sent.extensions).toEqual(["mov"]);
+    expect(sent.modified_after).toBe("2026-08-04");
+  });
+
+  it("keeps name_terms when they are the only narrowing", () => {
+    // Otherwise the query would match every file in the index.
+    expect(engineSpec(spec({ name_terms: ["resume"] })).name_terms).toEqual(["resume"]);
+    // path_hints narrows a PLACE, not a name, so "resume in downloads" still
+    // needs the name as a predicate — a whole folder is not an answer.
+    const withHint = engineSpec(spec({ name_terms: ["resume"], path_hints: ["downloads"] }));
+    expect(withHint.name_terms).toEqual(["resume"]);
+  });
+});
+
+describe("runAiSearch name-term softening", () => {
+  it("sends no name_terms but still ranks by them when other filters exist", async () => {
+    const calls = stubApi({
+      aiText: JSON.stringify({
+        name_terms: ["video"],
+        extensions: ["mov", "mp4"],
+        modified_after: "2026-08-04",
+      }),
+      entries: [entry("Downloads/IMG_1234.mov"), entry("Movies/video-final.mp4")],
+    });
+    const res = await runAiSearch(HOME, "videos I downloaded last week");
+    // One model call, one engine query — the deleted name-stripped retry is
+    // not back; the softening happens BEFORE the single request.
+    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(calls.sent[0].name_terms).toEqual([]);
+    // The unnamed video survives, and the named one still ranks first.
+    expect(res.hits.map((h) => h.path)).toEqual([
+      `${HOME}/Movies/video-final.mp4`,
+      `${HOME}/Downloads/IMG_1234.mov`,
+    ]);
+    // The ECHO shows what the model understood, not what the engine was sent.
+    expect(res.spec.name_terms).toEqual(["video"]);
   });
 
   it("propagates a relay failure", async () => {

--- a/frontend/src/apps/explorer/lib/ai-search.test.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.test.ts
@@ -167,12 +167,11 @@ function stubApi(opts: {
   aiText?: string;
   aiStatus?: number;
   entries?: SearchFileEntry[];
-}): string[] & { sent: AiSearchSpec[] } {
-  const calls = [] as unknown as string[] & { sent: AiSearchSpec[] };
-  calls.sent = [];
+}): { urls: string[]; sent: AiSearchSpec[] } {
+  const calls = { urls: [] as string[], sent: [] as AiSearchSpec[] };
   globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
     const u = String(url);
-    calls.push(u);
+    calls.urls.push(u);
     if (u === "/api/search/files" && typeof init?.body === "string")
       calls.sent.push(JSON.parse(init.body) as AiSearchSpec);
     if (u === "/api/ai") {
@@ -194,7 +193,7 @@ describe("runAiSearch", () => {
       entries: [entry("data/weather.csv")],
     });
     const res = await runAiSearch(HOME, "weather spreadsheet");
-    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(calls.urls).toEqual(["/api/ai", "/api/search/files"]);
     expect(res.hits.map((h) => h.path)).toEqual([`${HOME}/data/weather.csv`]);
     expect(res.spec.name_terms).toEqual(["weather"]);
   });
@@ -208,7 +207,7 @@ describe("runAiSearch", () => {
       entries: [],
     });
     const res = await runAiSearch(HOME, "weather spreadsheet");
-    expect(calls.filter((c) => c === "/api/search/files")).toHaveLength(1);
+    expect(calls.urls.filter((c) => c === "/api/search/files")).toHaveLength(1);
     expect(res.hits).toEqual([]);
   });
 
@@ -217,7 +216,7 @@ describe("runAiSearch", () => {
     await expect(runAiSearch(HOME, "weather")).rejects.toThrow(/could not/i);
     // Nothing was sent to the engine: a keyword search on the user's own words
     // would be a different question answered silently.
-    expect(calls).toEqual(["/api/ai"]);
+    expect(calls.urls).toEqual(["/api/ai"]);
   });
 
   it("reports a spec that narrows nothing the engine understands", async () => {
@@ -225,7 +224,7 @@ describe("runAiSearch", () => {
     // half the disk — the endpoint would refuse it a round trip later.
     const calls = stubApi({ aiText: JSON.stringify({ kind: "dir" }) });
     await expect(runAiSearch(HOME, "show me folders")).rejects.toThrow(/narrow/i);
-    expect(calls).toEqual(["/api/ai"]);
+    expect(calls.urls).toEqual(["/api/ai"]);
   });
 
   it("answers a path-hints-only query — a place IS something to narrow by", async () => {
@@ -236,7 +235,7 @@ describe("runAiSearch", () => {
       entries: [entry("Downloads/a.csv")],
     });
     const res = await runAiSearch(HOME, "stuff in downloads");
-    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(calls.urls).toEqual(["/api/ai", "/api/search/files"]);
     expect(calls.sent[0].path_hints).toEqual(["downloads"]);
     expect(res.hits.map((h) => h.path)).toEqual([`${HOME}/Downloads/a.csv`]);
   });
@@ -279,7 +278,7 @@ describe("runAiSearch name-term softening", () => {
     const res = await runAiSearch(HOME, "videos I downloaded last week");
     // One model call, one engine query — the deleted name-stripped retry is
     // not back; the softening happens BEFORE the single request.
-    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(calls.urls).toEqual(["/api/ai", "/api/search/files"]);
     expect(calls.sent[0].name_terms).toEqual([]);
     // The unnamed video survives, and the named one still ranks first.
     expect(res.hits.map((h) => h.path)).toEqual([

--- a/frontend/src/apps/explorer/lib/ai-search.test.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import {
-  fallbackSpec,
-  hasEngineNarrowing,
   hasNonNameFilters,
   parseAiSearchSpec,
   rankHits,
+  runAiSearch,
+  type AiSearchSpec,
 } from "./ai-search";
 import type { SearchFileEntry } from "@platform/lib/api";
 
@@ -13,6 +13,23 @@ const NOW = 1_800_000_000; // epoch seconds, for mtime ordering only
 
 function entry(rel: string, over: Partial<SearchFileEntry> = {}): SearchFileEntry {
   return { path: `${HOME}/${rel}`, is_dir: false, size: 1000, mtime: NOW - 3600, ...over };
+}
+
+// A spec builder for the tests. There is no `fallbackSpec` any more — an
+// unusable model reply is reported, not substituted (see runAiSearch) — so the
+// empty-spec shape lives here, where only the tests need it.
+function spec(over: Partial<AiSearchSpec> = {}): AiSearchSpec {
+  return {
+    name_terms: [],
+    extensions: [],
+    kind: "any",
+    modified_after: null,
+    modified_before: null,
+    min_size_bytes: null,
+    max_size_bytes: null,
+    path_hints: [],
+    ...over,
+  };
 }
 
 describe("parseAiSearchSpec", () => {
@@ -69,31 +86,18 @@ describe("parseAiSearchSpec", () => {
 
 describe("hasNonNameFilters", () => {
   it("is false for a name-only spec, true once any real filter is set", () => {
-    expect(hasNonNameFilters(fallbackSpec("weather"))).toBe(false);
-    expect(hasNonNameFilters({ ...fallbackSpec(""), extensions: ["mov"] })).toBe(true);
-    expect(hasNonNameFilters({ ...fallbackSpec(""), modified_after: "2026-08-04" })).toBe(true);
-    expect(hasNonNameFilters({ ...fallbackSpec(""), max_size_bytes: 100 })).toBe(true);
-  });
-});
-
-describe("hasEngineNarrowing", () => {
-  it("is false for a location/kind-only spec — path_hints never reach the engine", () => {
-    expect(hasEngineNarrowing({ ...fallbackSpec(""), path_hints: ["downloads"] })).toBe(false);
-    expect(hasEngineNarrowing({ ...fallbackSpec(""), kind: "dir" })).toBe(false);
-  });
-
-  it("is true once name terms or any real filter is set", () => {
-    expect(hasEngineNarrowing(fallbackSpec("weather"))).toBe(true);
-    expect(hasEngineNarrowing({ ...fallbackSpec(""), extensions: ["mov"] })).toBe(true);
+    expect(hasNonNameFilters(spec({ name_terms: ["weather"] }))).toBe(false);
+    expect(hasNonNameFilters(spec({ extensions: ["mov"] }))).toBe(true);
+    expect(hasNonNameFilters(spec({ modified_after: "2026-08-04" }))).toBe(true);
+    expect(hasNonNameFilters(spec({ max_size_bytes: 100 }))).toBe(true);
   });
 });
 
 describe("rankHits", () => {
   it("hard-drops non-matching entries when name terms are the only filter", () => {
-    const spec = fallbackSpec("resume cv");
     const hits = rankHits(
       [entry("docs/resume-2024.pdf"), entry("docs/notes.txt")],
-      spec,
+      spec({ name_terms: ["resume", "cv"] }),
       HOME,
     );
     expect(hits.map((h) => h.path)).toEqual([`${HOME}/docs/resume-2024.pdf`]);
@@ -102,14 +106,13 @@ describe("rankHits", () => {
   it("keeps unmatched entries when other filters exist (soft terms)", () => {
     // "video downloaded today": extension+date pinned, "video" not in the
     // filename — IMG_1234.mov must survive and matching names rank first.
-    const spec = {
-      ...fallbackSpec("video"),
-      extensions: ["mov", "mp4"],
-      modified_after: "2026-08-04",
-    };
     const hits = rankHits(
       [entry("Downloads/IMG_1234.mov"), entry("Movies/video-final.mp4")],
-      spec,
+      spec({
+        name_terms: ["video"],
+        extensions: ["mov", "mp4"],
+        modified_after: "2026-08-04",
+      }),
       HOME,
     );
     expect(hits).toHaveLength(2);
@@ -117,13 +120,13 @@ describe("rankHits", () => {
   });
 
   it("boosts path hints and orders term-less specs by recency", () => {
-    const spec = { ...fallbackSpec(""), extensions: ["mov"], path_hints: ["downloads"] };
+    const withHints = spec({ extensions: ["mov"], path_hints: ["downloads"] });
     const hits = rankHits(
       [
         entry("Movies/a.mov", { mtime: NOW - 10 }),
         entry("Downloads/b.mov", { mtime: NOW - 9999 }),
       ],
-      spec,
+      withHints,
       HOME,
     );
     // The hint boost outweighs recency; without hints recency would win.
@@ -134,7 +137,7 @@ describe("rankHits", () => {
         entry("Movies/a.mov", { mtime: NOW - 10 }),
         entry("Downloads/b.mov", { mtime: NOW - 9999 }),
       ],
-      { ...spec, path_hints: [] },
+      { ...withHints, path_hints: [] },
       HOME,
     );
     expect(noHints[0].path).toBe(`${HOME}/Movies/a.mov`);
@@ -142,8 +145,94 @@ describe("rankHits", () => {
 
   it("scores against the home-relative path, not /Users/<name>", () => {
     // "me" appears in /Users/me — rooting at "/" would match every entry.
-    const spec = fallbackSpec("me");
-    const hits = rankHits([entry("Downloads/movie.mov"), entry("notes.txt")], spec, HOME);
+    const hits = rankHits(
+      [entry("Downloads/movie.mov"), entry("notes.txt")],
+      spec({ name_terms: ["me"] }),
+      HOME,
+    );
     expect(hits.map((h) => h.path)).toEqual([`${HOME}/Downloads/movie.mov`]);
+  });
+});
+
+// -- runAiSearch: one model call, one engine query, no substitutions ----------
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub /api/ai and /api/search/files; records every request URL in order. */
+function stubApi(opts: {
+  aiText?: string;
+  aiStatus?: number;
+  entries?: SearchFileEntry[];
+}): string[] {
+  const calls: string[] = [];
+  globalThis.fetch = mock(async (url: string | URL | Request) => {
+    const u = String(url);
+    calls.push(u);
+    if (u === "/api/ai") {
+      if (opts.aiStatus && opts.aiStatus !== 200)
+        return jsonResponse({ error: "claude is not installed" }, opts.aiStatus);
+      return jsonResponse({ ok: true, result: { text: opts.aiText ?? "{}" } });
+    }
+    if (u === "/api/search/files")
+      return jsonResponse({ ok: true, entries: opts.entries ?? [], truncated: false });
+    throw new Error("unexpected fetch: " + u);
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+describe("runAiSearch", () => {
+  it("makes exactly one model call and one engine query", async () => {
+    const calls = stubApi({
+      aiText: JSON.stringify({ name_terms: ["weather"], extensions: ["csv"] }),
+      entries: [entry("data/weather.csv")],
+    });
+    const res = await runAiSearch(HOME, "weather spreadsheet");
+    expect(calls).toEqual(["/api/ai", "/api/search/files"]);
+    expect(res.hits.map((h) => h.path)).toEqual([`${HOME}/data/weather.csv`]);
+    expect(res.spec.name_terms).toEqual(["weather"]);
+  });
+
+  it("does not retry the engine when the first result set is empty", async () => {
+    // The old pipeline fired a second /api/search/files with name_terms
+    // stripped. AI search is now a deliberate action over instant index
+    // results, so an empty answer is the answer.
+    const calls = stubApi({
+      aiText: JSON.stringify({ name_terms: ["weather"], extensions: ["csv"] }),
+      entries: [],
+    });
+    const res = await runAiSearch(HOME, "weather spreadsheet");
+    expect(calls.filter((c) => c === "/api/search/files")).toHaveLength(1);
+    expect(res.hits).toEqual([]);
+  });
+
+  it("reports an unusable model reply instead of searching the raw words", async () => {
+    const calls = stubApi({ aiText: "Sure! I can help you find files." });
+    await expect(runAiSearch(HOME, "weather")).rejects.toThrow(/could not/i);
+    // Nothing was sent to the engine: a keyword search on the user's own words
+    // would be a different question answered silently.
+    expect(calls).toEqual(["/api/ai"]);
+  });
+
+  it("reports a spec that narrows nothing the engine understands", async () => {
+    // "in downloads" parses fine but only sets path_hints, which is
+    // client-side ranking and never reaches the engine.
+    const calls = stubApi({ aiText: JSON.stringify({ path_hints: ["downloads"] }) });
+    await expect(runAiSearch(HOME, "stuff in downloads")).rejects.toThrow(/narrow/i);
+    expect(calls).toEqual(["/api/ai"]);
+  });
+
+  it("propagates a relay failure", async () => {
+    stubApi({ aiStatus: 503 });
+    await expect(runAiSearch(HOME, "weather")).rejects.toThrow(/claude is not installed/);
   });
 });

--- a/frontend/src/apps/explorer/lib/ai-search.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.ts
@@ -5,10 +5,19 @@
 // the indexed roots, home by default, and reports a missing index as an error
 // rather than as an empty disk), and the hits are ranked client-side with the
 // shared fuzzy matcher. The model never sees the filesystem and never returns
-// anything executable — its output is data,
-// validated field by field on BOTH sides of the wire (here at the parse
-// boundary, and again in the server's _parse_spec), and a garbage reply
-// degrades to a plain term search on the user's own words.
+// anything executable — its output is data, validated field by field on BOTH
+// sides of the wire (here at the parse boundary, and again in the server's
+// _parse_spec).
+//
+// This is a DELIBERATE action, not the default path: the explorer's home page
+// answers plain filename queries instantly from the file index, and AI search
+// is one row the user has to pick (see FilesHome). Everything that existed to
+// make an AI-first box tolerable is therefore gone — no keyword fallback spec
+// when the model replies with garbage, no name-terms-stripped retry when the
+// first engine query comes up empty. One model call, one engine query, and a
+// failure is REPORTED: the index results the user was already looking at are
+// the fallback, and silently answering a different question (a keyword search
+// on their raw words) would be worse than saying so.
 import { aiComplete, searchFiles, type SearchFileEntry } from "@platform/lib/api";
 import { fuzzyMatch } from "@platform/lib/fuzzy";
 
@@ -42,7 +51,6 @@ export interface AiSearchHit extends SearchFileEntry {
 export interface AiSearchResult {
   hits: AiSearchHit[];
   truncated: boolean; // the engine hit its result cap
-  usedFallback: boolean; // the model reply was unusable; plain term search ran
   spec: AiSearchSpec;
 }
 
@@ -65,6 +73,9 @@ export function aiSearchSystemPrompt(): string {
     ' "max_size_bytes": number or null,\n' +
     ' "path_hints": [folder-name words the query implies, empty if none]}\n' +
     "Guidelines:\n" +
+    "- At least one of name_terms, extensions, or a date/size bound MUST be " +
+    "set: path_hints and kind are ranking hints the search engine cannot " +
+    "narrow on, so a reply carrying only those has no answer to give.\n" +
     "- name_terms is ONLY for words plausibly in the filename itself " +
     "(a project name, a topic, 'resume'). NEVER put file-type or media-type " +
     "words there — a video file is rarely named 'video'. Filler ('file', " +
@@ -84,9 +95,7 @@ export function aiSearchSystemPrompt(): string {
     "small/tiny→max_size_bytes 100000.\n" +
     "- 'folder'/'directory'→kind \"dir\".\n" +
     "- Location words go to path_hints: downloaded/downloads→downloads; " +
-    "desktop→desktop; documents→documents; photos/pictures→pictures.\n" +
-    "- When the query is only a name, everything except name_terms stays at " +
-    "its empty/null default."
+    "desktop→desktop; documents→documents; photos/pictures→pictures."
   );
 }
 
@@ -130,21 +139,6 @@ export function parseAiSearchSpec(text: string): AiSearchSpec | null {
     min_size_bytes: posNum(o.min_size_bytes),
     max_size_bytes: posNum(o.max_size_bytes),
     path_hints: strings(o.path_hints).slice(0, 4),
-  };
-}
-
-// When the relay is down or replied garbage: the user's own words become
-// name_terms, so the search still does something sensible.
-export function fallbackSpec(query: string): AiSearchSpec {
-  return {
-    name_terms: query.split(/\s+/).filter(Boolean).slice(0, 8),
-    extensions: [],
-    kind: "any",
-    modified_after: null,
-    modified_before: null,
-    min_size_bytes: null,
-    max_size_bytes: null,
-    path_hints: [],
   };
 }
 
@@ -195,9 +189,9 @@ export function hasNonNameFilters(spec: AiSearchSpec): boolean {
 // path_hints is client-side-only (soft ranking, see rankHits) and never
 // reaches /api/search/files, so a spec with only path_hints/kind — e.g. "in
 // downloads" — has zero engine narrowing even though the model parsed fine.
-// Sending it anyway hits "spec has no narrowing constraints" on macOS, or a
-// match-everything home walk elsewhere.
-export function hasEngineNarrowing(spec: AiSearchSpec): boolean {
+// Checked here rather than left to the server purely for the message: the
+// endpoint would reject it too, one round trip later, in its own words.
+function hasEngineNarrowing(spec: AiSearchSpec): boolean {
   return spec.name_terms.length > 0 || hasNonNameFilters(spec);
 }
 
@@ -241,47 +235,28 @@ export function rankHits(
   return hits.slice(0, MAX_HITS);
 }
 
-// Name terms are a hard WHERE in the engine too (an OR of ILIKE substrings), so
-// a spec that ALSO carries real filters retries without them when the first pass
-// comes up empty — same rationale as the soft-term ranking above: "video
-// downloaded today" has its extension and date pinned, and IMG_1234.mov must not
-// be lost to a filename that never says "video". The retry therefore still earns
-// its keep against the index engine, and now costs one more SQL query rather
-// than one more Spotlight run.
-async function queryEngine(spec: AiSearchSpec, signal?: AbortSignal) {
-  const first = await searchFiles(spec, signal);
-  if (first.entries.length || !spec.name_terms.length || !hasNonNameFilters(spec))
-    return first;
-  return searchFiles({ ...spec, name_terms: [] }, signal);
-}
-
-// The full pipeline: model → spec → the index engine → rank.
+// The full pipeline: model → spec → the index engine → rank. One round trip
+// each, and every failure throws for the caller to show — see the module
+// header on why there is nothing to degrade to here.
 export async function runAiSearch(
   home: string,
   query: string,
   signal?: AbortSignal,
 ): Promise<AiSearchResult> {
-  let spec: AiSearchSpec | null = null;
-  try {
-    spec = parseAiSearchSpec(await aiComplete(query, aiSearchSystemPrompt()));
-  } catch {
-    // relay down / claude missing — fall through to the fallback spec
-  }
-  // A spec that parsed fine but narrows nothing the engine understands
-  // (location-only: "in downloads") degrades the same as a parse failure —
-  // otherwise it reaches the engine as an unnarrowed query and errors or
-  // returns whatever the walk hit first.
-  let usedFallback = false;
-  if (spec === null || !hasEngineNarrowing(spec)) {
-    usedFallback = true;
-    spec = fallbackSpec(query);
-  }
+  // A relay failure (no claude, model error) propagates as-is: its message is
+  // already the most specific thing anyone can say about it.
+  const spec = parseAiSearchSpec(await aiComplete(query, aiSearchSystemPrompt()));
+  if (spec === null)
+    throw new Error(
+      "AI search could not read the model's reply as a filter. " +
+        "Try rephrasing, or search by name.",
+    );
+  if (!hasEngineNarrowing(spec))
+    throw new Error(
+      "AI search understood a place but nothing to narrow by — add a name, " +
+        "a file type, or a date.",
+    );
   if (signal?.aborted) throw new DOMException("aborted", "AbortError");
-  const res = await queryEngine(spec, signal);
-  return {
-    hits: rankHits(res.entries, spec, home),
-    truncated: res.truncated,
-    usedFallback,
-    spec,
-  };
+  const res = await searchFiles(spec, signal);
+  return { hits: rankHits(res.entries, spec, home), truncated: res.truncated, spec };
 }

--- a/frontend/src/apps/explorer/lib/ai-search.ts
+++ b/frontend/src/apps/explorer/lib/ai-search.ts
@@ -14,7 +14,8 @@
 // is one row the user has to pick (see FilesHome). Everything that existed to
 // make an AI-first box tolerable is therefore gone — no keyword fallback spec
 // when the model replies with garbage, no name-terms-stripped retry when the
-// first engine query comes up empty. One model call, one engine query, and a
+// first engine query comes up empty (the softening that retry existed for is
+// decided UP FRONT instead — see engineSpec). One model call, one engine query, and a
 // failure is REPORTED: the index results the user was already looking at are
 // the fallback, and silently answering a different question (a keyword search
 // on their raw words) would be worse than saying so.
@@ -38,9 +39,12 @@ export interface AiSearchSpec {
   modified_before: string | null;
   min_size_bytes: number | null;
   max_size_bytes: number | null;
-  // Directory-name hints ("in my photos folder", "downloaded" → downloads) —
-  // soft ranking boosts, never hard filters, because the model is guessing
-  // at folder names it cannot see.
+  // Directory-name hints ("in my photos folder", "downloaded" → downloads).
+  // A real engine constraint: each hint must match a path SEGMENT, OR'd across
+  // hints and ANDed with the rest of the spec (see search.py). It used to be
+  // documented as a client-side ranking boost, which made "Downloads this week"
+  // execute as a date filter over the whole index and truncate to the newest
+  // rows ANYWHERE — a boost cannot recover rows the SQL already dropped.
   path_hints: string[];
 }
 
@@ -73,9 +77,9 @@ export function aiSearchSystemPrompt(): string {
     ' "max_size_bytes": number or null,\n' +
     ' "path_hints": [folder-name words the query implies, empty if none]}\n' +
     "Guidelines:\n" +
-    "- At least one of name_terms, extensions, or a date/size bound MUST be " +
-    "set: path_hints and kind are ranking hints the search engine cannot " +
-    "narrow on, so a reply carrying only those has no answer to give.\n" +
+    "- At least one of name_terms, extensions, path_hints, or a date/size " +
+    "bound MUST be set: kind alone (\"folders\") still matches half the disk, " +
+    "so a reply carrying only that has no answer to give.\n" +
     "- name_terms is ONLY for words plausibly in the filename itself " +
     "(a project name, a topic, 'resume'). NEVER put file-type or media-type " +
     "words there — a video file is rarely named 'video'. Filler ('file', " +
@@ -95,7 +99,9 @@ export function aiSearchSystemPrompt(): string {
     "small/tiny→max_size_bytes 100000.\n" +
     "- 'folder'/'directory'→kind \"dir\".\n" +
     "- Location words go to path_hints: downloaded/downloads→downloads; " +
-    "desktop→desktop; documents→documents; photos/pictures→pictures."
+    "desktop→desktop; documents→documents; photos/pictures→pictures. These " +
+    "RESTRICT the search to folders with that exact name, so only name a place " +
+    "the query actually asks for — a guess excludes everywhere else."
   );
 }
 
@@ -160,7 +166,8 @@ export function describeSpec(spec: AiSearchSpec): string {
     parts.push(`modified ${fmtRange(spec.modified_after, spec.modified_before)}`);
   if (spec.min_size_bytes !== null) parts.push(`≥${fmtBytes(spec.min_size_bytes)}`);
   if (spec.max_size_bytes !== null) parts.push(`≤${fmtBytes(spec.max_size_bytes)}`);
-  if (spec.path_hints.length) parts.push("near " + spec.path_hints.join(", "));
+  // "in", not "near": the engine restricts to these folders (see path_hints).
+  if (spec.path_hints.length) parts.push("in " + spec.path_hints.join(", "));
   return parts.join(" · ");
 }
 
@@ -185,21 +192,41 @@ export function hasNonNameFilters(spec: AiSearchSpec): boolean {
   );
 }
 
-// Whether the spec gives the ENGINE (server) anything to narrow on.
-// path_hints is client-side-only (soft ranking, see rankHits) and never
-// reaches /api/search/files, so a spec with only path_hints/kind — e.g. "in
-// downloads" — has zero engine narrowing even though the model parsed fine.
-// Checked here rather than left to the server purely for the message: the
-// endpoint would reject it too, one round trip later, in its own words.
+// Whether the spec gives the ENGINE (server) anything to narrow on. Every
+// field but `kind` counts — path_hints included, since it is a path-segment
+// WHERE clause (search.py), so "in downloads" is answerable. Only a spec that
+// narrows nothing at all is refused here, one round trip before the endpoint
+// would refuse it in its own words.
 function hasEngineNarrowing(spec: AiSearchSpec): boolean {
-  return spec.name_terms.length > 0 || hasNonNameFilters(spec);
+  return spec.name_terms.length > 0 || spec.path_hints.length > 0 || hasNonNameFilters(spec);
 }
 
-// Rank the engine's hits: fuzzy name-term score + path-hint boost, recency
-// tie-break (and the whole order when the spec has no name terms). The
-// engine already applied the HARD filters (ext/kind/date/size); name terms
-// are re-scored here because the engine matches them with a dumb
-// case-insensitive substring (SQL ILIKE) and cannot rank.
+/**
+ * The spec as the ENGINE should execute it: name terms dropped when the spec
+ * narrows on anything else.
+ *
+ * The server ANDs name_terms in as an OR of ILIKEs, which is a hard filter on
+ * the file's name — and for "videos I downloaded last week" that is the wrong
+ * question: the query is already pinned by extension and date, and IMG_1234.mov
+ * would be excluded for never saying "video". So when there is other real
+ * narrowing the terms become boost-only and rankHits alone uses them (its soft
+ * branch, previously unreachable in production). When they are the ONLY
+ * narrowing they must stay a predicate — otherwise the query matches the index.
+ *
+ * This is deliberately not the deleted name-terms-stripped RETRY: the decision
+ * is made before the single request, so it is still one model call and one
+ * engine query.
+ */
+export function engineSpec(spec: AiSearchSpec): AiSearchSpec {
+  return hasNonNameFilters(spec) ? { ...spec, name_terms: [] } : spec;
+}
+
+// Rank the engine's hits: fuzzy name-term score, recency tie-break (and the
+// whole order when the spec has no name terms). The engine applied the hard
+// filters it was sent (ext/kind/date/size/path); name terms are scored here
+// because the engine either matched them with a dumb case-insensitive substring
+// or — under engineSpec's softening — never saw them at all, and cannot rank
+// either way. path_hints gets no boost: every returned row already matches one.
 export function rankHits(
   entries: SearchFileEntry[],
   spec: AiSearchSpec,
@@ -225,10 +252,6 @@ export function rankHits(
       }
       if (matched === 0 && !soft) continue;
     }
-    const dirPart = rel.slice(0, rel.lastIndexOf("/") + 1).toLowerCase();
-    for (const hint of spec.path_hints) {
-      if (dirPart.includes(hint.toLowerCase())) score += 10;
-    }
     hits.push({ ...e, score });
   }
   hits.sort((a, b) => b.score - a.score || (b.mtime ?? 0) - (a.mtime ?? 0));
@@ -253,10 +276,12 @@ export async function runAiSearch(
     );
   if (!hasEngineNarrowing(spec))
     throw new Error(
-      "AI search understood a place but nothing to narrow by — add a name, " +
-        "a file type, or a date.",
+      "AI search found nothing to narrow by — add a name, a place, a file " +
+        "type, or a date.",
     );
   if (signal?.aborted) throw new DOMException("aborted", "AbortError");
-  const res = await searchFiles(spec, signal);
+  // The engine runs the softened spec; the ECHO shows what the model
+  // understood, so a wrong interpretation is still visible.
+  const res = await searchFiles(engineSpec(spec), signal);
   return { hits: rankHits(res.entries, spec, home), truncated: res.truncated, spec };
 }

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -6,6 +6,7 @@ import {
   homeCountNote,
   homeHitsFrom,
   pathShortcut,
+  redirectsToSearch,
   stepHighlight,
 } from "./home-search";
 import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
@@ -86,10 +87,12 @@ describe("homeHitsFrom", () => {
 describe("homeCountNote", () => {
   it("states the true total and owns up to the display cap", () => {
     expect(homeCountNote(1, false)).toBe("1 match");
-    expect(homeCountNote(7, false)).toBe("7 matches");
+    expect(homeCountNote(HOME_RESULT_CAP, false)).toBe(`${HOME_RESULT_CAP} matches`);
     expect(homeCountNote(HOME_RESULT_CAP + 60, false)).toBe(
-      `Showing top ${HOME_RESULT_CAP} of 100`,
+      `Showing top ${HOME_RESULT_CAP} of ${HOME_RESULT_CAP + 60}`,
     );
+    // Four figures read as a number, not a digit run.
+    expect(homeCountNote(4690, false)).toBe(`Showing top ${HOME_RESULT_CAP} of 4,690`);
     // A truncated corpus is a second, independent "there was more than this".
     expect(homeCountNote(3, true)).toBe("3+ matches");
   });
@@ -134,5 +137,53 @@ describe("keyboard rows", () => {
     // A highlight past the end of a shrinking list clamps to the AI row rather
     // than addressing a row that is no longer on screen.
     expect(activeRow(9, 3)).toBe(3);
+  });
+});
+
+describe("redirectsToSearch", () => {
+  const key = (over: Partial<Parameters<typeof redirectsToSearch>[0]> = {}) => ({
+    key: "a",
+    ctrlKey: false,
+    altKey: false,
+    metaKey: false,
+    tagName: "DIV",
+    isContentEditable: false,
+    isSearchInput: false,
+    ...over,
+  });
+
+  it("claims a printable keystroke aimed at the page", () => {
+    expect(redirectsToSearch(key())).toBe(true);
+    expect(redirectsToSearch(key({ key: "7" }))).toBe(true);
+    expect(redirectsToSearch(key({ key: "~" }))).toBe(true);
+    expect(redirectsToSearch(key({ key: "/" }))).toBe(true);
+    // Shift is part of typing, not a command.
+    expect(redirectsToSearch(key({ key: "A" }))).toBe(true);
+    // Correcting a query has to reach the box too.
+    expect(redirectsToSearch(key({ key: "Backspace" }))).toBe(true);
+  });
+
+  it("leaves shortcuts alone", () => {
+    expect(redirectsToSearch(key({ ctrlKey: true }))).toBe(false);
+    expect(redirectsToSearch(key({ metaKey: true }))).toBe(false);
+    expect(redirectsToSearch(key({ altKey: true }))).toBe(false);
+  });
+
+  it("leaves navigation and other non-printable keys alone", () => {
+    for (const k of ["Enter", "Escape", "Tab", "ArrowDown", "ArrowUp", "F5", "Shift"])
+      expect(redirectsToSearch(key({ key: k }))).toBe(false);
+  });
+
+  it("never steals from another field", () => {
+    expect(redirectsToSearch(key({ tagName: "INPUT" }))).toBe(false);
+    expect(redirectsToSearch(key({ tagName: "TEXTAREA" }))).toBe(false);
+    expect(redirectsToSearch(key({ tagName: "SELECT" }))).toBe(false);
+    expect(redirectsToSearch(key({ isContentEditable: true }))).toBe(false);
+  });
+
+  it("is a no-op when the search box already has the caret", () => {
+    // Not merely redundant: focusing on every keystroke would reset the caret
+    // to the end, so editing the middle of a query would be impossible.
+    expect(redirectsToSearch(key({ tagName: "INPUT", isSearchInput: true }))).toBe(false);
   });
 });

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -6,8 +6,10 @@ import {
   homeCountNote,
   homeHitsFrom,
   pathShortcut,
+  rankingSettled,
   redirectsToSearch,
   stepHighlight,
+  submitRow,
 } from "./home-search";
 import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
 import type { SearchHit } from "@apps/explorer/listing/types";
@@ -131,12 +133,56 @@ describe("keyboard rows", () => {
   });
 
   it("pre-selects the AI row on zero matches, and nothing otherwise", () => {
-    expect(activeRow(null, 0)).toBe(0); // the AI row is the only content
-    expect(activeRow(null, 5)).toBeNull(); // Enter does nothing yet
-    expect(activeRow(2, 5)).toBe(2);
+    expect(activeRow(null, 0, true)).toBe(0); // the AI row is the only content
+    expect(activeRow(null, 5, true)).toBeNull(); // no highlight to render
+    expect(activeRow(2, 5, true)).toBe(2);
     // A highlight past the end of a shrinking list clamps to the AI row rather
     // than addressing a row that is no longer on screen.
-    expect(activeRow(9, 3)).toBe(3);
+    expect(activeRow(9, 3, true)).toBe(3);
+  });
+
+  it("does not pre-select the AI row until ranking has settled on zero", () => {
+    // "Nothing scored yet" and "zero matches" look identical as a count, and
+    // pre-selecting on the first made Enter during the corpus load or the
+    // 120ms debounce spend a model call on a query with instant matches.
+    expect(activeRow(null, 0, false)).toBeNull();
+    // An explicit arrow-key choice is the user's, settled or not.
+    expect(activeRow(1, 0, false)).toBe(0);
+  });
+});
+
+describe("submitRow", () => {
+  it("opens the top hit when Enter is pressed with no highlight", () => {
+    // Previously a silent no-op: every other search box in the app commits on
+    // Enter, and the top hit is what the list is offering.
+    expect(submitRow(null, 5, true)).toBe(0);
+  });
+
+  it("runs the AI row only once ranking has settled on zero hits", () => {
+    expect(submitRow(null, 0, true)).toBe(0); // fileCount 0 → the AI row
+    // Mid-scan: nothing to commit yet, and the AI row must not be armed.
+    expect(submitRow(null, 0, false)).toBeNull();
+  });
+
+  it("honours an explicit highlight, including the AI row", () => {
+    expect(submitRow(2, 5, true)).toBe(2);
+    expect(submitRow(5, 5, true)).toBe(5);
+  });
+});
+
+describe("rankingSettled", () => {
+  it("is false while the corpus or the scan is still in flight", () => {
+    expect(rankingSettled("idle", false)).toBe(false);
+    expect(rankingSettled("loading", false)).toBe(false);
+    expect(rankingSettled("ok", true)).toBe(false);
+  });
+
+  it("is true once a scan finishes, and for a corpus that will never come", () => {
+    expect(rankingSettled("ok", false)).toBe(true);
+    // Nothing further is coming for these, and the AI row is the only content
+    // left — so Enter must reach it.
+    expect(rankingSettled("cold", false)).toBe(true);
+    expect(rankingSettled("error", false)).toBe(true);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "bun:test";
+import {
+  HOME_RESULT_CAP,
+  activeRow,
+  corpusFrom,
+  homeCountNote,
+  homeHitsFrom,
+  pathShortcut,
+  stepHighlight,
+} from "./home-search";
+import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
+import type { SearchHit } from "@apps/explorer/listing/types";
+
+const HOME = "/Users/me";
+
+function walkEntry(rel: string, over: Partial<WalkEntry> = {}): WalkEntry {
+  return { rel, is_dir: false, size: 10, mtime: 1_800_000_000, ...over };
+}
+
+function hit(rel: string, over: Partial<WalkEntry> = {}): SearchHit {
+  return { entry: walkEntry(rel, over), positions: [], score: 1, longestRun: 1, tier: 1, depth: 1 };
+}
+
+function indexResult(over: Partial<IndexSearchResult> = {}): IndexSearchResult {
+  return {
+    covered: true,
+    fresh: true,
+    root: HOME,
+    entries: [walkEntry("Downloads/a.csv")],
+    truncated: false,
+    total: 1,
+    updated: null,
+    age_s: null,
+    ...over,
+  };
+}
+
+describe("pathShortcut", () => {
+  it("expands ~ and ~/… against home", () => {
+    expect(pathShortcut("~", HOME)).toBe(HOME);
+    expect(pathShortcut("~/Downloads", HOME)).toBe(`${HOME}/Downloads`);
+  });
+
+  it("keeps absolute posix paths and normalizes trailing slashes", () => {
+    expect(pathShortcut("/etc", HOME)).toBe("/etc");
+    expect(pathShortcut("/etc/", HOME)).toBe("/etc");
+    // The root itself must survive being stripped.
+    expect(pathShortcut("/", HOME)).toBe("/");
+  });
+
+  it("normalizes drive-letter paths and keeps a drive root's slash", () => {
+    expect(pathShortcut("C:\\Users\\me", HOME)).toBe("C:/Users/me");
+    // Bare "C:" reads as cwd-relative, so a drive root keeps its slash.
+    expect(pathShortcut("C:/", HOME)).toBe("C:/");
+  });
+
+  it("is null for anything that is not a path — that is a search, not a jump", () => {
+    expect(pathShortcut("weather csv", HOME)).toBeNull();
+    expect(pathShortcut("Downloads", HOME)).toBeNull();
+    // A backslash is a legal POSIX filename char, so this is not a path.
+    expect(pathShortcut("a\\b", HOME)).toBeNull();
+    expect(pathShortcut("  ", HOME)).toBeNull();
+  });
+});
+
+describe("homeHitsFrom", () => {
+  it("absolutizes rel paths against home and carries the entry's facts", () => {
+    const rows = homeHitsFrom([hit("Downloads/a.csv", { size: 42, is_dir: false })], HOME);
+    expect(rows).toEqual([
+      {
+        path: `${HOME}/Downloads/a.csv`,
+        rel: "Downloads/a.csv",
+        is_dir: false,
+        size: 42,
+        mtime: 1_800_000_000,
+      },
+    ]);
+  });
+
+  it("caps the rendered rows without touching the ranking behind them", () => {
+    const many = Array.from({ length: HOME_RESULT_CAP + 25 }, (_, i) => hit(`f${i}.txt`));
+    expect(homeHitsFrom(many, HOME)).toHaveLength(HOME_RESULT_CAP);
+  });
+});
+
+describe("homeCountNote", () => {
+  it("states the true total and owns up to the display cap", () => {
+    expect(homeCountNote(1, false)).toBe("1 match");
+    expect(homeCountNote(7, false)).toBe("7 matches");
+    expect(homeCountNote(HOME_RESULT_CAP + 60, false)).toBe(
+      `Showing top ${HOME_RESULT_CAP} of 100`,
+    );
+    // A truncated corpus is a second, independent "there was more than this".
+    expect(homeCountNote(3, true)).toBe("3+ matches");
+  });
+});
+
+describe("corpusFrom", () => {
+  it("is ok for a covered root", () => {
+    expect(corpusFrom(indexResult())).toEqual({
+      status: "ok",
+      entries: [walkEntry("Downloads/a.csv")],
+      truncated: false,
+    });
+  });
+
+  it("is cold — not empty — when the index has not covered the root yet", () => {
+    // The honest answer is "still building", never "no matches": the home page
+    // has no live walk to fall back on, so a miss here is the app's state.
+    expect(corpusFrom(indexResult({ covered: false, entries: [] }))).toEqual({ status: "cold" });
+  });
+});
+
+describe("keyboard rows", () => {
+  // Rows are the file hits followed by ONE action row (Search with AI), so the
+  // AI row's index is always the file count.
+  it("steps down from nothing to the first row and wraps at both ends", () => {
+    expect(stepHighlight(null, 3, 1)).toBe(0);
+    expect(stepHighlight(2, 3, 1)).toBe(3); // the AI row
+    expect(stepHighlight(3, 3, 1)).toBe(0); // wrapped past the AI row
+    expect(stepHighlight(null, 3, -1)).toBe(3); // up from nothing = the AI row
+    expect(stepHighlight(0, 3, -1)).toBe(3);
+  });
+
+  it("walks only the AI row when there are no file hits", () => {
+    expect(stepHighlight(null, 0, 1)).toBe(0);
+    expect(stepHighlight(0, 0, 1)).toBe(0);
+  });
+
+  it("pre-selects the AI row on zero matches, and nothing otherwise", () => {
+    expect(activeRow(null, 0)).toBe(0); // the AI row is the only content
+    expect(activeRow(null, 5)).toBeNull(); // Enter does nothing yet
+    expect(activeRow(2, 5)).toBe(2);
+    // A highlight past the end of a shrinking list clamps to the AI row rather
+    // than addressing a row that is no longer on screen.
+    expect(activeRow(9, 3)).toBe(3);
+  });
+});

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -108,6 +108,50 @@ export function corpusFrom(res: IndexSearchResult): CorpusState {
   return { status: "ok", entries: corpus.entries, truncated: corpus.truncated };
 }
 
+// -- typing anywhere is typing here ------------------------------------------
+
+/** The parts of a keydown that decide whether the search box should claim it. */
+export interface KeyIntent {
+  key: string;
+  ctrlKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  /** `tagName` of the event target, uppercase as the DOM reports it. */
+  tagName: string | undefined;
+  isContentEditable: boolean;
+  /** The target IS the search box — it already has the caret. */
+  isSearchInput: boolean;
+}
+
+/**
+ * Whether a keystroke aimed at the page should be redirected into the box.
+ *
+ * This page's whole purpose is to be typed into, so a printable key that no
+ * other field wants belongs in the search bar — nobody should have to click a
+ * search box on a search page. The exclusions are what keep that from being
+ * theft:
+ *
+ *  * a ctrl/alt/meta chord is a COMMAND, not typing, and swallowing focus from
+ *    one would break every app shortcut on the page. Shift is not in that list:
+ *    a capital letter is typing.
+ *  * another input/textarea/select/contenteditable owns its own keystrokes.
+ *  * the box already having the caret has to be a no-op, not a redundant
+ *    focus(): re-focusing collapses the selection to the end, which would make
+ *    editing the middle of a query impossible.
+ *
+ * `key.length === 1` is the printable test that doesn't enumerate alphabets (it
+ * admits every letter, digit, and symbol in any script while rejecting the named
+ * keys — "Enter", "Tab", "ArrowUp", "F5"). Backspace is admitted on top of it so
+ * a correction reaches the box rather than the browser's back gesture.
+ */
+export function redirectsToSearch(e: KeyIntent): boolean {
+  if (e.ctrlKey || e.altKey || e.metaKey) return false;
+  if (e.key.length !== 1 && e.key !== "Backspace") return false;
+  if (e.isSearchInput) return false;
+  if (e.isContentEditable) return false;
+  return e.tagName !== "INPUT" && e.tagName !== "TEXTAREA" && e.tagName !== "SELECT";
+}
+
 // -- the row model the keyboard walks ----------------------------------------
 //
 // The rendered list is `fileCount` file rows followed by exactly ONE action row

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -1,0 +1,146 @@
+// The explorer home page's instant search: what a keystroke is worth before
+// anyone asks a model anything.
+//
+// The home page used to be an AI-first composer — every query, including
+// "invoice", spent a round trip through haiku to learn that "invoice" is a
+// filename. The file index already holds the whole home tree, and the in-folder
+// search already knows how to rank a corpus of it, so typing here now ranks
+// locally and paints as you type; AI search is one row at the bottom of the
+// results (see FilesHome), taken only when the user asks for it.
+//
+// The RANKING is deliberately not reimplemented: scoring, the substring-beats-
+// fuzzy invariant, hidden-entry intent and the comparator all live in
+// listing/search.ts, and two search boxes in the same app that order results
+// differently is a bug the user experiences as "it found it last time".
+//
+// The one thing that must not be papered over is a cold index. The home page
+// has no live-walk fallback (that is the listing's job, one folder at a time),
+// so an uncovered root is reported as "still building", never as "no matches" —
+// blaming the user's files for the app's state is exactly the failure the
+// server's search.py refuses to make.
+import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
+import { indexCorpusFrom } from "@apps/explorer/listing/index-corpus";
+import type { SearchHit } from "@apps/explorer/listing/types";
+
+// Rows rendered at most. Smaller than the listing's SEARCH_RESULT_CAP: this
+// list sits under a hero on a launcher page, not in a scrollable file table,
+// and past a screenful the useful move is a better query. Ranking still runs
+// over the whole corpus — the note below owns up to what is not shown.
+export const HOME_RESULT_CAP = 40;
+
+// How still the query must be before the corpus is re-scanned. Short enough to
+// read as "while typing", long enough that a burst of keystrokes costs one scan
+// instead of one each. The corpus itself is fetched once and reused, so this
+// debounces scoring, not the network.
+export const INSTANT_DEBOUNCE_MS = 120;
+
+// One rendered result row. `path` is absolute (the index's corpus is relative
+// to the searched root), which is what navigation and the icon helpers want.
+export interface HomeHit {
+  path: string;
+  rel: string;
+  is_dir: boolean;
+  size: number | null;
+  mtime: number | null;
+}
+
+// The corpus behind the instant search, or why there isn't one.
+export type CorpusState =
+  | { status: "idle" }
+  | { status: "loading" }
+  | { status: "ok"; entries: WalkEntry[]; truncated: boolean }
+  // The index has not covered the home root yet — no answer, not zero answers.
+  | { status: "cold" }
+  | { status: "error"; message: string };
+
+/**
+ * The filesystem path a query is really an address for, or null.
+ *
+ * A pasted or typed `/…`, `~/…` or `C:\…` is an exact address, and searching
+ * for it would be answering a question nobody asked. The caller still has to
+ * `statPath` it: a path that does not exist falls back to being a search.
+ */
+export function pathShortcut(query: string, home: string): string | null {
+  const q = query.trim();
+  if (!/^(\/|~\/|~$|[A-Za-z]:[\\/])/.test(q)) return null;
+  let fsPath = q === "~" || q.startsWith("~/") ? home + q.slice(1) : q;
+  // Backslashes are only separators in drive-letter paths (same rule as the
+  // shell's path codec) — on POSIX "\" is a legal filename char.
+  if (/^[A-Za-z]:[\\/]/.test(fsPath)) fsPath = fsPath.replace(/\\/g, "/");
+  // Strip a trailing slash but keep roots whole: "/" stays "/", and a drive
+  // root keeps its slash (bare "C:" reads as cwd-relative).
+  fsPath = fsPath.replace(/\/+$/, "") || "/";
+  if (/^[A-Za-z]:$/.test(fsPath)) fsPath += "/";
+  return fsPath;
+}
+
+/** The rows to render, in rank order: the top of the ranking, absolutized. */
+export function homeHitsFrom(hits: SearchHit[], home: string): HomeHit[] {
+  return hits.slice(0, HOME_RESULT_CAP).map((h) => ({
+    path: home + "/" + h.entry.rel,
+    rel: h.entry.rel,
+    is_dir: h.entry.is_dir,
+    size: h.entry.size,
+    mtime: h.entry.mtime,
+  }));
+}
+
+/**
+ * The match count, phrased like the listing's (listing/result-cap) so the two
+ * searches sound like one app.
+ *
+ * `corpusTruncated` is the index's own entry cap — a separate, pre-existing
+ * "there was more than this" that the number carries as a `+`. Both truncations
+ * can be true at once, and the count stays TRUE either way: reporting the
+ * capped number would be a lie about the disk.
+ */
+export function homeCountNote(total: number, corpusTruncated: boolean): string {
+  const suffix = corpusTruncated ? "+" : "";
+  const n = total.toLocaleString();
+  if (total <= HOME_RESULT_CAP) return `${n}${suffix} match${total === 1 ? "" : "es"}`;
+  return `Showing top ${HOME_RESULT_CAP} of ${n}${suffix}`;
+}
+
+/** An index response as a corpus, or `cold` when it cannot answer for the root. */
+export function corpusFrom(res: IndexSearchResult): CorpusState {
+  const corpus = indexCorpusFrom(res);
+  if (corpus === null) return { status: "cold" };
+  return { status: "ok", entries: corpus.entries, truncated: corpus.truncated };
+}
+
+// -- the row model the keyboard walks ----------------------------------------
+//
+// The rendered list is `fileCount` file rows followed by exactly ONE action row
+// (Search with AI), so the AI row's index is always `fileCount`. Keeping that
+// as arithmetic rather than a flag is what makes ↑/↓ a single wrap-around step
+// over a heterogeneous list.
+
+/** Whether row `index` is the AI action row rather than a file. */
+export function isAiRow(index: number, fileCount: number): boolean {
+  return index >= fileCount;
+}
+
+/** Move the highlight by one row, wrapping, entering the list from either end. */
+export function stepHighlight(
+  current: number | null,
+  fileCount: number,
+  delta: 1 | -1,
+): number {
+  const n = fileCount + 1;
+  if (current === null) return delta === 1 ? 0 : n - 1;
+  return (current + delta + n) % n;
+}
+
+/**
+ * The row Enter activates: the explicit highlight, clamped into the list.
+ *
+ * With no highlight there is only one sensible default, and it is the zero-hit
+ * case: the AI row is then the only content on screen, so it is pre-selected
+ * and Enter runs it. With file hits showing, Enter waits for a choice — firing
+ * an AI search because someone pressed Enter out of habit would spend a model
+ * call on results they were already reading.
+ */
+export function activeRow(highlight: number | null, fileCount: number): number | null {
+  if (highlight === null) return fileCount === 0 ? 0 : null;
+  return Math.min(highlight, fileCount);
+}

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -22,11 +22,16 @@ import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
 import { indexCorpusFrom } from "@apps/explorer/listing/index-corpus";
 import type { SearchHit } from "@apps/explorer/listing/types";
 
-// Rows rendered at most. Smaller than the listing's SEARCH_RESULT_CAP: this
-// list sits under a hero on a launcher page, not in a scrollable file table,
-// and past a screenful the useful move is a better query. Ranking still runs
-// over the whole corpus — the note below owns up to what is not shown.
-export const HOME_RESULT_CAP = 40;
+// Rows rendered at most. Far smaller than the listing's SEARCH_RESULT_CAP, and
+// the number is set by what has to stay VISIBLE rather than by how many hits are
+// interesting: "Search with AI" is the LAST row of this list, so any cap that
+// overflows the viewport hides the one action a user who isn't finding their file
+// needs — at 40 it sat two screens down, reachable only by scrolling past the
+// results that had already failed them. Ten rows plus the AI row fit a laptop
+// screen. Ranking still runs over the whole corpus (the note below owns up to
+// what is not shown); past ten rows the useful move is a better query or the AI
+// row, not more scrolling.
+export const HOME_RESULT_CAP = 10;
 
 // How still the query must be before the corpus is re-scanned. Short enough to
 // read as "while typing", long enough that a burst of keystrokes costs one scan

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -181,15 +181,53 @@ export function stepHighlight(
 }
 
 /**
- * The row Enter activates: the explicit highlight, clamped into the list.
+ * Whether the instant results are a FINISHED answer for the current query.
  *
- * With no highlight there is only one sensible default, and it is the zero-hit
- * case: the AI row is then the only content on screen, so it is pre-selected
- * and Enter runs it. With file hits showing, Enter waits for a choice — firing
- * an AI search because someone pressed Enter out of habit would spend a model
- * call on results they were already reading.
+ * `fileCount === 0` alone cannot tell "not scored yet" from "nothing matches",
+ * and the difference is a paid model call: while the corpus loads or the 120ms
+ * debounce runs, a query with plenty of instant matches shows zero of them.
+ * `cold` and `error` are settled too — no ranking is ever coming for those, so
+ * the AI row really is the only content left.
  */
-export function activeRow(highlight: number | null, fileCount: number): number | null {
-  if (highlight === null) return fileCount === 0 ? 0 : null;
+export function rankingSettled(status: CorpusState["status"], scanning: boolean): boolean {
+  if (status === "idle" || status === "loading") return false;
+  return !scanning;
+}
+
+/**
+ * The row the highlight is ON: the explicit choice, clamped into the list.
+ *
+ * With no highlight there is one default, and it is the settled zero-hit case:
+ * the AI row is then the only content on screen, so it is pre-selected. That
+ * pre-selection is gated on `settled` because it ARMS Enter — offering it while
+ * the scan is still running spends a model call on a query that was about to
+ * answer itself. With file hits showing there is no highlight until the user
+ * picks one; `submitRow` is what Enter consults.
+ */
+export function activeRow(
+  highlight: number | null,
+  fileCount: number,
+  settled: boolean,
+): number | null {
+  if (highlight === null) return fileCount === 0 && settled ? 0 : null;
   return Math.min(highlight, fileCount);
+}
+
+/**
+ * The row Enter commits, which is not always the highlighted one.
+ *
+ * With hits on screen and no arrow-key choice, Enter opens the TOP hit. It used
+ * to resolve to null and do nothing at all — a silent no-op, in the one box in
+ * this app where Enter is the obvious gesture. It still never falls through to
+ * the AI row that way: reaching a paid action takes either zero settled hits or
+ * an explicit highlight.
+ */
+export function submitRow(
+  highlight: number | null,
+  fileCount: number,
+  settled: boolean,
+): number | null {
+  const row = activeRow(highlight, fileCount, settled);
+  if (row !== null) return row;
+  return fileCount > 0 ? 0 : null;
 }

--- a/frontend/src/apps/explorer/listing/scan-job.test.ts
+++ b/frontend/src/apps/explorer/listing/scan-job.test.ts
@@ -196,10 +196,11 @@ test("finding nothing yet is not the same as being finished", () => {
 test("the consumer clears its pending state only on a FINAL publish", () => {
   // Source guard: the flag exists on the publish, and dropping it on the way
   // into state is exactly the regression (the hook used to record only
-  // {q, items}, so any publish read as settled).
-  const hook = readFileSync(join(import.meta.dir, "useWalkSearch.ts"), "utf8");
+  // {q, items}, so any publish read as settled). There is ONE consumer now —
+  // both search boxes share useRankedScan — so this guards one file, not two.
+  const hook = readFileSync(join(import.meta.dir, "useRankedScan.ts"), "utf8");
   expect(hook).toMatch(/onPublish:\s*\(result,\s*done\)\s*=>\s*setScanned\(\{\s*\.\.\.result,\s*done\s*\}\)/);
-  expect(hook).toMatch(/scanPending\s*=\s*searching\s*&&\s*\(scanned\.q\s*!==\s*q\s*\|\|\s*!scanned\.done\)/);
+  expect(hook).toMatch(/pending\s*=\s*scanned\.q\s*!==\s*q\s*\|\|\s*!scanned\.done/);
 });
 
 test("progress is reported per slice so a cancelled scan can resume", () => {

--- a/frontend/src/apps/explorer/listing/useRankedScan.ts
+++ b/frontend/src/apps/explorer/listing/useRankedScan.ts
@@ -1,0 +1,131 @@
+// The one place a corpus gets fuzzy-ranked against a query.
+//
+// Both search boxes in this app do the same thing to a flat entry list: score
+// it, sort it by the shared comparator, and publish the result TAGGED with the
+// query it was computed for. That was written out twice — the in-folder search
+// (useWalkSearch) and the home page (FilesHome) — and the subtleties that make
+// it correct are exactly the kind that rot in a copy. The home page's copy had
+// already dropped `onProgress`, so a scan cancelled mid-flight started over
+// instead of resuming.
+//
+// The load-bearing parts, once:
+//
+//  * an EFFECT, not a memo. A full scan of an index-backed corpus (200k
+//    entries) is far too much work for a keystroke, and a memo cannot be
+//    interrupted once it starts. scan-job slices it, yields between slices, and
+//    is cancelled the moment the query, hidden-intent or corpus moves.
+//  * the query TAG is committed WITH the data. On the first render after `q`
+//    changes, this state still holds the previous query's rows, so anything
+//    that tags it at render time labels the old query's rows with the new
+//    query. See lib/search-hold.
+//  * `done` distinguishes "this is the whole answer for q" from "this is what
+//    the scan has found so far". Without it an intermediate slice read as a
+//    settled result and a zero-hit moment mid-scan rendered a confident "no
+//    matches".
+//  * incremental resume. As long as query, hidden-intent and the entries ARRAY
+//    are unchanged, only entries appended since the last progress mark get
+//    scored, so a stream flush near the tail of a big walk costs one small scan
+//    rather than a re-scan of everything.
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { WalkEntry } from "@platform/lib/api";
+import type { QueryTagged } from "@platform/lib/search-hold";
+import { startScanJob } from "@apps/explorer/listing/scan-job";
+import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
+import {
+  RERANK_COMMIT_MS,
+  SCAN_IMMEDIATE_MAX,
+  SCAN_SLICE,
+  type SearchHit,
+} from "@apps/explorer/listing/types";
+
+/**
+ * Rank `entries` against `q`, incrementally and interruptibly.
+ *
+ * `entries` is null when there is nothing to scan (no corpus yet, or no query),
+ * which publishes a settled empty answer for `q` rather than leaving the
+ * previous query's rows tagged as current.
+ *
+ * `debounceMs` is how still the query must be before a scan starts — the two
+ * callers debounce differently (a streamed walk arrives in flushes, the home
+ * page's corpus arrives once), so it is a parameter rather than a constant.
+ *
+ * Stream flushes reuse the same entries array (it is appended in place), so the
+ * array identity cannot tell the job that more arrived — its length can, which
+ * is why the length is a dep of its own.
+ */
+export function useRankedScan(entries: WalkEntry[] | null, q: string, debounceMs: number) {
+  const showHidden = queryWantsHidden(q);
+  const [scanned, setScanned] = useState<QueryTagged<SearchHit> & { done: boolean }>(() => ({
+    q: "",
+    items: [],
+    done: true,
+  }));
+
+  // Incremental-scoring cache, which also carries a chunked scan's PROGRESS so
+  // a job cancelled mid-flight (by the next stream flush) resumes.
+  const scoreCache = useRef<{
+    q: string;
+    showHidden: boolean;
+    entries: WalkEntry[] | null;
+    scored: number; // how many of `entries` have been scored already
+    ranked: SearchHit[];
+  }>({ q: "", showHidden: false, entries: null, scored: 0, ranked: [] });
+
+  const scannable = q === "" ? null : entries;
+  const entryCount = scannable ? scannable.length : 0;
+
+  useEffect(() => {
+    if (scannable === null) {
+      // Nothing to scan, and no scan is in flight, so this IS the final answer
+      // for q — what is outstanding (a walk, a corpus fetch) is the caller's to
+      // report on. Kept identity-stable so it is not a render loop.
+      setScanned((prev) =>
+        prev.q === q && prev.items.length === 0 && prev.done
+          ? prev
+          : { q, items: [], done: true },
+      );
+      return;
+    }
+    const cache = scoreCache.current;
+    const resumable =
+      cache.entries === scannable && cache.q === q && cache.showHidden === showHidden;
+    if (!resumable) {
+      scoreCache.current = { q, showHidden, entries: scannable, scored: 0, ranked: [] };
+    }
+    const live = scoreCache.current;
+    return startScanJob(
+      {
+        q,
+        showHidden,
+        entries: scannable,
+        from: live.scored,
+        ranked: live.ranked,
+        sliceSize: SCAN_SLICE,
+        immediateMax: SCAN_IMMEDIATE_MAX,
+        debounceMs,
+        commitMs: RERANK_COMMIT_MS,
+      },
+      {
+        score: scoreEntries,
+        sort: (hitsToSort) => hitsToSort.sort(rankCompare),
+        now: Date.now,
+        setTimer: (fn, ms) => window.setTimeout(fn, ms),
+        clearTimer: (id) => window.clearTimeout(id),
+        onPublish: (result, done) => setScanned({ ...result, done }),
+        onProgress: (n) => {
+          live.scored = n;
+        },
+      },
+    );
+  }, [q, showHidden, scannable, entryCount, debounceMs]);
+
+  // Rows are dropped unless they were computed for the CURRENT query, so a scan
+  // still catching up never shows the previous query's matches — the same rule
+  // search-hold enforces downstream, applied at the source.
+  const ranked = useMemo(() => (scanned.q === q ? scanned.items : []), [scanned, q]);
+  // True until a FINAL publish for the current query lands. Cleared by the tag
+  // alone, an intermediate slice would end the "Searching…" state early.
+  const pending = scanned.q !== q || !scanned.done;
+
+  return { scanned, ranked, pending };
+}

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -21,21 +21,18 @@ import {
 } from "@platform/lib/index-freshness";
 import { replaceSearch } from "@platform/lib/router";
 import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "@platform/lib/search-hold";
-import { startScanJob } from "@apps/explorer/listing/scan-job";
+import { useRankedScan } from "@apps/explorer/listing/useRankedScan";
 import { shouldReconcile } from "@apps/explorer/listing/revalidate";
 import { capHits } from "@apps/explorer/listing/result-cap";
 import {
   IDLE_WALK,
   RERANK_COMMIT_MS,
   SCAN_DEBOUNCE_MS,
-  SCAN_IMMEDIATE_MAX,
-  SCAN_SLICE,
   STREAM_FLUSH_MS,
   URL_SYNC_MS,
   type SearchHit,
   type WalkState,
 } from "@apps/explorer/listing/types";
-import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
 
 function currentQuery(): string {
   return new URLSearchParams(location.search).get("q") || "";
@@ -292,112 +289,28 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     }, URL_SYNC_MS);
   };
 
-  // Incremental-scoring cache for the corpus. As long as the query,
-  // hidden-intent and entries array are unchanged, only entries appended
-  // since `scored` get fuzzy-matched and merged into the previous ranked
-  // list — so a stream flush near the tail of a 200k walk costs one small
-  // scan, not a re-scan of everything. Any change to query/hidden/array
-  // starts a fresh scan. It also carries a chunked scan's PROGRESS, so a job
-  // cancelled mid-flight (by the next stream flush) resumes instead of
-  // starting over.
-  const scoreCache = useRef<{
-    q: string;
-    showHidden: boolean;
-    entries: WalkEntry[] | null;
-    scored: number; // how many of `entries` have been scored already
-    ranked: SearchHit[];
-  }>({ q: "", showHidden: false, entries: null, scored: 0, ranked: [] });
-
-  // The scan's published output, tagged with the query it was computed for.
-  // That tag is the whole reason this is not re-derived at render time: see
-  // lib/search-hold, and scan-job's header.
-  // `done` distinguishes "this is the whole answer for q" from "this is what
-  // the scan has found so far". Without it an intermediate slice — or the
-  // empty publish for a folder with no corpus — read as a settled result, and
-  // a zero-hit moment mid-scan rendered a confident "No matches".
-  const [scanned, setScanned] = useState<QueryTagged<SearchHit> & { done: boolean }>(
-    () => ({ q: "", items: [], done: true }),
-  );
-
-  const showHidden = queryWantsHidden(q);
+  // The corpus to rank, once this generation's walk has entries to offer.
   const corpus =
     searching && (validWalk.status === "ok" || validWalk.status === "streaming")
       ? validWalk.entries
       : null;
-  // Stream flushes reuse the same entries ARRAY (it is appended in place), so
-  // the array identity cannot tell the job that more arrived — its length can.
-  const corpusLen = corpus ? corpus.length : 0;
 
-  // The scan itself. An effect, not a memo: a full scan of an index-backed
-  // corpus is far too much work to do synchronously on a keystroke, and a
-  // memo cannot be interrupted once it starts (useDeferredValue only buys the
-  // cheap echo render before it). scan-job slices it, yields between slices,
-  // and is cancelled here the moment the query, hidden-intent or corpus moves.
-  useEffect(() => {
-    if (corpus === null) {
-      // No corpus to scan (the walk is idle, streaming its first batch, or
-      // errored). No scan is in flight, so this IS the final answer for q —
-      // what is outstanding is the walk, which validWalk reports on its own.
-      setScanned((prev) =>
-        prev.q === q && prev.items.length === 0 && prev.done
-          ? prev
-          : { q, items: [], done: true },
-      );
-      return;
-    }
-    const cache = scoreCache.current;
-    const resumable =
-      cache.entries === corpus && cache.q === q && cache.showHidden === showHidden;
-    if (!resumable) {
-      scoreCache.current = { q, showHidden, entries: corpus, scored: 0, ranked: [] };
-    }
-    const live = scoreCache.current;
-    return startScanJob(
-      {
-        q,
-        showHidden,
-        entries: corpus,
-        from: live.scored,
-        ranked: live.ranked,
-        sliceSize: SCAN_SLICE,
-        immediateMax: SCAN_IMMEDIATE_MAX,
-        debounceMs: SCAN_DEBOUNCE_MS,
-        commitMs: RERANK_COMMIT_MS,
-      },
-      {
-        score: scoreEntries,
-        sort: (hitsToSort) => hitsToSort.sort(rankCompare),
-        now: Date.now,
-        setTimer: (fn, ms) => window.setTimeout(fn, ms),
-        clearTimer: (id) => window.clearTimeout(id),
-        onPublish: (result, done) => setScanned({ ...result, done }),
-        onProgress: (n) => {
-          live.scored = n;
-        },
-      },
-    );
-  }, [q, showHidden, corpus, corpusLen]);
+  // The scan itself — incremental, sliced and cancellable, shared with the
+  // explorer home page's box (listing/useRankedScan carries the reasoning).
+  const { ranked, pending } = useRankedScan(corpus, q, SCAN_DEBOUNCE_MS);
 
-  // What the rest of the hook consumes. Rows are dropped unless they were
-  // computed for the CURRENT query, so a scan still catching up never shows
-  // the previous query's matches — the same rule search-hold enforces
-  // downstream, applied at the source.
+  // What the rest of the hook consumes.
   // Relevance (the fuzzy rank) is the only order search results have. Column
   // sorting used to be offered here and was withdrawn with the Size/Modified
   // headers: the hit set is capped and, mid-walk, partial — a by-date or
   // by-size ordering over it reads as an answer to a question the data cannot
   // answer, and the search UI already warns the coverage is approximate.
-  const hits = useMemo(() => {
-    if (!searching || scanned.q !== q) return [];
-    return scanned.items;
-  }, [searching, scanned, q]);
+  const hits = useMemo(() => (searching ? ranked : []), [searching, ranked]);
 
   // True while the scan for the current query has not published yet — the
   // spinner and the dimmed-rows treatment key off this, so it has to mean
   // "an answer is still coming", not merely "the deferred value lags".
-  // Pending until a FINAL publish for the current query lands. Cleared by the
-  // tag alone, an intermediate slice would end the "Searching…" state early.
-  const scanPending = searching && (scanned.q !== q || !scanned.done);
+  const scanPending = searching && pending;
   const isStale = deferredStale || scanPending;
 
   // --- Streaming re-rank throttle (B4) --------------------------------------

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -408,10 +408,6 @@ export interface SearchFileEntry {
 export interface SearchFilesResult {
   entries: SearchFileEntry[];
   truncated: boolean;
-  // Always "index" now that the index is the only engine; kept in the response
-  // for older clients and because "what answered this" is the first support
-  // question about a surprising result.
-  engine: string;
 }
 
 // File search from a filter spec (see apps/explorer/lib/ai-search), scoped to

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -430,8 +430,11 @@ export async function searchFiles(
   return data as SearchFilesResult;
 }
 
-export function statPath(fsPath: string): Promise<StatResult> {
-  return getJson<StatResult>("/api/fs/stat?path=" + encodeURIComponent(fsPath));
+// `signal` matters for callers that stat on a user's behalf and then navigate:
+// a stat on a slow mount can resolve after the user has moved on, and acting on
+// it would move them back. See FilesHome's path shortcut.
+export function statPath(fsPath: string, signal?: AbortSignal): Promise<StatResult> {
+  return getJson<StatResult>("/api/fs/stat?path=" + encodeURIComponent(fsPath), { signal });
 }
 
 // Deferred condition.py verdicts (CT-12): {mode: allowed} for every entry

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -120,25 +120,64 @@
   border-color: var(--fg-muted);
 }
 
+/* The home search bar and the result list under it (see FilesHome). One
+   column: the bar, then the results panel attached to its bottom edge. It is
+   deliberately NOT the /apps chat composer any more — no footer bar, no send
+   button, no multiline — because this box answers while you type and a
+   submit affordance would describe a contract it no longer has. */
 .files-search-wrap {
   text-align: left;
 }
 
-/* Anchor for the clear ✕ riding the input's right edge. */
-.files-search-field {
-  position: relative;
+/* One row: magnifier · input · Clear. A flex row rather than an absolutely
+   positioned overlay, so the input simply gets the space that is left. */
+.files-search {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 2px 10px color-mix(in srgb, var(--fg) 5%, transparent);
+  transition: border-color 120ms ease;
 }
 
-/* Keep typed text from running under the Clear pill. */
-.files-search-field .home-composer-input,
-.files-search-field .home-composer-input:focus {
-  padding-right: 70px;
+.files-search:focus-within {
+  border-color: var(--fg-muted);
+}
+
+.files-search-icon {
+  flex: none;
+  display: inline-flex;
+  color: var(--fg-muted);
+}
+
+/* Doubled-up :focus to beat the global input styles (border/ring), which would
+   otherwise draw a second box inside the bar. */
+.files-search-input,
+.files-search-input:focus {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 12px 0;
+  border: none;
+  outline: none;
+  box-shadow: none;
+  background: transparent;
+  font-size: 14px;
+  line-height: 1.4;
+  color: inherit;
+}
+
+/* WebKit's own clear button would sit beside the Clear pill saying the same
+   thing, and it cannot be styled to match. */
+.files-search-input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  appearance: none;
 }
 
 .files-search-clear {
-  position: absolute;
-  top: 10px;
-  right: 10px;
+  flex: none;
   padding: 3px 10px;
   font-size: 11.5px;
   font-weight: 600;
@@ -153,17 +192,31 @@
   color: var(--fg);
 }
 
-.fh-section {
-  margin-top: 30px;
+/* The results panel: attached to the bar, not a separate card floating below
+   it — hence the small gap and no border of its own. */
+.fh-panel {
+  margin-top: 10px;
 }
 
-.fh-heading {
-  margin: 0 0 12px;
-  font-size: 13px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
+/* The line above the list: match count and the keys that drive it, or why
+   there is no count (index still building, a failure, a scan in flight). */
+.fh-result-note {
+  margin: 0 0 8px;
+  font-size: 12px;
   color: var(--fg-muted);
+}
+
+.fh-result-note kbd {
+  font: inherit;
+  padding: 0 4px;
+  margin: 0 1px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-alt);
+}
+
+.fh-section {
+  margin-top: 30px;
 }
 
 .fh-empty {
@@ -187,17 +240,35 @@
   border-top: 1px solid var(--border);
 }
 
+/* Rows are <a> for files and a <button> for the AI action, so the box model is
+   stated here rather than inherited from either element's defaults. */
 .fh-result {
   display: flex;
+  width: 100%;
   align-items: center;
   gap: 10px;
   padding: 8px 14px;
+  text-align: left;
   text-decoration: none;
   color: inherit;
+  background: none;
+  border: none;
+  font: inherit;
+  cursor: pointer;
 }
 
-.fh-result:hover {
+/* Hover and the keyboard highlight are ONE treatment: the pointer moves the
+   highlight (onMouseMove in FilesHome), so two different tints would claim
+   there are two selections. */
+.fh-result:hover,
+.fh-result.is-active {
   background: var(--bg-alt);
+}
+
+/* The active row also gets an accent edge — the tint alone is too quiet to
+   follow with the arrow keys while reading down the list. */
+.fh-result.is-active {
+  box-shadow: inset 2px 0 0 var(--accent);
 }
 
 .fh-result-icon {
@@ -239,9 +310,65 @@
   text-align: right;
 }
 
-/* The "Understood as: …" echo line above search results. */
+/* -- the AI action row -------------------------------------------------------
+   The last row in the list is not a file: it costs a model call and a wait, so
+   it reads as an action — accent glyph, accent label, a faint accent wash — and
+   never like the hits above it. On a zero-hit query it is the only row, and
+   FilesHome pre-selects it. */
+.fh-ai-row {
+  background: color-mix(in srgb, var(--accent) 6%, transparent);
+}
+
+.fh-ai-row:hover,
+.fh-ai-row.is-active {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+
+.fh-ai-row .fh-result-name {
+  color: var(--accent);
+}
+
+.fh-ai-glyph {
+  color: var(--accent);
+}
+
+.fh-ai-row:disabled {
+  cursor: default;
+}
+
+.fh-ai-row .fh-result-meta kbd {
+  font: inherit;
+  padding: 0 4px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg);
+}
+
+/* The AI badge on the spec echo above AI results — the results on screen came
+   from a model, and the line that says how it read the query says so too. */
+.fh-ai-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-right: 8px;
+  padding: 1px 7px 1px 5px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+  vertical-align: middle;
+}
+
+.fh-ai-badge svg {
+  width: 11px;
+  height: 11px;
+}
+
+/* The "Understood as: …" echo line above AI search results. */
 .fh-search-summary {
-  margin: -4px 0 14px;
+  margin: 0 0 8px;
   font-size: 12.5px;
   color: var(--fg-muted);
 }

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -4,9 +4,17 @@ The AI search on the explorer homepage translates a natural-language query into
 a small filter spec CLIENT-side (one /api/ai call); this endpoint is the
 execution half, and the app's own DuckDB/parquet index (`fused_render/index`) is
 the ONE engine that answers it. The index holds every fact the spec filters on —
-name, ext, size, mtime — so the whole spec becomes one SQL query over the `files`
-and `dirs` views and rows come back straight from parquet: no `stat`, no walk, no
-subprocess, and therefore no syscall a wedged mount could swallow.
+name, ext, size, mtime, and the path itself — so the whole spec becomes one SQL
+query over the `files` and `dirs` views and rows come back straight from parquet:
+no `stat`, no walk, no subprocess, and therefore no syscall a wedged mount could
+swallow.
+
+EVERY field of the spec is a constraint, `path_hints` included. It was once
+documented as client-side ranking only, and that was a bug with a name: the
+endpoint dropped it, so "Downloads this week" executed as `mtime >= …` over the
+whole index, `_collect` truncated to the SEARCH_MAX_RESULTS newest rows ANYWHERE,
+and a ranking boost applied afterwards could not recover a Downloads row the SQL
+had already thrown away. A location the user named narrows the query here.
 
 There is deliberately NO fallback. Spotlight (`mdfind`) and the bounded home walk
 both used to sit behind this endpoint, and both are gone: two engines that answer
@@ -105,8 +113,10 @@ def _day_bound_epoch(date_str: str, end: bool) -> float:
 def _parse_spec(body: dict):
     """Coerce the request body into a clean spec dict, or raise ValueError.
 
-    Only the keys named below are carried; anything else in the body is ignored
-    (`path_hints` is client-side ranking only)."""
+    Only the keys named below are carried; anything else in the body is ignored.
+    `path_hints` is among them: it is a path-segment WHERE clause, not a ranking
+    hint (see the module docstring), and it is cleaned exactly like `name_terms`
+    because it lands in a LIKE pattern the same way."""
 
     def strings(key, limit, clean):
         raw = body.get(key)
@@ -158,6 +168,10 @@ def _parse_spec(body: dict):
         raise ValueError("'kind' must be 'file', 'dir', or 'any'")
     spec = {
         "name_terms": strings("name_terms", 8, clean_term),
+        # Capped tighter than name_terms: each hint is an OR'd LIKE over the
+        # PATH, and a model listing eight guessed folder names would widen the
+        # query rather than place it.
+        "path_hints": strings("path_hints", 4, clean_term),
         "extensions": strings("extensions", 8, clean_ext),
         "kind": kind,
         "min_size_bytes": pos_num("min_size_bytes"),
@@ -235,14 +249,16 @@ def _drop_gitignored(entries):
 # ------------------------------------------------------------ the index engine
 
 # Spec fields that NARROW a query. `kind` is deliberately absent: "folders"
-# still matches half the disk, so it is not enough on its own.
+# still matches half the disk, so it is not enough on its own. The two tuples
+# differ only in how emptiness reads — a list is empty, a scalar is None.
+_NARROWING_LISTS = ("name_terms", "path_hints", "extensions")
 _NARROWING_KEYS = (
     "modified_after", "modified_before", "min_size_bytes", "max_size_bytes",
 )
 
 
 def _has_narrowing(spec) -> bool:
-    return bool(spec["name_terms"] or spec["extensions"]) or any(
+    return any(spec[k] for k in _NARROWING_LISTS) or any(
         spec[k] is not None for k in _NARROWING_KEYS)
 
 
@@ -252,16 +268,18 @@ def _dir_narrowing(spec) -> bool:
     Extension and size are file facts a dirs row cannot answer, so an
     extensions-only spec ("find my mp4s") narrows the files view and nothing
     else — and a dirs branch with no predicate left would return every folder in
-    the index, spending the result cap on rows that answer nothing."""
-    return bool(spec["name_terms"]) or any(
+    the index, spending the result cap on rows that answer nothing. A path hint
+    IS answerable by a dirs row: the hint matches a segment of `dir`."""
+    return bool(spec["name_terms"] or spec["path_hints"]) or any(
         spec[k] is not None for k in ("modified_after", "modified_before"))
 
 
 def _index_where(spec, *, path_expr, name_expr, mtime_expr,
-                 ext_expr=None, size_expr=None) -> str:
+                 ext_expr=None, size_expr=None, path_is_dir=False) -> str:
     """The WHERE clause for one index view. `ext_expr`/`size_expr` are None for
     the dirs view: extension and size are FILE facts, and the dirs table has no
-    size column at all.
+    size column at all. `path_is_dir` says `path_expr` names a DIRECTORY, which
+    changes only how a path hint may match it (see below).
 
     Every value reaching SQL here is either a number cast in Python or a name
     term escaped with `like_literal` (quotes doubled, LIKE metachars escaped) —
@@ -279,6 +297,23 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr,
         pieces.append("(" + " OR ".join(
             f"{name_expr} ILIKE '%{like_literal(t)}%' ESCAPE '\\'"
             for t in spec["name_terms"]) + ")")
+    if spec["path_hints"]:
+        # A hint names a FOLDER, so it constrains a path SEGMENT rather than any
+        # substring: `~/Downloads/x.csv` is in downloads, `~/my-downloads-backup`
+        # is not, and neither is a file merely NAMED downloads-old.csv. The index
+        # stores posix paths on every platform (index/ignore.norm), so '/<hint>/'
+        # is the segment shape. OR'd across hints, because the model lists the
+        # places a query could mean; AND'd with everything else, because the user
+        # named a location and the other half of the spec still applies.
+        ors = []
+        for hint in spec["path_hints"]:
+            lit = like_literal(hint)
+            ors.append(f"{path_expr} ILIKE '%/{lit}/%' ESCAPE '\\'")
+            # A dirs row IS the directory, so its own final segment counts too —
+            # otherwise "the downloads folder" could never return ~/Downloads.
+            if path_is_dir:
+                ors.append(f"{path_expr} ILIKE '%/{lit}' ESCAPE '\\'")
+        pieces.append("(" + " OR ".join(ors) + ")")
     if ext_expr is not None and spec["extensions"]:
         # clean_ext restricts these to [a-z0-9]{1,12}; re-checked here so the
         # literal is provably quote-free however this spec was built.
@@ -334,7 +369,7 @@ def _dirs_query(cfg, spec) -> str:
         f"true AS is_dir FROM {dirs_src(cfg)} "
         f"WHERE " + _index_where(spec, path_expr="dir",
                                  name_expr="regexp_extract(dir, '[^/]*$')",
-                                 mtime_expr=dmtime)
+                                 mtime_expr=dmtime, path_is_dir=True)
         + f" ORDER BY {depth_expr('dir')}, dir")
 
 

--- a/fused_render/server/routers/search.py
+++ b/fused_render/server/routers/search.py
@@ -21,10 +21,9 @@ query. The consequences are owned rather than papered over:
   * no index yet, or an index that cannot be read, is an ERROR (503 / 502) with
     a message a search box can show. Reporting it as "no matches" would blame
     the user's files for the app's state.
-  * `created_after` / `created_before` are REFUSED: the index stores `mtime` and
-    no birth time, and no engine is left that could stat for one. Only a stale
-    client can still send them; quietly searching by modification date instead
-    would answer a different question than the one asked.
+  * there is no creation-date filter at all: the index stores `mtime` and no
+    birth time, and no engine is left that could stat for one. The client's spec
+    has no such field to send.
 
 Freshness is deliberately not a gate — a scan in flight keeps serving its last
 completed generation, exactly as `query.FRESH_MAX_AGE_S` is informational for the
@@ -41,7 +40,6 @@ match-everything query.
 import logging
 import os
 import re
-import time
 from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Body
@@ -83,11 +81,8 @@ SEARCH_MAX_PAGES = 5
 _EXT_ALLOWED = set("abcdefghijklmnopqrstuvwxyz0123456789")
 
 # Date-range spec fields: (key, is_range_end). Modified only — see the module
-# docstring on created_*.
+# docstring on creation dates.
 _DATE_FIELDS = (("modified_after", False), ("modified_before", True))
-# Creation-date fields a stale client may still send. Named so they can be
-# refused explicitly instead of ignored.
-_REFUSED_DATE_FIELDS = ("created_after", "created_before")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
@@ -110,10 +105,8 @@ def _day_bound_epoch(date_str: str, end: bool) -> float:
 def _parse_spec(body: dict):
     """Coerce the request body into a clean spec dict, or raise ValueError.
 
-    Fields the engine does not implement are IGNORED (`path_hints` is
-    client-side ranking only), with one exception: the creation-date fields are
-    refused outright, because dropping a date filter silently would answer a
-    different question than the caller asked."""
+    Only the keys named below are carried; anything else in the body is ignored
+    (`path_hints` is client-side ranking only)."""
 
     def strings(key, limit, clean):
         raw = body.get(key)
@@ -160,11 +153,6 @@ def _parse_spec(body: dict):
             raise ValueError(f"'{key}' is not a real date")
         return v
 
-    for key in _REFUSED_DATE_FIELDS:
-        if body.get(key) is not None:
-            raise ValueError(
-                f"'{key}' is not supported: the file index records modification "
-                f"time only. Use 'modified_after'/'modified_before'.")
     kind = body.get("kind", "any")
     if kind not in ("file", "dir", "any"):
         raise ValueError("'kind' must be 'file', 'dir', or 'any'")
@@ -172,9 +160,6 @@ def _parse_spec(body: dict):
         "name_terms": strings("name_terms", 8, clean_term),
         "extensions": strings("extensions", 8, clean_ext),
         "kind": kind,
-        # Legacy field, still honored: older clients (and a model told about
-        # both shapes) may send it. Ranges are the primary form.
-        "modified_within_days": pos_num("modified_within_days"),
         "min_size_bytes": pos_num("min_size_bytes"),
         "max_size_bytes": pos_num("max_size_bytes"),
     }
@@ -252,8 +237,7 @@ def _drop_gitignored(entries):
 # Spec fields that NARROW a query. `kind` is deliberately absent: "folders"
 # still matches half the disk, so it is not enough on its own.
 _NARROWING_KEYS = (
-    "modified_within_days", "modified_after", "modified_before",
-    "min_size_bytes", "max_size_bytes",
+    "modified_after", "modified_before", "min_size_bytes", "max_size_bytes",
 )
 
 
@@ -270,11 +254,10 @@ def _dir_narrowing(spec) -> bool:
     else — and a dirs branch with no predicate left would return every folder in
     the index, spending the result cap on rows that answer nothing."""
     return bool(spec["name_terms"]) or any(
-        spec[k] is not None for k in
-        ("modified_within_days", "modified_after", "modified_before"))
+        spec[k] is not None for k in ("modified_after", "modified_before"))
 
 
-def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
+def _index_where(spec, *, path_expr, name_expr, mtime_expr,
                  ext_expr=None, size_expr=None) -> str:
     """The WHERE clause for one index view. `ext_expr`/`size_expr` are None for
     the dirs view: extension and size are FILE facts, and the dirs table has no
@@ -303,9 +286,6 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
         if exts:
             pieces.append(f"lower({ext_expr}) IN ("
                           + ",".join(f"'{e}'" for e in exts) + ")")
-    if spec["modified_within_days"] is not None:
-        cutoff = now_s - spec["modified_within_days"] * 86400
-        pieces.append(f"{mtime_expr} >= {float(cutoff)!r}")
     # Local-day bounds, inclusive on both ends: `before 2026-08-05` runs to the
     # midnight AFTER the 5th.
     if spec["modified_after"] is not None:
@@ -322,7 +302,7 @@ def _index_where(spec, *, path_expr, name_expr, mtime_expr, now_s,
     return " AND ".join(pieces)
 
 
-def _files_query(cfg, parts, spec, now_s) -> str:
+def _files_query(cfg, parts, spec) -> str:
     """The files view, newest first. Ordering only decides WHICH rows survive
     the budget (the client re-ranks every hit), and recency is the best sample
     of a file corpus. `path` breaks ties so paging is deterministic."""
@@ -330,11 +310,11 @@ def _files_query(cfg, parts, spec, now_s) -> str:
         f"SELECT path, size, mtime, false AS is_dir FROM {files_src(cfg, parts)} "
         f"WHERE " + _index_where(spec, path_expr="path", name_expr="name",
                                  mtime_expr="mtime", ext_expr="ext",
-                                 size_expr="size", now_s=now_s)
+                                 size_expr="size")
         + " ORDER BY mtime DESC, path")
 
 
-def _dirs_query(cfg, spec, now_s) -> str:
+def _dirs_query(cfg, spec) -> str:
     """The dirs view, SHALLOWEST first.
 
     Not by mtime, unlike files: a dirs row's mtime_ns can be 0 ("unknown" — a
@@ -354,7 +334,7 @@ def _dirs_query(cfg, spec, now_s) -> str:
         f"true AS is_dir FROM {dirs_src(cfg)} "
         f"WHERE " + _index_where(spec, path_expr="dir",
                                  name_expr="regexp_extract(dir, '[^/]*$')",
-                                 mtime_expr=dmtime, now_s=now_s)
+                                 mtime_expr=dmtime)
         + f" ORDER BY {depth_expr('dir')}, dir")
 
 
@@ -413,7 +393,6 @@ def _index_entries(cfg, spec, cap, *, parts=None, dirs=False):
     would return every row twice."""
     import duckdb
 
-    now_s = time.time()
     con = duckdb.connect()
     # The reserve is a rule for SHARING the cap, so it only applies while both
     # branches are live. A folder-only search — `kind: "dir"`, or an index whose
@@ -421,12 +400,12 @@ def _index_entries(cfg, spec, cap, *, parts=None, dirs=False):
     # the whole cap, the same deal files get.
     dirs_budget = min(SEARCH_DIRS_RESERVE, cap) if parts else cap
     dir_entries, dirs_more = (
-        _collect(con, _dirs_query(cfg, spec, now_s), dirs_budget)
+        _collect(con, _dirs_query(cfg, spec), dirs_budget)
         if dirs else ([], False))
     # Files ask for the WHOLE cap and give back whatever the folders took, so an
     # unused folder reserve costs nothing.
     file_entries, files_more = (
-        _collect(con, _files_query(cfg, parts, spec, now_s), cap)
+        _collect(con, _files_query(cfg, parts, spec), cap)
         if parts else ([], False))
     room = cap - len(dir_entries)
     entries = dir_entries + file_entries[:room]
@@ -480,11 +459,7 @@ def _search_index(spec, cfg=None):
         logger.exception("the index search query failed")
         raise RuntimeError(
             f"the file index could not be searched: {type(e).__name__}") from e
-    return {"entries": entries, "truncated": truncated,
-            # Constant now that the index is the only engine. Kept in the
-            # response because old clients read it, and because a support
-            # question about a surprising result starts with "what answered it".
-            "engine": "index"}
+    return {"entries": entries, "truncated": truncated}
 
 
 @router.post("/api/search/files")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -25,7 +25,6 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
             "name_terms": ['we"ather\\', "  ", "ok"],
             "extensions": [".MOV", "tar.gz", "c/v", "mp4"],
             "kind": "file",
-            "modified_within_days": 1,
             "min_size_bytes": 10,
         }
     )
@@ -34,7 +33,6 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
     # dot peeled + lowercased; anything outside [a-z0-9]{1,12} dropped
     assert parsed["extensions"] == ["mov", "mp4"]
     assert parsed["kind"] == "file"
-    assert parsed["modified_within_days"] == 1
     assert parsed["min_size_bytes"] == 10
 
 
@@ -44,7 +42,7 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
         {"name_terms": "notalist"},
         {"name_terms": [1]},
         {"kind": "everything"},
-        {"modified_within_days": -1},
+        {"min_size_bytes": -1},
         {"min_size_bytes": True},
         {"modified_after": "last week"},
         {"modified_before": "2026-02-31"},
@@ -56,16 +54,14 @@ def test_parse_spec_rejects_malformed_bodies(body):
         _parse_spec(body)
 
 
-@pytest.mark.parametrize("key", ["created_after", "created_before"])
-def test_parse_spec_refuses_a_creation_date_filter(key):
-    """The index stores `mtime` and no birth time, and it is the only engine —
-    so a created_* filter is unanswerable. It is REFUSED rather than dropped:
-    silently searching by modification date instead would answer a different
-    question than the caller asked. Only a stale client can still send one."""
-    with pytest.raises(ValueError, match="created"):
-        _parse_spec({"name_terms": ["x"], key: "2026-06-01"})
-    # ...and the key is not in the parsed spec at all
-    assert key not in _parse_spec({"name_terms": ["x"]})
+@pytest.mark.parametrize(
+    "key", ["created_after", "created_before", "modified_within_days"])
+def test_parse_spec_carries_no_legacy_keys(key):
+    """The only client of this endpoint is the explorer's AI search, and it
+    sends neither a creation-date filter (the index records mtime only) nor the
+    old `modified_within_days` shape. Both are gone from the spec entirely —
+    unknown keys in the body are simply not carried, like any other."""
+    assert key not in _parse_spec({"name_terms": ["x"], key: "2026-06-01"})
 
 
 def test_day_bounds_are_inclusive_local_days():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -36,10 +36,21 @@ def test_parse_spec_cleans_terms_extensions_and_numbers():
     assert parsed["min_size_bytes"] == 10
 
 
+def test_parse_spec_carries_path_hints_cleaned_and_capped():
+    """`path_hints` is a real engine constraint (it narrows to a path SEGMENT),
+    so it is carried — and cleaned exactly like `name_terms`, because it lands
+    in a LIKE pattern the same way."""
+    parsed = _parse_spec(
+        {"path_hints": ['down"loads\\', "  ", "desktop", "a", "b", "c", "d"]})
+    assert parsed["path_hints"] == ["downloads", "desktop", "a", "b"]
+
+
 @pytest.mark.parametrize(
     "body",
     [
         {"name_terms": "notalist"},
+        {"path_hints": "notalist"},
+        {"path_hints": [1]},
         {"name_terms": [1]},
         {"kind": "everything"},
         {"min_size_bytes": -1},

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -35,6 +35,7 @@ def spec(**over):
         "modified_before": None,
         "min_size_bytes": None,
         "max_size_bytes": None,
+        "path_hints": [],
     }
     base.update(over)
     return base
@@ -137,6 +138,70 @@ def test_index_engine_skips_the_dirs_view_when_nothing_narrows_a_directory(tmp_p
     # every folder there is — there is no wider engine to hand it to.
     with pytest.raises(ValueError, match="folder"):
         _search_index(spec(extensions=["mp4"], kind="dir"), cfg)
+
+
+def test_index_engine_narrows_by_path_hint_segment(tmp_path):
+    """A hint names a FOLDER, so it matches a path SEGMENT, not any substring.
+
+    "Downloads this week" used to reach the engine as `mtime >= …` alone — half
+    the disk — and the 400-row recency window it truncated to held no Downloads
+    row at all, so the client's ranking boost had nothing to boost. The hint is
+    a WHERE clause now, and `~/my-downloads-backup` is not `~/Downloads`."""
+    cfg = _index(tmp_path, "/r", [
+        ("/r/Downloads/x.csv", 10, 100.0),
+        ("/r/my-downloads-backup/x.csv", 10, 200.0),
+        ("/r/downloads-old.csv", 10, 300.0),
+        ("/r/Documents/y.csv", 10, 400.0),
+    ])
+    # kind="file" so this pins the FILES view alone; the dirs view's own
+    # segment rule (the folder itself) has its own test below.
+    out = _search_index(
+        spec(kind="file", extensions=["csv"], path_hints=["downloads"]), cfg)
+    assert _paths(out) == ["/r/Downloads/x.csv"]
+
+
+def test_index_engine_ors_path_hints_and_ands_them_with_the_rest(tmp_path):
+    cfg = _index(tmp_path, "/r", [
+        ("/r/Downloads/a.csv", 10, 100.0),
+        ("/r/Desktop/b.csv", 10, 100.0),
+        ("/r/Desktop/c.txt", 10, 100.0),
+        ("/r/Music/d.csv", 10, 100.0),
+    ])
+    out = _search_index(
+        spec(kind="file", extensions=["csv"],
+             path_hints=["downloads", "desktop"]), cfg)
+    assert _paths(out) == ["/r/Desktop/b.csv", "/r/Downloads/a.csv"]
+
+
+def test_index_engine_path_hint_matches_a_dir_by_its_own_last_segment(tmp_path):
+    """A dirs row IS a directory, so the hint has to match its final segment as
+    well as an ancestor one — otherwise "the downloads folder" could never
+    return ~/Downloads itself."""
+    cfg = _index(tmp_path, "/r", [], dirs=[
+        "/r/Downloads", "/r/Downloads/inner", "/r/my-downloads-backup",
+        "/r/Documents"])
+    out = _search_index(spec(kind="dir", path_hints=["downloads"]), cfg)
+    assert _paths(out) == ["/r/Downloads", "/r/Downloads/inner"]
+
+
+def test_index_engine_answers_a_path_hints_only_spec(tmp_path):
+    """path_hints narrows, so it is enough on its own: "in downloads" is a
+    legitimately answerable query rather than a rejected one."""
+    cfg = _index(tmp_path, "/r", [("/r/Downloads/a.csv", 10, 100.0),
+                                  ("/r/Documents/b.csv", 10, 100.0)],
+                 dirs=["/r/Downloads", "/r/Documents"])
+    out = _search_index(spec(path_hints=["downloads"]), cfg)
+    assert _paths(out) == ["/r/Downloads", "/r/Downloads/a.csv"]
+
+
+def test_index_engine_path_hint_metachars_stay_literal(tmp_path):
+    """`_` is a LIKE wildcard; a hint carrying one must not match a lookalike
+    sibling (the like_literal + ESCAPE contract)."""
+    cfg = _index(tmp_path, "/r", [("/r/pro_j/a.csv", 10, 100.0),
+                                  ("/r/pro-j/b.csv", 10, 100.0)])
+    out = _search_index(
+        spec(kind="file", extensions=["csv"], path_hints=["pro_j"]), cfg)
+    assert _paths(out) == ["/r/pro_j/a.csv"]
 
 
 def test_index_engine_lets_dirs_past_extension_and_size_filters(tmp_path):

--- a/tests/test_search_index.py
+++ b/tests/test_search_index.py
@@ -31,7 +31,6 @@ def spec(**over):
         "name_terms": [],
         "extensions": [],
         "kind": "any",
-        "modified_within_days": None,
         "modified_after": None,
         "modified_before": None,
         "min_size_bytes": None,
@@ -77,7 +76,6 @@ def test_index_engine_matches_name_terms_case_insensitively(tmp_path):
                                   ("/r/notes.txt", 20, 200.0)])
     out = _search_index(spec(name_terms=["weather"]), cfg)
     assert _paths(out) == ["/r/Weather Report.csv"]
-    assert out["engine"] == "index"
     assert out["truncated"] is False
 
 
@@ -172,16 +170,6 @@ def test_index_engine_date_ranges_are_inclusive_local_days(tmp_path):
     out = _search_index(
         spec(modified_after="2026-06-01", modified_before="2026-06-30"), cfg)
     assert _paths(out) == ["/r/first-instant.txt", "/r/last-instant.txt"]
-
-
-def test_index_engine_honors_modified_within_days(tmp_path):
-    import time
-
-    now = time.time()
-    cfg = _index(tmp_path, "/r", [("/r/fresh.txt", 10, now - 3600),
-                                  ("/r/stale.txt", 10, now - 10 * 86400)])
-    out = _search_index(spec(modified_within_days=2), cfg)
-    assert _paths(out) == ["/r/fresh.txt"]
 
 
 def test_index_engine_screens_hidden_and_junk_paths(tmp_path):
@@ -395,10 +383,10 @@ def test_a_never_built_index_is_an_error_not_an_empty_disk(tmp_path):
 
 def test_a_zero_hit_query_is_an_honest_empty_result(tmp_path):
     """A miss is a miss. There is no wider engine to consult, so an empty
-    result set is the answer — reported as one, with `engine` still set."""
+    result set is the answer — reported as one."""
     cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
     out = _search_index(spec(name_terms=["nothing-like-this"]), cfg)
-    assert out == {"entries": [], "truncated": False, "engine": "index"}
+    assert out == {"entries": [], "truncated": False}
 
 
 def test_index_engine_refuses_a_spec_with_no_narrowing_constraint(tmp_path):
@@ -437,7 +425,9 @@ def test_the_endpoint_has_no_engine_but_the_index(client, tmp_path, monkeypatch)
     res = client.post("/api/search/files", json={"name_terms": ["quarterly"]})
     assert res.status_code == 200
     body = res.json()
-    assert body["engine"] == "index"
+    # No `engine` discriminator in the response: with one engine it only ever
+    # said "index", and the one client that reads this never used it.
+    assert "engine" not in body
     assert [e["path"] for e in body["entries"]] == ["/r/quarterly.csv"]
 
 
@@ -455,14 +445,4 @@ def test_the_endpoint_returns_an_empty_ok_for_a_miss(client, tmp_path, monkeypat
     monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
     res = client.post("/api/search/files", json={"name_terms": ["zzzz"]})
     assert res.status_code == 200
-    assert res.json() == {"ok": True, "entries": [], "truncated": False,
-                          "engine": "index"}
-
-
-def test_the_endpoint_rejects_a_creation_date_filter(client, tmp_path, monkeypatch):
-    cfg = _index(tmp_path, "/r", [("/r/a.txt", 10, 100.0)])
-    monkeypatch.setattr(search_mod, "load_config", lambda: cfg)
-    res = client.post("/api/search/files",
-                      json={"name_terms": ["a"], "created_after": "2026-06-01"})
-    assert res.status_code == 400
-    assert "created" in res.json()["error"]
+    assert res.json() == {"ok": True, "entries": [], "truncated": False}


### PR DESCRIPTION
## Summary

- **The explorer home page is a search bar again, not an AI composer.** Typing ranks the home tree instantly from the file index and paints as you go — a plain `invoice` no longer spends a haiku round trip to learn that `invoice` is a filename.
- **Typing anywhere on the page lands in the box.** The caret starts there, and any printable keystroke aimed at nothing else focuses it — nobody should have to click a search box on a search page. Chords (ctrl/alt/meta), other fields, and the box already holding the caret are all left alone; that last one matters because a redundant `focus()` would collapse the caret to the end and make editing the middle of a query impossible.
- **Ten result rows, not forty.** The AI row is the last row, so the cap decides whether it is visible: at 40 it sat two screens below the fold, exactly where a user who has just failed to find their file will not look.
- **AI search became one row at the bottom of the results**, taken deliberately. With zero index matches it is the only row and is pre-selected, so the "I meant something fuzzier" case is one Enter away; with hits showing, Enter waits for a choice rather than spending a model call on results you were already reading.
- **A cold index is reported, never faked.** The home page has no live-walk fallback (that's the listing's job), so an uncovered root reads "still building" with AI as the primary action — not "no matches".
- **The AI path shed everything that existed only to make AI-first tolerable**: the keyword `fallbackSpec`, the `hasEngineNarrowing` silent downgrade, and the name-terms-stripped retry query are gone. One model call, one engine query, and a failure surfaces in the banner — the index results the user still has are the real fallback.
- **Dead legacy dropped from the search router**: `modified_within_days`, the `created_*` refusal branch, and the constant `"engine": "index"` response field. No non-frontend consumers existed; removing the relative-days cutoff also stranded `now_s` and the `time` import through four helpers.

## Visuals

The rewired flow — everything above `Navigate` happens with no model involved:

```mermaid
flowchart TD
    K[Keystroke anywhere] --> F{"printable? no chord?<br/>no other field?"}
    F -->|no| P[left to the page]
    F -->|yes| D[focus box, debounce 120ms]
    D --> R[rank corpus locally]
    R --> L[File rows + 'Search with AI' row]
    L -->|pick a file| N[Navigate]
    L -->|pick the AI row| A[POST /api/ai → spec]
    A --> E[POST /api/search/files]
    E --> H[AI results + 'Understood as' echo]
```

The corpus behind `rank corpus locally` is fetched once per index generation, not per keystroke; a cold index short-circuits `rank` to a "still building" note.

## Usage

Open `/explorer` and type. No click, no Enter.

| Input | Behaviour |
|---|---|
| `csv` | instant ranked index results, capped at 10 with a `Showing top 10 of 4,690+` note |
| `↑` / `↓` | move the highlight across file rows and the AI row |
| `Enter` | opens the highlighted row; with zero matches, runs the AI search |
| `~/Downloads` | `statPath`s clean → navigates straight there instead of searching |
| `big png images from this year` → AI row | one model call → one engine query, with the `Understood as: .png · files · modified since 2026-01-01 · ≥10MB` echo |
| `Esc` | clears |
| type after a stray background click | focus returns to the box and the character lands in it |
| `Ctrl`/`Cmd`/`Alt` + key | left to the page — shortcuts are not typing |

`?q=` is written only for a committed AI search (so a reload restores it), and dropped once the query is edited — not on every keystroke.

## Test Plan

- [x] **Automated, new**: `redirectsToSearch` in `home-search.test.ts` — printable keys (incl. non-Latin symbols and Backspace) claimed; ctrl/alt/meta chords, named keys, other `INPUT`/`TEXTAREA`/`SELECT`/contenteditable targets, and the box-already-focused case all left alone.
- [x] **Automated, new**: `frontend/src/apps/explorer/lib/home-search.test.ts` — path shortcut forms (`~`, `~/`, drive letters, trailing slashes), the cap/count note incl. index-truncation `+`, `cold` vs `ok` corpus decisions, and the keyboard row arithmetic (`stepHighlight` wrap-around, `activeRow` zero-hit pre-selection).
- [x] **Automated, updated**: `frontend/src/apps/explorer/lib/ai-search.test.ts` — pins that a garbage model reply and a path-hints-only spec both throw and that **nothing** reaches `/api/search/files`, and that an empty result set no longer triggers a retry call.
- [x] **Automated, updated**: `tests/test_search.py`, `tests/test_search_index.py` — legacy keys removed from the spec surface. 44 pass.
- [x] Full frontend suite **581 pass / 0 fail**; `tsc --noEmit` clean; `check:boundaries` OK (209 files).
- [x] **Manual, browser-driven**: on a fresh `/explorer` load, `c` `s` `v` pressed with nothing clicked produced `Showing top 10 of 4,690+` with the AI row on screen unscrolled; after clicking a non-focusable background element, the next character still landed in the box.
- [x] **Manual, in the running dev server** (screenshotted locally, browser-driven): instant results while typing; 40 rows + AI row as the 41st option; ↑/↓ highlight; zero-match state; clicking **Search with AI** ran the real pipeline (6 hits for `csv spreadsheets`, an honest zero for `big png images from this year`); `~/Downloads` navigation; `?q=` restore on reload and drop on edit; light theme spot-checked.
- [ ] **Not verified**: a genuinely cold index (this machine's is fully built) and `/api/ai` being down — both paths are covered by unit tests only.

### Known cost worth a reviewer's eye

The corpus fetch is `GET /api/index/search?root=$HOME` with no `q`, which is **~26 MB / ~2.0 s** on a 175k-entry home — paid once on the first keystroke, then reused. Passing `q=` server-side would avoid it but bypasses the client-side fuzzy ranking this deliberately shares with the in-folder listing search, so the two boxes can't order results differently. Scoring runs through `listing/scan-job.ts` (yielding), not a synchronous pass, so the big corpus doesn't freeze the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
