### PR TITLE
Split file preview: content pane + Claude/Git/History companion sidebar

### DIFF
--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -26,6 +26,8 @@ import { useEffect, useRef, useState, type MouseEvent, type ReactNode } from "re
 import { modeTitle } from "@platform/lib/mode-name";
 import { copyToClipboard } from "@platform/lib/clipboard";
 import { pushToast } from "@platform/lib/toast";
+import { MenuIcons } from "@platform/ui/MenuIcons";
+import { SplitDownIcon, SplitRightIcon } from "@platform/ui/SplitIcons";
 
 // Keep the popup on screen: it is right-aligned to the trigger in spirit, but
 // clamping the LEFT edge is what actually matters near the window's edge.
@@ -132,12 +134,20 @@ function CheckIcon() {
   );
 }
 
+// VERTICAL `⋮`, not the horizontal `···` it was — in every bar that carries this
+// menu, because there is one glyph for one meaning. It earns the rotation in the
+// place it is most used: the crumb strip, immediately after the path's last
+// segment (both the title bar's PathOverflow and the panel pane bars sit there),
+// where a horizontal triplet reads as a continuation of the path — three more
+// dots in a row of `/`-joined segments, i.e. "the path goes on". Turned upright
+// it reads as a control, and it is the same "more, about this thing" affordance
+// every file manager puts beside a row.
 function EllipsisIcon() {
   return (
     <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
-      <circle cx="5" cy="12" r="1.7" />
+      <circle cx="12" cy="5" r="1.7" />
       <circle cx="12" cy="12" r="1.7" />
-      <circle cx="19" cy="12" r="1.7" />
+      <circle cx="12" cy="19" r="1.7" />
     </svg>
   );
 }
@@ -239,7 +249,16 @@ export function ModeMenu({ entries, active, busy, onSelect }: ModeMenuProps) {
 export interface OverflowItem {
   label: string;
   onClick: () => void;
+  // Optional leading glyph, in the same 16px slot the mode rows use
+  // (.bar-menu-item-icon). A menu is all-or-nothing about icons in practice —
+  // one iconless row among icon'd ones reads as a broken row — so a caller
+  // either gives every item one or none.
+  icon?: ReactNode;
 }
+
+// A menu may group its items. Same shape as ContextMenu's entry list, so the
+// two menus describe a separator the same way.
+export type OverflowEntry = OverflowItem | "separator";
 
 // The path `···`: the two low-frequency one-shots every view OF A PATH offers.
 // It lives here rather than in the bar that used to own it because it now has
@@ -260,24 +279,46 @@ function revealInFileManager(path: string): void {
   });
 }
 
