### PR TITLE
Map viewer: fill/line opacity, drag-and-drop import, categorical rasters

### DIFF
--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -77,6 +77,8 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(HERE), "shared"))
 from appenv import skill_plugin_dir as _skill_plugin_dir
 from appenv import workspace_dir as _workspace_dir
+from private_dir import private_dir as _private_dir_under
+from private_dir import require_private as _require_private
 from procutil import pid_alive as _pid_alive
 
 def _runs_root() -> str:
@@ -667,99 +669,12 @@ def _state_dir(run_dir: str) -> str:
     return os.path.join(run_dir, "appstate")
 
 
-def _within_our_tree(path: str) -> bool:
-    """Whether `path` is our runs root or something under it — i.e. a
-    directory we are responsible for, rather than the system's temp root."""
-    root = os.path.dirname(RUNS)
-    return os.path.abspath(path) == root or \
-        os.path.abspath(path).startswith(root + os.sep)
-
-
-def _require_private(path: str) -> None:
-    """Refuse a directory in our tree that we did not make, or that anyone
-    else can write to.
-
-    The temp root is world-writable, and our path under it is *predictable* —
-    `fused_render_claude-<uid>` names the victim. So another account can
-    pre-create it, or `runs` inside it, before we ever run. Adopting that hands
-    them the parent of every run dir, and the parent is enough: the sticky bit
-    that stops one account renaming another's entry protects OUR entries in
-    /tmp, but it is not inherited by a directory THEY created. They can rename
-    the 0700 run dir aside the instant after `mkdir` returns and leave a
-    world-readable one in its place, and the transcript, the user's message
-    and every tool payload get written into it. The 0700 means nothing if the
-    thing above it is theirs.
-
-    `lstat`, not `stat`: a symlink is not a directory we own, however good its
-    target looks. Raising is the right outcome — an attacker who plants the
-    directory can deny us the chat, but a loud failure is not a disclosure.
-    """
-    st = os.lstat(path)
-    if not stat.S_ISDIR(st.st_mode):
-        raise NotADirectoryError(
-            "%s is not a directory (a symlink or file is in the way)" % path)
-    geteuid = getattr(os, "geteuid", None)
-    if geteuid is None:
-        return  # Windows: no uid model here, and its temp dir is already per-user
-    if st.st_uid != geteuid():
-        raise PermissionError(
-            "%s belongs to uid %d, not %d — refusing to keep this conversation "
-            "under a directory another account controls" % (path, st.st_uid, geteuid()))
-    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
-        raise PermissionError(
-            "%s is writable by others (mode %04o) — refusing to keep this "
-            "conversation there" % (path, stat.S_IMODE(st.st_mode)))
-
-
 def _private_dir(path: str) -> None:
-    """Create `path` and any missing parents as `rwx------`.
-
-    The run tree lives under the shared temp root, and on a typical Linux box
-    that means /tmp with a default 0755 for anything created in it — while a
-    run dir holds the entire conversation: `out.jsonl` is the transcript,
-    `meta.json` the user's message, and `perm/*.req.json` every tool payload
-    there is (commands, edited file content, web inputs). None of it should be
-    readable by another local account. macOS' per-user temp root happens to
-    make the exposure moot there, which is exactly why it cannot be relied on.
-
-    Levels are created one at a time because `os.makedirs` has applied `mode`
-    to the leaf only since 3.7. Existing directories are deliberately NOT
-    chmod'ed: the chain starts at a directory we do not own (tightening the
-    temp root would be a far worse bug than the one being fixed), and the run
-    dir underneath — always freshly created here, always 0700 — is the level
-    that actually contains the data.
-
-    Parents tolerate losing the race, the leaf does not. Our root and `runs`
-    are shared by every run of ours, so two templates starting their first run
-    at once both find them missing and both call mkdir — and the loser used to
-    abort `_start`, so the user's message simply never sent. Whoever won is
-    fine, PROVIDED it is ours (`_require_private`). The **leaf** stays an
-    exclusive create: it is this run's private 0700 boundary, so finding one
-    already there means a run-id collision or somebody else's directory, and
-    quietly adopting it is the wrong answer.
-    """
-    path = os.path.abspath(path)
-    missing = []
-    head = os.path.dirname(path)
-    while head and not os.path.isdir(head):
-        head, tail = os.path.split(head)
-        if not tail:
-            break
-        missing.append(tail)
-    # `head` is the deepest thing that already exists. Anything from our own
-    # root downwards has to be vouched for before we build on it; above that
-    # is the temp root, which belongs to the system.
-    if _within_our_tree(head):
-        _require_private(head)
-    for tail in reversed(missing):
-        head = os.path.join(head, tail)
-        try:
-            os.mkdir(head, 0o700)
-        except FileExistsError:
-            # Somebody got here first. A concurrent run of ours is fine; a
-            # directory another account planted is not.
-            _require_private(head)
-    os.mkdir(path, 0o700)
+    """shared/private_dir.py's `private_dir`, anchored at our own root (the
+    parent of `RUNS`, read per call): anything from it downwards is vouched
+    for before being built on; above it is the temp root, which belongs to
+    the system."""
+    _private_dir_under(path, os.path.dirname(RUNS))
 
 
 def _private_open(path: str):

--- a/fused_render/templates/map/discover.py
+++ b/fused_render/templates/map/discover.py
@@ -1,9 +1,14 @@
-"""Mount-safe filesystem discovery for the Map Viewer file-picker modal."""
+"""Mount-safe filesystem discovery for the Map Viewer file-picker modal, and
+the staging directory OS drag-and-drops upload into (action="drops_dir")."""
 from __future__ import annotations
 
 import json
 import os
+import stat
 import string
+import sys
+import tempfile
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -11,9 +16,15 @@ from pathlib import Path
 from typing import Any
 
 if __package__:
+    from ..shared.private_dir import private_dir, require_private
     from .geo_paths import is_remote_path, normalize_remote_path
 else:
+    if "__file__" not in globals():
+        __file__ = os.path.join(sys.path[0], "discover.py")
+    sys.path.insert(0, os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "shared"))
     from geo_paths import is_remote_path, normalize_remote_path
+    from private_dir import private_dir, require_private
 
 
 RASTER = (
@@ -209,7 +220,100 @@ def _local_payload(requested: str) -> dict[str, Any]:
     return _payload(str(path), triples, selected=selected)
 
 
-def main(dir: str = "", src: str = "") -> dict[str, Any]:
+def _drops_root() -> str:
+    """Where OS drag-and-drops are staged: a per-user tree under the shared
+    temp root, the same layout as claude/agent.py's `_runs_root` and for the
+    same reason — one shared name cannot be both 0700-private and usable by a
+    second account, and a per-uid root dissolves the contention. POSIX-only
+    suffix: Windows has no `geteuid` and its temp dir is already per-user."""
+    geteuid = getattr(os, "geteuid", None)
+    suffix = "-%d" % geteuid() if geteuid is not None else ""
+    return os.path.join(tempfile.gettempdir(), "fused_render_map" + suffix, "drops")
+
+
+DROPS = _drops_root()
+
+# Staged drops are scratch, not storage: a file only has to outlive the map
+# session whose layer points at it, but it can be a multi-GB raster — so the
+# TTL is generous (a week comfortably outlives any open session) and the count
+# backstop small next to the screenshot pruner's 200 tiny crops.
+DROPS_TTL = 7 * 24 * 3600
+DROPS_KEEP = 50
+
+
+def _prune_drops() -> None:
+    """Drop staged files whose session is long gone. Best-effort throughout:
+    this is housekeeping on a temp directory, and no failure here is worth
+    refusing the user their drop over."""
+    try:
+        names = os.listdir(DROPS)
+    except OSError:
+        return
+    now = time.time()
+    aged = []
+    for name in names:
+        path = os.path.join(DROPS, name)
+        try:
+            mtime = os.lstat(path).st_mtime
+        except OSError:
+            continue
+        aged.append((mtime, path))
+    stale = [p for m, p in aged if now - m > DROPS_TTL]
+    # Oldest first, so what survives the count cap is the recent session.
+    aged.sort()
+    excess = [p for _m, p in aged[:max(0, len(aged) - DROPS_KEEP)]]
+    for path in set(stale) | set(excess):
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def _drops_dir() -> dict[str, Any]:
+    """Ensure the drop staging directory exists and hand its path to the page.
+
+    Same shape and same asymmetry as claude/agent.py's `_shots_dir`: the
+    directory is SHARED and long-lived, so an existing one is adopted rather
+    than refused — but only after `require_private` vouches for it, and on
+    POSIX a merely world-READABLE one is tightened or refused (the drops are
+    the user's own data files). A refusal (`require_private` raising)
+    propagates; an ordinary OSError becomes an error dict, which the page
+    surfaces as a failed drop rather than a crash.
+    """
+    if os.path.isdir(DROPS):
+        require_private(DROPS)
+        if hasattr(os, "geteuid"):
+            try:
+                mode = stat.S_IMODE(os.lstat(DROPS).st_mode)
+                if mode & ~0o700:
+                    os.chmod(DROPS, 0o700)
+                    # Re-read rather than trust the call: an ACL, or a
+                    # filesystem that does not carry unix modes, can accept a
+                    # chmod and keep the bits exactly where they were.
+                    mode = stat.S_IMODE(os.lstat(DROPS).st_mode)
+            except OSError as error:
+                return {"error": f"Could not secure the drop directory: {error}"}
+            if mode & ~0o700:
+                return {
+                    "error": "The drop directory is readable by others "
+                    f"(mode {mode:04o}) and could not be tightened"
+                }
+    else:
+        try:
+            private_dir(DROPS, os.path.dirname(DROPS))
+        except FileExistsError:
+            # Another page asked at the same moment. Theirs is fine if it is
+            # ours; require_private is what decides that (and raises if not).
+            require_private(DROPS)
+        except OSError as error:
+            return {"error": f"Could not prepare the drop directory: {error}"}
+    _prune_drops()
+    return {"dir": DROPS}
+
+
+def main(dir: str = "", src: str = "", action: str = "") -> dict[str, Any]:
+    if action == "drops_dir":
+        return _drops_dir()
     requested = os.path.abspath(clean_path(dir) or str(Path.home()))
     if src:
         status, metadata = _stat(src, requested)

--- a/fused_render/templates/map/geo_classify.py
+++ b/fused_render/templates/map/geo_classify.py
@@ -34,7 +34,7 @@ import os
 
 from geo_paths import is_remote_path, normalize_remote_path
 from optional_runtime import require
-from raster_categories import classify_categories
+from raster_categories import classify_categories, resolve_render_mode
 
 # ---- output caps (keep artifacts screen-sized / network-friendly) -----------
 MAX_RASTER_DIM = 1400        # longest edge of the reprojected raster PNG
@@ -702,7 +702,7 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
         except Exception:
             categories = None
     requested_mode = str(opts.get("render_mode") or "")
-    categorical = bool(categories) and ds.count < 3 and requested_mode != "single"
+    categorical = resolve_render_mode(ds.count, categories, embedded_colormap, requested_mode) == "categorical"
     warp_resampling = Resampling.nearest if categorical else Resampling.bilinear
 
     with WarpedVRT(ds, crs="EPSG:4326", resampling=warp_resampling) as vrt:
@@ -810,7 +810,7 @@ def _render_array(arr, bounds, artifact_dir, artifact_id, opts, detected):
     if count < 3:
         categories = classify_categories(arr[0], dtype0, overrides=opts.get("category_colors"))
     requested_mode = str(opts.get("render_mode") or "")
-    categorical = bool(categories) and count < 3 and requested_mode != "single"
+    categorical = resolve_render_mode(count, categories, None, requested_mode) == "categorical"
 
     category_colors = {}
     if count >= 3:

--- a/fused_render/templates/map/geo_classify.py
+++ b/fused_render/templates/map/geo_classify.py
@@ -27,12 +27,14 @@ Descriptor shape:
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import math
 import os
 
 from geo_paths import is_remote_path, normalize_remote_path
 from optional_runtime import require
+from raster_categories import classify_categories
 
 # ---- output caps (keep artifacts screen-sized / network-friendly) -----------
 MAX_RASTER_DIM = 1400        # longest edge of the reprojected raster PNG
@@ -675,13 +677,41 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
     d["crs_original"] = ds.crs.to_string()
     warnings = []
 
-    with WarpedVRT(ds, crs="EPSG:4326", resampling=Resampling.bilinear) as vrt:
+    # Categorical eligibility is decided from the source dataset, before
+    # reprojection: a bilinear warp would blend adjacent integer class codes
+    # into meaningless values, so a categorical raster must be resampled
+    # with "nearest" for the warp too, not just for the final render.
+    dtype0 = str(ds.dtypes[0])
+    embedded_colormap = None
+    if ds.count < 3:
+        with contextlib.suppress(ValueError):
+            embedded_colormap = ds.colormap(1)
+    categories = None
+    if ds.count < 3:
+        try:
+            sample = ds.read(
+                1,
+                out_shape=(min(ds.height, 256), min(ds.width, 256)),
+                resampling=Resampling.nearest,
+                masked=True,
+            )
+            categories = classify_categories(
+                sample, dtype0, embedded_colormap=embedded_colormap,
+                overrides=opts.get("category_colors"),
+            )
+        except Exception:
+            categories = None
+    requested_mode = str(opts.get("render_mode") or "")
+    categorical = bool(categories) and ds.count < 3 and requested_mode != "single"
+    warp_resampling = Resampling.nearest if categorical else Resampling.bilinear
+
+    with WarpedVRT(ds, crs="EPSG:4326", resampling=warp_resampling) as vrt:
         scale = min(1.0, MAX_RASTER_DIM / max(vrt.width, vrt.height))
         out_h = max(1, int(round(vrt.height * scale)))
         out_w = max(1, int(round(vrt.width * scale)))
         count = vrt.count
         data = vrt.read(out_shape=(count, out_h, out_w),
-                        resampling=Resampling.bilinear, masked=True)
+                        resampling=warp_resampling, masked=True)
         b = vrt.bounds  # (left, bottom, right, top) in EPSG:4326
 
     bounds = [float(b[0]), float(b[1]), float(b[2]), float(b[3])]
