### PR TITLE
Folder cards peek at index.html and readme.md by name, not by extension

### DIFF
--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -14,12 +14,8 @@ import { navigate, navigateUrl, urlForFsPath, EMBED_PREFIX, VIEW_PREFIX } from "
 import { listDir, rawUrl, statPath } from "@platform/lib/api";
 import type { FsEntry } from "@platform/lib/api";
 import { basename } from "@platform/lib/format";
-import {
-  bestPeekFile,
-  isPreviewImage,
-  peekRank,
-  peekRankIsUnbeatable,
-} from "@apps/explorer/lib/folder-peek";
+import { bestPeekFile, foldProbePick, isPreviewImage, peekRank } from "@apps/explorer/lib/folder-peek";
+import type { ProbePick } from "@apps/explorer/lib/folder-peek";
 import { iconForEntry } from "@platform/ui/FileIcons";
 import { armBookmark, isBookmarkMissing, splitBookmarkUrl } from "@platform/lib/bookmarks";
 import type { Bookmark } from "@platform/lib/bookmarks";
@@ -160,7 +156,7 @@ function FolderStack({ path }: { path: string }) {
         setSubPeek(null); // a direct file child wins — no probe needed
         return;
       }
-      let best: { path: string; rank: number; dir: string } | null = null;
+      let best: ProbePick | null = null;
       for (const d of teaser.filter((e) => e.is_dir).slice(0, APP_PROBE_LIMIT)) {
         const subPath = joinPath(path, d.name);
         let sub: FsEntry[];
@@ -172,14 +168,19 @@ function FolderStack({ path }: { path: string }) {
         if (!alive) return;
         const f = bestPeekFile(teaserEntries(sub));
         if (!f) continue;
-        const rank = peekRank(f.name);
-        if (!best || rank < best.rank)
-          best = { path: joinPath(subPath, f.name), rank, dir: d.name };
-        // Stop as soon as nothing later can beat this — an authored image, or
-        // a page, which is what "there is a fused app in here" looks like. One
-        // listDir instead of three per card, which on an rclone/NFS target is
-        // the difference between a card and a stalled mount listing.
-        if (peekRankIsUnbeatable(rank)) break;
+        // Stop as soon as nothing later can beat what we HOLD — an authored
+        // image, or a page, which is what "there is a fused app in here" looks
+        // like. One listDir instead of three per card, which on an rclone/NFS
+        // target is the difference between a card and a stalled mount listing.
+        // foldProbePick owns both halves of that decision; see it for why the
+        // stop test must be on the winner and not on this candidate.
+        const folded = foldProbePick(best, {
+          path: joinPath(subPath, f.name),
+          rank: peekRank(f.name),
+          dir: d.name,
+        });
+        best = folded.best;
+        if (folded.done) break;
       }
       setSubPeek(best ? { path: best.path, dir: best.dir } : null);
     })();

