### PR TITLE
Fix flaky test_index_freshness worker crash (scope the os.stat monkeypatch)

### DIFF
--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -223,8 +223,21 @@ def test_a_mount_backed_folder_is_refused_without_touching_the_kernel(
     cfg = _index(tmp_path, root, {root: 1 * NS, under: 1 * NS})
     monkeypatch.setattr(runner, "_mounts_dir", lambda: mounts)
 
-    def boom(_p):
-        raise AssertionError("stat reached a mount-backed path")
+    # Scoped to `under`, not a blanket boom() on every os.stat call: `os` is a
+    # single process-wide module object, so patching it unconditionally also
+    # patches every OTHER thread's os.stat — including Python's own linecache,
+    # which pytest's thread-exception hook calls (to format a DIFFERENT
+    # thread's traceback) at whatever moment that thread happens to raise.
+    # That corrupted the hook itself under xdist, intermittently failing an
+    # unrelated test or crashing a worker outright. Only refusing the one path
+    # this test cares about keeps the assertion just as sharp while leaving
+    # every other os.stat call in the process alone.
+    real_stat = os.stat
+
+    def boom(p, *args, **kwargs):
+        if isinstance(p, str) and p == under:
+            raise AssertionError("stat reached a mount-backed path")
+        return real_stat(p, *args, **kwargs)
 
     monkeypatch.setattr(freshness.os, "stat", boom)
     now = 10 ** 10


### PR DESCRIPTION
## Summary

`test_a_mount_backed_folder_is_refused_without_touching_the_kernel` (`tests/test_index_freshness.py`) patches `os.stat` unconditionally to prove a mount-backed path is refused without ever calling `stat` on it. Since `os` is a single process-wide module object, that patch isn't scoped to the test's own call — it also intercepts every *other* thread's `os.stat`, including calls made deep inside Python's own `linecache` module when formatting a traceback.

Under `pytest-xdist`, if some unrelated background thread from another test raises while this test's patch happens to be active, pytest's `_pytest/threadexception.py` hook tries to format *that* thread's traceback — which calls `linecache.getline` → `os.stat` to read source lines — and hits the patched `boom()` instead of the real `os.stat`. That corrupts the hook itself, and depending on timing either fails an unrelated test with an `ExceptionGroup` or crashes an entire xdist worker outright (`INTERNALERROR`).

This is not hypothetical — I saw it happen twice in a row on an unrelated PR's CI (`fused-render#460`), and confirmed it's not caused by that PR: main's own CI run at the exact commit that PR had just merged in (`2b99d536`) hit the identical `INTERNALERROR` crash on this same test, independent of any other branch. I also reproduced the exact mechanism directly (patch `os.stat` unconditionally, raise in an unrelated background thread, watch `threading.excepthook`'s traceback formatter crash; then repeat with the scoped patch and watch it format cleanly).

## Fix

Scope the patch to the one path this test actually cares about (`under`, the mount-backed folder), and delegate every other call to the real `os.stat`. The assertion is exactly as strong — `os.stat` on the mount-backed path still fails the test — but every other call in the process (other threads, `linecache`, whatever) is left alone.

## Test plan

- [x] `pytest tests/test_index_freshness.py -v` — all 19 tests pass, including the fixed one.
- [x] Full suite (`pytest -q`, dev extra only) — no new failures; the 8 pre-existing failures in that run (`test_engine.py`, `test_deploy.py`, `test_server_ai.py`) are unrelated environment-setup gaps in a minimal venv (missing `pip`/`bundled`/`fused` extras per `docs` setup notes), not regressions from this change.
- [x] Standalone repro script confirming the root cause: with the old unconditional `boom()`, formatting an unrelated thread's traceback crashes; with the scoped version, it formats fine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UUakWNdUsf6bZCTt4eDa13)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; production mount-guard behavior is unchanged.
> 
> **Overview**
> Fixes **flaky xdist / worker crashes** in `test_a_mount_backed_folder_is_refused_without_touching_the_kernel` by narrowing the `freshness.os.stat` monkeypatch.
> 
> Instead of replacing every `os.stat` with a blanket `boom()`, the stub **only raises** when the path is the mount-backed folder `under` and **delegates** all other calls to the real `os.stat`. The test still proves `note_folder_opened` refuses mount-backed paths without touching the kernel, but other threads (e.g. pytest’s thread-exception hook → `linecache`) no longer hit a process-wide broken `stat`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c05df5cacc0166b0ea8982b4e4a29c44ee2f4847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->