### PR TITLE
Search: keep answering while the index rescans

### DIFF
--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -7,7 +7,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { navigate, replaceSearch, urlForFsPath } from "@platform/lib/router";
 import { basename, formatMtime, formatMtimeFull, formatSize } from "@platform/lib/format";
 import { iconForEntry } from "@platform/ui/FileIcons";
-import type { Config, ClaudeSessionFolder, GitRepos } from "@platform/lib/api";
+import type { Config, ClaudeSessionFolder, GitRepos, IndexStatus } from "@platform/lib/api";
+import { indexCaveat } from "@apps/explorer/listing/index-caveat";
 import { getClaudeSessionFolders, getGitRepos, indexSearch, statPath } from "@platform/lib/api";
 import { allBookmarks, hydrateBookmarks, loadBookmarks } from "@platform/lib/bookmarks";
 import { useBookmarksVersion, useUrlVersion } from "@platform/lib/hooks";
@@ -235,10 +236,13 @@ function AiResults({ home, query, result }: { home: string; query: string; resul
 function FilesSearch({
   home,
   initialQuery,
+  indexScan,
   onActiveChange,
 }: {
   home: string;
   initialQuery: string;
+  /** The shared index poll (see FilesHome) — this box adds no poller of its own. */
+  indexScan: IndexStatus | null;
   onActiveChange: (active: boolean) => void;
 }) {
   const [query, setQuery] = useState(initialQuery);
@@ -435,6 +439,13 @@ function FilesSearch({
   // pre-selection, so Enter during the corpus load or the scan debounce cannot
   // spend a model call on a query that was about to answer itself.
   const settled = rankingSettled(view.status, scanning);
+  // The indexing caveat, same helper and same two messages as the listing's
+  // search chip (listing/index-caveat) so the two boxes make the same claim in
+  // the same words. It is the piece that makes a lagging answer read as
+  // intentional: with rows on screen from a corpus a generation behind and
+  // nothing saying why, the box just looks wrong. The rows themselves dim
+  // while `view.stale`, the same treatment the listing gives held results.
+  const caveat = active && !showingAi ? indexCaveat(indexScan) : null;
   const current = activeRow(highlight, hits.length, settled);
 
   const openRow = (row: number) => {
@@ -545,8 +556,19 @@ function FilesSearch({
                 <kbd>↓</kbd> to pick · <kbd>esc</kbd> to clear
               </>
             )}
+            {caveat && (
+              <span className="fh-index-chip" title={caveat.title}>
+                <span className="fh-index-spinner" aria-hidden="true" />
+                {caveat.note}
+              </span>
+            )}
           </p>
-          <ul className="fh-results" id="fh-result-list" role="listbox" aria-label="Search results">
+          <ul
+            className={"fh-results" + (view.stale ? " is-stale" : "")}
+            id="fh-result-list"
+            role="listbox"
+            aria-label="Search results"
+          >
             {hits.map((hit, i) => (
               <FileRow
                 key={hit.path}
@@ -654,6 +676,11 @@ export default function FilesHome({ config }: { config: Config }) {
   // an empty repo list.
   const [repos, setRepos] = useState<GitRepos | null>(null);
   const [reposFailed, setReposFailed] = useState(false);
+  // Search takes over the page body (bookmarks/recents hide behind it) for as
+  // long as there is a query — instant results appear while typing, so the
+  // grids yield from the first keystroke rather than on a submit. Declared
+  // here because the index poll below is shared with the search box.
+  const [searching, setSearching] = useState(false);
   // ...but "one GET on mount" alone would strand the user, because the answer can
   // arrive LATER: this list is derived from the file index, and a homepage opened
   // while the first scan is running would sit on "Still building…" until something
@@ -670,7 +697,14 @@ export default function FilesHome({ config }: { config: Config }) {
   // arrived — which froze `indexKey` below, so the cards and their "Reindexing"
   // note stayed on screen forever, even after the scan that would have cleared
   // them finished.
-  const indexScan = useIndexStatus(reposNeedsIndexPoll(repos));
+  //
+  // `searching` widens the same poll rather than adding a second one: the
+  // search box needs the scan state for its "indexing…" caveat, and the repos
+  // gate goes quiet exactly when the index is healthy — which is when a scan
+  // starting mid-session would otherwise go unnoticed by the box. One poller,
+  // two consumers, the listing's rule (poll only while a search is open) still
+  // honoured for the search half.
+  const indexScan = useIndexStatus(reposNeedsIndexPoll(repos) || searching);
   // Refetch whenever the index's OBSERVABLE STATE changes — not when a scan
   // "completes". Completion was the previous trigger and it was subtly wrong:
   // `last_completed_at` is read off the manifest, and a cancelled, failed or
@@ -747,10 +781,6 @@ export default function FilesHome({ config }: { config: Config }) {
     tabParam === "repos"
       ? tabParam
       : "sessions";
-  // Search takes over the page body (bookmarks/recents hide behind it) for as
-  // long as there is a query — instant results appear while typing, so the
-  // grids yield from the first keystroke rather than on a submit.
-  const [searching, setSearching] = useState(false);
   // A ?q= present at load was a committed AI search; FilesSearch re-runs it.
   const initialQuery = useRef(new URLSearchParams(location.search).get("q") || "").current;
 
@@ -762,7 +792,12 @@ export default function FilesHome({ config }: { config: Config }) {
             "Find and preview your files" restatement above the box only
             pushed the one thing you came to use further down. */}
         <header className="home-hero files-hero">
-          <FilesSearch home={home} initialQuery={initialQuery} onActiveChange={setSearching} />
+          <FilesSearch
+            home={home}
+            initialQuery={initialQuery}
+            indexScan={indexScan}
+            onActiveChange={setSearching}
+          />
         </header>
 
         {searching ? null : (

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -570,6 +570,18 @@ function FilesSearch({
 
       {ai.status === "failed" && <ErrorBanner>{ai.message}</ErrorBanner>}
 
+      {/* A refetch failed while rows are still in hand. The rows stay — they
+          are the best answer available on a page with no live walk — but the
+          failure is said out loud, because typing is the retry gesture
+          (`retryNonce`) and a retry that reports nothing leaves the user
+          pressing keys into silence. The no-rows case is not this banner: it
+          is the whole content of the result note below. */}
+      {active && !showingAi && view.entries !== null && view.message !== "" && (
+        <ErrorBanner>
+          Couldn't refresh the file index ({view.message}) — showing the last results.
+        </ErrorBanner>
+      )}
+
       {!active ? null : showingAi ? (
         <AiResults home={home} query={ai.query} result={ai.result} />
       ) : (

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -272,8 +272,21 @@ function FilesSearch({
   const [fetchLifecycle, setFetchLifecycle] = useState(lifecycle);
   const [corpus, setCorpus] = useState<CorpusState>({ status: "idle" });
   useEffect(() => {
-    if (corpus.status !== "ok") setFetchLifecycle(lifecycle);
-  }, [lifecycle, corpus.status]);
+    // Two ways the pin comes off, and between them they are what stop it from
+    // being a one-way door — pinned on the session's first corpus with nothing
+    // to ever move it, the box would rank an hour-old corpus and caption it
+    // "not refreshed" forever.
+    //
+    //   * there is nothing to lose (no corpus yet), which is the first-scan
+    //     case this signal was added for;
+    //   * THE SEARCH ENDED. Nothing is on screen to be pulled out from under
+    //     anyone, so adopting costs the user nothing and the next search opens
+    //     on current data. This is exactly the boundary the in-folder search
+    //     already reconciles at (revalidate.shouldReconcile returns true the
+    //     moment `searching` goes false), and the two boxes should not disagree
+    //     about when a search is over.
+    if (corpus.status !== "ok" || !active) setFetchLifecycle(lifecycle);
+  }, [lifecycle, corpus.status, active]);
   // Which generation the corpus IN HAND actually reflects, which is not the
   // same question as when the fetch is allowed to re-run: a refetch forced by
   // something else (an in-app rename, a retry) still comes back with current
@@ -587,7 +600,13 @@ function FilesSearch({
             )}
             {caveat && (
               <span className="fh-index-chip" title={caveat.title}>
-                <span className="fh-index-spinner" aria-hidden="true" />
+                {/* Only while a scan is actually running. The chip also carries
+                    the "not refreshed" caveat, whose entire point is that NO
+                    work is in flight — a spinner there asserts the opposite of
+                    what the words next to it say. (Listing.tsx keeps its
+                    spinner on walk status for the same reason: the spinner
+                    tracks work, the caveat tracks trust.) */}
+                {indexScan?.scanning && <span className="fh-index-spinner" aria-hidden="true" />}
                 {caveat.note}
               </span>
             )}

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -32,15 +32,18 @@ import {
   INSTANT_DEBOUNCE_MS,
   activeRow,
   corpusFrom,
+  homeCorpusView,
   homeCountNote,
   homeHitsFrom,
   isAiRow,
+  nextHeldHomeCorpus,
   pathShortcut,
   rankingSettled,
   redirectsToSearch,
   stepHighlight,
   submitRow,
   type CorpusState,
+  type HeldHomeCorpus,
   type HomeHit,
 } from "@apps/explorer/lib/home-search";
 import { useRankedScan } from "@apps/explorer/listing/useRankedScan";
@@ -292,13 +295,22 @@ function FilesSearch({
     return () => ctl.abort();
   }, [home, wanted, lifecycle, mutations, retryNonce]);
 
+  // A corpus once in hand keeps answering while the next one is fetched. The
+  // rescan that republishes this fetch used to put the box back into `cold`
+  // for its duration — "The file index is still building", zero rows, for an
+  // index that was built. Only never having had a corpus may suppress rows;
+  // being a generation behind is a note, not a downgrade (lib/home-search,
+  // and lib/repos.ts for the same rule on the repo cards).
+  const heldCorpus = useRef<HeldHomeCorpus | null>(null);
+  heldCorpus.current = nextHeldHomeCorpus(corpus, heldCorpus.current);
+  const view = homeCorpusView(corpus, heldCorpus.current);
+
   // -- ranking ---------------------------------------------------------------
   // The same sliced, cancellable scan the in-folder search runs — literally the
   // same hook (listing/useRankedScan): a covered home root can be 200k entries,
   // and scoring that synchronously on a keystroke is the typing freeze
   // listing/scan-job exists to prevent.
-  const entries = corpus.status === "ok" ? corpus.entries : null;
-  const { ranked, pending } = useRankedScan(entries, q, INSTANT_DEBOUNCE_MS);
+  const { ranked, pending } = useRankedScan(view.entries, q, INSTANT_DEBOUNCE_MS, view.key);
   const hits = useMemo(() => homeHitsFrom(ranked, home), [ranked, home]);
   const scanning = active && pending;
 
@@ -422,7 +434,7 @@ function FilesSearch({
   // Whether the instant list is a finished answer. Gates the AI row's
   // pre-selection, so Enter during the corpus load or the scan debounce cannot
   // spend a model call on a query that was about to answer itself.
-  const settled = rankingSettled(corpus.status, scanning);
+  const settled = rankingSettled(view.status, scanning);
   const current = activeRow(highlight, hits.length, settled);
 
   const openRow = (row: number) => {
@@ -510,19 +522,24 @@ function FilesSearch({
       ) : (
         <div className="fh-panel">
           <p className="fh-result-note">
-            {corpus.status === "cold" ? (
+            {/* `view.status`, not `corpus.status`: a refetch (a rescan, an
+                in-app rename) puts the FETCH back into loading/cold while the
+                corpus we are still ranking sits in hand. Branching on the raw
+                fetch state meant a mid-rescan search claimed the index was
+                "still building" over the rows it was showing. */}
+            {view.status === "cold" ? (
               // Never "no matches" for an index that has not been built: that
               // would blame the user's files for the app's state.
               "The file index is still building — AI search can answer in the meantime."
-            ) : corpus.status === "error" ? (
-              `The file index could not be searched: ${corpus.message}`
-            ) : corpus.status !== "ok" || scanning ? (
+            ) : view.status === "error" ? (
+              `The file index could not be searched: ${view.message}`
+            ) : view.status !== "ok" || scanning ? (
               "Searching…"
             ) : ranked.length === 0 ? (
               `No file name matched “${q}” — AI search can look at dates, types and sizes.`
             ) : (
               <>
-                {homeCountNote(ranked.length, corpus.truncated)}
+                {homeCountNote(ranked.length, view.truncated)}
                 {" · "}
                 <kbd>↑</kbd>
                 <kbd>↓</kbd> to pick · <kbd>esc</kbd> to clear

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -256,12 +256,32 @@ function FilesSearch({
   // Fetched ONCE per index generation, not per keystroke: the index answers
   // with the whole covered subtree, so re-asking on every letter would spend a
   // round trip to receive the same rows. Ranking is what runs per query.
-  const [corpus, setCorpus] = useState<CorpusState>({ status: "idle" });
   // A scan finishing or the index being deleted changes what the corpus IS,
   // and no other signal reports it (the filesystem did not change) — see
   // lib/index-freshness.
   const [lifecycle, setLifecycle] = useState(indexLifecycleCount);
   useEffect(() => subscribeIndexLifecycle(() => setLifecycle(indexLifecycleCount())), []);
+  // ...but it is RECORDED, not applied. Scans complete often, and refetching on
+  // each one swapped the rows out from under whoever was reading them — the
+  // exact churn this page is being fixed to stop. A corpus in hand therefore
+  // pins the fetch generation and keeps answering, captioned "indexing…" and
+  // dimmed; only having nothing to lose lets the fetch follow the index, which
+  // is precisely the case this signal was added for (the first scan finishing
+  // while the page sits on "still building"). The same posture the in-folder
+  // search takes for its dir-watch bumps (listing/revalidate).
+  const [fetchLifecycle, setFetchLifecycle] = useState(lifecycle);
+  const [corpus, setCorpus] = useState<CorpusState>({ status: "idle" });
+  useEffect(() => {
+    if (corpus.status !== "ok") setFetchLifecycle(lifecycle);
+  }, [lifecycle, corpus.status]);
+  // Which generation the corpus IN HAND actually reflects, which is not the
+  // same question as when the fetch is allowed to re-run: a refetch forced by
+  // something else (an in-app rename, a retry) still comes back with current
+  // data and has to clear this, or the caveat would stick forever. Stamped
+  // from the moment the request was ISSUED, so a scan that completes while it
+  // is in flight leaves the answer marked behind rather than falsely current.
+  const corpusLifecycle = useRef(lifecycle);
+  const corpusBehind = corpusLifecycle.current !== lifecycle;
   // An in-app rename/delete moves paths the fetched corpus already holds, so
   // search would find the old name and the click would 404. It is a REFETCH
   // trigger, not a gate: `indexMayAnswer(home)` used to disable instant search
@@ -288,10 +308,13 @@ function FilesSearch({
   useEffect(() => {
     if (!wanted) return;
     const ctl = new AbortController();
+    const issuedAt = indexLifecycleCount();
     setCorpus((prev) => (prev.status === "ok" ? prev : { status: "loading" }));
     indexSearch(home, { signal: ctl.signal }).then(
       (res) => {
-        if (!ctl.signal.aborted) setCorpus(corpusFrom(res));
+        if (ctl.signal.aborted) return;
+        corpusLifecycle.current = issuedAt;
+        setCorpus(corpusFrom(res));
       },
       (err: Error) => {
         if (ctl.signal.aborted || err.name === "AbortError") return;
@@ -299,7 +322,7 @@ function FilesSearch({
       },
     );
     return () => ctl.abort();
-  }, [home, wanted, lifecycle, mutations, retryNonce]);
+  }, [home, wanted, fetchLifecycle, mutations, retryNonce]);
 
   // A corpus once in hand keeps answering while the next one is fetched. The
   // rescan that republishes this fetch used to put the box back into `cold`
@@ -310,6 +333,10 @@ function FilesSearch({
   const heldCorpus = useRef<HeldHomeCorpus | null>(null);
   heldCorpus.current = nextHeldHomeCorpus(corpus, heldCorpus.current);
   const view = homeCorpusView(corpus, heldCorpus.current);
+  // Behind either because the fetch is deliberately pinned to an older index
+  // generation, or because the rows on screen are the held ones while a fetch
+  // the user's own action forced actually runs.
+  const behind = view.entries !== null && (corpusBehind || view.stale);
 
   // -- ranking ---------------------------------------------------------------
   // The same sliced, cancellable scan the in-folder search runs — literally the
@@ -447,7 +474,7 @@ function FilesSearch({
   // intentional: with rows on screen from a corpus a generation behind and
   // nothing saying why, the box just looks wrong. The rows themselves dim
   // while `view.stale`, the same treatment the listing gives held results.
-  const caveat = active && !showingAi ? indexCaveat(indexScan) : null;
+  const caveat = active && !showingAi ? indexCaveat(indexScan, behind) : null;
   const current = activeRow(highlight, hits.length, settled);
 
   const openRow = (row: number) => {
@@ -566,7 +593,7 @@ function FilesSearch({
             )}
           </p>
           <ul
-            className={"fh-results" + (view.stale ? " is-stale" : "")}
+            className={"fh-results" + (behind ? " is-stale" : "")}
             id="fh-result-list"
             role="listbox"
             aria-label="Search results"

--- a/frontend/src/apps/explorer/FilesHome.tsx
+++ b/frontend/src/apps/explorer/FilesHome.tsx
@@ -270,7 +270,9 @@ function FilesSearch({
   // for the rest of the session — while the index was in fact built. The home
   // page has no live walk to fall back on, so switching search OFF is the worst
   // available outcome: a corpus one rename stale beats no corpus at all.
-  // (useWalkSearch keeps the gate because it HAS a live walk to prefer.)
+  // (useWalkSearch keeps the gate: it has a live walk that can answer the
+  // renamed folder correctly, and racing the index against that walk does not
+  // change the calculus — the index would win the race with the wrong name.)
   const [mutations, setMutations] = useState(fsMutationCount);
   useEffect(() => subscribeFsMutations(() => setMutations(fsMutationCount())), []);
   // Bumped by a real gesture (typing) to re-run a failed fetch. Without it a

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -1437,9 +1437,19 @@ export default function Listing({
           )}
           <div
             ref={scrollRef}
-            /* Dimmed both when the deferred render lags a keystroke and while
-             held (pre-refresh) results stand in for a re-running walk. */
-            className={"listing-scroll" + (isStale || showingHeld ? " listing-stale" : "")}
+            /* Two different dims, two different claims. `listing-stale` means
+               an answer is on its way (the deferred render lags a keystroke,
+               the scan is mid-flight, or held results stand in for a walk that
+               is re-running). `listing-behind` means the opposite: no answer is
+               coming, these results are a generation old and staying that way
+               until a boundary (listing/revalidate). The second can last the
+               whole session, so it is deliberately the lighter of the two —
+               it has to be legible to read under, not merely noticeable. */
+            className={
+              "listing-scroll" +
+              (isStale || showingHeld ? " listing-stale" : "") +
+              (behind ? " listing-behind" : "")
+            }
             /* The background means THIS FOLDER: "move these here". It lights up
                (.drop-into, painted by row-drag.ts) only when that would actually
                move something — dropping rows into the folder they already live

--- a/frontend/src/apps/explorer/Listing.tsx
+++ b/frontend/src/apps/explorer/Listing.tsx
@@ -199,6 +199,7 @@ export default function Listing({
     setQuery,
     searching,
     isStale,
+    behind,
     scanPending,
     validWalk,
     prefetchWalk,
@@ -1265,7 +1266,7 @@ export default function Listing({
   // facts are about the same search, and one line says both. Which message
   // appears is a claim about how far the results can be trusted, so it lives
   // in a pure, tested helper (listing/index-caveat).
-  const caveat = searching ? indexCaveat(indexScan) : null;
+  const caveat = searching ? indexCaveat(indexScan, behind) : null;
   if (caveat) {
     searchCount = withCaveat(searchCount, caveat);
     searchCountFull = caveat.title;

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -3,13 +3,16 @@ import {
   HOME_RESULT_CAP,
   activeRow,
   corpusFrom,
+  homeCorpusView,
   homeCountNote,
   homeHitsFrom,
+  nextHeldHomeCorpus,
   pathShortcut,
   rankingSettled,
   redirectsToSearch,
   stepHighlight,
   submitRow,
+  type CorpusState,
 } from "./home-search";
 import type { IndexSearchResult, WalkEntry } from "@platform/lib/api";
 import type { SearchHit } from "@apps/explorer/listing/types";
@@ -102,17 +105,86 @@ describe("homeCountNote", () => {
 
 describe("corpusFrom", () => {
   it("is ok for a covered root", () => {
-    expect(corpusFrom(indexResult())).toEqual({
+    expect(corpusFrom(indexResult({ updated: 7 }))).toEqual({
       status: "ok",
       entries: [walkEntry("Downloads/a.csv")],
       truncated: false,
+      key: `${HOME}|7`,
     });
+  });
+
+  it("gives the same key to the same (root, generation) — a refetch is the same corpus", () => {
+    expect(corpusFrom(indexResult({ updated: 7 }))).toMatchObject({ key: `${HOME}|7` });
+    expect(corpusFrom(indexResult({ updated: 8 }))).toMatchObject({ key: `${HOME}|8` });
+  });
+
+  it("gives NO key when the response carries no generation, rather than a shared one", () => {
+    expect(corpusFrom(indexResult({ updated: null }))).toMatchObject({ key: "" });
   });
 
   it("is cold — not empty — when the index has not covered the root yet", () => {
     // The honest answer is "still building", never "no matches": the home page
     // has no live walk to fall back on, so a miss here is the app's state.
     expect(corpusFrom(indexResult({ covered: false, entries: [] }))).toEqual({ status: "cold" });
+  });
+});
+
+describe("the home corpus hold", () => {
+  const A = [walkEntry("a.txt")];
+  const B = [walkEntry("b.txt")];
+  const okA: CorpusState = { status: "ok", entries: A, truncated: false, key: "k1" };
+  const okB: CorpusState = { status: "ok", entries: B, truncated: true, key: "k2" };
+
+  it("holds a real corpus and nothing else", () => {
+    expect(nextHeldHomeCorpus(okA, null)).toEqual({ entries: A, truncated: false, key: "k1" });
+    const held = nextHeldHomeCorpus(okA, null);
+    expect(nextHeldHomeCorpus({ status: "loading" }, held)).toBe(held!);
+    expect(nextHeldHomeCorpus({ status: "cold" }, held)).toBe(held!);
+    expect(nextHeldHomeCorpus({ status: "error", message: "x" }, held)).toBe(held!);
+  });
+
+  it("is identity-stable, and adopts a new corpus", () => {
+    const held = nextHeldHomeCorpus(okA, null);
+    expect(nextHeldHomeCorpus(okA, held)).toBe(held!);
+    expect(nextHeldHomeCorpus(okB, held)).toEqual({ entries: B, truncated: true, key: "k2" });
+  });
+
+  it("shows the fresh corpus when there is one", () => {
+    expect(homeCorpusView(okA, null)).toEqual({
+      entries: A, truncated: false, key: "k1", stale: false, status: "ok", message: "",
+    });
+  });
+
+  it("keeps answering from the previous corpus while a refetch runs", () => {
+    // The whole point: a rescan republishes the fetch, and `cold`/`loading`
+    // mid-refetch must not take the rows away — only never having had a corpus
+    // may do that (lib/repos.ts applies the same rule to the repo cards).
+    const held = nextHeldHomeCorpus(okA, null);
+    for (const state of [
+      { status: "loading" } as CorpusState,
+      { status: "cold" } as CorpusState,
+      { status: "error", message: "boom" } as CorpusState,
+    ]) {
+      expect(homeCorpusView(state, held)).toEqual({
+        entries: A, truncated: false, key: "k1", stale: true, status: "ok", message: "",
+      });
+    }
+  });
+
+  it("suppresses rows ONLY when no corpus has ever been in hand", () => {
+    expect(homeCorpusView({ status: "cold" }, null)).toEqual({
+      entries: null, truncated: false, key: "", stale: false, status: "cold", message: "",
+    });
+    expect(homeCorpusView({ status: "error", message: "x" }, null)).toMatchObject({
+      status: "error",
+      message: "x",
+    });
+    expect(homeCorpusView({ status: "loading" }, null).status).toBe("loading");
+  });
+
+  it("reads as settled while stale — held rows are a finished answer, not a pending one", () => {
+    const held = nextHeldHomeCorpus(okA, null);
+    expect(rankingSettled(homeCorpusView({ status: "loading" }, held).status, false)).toBe(true);
   });
 });
 

--- a/frontend/src/apps/explorer/lib/home-search.test.ts
+++ b/frontend/src/apps/explorer/lib/home-search.test.ts
@@ -155,6 +155,24 @@ describe("the home corpus hold", () => {
     });
   });
 
+  it("keeps the rows AND reports a failed refetch", () => {
+    // Holding the rows is right — dropping a working search to show an error
+    // would be the worse trade on a page with no live walk to fall back on.
+    // Swallowing the failure is not: `retryNonce` retries on a keystroke, and
+    // a retry that reports nothing at all leaves the user pressing keys into
+    // silence. So: both.
+    const held = nextHeldHomeCorpus(okA, null);
+    const view = homeCorpusView({ status: "error", message: "boom" }, held);
+    expect(view.entries).toBe(A);
+    expect(view.stale).toBe(true);
+    expect(view.status).toBe("ok");
+    expect(view.message).toBe("boom");
+  });
+
+  it("has nothing to report once a refetch succeeds", () => {
+    expect(homeCorpusView(okA, nextHeldHomeCorpus(okA, null)).message).toBe("");
+  });
+
   it("keeps answering from the previous corpus while a refetch runs", () => {
     // The whole point: a rescan republishes the fetch, and `cold`/`loading`
     // mid-refetch must not take the rows away — only never having had a corpus
@@ -162,8 +180,10 @@ describe("the home corpus hold", () => {
     const held = nextHeldHomeCorpus(okA, null);
     for (const state of [
       { status: "loading" } as CorpusState,
+      // `cold` too: the index being gone does not make the paths in hand
+      // untrue, and a cold state re-fetches on the next lifecycle bump, so
+      // this recovers on its own the moment an index exists again.
       { status: "cold" } as CorpusState,
-      { status: "error", message: "boom" } as CorpusState,
     ]) {
       expect(homeCorpusView(state, held)).toEqual({
         entries: A, truncated: false, key: "k1", stale: true, status: "ok", message: "",

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -53,10 +53,92 @@ export interface HomeHit {
 export type CorpusState =
   | { status: "idle" }
   | { status: "loading" }
-  | { status: "ok"; entries: WalkEntry[]; truncated: boolean }
+  // `key` names the corpus CONTENT (the index generation it came from), so a
+  // refetch that returns the same rows is recognisable as the same corpus even
+  // though it is a new array — see listing/useRankedScan's resume check. "" is
+  // "no stable identity", which never resumes.
+  | { status: "ok"; entries: WalkEntry[]; truncated: boolean; key: string }
   // The index has not covered the home root yet — no answer, not zero answers.
   | { status: "cold" }
   | { status: "error"; message: string };
+
+/** A corpus already in hand, retained across refetches. */
+export interface HeldHomeCorpus {
+  entries: WalkEntry[];
+  truncated: boolean;
+  key: string;
+}
+
+/**
+ * What the search box should actually rank and render.
+ *
+ * The rule is the one lib/repos.ts already applies to the repo cards, for the
+ * same reason: HAVING AN ANSWER and THE ANSWER BEING CURRENT are two different
+ * facts, and only the first may suppress rows. A rescan republishes the corpus
+ * fetch, and the home page's fetch effect used to answer `cold` while it was in
+ * flight — so mid-rescan the box said "The file index is still building" with
+ * zero rows, for an index that was built and searchable. `cold` is a claim
+ * about the index having never covered this root; it is not a state a REFETCH
+ * can put the page into.
+ *
+ * So a corpus once in hand keeps answering, marked `stale`, until a fresh one
+ * replaces it. `status` is what the copy branches on and reads "ok" whenever
+ * there are rows, so a stale corpus can never route to a message that denies
+ * having one.
+ */
+export interface HomeCorpusView {
+  /** The rows to rank, or null when no corpus has EVER been in hand. */
+  entries: WalkEntry[] | null;
+  truncated: boolean;
+  key: string;
+  /** These rows are a generation behind. The caller must SAY so. */
+  stale: boolean;
+  status: CorpusState["status"];
+  /** The failure to report, when `status` is "error" and only then. */
+  message: string;
+}
+
+/** What to retain after this render. Only a real corpus replaces the hold. */
+export function nextHeldHomeCorpus(
+  state: CorpusState,
+  held: HeldHomeCorpus | null,
+): HeldHomeCorpus | null {
+  if (state.status !== "ok") return held;
+  if (held !== null && held.entries === state.entries) return held;
+  return { entries: state.entries, truncated: state.truncated, key: state.key };
+}
+
+export function homeCorpusView(
+  state: CorpusState,
+  held: HeldHomeCorpus | null,
+): HomeCorpusView {
+  if (state.status === "ok")
+    return {
+      entries: state.entries,
+      truncated: state.truncated,
+      key: state.key,
+      stale: false,
+      status: "ok",
+      message: "",
+    };
+  if (held !== null)
+    return {
+      entries: held.entries,
+      truncated: held.truncated,
+      key: held.key,
+      stale: true,
+      status: "ok",
+      message: "",
+    };
+  return {
+    entries: null,
+    truncated: false,
+    key: "",
+    stale: false,
+    status: state.status,
+    message: state.status === "error" ? state.message : "",
+  };
+}
 
 /**
  * The filesystem path a query is really an address for, or null.
@@ -110,7 +192,12 @@ export function homeCountNote(total: number, corpusTruncated: boolean): string {
 export function corpusFrom(res: IndexSearchResult): CorpusState {
   const corpus = indexCorpusFrom(res);
   if (corpus === null) return { status: "cold" };
-  return { status: "ok", entries: corpus.entries, truncated: corpus.truncated };
+  // (root, generation) is the corpus's identity: the same pair always yields
+  // the same rows, so a refetch triggered by something other than the index
+  // moving (an in-app rename, a retry) is recognisable as the same corpus. A
+  // response with no `updated` gets no identity rather than a shared one.
+  const key = typeof res.updated === "number" ? `${res.root}|${res.updated}` : "";
+  return { status: "ok", entries: corpus.entries, truncated: corpus.truncated, key };
 }
 
 // -- typing anywhere is typing here ------------------------------------------

--- a/frontend/src/apps/explorer/lib/home-search.ts
+++ b/frontend/src/apps/explorer/lib/home-search.ts
@@ -94,7 +94,23 @@ export interface HomeCorpusView {
   /** These rows are a generation behind. The caller must SAY so. */
   stale: boolean;
   status: CorpusState["status"];
-  /** The failure to report, when `status` is "error" and only then. */
+  /**
+   * The last fetch's failure, or "".
+   *
+   * Reported whether or not rows are being held, which is the one place this
+   * view deliberately does NOT simplify to a single state. Held rows plus a
+   * failure is a real, nameable situation — "these still work, the refresh
+   * didn't" — and collapsing it either way is a bug: dropping the rows breaks
+   * a search that was working, and dropping the message makes `retryNonce`
+   * (which retries on a keystroke) a gesture with no feedback at all.
+   *
+   * listing/corpus-hold takes the opposite line for the in-folder search —
+   * an errored walk yields no rows, the error IS the answer — and the
+   * difference is not an inconsistency. There the walk is the fallback, so a
+   * failure means search genuinely has nothing and the user's move is to
+   * retry. Here the index is the only source there is, so the rows in hand are
+   * the best answer available and throwing them away buys nothing.
+   */
   message: string;
 }
 
@@ -121,6 +137,7 @@ export function homeCorpusView(
       status: "ok",
       message: "",
     };
+  const message = state.status === "error" ? state.message : "";
   if (held !== null)
     return {
       entries: held.entries,
@@ -128,7 +145,7 @@ export function homeCorpusView(
       key: held.key,
       stale: true,
       status: "ok",
-      message: "",
+      message,
     };
   return {
     entries: null,
@@ -136,7 +153,7 @@ export function homeCorpusView(
     key: "",
     stale: false,
     status: state.status,
-    message: state.status === "error" ? state.message : "",
+    message,
   };
 }
 

--- a/frontend/src/apps/explorer/listing/corpus-hold.test.ts
+++ b/frontend/src/apps/explorer/listing/corpus-hold.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { nextHeldCorpus, scannableCorpus } from "@apps/explorer/listing/corpus-hold";
+import { corpusKey, nextHeldCorpus, scannableCorpus } from "@apps/explorer/listing/corpus-hold";
 import type { WalkState } from "@apps/explorer/listing/types";
 import type { WalkEntry } from "@platform/lib/api";
 
@@ -16,6 +16,29 @@ function streaming(es: WalkEntry[], key = "k1", forRefresh = 0): WalkState {
 function ok(es: WalkEntry[], key = "k1", forRefresh = 0): WalkState {
   return { status: "ok", entries: es, truncated: false, total: es.length, key, forRefresh };
 }
+
+describe("corpusKey", () => {
+  it("is the same corpus for the same folder, generation and source", () => {
+    expect(corpusKey("walk", "/p", 3, 0)).toBe(corpusKey("walk", "/p", 3, 0));
+  });
+
+  it("separates a RETRY from the attempt it replaces", () => {
+    // The bug: a retry keeps the folder and the generation (only `retryNonce`
+    // moves), so a walk that streamed 500 entries and then failed had those
+    // 500 hits resumed over a brand-new walk's array. A retry usually happens
+    // because something changed, which is exactly when those rows differ.
+    expect(corpusKey("walk", "/p", 3, 1)).not.toBe(corpusKey("walk", "/p", 3, 0));
+  });
+
+  it("separates the two racing sources, which do not return the same rows", () => {
+    expect(corpusKey("index", "/p", 3, 0)).not.toBe(corpusKey("walk", "/p", 3, 0));
+  });
+
+  it("separates folders and generations", () => {
+    expect(corpusKey("walk", "/q", 3, 0)).not.toBe(corpusKey("walk", "/p", 3, 0));
+    expect(corpusKey("walk", "/p", 4, 0)).not.toBe(corpusKey("walk", "/p", 3, 0));
+  });
+});
 
 describe("nextHeldCorpus", () => {
   it("retains a settled corpus", () => {

--- a/frontend/src/apps/explorer/listing/corpus-hold.test.ts
+++ b/frontend/src/apps/explorer/listing/corpus-hold.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import { nextHeldCorpus, scannableCorpus } from "@apps/explorer/listing/corpus-hold";
+import type { WalkState } from "@apps/explorer/listing/types";
+import type { WalkEntry } from "@platform/lib/api";
+
+function entries(...rels: string[]): WalkEntry[] {
+  return rels.map((rel) => ({ rel, is_dir: false, size: 1, mtime: 2 }));
+}
+
+const A = entries("a.txt", "b.txt");
+const B = entries("c.txt");
+
+function streaming(es: WalkEntry[], key = "k1", forRefresh = 0): WalkState {
+  return { status: "streaming", entries: es, count: es.length, key, forRefresh };
+}
+function ok(es: WalkEntry[], key = "k1", forRefresh = 0): WalkState {
+  return { status: "ok", entries: es, truncated: false, total: es.length, key, forRefresh };
+}
+
+describe("nextHeldCorpus", () => {
+  it("retains a settled corpus", () => {
+    expect(nextHeldCorpus(ok(A), null)).toEqual({ entries: A, key: "k1" });
+  });
+
+  it("retains a partial streamed corpus too — some rows beat none", () => {
+    expect(nextHeldCorpus(streaming(A), null)).toEqual({ entries: A, key: "k1" });
+  });
+
+  it("keeps the previous hold when the walk is invalidated to idle", () => {
+    const held = nextHeldCorpus(ok(A), null);
+    expect(nextHeldCorpus({ status: "idle" }, held)).toBe(held!);
+  });
+
+  it("keeps the previous hold while the new walk has nothing yet", () => {
+    const held = nextHeldCorpus(ok(A), null);
+    expect(nextHeldCorpus(streaming([], "k2", 1), held)).toBe(held!);
+  });
+
+  it("is identity-stable across re-renders of the same corpus", () => {
+    const held = nextHeldCorpus(ok(A), null);
+    expect(nextHeldCorpus(ok(A), held)).toBe(held!);
+  });
+
+  it("adopts the new generation once it has entries", () => {
+    const held = nextHeldCorpus(ok(A), null);
+    expect(nextHeldCorpus(ok(B, "k2", 1), held)).toEqual({ entries: B, key: "k2" });
+  });
+});
+
+describe("scannableCorpus", () => {
+  it("scans nothing outside search", () => {
+    expect(scannableCorpus(false, ok(A), { entries: A, key: "k1" }).entries).toBeNull();
+  });
+
+  it("scans the current corpus when it has one", () => {
+    expect(scannableCorpus(true, ok(A), null)).toEqual({ entries: A, key: "k1", stale: false });
+  });
+
+  it("scans a settled EMPTY corpus rather than the hold — that is a real answer", () => {
+    const none: WalkEntry[] = [];
+    expect(scannableCorpus(true, ok(none, "k2", 1), { entries: A, key: "k1" })).toEqual({
+      entries: none,
+      key: "k2",
+      stale: false,
+    });
+  });
+
+  it("scans the held corpus, marked stale, while a refetch is in flight", () => {
+    // The bug this exists for: the fetch effect publishes an EMPTY streaming
+    // state before the request resolves, so a keystroke during a refetch used
+    // to rank against nothing and paint a blank list.
+    expect(scannableCorpus(true, streaming([], "k2", 1), { entries: A, key: "k1" })).toEqual({
+      entries: A,
+      key: "k1",
+      stale: true,
+    });
+  });
+
+  it("scans the held corpus while the walk is invalidated to idle", () => {
+    expect(scannableCorpus(true, { status: "idle" }, { entries: A, key: "k1" })).toEqual({
+      entries: A,
+      key: "k1",
+      stale: true,
+    });
+  });
+
+  it("prefers the fresh corpus the moment its first batch lands", () => {
+    expect(scannableCorpus(true, streaming(B, "k2", 1), { entries: A, key: "k1" })).toEqual({
+      entries: B,
+      key: "k2",
+      stale: false,
+    });
+  });
+
+  it("scans nothing when the walk errored — the error is the answer", () => {
+    expect(
+      scannableCorpus(true, { status: "error", message: "nope", key: "k2", forRefresh: 1 }, {
+        entries: A,
+        key: "k1",
+      }).entries,
+    ).toBeNull();
+  });
+
+  it("scans nothing when nothing has ever been in hand", () => {
+    expect(scannableCorpus(true, { status: "idle" }, null).entries).toBeNull();
+  });
+});

--- a/frontend/src/apps/explorer/listing/corpus-hold.ts
+++ b/frontend/src/apps/explorer/listing/corpus-hold.ts
@@ -1,0 +1,74 @@
+// Stale-while-revalidate for the in-folder search's CORPUS (the rows to rank),
+// as distinct from lib/search-hold which does it for the ranked RESULTS.
+//
+// The two are not interchangeable, and that is the whole reason this exists.
+// search-hold is query-tagged on purpose — held rows are only ever rendered
+// under the query they were computed for — so it deliberately gives nothing
+// back when the query changes. A keystroke during a corpus refetch is exactly
+// that case: the fetch effect publishes an empty `streaming` state before the
+// request resolves, so the new query ranked against an empty array and the
+// result list blanked. Holding the previous generation's ENTRIES instead lets
+// the new query rank against a one-generation-stale corpus and paint
+// immediately, which is a strictly better answer than none.
+//
+// What keeps that honest: the hold is only ever consulted while the current
+// generation's walk is UNSETTLED, it is reported back as `stale: true` (the
+// caller dims the rows and keeps the spinner up — Listing's `listing-stale`),
+// and it is dropped the instant the fresh corpus has anything to say. A
+// SETTLED walk always wins, including a settled EMPTY one: "the file was just
+// deleted" is a real answer and must not be papered over by yesterday's rows.
+import type { WalkEntry } from "@platform/lib/api";
+import type { WalkState } from "@apps/explorer/listing/types";
+
+export interface HeldCorpus {
+  entries: WalkEntry[];
+  /** The corpus identity this array carries — see WalkState.key. */
+  key: string;
+}
+
+export interface ScannableCorpus {
+  /** The rows to rank, or null when there is nothing to rank at all. */
+  entries: WalkEntry[] | null;
+  /** WalkState.key of `entries`; "" when there are none. */
+  key: string;
+  /** These rows are a generation behind. The caller must SAY so. */
+  stale: boolean;
+}
+
+const NOTHING: ScannableCorpus = { entries: null, key: "", stale: false };
+
+/**
+ * What to retain as the fallback corpus after this render.
+ *
+ * Any walk with rows in it — settled or still streaming — replaces the hold;
+ * a partial corpus is still a better stand-in than an empty one. Anything else
+ * keeps whatever was already held, identity-stable so a re-render of the same
+ * corpus does not churn the callers keyed on it.
+ */
+export function nextHeldCorpus(walk: WalkState, held: HeldCorpus | null): HeldCorpus | null {
+  if ((walk.status === "ok" || walk.status === "streaming") && walk.entries.length > 0) {
+    return held !== null && held.entries === walk.entries ? held : { entries: walk.entries, key: walk.key };
+  }
+  return held;
+}
+
+/**
+ * The corpus to rank right now, and whether it is a generation behind.
+ *
+ * An errored walk yields nothing deliberately: the error is what the user is
+ * shown, and standing rows in front of it would hide a failure they can retry.
+ */
+export function scannableCorpus(
+  searching: boolean,
+  walk: WalkState,
+  held: HeldCorpus | null,
+): ScannableCorpus {
+  if (!searching) return NOTHING;
+  // A settled walk is the answer, even when it is empty.
+  if (walk.status === "ok") return { entries: walk.entries, key: walk.key, stale: false };
+  if (walk.status === "streaming" && walk.entries.length > 0)
+    return { entries: walk.entries, key: walk.key, stale: false };
+  if ((walk.status === "idle" || walk.status === "streaming") && held !== null)
+    return { entries: held.entries, key: held.key, stale: true };
+  return NOTHING;
+}

--- a/frontend/src/apps/explorer/listing/corpus-hold.ts
+++ b/frontend/src/apps/explorer/listing/corpus-hold.ts
@@ -20,6 +20,32 @@
 import type { WalkEntry } from "@platform/lib/api";
 import type { WalkState } from "@apps/explorer/listing/types";
 
+/**
+ * The corpus identity a fetch will produce (WalkState.key).
+ *
+ * Everything that can change the ROWS has to be in here, because downstream
+ * this is taken as a promise that two arrays hold the same entries in the same
+ * order (listing/scan-resume). Each part earns its place:
+ *
+ *  * `source` — the index and the live walk race for one generation
+ *    (listing/source-race) and do not return the same rows.
+ *  * `fsPath`, `forRefresh` — the folder, and the generation it was fetched
+ *    for.
+ *  * `attempt` — the retry counter. Omitting it was a bug: a retry keeps the
+ *    same folder and the same generation, so an aborted walk's 500 scored
+ *    entries were resumed over a brand-new array from a brand-new walk of the
+ *    filesystem. A retry usually happens BECAUSE something changed, so those
+ *    rows are exactly the ones not guaranteed to match.
+ */
+export function corpusKey(
+  source: "walk" | "index",
+  fsPath: string,
+  forRefresh: number,
+  attempt: number,
+): string {
+  return `${source}:${fsPath}:${forRefresh}:${attempt}`;
+}
+
 export interface HeldCorpus {
   entries: WalkEntry[];
   /** The corpus identity this array carries — see WalkState.key. */

--- a/frontend/src/apps/explorer/listing/index-caveat.test.ts
+++ b/frontend/src/apps/explorer/listing/index-caveat.test.ts
@@ -38,6 +38,20 @@ describe("indexCaveat", () => {
     expect(c.note).toContain("4,321");
     expect(c.title).toContain("searched live");
   });
+
+  it("says results are a generation behind when nothing is running", () => {
+    // The deal the search makes when it refuses to refetch mid-read
+    // (listing/revalidate): stale is fine, silently stale is not.
+    const c = indexCaveat(status({ scanning: false }), true)!;
+    expect(c.note).toBe("not refreshed");
+    expect(c.title).toContain("clear the search");
+    // ...and with no status at all, which is the pre-first-poll state.
+    expect(indexCaveat(null, true)!.note).toBe("not refreshed");
+  });
+
+  it("prefers the running-scan message, which already implies the same thing", () => {
+    expect(indexCaveat(status(), true)!.note).toBe("indexing…");
+  });
 });
 
 describe("withCaveat", () => {

--- a/frontend/src/apps/explorer/listing/index-caveat.ts
+++ b/frontend/src/apps/explorer/listing/index-caveat.ts
@@ -13,26 +13,44 @@ export interface IndexCaveat {
   title: string;
 }
 
-// `has_index` splits the two cases. An index that already exists keeps
+// `has_index` splits the two scanning cases. An index that already exists keeps
 // answering while a rescan runs (the last completed generation), so the user
 // is told the results may lag. With no index yet the live walk is answering,
 // so the same spinner means progress, not staleness.
+//
+// `behind` is the third message and the quiet one: no scan is running, but
+// these results were computed from an older generation of the tree and the
+// search is deliberately not refetching (listing/revalidate — swapping the
+// rows out from under someone reading them is worse than being a little
+// behind). That trade is only defensible if it is stated, which is what this
+// says. A running scan outranks it: "indexing…" already implies the same
+// caveat and names the reason.
 export function indexCaveat(
   status: IndexStatus | null | undefined,
+  behind = false,
 ): IndexCaveat | null {
-  if (!status || !status.scanning) return null;
-  if (status.has_index) {
+  if (status && status.scanning) {
+    if (status.has_index) {
+      return {
+        note: "indexing…",
+        title:
+          "A scan is running. Results come from the last completed index, so a very recent change may be missing.",
+      };
+    }
     return {
-      note: "indexing…",
+      note: `building index… ${(status.files || 0).toLocaleString()} files`,
       title:
-        "A scan is running. Results come from the last completed index, so a very recent change may be missing.",
+        "Building the file index for the first time. This folder is being searched live meanwhile.",
     };
   }
-  return {
-    note: `building index… ${(status.files || 0).toLocaleString()} files`,
-    title:
-      "Building the file index for the first time. This folder is being searched live meanwhile.",
-  };
+  if (behind) {
+    return {
+      note: "not refreshed",
+      title:
+        "This folder or the file index changed since these results were computed. They are kept as they are rather than swapped out while you read them — clear the search and run it again for the newest.",
+    };
+  }
+  return null;
 }
 
 // The chip carries both facts when both exist — one element, because the chip

--- a/frontend/src/apps/explorer/listing/revalidate.ts
+++ b/frontend/src/apps/explorer/listing/revalidate.ts
@@ -9,17 +9,30 @@
 // the user is trying to read their results.
 //
 // So a watch bump during an active search is RECORDED, not applied. The search
-// keeps rendering the generation it already has, undimmed, and reconciles at a
-// boundary where a repaint costs the user nothing: the query changes, or the
-// search ends. Nothing is scored across generations — deferring means keeping
-// the old generation's completed results wholesale, never mixing new entries
-// into them.
+// keeps rendering the generation it already has and reconciles only where a
+// repaint costs the user nothing. Nothing is scored across generations —
+// deferring means keeping the old generation's completed results wholesale,
+// never mixing new entries into them.
 //
-// The exception is a change THIS APP made. A user who renames a file and does
-// not see the new name has been shown something false, and "don't bother
+// A QUERY CHANGE is no longer one of those places, and that is the whole of
+// this file's second version. Treating it as a boundary meant every keystroke
+// after any background churn adopted the pending generation, which invalidated
+// the corpus, which spent a round trip before the new query could rank
+// anything — a blank list on a keystroke, which is worse than any staleness it
+// avoided. The index bumps the same counter every time a scan completes
+// (lib/index-freshness), and scans complete often, so this was not a rare
+// path. Ranking a new query against the corpus in hand is instant; the caller
+// dims the rows and captions them, and being a generation behind is a state
+// this search can live in. What remains is: the search ending (nothing is on
+// screen to protect, and it is what re-arms the next search with fresh data)
+// and an in-app mutation.
+//
+// That mutation exception is not negotiable. A user who renames a file and
+// does not see the new name has been shown something false, and "don't bother
 // updating stale results" was never meant to cover that. In-app mutations are
 // already tracked for the index corpus (lib/index-freshness), so the same
-// signal reconciles the walk immediately.
+// signal reconciles the walk immediately — and the caller drops its held
+// corpus with it, since that corpus holds the pre-rename name.
 
 export interface RevalidateInput {
   /** Latest generation from the dir watch. */
@@ -37,9 +50,9 @@ export interface RevalidateInput {
 /**
  * Whether the pending watch generation should be adopted now.
  *
- * Boundaries the caller drives directly (a query change, a focus) do not go
- * through here — they reconcile unconditionally, because the results are being
- * replaced at that moment anyway.
+ * Every boundary goes through here. Nothing the caller does reconciles on its
+ * own any more — the one thing that used to (a query change) is precisely the
+ * churn described above.
  */
 export function shouldReconcile(input: RevalidateInput): boolean {
   // Nothing pending.

--- a/frontend/src/apps/explorer/listing/scan-resume.test.ts
+++ b/frontend/src/apps/explorer/listing/scan-resume.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { canResumeScan, type ScanCache } from "@apps/explorer/listing/scan-resume";
+import type { WalkEntry } from "@platform/lib/api";
+
+function entries(n: number): WalkEntry[] {
+  return Array.from({ length: n }, (_, i) => ({
+    rel: `f${i}.txt`,
+    is_dir: false,
+    size: 1,
+    mtime: 2,
+  }));
+}
+
+const A = entries(100);
+
+function cache(over: Partial<ScanCache> = {}): ScanCache {
+  return { q: "rep", showHidden: false, entries: A, key: "k1", scored: 100, ...over };
+}
+
+describe("canResumeScan", () => {
+  it("resumes a streaming walk — one array, appended in place", () => {
+    expect(canResumeScan(cache(), { q: "rep", showHidden: false, entries: A, key: "k1" })).toBe(true);
+  });
+
+  it("resumes a REFETCH of the same corpus, which is a different array", () => {
+    // The bug: an in-app rename or an error retry re-runs the fetch, and the
+    // whole 200k-entry corpus was re-scored because the array was new.
+    const refetched = entries(100);
+    expect(canResumeScan(cache(), { q: "rep", showHidden: false, entries: refetched, key: "k1" })).toBe(
+      true,
+    );
+  });
+
+  it("re-scores from zero when the corpus content changed", () => {
+    expect(
+      canResumeScan(cache(), { q: "rep", showHidden: false, entries: entries(120), key: "k2" }),
+    ).toBe(false);
+  });
+
+  it("re-scores from zero when the corpus has no identity to claim", () => {
+    expect(
+      canResumeScan(cache({ key: "" }), { q: "rep", showHidden: false, entries: entries(100), key: "" }),
+    ).toBe(false);
+  });
+
+  it("re-scores when the new array is shorter than the progress mark", () => {
+    // A retry rebuilds the array from empty; resuming at 100 would skip every
+    // row it has streamed so far.
+    expect(
+      canResumeScan(cache(), { q: "rep", showHidden: false, entries: entries(20), key: "k1" }),
+    ).toBe(false);
+  });
+
+  it("never resumes across a query or hidden-intent change", () => {
+    expect(canResumeScan(cache(), { q: "repo", showHidden: false, entries: A, key: "k1" })).toBe(false);
+    expect(canResumeScan(cache(), { q: "rep", showHidden: true, entries: A, key: "k1" })).toBe(false);
+  });
+});

--- a/frontend/src/apps/explorer/listing/scan-resume.ts
+++ b/frontend/src/apps/explorer/listing/scan-resume.ts
@@ -1,0 +1,50 @@
+// When a partially-scored corpus may be picked up where it was left, instead of
+// being re-scored from zero.
+//
+// The incremental score cache in listing/useRankedScan holds `ranked` (hits for
+// the first `scored` entries) plus the query and hidden-intent they were scored
+// under. Resuming is only sound when the entries those hits came from are still
+// the entries the job is about to continue over — otherwise the cache carries
+// hits for rows that no longer exist, which shows a deleted file as a match.
+//
+// The original rule was array IDENTITY, which is exactly right for a streaming
+// walk (batches append in place) and useless for anything else: a REFETCH is
+// always a new array, so the whole corpus was re-scored every time the fetch
+// re-ran — including for the refetches that cannot change the corpus at all (an
+// in-app rename bumps the home page's fetch key; a retry after an error re-runs
+// it). On a 200k-entry home corpus that is the difference between a keystroke
+// and a stall.
+//
+// So identity is joined by a KEY: a caller-supplied name for the corpus's
+// content (WalkState.key / CorpusState.key — a (root, index generation) pair,
+// or a folder plus its walk generation). Same key means same rows in the same
+// order. The empty string is "no identity" and never resumes, so a caller that
+// cannot make that promise simply does not make it.
+import type { WalkEntry } from "@platform/lib/api";
+
+export interface ScanCache {
+  q: string;
+  showHidden: boolean;
+  entries: WalkEntry[] | null;
+  key: string;
+  /** How many of `entries` have been scored into `ranked`. */
+  scored: number;
+}
+
+export interface ScanTarget {
+  q: string;
+  showHidden: boolean;
+  entries: WalkEntry[];
+  key: string;
+}
+
+export function canResumeScan(cache: ScanCache, next: ScanTarget): boolean {
+  if (cache.q !== next.q || cache.showHidden !== next.showHidden) return false;
+  // The streaming case: one array, appended in place.
+  if (cache.entries === next.entries) return true;
+  if (next.key === "" || cache.key !== next.key) return false;
+  // Same corpus, new array — but only past what was already scored. A retry
+  // rebuilds the array from empty and grows it again, and resuming at a mark
+  // beyond its current end would skip rows entirely.
+  return next.entries.length >= cache.scored;
+}

--- a/frontend/src/apps/explorer/listing/source-race.test.ts
+++ b/frontend/src/apps/explorer/listing/source-race.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { startRace, type Source } from "@apps/explorer/listing/source-race";
+
+function race() {
+  const cancelled: Source[] = [];
+  return { cancelled, r: startRace((loser) => cancelled.push(loser)) };
+}
+
+describe("startRace", () => {
+  it("lets the first source to produce publish, and cancels the other", () => {
+    const { cancelled, r } = race();
+    expect(r.claim("index")).toBe(true);
+    expect(cancelled).toEqual(["walk"]);
+    expect(r.winner()).toBe("index");
+  });
+
+  it("refuses the loser, however late it produces", () => {
+    const { r } = race();
+    r.claim("walk");
+    expect(r.claim("index")).toBe(false);
+    expect(r.claim("index")).toBe(false);
+  });
+
+  it("lets the winner keep publishing — a stream claims on every flush", () => {
+    const { cancelled, r } = race();
+    expect(r.claim("walk")).toBe(true);
+    expect(r.claim("walk")).toBe(true);
+    expect(r.claim("walk")).toBe(true);
+    // Cancelled once, not once per batch.
+    expect(cancelled).toEqual(["index"]);
+  });
+
+  it("is unclaimed until someone produces", () => {
+    const { cancelled, r } = race();
+    expect(r.claimed()).toBe(false);
+    expect(r.winner()).toBeNull();
+    expect(cancelled).toEqual([]);
+  });
+});

--- a/frontend/src/apps/explorer/listing/source-race.ts
+++ b/frontend/src/apps/explorer/listing/source-race.ts
@@ -1,0 +1,51 @@
+// Which of the two corpus sources — the file index or the live streamed walk —
+// is allowed to publish, when both are running at once.
+//
+// The index is normally the fast one, but it is not reliably fast: the first
+// search after a scan completes pays a whole-corpus gitignore sweep on the
+// server (server/index_gitignore.py), and while that runs the box showed
+// nothing at all for seconds and then everything at once — strictly worse than
+// the streamed walk it replaced, which paints from its first NDJSON batch.
+// So the walk is started if the index has not produced within a short budget
+// (INDEX_RACE_MS) and the two race.
+//
+// The rule that makes that safe is FIRST TO PRODUCE TAKES THE WHOLE ANSWER.
+// Interleaving the two entry lists would double-count every path they share —
+// duplicate rows, and a "N matches" count that is simply wrong — so exactly
+// one source ever writes into the entries array, and the loser is cancelled
+// so the server-side walk generator is closed rather than left streaming into
+// nothing.
+//
+// Pure and separate from the hook because "who may write" is the one thing
+// here that must not be wrong, and a closure buried in an effect is not
+// something a test can pin.
+
+export type Source = "index" | "walk";
+
+export interface SourceRace {
+  /**
+   * Whether `who` may publish. The first source to ask wins and keeps winning;
+   * every later ask by the loser answers false. Claiming cancels the other
+   * source exactly once.
+   */
+  claim(who: Source): boolean;
+  /** Whether anyone has produced yet. */
+  claimed(): boolean;
+  /** Who won, or null while both are still running. */
+  winner(): Source | null;
+}
+
+export function startRace(cancel: (loser: Source) => void): SourceRace {
+  let won: Source | null = null;
+  return {
+    claim(who) {
+      if (won === null) {
+        won = who;
+        cancel(who === "index" ? "walk" : "index");
+      }
+      return won === who;
+    },
+    claimed: () => won !== null,
+    winner: () => won,
+  };
+}

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -87,6 +87,13 @@ export const URL_SYNC_MS = 200;
 // flushes immediately (lastFlush starts at 0), so first paint isn't delayed.
 export const STREAM_FLUSH_MS = 200;
 
+// How long the index gets to answer before the live walk is started alongside
+// it (listing/source-race). Short: it is a budget, not a timeout — the index
+// usually answers well inside it, and when it does not, the walk is already
+// streaming rows by the time the index arrives. Long enough that the common
+// fast answer does not pay for a second request the user will never see.
+export const INDEX_RACE_MS = 150;
+
 // How still the query must be before a BIG corpus is re-scored. The index
 // answers a covered folder instantly and whole (up to MAX_CORPUS entries), so
 // unlike a streamed walk there is no ramp-up: the first keystroke already has

--- a/frontend/src/apps/explorer/listing/types.ts
+++ b/frontend/src/apps/explorer/listing/types.ts
@@ -126,11 +126,27 @@ export type ListingState =
 // re-fetch (fetching is driven by `walkReq` — see useWalkSearch). The
 // component remounts per folder (keyed on fsPath in App), so no path tagging
 // is needed.
+//
+// `key` names the CONTENT this corpus is: same key ⇒ same entries, whoever
+// asked and however many times. It is not the same claim as `forRefresh`,
+// which only says which generation the fetch was tagged with — a retry inside
+// one generation builds a brand-new array holding the same rows, and the index
+// and the live walk can each answer for one generation (listing/useWalkSearch
+// races them). Two things read it: the corpus hold (listing/corpus-hold) and
+// the incremental scorer's resume check (listing/useRankedScan), both of which
+// need "is this the same corpus?" and cannot get that from array identity.
 export type WalkState =
   | { status: "idle" }
-  | { status: "streaming"; entries: WalkEntry[]; count: number; forRefresh: number }
-  | { status: "ok"; entries: WalkEntry[]; truncated: boolean; total: number; forRefresh: number }
-  | { status: "error"; message: string; forRefresh: number };
+  | { status: "streaming"; entries: WalkEntry[]; count: number; key: string; forRefresh: number }
+  | {
+      status: "ok";
+      entries: WalkEntry[];
+      truncated: boolean;
+      total: number;
+      key: string;
+      forRefresh: number;
+    }
+  | { status: "error"; message: string; key: string; forRefresh: number };
 
 export const IDLE_WALK: WalkState = { status: "idle" };
 

--- a/frontend/src/apps/explorer/listing/useRankedScan.ts
+++ b/frontend/src/apps/explorer/listing/useRankedScan.ts
@@ -22,14 +22,21 @@
 //    the scan has found so far". Without it an intermediate slice read as a
 //    settled result and a zero-hit moment mid-scan rendered a confident "no
 //    matches".
-//  * incremental resume. As long as query, hidden-intent and the entries ARRAY
-//    are unchanged, only entries appended since the last progress mark get
-//    scored, so a stream flush near the tail of a big walk costs one small scan
-//    rather than a re-scan of everything.
+//  * incremental resume. As long as query, hidden-intent and the CORPUS are
+//    unchanged, only entries appended since the last progress mark get scored,
+//    so a stream flush near the tail of a big walk costs one small scan rather
+//    than a re-scan of everything. "Unchanged" used to mean the entries ARRAY
+//    was identical, which a refetch can never satisfy — so every corpus
+//    refetch, including the ones triggered by things that do not change the
+//    corpus at all (an in-app rename, a retry after an error), re-scored the
+//    whole 200k-entry home corpus from zero. `corpusKey` is the caller's claim
+//    that two arrays hold the same rows; see the resume check below for what
+//    that claim has to be worth.
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { WalkEntry } from "@platform/lib/api";
 import type { QueryTagged } from "@platform/lib/search-hold";
 import { startScanJob } from "@apps/explorer/listing/scan-job";
+import { canResumeScan, type ScanCache } from "@apps/explorer/listing/scan-resume";
 import { queryWantsHidden, rankCompare, scoreEntries } from "@apps/explorer/listing/search";
 import {
   RERANK_COMMIT_MS,
@@ -52,8 +59,21 @@ import {
  * Stream flushes reuse the same entries array (it is appended in place), so the
  * array identity cannot tell the job that more arrived — its length can, which
  * is why the length is a dep of its own.
+ *
+ * `corpusKey` identifies the corpus CONTENT: two arrays carrying the same key
+ * hold the same rows in the same order, whoever fetched them and whenever. It
+ * is what lets the incremental score cache survive a refetch. The caller owes
+ * that guarantee — a key that stayed the same across a genuine content change
+ * would leave the cache holding hits for entries that are no longer there —
+ * which is why "" means "no identity" and never resumes. It is optional, and a
+ * caller that omits it gets the array-identity rule and nothing more.
  */
-export function useRankedScan(entries: WalkEntry[] | null, q: string, debounceMs: number) {
+export function useRankedScan(
+  entries: WalkEntry[] | null,
+  q: string,
+  debounceMs: number,
+  corpusKey = "",
+) {
   const showHidden = queryWantsHidden(q);
   const [scanned, setScanned] = useState<QueryTagged<SearchHit> & { done: boolean }>(() => ({
     q: "",
@@ -63,13 +83,14 @@ export function useRankedScan(entries: WalkEntry[] | null, q: string, debounceMs
 
   // Incremental-scoring cache, which also carries a chunked scan's PROGRESS so
   // a job cancelled mid-flight (by the next stream flush) resumes.
-  const scoreCache = useRef<{
-    q: string;
-    showHidden: boolean;
-    entries: WalkEntry[] | null;
-    scored: number; // how many of `entries` have been scored already
-    ranked: SearchHit[];
-  }>({ q: "", showHidden: false, entries: null, scored: 0, ranked: [] });
+  const scoreCache = useRef<ScanCache & { ranked: SearchHit[] }>({
+    q: "",
+    showHidden: false,
+    entries: null,
+    key: "",
+    scored: 0, // how many of `entries` have been scored already
+    ranked: [],
+  });
 
   const scannable = q === "" ? null : entries;
   const entryCount = scannable ? scannable.length : 0;
@@ -87,10 +108,14 @@ export function useRankedScan(entries: WalkEntry[] | null, q: string, debounceMs
       return;
     }
     const cache = scoreCache.current;
-    const resumable =
-      cache.entries === scannable && cache.q === q && cache.showHidden === showHidden;
-    if (!resumable) {
-      scoreCache.current = { q, showHidden, entries: scannable, scored: 0, ranked: [] };
+    const target = { q, showHidden, entries: scannable, key: corpusKey };
+    if (canResumeScan(cache, target)) {
+      // Point the cache at the array the job will actually walk: on a refetch
+      // that is a NEW array holding the same rows, and the next resume check
+      // compares against it.
+      cache.entries = scannable;
+    } else {
+      scoreCache.current = { ...target, scored: 0, ranked: [] };
     }
     const live = scoreCache.current;
     return startScanJob(
@@ -117,7 +142,7 @@ export function useRankedScan(entries: WalkEntry[] | null, q: string, debounceMs
         },
       },
     );
-  }, [q, showHidden, scannable, entryCount, debounceMs]);
+  }, [q, showHidden, scannable, entryCount, debounceMs, corpusKey]);
 
   // Rows are dropped unless they were computed for the CURRENT query, so a scan
   // still catching up never shows the previous query's matches — the same rule

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -20,7 +20,12 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { indexSearch, walkDirStream } from "@platform/lib/api";
 import type { WalkEntry } from "@platform/lib/api";
 import { indexCorpusFrom } from "@apps/explorer/listing/index-corpus";
-import { nextHeldCorpus, scannableCorpus, type HeldCorpus } from "@apps/explorer/listing/corpus-hold";
+import {
+  corpusKey,
+  nextHeldCorpus,
+  scannableCorpus,
+  type HeldCorpus,
+} from "@apps/explorer/listing/corpus-hold";
 import {
   fsMutationCount,
   indexLifecycleCount,
@@ -190,11 +195,11 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     let pending: WalkEntry[] = [];
     let lastFlush = 0;
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
-    // Corpus identities for the two sources (WalkState.key). Distinct per
-    // source as well as per generation: both may answer for one generation
-    // (they race below), and their entry lists are not the same rows.
-    const walkKey = `walk:${fsPath}:${forRefresh}`;
-    const indexKey = `index:${fsPath}:${forRefresh}`;
+    // Corpus identities for the two sources (WalkState.key). `retryNonce` is
+    // in there because a retry is a fresh walk of the filesystem under an
+    // unchanged folder and generation — see corpusKey.
+    const walkKey = corpusKey("walk", fsPath, forRefresh, retryNonce);
+    const indexKey = corpusKey("index", fsPath, forRefresh, retryNonce);
     const flush = () => {
       if (flushTimer !== null) {
         clearTimeout(flushTimer);

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -378,7 +378,7 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
 
   // The scan itself — incremental, sliced and cancellable, shared with the
   // explorer home page's box (listing/useRankedScan carries the reasoning).
-  const { ranked, pending } = useRankedScan(corpus.entries, q, SCAN_DEBOUNCE_MS);
+  const { ranked, pending } = useRankedScan(corpus.entries, q, SCAN_DEBOUNCE_MS, corpus.key);
 
   // What the rest of the hook consumes.
   // Relevance (the fuzzy rank) is the only order search results have. Column

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -513,18 +513,31 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // long as that takes on a big folder. Hold the last ranked answer and keep
   // rendering it (dimmed, with the spinner) until the fresh one is ready.
   //
-  // This changes only what is DISPLAYED. The invalidation machinery is
-  // untouched: a stale walk is still never scored against a new tree — `hits`
-  // remains derived from validWalk alone, and these held rows are not fed back
-  // into scoring.
+  // This changes only what is DISPLAYED: these held rows are never fed back
+  // into scoring, so a ranking is always something the scorer actually
+  // produced rather than something reassembled here.
+  //
+  // It used to be able to claim more — that `hits` came from validWalk alone,
+  // so a stale walk was structurally incapable of being scored against a new
+  // tree. That is no longer true and should not be read as if it were: `hits`
+  // now ranks whatever `scannableCorpus` hands over, which can be the previous
+  // generation's entries (listing/corpus-hold), and the corpus is deliberately
+  // not re-fetched on background churn at all (listing/revalidate). Scoring a
+  // stale corpus is the intended behaviour. What replaces the old structural
+  // guarantee is a reporting obligation: every path that ranks against
+  // something other than the current generation surfaces it — `corpus.stale`
+  // and `generationBehind` above, which drive the dimming and the chip. The
+  // invariant is now "never silently", not "never".
   //
   // Both halves of the decision — what to retain, and what to render — live in
   // lib/search-hold, pure and query-tagged: rows are only ever shown under the
   // query they were computed for, so the ONE thing this must never do (show the
   // previous query's matches under a new query) is structurally impossible
   // rather than a condition someone has to remember. A query change falls
-  // through to "Searching…" exactly as before; only a same-query invalidation
-  // holds. The hold applies only while the current-generation walk is unsettled
+  // through to "Searching…" exactly as before — and now rarely reaches it,
+  // since the corpus survives the keystroke and the new query ranks
+  // immediately; only a same-query invalidation holds. The hold applies only
+  // while the current-generation walk is unsettled
   // — a COMPLETED walk with no hits is a real "no matches" answer (the file was
   // just deleted, say) and replaces the held rows.
   const heldHits = useRef<QueryTagged<SearchHit> | null>(null);

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -253,9 +253,23 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
       startWalk();
     };
     // A folder this app has already marked dirty is decided before any
-    // request: the index is not merely slower here, it is WRONG (it would
-    // offer the pre-rename name), so there is nothing to race — see the note
-    // on the resolution-time check below.
+    // request, and the walk race above does NOT soften that.
+    //
+    // The race was the reason to revisit this gate: with the walk running
+    // anyway, refusing the index looks like it only costs latency. It does
+    // not. The index is not slower here, it is WRONG — its corpus predates
+    // the rename, so it would answer with the old name — and it would win the
+    // race handily, because answering from a corpus already on disk is exactly
+    // what it is fast at. A race fixes a slow answer, never a false one.
+    //
+    // Narrowing the gate to the mutated folder itself is not available either:
+    // in-folder search is recursive, so a rename anywhere below `fsPath`
+    // poisons its corpus, and a renamed ANCESTOR moves every path inside it.
+    // Both directions of lib/index-freshness's check are load-bearing (its
+    // test file pins them). The documented cost stands: one rename pins this
+    // folder and its ancestors to the live walk for the session, which the
+    // home page rightly refuses to pay because it has no walk to fall back
+    // on (see FilesHome) and which this box can afford because it does.
     if (!indexMayAnswer(fsPath)) {
       startWalk();
     } else {

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -25,8 +25,10 @@ import { nextHeldHits, resolveDisplayedHits, type QueryTagged } from "@platform/
 import { useRankedScan } from "@apps/explorer/listing/useRankedScan";
 import { shouldReconcile } from "@apps/explorer/listing/revalidate";
 import { capHits } from "@apps/explorer/listing/result-cap";
+import { startRace } from "@apps/explorer/listing/source-race";
 import {
   IDLE_WALK,
+  INDEX_RACE_MS,
   RERANK_COMMIT_MS,
   SCAN_DEBOUNCE_MS,
   STREAM_FLUSH_MS,
@@ -139,10 +141,22 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // streamed walk runs exactly as it always did. The fallback is silent by
   // design: none of those is an error the user can act on, and every one of
   // them is normal in the seconds after a first launch.
+  //
+  // They RACE rather than queue. Awaiting the index in full made it strictly
+  // worse than the walk it replaced whenever it was slow (the gitignore sweep
+  // after a scan): nothing on screen for seconds, then everything at once,
+  // where the walk would have painted its first batch in ~100ms. So the walk
+  // starts if the index has not produced within INDEX_RACE_MS, and exactly one
+  // of them ends up owning the answer — see listing/source-race for why
+  // interleaving them is not an option.
   useEffect(() => {
     if (walkReq === null) return;
     const forRefresh = walkReq;
-    const ctrl = new AbortController();
+    // One controller per source: the race aborts the LOSER on its own (which
+    // closes the server-side walk generator) while the winner keeps running.
+    // Cleanup aborts both.
+    const ctrl = { index: new AbortController(), walk: new AbortController() };
+    const race = startRace((loser) => ctrl[loser].abort());
     let alive = true;
     const entries: WalkEntry[] = [];
     // Flush throttle (STREAM_FLUSH_MS): entries accumulate in `pending`
@@ -162,6 +176,10 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
         clearTimeout(flushTimer);
         flushTimer = null;
       }
+      // Producing is what claims the race, so the FIRST flush is where the walk
+      // wins — and where it loses, if the index already answered. Nothing is
+      // pushed on a loss: `entries` only ever holds one source's rows.
+      if (!race.claim("walk")) return;
       for (const e of pending) entries.push(e); // no spread: a big chunk would blow the arg limit
       pending = [];
       lastFlush = Date.now();
@@ -174,12 +192,23 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     // instead of letting an unsettled state quietly carry last generation's
     // rows under a fresh tag.
     setWalk({ status: "streaming", entries, count: 0, key: walkKey, forRefresh });
-    const liveWalk = () =>
-      walkDirStream(fsPath, {
+    // A walk that fails while the index is still in flight is NOT the answer
+    // yet — the index may still cover this folder — so its error is remembered
+    // and surfaced only once the index has been ruled out. Without that, an
+    // early walk failure (the race started it, the folder is unreadable) would
+    // paint "Search failed" over an index answer that was one tick away.
+    let walkError: Error | null = null;
+    let indexPending = false;
+    let walkStarted = false;
+    let raceTimer: ReturnType<typeof setTimeout> | null = null;
+    const startWalk = () => {
+      if (walkStarted) return;
+      walkStarted = true;
+      void walkDirStream(fsPath, {
         hidden: true,
-        signal: ctrl.signal,
+        signal: ctrl.walk.signal,
         onBatch: (batch) => {
-          if (!alive) return;
+          if (!alive || race.winner() === "index") return;
           for (const e of batch) pending.push(e);
           const wait = STREAM_FLUSH_MS - (Date.now() - lastFlush);
           if (wait <= 0) flush();
@@ -189,7 +218,9 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
         (end) => {
           if (!alive) return;
           if (flushTimer !== null) clearTimeout(flushTimer);
+          if (!race.claim("walk")) return;
           for (const e of pending) entries.push(e);
+          pending = [];
           setWalk({
             status: "ok",
             entries,
@@ -202,55 +233,80 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
         (err: Error) => {
           if (!alive || err.name === "AbortError") return;
           if (flushTimer !== null) clearTimeout(flushTimer);
+          if (race.winner() === "index") return;
+          walkError = err;
+          if (indexPending) return; // the index still might answer
+          race.claim("walk");
           setWalk({ status: "error", message: err.message, key: walkKey, forRefresh });
         }
       );
-    // A folder this app has already marked dirty is decided before any
-    // request: the walk is what will answer anyway, so waiting out the index
-    // round-trip (plus its gitignore filter) only delays the first results.
-    // The same check repeats at resolution time below for the race where the
-    // mutation lands while the fetch is in flight.
-    if (!indexMayAnswer(fsPath)) {
-      void liveWalk();
-      return () => {
-        alive = false;
-        if (flushTimer !== null) clearTimeout(flushTimer);
-        ctrl.abort();
-      };
-    }
-    indexSearch(fsPath, { signal: ctrl.signal }).then(
-      (res) => {
-        if (!alive) return;
-        // A folder this app has changed since the last scan is walked live:
-        // the corpus predates the change, so it would offer the old name and
-        // never the new one (lib/index-freshness). Out-of-band edits keep the
-        // documented trade — an instant, mostly-right answer.
-        const corpus = indexMayAnswer(fsPath) ? indexCorpusFrom(res) : null;
-        if (!corpus) {
-          void liveWalk();
-          return;
-        }
-        for (const e of corpus.entries) entries.push(e);
-        setWalk({
-          status: "ok",
-          entries,
-          truncated: corpus.truncated,
-          total: entries.length,
-          key: indexKey,
-          forRefresh,
-        });
-      },
-      (err: Error) => {
-        // Includes the abort case: a cleanup aborts BOTH requests, and
-        // liveWalk would immediately abort too, so the guard covers it.
-        if (!alive || err.name === "AbortError") return;
-        void liveWalk();
+    };
+    // The index has nothing for this folder (uncovered, dirty, or the request
+    // failed). Whatever the walk is doing is now the only answer there will be.
+    const indexIsOut = () => {
+      if (race.winner() === "walk") return; // it already produced; nothing to do
+      if (walkError !== null) {
+        race.claim("walk");
+        setWalk({ status: "error", message: walkError.message, key: walkKey, forRefresh });
+        return;
       }
-    );
+      startWalk();
+    };
+    // A folder this app has already marked dirty is decided before any
+    // request: the index is not merely slower here, it is WRONG (it would
+    // offer the pre-rename name), so there is nothing to race — see the note
+    // on the resolution-time check below.
+    if (!indexMayAnswer(fsPath)) {
+      startWalk();
+    } else {
+      indexPending = true;
+      // The budget. If the index has produced nothing by now, stop waiting on
+      // it and let the walk stream while it finishes (listing/source-race).
+      raceTimer = setTimeout(() => {
+        if (alive && !race.claimed()) startWalk();
+      }, INDEX_RACE_MS);
+      indexSearch(fsPath, { signal: ctrl.index.signal }).then(
+        (res) => {
+          if (!alive) return;
+          indexPending = false;
+          // A folder this app has changed since the last scan is walked live:
+          // the corpus predates the change, so it would offer the old name and
+          // never the new one (lib/index-freshness). Re-checked here for the
+          // race where the mutation lands while the fetch is in flight.
+          // Out-of-band edits keep the documented trade — an instant,
+          // mostly-right answer.
+          const corpus = indexMayAnswer(fsPath) ? indexCorpusFrom(res) : null;
+          if (!corpus) {
+            indexIsOut();
+            return;
+          }
+          if (!race.claim("index")) return; // the walk beat it; its rows stand
+          for (const e of corpus.entries) entries.push(e);
+          setWalk({
+            status: "ok",
+            entries,
+            truncated: corpus.truncated,
+            total: entries.length,
+            key: indexKey,
+            forRefresh,
+          });
+        },
+        (err: Error) => {
+          if (!alive) return;
+          indexPending = false;
+          // An abort here is either the cleanup or the race cancelling the
+          // loser; neither is a reason to start anything.
+          if (err.name === "AbortError") return;
+          indexIsOut();
+        }
+      );
+    }
     return () => {
       alive = false;
       if (flushTimer !== null) clearTimeout(flushTimer);
-      ctrl.abort();
+      if (raceTimer !== null) clearTimeout(raceTimer);
+      ctrl.index.abort();
+      ctrl.walk.abort();
     };
   }, [fsPath, walkReq, retryNonce]);
 

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -437,18 +437,21 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // spinner and the dimmed-rows treatment key off this, so it has to mean
   // "an answer is still coming", not merely "the deferred value lags".
   const scanPending = searching && pending;
-  // The corpus is a generation behind and is STAYING that way until a real
-  // boundary (listing/revalidate): the folder or the index moved and this
-  // search deliberately did not follow. That is a fine state to be in, but only
-  // if it is visible — "stale but honestly labelled" is the whole deal, and it
-  // is what separates this from the bug it replaced. The dimming says it here;
-  // the chip in Listing.tsx says it in words.
+  // `corpus.stale` — rows from the hold while a fetch is actually running —
+  // joins the two pre-existing reasons: rows ranked against a previous
+  // generation's corpus are exactly as provisional as rows the scan has not
+  // finished producing, and all of them must read as such. All three are
+  // MOMENTARY, which is what the heavy dim they drive is calibrated for.
+  const isStale = deferredStale || scanPending || corpus.stale;
+  // Being a generation behind is not momentary: the folder or the index moved
+  // and this search deliberately did not follow, and it will stay that way
+  // until a real boundary (listing/revalidate). That is a fine state to be in,
+  // but only if it is visible — "stale but honestly labelled" is the whole
+  // deal. It gets a treatment of its own rather than the in-flight one, because
+  // a dim that can persist for the whole session has to be legible to read
+  // under, and because "an answer is coming" and "no answer is coming, this is
+  // it" are different claims. Reported separately for exactly that reason.
   const generationBehind = searching && pinned !== gen;
-  // `corpus.stale` (rows from the hold, while a fetch actually runs) joins the
-  // two pre-existing reasons: rows ranked against a previous generation's
-  // corpus are exactly as provisional as rows the scan has not finished
-  // producing, and all of them must read as such.
-  const isStale = deferredStale || scanPending || corpus.stale || generationBehind;
 
   // --- Streaming re-rank throttle (B4) --------------------------------------
   // Every stream flush re-scores the newly arrived entries and merges them into
@@ -546,10 +549,10 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     q,
     searching,
     isStale,
-    // Specifically "these results are computed from an older generation of the
-    // tree", as opposed to the other two things isStale folds in (a deferred
-    // render, an unfinished scan), which are momentary. Drives the caveat chip.
-    behind: generationBehind || corpus.stale,
+    // "These results are computed from an older generation of the tree, and
+    // nothing is on its way to fix that" — see above. Drives the caveat chip
+    // and its own, lighter dim.
+    behind: generationBehind,
     scanPending,
     validWalk,
     prefetchWalk,

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -1,13 +1,21 @@
 // The in-folder search: query state (URL-synced), the streamed recursive walk,
 // incremental fuzzy scoring, the render-side re-rank throttle, the
-// stale-while-revalidate hold across dir-watch refreshes, and the result cap.
+// stale-while-revalidate holds, and the result cap.
 //
 // A non-empty query swaps the listing for flat, rank-ordered results over a
 // recursive walk of the folder. The walk STREAMS (NDJSON batches,
 // breadth-first from the server): results paint from the first batch and
 // refine while deeper levels are still arriving, so feedback is instant even
-// on huge trees. The walk starts lazily on first focus (or a URL-seeded
-// query) and is cached until the dir watch fires.
+// on huge trees. The walk starts lazily on first focus (or a URL-seeded query).
+//
+// The corpus is then KEPT. Neither a dir-watch event nor a scan completing
+// re-fetches it: both are recorded and the results stay put, dimmed and
+// captioned "not refreshed", until a boundary where a repaint costs the user
+// nothing — the search ending, or a change this app itself made. That is the
+// deliberate trade this file makes, and it is worth restating because it is
+// the opposite of what a cache usually does: a corpus a few minutes old that
+// says so beats one that keeps being pulled out from under the reader. See
+// listing/revalidate.
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { indexSearch, walkDirStream } from "@platform/lib/api";
 import type { WalkEntry } from "@platform/lib/api";
@@ -71,12 +79,12 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // the input can have settled while the chunked scan for it is still running.
   const deferredStale = query.trim() !== q;
 
-  // The index being deleted or a scan completing invalidates the fetched
-  // corpus the same way a dir-watch bump does, and needs its own signal: the
-  // filesystem didn't change, so no watch refresh will ever re-key the fetch
-  // (lib/index-freshness). Composed into `gen` so it rides the SAME deferral —
-  // adopted at the boundaries while a search is on screen, immediately
-  // otherwise — rather than swapping results mid-read.
+  // The index being deleted or a scan completing dates the fetched corpus the
+  // same way a dir-watch bump does, and needs its own signal: the filesystem
+  // didn't change, so no watch refresh will ever re-key the fetch
+  // (lib/index-freshness). Composed into `gen` so it rides the SAME deferral,
+  // which matters more for this one than for the watch: scans complete often,
+  // and treating each as an invalidation is what made search blank mid-read.
   const [lifecycle, setLifecycle] = useState(indexLifecycleCount);
   useEffect(() => subscribeIndexLifecycle(() => setLifecycle(indexLifecycleCount())), []);
   // The generation this hook answers for: dir-watch refreshes plus index
@@ -93,7 +101,17 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   const appliedMutations = useRef(mutations);
   useEffect(() => subscribeFsMutations(() => setMutations(fsMutationCount())), []);
 
+  // The corpus retained across an invalidation, so a refetch never blanks the
+  // rows (listing/corpus-hold). Declared here because the reconcile below has
+  // to be able to throw it away.
+  const heldCorpus = useRef<HeldCorpus | null>(null);
+
   const reconcile = () => {
+    // A reconcile forced by THIS APP's own mutation must not leave the old
+    // corpus standing in for the refetch: it holds the pre-rename name, which
+    // is the one thing search must never offer back (lib/index-freshness).
+    // Every other reconcile is background churn, where holding is the point.
+    if (fsMutationCount() !== appliedMutations.current) heldCorpus.current = null;
     appliedMutations.current = fsMutationCount();
     setMutations(appliedMutations.current);
     setPinned(gen);
@@ -149,6 +167,12 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // starts if the index has not produced within INDEX_RACE_MS, and exactly one
   // of them ends up owning the answer — see listing/source-race for why
   // interleaving them is not an option.
+  //
+  // Note what this effect does NOT do: run when there is already a corpus. It
+  // is driven by `walkReq`, which only moves when `validWalk` reads idle — and
+  // background churn no longer makes it read idle (listing/revalidate). So the
+  // race, and the second request it can cost, are confined to the case they
+  // are for: this folder has nothing to show yet.
   useEffect(() => {
     if (walkReq === null) return;
     const forRefresh = walkReq;
@@ -355,17 +379,23 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
 
   const setQuery = (value: string) => {
     setQueryState(value);
-    // A query change is a boundary: the rows are being replaced anyway, so a
-    // generation deferred during the previous query lands here for free.
-    reconcile();
-    // Editing the query is also a user gesture: if the last walk attempt
-    // failed, give it another shot instead of leaving search dead forever.
+    // A query change is deliberately NOT a revalidation boundary any more.
+    //
+    // It used to be, on the reasoning that the rows are being replaced anyway
+    // so a deferred generation lands for free. It is not free: adopting the
+    // generation invalidates the corpus, which re-runs the fetch, which means
+    // every keystroke that arrives after any background churn pays a round
+    // trip before it can rank anything. Ranking the new query against the
+    // corpus already in hand — a generation old, dimmed, and captioned — is
+    // both instant and honest, and being a generation behind is a state this
+    // search can simply live in (listing/revalidate).
+    //
+    // Editing the query is still a user gesture, so it is still the retry for
+    // a failed walk: otherwise search stays dead until something else moves.
     // (An idle walk needs no handling here — the auto-request effect fires
     // as soon as the non-empty query state lands.)
     if (validWalk.status === "error") {
-      // `gen`, not `pinned`: the reconcile above is setting pinned to it,
-      // and that state has not landed yet inside this handler.
-      setWalkReq(gen);
+      setWalkReq(pinned);
       setRetryNonce((n) => n + 1);
     }
     if (!urlSync) return;
@@ -379,14 +409,15 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     }, URL_SYNC_MS);
   };
 
-  // The corpus to rank. The previous generation's entries stay scannable while
-  // the next one is fetched, so a keystroke landing mid-refetch ranks against a
-  // one-generation-stale corpus and paints at once instead of ranking against
-  // an empty array and blanking (listing/corpus-hold). The hold is captured
-  // from `validWalk` during render, exactly like the ranked-hit hold below —
-  // by the render where `pinned` moves and validWalk reads idle, this ref is
-  // already carrying the corpus from the render before it.
-  const heldCorpus = useRef<HeldCorpus | null>(null);
+  // The corpus to rank. Background churn no longer invalidates it at all — a
+  // keystroke ranks against whatever is in hand (see setQuery) — so the hold
+  // covers what is left: the search ending and being reopened, and a fetch
+  // that is genuinely re-running. The previous generation's entries stay
+  // scannable so those never blank the rows either (listing/corpus-hold). The
+  // hold is captured from `validWalk` during render, exactly like the
+  // ranked-hit hold below — by the render where `pinned` moves and validWalk
+  // reads idle, this ref is already carrying the corpus from the render before
+  // it, unless the reconcile above deliberately dropped it.
   heldCorpus.current = nextHeldCorpus(validWalk, heldCorpus.current);
   const corpus = scannableCorpus(searching, validWalk, heldCorpus.current);
 
@@ -406,10 +437,18 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // spinner and the dimmed-rows treatment key off this, so it has to mean
   // "an answer is still coming", not merely "the deferred value lags".
   const scanPending = searching && pending;
-  // `corpus.stale` joins the two pre-existing reasons: rows ranked against the
-  // previous generation's corpus are exactly as provisional as rows the scan
-  // has not finished producing, and both must read as such.
-  const isStale = deferredStale || scanPending || corpus.stale;
+  // The corpus is a generation behind and is STAYING that way until a real
+  // boundary (listing/revalidate): the folder or the index moved and this
+  // search deliberately did not follow. That is a fine state to be in, but only
+  // if it is visible — "stale but honestly labelled" is the whole deal, and it
+  // is what separates this from the bug it replaced. The dimming says it here;
+  // the chip in Listing.tsx says it in words.
+  const generationBehind = searching && pinned !== gen;
+  // `corpus.stale` (rows from the hold, while a fetch actually runs) joins the
+  // two pre-existing reasons: rows ranked against a previous generation's
+  // corpus are exactly as provisional as rows the scan has not finished
+  // producing, and all of them must read as such.
+  const isStale = deferredStale || scanPending || corpus.stale || generationBehind;
 
   // --- Streaming re-rank throttle (B4) --------------------------------------
   // Every stream flush re-scores the newly arrived entries and merges them into
@@ -507,6 +546,10 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     q,
     searching,
     isStale,
+    // Specifically "these results are computed from an older generation of the
+    // tree", as opposed to the other two things isStale folds in (a deferred
+    // render, an unfinished scan), which are momentary. Drives the caveat chip.
+    behind: generationBehind || corpus.stale,
     scanPending,
     validWalk,
     prefetchWalk,

--- a/frontend/src/apps/explorer/listing/useWalkSearch.ts
+++ b/frontend/src/apps/explorer/listing/useWalkSearch.ts
@@ -12,6 +12,7 @@ import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { indexSearch, walkDirStream } from "@platform/lib/api";
 import type { WalkEntry } from "@platform/lib/api";
 import { indexCorpusFrom } from "@apps/explorer/listing/index-corpus";
+import { nextHeldCorpus, scannableCorpus, type HeldCorpus } from "@apps/explorer/listing/corpus-hold";
 import {
   fsMutationCount,
   indexLifecycleCount,
@@ -151,6 +152,11 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     let pending: WalkEntry[] = [];
     let lastFlush = 0;
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
+    // Corpus identities for the two sources (WalkState.key). Distinct per
+    // source as well as per generation: both may answer for one generation
+    // (they race below), and their entry lists are not the same rows.
+    const walkKey = `walk:${fsPath}:${forRefresh}`;
+    const indexKey = `index:${fsPath}:${forRefresh}`;
     const flush = () => {
       if (flushTimer !== null) {
         clearTimeout(flushTimer);
@@ -159,9 +165,15 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
       for (const e of pending) entries.push(e); // no spread: a big chunk would blow the arg limit
       pending = [];
       lastFlush = Date.now();
-      setWalk({ status: "streaming", entries, count: entries.length, forRefresh });
+      setWalk({ status: "streaming", entries, count: entries.length, key: walkKey, forRefresh });
     };
-    setWalk({ status: "streaming", entries, count: 0, forRefresh });
+    // Published BEFORE either source has answered, so search reads as "in
+    // flight" from this instant. It is deliberately empty rather than
+    // preserving the old rows: what stands in meanwhile is the HELD corpus
+    // (listing/corpus-hold), which keeps that stand-in explicitly marked stale
+    // instead of letting an unsettled state quietly carry last generation's
+    // rows under a fresh tag.
+    setWalk({ status: "streaming", entries, count: 0, key: walkKey, forRefresh });
     const liveWalk = () =>
       walkDirStream(fsPath, {
         hidden: true,
@@ -178,12 +190,19 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
           if (!alive) return;
           if (flushTimer !== null) clearTimeout(flushTimer);
           for (const e of pending) entries.push(e);
-          setWalk({ status: "ok", entries, truncated: end.truncated, total: end.total, forRefresh });
+          setWalk({
+            status: "ok",
+            entries,
+            truncated: end.truncated,
+            total: end.total,
+            key: walkKey,
+            forRefresh,
+          });
         },
         (err: Error) => {
           if (!alive || err.name === "AbortError") return;
           if (flushTimer !== null) clearTimeout(flushTimer);
-          setWalk({ status: "error", message: err.message, forRefresh });
+          setWalk({ status: "error", message: err.message, key: walkKey, forRefresh });
         }
       );
     // A folder this app has already marked dirty is decided before any
@@ -217,6 +236,7 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
           entries,
           truncated: corpus.truncated,
           total: entries.length,
+          key: indexKey,
           forRefresh,
         });
       },
@@ -289,15 +309,20 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
     }, URL_SYNC_MS);
   };
 
-  // The corpus to rank, once this generation's walk has entries to offer.
-  const corpus =
-    searching && (validWalk.status === "ok" || validWalk.status === "streaming")
-      ? validWalk.entries
-      : null;
+  // The corpus to rank. The previous generation's entries stay scannable while
+  // the next one is fetched, so a keystroke landing mid-refetch ranks against a
+  // one-generation-stale corpus and paints at once instead of ranking against
+  // an empty array and blanking (listing/corpus-hold). The hold is captured
+  // from `validWalk` during render, exactly like the ranked-hit hold below —
+  // by the render where `pinned` moves and validWalk reads idle, this ref is
+  // already carrying the corpus from the render before it.
+  const heldCorpus = useRef<HeldCorpus | null>(null);
+  heldCorpus.current = nextHeldCorpus(validWalk, heldCorpus.current);
+  const corpus = scannableCorpus(searching, validWalk, heldCorpus.current);
 
   // The scan itself — incremental, sliced and cancellable, shared with the
   // explorer home page's box (listing/useRankedScan carries the reasoning).
-  const { ranked, pending } = useRankedScan(corpus, q, SCAN_DEBOUNCE_MS);
+  const { ranked, pending } = useRankedScan(corpus.entries, q, SCAN_DEBOUNCE_MS);
 
   // What the rest of the hook consumes.
   // Relevance (the fuzzy rank) is the only order search results have. Column
@@ -311,7 +336,10 @@ export function useWalkSearch(fsPath: string, refresh: number, urlSync = true) {
   // spinner and the dimmed-rows treatment key off this, so it has to mean
   // "an answer is still coming", not merely "the deferred value lags".
   const scanPending = searching && pending;
-  const isStale = deferredStale || scanPending;
+  // `corpus.stale` joins the two pre-existing reasons: rows ranked against the
+  // previous generation's corpus are exactly as provisional as rows the scan
+  // has not finished producing, and both must read as such.
+  const isStale = deferredStale || scanPending || corpus.stale;
 
   // --- Streaming re-rank throttle (B4) --------------------------------------
   // Every stream flush re-scores the newly arrived entries and merges them into

--- a/frontend/src/platform/lib/index-freshness.test.ts
+++ b/frontend/src/platform/lib/index-freshness.test.ts
@@ -32,6 +32,24 @@ test("renaming an ANCESTOR invalidates the folder below it", () => {
   expect(indexMayAnswer("/home/me/proj/src")).toBe(false);
 });
 
+test("a rename several levels down still pins every folder above it to the walk", () => {
+  // The invariant the gate exists for, and the reason racing the index against
+  // the live walk (listing/source-race) does not weaken it: the index would
+  // WIN that race and answer instantly with the pre-rename name. A race fixes a
+  // slow answer, never a wrong one — so both directions of the check stay, and
+  // "narrow it to the mutated folder itself" is not available.
+  noteFsMutation("/home/me/proj/src/deep/nested/renamed.ts");
+  for (const folder of [
+    "/home/me",
+    "/home/me/proj",
+    "/home/me/proj/src",
+    "/home/me/proj/src/deep",
+    "/home/me/proj/src/deep/nested",
+  ]) {
+    expect(indexMayAnswer(folder)).toBe(false);
+  }
+});
+
 test("a sibling prefix is not a subtree", () => {
   // /home/me/proj-old must not be read as "inside /home/me/proj".
   noteFsMutation("/home/me/proj-old/a.txt");

--- a/frontend/src/styles/explorer.css
+++ b/frontend/src/styles/explorer.css
@@ -1453,6 +1453,17 @@ table.listing-table tr.skel-row:hover {
   transition: opacity 0.1s ease-out;
 }
 
+/* Results a generation behind, with nothing on its way to replace them: the
+   search deliberately does not refetch while you are reading (listing/
+   revalidate), and the chip in the input says so in words. Much lighter than
+   .listing-stale above, because this one is not a flicker — it can hold for as
+   long as the search is open, and rows nobody can read are worse than rows
+   that are a few minutes old. The two compound when both apply, which is
+   correct: that is genuinely the least certain state there is. */
+.listing-behind {
+  opacity: 0.86;
+}
+
 /* Shared search-input chrome (explorer header + sidebar bookmarks). */
 .listing-search-input,
 .bookmark-search-input {

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -242,10 +242,12 @@
   }
 }
 
-/* Rows ranked against a corpus a generation behind. The listing dims held
-   results the same way (.listing-stale); the chip above says why. */
+/* Rows ranked against a corpus a generation behind, matching the listing's
+   .listing-behind — light on purpose, because this state can hold for as long
+   as the box is open and rows nobody can read are worse than rows a few
+   minutes old. The chip above says why in words. */
 .fh-results.is-stale {
-  opacity: 0.55;
+  opacity: 0.86;
 }
 
 .fh-result-note kbd {

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -206,6 +206,48 @@
   color: var(--fg-muted);
 }
 
+/* The "indexing…" caveat, rendered at the end of that same line rather than as
+   a banner of its own: it is a footnote on the count next to it, and an index
+   is always a little behind the filesystem, so a louder treatment would cry
+   wolf permanently. Same two messages as the listing's search chip
+   (listing/index-caveat) — one claim, one wording, two boxes. */
+.fh-index-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-left: 8px;
+  padding: 1px 7px 1px 6px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-alt);
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--fg-muted);
+  vertical-align: baseline;
+}
+
+.fh-index-spinner {
+  width: 9px;
+  height: 9px;
+  flex: none;
+  border: 1.5px solid var(--border);
+  border-top-color: var(--fg-muted);
+  border-radius: 50%;
+  animation: fh-index-spin 0.6s linear infinite;
+}
+
+@keyframes fh-index-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Rows ranked against a corpus a generation behind. The listing dims held
+   results the same way (.listing-stale); the chip above says why. */
+.fh-results.is-stale {
+  opacity: 0.55;
+}
+
 .fh-result-note kbd {
   font: inherit;
   padding: 0 4px;

--- a/frontend/src/styles/reduced-motion.css
+++ b/frontend/src/styles/reduced-motion.css
@@ -12,6 +12,7 @@
   }
 
   .listing-search-spinner,
+  .fh-index-spinner,
   .deploy-spinner,
   .mode-icon-spinner {
     animation: none !important;

--- a/fused_render/index/freshness.py
+++ b/fused_render/index/freshness.py
@@ -40,10 +40,19 @@ QUIET_S = 30.0
 # Floor between scans of one root STARTED by this path. Read off `scans.json`
 # via runner.last_scan, which the startup scheduler and the manual buttons also
 # stamp — so a scan that just ran for any reason suppresses a trigger, and the
-# trigger needs no state file of its own. Much lower than the startup
-# debounce (routers/index.SCAN_DEBOUNCE_S, 15 min) on purpose: that one exists
-# to stop a reload loop, this one to stop a browsing session from queueing.
-MIN_INTERVAL_S = 120.0
+# trigger needs no state file of its own. Still below the startup debounce
+# (routers/index.SCAN_DEBOUNCE_S, 15 min): that one exists to stop a reload
+# loop, this one to stop a browsing session from queueing.
+#
+# Raised from two minutes, because a completed scan is not free to the client:
+# it invalidates every fetched corpus in the app (platform/lib/index-status ->
+# index-freshness), and the explorer's answer to that is now to keep serving
+# what it has and say it is a generation behind rather than to refetch. Being a
+# few minutes behind is a labelled, readable state; a scan finishing every two
+# minutes under a churny home directory is a permanent "indexing…" and a
+# permanent dimming, which reads as broken. Freshness still wins over an
+# out-of-band change eventually, just not eagerly.
+MIN_INTERVAL_S = 600.0
 
 
 def enclosing_root(roots, path: str):

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -9,9 +9,9 @@ build junk (a gitignored dist/ of 100k generated files), with results
 flipping depending on whether the index or the walk answered. The corpus is
 therefore filtered HERE, with the same check-ignore oracle the walk uses.
 
-What is cached is the VERDICTS — a set of paths git called ignored — not the
-filtered entry list. That is the whole design, and it is what makes the two
-things this module used to get wrong impossible rather than guarded:
+What is cached is the VERDICTS — which paths git called ignored — not the
+filtered entry list, and each verdict is stamped with the ORACLE that decided
+it. Those two choices are the whole design:
 
   * PER INDEX ROOT, NOT PER REQUEST. The cache used to be an LRU of four
     filtered lists keyed on the REQUESTED root. The home page asks for one
@@ -21,22 +21,34 @@ things this module used to get wrong impossible rather than guarded:
     recursive subtree. Verdicts are keyed on the enclosing INDEX ROOT and the
     entry rels are re-based onto it, so a folder's corpus is answered out of
     its root's accumulated verdicts and browsing costs nothing.
-  * SUBSETS CANNOT MASQUERADE AS THE CORPUS. A stored entry LIST is only
-    correct for the request that produced it, which is why a `q`-narrowed, a
-    `limit`-capped and a `truncated` payload all had to be refused. A verdict
-    is a fact about ONE path and is equally true whichever request asked, so a
-    partial payload can safely both read and contribute — and a short list can
-    never be handed to a later full request under a `truncated` flag taken
-    from that request's own payload. `total` is recomputed after filtering.
+  * A VERDICT IS ONLY REUSABLE UNDER THE ORACLE THAT PRODUCED IT. Scope is
+    discovered per request (below), so two requests can consult genuinely
+    different rules for the same path — and a narrower one is the one that
+    misses rules, never the one that invents them. Reuse is therefore
+    conditional on the two requests agreeing about WHICH oracle decides the
+    path, not merely on the path having been seen. Without that condition the
+    first version of this pool was actively wrong: an in-folder search of a
+    gitignored `proj/dist` finds no `.gitignore` in its own corpus, answers
+    "nothing ignored", and — pooled as fact — suppressed every later home
+    search from ever asking, so the build directory leaked into search
+    permanently. Same through the other door for a `q`- or `limit`-narrowed
+    payload, and for a subset that can see only a NESTED marker while the
+    outer one that overrides it is out of view.
 
-A completed scan no longer costs a full re-sweep. The cache carries its
-verdicts across index generations and queries only the paths it has not seen
-before, so the first search after a scan pays for what CHANGED rather than
+An entry no oracle in this request can decide is neither filtered NOR pooled.
+That is the under-filtering bias below, kept honest: not deciding is allowed,
+recording a non-decision as a decision is not.
+
+A completed scan no longer costs a full re-sweep. The pool carries its
+verdicts across index generations — a generation stamp is not part of the key
+at all — and queries only the paths it has not decided under the current
+oracle, so the first search after a scan pays for what CHANGED rather than
 ~1s per 74k entries for everything. The staleness that buys is bounded by
-VERDICT_MAX_AGE_S: a file that became gitignored keeps being served until the
-next full sweep, and after that long the next generation change throws the
-whole set away and re-asks git. Newly-appeared paths are never stale — they
-are exactly the ones that get queried.
+VERDICT_MAX_AGE_S alone: an EDITED .gitignore (in either direction — a rule
+added, or a rule removed and its files still invisible) is not visible to any
+of the machinery here, so time is the only thing that can bound it, and the
+sweep therefore happens on age whatever the index is doing. Newly-appeared
+paths are never stale — they are exactly the ones that get queried.
 
 Scope is an approximation of the walk's online discovery, biased to
 under-filter (pruning is an optimization, never a hard dependency — the
@@ -48,12 +60,6 @@ walk takes the same posture when git is missing):
     `.gitignore`, the OUTERMOST marker claiming each entry; the oracle's
     work-tree graft cascades the nested ones below it. A repo whose rules
     live only in .git/info/exclude (no .gitignore anywhere) goes unfiltered.
-
-Scope is per REQUEST, so verdicts pooled under one index root can come from
-different scopes — a whole-root request sees .gitignore markers above a
-subfolder that a request for that subfolder alone would miss. That only ever
-filters MORE, in the direction of what the walk itself would do, so the pool
-stays on the honest side of the approximation.
 
 Mount-backed roots never get here: the index refuses to scan them, so they
 are never `covered` — no check-ignore (kernel I/O) can be aimed at a mount.
@@ -72,38 +78,49 @@ _CACHE_ROOTS = 4
 _cache: "OrderedDict[str, _Verdicts]" = OrderedDict()
 _cache_lock = Lock()
 
-# How long a pool may be carried across index generations before the next
-# generation change discards it and re-asks git about everything.
+# How long a pool may live before it is discarded and git is re-asked about
+# everything.
 #
-# This is the bound on the one staleness verdict reuse introduces: a path that
-# BECAME gitignored (someone edited a .gitignore) keeps being served until the
-# sweep. Five minutes is chosen against what it costs to be wrong — a few
-# minutes of a build directory still showing in search — versus what a full
-# sweep costs on every scan completion, which is the multi-second stall this
-# module was rebuilt to remove. Scans complete far more often than .gitignore
-# files change.
+# This is the bound on the one staleness verdict reuse introduces, and it is
+# the ONLY thing that can bound it: an edited .gitignore moves nothing this
+# module or the index can observe, in either direction — a rule added leaves a
+# build directory showing in search, a rule removed leaves its files invisible
+# to search. So the sweep is on age alone. It used to be ANDed with an index
+# generation change, which meant a settled index never swept at all and
+# "bounded" was simply false.
+#
+# Five minutes is chosen against what it costs to be wrong (a few minutes of a
+# wrong answer about files the user just re-scoped) versus what a sweep costs
+# (seconds on a 315k corpus, paid by whichever search runs next). The pool
+# absorbs everything else — scan completions, new files, folder browsing — so
+# this is the only sweep there is.
 VERDICT_MAX_AGE_S = 300.0
+
+# The name of "no oracle in this request's scope can decide this entry". Not a
+# verdict: such an entry is passed through unfiltered and left out of the pool.
+_UNDECIDED = ""
 
 
 class _Verdicts:
     """git's answers for one index root, accumulated across requests.
 
-    `seen` is every rel asked about (relative to the index root); `ignored` is
-    the subset git called ignored. A rel absent from `seen` has no verdict yet
-    and must be queried — which is what makes a corpus that grew by 200 files
-    cost 200 queries rather than 315,000.
+    `decider` maps a rel (relative to the index root) to the NAME of the oracle
+    that answered for it; `ignored` is the subset git called ignored. A rel is
+    a cache hit only when the current request would consult the same oracle —
+    which is what makes a corpus that grew by 200 files cost 200 queries rather
+    than 315,000, without letting a request that could not see the rules answer
+    for one that can.
     """
 
-    __slots__ = ("updated", "swept_at", "ignored", "seen")
+    __slots__ = ("swept_at", "ignored", "decider")
 
-    def __init__(self, updated, swept_at: float):
-        self.updated = updated
-        # When this pool was last started from EMPTY. Not moved by an
-        # incremental top-up, or the staleness bound would never be reached on
-        # a corpus that keeps growing.
+    def __init__(self, swept_at: float):
+        # When this pool was created. Never moved by an incremental top-up, or
+        # the staleness bound would never be reached on a corpus that keeps
+        # growing.
         self.swept_at = swept_at
         self.ignored: set = set()
-        self.seen: set = set()
+        self.decider: dict = {}
 
 
 def filter_corpus(out: dict, index_root: str | None = None) -> dict:
@@ -126,10 +143,13 @@ def filter_corpus(out: dict, index_root: str | None = None) -> dict:
     prefix = _rel_prefix(base, root)
     if prefix is None:
         base, prefix = root, ""
-    ignored = _pooled_verdicts(base, prefix, root, entries, out.get("updated"))
-    if not ignored:
+    # Indexes, not rels: a corpus may legitimately repeat a rel (it cannot
+    # today, but nothing here should depend on that) and the decider is
+    # per-entry.
+    drop = _pooled_verdicts(base, prefix, root, entries)
+    if not drop:
         return {**out, "total": len(entries)}
-    kept = [e for e in entries if prefix + e["rel"] not in ignored]
+    kept = [e for i, e in enumerate(entries) if i not in drop]
     return {**out, "entries": kept, "total": len(kept)}
 
 
@@ -146,100 +166,136 @@ def _rel_prefix(base: str, root: str):
     return None
 
 
-def _pooled_verdicts(base: str, prefix: str, root: str, entries: list, updated) -> set:
-    """The index-root-relative rels of `entries` that git calls ignored.
+def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
+    """The INDEXES into `entries` that git calls ignored.
 
-    Reads what the pool already knows, queries git for the rest, and folds the
-    answers back in. The git work happens OUTSIDE the lock: it is the second
-    (or the ten-second) part, and holding a lock across it would serialize
-    every search in the app behind one folder's first sweep.
+    Reads what the pool already decided UNDER THE SAME ORACLE, queries git for
+    the rest, and folds the answers back in. The git work happens OUTSIDE the
+    lock: it is the second (or the ten-second) part, and holding a lock across
+    it would serialize every search in the app behind one folder's first sweep.
     """
+    # Pure string work, no git: which oracle this request would consult for
+    # each entry. Computed for the WHOLE corpus every time — a few tens of
+    # milliseconds — because it is half of the cache key.
+    top, deciders = _deciders(root, entries, prefix)
+    rels = [prefix + e["rel"] for e in entries]
     now = time.time()
     with _cache_lock:
         pool = _cache.get(base)
-        if pool is None or (
-            pool.updated != updated and (now - pool.swept_at) >= VERDICT_MAX_AGE_S
-        ):
-            pool = _Verdicts(updated, now)
+        if pool is None or (now - pool.swept_at) >= VERDICT_MAX_AGE_S:
+            pool = _Verdicts(now)
             _cache[base] = pool
-        pool.updated = updated
         _cache.move_to_end(base)
         while len(_cache) > _CACHE_ROOTS:
             _cache.popitem(last=False)
-        rels = [prefix + e["rel"] for e in entries]
-        known = {r for r in rels if r in pool.ignored}
-        unknown = [e for e, r in zip(entries, rels) if r not in pool.seen]
-    if not unknown:
-        return known
-    fresh = _ignored(root, entries, {e["rel"] for e in unknown})
+        drop, want = set(), set()
+        for i, (name, _marker) in enumerate(deciders):
+            # Nothing in this request's scope can decide this entry. Pass it
+            # through (the under-filtering bias) and, crucially, do not record
+            # that as a verdict: a wider request must still get to ask.
+            if name == _UNDECIDED:
+                continue
+            if pool.decider.get(rels[i]) == name:
+                if rels[i] in pool.ignored:
+                    drop.add(i)
+            else:
+                want.add(i)
+    if not want:
+        return drop
+    fresh = _ignored(root, entries, top, deciders, want)
     with _cache_lock:
         # A concurrent request may have swept the pool out from under us; its
         # verdicts are no less true, but they belong to the pool that asked for
         # them, so they are simply dropped rather than mixed into a new one.
         if _cache.get(base) is pool:
-            pool.seen.update(prefix + e["rel"] for e in unknown)
-            pool.ignored.update(prefix + r for r in fresh)
-    return known | {prefix + r for r in fresh}
+            for i in want:
+                rel = rels[i]
+                pool.decider[rel] = deciders[i][0]
+                if i in fresh:
+                    pool.ignored.add(rel)
+                else:
+                    # It may have been ignored under a DIFFERENT oracle before;
+                    # this request's answer supersedes it, in both directions.
+                    pool.ignored.discard(rel)
+    return drop | fresh
 
 
-def _ignored(root: str, entries: list, only: set) -> set:
-    """The rels in `only` that git calls ignored, relative to `root`.
+def _deciders(root: str, entries: list, prefix: str):
+    """`(repo_toplevel, [(name, marker), ...])` — the oracle for each entry.
 
-    Marker discovery reads the WHOLE `entries` list even though only a subset
-    is queried: the `.gitignore` that decides a path is itself a corpus entry,
-    and once its verdict is known it drops out of `only` — narrowing scope with
+    `name` identifies that oracle relative to the INDEX ROOT, so two requests
+    scoped differently can be compared: an in-folder search of `~/proj` and a
+    home search over `~` both name `~/proj`'s .gitignore "dir:proj" and may
+    share its verdicts, while a request that could see no marker at all names
+    `_UNDECIDED` and shares nothing. That comparison is the whole guard.
+
+    `marker` is the same oracle as a rel under `root` ('' = root itself), which
+    is what actually builds it; None when nothing in scope decides the entry.
+
+    Discovery reads the WHOLE `entries` list, never the subset being queried:
+    the `.gitignore` that decides a path is itself a corpus entry, and once its
+    own verdict is pooled it drops out of the query set — narrowing scope with
     it would silently stop filtering everything it covers.
     """
     top = _repo_toplevel(root)
     if top is not None:
         # Inside a repo the oracle sits at the TOPLEVEL — an oracle at the
-        # searched subfolder would take the no-repo graft path (no .git
-        # there) and never see the toplevel's rules. Queries are the entry
-        # rels re-based onto the toplevel; git cascades nested .gitignore
-        # files from there by itself.
-        base = os.path.relpath(root, top).replace(os.sep, "/")
-        prefix = "" if base in (".", "") else base + "/"
-        rels = [e["rel"] for e in entries if e["rel"] in only]
-        if not rels:
-            return set()
-        oracle = _IgnoreOracle(top)
-        try:
-            verdicts = oracle.ignored([prefix + r for r in rels])
-        finally:
-            oracle.close()
-        if not verdicts:
-            return set()
-        return {r for r in rels if prefix + r in verdicts}
+        # searched subfolder would take the no-repo graft path (no .git there)
+        # and never see the toplevel's rules. It decides every entry whatever
+        # the corpus happens to contain, so this branch has no undecidable
+        # case, and its name is the toplevel rather than a corpus rel because
+        # that is genuinely a different set of rules from the graft below.
+        return top, [("repo:" + top, None)] * len(entries)
     oracle_rels = _oracle_roots(entries)
     if not oracle_rels:
-        return set()
-    # oracle rel -> [(entry rel, path rel to that oracle root)]
-    by_oracle: dict = {rel: [] for rel in oracle_rels}
+        return None, [(_UNDECIDED, None)] * len(entries)
+    out = []
     marker_for_dir: dict = {}
     for e in entries:
         rel = e["rel"]
-        if rel not in only:
-            continue
         d = rel.rsplit("/", 1)[0] if "/" in rel else ""
         marker = marker_for_dir.get(d, "?")
         if marker == "?":
             marker = _outermost(d, oracle_rels)
             marker_for_dir[d] = marker
-        if marker is None:
-            continue
-        sub = rel if marker == "" else rel[len(marker) + 1:]
-        by_oracle[marker].append((rel, sub))
+        out.append((_UNDECIDED, None) if marker is None
+                   else ("dir:" + (prefix + marker).rstrip("/"), marker))
+    return None, out
+
+
+def _ignored(root: str, entries: list, top, deciders: list, want: set) -> set:
+    """The indexes in `want` that git calls ignored."""
+    if top is not None:
+        base = os.path.relpath(root, top).replace(os.sep, "/")
+        prefix = "" if base in (".", "") else base + "/"
+        # Queries are the entry rels re-based onto the toplevel; git cascades
+        # nested .gitignore files from there by itself.
+        idxs = sorted(want)
+        queries = [prefix + entries[i]["rel"] for i in idxs]
+        oracle = _IgnoreOracle(top)
+        try:
+            verdicts = oracle.ignored(queries)
+        finally:
+            oracle.close()
+        if not verdicts:
+            return set()
+        return {i for i, q in zip(idxs, queries) if q in verdicts}
+    # marker -> [(entry index, path rel to that oracle root)]
+    by_oracle: dict = {}
+    for i in sorted(want):
+        marker = deciders[i][1]
+        rel = entries[i]["rel"]
+        by_oracle.setdefault(marker, []).append(
+            (i, rel if marker == "" else rel[len(marker) + 1:]))
     drop = set()
     for marker, queries in by_oracle.items():
-        if not queries:
-            continue
         oracle = _IgnoreOracle(os.path.join(root, marker) if marker else root)
         try:
             verdicts = oracle.ignored([sub for _, sub in queries])
         finally:
             oracle.close()
         if verdicts:
-            drop.update(rel for rel, sub in queries if sub in verdicts)
+            drop.update(i for i, sub in queries if sub in verdicts)
     return drop
 
 

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -9,11 +9,34 @@ build junk (a gitignored dist/ of 100k generated files), with results
 flipping depending on whether the index or the walk answered. The corpus is
 therefore filtered HERE, with the same check-ignore oracle the walk uses.
 
-Filtered once per compaction, not per keystroke: the verdict for a given
-(root, index generation) cannot change, so it is cached against the
-manifest's `updated` stamp. The first in-folder search after a scan pays the
-git queries (~14µs each, so ~1s on a 74k-entry corpus — still far below the
-walk it replaces); every search after that is a cache hit.
+What is cached is the VERDICTS — a set of paths git called ignored — not the
+filtered entry list. That is the whole design, and it is what makes the two
+things this module used to get wrong impossible rather than guarded:
+
+  * PER INDEX ROOT, NOT PER REQUEST. The cache used to be an LRU of four
+    filtered lists keyed on the REQUESTED root. The home page asks for one
+    root and kept its slot; the in-folder search asks with the CURRENT FOLDER,
+    so every folder was a distinct key and browsing five folders evicted the
+    first — re-paying a full check-ignore sweep over that folder's entire
+    recursive subtree. Verdicts are keyed on the enclosing INDEX ROOT and the
+    entry rels are re-based onto it, so a folder's corpus is answered out of
+    its root's accumulated verdicts and browsing costs nothing.
+  * SUBSETS CANNOT MASQUERADE AS THE CORPUS. A stored entry LIST is only
+    correct for the request that produced it, which is why a `q`-narrowed, a
+    `limit`-capped and a `truncated` payload all had to be refused. A verdict
+    is a fact about ONE path and is equally true whichever request asked, so a
+    partial payload can safely both read and contribute — and a short list can
+    never be handed to a later full request under a `truncated` flag taken
+    from that request's own payload. `total` is recomputed after filtering.
+
+A completed scan no longer costs a full re-sweep. The cache carries its
+verdicts across index generations and queries only the paths it has not seen
+before, so the first search after a scan pays for what CHANGED rather than
+~1s per 74k entries for everything. The staleness that buys is bounded by
+VERDICT_MAX_AGE_S: a file that became gitignored keeps being served until the
+next full sweep, and after that long the next generation change throws the
+whole set away and re-asks git. Newly-appeared paths are never stale — they
+are exactly the ones that get queried.
 
 Scope is an approximation of the walk's online discovery, biased to
 under-filter (pruning is an optimization, never a hard dependency — the
@@ -26,58 +49,147 @@ walk takes the same posture when git is missing):
     work-tree graft cascades the nested ones below it. A repo whose rules
     live only in .git/info/exclude (no .gitignore anywhere) goes unfiltered.
 
+Scope is per REQUEST, so verdicts pooled under one index root can come from
+different scopes — a whole-root request sees .gitignore markers above a
+subfolder that a request for that subfolder alone would miss. That only ever
+filters MORE, in the direction of what the walk itself would do, so the pool
+stays on the honest side of the approximation.
+
 Mount-backed roots never get here: the index refuses to scan them, so they
 are never `covered` — no check-ignore (kernel I/O) can be aimed at a mount.
 """
 import os
+import time
 from collections import OrderedDict
 from threading import Lock
 
 from fused_render.server.gitignore import _IgnoreOracle, _repo_toplevel
 
-# Filtered corpora kept per root. Small: entries for a couple of hundred
-# thousand files are tens of MB, and a stale generation's cache is dead
-# weight the moment `updated` moves.
+# Verdict pools kept per INDEX ROOT. Four is generous now that folders share
+# their root's pool: a machine with more than four configured scan roots is
+# already unusual, and a pool evicted here costs one re-sweep, not correctness.
 _CACHE_ROOTS = 4
-_cache: "OrderedDict[str, tuple]" = OrderedDict()
+_cache: "OrderedDict[str, _Verdicts]" = OrderedDict()
 _cache_lock = Lock()
 
+# How long a pool may be carried across index generations before the next
+# generation change discards it and re-asks git about everything.
+#
+# This is the bound on the one staleness verdict reuse introduces: a path that
+# BECAME gitignored (someone edited a .gitignore) keeps being served until the
+# sweep. Five minutes is chosen against what it costs to be wrong — a few
+# minutes of a build directory still showing in search — versus what a full
+# sweep costs on every scan completion, which is the multi-second stall this
+# module was rebuilt to remove. Scans complete far more often than .gitignore
+# files change.
+VERDICT_MAX_AGE_S = 300.0
 
-def filter_corpus(out: dict, cacheable: bool = True) -> dict:
+
+class _Verdicts:
+    """git's answers for one index root, accumulated across requests.
+
+    `seen` is every rel asked about (relative to the index root); `ignored` is
+    the subset git called ignored. A rel absent from `seen` has no verdict yet
+    and must be queried — which is what makes a corpus that grew by 200 files
+    cost 200 queries rather than 315,000.
+    """
+
+    __slots__ = ("updated", "swept_at", "ignored", "seen")
+
+    def __init__(self, updated, swept_at: float):
+        self.updated = updated
+        # When this pool was last started from EMPTY. Not moved by an
+        # incremental top-up, or the staleness bound would never be reached on
+        # a corpus that keeps growing.
+        self.swept_at = swept_at
+        self.ignored: set = set()
+        self.seen: set = set()
+
+
+def filter_corpus(out: dict, index_root: str | None = None) -> dict:
     """`search_under`'s response with gitignored entries removed.
 
-    Only a covered response with entries is touched; `total` is recomputed
-    and `truncated` preserved (the cap was applied to the unfiltered set, so
-    "there was more" stays true). The caller passes `cacheable=False` for a
-    server-side-filtered query (`q`) or a capped `limit`: either entry list is
-    a SUBSET, and the cache holds only the whole-corpus answer the explorer
-    asks for. A truncated payload is refused here on the same grounds, since
-    the cap can also come from MAX_CORPUS rather than the caller — the cache
-    is keyed on the generation alone, so a stored subset would be handed to
-    the next full request under a `truncated` flag taken from its own fresh
-    payload: a short list presented as the complete corpus."""
+    Only a covered response with entries is touched; `total` is recomputed and
+    `truncated` preserved (the cap was applied to the unfiltered set, so "there
+    was more" stays true).
+
+    `index_root` is the configured scan root this request's folder lives under,
+    and is what the verdict pool is keyed on. Omitted (or not actually an
+    ancestor of the requested root) it falls back to the requested root, which
+    is correct but gives that folder a pool of its own.
+    """
     root = out.get("root") or ""
-    if not out.get("covered") or not out.get("entries") or not root:
+    entries = out.get("entries")
+    if not out.get("covered") or not entries or not root:
         return out
-    cacheable = cacheable and not out.get("truncated")
-    updated = out.get("updated")
-    if cacheable:
-        with _cache_lock:
-            hit = _cache.get(root)
-            if hit is not None and hit[0] == updated:
-                _cache.move_to_end(root)
-                return {**out, "entries": hit[1], "total": len(hit[1])}
-    entries = _apply(root, out["entries"])
-    if cacheable:
-        with _cache_lock:
-            _cache[root] = (updated, entries)
-            _cache.move_to_end(root)
-            while len(_cache) > _CACHE_ROOTS:
-                _cache.popitem(last=False)
-    return {**out, "entries": entries, "total": len(entries)}
+    base = index_root or root
+    prefix = _rel_prefix(base, root)
+    if prefix is None:
+        base, prefix = root, ""
+    ignored = _pooled_verdicts(base, prefix, root, entries, out.get("updated"))
+    if not ignored:
+        return {**out, "total": len(entries)}
+    kept = [e for e in entries if prefix + e["rel"] not in ignored]
+    return {**out, "entries": kept, "total": len(kept)}
 
 
-def _apply(root: str, entries: list) -> list:
+def _rel_prefix(base: str, root: str):
+    """`root` as a path prefix relative to `base` ('' or 'a/b/'), or None when
+    `root` does not live under `base`."""
+    b = base if base == "/" else (base or "").rstrip("/")
+    r = root if root == "/" else (root or "").rstrip("/")
+    if b == r:
+        return ""
+    sep = "/" if b == "/" else b + "/"
+    if r.startswith(sep):
+        return r[len(sep):] + "/"
+    return None
+
+
+def _pooled_verdicts(base: str, prefix: str, root: str, entries: list, updated) -> set:
+    """The index-root-relative rels of `entries` that git calls ignored.
+
+    Reads what the pool already knows, queries git for the rest, and folds the
+    answers back in. The git work happens OUTSIDE the lock: it is the second
+    (or the ten-second) part, and holding a lock across it would serialize
+    every search in the app behind one folder's first sweep.
+    """
+    now = time.time()
+    with _cache_lock:
+        pool = _cache.get(base)
+        if pool is None or (
+            pool.updated != updated and (now - pool.swept_at) >= VERDICT_MAX_AGE_S
+        ):
+            pool = _Verdicts(updated, now)
+            _cache[base] = pool
+        pool.updated = updated
+        _cache.move_to_end(base)
+        while len(_cache) > _CACHE_ROOTS:
+            _cache.popitem(last=False)
+        rels = [prefix + e["rel"] for e in entries]
+        known = {r for r in rels if r in pool.ignored}
+        unknown = [e for e, r in zip(entries, rels) if r not in pool.seen]
+    if not unknown:
+        return known
+    fresh = _ignored(root, entries, {e["rel"] for e in unknown})
+    with _cache_lock:
+        # A concurrent request may have swept the pool out from under us; its
+        # verdicts are no less true, but they belong to the pool that asked for
+        # them, so they are simply dropped rather than mixed into a new one.
+        if _cache.get(base) is pool:
+            pool.seen.update(prefix + e["rel"] for e in unknown)
+            pool.ignored.update(prefix + r for r in fresh)
+    return known | {prefix + r for r in fresh}
+
+
+def _ignored(root: str, entries: list, only: set) -> set:
+    """The rels in `only` that git calls ignored, relative to `root`.
+
+    Marker discovery reads the WHOLE `entries` list even though only a subset
+    is queried: the `.gitignore` that decides a path is itself a corpus entry,
+    and once its verdict is known it drops out of `only` — narrowing scope with
+    it would silently stop filtering everything it covers.
+    """
     top = _repo_toplevel(root)
     if top is not None:
         # Inside a repo the oracle sits at the TOPLEVEL — an oracle at the
@@ -87,22 +199,27 @@ def _apply(root: str, entries: list) -> list:
         # files from there by itself.
         base = os.path.relpath(root, top).replace(os.sep, "/")
         prefix = "" if base in (".", "") else base + "/"
+        rels = [e["rel"] for e in entries if e["rel"] in only]
+        if not rels:
+            return set()
         oracle = _IgnoreOracle(top)
         try:
-            verdicts = oracle.ignored([prefix + e["rel"] for e in entries])
+            verdicts = oracle.ignored([prefix + r for r in rels])
         finally:
             oracle.close()
         if not verdicts:
-            return entries
-        return [e for e in entries if prefix + e["rel"] not in verdicts]
+            return set()
+        return {r for r in rels if prefix + r in verdicts}
     oracle_rels = _oracle_roots(entries)
     if not oracle_rels:
-        return entries
-    # entry index -> (oracle rel, path rel to that oracle root)
+        return set()
+    # oracle rel -> [(entry rel, path rel to that oracle root)]
     by_oracle: dict = {rel: [] for rel in oracle_rels}
     marker_for_dir: dict = {}
-    for i, e in enumerate(entries):
+    for e in entries:
         rel = e["rel"]
+        if rel not in only:
+            continue
         d = rel.rsplit("/", 1)[0] if "/" in rel else ""
         marker = marker_for_dir.get(d, "?")
         if marker == "?":
@@ -111,7 +228,7 @@ def _apply(root: str, entries: list) -> list:
         if marker is None:
             continue
         sub = rel if marker == "" else rel[len(marker) + 1:]
-        by_oracle[marker].append((i, sub))
+        by_oracle[marker].append((rel, sub))
     drop = set()
     for marker, queries in by_oracle.items():
         if not queries:
@@ -122,15 +239,13 @@ def _apply(root: str, entries: list) -> list:
         finally:
             oracle.close()
         if verdicts:
-            drop.update(i for i, sub in queries if sub in verdicts)
-    if not drop:
-        return entries
-    return [e for i, e in enumerate(entries) if i not in drop]
+            drop.update(rel for rel, sub in queries if sub in verdicts)
+    return drop
 
 
 def _oracle_roots(entries: list):
     """Standalone oracle roots as rels ('' = the root itself), outermost
-    semantics — the no-repo case only (the repo case is handled in _apply
+    semantics — the no-repo case only (the repo case is handled in _ignored
     with one oracle at the toplevel). Every corpus dir holding a .gitignore
     is a standalone ignore root, exactly as the walk treats one."""
     markers = set()

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -132,19 +132,59 @@ async def startup_scan(start_dir: str | None = None) -> None:
 # opens AND again on every watch tick of a folder being displayed, so the hook
 # is called far more often than a check costs — and a check opens duckdb over
 # dirs.parquet. A plain non-reentrant lock, acquired by the request thread and
-# released by the worker, is the whole throttle.
+# released by the worker, is the whole concurrency control.
 _freshness_slot = threading.Lock()
+
+# ...but a non-reentrant lock is not a debounce: it drops the checks that
+# OVERLAP one, not the ones that follow it, so opening folders in sequence
+# checked on every single open. Each check opens duckdb over dirs.parquet, and
+# every check that does fire a scan ends by invalidating every corpus the
+# client has fetched (platform/lib/index-status). So a root is checked at most
+# this often, whatever the explorer is doing.
+#
+# Deliberately coarse. The client's posture is now to keep serving the corpus
+# it has and label it a generation behind rather than to refetch on every
+# index event (listing/revalidate), which makes an eager freshness check worth
+# much less than it used to be and its side effect — a scan completing mid-read
+# — worth avoiding. freshness.MIN_INTERVAL_S is the second, longer floor on the
+# SCANS themselves; this one is about the checks.
+FRESHNESS_CHECK_S = 60.0
+
+# root -> when it was last checked. Bounded by the number of configured scan
+# roots (a handful), so it needs no eviction.
+_freshness_checked: dict = {}
+_freshness_checked_lock = threading.Lock()
+
+
+def _freshness_due(root: str, now: float) -> bool:
+    """Whether `root` is due a check, stamping it when it is."""
+    with _freshness_checked_lock:
+        last = _freshness_checked.get(root)
+        if last is not None and (now - last) < FRESHNESS_CHECK_S:
+            return False
+        _freshness_checked[root] = now
+        return True
 
 
 def _run_freshness_check(path: str) -> None:
     """The check itself, off the request thread. Never raises: a listing must
     not fail, or slow down, because index housekeeping did."""
     try:
+        import time
+
         cfg = load_config()
-        root = freshness.note_folder_opened(cfg, path, scan_roots(cfg))
-        if root:
+        roots = scan_roots(cfg)
+        # The debounce is keyed on the enclosing ROOT, not the folder: a scan
+        # is per root, so two folders under one root are the same question. A
+        # folder under no root has no question to ask at all, and
+        # note_folder_opened would answer None anyway.
+        root = enclosing_root(roots, path)
+        if root is None or not _freshness_due(root, time.time()):
+            return
+        started = freshness.note_folder_opened(cfg, path, roots)
+        if started:
             logger.info("index: %s changed since the last scan; rescanning %s",
-                        path, root)
+                        path, started)
     except Exception:  # noqa: BLE001 - housekeeping must never surface
         logger.exception("could not check index freshness for %s", path)
     finally:

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -29,6 +29,7 @@ from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 
 from fused_render.index import freshness, runner
+from fused_render.index.freshness import enclosing_root
 from fused_render.index.config import IndexConfig, load_config, save_config
 from fused_render.index.guarded_query import MAX_LIMIT, run_guarded
 from fused_render.index.ignore import default_ignore, norm
@@ -305,12 +306,15 @@ def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
     what search shows (server/index_gitignore.py)."""
     if not root.strip():
         return _error("'root' is required")
-    out = index_search(load_config(), root, q=q, limit=limit)
-    # Only a whole-corpus request may use the filter cache: it is keyed on the
-    # index generation alone, so a narrowed request (`q`, or a caller-supplied
-    # cap) would both be served the wrong list and store its own subset for
-    # everyone else on that generation.
-    out = filter_corpus(out, cacheable=not q.strip() and limit >= MAX_CORPUS)
+    cfg = load_config()
+    out = index_search(cfg, root, q=q, limit=limit)
+    # Filtered per INDEX ROOT, not per requested folder: the explorer's
+    # in-folder search asks with whichever folder is open, and a cache keyed on
+    # that re-paid a whole-subtree check-ignore sweep every time browsing
+    # evicted a folder. `out["root"]` (not the raw query string) is the
+    # canonical spelling the corpus rels are relative to.
+    index_root = enclosing_root(scan_roots(cfg), out.get("root") or root)
+    out = filter_corpus(out, index_root=index_root)
     return {"ok": True, **out}
 
 

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -287,21 +287,26 @@ def test_saving_the_config_answers_in_the_same_shape_as_reading_it(home, tmp_pat
     assert saved["configured_roots"] == read["configured_roots"] == []
 
 
-def test_a_limited_search_never_touches_the_corpus_cache(home, tmp_path, monkeypatch):
-    """The cache is keyed on (root, generation) only, so a small-limit request
-    would store its PREFIX of the corpus and the next full request for the
-    same generation would be served that prefix — while reporting `truncated`
-    from its own fresh payload, i.e. claiming the short list was complete.
-    Only a genuine whole-corpus request may take part."""
+def test_a_search_is_filtered_against_its_enclosing_index_root(home, tmp_path,
+                                                              monkeypatch):
+    """The gitignore filter pools its verdicts per INDEX ROOT, so the route has
+    to tell it which one this folder lives under. Keyed on the REQUESTED folder
+    instead (the old behaviour), browsing five folders evicted the first and
+    re-paid a full check-ignore sweep of its whole recursive subtree."""
     seen = []
     monkeypatch.setattr(index_router, "filter_corpus",
-                        lambda out, cacheable=True: seen.append(cacheable) or out)
+                        lambda out, index_root=None: seen.append(index_root) or out)
+    sub = tmp_path / "sub"
+    sub.mkdir()
     client = _client(tmp_path)
-    client.get(f"/api/index/search?root={tmp_path}&limit=5")
+    client.post("/api/index/config", json={"roots": [str(tmp_path)]},
+                headers={"X-Fused": "1"})
     client.get(f"/api/index/search?root={tmp_path}")
-    client.get(f"/api/index/search?root={tmp_path}&limit={index_router.MAX_CORPUS}")
-    client.get(f"/api/index/search?root={tmp_path}&q=x")
-    assert seen == [False, True, True, False]
+    client.get(f"/api/index/search?root={sub}")
+    # Both requests pool under the configured root, whichever folder was asked
+    # for. A folder outside every root has no pool to share and gets None.
+    client.get(f"/api/index/search?root={tmp_path.parent}")
+    assert seen == [str(tmp_path), str(tmp_path), None]
 
 
 def test_saving_the_ignore_list_preserves_comments_and_blank_lines(home, tmp_path):

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -758,6 +758,7 @@ def test_a_stale_open_folder_gets_its_configured_root_rescanned(
     monkeypatch.setattr(index_router.runner, "start",
                         lambda cfg, root, full=False: started.append(root)
                         or {"run_id": "r1", "root": root})
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
     src = _tree(tmp_path)
     cfg = load_config()
     cfg.roots = [str(src)]
@@ -768,6 +769,47 @@ def test_a_stale_open_folder_gets_its_configured_root_rescanned(
     monkeypatch.setattr(index_router.freshness, "QUIET_S", 0.0)
     index_router._run_freshness_check(str(sub))
     assert started == [str(src)]
+
+
+def test_a_root_checked_moments_ago_is_not_checked_again(home, tmp_path,
+                                                         monkeypatch):
+    """The in-flight lock drops OVERLAPPING checks, not the ones that follow —
+    so browsing folder to folder checked (and could rescan) on every open, and
+    every scan that completed invalidated every corpus the client had fetched.
+    A root is now checked at most once per FRESHNESS_CHECK_S."""
+    checked = []
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: checked.append(path) or None)
+    src = _tree(tmp_path)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_router._run_freshness_check(str(src / "sub"))
+    # A second folder UNDER THE SAME ROOT is the same question: a scan is per
+    # root, so checking again buys nothing.
+    index_router._run_freshness_check(str(src))
+    assert checked == [str(src / "sub")]
+    # ...and it comes back round once the window has passed.
+    index_router._freshness_checked[str(src)] -= index_router.FRESHNESS_CHECK_S + 1
+    index_router._run_freshness_check(str(src))
+    assert checked == [str(src / "sub"), str(src)]
+
+
+def test_a_folder_outside_every_root_never_reaches_the_index(home, tmp_path,
+                                                             monkeypatch):
+    """Cheapest gate first: no enclosing root means no scan is possible, so the
+    duckdb lookup behind note_folder_opened must not be paid at all."""
+    checked = []
+    monkeypatch.setattr(index_router, "_freshness_checked", {})
+    monkeypatch.setattr(index_router.freshness, "note_folder_opened",
+                        lambda cfg, path, roots: checked.append(path) or None)
+    src = _tree(tmp_path)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_router._run_freshness_check(str(tmp_path.parent))
+    assert checked == []
 
 
 # -- guarded SQL ---------------------------------------------------------------

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -69,19 +69,19 @@ def test_an_uncovered_response_is_untouched(tmp_path, monkeypatch):
 
 
 def _counting_queries(monkeypatch):
-    """Every rel `_ignored` actually asks git about, across all calls."""
+    """Every rel `_ignored` actually asks git about, one list per call."""
     asked = []
     real = index_gitignore._ignored
 
-    def counting(root, entries, only):
-        asked.append(sorted(only))
-        return real(root, entries, only)
+    def counting(root, entries, top, deciders, want):
+        asked.append(sorted(entries[i]["rel"] for i in want))
+        return real(root, entries, top, deciders, want)
 
     monkeypatch.setattr(index_gitignore, "_ignored", counting)
     return asked
 
 
-def test_a_repeated_search_of_one_generation_asks_git_nothing(tmp_path, monkeypatch):
+def test_a_repeated_search_asks_git_nothing(tmp_path, monkeypatch):
     _fresh_cache(monkeypatch)
     proj = tmp_path / "proj"
     proj.mkdir()
@@ -95,12 +95,15 @@ def test_a_repeated_search_of_one_generation_asks_git_nothing(tmp_path, monkeypa
     assert "proj/a.log" not in [e["rel"] for e in first["entries"]]
 
 
-def test_a_new_generation_only_asks_about_paths_it_has_not_seen(tmp_path, monkeypatch):
-    """The point of item 5: a completed scan must not cost a full re-sweep.
+def test_a_grown_corpus_only_asks_about_the_paths_it_has_not_decided(
+        tmp_path, monkeypatch):
+    """A completed scan must not cost a full re-sweep.
 
     A scan finishing moves `updated`, and the old cache threw everything away
     and re-ran check-ignore over the whole corpus — ~1s per 74k entries, on the
     very next keystroke, while the scan's workers were still competing for IO.
+    The generation is not part of the pool key at all now; what a new one
+    brings is new PATHS, and only those are asked about.
     """
     _fresh_cache(monkeypatch)
     proj = tmp_path / "proj"
@@ -116,10 +119,10 @@ def test_a_new_generation_only_asks_about_paths_it_has_not_seen(tmp_path, monkey
     assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py", "proj/b.py"]
 
 
-def test_verdicts_are_thrown_away_once_they_are_too_old(tmp_path, monkeypatch):
-    """The bound on reuse: a path that BECAME gitignored must not be served
-    forever. After VERDICT_MAX_AGE_S the next generation change re-asks git
-    about everything."""
+def test_verdicts_survive_a_new_generation_until_they_are_too_old(
+        tmp_path, monkeypatch):
+    """Reuse across an index generation, and its bound: a path that BECAME
+    gitignored is served until the pool ages out, and not past that."""
     _fresh_cache(monkeypatch)
     proj = tmp_path / "proj"
     proj.mkdir()
@@ -169,6 +172,87 @@ def test_a_root_outside_the_index_root_gets_its_own_pool(tmp_path, monkeypatch):
     out = filter_corpus(_out(str(proj), [".gitignore", "a.log", "a.py"]),
                         index_root="/somewhere/else")
     assert [e["rel"] for e in out["entries"]] == [".gitignore", "a.py"]
+
+
+def test_a_scope_that_cannot_see_the_rules_pools_nothing(tmp_path, monkeypatch):
+    """A NEGATIVE verdict is only worth pooling when the request could actually
+    have found the rule that would have made it positive.
+
+    Searching inside a gitignored folder puts the deciding `.gitignore` ABOVE
+    the request's corpus, so the no-repo branch finds no marker and answers
+    "nothing ignored". Written into the pool as fact, that answer then
+    suppressed every later, wider request from ever asking — so the home search
+    started serving the build directory that `origin/main` filtered out, for
+    the rest of the server's life.
+    """
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    (proj / "dist").mkdir(parents=True)
+    (proj / ".gitignore").write_text("dist/\n", encoding="utf-8")
+    root = str(tmp_path)
+    # The in-folder search of proj/dist: no marker in sight, nothing filtered.
+    inner = filter_corpus(_out(str(proj / "dist"), ["x.js"]), index_root=root)
+    assert [e["rel"] for e in inner["entries"]] == ["x.js"]
+    # The home search still filters it, because the pool never accepted the
+    # inner request's blind answer.
+    out = filter_corpus(_out(root, [
+        "proj/.gitignore", "proj/dist/x.js", "proj/keep.py"]), index_root=root)
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/keep.py"]
+
+
+def test_a_narrowed_payload_pools_nothing_it_could_not_decide(tmp_path, monkeypatch):
+    """Same hazard through the other door: a `q`- or `limit`-narrowed response
+    can omit the `.gitignore` that decides its own entries."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    filter_corpus(_out(root, ["proj/a.log"]), index_root=root)
+    out = filter_corpus(_out(root, ["proj/.gitignore", "proj/a.log", "proj/a.py"]),
+                        index_root=root)
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py"]
+
+
+def test_a_narrower_marker_does_not_answer_for_the_outer_one(tmp_path, monkeypatch):
+    """A request that sees only the INNER `.gitignore` decides its entries
+    under rules the outer one would have overridden, so its verdicts must not
+    be reused by a request that can see both."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    (proj / "sub").mkdir(parents=True)
+    (proj / ".gitignore").write_text("*.outer\n", encoding="utf-8")
+    (proj / "sub" / ".gitignore").write_text("*.inner\n", encoding="utf-8")
+    root = str(tmp_path)
+    # Only the inner marker is visible here, so x.outer reads clean.
+    inner = filter_corpus(_out(root, ["proj/sub/.gitignore", "proj/sub/x.outer"]),
+                          index_root=root)
+    assert "proj/sub/x.outer" in [e["rel"] for e in inner["entries"]]
+    out = filter_corpus(_out(root, [
+        "proj/.gitignore", "proj/sub/.gitignore", "proj/sub/x.outer",
+        "proj/sub/keep.py"]), index_root=root)
+    assert [e["rel"] for e in out["entries"]] == [
+        "proj/.gitignore", "proj/sub/.gitignore", "proj/sub/keep.py"]
+
+
+def test_the_pool_is_re_swept_once_it_is_too_old_whatever_the_generation(
+        tmp_path, monkeypatch):
+    """The staleness bound has to be a bound. Gated on a generation change as
+    well, it never fired at all on a settled index — and a rule REMOVED from a
+    .gitignore kept its paths invisible to search for the server's lifetime."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    rels = ["proj/.gitignore", "proj/a.log"]
+    root = str(tmp_path)
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 1
+    (proj / ".gitignore").write_text("nothing-here\n", encoding="utf-8")
+    # Same generation, so nothing else would ever re-ask.
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 1
+    for pool in index_gitignore._cache.values():
+        pool.swept_at -= index_gitignore.VERDICT_MAX_AGE_S + 1
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 2
 
 
 def test_a_narrowed_payload_cannot_masquerade_as_the_corpus(tmp_path, monkeypatch):

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -68,58 +68,123 @@ def test_an_uncovered_response_is_untouched(tmp_path, monkeypatch):
     assert filter_corpus(out) is out
 
 
-def test_the_verdict_is_cached_per_index_generation(tmp_path, monkeypatch):
-    """The git queries run once per (root, updated) — every later search of
-    the same generation is a cache hit; a new compaction re-filters."""
+def _counting_queries(monkeypatch):
+    """Every rel `_ignored` actually asks git about, across all calls."""
+    asked = []
+    real = index_gitignore._ignored
+
+    def counting(root, entries, only):
+        asked.append(sorted(only))
+        return real(root, entries, only)
+
+    monkeypatch.setattr(index_gitignore, "_ignored", counting)
+    return asked
+
+
+def test_a_repeated_search_of_one_generation_asks_git_nothing(tmp_path, monkeypatch):
     _fresh_cache(monkeypatch)
     proj = tmp_path / "proj"
     proj.mkdir()
     (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
-    calls = []
-    real = index_gitignore._apply
-
-    def counting(root, entries):
-        calls.append(root)
-        return real(root, entries)
-
-    monkeypatch.setattr(index_gitignore, "_apply", counting)
+    asked = _counting_queries(monkeypatch)
     rels = ["proj/.gitignore", "proj/a.log", "proj/a.py"]
     first = filter_corpus(_out(str(tmp_path), rels, updated=1.0))
     again = filter_corpus(_out(str(tmp_path), rels, updated=1.0))
-    assert len(calls) == 1
+    assert len(asked) == 1
     assert [e["rel"] for e in again["entries"]] == [e["rel"] for e in first["entries"]]
-    filter_corpus(_out(str(tmp_path), rels, updated=2.0))
-    assert len(calls) == 2
+    assert "proj/a.log" not in [e["rel"] for e in first["entries"]]
 
 
-def test_a_query_filtered_response_is_never_cached(tmp_path, monkeypatch):
+def test_a_new_generation_only_asks_about_paths_it_has_not_seen(tmp_path, monkeypatch):
+    """The point of item 5: a completed scan must not cost a full re-sweep.
+
+    A scan finishing moves `updated`, and the old cache threw everything away
+    and re-ran check-ignore over the whole corpus — ~1s per 74k entries, on the
+    very next keystroke, while the scan's workers were still competing for IO.
+    """
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    asked = _counting_queries(monkeypatch)
+    rels = ["proj/.gitignore", "proj/a.log", "proj/a.py"]
+    filter_corpus(_out(str(tmp_path), rels, updated=1.0))
+    out = filter_corpus(_out(str(tmp_path), rels + ["proj/b.log", "proj/b.py"], updated=2.0))
+    assert asked[1] == ["proj/b.log", "proj/b.py"]
+    # ...and the newly-appeared ones are filtered on the same pass, so a build
+    # directory that appeared since the last scan never leaks into search.
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py", "proj/b.py"]
+
+
+def test_verdicts_are_thrown_away_once_they_are_too_old(tmp_path, monkeypatch):
+    """The bound on reuse: a path that BECAME gitignored must not be served
+    forever. After VERDICT_MAX_AGE_S the next generation change re-asks git
+    about everything."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("nothing-here\n", encoding="utf-8")
+    rels = ["proj/.gitignore", "proj/a.log"]
+    assert len(filter_corpus(_out(str(tmp_path), rels, updated=1.0))["entries"]) == 2
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    # Still served from the pooled verdicts — that is the bounded staleness.
+    assert len(filter_corpus(_out(str(tmp_path), rels, updated=2.0))["entries"]) == 2
+    for pool in index_gitignore._cache.values():
+        pool.swept_at -= index_gitignore.VERDICT_MAX_AGE_S + 1
+    assert [e["rel"] for e in filter_corpus(
+        _out(str(tmp_path), rels, updated=3.0))["entries"]] == ["proj/.gitignore"]
+
+
+def test_a_folder_is_answered_out_of_its_index_root_pool(tmp_path, monkeypatch):
+    """Item 4: browsing folders must not evict each other.
+
+    The old cache was keyed on the REQUESTED root, so five folders opened in a
+    row evicted the first and re-paid a full check-ignore sweep of its whole
+    recursive subtree. Verdicts pool per index root, so a subfolder's corpus is
+    answered from what the root already asked.
+    """
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    filter_corpus(_out(root, ["proj/.gitignore", "proj/a.log", "proj/a.py"]),
+                  index_root=root)
+    asked = _counting_queries(monkeypatch)
+    # Now the in-folder search of proj/, whose rels are relative to proj/.
+    out = filter_corpus(_out(str(proj), [".gitignore", "a.log", "a.py"]),
+                        index_root=root)
+    assert asked == []  # every verdict was already pooled
+    assert [e["rel"] for e in out["entries"]] == [".gitignore", "a.py"]
+    assert out["total"] == 2
+    assert len(index_gitignore._cache) == 1
+
+
+def test_a_root_outside_the_index_root_gets_its_own_pool(tmp_path, monkeypatch):
+    """A mis-stated index_root must not silently re-base rels onto it."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    out = filter_corpus(_out(str(proj), [".gitignore", "a.log", "a.py"]),
+                        index_root="/somewhere/else")
+    assert [e["rel"] for e in out["entries"]] == [".gitignore", "a.py"]
+
+
+def test_a_narrowed_payload_cannot_masquerade_as_the_corpus(tmp_path, monkeypatch):
+    """A `q`-filtered or capped response is a SUBSET. It may contribute
+    verdicts (a verdict is a fact about one path, true for every request), but
+    a later full request must still get every row it asked about."""
     _fresh_cache(monkeypatch)
     proj = tmp_path / "proj"
     proj.mkdir()
     (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
     subset = _out(str(tmp_path), ["proj/.gitignore", "proj/a.log"])
-    filter_corpus(subset, cacheable=False)
+    subset["truncated"] = True
+    filter_corpus(subset)
     full = filter_corpus(_out(str(tmp_path), [
         "proj/.gitignore", "proj/a.log", "proj/a.py"]))
-    assert "proj/a.py" in [e["rel"] for e in full["entries"]]
-
-
-def test_a_truncated_response_is_never_cached(tmp_path, monkeypatch):
-    """A capped payload is a PREFIX of the corpus, not the corpus. Caching it
-    under the generation key would serve that prefix to the next full-corpus
-    request for the same generation — which reports `truncated` from its own
-    fresh payload, so it would claim a complete corpus while handing back the
-    short list."""
-    _fresh_cache(monkeypatch)
-    proj = tmp_path / "proj"
-    proj.mkdir()
-    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
-    capped = _out(str(tmp_path), ["proj/.gitignore", "proj/a.log"])
-    capped["truncated"] = True
-    filter_corpus(capped)
-    full = filter_corpus(_out(str(tmp_path), [
-        "proj/.gitignore", "proj/a.log", "proj/a.py"]))
-    assert "proj/a.py" in [e["rel"] for e in full["entries"]]
+    assert [e["rel"] for e in full["entries"]] == ["proj/.gitignore", "proj/a.py"]
     assert full["total"] == len(full["entries"])
 
 


### PR DESCRIPTION
## Summary

- **Search stops going blank while the file index rescans.** Both search boxes — the explorer home page and the in-folder listing — now keep serving the corpus they already have and say so, instead of discarding it. Previously a completed scan invalidated every fetched corpus app-wide, and the home page rendered a cold index as a terminal "still building" with zero rows.
- **The refetch is the thing removed, not just the blank.** A query change is no longer a revalidation boundary (`listing/revalidate.ts`), so a keystroke after background churn ranks against the corpus in hand rather than spending a round trip on an empty list. Being a generation behind is now a state search can sit in; swapping rows out from under someone reading them is not.
- **Staleness is labelled, never silent.** A third caveat message ("not refreshed") covers the new quiet case — no scan running, results deliberately not refreshed — alongside a lighter dim (`.listing-behind`, 0.86) distinct from the existing in-flight dim (`.listing-stale`, 0.6). "An answer is coming" and "this is the answer, and it is old" are different claims and now read differently.
- **The multi-second stall behind it is gone.** `server/index_gitignore.py` now caches per-path gitignore *verdicts* pooled per index root instead of filtered entry lists per requested folder, so a new generation queries only unseen paths and browsing folders no longer evicts the cache. Freshness-triggered rescans are debounced per root, so folder browsing can't queue scan after scan.

Scans were observed completing three times in 40 seconds on a ~315k-file home directory, each one invalidating every corpus and forcing a fresh `git check-ignore` sweep (~1s per 74k entries) before search could answer again.

## Visuals

The delta is on the left branch — it did not exist before, and every keystroke took the right one.

```mermaid
flowchart TD
    A[Query typed] --> B{Corpus already in hand?}
    B -->|yes, even if stale| C[Rank against it]
    C --> D[Rows, dimmed + captioned]
    B -->|no| E[Fetch index, race live walk at 150ms]
    E --> F[Rows]
```

Reconciliation still happens, but only where a repaint is free: the search ending, or an in-app mutation (a rename must never keep showing the old name — the held corpus is dropped with it).

## Usage

Not directly user-invocable; this changes behavior on paths that already exist.

To observe it:

```bash
scripts/dev.sh
# open the explorer, type in either search box
# then trigger a rescan: Preferences > Indexing > Re-index
```

Results stay on screen throughout, dimmed, with `indexing…` in the count chip. Previously they blanked to "Searching…" until the scan finished and the corpus refetched. Clearing and re-running the search is the escape hatch to force fresh results, and the `not refreshed` tooltip says so.

## Test Plan

- [x] **Automated, new:** `listing/corpus-hold.test.ts`, `listing/source-race.test.ts`, `listing/scan-resume.test.ts`
- [x] **Automated, extended:** `lib/home-search.test.ts`, `listing/index-caveat.test.ts`, `platform/lib/index-freshness.test.ts`, `tests/test_index_gitignore.py`, `tests/test_index_api.py`
- [x] Frontend suite: 805 pass (was 764 on main)
- [x] Full Python suite: 5881 pass, 109 skipped (was 5872 on main)
- [x] **Post-review fixes:** code review found 7 issues, all fixed in the last 5 commits. The one that mattered was a correctness regression this PR introduced: the verdict pool recorded a rel as decided whatever the request's scope was, so a search inside a gitignored `proj/dist` — which cannot see the deciding `.gitignore` — pooled its files as clean and suppressed every later search from asking. Verdicts are now stamped with the oracle that decided them, and an entry no oracle in scope can decide is passed through unfiltered and *not* pooled. 4 regression tests; none of the 78 existing ones caught any variant.
- [x] **Known baseline gap:** 6 tests in `tests/test_browse_mount.py::test_remote_*` fail with `kernel filesystem access on a remote path`. They fail identically on a clean `main` checkout in this environment and are unrelated to this change.
- [ ] **Coverage gap, called out:** the repo has no React test infra (no jsdom/testing-library), so hook-level behavior — "a keystroke does not refetch", "the hold is dropped on mutation" — is not directly covered. Every decision was extracted into pure helpers that are tested; the wiring is not.
- [ ] **Manual:** rename a file in a folder, then search it — the new name must appear and the old must not (this is the one invariant staleness tolerance does not extend to)
- [ ] **Manual:** browse five folders, searching in each, then re-search the first — should be instant, not a fresh `check-ignore` sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)