--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -126,8 +126,9 @@ function ImagePreview({ src, fallback }: { src: string; fallback: ReactNode }) {
 
 // The stack body of a folder card: back-to-front fanned chips over an
 // optional preview peeking out underneath the front chip. The peek is the
-// folder's best direct file child (peekRank: `preview.png` first, then
-// PEEK_EXT_ORDER); a folder holding only subfolders (a deploy dir of apps)
+// folder's best direct file child (peekRank: `preview.png`, `index.html`,
+// `readme.md`, then by extension tier); a folder holding only subfolders (a
+// deploy dir of apps)
 // probes its first few subfolders and peeks the best-ranked file found there —
 // an authored preview.png anywhere wins the probe outright.
 function FolderStack({ path }: { path: string }) {

--- a/frontend/src/apps/explorer/lib/folder-peek.test.ts
+++ b/frontend/src/apps/explorer/lib/folder-peek.test.ts
@@ -8,10 +8,12 @@ import type { FsEntry } from "@platform/lib/api";
 import {
   PREVIEW_IMAGE_NAME,
   bestPeekFile,
+  foldProbePick,
   isPreviewImage,
   peekRank,
   peekRankIsUnbeatable,
 } from "@apps/explorer/lib/folder-peek";
+import type { ProbePick } from "@apps/explorer/lib/folder-peek";
 
 function f(name: string, is_dir = false): FsEntry {
   return { name, is_dir, size: null, mtime: null };
@@ -87,6 +89,53 @@ test("the peeked child is the best-ranked file, never a directory", () => {
     "about.html",
   );
   expect(bestPeekFile([f("only-a-folder", true)])).toBe(null);
+});
+
+// The probed-subfolder walk, run over a sequence of finds the way the card's
+// effect does: fold each one in, stop when the fold says so.
+function walk(finds: string[]): { dir: string; visited: number } | null {
+  let best: ProbePick | null = null;
+  let visited = 0;
+  for (const [i, name] of finds.entries()) {
+    visited++;
+    const dir = `sub${i}`;
+    const folded = foldProbePick(best, { path: `/w/${dir}/${name}`, rank: peekRank(name), dir });
+    best = folded.best;
+    if (folded.done) break;
+  }
+  return best && { dir: best.dir, visited };
+}
+
+test("the probe stops on the pick that won, not on the candidate it just saw", () => {
+  // The regression this fold exists for. A `readme.md` does not stop the walk
+  // (it isn't evidence of an app), but it DOES outrank a plain html — so an
+  // `about.html` in the second subfolder is unbeatable-enough to break the loop
+  // while losing to the readme already held. Stopping on the candidate
+  // abandoned the search with the readme, never reaching sub2's index.html.
+  expect(walk(["README.md", "about.html", "index.html"])).toEqual({
+    dir: "sub2",
+    visited: 3,
+  });
+});
+
+test("the probe still stops the moment it holds something unbeatable", () => {
+  // The other half: the early exit is what keeps a folder-of-apps card to ONE
+  // listDir instead of three, which on an rclone/NFS target is the difference
+  // between a card and a stalled mount.
+  expect(walk(["index.html", "preview.png"])).toEqual({ dir: "sub0", visited: 1 });
+  expect(walk(["app.html", "index.html"])).toEqual({ dir: "sub0", visited: 1 });
+  expect(walk([PREVIEW_IMAGE_NAME, "index.html"])).toEqual({ dir: "sub0", visited: 1 });
+  // Nothing stoppable anywhere: the walk runs out, keeping the best it saw.
+  expect(walk(["notes.txt", "data.json", "notes.md"])).toEqual({ dir: "sub2", visited: 3 });
+  expect(walk([])).toBe(null);
+});
+
+test("a probe tie keeps the earlier subfolder", () => {
+  // Subfolders are walked in order, so the first is the folder's own
+  // alphabetical answer — a later equal find must not steal the front sheet.
+  const held: ProbePick = { path: "/w/sub0/notes.md", rank: peekRank("notes.md"), dir: "sub0" };
+  const tie: ProbePick = { path: "/w/sub1/other.md", rank: peekRank("other.md"), dir: "sub1" };
+  expect(foldProbePick(held, tie).best.dir).toBe("sub0");
 });
 
 test("a peeked preview.png is recognised from its full path", () => {

--- a/frontend/src/apps/explorer/lib/folder-peek.test.ts
+++ b/frontend/src/apps/explorer/lib/folder-peek.test.ts
@@ -17,15 +17,30 @@ function f(name: string, is_dir = false): FsEntry {
   return { name, is_dir, size: null, mtime: null };
 }
 
-test("preview.png outranks every extension, index.html included", () => {
+test("the three entry-point names rank first, in order, above every other file", () => {
   // The change this ordering exists for: an html used to win outright, so a
   // fused app folder always showed its page rendered live. An authored
   // screenshot is a deliberate statement about what the folder looks like, and
-  // beats anything derived.
+  // beats anything derived; the two conventional entry-point names follow it,
+  // and only then does anything else get a turn.
   expect(peekRank(PREVIEW_IMAGE_NAME)).toBeLessThan(peekRank("index.html"));
   expect(peekRank("index.html")).toBeLessThan(peekRank("README.md"));
-  expect(peekRank("README.md")).toBeLessThan(peekRank("data.json"));
+  expect(peekRank("README.md")).toBeLessThan(peekRank("about.html"));
+  expect(peekRank("about.html")).toBeLessThan(peekRank("notes.md"));
+  expect(peekRank("notes.md")).toBeLessThan(peekRank("data.json"));
   expect(peekRank("data.json")).toBeLessThan(peekRank("notes.txt"));
+});
+
+test("the entry-point names beat their own extension tier, whatever the case", () => {
+  // The whole point of naming them: alphabetical tie-breaking used to hand the
+  // peek to `about.html` over `index.html` and to `changelog.md` over the
+  // readme — a card showing the folder's least representative page.
+  expect(peekRank("index.html")).toBeLessThan(peekRank("about.html"));
+  expect(peekRank("INDEX.HTML")).toBe(peekRank("index.html"));
+  expect(peekRank("readme.md")).toBeLessThan(peekRank("changelog.md"));
+  expect(peekRank("README.md")).toBe(peekRank("readme.md"));
+  // Only the exact names — a readme in another format is an ordinary .txt.
+  expect(peekRank("readme.txt")).toBe(peekRank("notes.txt"));
 });
 
 test("only that exact name is the authored preview, case included", () => {
@@ -44,15 +59,32 @@ test("the subfolder probe stops at a page, not only at an image", () => {
   // listDir into three — the sequential-listing pattern that stalls mounts.
   expect(peekRankIsUnbeatable(peekRank(PREVIEW_IMAGE_NAME))).toBe(true);
   expect(peekRankIsUnbeatable(peekRank("index.html"))).toBe(true);
+  expect(peekRankIsUnbeatable(peekRank("about.html"))).toBe(true);
+  // A readme outranks a plain html in the PEEK order but must not stop the
+  // probe: a readme in the first subfolder would otherwise hide a real app in
+  // the second. This is why the stop rule is a set and not a `<=` threshold.
   expect(peekRankIsUnbeatable(peekRank("README.md"))).toBe(false);
   expect(peekRankIsUnbeatable(peekRank("notes.txt"))).toBe(false);
 });
 
 test("the peeked child is the best-ranked file, never a directory", () => {
-  const entries = [f("assets", true), f("data.json"), f("index.html"), f("preview.png")];
+  // `about.html` sorts before `index.html`, and `changelog.md` before the
+  // readme — the alphabetical tie-break must not get a say over the names.
+  const entries = [
+    f("assets", true),
+    f("about.html"),
+    f("changelog.md"),
+    f("data.json"),
+    f("index.html"),
+    f("preview.png"),
+    f("README.md"),
+  ];
   expect(bestPeekFile(entries)?.name).toBe("preview.png");
-  expect(bestPeekFile(entries.filter((e) => e.name !== "preview.png"))?.name).toBe(
-    "index.html",
+  const drop = (names: string[]) => entries.filter((e) => !names.includes(e.name));
+  expect(bestPeekFile(drop(["preview.png"]))?.name).toBe("index.html");
+  expect(bestPeekFile(drop(["preview.png", "index.html"]))?.name).toBe("README.md");
+  expect(bestPeekFile(drop(["preview.png", "index.html", "README.md"]))?.name).toBe(
+    "about.html",
   );
   expect(bestPeekFile([f("only-a-folder", true)])).toBe(null);
 });

--- a/frontend/src/apps/explorer/lib/folder-peek.ts
+++ b/frontend/src/apps/explorer/lib/folder-peek.ts
@@ -3,6 +3,10 @@
 // one per card is the whole embed budget — so this ranking decides the single
 // thing a folder shows about itself.
 //
+// The order, best first: `preview.png`, `index.html`, `readme.md`, then any
+// other file by extension tier. Ties break alphabetically, since entries arrive
+// sorted.
+//
 // Pure and DOM-free, in lib/ rather than beside the card component, so the rule
 // can be pinned by a test that imports a function instead of a React tree (the
 // same reason lib/app-button.ts exists).
@@ -23,37 +27,67 @@ import type { FsEntry } from "@platform/lib/api";
 // a file, and would be a poor guess at what the folder is about.
 export const PREVIEW_IMAGE_NAME = "preview.png";
 
-// Peek priority for everything else: an html (the folder is a fused-app — show
-// the app itself) beats an md (the folder's story) beats a json beats anything
-// else.
-const PEEK_EXT_ORDER = ["html", "htm", "md", "markdown", "json"];
+const PREVIEW_RANK = 0;
 
-// The best rank an ordinary page can reach — `preview.png` alone outranks it.
-// Named because the subfolder probe stops here: see `peekRankIsUnbeatable`.
-export const PAGE_RANK = 1;
+// Conventional entry-point names, ranked ABOVE their own extension tier and
+// above every other extension: these three names are the folder introducing
+// itself, and one of them is almost always what an author would have picked by
+// hand. `index.html` first (the folder is a fused-app — show the app itself),
+// then `readme.md` (the folder's story), and only then any other file.
+//
+// Matched case-INSENSITIVELY, unlike `preview.png` above: `README.md` is at
+// least as common as the lowercase spelling, and nothing on the server side
+// depends on this list agreeing byte-for-byte with a directory entry, so the
+// filesystem-parity argument that forces an exact match there does not apply.
+const NAMED_PEEK_ORDER = ["index.html", "index.htm", "readme.md"];
+const NAMED_BASE = PREVIEW_RANK + 1;
+
+// Peek priority for everything not named above: an html beats an md beats a
+// json beats anything else.
+const PEEK_EXT_ORDER = ["html", "htm", "md", "markdown", "json"];
+const PEEK_EXT_BASE = NAMED_BASE + NAMED_PEEK_ORDER.length;
+
+// The best rank an ordinary (non-index) page can reach.
+export const PAGE_RANK = PEEK_EXT_BASE + PEEK_EXT_ORDER.indexOf("html");
 
 export function peekRank(name: string): number {
-  // Rank 0 is reserved for the authored image; the extension tiers start at 1.
-  if (name === PREVIEW_IMAGE_NAME) return 0;
-  const dot = name.lastIndexOf(".");
-  const ext = dot === -1 ? "" : name.slice(dot + 1).toLowerCase();
+  if (name === PREVIEW_IMAGE_NAME) return PREVIEW_RANK;
+  const lower = name.toLowerCase();
+  const named = NAMED_PEEK_ORDER.indexOf(lower);
+  if (named !== -1) return NAMED_BASE + named;
+  const dot = lower.lastIndexOf(".");
+  const ext = dot === -1 ? "" : lower.slice(dot + 1);
   const idx = PEEK_EXT_ORDER.indexOf(ext);
-  return PAGE_RANK + (idx === -1 ? PEEK_EXT_ORDER.length : idx);
+  return PEEK_EXT_BASE + (idx === -1 ? PEEK_EXT_ORDER.length : idx);
 }
+
+// The ranks a probe may stop on: the authored image, an index page, or any
+// other html page — everything that answers "there is a fused app in here".
+//
+// Deliberately NOT a `rank <= PAGE_RANK` threshold, even though that used to be
+// the rule: `readme.md` now outranks a plain html in the peek order, and a
+// threshold would swallow it. A readme in the FIRST subfolder must not stop the
+// probe from finding an actual app in the second — a readme is what a folder
+// says about itself, not evidence of a page worth rendering.
+const STOP_RANKS = new Set([
+  PREVIEW_RANK,
+  ...["index.html", "index.htm"].map(peekRank),
+  ...["html", "htm"].map((e) => PEEK_EXT_BASE + PEEK_EXT_ORDER.indexOf(e)),
+]);
 
 // Whether a probe that found this rank can stop looking. The subfolder probe
 // walks up to APP_PROBE_LIMIT children, each one a `listDir` round trip, and a
 // folder-of-apps card would otherwise always pay for all of them — on an
 // rclone/NFS target that is the sequential-listing pattern that stalls mounts.
 //
-// It stops at a PAGE, not only at rank 0, and that is the point: `.html` used to
-// BE rank 0, so the old `rank === 0` exit fired for the common case; inserting
-// `preview.png` above it silently made the exit unreachable there. What the
-// probe is looking for is "a fused app in here", an html answers that, and the
-// only thing that could outrank one is an authored image in an EARLIER
-// subfolder — which the probe would already have seen, since it walks in order.
+// It stops at a PAGE, not only at the image rank, and that is the point:
+// `.html` used to BE rank 0, so an old `rank === 0` exit fired for the common
+// case; inserting `preview.png` above it silently made the exit unreachable
+// there. The residual imprecision is accepted deliberately: a later subfolder
+// could hold an `index.html` that outranks the plain page we stopped on, and
+// paying two more listings to find it is not worth a stalled mount.
 export function peekRankIsUnbeatable(rank: number): boolean {
-  return rank <= PAGE_RANK;
+  return STOP_RANKS.has(rank);
 }
 
 // The file worth peeking at among a folder's teaser entries: best rank wins;

--- a/frontend/src/apps/explorer/lib/folder-peek.ts
+++ b/frontend/src/apps/explorer/lib/folder-peek.ts
@@ -90,6 +90,35 @@ export function peekRankIsUnbeatable(rank: number): boolean {
   return STOP_RANKS.has(rank);
 }
 
+// One probed subfolder's best file: where it is, how good it is, and which
+// subfolder it came from (that subfolder becomes the card's front sheet).
+export type ProbePick = { path: string; rank: number; dir: string };
+
+// Fold a probed subfolder's find into the running pick, and say whether the
+// walk can stop.
+//
+// The stop test is on the pick that WON, never on the candidate just examined,
+// and the two are not the same question now that a stop rank is a set instead
+// of a threshold. Under the old `rank <= PAGE_RANK` rule they could not
+// diverge: any rank low enough to stop the walk was also low enough to beat
+// whatever was held. With `readme.md` ranked above a plain html but
+// deliberately absent from the stop set, an `about.html` in the second
+// subfolder is good enough to stop the walk yet not good enough to displace a
+// readme from the first — abandoning the search with the readme still held,
+// and an `index.html` in the third subfolder never looked at.
+//
+// Pure and here rather than inline in the effect that calls it, so this rule
+// is pinned by a test instead of by a React tree.
+export function foldProbePick(
+  best: ProbePick | null,
+  candidate: ProbePick,
+): { best: ProbePick; done: boolean } {
+  // Ties keep the incumbent: subfolders are walked in order, so the earlier one
+  // is the folder's own alphabetical answer.
+  const next = !best || candidate.rank < best.rank ? candidate : best;
+  return { best: next, done: peekRankIsUnbeatable(next.rank) };
+}
+
 // The file worth peeking at among a folder's teaser entries: best rank wins;
 // entries arrive alphabetically sorted, so ties keep the first.
 export function bestPeekFile(entries: FsEntry[]): FsEntry | null {


### PR DESCRIPTION
## Summary

- A folder card on the Explorer homepage gets **one** live preview, and its peek ranking was extension-only — so the alphabetical tie-break inside a tier picked the file. `about.html` beat `index.html`; `changelog.md` beat `readme.md`. The card showed the folder's *least* representative page.
- The two conventional entry-point names are now ranked explicitly, above every other file: **`preview.png` → `index.html` → `readme.md` → other html → other md → json → the rest.** Matched case-insensitively, so `README.md` counts.
- `preview.png` stays an exact, case-**sensitive** match. It has to agree byte-for-byte with the server's `app_preview_image` (`fused_render/app_listing.py`), or one folder reports two different thumbnails depending on whether the filesystem folds case.
- The subfolder probe's early-exit test becomes a **set of stop ranks** rather than a `<= PAGE_RANK` threshold — see the diagram; this is the one non-obvious part of the change, and the source of the one bug review caught (below).

## Visuals

Why the probe's stop rule could not stay a threshold. `readme.md` now outranks a plain html in the peek order, so `rank <= PAGE_RANK` would have swallowed it — and a readme in the first probed subfolder would then hide a real app in the second.

```mermaid
flowchart TD
    A[Probe subfolder] --> B[Best file here]
    B --> C{Stop rank?}
    C -->|"preview.png, index page, any html"| D[Peek it, skip 2 listings]
    C -->|"readme.md, everything else"| E[Keep probing]
    E --> A
```

Peek order, best first:

| rank | matches |
|---|---|
| 0 | `preview.png` — exact name, case-sensitive |
| 1–2 | `index.html`, `index.htm` |
| 3 | `readme.md` |
| 4–5 | any other `.html` / `.htm` |
| 6–7 | any other `.md` / `.markdown` |
| 8 | `.json` |
| 9 | everything else |

Ties still break alphabetically, since entries arrive sorted.

### Review fix (4b421acd)

Swapping the threshold for a set broke an invariant the threshold had been holding for free: any rank low enough to *stop* the walk had also been low enough to *beat* whatever the walk was holding. `readme.md` sits above a plain html but outside the stop set, so `about.html` in the second subfolder halted the walk without displacing a readme from the first — and an `index.html` in the third was never looked at.

Both halves of that decision now live in one pure `foldProbePick`, which stops on the **winner** rather than on the candidate just examined.

## Usage

Not user-invocable — no API, flag, or setting. The behavior is visible on the Explorer homepage: a folder card whose folder contains both `index.html` and an alphabetically-earlier html now previews `index.html`; one containing `README.md` and `changelog.md` now previews the readme.

To change the ordering, edit `NAMED_PEEK_ORDER` in `frontend/src/apps/explorer/lib/folder-peek.ts`. Moving `"readme.md"` out of that list drops it back to its extension tier, i.e. below a plain `.html`.

## Test Plan

- [x] `frontend/src/apps/explorer/lib/folder-peek.test.ts` — extended: full best-first ordering chain; named files beating their own extension tier; case-insensitivity (`INDEX.HTML`, `README.md`); `readme.txt` getting no boost; `bestPeekFile` picking the named file over alphabetically-earlier siblings; the probe stop set including plain html but **not** `readme.md`.
- [x] `foldProbePick` tests — the probe walk replayed over subfolder sequences, asserting both the pick and **how many subfolders were visited**: it stops on the winner (`[README.md, about.html, index.html]` → the index, 3 visited), it still exits after one listing when it holds something unbeatable (the mount-stall guard), and a tie keeps the earlier subfolder. Guard verified to bite: the pre-fix loop returns the readme after 2 visits.
- [x] Full frontend suite: `cd frontend && bun test` → 748 pass, 0 fail.
- [x] `cd frontend && bunx tsc --noEmit` → clean.
- [ ] Reviewer check, Explorer homepage: a folder with `about.html` + `index.html` previews `index.html`; a folder with `changelog.md` + `README.md` previews the readme; a folder with an authored `preview.png` still shows the still image, not an embed.

Python is untouched — frontend-only change, so the pytest suite was not run.
