### PR TITLE
Companion sidebar: always-3 dropdown with disabled reasons + annotate the content pane

### DIFF
--- a/frontend/src/apps/explorer/BarMenu.tsx
+++ b/frontend/src/apps/explorer/BarMenu.tsx
@@ -142,6 +142,16 @@ export interface ModeMenuEntry {
   // Condition.py gate not yet resolved (CT-12): listed as a disabled spinner
   // row until the background /api/fs/conditions verdict lands.
   pending?: boolean;
+  // Listed, disabled, and SAYING WHY — the row keeps its icon and its name and
+  // hands this string to the native tooltip. Used by the two COMPANION surfaces
+  // (the file preview's sidebar, the folder listing's pane), whose mode list is
+  // a closed set the user is entitled to see all of even where a member is
+  // unavailable; the reasons themselves are canned in lib/mode-visibility, which
+  // is also where the argument for showing them is written down.
+  //
+  // Not a second spelling of `pending`: pending says "we don't know yet" and
+  // spins, this says "we know, and here is the answer".
+  disabledReason?: string;
 }
 
 interface ModeMenuProps {
@@ -159,10 +169,18 @@ interface ModeMenuProps {
 export function ModeMenu({ entries, active, busy, onSelect }: ModeMenuProps) {
   const { pos, rootRef, toggle, close } = useMenuAnchor();
   const activeEntry = entries.find((e) => e.mode === active) ?? null;
-  // One mode is not a choice — the same rule the icon strips used — unless
+  // One ROW is not a choice — the same rule the icon strips used — unless
   // nothing is active (a caller whose surface can show no mode at all, e.g. the
   // listing pane's self target), where that one entry is the only way to pick
   // anything and the trigger is what offers it.
+  //
+  // Counted over the ROWS, disabled ones included, and that is the rule rather
+  // than an oversight. A companion surface passes its whole closed list — three
+  // rows over every file, some of them disabled placeholders explaining
+  // themselves (see `disabledReason`) — and the menu renders, because those rows
+  // are the answer to "why is there only one thing here?". Hiding a menu whose
+  // only ENABLED row is the active one is what made a file outside a git
+  // repository open with no switcher at all.
   if (!entries.length || (entries.length === 1 && activeEntry)) return null;
 
   const switching = busy !== null && busy !== undefined;
@@ -210,8 +228,14 @@ export function ModeMenu({ entries, active, busy, onSelect }: ModeMenuProps) {
                 (e.mode === activeEntry?.mode ? " active" : "") +
                 (e.pending ? " pending" : "")
               }
-              disabled={e.pending}
-              title={e.pending ? "Checking if this view applies…" : undefined}
+              /* Two ways to be unselectable, one mechanism: the native disabled
+                 button and its native tooltip (`.bar-menu-item:disabled` in
+                 explorer.css dims both alike). The spinner is the PENDING one's
+                 alone — an unavailable row keeps its own icon, because it is not
+                 waiting for anything and a spinner over a settled answer reads
+                 as a menu that never finishes loading. */
+              disabled={e.pending || !!e.disabledReason}
+              title={e.pending ? "Checking if this view applies…" : e.disabledReason}
               onClick={() => {
                 close();
                 onSelect(e.mode);

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -258,21 +258,33 @@ export default function Listing({
   // pane's chat is the FOLDER VIEW's companion, aimed at whichever row is
   // selected, so which chat template to use is a question about the folder too.
   //
-  // A folder outside a repository loses the Git pill, and one on a mount loses
-  // both (each gate refuses a mount-backed path) — at which point the pill hides
-  // itself, "one mode is not a choice", and the pane is what it always was.
+  // A folder outside a repository cannot SHOW Git, and one on a mount can show
+  // neither companion (each gate refuses a mount-backed path) — at which point the
+  // pane's switcher lists them disabled, saying why (pane-side's paneSideMenu),
+  // rather than shrinking to a Preview-only pill and hiding itself.
   const folderClaude = useDirMode(paneEnabled ? fsPath : null, "claude");
   const folderGit = useDirMode(paneEnabled ? fsPath : null, "git");
   // While the probe is in flight the entries are PLACEHOLDERS with no template
   // path (lib/dir-mode), which would build a `path=null` iframe URL — so a
-  // pending companion is simply not offered yet. Unlike the file sidebar there is
-  // nothing to protect by listing it early: the folder's `_side` is never
-  // reconciled away (pane-side's activePaneSide leaves an unavailable request in
-  // the URL on purpose), so a `?_side=git` deep link survives the wait and lands
-  // the moment the verdict does.
+  // pending companion is not SELECTABLE yet. Unlike the file sidebar there is
+  // nothing to protect by treating it as selectable early: the folder's `_side` is
+  // never reconciled away (pane-side's activePaneSide leaves an unavailable
+  // request in the URL on purpose), so a `?_side=git` deep link survives the wait
+  // and lands the moment the verdict does.
+  //
+  // The extra fields ride along for the SWITCHER alone, which has to say more
+  // than "offered": the flags tell "we don't know yet" (spinner) from "not here"
+  // (the disabled reason), and the bindings are where a disabled row gets the
+  // mode's REAL icon — lib/dir-mode keeps a denied entry for exactly that, so the
+  // Git row is the Git glyph dimmed instead of a boxed "G". Nothing else reads
+  // either; what the pane may BE is still `claude`/`git` alone.
   const sideEntries = {
     claude: folderClaude.pending ? null : folderClaude.entry,
     git: folderGit.pending ? null : folderGit.entry,
+    claudePending: folderClaude.pending,
+    gitPending: folderGit.pending,
+    claudeBound: folderClaude.bound,
+    gitBound: folderGit.bound,
   };
   const paneSide = activePaneSide(paneSideList(sideEntries), sideState.mode);
   const paneOpen = pane.on && sideState.open;

--- a/frontend/src/apps/explorer/ListingPreviewPane.tsx
+++ b/frontend/src/apps/explorer/ListingPreviewPane.tsx
@@ -44,7 +44,7 @@ import {
   paneOpenAction,
 } from "@apps/explorer/listing/pane-modes";
 import {
-  paneSideList,
+  paneSideMenu,
   paneSideTarget,
   type PaneSide,
   type PaneSideEntries,
@@ -162,14 +162,19 @@ export default function ListingPreviewPane({
   const { rootRef, guardProps } = usePaneFocusGuard<HTMLDivElement>();
 
   // --- the pane's three modes (listing/pane-side.ts) --------------------------
-  // Which are on offer follows entirely from what the FOLDER gave us: `preview`
-  // always, the companions only where the folder has an entry for them. Nothing
+  // ALL THREE, ALWAYS. Which are SELECTABLE follows entirely from what the FOLDER
+  // gave us — `preview` always, the companions only where the folder has an entry
+  // — and the rest are drawn disabled with the reason (paneSideMenu). Nothing
   // about the selected row enters into it, which is what lets the pill hold still
-  // as the user arrows down the list.
-  const sides = paneSideList(sideEntries);
+  // as the user arrows down the list; and because the row count no longer moves
+  // either, the menu itself stops appearing and disappearing as the user walks
+  // from a repository into a folder outside one.
   const sideMenu = (
     <ModeMenu
-      entries={sides.map((m) => ({ mode: m, icon: paneSideIcon(m, sideEntries) }))}
+      entries={paneSideMenu(sideEntries).map((e) => ({
+        ...e,
+        icon: paneSideIcon(e.mode, sideEntries),
+      }))}
       active={side}
       onSelect={(m) => onSelectSide(m as PaneSide)}
     />

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -494,12 +494,25 @@ function TemplatePreview({
   // stripped before the verdict) but decides nothing — it cannot turn the split
   // on for a file that has no companion of its own, cannot become the toggle's
   // target, and cannot leave a `_side` behind if the verdict is no.
+  //
+  // `bound` is the icon supply for the DISABLED rows, and it is the one place
+  // this component deliberately reaches past `templates` to the raw stat: a
+  // companion whose gate said no was filtered out upstream (Preview's
+  // `visibleModes`), and with it went the icon the switcher still has to draw —
+  // an unavailable Claude is the Claude glyph dimmed, not a boxed "C". The
+  // parent's `git` binding comes the same way from lib/dir-mode, which keeps it
+  // through a denial for exactly this. Icons only: `path` never crosses over
+  // (lib/preview-side), so none of these can become something to frame.
   const split = sideSplit({
     splitCapable,
     content: parts.content,
     own: parts.sidebar,
     borrowed: borrowedGit,
     borrowedPending,
+    bound: [
+      ...partitionModes(stat.templates).sidebar,
+      ...(parentGit.bound ? [parentGit.bound] : []),
+    ],
   });
   const sideOn = split.on;
   // What the CONTENT pane may show, and what the SIDEBAR may show. Unsplit
@@ -510,6 +523,13 @@ function TemplatePreview({
   // the pending entry for the deep link's sake.
   const contentModes = split.offered ? parts.content : templates;
   const sidebarModes = split.offered ? split.all : [];
+  // What the sidebar's switcher DRAWS, which is a longer list than the one above:
+  // all three companions, the ones this file cannot show disabled and explaining
+  // themselves (lib/preview-side). Kept apart from `sidebarModes` on purpose —
+  // every decision below (`sideEntry`, `activeSide`, the toggle, the reconcile)
+  // reads the short list, so a disabled row can be rendered without becoming
+  // something the URL or the split can land on.
+  const sidebarMenu = split.offered ? split.menu : [];
   // Pending, for a SIDEBAR entry. The borrowed `git` entry is gated on the
   // PARENT's verdicts, resolved by lib/dir-mode — not on any of this file's, so
   // it cannot go through `isPending` (which reads `conditions`, this file's map,
@@ -1058,6 +1078,32 @@ function TemplatePreview({
                 key={m}
                 className={"preview-frame" + (m === shown ? " is-shown" : "")}
                 src={srcFor(m) as string}
+                /* The shell's ONE contribution to annotation, and deliberately
+                   the whole of it: the claude sidebar looks this attribute up
+                   through `parent.document` and treats the frame it marks as the
+                   document its notes point at — see
+                   fused_render/templates/claude/template.html (the annotate
+                   target seam). Nothing here knows what annotation is, and the
+                   template stays host-agnostic: no mark, no annotate switch.
+
+                   The contract is "exactly one, and it is the content the reader
+                   is looking at". So it rides `shown` and not `activeMode`: the
+                   swap above keeps BOTH frames mounted while the incoming
+                   document loads, and only the shown one is on screen (the other
+                   is transparent and un-clickable), so marking the active mode
+                   mid-swap would aim the pins at a frame nobody can see. `shown`
+                   catches up the moment that frame paints.
+
+                   `splitCapable` is what keeps it to the single-file explorer
+                   preview: a folder renders <Listing> and never reaches this
+                   branch, and a panel/tab embed has no sidebar to answer the
+                   mark. When no content pane shows at all — a listing, a pending
+                   gate, the fallback card — no frame renders and the mark is
+                   simply absent, which is exactly how the template is told
+                   there is nothing to annotate. */
+                data-fused-annotate-target={
+                  splitCapable && m === shown ? "" : undefined
+                }
                 onLoad={(e) => {
                   // Completes the swap: the incoming document has painted, so
                   // it can take over from the frame being held. Recorded so a
@@ -1117,10 +1163,11 @@ function TemplatePreview({
         sideSlot &&
         createPortal(
           <PreviewSidebar
-            entries={sidebarModes.map((t) => ({
+            entries={sidebarMenu.map((t) => ({
               mode: t.mode,
               icon: templateModeIcon(t),
               pending: isSidePending(t),
+              disabledReason: t.disabledReason,
             }))}
             active={activeSide}
             src={sideEntry && isSidePending(sideEntry) ? null : sideSrcFor(activeSide)}

--- a/frontend/src/apps/explorer/PreviewSidebar.tsx
+++ b/frontend/src/apps/explorer/PreviewSidebar.tsx
@@ -99,6 +99,10 @@ export interface SidebarEntry {
   icon: ReactNode;
   // Condition.py gate not yet resolved (CT-12) — listed, not selectable.
   pending?: boolean;
+  // This file cannot show the companion, and this is why (mode-visibility's
+  // canned reasons). Listed, disabled, tooltipped — never selectable, and never
+  // the `active` one.
+  disabledReason?: string;
 }
 
 export default function PreviewSidebar({
@@ -108,9 +112,11 @@ export default function PreviewSidebar({
   onSelect,
   onClose,
 }: {
-  // The visible sidebar modes for this file, registry order.
+  // The switcher's whole list: every companion, in SIDEBAR_MODES order, the ones
+  // this file cannot show disabled and carrying their reason.
   entries: SidebarEntry[];
-  // The one being shown (always present in `entries`).
+  // The one being shown — always one of the SELECTABLE entries, never a disabled
+  // placeholder (Preview resolves `_side` against the short list; lib/preview-side).
   active: string;
   // Its /render URL, or null while its gate is still resolving.
   src: string | null;
@@ -178,8 +184,6 @@ export default function PreviewSidebar({
     divider.addEventListener("pointercancel", onUp);
   };
 
-  const activeEntry = entries.find((e) => e.mode === active) ?? null;
-
   return (
     <>
       <div
@@ -199,22 +203,20 @@ export default function PreviewSidebar({
               while it is up, the only one — the title bar's opener is not
               rendered. The listing pane's header opens with the same button. */}
           <SideCloseButton what={modeTitle(active)} onClick={onClose} />
-          {/* The shared mode control, over this file's companions, at the strip's
-              far end (the tail's auto margin packs it there — .side-header-tail,
-              the same wrapper the listing pane's header uses). It hides itself at
-              one entry ("one mode is not a choice", BarMenu) — which would leave
-              this strip a lone chevron over an unlabelled document, so the
-              single-entry case renders the name flat instead of as a menu. Same
-              icon, same words, nothing to click. */}
+          {/* The shared mode control, over the companions, at the strip's far end
+              (the tail's auto margin packs it there — .side-header-tail, the same
+              wrapper the listing pane's header uses).
+
+              ALWAYS a menu now. This used to fall back to a flat, unclickable
+              label whenever `entries` was down to one, because BarMenu hides a
+              one-row menu and the strip would otherwise have been a lone chevron
+              over an unlabelled document. The list no longer shrinks: `entries`
+              is all three companions on every file, the unavailable ones disabled
+              and carrying the reason (lib/preview-side's `menu`), so there is
+              always a menu to draw and always more in it than the mode you are
+              looking at. */}
           <div className="side-header-tail">
-            {entries.length > 1 ? (
-              <ModeMenu entries={entries} active={active} onSelect={onSelect} />
-            ) : (
-              <span className="preview-side-name">
-                <span className="mode-menu-icon">{activeEntry?.icon}</span>
-                {modeTitle(active)}
-              </span>
-            )}
+            <ModeMenu entries={entries} active={active} onSelect={onSelect} />
           </div>
         </div>
         {src === null ? (

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -26,7 +26,11 @@
 // any moment, and each sits where its own action makes sense.
 import type { ReactNode } from "react";
 import { templateModeIcon } from "@apps/explorer/ModeSwitcher";
-import type { PaneSide, PaneSideEntries } from "@apps/explorer/listing/pane-side";
+import {
+  paneSideIconEntry,
+  type PaneSide,
+  type PaneSideEntries,
+} from "@apps/explorer/listing/pane-side";
 
 function CloseChevron() {
   return (
@@ -116,11 +120,22 @@ const PREVIEW_SIDE_ICON = (
 // Icon for one of the folder pane's three modes. `claude` and `git` are real
 // templates borrowed from the folder (lib/dir-mode), so they get their registry
 // icon exactly as they do on every other mode surface; `preview` gets the baked
-// one above. Null entries never reach here — a mode with no entry is not offered
-// (pane-side's paneSideList) — but the fallback is the placeholder box
-// templateModeIcon draws for an icon-less template rather than a hole in the bar.
+// one above.
+//
+// An UNOFFERED mode is now an ordinary case rather than an impossible one: the
+// switcher lists all three and disables the ones the folder cannot show
+// (pane-side's paneSideMenu), so a folder outside a repository draws a Git row
+// with no framable entry behind it. It still wears the GIT ICON — a disabled row
+// is the mode with the click taken away, and the glyph is the last thing that may
+// change — which is what `paneSideIconEntry` is for: the offered entry, else the
+// binding the stat reported before the gate refused it (lib/dir-mode's `bound`).
+//
+// Only a mode bound NOWHERE falls through to templateModeIcon's letter box, since
+// then no real glyph exists to draw. It must never fall back to the PREVIEW
+// glyph, which this briefly did: two rows wearing one icon in a three-row menu
+// reads as a duplicate entry rather than as an unavailable one.
 export function paneSideIcon(side: PaneSide, entries: PaneSideEntries): ReactNode {
   if (side === "preview") return PREVIEW_SIDE_ICON;
-  const entry = side === "claude" ? entries.claude : entries.git;
-  return entry ? templateModeIcon(entry) : PREVIEW_SIDE_ICON;
+  const entry = paneSideIconEntry(side, entries);
+  return templateModeIcon(entry ?? { mode: side, path: null, icon: null });
 }

--- a/frontend/src/apps/explorer/lib/dir-mode.ts
+++ b/frontend/src/apps/explorer/lib/dir-mode.ts
@@ -90,6 +90,21 @@ export interface DirMode {
   // when the directory does not offer the mode at all — an unknown mode, an
   // explicit gate denial, or a probe that failed outright.
   entry: TemplateEntry | null;
+  // The directory's entry as the STAT reported it, gate verdict or not: non-null
+  // whenever the registry binds the mode here, including when the gate went on to
+  // deny it. `entry` is what may be FRAMED; this is what the mode IS.
+  //
+  // It exists for one job, and the job earns the extra field: the companion
+  // switchers list a mode they cannot show as a DISABLED row (lib/preview-side,
+  // listing/pane-side), and a disabled row has to wear the mode's real icon —
+  // "the same thing, switched off" rather than a different-looking thing. Read
+  // off `entry`, those rows fell through to templateModeIcon's last-resort letter
+  // box, so the Git row was the Git logo inside a repository and a boxed "G" one
+  // folder outside it.
+  //
+  // Null while `pending` (the stat has not answered, so there is nothing to know
+  // yet), and null when the directory does not bind the mode at all.
+  bound: TemplateEntry | null;
   // The probe is still in flight.
   //
   // Callers list the placeholder as a PENDING switcher entry rather than waiting
@@ -101,11 +116,12 @@ export interface DirMode {
 }
 
 // Shared, so a caller that re-renders without changing directory does not get a
-// fresh object and a pointless commit.
-const ABSENT: DirMode = { entry: null, pending: false };
+// fresh object and a pointless commit. Used for every "nothing here" answer that
+// carries no binding either: no directory to ask, and a probe that failed.
+const ABSENT: DirMode = { entry: null, bound: null, pending: false };
 
 function placeholderFor(mode: string): DirMode {
-  return { entry: { mode, path: null, icon: null }, pending: true };
+  return { entry: { mode, path: null, icon: null }, bound: null, pending: true };
 }
 
 // `dir === null` switches the whole thing off and makes no request — how callers
@@ -125,9 +141,15 @@ export function useDirMode(dir: string | null, mode: string): DirMode {
     loadDirModes(dir).then(
       (r) => {
         if (!alive) return;
-        const entry = r.templates.find((e) => e.mode === mode) ?? null;
+        // The binding is what the stat says; `entry` is that binding only if the
+        // gate also allows it. A DENIED mode therefore settles as
+        // `{ entry: null, bound: <the entry> }` — not offered, but still known,
+        // which is what lets a disabled switcher row wear its real icon.
+        const bound = r.templates.find((e) => e.mode === mode) ?? null;
         setState(
-          entry && isModeVisible(entry, r.conditions) ? { entry, pending: false } : ABSENT
+          bound && isModeVisible(bound, r.conditions)
+            ? { entry: bound, bound, pending: false }
+            : { entry: null, bound, pending: false }
         );
       },
       () => {

--- a/frontend/src/apps/explorer/lib/preview-side.test.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.test.ts
@@ -5,14 +5,25 @@ import {
   initialSide,
   sideToggleTarget,
   reconcileSideSearch,
+  type SideEntry,
   type SideSplitInput,
 } from "@apps/explorer/lib/preview-side";
 
+// The canned reasons, spelled out here rather than imported: they are COPY the
+// user reads, so a test that re-derives them from the same constant would agree
+// with any rewording, silently, including a bad one.
+const NO_REPO = "Not inside a git repository";
+const NO_HISTORY = "No history for this file";
+const NO_CLAUDE = "Claude is not available for this file";
+
+// A registered template, icon and all — the icon matters here because a disabled
+// switcher row has to be able to find it.
 const t = (mode: string): TemplateEntry => ({
   mode,
   path: `/tpl/${mode}/template.html`,
-  icon: null,
+  icon: `/tpl/${mode}/icon.svg`,
 });
+const iconOf = (mode: string) => `/tpl/${mode}/icon.svg`;
 
 // What lib/dir-mode hands over while the parent's stat + gate are still in
 // flight: the mode name and nothing else.
@@ -24,6 +35,9 @@ const claude = t("claude");
 const history = t("history");
 
 const names = (entries: TemplateEntry[]) => entries.map((e) => e.mode);
+// A switcher row as the header describes it: the mode, and the reason it is
+// disabled if it is one of the placeholders.
+const rows = (entries: SideEntry[]) => entries.map((e) => [e.mode, e.disabledReason ?? null]);
 
 // The three states of the borrowed entry, over a file that has some content
 // template (an image, a table, its source) and whatever companions of its own.
@@ -64,6 +78,16 @@ describe("sideSplit", () => {
     expect(names(s.all)).toEqual([]);
   });
 
+  // The gate-denied `git` of a file whose parent IS a repository but whose gate
+  // refused it (a mount) is the same input as an absent one: dir-mode resolves an
+  // explicit denial to a null entry, and from the user's side "denied" and "never
+  // bound" are one fact — see mode-visibility's canned reasons.
+  it("does not confuse a denied companion with a settled one", () => {
+    const s = sideSplit(file([claude], "no"));
+    expect(names(s.settled)).toEqual(["claude"]);
+    expect(names(s.all)).toEqual(["claude"]);
+  });
+
   // A file with a companion of its OWN splits from the first paint, verdict or
   // not — the pending placeholder rides along in `all` without deciding anything.
   it("splits on the file's own companions while the borrowed one is pending", () => {
@@ -92,6 +116,123 @@ describe("sideSplit", () => {
     const s = sideSplit({ ...file([claude], "yes"), splitCapable: false });
     expect(s.on).toBe(false);
     expect(s.offered).toBe(false);
+  });
+});
+
+// THE SWITCHER'S ROWS: always three, the unavailable ones explaining themselves.
+describe("sideSplit's menu", () => {
+  it("lists every companion over a file that has none of them", () => {
+    // A .pdf outside a repository: nothing is on offer, and the menu says so
+    // three times instead of collapsing to a control that isn't there.
+    expect(rows(sideSplit(file([], "no")).menu)).toEqual([
+      ["claude", NO_CLAUDE],
+      ["git", NO_REPO],
+      ["history", NO_HISTORY],
+    ]);
+  });
+
+  it("explains only the ones that are missing", () => {
+    expect(rows(sideSplit(file([claude], "yes")).menu)).toEqual([
+      ["claude", null],
+      ["git", null],
+      ["history", NO_HISTORY],
+    ]);
+  });
+
+  // A denied borrowed git is a listed, disabled Git row — the finding this
+  // whole list exists for: the file used to show "Claude" alone, and a menu of
+  // one hid itself, so there was no switcher at all.
+  it("keeps a denied borrowed git on the list, disabled", () => {
+    const menu = sideSplit(file([claude, history], "no")).menu;
+    expect(rows(menu)).toEqual([
+      ["claude", null],
+      ["git", NO_REPO],
+      ["history", null],
+    ]);
+    // A placeholder is a row, not a template: nothing to frame.
+    expect(menu.find((e) => e.mode === "git")!.path).toBe(null);
+  });
+
+  // Undecided is not the same as unavailable, and must not be reported as it:
+  // the entry stays REAL (the caller draws CT-12's spinner) until the verdict.
+  it("leaves a pending borrowed git unexplained", () => {
+    const menu = sideSplit(file([claude], "pending")).menu;
+    expect(rows(menu)).toEqual([
+      ["claude", null],
+      ["git", null],
+      ["history", NO_HISTORY],
+    ]);
+    expect(menu.find((e) => e.mode === "git")).toBe(GIT_PLACEHOLDER);
+  });
+
+  // The rows are for DRAWING. Every decision keeps reading the short lists, which
+  // is the whole reason `menu` is a third list rather than a flag on `all`.
+  it("decides nothing", () => {
+    const s = sideSplit(file([], "no"));
+    expect(s.menu.length).toBe(3);
+    expect(s.on).toBe(false);
+    expect(s.offered).toBe(false);
+    expect(names(s.settled)).toEqual([]);
+    expect(names(s.all)).toEqual([]);
+    // ...not a toggle target, and not a `_side` the URL may hold.
+    expect(sideToggleTarget(s.settled, null, null)).toBe(null);
+    expect(initialSide("?_side=git", s)).toBe(null);
+    expect(initialSide("?_side=claude", s)).toBe(null);
+  });
+
+  // A DISABLED ROW IS THE MODE WITH THE CLICK TAKEN AWAY, so it keeps the mode's
+  // own glyph. It shipped without this and the screenshot said it plainly: the
+  // sidebar drew Claude's real icon beside a boxed "G" and a boxed "H", which
+  // reads as two unknown modes rather than as two unavailable familiar ones.
+  it("dresses a disabled row in the mode's real icon", () => {
+    // The file BINDS claude and history — the gate is what denied them, and the
+    // filter that dropped them took the icons with it (Preview re-supplies them
+    // from the raw stat).
+    const s = sideSplit({ ...file([], "no"), bound: [claude, history, GIT] });
+    expect(s.menu.map((e) => [e.mode, e.icon])).toEqual([
+      ["claude", iconOf("claude")],
+      ["git", iconOf("git")],
+      ["history", iconOf("history")],
+    ]);
+    // ...and they are still disabled rows, not entries: no path, and the reason
+    // is what makes them unselectable.
+    expect(rows(s.menu)).toEqual([
+      ["claude", NO_CLAUDE],
+      ["git", NO_REPO],
+      ["history", NO_HISTORY],
+    ]);
+    expect(s.menu.every((e) => e.path === null)).toBe(true);
+  });
+
+  it("takes a denied borrowed git's icon from the parent's binding", () => {
+    // dir-mode keeps the parent's entry through the denial for exactly this: the
+    // folder is not a repository, so there is nothing to FRAME, but the mode is
+    // bound one level up and its glyph exists.
+    const s = sideSplit({ ...file([claude], "no"), bound: [claude, GIT] });
+    expect(s.menu.find((e) => e.mode === "git")!.icon).toBe(iconOf("git"));
+    // The real entries are untouched — same objects, not rebuilt copies.
+    expect(s.menu.find((e) => e.mode === "claude")).toBe(claude);
+  });
+
+  it("falls back to no icon only where the mode is bound nowhere", () => {
+    // Nothing registers `history` for this file type anywhere, so there is no
+    // real glyph in existence; the caller draws its last-resort letter box.
+    const s = sideSplit({ ...file([claude], "yes"), bound: [claude, GIT] });
+    expect(s.menu.find((e) => e.mode === "history")!.icon).toBe(null);
+  });
+
+  // A user registry may bind a companion of its own into this half. It has no
+  // canned reason and no rank, so it lands after the three rather than being
+  // dropped from the rows the way an unknown mode is dropped from the order.
+  it("keeps an unknown companion at the end", () => {
+    const notes = t("notes");
+    const s = sideSplit({ ...file([claude], "yes"), own: [claude, notes] });
+    expect(rows(s.menu)).toEqual([
+      ["claude", null],
+      ["git", null],
+      ["history", NO_HISTORY],
+      ["notes", null],
+    ]);
   });
 });
 
@@ -273,6 +414,9 @@ describe("a companion-less file in a folder with no working tree", () => {
     ).toBe(null);
     // The verdict lands: the entry is gone, so the active side is gone...
     expect(denied.all.some((e) => e.mode === "git")).toBe(false);
+    // ...while the ROW stays, now saying why, which is the one thing that
+    // changed: the user sees an explanation where the switcher used to shrink.
+    expect(denied.menu.find((e) => e.mode === "git")?.disabledReason).toBe(NO_REPO);
     // ...and the param goes with it rather than into the session sidecar.
     expect(
       reconcileSideSearch("?_side=git", {

--- a/frontend/src/apps/explorer/lib/preview-side.ts
+++ b/frontend/src/apps/explorer/lib/preview-side.ts
@@ -37,8 +37,32 @@
 // either way, so the only question open is whether it is allowed; treating it as
 // unsettled would move it between the content menu and the sidebar as the verdict
 // landed, which is a worse flash than the one this module removes.
+//
+// THE THIRD LIST, `menu`, and why it is not either of the two above: what the
+// SWITCHER shows is now ALL THREE COMPANIONS, ALWAYS — the ones this file has not
+// got listed as disabled rows carrying the reason why (mode-visibility's
+// `unavailableReason`, where the argument for saying it out loud is written down).
+// So the sidebar's header reads the same over every file, and a file outside a
+// repository gets a Git row that explains itself instead of a switcher that
+// quietly shrank — or, at one entry, disappeared.
+//
+// A disabled row is a LABEL, not a mode, and none of the rules above may see it:
+// it does not turn the split `on`, it is not `settled`, it never becomes the
+// toggle's target, and `initialSide`/`reconcileSideSearch` resolve a `?_side`
+// naming it exactly as they resolve one naming a mode nobody has ever heard of —
+// away. Hence three lists rather than a flag on one: `menu` is for drawing,
+// `all` is what a `_side` may name, `settled` is what actually exists. Feeding
+// the drawing list to any of the decisions would put a file back on a Git view
+// its folder cannot produce, which is the failure `on` vs `offered` exists to
+// prevent, arrived at from the other direction.
 import type { TemplateEntry } from "@platform/lib/api";
-import { defaultSidebarMode, isSidebarMode, orderSidebarModes } from "@platform/lib/mode-visibility";
+import {
+  SIDEBAR_MODES,
+  defaultSidebarMode,
+  isSidebarMode,
+  orderSidebarModes,
+  unavailableReason,
+} from "@platform/lib/mode-visibility";
 
 export interface SideSplitInput {
   // Whether this surface splits at all (a single file on the explorer route, in
@@ -52,11 +76,40 @@ export interface SideSplitInput {
   // because the file has a `git` of its own).
   borrowed: TemplateEntry | null;
   borrowedPending: boolean;
+  // Every companion that EXISTS AS A BINDING, whether or not it may be shown: the
+  // file's own sidebar templates BEFORE the visibility filter, plus the parent's
+  // `git` however its gate voted (lib/dir-mode's `bound`). Order and duplicates
+  // are irrelevant — exactly one field is ever read off these.
+  //
+  // That field is the ICON, and it is the whole reason the input exists. A
+  // disabled row is the same mode with the click taken away — same glyph, same
+  // name, dimmed — and building it from nothing gave it templateModeIcon's
+  // last-resort letter box instead: Git was the Git logo inside a repository and a
+  // boxed "G" one folder outside it. Two glyphs for one mode reads as two
+  // different modes, which is the one thing a disabled row must not do.
+  //
+  // Optional because a surface that never draws the menu (anything with
+  // `splitCapable` false) has no icons to look up.
+  bound?: TemplateEntry[];
+}
+
+// A switcher row. A real companion is its TemplateEntry unchanged; a companion
+// this file cannot show is a placeholder carrying the reason it is disabled, and
+// its icon if the mode is bound anywhere. The two are told apart by
+// `disabledReason` alone, so a consumer that only draws rows needs to know
+// nothing else — and `path` stays null on a placeholder, so nothing can build a
+// render URL out of one by mistake.
+export interface SideEntry extends TemplateEntry {
+  disabledReason?: string;
 }
 
 export interface SideSplit {
-  // The sidebar switcher's list, in SIDEBAR_MODES order, pending placeholder
-  // included.
+  // What the switcher DRAWS: every companion in SIDEBAR_MODES, always, with the
+  // unavailable ones disabled and explained. Nothing decides anything from this
+  // list — see the header.
+  menu: SideEntry[];
+  // The companions a `_side` may NAME: the real entries plus a still-pending
+  // borrowed placeholder, in SIDEBAR_MODES order. Not what the switcher shows.
   all: TemplateEntry[];
   // Those known to exist — `all` minus a still-pending borrowed entry.
   settled: TemplateEntry[];
@@ -64,6 +117,39 @@ export interface SideSplit {
   on: boolean;
   // Something may yet land in the sidebar, so a `_side` naming it is tolerated.
   offered: boolean;
+}
+
+// The switcher's rows: the closed list of companions, each one either the real
+// entry or a disabled placeholder. A PENDING borrowed entry is a real entry here
+// and NOT a disabled one — its probe has not answered, so "not inside a git
+// repository" would be a claim rather than a report; the caller renders it as the
+// spinner row CT-12 already defines and it either becomes selectable or becomes
+// disabled when the verdict lands.
+//
+// A disabled row wears the mode's OWN icon wherever the mode is bound at all —
+// `bound` above says where those come from and why it matters. The letter box
+// templateModeIcon falls back to is reached only by a mode NOTHING binds (a file
+// type with no `history` template registered anywhere), where there is no real
+// glyph in existence to use.
+//
+// The trailing loop is for a companion that is NOT one of SIDEBAR_MODES — a user
+// registry binding one of its own into this half. It has no canned reason and no
+// fixed rank, so it keeps its place at the end, which is where orderSidebarModes
+// puts it too.
+function sidebarMenu(all: TemplateEntry[], bound: TemplateEntry[]): SideEntry[] {
+  const menu: SideEntry[] = (SIDEBAR_MODES as readonly string[]).map(
+    (mode) =>
+      all.find((e) => e.mode === mode) ?? {
+        mode,
+        // A placeholder is a row, never a template: no path, so no URL can be
+        // built from it even by accident.
+        path: null,
+        icon: bound.find((e) => e.mode === mode)?.icon ?? null,
+        disabledReason: unavailableReason(mode),
+      }
+  );
+  for (const e of all) if (!isSidebarMode(e.mode)) menu.push(e);
+  return menu;
 }
 
 export function sideSplit(i: SideSplitInput): SideSplit {
@@ -74,6 +160,7 @@ export function sideSplit(i: SideSplitInput): SideSplit {
   // renders as it did before the split existed: chat, full width, content mode.
   const splittable = i.splitCapable && i.content.length > 0;
   return {
+    menu: sidebarMenu(all, i.bound ?? []),
     all,
     settled,
     on: splittable && settled.length > 0,
@@ -83,7 +170,11 @@ export function sideSplit(i: SideSplitInput): SideSplit {
 
 // `_side` as read at MOUNT, exactly like `_mode`, so a bookmark or a shared link
 // restores the split. Resolved against `all` (see the header) so a `?_side=git`
-// deep link survives until the borrowed probe answers.
+// deep link survives until the borrowed probe answers — and, for the same reason
+// stated the other way round, so a `?_side=git` on a file whose Git row is the
+// DISABLED placeholder resolves to null. The row is in `menu`, not in `all`; a
+// deep link to it is a deep link to an explanation, and is dropped exactly like
+// a `_side` naming a mode that does not exist.
 //
 // LEGACY DEEP LINKS are the second branch. `?_mode=claude` is what every
 // bookmark, recent, saved session and shared URL from before the split says, and
@@ -130,7 +221,10 @@ export function sideToggleTarget(
 //   2. a `_side` this file cannot honour: a param carried in from another view
 //      (the folder pane writes `_side` too), or one whose gate has just DENIED
 //      the mode. It goes, rather than sitting in the URL for a session sidecar to
-//      record and replay on the next bare open (lib/session).
+//      record and replay on the next bare open (lib/session). The denied mode is
+//      still LISTED — as the disabled row that says why (see the header) — and
+//      that changes nothing here: a row the user cannot select is not a state the
+//      URL is allowed to hold.
 //   3. write `_side` when state moved without the user's click.
 //
 // A still-PENDING borrowed entry is neither honoured nor stripped: `activeSide`

--- a/frontend/src/apps/explorer/listing/pane-side.test.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.test.ts
@@ -6,7 +6,9 @@ import {
   PANE_SIDE_OFF,
   activePaneSide,
   paneKey,
+  paneSideIconEntry,
   paneSideList,
+  paneSideMenu,
   paneSideParam,
   paneSideTarget,
   parsePaneSide,
@@ -89,8 +91,9 @@ describe("paneSideParam", () => {
 // identity, and a row with no template at all still has the metadata card.
 describe("paneSideList", () => {
   test("a folder with neither companion offers Preview alone", () => {
-    // A mount-backed folder: both gates refuse a mount, so the pill hides itself
-    // and the pane is what it was before the split.
+    // A mount-backed folder: both gates refuse a mount, so the pane can only ever
+    // BE Preview. The switcher still lists all three (paneSideMenu) — this list
+    // is what the pane may show, not what the header contains.
     expect(paneSideList(NONE)).toEqual(["preview"]);
   });
 
@@ -103,6 +106,107 @@ describe("paneSideList", () => {
       "preview",
       "claude",
     ]);
+  });
+});
+
+// WHAT THE SWITCHER DRAWS, which is all three whatever the folder offers — the
+// folder half of the file sidebar's rule. An unofferable mode is a disabled row
+// carrying its reason, so the header holds still as the user walks from a
+// repository into a folder outside one instead of shedding pills (and, at one
+// pill, hiding the control altogether).
+describe("paneSideMenu", () => {
+  // Copy the user reads, so it is written out here rather than re-derived from
+  // the constant it is testing.
+  const NO_REPO = "Not inside a git repository";
+  const NO_CLAUDE = "Claude is not available for this file";
+  const rows = (e: Parameters<typeof paneSideMenu>[0]) =>
+    paneSideMenu(e).map((r) => [r.mode, r.disabledReason ?? (r.pending ? "…" : null)]);
+
+  test("a folder in a repository offers all three, none explained", () => {
+    expect(rows(BOTH)).toEqual([
+      ["preview", null],
+      ["claude", null],
+      ["git", null],
+    ]);
+  });
+
+  test("a folder outside a repository keeps Git, disabled and explained", () => {
+    expect(rows({ claude: entry("claude"), git: null })).toEqual([
+      ["preview", null],
+      ["claude", null],
+      ["git", NO_REPO],
+    ]);
+  });
+
+  test("a mount-backed folder still gets a switcher", () => {
+    // Both gates refuse a mount. This used to be a one-pill menu, which hid
+    // itself, leaving the pane header a lone chevron.
+    expect(rows(NONE)).toEqual([
+      ["preview", null],
+      ["claude", NO_CLAUDE],
+      ["git", NO_REPO],
+    ]);
+  });
+
+  test("an undecided probe spins rather than claiming a reason", () => {
+    // "Not inside a git repository" before anyone has looked is a guess, and one
+    // that flips to a working Git pill a moment later.
+    expect(rows({ claude: null, git: null, claudePending: true, gitPending: true })).toEqual([
+      ["preview", null],
+      ["claude", "…"],
+      ["git", "…"],
+    ]);
+    // The two probes land independently: a settled denial beside an open probe
+    // is the usual frame, and each row says only what is known of IT.
+    expect(rows({ claude: null, git: null, gitPending: true })).toEqual([
+      ["preview", null],
+      ["claude", NO_CLAUDE],
+      ["git", "…"],
+    ]);
+  });
+
+  test("Preview is never explained away", () => {
+    // It is the pane's identity — it cannot be unavailable, so it never carries
+    // a reason and is always selectable.
+    for (const e of [NONE, BOTH, { claude: null, git: null, gitPending: true }])
+      expect(paneSideMenu(e)[0]).toEqual({ mode: "preview" });
+  });
+
+  test("the rows decide nothing", () => {
+    // What the pane may BE is still paneSideList's answer: a disabled row must
+    // not become a mode the pane can land on.
+    const outside = { claude: entry("claude"), git: null };
+    expect(paneSideMenu(outside).length).toBe(3);
+    expect(paneSideList(outside)).toEqual(["preview", "claude"]);
+    expect(activePaneSide(paneSideList(outside), "git")).toBe("preview");
+  });
+});
+
+// WHERE A ROW'S ICON COMES FROM. A disabled row is the mode with the click taken
+// away, so it wears the mode's own glyph — never a generic one, and never
+// Preview's (two identical icons in a three-row menu read as a duplicate entry).
+describe("paneSideIconEntry", () => {
+  const git = entry("git");
+
+  test("an offered mode uses its own entry", () => {
+    expect(paneSideIconEntry("git", BOTH)).toBe(BOTH.git);
+    expect(paneSideIconEntry("claude", BOTH)).toBe(BOTH.claude);
+  });
+
+  test("a disabled mode falls back to the binding the gate refused", () => {
+    // A folder outside a repository: nothing to frame, but `git` is bound and its
+    // icon exists — dir-mode keeps the entry through the denial for this.
+    expect(paneSideIconEntry("git", { claude: null, git: null, gitBound: git })).toBe(git);
+  });
+
+  test("a mode bound nowhere has no icon to offer", () => {
+    // The caller's last resort, and only here.
+    expect(paneSideIconEntry("git", NONE)).toBe(null);
+    expect(paneSideIconEntry("claude", NONE)).toBe(null);
+  });
+
+  test("the offered entry always outranks the binding", () => {
+    expect(paneSideIconEntry("git", { claude: null, git, gitBound: entry("stale") })).toBe(git);
   });
 });
 

--- a/frontend/src/apps/explorer/listing/pane-side.ts
+++ b/frontend/src/apps/explorer/listing/pane-side.ts
@@ -29,6 +29,7 @@
 // a NON-DEFAULT content template for a previewed row inside the pane; the
 // expand button opens the row full-screen, where the content switcher lives.
 import type { TemplateEntry } from "@platform/lib/api";
+import { unavailableReason } from "@platform/lib/mode-visibility";
 
 export const PANE_SIDE_MODES = ["preview", "claude", "git"] as const;
 
@@ -94,10 +95,14 @@ export function paneSideParam(state: PaneSideState): string | null {
 // Which of the three a folder actually offers. `preview` ALWAYS — it is the
 // pane's identity, and even a row with no template at all has a preview state
 // (the metadata card). The other two exist only while the folder's own entry for
-// them does (dir-mode.ts), so a folder outside a repository has no Git pill and a
-// mount-backed folder — where both gates refuse — has only Preview, at which
-// point the shared ModeMenu hides itself ("one mode is not a choice", BarMenu)
-// and the header is a chevron over the pane, exactly as it was before the split.
+// them does (dir-mode.ts), so a folder outside a repository can be SHOWN no Git
+// and a mount-backed folder — where both gates refuse — can be shown neither
+// companion.
+//
+// What the switcher DRAWS is a different question and `paneSideMenu` below
+// answers it: an unofferable mode is listed as a disabled row rather than
+// dropped, so this list is what the pane may be ON, never what the header
+// contains.
 //
 // Order is by construction, not by sorting: this list IS the switcher's order.
 export interface PaneSideEntries {
@@ -106,6 +111,19 @@ export interface PaneSideEntries {
   // own default template, resolved from the row's stat by pane-modes.ts.
   claude: TemplateEntry | null;
   git: TemplateEntry | null;
+  // The dir-mode probe behind that null has not answered yet (Listing passes the
+  // flag alongside; the entry stays null because a placeholder has no template
+  // path to frame). Only the MENU reads these — an undecided mode is neither
+  // offered nor denied, so it is drawn as CT-12's spinner row rather than as a
+  // disabled one asserting a reason nobody has established.
+  claudePending?: boolean;
+  gitPending?: boolean;
+  // The folder's entry for a mode it will not SHOW: the binding as the stat
+  // reported it, gate verdict or not (lib/dir-mode's `bound`). Read for one thing
+  // only — see `paneSideIconEntry` — and never as an offer: a mode is on offer
+  // when `claude`/`git` above is non-null, and nowhere else.
+  claudeBound?: TemplateEntry | null;
+  gitBound?: TemplateEntry | null;
 }
 
 export function paneSideList(entries: PaneSideEntries): PaneSide[] {
@@ -113,6 +131,57 @@ export function paneSideList(entries: PaneSideEntries): PaneSide[] {
   if (entries.claude) list.push("claude");
   if (entries.git) list.push("git");
   return list;
+}
+
+// One row per mode, ALWAYS all three, which is the folder half of the rule the
+// file sidebar states at length (lib/preview-side, mode-visibility's
+// `unavailableReason`): a closed list of companions is one the user is entitled
+// to see all of, with the unavailable members disabled and saying why, rather
+// than a header that quietly shrank — and, at one row, hid its switcher
+// altogether, leaving a mount-backed folder's pane with a chevron and nothing
+// else.
+//
+// `preview` never carries a reason: it is the pane's identity and cannot be
+// unavailable. The other two are disabled when the folder has no entry for them,
+// or spinning while the probe is still out.
+export interface PaneSideMenuEntry {
+  mode: PaneSide;
+  // Gate/stat still in flight — disabled spinner, no claim made.
+  pending?: boolean;
+  // Not on offer here, and this is why — disabled, with the reason as its title.
+  disabledReason?: string;
+}
+
+export function paneSideMenu(entries: PaneSideEntries): PaneSideMenuEntry[] {
+  const companion = (mode: "claude" | "git"): PaneSideMenuEntry => {
+    if (entries[mode]) return { mode };
+    const pending = mode === "claude" ? entries.claudePending : entries.gitPending;
+    return pending ? { mode, pending: true } : { mode, disabledReason: unavailableReason(mode) };
+  };
+  return [{ mode: "preview" }, companion("claude"), companion("git")];
+}
+
+// WHICH TEMPLATE A ROW TAKES ITS ICON FROM — the offered entry, and failing that
+// the binding behind a disabled row. Null means the mode is bound nowhere and the
+// caller has to draw something of its own.
+//
+// A decision rather than a line inside the icon function because it is the same
+// rule the file sidebar's menu applies (lib/preview-side's `bound`) and the same
+// bug if it is got wrong: a disabled row is the mode with the click taken away,
+// so it keeps the mode's glyph. Falling back to a generic one made the Git row
+// look like a different mode outside a repository than inside it — and falling
+// back to the PREVIEW glyph, which this once did, put two identical icons in a
+// three-row menu.
+//
+// `preview` is not here: it is not a template at all (the row's own default view)
+// and its glyph is baked into the shell.
+export function paneSideIconEntry(
+  side: Exclude<PaneSide, "preview">,
+  entries: PaneSideEntries
+): TemplateEntry | null {
+  return side === "claude"
+    ? (entries.claude ?? entries.claudeBound ?? null)
+    : (entries.git ?? entries.gitBound ?? null);
 }
 
 // The mode the pane SHOWS for a requested one: the request while it is still on

--- a/frontend/src/platform/lib/mode-visibility.ts
+++ b/frontend/src/platform/lib/mode-visibility.ts
@@ -80,6 +80,41 @@ export const SIDEBAR_MODES = ["claude", "git", "history"] as const;
 
 const SIDEBAR_MODE_SET: ReadonlySet<string> = new Set(SIDEBAR_MODES);
 
+// WHY A COMPANION IS NOT ON OFFER, in the words the switcher puts on it.
+//
+// The companion surfaces (the file sidebar, the folder pane) do NOT drop a
+// companion they cannot show: they list it DISABLED, with one of these as its
+// `title`. That is the opposite of what the content-mode policy at the top of
+// this file does with a denied entry, and the difference is the surfaces, not a
+// change of mind. A content mode list is OPEN — it is whatever the registry
+// bound to this extension, and a user has no expectation about its length, so a
+// missing entry is invisible rather than confusing. The companion list is
+// CLOSED and always the same three; a user who has seen Claude / Git / History
+// beside one file and only Claude beside the next has been told nothing about
+// why, and on the two-entry path the menu used to hide itself outright, so a
+// file outside a repository had no switcher at all. Naming the reason costs one
+// disabled row and answers the question the empty space raised.
+//
+// The reasons are CANNED CLIENT-SIDE and per MODE, not per verdict: /api/fs/
+// conditions is bool-only by design (a gate is a condition.py returning a bool,
+// not a message), and the three conditions are stable enough to say in a
+// sentence — the working tree, the file's history, the chat's applicability. A
+// mode is equally unavailable whether its gate said no or the file never bound
+// the template at all, and from the user's side those are the same fact, so one
+// string covers both.
+const UNAVAILABLE_REASONS: Record<string, string> = {
+  claude: "Claude is not available for this file",
+  git: "Not inside a git repository",
+  history: "No history for this file",
+};
+
+// Deliberately total: a user registry can bind a mode of its own into either
+// companion list, and a disabled row with a vague tooltip still beats a row
+// whose tooltip is the word "undefined".
+export function unavailableReason(mode: string): string {
+  return UNAVAILABLE_REASONS[mode] ?? "Not available here";
+}
+
 export function isSidebarMode(mode: string): boolean {
   return SIDEBAR_MODE_SET.has(mode);
 }

--- a/frontend/src/styles/preview.css
+++ b/frontend/src/styles/preview.css
@@ -291,11 +291,9 @@
    collapses toward, and the mode control is packed to the far end the way the crumb
    bar's own controls are. That far end is `.side-header-tail` (explorer.css), the
    ONE auto margin the two side-column headers share — so the right-hand end holds
-   whichever of the two things renders there (the ModeMenu, or the flat
-   .preview-side-name label a one-companion file gets) without either needing a rule
-   of its own, and the strip cannot be thrown off by what does or does not render at
-   its left end. The explicit `height` is what stands the bar up; same dependency,
-   same reason, as .pane-header. */
+   whatever renders there without needing a rule of its own, and the strip cannot be
+   thrown off by what does or does not render at its left end. The explicit `height`
+   is what stands the bar up; same dependency, same reason, as .pane-header. */
 .preview-side-header {
   flex: 0 0 auto;
   display: flex;
@@ -307,23 +305,6 @@
   box-sizing: border-box;
   border-bottom: 1px solid var(--border);
   background: var(--bg-alt);
-}
-
-/* The one-companion case: the same icon and words the menu would show, with
-   nothing to click (BarMenu's ModeMenu hides itself at one entry — "one mode is
-   not a choice" — which would leave this strip empty over an unlabelled
-   document). Deliberately NOT .bar-ctl-bordered: it is a label, and a plate
-   around it would invite the click it does not take. */
-.preview-side-name {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 2px;
-  font-size: 12px;
-  line-height: 1;
-  color: var(--fg);
-  white-space: nowrap;
 }
 
 /* Fills what the header leaves. flex, not height:100%, so the header can't push

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -3420,7 +3420,19 @@ function enterNoPane() {
   //    to come back to, and it doubles as the fallback for the one case with no
   //    point to aim at — a note whose element no longer resolves — which the
   //    `sidebar` class positions under the #anntools strip. See the stylesheet.
+  //
+  //    The close FIRST, because this teardown is not the first thing that can
+  //    happen to the composer. paneURL awaits a fetch before it answers `null`,
+  //    and the poll that injects the annotation layer and wires the pane's click
+  //    handler ran at the end of the script — so a reader who clicks the pane in
+  //    that gap has an open composer, portaled, before this line is reached.
+  //    Yanking a live one across documents with `appendChild` would leave it
+  //    visible in the chat column at a coordinate that meant something in
+  //    someone else's viewport. Closing it is the same close Escape does, and it
+  //    is what puts the node back in this document so the move below is a move
+  //    within one document again.
   if (CHAT_ONLY) {
+    annCloseComposer();
     annPop.classList.add("sidebar");
     document.getElementById("chat").appendChild(annPop);
   }
@@ -3557,7 +3569,8 @@ const annChipsEls = [
 //                whose clientWidth/clientHeight IS the framed viewport
 //   annLayerRoot the shadow root the composer is portaled into, hosted only;
 //                null in the split layout, where #annpop is already over the
-//                pane and has nowhere to go
+//                pane and has nowhere to go — which is also what makes the
+//                portal unreachable there without a second flag
 //
 // `annFrame` may be NULL in CHAT_ONLY (no marked frame yet, or none at all), so
 // every read of it is guarded. In the split layout it is the element itself and
@@ -3575,13 +3588,6 @@ let annPins = document.getElementById("annpins");
 let annHl = document.getElementById("annhl");
 let annStageEl = document.getElementById("leftview");
 let annLayerRoot = null;
-// Where #annpop sits when it is NOT portaled. Captured on the first portal
-// rather than written down here, because the answer depends on a teardown that
-// has not run yet: enterNoPane moves the composer out of #leftview (which it is
-// about to remove) and into #chat, and THAT is the seat the composer has to
-// come back to. Reading it at portal time is reading it after every move that
-// can happen to it.
-let annPopHome = null;
 // The re-render observer on the target's document, declared UP HERE with the
 // rest of the target's state rather than beside the wiring that installs it: in
 // the hosted layout the first wiring happens during the boot renderAnn (which
@@ -3589,6 +3595,59 @@ let annPopHome = null;
 // lines before the wiring section — and a `let` read before its declaration is
 // a temporal-dead-zone ReferenceError, not an undefined.
 let annObserver = null;
+// And the document it is pointed at, which is what makes annObserveTarget cheap
+// enough to ask on every sync.
+let annObservedDoc = null;
+
+// Scroll and mutation storms coalesce to one re-render per frame. One queue for
+// every document, because renderAnn repaints the whole target either way, and a
+// per-document copy would just mean two rAFs doing one job after a mark move.
+let annRenderQueued = false;
+function annQueueRender() {
+  if (annRenderQueued) return;
+  annRenderQueued = true;
+  requestAnimationFrame(() => { annRenderQueued = false; renderAnn(); });
+}
+
+// Point the re-render observer at the target's document. ONE observer, moved,
+// rather than one per document left running: the ones we would leave behind are
+// on documents nothing is drawing pins into, and each would still wake this
+// frame on every mutation of a pane the reader is not annotating.
+//
+// It has to MOVE, and that is the whole reason this is not inside annWireTarget's
+// run-once block where it started. The shell keeps its pane-mode iframes mounted
+// and moves the mark between them; re-selecting a frame we already wired runs no
+// wiring at all (`__fusedAnnWatched`, `__fusedAnnWired`), so an observer left on
+// the frame the reader just LEFT is an observer that never fires for the frame
+// they are looking at — the app re-renders under the pins and the pins stay where
+// the old DOM put them until something else redraws.
+//
+// Idempotent on the document, so callers do not have to know whether anything
+// changed: annSyncTarget asks on every render and pays one comparison for it.
+function annObserveTarget(doc) {
+  if (doc === annObservedDoc) return;
+  if (annObserver) annObserver.disconnect();
+  annObserver = null;
+  annObservedDoc = doc || null;
+  if (!doc) return;
+  // Records, not a bare annQueueRender, for the one mutation that is not the app
+  // changing: our own. The shadow tree the pins live in is invisible to this
+  // observer (which is half of why the layer is behind one), but the layer's
+  // HOST element is an ordinary child of the app's body, so its arrival is an
+  // ordinary childList record — and a render triggered by having rendered is at
+  // best a wasted frame and at worst a loop.
+  annObserver = new MutationObserver((records) => {
+    const ours = (n) => n.nodeType === 1 && n.hasAttribute
+                        && n.hasAttribute(ANN_LAYER_MARK);
+    for (const r of records) {
+      const moved = [...r.addedNodes, ...r.removedNodes];
+      if (moved.length && moved.every(ours)) continue;
+      annQueueRender();
+      return;
+    }
+  });
+  annObserver.observe(doc.body || doc.documentElement, { childList: true, subtree: true });
+}
 
 // The host's marked content pane, or null. The mark is an attribute the shell
 // stamps on the iframe it is currently showing (Preview.tsx) — a mark, not a
@@ -3758,8 +3817,9 @@ function annInjectLayer(doc) {
 
 // Point the four bindings at whatever the host is showing NOW. Cheap enough to
 // call on every render and every poll: one querySelector in the host document,
-// one in the target's. Returns whether the FRAME changed, which is the only part
-// a caller has ever needed to know about.
+// one in the target's. Returns whether the FRAME changed — the poll acts on it,
+// because a mark that moves between two frames the shell keeps mounted is a
+// change nothing else in this file can hear (see annPollTarget).
 //
 // The layer is re-resolved every time, not only when the frame moves, because a
 // pane that live-reloads gets a brand new document with no layer in it — and
@@ -3778,7 +3838,13 @@ function annSyncTarget() {
   // stops the re-entry from recursing), and the frame resolved at DECLARATION
   // time never "moved" at all.
   if (next) annWatchTarget(next);
-  const layer = annInjectLayer(annTargetDoc());
+  const doc = annTargetDoc();
+  // The re-render observer follows the target from here, because THIS is the
+  // function that knows where the target is. Re-selecting an already-wired frame
+  // never reaches annWireTarget, so that path cannot be the only one that moves
+  // it. Idempotent, so the cost on an ordinary render is one comparison.
+  annObserveTarget(doc);
+  const layer = annInjectLayer(doc);
   annPins = layer && layer.pins;
   annHl = layer && layer.hl;
   annStageEl = layer && layer.stage;
@@ -3999,12 +4065,17 @@ function renderAnn() {
 const annDelBtn = document.getElementById("anndel");
 
 // ── the composer's two seats ──────────────────────────────────────────────
-// Is #annpop currently living in someone else's document? Asked as "not where
-// it belongs" rather than "is it in a shadow root", because the answer has to
-// stay true for a root that has since been thrown away — a reloaded pane leaves
-// the node parented to a dead shadow tree, and that is precisely the case
-// annSyncTarget needs to recognise.
-const annPortaled = () => !!annPopHome && annPop.parentNode !== annPopHome;
+// Is #annpop currently living in someone else's document? OWNERSHIP is the
+// question, not parentage, and that is what makes the answer survive everything
+// that can happen to the node while it is away: a pane that reloads leaves it
+// parented to a dead shadow tree, an `adoptNode` that lands and an `appendChild`
+// that then throws leaves it parented to nothing at all. `ownerDocument` is
+// what `adoptNode` changes and the only thing that is still true in both.
+//
+// It is also the reason there is no remembered home node. One used to be
+// captured at the first portal, which was a race with a teardown that had not
+// run yet — see annUnportalPop.
+const annPortaled = () => annPop.ownerDocument !== document;
 
 // Move the REAL composer into the target document's overlay, so it can be drawn
 // beside the element it describes. An iframe cannot paint outside its own box,
@@ -4028,10 +4099,6 @@ function annPortalPop() {
   if (!annLayerRoot) return false;
   if (annPop.getRootNode() === annLayerRoot) return true;
   try {
-    // Captured on the way out, not at declaration: enterNoPane has by now moved
-    // the composer from #leftview (which it removed) into #chat, and #chat is
-    // the seat it must come back to. See annPopHome.
-    if (!annPopHome) annPopHome = annPop.parentNode;
     annLayerRoot.ownerDocument.adoptNode(annPop);
     annLayerRoot.appendChild(annPop);
   } catch (err) {
@@ -4045,13 +4112,30 @@ function annPortalPop() {
 // a dead tree. Returning it on close means the node spends all of its idle life
 // in the document that owns it.
 //
+// The home is RESOLVED HERE, every time, and never remembered from an earlier
+// visit. Remembering it was a race: annPollTarget injects the layer and wires
+// the target's click handler at the end of THIS script, while enterNoPane —
+// which is what moves the composer out of #leftview and into #chat — waits on
+// an `await fetch` inside paneURL. A click in the pane that lands in that gap
+// portals a composer whose parent is still #leftview, and #leftview is exactly
+// what the teardown then removes: coming "home" would have meant appending into
+// a detached column, i.e. a composer that opens into nothing. Asking the
+// document is a question with only one right answer at any moment.
+//
+// #chat rather than the original parent for the same reason it is where
+// enterNoPane parks it: the split layout never portals (there is nothing to
+// portal INTO — annLayerRoot is null without a marked frame), so every node
+// that comes back through here is a sidebar one, and the sidebar's seat is the
+// chat column. <body> only if that column is somehow gone, because a node
+// dropped nowhere is a composer that can never be opened again.
+//
 // The `sidebar` class is left alone through both moves. It says "parked in the
 // chat column" and that is still what it will mean when the node gets back; the
 // shadow root simply has no rule matching it, so it is inert while portaled.
 function annUnportalPop() {
   if (!annPortaled()) return;
   document.adoptNode(annPop);
-  annPopHome.appendChild(annPop);
+  (document.getElementById("chat") || document.body).appendChild(annPop);
 }
 
 // (x, y) are the click's FRAME viewport coordinates — the same space the pins
@@ -4290,14 +4374,27 @@ annSetMode(fused.params.get("annmode") !== "0");
 const ANN_TARGET_POLL_MS = 750;
 function annPollTarget() {
   const had = !!annFrame;
-  annSyncTarget();
+  const moved = annSyncTarget();
   const has = !!annFrame;
   // Hidden, not disabled: a switch that cannot do anything is not a promise
   // worth keeping on screen — the same rule the narrow layout applies to the
   // controls of a hidden pane. (#annbtn's own `display: flex` outranks the UA's
   // [hidden] rule, so the stylesheet spells the hiding out.)
   annBtn.hidden = !has;
-  if (has === had) return;
+  if (has === had) {
+    // Same ANSWER, different FRAME: the shell switched the pane's mode between
+    // two iframes it keeps mounted and moved the mark from one to the other.
+    // The switch has nothing to say about that — there was a target before and
+    // there is one now — but the pins do, and nobody else is going to draw
+    // them. Every other repaint on this path is somebody's `load`, and the two
+    // frames both loaded long ago: annWatchTarget refuses a frame it has
+    // already adopted (`__fusedAnnWatched`), so no wiring runs and no render
+    // comes with it. The layer we just re-resolved is the one THAT frame was
+    // left with, painted from whatever `annotations` said when it was last on
+    // screen — a note added, deleted or sent in the meantime is not in it.
+    if (moved) renderAnn();
+    return;
+  }
   // A target that has just ARRIVED re-applies the boot default, because the boot
   // itself may have run before the host stamped anything — the switch would then
   // read "Annotate" while the URL says the mode is on. Through annSetMode, the
@@ -4360,6 +4457,13 @@ function annWireTarget() {
   watchApp();
   const doc = annTargetDoc();
   if (!doc) return;
+  // ABOVE the run-once guard, because the observer is not a listener on this
+  // document — it is a single instance that has to point at whichever document
+  // is the target NOW, and re-selecting an already-wired one is exactly the case
+  // the guard below skips. The split layout reaches it only through here;
+  // hosted, annSyncTarget asks as well, and both are no-ops for a document we
+  // already watch.
+  annObserveTarget(doc);
   // One wiring per DOCUMENT, marked on the document itself (the same trick, and
   // for the same reason, as watchWindow's `__fusedAppWatched`): a reload brings a
   // fresh document and must be wired again, while re-adopting a frame we already
@@ -4467,32 +4571,10 @@ function annWireTarget() {
     annPlaceHl(el);
     annOpenComposer(e.clientX, e.clientY, anchor);
   }, true);
-  // Scroll and mutation storms coalesce to one re-render per frame.
-  let queued = false;
-  const queueRender = () => {
-    if (queued) return;
-    queued = true;
-    requestAnimationFrame(() => { queued = false; renderAnn(); });
-  };
-  doc.addEventListener("scroll", queueRender, { capture: true, passive: true });
-  if (annObserver) annObserver.disconnect();
-  // Records, not a bare queueRender, for the one mutation that is not the app
-  // changing: our own. The shadow tree the pins live in is invisible to this
-  // observer (which is half of why the layer is behind one), but the layer's
-  // HOST element is an ordinary child of the app's body, so its arrival is an
-  // ordinary childList record — and a render triggered by having rendered is at
-  // best a wasted frame and at worst a loop.
-  annObserver = new MutationObserver((records) => {
-    const ours = (n) => n.nodeType === 1 && n.hasAttribute
-                        && n.hasAttribute(ANN_LAYER_MARK);
-    for (const r of records) {
-      const moved = [...r.addedNodes, ...r.removedNodes];
-      if (moved.length && moved.every(ours)) continue;
-      queueRender();
-      return;
-    }
-  });
-  annObserver.observe(doc.body || doc.documentElement, { childList: true, subtree: true });
+  // Scroll storms coalesce to one re-render per frame. A per-DOCUMENT listener,
+  // so it belongs in this run-once block; the mutation half does NOT and lives
+  // in annObserveTarget, called above.
+  doc.addEventListener("scroll", annQueueRender, { capture: true, passive: true });
   renderAnn();
 }
 // The split layout's own pane, wired the way it always was: one frame, ours,

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -191,6 +191,13 @@
     cursor: pointer;
     transition: color .12s;
   }
+  /* The switch is HIDDEN, not disabled, when there is nothing to annotate — the
+     sidebar layout's case, where the target is the host's content pane and the
+     host may be showing something unmarked (annPollTarget). Same rule the narrow
+     layout follows for the controls of a hidden pane: absent beats dead. Needs a
+     declaration of its own because `display: flex` above outranks the UA's
+     `[hidden] { display: none }`, exactly as #leftbar[hidden] does. */
+  #annbtn[hidden] { display: none; }
   #annbtn:hover { color: var(--fg); }
   #annbtn.on { color: var(--fg); }
   /* Where the row's shrinking actually happens — on the TEXT, not on the track,
@@ -370,6 +377,13 @@
      auto-margin owner — is out of the document, so the kebab, the one control
      the teardown keeps, anchors the right-hand end itself. */
   body.nopane #kebab { margin-left: auto; }
+  /* Unless the switch is still there and still usable, which is the sidebar
+     layout (chat_only): it keeps its auto margin, and TWO of them would split
+     the row's free space between them and float the switch into the middle
+     instead of parking it at the end. `:not([hidden])` and not a bare `#annbtn`,
+     because a hidden switch takes no space and the kebab has to slide back to
+     the end while it is away. */
+  body.nopane #annbtn:not([hidden]) ~ #kebab { margin-left: 0; }
   #kebabbtn {
     display: flex;
     align-items: center;
@@ -487,6 +501,36 @@
     border-radius: 12px;
     padding: 10px;
     box-shadow: 0 6px 24px var(--shadow);
+  }
+  /* The note composer's FALLBACK seat in the sidebar layout, and only that.
+     The composer describes an element in another column of the HOST's window,
+     so where it belongs is beside THAT element — and an iframe cannot draw
+     outside its own bounds, so annPlacePop PORTALS the node into the target
+     document's injected overlay and places it at the click there. None of these
+     rules apply on that path: the shadow root the composer moves into has never
+     heard of this stylesheet and carries its own copy of the composer's looks
+     (ANN_LAYER_CSS).
+
+     What is left for this rule is the case with no point to aim at — a chip
+     opened for a note whose element no longer resolves, or a host showing
+     nothing marked at all. The composer then stays HERE, parked directly under
+     the #anntools strip (the 51px) and spanning the column: a text box the
+     reader can still type in, rather than one placed at a coordinate we do not
+     have.
+
+     `fixed`, not absolute: this document IS the sidebar column, so the frame's
+     viewport is the column and no positioned ancestor has to be invented for
+     it. That also keeps it clear of #chat's `overflow: hidden`, which would
+     otherwise clip a popover placed at the very top of the column. Above
+     #kebabpop's 30 — it is a text field the reader is typing in, and nothing in
+     the strip may land on top of it. */
+  #annpop.sidebar {
+    position: fixed;
+    z-index: 40;
+    top: 51px;
+    left: 12px;
+    right: 12px;
+    width: auto;
   }
   #annpop textarea {
     width: 100%;
@@ -2322,8 +2366,21 @@ const BASENAME = FILE.split("/").pop();
 // preview of the same target (the explorer's `_side` split — Preview.tsx and
 // PreviewSidebar.tsx), so our own left half would be that file previewed twice
 // in one window, the inner copy a few hundred pixels wide. The host says so with
-// `chat_only=1`, and we take the pane away: no second preview, no divider, no
-// annotate switch, and the chat column runs full width.
+// `chat_only=1`, and we take the pane away: no second preview, no divider, and
+// the chat column runs full width.
+//
+// The ANNOTATE SWITCH is the one thing that does not go with the pane, and it
+// used to: the pane was what a note pointed at, so removing the pane removed the
+// feature, and #456 shipped a sidebar from which nothing could be annotated at
+// all. The switch is kept and RETARGETED instead — at the host's own content
+// pane, the middle column, which is the preview this chat is beside and the one
+// the reader is actually looking at. That target is found by mark, not by
+// arrangement: the shell stamps `data-fused-annotate-target` on the content
+// iframe it is showing (Preview.tsx) and we read it back through
+// `window.parent.document`, same-origin, no postMessage (D3/D4). A host that
+// marks nothing — a foreign embedder, a cross-origin parent, or our own shell
+// on a surface with no content pane — leaves the switch hidden and this page
+// degrades to exactly the chat it was. See the annotate target seam below.
 //
 // A HOST fact, not view state, which is why it is read once into a const and
 // never written: nothing in here toggles it, and someone who reaches this URL
@@ -2660,6 +2717,16 @@ function outlineNode(el, depth, budget, doc) {
   }
   out.children = [];
   for (const kid of kids) {
+    // Our own pin layer is not part of the app. In the sidebar layout it is
+    // injected into the app's own <body> (annInjectLayer), so unlike every other
+    // piece of this UI it CAN be reached from here — and an element describing
+    // the reader's annotations, presented to the agent as part of the page it is
+    // editing, is a lie about the source. Skipped without spending budget: it is
+    // one empty div, and its shadow tree is not walkable from here anyway.
+    // The attribute is spelled out rather than read from ANN_LAYER_MARK because
+    // that const is declared a thousand lines below this one, and the walk has
+    // no business depending on the annotation section having been reached.
+    if (kid.hasAttribute && kid.hasAttribute("data-fused-annotate")) continue;
     if (budget.left <= 0) {
       out.truncated = (kids.length - out.children.length) + " sibling(s) not shown";
       break;
@@ -3294,6 +3361,15 @@ function applyLeftMode() {
 // BOOT already did on the strength of a param, before anyone knew there was no
 // pane. Both were live bugs found by opening a folder URL that still carried an
 // old bookmark's `annotations` and `paneview=preview`.
+//
+// CHAT_ONLY takes this same path (paneURL answers `null` for every kind there)
+// and it is the one caller for which "no pane of ours" is NOT "nothing to
+// annotate": the host has a pane, it is marked, and the notes point at it. So
+// the three annotation steps below are the ones that ask first — the list is
+// kept, the mode is left as the boot default found it, and the switch stays in
+// the strip. Everything else — the column, the divider, the picker, the view
+// toggle, the narrow view classes — goes exactly as it does for a folder,
+// because all of that is about OUR layout and our layout really is gone.
 function enterNoPane() {
   // 1. Drop the notes and repaint, while `noPane` is still false so renderAnn
   //    actually runs. In-memory only: `pending` is what composeOutgoing reads,
@@ -3303,13 +3379,21 @@ function enterNoPane() {
   //    later `noPane` early-return would have frozen on screen. A chip showing a
   //    note that cannot be sent is a worse lie than no chip. The param itself is
   //    left alone (see above): this drops the list, it does not rewrite the URL.
-  annotations = [];
+  //
+  //    Not in CHAT_ONLY: there the notes are anchored to the HOST's pane, which
+  //    is still on screen, and `annotations` is the shell URL's own param (this
+  //    page sets no boundary, D46/D72) — the very list the sidebar was reopened
+  //    to carry on with. Emptying it would silently discard a review because we
+  //    took OUR column away.
+  if (!CHAT_ONLY) annotations = [];
   renderAnn();
   noPane = true;
   // 2. Through annSetMode, the one door in and out of the mode: the boot default
   //    already armed it. With `noPane` set the call is a plain disarm that writes
-  //    no param (see there).
-  annSetMode(false);
+  //    no param (see there). CHAT_ONLY skips it for the same reason as step 1 —
+  //    annSetMode's own guard is `annCapable()`, not `noPane`, so a disarm here
+  //    would be a real disarm of a mode that still has a target.
+  if (!CHAT_ONLY) annSetMode(false);
   // 3. And drop the narrow layout's view class, which boot stamped from
   //    `paneview`. It has to go rather than be left inert: `view-preview`
   //    collapses #chat to its #anntools strip inside the 800px block, and with
@@ -3321,9 +3405,30 @@ function enterNoPane() {
   //    way back to the chat list; the home view hides it by CSS, same as ever)
   //    and the kebab. The `nopane` class hands the kebab the row's auto margin
   //    — #annbtn, the usual owner, is about to leave the document — so the ⋮
-  //    keeps the right-hand seat it has in every other layout.
+  //    keeps the right-hand seat it has in every other layout. (In CHAT_ONLY the
+  //    switch stays and takes its margin back; the stylesheet says so, scoped to
+  //    a switch that is actually THERE and not merely hidden.)
   document.body.classList.add("nopane");
+  // 5. Rescue the note composer BEFORE the column it lives in is removed — it
+  //    is declared inside #leftview, and the loop below takes #leftview's
+  //    ancestor out of the document.
+  //
+  //    #chat is where it comes to REST, not where it works. The composer
+  //    describes an element in the host's pane, so when it opens it is portaled
+  //    into that pane's document and placed at the click (annPortalPop), and
+  //    annCloseComposer brings it back here. This move is what gives it a seat
+  //    to come back to, and it doubles as the fallback for the one case with no
+  //    point to aim at — a note whose element no longer resolves — which the
+  //    `sidebar` class positions under the #anntools strip. See the stylesheet.
+  if (CHAT_ONLY) {
+    annPop.classList.add("sidebar");
+    document.getElementById("chat").appendChild(annPop);
+  }
   for (const id of ["annbtn", "leftmode", "viewbtn", "left", "divider"]) {
+    // The switch is the exception CHAT_ONLY buys: it acts on the host's pane
+    // now, which this layout still has. Everything else in this list acts on
+    // the column being removed.
+    if (CHAT_ONLY && id === "annbtn") continue;
     const el = document.getElementById(id);
     if (el) el.remove();
   }
@@ -3424,18 +3529,275 @@ document.getElementById("divider").addEventListener("mousedown", (e) => {
 // screenshots or raw coordinates, so Claude can map each note straight back
 // to the app's HTML source. Lifecycle: pending → `sent` (stamped when a
 // message carries it; pin dims) → gone (auto-resolved when that run finishes
-// cleanly). The list is persisted in the pane-local `annotations` param so a
-// reload mid-review keeps the pins; it never rides the shell URL.
+// cleanly). The list is persisted in the `annotations` param so a reload
+// mid-review keeps the pins — which, since this page sets no param boundary,
+// means the URL the runtime writes to: this frame's own when it is the page,
+// the SHELL's when it is framed (D46/D72). Framed is the case that matters:
+// the sidebar and the pane it annotates then share one URL and one review.
 const annBtn = document.getElementById("annbtn");
-const annPins = document.getElementById("annpins");
-const annHl = document.getElementById("annhl");
 const annPop = document.getElementById("annpop");
 const annTa = annPop.querySelector("textarea");
 const annChipsEls = [
   document.getElementById("annchips-home"),
   document.getElementById("annchips-chat"),
 ];
-const annFrame = document.getElementById("leftframe");
+
+// ── the annotate target: WHICH document a note points at ──────────────────
+// Bindings rather than constants, and that is the entire retargeting
+// mechanism: everything downstream (renderAnn, annPlaceHl, annSetMode, the
+// capture, the anchor extraction) names them and never asks which layout it is
+// in. Standalone and full-split they hold exactly what they always held — our
+// own frame and the overlay nodes sitting over it in #leftview — so that path
+// is unchanged by construction. CHAT_ONLY repoints them (annSyncTarget).
+//
+//   annFrame     the iframe whose document is annotated
+//   annPins      the box the pins are appended to
+//   annHl        the hover/selection ring
+//   annStageEl   the box pin coordinates are measured against — i.e. the thing
+//                whose clientWidth/clientHeight IS the framed viewport
+//   annLayerRoot the shadow root the composer is portaled into, hosted only;
+//                null in the split layout, where #annpop is already over the
+//                pane and has nowhere to go
+//
+// `annFrame` may be NULL in CHAT_ONLY (no marked frame yet, or none at all), so
+// every read of it is guarded. In the split layout it is the element itself and
+// can only ever be detached, never null — the no-pane path removes it, and
+// appWindow's `isConnected` check is what notices.
+const annOwnFrame = document.getElementById("leftframe");
+// Resolved at declaration, not at the first poll: the boot arm (annSetMode, way
+// below) asks `annCapable()` before either of those runs, and answering it with
+// OUR frame in the hosted layout would arm the mode over a column that is about
+// to be removed. The overlay bindings below are left pointing at the split
+// layout's nodes for the same few statements — nothing reads them until the boot
+// renderAnn, which syncs first.
+let annFrame = CHAT_ONLY ? annMarkedFrame() : annOwnFrame;
+let annPins = document.getElementById("annpins");
+let annHl = document.getElementById("annhl");
+let annStageEl = document.getElementById("leftview");
+let annLayerRoot = null;
+// Where #annpop sits when it is NOT portaled. Captured on the first portal
+// rather than written down here, because the answer depends on a teardown that
+// has not run yet: enterNoPane moves the composer out of #leftview (which it is
+// about to remove) and into #chat, and THAT is the seat the composer has to
+// come back to. Reading it at portal time is reading it after every move that
+// can happen to it.
+let annPopHome = null;
+// The re-render observer on the target's document, declared UP HERE with the
+// rest of the target's state rather than beside the wiring that installs it: in
+// the hosted layout the first wiring happens during the boot renderAnn (which
+// syncs the target, which adopts the frame, which wires it) — several hundred
+// lines before the wiring section — and a `let` read before its declaration is
+// a temporal-dead-zone ReferenceError, not an undefined.
+let annObserver = null;
+
+// The host's marked content pane, or null. The mark is an attribute the shell
+// stamps on the iframe it is currently showing (Preview.tsx) — a mark, not a
+// position, so this cannot be fooled by a layout change and does not care how
+// many frames the host keeps mounted.
+//
+// Everything about this is guarded and every failure is the same answer, null:
+// a parent that is not there (this page opened directly), a parent that is
+// cross-origin (someone else's embed — `parent.document` THROWS), a host that
+// marks nothing, or a mark on something that is not an iframe. Null means the
+// switch is hidden and this page is a chat; it never means an error.
+function annMarkedFrame() {
+  try {
+    const host = window.parent;
+    if (!host || host === window) return null;
+    const el = host.document.querySelector("[data-fused-annotate-target]");
+    return el && el.tagName === "IFRAME" ? el : null;
+  } catch (err) {
+    return null;
+  }
+}
+function annTargetDoc() {
+  try {
+    return annFrame ? annFrame.contentDocument : null;
+  } catch (err) {
+    return null;   // navigating, or a frame that turned out to be cross-origin
+  }
+}
+// Is there anything to annotate right now? The question `noPane` used to answer
+// alone, and it stopped being the same question when the sidebar arrived: there
+// the pane is gone AND there is a target. Standalone it is still exactly
+// "do we have a pane"; hosted it is "is the host showing something marked",
+// which is a live fact — the mark moves with the pane's mode switcher and
+// disappears when the host shows a listing (annPollTarget).
+const annCapable = () => (CHAT_ONLY ? !!annFrame : !noPane);
+
+// The annotation layer, in CHAT_ONLY, cannot live in this document: the target
+// is a sibling iframe somewhere else in the host's layout, and an overlay here
+// would be pins drawn over the chat. So it is INJECTED into the target's own
+// document, where the coordinate space is the one annStageRect already works in
+// and the pins scroll with the content for free (the frame's own scroll handler
+// re-renders them, exactly as it does in the split layout).
+//
+// The note COMPOSER lands in here too, on demand: an iframe cannot draw outside
+// its own bounds, so a popover that has to appear beside the element it
+// describes has to be a node in that element's document. annPortalPop moves the
+// real #annpop in and annCloseComposer moves it back — see there. That is why
+// this shadow root is handed back whole (`root`) and not just its two overlay
+// boxes.
+//
+// It goes in behind a SHADOW ROOT, and that buys three separate guarantees that
+// would each otherwise need code:
+//   * style isolation, both ways. The previewed document is arbitrary — user
+//     HTML, any template — and neither its `div { … }` rules nor our `.annpin`
+//     may reach each other. No naming scheme is safe against arbitrary CSS;
+//     a shadow boundary is.
+//   * the capture. shotPane clones the app's <body>, and cloneNode does NOT
+//     clone a shadow tree — so the pins cannot appear in a screenshot for the
+//     same structural reason they cannot in the split layout, where they live in
+//     the parent document.
+//   * the MutationObserver. It watches the app's body for re-renders; mutations
+//     inside a shadow root are not reported to a light-DOM observer, so drawing
+//     a pin cannot re-trigger the render that drew it.
+// The host element is APPENDED to <body>, never prepended: anchors are
+// tag:nth-of-type paths, and a new first child would renumber every one of them.
+const ANN_LAYER_CSS = [
+  ":host { all: initial; }",
+  // The reset this file's own `* { box-sizing: border-box }` gives every rule
+  // above, restated because a shadow tree inherits no stylesheet: without it the
+  // ring's 1.5px border grows the box it is supposed to trace (measured — a
+  // 400×60 element drew a 402×62 ring) and the pin stops being 22px round.
+  "* { box-sizing: border-box; }",
+  ".pins { position: absolute; inset: 0; overflow: hidden; pointer-events: none; }",
+  // Literal colours, not tokens: this stylesheet lives in someone else's
+  // document, which has never heard of this page's palette. They are the
+  // template's --accent / --on-accent, with a light ring and a soft shadow so
+  // the pin reads on a dark app and a white page alike.
+  ".annpin { position: absolute; transform: translate(-50%, -50%); min-width: 22px;"
+  + " height: 22px; padding: 0 4px; border-radius: 999px; background: #d97757;"
+  + " color: #1a1a1a; border: 1.5px solid rgba(255, 255, 255, .9);"
+  + " font: 600 12px/1 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  + " display: flex; align-items: center; justify-content: center;"
+  + " pointer-events: auto; cursor: pointer; user-select: none;"
+  + " box-shadow: 0 1px 4px rgba(0, 0, 0, .35); }",
+  ".annpin.sent { opacity: .55; cursor: default; }",
+  // No `inset` on this one, unlike .pins: annPlaceHl gives it all four of
+  // left/top/width/height, and a stray `right: 0` would leave an over-constrained
+  // box the moment one of them is missing.
+  ".hl { position: absolute; display: none; pointer-events: none;"
+  + " border: 1.5px solid #d97757; border-radius: 4px;"
+  + " background: rgba(217, 119, 87, .14); }",
+  // The note composer's looks, restated for the document it gets PORTALED into
+  // (annPortalPop). The node is the very one the markup declares — its handlers
+  // and its draft ride along — but a stylesheet does not: `#annpop` and friends
+  // in the page's own <style> cannot reach across a shadow boundary into
+  // someone else's document, and without these rules the composer arrives as an
+  // unstyled UA text box floating over the app. Same selectors, same numbers as
+  // the rules up there (280px, 12px radius, 10px padding), so the two copies can
+  // be read side by side.
+  //
+  // Literal colours for the same reason the pin's are, and — like the pin — ONE
+  // fixed set rather than a light/dark pair: the app underneath is arbitrary and
+  // its theme is not ours to read. So the card brings its own ground (the
+  // template's dark --surface/--bg) plus a light hairline and a deep shadow,
+  // which is what separates it from a dark app and a white page alike.
+  //
+  // `pointer-events: auto` is load-bearing: the layer host is `none` so the app
+  // stays clickable through it, and a textarea that inherits that cannot be
+  // typed in. `position: absolute` inside a `fixed` host means annPlacePop's
+  // coordinates are the framed viewport's — the same space the pins use.
+  "#annpop { position: absolute; display: none; width: 280px; padding: 10px;"
+  + " background: #26282f; border: 1px solid rgba(255, 255, 255, .22);"
+  + " border-radius: 12px; box-shadow: 0 6px 24px rgba(0, 0, 0, .45);"
+  + " font: 400 13px/1.45 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  + " color: #ececf1; pointer-events: auto; }",
+  // `font: inherit` in the page's copy; spelled out here because `:host { all:
+  // initial }` means there is nothing above to inherit but the UA default.
+  "#annpop textarea { display: block; width: 100%; background: #191a1e;"
+  + " border: 1px solid #34363e; border-radius: 8px; color: #ececf1;"
+  + " font: 400 13px/1.45 -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;"
+  + " padding: 7px 9px; margin: 0; resize: none; outline: none; }",
+  "#annpop .hint { color: #8a8f99; font-size: 11px; margin-top: 5px;"
+  + " display: flex; align-items: center; }",
+  "#annpop #anndel { margin-left: 8px; border: 0; background: transparent;"
+  + " color: #f26d6d; font: inherit; font-size: 11px; cursor: pointer;"
+  + " padding: 0 2px; }",
+].join("\n");
+// The marker attribute is on the HOST element, so one `closest()` tells the
+// frame's own handlers that a click or a hover landed on our layer rather than
+// on the app — see the wiring below. It is also what makes the layer findable
+// again after a re-render of this function.
+const ANN_LAYER_MARK = "data-fused-annotate";
+function annInjectLayer(doc) {
+  if (!doc || !doc.body) return null;
+  let host = doc.querySelector("[" + ANN_LAYER_MARK + "]");
+  // No shadow root means someone else's element wearing our attribute, or a
+  // half-built one from a torn-down document: start again rather than trust it.
+  if (host && !host.shadowRoot) { host.remove(); host = null; }
+  if (!host) {
+    host = doc.createElement("div");
+    host.setAttribute(ANN_LAYER_MARK, "layer");
+    // Inline, because a stylesheet of ours in a document of theirs is one
+    // `div { position: static }` away from being overruled — and these five
+    // declarations are the ones that decide whether the layer is a layer at all.
+    // `fixed` makes the layer's box the framed VIEWPORT, which is the coordinate
+    // space every pin position is already computed in.
+    host.setAttribute("style", "position: fixed; inset: 0; display: block;"
+      + " margin: 0; padding: 0; border: 0; z-index: 2147483646;"
+      + " pointer-events: none;");
+    const root = host.attachShadow({ mode: "open" });
+    const style = doc.createElement("style");
+    style.textContent = ANN_LAYER_CSS;
+    const hl = doc.createElement("div");
+    hl.className = "hl";
+    const pins = doc.createElement("div");
+    pins.className = "pins";
+    // Ring first, pins second: painted in tree order, so a pin is never hidden
+    // behind the ring of the element it marks (#annpins/#annhl do this with
+    // z-index in the split layout, where they are not siblings of nothing else).
+    root.append(style, hl, pins);
+    doc.body.appendChild(host);
+  }
+  const root = host.shadowRoot;
+  return { root, pins: root.querySelector(".pins"), hl: root.querySelector(".hl"),
+           stage: doc.documentElement };
+}
+
+// Point the four bindings at whatever the host is showing NOW. Cheap enough to
+// call on every render and every poll: one querySelector in the host document,
+// one in the target's. Returns whether the FRAME changed, which is the only part
+// a caller has ever needed to know about.
+//
+// The layer is re-resolved every time, not only when the frame moves, because a
+// pane that live-reloads gets a brand new document with no layer in it — and
+// the shell's mode switch, which moves the mark to another frame, is only the
+// louder version of the same thing.
+function annSyncTarget() {
+  if (!CHAT_ONLY) return false;
+  const next = annMarkedFrame();
+  const moved = next !== annFrame;
+  annFrame = next;
+  // Assigned BEFORE the adoption, because annWatchTarget wires the document that
+  // is already in the frame (nothing else would — its `load` fired long ago) and
+  // that wiring re-enters here; it has to find the move already made. The
+  // adoption is asked for on every sync rather than only on a move: it is a
+  // no-op for a frame we already hold (`__fusedAnnWatched`, which is also what
+  // stops the re-entry from recursing), and the frame resolved at DECLARATION
+  // time never "moved" at all.
+  if (next) annWatchTarget(next);
+  const layer = annInjectLayer(annTargetDoc());
+  annPins = layer && layer.pins;
+  annHl = layer && layer.hl;
+  annStageEl = layer && layer.stage;
+  annLayerRoot = (layer && layer.root) || null;
+  // The composer, while portaled, is a node we LENT to that document — and this
+  // is the one place that can notice the loan has gone bad. A live reload
+  // replaces the document and annInjectLayer builds a fresh layer in it; the
+  // shell's mode switch moves the mark to another frame entirely; an unmarked
+  // pane leaves no layer at all. In every one of those the root we handed the
+  // composer to is not the root we just resolved, and the node is either
+  // detached or floating over a document nobody is annotating any more.
+  //
+  // Close it, which also brings the node home. A close DROPS the draft, and
+  // that is the honest outcome rather than a bug: the anchor the half-typed
+  // note pointed at went with the document. Silently keeping the text would be
+  // keeping it against an element that no longer exists.
+  if (annPortaled() && annPop.getRootNode() !== annLayerRoot) annCloseComposer();
+  return moved;
+}
 
 let annOn = false;
 let annDraft = null;    // anchor of a NEW note being composed
@@ -3515,6 +3877,10 @@ function annContentBox(el) {
 // Element rect in #leftview coordinates: the iframe fills #leftview, so the
 // element's viewport rect inside the frame is already the stage rect. (The control
 // strip is a sibling ABOVE #leftview, so it does not enter this coordinate space.)
+// The retargeted layout needs no second reading of this and that is why the
+// injected layer is `position: fixed` inside the target's own document: its box
+// is that document's viewport, so "the element's rect inside its frame" goes on
+// being the whole answer — see annInjectLayer.
 function annStageRect(el) {
   const r = el.getBoundingClientRect();
   return { left: r.left, top: r.top, width: r.width, height: r.height };
@@ -3532,15 +3898,25 @@ function renderAnn() {
   // target does not have, and #annpins itself is out of the document. `annotations`
   // is already emptied by enterNoPane, so this is belt-and-braces against a later
   // caller — of which there are five, including a params.onChange for EVERY param.
-  if (noPane) return;
+  //
+  // CHAT_ONLY is `noPane` too and means none of that: the notes point at the
+  // host's pane, and the chips are the payload of a message this chat can still
+  // send. So the flag stops being the whole answer here and the two halves are
+  // asked separately — the pins need a layer (annSyncTarget hands back nulls
+  // when the host is showing nothing marked), the chips need only the list.
+  if (noPane && !CHAT_ONLY) return;
+  annSyncTarget();
   // pins over the frame
-  annPins.innerHTML = "";
-  annPins.style.display = annOn ? "" : "none";
-  const doc = annOn ? annFrame.contentDocument : null;
+  if (annPins) {
+    annPins.innerHTML = "";
+    annPins.style.display = annOn ? "" : "none";
+  }
+  const doc = annOn && annPins ? annTargetDoc() : null;
   // #leftview, not #left: pins are placed in FRAME viewport coordinates, so their
   // host must be the box the iframe fills — #left also holds the control strip,
-  // and measuring that would put every pin the strip's height too high.
-  const host = document.getElementById("leftview");
+  // and measuring that would put every pin the strip's height too high. Hosted,
+  // the same box is the target document's own viewport (annSyncTarget).
+  const host = annStageEl;
   annotations.forEach((c, i) => {
     const el = doc ? annResolve(c, doc) : null;
     if (!el) return;  // detached / frame not loaded: the chip still shows it
@@ -3554,7 +3930,10 @@ function renderAnn() {
     }
     // Scrolled out of the framed viewport: no pin this frame — the chip stays.
     if (y < 0 || y > host.clientHeight || x < 0) return;
-    const pin = document.createElement("div");
+    // Created in the layer's OWN document: hosted, that is the app's, and a node
+    // minted here would be adopted into it on append anyway — doing it by hand
+    // keeps the two documents' nodes from being quietly swapped between them.
+    const pin = annPins.ownerDocument.createElement("div");
     pin.className = "annpin" + (c.sent ? " sent" : "");
     pin.style.left = Math.min(host.clientWidth - 14, Math.max(14, x)) + "px";
     pin.style.top = Math.max(14, y) + "px";
@@ -3579,12 +3958,26 @@ function renderAnn() {
       txt.textContent = c.content;
       txt.title = c.content + " — click to edit";
       txt.style.cursor = "pointer";
-      // Edit from the chip too: the popup lives over the left pane, so place
-      // it at the note's pin when it resolves, else roughly centered.
+      // Edit from the chip too. The popover belongs beside the element the note
+      // is about, so resolve that element in the TARGET document (ours in the
+      // split layout, the host's pane in the sidebar) and hand annPlacePop its
+      // rect — the same coordinates a click on the pin would have produced.
+      //
+      // Nothing to resolve is where the two layouts part. Standalone the
+      // popover has a pane of its own to sit over, so it is roughly centred
+      // there and the reader still sees it against the preview. Hosted there is
+      // no such consolation prize: a coordinate invented in someone else's
+      // viewport would put the composer over an arbitrary part of the app,
+      // beside nothing. NULL says so, and annPlacePop parks the composer in
+      // this column instead of portaling it to a point that means nothing.
       txt.onclick = () => {
-        const el2 = annFrame.contentDocument ? annResolve(c, annFrame.contentDocument) : null;
+        const d = annTargetDoc();
+        const el2 = d ? annResolve(c, d) : null;
         const r = el2 && el2.getBoundingClientRect();
-        annOpenEditor(c, r ? r.right : host.clientWidth / 3, r ? r.top : host.clientHeight / 3);
+        const w = host ? host.clientWidth : 0, h = host ? host.clientHeight : 0;
+        const cx = r ? r.right : (CHAT_ONLY ? null : w / 3);
+        const cy = r ? r.top : (CHAT_ONLY ? null : h / 3);
+        annOpenEditor(c, cx, cy);
       };
       const x = document.createElement("button");
       x.type = "button";
@@ -3604,11 +3997,98 @@ function renderAnn() {
 }
 
 const annDelBtn = document.getElementById("anndel");
+
+// ── the composer's two seats ──────────────────────────────────────────────
+// Is #annpop currently living in someone else's document? Asked as "not where
+// it belongs" rather than "is it in a shadow root", because the answer has to
+// stay true for a root that has since been thrown away — a reloaded pane leaves
+// the node parented to a dead shadow tree, and that is precisely the case
+// annSyncTarget needs to recognise.
+const annPortaled = () => !!annPopHome && annPop.parentNode !== annPopHome;
+
+// Move the REAL composer into the target document's overlay, so it can be drawn
+// beside the element it describes. An iframe cannot paint outside its own box,
+// and the target is a sibling frame elsewhere in the host's layout — so there is
+// no placement in this column that puts the text box next to the ring. The node
+// has to go there.
+//
+// The node, not a copy. Everything the composer is lives on it: the keydown
+// handler that saves on Enter and closes on Escape, the delete button's click,
+// the textarea's current text. All of those are addEventListener bindings and
+// closures over THIS document's state (`annotations`, `annDraft`, `annEditing`,
+// the chat composer), and a moved node keeps every one of them — a rebuilt
+// popover would be a second implementation to keep in step. `adoptNode` is
+// spelled out even though `appendChild` would adopt implicitly: the ownership
+// change is the whole point of this function, and it should read like it.
+//
+// Returns whether the move happened. False means there is nothing to portal
+// into — no marked frame, or a pane whose document we cannot reach — and the
+// caller parks the composer here instead.
+function annPortalPop() {
+  if (!annLayerRoot) return false;
+  if (annPop.getRootNode() === annLayerRoot) return true;
+  try {
+    // Captured on the way out, not at declaration: enterNoPane has by now moved
+    // the composer from #leftview (which it removed) into #chat, and #chat is
+    // the seat it must come back to. See annPopHome.
+    if (!annPopHome) annPopHome = annPop.parentNode;
+    annLayerRoot.ownerDocument.adoptNode(annPop);
+    annLayerRoot.appendChild(annPop);
+  } catch (err) {
+    return false;   // document torn down mid-gesture: park it instead
+  }
+  return true;
+}
+// And back again, on every close. Not merely tidiness: a pane that reloads or a
+// mark that moves would otherwise leave an idle composer orphaned in a document
+// nothing points at any more, and the next open would find `annPop` parented to
+// a dead tree. Returning it on close means the node spends all of its idle life
+// in the document that owns it.
+//
+// The `sidebar` class is left alone through both moves. It says "parked in the
+// chat column" and that is still what it will mean when the node gets back; the
+// shadow root simply has no rule matching it, so it is inert while portaled.
+function annUnportalPop() {
+  if (!annPortaled()) return;
+  document.adoptNode(annPop);
+  annPopHome.appendChild(annPop);
+}
+
+// (x, y) are the click's FRAME viewport coordinates — the same space the pins
+// are in — and they place the popover beside what the note is about.
+//
+// ONE placement rule for both layouts, because after the portal both are the
+// same problem: the popover sits in a box whose coordinate space IS the framed
+// viewport (#leftview over our own iframe; the `fixed` layer host inside the
+// target's document, hosted), so `annStageEl` is the pane either way and the
+// arithmetic below is the arithmetic the split layout has always used. Ten
+// pixels down and right of the click, clamped so a click near an edge does not
+// push the box off the pane.
+//
+// CHAT_ONLY only adds the question of WHERE the node lives, and the answer has
+// exactly one fallback: null coordinates (the chip-edit path, for a note whose
+// element no longer resolves) or no layer to portal into (nothing marked, a
+// document mid-navigation) leave the composer parked in this column under the
+// #anntools strip, positioned by the stylesheet's `.sidebar` rule. That is the
+// one case where a text box the reader can reach beats a text box beside the
+// right element, because there is no right element to be beside.
 function annPlacePop(x, y) {
-  const host = document.getElementById("leftview");   // see renderAnn
+  const aimed = Number.isFinite(x) && Number.isFinite(y);
+  if (CHAT_ONLY && !(aimed && annPortalPop())) {
+    annUnportalPop();
+    annPop.style.display = "block";
+    annPop.style.left = "";   // parked: the stylesheet spans the column
+    annPop.style.top = "";
+    annTa.focus();
+    return;
+  }
+  const host = annStageEl;   // see renderAnn
   annPop.style.display = "block";
   annPop.style.left = Math.min(host.clientWidth - 292, Math.max(0, x + 10)) + "px";
   annPop.style.top = Math.min(host.clientHeight - 110, Math.max(0, y + 10)) + "px";
+  // Across the frame boundary, hosted — which is allowed (same origin) and is
+  // what the reader expects: their pointer is already in the pane, and the
+  // textarea they are about to type in is now a node of that pane's document.
   annTa.focus();
 }
 function annOpenComposer(x, y, anchor) {
@@ -3640,6 +4120,12 @@ function annCloseComposer() {
   annPop.style.display = "none";
   annDraft = null;
   annEditing = null;
+  // Home before the next open, always — including the closes that are not the
+  // reader's (annSetMode's disarm, a chip deleted out from under the editor,
+  // annSyncTarget noticing the pane it was lent to is gone). An idle composer
+  // parked in someone else's document is a node that a reload can orphan, and
+  // this is the single choke point every close already goes through.
+  annUnportalPop();
 }
 // A fresh note usually precedes a "go apply it" message: seed the visible
 // composer so sending is one keypress. Only when it's empty — never clobber
@@ -3662,6 +4148,14 @@ function annPrefillComposer() {
 // it fires before the target's own handlers; pins and chips are exempt — their
 // click handlers own the toggle/reopen behavior and a mousedown-close here
 // would make the pin's toggle reopen instead.
+//
+// THIS document's half of the dismissal. The other half hangs off the target's
+// document (annWireTarget), because a click inside a frame never bubbles out of
+// it, and while portaled the composer is over there — so each document dismisses
+// what the other cannot see, and each exempts the composer's own subtree. The
+// `contains` below covers it here; over there the event RETARGETS at the shadow
+// boundary, so a mousedown in the textarea arrives as the layer host and the
+// layer's own exemption already catches it.
 document.addEventListener("mousedown", (e) => {
   if (annPop.style.display !== "block") return;
   const t = e.target;
@@ -3713,17 +4207,23 @@ const annIdleTitle = () =>
 // mode too, and a second copy of this would be a second chance for the banner's
 // text to disagree with `annOn`.
 function annSetMode(on) {
-  // A target with no pane can never be armed, whoever asks. Enforced HERE rather
-  // than only at the button because arming has four entry points (the click, the
-  // boot default below, the `annmode` param, the app menu's exit action) and a
-  // check at each of them is a check that a fifth one will forget. `annmode=1`
-  // left in a URL from a folder that used to have an app entry is the concrete
-  // case: it would arm a layer over a column that is not in the document.
+  // Nothing to point at can never be armed, whoever asks. Enforced HERE rather
+  // than only at the button because arming has five entry points (the click, the
+  // boot default below, the `annmode` param, the app menu's exit action, and the
+  // hosted re-arm when a target appears) and a check at each of them is a check
+  // that a sixth one will forget. `annmode=1` left in a URL from a folder that
+  // used to have an app entry is the concrete case: it would arm a layer over a
+  // column that is not in the document.
+  //
+  // `annCapable()`, not `noPane`: the sidebar has no pane of its own and a
+  // perfectly good target, and asking the layout question there would refuse to
+  // arm the one layout this feature was rebuilt for. Standalone the predicate IS
+  // `!noPane`, so nothing about the split layout changes.
   //
   // Returns BEFORE the param write, deliberately: `annmode` on a folder URL is
   // ignored, not rewritten (see enterNoPane). Everything below this line reads
   // or writes nodes that enterNoPane has removed.
-  if (noPane) { annOn = false; return; }
+  if (!annCapable()) { annOn = false; return; }
   annOn = on;
   // STILL THE ONE WRITER — but it does not write when the URL already MEANS
   // this. `annmode` is effectively-on: absent, or anything that is not "0".
@@ -3756,13 +4256,60 @@ function annSetMode(on) {
   // appears in annotate mode and it follows what the user is aiming at).
   annBtn.title = annOn ? "Annotating — click an element to add a note · Esc or click this button to stop"
                        : annIdleTitle();
-  if (!annOn) { annHl.style.display = "none"; annCloseComposer(); }
+  // The ring can be gone rather than merely hidden: hosted, it lives in the
+  // target's document and that document may have been replaced (or unmarked)
+  // since it was drawn. Nothing to hide is the same outcome as hidden.
+  if (!annOn) { if (annHl) annHl.style.display = "none"; annCloseComposer(); }
 }
 
 annBtn.addEventListener("click", () => annSetMode(!annOn));
 // Annotate mode is ON by default: an unset param means armed, and only an
 // explicit "0" (the user slid it off, or pressed Escape) starts it disarmed.
 annSetMode(fused.params.get("annmode") !== "0");
+
+// ── hosted only: keeping up with a target this document cannot hear ────────
+// The split layout is told about its pane by the pane itself — one iframe, one
+// `load` event, ours. The sidebar's target belongs to the host: it appears after
+// the shell's first paint, it is REPLACED when the reader switches the pane's
+// mode (the mark moves to another frame), and it disappears when the pane shows
+// something unannotatable. None of that reaches this document as an event, and
+// the one mechanism that would carry it — postMessage — is the thing this
+// template deliberately does not have (D3/D4).
+//
+// So the switch asks, and asking is one querySelector in the parent document
+// plus one in the target's. Cheap, and only ever in this layout. Two triggers,
+// for the two ways the answer changes:
+//   * focus — the reader came back to this frame, very often by way of clicking
+//     something in the host that changed the pane;
+//   * a slow interval, for everything else (the shell's own mode switch, a
+//     folder navigation) — slow enough to be free, quick enough that the switch
+//     is there by the time a hand gets to it.
+// A MutationObserver on the host's document would be the precise version and is
+// not worth it: it means holding a live observer on someone else's DOM for the
+// life of the session to learn a fact two cheap reads already give us.
+const ANN_TARGET_POLL_MS = 750;
+function annPollTarget() {
+  const had = !!annFrame;
+  annSyncTarget();
+  const has = !!annFrame;
+  // Hidden, not disabled: a switch that cannot do anything is not a promise
+  // worth keeping on screen — the same rule the narrow layout applies to the
+  // controls of a hidden pane. (#annbtn's own `display: flex` outranks the UA's
+  // [hidden] rule, so the stylesheet spells the hiding out.)
+  annBtn.hidden = !has;
+  if (has === had) return;
+  // A target that has just ARRIVED re-applies the boot default, because the boot
+  // itself may have run before the host stamped anything — the switch would then
+  // read "Annotate" while the URL says the mode is on. Through annSetMode, the
+  // one door, so the label, aria-pressed, the param and the pins agree.
+  if (has) annSetMode(fused.params.get("annmode") !== "0");
+  // And a target that has GONE disarms without writing the param: annSetMode
+  // refuses (annCapable is false now) after setting annOn, which is exactly the
+  // "ignored, not rewritten" posture a stale `annmode` gets everywhere else. The
+  // repaint is ours to ask for, since that early return skips it — the chips
+  // stay, the pins went with the document.
+  else { annSetMode(false); renderAnn(); }
+}
 
 // Auto-send: a saved NEW note goes to Claude immediately, always — there is no
 // off switch. The `filled`/`sending` guards below are the only gates.
@@ -3782,15 +4329,58 @@ function annAutoSubmit() {
 // Wire the framed app on every load (the app live-reloads on Claude's edits;
 // pins re-resolve against the fresh DOM). Handlers stay attached and gate on
 // `annOn`, so toggling never needs a rewire.
-let annObserver = null;
-annFrame.addEventListener("load", () => {
+//
+// Adopt a frame as the target: hear its future loads, and wire whatever document
+// is in it NOW. That second half is what the split layout never needed — its
+// frame is empty until we give it a src, so `load` always arrives after this
+// script — and what the hosted layout cannot do without: the shell's pane was
+// loaded long before this sidebar booted, and a document already in a frame
+// fires no event for a listener that arrives late.
+function annWatchTarget(frame) {
+  if (!frame || frame.__fusedAnnWatched) return;
+  frame.__fusedAnnWatched = true;
+  frame.addEventListener("load", annWireTarget);
+  // `about:blank` is not a document that was already there, it is the
+  // placeholder before the first real one (every frame starts on it, ours
+  // included until paneReady gives it a src) — and its `load` is coming anyway.
+  try {
+    const w = frame.contentWindow;
+    if (w && String(w.location.href) !== "about:blank") annWireTarget();
+  } catch (err) { /* cross-origin or mid-navigation: nothing to wire */ }
+}
+function annWireTarget() {
   // The app-state channel hangs off the same event, for the same reason: this is
   // where a fresh document appears, so it is where the console has to be
   // re-wrapped and a reload marked. See watchApp.
+  //
+  // Hosted, the sync comes FIRST: a load event here can be the pane changing
+  // mode under us, and the mark may already have moved to another frame — the
+  // one we want is whichever one is marked now, never "the one that fired".
+  if (CHAT_ONLY) annSyncTarget();
   watchApp();
-  const doc = annFrame.contentDocument;
+  const doc = annTargetDoc();
   if (!doc) return;
+  // One wiring per DOCUMENT, marked on the document itself (the same trick, and
+  // for the same reason, as watchWindow's `__fusedAppWatched`): a reload brings a
+  // fresh document and must be wired again, while re-adopting a frame we already
+  // wired — the mark leaving and coming back as the reader switches the pane's
+  // mode to and fro — must not stack a second set of listeners on it.
+  if (doc.__fusedAnnWired) { renderAnn(); return; }
+  doc.__fusedAnnWired = true;
   const elementOf = (t) => (t && t.nodeType === 1 ? t : t && t.parentElement);
+  // Our own injected layer, seen from inside the app's document. In the split
+  // layout no such node exists (the pins are in THIS document, which the app's
+  // handlers cannot see) and this is always false; hosted, it is what keeps the
+  // overlay from being treated as part of the app — a pin is a control of ours,
+  // not an element a note can point at.
+  //
+  // The COMPOSER is inside that layer too while it is portaled, and the shadow
+  // boundary is what makes one test cover both: an event raised in the shadow
+  // tree is retargeted to the host for every listener out here, so a mousedown
+  // in the textarea, a hover over the card and a click on the delete button all
+  // arrive as the layer host — already marked, already exempt. Nothing here
+  // needs to know the composer moved.
+  const annOwnNode = (t) => !!(t && t.closest && t.closest("[" + ANN_LAYER_MARK + "]"));
   // Escape, again: annotate mode is used with the pointer (and usually focus) in
   // here, and keydowns do not cross the frame boundary. Without this the banner's
   // "Esc or click to stop" was a promise only the chat pane could keep.
@@ -3799,7 +4389,16 @@ annFrame.addEventListener("load", () => {
   // outside-click dismissal needs its own hook here. In annotate mode the
   // click handler below may immediately open a fresh composer on the clicked
   // element — that's the expected "move the popover" flow.
-  doc.addEventListener("mousedown", () => {
+  //
+  // Hosted this is the dismissal that MATTERS, not a mirror of the chat's: the
+  // composer is portaled into this very document, so every click that ought to
+  // dismiss it — anywhere on the app — lands here and nowhere else.
+  doc.addEventListener("mousedown", (e) => {
+    // Exempt, exactly as the pins and chips are in this document's own
+    // outside-click handler: a mousedown on a pin is the start of that pin's
+    // toggle, and closing the popover here would turn the toggle into a reopen.
+    // Retargeting makes this the composer's exemption too — see annOwnNode.
+    if (annOwnNode(e.target)) return;
     if (annPop.style.display === "block") annCloseComposer();
   }, true);
   // One placement path for both writers: the hover follow below and the click
@@ -3808,6 +4407,7 @@ annFrame.addEventListener("load", () => {
   // for the whole trip over (see the composer guard in mousemove), so at
   // click time it shows the box the user just left.
   const annPlaceHl = (el) => {
+    if (!annHl) return;   // hosted: the layer went with an unmarked document
     const r = annStageRect(el);
     annHl.style.display = "block";
     annHl.style.left = r.left + "px";
@@ -3817,6 +4417,9 @@ annFrame.addEventListener("load", () => {
   };
   doc.addEventListener("mousemove", (e) => {
     if (!annOn) return;
+    // Hovering our own pin is not hovering the app: leave the ring on whatever
+    // it was marking rather than jumping it to a 22px circle of ours.
+    if (annOwnNode(e.target)) return;
     // An open composer means the user CLICKED an element and is writing about
     // it: the highlight is that element's, and a hover that drags it away
     // makes the popover describe one box while the orange ring shows another.
@@ -3826,7 +4429,7 @@ annFrame.addEventListener("load", () => {
     if (annPop.style.display === "block") return;
     const el = elementOf(e.target);
     if (!el || el === doc.body || el === doc.documentElement) {
-      annHl.style.display = "none";
+      if (annHl) annHl.style.display = "none";
       return;
     }
     annPlaceHl(el);
@@ -3836,6 +4439,10 @@ annFrame.addEventListener("load", () => {
   // triggering them. Toggle off to use the app normally.
   doc.addEventListener("click", (e) => {
     if (!annOn) return;
+    // A pin of ours, hosted, is the one thing in this document that must reach
+    // its own handler: swallowing it here would eat the click that reopens the
+    // note's editor and then anchor a NEW note to the pin marking the old one.
+    if (annOwnNode(e.target)) return;
     e.preventDefault();
     e.stopPropagation();
     const el = elementOf(e.target);
@@ -3869,10 +4476,36 @@ annFrame.addEventListener("load", () => {
   };
   doc.addEventListener("scroll", queueRender, { capture: true, passive: true });
   if (annObserver) annObserver.disconnect();
-  annObserver = new MutationObserver(queueRender);
+  // Records, not a bare queueRender, for the one mutation that is not the app
+  // changing: our own. The shadow tree the pins live in is invisible to this
+  // observer (which is half of why the layer is behind one), but the layer's
+  // HOST element is an ordinary child of the app's body, so its arrival is an
+  // ordinary childList record — and a render triggered by having rendered is at
+  // best a wasted frame and at worst a loop.
+  annObserver = new MutationObserver((records) => {
+    const ours = (n) => n.nodeType === 1 && n.hasAttribute
+                        && n.hasAttribute(ANN_LAYER_MARK);
+    for (const r of records) {
+      const moved = [...r.addedNodes, ...r.removedNodes];
+      if (moved.length && moved.every(ours)) continue;
+      queueRender();
+      return;
+    }
+  });
   annObserver.observe(doc.body || doc.documentElement, { childList: true, subtree: true });
   renderAnn();
-});
+}
+// The split layout's own pane, wired the way it always was: one frame, ours,
+// adopted before it has a src. Hosted, `annFrame` is the host's or null and the
+// adoption happens in annSyncTarget instead — the target is not ours to assume,
+// so what starts there is the polling that keeps asking who it is.
+if (CHAT_ONLY) {
+  annPollTarget();
+  window.addEventListener("focus", annPollTarget);
+  setInterval(annPollTarget, ANN_TARGET_POLL_MS);
+} else {
+  annWatchTarget(annOwnFrame);
+}
 window.addEventListener("resize", renderAnn);
 renderAnn();  // chips from a persisted review show before the frame loads
 watchApp();   // a document already in the frame at boot never fires `load`
@@ -3887,8 +4520,8 @@ watchApp();   // a document already in the frame at boot never fires `load`
 // to be undone on the way out.
 //
 // Placed AFTER the annotation section on purpose: the first call re-measures the
-// pins, and renderAnn reads consts (annPins, annFrame, annotations) declared down
-// there — running this any earlier is a temporal-dead-zone ReferenceError.
+// pins, and renderAnn reads bindings (annPins, annFrame, annotations) declared
+// down there — running this any earlier is a temporal-dead-zone ReferenceError.
 const viewBtn = document.getElementById("viewbtn");
 // The view the last call applied, so a FLIP can be told from a re-application
 // (params.onChange fires for every param, `split` and `model` included). null
@@ -4558,7 +5191,10 @@ async function annCaptureShots(pending, deadline) {
     }
     return out;
   }
-  const doc = annFrame.contentDocument;
+  // Whatever `annFrame` currently points at — our pane, or the host's marked
+  // one — and it may be null in the sidebar layout, where the shotPane above has
+  // already answered "nothing to capture" for the same reason.
+  const doc = annFrame && annFrame.contentDocument;
   const stamp = new Date().toISOString().replace(/[^0-9]/g, "").slice(0, 14)
     + "-" + crypto.randomUUID().slice(0, 8);
   // A capture the walk could not finish — or could not trust — is a real picture

--- a/tests/test_claude_app_state.py
+++ b/tests/test_claude_app_state.py
@@ -993,11 +993,20 @@ def test_the_reload_marker_fires_on_the_frames_own_load(html):
 def test_the_watcher_is_wired_to_the_load_event_not_to_a_timer(html):
     """The interval existed only because the old /embed framing hid the reload
     from the outer frame. Hooking the same `load` the annotation rewiring uses
-    keeps one place where a fresh document is noticed."""
+    keeps one place where a fresh document is noticed.
+
+    The hook is a NAMED function rather than an inline listener now, because the
+    chat-only sidebar has a second way into it: its target is the host's content
+    pane, which loaded before this document booted, so a `load` that already
+    fired is not something this page can wait for — annWatchTarget wires the
+    document that is already there and hears the ones that follow. Both entries
+    land in the same function, which is what keeps "a fresh document appeared"
+    in one place."""
     assert "APP_WATCH_INTERVAL" not in html
     assert "setInterval(watchApp" not in html
-    start = html.index('annFrame.addEventListener("load"')
-    assert "watchApp()" in html[start:start + 500], "the load hook does not watch"
+    assert 'frame.addEventListener("load", annWireTarget);' in html
+    start = html.index("function annWireTarget() {")
+    assert "watchApp()" in html[start:start + 900], "the load hook does not watch"
 
 
 def test_a_document_is_only_wrapped_once_but_a_new_one_is_wrapped_again(html):
@@ -1366,7 +1375,7 @@ def test_escape_is_bound_inside_the_framed_app_too(html):
     the keydown lands — and a keydown in the frame's document does not bubble to
     this one. Binding only the parent document is why Escape looked broken while
     annotating: the same reason mousedown/mousemove/click are all bound on `doc`."""
-    load = html.index("annFrame.addEventListener(\"load\"")
+    load = html.index("function annWireTarget() {")
     body = html[load:html.index("// ── send one message", load)]
     assert "doc.addEventListener(\"keydown\", onEscape" in body, body[-3000:]
     # and the parent keeps its own binding, for an Escape pressed in the chat pane

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -520,7 +520,8 @@ def test_the_note_composer_is_portaled_to_the_click_in_the_target_document():
     unportal = code[code.index("function annUnportalPop() {"):]
     unportal = unportal[:unportal.index("\n}\n")]
     assert "document.adoptNode(annPop);" in unportal
-    assert "annPopHome.appendChild(annPop);" in unportal
+    assert '(document.getElementById("chat") || document.body).appendChild(annPop);' \
+        in unportal
     close = code[code.index("function annCloseComposer() {"):]
     close = close[:close.index("\n}\n")]
     assert "annUnportalPop();" in close
@@ -546,6 +547,112 @@ def test_the_note_composer_is_portaled_to_the_click_in_the_target_document():
     sync = code[code.index("function annSyncTarget() {"):]
     sync = sync[:sync.index("\n}\n")]
     assert "if (annPortaled() && annPop.getRootNode() !== annLayerRoot) annCloseComposer();" in sync
+
+
+def test_the_composer_never_remembers_a_home_that_a_teardown_can_remove():
+    """A remembered home node is a race with a teardown that has not run yet.
+    `paneURL` awaits a fetch before it answers `null`, and the poll that injects
+    the annotation layer and wires the pane's click handler runs at the END of
+    the script — so annotate mode is live, over the host's pane, for a whole
+    network round trip before `enterNoPane` moves the composer out of #leftview.
+    A click in that gap portaled a composer whose parent was still #leftview,
+    and #leftview is precisely what the teardown then removes: "home" would have
+    been a detached column, i.e. a composer that opens into nothing.
+
+    So the home is resolved at unportal time (#chat is the sidebar's seat at
+    every moment, before or after the teardown), and "am I portaled" is asked of
+    `ownerDocument` — the thing `adoptNode` changes — rather than of a
+    remembered parent. That answer also survives a pane reload leaving the node
+    on a dead shadow tree, and an `adoptNode` that lands before an `appendChild`
+    that throws.
+
+    And the teardown closes any live composer before it moves anything, so it
+    never yanks an open one across documents into a coordinate that meant
+    something in someone else's viewport.
+    """
+    code = _pane_code()
+    assert "const annPortaled = () => annPop.ownerDocument !== document;" in code
+    assert "annPopHome" not in code, \
+        "no remembered home node — that was the race"
+    portal = code[code.index("function annPortalPop() {"):]
+    portal = portal[:portal.index("\n}\n")]
+    assert "parentNode" not in portal, "the portal records nothing about where it came from"
+
+    no_pane = code[code.index("function enterNoPane()"):]
+    no_pane = no_pane[:no_pane.index("\n}\n")]
+    assert no_pane.index("annCloseComposer();") < no_pane.index("appendChild(annPop)"), \
+        "a live portaled composer is closed before the rescue moves anything"
+
+
+def test_a_mark_that_moves_between_two_mounted_frames_repaints_the_pins():
+    """The shell keeps its pane-mode iframes mounted and moves the mark between
+    them, so "is there a target" can be true on both sides of a switch while the
+    TARGET is a different document. The poll's arrived/departed branches say
+    nothing about that case, and nothing else covers it: annWatchTarget refuses a
+    frame it has already adopted, so no wiring runs and no render comes with it,
+    and the layer we re-resolve is the one that frame was left with — painted
+    from whatever `annotations` said when it was last on screen.
+
+    annSyncTarget already computed the answer and was the only one who knew it.
+    The poll acts on it now.
+    """
+    code = _pane_code()
+    sync = code[code.index("function annSyncTarget() {"):]
+    sync = sync[:sync.index("\n}\n")]
+    assert "const moved = next !== annFrame;" in sync
+    assert "return moved;" in sync
+    poll = code[code.index("function annPollTarget() {"):]
+    poll = poll[:poll.index("\n}\n")]
+    assert "const moved = annSyncTarget();" in poll, \
+        "the poll has to keep the answer to act on it"
+    assert "if (moved) renderAnn();" in poll
+    assert poll.index("if (moved) renderAnn();") < poll.index("if (has) annSetMode("), \
+        "the same-answer branch is where a moved mark lands"
+
+
+def test_the_re_render_observer_follows_the_target_document():
+    """One repaint on the switch is not enough on its own: the pins also have to
+    keep up with the app RE-RENDERING under them, and that is the
+    MutationObserver's job. It was installed inside annWireTarget's run-once
+    block — precisely the path a re-selected frame skips — so after a mark moved
+    back to a frame we had already wired, the observer was still watching the
+    pane the reader LEFT. The app they were looking at could redraw and no pin
+    would move.
+
+    So it is hoisted out of that block and owned by a function whose only job is
+    "watch whichever document is the target now", idempotent on the document so
+    both callers can ask without knowing whether anything changed: annSyncTarget
+    (where a moved mark is noticed) and annWireTarget above its guard (the split
+    layout's only route, and every load's).
+
+    Still ONE observer, moved rather than accumulated — one left on an unwatched
+    pane would go on waking this frame for mutations nobody is drawing pins for.
+    """
+    code = _pane_code()
+    obs = code[code.index("function annObserveTarget(doc) {"):]
+    obs = obs[:obs.index("\n}\n")]
+    assert "if (doc === annObservedDoc) return;" in obs, "idempotent on the document"
+    assert "if (annObserver) annObserver.disconnect();" in obs, \
+        "the old document is let go before the new one is taken"
+    assert "annObserver.observe(doc.body || doc.documentElement," in obs
+    assert "hasAttribute(ANN_LAYER_MARK)" in obs, \
+        "our own layer's arrival must not re-trigger the render that drew it"
+
+    # Nothing installs an observer anywhere else, and in particular not inside
+    # the run-once wiring block that started this bug.
+    assert code.count("new MutationObserver") == 1
+    wire = code[code.index("function annWireTarget() {"):]
+    wire = wire[:wire.index("\n}\n")]
+    assert wire.index("annObserveTarget(doc);") < wire.index("if (doc.__fusedAnnWired)"), \
+        "above the guard, or a re-selected frame never re-points it"
+    sync = code[code.index("function annSyncTarget() {"):]
+    sync = sync[:sync.index("\n}\n")]
+    assert "annObserveTarget(doc);" in sync
+
+    # The render queue moved out with it and is shared: one rAF, not one per
+    # document left over from an earlier target.
+    assert "function annQueueRender() {" in code
+    assert 'doc.addEventListener("scroll", annQueueRender,' in wire
 
 
 def test_the_portaled_composer_takes_its_styling_with_it():

--- a/tests/test_claude_kind.py
+++ b/tests/test_claude_kind.py
@@ -350,14 +350,24 @@ def test_the_no_pane_state_undoes_what_boot_did_from_a_stale_param():
 
 
 def test_nothing_drives_the_pane_machinery_once_the_pane_is_gone():
-    """One flag, checked in the four functions that would otherwise write to
-    detached nodes or to a param describing a layout that no longer exists.
+    """One flag, checked in the functions that would otherwise write to detached
+    nodes or to a param describing a layout that no longer exists.
 
     `paneEmbedded` — the "this pane is the embedded listing, refuse to arm"
     flag — is deleted rather than repurposed: there is no embedded listing any
     more, and the condition it guarded (an annotate button over a pane whose
     clicks can never resolve) is now impossible by construction, because the
     button is not in the document.
+
+    ANNOTATION IS NO LONGER ONE OF THOSE FUNCTIONS, and that split is the point.
+    `noPane` answers "is OUR column gone", which the chat-only sidebar (#456)
+    turned into a different question from "is there anything to annotate": there
+    the column is gone AND the notes have a target — the host's own content pane,
+    marked with `data-fused-annotate-target` and resolved through
+    `window.parent.document`. So annSetMode asks `annCapable()` instead, which IS
+    `!noPane` in the split layout and "is the host showing something marked" in
+    the sidebar. The layout appliers keep the flag: that layout really is ours
+    and really is gone.
     """
     code = _pane_code()
     assert "let noPane = false;" in code
@@ -367,12 +377,226 @@ def test_nothing_drives_the_pane_machinery_once_the_pane_is_gone():
     # rewritten.
     ann = code[code.index("function annSetMode(on) {"):]
     ann = ann[:ann.index("\nannBtn.addEventListener")]
-    assert "if (noPane) { annOn = false; return; }" in ann
-    assert ann.index("if (noPane)") < ann.index('fused.params.set("annmode"')
-    for fn in ("function applySplit() {", "function applyNarrowView() {",
-               "function renderAnn() {"):
+    assert "if (!annCapable()) { annOn = false; return; }" in ann
+    assert ann.index("if (!annCapable())") < ann.index('fused.params.set("annmode"')
+    # …and the predicate is the flag itself wherever there is no host pane.
+    assert "const annCapable = () => (CHAT_ONLY ? !!annFrame : !noPane);" in code
+    for fn in ("function applySplit() {", "function applyNarrowView() {"):
         body = code[code.index(fn):code.index(fn) + 300]
         assert "if (noPane) return;" in body, fn
+    # renderAnn draws two things and they answer differently now: the pins need a
+    # layer (null bindings when the host shows nothing marked, and the loop is
+    # skipped), the chips are the payload of a message this chat can still send.
+    render = code[code.index("function renderAnn() {"):]
+    render = render[:render.index("\n}\n")]
+    assert "if (noPane && !CHAT_ONLY) return;" in render
+    assert "if (annPins) {" in render
+
+
+def _preview_tsx() -> str:
+    with open(os.path.join("frontend", "src", "apps", "explorer", "Preview.tsx"),
+              encoding="utf-8") as f:
+        return f.read()
+
+
+def test_the_sidebar_annotates_the_hosts_content_pane_through_one_attribute():
+    """The whole contract between the shell and the chat, and it is one attribute.
+
+    The sidebar (`chat_only=1`) has no pane of its own, so annotation had nothing
+    to point at and #456 shipped a split from which nothing could be annotated.
+    The switch comes back aimed at the HOST's content pane — the middle column,
+    the preview this chat is beside — found by a mark the shell stamps on the
+    iframe it is currently showing.
+
+    A MARK, not an arrangement: the shell says which frame is the content, and
+    this page reads it back through `parent.document`. Nothing else crosses. The
+    shell learns no annotation vocabulary (one attribute, one comment), and the
+    template stays host-agnostic — a parent that is absent, cross-origin, or
+    marks nothing yields null, which hides the switch instead of erroring.
+
+    Both halves are asserted here on purpose: an attribute is a contract only
+    while its two ends spell it the same way, and neither file's own test suite
+    would notice the other renaming it.
+    """
+    tsx = _preview_tsx()
+    code = _pane_code()
+    # The shell's half: on the frame that is SHOWN (the swap keeps two mounted,
+    # and only one of them is on screen), and only where a sidebar can exist —
+    # `splitCapable` is the single-file explorer preview, never a folder listing,
+    # never a panel/tab embed.
+    assert "data-fused-annotate-target={" in tsx
+    assert "splitCapable && m === shown" in tsx
+    # The template's half: same spelling, read off the parent, guarded.
+    assert 'host.document.querySelector("[data-fused-annotate-target]")' in code
+    marked = code[code.index("function annMarkedFrame() {"):]
+    marked = marked[:marked.index("\n}")]
+    assert "window.parent" in marked
+    assert "catch" in marked, "a cross-origin parent THROWS on .document"
+    assert 'el.tagName === "IFRAME"' in marked
+    # No second channel grew alongside it (D3/D4).
+    assert "postMessage" not in code
+
+
+def test_the_hosted_pin_overlay_is_injected_into_the_target_document():
+    """Pins belong over the element they mark, and in the sidebar layout that
+    element is in another column of the HOST's window — an overlay in this
+    document would be pins drawn over the chat. So the layer is injected into the
+    target's own document, where `annStageRect`'s coordinates already mean
+    something and the frame's own scroll handler keeps them true.
+
+    Behind a SHADOW ROOT, which is not decoration: it is what keeps an arbitrary
+    previewed template's CSS off our pins and ours off theirs, what keeps the
+    pins out of `shotPane`'s clone (cloneNode does not clone a shadow tree — the
+    same structural guarantee the split layout gets by living in a different
+    document), and what keeps the re-render observer from seeing the render it
+    caused.
+
+    APPENDED, never prepended: anchors are `tag:nth-of-type` paths from <body>,
+    and a new first child would renumber every one of them.
+    """
+    code = _pane_code()
+    inject = code[code.index("function annInjectLayer(doc) {"):]
+    inject = inject[:inject.index("\n}\n")]
+    assert 'attachShadow({ mode: "open" })' in inject
+    assert "doc.body.appendChild(host);" in inject
+    assert "prepend" not in inject and "insertBefore" not in inject
+    assert "position: fixed" in inject, "the layer's box is the framed viewport"
+    # Found again rather than stacked: a second call on the same document reuses
+    # the layer it already put there.
+    assert 'doc.querySelector("[" + ANN_LAYER_MARK + "]")' in inject
+    # The injected stylesheet travels with the injection and names no token — it
+    # lives in a document that never heard of this page's palette.
+    css = code[code.index("const ANN_LAYER_CSS = ["):]
+    css = css[:css.index('].join("\\n");')]
+    assert "var(--" not in css
+    assert "box-sizing: border-box" in css, \
+        "no reset comes with a shadow tree, and the ring's border would grow it"
+    # And the app's own outline never reports our layer as part of the app.
+    outline = code[code.index("function outlineNode("):]
+    outline = outline[:outline.index("\n}\n")]
+    assert 'hasAttribute("data-fused-annotate")' in outline
+
+
+def test_the_note_composer_is_portaled_to_the_click_in_the_target_document():
+    """The composer belongs beside the element it describes, and in the sidebar
+    layout that element is in another column of the HOST's window. An iframe
+    cannot paint outside its own box, so no placement in this column can put the
+    text box next to the ring — the NODE has to move into the target's document,
+    into the same injected overlay the pins live in.
+
+    The real node, moved with `adoptNode`, never a rebuilt copy: the keydown that
+    saves on Enter and closes on Escape, the delete button's click and the
+    textarea's text all ride on it, and every one of those closes over this
+    document's state (`annotations`, `annDraft`, `annEditing`). A second popover
+    would be a second implementation to keep in step.
+
+    Placement is then the SPLIT LAYOUT'S OWN arithmetic, unchanged, because after
+    the portal both layouts are the same problem: a box whose coordinate space is
+    the framed viewport. #chat stops being where the composer works and becomes
+    where it RESTS — the seat annCloseComposer returns it to, so a pane reload
+    can never orphan an idle composer in a dead document.
+    """
+    code = _pane_code()
+    # Still rescued out of #left before the teardown removes the column — that is
+    # what gives the composer a document to come home to.
+    no_pane = code[code.index("function enterNoPane()"):]
+    no_pane = no_pane[:no_pane.index("\n}\n")]
+    assert 'annPop.classList.add("sidebar");' in no_pane
+    assert 'document.getElementById("chat").appendChild(annPop);' in no_pane
+    assert no_pane.index("appendChild(annPop)") < no_pane.index('for (const id of ["annbtn"'), \
+        "rescued BEFORE the column it lives in is removed"
+
+    # Out: adopted into the layer's shadow root, which annInjectLayer hands back
+    # whole for exactly this.
+    portal = code[code.index("function annPortalPop() {"):]
+    portal = portal[:portal.index("\n}\n")]
+    assert "annLayerRoot.ownerDocument.adoptNode(annPop);" in portal
+    assert "annLayerRoot.appendChild(annPop);" in portal
+    assert "if (!annLayerRoot) return false;" in portal, \
+        "nothing to portal into means the caller parks it, not a throw"
+    assert "root, pins:" in code, "the shadow root is part of the layer handle"
+
+    # Back: on EVERY close, so the node's idle life is spent in its own document.
+    unportal = code[code.index("function annUnportalPop() {"):]
+    unportal = unportal[:unportal.index("\n}\n")]
+    assert "document.adoptNode(annPop);" in unportal
+    assert "annPopHome.appendChild(annPop);" in unportal
+    close = code[code.index("function annCloseComposer() {"):]
+    close = close[:close.index("\n}\n")]
+    assert "annUnportalPop();" in close
+
+    # One placement rule, the split layout's, for both layouts.
+    place = code[code.index("function annPlacePop(x, y) {"):]
+    place = place[:place.index("\n}")]
+    assert "Math.min(host.clientWidth - 292, Math.max(0, x + 10))" in place
+    assert "Math.min(host.clientHeight - 110, Math.max(0, y + 10))" in place
+    assert place.count("annPop.style.left") == 2, \
+        "one placement, one park — no third coordinate system"
+    # The parked fallback survives, for the one case with no point to aim at.
+    assert "annUnportalPop();" in place
+    assert "#annpop.sidebar {" in _pane_source()
+    # And the chip-edit path says so with nulls rather than inventing a point in
+    # someone else's viewport.
+    render = code[code.index("function renderAnn() {"):]
+    assert "const cx = r ? r.right : (CHAT_ONLY ? null : w / 3);" in render
+
+    # A target that reloads or unmarks while the composer is open takes the
+    # composer's document with it: the sync closes it (dropping the draft, which
+    # is what any close does) rather than leaving a node in a dead tree.
+    sync = code[code.index("function annSyncTarget() {"):]
+    sync = sync[:sync.index("\n}\n")]
+    assert "if (annPortaled() && annPop.getRootNode() !== annLayerRoot) annCloseComposer();" in sync
+
+
+def test_the_portaled_composer_takes_its_styling_with_it():
+    """`#annpop`'s rules live in this page's <style>, and a stylesheet does not
+    cross a shadow boundary into another document — so a composer portaled to the
+    target with nothing else done would arrive as a bare UA text box floating
+    over the app. The injected stylesheet carries a second copy, literal-valued
+    like everything else in there (the app has never heard of this palette).
+
+    `pointer-events: auto` is the load-bearing one: the layer host is
+    `pointer-events: none` so the app stays clickable through it, and a textarea
+    that inherits that cannot be typed in.
+    """
+    code = _pane_code()
+    css = code[code.index("const ANN_LAYER_CSS = ["):]
+    css = css[:css.index('].join("\\n");')]
+    assert "#annpop {" in css
+    assert "#annpop textarea {" in css
+    assert "#annpop .hint {" in css
+    assert "#annpop #anndel {" in css
+    # Same box as the page's own rule, so the two copies read alike.
+    assert "width: 280px" in css and "border-radius: 12px" in css
+    assert "padding: 10px" in css
+    assert "pointer-events: auto" in css, "the layer host is pointer-events: none"
+    assert "position: absolute" in css, \
+        "absolute inside the fixed layer host = framed-viewport coordinates"
+
+
+def test_the_hosted_switch_hides_itself_when_the_host_shows_nothing_marked():
+    """The mark is a live fact: it arrives after the shell's first paint, moves
+    to another frame when the reader switches the pane's mode, and goes away when
+    the pane shows something unannotatable. None of that reaches this document as
+    an event, and postMessage is the thing this template deliberately does not
+    have — so the switch asks, on focus and on a slow interval.
+
+    Hidden, not disabled: the same rule the narrow layout applies to the controls
+    of a hidden half. And only ever in this layout — the split pane hears about
+    itself from its own `load` event.
+    """
+    code = _pane_code()
+    poll = code[code.index("function annPollTarget() {"):]
+    poll = poll[:poll.index("\n}")]
+    assert "annBtn.hidden = !has;" in poll
+    assert "#annbtn[hidden] { display: none; }" in _pane_source(), \
+        "`display: flex` outranks the UA's [hidden] rule"
+    start = code.index("if (CHAT_ONLY) {\n  annPollTarget();")
+    wiring = code[start:start + 400]
+    assert 'window.addEventListener("focus", annPollTarget);' in wiring
+    assert "setInterval(annPollTarget, ANN_TARGET_POLL_MS);" in wiring
+    assert "annWatchTarget(annOwnFrame);" in wiring, \
+        "and the split layout still adopts its own frame instead"
 
 
 def test_a_stale_split_param_on_a_folder_url_is_ignored_not_an_error():


### PR DESCRIPTION
## What

Review feedback on the #456 split preview:

1. **Always-3 companion dropdown.** The file sidebar (Claude/Git/History) and folder pane switcher (Preview/Claude/Git) now always list every companion. An unavailable one renders disabled with its real template icon and a tooltip reason — "Not inside a git repository" / "No history for this file" — instead of vanishing (which previously also hid the whole menu at one entry). Placeholders are menu-only: split on/off, toggle targets, `_side` URL resolution and session reconcile never see them. Gate-pending keeps the existing spinner row.

2. **Annotation returns** (was unreachable since chat_only removed the claude template's internal pane). The shell stamps `data-fused-annotate-target` on the active content iframe — its only involvement. The chat_only claude sidebar resolves that same-origin sibling frame and annotates it: pin/highlight overlay and the note composer portal into the target document's overlay shadow root (self-contained CSS, adoptNode round-trip), the composer opening at the click point exactly like the standalone layout. No postMessage (D3/D4 stands); the host contract is one attribute, and the template degrades to plain chat when nothing is marked.

## Testing

- `bun test`: 694 pass (9 pre-existing `shortcut-chord` failures, present on clean main)
- pytest: 5862 pass; 1 pre-existing failure `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, fails identically on clean origin/main
- `tsc --noEmit` + boundaries clean
- Live Playwright verification: dropdown states in/out of a repo (tooltips, disabled no-ops), annotate end-to-end (pin + composer at click+10px, right-edge clamp, pane mode switch closes cleanly, zero console errors), no annotate affordance with sidebar closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches companion URL reconciliation, dir-mode visibility, and same-origin cross-frame annotation; behavior is heavily tested but the claude template change is large and user-facing.
> 
> **Overview**
> **Companion switchers** on the file preview sidebar and folder listing pane now always show the full closed set (Claude/Git/History or Preview/Claude/Git). Modes that cannot be used stay in the menu as **disabled rows** with canned tooltip reasons from `unavailableReason`, real mode icons via `bound` / `paneSideIconEntry`, and pending rows still spin. `ModeMenu` no longer hides when only one row is enabled, and `PreviewSidebar` always uses the menu instead of a flat label.
> 
> Split/URL behavior is unchanged: a separate **`menu`** list is for drawing only; `all` / `settled` / `paneSideList` still drive `_side`, toggles, and framing.
> 
> **Chat-only sidebar annotation** is restored by stamping **`data-fused-annotate-target`** on the explorer’s visible content iframe (`shown`, `splitCapable` only). The Claude template resolves that frame through `parent.document`, injects pins into the target document, portals the note composer with `adoptNode`, polls when the mark moves between mounted frames, and uses `annCapable()` instead of `noPane` for arming annotate mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff61d4e1f95e51bafa0277a7892d85e2a97d421b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->