### PR TITLE
Community search bar spans full content width

### DIFF
--- a/core_apps/community/index.html
+++ b/core_apps/community/index.html
@@ -28,7 +28,7 @@
   /* Prominent centered search with tag autocomplete */
   .searchbar { display: flex; justify-content: center; margin: 16px 0 14px; }
   .searchbox { position: relative; display: flex; align-items: center; gap: 7px;
-    width: 100%; max-width: 560px; background: var(--panel);
+    width: 100%; background: var(--panel);
     border: 1px solid var(--line); border-radius: 10px; padding: 8px 13px; }
   .searchbox:focus-within { border-color: var(--accent);
     box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent); }


### PR DESCRIPTION
Search box in community marketplace was capped at 560px, looked too small. Removed the max-width so it spans the full content width; the page wrapper's 24px horizontal padding still applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CSS change with no logic, API, or data impact.
> 
> **Overview**
> The community marketplace search field no longer caps at **560px**; `.searchbox` keeps `width: 100%` so it stretches across the `.wrap` content area (still bounded by the page’s **1060px** max width and horizontal padding).
> 
> This is a **visual-only** CSS tweak in `core_apps/community/index.html`—search, tag tokens, and autocomplete behavior are unchanged; the dropdown simply matches the wider input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90d2ac28efc71fd56f8f5838d90af0a738128e4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->