-export function PathOverflow({ fsPath }: { fsPath: string }) {
+// `onSplit` (a FILE preview only — see Breadcrumb) adds the two split-entry
+// items. They used to be a pair of naked glyphs in the bar's own layout zone,
+// behind a hairline, at the far right of the window. Two problems with that: the
+// zone existed for those two buttons and nothing else, so a rule and a group
+// were carrying one action each; and "open this view split" is about the PATH,
+// which is what this menu is about and what it now sits next to. As menu rows
+// they also finally get names — "Split right" is not something the filled-half
+// rectangle glyph ever said out loud.
+export function PathOverflow({
+  fsPath,
+  onSplit,
+}: {
+  fsPath: string;
+  onSplit?: (dir: "row" | "col") => void;
+}) {
   const copyPath = async () => {
     if (await copyToClipboard(fsPath)) pushToast({ msg: "Path copied", tone: "info" });
     else pushToast({ msg: "Couldn't copy the path", tone: "error" });
   };
-  return (
-    <OverflowMenu
-      items={[
-        { label: "Open in " + FILE_MANAGER, onClick: () => revealInFileManager(fsPath) },
-        { label: "Copy path", onClick: () => void copyPath() },
-      ]}
-    />
-  );
+  const items: OverflowEntry[] = [
+    {
+      label: "Open in " + FILE_MANAGER,
+      icon: MenuIcons.reveal,
+      onClick: () => revealInFileManager(fsPath),
+    },
+    { label: "Copy path", icon: MenuIcons.copyPath, onClick: () => void copyPath() },
+  ];
+  if (onSplit) {
+    items.push(
+      "separator",
+      { label: "Split right", icon: <SplitRightIcon size={16} />, onClick: () => onSplit("row") },
+      { label: "Split down", icon: <SplitDownIcon size={16} />, onClick: () => onSplit("col") }
+    );
+  }
+  return <OverflowMenu items={items} />;
 }
 
-// `···` menu for the bars' layout zone. Renders nothing when it has no items,
-// so a caller can pass a conditional list without guarding the control itself.
-export function OverflowMenu({ items, title = "More actions" }: { items: OverflowItem[]; title?: string }) {
+// `⋮` menu for the bars. Renders nothing when it has no items, so a caller can
+// pass a conditional list without guarding the control itself.
+export function OverflowMenu({ items, title = "More actions" }: { items: OverflowEntry[]; title?: string }) {
   const { pos, rootRef, toggle, close } = useMenuAnchor("right");
   if (items.length === 0) return null;
   return (
@@ -306,20 +347,25 @@ export function OverflowMenu({ items, title = "More actions" }: { items: Overflo
           aria-label={title}
           style={{ top: pos.top, left: pos.left, right: pos.right }}
         >
-          {items.map((item) => (
-            <button
-              key={item.label}
-              type="button"
-              role="menuitem"
-              className="bar-menu-item"
-              onClick={() => {
-                close();
-                item.onClick();
-              }}
-            >
-              <span className="bar-menu-item-label">{item.label}</span>
-            </button>
-          ))}
+          {items.map((item, i) =>
+            item === "separator" ? (
+              <div key={"sep" + i} className="bar-menu-sep" role="separator" />
+            ) : (
+              <button
+                key={item.label}
+                type="button"
+                role="menuitem"
+                className="bar-menu-item"
+                onClick={() => {
+                  close();
+                  item.onClick();
+                }}
+              >
+                {item.icon && <span className="bar-menu-item-icon">{item.icon}</span>}
+                <span className="bar-menu-item-label">{item.label}</span>
+              </button>
+            )
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -1,16 +1,19 @@
 // Crumb bar, in three zones left to right:
 //
-//   path    ★ bookmark button, then the crumbs (or the editable path field)
+//   path    ★ bookmark button, the crumbs (or the editable path field), then the
+//           path `⋮` — reveal, copy path, and (a file only) the two splits
 //   mode    the `#topbar-mode-slot` portal target — Preview renders the view's
-//           conditional primary action and the shared mode control into it
+//           conditional primary action, the shared mode control and the preview
+//           sidebar's toggle into it
 //   search  over a FOLDER only: the listing's search row portals in here, so
 //           its column has one header strip instead of two (search-slot.ts)
-//   layout  a hairline rule, then split-right / split-down / `···`
 //
 // The Finder and split glyphs used to live INSIDE the crumb strip, welded to
 // the last path segment: the path zone was not only the path, and "open in
-// Finder" (rare) sat at the same weight as the splits (frequent). Reveal and
-// "Copy path" moved into the `···` overflow; the splits form the layout group.
+// Finder" (rare) sat at the same weight as the splits (frequent). They then
+// separated — reveal/copy into a `···` overflow, the splits into a layout zone
+// of their own at the bar's far right — and have since converged again, as
+// NAMED ITEMS in the one path menu (see LayoutZone's epitaph below).
 //
 // Rendered by every view: path crumbs for listing/preview, a static label for
 // the layout modes (LM-11 / TM-9 — ★/update still operate on currentUrl()).
@@ -37,7 +40,6 @@ import { resolveCloudUrl } from "@platform/lib/api";
 import { pushToast } from "@platform/lib/toast";
 import { encodePaneSegment, splitShellSearch } from "@platform/lib/layout-codec";
 import { panelUrl } from "@apps/explorer/Panel";
-import { SplitRightIcon, SplitDownIcon } from "@platform/ui/SplitIcons";
 import { PathOverflow } from "@apps/explorer/BarMenu";
 import { springDisarms } from "@apps/explorer/listing/drag-drop";
 import { cameFromSelParam } from "@apps/explorer/listing/selection";
@@ -214,44 +216,18 @@ function FolderSearchSlot() {
   return <div className="crumb-search-slot" ref={ref} />;
 }
 
-// Split entry buttons: the bar's layout zone, in the same position in every
-// state so the hand learns where layout lives. Nothing here for a folder at
-// all (listing/folder-chrome.ts says which state we are in): the splits are
-// the pair that make least sense over a view that already IS a split, and with
-// them gone the rule and the hairline would be a zone with nothing in it.
-// The path `···` used to end this zone; it now travels with the path itself
-// (see the crumb strip below), which is what it acts on.
-function LayoutZone({ fsPath }: { fsPath: string }) {
-  const claimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
-  if (claimed) return null;
-  return (
-    <>
-      <span className="bar-rule" aria-hidden="true" />
-      <div className="bar-zone">
-        <button
-          type="button"
-          id="split-right-btn"
-          className="bar-ctl bar-ctl-icon"
-          title="Open this view in panel mode, split right"
-          aria-label="Split right"
-          onClick={() => enterPanel(fsPath, "row")}
-        >
-          <SplitRightIcon />
-        </button>
-        <button
-          type="button"
-          id="split-down-btn"
-          className="bar-ctl bar-ctl-icon"
-          title="Open this view in panel mode, split down"
-          aria-label="Split down"
-          onClick={() => enterPanel(fsPath, "col")}
-        >
-          <SplitDownIcon />
-        </button>
-      </div>
-    </>
-  );
-}
+// The bar's LAYOUT ZONE is gone, and with it the hairline that made it read as
+// a zone. It held exactly two controls — split-right and split-down, for a file
+// preview only (a folder never had them: the splits make least sense over a view
+// that already IS a split) — as unlabelled filled-rectangle glyphs pinned to the
+// far right of the window, an inch of empty bar away from the path they act on.
+// Both are items in the path `⋮` now (BarMenu's PathOverflow), where they sit
+// beside "Open in Finder"/"Copy path", carry their names, and travel with the
+// path itself. `enterPanel` below is unchanged and is still what they call.
+//
+// Which state we are in — file or folder — is `listing/folder-chrome.ts`'s
+// claim, read where the menu is rendered rather than by a zone component of its
+// own.
 
 // A pending copy/cut is shown ONLY on the affected rows (Listing.tsx marks them
 // with a badge and edge bar). There is deliberately no global chip here: the
@@ -454,6 +430,10 @@ export function Breadcrumb({
   const captureBar = (el: HTMLElement | null) => {
     if (el) barRef.current = el.parentElement;
   };
+  // Folder or file? The listing claims the bar's chrome over a folder
+  // (listing/folder-chrome.ts) — the one thing that decides whether the path
+  // menu offers the splits (see PathOverflow below).
+  const folderClaimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
   const [editing, setEditing] = useState(false);
   // Set by the click-away below for the rest of its gesture — see the bar's
   // click handler, which must not treat that same click as "open the field".
@@ -707,17 +687,23 @@ export function Breadcrumb({
           {pieces}
         </div>
       )}
-      {/* The path `···` — "Open in Finder", "Copy path" — sits immediately
-          right of the name it acts on, in every view. It used to end the bar's
-          layout zone for a file and the search row for a folder: two homes,
-          both of them the bar's far right, neither of them next to the thing
-          being opened or copied. The crumb strip stops growing (explorer.css)
-          so this stays against the path rather than drifting to the edge. */}
-      <PathOverflow fsPath={fsPath} />
+      {/* The path `⋮` — "Open in Finder", "Copy path", and for a FILE the two
+          split-entry actions — sits immediately right of the name it acts on, in
+          every view. It used to end the bar's layout zone for a file and the
+          search row for a folder: two homes, both of them the bar's far right,
+          neither of them next to the thing being opened or copied. The crumb
+          strip stops growing (explorer.css) so this stays against the path
+          rather than drifting to the edge.
+          No splits over a FOLDER (the chrome claim is how we know): they make
+          least sense over a view that already is a split, which is why the old
+          layout zone hid itself there too. */}
+      <PathOverflow
+        fsPath={fsPath}
+        onSplit={folderClaimed ? undefined : (dir) => enterPanel(fsPath, dir)}
+      />
       <UpdateBookmarkButton />
       <TopbarActionsSlot />
       <FolderSearchSlot />
-      <LayoutZone fsPath={fsPath} />
     </>
   );
 }

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -12,6 +12,7 @@
 //   search.ts              fuzzy scoring / ranking (pure)
 //   selection.ts           selection model + cross-remount stash (pure)
 //   pane.ts                preview-pane split (usePreviewPane: width + drag)
+//   pane-side.ts           the pane's three modes + the `_side` param (pure)
 //   row-utils.ts           RowCtx batch helpers
 //   bits.tsx               skeleton rows, ClipMark, highlight, scroll anchor
 //   useDirListing.ts       /api/fs/list fetch, Load more, dir watch, new-row cue
@@ -65,6 +66,18 @@ import {
   measureScrollAnchor,
 } from "@apps/explorer/listing/bits";
 import { usePreviewPane } from "@apps/explorer/listing/pane";
+import {
+  activePaneSide,
+  paneKey,
+  paneSideList,
+  paneSideParam,
+  parsePaneSide,
+  type PaneSide,
+  type PaneSideState,
+} from "@apps/explorer/listing/pane-side";
+import { useDirMode } from "@apps/explorer/lib/dir-mode";
+import { SideToggleButton, paneSideIcon } from "@apps/explorer/SideChrome";
+import { modeTitle } from "@platform/lib/mode-name";
 import { passedDragSlop } from "@apps/explorer/listing/marquee";
 import {
   INITIAL_SEARCH_SELECT,
@@ -224,10 +237,68 @@ export default function Listing({
   // in its own column. A flag that could only ever be written beside another
   // one is the "three places to agree about one bit" the pane's own history
   // (pane.ts) is a warning about.
-  const { pane, splitRef, onDividerPointerDown } = usePreviewPane(
-    fsPath,
-    !embedded && !IS_SNAPSHOT
+  const paneEnabled = !embedded && !IS_SNAPSHOT;
+  const { pane, splitRef, onDividerPointerDown } = usePreviewPane(fsPath, paneEnabled);
+
+  // --- the pane's THREE modes, and whether it is open at all ------------------
+  // `pane.on` above is the LAYOUT's answer ("is there room for two columns?",
+  // pane.ts) and is not a choice. This is the user's, on top of it: which of the
+  // pane's three modes it is showing, or that they have shut it — recorded as
+  // `_side` on the folder URL, whose semantics (and why an ABSENT one means OPEN
+  // here while it means CLOSED on a file view) are written down in
+  // listing/pane-side.ts.
+  //
+  // The mode is kept here and not in the pane because the pane is keyed on the
+  // previewed row and remounts as the selection moves, while a chosen mode must
+  // not; and because the reopening half of the affordance has to render while
+  // the pane does not exist at all (see the search row below).
+  const [sideState, setSideState] = useState<PaneSideState>(() =>
+    parsePaneSide(paneEnabled ? new URLSearchParams(location.search).get("_side") : null)
   );
+  // Both companions' entries come from the OPEN FOLDER, resolved through the
+  // ordinary stat + condition machinery (lib/dir-mode — which caches per
+  // directory, so this is one probe for the folder rather than one per selection).
+  // `git` because a working tree belongs to the folder; `claude` because the
+  // pane's chat is the FOLDER VIEW's companion, aimed at whichever row is
+  // selected, so which chat template to use is a question about the folder too.
+  //
+  // A folder outside a repository loses the Git pill, and one on a mount loses
+  // both (each gate refuses a mount-backed path) — at which point the pill hides
+  // itself, "one mode is not a choice", and the pane is what it always was.
+  const folderClaude = useDirMode(paneEnabled ? fsPath : null, "claude");
+  const folderGit = useDirMode(paneEnabled ? fsPath : null, "git");
+  // While the probe is in flight the entries are PLACEHOLDERS with no template
+  // path (lib/dir-mode), which would build a `path=null` iframe URL — so a
+  // pending companion is simply not offered yet. Unlike the file sidebar there is
+  // nothing to protect by listing it early: the folder's `_side` is never
+  // reconciled away (pane-side's activePaneSide leaves an unavailable request in
+  // the URL on purpose), so a `?_side=git` deep link survives the wait and lands
+  // the moment the verdict does.
+  const sideEntries = {
+    claude: folderClaude.pending ? null : folderClaude.entry,
+    git: folderGit.pending ? null : folderGit.entry,
+  };
+  const paneSide = activePaneSide(paneSideList(sideEntries), sideState.mode);
+  const paneOpen = pane.on && sideState.open;
+  // One writer for both halves of the state, and it writes the URL only where the
+  // listing owns one: an embedded pane (the preview pane's own `_listing` mode) is
+  // URL-silent by contract, and it never has a pane of its own anyway.
+  const setSide = (next: PaneSideState) => {
+    setSideState(next);
+    if (!paneEnabled) return;
+    const params = new URLSearchParams(location.search);
+    const v = paneSideParam(next);
+    if (v === null) params.delete("_side");
+    else params.set("_side", v);
+    const qs = params.toString();
+    replaceSearch(location.pathname + (qs ? "?" + qs : ""));
+  };
+  // Reopening keeps the mode the pane was shut on, so closing and reopening is
+  // not a reset. Session-only — see paneSideParam on why the URL records only
+  // "shut".
+  const openSide = () => setSide({ open: true, mode: sideState.mode });
+  const closeSide = () => setSide({ open: false, mode: sideState.mode });
+  const selectSide = (mode: PaneSide) => setSide({ open: true, mode });
 
   const clipboard = useClipboard();
 
@@ -1156,11 +1227,30 @@ export default function Listing({
                   </span>
                 )}
               </div>
-              {/* No pane toggle here any more. The split is decided by the
-                  container's width (listing/pane.ts), so there is no state for
-                  a button to flip — and a control that only ever restated what
-                  the layout already showed was one more thing in a row that is
-                  meant to be the search box. */}
+              {/* THE PANE'S OPENER, and the second half of one affordance: the
+                  closing chevron is a control ON the pane's own header, at the
+                  seam it collapses toward (SideChrome, where the split is written
+                  down), so this button is on screen only while the pane is SHUT.
+
+                  It is not the old pane toggle coming back. That one was an
+                  on/off for a bit the layout could answer itself, and it went
+                  when the split became purely a measurement of the container's
+                  width (listing/pane.ts) — `pane.on` below is still that
+                  measurement, and this button does not exist when it says no. It
+                  is a mode control: it says WHICH of the pane's three would
+                  return, wearing that mode's own icon, which is a thing the
+                  layout cannot answer.
+
+                  Here rather than in the crumb bar because over a folder THIS ROW
+                  is the bar (it portals into it — search-slot.ts), and this is the
+                  folder's own chrome, beside the folder's own search box. */}
+              {pane.on && !sideState.open && (
+                <SideToggleButton
+                  what={modeTitle(paneSide)}
+                  icon={paneSideIcon(paneSide, sideEntries)}
+                  onClick={openSide}
+                />
+              )}
               {/* The path `···` is not here any more: it rides the crumb strip
                   now (Breadcrumb.tsx), immediately right of the folder name it
                   acts on, which is one home instead of this row's and the
@@ -1260,7 +1350,7 @@ export default function Listing({
             </table>
           </div>
         </div>
-        {pane.on && (
+        {paneOpen && (
           <>
             <div
               className="listing-divider"
@@ -1278,19 +1368,22 @@ export default function Listing({
               // pixel floors are the slot's / the list's CSS min-widths.
               style={{ flexBasis: `${pane.frac * 100}%` }}
             >
-              {/* Keyed on the previewed path: switching rows remounts the pane,
-                  so a stale iframe never lingers a frame while the new row's
-                  stat/list resolves. Nothing selected → the pane previews THIS
-                  folder itself (self: its template or lone app — never its
-                  listing, which is already on the left). */}
+              {/* Keyed on WHAT THE PANE IS ABOUT (pane-side's paneKey), which is
+                  the previewed row for two of the three modes and the FOLDER for
+                  Git — see there. Keying on the row is what stops a stale iframe
+                  lingering a frame while the new row's stat/list resolves; keying
+                  Git on the folder instead is what stops arrow-keying down the
+                  listing reloading a `git status` per keystroke.
+                  Nothing selected → the pane previews THIS folder itself (self:
+                  its template or lone app — never its listing, which is already on
+                  the left). */}
               <ListingPreviewPane
-                key={
-                  sel.paths.length === 1 && leadRow
-                    ? leadRow.path
-                    : sel.paths.length === 0
-                      ? "self:" + fsPath
-                      : "none"
-                }
+                key={paneKey(
+                  paneSide,
+                  fsPath,
+                  sel.paths.length === 1 && leadRow ? leadRow.path : null,
+                  sel.paths.length
+                )}
                 row={
                   sel.paths.length === 1 && leadRow
                     ? leadRow
@@ -1306,6 +1399,11 @@ export default function Listing({
                       : null
                 }
                 selCount={sel.paths.length}
+                folder={fsPath}
+                side={paneSide}
+                sideEntries={sideEntries}
+                onSelectSide={selectSide}
+                onClose={closeSide}
               />
             </div>
           </>

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -1,27 +1,42 @@
-// Right-hand preview pane for the directory listing (views/Listing.tsx) —
-// selection-driven: previews the listing's lead row when exactly one row is
-// selected, and shows a neutral placeholder otherwise. Reuses the app's own
-// template pipeline for FILES AND FOLDERS alike: the selection is stat'ed to
-// discover its template modes and the default embeds as the normal /render
-// iframe. A folder's `_listing` mode mounts the real shell Listing component
-// (embedded — no URL writes, no nested pane, no global keyboard); a folder
-// with a lone top-level HTML "app" additionally offers the pane-only `_app`
-// mode that renders that app in place. The header carries a mode menu so the
-// previewed mode can be switched (pane-local, transient — it never touches
-// the URL or saved viewstate). The one target with NO menu and no preview is
-// the self target (nothing selected — the folder already open on the left):
-// see its branch below. Wire-up state (pane visibility, width, the divider
-// drag) stays in Listing — this component only owns what the pane shows for a
-// given selection.
+// Right-hand preview pane for the directory listing (views/Listing.tsx), and the
+// folder's half of the companion split the file view grew (Preview.tsx /
+// PreviewSidebar.tsx). It shows ONE OF THREE things — listing/pane-side.ts owns
+// the list and the `_side` param that records which:
+//
+//   Preview  the selection-driven preview it has always been: the listing's lead
+//            row when exactly one row is selected, a neutral placeholder
+//            otherwise. Reuses the app's own template pipeline for FILES AND
+//            FOLDERS alike — the selection is stat'ed to discover its template
+//            modes and its DEFAULT embeds as the normal /render iframe (which
+//            mode that is, is listing/pane-modes.ts's call). A folder's
+//            `_listing` mode mounts the real shell Listing component (embedded —
+//            no URL writes, no nested pane, no global keyboard); a folder with a
+//            lone top-level HTML "app" gets the pane-only `_app` mode instead,
+//            rendering that app in place.
+//   Claude   the chat, chat-only, about the selected row (about the FOLDER when
+//            the selection names no single row).
+//   Git      the OPEN FOLDER's working tree. The one mode whose subject is not
+//            the selection at all — see paneKey on why that matters.
+//
+// The two companions' template entries are the FOLDER's, resolved once by Listing
+// (lib/dir-mode) and handed down: neither changes with the selection, and this
+// component remounts on every selection change.
+//
+// The header is the file sidebar's header, to the button: the way out of the
+// column at its left end, the mode pill at its right (SideChrome). Wire-up state
+// — whether there is a pane at all, its width, the divider drag, and `_side`
+// itself — stays in Listing; this component owns only what the pane shows.
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { listDir, resolveConditions, statPath } from "@platform/lib/api";
 import type { TemplateEntry } from "@platform/lib/api";
-import { navigate, replaceSearch } from "@platform/lib/router";
+import { navigate } from "@platform/lib/router";
 import { formatSize } from "@platform/lib/format";
+import { modeTitle } from "@platform/lib/mode-name";
 import { isModeVisible } from "@platform/lib/mode-visibility";
 import { iconForEntry, isAppEntry } from "@platform/ui/FileIcons";
-import { KNOWN_SENTINEL_MODES, templateModeIcon } from "@apps/explorer/ModeSwitcher";
+import { KNOWN_SENTINEL_MODES } from "@apps/explorer/ModeSwitcher";
 import { ModeMenu } from "@apps/explorer/BarMenu";
+import { SideCloseButton, paneSideIcon } from "@apps/explorer/SideChrome";
 import { useAppButton } from "@apps/explorer/lib/app-button";
 import { withNoFocus } from "@apps/explorer/listing/frame-focus";
 import { usePaneFocusGuard } from "@apps/explorer/listing/usePaneFocusGuard";
@@ -36,6 +51,12 @@ import {
   paneModeList,
   paneOpenAction,
 } from "@apps/explorer/listing/pane-modes";
+import {
+  paneSideList,
+  paneSideTarget,
+  type PaneSide,
+  type PaneSideEntries,
+} from "@apps/explorer/listing/pane-side";
 
 // The selected row, as the pane needs it. Structurally a subset of Listing's
 // RowCtx, so the lead row can be passed straight through.
@@ -53,24 +74,11 @@ export interface PaneTarget {
 // the ordering rules in listing/pane-modes.ts).
 const APP_MODE = PANE_APP_MODE;
 
-// Monochrome switcher icon for the `_app` mode — currentColor like the other
-// mode icons, so it takes the switcher's muted/active tinting instead of the
-// colored file icon (which read as an odd yellow button in the strip).
-const APP_MODE_ICON = (
-  <svg
-    viewBox="0 0 24 24"
-    width="16"
-    height="16"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth="2"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-  >
-    <rect x="3" y="3" width="18" height="18" rx="3" />
-    <path d="M10 8.5l6 3.5-6 3.5z" />
-  </svg>
-);
+// `_app` no longer needs a SWITCHER ICON of its own. It had one — a monochrome
+// play-in-a-box, currentColor like every other mode glyph — for the pane's own
+// per-template menu, which listed `_app` beside the row's real templates. That
+// menu is gone (see the header below): `_app` is now only ever RENDERED, as one
+// of the things `Preview` can resolve to, and nothing draws it in a bar.
 
 // The stat'ed template picture for the selected row. `conditions` is null
 // while gated entries are still resolving (CT-12 deferred verdicts).
@@ -91,13 +99,6 @@ type InfoState =
 interface AppTarget {
   name: string;
   path: string;
-}
-
-// One entry of the pane's mode menu (template modes + pane sentinels) — the
-// shape BarMenu's shared ModeMenu takes.
-interface PaneMode {
-  mode: string;
-  icon: React.ReactNode;
 }
 
 // Portal target for the open folder's primary action (pane-action-slot.ts).
@@ -121,31 +122,37 @@ function PaneActionSlot() {
 export default function ListingPreviewPane({
   row,
   selCount,
+  folder,
+  side,
+  sideEntries,
+  onSelectSide,
+  onClose,
 }: {
   // The lead row when exactly one row is selected, else null.
   row: PaneTarget | null;
   // Total selected rows, for the multi-selection placeholder.
   selCount: number;
+  // The OPEN folder — the listing on the other side of the divider. `Git`'s
+  // subject, and `Claude`'s when the selection names no single row.
+  folder: string;
+  // Which of the three the pane is showing. Already resolved against what this
+  // folder offers (pane-side's activePaneSide, in Listing), so it is always a
+  // mode `sideEntries` can actually back.
+  side: PaneSide;
+  // The FOLDER's `claude` / `git` template entries, or null where the folder does
+  // not offer the mode (lib/dir-mode). Resolved by Listing, which does not remount
+  // per selection — see the module comment.
+  sideEntries: PaneSideEntries;
+  onSelectSide: (side: PaneSide) => void;
+  // Shuts the pane (`_side=off`). The listing's search row grows the reopening
+  // half of the affordance while the pane is down — SideChrome writes the split
+  // between the two down.
+  onClose: () => void;
 }) {
   const [info, setInfo] = useState<InfoState>({ status: "loading" });
   // Lone-app probe result for a folder: undefined = still loading, null =
   // no unambiguous app. Only drives the `_app` menu entry, never a default.
   const [app, setApp] = useState<AppTarget | null | undefined>(undefined);
-  // Mode override from the mode menu, synced to the URL as `_panelMode` so
-  // the chosen pane mode SURVIVES selection switches: the component is keyed
-  // on the previewed path (Listing) and remounts per selection, but each
-  // mount re-seeds from the URL. A selection that doesn't offer the mode
-  // falls back to its default (activeMode below) while the param stays put —
-  // the next selection that does offer it picks it up again.
-  const [modeOverride, setModeOverride] = useState<string | null>(
-    () => new URLSearchParams(location.search).get("_panelMode")
-  );
-  const selectMode = (m: string) => {
-    setModeOverride(m);
-    const params = new URLSearchParams(location.search);
-    params.set("_panelMode", m);
-    replaceSearch(location.pathname + "?" + params.toString());
-  };
 
   // Stat the selection — files and folders alike carry a template mode list
   // (folders at minimum the `_listing` sentinel). The cleanup flag is the
@@ -156,8 +163,14 @@ export default function ListingPreviewPane({
   // The self target renders without asking the server anything (no modes, no
   // app probe — see its branch below), so neither fetch is started for it.
   const self = !!row?.self;
+  // Only `Preview` is about the row's own templates. Claude and Git are handed
+  // their entry by the caller and aimed by `_file`, so in those two modes the
+  // stat and the lone-app probe below would both be work for an answer nothing
+  // reads — including on every selection change, since Claude stays mounted
+  // across one.
+  const previewing = side === "preview";
   useEffect(() => {
-    if (!path || self) return;
+    if (!path || self || !previewing) return;
     let alive = true;
     setInfo({ status: "loading" });
     statPath(path).then(
@@ -190,7 +203,7 @@ export default function ListingPreviewPane({
     return () => {
       alive = false;
     };
-  }, [path, self]);
+  }, [path, self, previewing]);
 
   // Folder lone-app probe, for the `_app` mode. A truncated listing is only a
   // partial page (server cap), so a lone HTML match in it doesn't prove it is
@@ -198,7 +211,7 @@ export default function ListingPreviewPane({
   // onSingleApp guard). Errors also just drop the mode; the embedded Listing
   // surfaces the folder's real error itself.
   useEffect(() => {
-    if (!path || !isDir || self) return;
+    if (!path || !isDir || self || !previewing) return;
     let alive = true;
     setApp(undefined);
     listDir(path).then(
@@ -217,7 +230,7 @@ export default function ListingPreviewPane({
     return () => {
       alive = false;
     };
-  }, [path, isDir, self]);
+  }, [path, isDir, self, previewing]);
 
   // The "Open as app" / "Add as app" button for a previewed FOLDER that holds a
   // lone top-level page — label, click and destination decided in one shared
@@ -232,41 +245,102 @@ export default function ListingPreviewPane({
   // returns; the branches it guards are the ones that render a frame.
   const { rootRef, guardProps } = usePaneFocusGuard<HTMLDivElement>();
 
+  // --- the pane's three modes (listing/pane-side.ts) --------------------------
+  // Which are on offer follows entirely from what the FOLDER gave us: `preview`
+  // always, the companions only where the folder has an entry for them. Nothing
+  // about the selected row enters into it, which is what lets the pill hold still
+  // as the user arrows down the list.
+  const sides = paneSideList(sideEntries);
+  const sideMenu = (
+    <ModeMenu
+      entries={sides.map((m) => ({ mode: m, icon: paneSideIcon(m, sideEntries) }))}
+      active={side}
+      onSelect={(m) => onSelectSide(m as PaneSide)}
+    />
+  );
+
   // The pane's chrome strip, and EVERY state gets one — a loading skeleton, an
   // error, the metadata card and the multi-selection placeholder alike. It is
   // the TOP BAR of the right-hand column now that the pane runs the full height
   // of the window, so it has to hold its height in every state or the seam it
   // shares with the crumb bar on the left breaks (see .pane-header).
   //
-  // It used to open with a COLLAPSE button, sitting on the seam it sent the
-  // pane back to. That went with the toggle: the split is now decided by the
-  // container's width (listing/pane.ts), so a closed pane would have had no
-  // way back short of resizing the window.
+  // It opens with the way OUT of the column and it ends with the mode pill, which
+  // is the file sidebar's header exactly (SideChrome, PreviewSidebar) — the two
+  // columns are the same column over a folder and over a file, so they wear the
+  // same bar.
   //
-  // It then carried the previewed row's ICON AND NAME. Those are gone too. The
-  // pane's subject is whichever row is selected, and that row is highlighted an
-  // inch to the left with its name in the same eyeline — restating it here put
-  // the loudest text in the strip on the one fact the layout already made
-  // obvious, and (unlike the crumb bar it now sits beside) it named a thing the
-  // bar's own controls do not act on.
+  // Both of those are in `strip` rather than in `extra`, i.e. in every state: a
+  // control that vanishes while a row stats is a control the user cannot rely on,
+  // and closing the pane is not something a loading preview should be able to
+  // take away. The same reasoning already put the OPEN FOLDER's primary action
+  // here (portaled down from Preview.tsx, pane-action-slot.ts — see there for why
+  // it is not in the title bar): it belongs to the folder on the left, not to
+  // whichever row the pane happens to be showing.
   //
-  // `extra` is what the settled preview puts in it: the mode menu and the
-  // open-full-screen button, at the strip's far end.
+  // The chevron went missing for a while in between. It used to sit on the seam it
+  // sent the pane back to, and went with the toggle when visibility became purely
+  // a measurement of the container's width (listing/pane.ts) — a closed pane had
+  // no way back short of resizing the window. It is back because the reopening
+  // half is back with it, in the listing's search row.
   //
-  // It opens with the OPEN FOLDER's primary action, portaled down from
-  // Preview.tsx (pane-action-slot.ts) — see there for why it is not in the
-  // title bar. In `strip` itself, so it is present in every state: that button
-  // belongs to the folder on the left, not to whichever row the pane happens
-  // to be showing, and it must not blink out while a preview loads.
+  // The strip also used to carry the previewed row's ICON AND NAME, and those are
+  // still gone: the row is highlighted an inch to the left with its name in the
+  // same eyeline, so restating it here put the loudest text in the strip on the
+  // one fact the layout already made obvious.
+  //
+  // `extra` is what only the settled Preview puts in it — the open-full-screen
+  // button and a folder-app's primary — at the far end, after the pill.
   const strip = (extra?: React.ReactNode) => (
     <div className="pane-header">
+      <SideCloseButton what={modeTitle(side)} onClick={onClose} />
       <PaneActionSlot />
-      {extra}
+      <div className="side-header-tail">
+        {sideMenu}
+        {extra}
+      </div>
     </div>
   );
 
-  // Placeholders need no fetch: nothing selected, or a multi-selection. No
-  // subject, so the strip carries nothing but an empty name.
+  // --- Claude and Git: the companions ----------------------------------------
+  // Both render straight from the FOLDER's entry, with no question asked about
+  // the selected row, so they come BEFORE every one of the row-driven branches
+  // below (the loading skeleton, the placeholders, the self target). Git in
+  // particular has to: its subject is the folder, so a folder with nothing
+  // selected still has a working tree to show.
+  //
+  // `_file` is where the two differ, and it is the whole of the difference —
+  // both templates are used exactly as they ship. paneSideTarget says which:
+  // the folder for Git, the selected row for Claude (the folder again when the
+  // selection names no single row, so the chat has something to be about).
+  const sideEntry = side === "claude" ? sideEntries.claude : side === "git" ? sideEntries.git : null;
+  if (sideEntry && sideEntry.path !== null) {
+    const target = paneSideTarget(side, folder, row && !row.self ? row.path : null);
+    // `chat_only=1` takes away the chat template's OWN left preview pane: in a
+    // column this narrow its copy of the target would be a second, differently
+    // run preview of the same thing (see Preview's sideSrcFor, and CHAT_ONLY in
+    // templates/claude/template.html). `_remote` is deliberately absent from
+    // both: Claude reads through the server either way, and the git gate refuses
+    // a mount-backed directory outright.
+    const chatOnly = side === "claude" ? "&chat_only=1" : "";
+    return (
+      <div className="listing-pane" ref={rootRef} {...guardProps}>
+        {strip()}
+        <iframe
+          className="pane-frame"
+          src={withNoFocus(
+            `/render?path=${encodeURIComponent(sideEntry.path)}` +
+              `&_file=${encodeURIComponent(target)}${chatOnly}`
+          )}
+          title={modeTitle(side)}
+        />
+      </div>
+    );
+  }
+
+  // Placeholders need no fetch: nothing selected, or a multi-selection. No row to
+  // preview, so the strip is the bare one — its chevron and its three-way pill,
+  // which are about the PANE and the folder rather than about the missing row.
   if (!row) {
     return (
       <div className="listing-pane">
@@ -281,24 +355,23 @@ export default function ListingPreviewPane({
   }
 
   // The SELF target — nothing selected, so the pane's subject is the folder
-  // already open on the left. It has no preview: just the folder's name and
-  // the hint that says what to do about it. No actions either — the folder's
-  // own primary ("Open as app") used to be handed down into this header, but a
-  // folder that HAS an app is not empty, so FS-16's auto-select means this
-  // row is barely ever on screen; the button belongs in the title bar, which
-  // is where it now stays whether the pane is open or not (Preview.tsx).
+  // already open on the left. It has no preview: just the hint that says what to
+  // do about it. No actions either — the folder's own primary ("Open as app")
+  // used to be handed down into this header, but a folder that HAS an app is not
+  // empty, so FS-16's auto-select means this row is barely ever on screen; the
+  // button belongs in the title bar, which is where it now stays whether the pane
+  // is open or not (Preview.tsx).
   //
-  // NO MODE MENU. The folder's peers under the `/` key are heavyweight opt-ins
-  // (the chat, git, history), so the picker's only job here was to offer a
-  // chat on the folder from a header that otherwise said "select something" —
-  // a "Choose view" chip pointing at a view nobody came for. The folder's own
-  // modes are still one click from the LEFT half (Preview's chip), and every
-  // entry in it previews on selection; and since opening a folder now
-  // auto-selects its first entry (FS-16) and a background click no longer
-  // deselects (FS-15), this state is reached essentially only by an empty
-  // folder or by a deliberate Escape. With no picker there is no mode,
-  // which is why this branch renders before any of the mode machinery — and
-  // why the stat/app-probe fetches above skip the self target entirely.
+  // NO PER-ROW MODE LIST, which is why this branch renders before all the mode
+  // machinery below and why the stat/app-probe fetches above skip the self target
+  // entirely: there is no row to resolve templates for. The pane's OWN three-way
+  // pill is in `strip` and so is present here like everywhere else — and it is
+  // exactly the control this state used to lack. The picker that was removed here
+  // was the per-row one: its only job in this state was to offer a chat on the
+  // folder from a header that otherwise said "select something", i.e. a "Choose
+  // view" chip pointing at a view nobody came for. Claude-on-the-folder is now a
+  // named mode of the pane rather than a mode of the absent row, so it is offered
+  // plainly instead of hidden behind a picker with nothing else in it.
   if (row.self) {
     return (
       <div className="listing-pane">
@@ -329,17 +402,22 @@ export default function ListingPreviewPane({
     );
   }
 
-  // --- the pane's mode list ---------------------------------------------------
+  // --- what `Preview` resolves to for this row --------------------------------
 
   // Mode order = pane priority, decided in listing/pane-modes.ts — which also
   // documents why a lone app leads over `_listing`, and why `app` and `_app`
-  // are never both offered. This component only turns those mode names into
-  // menu entries with icons.
+  // are never both offered. This component only turns that ranking into a
+  // rendered frame.
   //
   // Gate policy is the shared one (lib/mode-visibility), on every mode surface
-  // alike: an entry hides only on an EXPLICIT denial. A denied override is not
-  // pinned into the list — the active mode falls back to the pane's default
-  // (`activePaneMode` guards it), matching Preview.
+  // alike: an entry hides only on an EXPLICIT denial.
+  //
+  // What is gone is the CHOICE among them. The pane's header used to carry a
+  // switcher over this whole list, synced to `_panelMode` — one control for the
+  // row's templates, in a bar that now carries the pane's own three
+  // (listing/pane-side.ts explains the trade). So the list is read for its LEAD
+  // only: `Preview` means "this row's default view", and `activePaneMode` is
+  // called with no override.
   const allowed = (e: TemplateEntry) => isModeVisible(e, info.conditions);
   const embeddable = info.templates.filter((e) => e.mode !== "_listing" && allowed(e));
 
@@ -349,22 +427,13 @@ export default function ListingPreviewPane({
     isDir: !!row.isDir,
     hasApp: !!app,
   });
-  const byMode = new Map(info.templates.map((e) => [e.mode, e]));
-  const modes: PaneMode[] = modeNames.map((m) => ({
-    mode: m,
-    icon: m === APP_MODE ? APP_MODE_ICON : templateModeIcon(byMode.get(m) as TemplateEntry),
-  }));
 
-  // While the mode list is still undecided, hold the skeleton — the pane must
-  // never settle on an interim mode and then jump. Undecided means: the
-  // folder's app probe is in flight (`_app` would lead the list), or any
-  // gated template's verdict is unresolved (a higher-ranked conditional mode
-  // may still enter the list). This holds even with a `_panelMode` override
-  // seeded from the URL: the override's mode may itself still be absent from
-  // the interim list (a gated entry), so rendering before the list settles
-  // could show the default and then jump. Both signals resolve exactly once per mount (the component is
-  // keyed on the previewed path), and a user's switcher click can only happen
-  // after they resolve, so this never re-shows the skeleton post-settle.
+  // While that list is still undecided, hold the skeleton — the pane must never
+  // settle on an interim mode and then jump. Undecided means: the folder's app
+  // probe is in flight (`_app` would lead the list), or any gated template's
+  // verdict is unresolved (a higher-ranked conditional mode may still enter it).
+  // Both signals resolve exactly once per mount (the component is keyed on the
+  // previewed path), so this never re-shows the skeleton post-settle.
   const gatesPending =
     info.conditions === null &&
     info.templates.some((e) => e.conditional && e.mode !== "_listing");
@@ -376,10 +445,10 @@ export default function ListingPreviewPane({
       </div>
     );
   }
-  // Default = the first mode in pane priority order; the menu override wins
-  // while it's still offered. null = this row offers nothing at all, which
+  // The row's DEFAULT view — the first mode in pane priority order, with no
+  // override to beat it (see above). null = this row offers nothing at all, which
   // falls through to the metadata card at the bottom.
-  const activeMode = activePaneMode(modeNames, modeOverride);
+  const activeMode = activePaneMode(modeNames, null);
   const activeEntry = embeddable.find((e) => e.mode === activeMode) ?? null;
 
   // What the strip's far end offers for this row — decided in
@@ -393,17 +462,12 @@ export default function ListingPreviewPane({
     navigate(openTarget.path, { isDir: openTarget.isDir, mode: openTarget.mode });
   };
 
-  // The settled header: the shared strip, with the mode control and (for a row
-  // that has one) its open control after the name, at the far end of the strip.
-  // Every OTHER state renders the bare strip instead — same chrome, nothing to
-  // switch or expand yet. (The self target has its own, picker-less one and
-  // returns above.)
+  // The settled Preview's header: the shared strip (chevron, folder action, the
+  // pane's three-way pill) plus, at its very end, the controls that only mean
+  // something once a row's own view has resolved. Every OTHER state renders the
+  // bare strip — same chrome, nothing to expand yet.
   const header = strip(
     <>
-      {/* The same mode control the title bar and the pane bars carry. It used
-          to be four naked squares here, indistinguishable from the one-shot
-          glyphs beside them. */}
-      <ModeMenu entries={modes} active={activeMode ?? ""} onSelect={selectMode} />
       {/* Expand the previewed FILE full-screen — as a quiet icon, not the
           bordered "Open" primary it used to be. Nothing in this strip is a
           primary: the row's double-click and Enter already open it, so a
@@ -416,9 +480,14 @@ export default function ListingPreviewPane({
           restated them.
 
           It opens in the mode the pane is SHOWING (paneOpenTarget) — "make this
-          the whole view" cannot be the one action that discards the template
-          the user picked. The row's own double-click and Enter stay a plain
-          open: those are "open this thing", not "open what I am looking at". */}
+          the whole view" cannot be the one action that discards what is on
+          screen. The row's own double-click and Enter stay a plain open: those
+          are "open this thing", not "open what I am looking at".
+          Only in `Preview`, since only there is the pane showing the row's own
+          content. Claude and Git return well above this (and Git is not about
+          the row at all), so neither reaches here — "make this the whole view"
+          for a companion is a question about the FILE view's `_side`, and the way
+          to ask it is to open the row and use the sidebar there. */}
       {open.kind === "expand" && (
         <button
           type="button"

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -39,13 +39,17 @@ import {
   isModePending,
   isSidebarMode,
   partitionModes,
-  orderSidebarModes,
-  defaultSidebarMode,
   visibleModes,
   defaultMode,
   effectiveActive,
 } from "@platform/lib/mode-visibility";
 import { useDirMode } from "@apps/explorer/lib/dir-mode";
+import {
+  sideSplit,
+  initialSide,
+  sideToggleTarget,
+  reconcileSideSearch,
+} from "@apps/explorer/lib/preview-side";
 import { ModeMenu, OverflowMenu } from "@apps/explorer/BarMenu";
 import { SideToggleButton } from "@apps/explorer/SideChrome";
 import PreviewSidebar from "@apps/explorer/PreviewSidebar";
@@ -492,29 +496,38 @@ function TemplatePreview({
   const ownGit = parts.sidebar.some((e) => e.mode === "git");
   const parentGit = useDirMode(splitCapable && !ownGit ? parentDir : null, "git");
   const borrowedGit = ownGit ? null : parentGit.entry;
+  const borrowedPending = !ownGit && parentGit.pending;
   // Registry order for the file's own companions, then SIDEBAR_MODES order over
   // the assembled list — Claude / Git / History, whatever the registry ranked
-  // (see orderSidebarModes).
-  const sideAll = orderSidebarModes(
-    borrowedGit ? [...parts.sidebar, borrowedGit] : parts.sidebar
-  );
-  // ...and only while there is something to put on BOTH sides. A file whose only
-  // visible mode is `claude` has no content pane to put a sidebar next to, so it
-  // renders exactly as it did before the split existed: chat, full width, as a
-  // content mode.
-  const sideOn = splitCapable && parts.content.length > 0 && sideAll.length > 0;
+  // (see orderSidebarModes). `on` vs `offered` is the pending placeholder's whole
+  // story and lib/preview-side is where it is written down: while the borrowed
+  // probe is in flight the entry may be LISTED (so a `?_side=git` deep link is not
+  // stripped before the verdict) but decides nothing — it cannot turn the split
+  // on for a file that has no companion of its own, cannot become the toggle's
+  // target, and cannot leave a `_side` behind if the verdict is no.
+  const split = sideSplit({
+    splitCapable,
+    content: parts.content,
+    own: parts.sidebar,
+    borrowed: borrowedGit,
+    borrowedPending,
+  });
+  const sideOn = split.on;
   // What the CONTENT pane may show, and what the SIDEBAR may show. Unsplit
   // surfaces put everything in the content list, which is what keeps their
-  // behaviour byte-identical to before.
-  const contentModes = sideOn ? parts.content : templates;
-  const sidebarModes = sideOn ? sideAll : [];
+  // behaviour byte-identical to before. Keyed on `offered` rather than on `on`:
+  // the two differ only for a file with no companions of its own, where both
+  // branches are the same list anyway, and the sidebar half has to keep listing
+  // the pending entry for the deep link's sake.
+  const contentModes = split.offered ? parts.content : templates;
+  const sidebarModes = split.offered ? split.all : [];
   // Pending, for a SIDEBAR entry. The borrowed `git` entry is gated on the
   // PARENT's verdicts, resolved by lib/dir-mode — not on any of this file's, so
   // it cannot go through `isPending` (which reads `conditions`, this file's map,
   // and would call a borrowed entry settled the moment the file's own gates
   // landed). Everything else is an ordinary entry of this file's.
   const isSidePending = (t: TemplateEntry) =>
-    t.mode === "git" && !ownGit ? parentGit.pending : isPending(t);
+    t.mode === "git" && !ownGit ? borrowedPending : isPending(t);
 
   const defaultEntry = defaultTemplate(contentModes);
   // `mode` is what the user (or the URL) ASKED for; `entry` is what this paint
@@ -539,26 +552,14 @@ function TemplatePreview({
   // Read from the URL at mount, exactly like `_mode`, so a bookmark or a shared
   // link restores the split. Then owned as state and written back through
   // replaceSearch — the sidebar is a view of this same file, not a navigation.
-  const [side, setSideState] = useState<string | null>(() => {
-    if (!sideOn) return null;
-    const params = new URLSearchParams(location.search);
-    const want = params.get("_side");
-    // Against `sideAll` and not `parts.sidebar`, so a `?_side=git` deep link is
-    // captured at mount: the borrowed entry is on that list from the first render
-    // as a PENDING placeholder (lib/dir-mode explains why it has to be), where
-    // waiting for the real one would have let the reconciling effect below strip
-    // the param before the answer arrived.
-    if (want && sideAll.some((e) => e.mode === want)) return want;
-    // LEGACY DEEP LINKS. `?_mode=claude` is what every bookmark, recent, saved
-    // session and shared URL from before the split says, and it is still a
-    // perfectly clear request — "open this file's chat". It now means the
-    // SIDEBAR: the content pane falls back to its default mode (effectiveActive
-    // does that for free, since `claude` is no longer in its list) and the
-    // reconciling effect below rewrites the URL once.
-    const legacy = params.get("_mode");
-    if (legacy && sideAll.some((e) => e.mode === legacy)) return legacy;
-    return null;
-  });
+  // Resolved against the split's FULL list (pending placeholder included) and
+  // against `offered` rather than `on`, so a `?_side=git` deep link is captured at
+  // mount even for a file with no companion of its own — the verdict is what
+  // decides it, and waiting for the real entry would have let the reconciling
+  // effect below strip the param before the answer arrived (lib/preview-side).
+  const [side, setSideState] = useState<string | null>(() =>
+    initialSide(location.search, split)
+  );
   // Same request/paint distinction as `mode` above: a verdict that DENIES the
   // open companion drops it from `sidebarModes`, and this paint must not frame a
   // mode that is no longer on offer. Everything downstream reads `activeSide`.
@@ -577,16 +578,14 @@ function TemplatePreview({
   useEffect(() => {
     if (activeSide) setLastSide(activeSide);
   }, [activeSide]);
-  // What the toggle acts on, and so what it looks like: whatever is open, else
-  // the last thing that was, else this file's default companion (the chat, if it
-  // has one — lib/mode-visibility). Null only when the file has no companion at
-  // all, which is also when the button does not render.
-  const sideTarget =
-    activeSide ??
-    (lastSide && sidebarModes.some((e) => e.mode === lastSide)
-      ? lastSide
-      : defaultSidebarMode(sidebarModes));
-  const sideTargetEntry = sidebarModes.find((e) => e.mode === sideTarget) ?? null;
+  // What the toggle acts on, and so what it looks like (lib/preview-side). Over
+  // the SETTLED companions only: a placeholder whose probe may yet say "no
+  // repository here" must not put a button in the bar for the length of that
+  // probe and take it away again, and must not outrank a companion this file
+  // definitely has.
+  const sideTargets = sideOn ? split.settled : [];
+  const sideTarget = sideToggleTarget(sideTargets, activeSide, lastSide);
+  const sideTargetEntry = sideTargets.find((e) => e.mode === sideTarget) ?? null;
 
   // The box the sidebar goes in — StatView's, one level up from #content, so the
   // column stands beside the crumb bar rather than under it.
@@ -609,26 +608,25 @@ function TemplatePreview({
   // own clicks don't cover: the legacy `_mode=claude` migration above, and a
   // `_side` that named a mode this file doesn't offer (a carried-over param, or
   // a gate that has just denied it). Both are REPLACED, never pushed — neither
-  // is a place the Back button should have to visit.
+  // is a place the Back button should have to visit. The rules, including which
+  // of them a still-pending borrowed entry suspends, are in lib/preview-side.
   //
-  // Only ever on a splitting surface: a panel pane renders `claude` as its
-  // content mode and its `_mode` is the pane bar's to write, so nothing here may
-  // touch it.
+  // Guarded on `splitCapable` and not on the split being ON, which is the whole
+  // point: a borrowed `git` that resolves to DENIED takes the split off with it,
+  // and a `_side=git` left in the URL there is not inert — the session sidecar
+  // records the query (lib/session) and replays it on the next bare open.
   const sideKeys = sidebarModes.map((e) => e.mode).join(",");
   useEffect(() => {
-    if (!sideOn) return;
-    const params = new URLSearchParams(location.search);
-    const legacy = params.get("_mode");
-    const stale = legacy !== null && isSidebarMode(legacy);
-    if (params.get("_side") === activeSide && !stale) return; // already agrees
-    if (activeSide) params.set("_side", activeSide);
-    else params.delete("_side");
-    if (stale) params.delete("_mode");
-    const search = params.toString();
+    const search = reconcileSideSearch(location.search, {
+      splitCapable,
+      offered: split.offered,
+      activeSide,
+    });
+    if (search === null) return; // already agrees
     replaceSearch(location.pathname + (search ? "?" + search : ""));
     // `sideKeys` is in the deps because a landing verdict is what makes a
     // previously-fine `_side` stale.
-  }, [sideOn, activeSide, sideKeys]);
+  }, [splitCapable, split.offered, activeSide, sideKeys]);
   const deployEnabled = useDeployEnabled();
   // `_listing` sentinel (D81): the shell's built-in directory listing, mounted
   // in place of the preview iframe — no iframe, no `_file`. Every directory

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -15,7 +15,7 @@ import {
   deleteEntry,
 } from "@platform/lib/api";
 import type { Deployment, StatResult, TemplateEntry } from "@platform/lib/api";
-import { navigate, navigateUrl, urlForFsPath, replaceSearch } from "@platform/lib/router";
+import { navigate, navigateUrl, urlForFsPath, replaceSearch, IS_EMBED } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import { useRefreshOnReturn } from "@platform/lib/hooks";
 import { useDeployEnabled } from "@platform/lib/prefs";
@@ -37,11 +37,19 @@ import { pushToast } from "@platform/lib/toast";
 import { templateModeIcon, modeTitle, KNOWN_SENTINEL_MODES } from "@apps/explorer/ModeSwitcher";
 import {
   isModePending,
+  isSidebarMode,
+  partitionModes,
+  orderSidebarModes,
+  defaultSidebarMode,
   visibleModes,
   defaultMode,
   effectiveActive,
 } from "@platform/lib/mode-visibility";
+import { useDirMode } from "@apps/explorer/lib/dir-mode";
 import { ModeMenu, OverflowMenu } from "@apps/explorer/BarMenu";
+import { SideToggleButton } from "@apps/explorer/SideChrome";
+import PreviewSidebar from "@apps/explorer/PreviewSidebar";
+import { subscribePreviewSideSlot, previewSideSlot } from "@apps/explorer/preview-side-slot";
 import { subscribeTopbarSlot, topbarSlot } from "@apps/explorer/topbar-slot";
 import { subscribePaneActionSlot, paneActionSlot } from "@apps/explorer/pane-action-slot";
 import ContextMenu, { type MenuEntry, type MenuItem } from "@platform/ui/ContextMenu";
@@ -86,6 +94,16 @@ function Header({ fsPath, stat, children, afterName, onContextMenu }: HeaderProp
 function TopbarActions({ children }: { children: ReactNode }) {
   const slot = useSyncExternalStore(subscribeTopbarSlot, topbarSlot, () => null);
   return slot ? createPortal(children, slot) : null;
+}
+
+// The preview sidebar's slot, up at StatView level (preview-side-slot.ts). The
+// sidebar is a PAGE-LEVEL column — a sibling of the crumb bar and the content
+// TOGETHER, not something inside the body under the bar — so the bar ends at the
+// divider and the sidebar's own header is the top of its column. This view is
+// what knows whether there is a sidebar, so it renders the content and StatView
+// renders the box: same arrangement as TopbarActions above, other way round.
+function usePreviewSideSlot(): HTMLElement | null {
+  return useSyncExternalStore(subscribePreviewSideSlot, previewSideSlot, () => null);
 }
 
 // Where the open FOLDER's primary action goes. The preview pane's header when
@@ -440,7 +458,65 @@ function TemplatePreview({
   // verdict is still in flight (CT-12) are present but PENDING — shown in the
   // switcher as a disabled spinner, not selectable, never the default.
   const isPending = (t: TemplateEntry) => isModePending(t, conditions);
-  const defaultEntry = defaultTemplate(templates);
+
+  // --- the content/sidebar split (`_side`) ----------------------------------
+  // ONE surface splits: a single FILE opened on the explorer route in its own
+  // window. Everything else keeps `claude`/`history` as ordinary content modes,
+  // and deliberately:
+  //   * a DIRECTORY's chat is the folder-scoped one and has no file preview to
+  //     sit beside; its mode list is governed from the listing's pane instead
+  //     (see headerActions);
+  //   * `IS_EMBED` is every pane of panel/tab mode — those panes ARE a split the
+  //     user built, sized by them, with their own bar (PaneModeMenu) writing
+  //     `_mode`. A pane that grew a second split of its own would be answering a
+  //     layout question the user already answered;
+  //   * `appChrome` (the app builder) pins its own mode allowlist.
+  const splitCapable = !!actionsInTopbar && !stat.is_dir && !IS_EMBED && !appChrome;
+  const parts = partitionModes(templates);
+
+  // --- the BORROWED companion: `git`, from this file's parent folder ----------
+  // A working tree belongs to the FOLDER (templates/git/condition.py), so the
+  // registry keeps `git` on the universal "/" key alone and this file's own
+  // template list will never carry one. "What has changed in here" is worth just
+  // as much while reading a file, so the sidebar asks the PARENT DIRECTORY for
+  // its entry through the ordinary stat + condition machinery every mode surface
+  // uses (lib/dir-mode — which is also where the caching lives, so walking a
+  // folder file by file costs one probe rather than one per file). A parent
+  // outside a repository, or on a mount, denies the gate and there is simply no
+  // Git pill.
+  //
+  // Unless the file HAS one of its own: a user registry may bind `git` to a file
+  // extension, and then the entry is the file's, aimed at the file, and there is
+  // nothing to borrow — offering both would draw the same mode twice.
+  const parentDir = dirname(fsPath);
+  const ownGit = parts.sidebar.some((e) => e.mode === "git");
+  const parentGit = useDirMode(splitCapable && !ownGit ? parentDir : null, "git");
+  const borrowedGit = ownGit ? null : parentGit.entry;
+  // Registry order for the file's own companions, then SIDEBAR_MODES order over
+  // the assembled list — Claude / Git / History, whatever the registry ranked
+  // (see orderSidebarModes).
+  const sideAll = orderSidebarModes(
+    borrowedGit ? [...parts.sidebar, borrowedGit] : parts.sidebar
+  );
+  // ...and only while there is something to put on BOTH sides. A file whose only
+  // visible mode is `claude` has no content pane to put a sidebar next to, so it
+  // renders exactly as it did before the split existed: chat, full width, as a
+  // content mode.
+  const sideOn = splitCapable && parts.content.length > 0 && sideAll.length > 0;
+  // What the CONTENT pane may show, and what the SIDEBAR may show. Unsplit
+  // surfaces put everything in the content list, which is what keeps their
+  // behaviour byte-identical to before.
+  const contentModes = sideOn ? parts.content : templates;
+  const sidebarModes = sideOn ? sideAll : [];
+  // Pending, for a SIDEBAR entry. The borrowed `git` entry is gated on the
+  // PARENT's verdicts, resolved by lib/dir-mode — not on any of this file's, so
+  // it cannot go through `isPending` (which reads `conditions`, this file's map,
+  // and would call a borrowed entry settled the moment the file's own gates
+  // landed). Everything else is an ordinary entry of this file's.
+  const isSidePending = (t: TemplateEntry) =>
+    t.mode === "git" && !ownGit ? parentGit.pending : isPending(t);
+
+  const defaultEntry = defaultTemplate(contentModes);
   // `mode` is what the user (or the URL) ASKED for; `entry` is what this paint
   // can actually render. They differ for exactly one render whenever a verdict
   // lands and DROPS the requested mode (a URL-requested conditional that
@@ -449,8 +525,8 @@ function TemplatePreview({
   // reading the stale request meant the held-frame swap spent that paint with
   // no frame at all (a blank pane), then mounted a frame for the dropped mode
   // whose `srcFor` is null, and only unwound it once the state caught up.
-  const [mode, setModeState] = useState<string>(() => activeTemplate(templates).mode);
-  const entry = templates.find((t) => t.mode === mode) || defaultEntry;
+  const [mode, setModeState] = useState<string>(() => activeTemplate(contentModes).mode);
+  const entry = contentModes.find((t) => t.mode === mode) || defaultEntry;
   const activeMode = entry.mode;
   // Reconcile the request with what actually rendered. Purely bookkeeping now
   // (the switcher's selection, and the guard in setMode) — no rendering waits
@@ -458,6 +534,101 @@ function TemplatePreview({
   useEffect(() => {
     if (mode !== activeMode) setModeState(activeMode);
   }, [mode, activeMode]);
+
+  // --- `_side`: which companion the sidebar shows, absent = closed -----------
+  // Read from the URL at mount, exactly like `_mode`, so a bookmark or a shared
+  // link restores the split. Then owned as state and written back through
+  // replaceSearch — the sidebar is a view of this same file, not a navigation.
+  const [side, setSideState] = useState<string | null>(() => {
+    if (!sideOn) return null;
+    const params = new URLSearchParams(location.search);
+    const want = params.get("_side");
+    // Against `sideAll` and not `parts.sidebar`, so a `?_side=git` deep link is
+    // captured at mount: the borrowed entry is on that list from the first render
+    // as a PENDING placeholder (lib/dir-mode explains why it has to be), where
+    // waiting for the real one would have let the reconciling effect below strip
+    // the param before the answer arrived.
+    if (want && sideAll.some((e) => e.mode === want)) return want;
+    // LEGACY DEEP LINKS. `?_mode=claude` is what every bookmark, recent, saved
+    // session and shared URL from before the split says, and it is still a
+    // perfectly clear request — "open this file's chat". It now means the
+    // SIDEBAR: the content pane falls back to its default mode (effectiveActive
+    // does that for free, since `claude` is no longer in its list) and the
+    // reconciling effect below rewrites the URL once.
+    const legacy = params.get("_mode");
+    if (legacy && sideAll.some((e) => e.mode === legacy)) return legacy;
+    return null;
+  });
+  // Same request/paint distinction as `mode` above: a verdict that DENIES the
+  // open companion drops it from `sidebarModes`, and this paint must not frame a
+  // mode that is no longer on offer. Everything downstream reads `activeSide`.
+  const sideEntry = sidebarModes.find((e) => e.mode === side) ?? null;
+  const activeSide = sideEntry?.mode ?? null;
+  useEffect(() => {
+    if (side !== activeSide) setSideState(activeSide);
+  }, [side, activeSide]);
+  // Which companion a bare "open the sidebar" reopens: the last one the user had
+  // open on this file, so closing and reopening is not a reset. STATE, not a ref,
+  // because the toggle button RENDERS from it — it wears the icon of the mode it
+  // would open, so a closed sidebar that last showed History shows the History
+  // glyph, and a ref read during render is a value React does not promise is
+  // current.
+  const [lastSide, setLastSide] = useState<string | null>(null);
+  useEffect(() => {
+    if (activeSide) setLastSide(activeSide);
+  }, [activeSide]);
+  // What the toggle acts on, and so what it looks like: whatever is open, else
+  // the last thing that was, else this file's default companion (the chat, if it
+  // has one — lib/mode-visibility). Null only when the file has no companion at
+  // all, which is also when the button does not render.
+  const sideTarget =
+    activeSide ??
+    (lastSide && sidebarModes.some((e) => e.mode === lastSide)
+      ? lastSide
+      : defaultSidebarMode(sidebarModes));
+  const sideTargetEntry = sidebarModes.find((e) => e.mode === sideTarget) ?? null;
+
+  // The box the sidebar goes in — StatView's, one level up from #content, so the
+  // column stands beside the crumb bar rather than under it.
+  const sideSlot = usePreviewSideSlot();
+
+  const setSide = (next: string | null) => {
+    const params = new URLSearchParams(location.search);
+    if (next) params.set("_side", next);
+    else params.delete("_side");
+    const search = params.toString();
+    replaceSearch(location.pathname + (search ? "?" + search : ""));
+    setSideState(next);
+  };
+  const toggleSide = () => {
+    if (activeSide) setSide(null);
+    else if (sideTarget) setSide(sideTarget);
+  };
+
+  // Keep the URL honest about what is actually open, for the cases the user's
+  // own clicks don't cover: the legacy `_mode=claude` migration above, and a
+  // `_side` that named a mode this file doesn't offer (a carried-over param, or
+  // a gate that has just denied it). Both are REPLACED, never pushed — neither
+  // is a place the Back button should have to visit.
+  //
+  // Only ever on a splitting surface: a panel pane renders `claude` as its
+  // content mode and its `_mode` is the pane bar's to write, so nothing here may
+  // touch it.
+  const sideKeys = sidebarModes.map((e) => e.mode).join(",");
+  useEffect(() => {
+    if (!sideOn) return;
+    const params = new URLSearchParams(location.search);
+    const legacy = params.get("_mode");
+    const stale = legacy !== null && isSidebarMode(legacy);
+    if (params.get("_side") === activeSide && !stale) return; // already agrees
+    if (activeSide) params.set("_side", activeSide);
+    else params.delete("_side");
+    if (stale) params.delete("_mode");
+    const search = params.toString();
+    replaceSearch(location.pathname + (search ? "?" + search : ""));
+    // `sideKeys` is in the deps because a landing verdict is what makes a
+    // previously-fine `_side` stale.
+  }, [sideOn, activeSide, sideKeys]);
   const deployEnabled = useDeployEnabled();
   // `_listing` sentinel (D81): the shell's built-in directory listing, mounted
   // in place of the preview iframe — no iframe, no `_file`. Every directory
@@ -556,7 +727,7 @@ function TemplatePreview({
   const setMode = async (next: string) => {
     if (next === activeMode || switching.current) return;
     // Unresolved gate: not selectable (the switcher disables it too).
-    const target = templates.find((t) => t.mode === next);
+    const target = contentModes.find((t) => t.mode === next);
     if (target && isPending(target)) return;
     switching.current = true;
     setSwitchingTo(next);
@@ -620,6 +791,44 @@ function TemplatePreview({
     if (m === "_render") return `/render?path=${encodeURIComponent(fsPath)}`;
     const t = templates.find((x) => x.mode === m);
     return t ? `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(fsPath)}${remote}` : null;
+  };
+
+  // The SIDEBAR's iframe URL. Built here rather than through `srcFor` above,
+  // because the two differ on both of the things that URL says:
+  //
+  //   WHICH ENTRY. The borrowed `git` entry is not in `templates` (it is the
+  //   parent folder's — see above), so a lookup there would miss it. The lookup
+  //   is `sidebarModes`, which is the list the column is actually showing.
+  //
+  //   WHAT `_file` NAMES. For the companions of this file, this file. For a
+  //   borrowed `git`, the PARENT DIRECTORY — the template is unchanged and asks
+  //   git about whatever `_file` names, so aiming it at the folder is the whole
+  //   of the borrowing. `_remote` does not travel with it either: that flag says
+  //   where THIS FILE's bytes come from, and the git gate refuses a mount-backed
+  //   directory outright, so a borrowed target is never remote.
+  //
+  // Plus the one thing the sidebar has to tell a template about its host —
+  // `chat_only=1` for the chat. That template's own layout is a split whose left
+  // half is ITS copy of this file's preview (templates/claude/template.html),
+  // which in the sidebar would be the same file previewed twice in one window,
+  // the inner one a few hundred pixels wide. The param makes it take that half
+  // away and run the chat column full width; the template does it through its
+  // existing no-pane path (enterNoPane), the same designed absence a folder with
+  // no app entry gets.
+  //
+  // Null while the mode's gate is unresolved — a pending borrowed entry has no
+  // template path yet — and the column holds a spinner.
+  const sideSrcFor = (m: string): string | null => {
+    const t = sidebarModes.find((e) => e.mode === m);
+    if (!t || t.path === null) return null;
+    const borrowed = m === "git" && !ownGit;
+    const target = borrowed ? parentDir : fsPath;
+    const rem = borrowed ? "" : remote;
+    const chatOnly = m === "claude" ? "&chat_only=1" : "";
+    return (
+      `/render?path=${encodeURIComponent(t.path)}` +
+      `&_file=${encodeURIComponent(target)}${rem}${chatOnly}`
+    );
   };
 
   // Held-frame swap. Switching mode used to destroy the iframe and mount the
@@ -710,10 +919,10 @@ function TemplatePreview({
   // caller can take is a branch nothing can test. If another template ever frames
   // an embed of its counterpart's own target, the opt-out comes back with that
   // caller.
-  const otherEntry = templates.find((t) => t.mode !== "_listing");
+  const otherEntry = contentModes.find((t) => t.mode !== "_listing");
   const counterpart = defaultEntry.mode !== "_listing" ? defaultEntry.mode : otherEntry?.mode;
   const toggleListing =
-    otherEntry && templates.some((t) => t.mode === "_listing")
+    otherEntry && contentModes.some((t) => t.mode === "_listing")
       ? () => setMode(isListing ? (counterpart as string) : "_listing")
       : null;
 
@@ -721,8 +930,17 @@ function TemplatePreview({
   // IN PLACE (setMode does the editor-flush + `_mode` replaceState) rather than
   // re-navigating to the same path — no re-stat, no iframe teardown/rebuild
   // beyond the mode change the switcher would make anyway.
-  const loadOpenWith = () =>
-    Promise.resolve(buildOpenWithItems(templates, (m) => void setMode(m)));
+  //
+  // It lists EVERY mode, sidebar companions included — "Open With → Claude" is a
+  // request for the chat, and where the chat lives is this view's business, not
+  // the menu's. On a splitting surface that request opens the sidebar instead of
+  // replacing the content pane, which is the same answer the mode partition
+  // gives everywhere else.
+  const openMode = (m: string) => {
+    if (sideOn && isSidebarMode(m)) setSide(m);
+    else void setMode(m);
+  };
+  const loadOpenWith = () => Promise.resolve(buildOpenWithItems(templates, openMode));
   const fileMenu = usePreviewFileMenu(fsPath, stat, loadOpenWith);
 
   // The folder's relationship to the app system, and the button that follows
@@ -794,17 +1012,26 @@ function TemplatePreview({
           A control that has to be explained is worse than the standard one
           every user already has.
           ACCEPTED TRADEOFF, and this part IS the product decision: nothing
-          switches a folder INTO one of those modes from the explorer any more.
-          The pane's menu writes `_panelMode` — what the PANE previews — not
-          `_mode`, and the chip only ever offers the listing⇄counterpart pair.
-          So a folder's git/history/graph views are entered by `?_mode=` (a
-          URL, a bookmark, the file menu's Open With) and left by the chip. The
-          user chose that over two switchers in one view: for a folder, the
-          pane IS the explorer, and its peers are opt-in tools rather than ways
-          of looking at the listing. */}
+          switches a folder's own `_mode` from the explorer any more. The pane's
+          menu writes `_side` — which of the PANE's three the pane is showing
+          (Preview / Claude / Git, listing/pane-side.ts) — and the chip only ever
+          offers the listing⇄counterpart pair. So a folder's `_mode=history` /
+          `_mode=graph` views are entered by URL (a bookmark, the file menu's Open
+          With) and left by the chip. The user chose that over two switchers in one
+          view: for a folder, the pane IS the explorer, and its peers are opt-in
+          tools rather than ways of looking at the listing.
+          Two of those peers came BACK as pane modes rather than as `_mode` views,
+          and that is the same call rather than a reversal: the pane's Claude and
+          Git sit beside the listing instead of replacing it, so they are
+          companions to browsing the folder — which is exactly the argument the
+          file sidebar makes one level down. */}
       {!(stat.is_dir && !appChrome) && (
         <ModeMenu
-          entries={templates.map((t) => ({
+          /* Content modes only where the split is on: the companions
+             (`claude`, `git`, `history`) are the SIDEBAR's list, and offering them
+             here as well would be one control writing two different halves of
+             the screen. See the partition above. */
+          entries={contentModes.map((t) => ({
             mode: t.mode,
             icon: templateModeIcon(t),
             pending: isPending(t),
@@ -815,6 +1042,23 @@ function TemplatePreview({
              user is waiting on that button. */
           busy={switchingTo ?? (shown !== activeMode ? activeMode : null)}
           onSelect={setMode}
+        />
+      )}
+      {/* The sidebar's OPENER, immediately right of the mode control it
+          partitions with — the shared control (SideChrome), which is where the
+          "one affordance, two places, chosen by state" split between this button
+          and the column's own close chevron is written down. It renders only
+          while the column is SHUT, and it wears the COMPANION'S OWN ICON, so a
+          closed sidebar that last showed Git shows the Git glyph.
+
+          Absent entirely when this file has no companion at all (no `claude`, no
+          `git` in the parent, no `history`, or a gate denied them): a control for
+          nothing is worse than no control. */}
+      {sideTargetEntry && !activeSide && (
+        <SideToggleButton
+          what={modeTitle(sideTargetEntry.mode)}
+          icon={templateModeIcon(sideTargetEntry)}
+          onClick={toggleSide}
         />
       )}
       {/* Rightmost, per the bars' grammar: the low-frequency one-shots live in
@@ -951,6 +1195,30 @@ function TemplatePreview({
           </button>
         )}
       </div>
+      {/* The `_side` split's right-hand column, portaled UP to StatView's split
+          container (usePreviewSideSlot). It is a sibling of the whole left column
+          — crumb bar included — which is what makes the bar stop at the divider
+          and the sidebar's header line up with it at the top of the window.
+          The portal is also what keeps the CONTENT iframe alive across an
+          open/close: nothing above `.preview-body` is restructured, so React never
+          re-parents the frame, and re-parenting an iframe reloads its document
+          (the same rule the held-frame swap keeps for reordering). */}
+      {activeSide &&
+        sideSlot &&
+        createPortal(
+          <PreviewSidebar
+            entries={sidebarModes.map((t) => ({
+              mode: t.mode,
+              icon: templateModeIcon(t),
+              pending: isSidePending(t),
+            }))}
+            active={activeSide}
+            src={sideEntry && isSidePending(sideEntry) ? null : sideSrcFor(activeSide)}
+            onSelect={setSide}
+            onClose={() => setSide(null)}
+          />,
+          sideSlot
+        )}
       {fileMenu.overlays}
     </>
   );

--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -1,0 +1,242 @@
+// The file preview's right-hand SIDEBAR: the companion modes (`claude`, `git`,
+// `history` — lib/mode-visibility's SIDEBAR_MODES) rendered BESIDE the content
+// pane instead of in place of it.
+//
+// Why it exists: those are not other ways of looking at a file, they are things
+// you do while looking at it. As ordinary `_mode` entries they were mutually
+// exclusive with the view they are about — asking Claude about a .png meant
+// giving the .png up — and the chat template answered that by framing its own
+// copy of the preview in its own left half, i.e. a second, differently-run
+// preview of the same file nested inside the first one's window.
+//
+// `git` is the one this column does not get from the file: a working tree belongs
+// to the FOLDER, so the entry is borrowed from the file's parent directory and
+// aimed there (apps/explorer/lib/dir-mode.ts). Nothing in here knows that — the
+// entry list and the `src` both arrive as props — but it is why an entry can be
+// `pending` for a reason the file's own gate verdicts do not explain.
+//
+// Owned by TemplatePreview (Preview.tsx): the mode partition, the `_side` URL
+// param and the iframe URL shape are all its, so this component is the split's
+// right-hand column and the drag that sizes it, and nothing else.
+//
+// WHERE IT SITS is the layout's whole point. The split is PAGE-LEVEL: the left
+// column is the crumb bar AND the content under it, the right column is this, and
+// the divider runs the full height of the window between them. So the crumb bar
+// ends AT the divider, and this column's header row is the top of the window on
+// its side — the two strips reading as one bar split by a seam, exactly as the
+// listing and its preview pane do over a folder.
+//
+// It got there the wrong way first: rendered inside `.preview-body`, i.e. UNDER
+// the crumb bar, which then spanned the whole window and left this column's header
+// a bar-height below the left column's. Page-level means being a sibling of the
+// entire left column, and that column belongs to StatView (shell/App.tsx) — hence
+// the portal (preview-side-slot.ts). Rendered as a FRAGMENT of two flex items (the
+// divider and the column) into a `display: contents` slot, so both end up direct
+// flex children of the split container.
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { modeTitle } from "@platform/lib/mode-name";
+import { ModeMenu } from "@apps/explorer/BarMenu";
+import { SideCloseButton } from "@apps/explorer/SideChrome";
+import {
+  publishPreviewSideSlot,
+  retractPreviewSideSlot,
+} from "@apps/explorer/preview-side-slot";
+
+// The split container's class, and the drag's frame of reference. Looked up from
+// the divider with `closest` rather than handed down as a ref: the two live in
+// different components now (StatView owns the container, this owns the handle),
+// and a ref would have to be threaded through the portal to get here.
+const SPLIT_SEL = ".stat-split";
+
+// The page-level split's right-hand slot, rendered by StatView beside the left
+// column. `display: contents` (explorer.css) so the portaled divider and column
+// are flex children of the split itself, and so an EMPTY slot — every route, every
+// folder, every file with no companion mode — contributes nothing at all.
+export function PreviewSideSlot() {
+  const ref = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (el) publishPreviewSideSlot(el);
+    return () => retractPreviewSideSlot(el);
+  }, []);
+  return <div className="stat-side-slot" ref={ref} />;
+}
+
+// Sensible default and floors for the column, in PIXELS — unlike the listing's
+// preview pane (a fraction of its container, listing/pane-math.ts) this is a
+// sidebar: what it holds is a chat composer and a message column, whose
+// legibility is a width in pixels and not a share of the window. The content
+// pane keeps whatever is left, with its own floor so a drag can't swallow it.
+const DEFAULT_W = 400;
+const MIN_W = 280;
+const CONTENT_MIN_W = 320;
+
+const WIDTH_KEY = "fused-render:preview-side";
+
+// Best-effort persistence, the defensive localStorage pattern the rest of the
+// shell uses (lib/viewstate, lib/sidebarstate): a private-mode/quota failure
+// costs the remembered width and nothing else.
+function loadWidth(): number {
+  try {
+    const raw = localStorage.getItem(WIDTH_KEY);
+    const n = raw === null ? NaN : Number(raw);
+    return Number.isFinite(n) && n >= MIN_W ? n : DEFAULT_W;
+  } catch {
+    return DEFAULT_W;
+  }
+}
+
+function saveWidth(w: number): void {
+  try {
+    localStorage.setItem(WIDTH_KEY, String(Math.round(w)));
+  } catch {
+    /* ignore */
+  }
+}
+
+export interface SidebarEntry {
+  mode: string;
+  icon: ReactNode;
+  // Condition.py gate not yet resolved (CT-12) — listed, not selectable.
+  pending?: boolean;
+}
+
+export default function PreviewSidebar({
+  entries,
+  active,
+  src,
+  onSelect,
+  onClose,
+}: {
+  // The visible sidebar modes for this file, registry order.
+  entries: SidebarEntry[];
+  // The one being shown (always present in `entries`).
+  active: string;
+  // Its /render URL, or null while its gate is still resolving.
+  src: string | null;
+  onSelect: (mode: string) => void;
+  // Clears `_side`. The title bar's opener is hidden while this column is up
+  // (SideChrome writes the split down), so this is the only way out of it.
+  onClose: () => void;
+}) {
+  const [width, setWidth] = useState(loadWidth);
+  // The drag writes on release only: the width is a preference, and a
+  // read-modify-write per pointermove is a per-frame localStorage hit for a
+  // number that is only interesting once the user lets go.
+  const widthRef = useRef(width);
+  widthRef.current = width;
+  // The divider, and through it the split container (see SPLIT_SEL).
+  const dividerRef = useRef<HTMLDivElement>(null);
+  const splitEl = () => dividerRef.current?.closest<HTMLElement>(SPLIT_SEL) ?? null;
+
+  // A window narrower than the two floors together must not leave the content
+  // column at nothing: clamp on every container resize, not only on drag.
+  useEffect(() => {
+    const el = splitEl();
+    if (!el) return;
+    const clamp = () => {
+      const max = el.getBoundingClientRect().width - CONTENT_MIN_W;
+      if (max < MIN_W) return; // no room for both floors — CSS min-width holds
+      setWidth((w) => (w > max ? max : w));
+    };
+    clamp();
+    const ro = new ResizeObserver(clamp);
+    ro.observe(el);
+    return () => ro.disconnect();
+    // Mount-only: the container is the page-level split, which outlives this
+    // component (StatView owns it), so there is nothing here to re-resolve.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Pointer capture, like the listing's divider (listing/pane.ts): without it
+  // the drag dies the moment the cursor crosses into either iframe, which is
+  // most of what is on either side of this handle.
+  const onDividerPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const divider = e.currentTarget;
+    divider.setPointerCapture(e.pointerId);
+    divider.classList.add("dragging");
+    let resized = false;
+    const onMove = (ev: PointerEvent) => {
+      const rect = splitEl()?.getBoundingClientRect();
+      if (!rect) return;
+      const max = rect.width - CONTENT_MIN_W;
+      if (max < MIN_W) return; // container too narrow to express a split
+      const next = Math.min(max, Math.max(MIN_W, rect.right - ev.clientX));
+      resized = true;
+      setWidth((w) => (w === next ? w : next));
+    };
+    const onUp = () => {
+      divider.classList.remove("dragging");
+      divider.removeEventListener("pointermove", onMove);
+      divider.removeEventListener("pointerup", onUp);
+      divider.removeEventListener("pointercancel", onUp);
+      if (resized) saveWidth(widthRef.current);
+    };
+    divider.addEventListener("pointermove", onMove);
+    divider.addEventListener("pointerup", onUp);
+    divider.addEventListener("pointercancel", onUp);
+  };
+
+  const activeEntry = entries.find((e) => e.mode === active) ?? null;
+
+  return (
+    <>
+      <div
+        className="preview-side-divider"
+        ref={dividerRef}
+        onPointerDown={onDividerPointerDown}
+        role="separator"
+        aria-orientation="vertical"
+      />
+      <aside
+        className="preview-side"
+        style={{ flexBasis: width }}
+        aria-label={modeTitle(active) + " sidebar"}
+      >
+        <div className="preview-side-header">
+          {/* Leftmost, on the seam (SideChrome): the way out of this column, and
+              while it is up, the only one — the title bar's opener is not
+              rendered. The listing pane's header opens with the same button. */}
+          <SideCloseButton what={modeTitle(active)} onClick={onClose} />
+          {/* The shared mode control, over this file's companions, at the strip's
+              far end (the tail's auto margin packs it there — .side-header-tail,
+              the same wrapper the listing pane's header uses). It hides itself at
+              one entry ("one mode is not a choice", BarMenu) — which would leave
+              this strip a lone chevron over an unlabelled document, so the
+              single-entry case renders the name flat instead of as a menu. Same
+              icon, same words, nothing to click. */}
+          <div className="side-header-tail">
+            {entries.length > 1 ? (
+              <ModeMenu entries={entries} active={active} onSelect={onSelect} />
+            ) : (
+              <span className="preview-side-name">
+                <span className="mode-menu-icon">{activeEntry?.icon}</span>
+                {modeTitle(active)}
+              </span>
+            )}
+          </div>
+        </div>
+        {src === null ? (
+          /* The chosen sidebar mode is gate-pending (CT-12): hold the column
+             rather than frame a template whose condition may deny this file. */
+          <div className="preview-resolving">
+            <span className="mode-icon-spinner" />
+            Checking if this view applies…
+          </div>
+        ) : (
+          /* Keyed on the mode, so a switch replaces the document outright. No
+             held-frame cross-fade here (unlike the content pane): the sidebar is
+             a narrow column of chrome-heavy tools, and the two of them look
+             nothing alike — there is no illusion of continuity to protect. */
+          <iframe
+            key={active}
+            className="preview-side-frame"
+            src={src}
+            title={modeTitle(active)}
+          />
+        )}
+      </aside>
+    </>
+  );
+}

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -1,0 +1,126 @@
+// The chrome a RIGHT-HAND COMPANION COLUMN carries, shared by the two surfaces
+// that have one: the file preview's sidebar (PreviewSidebar, over a single file)
+// and the folder listing's preview pane (ListingPreviewPane, over a directory).
+//
+// The two arrived at the same layout from opposite ends and are now one thing
+// stated once — a header strip whose left end is the way OUT of the column and
+// whose right end is the mode control, over a full-height frame beside a
+// draggable seam. Keeping the buttons here rather than one copy each is what
+// makes "the folder pane matches the file sidebar" true rather than intended.
+//
+// ONE AFFORDANCE, TWO PLACES, CHOSEN BY STATE — the rule the listing pane's own
+// visibility control already followed (SPEC FS-10):
+//
+//   CLOSING is a control ON the column — the chevron below, first thing in the
+//   header, sitting on the seam the column collapses toward and pointing the way
+//   it goes.
+//   OPENING cannot live there, because a closed column hosts nothing, so that
+//   half is the mode-icon button in the host's own bar (the crumb bar for a file,
+//   the listing's search row for a folder), rendered ONLY while the column is
+//   shut.
+//
+// Both at once is what the file sidebar's middle version did, and it was the
+// wrong answer: the bar's toggle and the column's chevron sat a few pixels apart
+// across the divider, two buttons for one piece of state, which reads as a
+// rendering fault rather than as a choice. Exactly one of them is on screen at
+// any moment, and each sits where its own action makes sense.
+import type { ReactNode } from "react";
+import { templateModeIcon } from "@apps/explorer/ModeSwitcher";
+import type { PaneSide, PaneSideEntries } from "@apps/explorer/listing/pane-side";
+
+function CloseChevron() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width="16"
+      height="16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <polyline points="9 6 15 12 9 18" />
+    </svg>
+  );
+}
+
+// `what` names the panel in both labels — the mode's display name ("Claude",
+// "Git", "Preview"), so the tooltip says which panel rather than "the panel".
+export function SideCloseButton({ what, onClick }: { what: string; onClick: () => void }) {
+  const label = "Hide the " + what + " panel";
+  return (
+    <button
+      type="button"
+      className="bar-ctl bar-ctl-icon side-close"
+      title={label}
+      aria-label={label}
+      onClick={onClick}
+    >
+      <CloseChevron />
+    </button>
+  );
+}
+
+// The opener, and it wears the COMPANION'S OWN ICON rather than a chevron: a
+// chevron only ever said "a panel goes here", while the icon says WHICH panel, so
+// the button announces what the click will get you with no hover needed. Which
+// icon that is, is the caller's business — the mode it would reopen is the one
+// last open on that surface.
+export function SideToggleButton({
+  what,
+  icon,
+  onClick,
+}: {
+  what: string;
+  icon: ReactNode;
+  onClick: () => void;
+}) {
+  const label = "Show the " + what + " panel";
+  return (
+    <button
+      type="button"
+      className="bar-ctl bar-ctl-icon side-toggle"
+      title={label}
+      aria-label={label}
+      aria-expanded={false}
+      onClick={onClick}
+    >
+      <span className="mode-menu-icon">{icon}</span>
+    </button>
+  );
+}
+
+// The listing pane's "Preview" glyph. The other two panes wear their template's
+// own icon.svg, but `preview` is not a template — it is "whatever this row's
+// default view is" — so the shell bakes one, in the same 16px currentColor stroke
+// as every other glyph in these bars. A play button in a frame: render the row.
+const PREVIEW_SIDE_ICON = (
+  <svg
+    viewBox="0 0 24 24"
+    width="16"
+    height="16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <rect x="3" y="3" width="18" height="18" rx="3" />
+    <path d="M10 8.75 15.5 12 10 15.25Z" />
+  </svg>
+);
+
+// Icon for one of the folder pane's three modes. `claude` and `git` are real
+// templates borrowed from the folder (lib/dir-mode), so they get their registry
+// icon exactly as they do on every other mode surface; `preview` gets the baked
+// one above. Null entries never reach here — a mode with no entry is not offered
+// (pane-side's paneSideList) — but the fallback is the placeholder box
+// templateModeIcon draws for an icon-less template rather than a hole in the bar.
+export function paneSideIcon(side: PaneSide, entries: PaneSideEntries): ReactNode {
+  if (side === "preview") return PREVIEW_SIDE_ICON;
+  const entry = side === "claude" ? entries.claude : entries.git;
+  return entry ? templateModeIcon(entry) : PREVIEW_SIDE_ICON;
+}

--- a/frontend/src/apps/explorer/lib/dir-mode.ts
+++ b/frontend/src/apps/explorer/lib/dir-mode.ts
@@ -1,0 +1,142 @@
+// A template mode BORROWED FROM A DIRECTORY by a surface whose subject is not
+// that directory.
+//
+// `git` is what needs it. A working tree belongs to the FOLDER — you stash a
+// tree, not a file — so the registry binds `git` to the universal "/" directory
+// key alone and its gate refuses anything that is not a directory
+// (templates/git/condition.py writes both halves down). A FILE's own
+// `stat.templates` therefore never mentions git, and yet "what has changed in
+// here" is exactly as useful while reading one file as while browsing its folder.
+// Both companion sidebars borrow it: the file preview's from the file's PARENT
+// (apps/explorer/Preview.tsx), the listing pane's from the folder it is BROWSING
+// (apps/explorer/Listing.tsx). The listing pane borrows `claude` the same way —
+// its chat is the folder view's companion, aimed at whichever row is selected.
+//
+// Borrowing asks the server the same two questions every other mode surface
+// asks, about the directory instead of about the subject:
+//
+//   GET /api/fs/stat        does this directory offer the mode at all, and which
+//                           template folder backs it? (the iframe needs the
+//                           path, the switcher needs the icon)
+//   GET /api/fs/conditions   does its condition.py gate allow this directory?
+//
+// NOTHING HERE RELAXES EITHER ANSWER, and that is the point of going through the
+// server rather than hard-coding "files in a repo get a git tab". A user registry
+// that drops `git` from "/" drops it from these sidebars too, and a gate that
+// says false hides it exactly as it would on the folder's own mode menu — the
+// verdict policy is lib/mode-visibility's ONE policy, so an entry hides only on
+// an EXPLICIT denial and a failed probe cannot silently empty a switcher.
+import { useEffect, useState } from "react";
+import { resolveConditions, statPath, type TemplateEntry } from "@platform/lib/api";
+import { isModeVisible } from "@platform/lib/mode-visibility";
+import { KNOWN_SENTINEL_MODES } from "@apps/explorer/ModeSwitcher";
+
+// What one directory offers, as the two probes resolve it.
+interface DirModes {
+  templates: TemplateEntry[];
+  // Never null here (unlike the surfaces' own `conditions` state): the load
+  // below waits for the verdicts before it settles, because a borrowed mode has
+  // nothing to render in the meantime. `{}` is a FAILED call, not a denial.
+  conditions: Record<string, boolean>;
+}
+
+// Per-directory cache, because the callers ask for one answer REPEATEDLY. The
+// listing pane is keyed on the previewed row and remounts on every selection
+// change; the file preview remounts on every file opened. The directory under
+// both of them stays put, so without a cache arrow-keying down a folder would
+// re-stat and re-gate that folder once per keystroke — and the git gate forks a
+// `git rev-parse` each time.
+//
+// TTL'd rather than permanent: the answer is not immutable (a `git init`, a
+// registry edit) and a shell tab can live for days, so a stale "no repository
+// here" must not outlive the session. Long enough to cover a walk through a
+// folder, short enough that the fix for a wrong answer is to wait a moment.
+const TTL_MS = 30_000;
+
+const cache = new Map<string, { at: number; modes: Promise<DirModes> }>();
+
+function loadDirModes(dir: string): Promise<DirModes> {
+  const hit = cache.get(dir);
+  if (hit && Date.now() - hit.at < TTL_MS) return hit.modes;
+  const modes = statPath(dir).then(async (st) => {
+    // The same defensive sentinel filter every mode surface applies (SPEC
+    // PT-12): an entry with path===null that isn't a known sentinel would build
+    // a `path=null` render URL.
+    const templates = st.templates.filter(
+      (e) => e.path !== null || KNOWN_SENTINEL_MODES.has(e.mode)
+    );
+    if (!templates.some((e) => e.conditional)) return { templates, conditions: {} };
+    // A failed gate probe resolves to NO verdicts, which lib/mode-visibility
+    // reads as "show the entry" — never as a denial (see its header).
+    const conditions = await resolveConditions(dir).then(
+      (r) => r.conditions,
+      () => ({})
+    );
+    return { templates, conditions };
+  });
+  // A REJECTED load is not cached: a transient stat failure would otherwise hide
+  // the borrowed mode for the whole TTL. Guarded on identity so a newer entry
+  // for the same directory is never evicted by an older failure.
+  modes.catch(() => {
+    if (cache.get(dir)?.modes === modes) cache.delete(dir);
+  });
+  cache.set(dir, { at: Date.now(), modes });
+  return modes;
+}
+
+export interface DirMode {
+  // The directory's entry for the mode: a PLACEHOLDER while `pending` (the mode
+  // name only — the real template path and icon arrive with the stat), and null
+  // when the directory does not offer the mode at all — an unknown mode, an
+  // explicit gate denial, or a probe that failed outright.
+  entry: TemplateEntry | null;
+  // The probe is still in flight.
+  //
+  // Callers list the placeholder as a PENDING switcher entry rather than waiting
+  // to add a real one, which is CT-12's posture for a gated mode and holds here
+  // for a second reason as well: the mode's URL param is read at mount, so a
+  // `?_side=git` deep link would be resolved against a list that does not yet
+  // contain git and quietly rewritten away before the answer landed.
+  pending: boolean;
+}
+
+// Shared, so a caller that re-renders without changing directory does not get a
+// fresh object and a pointless commit.
+const ABSENT: DirMode = { entry: null, pending: false };
+
+function placeholderFor(mode: string): DirMode {
+  return { entry: { mode, path: null, icon: null }, pending: true };
+}
+
+// `dir === null` switches the whole thing off and makes no request — how callers
+// skip the probe on the surfaces that cannot show a borrowed mode at all (an
+// embedded listing, a panel pane, the app builder).
+export function useDirMode(dir: string | null, mode: string): DirMode {
+  const [state, setState] = useState<DirMode>(() =>
+    dir === null ? ABSENT : placeholderFor(mode)
+  );
+  useEffect(() => {
+    if (dir === null) {
+      setState(ABSENT);
+      return;
+    }
+    let alive = true;
+    setState(placeholderFor(mode));
+    loadDirModes(dir).then(
+      (r) => {
+        if (!alive) return;
+        const entry = r.templates.find((e) => e.mode === mode) ?? null;
+        setState(
+          entry && isModeVisible(entry, r.conditions) ? { entry, pending: false } : ABSENT
+        );
+      },
+      () => {
+        if (alive) setState(ABSENT);
+      }
+    );
+    return () => {
+      alive = false;
+    };
+  }, [dir, mode]);
+  return state;
+}

--- a/frontend/src/apps/explorer/lib/preview-side.test.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.test.ts
@@ -1,0 +1,285 @@
+import { describe, expect, it } from "bun:test";
+import type { TemplateEntry } from "@platform/lib/api";
+import {
+  sideSplit,
+  initialSide,
+  sideToggleTarget,
+  reconcileSideSearch,
+  type SideSplitInput,
+} from "@apps/explorer/lib/preview-side";
+
+const t = (mode: string): TemplateEntry => ({
+  mode,
+  path: `/tpl/${mode}/template.html`,
+  icon: null,
+});
+
+// What lib/dir-mode hands over while the parent's stat + gate are still in
+// flight: the mode name and nothing else.
+const GIT_PLACEHOLDER: TemplateEntry = { mode: "git", path: null, icon: null };
+const GIT: TemplateEntry = t("git");
+
+const image = t("image");
+const claude = t("claude");
+const history = t("history");
+
+const names = (entries: TemplateEntry[]) => entries.map((e) => e.mode);
+
+// The three states of the borrowed entry, over a file that has some content
+// template (an image, a table, its source) and whatever companions of its own.
+const file = (own: TemplateEntry[], git: "pending" | "yes" | "no"): SideSplitInput => ({
+  splitCapable: true,
+  content: [image],
+  own,
+  borrowed: git === "no" ? null : git === "yes" ? GIT : GIT_PLACEHOLDER,
+  borrowedPending: git === "pending",
+});
+
+describe("sideSplit", () => {
+  // THE BUG: a companion-less file (a .pdf, a video, anything with no chat and
+  // no history binding) borrowed a PENDING git placeholder and the split came on
+  // for it — which put a Git toggle in the bar for the length of the probe and
+  // took it away again when the parent turned out not to be a repository.
+  it("does not turn the split on for a pending borrowed git alone", () => {
+    const s = sideSplit(file([], "pending"));
+    expect(s.on).toBe(false);
+    expect(names(s.settled)).toEqual([]);
+    // Still LISTED, which is the other half of the policy: `_side=git` has to
+    // survive until the verdict (see initialSide).
+    expect(names(s.all)).toEqual(["git"]);
+    expect(s.offered).toBe(true);
+  });
+
+  it("turns it on once the probe says the parent has a working tree", () => {
+    const s = sideSplit(file([], "yes"));
+    expect(s.on).toBe(true);
+    expect(names(s.settled)).toEqual(["git"]);
+    expect(names(s.all)).toEqual(["git"]);
+  });
+
+  it("is off entirely once the probe denies", () => {
+    const s = sideSplit(file([], "no"));
+    expect(s.on).toBe(false);
+    expect(s.offered).toBe(false);
+    expect(names(s.all)).toEqual([]);
+  });
+
+  // A file with a companion of its OWN splits from the first paint, verdict or
+  // not — the pending placeholder rides along in `all` without deciding anything.
+  it("splits on the file's own companions while the borrowed one is pending", () => {
+    const s = sideSplit(file([claude, history], "pending"));
+    expect(s.on).toBe(true);
+    expect(names(s.settled)).toEqual(["claude", "history"]);
+    expect(names(s.all)).toEqual(["claude", "git", "history"]);
+  });
+
+  it("puts the settled borrowed entry in SIDEBAR_MODES order, not the input's", () => {
+    const s = sideSplit(file([history, claude], "yes"));
+    expect(names(s.all)).toEqual(["claude", "git", "history"]);
+    expect(names(s.settled)).toEqual(["claude", "git", "history"]);
+  });
+
+  // Both sides or neither: a file whose only visible mode is `claude` has no
+  // content pane to sit a sidebar beside, so it renders as a full-width content
+  // mode exactly as it did before the split existed.
+  it("needs a content pane as well as a companion", () => {
+    const s = sideSplit({ ...file([claude], "yes"), content: [] });
+    expect(s.on).toBe(false);
+    expect(s.offered).toBe(false);
+  });
+
+  it("is off on every surface that does not split", () => {
+    const s = sideSplit({ ...file([claude], "yes"), splitCapable: false });
+    expect(s.on).toBe(false);
+    expect(s.offered).toBe(false);
+  });
+});
+
+describe("initialSide", () => {
+  it("keeps a ?_side=git deep link alive while the probe is pending", () => {
+    // The reason the placeholder is listed at all: this runs at MOUNT, and a
+    // list without git would resolve the param to nothing and the reconcile
+    // would strip it before the answer landed.
+    expect(initialSide("?_side=git", sideSplit(file([], "pending")))).toBe("git");
+  });
+
+  it("drops it once the probe has denied", () => {
+    expect(initialSide("?_side=git", sideSplit(file([], "no")))).toBe(null);
+  });
+
+  it("honours a settled companion", () => {
+    expect(initialSide("?_side=history", sideSplit(file([history], "pending")))).toBe("history");
+  });
+
+  it("migrates a legacy ?_mode=claude into the sidebar", () => {
+    expect(initialSide("?_mode=claude", sideSplit(file([claude], "pending")))).toBe("claude");
+  });
+
+  it("ignores an unknown or absent request", () => {
+    const s = sideSplit(file([claude], "yes"));
+    expect(initialSide("?_side=nope", s)).toBe(null);
+    expect(initialSide("", s)).toBe(null);
+    // `_mode` naming a CONTENT mode is not a sidebar request.
+    expect(initialSide("?_mode=image", s)).toBe(null);
+  });
+
+  it("is null wherever the split is not on offer", () => {
+    expect(initialSide("?_side=claude", sideSplit({ ...file([claude], "yes"), splitCapable: false }))).toBe(null);
+  });
+});
+
+describe("sideToggleTarget", () => {
+  const targets = (i: SideSplitInput) => {
+    const s = sideSplit(i);
+    return s.on ? s.settled : [];
+  };
+
+  // THE BUG, second half: the toggle button renders from this, so a pending
+  // placeholder here is a button that appears and vanishes on every open.
+  it("has no target while the only candidate is a pending borrowed git", () => {
+    expect(sideToggleTarget(targets(file([], "pending")), null, null)).toBe(null);
+  });
+
+  it("never outranks a settled companion with a pending one", () => {
+    // defaultSidebarMode's order is Claude / Git / History, so an unfiltered
+    // list would have opened the pending Git over this file's real History.
+    expect(sideToggleTarget(targets(file([history], "pending")), null, null)).toBe("history");
+    // ...and picks Git once it is real.
+    expect(sideToggleTarget(targets(file([history], "yes")), null, null)).toBe("git");
+  });
+
+  it("prefers the chat when the file has one", () => {
+    expect(sideToggleTarget(targets(file([claude, history], "yes")), null, null)).toBe("claude");
+  });
+
+  it("reopens the last companion the user had open", () => {
+    expect(sideToggleTarget(targets(file([claude, history], "yes")), null, "history")).toBe("history");
+    // ...unless it is no longer on offer here.
+    expect(sideToggleTarget(targets(file([claude], "no")), null, "git")).toBe("claude");
+    // ...including when it is only PENDING: the button must not offer to open a
+    // column that may have nothing to show.
+    expect(sideToggleTarget(targets(file([claude], "pending")), null, "git")).toBe("claude");
+  });
+
+  it("acts on whatever is open, first of all", () => {
+    expect(sideToggleTarget(targets(file([claude], "yes")), "git", "claude")).toBe("git");
+  });
+});
+
+describe("reconcileSideSearch", () => {
+  // A denied borrowed git takes the split off with it, and the old guard
+  // ("return unless the split is on") meant the URL kept `_side=git` — which the
+  // session sidecar then recorded and replayed on the next bare open, so the
+  // stale param outlived the tab.
+  it("clears a `_side` the probe has just denied", () => {
+    expect(
+      reconcileSideSearch("?_side=git", { splitCapable: true, offered: false, activeSide: null })
+    ).toBe("");
+  });
+
+  it("leaves a pending `_side=git` alone until the verdict", () => {
+    expect(
+      reconcileSideSearch("?_side=git", { splitCapable: true, offered: true, activeSide: "git" })
+    ).toBe(null);
+  });
+
+  it("clears a `_side` carried in from another view", () => {
+    // The folder pane writes `_side` too (listing/pane-side), and router's
+    // navigate carries params across a hop.
+    expect(
+      reconcileSideSearch("?_side=off", { splitCapable: true, offered: true, activeSide: null })
+    ).toBe("");
+    expect(
+      reconcileSideSearch("?_side=preview&sort=size", {
+        splitCapable: true,
+        offered: true,
+        activeSide: null,
+      })
+    ).toBe("sort=size");
+  });
+
+  it("never touches the URL on a surface that does not split", () => {
+    // A folder's `_side` is the listing pane's, and a panel pane's `_mode` is
+    // the pane bar's — a stray write here would fight both.
+    for (const search of ["?_side=off", "?_side=git", "?_mode=claude"]) {
+      expect(
+        reconcileSideSearch(search, { splitCapable: false, offered: false, activeSide: null })
+      ).toBe(null);
+    }
+  });
+
+  it("migrates a legacy `_mode=claude` to `_side=claude`, once", () => {
+    expect(
+      reconcileSideSearch("?_mode=claude", { splitCapable: true, offered: true, activeSide: "claude" })
+    ).toBe("_side=claude");
+    // Already migrated: nothing more to say.
+    expect(
+      reconcileSideSearch("?_side=claude", { splitCapable: true, offered: true, activeSide: "claude" })
+    ).toBe(null);
+  });
+
+  it("leaves `_mode=claude` alone where the split never took it", () => {
+    // A file whose only mode is the chat renders it full width as a content
+    // mode; deleting its `_mode` would be deleting a live request.
+    expect(
+      reconcileSideSearch("?_mode=claude", { splitCapable: true, offered: false, activeSide: null })
+    ).toBe(null);
+  });
+
+  it("keeps the rest of the query", () => {
+    expect(
+      reconcileSideSearch("?_mode=claude&zoom=2", {
+        splitCapable: true,
+        offered: true,
+        activeSide: "claude",
+      })
+    ).toBe("zoom=2&_side=claude");
+    expect(
+      reconcileSideSearch("?zoom=2", { splitCapable: true, offered: true, activeSide: "history" })
+    ).toBe("zoom=2&_side=history");
+  });
+});
+
+// The lifecycle the finding is about, in the order the frames actually happen.
+describe("a companion-less file in a folder with no working tree", () => {
+  const pending = sideSplit(file([], "pending"));
+  const denied = sideSplit(file([], "no"));
+
+  it("opens bare: no split, no toggle, no URL churn", () => {
+    expect(pending.on).toBe(false);
+    expect(sideToggleTarget(pending.on ? pending.settled : [], null, null)).toBe(null);
+    expect(
+      reconcileSideSearch("", { splitCapable: true, offered: pending.offered, activeSide: null })
+    ).toBe(null);
+    // ...and the verdict changes none of that, so nothing flashed.
+    expect(denied.on).toBe(false);
+    expect(sideToggleTarget(denied.on ? denied.settled : [], null, null)).toBe(null);
+    expect(
+      reconcileSideSearch("", { splitCapable: true, offered: denied.offered, activeSide: null })
+    ).toBe(null);
+  });
+
+  it("opens on ?_side=git: tolerated while pending, cleared on the denial", () => {
+    const want = initialSide("?_side=git", pending);
+    expect(want).toBe("git");
+    // Listed while pending, so the param stands.
+    expect(pending.all.some((e) => e.mode === want)).toBe(true);
+    expect(
+      reconcileSideSearch("?_side=git", {
+        splitCapable: true,
+        offered: pending.offered,
+        activeSide: "git",
+      })
+    ).toBe(null);
+    // The verdict lands: the entry is gone, so the active side is gone...
+    expect(denied.all.some((e) => e.mode === "git")).toBe(false);
+    // ...and the param goes with it rather than into the session sidecar.
+    expect(
+      reconcileSideSearch("?_side=git", {
+        splitCapable: true,
+        offered: denied.offered,
+        activeSide: null,
+      })
+    ).toBe("");
+  });
+});

--- a/frontend/src/apps/explorer/lib/preview-side.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.ts
@@ -1,0 +1,156 @@
+// The file preview's `_side` split, as decisions rather than as JSX — the file
+// half of what pane-side.ts is for the folder listing's pane, and DOM-free for
+// the same reason: the rules below are all about a list that is ASSEMBLED from
+// two sources with different timings, which is exactly the thing a test should
+// pin and a React component should not be the only statement of.
+//
+// THE TWO SOURCES, and the whole reason this module exists:
+//
+//   OWN         the companions in the file's own stat.templates — `claude`,
+//               `history`, and a `git` only if a user registry bound one to the
+//               extension. These EXIST as of the stat; a conditional one's GATE
+//               may still be in flight (CT-12), but the entry is real.
+//   BORROWED    `git`, from the file's PARENT FOLDER (lib/dir-mode). Until that
+//               probe answers there is only a PLACEHOLDER — an entry whose path
+//               and icon are null and which may turn out not to exist at all,
+//               because the parent may be outside a repository.
+//
+// A placeholder is listed anyway, because `_side` is read from the URL at MOUNT:
+// resolve `?_side=git` against a list that does not mention git yet and the
+// reconcile below rewrites the param away before the answer lands. But listing it
+// is ALL it may do. A pending placeholder must not decide anything the user can
+// see, and that is the difference between `offered` and `on` below:
+//
+//   offered   there is SOMETHING that may end up in the sidebar, so a `_side`
+//             naming it is honoured instead of stripped. Pending included.
+//   on        the split is really on: a companion is KNOWN to exist, so the
+//             sidebar column and its toggle may render and the content pane's
+//             mode list drops the companions.
+//
+// Conflating the two is what made a companion-less file (a .pdf, a video) open
+// with a Git toggle in its bar for as long as the probe took and then lose it
+// again — a control flashing in and out on every open, for a folder that has no
+// working tree at all.
+//
+// Note the asymmetry with an OWN conditional companion, which DOES count as
+// settled while its gate resolves. Its entry is in this file's template list
+// either way, so the only question open is whether it is allowed; treating it as
+// unsettled would move it between the content menu and the sidebar as the verdict
+// landed, which is a worse flash than the one this module removes.
+import type { TemplateEntry } from "@platform/lib/api";
+import { defaultSidebarMode, isSidebarMode, orderSidebarModes } from "@platform/lib/mode-visibility";
+
+export interface SideSplitInput {
+  // Whether this surface splits at all (a single file on the explorer route, in
+  // its own window — see Preview's `splitCapable`).
+  splitCapable: boolean;
+  // The file's own modes, already partitioned (lib/mode-visibility).
+  content: TemplateEntry[];
+  own: TemplateEntry[];
+  // The parent folder's `git` entry — a placeholder while `borrowedPending`,
+  // null when the parent does not offer one (or there is nothing to borrow
+  // because the file has a `git` of its own).
+  borrowed: TemplateEntry | null;
+  borrowedPending: boolean;
+}
+
+export interface SideSplit {
+  // The sidebar switcher's list, in SIDEBAR_MODES order, pending placeholder
+  // included.
+  all: TemplateEntry[];
+  // Those known to exist — `all` minus a still-pending borrowed entry.
+  settled: TemplateEntry[];
+  // A companion is known to exist AND there is a content pane to put it beside.
+  on: boolean;
+  // Something may yet land in the sidebar, so a `_side` naming it is tolerated.
+  offered: boolean;
+}
+
+export function sideSplit(i: SideSplitInput): SideSplit {
+  const all = orderSidebarModes(i.borrowed ? [...i.own, i.borrowed] : i.own);
+  const settled = i.borrowedPending ? all.filter((e) => e !== i.borrowed) : all;
+  // ...and only while there is something to put on BOTH sides. A file whose only
+  // companion is `claude` has no content pane to sit a sidebar next to, so it
+  // renders as it did before the split existed: chat, full width, content mode.
+  const splittable = i.splitCapable && i.content.length > 0;
+  return {
+    all,
+    settled,
+    on: splittable && settled.length > 0,
+    offered: splittable && all.length > 0,
+  };
+}
+
+// `_side` as read at MOUNT, exactly like `_mode`, so a bookmark or a shared link
+// restores the split. Resolved against `all` (see the header) so a `?_side=git`
+// deep link survives until the borrowed probe answers.
+//
+// LEGACY DEEP LINKS are the second branch. `?_mode=claude` is what every
+// bookmark, recent, saved session and shared URL from before the split says, and
+// it is still a perfectly clear request — "open this file's chat". It now means
+// the SIDEBAR: the content pane falls back to its default mode (effectiveActive
+// does that for free, since `claude` is no longer in its list) and
+// `reconcileSideSearch` rewrites the URL once.
+export function initialSide(search: string, split: SideSplit): string | null {
+  if (!split.offered) return null;
+  const params = new URLSearchParams(search);
+  const has = (m: string | null) => !!m && split.all.some((e) => e.mode === m);
+  const want = params.get("_side");
+  if (has(want)) return want;
+  const legacy = params.get("_mode");
+  return has(legacy) ? legacy : null;
+}
+
+// What the toggle button acts on, and so what it looks like: whatever is open,
+// else the last thing that was, else this file's default companion (the chat, if
+// it has one — lib/mode-visibility). Null means the button does not render, which
+// is the answer while the only candidate is a pending placeholder: a control that
+// may be about to prove it has nothing to open is worse than no control.
+//
+// `targets` is the SETTLED list (empty when the split is off), never `all`.
+export function sideToggleTarget(
+  targets: TemplateEntry[],
+  activeSide: string | null,
+  lastSide: string | null
+): string | null {
+  if (activeSide) return activeSide;
+  if (lastSide && targets.some((e) => e.mode === lastSide)) return lastSide;
+  return defaultSidebarMode(targets);
+}
+
+// Keeping the URL honest about what is actually open, for the cases the user's
+// own clicks don't cover. Returns the query string to REPLACE the current one
+// with (no leading "?"), or null when it already agrees and must be left alone.
+//
+// Three jobs:
+//
+//   1. the legacy `?_mode=claude` migration above — drop the param the split
+//      re-homed, once. Only where the split is on offer, since everywhere else
+//      `_mode=claude` still names a real content mode.
+//   2. a `_side` this file cannot honour: a param carried in from another view
+//      (the folder pane writes `_side` too), or one whose gate has just DENIED
+//      the mode. It goes, rather than sitting in the URL for a session sidecar to
+//      record and replay on the next bare open (lib/session).
+//   3. write `_side` when state moved without the user's click.
+//
+// A still-PENDING borrowed entry is neither honoured nor stripped: `activeSide`
+// is the pending mode, `_side` already says so, and this returns null. The verdict
+// is what settles it — allowed keeps the param, denied brings us back to job 2.
+//
+// Only ever on a splitting surface: a panel pane renders `claude` as its content
+// mode and a folder's `_side` is the listing pane's (listing/pane-side.ts), so
+// nothing here may touch either.
+export function reconcileSideSearch(
+  search: string,
+  o: { splitCapable: boolean; offered: boolean; activeSide: string | null }
+): string | null {
+  if (!o.splitCapable) return null;
+  const params = new URLSearchParams(search);
+  const legacy = params.get("_mode");
+  const stale = o.offered && legacy !== null && isSidebarMode(legacy);
+  if (params.get("_side") === o.activeSide && !stale) return null;
+  if (o.activeSide) params.set("_side", o.activeSide);
+  else params.delete("_side");
+  if (stale) params.delete("_mode");
+  return params.toString();
+}

--- a/frontend/src/apps/explorer/listing/pane-side.test.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+import type { TemplateEntry } from "@platform/lib/api";
+import {
+  DEFAULT_PANE_SIDE,
+  PANE_SIDE_MODES,
+  PANE_SIDE_OFF,
+  activePaneSide,
+  paneKey,
+  paneSideList,
+  paneSideParam,
+  paneSideTarget,
+  parsePaneSide,
+  type PaneSide,
+} from "./pane-side";
+
+const entry = (mode: string): TemplateEntry => ({
+  mode,
+  path: `/t/${mode}/template.html`,
+  icon: `/t/${mode}/icon.svg`,
+  conditional: true,
+});
+
+const NONE = { claude: null, git: null };
+const BOTH = { claude: entry("claude"), git: entry("git") };
+
+test("the three, in the order the switcher shows them", () => {
+  expect(PANE_SIDE_MODES).toEqual(["preview", "claude", "git"]);
+  expect(DEFAULT_PANE_SIDE).toBe("preview");
+});
+
+// WHAT AN ABSENT `_side` MEANS, which is the one place the folder's reading of the
+// param deliberately differs from the file view's — see parsePaneSide.
+describe("parsePaneSide", () => {
+  test("no param at all is OPEN at Preview, not closed", () => {
+    // Every folder URL, bookmark and recent from before this param existed says
+    // nothing, and every one of them means the two-column folder view.
+    expect(parsePaneSide(null)).toEqual({ open: true, mode: "preview" });
+  });
+
+  test("`off` is the only closed state", () => {
+    expect(parsePaneSide(PANE_SIDE_OFF)).toEqual({ open: false, mode: "preview" });
+  });
+
+  test("a named mode opens the pane on it", () => {
+    expect(parsePaneSide("claude")).toEqual({ open: true, mode: "claude" });
+    expect(parsePaneSide("git")).toEqual({ open: true, mode: "git" });
+    expect(parsePaneSide("preview")).toEqual({ open: true, mode: "preview" });
+  });
+
+  test("an unknown value falls back silently, pane still open", () => {
+    // A hand-typed mode, or a `history` carried in from a file view — the router
+    // keeps `_side` across a directory hop. Same silent fallback an unknown
+    // `_mode` gets, and NOT a closed pane: a value nobody recognises must not
+    // take the folder view's other half away.
+    expect(parsePaneSide("history")).toEqual({ open: true, mode: "preview" });
+    expect(parsePaneSide("graph")).toEqual({ open: true, mode: "preview" });
+    expect(parsePaneSide("")).toEqual({ open: true, mode: "preview" });
+  });
+});
+
+// Round-tripping, and which state gets the CLEAN url.
+describe("paneSideParam", () => {
+  test("open at the default writes nothing", () => {
+    expect(paneSideParam({ open: true, mode: "preview" })).toBeNull();
+  });
+
+  test("open on a companion writes the mode", () => {
+    expect(paneSideParam({ open: true, mode: "claude" })).toBe("claude");
+    expect(paneSideParam({ open: true, mode: "git" })).toBe("git");
+  });
+
+  test("closed records only that it is closed, never the mode", () => {
+    // The mode to reopen on is session state (Listing), so a shared link to a
+    // one-column listing does not carry a companion nobody can see.
+    expect(paneSideParam({ open: false, mode: "git" })).toBe(PANE_SIDE_OFF);
+    expect(paneSideParam({ open: false, mode: "preview" })).toBe(PANE_SIDE_OFF);
+  });
+
+  test("every writable state parses back to itself, modulo the shut mode", () => {
+    for (const mode of PANE_SIDE_MODES) {
+      const open = { open: true, mode };
+      expect(parsePaneSide(paneSideParam(open))).toEqual(open);
+      expect(parsePaneSide(paneSideParam({ open: false, mode })).open).toBe(false);
+    }
+  });
+});
+
+// Which of the three a folder actually offers. `preview` always — it is the pane's
+// identity, and a row with no template at all still has the metadata card.
+describe("paneSideList", () => {
+  test("a folder with neither companion offers Preview alone", () => {
+    // A mount-backed folder: both gates refuse a mount, so the pill hides itself
+    // and the pane is what it was before the split.
+    expect(paneSideList(NONE)).toEqual(["preview"]);
+  });
+
+  test("a folder in a repository offers all three, in order", () => {
+    expect(paneSideList(BOTH)).toEqual(["preview", "claude", "git"]);
+  });
+
+  test("a folder outside a repository loses Git and keeps Claude", () => {
+    expect(paneSideList({ claude: entry("claude"), git: null })).toEqual([
+      "preview",
+      "claude",
+    ]);
+  });
+});
+
+// A request for a mode this folder hasn't got falls back — and the param is left
+// alone by the caller, so hopping out of a repository and back in does not reset
+// the pane.
+describe("activePaneSide", () => {
+  test("an offered request wins", () => {
+    expect(activePaneSide(paneSideList(BOTH), "git")).toBe("git");
+    expect(activePaneSide(paneSideList(BOTH), "claude")).toBe("claude");
+  });
+
+  test("an unavailable request lands on Preview", () => {
+    expect(activePaneSide(paneSideList(NONE), "git")).toBe("preview");
+    expect(activePaneSide(paneSideList({ claude: entry("claude"), git: null }), "git")).toBe(
+      "preview"
+    );
+  });
+});
+
+// The pane's REMOUNT identity, and the one thing it has to get right: Git is about
+// the FOLDER, so its key must not move with the selection.
+describe("paneKey", () => {
+  const folder = "/w/repo";
+
+  test("Git ignores the selection entirely", () => {
+    // Arrow-keying down a listing must not reload a `git status` per keystroke.
+    const a = paneKey("git", folder, "/w/repo/a.md", 1);
+    const b = paneKey("git", folder, "/w/repo/b.md", 1);
+    const none = paneKey("git", folder, null, 0);
+    const many = paneKey("git", folder, null, 3);
+    expect(a).toBe(b);
+    expect(a).toBe(none);
+    expect(a).toBe(many);
+  });
+
+  test("Claude follows the selected row, and falls back to the folder", () => {
+    expect(paneKey("claude", folder, "/w/repo/a.md", 1)).not.toBe(
+      paneKey("claude", folder, "/w/repo/b.md", 1)
+    );
+    // Nothing selected and a multi-selection are both "the folder itself".
+    expect(paneKey("claude", folder, null, 0)).toBe(paneKey("claude", folder, null, 4));
+  });
+
+  test("Preview keeps its three selection states apart", () => {
+    const row = paneKey("preview", folder, "/w/repo/a.md", 1);
+    const self = paneKey("preview", folder, null, 0);
+    const many = paneKey("preview", folder, null, 3);
+    expect(new Set([row, self, many]).size).toBe(3);
+  });
+
+  test("the modes never collide on one key", () => {
+    const keys = (PANE_SIDE_MODES as readonly PaneSide[]).map((m) =>
+      paneKey(m, folder, "/w/repo/a.md", 1)
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+// Three modes, two subjects.
+describe("paneSideTarget", () => {
+  const folder = "/w/repo";
+
+  test("Git is aimed at the folder, whatever is selected", () => {
+    expect(paneSideTarget("git", folder, "/w/repo/a.md")).toBe(folder);
+    expect(paneSideTarget("git", folder, null)).toBe(folder);
+  });
+
+  test("the other two are aimed at the row, and at the folder without one", () => {
+    expect(paneSideTarget("claude", folder, "/w/repo/a.md")).toBe("/w/repo/a.md");
+    expect(paneSideTarget("preview", folder, "/w/repo/a.md")).toBe("/w/repo/a.md");
+    expect(paneSideTarget("claude", folder, null)).toBe(folder);
+  });
+});

--- a/frontend/src/apps/explorer/listing/pane-side.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.ts
@@ -1,0 +1,164 @@
+// The listing preview pane's THREE modes, and the `_side` param that records
+// which one is showing — the folder half of the same split the file preview grew
+// (Preview.tsx / PreviewSidebar.tsx). Pure and DOM-free, like the pane's other
+// decision modules (pane-math, pane-modes), so the semantics below can be pinned
+// by a test with no router and no React.
+//
+// THE THREE, in this order, and it is a closed list rather than the registry's:
+//
+//   preview  the SELECTED ROW's own default view — the pane exactly as it has
+//            always been (pane-modes.ts still decides what that resolves to: a
+//            folder's embedded listing, a lone app, a file's first template).
+//   claude   the chat, `chat_only=1`, about the selected row.
+//   git      the OPEN FOLDER's working tree — not the row's. See dir-mode.ts:
+//            a working tree belongs to the folder, so `git` is bound to the
+//            universal "/" key alone and the pane borrows the folder's entry.
+//
+// Deliberately NO `history`. The file sidebar offers it because "what happened to
+// this file" is a question about the thing you are looking at; over a folder the
+// thing you are looking at is a LIST, and a per-row history in a column beside it
+// is a fourth pill for a view nobody browses into. It stays one click away — open
+// the row, and the file sidebar has it.
+//
+// This also RETIRES the pane's old per-template switcher (`_panelMode`), which
+// offered every mode the selected row resolved — image/photos/pano for a .png,
+// and `claude`/`history` among them. Two mode controls over one row is the thing
+// the bars' grammar has been converging away from (see Preview's headerActions on
+// why a folder has no top-bar switcher), and the companions are not row views at
+// all, which is the whole premise of the split. What is genuinely lost is picking
+// a NON-DEFAULT content template for a previewed row inside the pane; the
+// expand button opens the row full-screen, where the content switcher lives.
+import type { TemplateEntry } from "@platform/lib/api";
+
+export const PANE_SIDE_MODES = ["preview", "claude", "git"] as const;
+
+export type PaneSide = (typeof PANE_SIDE_MODES)[number];
+
+export const DEFAULT_PANE_SIDE: PaneSide = "preview";
+
+// The value `_side` takes when the user has SHUT the pane. Not a mode, and
+// spelled as a word rather than as an absent param for the reason in
+// `parsePaneSide` below.
+export const PANE_SIDE_OFF = "off";
+
+export interface PaneSideState {
+  open: boolean;
+  mode: PaneSide;
+}
+
+const OPEN_DEFAULT: PaneSideState = { open: true, mode: DEFAULT_PANE_SIDE };
+
+function isPaneSide(v: string): v is PaneSide {
+  return (PANE_SIDE_MODES as readonly string[]).includes(v);
+}
+
+// `_side` ON A FOLDER URL, and what an ABSENT one means. This is the one place
+// the folder's reading of the param differs from the file preview's, so it is
+// worth being explicit about both:
+//
+//   file    absent = CLOSED. The sidebar is an extra beside a content view that
+//           is already complete on its own, so nothing is the same as nothing.
+//   folder  absent = OPEN, at `preview`. The pane is not an extra — it IS the
+//           folder view's other half, on since long before this param existed,
+//           and it appears purely from the width of the split (pane.ts). Reading
+//           absence as "closed" would turn every existing folder URL, bookmark
+//           and recent into a one-column listing.
+//
+// Which is why closing is `_side=off` and not a deleted param: the two states an
+// absent param could mean are not the same here, so the SHUT one has to say so.
+// The open-at-default state is what gets the clean URL, per the `_mode` rule
+// (PT-9 — selecting the default deletes the param).
+//
+// An unknown value reads as the default rather than as an error: a hand-typed
+// `_side=graph`, or a `_side=history` carried in from a file view (router's
+// navigate keeps the param across a DIRECTORY hop), lands on `preview` with the
+// pane open. Same silent fallback an unknown `_mode` gets.
+export function parsePaneSide(raw: string | null): PaneSideState {
+  if (raw === null) return OPEN_DEFAULT;
+  if (raw === PANE_SIDE_OFF) return { open: false, mode: DEFAULT_PANE_SIDE };
+  return raw !== "" && isPaneSide(raw) ? { open: true, mode: raw } : OPEN_DEFAULT;
+}
+
+// What to write back — null means DELETE the param.
+//
+// A shut pane records only that it is shut, not what it last showed: the mode it
+// would reopen to is remembered in component state for the session (the same
+// place the file sidebar keeps its `lastSide`), so a reload of a closed pane
+// reopens at Preview. Encoding the pair would put a mode nobody can see into
+// every shared link of a one-column listing.
+export function paneSideParam(state: PaneSideState): string | null {
+  if (!state.open) return PANE_SIDE_OFF;
+  return state.mode === DEFAULT_PANE_SIDE ? null : state.mode;
+}
+
+// Which of the three a folder actually offers. `preview` ALWAYS — it is the
+// pane's identity, and even a row with no template at all has a preview state
+// (the metadata card). The other two exist only while the folder's own entry for
+// them does (dir-mode.ts), so a folder outside a repository has no Git pill and a
+// mount-backed folder — where both gates refuse — has only Preview, at which
+// point the shared ModeMenu hides itself ("one mode is not a choice", BarMenu)
+// and the header is a chevron over the pane, exactly as it was before the split.
+//
+// Order is by construction, not by sorting: this list IS the switcher's order.
+export interface PaneSideEntries {
+  // The OPEN FOLDER's `claude` / `git` template entries, or null when the folder
+  // does not offer the mode. `preview` needs no entry — it is the selected row's
+  // own default template, resolved from the row's stat by pane-modes.ts.
+  claude: TemplateEntry | null;
+  git: TemplateEntry | null;
+}
+
+export function paneSideList(entries: PaneSideEntries): PaneSide[] {
+  const list: PaneSide[] = ["preview"];
+  if (entries.claude) list.push("claude");
+  if (entries.git) list.push("git");
+  return list;
+}
+
+// The mode the pane SHOWS for a requested one: the request while it is still on
+// offer, else the default. A `_side` naming a mode this folder hasn't got — a
+// `git` carried in from a repository to a folder outside one — falls back here
+// and the param is deliberately LEFT ALONE, which is the posture `_panelMode` had
+// before it: the next folder that does offer the mode picks it up again, so a hop
+// out of a repo and back in does not silently reset the pane.
+export function activePaneSide(offered: PaneSide[], want: PaneSide): PaneSide {
+  return offered.includes(want) ? want : DEFAULT_PANE_SIDE;
+}
+
+// WHAT THE PANE IS ABOUT, as a React key — and it is not always the selected row,
+// which is the whole reason this is a function and not `row.path`.
+//
+// In `git` the subject is the FOLDER. The pane is keyed so that switching rows
+// remounts it (a stale iframe must not linger while the new row resolves), and
+// with the row in the key, arrow-keying down a listing would tear down and reload
+// the git view — a `git status` and a `git log` fork — on every keystroke, for a
+// view whose content did not change. So the selection is left out of it.
+//
+// `claude` and `preview` are both about the ROW, and drop to the folder itself
+// when the selection names no single one: the folder-scoped chat for `claude`, the
+// pane's self/placeholder states for `preview`.
+export function paneKey(
+  side: PaneSide,
+  folder: string,
+  // The lead row's path when EXACTLY ONE row is selected, else null.
+  rowPath: string | null,
+  selCount: number
+): string {
+  if (side === "git") return "git:" + folder;
+  if (side === "claude") return "claude:" + (rowPath ?? folder);
+  if (rowPath) return "preview:" + rowPath;
+  // Nothing selected previews the folder itself (the self target); a
+  // multi-selection previews nothing and needs no per-path identity.
+  return selCount === 0 ? "preview:self:" + folder : "preview:none";
+}
+
+// The path a mode's iframe is aimed at (`_file`). Three modes, two subjects: the
+// folder for `git`, the selected row for the other two — falling back to the
+// folder when there is no single row, so the chat has something to be about.
+export function paneSideTarget(
+  side: PaneSide,
+  folder: string,
+  rowPath: string | null
+): string {
+  return side === "git" ? folder : (rowPath ?? folder);
+}

--- a/frontend/src/apps/explorer/preview-side-slot.ts
+++ b/frontend/src/apps/explorer/preview-side-slot.ts
@@ -1,0 +1,24 @@
+// The preview sidebar's portal target, published as a store.
+//
+// The sidebar is a PAGE-LEVEL column: it stands beside the crumb bar and the
+// content together, running the full height of the window, so its header row is
+// the top of its own column rather than something under a bar that spans the
+// window. That makes it a sibling of the whole left column — and the left column
+// is `#breadcrumb` + `#content`, which StatView (shell/App.tsx) owns.
+//
+// Preview, which is the thing that KNOWS whether there is a sidebar and what is
+// in it, renders several levels below that. So StatView renders the slot and
+// Preview portals into it. Same arrangement, in the other direction, as the crumb
+// bar's own `#topbar-mode-slot`: the container and the content are owned by
+// different components, and a published node (rather than a getElementById at
+// mount) is what makes the portal survive the container being rebuilt — see
+// node-slot.ts.
+import { createNodeSlot } from "@apps/explorer/node-slot";
+
+const slot = createNodeSlot();
+
+export const publishPreviewSideSlot = slot.publish;
+export const retractPreviewSideSlot = slot.retract;
+export const previewSideSlot = slot.get;
+export const subscribePreviewSideSlot = slot.subscribe;
+export const resetPreviewSideSlot = slot.reset;

--- a/frontend/src/platform/lib/mode-visibility.test.ts
+++ b/frontend/src/platform/lib/mode-visibility.test.ts
@@ -3,6 +3,10 @@ import type { TemplateEntry } from "@platform/lib/api";
 import {
   visibleModes,
   isModePending,
+  isSidebarMode,
+  partitionModes,
+  orderSidebarModes,
+  defaultSidebarMode,
   defaultMode,
   effectiveActive,
 } from "@platform/lib/mode-visibility";
@@ -16,6 +20,7 @@ const t = (mode: string, conditional = false): TemplateEntry => ({
 
 const listing = t("_listing");
 const claude = t("claude");
+const git = t("git", true);
 const app = t("app", true);
 const split = t("claude_split", true);
 
@@ -53,6 +58,93 @@ describe("visibleModes", () => {
 
   it("is order-preserving", () => {
     expect(names(visibleModes([app, listing, claude], null))).toEqual(["app", "_listing", "claude"]);
+  });
+});
+
+describe("partitionModes", () => {
+  const image = t("image");
+  const history = t("history");
+
+  it("splits the companions out and preserves order in both halves", () => {
+    const { content, sidebar } = partitionModes([image, t("photos"), claude, history]);
+    expect(names(content)).toEqual(["image", "photos"]);
+    expect(names(sidebar)).toEqual(["claude", "history"]);
+  });
+
+  it("leaves a list with no companions entirely to the content pane", () => {
+    const { content, sidebar } = partitionModes([image, listing]);
+    expect(names(content)).toEqual(["image", "_listing"]);
+    expect(sidebar).toEqual([]);
+  });
+
+  it("agrees with isSidebarMode", () => {
+    expect(isSidebarMode("claude")).toBe(true);
+    expect(isSidebarMode("git")).toBe(true);
+    expect(isSidebarMode("history")).toBe(true);
+    expect(isSidebarMode("claude_split")).toBe(false);
+    expect(isSidebarMode("_render")).toBe(false);
+  });
+
+  // `git` is on SIDEBAR_MODES but never in a FILE's own template list: the
+  // registry keeps it on the universal "/" directory key and its gate refuses a
+  // file, so a file's partition can only ever see one if a user registry rebinds
+  // it. The file sidebar's own git entry is BORROWED from the parent folder and
+  // appended (lib/dir-mode), which is why `orderSidebarModes` exists.
+  it("does not invent a git entry for a file that has none", () => {
+    const { content, sidebar } = partitionModes([image, claude, history]);
+    expect(names(content)).toEqual(["image"]);
+    expect(names(sidebar)).toEqual(["claude", "history"]);
+  });
+
+  it("takes a file's own git entry into the sidebar half when there is one", () => {
+    // A user registry may bind `git` to a file extension; it is still a companion.
+    const { content, sidebar } = partitionModes([image, git, claude]);
+    expect(names(content)).toEqual(["image"]);
+    expect(names(sidebar)).toEqual(["git", "claude"]);
+  });
+
+  it("defaults the sidebar to the chat, whatever the registry's order was", () => {
+    // The registry ranks views for a FILE TYPE; this is a preference between the
+    // companions, so SIDEBAR_MODES order wins over the list's.
+    expect(defaultSidebarMode([history, git, claude])).toBe("claude");
+    expect(defaultSidebarMode([history, git])).toBe("git");
+    expect(defaultSidebarMode([history])).toBe("history");
+    expect(defaultSidebarMode([])).toBe(null);
+  });
+});
+
+// The switcher's order is Claude / Git / History for every file, because the list
+// is ASSEMBLED (git arrives from the parent folder and is appended) rather than
+// read off one registry key.
+describe("orderSidebarModes", () => {
+  const history = t("history");
+
+  it("puts the companions in SIDEBAR_MODES order, not the input's", () => {
+    expect(names(orderSidebarModes([history, claude]))).toEqual(["claude", "history"]);
+    // The shape the file sidebar actually builds: the file's own companions in
+    // registry order, then the borrowed git appended at the end.
+    expect(names(orderSidebarModes([claude, history, git]))).toEqual([
+      "claude",
+      "git",
+      "history",
+    ]);
+  });
+
+  it("leaves an unknown companion at the end, in the order it came", () => {
+    const mine = t("my_notes");
+    const yours = t("your_notes");
+    expect(names(orderSidebarModes([mine, history, yours, claude]))).toEqual([
+      "claude",
+      "history",
+      "my_notes",
+      "your_notes",
+    ]);
+  });
+
+  it("does not mutate its input", () => {
+    const input = [t("history"), claude];
+    orderSidebarModes(input);
+    expect(names(input)).toEqual(["history", "claude"]);
   });
 });
 

--- a/frontend/src/platform/lib/mode-visibility.ts
+++ b/frontend/src/platform/lib/mode-visibility.ts
@@ -52,6 +52,80 @@ export function isModeVisible(entry: TemplateEntry, verdicts: ConditionVerdicts)
   return verdicts[entry.mode] !== false; // absent verdict (failed call) shows
 }
 
+// --- content pane vs. sidebar (Preview's `_side`) ---------------------------
+// Some of the modes around a file are not another WAY OF LOOKING at it, they
+// are companions TO looking at it: the agent chat, the working tree it sits in,
+// and the file's own history all talk about the file while you are viewing it as
+// something (an image, a table, its source). Putting them in the same radio list
+// as the real content modes made them mutually exclusive with the view they are
+// about — asking Claude about a .png meant giving up looking at the .png.
+//
+// So on a single-file explorer preview they move to a right-hand SIDEBAR with
+// its own URL param (`_side`), and the content pane's own mode list drops them.
+// The partition lives here, with the rest of the mode policy, because every
+// surface has to agree on which side of the split a mode belongs to — and
+// because the surfaces that DON'T split (the panel/tab panes, the app builder)
+// must keep offering them as ordinary modes, which is only safe while "is this a
+// sidebar mode?" has one definition.
+//
+// `git` IS ON THIS LIST AND IS NOT IN ANY FILE'S TEMPLATE LIST, and both halves
+// of that are deliberate. The registry binds `git` to the universal "/" DIRECTORY
+// key alone and its gate refuses anything that is not a directory
+// (templates/git/condition.py: a working tree belongs to the folder, since you
+// stash a tree and not a file), so `partitionModes` will never pull a `git` entry
+// out of a file's own modes. The file sidebar BORROWS one from the file's parent
+// folder instead (apps/explorer/lib/dir-mode.ts) and inserts it here — which is
+// why the ordering below is a rule of its own rather than the registry's.
+export const SIDEBAR_MODES = ["claude", "git", "history"] as const;
+
+const SIDEBAR_MODE_SET: ReadonlySet<string> = new Set(SIDEBAR_MODES);
+
+export function isSidebarMode(mode: string): boolean {
+  return SIDEBAR_MODE_SET.has(mode);
+}
+
+// Split an ALREADY-VISIBLE list in two, order-preserving in both halves.
+export function partitionModes(entries: TemplateEntry[]): {
+  content: TemplateEntry[];
+  sidebar: TemplateEntry[];
+} {
+  return {
+    content: entries.filter((e) => !isSidebarMode(e.mode)),
+    sidebar: entries.filter((e) => isSidebarMode(e.mode)),
+  };
+}
+
+// The sidebar switcher's order: SIDEBAR_MODES', not the registry's.
+//
+// The registry ranks views for a FILE TYPE — which of `.png`'s viewers should
+// open first — and that is a genuinely different question from how the companions
+// rank against each other, which is the same answer for every file: the chat, the
+// working tree, then the history. It also has to be a rule here because the list
+// is ASSEMBLED rather than read: `git` is borrowed from the parent folder (see
+// above) and appended, so leaving the order to the input would put Git after
+// History for every file in a repository.
+//
+// Stable within a rank, so an unknown companion (a user registry binding one of
+// its own into this half) keeps its relative position at the end rather than
+// being reshuffled.
+export function orderSidebarModes(entries: TemplateEntry[]): TemplateEntry[] {
+  const rank = (mode: string) => {
+    const i = (SIDEBAR_MODES as readonly string[]).indexOf(mode);
+    return i === -1 ? SIDEBAR_MODES.length : i;
+  };
+  return [...entries].sort((a, b) => rank(a.mode) - rank(b.mode));
+}
+
+// Which sidebar mode a bare "open the sidebar" lands on: SIDEBAR_MODES order,
+// not the registry's, because this is a preference between the companions (the
+// chat first — it is the one users open the sidebar FOR) rather than a ranking of
+// views for a file type. Falls through to whatever IS on offer so a file that
+// only has `history` still opens something.
+export function defaultSidebarMode(sidebar: TemplateEntry[]): string | null {
+  for (const mode of SIDEBAR_MODES) if (sidebar.some((e) => e.mode === mode)) return mode;
+  return sidebar[0]?.mode ?? null;
+}
+
 // Order-preserving filter — the registry's own ranking is the menu order.
 export function visibleModes(
   entries: TemplateEntry[],

--- a/frontend/src/platform/lib/router.test.ts
+++ b/frontend/src/platform/lib/router.test.ts
@@ -67,15 +67,29 @@ describe("navigate carries the frozen-tree framing", () => {
     expect(url).toBe("/explorer/view/w/snap/a.md?snapshot=1");
   });
 
-  test("it rides alongside the sticky pane mode and an explicit mode", () => {
-    const url = pushedFrom("?snapshot=1&_panelMode=code&sort=size", () =>
+  test("it rides alongside the sticky pane state and an explicit mode", () => {
+    const url = pushedFrom("?snapshot=1&_side=git&sort=size", () =>
       navigate("/w/snap/docs", { isDir: true, mode: "claude" }),
     );
     expect(url).toContain("snapshot=1");
-    expect(url).toContain("_panelMode=code");
+    expect(url).toContain("_side=git");
     expect(url).toContain("_mode=claude");
     // Ordinary view params are still dropped by a hop.
     expect(url).not.toContain("sort=size");
+  });
+
+  // `_side` is the PANE's state, and the pane only exists over a folder — so a
+  // folder hop carries it and opening a file does not. The file view has a `_side`
+  // of its own (Preview's companion sidebar) whose absent value means CLOSED, and
+  // handing it the folder's `off`/`preview` would be handing it a mode it has no
+  // entry for; each surface seeds its own from its own URL.
+  test("the sticky pane state is folder-only", () => {
+    expect(pushedFrom("?_side=git", () => navigate("/w/docs", { isDir: true }))).toBe(
+      "/explorer/view/w/docs?_side=git",
+    );
+    expect(pushedFrom("?_side=git", () => navigate("/w/a.md", { isDir: false }))).toBe(
+      "/explorer/view/w/a.md",
+    );
   });
 
   test("an ordinary page invents no flag", () => {

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -174,12 +174,17 @@ export function navigate(
   opts?: { isDir?: boolean; mode?: string; sel?: string | null },
 ): void {
   // Navigating between files/dirs drops old view params (fresh query string) —
-  // EXCEPT the pane's chosen mode (`_panelMode`), which is sticky across
-  // DIRECTORY navigation: a folder hop keeps previewing in the mode the user
-  // picked. Reserved (`_`-prefixed) name, so no template-param shadowing
-  // concern, and directory-only for the same reason its companion was: a file
-  // view hosts a template iframe whose ancestor-climb (runtime.js D72 globals)
-  // reads every shell-URL param.
+  // EXCEPT the preview pane's own state (`_side`: which of its three modes it is
+  // showing, or that it is shut — listing/pane-side.ts), which is sticky across
+  // DIRECTORY navigation: a folder hop keeps the pane as the user left it, open on
+  // the same companion or closed. Reserved (`_`-prefixed) name, so no
+  // template-param shadowing concern, and directory-only for the same reason its
+  // predecessor was: a file view hosts a template iframe whose ancestor-climb
+  // (runtime.js D72 globals) reads every shell-URL param.
+  //
+  // It replaces `_panelMode`, which named which of the SELECTED ROW's templates
+  // the pane was previewing. That switcher is gone (pane-side.ts records the
+  // trade), so nothing writes the param and nothing would read one carried here.
   //
   // Its companion `preview` (the pane's on/off) is GONE, not merely unlisted:
   // the split is decided by the container's width now (listing/pane.ts), so
@@ -200,14 +205,14 @@ export function navigate(
   // survives the drop; a RELOAD or a copied link is where it bites, bringing
   // back the breadcrumb walking up into the snapshot cache's internals and the
   // preview pane inside the preview pane. Carried on FILE hops as well as
-  // folder ones, unlike `_panelMode`: the framed listing opens files too, and
+  // folder ones, unlike `_side`: the framed listing opens files too, and
   // the chrome the flag suppresses is the same chrome on a file view.
   const current = new URLSearchParams(location.search);
   const parts: string[] = [];
   if (current.get("snapshot") === "1") parts.push("snapshot=1");
   if (opts?.isDir === true) {
-    const panelMode = current.get("_panelMode");
-    if (panelMode !== null) parts.push("_panelMode=" + encodeURIComponent(panelMode));
+    const side = current.get("_side");
+    if (side !== null) parts.push("_side=" + encodeURIComponent(side));
   }
   // `opts.mode` picks the destination's template mode (`_mode`) — how the app
   // cards open a project folder straight into the plain app view (appEntry's

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -40,6 +40,7 @@ import { reconcileOsClipboard } from "@apps/explorer/lib/os-clipboard";
 import { BreadcrumbBar, StaticBreadcrumb } from "@apps/explorer/Breadcrumb";
 import Listing from "@apps/explorer/Listing";
 import Preview from "@apps/explorer/Preview";
+import { PreviewSideSlot } from "@apps/explorer/PreviewSidebar";
 import Panel from "@apps/explorer/Panel";
 import Tabs from "@apps/explorer/Tabs";
 import Preferences from "@shell/Preferences";
@@ -337,18 +338,36 @@ function StatView({
       );
     }
   }
+  // The PAGE-LEVEL split: this view's own column on the left — its bar and its
+  // content, one above the other — and, when a file preview opens one, the
+  // sidebar's column on the right (Preview's `_side`, apps/explorer/
+  // PreviewSidebar). The wrapper is unconditional so opening the sidebar cannot
+  // restructure the tree above `#content` and remount the view.
+  //
+  // The bar is INSIDE the left column, which is the whole point: it ends at the
+  // divider instead of spanning the window over both columns, so the sidebar's
+  // own header row is the top of the window on its side rather than a bar-height
+  // below the left one. Same shape as the listing and its preview pane over a
+  // folder (.listing-split / .listing-main), for the same reason.
+  //
+  // The slot stands empty on every route that has no sidebar — every folder, the
+  // app builder, learn, embed panes — and `display: contents` on an empty
+  // element costs the layout nothing (explorer.css).
   return (
-    <>
-      {/* Only the explorer carries a breadcrumb bar — the app builder and
-          learn render their content directly (no path chrome). BreadcrumbBar
-          owns the `#breadcrumb` box itself: over a folder it portals the whole
-          bar down into the listing's left column, so it can't be a wrapper
-          rendered here (Breadcrumb.tsx). */}
-      {variant === "explorer" && (
-        <BreadcrumbBar fsPath={fsPath} home={home} renderedTitle={renderedTitle} />
-      )}
-      <div id="content">{content}</div>
-    </>
+    <div className="stat-split">
+      <div className="stat-main">
+        {/* Only the explorer carries a breadcrumb bar — the app builder and
+            learn render their content directly (no path chrome). BreadcrumbBar
+            owns the `#breadcrumb` box itself: over a folder it portals the whole
+            bar down into the listing's left column, so it can't be a wrapper
+            rendered here (Breadcrumb.tsx). */}
+        {variant === "explorer" && (
+          <BreadcrumbBar fsPath={fsPath} home={home} renderedTitle={renderedTitle} />
+        )}
+        <div id="content">{content}</div>
+      </div>
+      <PreviewSideSlot />
+    </div>
   );
 }
 

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -283,11 +283,11 @@
   display: none;
 }
 
-/* …and takes the zone divider with it, so a static page (or a view still
-   resolving its stat) shows no stray hairline floating in the bar. */
-#topbar-mode-slot:empty + .bar-rule {
-  display: none;
-}
+/* It used to have to take a zone divider with it, so a static page (or a view
+   still resolving its stat) showed no stray hairline floating in the bar. The
+   crumb bar has no layout zone left to divide from — the splits are items in the
+   path `⋮` now (Breadcrumb.tsx) — so that pair, and the `.bar-rule` margin reset
+   that went with it, are gone. The panel bar below still needs both. */
 
 /* Same pair for the panel pane bar, whose mode menu (PaneModeMenu) renders
    nothing on a single-mode path and while the pane is still statting — the
@@ -301,11 +301,6 @@
   display: none;
 }
 
-/* #breadcrumb already spaces its children with `gap`, so the rule brings no
-   margin of its own here (it does in .panel-bar, whose gap is 2px). */
-#breadcrumb .bar-rule {
-  margin: 0;
-}
 
 /* ---- One control recipe for the explorer's bars --------------------------
    The title bar, the listing search row, the preview-pane header and the
@@ -399,6 +394,43 @@
   display: flex;
   align-items: center;
   gap: 2px;
+}
+
+/* ---- a side column's HEADER STRIP, and there are two of them --------------
+   The file preview's sidebar (.preview-side-header, preview.css) and the folder
+   listing's preview pane (.pane-header, below) are the SAME bar: the way OUT of
+   the column at its left end, the mode pill at its right, over a full-height
+   frame. The two components already share their buttons (SideChrome.tsx); this is
+   the layout half of that sharing.
+
+   NO RULE FOR THE BUTTONS THEMSELVES (.side-close, .side-toggle): both ride the
+   plain .bar-ctl-icon recipe above, and their glyphs are a 16px chevron / the
+   companion's own mode icon, in currentColor like everything else in these rows.
+   A `.side-toggle.active` pressed look lived here for one round, while the opener
+   stayed on screen with the panel open and the column carried a closing chevron of
+   its own. Exactly one of the two buttons is ever rendered now (SideChrome
+   documents the split), so there is no "on" state left for either to wear.
+
+   The far end is packed by an auto margin on a TAIL WRAPPER rather than on the
+   leading items, which is load-bearing and not a style preference: the left end
+   holds a VARIABLE number of things (the pane's also carries the open folder's
+   primary action, portaled in and usually absent), and an auto margin on whichever
+   of those renders last distributes the free space differently every time — with
+   two present, the middle one drifts to the centre. One auto margin, always on the
+   same element, packs the right end and leaves the left alone whatever is in it. */
+.side-header-tail {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+/* Nothing to pack — and an empty wrapper would still spend one of the strip's
+   8px gaps. (Reached by the pane's non-Preview states, whose strip has no
+   expand button to put here.) */
+.side-header-tail:empty {
+  display: none;
 }
 
 /* ---- The mode control ---------------------------------------------------
@@ -554,6 +586,17 @@
   color: var(--accent);
 }
 
+/* Group divider inside an overflow popup (the path `⋮` separates what it does
+   to the FILE — reveal, copy path — from what it does to the WINDOW: the two
+   splits). Inset to the rows' own padding so it reads as a break in the list
+   rather than a line drawn across the box. */
+.bar-menu-sep {
+  flex: 0 0 auto;
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border);
+}
+
 .star-btn {
   flex: 0 0 auto;
   font: inherit;
@@ -578,6 +621,37 @@
   color: var(--fg);
   border-color: var(--border);
   background: rgba(var(--tint), 0.08);
+}
+
+/* The PAGE-LEVEL split (shell/App.tsx StatView): this view's own column, and
+   then the preview sidebar's when a file preview opens one
+   (apps/explorer/PreviewSidebar). Always rendered, so with no sidebar it is
+   simply the single-column layout it was. Sits directly inside #main, which is a
+   flex COLUMN — hence the flex/min-height here, and `row` for the split. */
+.stat-split {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+}
+
+/* The left column: the crumb bar, then #content. The bar lives IN here rather
+   than spanning the window, so it ends at the divider and the sidebar's own
+   header row is the top of the window on its side — same arrangement, and the
+   same reason, as .listing-main over a folder. */
+.stat-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Portal target for the sidebar (preview-side-slot.ts). `display: contents` so
+   the divider and the column it holds become flex children of .stat-split
+   itself — and so the slot, empty on every route that has no sidebar, costs the
+   layout nothing whatsoever. */
+.stat-side-slot {
+  display: contents;
 }
 
 #content {
@@ -871,10 +945,12 @@
    standing the bar up in those states. It is not a nicety; without it the
    strip collapses to its border and the seam breaks.
 
-   `justify-content: flex-end` for the same reason: the strip's contents are
-   the mode menu and the open-full-screen glyph, which belong at the far end
-   the way the crumb bar's own controls do. With the name gone there is no
-   leading item left to push them there.
+   It leads with the way OUT of the column and ends with the mode pill — the file
+   sidebar's header exactly, and the shared `.side-header-tail` above is what packs
+   that end. `flex-start` here, therefore, rather than the `flex-end` this rule
+   carried while the strip had no leading item at all: the left end now holds the
+   close chevron and (for a folder with a page to open) the folder's own primary,
+   and those pack from the left like any bar's.
 
    Horizontal padding stays at the PANE's 10px gutter (the crumb bar keeps the
    listing's 16px): each bar lines up with the column underneath it, and the
@@ -883,7 +959,7 @@
   flex: 0 0 auto;
   display: flex;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
   gap: 8px;
   padding: var(--topbar-pad-y) 10px;
   height: var(--topbar-h);
@@ -893,20 +969,20 @@
 }
 
 /* Portal target for the open folder's "Open as app" (pane-action-slot.ts).
-   `display: contents` so the button is a flex item of the header itself and
-   picks up its gap and alignment, and `margin-right: auto` so it sits at the
-   header's LEFT end while the mode chip and the expand glyph stay packed
-   right: it belongs to the folder on the other side of the divider, not to the
-   row the rest of this bar is about.
+   `display: contents` so the button is a flex item of the header itself and picks
+   up its gap and alignment — landing it at the header's LEFT end beside the close
+   chevron, because it belongs to the folder on the other side of the divider and
+   not to the row the pill is about.
+
+   It used to carry `margin-right: auto` to get there, back when it was the strip's
+   only leading item; that job belongs to `.side-header-tail` now, and leaving a
+   second auto margin in the row would split the free space between the two and
+   float this button into the middle of the bar.
 
    :empty and it disappears — most folders have no lone page to open, and an
    empty item would still spend one of the header's 8px gaps. */
 .listing-pane .pane-action-slot {
   display: contents;
-}
-
-.listing-pane .pane-action-slot > * {
-  margin-right: auto;
 }
 
 /* Folder preview fallback: the folder's own entries, read-only. Narrower

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -240,6 +240,136 @@
   z-index: 1;
 }
 
+/* ---- the preview SIDEBAR (`_side`) ---------------------------------------
+   A file preview's right-hand column: the companion modes (`claude`,
+   `history`) beside the content pane instead of in place of it
+   (apps/explorer/PreviewSidebar.tsx).
+
+   PAGE-LEVEL, and that is the layout: both items below are flex children of
+   `.stat-split` (explorer.css), the row that holds this view's whole left column
+   — crumb bar AND content — as its other child. So the divider runs the full
+   height of the window, the crumb bar stops at it, and this column's header row
+   is the top of the window on its side. Rendered here by a portal from Preview
+   into StatView's slot (preview-side-slot.ts), which also means nothing above
+   `.preview-body` is restructured when the sidebar opens — the content iframe is
+   never re-parented, and so never reloaded.
+
+   The divider is the listing's, to the pixel (.listing-divider): a 5px
+   transparent strip with negative margins so the handle overhangs both
+   neighbours, painting the hairline only on hover/drag. Two draggable seams in
+   one app must not feel like two different controls. */
+.preview-side-divider {
+  flex: 0 0 5px;
+  cursor: col-resize;
+  background: transparent;
+  margin: 0 -2px;
+  z-index: 2;
+  /* The drag is pointer-captured; without this, touch scrolling fights it. */
+  touch-action: none;
+}
+
+.preview-side-divider:hover,
+.preview-side-divider.dragging {
+  background: var(--border);
+}
+
+/* An iframe is a separate document and would swallow the captured pointer
+   stream — inert BOTH sides for the drag's duration. */
+.stat-split:has(.preview-side-divider.dragging) iframe {
+  pointer-events: none;
+}
+
+/* The column, full height of the window. Its flex-basis is set inline in pixels
+   (PreviewSidebar): a sidebar's job is to hold a chat composer and a message
+   column legibly, which is a width, not a share of the window — hence px here
+   where the listing's pane is a fraction. The min-width is the same floor the
+   drag clamps to, and backstops a window resize that narrows the row under an
+   already-sized column.
+   `position: relative` anchors the seam below. */
+.preview-side {
+  flex: 0 0 auto;
+  min-width: 280px;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-alt);
+  position: relative;
+}
+
+/* The seam between the two columns, and where it STOPS — the listing pane's rule
+   (.listing-pane-slot::before), for the reason written out there: the two header
+   strips are the same height, background and bottom hairline precisely so they
+   read as ONE bar across the window, and a border-left running the full height
+   would cut that bar in two boxes. So the line starts where the CONTENT does.
+   The drag target is untouched — the divider is a separate full-height flex item,
+   transparent until hover. Only the painted line is short. */
+.preview-side::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: var(--topbar-h);
+  bottom: 0;
+  width: 1px;
+  background: var(--border);
+  pointer-events: none;
+}
+
+/* The column's own top strip, and it must match the crumb bar across the seam
+   the way the listing pane's header does (.pane-header, explorer.css): same
+   --topbar-h, same vertical padding, same hairline. The two are one bar across
+   the window, split by the divider.
+
+   Two items, at opposite ends: the close chevron leads, on the seam the column
+   collapses toward, and the mode control is packed to the far end the way the crumb
+   bar's own controls are. That far end is `.side-header-tail` (explorer.css), the
+   ONE auto margin the two side-column headers share — so the right-hand end holds
+   whichever of the two things renders there (the ModeMenu, or the flat
+   .preview-side-name label a one-companion file gets) without either needing a rule
+   of its own, and the strip cannot be thrown off by what does or does not render at
+   its left end. The explicit `height` is what stands the bar up; same dependency,
+   same reason, as .pane-header. */
+.preview-side-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: var(--topbar-pad-y) 10px;
+  height: var(--topbar-h);
+  box-sizing: border-box;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-alt);
+}
+
+/* The one-companion case: the same icon and words the menu would show, with
+   nothing to click (BarMenu's ModeMenu hides itself at one entry — "one mode is
+   not a choice" — which would leave this strip empty over an unlabelled
+   document). Deliberately NOT .bar-ctl-bordered: it is a label, and a plate
+   around it would invite the click it does not take. */
+.preview-side-name {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 2px;
+  font-size: 12px;
+  line-height: 1;
+  color: var(--fg);
+  white-space: nowrap;
+}
+
+/* Fills what the header leaves. flex, not height:100%, so the header can't push
+   it past the column's bottom edge (same as .listing-pane .pane-frame). */
+.preview-side-frame {
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  height: auto;
+  border: 0;
+  display: block;
+  background: var(--bg);
+}
+
 .metadata-card {
   margin: 24px;
   padding: 20px;

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1560,6 +1560,32 @@ function focusBox(el) {
 const FILE = fused.params.get("_file") || "";
 const BASENAME = FILE.split("/").pop();
 
+// Chat-only host: this document is framed as a SIDEBAR beside the shell's own
+// preview of the same target (the explorer's `_side` split — Preview.tsx and
+// PreviewSidebar.tsx), so our own left half would be that file previewed twice
+// in one window, the inner copy a few hundred pixels wide. The host says so with
+// `chat_only=1`, and we take the pane away: no second preview, no divider, no
+// annotate switch, and the chat column runs full width.
+//
+// A HOST fact, not view state, which is why it is read once into a const and
+// never written: nothing in here toggles it, and someone who reaches this URL
+// without the param wants the full split. The teardown is the template's
+// existing NO-PANE path (enterNoPane, below) — the same designed absence a
+// folder with no app entry gets — so this adds a reason to enter that state
+// rather than a second layout to maintain.
+//
+// Read off THIS FRAME'S OWN URL, not through fused.params, and that distinction
+// is the whole difference between a host fact and view state. This page sets no
+// `_fusedParamBoundary`, so its param target is the SHELL's URL (D46/D72) —
+// which is exactly right for `split`, `session_id`, `annotations` and the rest
+// (they belong in the shell URL, and so in a bookmark), and exactly wrong for
+// this: the host chose the layout when it built the iframe src, and putting that
+// choice on the shell URL would let it outlive the host that made it. `_file`
+// rides the same way for the same reason, and is special-cased in the runtime
+// to prove it; a leading underscore is reserved (unreadable through
+// fused.params), so this one is read directly.
+const CHAT_ONLY = new URLSearchParams(location.search).get("chat_only") === "1";
+
 if (!FILE) {
   document.body.innerHTML = '<div id="msg">No file selected (missing _file param).</div>';
   throw new Error("claude template: missing _file");
@@ -1808,10 +1834,12 @@ function searchParamsOf(search) {
 // `leftmode` and `paneview` are in here for the `split` reason: they are this
 // chat's own layout bookkeeping (which view the left pane frames, which of the
 // two views a narrow host shows), and reporting them to the model as params the
-// APP is running with would be describing our chrome as its state.
+// APP is running with would be describing our chrome as its state. `chat_only`
+// is the extreme case of that: it describes THIS DOCUMENT'S HOST (see
+// CHAT_ONLY), and there is no pane for it to be a param of.
 const CHAT_PARAMS = new Set(["_file", "_mode", "session_id", "run", "split",
                              "model", "effort", "permission", "annotations",
-                             "annmode", "leftmode", "paneview",
+                             "annmode", "leftmode", "paneview", "chat_only",
                              "path"]);
 
 function appParamsOf(all) {
@@ -2182,6 +2210,12 @@ async function paneURL() {
     const { entry } = await fused.runPython("./app.py", { dir: FILE });
     if (entry) {
       setTargetNoun("project");   // an app folder — the prompt says so too
+      // Chat-only host (see CHAT_ONLY): the pane is the host's, not ours. The
+      // NOUN is still set — it describes the target, and the system prompt and
+      // the placeholders need it either way — but `appEntry` is not: it names
+      // "the entry html the pane is rendering", and from here nothing is. Same
+      // as the no-pane folder below, which leaves it empty for the same reason.
+      if (CHAT_ONLY) return null;
       appEntry = entry;
       return "/render?path=" + encodeURIComponent(entry);
     }
@@ -2215,6 +2249,11 @@ async function paneURL() {
   // user's own override (§16), which stat has already resolved by the time we
   // see it.
   setTargetNoun("file");
+  // Chat-only host (see CHAT_ONLY) — before the entry lookup below, on purpose:
+  // the "no preview view for this file" throw is about a pane WE have to fill,
+  // and in this layout there is no pane to fail at filling. A file the host
+  // frames a chat for must not open with an error panel over a working chat.
+  if (CHAT_ONLY) return null;
   paneEntries = paneOfferable(st.templates);
   paneRemote = !!st.remote;
   const t = curLeftEntry();

--- a/tests/test_history_template.py
+++ b/tests/test_history_template.py
@@ -18,6 +18,7 @@ so nothing here goes through a package import.
 import importlib.util
 import json
 import os
+import re
 import shutil
 import subprocess
 
@@ -1113,16 +1114,29 @@ def test_the_framed_snapshot_listing_may_not_open_a_pane_of_its_own():
     test_claude_pane_mode_label.py: the template writes the flag, the shell
     honours it, and this suite owns the pair — the template's own tests cannot
     see the consequence, and a rule with a producer in one language and a
-    consumer in another is exactly the kind that gets half-removed."""
+    consumer in another is exactly the kind that gets half-removed.
+
+    The flag reaches `usePreviewPane` through a NAMED const rather than inline,
+    because the same "may this folder have a pane at all?" answer now gates three
+    more things beside the split (the pane's `_side` URL state and the two
+    companion-mode probes, both of which an embedded or framed listing must also
+    skip). So this follows one hop: the const is what carries the rule, and the
+    call is what consumes it. Asserting both is the point — a rename that keeps
+    the const and stops passing it would leave the rule true and unenforced."""
     listing = os.path.join(
         os.path.dirname(TEMPLATE_DIR), "..", "..", "frontend", "src", "apps",
         "explorer", "Listing.tsx")
     with open(os.path.normpath(listing), encoding="utf-8") as f:
         src = f.read()
+    gate = re.search(r"const\s+(\w+)\s*=\s*([^;]*IS_SNAPSHOT[^;]*);", src)
+    assert gate, \
+        "the shell no longer refuses a pane under the frozen-tree framing"
+    assert "embedded" in gate.group(2), \
+        "the pane gate stopped refusing an EMBEDDED listing as well"
     call = src[src.index("usePreviewPane("):]
     call = call[:call.index(");") + 2]
-    assert "IS_SNAPSHOT" in call, \
-        "the shell no longer refuses a pane under the frozen-tree framing"
+    assert gate.group(1) in call, \
+        "the frozen-tree gate is no longer what decides the pane's split"
     # And nothing drops the preview column any more: the split is the one
     # layout, for all three kinds.
     assert "enterNoPreview" not in src


### PR DESCRIPTION
## What

Splits the file preview into two parallel panels and brings the same pattern to the folder listing's preview pane.

**File view** (`/explorer/view/<file>`):
- Topbar mode switcher keeps only content templates (Image/Photos/Pano/…)
- New right sidebar hosts the companions — **Claude / Git / History** — toggled by a mode-icon button in the topbar (closed) / close chevron in the panel header (open); exactly one affordance visible at a time
- Sidebar state is shareable: `_side=claude|git|history` (absent = closed); legacy `?_mode=claude` deep links migrate once via replace
- Claude renders chat-only (`chat_only=1` hides the template's internal preview split)
- Git on a file borrows the **parent directory's** template + condition — registry and git template untouched; hidden outside a worktree
- Split right/down moved into the path kebab (now vertical ⋮)

**Folder view**: listing's preview pane adopts the same header (close chevron + pill) with exactly **Preview / Claude / Git** (no History). `_side=off` = closed, absent = open at Preview so existing folder URLs keep working; `_panelMode` retired (sticky-param behavior carried over to `_side`).

## Verification

- `tsc --noEmit`, `npm run build` (boundaries + vite) — pass
- Frontend unit tests: 53 pass on touched files (`mode-visibility`, `router`, `pane-side`); full `bun test` failures limited to pre-existing `shortcut-chord.test.ts` (reproduces on main)
- Backend: full suite `5161 passed, 131 skipped`; 3 persistent failures (`test_deploy` ×2, `test_calls` ×1) reproduce on clean main — pre-existing, unrelated
- Browser-verified on the dev server (DOM-asserted): toggle cycles, `_side` semantics, no content-iframe reload on open/close, chat-only Claude, parent-dir Git, non-repo files hide Git+History, folder pane 3-mode pill, panel/app/learn variants unchanged

## Notes / trade-offs

- Pane's per-template switcher (`_panelMode`) replaced by the 3-mode pill; row expand still reaches the full content-mode list
- Folder-pane Claude is offered for every row (entry is the folder's, not the row's) — deliberate, keeps Git mode stat-free

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches URL param semantics (`_side`, legacy migration), navigation stickiness, and large Preview/Listing orchestration; mistakes could break bookmarks, iframe reload behavior, or folder vs file pane state.
> 
> **Overview**
> Introduces a **content + companion sidebar** split for standalone file previews: content templates stay in the main pane and topbar mode menu, while **Claude / Git / History** move to a resizable right column driven by **`_side`** (with legacy `?_mode=claude` migration). **Git** can be borrowed from the parent directory when the file has no own git binding; Claude loads with **`chat_only=1`** so the template does not nest a second preview.
> 
> **Folder listings** get the same three-way pane (**Preview / Claude / Git**) with folder-scoped `_side` semantics (absent = open at Preview, `off` = closed). **`_panelMode`** and the per-row pane template switcher are retired in favor of default preview plus the pane pill; **`useDirMode`** caches directory template probes for borrowed companions.
> 
> **Chrome/layout**: removes the breadcrumb **layout zone** split buttons in favor of labeled items in **`PathOverflow`**; shared **`SideChrome`** open/close affordances; **`StatView`** wraps explorer in **`.stat-split`** with a portal target for the sidebar; overflow menus gain icons and separators.
> 
> **Router** sticks **`_side`** on directory hops only (replacing **`_panelMode`**). **`partitionModes`** / **`orderSidebarModes`** in `mode-visibility` define which modes are sidebar vs content everywhere surfaces must agree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433ec65b06bcd3d2f2c7e58ea3870d206dd148cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->