@@ -698,6 +728,7 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
     rescale = opts.get("rescale")  # optional [lo, hi]
 
     band_stats = []
+    category_colors = {}
     if count >= 3:
         chans = []
         for i in range(3):
@@ -712,6 +743,14 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
         alpha = np.where(valid_all, 255, 0).astype("uint8")
         rgba = np.dstack([chans[0], chans[1], chans[2], alpha])
         mode = "rgb"
+    elif categorical:
+        band = arr[0]
+        category_colors = {c["value"]: tuple(c["color"]) for c in categories}
+        rgba = np.zeros((out_h, out_w, 4), dtype="uint8")
+        for value, color in category_colors.items():
+            rgba[band == value] = color
+        band_stats.append({"index": 1, "p2": None, "p98": None})
+        mode = "categorical"
     else:
         band = arr[0]
         finite = band[np.isfinite(band)]
@@ -735,13 +774,15 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
     d["data"] = {"image_path": image_path}
     d["stats"] = {
         "bands": int(count), "width": int(out_w), "height": int(out_h),
-        "dtype": str(ds.dtypes[0]), "nodata": _finite(ds.nodata),
+        "dtype": dtype0, "nodata": _finite(ds.nodata),
         "band_stats": band_stats, "render_mode": mode,
+        "categories": categories,
     }
     d["style"] = {
         "opacity": 0.9, "colormap": colormap,
         "rescale": [band_stats[0].get("p2"), band_stats[0].get("p98")] if mode == "single" else None,
         "render_mode": mode,
+        "category_colors": {str(value): list(color) for value, color in category_colors.items()},
     }
     d["warnings"] = warnings
     return d
@@ -752,6 +793,7 @@ def _render_array(arr, bounds, artifact_dir, artifact_id, opts, detected):
     import numpy as np
     from PIL import Image
 
+    dtype0 = str(np.asarray(arr).dtype)
     arr = np.asarray(arr).astype("float64")
     if arr.ndim == 2:
         arr = arr[None, :, :]
@@ -764,6 +806,13 @@ def _render_array(arr, bounds, artifact_dir, artifact_id, opts, detected):
     d = _base(artifact_id, detected)
     d["bounds"] = [float(v) for v in bounds]
 
+    categories = None
+    if count < 3:
+        categories = classify_categories(arr[0], dtype0, overrides=opts.get("category_colors"))
+    requested_mode = str(opts.get("render_mode") or "")
+    categorical = bool(categories) and count < 3 and requested_mode != "single"
+
+    category_colors = {}
     if count >= 3:
         chans = []
         for i in range(3):
@@ -775,6 +824,13 @@ def _render_array(arr, bounds, artifact_dir, artifact_id, opts, detected):
         alpha = np.where(np.isfinite(arr[:3]).all(axis=0), 255, 0).astype("uint8")
         rgba = np.dstack([chans[0], chans[1], chans[2], alpha])
         mode = "rgb"
+    elif categorical:
+        band = arr[0]
+        category_colors = {c["value"]: tuple(c["color"]) for c in categories}
+        rgba = np.zeros((band.shape[0], band.shape[1], 4), dtype="uint8")
+        for value, color in category_colors.items():
+            rgba[band == value] = color
+        mode = "categorical"
     else:
         band = arr[0]
         finite = band[np.isfinite(band)]
@@ -790,6 +846,10 @@ def _render_array(arr, bounds, artifact_dir, artifact_id, opts, detected):
     d["kind"] = "raster_image"
     d["data"] = {"image_path": image_path}
     d["stats"] = {"bands": int(count), "render_mode": mode,
-                  "width": int(arr.shape[-1]), "height": int(arr.shape[-2])}
-    d["style"] = {"opacity": 0.9, "colormap": colormap, "render_mode": mode}
+                  "width": int(arr.shape[-1]), "height": int(arr.shape[-2]),
+                  "categories": categories}
+    d["style"] = {
+        "opacity": 0.9, "colormap": colormap, "render_mode": mode,
+        "category_colors": {str(value): list(color) for value, color in category_colors.items()},
+    }
     return d

--- a/fused_render/templates/map/geo_classify.py
+++ b/fused_render/templates/map/geo_classify.py
@@ -34,7 +34,7 @@ import os
 
 from geo_paths import is_remote_path, normalize_remote_path
 from optional_runtime import require
-from raster_categories import classify_categories, resolve_render_mode
+from raster_categories import classify_categories, read_pam_aux_xml, resolve_render_mode
 
 # ---- output caps (keep artifacts screen-sized / network-friendly) -----------
 MAX_RASTER_DIM = 1400        # longest edge of the reprojected raster PNG
@@ -683,9 +683,13 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
     # with "nearest" for the warp too, not just for the final render.
     dtype0 = str(ds.dtypes[0])
     embedded_colormap = None
+    aux_labels = None
     if ds.count < 3:
         with contextlib.suppress(ValueError):
             embedded_colormap = ds.colormap(1)
+        aux_colors, aux_labels = read_pam_aux_xml(ds.name)
+        if not embedded_colormap and aux_colors:
+            embedded_colormap = aux_colors
     categories = None
     if ds.count < 3:
         try:
@@ -697,7 +701,7 @@ def _render_raster(ds, artifact_dir, artifact_id, opts, detected):
             )
             categories = classify_categories(
                 sample, dtype0, embedded_colormap=embedded_colormap,
-                overrides=opts.get("category_colors"),
+                overrides=opts.get("category_colors"), labels=aux_labels,
             )
         except Exception:
             categories = None

