### PR TITLE
Explorer rail: one Home destination, one rail dialect everywhere

### DIFF
--- a/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
+++ b/frontend/src/apps/explorer/sidebar/ExplorerSidebar.tsx
@@ -5,50 +5,25 @@ import { SidebarFrame, NavItem, HOME_ICON } from "@platform/ui/sidebar/SidebarFr
 import type { SidebarRailItem } from "@platform/ui/sidebar/SidebarFrame";
 import { useUrlVersion } from "@platform/lib/hooks";
 import type { Config } from "@platform/lib/api";
-import { loadRecents, displayRecents, setRecentsCollapsed, useRecentsVersion } from "@apps/explorer/lib/recents";
 import BookmarksSection from "./BookmarksSection";
 import RecentsSection from "./RecentsSection";
 
-// Rail glyphs — outline versions of the marks the sections themselves use:
-// RecentsSection's clock and the bookmark rows' star, at the rail's 16px.
-const RECENTS_RAIL_ICON = (
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" aria-hidden="true">
-    <circle cx="8" cy="8" r="6.2" />
-    <path d="M8 4.8V8l2.3 1.6" />
-  </svg>
-);
-const BOOKMARKS_RAIL_ICON = (
-  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinejoin="round" aria-hidden="true">
-    <path d="M12 2.8l2.8 5.7 6.3.9-4.6 4.4 1.1 6.3L12 17.2l-5.6 2.9 1.1-6.3-4.6-4.4 6.3-.9L12 2.8z" />
-  </svg>
-);
+// One rail icon, and it is a DESTINATION like every shell rail icon: Home.
+// The rail briefly carried Recents/Bookmarks icons that expanded the sidebar
+// to their section — a second dialect the shell's rail didn't speak, so what
+// a rail click did depended on the route. Now both sidebars agree: icons
+// navigate and the rail stays collapsed; the chevron alone expands. Home is
+// the row this sidebar pins on top when expanded, so the collapsed strip
+// offers the same first move.
+const RAIL: SidebarRailItem[] = [
+  { key: "home", label: "Home", icon: HOME_ICON, href: "/explorer" },
+];
 
 export default function ExplorerSidebar({ config }: { config: Config }) {
   // Re-render on any nav/url change (active-item highlight).
   useUrlVersion();
-  // The rail mirrors the sections: Recents (which renders null when empty —
-  // so its icon disappears with it) above Bookmarks, the order they hold in
-  // the expanded sidebar.
-  useRecentsVersion();
-  const rail: SidebarRailItem[] = [
-    ...(displayRecents().length
-      ? [
-          {
-            key: "recents",
-            label: "Recents",
-            icon: RECENTS_RAIL_ICON,
-            // The icon promises the section, so a section-collapsed Recents
-            // opens with it — expanding to a hidden list would land nowhere.
-            onExpand: () => {
-              if (loadRecents().collapsed) void setRecentsCollapsed(false);
-            },
-          },
-        ]
-      : []),
-    { key: "bookmarks", label: "Bookmarks", icon: BOOKMARKS_RAIL_ICON },
-  ];
   return (
-    <SidebarFrame title="Explorer" homeHref="/explorer" rail={rail}>
+    <SidebarFrame title="Explorer" homeHref="/explorer" rail={RAIL}>
       <div className="sidebar-section">
         <NavItem href="/explorer" id="explorer-home-link" label="Home" icon={HOME_ICON} />
       </div>

--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -16,24 +16,21 @@ import {
 } from "@platform/lib/sidebarstate";
 import { useSidebarState } from "@platform/lib/hooks";
 
-/** One icon on the collapsed rail. Two dialects, by what the icon stands for:
-    a SECTION of this sidebar (explorer: bookmarks/recents) — click expands
-    the frame and `onExpand` reveals the section; or a DESTINATION (shell: the
-    sub-app list) — `href` set, click navigates and the sidebar STAYS
-    collapsed, expanding only via the chevron. The frame stays ignorant of
-    what the icons mean — owners describe them here. */
+/** One icon on the collapsed rail, and it is always a DESTINATION: click
+    navigates there and the rail STAYS collapsed — only the chevron expands.
+    One dialect on purpose. The explorer's rail briefly spoke a second one
+    (section icons that expanded the frame and revealed Recents/Bookmarks),
+    so what a rail click did depended on the route; every owner's icons now
+    behave like the shell's. The frame stays ignorant of what the icons
+    mean — owners describe them here. */
 export interface SidebarRailItem {
   key: string;
   /** Tooltip + accessible name; the rail shows only the icon. */
   label: string;
   icon: React.ReactNode;
-  /** Destination dialect: navigate here on click, keeping the rail collapsed.
-      Highlights as active on exact pathname match, like NavItem. */
-  href?: string;
-  /** Section dialect: runs after the click expands the frame — the owner's
-      chance to make the promised section actually visible (e.g. un-collapse
-      Recents). Ignored when `href` is set. */
-  onExpand?: () => void;
+  /** Navigate here on click. Highlights as active on exact pathname match,
+      like NavItem. */
+  href: string;
   /** Hairline above this item — a group boundary, mirroring the expanded
       sidebar's headings. */
   dividerBefore?: boolean;
@@ -152,10 +149,8 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
     // a full-height bar whose only content was an arrow). The expand control
     // stays on top — the ONE reopen control, on every route, pinned to the
     // same 24px line the sidebar header and the app bars stand on. Below it,
-    // the owner's section icons (SidebarRailItem): the collapsed state keeps
-    // saying what the sidebar HAS, and clicking an icon is "expand, showing me
-    // that" — the frame expands, then the owner's onExpand makes the section
-    // visible.
+    // the owner's destination icons (SidebarRailItem): clicking one navigates
+    // and the rail stays collapsed — the chevron alone expands.
     //
     // Still the same #sidebar node, so the <=700px media hide applies.
     return (
@@ -177,35 +172,20 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
               <React.Fragment key={item.key}>
                 {item.pinBottom && <span className="sidebar-rail-flex" aria-hidden="true" />}
                 {item.dividerBefore && <span className="sidebar-rail-sep" aria-hidden="true" />}
-                {item.href ? (
-                  <a
-                    href={item.href}
-                    className={
-                      "sidebar-rail-btn" + (location.pathname === item.href ? " active" : "")
-                    }
-                    aria-label={item.label}
-                    title={item.label}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      navigateUrl(item.href!);
-                    }}
-                  >
-                    {item.icon}
-                  </a>
-                ) : (
-                  <button
-                    type="button"
-                    className="sidebar-rail-btn"
-                    aria-label={`Expand sidebar to ${item.label}`}
-                    title={item.label}
-                    onClick={() => {
-                      setSidebarState((s) => ({ ...s, collapsed: false }));
-                      item.onExpand?.();
-                    }}
-                  >
-                    {item.icon}
-                  </button>
-                )}
+                <a
+                  href={item.href}
+                  className={
+                    "sidebar-rail-btn" + (location.pathname === item.href ? " active" : "")
+                  }
+                  aria-label={item.label}
+                  title={item.label}
+                  onClick={(e) => {
+                    e.preventDefault();
+                    navigateUrl(item.href);
+                  }}
+                >
+                  {item.icon}
+                </a>
               </React.Fragment>
             ))}
           </div>


