### PR TITLE
Split panes drop the preview column; one chevron for both sidebars; kebab chrome gate

### DIFF
--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -36,7 +36,7 @@ import {
   type ReactNode,
 } from "react";
 import { createPortal } from "react-dom";
-import { IS_SNAPSHOT, navigate, replaceSearch } from "@platform/lib/router";
+import { IS_PANEL_PANE, IS_SNAPSHOT, navigate, replaceSearch } from "@platform/lib/router";
 import { dirname, normDir } from "@apps/explorer/lib/fs-actions";
 import { acquireOverlay, releaseOverlay } from "@platform/lib/ui-overlay";
 import { isMod } from "@platform/lib/platform";
@@ -233,7 +233,27 @@ export default function Listing({
   // in its own column. A flag that could only ever be written beside another
   // one is the "three places to agree about one bit" the pane's own history
   // (pane.ts) is a warning about.
-  const paneEnabled = !embedded && !IS_SNAPSHOT;
+  //
+  // A PANEL PANE is the third, and it is the same shape of blind spot as the
+  // snapshot: a pane is a whole shell at `/explorer/embed/<path>`, so its
+  // Listing is that frame's own top-level one — `embedded=false`, `barChrome`
+  // true, everything about it says "I own this window". What it does not own is
+  // the layout: the user split it, and a pane of a 1600px window is ~800px,
+  // comfortably past PANE_SPLIT_MIN_W, so a split-right of a folder grew two
+  // half-width listings each with their own half-width preview. Four columns
+  // where the user asked for two, and the width test cannot object because the
+  // width is genuinely there. IS_PANEL_PANE is the host-side question the width
+  // cannot answer (see router.ts, including why `IS_EMBED` — which is also
+  // every TAB, where the pane is right and stays — is the wrong flag here).
+  //
+  // Switching it off HERE is the whole feature: `pane.on` is `paneEnabled &&`
+  // the measurement, so one predicate takes the slot, the divider, the closing
+  // chevron on the pane's header, the reopening SideToggleButton in the search
+  // row, the FS-16 auto-select (which waits on `pane.on` by design) and the two
+  // `useDirMode` companion probes with it. Nothing about the ROWS changes: a
+  // pane's listing still selects, arrow-keys, and opens on double-click/Enter —
+  // opening a file in a pane replaces that pane's document, which is the point.
+  const paneEnabled = !embedded && !IS_SNAPSHOT && !IS_PANEL_PANE;
   const { pane, splitRef, onDividerPointerDown } = usePreviewPane(paneEnabled);
 
   // --- the pane's THREE modes, and whether it is open at all ------------------

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -925,7 +925,12 @@ export default function Listing({
   // the button says it does. One element, three homes — the mtime th, the
   // search header's Path th, and (labels hidden) the empty folder's strip —
   // because the actions act on the current folder in every one of them.
-  const headerMenuBtn = (
+  //
+  // Only where this listing OWNS the bar chrome: the menu replaces the crumb
+  // bar's path `⋮`, so it belongs to the same view that dropped it. An
+  // embedded or pane-hosted listing never had that menu — and its "Split
+  // right" would rewrite the SHELL's URL from inside a nested surface.
+  const headerMenuBtn = !ownsBarChrome ? null : (
     <button
       type="button"
       className="listing-head-menu"

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -109,6 +109,10 @@ function inSearchSlot(slot: HTMLElement | null, row: ReactNode): ReactNode {
   return slot ? createPortal(row, slot) : row;
 }
 
+// Flips the tight-bar measurement is allowed at one bar width before it holds.
+// The reasoning is at `tightFlipRef` and at the layout effect it guards.
+const FLIP_BUDGET = 2;
+
 export default function Listing({
   fsPath,
   provisional = false,
@@ -330,6 +334,16 @@ export default function Listing({
   // already stands the crumbs down and takes the whole strip.
   const [tightBar, setTightBar] = useState(false);
   const [pinnedOpen, setPinnedOpen] = useState(false);
+  // How many times the tight-bar measurement may flip at one bar width before
+  // it stops arguing with itself — the convergence guarantee for the layout
+  // effect below, which has no dependency array and so re-enters on every
+  // commit it causes. Two is enough for every honest case: the first flip is
+  // the decision, the second absorbs a settling relayout (a scrollbar, a
+  // shed column) that legitimately reverses it. A third flip at an unchanged
+  // width is not new information, it is the bistable case, and past 50 of
+  // those React unmounts the whole tree with #185. Lives in a ref, not state,
+  // because spending budget must not itself schedule a render.
+  const tightFlipRef = useRef({ barW: -1, flips: 0 });
   const searchRowRef = useRef<HTMLDivElement>(null);
   // Path -> RowCtx for the rendered rows, read by the once-registered keydown
   // handler so Enter can pass the row's is_dir as a nav hint (assigned each
@@ -380,7 +394,8 @@ export default function Listing({
   // The tight-bar measurement. DOM-side on purpose: this row PORTALS into
   // #breadcrumb (the slot above), so the crumbs it shares the strip with are
   // reachable — and already coupled to this row by the bar's :has() rules.
-  // Two thresholds, deliberately apart, so the flip cannot oscillate:
+  // Two thresholds, meant to be far enough apart that the flip cannot
+  // oscillate:
   //   • fold: the crumbs are ellipsized (scrollWidth past clientWidth) even
   //     after the CSS yield order has bottomed out — the box is the only
   //     slack left to give.
@@ -390,11 +405,37 @@ export default function Listing({
   //     summed from the bar's visible children, not read off the crumbs:
   //     they are flex-grow 0 in slot mode, so their clientWidth hugs their
   //     content and never reports the strip's slack.
+  //
+  // THE GAP IS NOT ALWAYS A GAP, which is what FLIP_BUDGET below is for. Each
+  // threshold is read in the state the OTHER one produced — "are the crumbs
+  // ellipsized" is asked of the unfolded strip, "is there 150px free" of the
+  // folded one — so the pair only behaves as hysteresis while folding really
+  // does free more than unfolding costs. At bar widths where the box's own
+  // fold delta lands near that 150px the two verdicts contradict each other
+  // and the flip is bistable: fold → "path fits and there is room" → unfold →
+  // "path is ellipsized" → fold, forever.
+  //
+  // Forever, and synchronously, because this is a layout effect with no
+  // dependency array: React commits, runs it, `measure` setStates, which
+  // commits again and runs it again. Past 50 of those React gives up with
+  // "Maximum update depth exceeded" (#185) and unmounts the tree — a BLANK
+  // PAGE. Reproduced at viewport 1675–1800px on a folder whose preview pane
+  // hosts a directory: reopening the pane narrows this strip AND removes the
+  // SideToggleButton from it in one commit, landing the bar in that window.
+  //
+  // So the budget: a flip is spent, and once a bar width has spent its budget
+  // the measurement holds whatever it is showing until the width actually
+  // changes. A width where the thresholds agree converges in one flip and
+  // never touches the budget; a width where they contradict settles on one of
+  // the two legible states instead of taking the page down. Keyed on the bar's
+  // width because that is what the contradiction is a property of — a real
+  // resize is new information and earns a fresh budget.
+  //
   // No dependency array: crumbs content changes with navigation but their
   // clientWidth may not, so a ResizeObserver alone misses scrollWidth-only
-  // changes; re-measuring on every render is cheap and the guarded setState
-  // converges. Skipped while the user is in the box — measuring a strip the
-  // crumbs have stood down from (.searching hides them) reads zeros.
+  // changes; re-measuring on every render is cheap. Skipped while the user is
+  // in the box — measuring a strip the crumbs have stood down from
+  // (.searching hides them) reads zeros.
   useLayoutEffect(() => {
     if (embedded || searching || pinnedOpen) return;
     const row = searchRowRef.current;
@@ -426,11 +467,27 @@ export default function Listing({
       return bar.clientWidth - used;
     };
     const measure = () => {
-      setTightBar((folded) =>
-        folded
-          ? crumbs.scrollWidth > crumbs.clientWidth + 1 || freeInBar() < 150
-          : crumbs.scrollWidth > crumbs.clientWidth + 1
-      );
+      // Fresh width, fresh budget (see FLIP_BUDGET above).
+      const barW = bar.clientWidth;
+      const budget = tightFlipRef.current;
+      if (budget.barW !== barW) {
+        budget.barW = barW;
+        budget.flips = 0;
+      }
+      // Decided OUT HERE rather than inside a setState updater: the decision
+      // reads the DOM and spends the budget, and an updater must stay pure —
+      // React is free to call it more than once for one update, which would
+      // charge the budget twice for a single flip. `tightBar` is the currently
+      // RENDERED value and is current in this closure: the effect (and with it
+      // this observer) is rebuilt on every render, having no dependency array.
+      const folded = tightBar;
+      const next = folded
+        ? crumbs.scrollWidth > crumbs.clientWidth + 1 || freeInBar() < 150
+        : crumbs.scrollWidth > crumbs.clientWidth + 1;
+      if (next === folded) return;
+      if (budget.flips >= FLIP_BUDGET) return; // bistable at this width — hold
+      budget.flips += 1;
+      setTightBar(next);
     };
     measure();
     const ro = new ResizeObserver(measure);

--- a/frontend/src/apps/explorer/SideChrome.tsx
+++ b/frontend/src/apps/explorer/SideChrome.tsx
@@ -25,26 +25,9 @@
 // rendering fault rather than as a choice. Exactly one of them is on screen at
 // any moment, and each sits where its own action makes sense.
 import type { ReactNode } from "react";
+import Chevron from "@platform/ui/Chevron";
 import { templateModeIcon } from "@apps/explorer/ModeSwitcher";
 import type { PaneSide, PaneSideEntries } from "@apps/explorer/listing/pane-side";
-
-function CloseChevron() {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      width="16"
-      height="16"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <polyline points="9 6 15 12 9 18" />
-    </svg>
-  );
-}
 
 // `what` names the panel in both labels — the mode's display name ("Claude",
 // "Git", "Preview"), so the tooltip says which panel rather than "the panel".
@@ -58,7 +41,10 @@ export function SideCloseButton({ what, onClick }: { what: string; onClick: () =
       aria-label={label}
       onClick={onClick}
     >
-      <CloseChevron />
+      {/* Points RIGHT — this column is on the right, and right is the way it
+          goes when it collapses. The identical glyph mirrored is what the left
+          sidebar's collapse button wears (platform/ui/Chevron). */}
+      <Chevron dir="right" />
     </button>
   );
 }

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -88,6 +88,77 @@ export const IS_EMBED =
 // would be a second source of truth for a fact that never moves.
 export const IS_SNAPSHOT =
   new URLSearchParams(location.search).get("snapshot") === "1";
+
+// Is this pathname panel mode's sentinel route? Both prefixes, because panel
+// mode lives under the page's own one (Panel.tsx's PANEL_PATH) so that
+// entering/refreshing/exiting stays in the active mode — which means the shell
+// has to recognise either spelling. Exported so the two readers (App's route
+// dispatch, and IS_PANEL_PANE below, which asks it of a HOST document) cannot
+// drift into two spellings of one route.
+export function isPanelPath(pathname: string): boolean {
+  return pathname === VIEW_PREFIX + "_panel" || pathname === EMBED_PREFIX + "_panel";
+}
+
+// AM I A PANE OF A SPLIT? — the third framing flag, and the only one that is
+// not a fact about this document's own URL.
+//
+// A panel pane is a whole shell loaded at `/explorer/embed/<path>`, so from the
+// inside it looks exactly like a top-level window: it owns its bar chrome
+// (`barChrome && !embedded` is true in there), it reflects sort/`_side` into its
+// own address bar, it registers document-level keys. That is all deliberate —
+// a pane IS a browsing context, and everything in it should behave. The one
+// thing it must not do is grow the listing's own preview pane: the user already
+// answered the layout question by splitting, and half of a window is not two
+// readable columns. Exactly the argument Preview.tsx makes for the FILE
+// sidebar's `splitCapable`.
+//
+// So why not `IS_EMBED`, which is what `splitCapable` uses? Because it is too
+// coarse for THIS surface: it is also every TAB (Tabs.tsx frames the same
+// /embed shells), and a tab is full-window — there is no split, nothing was
+// answered, and its folder listing should keep the pane it has always had. It
+// is also bookmark cards and any external embed. `splitCapable` can afford the
+// looseness (a tab's file view genuinely doesn't want a second split either);
+// a folder listing cannot.
+//
+// And the panes themselves carry NOTHING to tell the two apart: Panel and Tabs
+// both build their iframe src through layout-codec's `embedSrc`, byte for byte
+// identical. A marker param would be the obvious fix and is a trap — `navigate`
+// deliberately drops the query on every hop (see there), so `?_pane=1` would
+// survive exactly until the user clicked a folder inside the pane, and keeping
+// it would mean adding a second exception beside `snapshot=1` to carry a bit
+// the host already knows.
+//
+// So ASK THE HOST. Climbing to an ancestor's URL is the shell's existing
+// same-origin idiom, not a new one: the template runtime reads its params off
+// ancestor URLs the same way (D3/D4/D46), and panel/tab shells already reach
+// down the other direction (readEmbedLoc reads a pane iframe's live location).
+// The host's pathname is the route sentinel itself, so there is no flag for
+// anyone to write, forget to write, or write inconsistently — one producer, and
+// it is the route.
+//
+// Climbs the whole chain rather than checking `parent` alone: a listing can sit
+// two frames deep inside a split (a pane showing the bookmarks page, whose
+// cards are embeds of their own), and being three levels down in a pane is
+// still being in a pane. `top` terminates it; the try/catch is for a
+// cross-origin ancestor (an external embed), where the answer is "not a pane" —
+// the same safe direction the flag's other cases point.
+//
+// Read ONCE at module init, like the two above, and for a stronger reason than
+// theirs: a document cannot be re-parented into or out of a frame, so the fact
+// physically cannot change without a fresh load of this document.
+export const IS_PANEL_PANE = (function inPanelHost(): boolean {
+  try {
+    let win: Window = window;
+    while (win !== win.parent) {
+      win = win.parent;
+      if (isPanelPath(win.location.pathname)) return true;
+    }
+  } catch {
+    // Cross-origin ancestor: not our panel.
+  }
+  return false;
+})();
+
 // URL prefix for this page's mode. Keeps refresh, in-listing navigation, and
 // param sync (iframe runtime's history.replaceState) inside the active prefix.
 const PREFIX = IS_EMBED ? EMBED_PREFIX : VIEW_PREFIX;

--- a/frontend/src/platform/ui/Chevron.tsx
+++ b/frontend/src/platform/ui/Chevron.tsx
@@ -1,0 +1,58 @@
+// THE COLLAPSE CHEVRON — one glyph, stated once, for every control whose job is
+// "this panel goes away in that direction".
+//
+// It exists because there were three hand-written copies of it and they had
+// drifted: the left sidebar's collapse button drew it at 14px, the collapsed
+// rail's expand button beside it at 16px, and the right-hand companion column's
+// close button (SideChrome) at 16px as a `<polyline>` instead of a `<path>`.
+// Same 24-unit grid and the same strokeWidth="2" in all three, which is exactly
+// what made the difference hard to name and impossible to unsee once named: a
+// 24-grid stroke of 2 renders at 2 x (box / 24) actual pixels, so 14px drew a
+// 1.17px line and 16px drew a 1.33px one. The chevron on the left of the window
+// was a THINNER chevron than the one on the right — a 14% weight difference
+// between two controls the eye reads as one pair, from a size nobody chose for a
+// reason.
+//
+// 16px is the app's icon norm (the bar and rail glyphs, ModeSwitcher, the
+// mode-side icons — all 16px on a 0 0 24 24 viewBox at strokeWidth 2), so the
+// two 16px copies were right and the 14px one was the outlier. Fixing it by
+// editing the 14 to a 16 would have left three copies free to drift again on the
+// next attribute anyone touched, hence a component: there is now one place where
+// this glyph's weight is decided, and no way for two chevrons to disagree.
+//
+// A `<path>` and not the polyline, because that is the form the rest of the
+// app's Lucide-style 24-grid icons use; with round caps and joins the two
+// primitives rasterise identically, so this is purely about having one spelling.
+//
+// DIRECTION IS THE ONLY PROP. The chevron always points the way the panel goes,
+// which is a fact about which seam the button sits on and not a style choice:
+// `left` for a left-hand sidebar collapsing away from the content, `right` for a
+// right-hand column doing the same, and the same glyph mirrored is what makes an
+// expand control legible as the inverse of its collapse control. Size and weight
+// are deliberately NOT props — a caller that wants a different weight wants a
+// different icon, and this file is the answer to callers having had that choice.
+
+// Both on the 24-unit grid, each a mirror of the other about x=12: (15,18) ->
+// (9,12) -> (15,6) points left, (9,18) -> (15,12) -> (9,6) points right.
+const D = {
+  left: "m15 18-6-6 6-6",
+  right: "m9 18 6-6-6-6",
+} as const;
+
+export default function Chevron({ dir }: { dir: "left" | "right" }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d={D[dir]} />
+    </svg>
+  );
+}

--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -5,6 +5,7 @@
 // recents, and app lists. Width/collapsed state is shared across all owners
 // (platform/lib/sidebarstate): switching sub-apps must not jump the layout.
 import React, { useRef, useState } from "react";
+import Chevron from "@platform/ui/Chevron";
 import { navigateUrl } from "@platform/lib/router";
 import {
   getSidebarState,
@@ -167,9 +168,8 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
           title="Expand sidebar"
           onClick={toggleSidebarCollapsed}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="m9 18 6-6-6-6" />
-          </svg>
+          {/* Mirrored: expanding sends the sidebar back out to the right. */}
+          <Chevron dir="right" />
         </button>
         {rail && rail.length > 0 && (
           <div className="sidebar-rail-items">
@@ -257,9 +257,11 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
           title="Collapse sidebar"
           onClick={toggleSidebarCollapsed}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-            <path d="m15 18-6-6 6-6" />
-          </svg>
+          {/* The shared glyph (platform/ui/Chevron) — this used to be a 14px
+              copy of it, which on the 24-unit grid drew a visibly thinner line
+              than the identical 16px chevron on the right-hand companion
+              column's close button. See there for the arithmetic. */}
+          <Chevron dir="left" />
         </button>
       </div>
 

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -16,7 +16,7 @@
 // which is the React equivalent of the vanilla shell rebuilding the view DOM
 // on each route() call (fresh iframes, fresh fetches, dropped local state).
 import { useEffect, useRef, useState } from "react";
-import { IS_EMBED, fsPathFromLocation, navHintIsDir } from "@platform/lib/router";
+import { IS_EMBED, fsPathFromLocation, isPanelPath, navHintIsDir } from "@platform/lib/router";
 import { useSessionRestore, useSessionTracking } from "@platform/lib/session";
 import { useRecentsTracking } from "@apps/explorer/lib/recents";
 import { statPath, getMounts, reconnectMount, type Config, type Mount, type StatResult } from "@platform/lib/api";
@@ -518,7 +518,10 @@ export default function App({ config }: { config: Config }) {
   }
 
   const pathname = location.pathname;
-  const isPanel = pathname === "/explorer/view/_panel" || pathname === "/explorer/embed/_panel";
+  // Via the router's predicate, not a second copy of the two spellings: a pane's
+  // Listing asks the SAME question of its host document (IS_PANEL_PANE), and one
+  // route must not be spelled in two places.
+  const isPanel = isPanelPath(pathname);
   const isTabs = pathname === "/explorer/view/_tab" || pathname === "/explorer/embed/_tab";
   const isPrefs = pathname === "/preferences";
   const isTemplates = pathname === "/templates";


### PR DESCRIPTION
Follow-up to #467 — three things:

## Changes

- **No preview pane inside a split** — a folder listing in a panel pane no longer offers the row-preview column (slot, divider, close chevron, reopen toggle, auto-select and dir-mode probes all follow from one `paneEnabled` gate). The signal is a new `IS_PANEL_PANE` (router.ts): it climbs the same-origin ancestor chain for panel mode's route sentinel — the shell's existing ask-the-host idiom. `IS_EMBED` was deliberately rejected: a **tab** is embedded too, full-window, and keeps its pane (verified as the controlled comparison). App.tsx's `isPanel` now reads the same helper.
- **One chevron for both sidebars** — left collapse chevron rendered the shared 24-grid strokeWidth-2 glyph in a 14px box vs the right panel's 16px, so its stroke rasterised 14% thinner. All three copies (left collapse, collapsed-rail expand, right close) now come from `platform/ui/Chevron.tsx` (16px, strokeWidth 2, `dir` the only prop).
- **Kebab chrome gate** (cherry-pick) — #467's merge raced its final push, so this bugbot fix missed it: the folder `⋮` now renders only when the listing owns the bar chrome; embedded/pane-hosted listings don't get it (their "Split right" would rewrite the shell URL from a nested surface).

- **Blank-page crash fix (pre-existing on main)** — the bar-tightness measurement (`Listing.tsx`, no-deps layout effect) could oscillate forever at bar widths where its fold/unfold thresholds contradict (each is measured in the layout the other produces); React bails at 50 nested updates (#185) and unmounts the tree — a fully blank page. Repro: close left sidebar → close right panel → reopen both at a ~1675-1800px window. The measurement now carries a 2-flip budget per bar width (decision outside the setState updater, budget resets on real width change), so a contradicting width settles instead of taking the page down. Verified by width sweep 1650-2100px + the reporter's exact sequence.

## Verification

- Playwright (headless Chrome), driven through the real folder kebab: full-window listing keeps its preview pane (open/close/reopen exact); Split right → 0 pane slots at 673px panes; **Split down → 0 pane slots at 1354px panes** (double the width threshold — proves the host predicate did it, not the width check); **tab mode at 1368px keeps its pane** (proves `IS_EMBED` would have regressed it). Chevrons measured in-DOM after: both 16×16, strokeWidth 2, effective stroke 1.333px vs 1.333px.
- `check:boundaries` OK, `tsc --noEmit` clean, `bun test` 744/744.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches explorer layout framing (ancestor window walk, preview-pane gating) and a synchronous layout measurement path; changes are targeted but affect split/tab behavior regressions if mis-detected.
> 
> **Overview**
> **Split panel panes** no longer grow a nested listing preview column: `paneEnabled` now also checks **`IS_PANEL_PANE`**, set at load by walking same-origin ancestors for the panel route via new **`isPanelPath`** (shell routing uses the same helper).
> 
> **Tight crumb-bar fold/unfold** gets a per-width **flip budget** (`FLIP_BUDGET` + `tightFlipRef`) so bistable measurements stop infinite layout-effect `setState` loops that could blank the page (#185).
> 
> **Folder header ⋮** renders only when **`ownsBarChrome`** is true, so embedded/pane listings don’t expose split actions that would rewrite the shell URL.
> 
> **Collapse chevrons** are centralized in **`platform/ui/Chevron`** (16px, `dir` only) and replace duplicated SVGs in the left sidebar rail and **`SideChrome`** close control.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66c7cc1310c4d9c565764894e2124243040287c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Screenshots

**Split right / Split down — no preview column in the panes**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-473-assets/split-no-preview.png" width="520" alt="split right, no pane" /> <img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-473-assets/split-down-no-preview.png" width="520" alt="split down, no pane" />

**Full window and tab mode keep the pane (regression + controlled comparison)**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-473-assets/fullwindow-preview-intact.png" width="520" alt="full window keeps pane" /> <img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-473-assets/tabmode-preview-intact.png" width="520" alt="tab keeps pane" />

**Chevrons before/after**

<img src="https://raw.githubusercontent.com/fusedio/fused-render/pr-473-assets/chevrons-before-after.png" width="640" alt="chevron unification" />

(Assets on the throwaway `pr-473-assets` branch; delete after merge.)

