### PR TITLE
Composer pill polish + collapsed-sidebar icon rail

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -385,9 +385,20 @@ export default function Listing({
     const crumbs = bar?.querySelector(".crumbs");
     if (!(bar instanceof HTMLElement) || !crumbs) return;
     const freeInBar = () => {
-      const kids = Array.from(bar.children).filter(
-        (el) => getComputedStyle(el).display !== "none"
-      );
+      // The bar's actual flex ITEMS, not bar.children: the search slot is
+      // `display: contents` (its rect reads 0), so its children participate
+      // in the bar's layout directly and must be counted in its place —
+      // skipping them overstates the free space by the whole search row.
+      const kids: Element[] = [];
+      const collect = (el: Element) => {
+        for (const child of Array.from(el.children)) {
+          const d = getComputedStyle(child).display;
+          if (d === "none") continue;
+          if (d === "contents") collect(child);
+          else kids.push(child);
+        }
+      };
+      collect(bar);
       const cs = getComputedStyle(bar);
       const gap = parseFloat(cs.columnGap) || 0;
       const used =
@@ -1284,7 +1295,17 @@ export default function Listing({
                   // search" was instructions for a control that needs none.
                   placeholder="Search…"
                   value={query}
-                  onFocus={prefetchWalk}
+                  // Focus pins the box open, whatever routed it here — the
+                  // magnifier click, or type-to-search landing focus on the
+                  // zero-width folded input (useListingSelection's
+                  // printable-key branch; the .iconized CSS keeps the input
+                  // focusable for exactly this). The pin also holds while a
+                  // focused user deletes their query — the box must not fold
+                  // away under the caret.
+                  onFocus={() => {
+                    setPinnedOpen(true);
+                    prefetchWalk();
+                  }}
                   // A pinned-open box that blurs still empty folds back to the
                   // magnifier (the pin exists only to be typed into); with a
                   // query it stays — .searching owns the strip from there.

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -303,6 +303,17 @@ export default function Listing({
 
   // Search input, so a keystroke anywhere in the listing can focus it.
   const searchInputRef = useRef<HTMLInputElement>(null);
+  // --- resting search box folds to a magnifier on a tight bar ---------------
+  // The bar's yield order (crumbs shrink → box shrinks, explorer.css) bottoms
+  // out with the PATH still ellipsized on a narrow middle column, while the
+  // idle box holds ~100px of placeholder. Past that point the box becomes a
+  // 28px icon and the path gets the strip back. `tightBar` is the measured
+  // fact; `pinnedOpen` is the user overriding it (clicked the icon — the box
+  // stays until it blurs empty). A non-empty query outranks both: `.searching`
+  // already stands the crumbs down and takes the whole strip.
+  const [tightBar, setTightBar] = useState(false);
+  const [pinnedOpen, setPinnedOpen] = useState(false);
+  const searchRowRef = useRef<HTMLDivElement>(null);
   // Path -> RowCtx for the rendered rows, read by the once-registered keydown
   // handler so Enter can pass the row's is_dir as a nav hint (assigned each
   // render from the rowCtxByPath memo below).
@@ -348,6 +359,62 @@ export default function Listing({
   // which is only ever over a folder that claimed the chrome; a host with no
   // crumb bar (the app builder) keeps the row in place as its own first strip.
   const barSearchSlot = useSyncExternalStore(subscribeSearchSlot, searchSlot, () => null);
+
+  // The tight-bar measurement. DOM-side on purpose: this row PORTALS into
+  // #breadcrumb (the slot above), so the crumbs it shares the strip with are
+  // reachable — and already coupled to this row by the bar's :has() rules.
+  // Two thresholds, deliberately apart, so the flip cannot oscillate:
+  //   • fold: the crumbs are ellipsized (scrollWidth past clientWidth) even
+  //     after the CSS yield order has bottomed out — the box is the only
+  //     slack left to give.
+  //   • unfold: the whole path is showing AND the bar has ≥150px genuinely
+  //     free — room the full resting box (needing a net ~120px over the
+  //     magnifier) can take without re-truncating anything. Free space is
+  //     summed from the bar's visible children, not read off the crumbs:
+  //     they are flex-grow 0 in slot mode, so their clientWidth hugs their
+  //     content and never reports the strip's slack.
+  // No dependency array: crumbs content changes with navigation but their
+  // clientWidth may not, so a ResizeObserver alone misses scrollWidth-only
+  // changes; re-measuring on every render is cheap and the guarded setState
+  // converges. Skipped while the user is in the box — measuring a strip the
+  // crumbs have stood down from (.searching hides them) reads zeros.
+  useLayoutEffect(() => {
+    if (embedded || searching || pinnedOpen) return;
+    const row = searchRowRef.current;
+    const bar = row?.closest("#breadcrumb");
+    const crumbs = bar?.querySelector(".crumbs");
+    if (!(bar instanceof HTMLElement) || !crumbs) return;
+    const freeInBar = () => {
+      const kids = Array.from(bar.children).filter(
+        (el) => getComputedStyle(el).display !== "none"
+      );
+      const cs = getComputedStyle(bar);
+      const gap = parseFloat(cs.columnGap) || 0;
+      const used =
+        kids.reduce((w, el) => w + el.getBoundingClientRect().width, 0) +
+        gap * Math.max(0, kids.length - 1) +
+        (parseFloat(cs.paddingLeft) || 0) +
+        (parseFloat(cs.paddingRight) || 0);
+      return bar.clientWidth - used;
+    };
+    const measure = () => {
+      setTightBar((folded) =>
+        folded
+          ? crumbs.scrollWidth > crumbs.clientWidth + 1 || freeInBar() < 150
+          : crumbs.scrollWidth > crumbs.clientWidth + 1
+      );
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(bar);
+    ro.observe(crumbs);
+    return () => ro.disconnect();
+  });
+
+  // The pin is a request to type: focus follows it in the same interaction.
+  useEffect(() => {
+    if (pinnedOpen) searchInputRef.current?.focus();
+  }, [pinnedOpen]);
 
   // No "Up" BUTTON beside the search box any more: the crumb strip above is
   // the same hop with a target the user can name, and the keyboard keeps its
@@ -1167,7 +1234,32 @@ export default function Listing({
                #breadcrumb:has(.listing-search.searching) in explorer.css.
                Nothing to hand upward: the row is portaled INTO the bar, so a
                class on the row is already inside the bar's subtree. */
-            <div className={"listing-search" + (searching ? " searching" : "")}>
+            <div
+              ref={searchRowRef}
+              className={
+                "listing-search" +
+                (searching ? " searching" : "") +
+                (tightBar && !searching && !pinnedOpen ? " iconized" : "")
+              }
+            >
+              {/* Tight bar (see the measurement above): the resting box is
+                  folded away by .iconized and this magnifier stands in for it.
+                  Clicking pins the box open and focuses it; blurring it still
+                  empty hands the strip back to the path. */}
+              {tightBar && !searching && !pinnedOpen && (
+                <button
+                  type="button"
+                  className="bar-ctl listing-search-open"
+                  aria-label="Search this folder"
+                  title="Search"
+                  onClick={() => setPinnedOpen(true)}
+                >
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <circle cx="11" cy="11" r="7" />
+                    <line x1="16.5" y1="16.5" x2="21" y2="21" />
+                  </svg>
+                </button>
+              )}
               {/* The box wraps input + pinned chips so the pane toggle can sit to
             their right without disturbing the chips' inside-the-input pin.
             `has-pin` says a chip is actually pinned right now, so the input
@@ -1193,11 +1285,22 @@ export default function Listing({
                   placeholder="Search…"
                   value={query}
                   onFocus={prefetchWalk}
+                  // A pinned-open box that blurs still empty folds back to the
+                  // magnifier (the pin exists only to be typed into); with a
+                  // query it stays — .searching owns the strip from there.
+                  onBlur={(e) => {
+                    if (!e.currentTarget.value) setPinnedOpen(false);
+                  }}
                   onChange={(e) => setQuery(e.target.value)}
                   onKeyDown={(e) => {
                     if (e.key === "Escape") {
                       e.preventDefault();
                       setQuery("");
+                      // Explicit, not left to onBlur: the blur below fires
+                      // before React writes the cleared value into the DOM,
+                      // so the handler would read the pre-Esc query and keep
+                      // the pin.
+                      setPinnedOpen(false);
                       e.currentTarget.blur();
                     }
                   }}

--- a/frontend/src/apps/explorer/lib/recents.ts
+++ b/frontend/src/apps/explorer/lib/recents.ts
@@ -191,12 +191,23 @@ export function recordRecentOpen(url: string, title?: string | null): Promise<vo
 }
 
 export function setRecentsCollapsed(collapsed: boolean): Promise<void> {
+  // Optimistic: the flip paints NOW, not a network round-trip later — the
+  // collapsed rail's Recents icon expands the sidebar in the same click and
+  // must reveal the list it promised, and the heading toggle should not lag
+  // the pointer either. Persistence follows behind; a failed PUT reverts.
+  const prev = cache.collapsed;
+  cache = { ...cache, collapsed };
+  notifyRecentsChanged();
   return enqueue(async () => {
     try {
       await putRecentsCollapsed(collapsed);
+      // Re-assert after the PUT: a refresh() already in the queue may have
+      // overwritten the optimistic flip with the server's pre-PUT snapshot.
       cache = { ...cache, collapsed };
       notifyRecentsChanged();
     } catch (e) {
+      cache = { ...cache, collapsed: prev };
+      notifyRecentsChanged();
       console.error("[fused] failed to persist recents collapse:", e);
     }
   });

--- a/frontend/src/apps/explorer/lib/recents.ts
+++ b/frontend/src/apps/explorer/lib/recents.ts
@@ -157,6 +157,9 @@ function displaySignature(slots: string[], entries: RecentEntry[], collapsed: bo
 async function refresh(): Promise<void> {
   const prevSig = displaySignature(slotPaths, cache.entries, cache.collapsed);
   cache = await getRecents();
+  // A snapshot fetched while a collapse write is in flight predates that
+  // write — the user's newest intent stays authoritative over it.
+  if (pendingCollapsed !== null) cache = { ...cache, collapsed: pendingCollapsed };
   slotPaths = computeSlots(slotPaths, cache.entries);
   // Notify only when the visible slice changed; identical-signature refreshes
   // (e.g. a re-record of an unchanged url) stay render-free.
@@ -190,25 +193,38 @@ export function recordRecentOpen(url: string, title?: string | null): Promise<vo
   });
 }
 
+// The user's latest collapse intent, authoritative while any write is in
+// flight: a refresh() snapshot fetched before the PUT landed must not undo
+// the optimistic flip, and under rapid toggles only the NEWEST intent may
+// win — an older call never re-asserts its own stale value on completion.
+let pendingCollapsed: boolean | null = null;
+let collapseWritesInFlight = 0;
+
 export function setRecentsCollapsed(collapsed: boolean): Promise<void> {
   // Optimistic: the flip paints NOW, not a network round-trip later — the
   // collapsed rail's Recents icon expands the sidebar in the same click and
   // must reveal the list it promised, and the heading toggle should not lag
-  // the pointer either. Persistence follows behind; a failed PUT reverts.
-  const prev = cache.collapsed;
+  // the pointer either. Persistence follows behind, serialized by enqueue.
+  pendingCollapsed = collapsed;
+  collapseWritesInFlight++;
   cache = { ...cache, collapsed };
   notifyRecentsChanged();
   return enqueue(async () => {
+    let persisted = true;
     try {
       await putRecentsCollapsed(collapsed);
-      // Re-assert after the PUT: a refresh() already in the queue may have
-      // overwritten the optimistic flip with the server's pre-PUT snapshot.
-      cache = { ...cache, collapsed };
-      notifyRecentsChanged();
     } catch (e) {
-      cache = { ...cache, collapsed: prev };
-      notifyRecentsChanged();
+      persisted = false;
       console.error("[fused] failed to persist recents collapse:", e);
+    }
+    if (--collapseWritesInFlight > 0) return; // a newer intent is still writing
+    pendingCollapsed = null;
+    // The cache already shows the latest intent; a successful FINAL write
+    // just confirmed the server agrees. A failed final write means the
+    // server kept some earlier state — reload it rather than lie about what
+    // survives a refresh.
+    if (!persisted) {
+      await refresh().catch((e) => console.error("[fused] failed to reload recents:", e));
     }
   });
 }

--- a/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
+++ b/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
@@ -2,16 +2,53 @@
 // the bookmark tree, and file recents. Owned by the explorer app — the shell
 // just picks this component when an explorer route is active.
 import { SidebarFrame, NavItem, HOME_ICON } from "@platform/ui/sidebar/SidebarFrame";
+import type { SidebarRailItem } from "@platform/ui/sidebar/SidebarFrame";
 import { useUrlVersion } from "@platform/lib/hooks";
 import type { Config } from "@platform/lib/api";
+import { loadRecents, displayRecents, setRecentsCollapsed, useRecentsVersion } from "@apps/explorer/lib/recents";
 import BookmarksSection from "./BookmarksSection";
 import RecentsSection from "./RecentsSection";
+
+// Rail glyphs — outline versions of the marks the sections themselves use:
+// RecentsSection's clock and the bookmark rows' star, at the rail's 16px.
+const RECENTS_RAIL_ICON = (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden="true">
+    <circle cx="8" cy="8" r="6.2" />
+    <path d="M8 4.8V8l2.3 1.6" />
+  </svg>
+);
+const BOOKMARKS_RAIL_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" aria-hidden="true">
+    <path d="M12 2.8l2.8 5.7 6.3.9-4.6 4.4 1.1 6.3L12 17.2l-5.6 2.9 1.1-6.3-4.6-4.4 6.3-.9L12 2.8z" />
+  </svg>
+);
 
 export default function ExplorerSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
+  // The rail mirrors the sections: Recents (which renders null when empty —
+  // so its icon disappears with it) above Bookmarks, the order they hold in
+  // the expanded sidebar.
+  useRecentsVersion();
+  const rail: SidebarRailItem[] = [
+    ...(displayRecents().length
+      ? [
+          {
+            key: "recents",
+            label: "Recents",
+            icon: RECENTS_RAIL_ICON,
+            // The icon promises the section, so a section-collapsed Recents
+            // opens with it — expanding to a hidden list would land nowhere.
+            onExpand: () => {
+              if (loadRecents().collapsed) void setRecentsCollapsed(false);
+            },
+          },
+        ]
+      : []),
+    { key: "bookmarks", label: "Bookmarks", icon: BOOKMARKS_RAIL_ICON },
+  ];
   return (
-    <SidebarFrame title="Explorer" homeHref="/explorer">
+    <SidebarFrame title="Explorer" homeHref="/explorer" rail={rail}>
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -16,6 +16,32 @@ import {
 } from "@platform/lib/sidebarstate";
 import { useSidebarState } from "@platform/lib/hooks";
 
+/** One icon on the collapsed rail. Two dialects, by what the icon stands for:
+    a SECTION of this sidebar (explorer: bookmarks/recents) — click expands
+    the frame and `onExpand` reveals the section; or a DESTINATION (shell: the
+    sub-app list) — `href` set, click navigates and the sidebar STAYS
+    collapsed, expanding only via the chevron. The frame stays ignorant of
+    what the icons mean — owners describe them here. */
+export interface SidebarRailItem {
+  key: string;
+  /** Tooltip + accessible name; the rail shows only the icon. */
+  label: string;
+  icon: React.ReactNode;
+  /** Destination dialect: navigate here on click, keeping the rail collapsed.
+      Highlights as active on exact pathname match, like NavItem. */
+  href?: string;
+  /** Section dialect: runs after the click expands the frame — the owner's
+      chance to make the promised section actually visible (e.g. un-collapse
+      Recents). Ignored when `href` is set. */
+  onExpand?: () => void;
+  /** Hairline above this item — a group boundary, mirroring the expanded
+      sidebar's headings. */
+  dividerBefore?: boolean;
+  /** Set on the FIRST item of a bottom-pinned cluster (the shell's settings
+      list) — pushes it and everything after to the rail's bottom edge. */
+  pinBottom?: boolean;
+}
+
 export interface SidebarFrameProps {
   /** Brand text next to the cube mark — names the owning context. */
   title: string;
@@ -23,6 +49,9 @@ export interface SidebarFrameProps {
   version?: string;
   /** Where the brand click lands; the front door of the owning app. */
   homeHref?: string;
+  /** Section icons for the collapsed rail. Optional — a sidebar without them
+      collapses to just the expand control. */
+  rail?: SidebarRailItem[];
   children: React.ReactNode;
 }
 
@@ -60,7 +89,7 @@ export function NavItem({
   );
 }
 
-export function SidebarFrame({ title, version, homeHref = "/apps", children }: SidebarFrameProps) {
+export function SidebarFrame({ title, version, homeHref = "/apps", rail, children }: SidebarFrameProps) {
   // Sidebar chrome: draggable width + collapsed flag, persisted once per
   // gesture (drag end / toggle), not per mousemove. The state lives in the
   // shared store (platform/lib/sidebarstate) rather than here so that a
@@ -119,36 +148,68 @@ export function SidebarFrame({ title, version, homeHref = "/apps", children }: S
   };
 
   if (sidebarCollapsed) {
-    // Collapsed: a slim strip carrying the ONE reopen control, the same one on
-    // every route. It briefly lived in the explorer's top bar instead, with
-    // this tab as the fallback for routes that have no top bar (Apps,
-    // Preferences, panel mode) — two dialects for one action, so which control
-    // you reached for depended on where you happened to be. The strip is the
-    // whole button; the tab is the visible part of it, pinned to the top so it
-    // lands on the same line as the bars beside it.
-    //
-    // Not the floating bubble this replaced either: anchored at `left: 100%`
-    // on a 10px strip, half of it hung off the viewport and it sat level with
-    // the explorer's bookmark star, reading as a second star.
+    // Collapsed: an icon RAIL, not the old anonymous 20px strip (which read as
+    // a full-height bar whose only content was an arrow). The expand control
+    // stays on top — the ONE reopen control, on every route, pinned to the
+    // same 24px line the sidebar header and the app bars stand on. Below it,
+    // the owner's section icons (SidebarRailItem): the collapsed state keeps
+    // saying what the sidebar HAS, and clicking an icon is "expand, showing me
+    // that" — the frame expands, then the owner's onExpand makes the section
+    // visible.
     //
     // Still the same #sidebar node, so the <=700px media hide applies.
     return (
       <nav id="sidebar" className={"sidebar-collapsed" + (resizing ? " sidebar-no-transition" : "")}>
         <button
           type="button"
-          className="sidebar-expand-strip"
+          className="sidebar-rail-btn sidebar-rail-expand"
           aria-label="Expand sidebar"
           title="Expand sidebar"
           onClick={toggleSidebarCollapsed}
         >
-          {/* Presentational — the strip is the button, so hover and focus key
-              off the strip's own state (sidebar.css). */}
-          <span className="sidebar-expand-tab" aria-hidden="true">
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="m9 18 6-6-6-6" />
-            </svg>
-          </span>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="m9 18 6-6-6-6" />
+          </svg>
         </button>
+        {rail && rail.length > 0 && (
+          <div className="sidebar-rail-items">
+            {rail.map((item) => (
+              <React.Fragment key={item.key}>
+                {item.pinBottom && <span className="sidebar-rail-flex" aria-hidden="true" />}
+                {item.dividerBefore && <span className="sidebar-rail-sep" aria-hidden="true" />}
+                {item.href ? (
+                  <a
+                    href={item.href}
+                    className={
+                      "sidebar-rail-btn" + (location.pathname === item.href ? " active" : "")
+                    }
+                    aria-label={item.label}
+                    title={item.label}
+                    onClick={(e) => {
+                      e.preventDefault();
+                      navigateUrl(item.href!);
+                    }}
+                  >
+                    {item.icon}
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    className="sidebar-rail-btn"
+                    aria-label={`Expand sidebar to ${item.label}`}
+                    title={item.label}
+                    onClick={() => {
+                      setSidebarState((s) => ({ ...s, collapsed: false }));
+                      item.onExpand?.();
+                    }}
+                  >
+                    {item.icon}
+                  </button>
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        )}
       </nav>
     );
   }

--- a/frontend/src/shell/ShellSidebar.tsx
+++ b/frontend/src/shell/ShellSidebar.tsx
@@ -13,6 +13,7 @@
 // third: it reads /api/claude-sessions, which is always there, and a CLAUDE
 // group holding only it would be a heading for one machine-wide list.)
 import { SidebarFrame, NavItem } from "@platform/ui/sidebar/SidebarFrame";
+import type { SidebarRailItem } from "@platform/ui/sidebar/SidebarFrame";
 import { LearnIcon } from "@platform/ui/FileIcons";
 import type { Config } from "@platform/lib/api";
 import { useUrlVersion, useLearnMountReady, useSessionsMountReady } from "@platform/lib/hooks";
@@ -83,6 +84,29 @@ const AI_MODELS_ICON = (
   </svg>
 );
 
+// Settings glyphs, hoisted so the rows and the collapsed rail share them.
+const TEMPLATES_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+
+const MOUNTS_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M17.5 19a4.5 4.5 0 1 0-.9-8.9 6 6 0 1 0-11.4 2.4A3.5 3.5 0 0 0 6.5 19h11z" />
+  </svg>
+);
+
+const PREFERENCES_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+  </svg>
+);
+
 export default function ShellSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
@@ -112,8 +136,46 @@ export default function ShellSidebar({ config }: { config: Config }) {
   const aiRuntime = useAiRuntime();
   const residentModels = aiRuntime.loaded.filter((m) => m.state === "ready");
 
+  // The collapsed rail mirrors the rows below one-for-one — same gates, same
+  // order, group boundaries as dividers, settings pinned to the bottom. Every
+  // icon is a DESTINATION (href), so a click navigates and the sidebar stays
+  // collapsed; only the chevron expands it. This sidebar is an app-switcher —
+  // its rows are places to go, unlike the explorer's sections, whose rail
+  // icons expand-and-reveal instead.
+  const railGroups: SidebarRailItem[][] = [
+    [
+      { key: "explorer", label: "Explorer", icon: EXPLORER_ICON, href: "/explorer" },
+      { key: "apps", label: "Build App", icon: APPS_ICON, href: "/apps" },
+    ],
+    sessionsMountReady || claudeConfigAvailable
+      ? [
+          ...(sessionsMountReady
+            ? [{ key: "sessions", label: "Inbox", icon: SESSIONS_ICON, href: "/sessions" }]
+            : []),
+          { key: "claude-artifacts", label: "Artifacts", icon: ARTIFACTS_ICON, href: "/claude-artifacts" },
+          ...(claudeConfigAvailable
+            ? [{ key: "claude-config", label: "Config", icon: CLAUDE_CONFIG_ICON, href: "/claude-config" }]
+            : []),
+        ]
+      : [],
+    learnMountReady
+      ? [{ key: "learn", label: "App Basics", icon: <LearnIcon />, href: "/learn" }]
+      : [],
+  ];
+  const rail: SidebarRailItem[] = [
+    ...railGroups
+      .filter((g) => g.length > 0)
+      .flatMap((g, i) => g.map((item, j) => (i > 0 && j === 0 ? { ...item, dividerBefore: true } : item))),
+    { key: "templates", label: "Templates", icon: TEMPLATES_ICON, href: "/templates", pinBottom: true },
+    { key: "mounts", label: "Mounts", icon: MOUNTS_ICON, href: "/mounts" },
+    ...(localModelsAvailable
+      ? [{ key: "ai-models", label: "AI Models", icon: AI_MODELS_ICON, href: "/ai-models" }]
+      : []),
+    { key: "preferences", label: "Preferences", icon: PREFERENCES_ICON, href: "/preferences" },
+  ];
+
   return (
-    <SidebarFrame title="Render" version={config.version}>
+    <SidebarFrame title="Render" version={config.version} rail={rail}>
       {/* Group headings reuse .sidebar-heading — the same primitive the
           explorer's Bookmarks/Recents headings use, so one dialect of "category
           label above rows" exists in the sidebar rather than two. */}
@@ -153,28 +215,9 @@ export default function ShellSidebar({ config }: { config: Config }) {
       {/* Settings — pinned to the bottom edge (margin-top: auto), the same
           list treatment as the sub-app list above. */}
       <div className="sidebar-section sidebar-settings">
-        <NavItem
-          href="/templates"
-          label="Templates"
-          icon={
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <rect x="3" y="3" width="7" height="7" rx="1" />
-              <rect x="14" y="3" width="7" height="7" rx="1" />
-              <rect x="3" y="14" width="7" height="7" rx="1" />
-              <rect x="14" y="14" width="7" height="7" rx="1" />
-            </svg>
-          }
-        />
+        <NavItem href="/templates" label="Templates" icon={TEMPLATES_ICON} />
         {/* PROTOTYPE: mounts entry — remote mounts. */}
-        <NavItem
-          href="/mounts"
-          label="Mounts"
-          icon={
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M17.5 19a4.5 4.5 0 1 0-.9-8.9 6 6 0 1 0-11.4 2.4A3.5 3.5 0 0 0 6.5 19h11z" />
-            </svg>
-          }
-        />
+        <NavItem href="/mounts" label="Mounts" icon={MOUNTS_ICON} />
         {/* Next to Mounts: both answer "what storage does this machine have
             attached", one remote and one the Hub filled in locally. */}
         {localModelsAvailable && (
@@ -201,12 +244,7 @@ export default function ShellSidebar({ config }: { config: Config }) {
         <NavItem
           href="/preferences"
           label="Preferences"
-          icon={
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.01a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.01a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.01a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
-            </svg>
-          }
+          icon={PREFERENCES_ICON}
           // Fused-account signed-in signal (SPEC AC-1), folded onto the
           // Preferences entry. Gated on Deploy being enabled — that's the
           // only reason a Fused account matters here.

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1225,8 +1225,14 @@ table.listing-table tr.skel-row:hover {
    input silently refuses focus and the feature dies while folded. The
    negative margin swallows the row's 8px gap, so the zero-width item leaves
    no seam. Never coexists with .searching: a non-empty query un-folds by
-   definition. */
-.listing-search.iconized .listing-search-box {
+   definition.
+
+   Scoped under the slot for specificity, not for scope (the fold only exists
+   in slot mode anyway): the `.has-pin` width rule below is (0,3,0) and later
+   in the file, so at equal specificity a narrow-bar multi-selection would
+   win the cascade and reopen a 260px hole the fold had just reclaimed —
+   invisible, because this rule's opacity would still apply. */
+.crumb-search-slot .listing-search.iconized .listing-search-box {
   flex: 0 0 0px;
   width: 0;
   min-width: 0;

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1203,11 +1203,25 @@ table.listing-table tr.skel-row:hover {
    over and gives up its own width, down to 96px — still the full "Search…"
    placeholder, just with no slack around it. Between the two floors the strip
    stays one line at any width the split allows, which is what keeps it the
-   same height as the pane header across the divider. */
+   same height as the pane header across the divider.
+
+   And past BOTH floors — the path still ellipsized with the box already at
+   96px — the box stops being worth its strip at all: Listing.tsx measures
+   that state and folds the resting box into a 28px magnifier (.iconized
+   below), handing the difference back to the path. The path outranks an idle
+   input; a click on the magnifier (or typing, ever) gets the box back. */
 #breadcrumb:has(.crumb-search-slot) .crumbs {
   flex-grow: 0;
   flex-shrink: 6;
   min-width: 120px;
+}
+
+/* The tight-bar fold (Listing.tsx's measurement): the resting box goes away
+   entirely — display, not width, so the row's gap goes with it — and the
+   .listing-search-open magnifier (a .bar-ctl) stands in. Never coexists with
+   .searching: a non-empty query un-folds by definition. */
+.listing-search.iconized .listing-search-box {
+  display: none;
 }
 
 /* …and once there is a query, the crumbs get out of the way entirely.

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1216,12 +1216,23 @@ table.listing-table tr.skel-row:hover {
   min-width: 120px;
 }
 
-/* The tight-bar fold (Listing.tsx's measurement): the resting box goes away
-   entirely — display, not width, so the row's gap goes with it — and the
-   .listing-search-open magnifier (a .bar-ctl) stands in. Never coexists with
-   .searching: a non-empty query un-folds by definition. */
+/* The tight-bar fold (Listing.tsx's measurement): the resting box collapses
+   to nothing and the .listing-search-open magnifier (a .bar-ctl) stands in.
+   Collapsed by WIDTH, not display: the input must stay focusable, because
+   type-to-search (useListingSelection's printable-key branch) lands focus on
+   it from anywhere in the listing — focus pins the box back open
+   (Listing.tsx), so the keystroke falls into a visible field. A display:none
+   input silently refuses focus and the feature dies while folded. The
+   negative margin swallows the row's 8px gap, so the zero-width item leaves
+   no seam. Never coexists with .searching: a non-empty query un-folds by
+   definition. */
 .listing-search.iconized .listing-search-box {
-  display: none;
+  flex: 0 0 0px;
+  width: 0;
+  min-width: 0;
+  margin-left: -8px;
+  overflow: hidden;
+  opacity: 0;
 }
 
 /* …and once there is a query, the crumbs get out of the way entirely.

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -74,88 +74,92 @@ body:has(.sidebar-resize-handle.resizing) {
   flex-shrink: 0;
 }
 
-/* Collapsed sidebar = a slim full-height strip that expands it back, carrying
-   the tab below — the SAME reopen control on every route (an explorer-only
-   topbar button briefly competed with it, so which control you reached for
-   depended on where you were). overflow stays visible so the tab can protrude
-   over #content, and the strip is lifted above it so a stacking context inside
-   #content can't paint over the tab. */
+/* Collapsed sidebar = an icon rail: the reopen control on top (the SAME one
+   on every route — an explorer-only topbar button briefly competed with it,
+   so which control you reached for depended on where you were), then the
+   owner's section icons (SidebarRailItem). 44px holds a centred column of the
+   28px controls the bars use, self-contained — no tab protruding over
+   #content like the old 20px strip needed. */
 #sidebar.sidebar-collapsed {
-  /* 20px, not the 10px this strip used to be: the tab protrudes 28px over
-     #content, and at 10px it landed on top of whatever the route's bar starts
-     with — the app header's title began at x26 against a tab ending at x28.
-     20px puts the content gutter at 36px and leaves the tab 8px of air on
-     every route, without the strip reading as a column of its own. */
-  flex: 0 0 20px;
-  width: 20px;
-  overflow: visible;
-  position: relative;
-  z-index: 10;
-}
-
-.sidebar-expand-strip {
-  position: relative;
-  flex: 1 1 auto;
-  display: flex;
+  flex: 0 0 44px;
+  width: 44px;
   align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: none;
-  color: var(--fg-muted);
-  cursor: pointer;
+  /* Puts the expand control's centre on 24px — the line the sidebar header,
+     #breadcrumb and the app header all stand on — so the control keeps its
+     position across collapse and expand, on every route. */
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
-.sidebar-expand-strip:hover {
-  background: rgba(var(--tint), 0.06);
-}
-
-/* The reopen tab. Anchored at the strip's LEFT edge, so all 28px of it are
-   on-screen, and at the top rather than mid-height: `top: 10px` centres it on
-   24px — the line the sidebar header, #breadcrumb and the app header all stand
-   on — so the control keeps its height across collapse and expand, on every
-   route. 28px square with a 16px glyph is the .bar-ctl-icon geometry the bars
-   use, and the hover below is their wash, so it reads as one of them.
-   Presentational: the STRIP is the button, so hover/focus key off its state. */
-.sidebar-expand-tab {
-  position: absolute;
-  top: 10px;
-  left: 0;
+/* 28px square, 16px glyph, .bar-ctl geometry and hover wash (explorer.css) —
+   the rail reads as a column of the same controls the bars use. */
+.sidebar-rail-btn {
   display: flex;
   align-items: center;
   justify-content: center;
   width: 28px;
   height: 28px;
+  flex-shrink: 0;
+  padding: 0;
+  border: none;
   border-radius: 8px;
-  background: var(--bg-alt);
-  border: 1px solid var(--border);
-  box-shadow: 0 1px 4px var(--shadow-sm);
+  background: none;
   color: var(--fg-muted);
-  z-index: 10;
+  cursor: pointer;
 }
 
-/* Same hover as .bar-ctl (explorer.css): rgba(--tint, 0.08) over the tab's
-   own --bg-alt, and the glyph up to full --fg. */
-.sidebar-expand-strip:hover .sidebar-expand-tab {
-  background: color-mix(in srgb, rgba(var(--tint), 0.08), var(--bg-alt));
-  border-color: color-mix(in srgb, var(--border) 60%, var(--fg-muted));
+/* Rail items come in two dialects (SidebarRailItem): <button> for "expand to
+   this section", <a> for "navigate there, stay collapsed" — one look. */
+a.sidebar-rail-btn {
+  text-decoration: none;
+}
+
+.sidebar-rail-btn:hover {
+  background: rgba(var(--tint), 0.08);
   color: var(--fg);
 }
 
-/* Focus ring on the strip, or on the tab when it carries one. */
-.sidebar-expand-strip:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: -2px;
+/* Same current-place treatment as .sidebar-item.active, on the icon alone. */
+.sidebar-rail-btn.active {
+  background: rgba(var(--tint), 0.08);
+  color: var(--fg);
 }
 
-.sidebar-expand-strip:focus-visible:has(.sidebar-expand-tab) {
-  outline: none;
-}
-
-.sidebar-expand-strip:focus-visible .sidebar-expand-tab {
+.sidebar-rail-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
   color: var(--fg);
+}
+
+/* Section icons sit apart from the expand control: a hairline divider says
+   "these are the sidebar's contents, that is its chrome". flex: 1 so a
+   pinBottom cluster (the shell's settings icons) can push to the bottom edge,
+   mirroring the expanded sidebar's layout. */
+.sidebar-rail-items {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Group boundary inside the rail — stands in for the expanded sidebar's
+   uppercase headings. */
+.sidebar-rail-sep {
+  width: 28px;
+  height: 1px;
+  flex-shrink: 0;
+  margin: 4px 0;
+  background: var(--border);
+}
+
+/* The flexible gap before a pinBottom cluster. */
+.sidebar-rail-flex {
+  flex: 1 1 auto;
 }
 
 /* Phones: give the whole width to the rendered view */

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -52,6 +52,10 @@
     --shadow: rgba(0, 0, 0, .4);
     --scrollbar: #3a3d45;
     --handle-hover: #4a4d57;
+    /* Caret for the composer's select pills. A data URI can't read
+       currentColor, so the stroke bakes in this theme's --dim — keep the two
+       in sync when either changes. */
+    --pill-caret: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8"><path d="M1.5 3l2.5 2.5L6.5 3" stroke="%239a9fa9" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>');
   }
   :root[data-theme="light"] {
     color-scheme: light;
@@ -83,6 +87,7 @@
     --shadow: rgba(0, 0, 0, .10);
     --scrollbar: #cdd0d6;
     --handle-hover: #a8adb6;
+    --pill-caret: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="8" height="8" viewBox="0 0 8 8"><path d="M1.5 3l2.5 2.5L6.5 3" stroke="%2361656c" stroke-width="1.2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></svg>');
   }
   * { box-sizing: border-box; }
   html, body { height: 100%; }
@@ -1342,7 +1347,7 @@
   }
   .composer-row .spacer { flex: 1; }
   .pill {
-    background: transparent;
+    background-color: transparent;
     border: 1px solid transparent;
     border-radius: 999px;
     color: var(--dim);
@@ -1353,7 +1358,28 @@
     outline: none;
     -webkit-appearance: none;
     appearance: none;
-    transition: background .12s, color .12s, filter .12s;
+    transition: background-color .12s, color .12s, filter .12s;
+  }
+  /* Select pills only (not pressable button pills): a caret so they read as
+     dropdowns at rest, and a JS-fitted width (see fitSelect) because an
+     appearance:none select otherwise sizes to its WIDEST option — "fable"
+     rendered inside a "sonnet"-wide pill, leaving dead space that made the
+     row's gaps look uneven. background-color (not the background shorthand)
+     everywhere on pills, or the hover repaint erases this caret. */
+  select.pill {
+    background-image: var(--pill-caret);
+    background-repeat: no-repeat;
+    background-position: right 9px center;
+    background-size: 8px 8px;
+    padding-right: 22px;
+    text-align: left;
+  }
+  /* outline:none above kills the UA focus ring; keyboard users still need a
+     receipt, mouse users still shouldn't get one on click. */
+  .pill:focus-visible {
+    border-color: var(--border-strong);
+    background-color: var(--surface-2);
+    color: var(--fg);
   }
   /* THE ONE RULE about hover and an active state, shared with #annbtn in the left
      pane's banner: a neutral hover never applies to a control that is switched on,
@@ -1366,9 +1392,10 @@
      the user is deciding whether to click. Relying on rule order for that is one
      reshuffle away from the bug coming back, and the next pressable pill in this
      row inherits the fix rather than rediscovering it. */
-  .pill:hover:not([aria-pressed="true"]) { background: var(--surface-2); color: var(--fg); }
+  .pill:hover:not([aria-pressed="true"]) { background-color: var(--surface-2); color: var(--fg); }
   .pill[aria-pressed="true"]:hover { filter: brightness(1.1); }
   .pill option { background: var(--bg); color: var(--fg); }
+  .pill option:disabled { color: var(--faint); }
   .send {
     width: 32px;
     height: 32px;
@@ -1382,6 +1409,9 @@
     padding: 0;
     cursor: pointer;
     flex-shrink: 0;
+    /* Redundant while the spacer is on the same line; keeps the button pinned
+       right when a narrow pane wraps it onto its own line. */
+    margin-left: auto;
     transition: filter .12s, transform .12s, opacity .12s;
   }
   .send:hover { filter: brightness(1.1); transform: translateY(-1px); }
@@ -2098,9 +2128,12 @@
           <textarea id="box" rows="1" placeholder="Reply to Claude…" spellcheck="false"
                     data-gramm="false" data-gramm_editor="false" data-enable-grammarly="false"></textarea>
           <div class="composer-row">
-            <select id="model" class="pill model-sel" title="Model"></select>
-            <select id="effort" class="pill effort-sel" title="Effort"></select>
-            <select id="perm" class="pill perm-sel" title="How much Claude may do without asking"></select>
+            <!-- aria-label, not title: the OS tooltip a title attr produces reads as
+                 unpolished chrome next to the pills, and the caret + visible value
+                 already say what each pill is. Screen readers keep the name. -->
+            <select id="model" class="pill model-sel" aria-label="Model"></select>
+            <select id="effort" class="pill effort-sel" aria-label="Effort"></select>
+            <select id="perm" class="pill perm-sel" aria-label="How much Claude may do without asking"></select>
             <span class="spacer"></span>
             <button class="send" type="submit" aria-label="Send">
               <svg class="ic-send" width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -2136,9 +2169,9 @@
           <textarea id="homebox" rows="2" placeholder="Ask Claude…" spellcheck="false"
                     data-gramm="false" data-gramm_editor="false" data-enable-grammarly="false"></textarea>
           <div class="composer-row">
-            <select id="hmodel" class="pill model-sel" title="Model"></select>
-            <select id="heffort" class="pill effort-sel" title="Effort"></select>
-            <select id="hperm" class="pill perm-sel" title="How much Claude may do without asking"></select>
+            <select id="hmodel" class="pill model-sel" aria-label="Model"></select>
+            <select id="heffort" class="pill effort-sel" aria-label="Effort"></select>
+            <select id="hperm" class="pill perm-sel" aria-label="How much Claude may do without asking"></select>
             <span class="spacer"></span>
             <button class="send" type="submit" aria-label="Send">
               <svg class="ic-send" width="14" height="14" viewBox="0 0 16 16" fill="none">
@@ -4873,6 +4906,9 @@ function fillSelect(el, values, label) {
     const o = document.createElement("option");
     o.value = v;
     o.textContent = v || label;
+    // The "" entry is a placeholder shown only when the current value is
+    // missing/invalid — never a choice the user can pick.
+    if (!v) o.disabled = true;
     el.appendChild(o);
   }
 }
@@ -4887,6 +4923,23 @@ document.querySelectorAll(".perm-sel").forEach((el) => {
   }
 });
 
+// An appearance:none select keeps the width of its WIDEST option, so a short
+// value renders in a wide pill ("fable" inside a "sonnet"-wide pill) with dead
+// space before the next pill — the row's gaps looked uneven. Hug the selected
+// label instead: measure it off-DOM and set an explicit width. Padding,
+// borders (and with them the caret gutter) come off the computed style so the
+// .pill CSS stays the single source of truth for them.
+const _fitCtx = document.createElement("canvas").getContext("2d");
+function fitSelect(el) {
+  const opt = el.selectedOptions[0];
+  if (!opt) return; // value not in options — keep the last fitted width
+  const s = getComputedStyle(el);
+  _fitCtx.font = `${s.fontStyle} ${s.fontWeight} ${s.fontSize} ${s.fontFamily}`;
+  const chrome = parseFloat(s.paddingLeft) + parseFloat(s.paddingRight) +
+    parseFloat(s.borderLeftWidth) + parseFloat(s.borderRightWidth);
+  el.style.width = `${Math.ceil(_fitCtx.measureText(opt.textContent).width + chrome)}px`;
+}
+
 function syncSelects() {
   document.querySelectorAll(".model-sel").forEach((el) => { el.value = curModel(); });
   document.querySelectorAll(".effort-sel").forEach((el) => { el.value = curEffort(); });
@@ -4894,6 +4947,7 @@ function syncSelects() {
   document.querySelectorAll(".perm-sel").forEach((el) => {
     el.value = PERMISSION_MODES.includes(perm) ? perm : DEFAULT_PERMISSION;
   });
+  document.querySelectorAll(".model-sel, .effort-sel, .perm-sel").forEach(fitSelect);
 }
 document.querySelectorAll(".model-sel").forEach((el) =>
   el.addEventListener("change", () => { fused.params.set("model", el.value); syncSelects(); }));

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1395,7 +1395,6 @@
   .pill:hover:not([aria-pressed="true"]) { background-color: var(--surface-2); color: var(--fg); }
   .pill[aria-pressed="true"]:hover { filter: brightness(1.1); }
   .pill option { background: var(--bg); color: var(--fg); }
-  .pill option:disabled { color: var(--faint); }
   .send {
     width: 32px;
     height: 32px;
@@ -4859,8 +4858,8 @@ const growHome = autoGrow(homebox);
 const VERBS = ["Thinking", "Pondering", "Vibing", "Noodling", "Brewing", "Simmering", "Mulling", "Percolating"];
 
 // ── model/effort/approvals selectors (home + composer sync via params) ──
-const MODELS = ["", "fable", "opus", "sonnet", "haiku"];
-const EFFORTS = ["", "low", "medium", "high", "xhigh", "max"];
+const MODELS = ["fable", "opus", "sonnet", "haiku"];
+const EFFORTS = ["low", "medium", "high", "xhigh", "max"];
 // How much Claude may do without stopping for a card. Values are agent.py's
 // PERMISSION_MODES keys; the labels say what the user gets. `auto` is a
 // broader opt-in, NOT a blanket one — Claude Code's own classifier judges each
@@ -4901,19 +4900,19 @@ const curEffort = () => fused.params.get("effort") || detectedEffort || DEFAULT_
 // The strictest mode is the default: more auto-approval is opted into, never
 // handed out by a missing param.
 const DEFAULT_PERMISSION = "prompt";
-function fillSelect(el, values, label) {
+// Real values only — no placeholder row: curModel()/curEffort() always
+// resolve to a concrete value, so the dropdown never needs a "model"/"effort"
+// entry the user shouldn't pick.
+function fillSelect(el, values) {
   for (const v of values) {
     const o = document.createElement("option");
     o.value = v;
-    o.textContent = v || label;
-    // The "" entry is a placeholder shown only when the current value is
-    // missing/invalid — never a choice the user can pick.
-    if (!v) o.disabled = true;
+    o.textContent = v;
     el.appendChild(o);
   }
 }
-document.querySelectorAll(".model-sel").forEach((el) => fillSelect(el, MODELS, "model"));
-document.querySelectorAll(".effort-sel").forEach((el) => fillSelect(el, EFFORTS, "effort"));
+document.querySelectorAll(".model-sel").forEach((el) => fillSelect(el, MODELS));
+document.querySelectorAll(".effort-sel").forEach((el) => fillSelect(el, EFFORTS));
 document.querySelectorAll(".perm-sel").forEach((el) => {
   for (const v of PERMISSION_MODES) {
     const o = document.createElement("option");


### PR DESCRIPTION
## What

Two UI passes, both browser-verified with Playwright:

**Claude template — composer pills**
- Placeholder options ("model" / "effort") are now `disabled` — only real values selectable; placeholder styled `--faint` in the list.
- Select pills read as dropdowns: theme-matched caret (`--pill-caret`), JS-fitted width (`fitSelect` — an `appearance:none` select otherwise sizes to its widest option, leaving dead space and uneven row gaps), `:focus-visible` ring, `aria-label` instead of `title` (kills the boxy native tooltip).
- Send button pins right when a narrow pane wraps it to its own line.

**Sidebar — collapsed icon rail**
- Collapsed sidebar was a 20px full-height strip with a protruding arrow tab; now a 44px icon rail with the expand chevron on top.
- One `SidebarRailItem` type, two owner-chosen dialects:
  - Explorer: **section** icons (Recents clock, Bookmarks star) — click expands and reveals the section (un-collapsing Recents if hidden); the Recents icon disappears with the empty section.
  - Shell: **destination** icons mirroring the app-switcher rows one-for-one (same gates, group dividers, settings cluster pinned to bottom) — click navigates and the rail stays collapsed; only the chevron expands. Active route highlighted.
- `SidebarFrame` stays section-agnostic; settings glyphs hoisted so rows and rail share them.

**Breadcrumb — tight-bar search fold**
- When the middle column is narrow enough that the path is still ellipsized after the CSS yield order bottoms out, the resting search box folds into a 28px magnifier and the path gets the strip back. Clicking pins the box open (focused); blurring it empty folds it again; a query keeps the whole strip as before. Fold/unfold thresholds are deliberately apart so the flip cannot oscillate.

## Screenshots

**Composer pills** — carets, fitted widths, unselectable placeholder:

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-468-assets/composer-dark.png" width="360" alt="Composer pills with carets and fitted widths" />

**Explorer sidebar** — collapsed rail (chevron / Recents / Bookmarks), and expanded after clicking the star:

<table><tr>
<td><img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-468-assets/explorer-rail.png" width="220" alt="Explorer collapsed rail" /></td>
<td><img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-468-assets/explorer-expanded.png" width="260" alt="Explorer expanded after clicking Bookmarks icon" /></td>
</tr></table>

**Shell sidebar** — collapsed rail mirroring the app-switcher, active route (Templates) highlighted, settings pinned to the bottom:

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-468-assets/shell-rail.png" width="220" alt="Shell collapsed rail with active Templates icon" />

**Breadcrumb on a tight bar** — the resting search box folds into a magnifier so the path keeps the strip; click (or type) brings it back:

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-468-assets/tightbar-narrow.png" width="360" alt="Narrow bar with search folded to a magnifier" />

*(Images live on the throwaway `pr-468-assets` orphan branch — delete it after merge.)*

## Testing

- `tsc --noEmit`, boundaries check, `bun test` (9 pre-existing `shortcut-chord.test.ts` failures, identical on main).
- Full pytest: 5869 passed locally; CI green across 3.10–3.13.
- Playwright E2E: placeholder unselectable in all 4 selects; rail 44px on explorer + shell routes, section-click expands with section visible, shell icon click navigates while staying collapsed, chevron expands, state survives reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared `SidebarFrame` chrome used on every route, plus ResizeObserver-driven breadcrumb layout and optimistic recents persistence races. UI-only, but regressions would be widely visible.
> 
> **Overview**
> Replaces the collapsed sidebar’s anonymous expand strip with a **44px icon rail**, and polishes two related chrome surfaces.
> 
> **Collapsed rail.** `SidebarFrame` now accepts optional `SidebarRailItem`s with two owner dialects: *section* icons expand and reveal (explorer Recents/Bookmarks), *destination* icons navigate while staying collapsed (shell app switcher, with group dividers and settings pinned bottom). Recents collapse flips **optimistically** so a rail click can expand and show the list in the same gesture.
> 
> **Tight-bar search.** When the crumb strip is still ellipsized after CSS yield bottoms out, the resting search box folds to a magnifier and gives width back to the path. Click or type-to-search pins it open; blur-empty or Esc folds it again.
> 
> **Composer pills.** Claude select pills drop placeholder options, gain theme-matched carets and JS-fitted widths, use `aria-label` instead of `title`, and keep the send button right-aligned when the row wraps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b177109f292ce57c6293f2afc760d8bf3ad7ecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