### PR DESCRIPTION
## What

Follow-up to #468, making the two sidebars' collapsed rails consistent:

- The explorer rail's Recents/Bookmarks icons (which expanded the sidebar to their section) are gone — replaced by a single **Home** icon that navigates to `/explorer` with the rail **staying collapsed**, exactly like the shell rail's icons. Only the chevron expands.
- `SidebarRailItem` drops the section (`onExpand`) dialect entirely: `href` is now required and the frame renders every rail icon as a link. One dialect, both sidebars.

## Screenshots

Collapsed explorer rail — chevron, divider, Home:

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-rail-home-assets/railhome-collapsed.png" width="220" alt="Explorer collapsed rail with single Home icon" />

*(Image lives on the throwaway `pr-rail-home-assets` orphan branch — delete after merge.)*

## Testing

- `tsc --noEmit` + boundaries check pass.
- Playwright on the live worktree server: collapsed explorer rail has exactly 2 controls (chevron + Home link), no Recents/Bookmarks icons; clicking Home lands `/explorer` with the rail still 44px (the shell sidebar's Explorer icon shows active there); chevron still expands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only sidebar rail consistency change with no auth, data, or backend impact. Removes a short-lived expand-to-section interaction in favor of navigation.
> 
> **Overview**
> Makes collapsed sidebar rails behave the same everywhere: **icons navigate and stay collapsed**; only the chevron expands.
> 
> Removes the explorer rail's Recents/Bookmarks section icons (which expanded the sidebar) and replaces them with a single **Home** link to `/explorer`.
> 
> `SidebarRailItem` drops the optional `onExpand` dialect — `href` is now required, and the frame always renders rail icons as navigation links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22197f404a59ec9d9971105fe76b4044a1c944bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->