--- a/fused_render/templates/map/map_render.py
+++ b/fused_render/templates/map/map_render.py
@@ -49,6 +49,7 @@ BACKEND_FILES = (
     HERE / "vector_engine.py",
     HERE / "geo_classify.py",
     HERE / "geo_paths.py",
+    HERE / "raster_categories.py",
 )
 RASTER_SUFFIXES = (
     ".tif", ".tiff", ".cog", ".vrt", ".jp2", ".j2k", ".img", ".ntf",
@@ -306,6 +307,8 @@ def main(
     warmup: str = "",
     source_url: str = "",
     source_origin: str = "",
+    render_mode: str = "",
+    category_colors: str = "",
 ):
     if warmup:
         try:
@@ -357,6 +360,13 @@ def main(
         try:
             lo, hi = (float(value) for value in rescale.split(","))
             options["rescale"] = [lo, hi]
+        except ValueError:
+            pass
+    if render_mode:
+        options["render_mode"] = render_mode
+    if category_colors:
+        try:
+            options["category_colors"] = json.loads(category_colors)
         except ValueError:
             pass
 

--- a/fused_render/templates/map/raster_categories.py
+++ b/fused_render/templates/map/raster_categories.py
@@ -38,6 +38,7 @@ def classify_categories(
     dtype: str,
     embedded_colormap: dict[int, tuple[int, ...]] | None = None,
     overrides: dict[str, Any] | None = None,
+    labels: dict[int, str] | None = None,
     cap: int = CATEGORY_CAP,
 ) -> list[dict[str, Any]] | None:
     """Return a per-value legend for a categorical raster, or ``None`` if
@@ -53,12 +54,14 @@ def classify_categories(
     presence alone makes the raster eligible, and its colors take
     precedence over the fallback ``PALETTE``. ``overrides`` is
     ``{str(value): "#hex" | [r,g,b,a]}`` from user edits in the style dock;
-    it wins over both.
+    it wins over both. ``labels`` is ``{value: class name}`` (e.g. from a
+    PAM raster attribute table); unnamed values keep ``str(value)``.
     """
     import numpy as np
 
     is_int = np.issubdtype(np.dtype(dtype), np.integer)
     sample = np.ma.compressed(values) if np.ma.is_masked(values) else np.asarray(values).ravel()
+    sample = sample[np.isfinite(sample)]
     if sample.size == 0:
         return None
     unique, sample_counts = np.unique(sample, return_counts=True)
@@ -89,15 +92,124 @@ def classify_categories(
             color = raw if len(raw) == 4 else raw[:3] + (255,)
         else:
             color = PALETTE[i % len(PALETTE)] + (255,)
+        name = labels.get(value) if labels else None
         categories.append(
             {
                 "value": value,
-                "label": str(value),
+                "label": str(value) if name is None else str(name),
                 "color": list(color),
                 "count": counts.get(value, 0),
             }
         )
     return categories
+
+
+# GDALRATFieldUsage codes from gdal.h.
+_GFU_NAME = 2
+_GFU_MINMAX = 5
+_GFU_RED, _GFU_GREEN, _GFU_BLUE, _GFU_ALPHA = 6, 7, 8, 9
+
+_RAT_NAME_ALIASES = {
+    "value": ("value",),
+    "red": ("red",),
+    "green": ("green",),
+    "blue": ("blue",),
+    "alpha": ("alpha",),
+    "name": ("class_name", "classname", "class name", "category", "label", "class", "name"),
+}
+
+
+def _rat_column(fields: list[tuple[str, int]], role: str, usage: int) -> int | None:
+    for index, (_, field_usage) in enumerate(fields):
+        if field_usage == usage:
+            return index
+    aliases = _RAT_NAME_ALIASES[role]
+    for index, (name, _) in enumerate(fields):
+        if name.lower() in aliases:
+            return index
+    return None
+
+
+def _parse_pam_band(band) -> tuple[dict[int, tuple[int, int, int, int]] | None, dict[int, str] | None]:
+    colors = None
+    table = band.find(".//ColorTable")
+    if table is not None:
+        colors = {
+            index: (
+                int(entry.get("c1", 0)),
+                int(entry.get("c2", 0)),
+                int(entry.get("c3", 0)),
+                int(entry.get("c4", 255)),
+            )
+            for index, entry in enumerate(table.findall("Entry"))
+        } or None
+
+    labels = None
+    rat = band.find(".//GDALRasterAttributeTable")
+    if rat is not None:
+        fields = [
+            (defn.findtext("Name", ""), int(defn.findtext("Usage", "0")))
+            for defn in rat.findall("FieldDefn")
+        ]
+        value_col = _rat_column(fields, "value", _GFU_MINMAX)
+        name_col = _rat_column(fields, "name", _GFU_NAME)
+        rgb_cols = [
+            _rat_column(fields, role, usage)
+            for role, usage in (("red", _GFU_RED), ("green", _GFU_GREEN), ("blue", _GFU_BLUE))
+        ]
+        alpha_col = _rat_column(fields, "alpha", _GFU_ALPHA)
+        rat_colors: dict[int, tuple[int, int, int, int]] = {}
+        rat_labels: dict[int, str] = {}
+        for row_index, row in enumerate(rat.findall("Row")):
+            cells = [cell.text or "" for cell in row.findall("F")]
+            value = (
+                int(float(cells[value_col]))
+                if value_col is not None and value_col < len(cells)
+                else row_index
+            )
+            if name_col is not None and name_col < len(cells) and cells[name_col].strip():
+                rat_labels[value] = cells[name_col].strip()
+            if all(col is not None and col < len(cells) for col in rgb_cols):
+                r, g, b = (int(float(cells[col])) for col in rgb_cols)
+                a = (
+                    int(float(cells[alpha_col]))
+                    if alpha_col is not None and alpha_col < len(cells)
+                    else 255
+                )
+                rat_colors[value] = (r, g, b, a)
+        # An embedded ColorTable outranks RAT colors, matching GDAL itself.
+        if colors is None and rat_colors:
+            colors = rat_colors
+        if rat_labels:
+            labels = rat_labels
+    return colors, labels
+
+
+def read_pam_aux_xml(
+    raster_path: str,
+) -> tuple[dict[int, tuple[int, int, int, int]] | None, dict[int, str] | None]:
+    """Class colors/labels from GDAL's PAM sidecar (``<raster_path>.aux.xml``).
+
+    Covers what rasterio has no API for: raster attribute tables, plus the
+    ColorTable case when GDAL's own sidecar discovery is disabled. The
+    sidecar is optional metadata, so any read/parse problem yields
+    ``(None, None)`` rather than failing the raster load.
+    """
+    import os
+    import xml.etree.ElementTree as ET
+
+    path = raster_path + ".aux.xml"
+    try:
+        if not os.path.isfile(path):
+            return None, None
+        root = ET.parse(path).getroot()
+        bands = root.findall(".//PAMRasterBand")
+        band = next((b for b in bands if b.get("band") == "1"), bands[0] if bands else None)
+        if band is None:
+            return None, None
+        return _parse_pam_band(band)
+    except Exception:
+        return None, None
 
 
 def resolve_render_mode(

--- a/fused_render/templates/map/raster_categories.py
+++ b/fused_render/templates/map/raster_categories.py
@@ -1,0 +1,100 @@
+"""Categorical (unique-value / paletted) raster classification shared by
+raster_engine.py's tiled path and geo_classify.py's one-shot path.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+CATEGORY_CAP = 30
+
+# Mirrors the CATEGORICAL swatch array in template.html so raster and vector
+# unique-value legends use the same colors.
+PALETTE: tuple[tuple[int, int, int], ...] = (
+    (255, 99, 71), (70, 193, 216), (255, 193, 7), (126, 211, 33), (171, 71, 188),
+    (255, 138, 101), (41, 182, 246), (141, 110, 99), (236, 64, 122), (102, 187, 106),
+)
+
+
+def _parse_override_color(value: Any) -> tuple[int, int, int, int] | None:
+    """Accept a "#rrggbb" hex string or an [r,g,b,(a)] sequence from the UI."""
+    if isinstance(value, str):
+        text = value.lstrip("#")
+        if len(text) != 6:
+            return None
+        try:
+            r, g, b = (int(text[i : i + 2], 16) for i in (0, 2, 4))
+        except ValueError:
+            return None
+        return (r, g, b, 255)
+    if isinstance(value, (list, tuple)) and len(value) >= 3:
+        r, g, b = int(value[0]), int(value[1]), int(value[2])
+        a = int(value[3]) if len(value) > 3 else 255
+        return (r, g, b, a)
+    return None
+
+
+def classify_categories(
+    values,
+    dtype: str,
+    embedded_colormap: dict[int, tuple[int, ...]] | None = None,
+    overrides: dict[str, Any] | None = None,
+    cap: int = CATEGORY_CAP,
+) -> list[dict[str, Any]] | None:
+    """Return a per-value legend for a categorical raster, or ``None`` if
+    *values* doesn't look like categorical data.
+
+    ``values`` is a sample of the band's pixel values (e.g. from a coarse
+    preview read) — it doesn't need to be exhaustive, just representative;
+    it may be a masked array (masked/nodata pixels are dropped).
+
+    ``embedded_colormap`` is GDAL's per-band color table
+    (``{int: (r,g,b,a)}``, from rasterio's ``dataset.colormap(band)``) when
+    the file ships its own palette (common for land-cover products); its
+    presence alone makes the raster eligible, and its colors take
+    precedence over the fallback ``PALETTE``. ``overrides`` is
+    ``{str(value): "#hex" | [r,g,b,a]}`` from user edits in the style dock;
+    it wins over both.
+    """
+    import numpy as np
+
+    is_int = np.issubdtype(np.dtype(dtype), np.integer)
+    sample = np.ma.compressed(values) if np.ma.is_masked(values) else np.asarray(values).ravel()
+    if sample.size == 0:
+        return None
+    unique, sample_counts = np.unique(sample, return_counts=True)
+    counts = {int(v): int(c) for v, c in zip(unique, sample_counts)}
+
+    eligible = bool(embedded_colormap) or (is_int and len(unique) <= cap)
+    if not eligible:
+        return None
+
+    if embedded_colormap:
+        candidates = [int(v) for v in unique if int(v) in embedded_colormap]
+        if not candidates:
+            # The table doesn't cover what's actually in the data (e.g. a
+            # stale/partial one) — fall back to the raw sample.
+            candidates = [int(v) for v in unique]
+    else:
+        candidates = [int(v) for v in unique]
+    candidates = sorted(candidates)[:cap]
+
+    overrides = overrides or {}
+    categories = []
+    for i, value in enumerate(candidates):
+        override = _parse_override_color(overrides.get(str(value)))
+        if override is not None:
+            color = override
+        elif embedded_colormap and value in embedded_colormap:
+            raw = tuple(int(c) for c in embedded_colormap[value])
+            color = raw if len(raw) == 4 else raw[:3] + (255,)
+        else:
+            color = PALETTE[i % len(PALETTE)] + (255,)
+        categories.append(
+            {
+                "value": value,
+                "label": str(value),
+                "color": list(color),
+                "count": counts.get(value, 0),
+            }
+        )
+    return categories

--- a/fused_render/templates/map/raster_categories.py
+++ b/fused_render/templates/map/raster_categories.py
@@ -69,14 +69,14 @@ def classify_categories(
         return None
 
     if embedded_colormap:
-        candidates = [int(v) for v in unique if int(v) in embedded_colormap]
+        candidates = sorted(int(v) for v in unique if int(v) in embedded_colormap)
         if not candidates:
             # The table doesn't cover what's actually in the data (e.g. a
-            # stale/partial one) — fall back to the raw sample.
-            candidates = [int(v) for v in unique]
+            # stale/partial one) — fall back to the raw sample, capped like
+            # the heuristic path below.
+            candidates = sorted(int(v) for v in unique)[:cap]
     else:
-        candidates = [int(v) for v in unique]
-    candidates = sorted(candidates)[:cap]
+        candidates = sorted(int(v) for v in unique)[:cap]
 
     overrides = overrides or {}
     categories = []
@@ -98,3 +98,33 @@ def classify_categories(
             }
         )
     return categories
+
+
+def resolve_render_mode(
+    count: int,
+    categories: list[dict[str, Any]] | None,
+    embedded_colormap: dict[int, tuple[int, ...]] | None,
+    requested_mode: str,
+) -> str:
+    """Decide "rgb" / "categorical" / "single" from band count, detected
+    categories, whether an embedded GDAL colormap backs them, and any
+    explicit ``opts["render_mode"]`` request (``""`` when nothing was
+    requested).
+
+    An embedded colormap is an authoritative signal ("this file IS paletted
+    data") and auto-defaults to categorical; the bare unique-value heuristic
+    (no colormap) is a weaker signal — plenty of ordinary continuous data is
+    coarsely quantized (an 8-bit hillshade, a small DEM) — so it only
+    switches to categorical on an explicit request, matching every other
+    style choice (colormap, opacity, ...) in never silently changing how an
+    already-open raster renders.
+    """
+    if count >= 3:
+        return "rgb"
+    if not categories:
+        return "single"
+    if requested_mode == "single":
+        return "single"
+    if requested_mode == "categorical":
+        return "categorical"
+    return "categorical" if embedded_colormap else "single"

--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -33,6 +33,7 @@ from geo_paths import (
     normalize_remote_path,
 )
 from optional_runtime import require
+from raster_categories import classify_categories
 
 
 AUTO_OPTIMIZE_MAX_BYTES = int(
@@ -249,6 +250,9 @@ class RasterSource:
     colormap: str
     rescale: list[list[float]]
     auto_rescale: bool = True
+    render_mode: str = "single"
+    categories: list[dict[str, Any]] | None = None
+    category_colors: dict[int, tuple[int, ...]] = field(default_factory=dict)
     preview_path: str | None = None
     optimized_path: str | None = None
     optimization: dict[str, Any] = field(
@@ -482,6 +486,7 @@ class RasterEngine:
             )
             requested = opts.get("rescale")
             auto_rescale = True
+            sample_data = None
             if (
                 isinstance(requested, list)
                 and len(requested) == 2
@@ -500,8 +505,50 @@ class RasterEngine:
                         np.all(preview_data.data == inferred_nodata, axis=0)[None, :, :],
                     )
                 rescale = _ranges(preview_data)
+                sample_data = preview_data
             else:
                 rescale = _dtype_ranges(dataset.dtypes, render_bands)
+
+            # Categorical eligibility only makes sense for a single-band
+            # source (an RGB composite isn't classified data). Reuses the
+            # preview read above when there is one; a manual/optimized
+            # rescale skips that read, so take one here instead purely to
+            # sample which discrete values are present.
+            categories = None
+            category_colors: dict[int, tuple[int, ...]] = {}
+            if render_bands == 1:
+                if sample_data is None:
+                    try:
+                        with Reader(locator) as reader:
+                            fallback_preview = reader.preview(indexes=indexes, max_size=256)
+                        sample_data = fallback_preview.array
+                        if inferred_nodata is not None:
+                            sample_data = sample_data.copy()
+                            sample_data.mask = np.logical_or(
+                                np.ma.getmaskarray(sample_data),
+                                np.all(sample_data.data == inferred_nodata, axis=0)[None, :, :],
+                            )
+                    except Exception:
+                        sample_data = None
+                embedded_colormap = None
+                with contextlib.suppress(ValueError):
+                    embedded_colormap = dataset.colormap(1)
+                if sample_data is not None:
+                    categories = classify_categories(
+                        sample_data,
+                        dataset.dtypes[0],
+                        embedded_colormap=embedded_colormap,
+                        overrides=opts.get("category_colors"),
+                    )
+                if categories:
+                    category_colors = {c["value"]: tuple(c["color"]) for c in categories}
+            requested_mode = str(opts.get("render_mode") or "")
+            if count >= 3:
+                render_mode = "rgb"
+            elif categories and requested_mode != "single":
+                render_mode = "categorical"
+            else:
+                render_mode = "single"
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", NoOverviewWarning)
@@ -535,6 +582,9 @@ class RasterEngine:
                 colormap=str(opts.get("colormap") or "viridis"),
                 rescale=rescale,
                 auto_rescale=auto_rescale,
+                render_mode=render_mode,
+                categories=categories,
+                category_colors=category_colors,
             )
 
         derivative = self.optimized_dir / f"{fingerprint}.tif"
@@ -585,6 +635,9 @@ class RasterEngine:
             existing = self.sources.get(fingerprint)
             if existing is not None:
                 existing.colormap = record.colormap
+                existing.render_mode = record.render_mode
+                existing.categories = record.categories
+                existing.category_colors = record.category_colors
                 if not record.auto_rescale:
                     existing.rescale = record.rescale
                     existing.auto_rescale = False
@@ -681,13 +734,17 @@ class RasterEngine:
                 "inferred_nodata": record.inferred_nodata,
                 "native_minzoom": record.minzoom,
                 "band_stats": stats,
-                "render_mode": "rgb" if record.count >= 3 else "single",
+                "render_mode": record.render_mode,
+                "categories": record.categories,
             },
             "style": {
                 "opacity": 0.9,
                 "colormap": record.colormap,
                 "rescale": record.rescale[0] if record.count < 3 else None,
-                "render_mode": "rgb" if record.count >= 3 else "single",
+                "render_mode": record.render_mode,
+                "category_colors": {
+                    str(value): list(color) for value, color in record.category_colors.items()
+                },
             },
             "minzoom": 0,
             "maxzoom": record.maxzoom,
@@ -961,7 +1018,12 @@ class RasterEngine:
                 return self.transparent_tile()
             locator = record.locator_for_zoom(z)
             revision = locator
-            key = (source_id, revision, z, x, y, record.colormap, tuple(map(tuple, record.rescale)))
+            categorical = record.render_mode == "categorical"
+            key = (
+                source_id, revision, z, x, y, record.colormap,
+                tuple(map(tuple, record.rescale)), record.render_mode,
+                tuple(sorted(record.category_colors.items())),
+            )
             cached = self.tile_cache.get(key)
             if cached is not None:
                 self.tile_cache.move_to_end(key)
@@ -970,6 +1032,7 @@ class RasterEngine:
             ranges = record.rescale
             colormap_name = record.colormap
             inferred_nodata = record.inferred_nodata
+            category_colors = record.category_colors
 
         try:
             with warnings.catch_warnings():
@@ -980,11 +1043,15 @@ class RasterEngine:
                         y,
                         z,
                         indexes=indexes,
+                        # Categorical class codes must never blend into
+                        # bogus intermediate values, including at the
+                        # lower-resolution preview derivative.
                         resampling_method=(
-                            "bilinear"
-                            if record.preview_path
-                            and locator == record.preview_path
-                            else "nearest"
+                            "nearest"
+                            if categorical or not (
+                                record.preview_path and locator == record.preview_path
+                            )
+                            else "bilinear"
                         ),
                     )
             if inferred_nodata is not None:
@@ -995,9 +1062,12 @@ class RasterEngine:
                     np.ma.getmaskarray(image.array),
                     invalid[None, :, :],
                 )
-            image.rescale(ranges)
-            color = cmap.get(colormap_name) if record.count < 3 else None
-            png = image.render(img_format="PNG", colormap=color)
+            if categorical and category_colors:
+                png = image.render(img_format="PNG", colormap=category_colors)
+            else:
+                image.rescale(ranges)
+                color = cmap.get(colormap_name) if record.count < 3 else None
+                png = image.render(img_format="PNG", colormap=color)
         except TileOutsideBounds:
             png = self.transparent_tile()
 

--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -33,7 +33,7 @@ from geo_paths import (
     normalize_remote_path,
 )
 from optional_runtime import require
-from raster_categories import classify_categories
+from raster_categories import classify_categories, resolve_render_mode
 
 
 AUTO_OPTIMIZE_MAX_BYTES = int(
@@ -251,6 +251,7 @@ class RasterSource:
     rescale: list[list[float]]
     auto_rescale: bool = True
     render_mode: str = "single"
+    auto_render_mode: bool = True
     categories: list[dict[str, Any]] | None = None
     category_colors: dict[int, tuple[int, ...]] = field(default_factory=dict)
     preview_path: str | None = None
@@ -516,6 +517,7 @@ class RasterEngine:
             # sample which discrete values are present.
             categories = None
             category_colors: dict[int, tuple[int, ...]] = {}
+            embedded_colormap = None
             if render_bands == 1:
                 if sample_data is None:
                     try:
@@ -530,7 +532,6 @@ class RasterEngine:
                             )
                     except Exception:
                         sample_data = None
-                embedded_colormap = None
                 with contextlib.suppress(ValueError):
                     embedded_colormap = dataset.colormap(1)
                 if sample_data is not None:
@@ -543,12 +544,7 @@ class RasterEngine:
                 if categories:
                     category_colors = {c["value"]: tuple(c["color"]) for c in categories}
             requested_mode = str(opts.get("render_mode") or "")
-            if count >= 3:
-                render_mode = "rgb"
-            elif categories and requested_mode != "single":
-                render_mode = "categorical"
-            else:
-                render_mode = "single"
+            render_mode = resolve_render_mode(count, categories, embedded_colormap, requested_mode)
 
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", NoOverviewWarning)
@@ -583,6 +579,7 @@ class RasterEngine:
                 rescale=rescale,
                 auto_rescale=auto_rescale,
                 render_mode=render_mode,
+                auto_render_mode=(requested_mode == ""),
                 categories=categories,
                 category_colors=category_colors,
             )
@@ -635,9 +632,11 @@ class RasterEngine:
             existing = self.sources.get(fingerprint)
             if existing is not None:
                 existing.colormap = record.colormap
-                existing.render_mode = record.render_mode
-                existing.categories = record.categories
-                existing.category_colors = record.category_colors
+                if not record.auto_render_mode or existing.auto_render_mode:
+                    existing.render_mode = record.render_mode
+                    existing.categories = record.categories
+                    existing.category_colors = record.category_colors
+                    existing.auto_render_mode = record.auto_render_mode
                 if not record.auto_rescale:
                     existing.rescale = record.rescale
                     existing.auto_rescale = False
@@ -692,11 +691,12 @@ class RasterEngine:
         self, record: RasterSource, artifact_id: str, warnings: list[str] | None = None
     ) -> dict[str, Any]:
         bands = 3 if record.count >= 3 else 1
+        categorical = record.render_mode == "categorical"
         stats = [
             {
                 "index": index + 1,
-                "p2": record.rescale[index][0],
-                "p98": record.rescale[index][1],
+                "p2": None if categorical else record.rescale[index][0],
+                "p98": None if categorical else record.rescale[index][1],
             }
             for index in range(min(bands, len(record.rescale)))
         ]
@@ -740,7 +740,7 @@ class RasterEngine:
             "style": {
                 "opacity": 0.9,
                 "colormap": record.colormap,
-                "rescale": record.rescale[0] if record.count < 3 else None,
+                "rescale": record.rescale[0] if record.count < 3 and not categorical else None,
                 "render_mode": record.render_mode,
                 "category_colors": {
                     str(value): list(color) for value, color in record.category_colors.items()

--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -33,7 +33,7 @@ from geo_paths import (
     normalize_remote_path,
 )
 from optional_runtime import require
-from raster_categories import classify_categories, resolve_render_mode
+from raster_categories import classify_categories, read_pam_aux_xml, resolve_render_mode
 
 
 AUTO_OPTIMIZE_MAX_BYTES = int(
@@ -110,19 +110,23 @@ def _raw_url(origin: str, path: str) -> str:
 
 
 @contextlib.contextmanager
-def _gdal_env():
+def _gdal_env(locator: str):
     import rasterio
 
-    with rasterio.Env(
-        GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
-        CPL_VSIL_CURL_USE_HEAD="YES",
-        GDAL_HTTP_MULTIRANGE="YES",
-        GDAL_HTTP_MAX_RETRY="2",
-        GDAL_HTTP_RETRY_DELAY="0.2",
-        CPL_VSIL_CURL_CHUNK_SIZE=str(64 << 10),
-        CPL_VSIL_CURL_CACHE_SIZE=str(16 << 20),
-        GDAL_NUM_THREADS="ALL_CPUS",
-    ):
+    options = {
+        "CPL_VSIL_CURL_USE_HEAD": "YES",
+        "GDAL_HTTP_MULTIRANGE": "YES",
+        "GDAL_HTTP_MAX_RETRY": "2",
+        "GDAL_HTTP_RETRY_DELAY": "0.2",
+        "CPL_VSIL_CURL_CHUNK_SIZE": str(64 << 10),
+        "CPL_VSIL_CURL_CACHE_SIZE": str(16 << 20),
+        "GDAL_NUM_THREADS": "ALL_CPUS",
+    }
+    # Skipping directory listings only pays off on remote sources, and for
+    # local files it blocks GDAL's PAM .aux.xml sidecar discovery.
+    if is_vsi_path(locator) or is_http_url(locator):
+        options["GDAL_DISABLE_READDIR_ON_OPEN"] = "EMPTY_DIR"
+    with rasterio.Env(**options):
         yield
 
 
@@ -435,7 +439,7 @@ class RasterEngine:
         from rio_tiler.io import Reader
 
         locator = self.locator(source, target)
-        with _gdal_env(), rasterio.open(locator) as dataset:
+        with _gdal_env(locator), rasterio.open(locator) as dataset:
             if dataset.driver in {"OGR_VRT"}:
                 raise ValueError("not a raster dataset")
             if dataset.crs is None:
@@ -534,12 +538,16 @@ class RasterEngine:
                         sample_data = None
                 with contextlib.suppress(ValueError):
                     embedded_colormap = dataset.colormap(1)
+                aux_colors, aux_labels = read_pam_aux_xml(locator)
+                if not embedded_colormap and aux_colors:
+                    embedded_colormap = aux_colors
                 if sample_data is not None:
                     categories = classify_categories(
                         sample_data,
                         dataset.dtypes[0],
                         embedded_colormap=embedded_colormap,
                         overrides=opts.get("category_colors"),
+                        labels=aux_labels,
                     )
                 if categories:
                     category_colors = {c["value"]: tuple(c["color"]) for c in categories}
@@ -812,6 +820,7 @@ class RasterEngine:
 
         with self.lock:
             record = self.sources[source_id]
+            categorical = record.render_mode == "categorical"
             record.optimization.update(
                 status="running",
                 progress=5,
@@ -833,7 +842,7 @@ class RasterEngine:
             if record.preview_path is None:
                 preview_temporary.unlink(missing_ok=True)
                 preview_stage.unlink(missing_ok=True)
-                with _gdal_env(), rasterio.open(record.locator) as source:
+                with _gdal_env(record.locator), rasterio.open(record.locator) as source:
                     scale = max(
                         1.0,
                         max(source.width, source.height) / PREVIEW_MAX_SIZE,
@@ -851,23 +860,28 @@ class RasterEngine:
                         if record.nodata is not None
                         else record.inferred_nodata
                     )
+                    # Categorical class codes must never blend into bogus
+                    # intermediate values, at any stage of derivative build.
+                    preview_resampling = (
+                        Resampling.nearest if categorical else Resampling.average
+                    )
                     if record.inferred_nodata is not None:
                         with WarpedVRT(
                             source,
                             src_nodata=record.inferred_nodata,
                             nodata=record.inferred_nodata,
-                            resampling=Resampling.average,
+                            resampling=preview_resampling,
                         ) as overview_source:
                             data = overview_source.read(
                                 indexes,
                                 out_shape=(len(indexes), height, width),
-                                resampling=Resampling.average,
+                                resampling=preview_resampling,
                             )
                     else:
                         data = source.read(
                             indexes,
                             out_shape=(len(indexes), height, width),
-                            resampling=Resampling.average,
+                            resampling=preview_resampling,
                         )
                     with self.lock:
                         record.optimization.update(
@@ -900,7 +914,7 @@ class RasterEngine:
                     BLOCKSIZE=256,
                     COMPRESS="DEFLATE",
                     OVERVIEWS="AUTO",
-                    OVERVIEW_RESAMPLING="AVERAGE",
+                    OVERVIEW_RESAMPLING="NEAREST" if categorical else "AVERAGE",
                 )
                 os.replace(preview_temporary, preview_destination)
                 preview_stage.unlink(missing_ok=True)
@@ -938,7 +952,7 @@ class RasterEngine:
                 )
 
             temporary.unlink(missing_ok=True)
-            with _gdal_env():
+            with _gdal_env(record.locator):
                 rio_copy(
                     record.locator,
                     temporary,
@@ -947,7 +961,7 @@ class RasterEngine:
                     COMPRESS="DEFLATE",
                     BIGTIFF="IF_SAFER",
                     OVERVIEWS="AUTO",
-                    OVERVIEW_RESAMPLING="AVERAGE",
+                    OVERVIEW_RESAMPLING="NEAREST" if categorical else "AVERAGE",
                 )
             os.replace(temporary, destination)
             with rasterio.open(destination) as dataset:
@@ -1037,7 +1051,7 @@ class RasterEngine:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", NoOverviewWarning)
-                with _gdal_env(), Reader(locator) as reader:
+                with _gdal_env(locator), Reader(locator) as reader:
                     image = reader.tile(
                         x,
                         y,

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -1807,14 +1807,10 @@ function sliderCtl(label, valTxt, min, max, val, on) {
 function alphaCtl(label, alpha, fallback, on) {
   const a = alpha ?? fallback;
   const pct = Math.round(a / 255 * 100);
-  const c = ctlShell(label, pct + "%");
-  const r = document.createElement("input"); r.type = "range"; r.min = 0; r.max = 100; r.value = pct;
-  r.oninput = e => {
-    const v = Number(e.target.value);
+  const c = sliderCtl(label, pct + "%", 0, 100, pct, v => {
     c.querySelector(".ctl-lbl b").textContent = v + "%";
     on(Math.round(v / 100 * 255));
-  };
-  c.appendChild(r);
+  });
   return c;
 }
 function selectCtl(label, opts, val, on) {
@@ -1839,15 +1835,13 @@ function categoryRow(cat, s, L) {
   if (!s.category_labels) s.category_labels = {};
   const row = document.createElement("div"); row.className = "catrow";
   const swatch = document.createElement("input"); swatch.type = "color";
-  // style.category_colors starts out backend-populated as [r,g,b,a] arrays
-  // (same convention as fill_color/line_color); once the user edits a
-  // swatch it becomes a "#rrggbb" string like any other color input's value.
-  const stored = s.category_colors[key];
-  swatch.value = typeof stored === "string" ? stored : rgbToHex(stored || cat.color);
+  swatch.value = rgbToHex(s.category_colors[key] || cat.color);
   // change (not input): a raster color edit re-renders on the backend, so
   // it should commit once the picker closes rather than spam requests
-  // while the user is still dragging inside it.
-  swatch.onchange = e => { s.category_colors[key] = e.target.value; s._touched = true; reloadRaster(L); };
+  // while the user is still dragging inside it. Store as [r,g,b,a] (via
+  // hexToRgb), the same shape category_colors already carries for the
+  // untouched entries and the same convention fill_color/line_color use.
+  swatch.onchange = e => { s.category_colors[key] = [...hexToRgb(e.target.value), 255]; s._touched = true; reloadRaster(L); };
   const text = document.createElement("input"); text.type = "text";
   text.value = s.category_labels[key] ?? cat.label;
   text.oninput = e => { s.category_labels[key] = e.target.value; s._touched = true; };
@@ -2081,7 +2075,8 @@ async function resolveUploadDir() {
   if (state.dir) return state.dir;
   if (!homeDirPromise) {
     homeDirPromise = fused.runPython("./discover.py", { dir: "", src: location.origin })
-      .then(result => result.dir || "");
+      .then(result => result.dir || "")
+      .catch(error => { homeDirPromise = null; throw error; });
   }
   return homeDirPromise;
 }
@@ -2089,6 +2084,10 @@ function joinPath(dir, name) {
   const sep = dir.includes("\\") && !dir.includes("/") ? "\\" : "/";
   return dir.replace(/[\\/]+$/, "") + sep + name;
 }
+// Any fused.stat failure (not just a 404) reads as "path is free" — the
+// upload right behind this will fail loudly on its own if something else
+// was actually wrong, so nothing is hidden by being optimistic (same
+// tradeoff as markdown/template.html's mediaExists/freeMediaName).
 async function uniqueDestPath(dir, name) {
   const dot = name.lastIndexOf(".");
   const stem = dot > 0 ? name.slice(0, dot) : name;
@@ -2102,9 +2101,9 @@ async function uniqueDestPath(dir, name) {
   return joinPath(dir, candidate);
 }
 async function importDroppedFile(file) {
-  const dir = await resolveUploadDir();
-  if (!dir) { toast("bad", "Couldn't drop " + file.name, "No destination folder available."); return; }
   try {
+    const dir = await resolveUploadDir();
+    if (!dir) { toast("bad", "Couldn't drop " + file.name, "No destination folder available."); return; }
     const dest = await uniqueDestPath(dir, file.name);
     await fused.uploadFile(dest, file);
     await loadTarget(dest, dest.split(/[\\/]/).pop());

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -591,6 +591,12 @@ const BASEMAPS = {
 /* ---- map -------------------------------------------------------------- */
 const startCam = (P.get("cam") || "37.7749,-122.4194,11").split(",").map(Number);
 let baseName = ["dark","light","sat"].includes(P.get("base")) ? P.get("base") : "light";
+// map.isStyleLoaded() requires every source's tiles to be fully loaded, not
+// just the style itself — waiting on it to add/remove a single layer means a
+// big raster/vector layer still streaming tiles blocks touching ANY layer.
+// addLayer/removeLayer only actually need the style's initial load done, so
+// track that lighter, one-shot condition ourselves via "style.load".
+let styleReady = false;
 const map = new maplibregl.Map({
   container: "map", style: BASEMAPS[baseName],
   center: [startCam[1] || -122.4194, startCam[0] || 37.7749], zoom: startCam[2] || 11,
@@ -1067,7 +1073,9 @@ function boundsFeature(bounds) {
 }
 
 function rebuildRasterTiles() {
-  if (!map.isStyleLoaded()) return;
+  // Only false for the brief window between a basemap switch and its
+  // "style.load" — which already re-runs this once ready, so just bail.
+  if (!styleReady) return;
   const wanted = new Map();
   for (const L of state.layers.values()) {
     const d = L.descriptor;
@@ -1171,7 +1179,7 @@ function removeVectorSource(sourceId) {
   if (map.getSource(ids.source)) map.removeSource(ids.source);
 }
 function rebuildVectorTiles() {
-  if (!map.isStyleLoaded()) return;
+  if (!styleReady) return;
   const wanted = new Map();
   for (const L of state.layers.values()) {
     const d = L.descriptor;
@@ -1697,7 +1705,9 @@ function vectorControls(body, L) {
       rebuildDeck(); renderLayerCards();
     }));
     body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
-      s.line_color = [...(s.line_color||L.defaultColor).slice(0,3), a]; s._touched=true; rebuildDeck(); renderLayerCards();
+      s.line_color = [...(s.line_color||L.defaultColor).slice(0,3), a]; s._touched=true;
+      if (isPoint) { s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; }
+      rebuildDeck(); renderLayerCards();
     }));
   }
   if (!isPoint) body.appendChild(sliderCtl("Line width", (s.line_width??1.5).toFixed(1), 0, 8, Math.round((s.line_width??1.5)*2),
@@ -1733,6 +1743,7 @@ function vectorTileControls(body, L) {
   }));
   body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
     s.line_color = [...(s.line_color || L.defaultColor).slice(0,3), a]; s._touched = true;
+    if (isPoint) { s.fill_color = [...(s.fill_color || L.defaultColor).slice(0,3), a]; }
     rebuildVectorTiles(); renderLayerCards();
   }));
   if (!isPoint) body.appendChild(sliderCtl("Line width", (s.line_width ?? 1.5).toFixed(1), 0, 8, Math.round((s.line_width ?? 1.5) * 2),
@@ -1971,9 +1982,11 @@ function setBasemap(name) {
   if (!BASEMAPS[name] || name === baseName) return;
   baseName = name; P.set("base", name);
   qs("basemap-seg").querySelectorAll("button").forEach(b => b.classList.toggle("on", b.dataset.b === name));
+  styleReady = false;
   map.setStyle(BASEMAPS[name]);   // overlay is a control → survives setStyle
 }
 map.on("style.load", () => {
+  styleReady = true;
   rasterSourceIds = new Set();
   vectorSourceIds = new Set();
   for (const L of state.layers.values()) L._tileUrl = null;
@@ -2070,45 +2083,88 @@ qs("importpath").onkeydown = event => {
 };
 
 /* ---- drag-and-drop import: drop OS files straight onto the map -------- */
-let homeDirPromise = null;
+// Ad-hoc drops (no folder browsed yet) land in a temp staging dir, not the
+// user's home folder — discover.py prunes it, so a stray drop never piles
+// up in Home forever.
+let dropsDirPromise = null;
 async function resolveUploadDir() {
   if (state.dir) return state.dir;
-  if (!homeDirPromise) {
-    homeDirPromise = fused.runPython("./discover.py", { dir: "", src: location.origin })
-      .then(result => result.dir || "")
-      .catch(error => { homeDirPromise = null; throw error; });
+  if (!dropsDirPromise) {
+    dropsDirPromise = fused.runPython("./discover.py", { action: "drops_dir" })
+      .then(result => {
+        if (result.error) throw new Error(result.error);
+        return result.dir || "";
+      })
+      .catch(error => { dropsDirPromise = null; throw error; });
   }
-  return homeDirPromise;
+  return dropsDirPromise;
 }
 function joinPath(dir, name) {
   const sep = dir.includes("\\") && !dir.includes("/") ? "\\" : "/";
   return dir.replace(/[\\/]+$/, "") + sep + name;
 }
+// GIS sidecars that ride along with a primary file (shapefile members,
+// world files, PAM metadata): uploaded, but never loaded as layers.
+const SIDECAR_EXTENSIONS = [
+  ".shx", ".dbf", ".prj", ".cpg", ".sbn", ".sbx", ".shp.xml",
+  ".qix", ".qpj", ".aux.xml", ".ovr", ".tfw", ".tifw", ".wld",
+];
+function isSidecarName(name) {
+  const lower = name.toLowerCase();
+  return SIDECAR_EXTENSIONS.some(ext => lower.endsWith(ext));
+}
+// Split on the FIRST dot so files pairing on a shared basename
+// (farms.shp + farms.shx, landcover.tif + landcover.tif.aux.xml) get a
+// collision suffix inserted at the same spot and stay paired.
+function splitDroppedName(name) {
+  const dot = name.indexOf(".", 1);
+  return dot > 0 ? [name.slice(0, dot), name.slice(dot)] : [name, ""];
+}
 // Any fused.stat failure (not just a 404) reads as "path is free" — the
 // upload right behind this will fail loudly on its own if something else
 // was actually wrong, so nothing is hidden by being optimistic (same
 // tradeoff as markdown/template.html's mediaExists/freeMediaName).
-async function uniqueDestPath(dir, name) {
-  const dot = name.lastIndexOf(".");
-  const stem = dot > 0 ? name.slice(0, dot) : name;
-  const ext = dot > 0 ? name.slice(dot) : "";
-  let candidate = name;
-  for (let i = 1; i <= 100; i++) {
-    const path = joinPath(dir, candidate);
-    try { await fused.stat(path); } catch { return path; }
-    candidate = `${stem} (${i})${ext}`;
-  }
-  return joinPath(dir, candidate);
+async function pathIsFree(path) {
+  try { await fused.stat(path); return false; } catch { return true; }
 }
-async function importDroppedFile(file) {
+async function groupDestPaths(dir, group) {
+  let candidate = group.map(file => joinPath(dir, file.name));
+  for (let i = 1; i <= 100; i++) {
+    const free = await Promise.all(candidate.map(pathIsFree));
+    if (free.every(Boolean)) break;
+    candidate = group.map(file => {
+      const [stem, rest] = splitDroppedName(file.name);
+      return joinPath(dir, `${stem} (${i})${rest}`);
+    });
+  }
+  return candidate;
+}
+async function importDroppedFiles(files) {
+  let dir = "";
   try {
-    const dir = await resolveUploadDir();
-    if (!dir) { toast("bad", "Couldn't drop " + file.name, "No destination folder available."); return; }
-    const dest = await uniqueDestPath(dir, file.name);
-    await fused.uploadFile(dest, file);
-    await loadTarget(dest, dest.split(/[\\/]/).pop());
+    dir = await resolveUploadDir();
   } catch (error) {
-    toast("bad", "Couldn't add " + file.name, error.message);
+    toast("bad", "Couldn't drop files", error.message);
+    return;
+  }
+  if (!dir) { toast("bad", "Couldn't drop files", "No destination folder available."); return; }
+  const groups = new Map();
+  for (const file of files) {
+    const key = splitDroppedName(file.name)[0].toLowerCase();
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key).push(file);
+  }
+  for (const group of groups.values()) {
+    try {
+      const dests = await groupDestPaths(dir, group);
+      for (let i = 0; i < group.length; i++) await fused.uploadFile(dests[i], group[i]);
+      for (let i = 0; i < group.length; i++) {
+        if (isSidecarName(group[i].name)) continue;
+        await loadTarget(dests[i], dests[i].split(/[\\/]/).pop());
+      }
+    } catch (error) {
+      toast("bad", "Couldn't add " + group.map(file => file.name).join(", "), error.message);
+    }
   }
 }
 const mapwrap = qs("mapwrap"), dropzone = qs("dropzone");
@@ -2132,7 +2188,7 @@ mapwrap.addEventListener("drop", async event => {
   event.preventDefault();
   dragDepth = 0;
   dropzone.classList.add("hidden");
-  for (const file of event.dataTransfer.files) await importDroppedFile(file);
+  await importDroppedFiles([...event.dataTransfer.files]);
 });
 
 /* toast */

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -295,6 +295,14 @@
   .swatchrow { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
   .swatch { display: flex; align-items: center; gap: 5px; font-size: 11px; color: var(--muted); }
   .swatch i { width: 11px; height: 11px; border-radius: 3px; display: inline-block; }
+  .catlist { margin-top: 8px; display: flex; flex-direction: column; gap: 5px; max-height: 260px; overflow-y: auto; }
+  .catrow { display: flex; align-items: center; gap: 7px; }
+  .catrow input[type=color] { width: 22px; height: 22px; flex: none; }
+  .catrow input[type=text] {
+    flex: 1; min-width: 0; border: 1px solid var(--border); border-radius: 6px;
+    padding: 4px 7px; font-size: 11.5px; color: var(--text); background: var(--panel-2);
+  }
+  .catrow .catcount { flex: none; font-size: 10px; color: var(--faint); font-family: var(--mono); }
 
   /* right-docked style panel */
   #stylepanel {
@@ -369,6 +377,13 @@
   .hidden { display: none !important; }
   .mono { font-family: var(--mono); }
   #boot-msg { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 13px; z-index: 30; }
+
+  #dropzone {
+    position: absolute; inset: 10px; z-index: 40; display: flex; align-items: center; justify-content: center;
+    border: 2px dashed var(--accent); border-radius: var(--r); background: rgba(255,62,0,.08);
+    color: var(--accent); font-size: 15px; font-weight: 600; pointer-events: none;
+  }
+  #dropzone.hidden { display: none; }
 </style>
 </head>
 <body>
@@ -376,6 +391,7 @@
   <main id="mapwrap">
     <div id="map"></div>
     <div id="boot-msg">initializing…</div>
+    <div id="dropzone" class="hidden">Drop files to add as layers</div>
 
     <button id="btn-panel" class="hidden" title="Show panel">
       <svg width="19" height="19" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l9 5-9 5-9-5 9-5zM3 12l9 5 9-5M3 17l9 5 9-5"/></svg>
@@ -870,6 +886,8 @@ async function loadTarget(target, name) {
     const desc = await fused.runPython("./map_render.py", {
       target, colormap: (L.style && L.style.colormap) || "viridis",
       rescale: (L.style && L.style.rescale) ? L.style.rescale.join(",") : "",
+      render_mode: (L.style && L.style.render_mode) || "",
+      category_colors: JSON.stringify((L.style && L.style.category_colors) || {}),
       ...sourceArgs(target),
     });
     L.loading = false; L.descriptor = desc;
@@ -1585,7 +1603,20 @@ function renderStyleDock() {
 
 function rasterControls(body, L) {
   const s = L.style, d = L.descriptor;
-  if (s.render_mode !== "rgb") {
+  const categories = d.stats.categories;
+  if (categories && categories.length) {
+    body.appendChild(selectCtl("Render", ["Continuous", "Categorical"],
+      s.render_mode === "categorical" ? "Categorical" : "Continuous",
+      v => {
+        s.render_mode = v === "Categorical" ? "categorical" : "single";
+        s._touched = true; reloadRaster(L);
+      }));
+  }
+  if (s.render_mode === "categorical" && categories && categories.length) {
+    const list = document.createElement("div"); list.className = "catlist";
+    for (const cat of categories) list.appendChild(categoryRow(cat, s, L));
+    body.appendChild(list);
+  } else if (s.render_mode !== "rgb") {
     body.appendChild(selectCtl("Colormap", Object.keys(CMAPS), s.colormap || "viridis", v => {
       s.colormap = v; s._touched = true; reloadRaster(L);
     }));
@@ -1652,13 +1683,21 @@ function vectorControls(body, L) {
     body.appendChild(leg);
   } else {
     // fill + line color pickers
-    if (!isLine) body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color||L.defaultColor), hex => {
-      const a = (s.fill_color && s.fill_color[3]) ?? 90; s.fill_color = [...hexToRgb(hex), a]; s._touched=true; rebuildDeck(); renderLayerCards();
-    }));
+    if (!isLine) {
+      body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color||L.defaultColor), hex => {
+        const a = (s.fill_color && s.fill_color[3]) ?? 90; s.fill_color = [...hexToRgb(hex), a]; s._touched=true; rebuildDeck(); renderLayerCards();
+      }));
+      body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 90, a => {
+        s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; s._touched=true; rebuildDeck(); renderLayerCards();
+      }));
+    }
     body.appendChild(colorCtl("Line / point", rgbToHex(s.line_color||L.defaultColor), hex => {
       const a = (s.line_color && s.line_color[3]) ?? 220; s.line_color = [...hexToRgb(hex), a]; s._touched=true;
       if (isPoint) { const fa=(s.fill_color&&s.fill_color[3])??220; s.fill_color=[...hexToRgb(hex),fa]; }
       rebuildDeck(); renderLayerCards();
+    }));
+    body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
+      s.line_color = [...(s.line_color||L.defaultColor).slice(0,3), a]; s._touched=true; rebuildDeck(); renderLayerCards();
     }));
   }
   if (!isPoint) body.appendChild(sliderCtl("Line width", (s.line_width??1.5).toFixed(1), 0, 8, Math.round((s.line_width??1.5)*2),
@@ -1672,11 +1711,17 @@ function vectorTileControls(body, L) {
   const gtypes = d.stats.geometry_types || [];
   const isPoint = gtypes.some(g => g.includes("Point"));
   const isLine = gtypes.some(g => g.includes("Line"));
-  if (!isLine) body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color || L.defaultColor), hex => {
-    const alpha = (s.fill_color && s.fill_color[3]) ?? 90;
-    s.fill_color = [...hexToRgb(hex), alpha]; s._touched = true;
-    rebuildVectorTiles(); renderLayerCards();
-  }));
+  if (!isLine) {
+    body.appendChild(colorCtl("Fill", rgbToHex(s.fill_color || L.defaultColor), hex => {
+      const alpha = (s.fill_color && s.fill_color[3]) ?? 90;
+      s.fill_color = [...hexToRgb(hex), alpha]; s._touched = true;
+      rebuildVectorTiles(); renderLayerCards();
+    }));
+    body.appendChild(alphaCtl("Fill opacity", s.fill_color && s.fill_color[3], 90, a => {
+      s.fill_color = [...(s.fill_color || L.defaultColor).slice(0,3), a]; s._touched = true;
+      rebuildVectorTiles(); renderLayerCards();
+    }));
+  }
   body.appendChild(colorCtl("Line / point", rgbToHex(s.line_color || L.defaultColor), hex => {
     const alpha = (s.line_color && s.line_color[3]) ?? 220;
     s.line_color = [...hexToRgb(hex), alpha]; s._touched = true;
@@ -1684,6 +1729,10 @@ function vectorTileControls(body, L) {
       const fillAlpha = (s.fill_color && s.fill_color[3]) ?? 220;
       s.fill_color = [...hexToRgb(hex), fillAlpha];
     }
+    rebuildVectorTiles(); renderLayerCards();
+  }));
+  body.appendChild(alphaCtl("Line opacity", s.line_color && s.line_color[3], 220, a => {
+    s.line_color = [...(s.line_color || L.defaultColor).slice(0,3), a]; s._touched = true;
     rebuildVectorTiles(); renderLayerCards();
   }));
   if (!isPoint) body.appendChild(sliderCtl("Line width", (s.line_width ?? 1.5).toFixed(1), 0, 8, Math.round((s.line_width ?? 1.5) * 2),
@@ -1711,6 +1760,9 @@ function binaryPointControls(body, L) {
     body.appendChild(colorCtl("Color", rgbToHex(s.fill_color||L.defaultColor), hex => {
       const a = (s.fill_color && s.fill_color[3]) ?? 220; s.fill_color = [...hexToRgb(hex), a]; s._touched = true; rebuildDeck(); renderLayerCards();
     }));
+    body.appendChild(alphaCtl("Opacity", s.fill_color && s.fill_color[3], 220, a => {
+      s.fill_color = [...(s.fill_color||L.defaultColor).slice(0,3), a]; s._touched = true; rebuildDeck(); renderLayerCards();
+    }));
   }
   body.appendChild(sliderCtl("Point size", String(s.point_radius??4), 1, 24, s.point_radius??4,
     v => { s.point_radius = v; s._touched = true; rebuildDeck(); updateCtlLabel(body,"Point size",String(v)); }));
@@ -1720,7 +1772,10 @@ async function reloadRaster(L) {
   L.loading = true; renderFileList();
   try {
     const desc = await fused.runPython("./map_render.py", { target: L.target, colormap: L.style.colormap || "viridis",
-      rescale: L.style.rescale ? L.style.rescale.join(",") : "", ...sourceArgs(L.target) });
+      rescale: L.style.rescale ? L.style.rescale.join(",") : "",
+      render_mode: L.style.render_mode || "",
+      category_colors: JSON.stringify(L.style.category_colors || {}),
+      ...sourceArgs(L.target) });
     L.loading = false;
     if (desc.status === "ok") {
       const keepStyle = L.style; L.descriptor = desc; L.style = Object.assign({}, desc.style, keepStyle);
@@ -1746,6 +1801,22 @@ function sliderCtl(label, valTxt, min, max, val, on) {
   const r = document.createElement("input"); r.type="range"; r.min=min; r.max=max; r.value=val;
   r.oninput = e => on(Number(e.target.value)); c.appendChild(r); return c;
 }
+// Alpha-only slider: colorCtl's native <input type=color> has no alpha channel,
+// so fill/line transparency (an [r,g,b,a] byte already carried on the style)
+// needs its own control. `alpha` is 0-255; `on` receives the same range.
+function alphaCtl(label, alpha, fallback, on) {
+  const a = alpha ?? fallback;
+  const pct = Math.round(a / 255 * 100);
+  const c = ctlShell(label, pct + "%");
+  const r = document.createElement("input"); r.type = "range"; r.min = 0; r.max = 100; r.value = pct;
+  r.oninput = e => {
+    const v = Number(e.target.value);
+    c.querySelector(".ctl-lbl b").textContent = v + "%";
+    on(Math.round(v / 100 * 255));
+  };
+  c.appendChild(r);
+  return c;
+}
 function selectCtl(label, opts, val, on) {
   const c = ctlShell(label, "");
   const sel = document.createElement("select");
@@ -1758,6 +1829,32 @@ function colorCtl(label, hex, on) {
   inp.oninput = e => on(e.target.value);
   c.querySelector(".ctl-lbl b").replaceWith(inp);   // swatch sits on the label's right
   return c;
+}
+// One row of a categorical raster's legend: a swatch (recolors the raster,
+// needs a backend re-render) plus a free-text label (cosmetic only — the
+// value it's keyed to is still what gets rendered on the map).
+function categoryRow(cat, s, L) {
+  const key = String(cat.value);
+  if (!s.category_colors) s.category_colors = {};
+  if (!s.category_labels) s.category_labels = {};
+  const row = document.createElement("div"); row.className = "catrow";
+  const swatch = document.createElement("input"); swatch.type = "color";
+  // style.category_colors starts out backend-populated as [r,g,b,a] arrays
+  // (same convention as fill_color/line_color); once the user edits a
+  // swatch it becomes a "#rrggbb" string like any other color input's value.
+  const stored = s.category_colors[key];
+  swatch.value = typeof stored === "string" ? stored : rgbToHex(stored || cat.color);
+  // change (not input): a raster color edit re-renders on the backend, so
+  // it should commit once the picker closes rather than spam requests
+  // while the user is still dragging inside it.
+  swatch.onchange = e => { s.category_colors[key] = e.target.value; s._touched = true; reloadRaster(L); };
+  const text = document.createElement("input"); text.type = "text";
+  text.value = s.category_labels[key] ?? cat.label;
+  text.oninput = e => { s.category_labels[key] = e.target.value; s._touched = true; };
+  const count = document.createElement("span"); count.className = "catcount";
+  count.textContent = cat.count != null ? cat.count.toLocaleString() : "";
+  row.append(swatch, text, count);
+  return row;
 }
 const fmt = v => v == null ? "—" : (Math.abs(v) >= 1000 || (v !== 0 && Math.abs(v) < 0.01) ? Number(v).toExponential(1) : Number(v).toFixed(2));
 
@@ -1977,6 +2074,67 @@ qs("btn-importpath").onclick = importDirectPath;
 qs("importpath").onkeydown = event => {
   if (event.key === "Enter") importDirectPath();
 };
+
+/* ---- drag-and-drop import: drop OS files straight onto the map -------- */
+let homeDirPromise = null;
+async function resolveUploadDir() {
+  if (state.dir) return state.dir;
+  if (!homeDirPromise) {
+    homeDirPromise = fused.runPython("./discover.py", { dir: "", src: location.origin })
+      .then(result => result.dir || "");
+  }
+  return homeDirPromise;
+}
+function joinPath(dir, name) {
+  const sep = dir.includes("\\") && !dir.includes("/") ? "\\" : "/";
+  return dir.replace(/[\\/]+$/, "") + sep + name;
+}
+async function uniqueDestPath(dir, name) {
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : "";
+  let candidate = name;
+  for (let i = 1; i <= 100; i++) {
+    const path = joinPath(dir, candidate);
+    try { await fused.stat(path); } catch { return path; }
+    candidate = `${stem} (${i})${ext}`;
+  }
+  return joinPath(dir, candidate);
+}
+async function importDroppedFile(file) {
+  const dir = await resolveUploadDir();
+  if (!dir) { toast("bad", "Couldn't drop " + file.name, "No destination folder available."); return; }
+  try {
+    const dest = await uniqueDestPath(dir, file.name);
+    await fused.uploadFile(dest, file);
+    await loadTarget(dest, dest.split(/[\\/]/).pop());
+  } catch (error) {
+    toast("bad", "Couldn't add " + file.name, error.message);
+  }
+}
+const mapwrap = qs("mapwrap"), dropzone = qs("dropzone");
+let dragDepth = 0;
+mapwrap.addEventListener("dragenter", event => {
+  if (!event.dataTransfer.types.includes("Files")) return;
+  event.preventDefault();
+  dragDepth++;
+  dropzone.classList.remove("hidden");
+});
+mapwrap.addEventListener("dragover", event => {
+  if (!event.dataTransfer.types.includes("Files")) return;
+  event.preventDefault();
+});
+mapwrap.addEventListener("dragleave", () => {
+  dragDepth = Math.max(0, dragDepth - 1);
+  if (dragDepth === 0) dropzone.classList.add("hidden");
+});
+mapwrap.addEventListener("drop", async event => {
+  if (!event.dataTransfer.types.includes("Files")) return;
+  event.preventDefault();
+  dragDepth = 0;
+  dropzone.classList.add("hidden");
+  for (const file of event.dataTransfer.files) await importDroppedFile(file);
+});
 
 /* toast */
 let toastTimer = null;

--- a/fused_render/templates/map/vector_engine.py
+++ b/fused_render/templates/map/vector_engine.py
@@ -64,6 +64,13 @@ MVT_BUFFER = 64
 WEB_MERCATOR_LIMIT = math.pi * 6378137.0
 MAX_LATITUDE = 85.0511287798066
 ENGINE_VERSION = "native-mvt-v1"
+# The MVT tile pyramid's {z}/{x}/{y} math is fixed to EPSG:4326 — this is this
+# pipeline's "canvas CRS" (the same role QGIS's project CRS plays: every layer,
+# regardless of its own native CRS, is reprojected on-the-fly for that one
+# render/tile). The source file's CRS is never touched. Previously left
+# implicit, relying on GDAL's OGR MVT writer to silently reproject internally
+# (GDAL >= 3.4 behavior) — now made explicit.
+TILE_CRS = "EPSG:4326"
 
 
 VECTOR_RUNTIME = {
@@ -231,10 +238,42 @@ def _buffered_bounds(
     )
 
 
+def _reproject_wkb(table: Any, geometry_name: str, source_crs: str) -> Any:
+    import pyarrow as pa
+    import shapely
+    from pyproj import Transformer
+
+    transformer = Transformer.from_crs(source_crs, TILE_CRS, always_xy=True)
+
+    def _project(coordinates):
+        projected = coordinates.copy()
+        projected[:, 0], projected[:, 1] = transformer.transform(
+            coordinates[:, 0], coordinates[:, 1]
+        )
+        return projected
+
+    index = table.schema.get_field_index(geometry_name)
+    geometries = shapely.from_wkb(
+        table.column(index).to_numpy(zero_copy_only=False)
+    )
+    projected = shapely.to_wkb(shapely.transform(geometries, _project))
+    return table.set_column(
+        index,
+        pa.field(geometry_name, pa.binary()),
+        pa.array(projected, type=pa.binary()),
+    )
+
+
 @contextlib.contextmanager
 def _gdal_env():
+    import pyogrio
     import rasterio
 
+    # A .shp dragged in without its .shx sidecar (browsers only upload the
+    # file the user dropped) is recoverable: the .shx is a redundant index
+    # GDAL can rebuild. Binary wheels give pyogrio a GDAL copy of its own
+    # that rasterio.Env can't reach, so the option is set on both.
+    pyogrio.set_gdal_config_options({"SHAPE_RESTORE_SHX": True})
     with rasterio.Env(
         GDAL_DISABLE_READDIR_ON_OPEN="EMPTY_DIR",
         CPL_VSIL_CURL_USE_HEAD="YES",
@@ -243,6 +282,7 @@ def _gdal_env():
         GDAL_HTTP_RETRY_DELAY="0.2",
         CPL_VSIL_CURL_CHUNK_SIZE=str(64 << 10),
         CPL_VSIL_CURL_CACHE_SIZE=str(16 << 20),
+        SHAPE_RESTORE_SHX="YES",
     ):
         yield
 
@@ -571,6 +611,11 @@ class VectorEngine:
             )
         if table.num_rows > MAX_TILE_FEATURES:
             return None, None
+        if source.crs.upper() not in {"EPSG:4326", "OGC:CRS84"}:
+            table = _reproject_wkb(
+                table, metadata["geometry_name"], metadata["crs"]
+            )
+            metadata["crs"] = TILE_CRS
         return metadata, table
 
     def _overview_frame(
@@ -655,7 +700,7 @@ class VectorEngine:
             {"feature_count": [int(row[2]) for row in rows]},
             geometry=geometries,
             crs=source.crs,
-        )
+        ).to_crs(TILE_CRS)
 
     def _native_tile(
         self,
@@ -691,17 +736,18 @@ class VectorEngine:
                 "NAME": "layer",
             }
             if arrow_table is not None and metadata is not None:
-                pyogrio.write_arrow(
-                    arrow_table,
-                    output,
-                    layer="layer",
-                    driver="MVT",
-                    geometry_name=metadata["geometry_name"],
-                    geometry_type=metadata["geometry_type"],
-                    crs=metadata["crs"],
-                    dataset_options=dataset_options,
-                    layer_options=layer_options,
-                )
+                with _gdal_env():
+                    pyogrio.write_arrow(
+                        arrow_table,
+                        output,
+                        layer="layer",
+                        driver="MVT",
+                        geometry_name=metadata["geometry_name"],
+                        geometry_type=metadata["geometry_type"],
+                        crs=TILE_CRS,
+                        dataset_options=dataset_options,
+                        layer_options=layer_options,
+                    )
             else:
                 return b""
 
@@ -738,7 +784,7 @@ class VectorEngine:
                 metadata={
                     "geometry_name": overview.geometry.name,
                     "geometry_type": "Polygon",
-                    "crs": source.crs,
+                    "crs": TILE_CRS,
                 },
                 arrow_table=overview.to_arrow(
                     index=False,

--- a/fused_render/templates/shared/private_dir.py
+++ b/fused_render/templates/shared/private_dir.py
@@ -1,0 +1,116 @@
+"""Adopting and creating private directories under the shared temp root.
+
+Extracted verbatim from claude/agent.py, whose run dirs and annotation
+screenshots these rules were written for — the docstrings still speak in
+terms of conversations and transcripts, and the threat model they describe
+is the general one: a predictable path under a world-writable temp root can
+be pre-created by another local account. The map viewer's drag-and-drop
+staging dir shares the same rules now.
+
+Not a package: each backend loads this by path (the templates tree is always
+staged as one unit, so ../shared/ resolves from any template folder).
+"""
+import os
+import stat
+
+
+def _within_tree(path: str, root: str) -> bool:
+    """Whether `path` is the caller's own root or something under it — i.e. a
+    directory the caller is responsible for, rather than the system's temp
+    root."""
+    root = os.path.abspath(root)
+    return os.path.abspath(path) == root or \
+        os.path.abspath(path).startswith(root + os.sep)
+
+
+def require_private(path: str) -> None:
+    """Refuse a directory in our tree that we did not make, or that anyone
+    else can write to.
+
+    The temp root is world-writable, and our path under it is *predictable* —
+    `fused_render_claude-<uid>` names the victim. So another account can
+    pre-create it, or `runs` inside it, before we ever run. Adopting that hands
+    them the parent of every run dir, and the parent is enough: the sticky bit
+    that stops one account renaming another's entry protects OUR entries in
+    /tmp, but it is not inherited by a directory THEY created. They can rename
+    the 0700 run dir aside the instant after `mkdir` returns and leave a
+    world-readable one in its place, and the transcript, the user's message
+    and every tool payload get written into it. The 0700 means nothing if the
+    thing above it is theirs.
+
+    `lstat`, not `stat`: a symlink is not a directory we own, however good its
+    target looks. Raising is the right outcome — an attacker who plants the
+    directory can deny us the chat, but a loud failure is not a disclosure.
+    """
+    st = os.lstat(path)
+    if not stat.S_ISDIR(st.st_mode):
+        raise NotADirectoryError(
+            "%s is not a directory (a symlink or file is in the way)" % path)
+    geteuid = getattr(os, "geteuid", None)
+    if geteuid is None:
+        return  # Windows: no uid model here, and its temp dir is already per-user
+    if st.st_uid != geteuid():
+        raise PermissionError(
+            "%s belongs to uid %d, not %d — refusing to keep this conversation "
+            "under a directory another account controls" % (path, st.st_uid, geteuid()))
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise PermissionError(
+            "%s is writable by others (mode %04o) — refusing to keep this "
+            "conversation there" % (path, stat.S_IMODE(st.st_mode)))
+
+
+def private_dir(path: str, tree_root: str) -> None:
+    """Create `path` and any missing parents as `rwx------`.
+
+    `tree_root` is the caller's own root under the temp dir (the parent of
+    claude's `runs`, the parent of the map viewer's `drops`): every existing
+    ancestor from it downwards is vouched for with `require_private` before
+    anything is built on it; above it is the temp root, which belongs to the
+    system.
+
+    The run tree lives under the shared temp root, and on a typical Linux box
+    that means /tmp with a default 0755 for anything created in it — while a
+    run dir holds the entire conversation: `out.jsonl` is the transcript,
+    `meta.json` the user's message, and `perm/*.req.json` every tool payload
+    there is (commands, edited file content, web inputs). None of it should be
+    readable by another local account. macOS' per-user temp root happens to
+    make the exposure moot there, which is exactly why it cannot be relied on.
+
+    Levels are created one at a time because `os.makedirs` has applied `mode`
+    to the leaf only since 3.7. Existing directories are deliberately NOT
+    chmod'ed: the chain starts at a directory we do not own (tightening the
+    temp root would be a far worse bug than the one being fixed), and the run
+    dir underneath — always freshly created here, always 0700 — is the level
+    that actually contains the data.
+
+    Parents tolerate losing the race, the leaf does not. Our root and `runs`
+    are shared by every run of ours, so two templates starting their first run
+    at once both find them missing and both call mkdir — and the loser used to
+    abort `_start`, so the user's message simply never sent. Whoever won is
+    fine, PROVIDED it is ours (`require_private`). The **leaf** stays an
+    exclusive create: it is this run's private 0700 boundary, so finding one
+    already there means a run-id collision or somebody else's directory, and
+    quietly adopting it is the wrong answer.
+    """
+    path = os.path.abspath(path)
+    missing = []
+    head = os.path.dirname(path)
+    while head and not os.path.isdir(head):
+        head, tail = os.path.split(head)
+        if not tail:
+            break
+        missing.append(tail)
+    # `head` is the deepest thing that already exists. Anything from the
+    # caller's own root downwards has to be vouched for before we build on it;
+    # above that is the temp root, which belongs to the system.
+    if _within_tree(head, tree_root):
+        require_private(head)
+    for tail in reversed(missing):
+        head = os.path.join(head, tail)
+        try:
+            os.mkdir(head, 0o700)
+        except FileExistsError:
+            # Somebody got here first. A concurrent run of ours is fine; a
+            # directory another account planted is not.
+            require_private(head)
+    os.mkdir(path, 0o700)

--- a/tests/test_map_drops_dir.py
+++ b/tests/test_map_drops_dir.py
@@ -1,0 +1,242 @@
+"""OS drag-and-drop staging for the Map Viewer.
+
+An ad-hoc drop (no folder browsed yet) used to resolve `dir=""` to the user's
+real home folder, so a stray drag out of Explorer landed there permanently and
+repeated drops of the same name piled up as `name (1).gpkg`, `name (2).gpkg`
+forever. Drops now stage in a pruned per-user directory under the temp root
+(`discover.py main(action="drops_dir")`), built on the same private-directory
+rules claude/agent.py uses for its screenshots (`shared/private_dir.py`).
+"""
+import importlib.util
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+
+MAP = os.path.join("fused_render", "templates", "map")
+TEMPLATE = os.path.join(MAP, "template.html")
+
+
+@pytest.fixture
+def discover():
+    if os.path.abspath(MAP) not in sys.path:
+        sys.path.insert(0, os.path.abspath(MAP))
+    spec = importlib.util.spec_from_file_location(
+        "map_drops_discover", os.path.join(MAP, "discover.py"))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture
+def html():
+    return open(TEMPLATE, encoding="utf-8").read()
+
+
+# ---------------------------------------------------- preparing the directory
+
+def test_drops_stage_under_the_shared_temp_root(discover):
+    """The bug this exists to fix: `dir=""` resolved to Path.home(), so an
+    ad-hoc drop landed permanently in the user's home folder. Staged drops
+    live under the temp root instead (which DesktopPaths redirects to the
+    app's own dotdir for every child process)."""
+    assert discover.DROPS.startswith(tempfile.gettempdir() + os.sep)
+    assert os.path.basename(discover.DROPS) == "drops"
+
+
+def test_the_drops_dir_is_created_private_and_adopted_on_a_second_call(
+        discover, tmp_path, monkeypatch):
+    """Two drops in one session: the second call adopts the directory the
+    first one made, rather than refusing or recreating it."""
+    drops = tmp_path / "fused_render_map" / "drops"
+    monkeypatch.setattr(discover, "DROPS", str(drops))
+    assert discover.main(action="drops_dir") == {"dir": str(drops)}
+    assert os.path.isdir(drops)
+    if hasattr(os, "geteuid"):
+        assert stat.S_IMODE(os.lstat(drops).st_mode) == 0o700
+    assert discover.main(action="drops_dir") == {"dir": str(drops)}
+
+
+@pytest.mark.skipif(not hasattr(os, "geteuid"), reason="POSIX mode bits")
+def test_a_drops_dir_anyone_can_write_to_is_refused(discover, tmp_path,
+                                                    monkeypatch):
+    """The temp root is world-writable and our path under it is predictable,
+    so another account can pre-create this directory. Adopting theirs would
+    hand them every file this user drops."""
+    drops = tmp_path / "fused_render_map" / "drops"
+    drops.mkdir(parents=True)
+    os.chmod(drops, 0o777)
+    monkeypatch.setattr(discover, "DROPS", str(drops))
+    with pytest.raises(PermissionError):
+        discover._drops_dir()
+
+
+@pytest.mark.skipif(not hasattr(os, "geteuid"), reason="POSIX mode bits")
+def test_an_adopted_drops_dir_is_tightened_to_owner_only(discover, tmp_path,
+                                                         monkeypatch):
+    drops = tmp_path / "fused_render_map" / "drops"
+    drops.mkdir(parents=True)
+    os.chmod(drops, 0o755)
+    monkeypatch.setattr(discover, "DROPS", str(drops))
+    assert discover._drops_dir() == {"dir": str(drops)}
+    assert stat.S_IMODE(os.lstat(drops).st_mode) == 0o700
+
+
+def test_a_drops_dir_that_cannot_be_made_is_an_error_not_a_crash(
+        discover, tmp_path, monkeypatch):
+    """No directory means no drop, which the page surfaces as a toast. It must
+    never be an unhandled traceback."""
+    blocker = tmp_path / "fused_render_map"
+    blocker.write_text("not a directory")
+    monkeypatch.setattr(discover, "DROPS", str(blocker / "drops"))
+    out = discover._drops_dir()
+    assert out.get("error") and "dir" not in out
+
+
+# ------------------------------------------------------------------- pruning
+
+def test_a_fresh_drop_survives_pruning(discover, tmp_path, monkeypatch):
+    """Two drops in a row must not eat each other: only TTL-expired files and
+    the oldest past the count cap go."""
+    drops = tmp_path / "drops"
+    drops.mkdir()
+    monkeypatch.setattr(discover, "DROPS", str(drops))
+    monkeypatch.setattr(discover, "DROPS_KEEP", 3)
+    fresh = drops / "parcels.gpkg"
+    fresh.write_bytes(b"x" * 32)
+    stale = drops / "ancient.tif"
+    stale.write_bytes(b"x")
+    os.utime(stale, (0, time.time() - discover.DROPS_TTL - 60))
+    for i in range(4):
+        p = drops / ("old%d.tif" % i)
+        p.write_bytes(b"x")
+        os.utime(p, (0, time.time() - 3600 - i))
+    discover._prune_drops()
+    assert fresh.exists(), "a file dropped a moment ago must survive"
+    assert not stale.exists(), "a TTL-expired file must not"
+    assert len(list(drops.iterdir())) <= 3
+
+
+def test_pruning_never_fails_the_action(discover, tmp_path, monkeypatch):
+    monkeypatch.setattr(discover, "DROPS", str(tmp_path / "never-made"))
+    discover._prune_drops()  # must not raise
+
+
+def test_a_dropped_file_can_outlive_the_session_that_made_it(discover):
+    """The staged path is what the layer references, so it has to survive at
+    least a long working session — days, not the hours a screenshot gets."""
+    assert discover.DROPS_TTL >= 24 * 3600
+
+
+# ------------------------------------------------------------------- the wire
+
+def test_the_page_asks_for_the_directory_by_the_action_the_backend_serves(
+        discover, html, tmp_path, monkeypatch):
+    assert 'action: "drops_dir"' in html
+    drops = tmp_path / "fused_render_map" / "drops"
+    monkeypatch.setattr(discover, "DROPS", str(drops))
+    assert discover.main(action="drops_dir") == {"dir": str(drops)}
+
+
+def test_the_browse_listing_is_untouched_by_the_new_action_default(discover,
+                                                                   tmp_path):
+    (tmp_path / "scene.tif").write_bytes(b"x")
+    out = discover.main(dir=str(tmp_path))
+    assert out["dir"] == str(tmp_path)
+    assert [e["name"] for e in out["entries"]] == ["scene.tif"]
+
+
+# ---------------------------------------------- the page's own JS, under node
+
+def _node(html, body):
+    """Run resolveUploadDir out of template.html under node, with the fused
+    bridge stubbed. Same extraction idea as tests/test_claude_shots.py's
+    `_node`: the function ends at the first closing brace at column 0."""
+    if not shutil.which("node"):
+        pytest.skip("node is needed to run the page's own upload-dir helper")
+    chunks = []
+    for name in ("let dropsDirPromise", "async function resolveUploadDir("):
+        start = html.index(name)
+        if name.startswith("let "):
+            chunks.append(html[start:html.index("\n", start)])
+        else:
+            chunks.append(html[start:html.index("\n}\n", start) + 3])
+    script = body + "\n" + "\n".join(chunks) + "\nmain();"
+    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def test_a_browsed_folder_still_wins_over_the_staging_dir(html):
+    """Once the user has picked a folder in the file browser, drops keep
+    landing there — the staging dir is only the no-folder fallback."""
+    out = _node(html, """
+var state = {dir: "C:/data"};
+var calls = [];
+var fused = {runPython: async (s, p) => { calls.push(p); return {dir: "/tmp/d"}; }};
+async function main() {
+  const dir = await resolveUploadDir();
+  console.log(JSON.stringify({dir: dir, calls: calls}));
+}
+""")
+    assert out == {"dir": "C:/data", "calls": []}
+
+
+def test_two_drops_share_one_backend_call(html):
+    out = _node(html, """
+var state = {dir: ""};
+var calls = [];
+var fused = {runPython: async (s, p) => { calls.push([s, p]); return {dir: "/tmp/drops"}; }};
+async function main() {
+  const a = await resolveUploadDir();
+  const b = await resolveUploadDir();
+  console.log(JSON.stringify({a: a, b: b, calls: calls}));
+}
+""")
+    assert out["a"] == out["b"] == "/tmp/drops"
+    assert out["calls"] == [["./discover.py", {"action": "drops_dir"}]]
+
+
+def test_a_failed_resolution_is_retried_not_cached(html):
+    """The reset-on-failure that was itself a recent bug fix: a rejected
+    promise must not poison every later drop of the session."""
+    out = _node(html, """
+var state = {dir: ""};
+var n = 0;
+var fused = {runPython: async () => {
+  if (++n === 1) throw new Error("engine cold");
+  return {dir: "/tmp/drops"};
+}};
+async function main() {
+  let firstError = "";
+  try { await resolveUploadDir(); } catch (e) { firstError = e.message; }
+  const dir = await resolveUploadDir();
+  console.log(JSON.stringify({firstError: firstError, dir: dir, n: n}));
+}
+""")
+    assert out == {"firstError": "engine cold", "dir": "/tmp/drops", "n": 2}
+
+
+def test_a_backend_error_dict_fails_the_drop_with_its_message(html):
+    """`_drops_dir` degrades OS trouble to `{"error": ...}`; the page has to
+    turn that into a thrown (and toasted) failure, not upload into ''."""
+    out = _node(html, """
+var state = {dir: ""};
+var results = [{error: "Could not prepare the drop directory: disk full"},
+               {dir: "/tmp/drops"}];
+var fused = {runPython: async () => results.shift()};
+async function main() {
+  let msg = "";
+  try { await resolveUploadDir(); } catch (e) { msg = e.message; }
+  const dir = await resolveUploadDir();
+  console.log(JSON.stringify({msg: msg, dir: dir}));
+}
+""")
+    assert "disk full" in out["msg"]
+    assert out["dir"] == "/tmp/drops", "an error dict must also reset the memo"

--- a/tests/test_map_vector_pipeline.py
+++ b/tests/test_map_vector_pipeline.py
@@ -55,6 +55,26 @@ def _make_grid(path: Path, width: int = 40, height: int = 40) -> None:
     frame.to_file(path, layer="segments", driver="GPKG", engine="pyogrio")
 
 
+def _make_utm_grid(path: Path, width: int = 20, height: int = 20) -> None:
+    cell = 2000.0
+    geometries = []
+    classes = []
+    for row in range(height):
+        for column in range(width):
+            west = 500000.0 + column * cell
+            south = 2200000.0 + row * cell
+            geometries.append(
+                box(west, south, west + cell * 0.8, south + cell * 0.8)
+            )
+            classes.append((row + column) % 7)
+    frame = gpd.GeoDataFrame(
+        {"class": classes},
+        geometry=geometries,
+        crs="EPSG:32639",
+    )
+    frame.to_file(path, layer="segments", driver="GPKG", engine="pyogrio")
+
+
 def _request(path: Path) -> dict:
     return {
         "target": str(path),
@@ -143,6 +163,66 @@ def test_tile_outside_source_is_empty(tmp_path, monkeypatch):
     x, y = _tile(120.0, 50.0, 8)
 
     assert engine.tile(descriptor["data"]["source_id"], 8, x, y) == b""
+
+
+def _decoded_points(value):
+    if isinstance(value[0], (int, float)):
+        return [value]
+    return [point for item in value for point in _decoded_points(item)]
+
+
+def test_projected_crs_geopackage_serves_correctly_placed_tiles(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "utm.gpkg"
+    _make_utm_grid(source)
+    monkeypatch.setattr(vector_engine, "VECTOR_TILE_MIN_FEATURES", 10)
+    engine = _engine()
+
+    descriptor = engine.try_describe(_request(source))
+
+    assert descriptor["status"] == "ok"
+    assert descriptor["crs_original"] == "EPSG:32639"
+    west, south, east, north = descriptor["bounds"]
+    assert 50.9 < west < east < 51.5
+    assert 19.5 < south < north < 20.5
+
+    zoom = 10
+    x, y = _tile((west + east) / 2.0, (south + north) / 2.0, zoom)
+    tile = engine.tile(descriptor["data"]["source_id"], zoom, x, y)
+
+    assert tile
+    features = mapbox_vector_tile.decode(tile)["layer"]["features"]
+    assert features
+    for feature in features:
+        for px, py in _decoded_points(feature["geometry"]["coordinates"]):
+            assert -1024 <= px <= 5120
+            assert -1024 <= py <= 5120
+
+
+def test_projected_crs_dense_overview_is_reprojected(tmp_path, monkeypatch):
+    source = tmp_path / "utm.gpkg"
+    _make_utm_grid(source)
+    monkeypatch.setattr(vector_engine, "VECTOR_TILE_MIN_FEATURES", 10)
+    monkeypatch.setattr(vector_engine, "MAX_TILE_FEATURES", 50)
+    engine = _engine()
+    descriptor = engine.try_describe(_request(source))
+    west, south, east, north = descriptor["bounds"]
+
+    zoom = 8
+    x, y = _tile((west + east) / 2.0, (south + north) / 2.0, zoom)
+    tile = engine.tile(descriptor["data"]["source_id"], zoom, x, y)
+
+    assert tile
+    features = mapbox_vector_tile.decode(tile)["layer"]["features"]
+    assert features
+    assert all(
+        feature["properties"]["feature_count"] > 0 for feature in features
+    )
+    for feature in features:
+        for px, py in _decoded_points(feature["geometry"]["coordinates"]):
+            assert -1024 <= px <= 5120
+            assert -1024 <= py <= 5120
 
 
 def test_vector_tile_is_served_over_the_daemon_endpoint(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Fill/Line color pickers gain a companion opacity slider — `fill_color`/`line_color` already carried an alpha byte but no control ever wrote to it, so a polygon's fill couldn't be made transparent without also dimming its outline.
- Files can be dragged from the OS straight onto the map to add layers (uploads via the existing `fused.uploadFile`, filename-collision-safe, loads through the same path the file browser uses).
- Raster styling gains categorical (unique-value / paletted) support in both the tiled and one-shot raster pipelines: detects an embedded GDAL color table or a low-cardinality integer band, and gives an editable per-category color/label legend in the style dock. New shared `raster_categories.py` module.

## Test plan
- [x] `tests/test_map_raster_pipeline.py` passes (16/16)
- [x] Verified `classify_categories` directly: unique-value heuristic, embedded-colormap precedence, user overrides, float/high-cardinality ineligibility, masked-array nodata handling
- [x] Verified `raster_engine.py`'s `RasterEngine.try_describe`/`.tile()` end-to-end against synthetic categorical GeoTIFFs (with and without an embedded color table): correct pixel-exact tile colors, color-override cache-busting, continuous-mode fallback
- [x] Verified `geo_classify.py`'s `_render_raster`/`_render_array` one-shot categorical path the same way
- [x] Drove the real running app in-browser: Fill/Line opacity persistence across style-dock reopen, drag-and-drop upload + collision suffixing + layer load, categorical swatch/label editing and re-render through the live daemon

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core raster/vector render pipelines and introduces a new temp-dir staging path with ownership/mode checks. Not auth-critical, but incorrect private-dir or CRS handling could leak staged files or misplace layers.
> 
> **Overview**
> Adds three Map Viewer capabilities: **categorical raster styling**, **OS drag-and-drop layer import**, and **fill/line opacity** controls.
> 
> **Categorical rasters.** New shared `raster_categories.py` detects paletted / low-cardinality integer bands (GDAL color tables, PAM `.aux.xml` labels) and drives both the tiled (`raster_engine`) and one-shot (`geo_classify`) paths. Categorical mode uses nearest resampling end-to-end so class codes never blend. The style dock gains a Continuous/Categorical toggle plus an editable per-value color/label legend.
> 
> **Drag-and-drop import.** Files dropped on the map upload via `fused.uploadFile`, keep shapefile/PAM sidecars paired with collision-safe suffixes, and load through the normal layer path. Ad-hoc drops stage in a pruned per-user temp dir (`discover.py` `action=drops_dir`) instead of Home. Private-dir helpers are extracted to `shared/private_dir.py` and reused by Claude’s run tree.
> 
> **Opacity + vector fixes.** Style dock alpha sliders finally write the existing fill/line alpha byte. Vector tiles explicitly reproject non-4326 sources to `EPSG:4326` before MVT encode, and GDAL restores missing `.shx` sidecars for incomplete shapefile drops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee96bff4471d5cfa0520cf57581b41b6353261f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->