### PR TITLE
Explorer chrome polish: breadcrumb click scope, seams, mode menu, app-button placement

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,6 +52,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1237,6 +1238,7 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1306,6 +1308,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1594,6 +1597,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1635,6 +1639,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1814,6 +1819,7 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -52,7 +52,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1238,7 +1237,6 @@
       "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1308,7 +1306,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001800",
@@ -1597,7 +1594,6 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1639,7 +1635,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -1819,7 +1814,6 @@
       "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",

--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -123,7 +123,10 @@ function CaretIcon({ open }: { open: boolean }) {
 // dots in a row of `/`-joined segments, i.e. "the path goes on". Turned upright
 // it reads as a control, and it is the same "more, about this thing" affordance
 // every file manager puts beside a row.
-function EllipsisIcon() {
+// Exported so the folder listing's header `⋮` (Listing.tsx) is the SAME glyph
+// as the bars' — it opens a menu of the same actions, and a second hand-rolled
+// triplet would drift.
+export function EllipsisIcon() {
   return (
     <svg viewBox="0 0 24 24" width="16" height="16" fill="currentColor" aria-hidden="true">
       <circle cx="12" cy="5" r="1.7" />

--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -12,7 +12,7 @@
 // glyph. An earlier pass put it in a filled accent chip to mark "this is the
 // active mode"; on screen that read as a coloured badge shouting for
 // attention in a row of quiet chrome. The accent survives where it costs
-// nothing — the checkmark on the dropdown's active row.
+// nothing — the wash on the dropdown's active row (.bar-menu-item.active).
 //
 // OverflowMenu is the `···` companion: low-frequency one-shot actions (reveal
 // in the file manager, copy path, open in a new tab) that used to be welded
@@ -111,25 +111,6 @@ function CaretIcon({ open }: { open: boolean }) {
       aria-hidden="true"
     >
       <polyline points={open ? "18 15 12 9 6 15" : "6 9 12 15 18 9"} />
-    </svg>
-  );
-}
-
-function CheckIcon() {
-  return (
-    <svg
-      className="bar-menu-check"
-      viewBox="0 0 24 24"
-      width="14"
-      height="14"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <polyline points="20 6 9 17 4 12" />
     </svg>
   );
 }
@@ -237,7 +218,6 @@ export function ModeMenu({ entries, active, busy, onSelect }: ModeMenuProps) {
                 {e.pending ? <span className="mode-icon-spinner" /> : e.icon}
               </span>
               <span className="bar-menu-item-label">{modeTitle(e.mode)}</span>
-              {e.mode === activeEntry?.mode && <CheckIcon />}
             </button>
           ))}
         </div>

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -487,22 +487,12 @@ export function Breadcrumb({
   renderedTitle?: string | null;
 }) {
   const crumbsRef = useRef<HTMLDivElement | null>(null);
-  // The bar around whichever of the two the strip is currently showing (crumbs
-  // or the edit field) — captured from the live one, so the free-space handler
-  // below stays bound across the swap instead of dropping out in edit mode.
-  const barRef = useRef<HTMLElement | null>(null);
-  const captureBar = (el: HTMLElement | null) => {
-    if (el) barRef.current = el.parentElement;
-  };
   // Folder or file? The listing claims the bar's chrome over a folder
   // (listing/folder-chrome.ts) — the one thing that decides whether the path
   // menu offers the splits (see PathOverflow below).
   const folderClaimed = useSyncExternalStore(subscribeFolderChrome, folderChromeClaimed, () => false);
   const [editing, setEditing] = useState(false);
-  // Set by the click-away below for the rest of its gesture — see the bar's
-  // click handler, which must not treat that same click as "open the field".
-  const justClosed = useRef(false);
-  // Read by that always-on listener, which must not rebind on every toggle.
+  // Read by the always-on click-away listener, which must not rebind on every toggle.
   const editingRef = useRef(false);
   editingRef.current = editing;
   const { springProps, dropProps, armedTarget } = useSpringLoadedCrumbs();
@@ -560,28 +550,10 @@ export function Breadcrumb({
     refreshDropTarget();
   }, [fsPath, armedTarget, editing]);
 
-  // The same click-to-edit, extended to the BAR's own free space — the gap
-  // between the crumbs and the folder-search box, which belongs to #breadcrumb
-  // rather than to the crumb strip (the strip stops growing once the search
-  // slot is mounted, explorer.css). Bound to the parent node here instead of
-  // being handed down from BreadcrumbBar so the edit state stays in one
-  // component; `e.target === bar` keeps it to the bar's own background, never
-  // a click that landed on one of its children.
-  useEffect(() => {
-    const bar = barRef.current;
-    if (!bar) return;
-    const onClick = (e: MouseEvent) => {
-      if (e.target !== bar) return;
-      // The click that CLOSED the field is still travelling: pointerdown ran
-      // the click-away below, and this is the same gesture's click arriving on
-      // the background the field just vacated. Without this it would read as a
-      // fresh click on free space and reopen what the user just dismissed.
-      if (justClosed.current) return;
-      setEditing(true);
-    };
-    bar.addEventListener("click", onClick);
-    return () => bar.removeEventListener("click", onClick);
-  }, [editing]);
+  // Click-to-edit stops at the crumb strip itself (.crumbs onClick below).
+  // The bar's own background — the free space right of the crumbs, and the
+  // vertical padding above/below the text — is deliberately NOT a target:
+  // a click meant for the chrome kept turning into an open path field.
 
   // Click-away, closing the path field. `onBlur` alone is not enough: whether
   // a mouse-down on non-focusable chrome (the bar's own background, a gap in
@@ -593,20 +565,15 @@ export function Breadcrumb({
   // deliberately doesn't take focus (BarMenu.tsx), so its menu opens over an
   // open field rather than closing it out from under the pointer.
   //
-  // Bound once for the bar's lifetime, not per edit session, because it owns
-  // `justClosed` on both edges: every gesture starts by clearing the flag, so
-  // it lives exactly from the pointerdown that closes the field to the next
-  // press — long enough to cover that gesture's own click (which arrives in a
-  // later task, so a timer can't span it), and no longer.
+  // Bound once for the bar's lifetime, not per edit session (editingRef keeps
+  // it reading fresh state without rebinding).
   useEffect(() => {
     const onDown = (e: PointerEvent) => {
-      justClosed.current = false;
       if (!editingRef.current) return;
       const t = e.target as HTMLElement | null;
       if (!t) return;
       if (t.classList?.contains("crumb-edit")) return;
       if (t.closest?.(".bar-overflow, .bar-menu-popup")) return;
-      justClosed.current = true;
       setEditing(false);
     };
     document.addEventListener("pointerdown", onDown, true);
@@ -758,7 +725,6 @@ export function Breadcrumb({
       {editing ? (
         <input
           className="crumb-edit"
-          ref={captureBar}
           defaultValue={displayPath}
           spellCheck={false}
           autoFocus
@@ -780,18 +746,16 @@ export function Breadcrumb({
           onBlur={() => setEditing(false)} // a stray click cancels rather than commits
         />
       ) : (
-        // Click-to-edit, like a browser's location bar. Anything in the strip
-        // that is not itself a control turns it editable: the whitespace right
-        // of the crumbs, the "/" separators, and the current folder's own
-        // (unlinked) crumb. Only the ancestor crumbs — real links, plus the
+        // Click-to-edit, like a browser's location bar — but only inside the
+        // strip itself: the "/" separators, the current folder's own (unlinked)
+        // crumb, and the strip's residual whitespace. The bar's background
+        // outside the strip is chrome, not path (see the note above the
+        // click-away effect). Only the ancestor crumbs — real links, plus the
         // bar's buttons — keep their own behaviour, which is why this tests
         // for an enclosing control rather than for the strip itself.
         <div
           className="crumbs"
-          ref={(el) => {
-            crumbsRef.current = el;
-            captureBar(el);
-          }}
+          ref={crumbsRef}
           onWheel={onWheel}
           onClick={(e) => {
             if (!(e.target as HTMLElement).closest("a, button, input")) setEditing(true);

--- a/frontend/src/apps/explorer/Breadcrumb.tsx
+++ b/frontend/src/apps/explorer/Breadcrumb.tsx
@@ -1,7 +1,7 @@
 // Crumb bar, in three zones left to right:
 //
-//   path    ★ bookmark button, the crumbs (or the editable path field), then the
-//           path `⋮` — reveal, copy path, and (a file only) the two splits
+//   path    ★ bookmark button, the crumbs (or the editable path field), then —
+//           over a FILE only — the path `⋮`: reveal, copy path, the two splits
 //   mode    the `#topbar-mode-slot` portal target — Preview renders the view's
 //           conditional primary action, the shared mode control and the preview
 //           sidebar's toggle into it
@@ -20,7 +20,7 @@
 import React, { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
 import { createPortal } from "react-dom";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
-import { navigate, navigateUrl, currentUrl, IS_EMBED } from "@platform/lib/router";
+import { navigate, currentUrl, IS_EMBED } from "@platform/lib/router";
 import { basename } from "@platform/lib/format";
 import { isMod } from "@platform/lib/platform";
 import {
@@ -38,9 +38,8 @@ import { useUrlVersion, useBookmarksVersion, notifyBookmarksChanged } from "@pla
 import { urlScheme, isCloudScheme, fileUrlToPath } from "@platform/lib/path-url";
 import { resolveCloudUrl } from "@platform/lib/api";
 import { pushToast } from "@platform/lib/toast";
-import { encodePaneSegment, splitShellSearch } from "@platform/lib/layout-codec";
-import { panelUrl } from "@apps/explorer/Panel";
 import { PathOverflow } from "@apps/explorer/BarMenu";
+import { enterPanel } from "@apps/explorer/lib/split-actions";
 import { springDisarms } from "@apps/explorer/listing/drag-drop";
 import { cameFromSelParam } from "@apps/explorer/listing/selection";
 import {
@@ -287,7 +286,8 @@ function FolderSearchSlot() {
 // far right of the window, an inch of empty bar away from the path they act on.
 // Both are items in the path `⋮` now (BarMenu's PathOverflow), where they sit
 // beside "Open in Finder"/"Copy path", carry their names, and travel with the
-// path itself. `enterPanel` below is unchanged and is still what they call.
+// path itself. They still call `enterPanel` (lib/split-actions.ts, lifted out of
+// this file once the listing's own `⋮` became a second caller).
 //
 // Which state we are in — file or folder — is `listing/folder-chrome.ts`'s
 // claim, read where the menu is rendered rather than by a zone component of its
@@ -392,22 +392,6 @@ function TopbarActionsSlot() {
     return () => retractTopbarSlot(el);
   }, []);
   return <div ref={ref} id="topbar-mode-slot" className="crumb-actions preview-actions" />;
-}
-
-// Split entry (LM-10): two panes side by side (`dir` "row", `,` in the codec)
-// or stacked ("col", `;`), both showing the current view — entering split mode
-// with a single pane looked like nothing happened. The current view's WHOLE
-// query goes pane-local, inside each `_layout` segment (LM-3/D72): nothing is
-// promoted to the top-level pool — global params exist only when the user
-// hand-types them on the shell URL. Read via splitShellSearch, not raw
-// URLSearchParams (D51): a stray `_layout=(…)` span carries literal `&` that
-// would parse as junk keys; the codec read excludes the span, so it is
-// dropped — the strict-read semantics.
-function enterPanel(fsPath: string, dir: "row" | "col"): void {
-  const { params } = splitShellSearch(location.search);
-  const paneQ = params.toString();
-  const seg = encodePaneSegment(fsPath, paneQ ? "?" + paneQ : "");
-  navigateUrl(panelUrl(seg + (dir === "row" ? "," : ";") + seg, null));
 }
 
 // Open a URL typed/pasted into the path bar. Every failure is an error toast
@@ -764,20 +748,20 @@ export function Breadcrumb({
           {pieces}
         </div>
       )}
-      {/* The path `⋮` — "Open in Finder", "Copy path", and for a FILE the two
-          split-entry actions — sits immediately right of the name it acts on, in
-          every view. It used to end the bar's layout zone for a file and the
-          search row for a folder: two homes, both of them the bar's far right,
-          neither of them next to the thing being opened or copied. The crumb
-          strip stops growing (explorer.css) so this stays against the path
-          rather than drifting to the edge.
-          No splits over a FOLDER (the chrome claim is how we know): they make
-          least sense over a view that already is a split, which is why the old
-          layout zone hid itself there too. */}
-      <PathOverflow
-        fsPath={fsPath}
-        onSplit={folderClaimed ? undefined : (dir) => enterPanel(fsPath, dir)}
-      />
+      {/* The path `⋮` — "Open in Finder", "Copy path", the two split-entry
+          actions — sits immediately right of the name it acts on. The crumb
+          strip stops growing (explorer.css) so it stays against the path rather
+          than drifting to the edge.
+          A FILE only, and the chrome claim is how we know. Over a FOLDER the
+          listing owns this bar, and it now carries the same actions itself, at
+          the right end of its column header (Listing.tsx) — where they sit with
+          the folder's other operations (new file, paste, refresh) instead of
+          being split between a path menu and a right-click. Two `⋮`s a few
+          pixels apart, offering overlapping sets, was the thing to fix; this bar
+          gives its one up. */}
+      {!folderClaimed && (
+        <PathOverflow fsPath={fsPath} onSplit={(dir) => enterPanel(fsPath, dir)} />
+      )}
       <UpdateBookmarkButton />
       <TopbarActionsSlot />
       <FolderSearchSlot />

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -46,6 +46,9 @@ import { getViewState, setViewState } from "@platform/lib/viewstate";
 import { useFlip, FLIP_KEY_ATTR } from "@platform/lib/flip";
 import { useClipboard } from "@apps/explorer/lib/fs-clipboard";
 import ContextMenu from "@platform/ui/ContextMenu";
+import { SplitDownIcon, SplitRightIcon } from "@platform/ui/SplitIcons";
+import { EllipsisIcon } from "@apps/explorer/BarMenu";
+import { enterPanel } from "@apps/explorer/lib/split-actions";
 import { PromptDialog, ConfirmDialog } from "@apps/explorer/FsDialogs";
 import ListingPreviewPane from "@apps/explorer/ListingPreviewPane";
 import { resultCountLabel } from "@apps/explorer/listing/result-cap";
@@ -874,6 +877,43 @@ export default function Listing({
     setMenu({ x: e.clientX, y: e.clientY, items: backgroundMenu() });
   };
 
+  // The header `⋮` (right end of the MODIFIED column). Everything here is about
+  // THIS FOLDER, which is what the crumb bar's own `⋮` used to be for over a
+  // listing — that one is gone (Breadcrumb.tsx) and its two unique items moved
+  // in below the background menu's set, so there is one place to look instead
+  // of a path menu and a right-click each holding half the folder's actions.
+  //
+  // Discoverability is the whole point of the button: the same items were
+  // already a right-click on the background, which nobody finds, and which an
+  // empty folder gives you no obvious surface to try.
+  const openHeaderMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation(); // never sorts — the th around it is a sort control
+    const r = e.currentTarget.getBoundingClientRect();
+    setMenu({
+      // Right-ish alignment by hand: ContextMenu only clamps at the VIEWPORT
+      // edge, and with a preview pane open this button is nowhere near it, so
+      // an unbiased x would hang the popup off to the right of the column.
+      // 220 is the menu's own min-width (context-menu.css).
+      x: Math.max(4, r.right - 220),
+      y: r.bottom + 2,
+      items: [
+        ...backgroundMenu(),
+        "separator",
+        {
+          label: "Split right",
+          icon: <SplitRightIcon size={16} />,
+          onClick: () => enterPanel(fsPath, "row"),
+        },
+        {
+          label: "Split down",
+          icon: <SplitDownIcon size={16} />,
+          onClick: () => enterPanel(fsPath, "col"),
+        },
+      ],
+    });
+  };
+
   // --- table body -----------------------------------------------------------
 
   let body: React.ReactNode;
@@ -1419,6 +1459,32 @@ export default function Listing({
                             >
                               ▲
                             </span>
+                          )}
+                          {/* The folder's `⋮`, absolutely positioned against
+                              the LAST header cell's right edge (the th is
+                              sticky, so it is already the positioned ancestor)
+                              — NOT a fourth column: rows have three cells, and
+                              a column they don't render breaks their
+                              backgrounds. It overlays the header's own padding,
+                              which is why .col-mtime reserves room for it
+                              (explorer.css) rather than letting it land on the
+                              sort arrow.
+                              Both handlers stop propagation: the th sorts on
+                              click, and a press that re-sorts the listing under
+                              the menu about to open is not what the button
+                              says it does. */}
+                          {key === "mtime" && (
+                            <button
+                              type="button"
+                              className="listing-head-menu"
+                              aria-haspopup="menu"
+                              aria-label="Folder actions"
+                              title="Folder actions"
+                              onPointerDown={(e) => e.stopPropagation()}
+                              onClick={openHeaderMenu}
+                            >
+                              <EllipsisIcon />
+                            </button>
                           )}
                         </th>
                       ),

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -914,6 +914,31 @@ export default function Listing({
     });
   };
 
+  // The folder's `⋮`, absolutely positioned against the LAST header cell's
+  // right edge (the th is sticky, so it is already the positioned ancestor) —
+  // NOT a fourth column: rows have three cells, and a column they don't render
+  // breaks their backgrounds. It overlays the header's own padding, which is
+  // why .col-mtime reserves room for it (explorer.css) rather than letting it
+  // land on the sort arrow.
+  // Both handlers stop propagation: the normal header's th sorts on click, and
+  // a press that re-sorts the listing under the menu about to open is not what
+  // the button says it does. One element, three homes — the mtime th, the
+  // search header's Path th, and (labels hidden) the empty folder's strip —
+  // because the actions act on the current folder in every one of them.
+  const headerMenuBtn = (
+    <button
+      type="button"
+      className="listing-head-menu"
+      aria-haspopup="menu"
+      aria-label="Folder actions"
+      title="Folder actions"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={openHeaderMenu}
+    >
+      <EllipsisIcon />
+    </button>
+  );
+
   // --- table body -----------------------------------------------------------
 
   let body: React.ReactNode;
@@ -1423,9 +1448,10 @@ export default function Listing({
             onContextMenu={openBackgroundMenu}
           >
             <table className="listing-table">
-              {/* Header row hidden (not unmounted — the sticky header's box is
-                  part of the table's own layout) over an empty folder: see
-                  `emptyDir`. */}
+              {/* Over an empty folder the column LABELS hide (visibility, see
+                  .listing-head-empty) but the strip stays: the folder `⋮`
+                  lives on it, and an empty folder is where that menu matters
+                  most. */}
               <thead className={emptyDir ? "listing-head-empty" : undefined}>
                 <tr>
                   {searching ? (
@@ -1435,7 +1461,14 @@ export default function Listing({
                     // that by name or date presents it as an answer it isn't,
                     // and the search box already says the coverage is
                     // approximate (listing/index-caveat).
-                    <th className="col-name">Path</th>
+                    // The folder `⋮` stays through a search: its actions act on
+                    // the CURRENT folder either way, and search replacing the
+                    // one header that carried it would make the control come
+                    // and go with the query.
+                    <th className="col-name">
+                      Path
+                      {headerMenuBtn}
+                    </th>
                   ) : (
                     (Object.entries(SORT_KEYS) as [SortKey, string][]).map(
                       ([key, label]) => (
@@ -1447,7 +1480,11 @@ export default function Listing({
                           }
                           onClick={() => setSort(key)}
                         >
-                          {label}
+                          {/* Wrapped so the empty-folder state can hide the
+                              LABEL without unmounting the strip — the `⋮` on
+                              this row must survive it (explorer.css,
+                              .listing-head-empty). */}
+                          <span className="col-label">{label}</span>
                           {/* One glyph that ROTATES for desc (see .sort-arrow):
                           swapping ▲ for ▼ replaced the element, so the change
                           could only ever pop. */}
@@ -1460,32 +1497,7 @@ export default function Listing({
                               ▲
                             </span>
                           )}
-                          {/* The folder's `⋮`, absolutely positioned against
-                              the LAST header cell's right edge (the th is
-                              sticky, so it is already the positioned ancestor)
-                              — NOT a fourth column: rows have three cells, and
-                              a column they don't render breaks their
-                              backgrounds. It overlays the header's own padding,
-                              which is why .col-mtime reserves room for it
-                              (explorer.css) rather than letting it land on the
-                              sort arrow.
-                              Both handlers stop propagation: the th sorts on
-                              click, and a press that re-sorts the listing under
-                              the menu about to open is not what the button
-                              says it does. */}
-                          {key === "mtime" && (
-                            <button
-                              type="button"
-                              className="listing-head-menu"
-                              aria-haspopup="menu"
-                              aria-label="Folder actions"
-                              title="Folder actions"
-                              onPointerDown={(e) => e.stopPropagation()}
-                              onClick={openHeaderMenu}
-                            >
-                              <EllipsisIcon />
-                            </button>
-                          )}
+                          {key === "mtime" && headerMenuBtn}
                         </th>
                       ),
                     )

--- a/frontend/src/apps/explorer/ModeSwitcher.tsx
+++ b/frontend/src/apps/explorer/ModeSwitcher.tsx
@@ -23,12 +23,14 @@ export const KNOWN_SENTINEL_MODES = new Set(["_render", "_listing"]);
 export { modeTitle } from "@platform/lib/mode-name";
 
 // Shell-baked icon for the "_render" sentinel (PT-12) — sentinels have no
-// template folder, so there's no icon.svg to fetch. Component-local, matches
-// the old hardcoded Rendered|Source eye glyph.
+// template folder, so there's no icon.svg to fetch. Component-local; the same
+// play-in-a-rounded-box glyph as the folder pane's Preview side
+// (PREVIEW_SIDE_ICON, SideChrome.tsx), because the two are the same "look at
+// the rendered thing" idea and used to wear different icons (an eye here).
 const RENDER_SENTINEL_ICON = (
   <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
-    <circle cx="12" cy="12" r="3" />
+    <rect x="3" y="3" width="18" height="18" rx="3" />
+    <path d="M10 8.75 15.5 12 10 15.25Z" />
   </svg>
 );
 

--- a/frontend/src/apps/explorer/lib/split-actions.ts
+++ b/frontend/src/apps/explorer/lib/split-actions.ts
@@ -1,0 +1,30 @@
+// Entering split (panel) mode from wherever the action is offered.
+//
+// This lived inside Breadcrumb.tsx while the path `⋮` was its only caller. It
+// now has two: the FILE preview's path menu (BarMenu's PathOverflow) and the
+// folder listing's own header `⋮` (Listing.tsx) — the folder's splits moved out
+// of the crumb bar and onto the listing it acts on. One module rather than a
+// second copy, and rather than Listing importing the crumb bar for it.
+//
+// The Panel import is the same acyclic exception the crumb bar already takes
+// (Breadcrumb -> Panel for `panelUrl`): a function referenced at call time, not
+// module-evaluation time.
+import { navigateUrl } from "@platform/lib/router";
+import { encodePaneSegment, splitShellSearch } from "@platform/lib/layout-codec";
+import { panelUrl } from "@apps/explorer/Panel";
+
+// Split entry (LM-10): two panes side by side (`dir` "row", `,` in the codec)
+// or stacked ("col", `;`), both showing the current view — entering split mode
+// with a single pane looked like nothing happened. The current view's WHOLE
+// query goes pane-local, inside each `_layout` segment (LM-3/D72): nothing is
+// promoted to the top-level pool — global params exist only when the user
+// hand-types them on the shell URL. Read via splitShellSearch, not raw
+// URLSearchParams (D51): a stray `_layout=(…)` span carries literal `&` that
+// would parse as junk keys; the codec read excludes the span, so it is
+// dropped — the strict-read semantics.
+export function enterPanel(fsPath: string, dir: "row" | "col"): void {
+  const { params } = splitShellSearch(location.search);
+  const paneQ = params.toString();
+  const seg = encodePaneSegment(fsPath, paneQ ? "?" + paneQ : "");
+  navigateUrl(panelUrl(seg + (dir === "row" ? "," : ";") + seg, null));
+}

--- a/frontend/src/apps/explorer/listing/column-shedding.test.ts
+++ b/frontend/src/apps/explorer/listing/column-shedding.test.ts
@@ -71,15 +71,31 @@ test("a shed column's HEADER is never display:none", () => {
 
 test("a shed column's header collapses to a zero px width with no box", () => {
   const collapsed = shedding.flatMap((block) =>
-    SHED.map((col) => ruleFor(block.body, `th.${col}`)).filter((d): d is string => d !== null),
+    SHED.map((col) => [col, ruleFor(block.body, `th.${col}`)] as const).filter(
+      (p): p is readonly [string, string] => p[1] !== null,
+    ),
   );
   expect(collapsed.length).toBe(2); // MODIFIED and SIZE, one step each
-  for (const decls of collapsed) {
+  for (const [col, decls] of collapsed) {
     expect(decls).toMatch(/width:\s*0\b/);
     expect(decls).toMatch(/padding:\s*0\b/);
     // Content must not paint over the neighbouring column once the box is gone.
+    // The label goes quiet by font-size in both cells.
     expect(decls).toMatch(/font-size:\s*0\b/);
-    expect(decls).toMatch(/overflow:\s*hidden/);
+    if (col === "col-size") {
+      // Nothing else lives in this cell, so one clip covers the rest of it.
+      expect(decls).toMatch(/overflow:\s*hidden/);
+    } else {
+      // MODIFIED is the last column, so its right edge is the TABLE's — which
+      // is where the folder `⋮` is pinned (.listing-head-menu, Listing.tsx),
+      // and it has to survive the collapse or the folder's menu disappears
+      // whenever the listing is narrow. So this cell must NOT clip, and the one
+      // piece of content that font-size:0 cannot silence — the sort arrow,
+      // which sets its own 9px — is hidden by a rule of its own instead.
+      expect(decls).not.toMatch(/overflow:\s*hidden/);
+      const block = shedding.find((b) => b.body.includes(`th.${col}`))!;
+      expect(ruleFor(block.body, `th.${col} .sort-arrow`)).toMatch(/display:\s*none/);
+    }
   }
 });
 

--- a/frontend/src/apps/explorer/listing/useFileOps.ts
+++ b/frontend/src/apps/explorer/listing/useFileOps.ts
@@ -648,6 +648,7 @@ export function useFileOps({
     "separator",
     { label: "Refresh", icon: MenuIcons.refresh, onClick: refetch },
     { label: "Reveal in Finder", icon: MenuIcons.reveal, onClick: () => doReveal(normDir(base)) },
+    { label: "Copy path", icon: MenuIcons.copyPath, onClick: () => doCopyPath(normDir(base)) },
     {
       label: "Open in Claude Code",
       icon: MenuIcons.openWith,

--- a/frontend/src/platform/lib/mode-name.test.ts
+++ b/frontend/src/platform/lib/mode-name.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { modeTitle } from "./mode-name";
 
 test("sentinel modes read as their shell names, not as underscore junk", () => {
-  expect(modeTitle("_render")).toBe("Rendered");
+  expect(modeTitle("_render")).toBe("Render");
   expect(modeTitle("_listing")).toBe("Listing");
 });
 

--- a/frontend/src/platform/lib/mode-name.ts
+++ b/frontend/src/platform/lib/mode-name.ts
@@ -7,7 +7,7 @@
 // Modes the shell renders with no template folder (SPEC PT-12/D81) — their
 // keys are internal sentinels and must never be shown as typed.
 const SENTINEL_NAMES: Record<string, string> = {
-  _render: "Rendered",
+  _render: "Render",
   _listing: "Listing",
 };
 

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1513,9 +1513,17 @@ table.listing-table {
   border-collapse: collapse;
 }
 
-/* Empty folder: no column headers over zero rows (Listing.tsx `emptyDir`). */
-table.listing-table thead.listing-head-empty {
-  display: none;
+/* Empty folder: the column LABELS describe no rows, so they hide — but the
+   strip itself stays, because the folder `⋮` lives on it and an empty folder
+   is exactly where that menu matters most (no row to right-click, and the
+   background context menu is the least discoverable surface in the app).
+   `visibility` rather than the whole thead's old `display: none` so the strip
+   keeps its height and hairline and the `⋮` doesn't jump when the first entry
+   lands. Sorting an empty listing is a no-op, so the still-clickable th costs
+   nothing. */
+table.listing-table thead.listing-head-empty .col-label,
+table.listing-table thead.listing-head-empty .sort-arrow {
+  visibility: hidden;
 }
 
 /* SIZE is a quantity: right-aligned so the magnitudes line up by digit, header

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -312,6 +312,26 @@
   display: none;
 }
 
+/* A filled slot in the FOLDER bar (search row present) belongs to the right
+   cluster: the slot eats the free width, so its content ("Add as app") sits
+   against the search box at the bar's own fixed gap — never mid-bar, never a
+   screen-width-dependent distance from the box it acts beside. The two rules
+   below hand the free-width-eating job to the slot for exactly that state:
+   with two auto margins in one row the slack splits between them and the
+   button strands in the middle, which is the layout this pair exists to
+   prevent. */
+#breadcrumb:has(.crumb-search-slot) #topbar-mode-slot:not(:empty) {
+  margin-left: auto;
+}
+
+#breadcrumb:has(.crumb-search-slot) > .bar-overflow {
+  margin-right: 0;
+}
+
+#breadcrumb:has(#topbar-mode-slot:not(:empty)) .crumb-search-slot > .listing-search {
+  margin-left: 0;
+}
+
 /* It used to have to take a zone divider with it, so a static page (or a view
    still resolving its stat) showed no stray hairline floating in the bar. The
    crumb bar has no layout zone left to divide from — the splits are items in the
@@ -467,7 +487,7 @@
    a caret. The icon is plain currentColor at the bars' standard 16px — it
    spent one iteration inside a filled accent chip, which turned the quietest
    row in the app into a badge competing for attention. The accent's only
-   remaining job here is the checkmark on the dropdown's active row. */
+   remaining job here is the wash on the dropdown's active row. */
 .mode-menu {
   position: relative;
   flex: 0 0 auto;
@@ -535,10 +555,10 @@
   box-shadow: 0 8px 24px var(--shadow-md);
 }
 
-/* The 180px floor is sized for MODE rows — icon + label + checkmark, which
-   need to hold a column. An overflow menu carries plain labels, so it sizes to
-   its content instead; on a one-item menu ("Open in explorer") the floor was
-   ~50px of dead width. */
+/* The 180px floor is sized for MODE rows — icon + label, which need to hold a
+   column. An overflow menu carries plain labels, so it sizes to its content
+   instead; on a one-item menu ("Open in explorer") the floor was ~50px of
+   dead width. */
 .bar-overflow .bar-menu-popup {
   min-width: 120px;
   width: max-content;
@@ -570,9 +590,9 @@
   cursor: default;
 }
 
-/* Plain glyph, no box: the row's own hover wash and the checkmark carry the
-   state, and a bordered well around every icon made the list read as a grid
-   of buttons rather than a set of choices. */
+/* Plain glyph, no box: the row's own hover/active wash carries the state,
+   and a bordered well around every icon made the list read as a grid of
+   buttons rather than a set of choices. */
 .bar-menu-item-icon {
   flex: 0 0 auto;
   display: inline-flex;
@@ -600,19 +620,21 @@
 }
 
 /* The active row is the mode you are looking at — semibold, brighter glyph,
-   and the accent tick. That tick is the last accent left in this chrome, and
-   it still means exactly one thing: the active view mode. */
+   and an accent wash over the whole row (it replaced a trailing checkmark:
+   the row itself now carries the state). That wash is the last accent left
+   in this chrome, and it still means exactly one thing: the active view
+   mode. Kept stronger than the 8% hover tint so the two never blur. */
 .bar-menu-item.active {
   font-weight: 600;
+  background: color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.bar-menu-item.active:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--accent) 22%, transparent);
 }
 
 .bar-menu-item.active .bar-menu-item-icon {
   color: var(--fg);
-}
-
-.bar-menu-check {
-  flex: 0 0 auto;
-  color: var(--accent);
 }
 
 /* Group divider inside an overflow popup (the path `⋮` separates what it does
@@ -831,9 +853,13 @@
   touch-action: none;
 }
 
+/* Accent on hover/drag — the same affordance as the left sidebar's resize
+   handle (.sidebar-resize-handle, sidebar.css): every draggable seam in the
+   app lights up the same way. */
 .listing-divider:hover,
 .listing-divider.dragging {
-  background: var(--border);
+  background: var(--accent);
+  opacity: 0.35;
 }
 
 /* While the divider drags, the pane's iframe must not swallow the captured
@@ -859,30 +885,26 @@
   position: relative;
 }
 
-/* The seam between the two columns, and where it STOPS.
+/* The seam between the two columns — full height, header row included.
 
-   It used to be a `border-left` on .listing-pane, which ran the full height —
-   including across the header row, where it cut the two strips into two boxes.
-   They are the same height, the same background and the same hairline at the
-   bottom precisely so they read as one bar across the window; a rule down the
-   middle of that undid it. So the seam now starts where the content does.
+   It briefly stopped at the header (`top: var(--topbar-h)`) so the crumb bar
+   and the pane header would read as one bar across the window, but that left
+   the seam's top segment a different color from the run below it wherever the
+   two sides' top strips don't share a background — one line, two colors.
+   A single continuous hairline won.
 
    On the SLOT rather than on .listing-pane, because the pane is the scroll
    container: an absolutely-positioned line inside it is laid out against the
    padding box and would scroll away with a tall preview. The slot does not
-   scroll, so the line stays put. `top` is the shared strip height — the same
-   token the three bars use, so the seam meets the header's own bottom hairline
-   at exactly the corner in every host (with a crumb bar or, in the app
-   builder, with the search row as the left column's first strip).
+   scroll, so the line stays put.
 
    The DRAG target is untouched: .listing-divider is a separate 5px flex item
-   spanning the full height, transparent until hover, and it still is. Only the
-   painted line got shorter. */
+   spanning the full height, transparent until hover. */
 .listing-pane-slot::before {
   content: "";
   position: absolute;
   left: 0;
-  top: var(--topbar-h);
+  top: 0;
   bottom: 0;
   width: 1px;
   background: var(--border);
@@ -1545,7 +1567,7 @@ table.listing-table th.sortable:hover {
 }
 
 /* The accent means "the view mode you are in" and nothing else (only the
-   checkmark in the mode dropdown carries it). A sorted header is not a mode:
+   active row's wash in the mode dropdown carries it). A sorted header is not a mode:
    it needs to read as the selected one among three muted headers, which full
    --fg at 600 already does — and the arrow says which way. */
 table.listing-table th.sorted {

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -813,10 +813,18 @@
     padding: 0;
     border: 0;
     box-shadow: none;
-    overflow: hidden;
     /* The label and sort arrow still exist in the cell; fixed layout would
        otherwise let them paint straight over MODIFIED's neighbour. */
     font-size: 0;
+  }
+  /* This used to be `overflow: hidden` on the cell above, which now also has
+     the folder `⋮` riding its right edge — and at width 0 that edge is the
+     TABLE's right edge, exactly where the button still belongs, so clipping the
+     cell would delete the menu at narrow widths. The two things that actually
+     needed clipping are silenced directly instead: the label by the font-size
+     above, the arrow (which carries its own 9px size) here. */
+  table.listing-table thead th.col-mtime .sort-arrow {
+    display: none;
   }
 }
 
@@ -1532,8 +1540,12 @@ table.listing-table th.col-size {
   width: 96px;
 }
 
+/* The extra right padding is the folder `⋮`'s berth: that button overlays this
+   cell rather than taking a column of its own (see .listing-head-menu below),
+   so the label and its sort arrow have to stop short of it. */
 table.listing-table th.col-mtime {
   width: 172px;
+  padding-right: 34px;
 }
 
 table.listing-table th {
@@ -1553,6 +1565,38 @@ table.listing-table th {
      rides with the header instead. */
   box-shadow: inset 0 -1px 0 var(--border);
   user-select: none;
+}
+
+/* The folder's `⋮` — the listing's own menu of what the crumb bar's path menu
+   used to offer over a folder, plus the background right-click's set. Pinned to
+   the last header cell's right edge; the sticky th is the positioned ancestor,
+   so this needs no wrapper. Vertically centred against a header whose height is
+   set by its text, hence the translate rather than a matching height.
+   Left as --fg-muted with the labels beside it: it is chrome for the folder,
+   not a fourth column heading, and it should not out-weigh the sorted column. */
+table.listing-table .listing-head-menu {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background 90ms var(--ease-out), color 90ms var(--ease-out);
+}
+
+/* The same wash every other quiet icon button in the chrome uses (.bar-ctl). */
+table.listing-table .listing-head-menu:hover {
+  background: rgba(var(--tint), 0.08);
+  color: var(--fg);
 }
 
 /* Only a header that sorts something gets the affordance. Search mode's single

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -233,9 +233,12 @@
   touch-action: none;
 }
 
+/* Accent on hover/drag — matches .listing-divider and the left sidebar's
+   resize handle (.sidebar-resize-handle, sidebar.css). */
 .preview-side-divider:hover,
 .preview-side-divider.dragging {
-  background: var(--border);
+  background: var(--accent);
+  opacity: 0.35;
 }
 
 /* An iframe is a separate document and would swallow the captured pointer
@@ -261,18 +264,18 @@
   position: relative;
 }
 
-/* The seam between the two columns, and where it STOPS — the listing pane's rule
-   (.listing-pane-slot::before), for the reason written out there: the two header
-   strips are the same height, background and bottom hairline precisely so they
-   read as ONE bar across the window, and a border-left running the full height
-   would cut that bar in two boxes. So the line starts where the CONTENT does.
-   The drag target is untouched — the divider is a separate full-height flex item,
-   transparent until hover. Only the painted line is short. */
+/* The seam between the two columns — full height, the listing pane's rule
+   (.listing-pane-slot::before), for the reason written out there: a seam that
+   stopped at the header left its top segment a different color from the run
+   below it (the file view's left column is content, not a matching bg-alt
+   strip), so the line reads broken. One continuous hairline instead.
+   The drag target is untouched — the divider is a separate full-height flex
+   item, transparent until hover. */
 .preview-side::before {
   content: "";
   position: absolute;
   left: 0;
-  top: var(--topbar-h);
+  top: 0;
   bottom: 0;
   width: 1px;
   background: var(--border);

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -3031,7 +3031,7 @@ const leftPop = document.getElementById("leftmodepop");     // its listbox
 // The shell's `modeTitle` (lib/mode-name.ts), reimplemented in four lines: a
 // template is a standalone document and cannot import the shell's TS. Worth the
 // duplication because the picker's labels must read the same as the explorer's
-// mode switcher does for the same file — "Rendered" for the `_render` sentinel,
+// mode switcher does for the same file — "Render" for the `_render` sentinel,
 // and a capitalized folder name otherwise, since a folder name is chosen for the
 // filesystem, not for a label. (`_listing` never appears in a FILE's entries and
 // the two chat modes are already filtered out, so they are not here.)
@@ -3043,7 +3043,7 @@ const leftPop = document.getElementById("leftmodepop");     // its listbox
 // not a display string. A label that disagreed with the mode switcher one strip
 // away would read as two different views.
 function paneModeLabel(mode) {
-  if (mode === "_render") return "Rendered";
+  if (mode === "_render") return "Render";
   // No `history` row: the mode key IS the word, so the capitalize below
   // already produces "History" — the same string the shell's humanizer gives
   // it. It earned an explicit row only while the key was spelled `versions`.

--- a/tests/test_claude_pane_mode_label.py
+++ b/tests/test_claude_pane_mode_label.py
@@ -50,6 +50,10 @@ def _pane_label(modes):
 
 def test_the_labels_the_picker_already_agreed_on_still_hold():
     """The mapping is a lookup table, and adding a row to one is how you break
-    another. `_render` is the shell's sentinel name; an unknown key still gets
-    the humanizer rather than a guess."""
-    assert _pane_label(["_render", "duckdb"]) == ["Rendered", "Duckdb"]
+    another. `_render` is the shell's sentinel name — pinned to the shell's own
+    table the same way `app` is above, so the next rename fails here rather
+    than shipping two names a strip apart. An unknown key still gets the
+    humanizer rather than a guess."""
+    want = _shell_label("_render")
+    assert want == "Render", "read from the shell; update the template if this changed"
+    assert _pane_label(["_render", "duckdb"]) == [want, "Duckdb"]


### PR DESCRIPTION
## Changes

- **Breadcrumb click-to-edit scoped to the text strip** — clicking the bar's background (above/below the path text, free space right of the crumbs) no longer opens the path edit field; only clicks inside `.crumbs` do. Removes the bar-level handler and the `justClosed` reopen guard it required.
- **Divider hover accent** — `.listing-divider` and `.preview-side-divider` hover/drag show `var(--accent)` @ 0.35 opacity, matching the left sidebar's resize handle so all draggable seams share one affordance.
- **Full-height column seams** — `.listing-pane-slot::before` / `.preview-side::before` start at `top: 0` instead of under the header row; the stopped seam read as a broken two-color line wherever the two sides' top strips don't share a background (e.g. file view with a content toolbar on the left).
- **Mode dropdown selection style** — active row gets an accent background wash (`color-mix(in srgb, var(--accent) 16%, transparent)`, 22% on hover) + semibold instead of a trailing checkmark; `CheckIcon` removed.
- **`_render` mode rename + icon** — label "Rendered" → "Render"; icon is now the play-in-rounded-box glyph (same as the folder pane's Preview side) instead of the eye. The Claude template's duplicate `paneModeLabel` is synced (bugbot catch), and its pinning test now reads the `_render` label out of the shell's own table so the next rename fails the test instead of shipping drift.
- The folder bar's filled `#topbar-mode-slot` owns the free-width auto margin (search box drops its own), so slot content keeps the bar's fixed 10px gap to the search box at any viewport width.

- **Folder actions kebab in the listing header** — the path `⋮` is gone for the folder listing (file views keep theirs); a kebab at the right end of the MODIFIED column header opens the background right-click menu plus "Copy path" (also added to the right-click menu itself, under "Reveal in Finder") and "Split right" / "Split down" (`enterPanel` lifted to `lib/split-actions.ts`). The narrow-container shed rule no longer clips the button (sort arrow hides explicitly instead; guard test updated).

> Note: this branch originally also re-homed the "Open/Add as app" button next to the search box; that button was retired entirely on main (#465 / D264) while this PR was open, so that part was dropped in the rebase.

## Screenshots

**Listing header kebab (replaces the path kebab in folder views)**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/header-kebab-closed.png" width="520" alt="kebab in header" /> <img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/header-kebab-open.png" width="520" alt="kebab menu open" />

**Breadcrumb: bar-background click does nothing, text click edits**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/c1b-top-edge-click.png" width="520" alt="click above text: no edit" /> <img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/c1d-lastcrumb-click.png" width="520" alt="click on crumb text: edit field opens" />

**Divider hover accent**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/c2-divider-hover-DARK-zoom.png" width="360" alt="divider hover accent" />

**Seam runs full height through the header row**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/c3-full-window-seam.png" width="640" alt="continuous seam" />

**Mode dropdown: accent wash instead of checkmark**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/modemenu-active-wash.png" width="300" alt="active row wash" />

**"Render" label + play-in-box icon**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-467-assets/render-icon-box.png" width="300" alt="Render mode icon" />

(Screenshot assets live on the throwaway `pr-467-assets` branch; delete it after merge.)

## Verification

- Playwright (headless Chrome) against the dev server: breadcrumb click targets, divider hover computed styles (dark + light accents), seam continuity, dropdown active-row styles, file-view regression checks.
- `tsc --noEmit` clean; `bun test` passes (9 pre-existing `shortcut-chord.test.ts` failures reproduce on clean `main`, unrelated); `tests/test_claude_pane_mode_label.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches explorer navigation chrome and split-entry affordances (where folder splits live, path-edit click targets). Mostly UI/layout with no auth or data-path changes, but regressions would affect everyday folder workflows.
> 
> **Overview**
> **Moves folder actions into a listing-header kebab** and polishes related explorer chrome.
> 
> Over folders, the path `⋮` is removed from the crumb bar. A new header kebab on the MODIFIED (or Path-while-searching) column opens the background menu plus **Split right/down**, with **Copy path** also added to the right-click background menu. `enterPanel` is extracted to `lib/split-actions.ts` for the shared callers. File views keep their path overflow menu.
> 
> Also:
> - **Click-to-edit** is scoped to the crumb strip only — bar background clicks no longer open the path field.
> - Mode dropdown marks the active row with an **accent wash** instead of a trailing checkmark.
> - `_render` is renamed **Render** (play-in-box icon), synced in the Claude template with a drift-pinning test.
> - Split dividers use the shared accent hover; column seams run full height through the header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e6b2b3d9bc1d761173a71088f35a79fee6c57e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

