### PR TITLE
Add /claude-published: an index of pages Claude published from this machine

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1883,6 +1883,42 @@ export function getClaudeSessionFolders(): Promise<{ folders: ClaudeSessionFolde
   return getJson<{ folders: ClaudeSessionFolder[] }>("/api/claude-sessions");
 }
 
+// -- Claude artifacts (GET /api/claude-artifacts) -----------------------------
+// Pages Claude PUBLISHED from this machine with its Artifact tool — the local
+// html/md file it rendered, paired with the claude.ai URL it was published to,
+// for shell/ClaudeArtifacts.tsx. Newest first (`updated_at` desc), one entry per
+// artifact rather than per session, so a session that published three pages
+// contributes three cards.
+//
+// The pairing is what makes the page useful and also what makes both halves
+// nullable: the local file is the only thing that can be PREVIEWED, and the
+// remote URL is the only thing that survives the file being deleted. Hence
+// `exists`, which the server checks per request — a card reads it to choose
+// between opening the file here and opening the published page there.
+export interface ClaudeArtifact {
+  /** The local html/md file Claude rendered. Absolute, ready for navigate(). */
+  file_path: string;
+  /** Whether that file is still on disk, checked server-side per request. */
+  exists: boolean;
+  /** Where it was published: https://claude.ai/code/artifact/<id>. */
+  remote_url: string;
+  /** The page's own <title>, or null when it had none. */
+  title: string | null;
+  description: string | null;
+  /** The tab emoji the publish declared, e.g. "🤿". Null when unset. */
+  favicon: string | null;
+  session_id: string | null;
+  /** Project directory of the session that published it. */
+  cwd: string | null;
+  /** Epoch seconds; null for artifacts whose record predates the field. */
+  created_at: number | null;
+  updated_at: number | null;
+}
+
+export function getClaudeArtifacts(): Promise<{ artifacts: ClaudeArtifact[] }> {
+  return getJson<{ artifacts: ClaudeArtifact[] }>("/api/claude-artifacts");
+}
+
 // -- AI Models (GET /api/ai-models) -------------------------------------
 // What the Hugging Face cache holds on this machine, for the sidebar's "Local
 // models" page (shell/AiModels.tsx). One entry per cached repo, biggest

--- a/frontend/src/shell.css
+++ b/frontend/src/shell.css
@@ -30,4 +30,8 @@
 @import "./styles/templates.css";
 @import "./styles/home.css";
 @import "./styles/reduced-motion.css";
+/* Last, and two pages now layer over its card: the /apps hub owns the file, and
+   /claude-artifacts reuses .apps-cards/.app-pcard with its own `ca-` section at
+   the bottom of it — which can only override the card from here, after
+   claude-config.css, where the rest of that page's chrome lives. */
 @import "./styles/apps.css";

--- a/frontend/src/shell/App.tsx
+++ b/frontend/src/shell/App.tsx
@@ -8,6 +8,7 @@
 //   "/claude-config"         -> Claude config panel (native, no mount)
 //   "/claude-md"             -> legacy; redirects into the panel's MD Files tab
 //   "/claude-artifacts"      -> project folders with Claude Code sessions
+//   "/claude-published"      -> pages Claude published with its Artifact tool
 //   "/ai-models"             -> Hugging Face cache inventory
 //   "/preferences|/templates|/mounts" -> settings pages
 // Legacy pre-rename urls (/view/..., /embed/..., /view/_prefs-family) are
@@ -62,6 +63,7 @@ const ClaudeConfig = lazy(() =>
   import("@apps/claude_config").then((m) => ({ default: m.ClaudeConfig })),
 );
 const ClaudeArtifacts = lazy(() => import("@shell/ClaudeArtifacts"));
+const ClaudePublished = lazy(() => import("@shell/ClaudePublished"));
 const BookmarkOpen = lazy(() => import("@apps/explorer/BookmarkOpen"));
 
 type StatState =
@@ -582,6 +584,7 @@ export default function App({ config }: { config: Config }) {
   const isCommunity = pathname === "/community";
   const isClaudeConfig = pathname === "/claude-config";
   const isClaudeArtifacts = pathname === "/claude-artifacts";
+  const isClaudePublished = pathname === "/claude-published";
   const isBookmark = pathname === "/explorer/view/_bookmark";
   // `/apps/<tag>/<name>` used to resolve HERE, to the app folder under the
   // workspace (a pure fused_dir codec) or — for the virtual "linked" tag, whose
@@ -591,7 +594,7 @@ export default function App({ config }: { config: Config }) {
   // carries with no lookup at all. Anything under /apps that isn't the hub falls
   // through to the "Unrecognized URL" branch below, deliberately unredirected.
   const isSentinel =
-    isPanel || isTabs || isPrefs || isTemplates || isMounts || isAiModels || isApps || isExplorerHome || isLearn || isSessions || isCommunity || isClaudeConfig || isClaudeArtifacts || isBookmark;
+    isPanel || isTabs || isPrefs || isTemplates || isMounts || isAiModels || isApps || isExplorerHome || isLearn || isSessions || isCommunity || isClaudeConfig || isClaudeArtifacts || isClaudePublished || isBookmark;
   const fsPath = isSentinel ? null : fsPathFromLocation();
   // Browsing to a `.bookmark` file in the explorer opens it like a Finder
   // double-click (SB-9): same component as the `_bookmark` sentinel, fed the
@@ -625,6 +628,8 @@ export default function App({ config }: { config: Config }) {
                       ? "Claude Config"
                       : isClaudeArtifacts
                       ? "Artifacts"
+                      : isClaudePublished
+                      ? "Published"
                       : isBookmark || bookmarkFile
                       ? "Bookmark"
                       : fsPath
@@ -776,6 +781,17 @@ export default function App({ config }: { config: Config }) {
         <div className="cc-page">
           <Suspense fallback={<RouteFallback />}>
             <ClaudeArtifacts />
+          </Suspense>
+        </div>
+      </div>
+    );
+  } else if (isClaudePublished) {
+    // Published — pages Claude published with its Artifact tool, as a grid.
+    main = (
+      <div id="content" key={epoch}>
+        <div className="cc-page">
+          <Suspense fallback={<RouteFallback />}>
+            <ClaudePublished />
           </Suspense>
         </div>
       </div>

--- a/frontend/src/shell/ClaudePublished.tsx
+++ b/frontend/src/shell/ClaudePublished.tsx
@@ -1,0 +1,313 @@
+// /claude-published: the pages Claude PUBLISHED from this machine — every page
+// it rendered with its Artifact tool, as a grid of preview cards
+// (GET /api/claude-artifacts, newest first).
+//
+// A sibling of /claude-artifacts, not a replacement for it: that page is a
+// second door onto the Explorer homepage's folder list — one card per project
+// directory holding Claude Code transcripts, a CONVERSATION each. An artifact
+// is a THING a conversation produced, and the thing is what someone comes back
+// looking for; the two lists answer different questions, so they are two pages.
+//
+// Every artifact has two bodies and the card has to hold both:
+//
+//   - the LOCAL file Claude rendered (html or md), which is the only one that
+//     can be previewed or edited, and which the user may have since deleted;
+//   - the PUBLISHED page on claude.ai, which is the only one that survives that
+//     deletion, and the only one that can be shared.
+//
+// Hence `exists` decides the card's primary destination — the file here while it
+// is here, the published page once it is not — and the footer carries a small
+// door to the published page either way, so "give me the link" is always one
+// click and never has to fight the card for the same click.
+//
+// The card vocabulary is the /apps hub's (.apps-cards / .app-pcard, plus the
+// scaled-iframe thumbnail trick from AppPreviewCard); the page chrome is the
+// Claude config family's (.cc-root / .cc-main / .cc-page-head). Only what
+// neither has an answer for is local — see the `ca-` section at the end of
+// styles/apps.css.
+import { useEffect, useMemo, useState } from "react";
+import { getClaudeArtifacts, type ClaudeArtifact } from "@platform/lib/api";
+import { isBrowserHandledClick } from "@platform/lib/appEntry";
+import { basename, formatMtimeFull, timeAgo } from "@platform/lib/format";
+import { navigate, urlForFsPath } from "@platform/lib/router";
+import { ErrorBanner } from "@platform/ui/ErrorBanner";
+import { SkeletonLines } from "@platform/ui/Skeleton";
+
+type Loaded<T> =
+  | { status: "loading" }
+  | { status: "ok"; data: T }
+  | { status: "error"; message: string };
+
+// Same pure-CSS scale-down as AppPreviewCard: the iframe renders at 400% of the
+// thumb box and is scaled to 25%, so the visual size is exactly the box whatever
+// width the grid column resolves to.
+const PREVIEW_SCALE = 0.25;
+
+// A card is never blank and never lies about what it is showing: when there is
+// no live preview to render, the artifact's own tab emoji stands in for it, and
+// an artifact published without one gets the generic page glyph.
+const FALLBACK_GLYPH = "📄";
+
+// Whether the local file can be previewed AS ITSELF. `/render` serves a file's
+// bytes as html with the runtime injected — exactly right for the html Claude
+// publishes, and wrong for the md it also publishes: markdown through that route
+// paints as one wall of unwrapped source, which is a worse thumbnail than no
+// thumbnail. Rendering md properly means resolving its preview TEMPLATE from the
+// registry (`/render?path=<template>&_file=<file>`, see explorer/Preview.tsx),
+// which is a per-card round trip this grid has no business making. So md falls
+// through to the glyph tile, the same way an app with no page entry does.
+function isRenderablePage(fsPath: string): boolean {
+  return /\.html?$/i.test(fsPath);
+}
+
+// What to call it. The <title> Claude gave the page if it gave one, else the
+// file's own name — never a bare "Untitled", which tells the reader nothing they
+// could use to find it again.
+function labelFor(a: ClaudeArtifact): string {
+  return a.title?.trim() || basename(a.file_path);
+}
+
+// Client-side filter over the three things a person actually remembers about an
+// artifact: what it was called, what it said it was, and what the file is named.
+function matchesQuery(a: ClaudeArtifact, q: string): boolean {
+  if (q === "") return true;
+  return (
+    (a.title ?? "").toLowerCase().includes(q) ||
+    (a.description ?? "").toLowerCase().includes(q) ||
+    basename(a.file_path).toLowerCase().includes(q)
+  );
+}
+
+function ExternalIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14 4h6v6" />
+      <path d="M20 4l-8.5 8.5" />
+      <path d="M18 14v4a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4" />
+    </svg>
+  );
+}
+
+// One artifact.
+//
+// NOT a single <a> like AppPreviewCard, and the difference is forced: this card
+// has two destinations, and an <a> inside an <a> is invalid HTML (nested
+// interactive content) — React will build that DOM but no reader should have to
+// make sense of it. Instead the card is a plain box, the TITLE is the real link,
+// and its stretched ::after covers the whole card (styles/apps.css). The
+// browser's own gestures therefore still work anywhere on the card — middle
+// click, Cmd/Ctrl-click, "Open in New Tab", copy link — which is the whole
+// reason AppPreviewCard is an anchor in the first place. The published-page link
+// sits above that overlay (z-index) so it keeps its own click without any
+// event-bubbling trickery: it is not inside the primary link to begin with.
+function ArtifactCard({ artifact }: { artifact: ClaudeArtifact }) {
+  const title = labelFor(artifact);
+  const ago = timeAgo(artifact.updated_at);
+  const live = artifact.exists && isRenderablePage(artifact.file_path);
+  // Gone from disk: the published page is all that is left, so that is where the
+  // card goes — in a new tab, because it leaves the app. While the file IS here
+  // the card opens it HERE, through the shell's own navigation (the href carries
+  // the same target so a new tab lands in the same place).
+  const local = artifact.exists;
+  const href = local ? urlForFsPath(artifact.file_path) : artifact.remote_url;
+
+  return (
+    <div className="app-pcard ca-card">
+      <span
+        className={
+          "app-pcard-thumb ca-card-thumb" +
+          (live ? "" : " ca-card-thumb-tinted") +
+          (artifact.exists ? "" : " ca-card-thumb-gone")
+        }
+        // The live preview and the glyph are decoration — the title says the same
+        // thing in text. The MISSING notice is not: it is the one piece of state
+        // only this box reports, so that card leaves the thumb readable.
+        aria-hidden={artifact.exists ? true : undefined}
+      >
+        {live ? (
+          <>
+            <iframe
+              src={`/render?path=${encodeURIComponent(artifact.file_path)}`}
+              style={{
+                width: `${100 / PREVIEW_SCALE}%`,
+                height: `${100 / PREVIEW_SCALE}%`,
+                transform: `scale(${PREVIEW_SCALE})`,
+              }}
+              loading="lazy"
+              tabIndex={-1}
+              scrolling="no"
+              title=""
+            />
+            {/* Display-only: the shield keeps every pointer event off the page
+                inside the frame, so it lands on the card's stretched link. */}
+            <span className="app-pcard-shield" />
+          </>
+        ) : (
+          <>
+            <span className="ca-card-glyph">{artifact.favicon || FALLBACK_GLYPH}</span>
+            {!artifact.exists && <span className="ca-card-gone">file removed</span>}
+          </>
+        )}
+      </span>
+      <span className="app-pcard-body ca-card-body">
+        <span className="ca-card-head">
+          {/* Repeated from the tinted tile on purpose: the emoji is how the user
+              recognises the artifact, and on a card WITH a live preview the tile
+              never shows it. */}
+          <span className="ca-card-favicon" aria-hidden="true">
+            {artifact.favicon || FALLBACK_GLYPH}
+          </span>
+          <a
+            className="ca-card-title"
+            href={href}
+            target={local ? undefined : "_blank"}
+            rel={local ? undefined : "noopener noreferrer"}
+            title={local ? artifact.file_path : `${artifact.file_path} (removed) — open ${artifact.remote_url}`}
+            onClick={(e) => {
+              // Only a plain left click is ours; every modifier and the middle
+              // button already mean "somewhere other than this tab" and belong
+              // to the href. A remote target is the browser's outright.
+              if (!local || isBrowserHandledClick(e)) return;
+              e.preventDefault();
+              navigate(artifact.file_path);
+            }}
+          >
+            {title}
+          </a>
+        </span>
+        {artifact.description && (
+          <span className="ca-card-desc" title={artifact.description}>
+            {artifact.description}
+          </span>
+        )}
+        <span className="ca-card-foot">
+          <span className="ca-card-ago" title={formatMtimeFull(artifact.updated_at) || undefined}>
+            {ago ?? "—"}
+          </span>
+          {/* Always present, even on the card whose primary link already points
+              here: "where is the shareable link" should be answered by the same
+              spot on every card, not by first working out whether the local file
+              survived. */}
+          <a
+            className="ca-card-remote"
+            href={artifact.remote_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            title={`Open the published page — ${artifact.remote_url}`}
+            aria-label={`Open the published page for ${title}`}
+          >
+            <ExternalIcon />
+          </a>
+        </span>
+      </span>
+    </div>
+  );
+}
+
+export default function ClaudePublished() {
+  // One cheap GET on mount — no client-side cache to reconcile, and the shell
+  // remounts this page on every navigation anyway (App.tsx keys on nav epoch).
+  const [state, setState] = useState<Loaded<ClaudeArtifact[]>>({ status: "loading" });
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    let alive = true;
+    getClaudeArtifacts().then(
+      ({ artifacts }) => alive && setState({ status: "ok", data: artifacts }),
+      (e: Error) => alive && setState({ status: "error", message: e.message }),
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const all = state.status === "ok" ? state.data : [];
+  const q = query.trim().toLowerCase();
+  // No sort control: the server already answers newest-first, and "which one did
+  // I just make" is the only ordering anyone wants from a list of artifacts.
+  // Filtering never reorders, so a card cannot move under the cursor.
+  const shown = useMemo(() => all.filter((a) => matchesQuery(a, q)), [all, q]);
+
+  return (
+    <div className="cc-root">
+      <main className="cc-main">
+        <div className="cc-page-head">
+          <div>
+            <h2 className="cc-heading">Published</h2>
+            <div className="cc-caption">pages Claude published on this machine</div>
+          </div>
+        </div>
+
+        <div className="cc-toolbar">
+          <div className="apps-search">
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <circle cx="11" cy="11" r="7" />
+              <path d="M21 21l-4.3-4.3" />
+            </svg>
+            <input
+              type="search"
+              placeholder="Search artifacts…"
+              aria-label="Search artifacts by title, description or file name"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+            />
+          </div>
+          {state.status === "ok" && (
+            <div className="cc-count">
+              {shown.length === all.length
+                ? `${all.length} artifact${all.length === 1 ? "" : "s"}`
+                : `${shown.length} of ${all.length} artifacts`}
+            </div>
+          )}
+        </div>
+
+        {state.status === "error" && <ErrorBanner>{state.message}</ErrorBanner>}
+        {state.status === "loading" && <SkeletonLines rows={4} label="Loading artifacts" />}
+        {state.status === "ok" &&
+          (shown.length === 0 ? (
+            <div className="cc-empty">
+              {all.length === 0 ? (
+                <>
+                  No Claude artifacts found on this machine.
+                  <div className="ca-empty-sub">
+                    Artifacts are pages Claude publishes with its Artifact tool — a report, a
+                    dashboard, a write-up. Ask it to publish one and it shows up here.
+                  </div>
+                </>
+              ) : (
+                "No artifacts match — clear the search."
+              )}
+            </div>
+          ) : (
+            <div className="apps-cards">
+              {shown.map((a) => (
+                // Keyed on the published url, which the server dedupes on — a
+                // file republished twice is two artifacts and two cards.
+                <ArtifactCard key={a.remote_url} artifact={a} />
+              ))}
+            </div>
+          ))}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -88,6 +88,17 @@ const ARTIFACTS_ICON = (
   </svg>
 );
 
+// Page with an up-and-out arrow — the Published page lists the pages Claude
+// published to claude.ai with its Artifact tool, so the glyph is "a document
+// that left the machine".
+const PUBLISHED_ICON = (
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M14 3H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+    <path d="M15 3h6v6" />
+    <path d="M21 3l-8 8" />
+  </svg>
+);
+
 // Stacked disks — the AI Models entry is an inventory of what the Hugging
 // Face cache is storing on this machine, so it reads as storage, not as a chip.
 const AI_MODELS_ICON = (
@@ -261,7 +272,10 @@ export default function GlobalSidebar({ config }: { config: Config }) {
       ? [{ href: "/community", label: "Showcase", icon: COMMUNITY_ICON }]
       : []),
     ...(sessionsMountReady || claudeConfigAvailable
-      ? [{ href: "/claude-artifacts", label: "Artifacts", icon: ARTIFACTS_ICON }]
+      ? [
+          { href: "/claude-artifacts", label: "Artifacts", icon: ARTIFACTS_ICON },
+          { href: "/claude-published", label: "Published", icon: PUBLISHED_ICON },
+        ]
       : []),
     ...(claudeConfigAvailable
       ? [{ href: "/claude-config", label: "Config", icon: CLAUDE_CONFIG_ICON }]

--- a/frontend/src/styles/apps.css
+++ b/frontend/src/styles/apps.css
@@ -263,3 +263,158 @@
   flex: 0 0 auto;
   margin-left: auto;
 }
+
+/* -- Claude artifacts (/claude-artifacts) -------------------------------------
+   shell/ClaudeArtifacts.tsx reuses this file's card, not the other way round:
+   its grid IS .apps-cards and its cards ARE .app-pcard, thumbnail trick and
+   shield included. Only the three things an artifact card has that an app card
+   does not live here — the emoji identity, a description line, and a SECOND
+   destination (the published claude.ai page) alongside the primary one.
+ *
+ * It therefore has to sit AFTER .app-pcard*, which is why the section is in this
+ * file at the bottom rather than beside the page's own cc- chrome in
+ * claude-config.css: that stylesheet is imported BEFORE this one (see
+ * shell.css), so its rules could not override the card's. */
+
+/* Positioned so the title link's stretched ::after has a containing block — and
+   the inherited `overflow: hidden` then clips that overlay to exactly the card's
+   rounded box, which is the area it is meant to cover. */
+.ca-card {
+  position: relative;
+}
+
+/* Preview on top, text below — the reverse of the app card, because an artifact
+   is a PAGE and the page is what identifies it. So the thumb's hairline moves to
+   the edge it now shares with the body. */
+.ca-card .ca-card-thumb {
+  border-top: none;
+  border-bottom: 1px solid var(--border);
+}
+
+/* No live render (md, or the file is gone): a tinted tile instead of a blank
+   box. Neutral, not accent — accent stays reserved for focus/selection. */
+.ca-card-thumb-tinted {
+  background: color-mix(in srgb, var(--fg-muted) 8%, var(--bg));
+}
+
+.ca-card-glyph {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 52px;
+  line-height: 1;
+}
+
+/* Faded when the file is gone, so the tile reads as an absence at a glance —
+   before the "file removed" line underneath it has been read. */
+.ca-card-thumb-gone .ca-card-glyph {
+  opacity: 0.45;
+}
+
+/* Said quietly at the bottom of the tile: the card still works (its link goes to
+   the published page), so this is a note, not an error. */
+.ca-card-gone {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.ca-card-body {
+  gap: 6px;
+}
+
+.ca-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ca-card-favicon {
+  flex: 0 0 auto;
+  font-size: 15px;
+  line-height: 1;
+}
+
+/* The card's primary link. Its ::after is stretched over the whole card so every
+   browser gesture that works on an anchor works anywhere on the card — the
+   property AppPreviewCard gets by BEING an anchor, which this card cannot be
+   (it holds a second link, and anchors do not nest). z-index lifts it over the
+   thumbnail's pointer-events shield, which is a plain positioned span. */
+.ca-card-title {
+  min-width: 0;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--fg);
+  text-decoration: none;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ca-card-title::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+}
+
+.ca-card-desc {
+  font-size: 12px;
+  color: var(--fg-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ca-card-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--fg-muted);
+}
+
+.ca-card-ago {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Above the stretched overlay (z-index 2 > 1) so it keeps its own click without
+   any event-bubbling trickery — it is not inside the primary link at all. */
+.ca-card-remote {
+  position: relative;
+  z-index: 2;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+
+.ca-card-remote:hover {
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg-muted) 40%, var(--border));
+}
+
+/* The empty state's second line: what an artifact IS, for the very likely reader
+   who has never published one and would otherwise read "none found" as a fault. */
+.ca-empty-sub {
+  max-width: 46ch;
+  margin: 8px auto 0;
+  font-size: 12px;
+  line-height: 1.5;
+}

--- a/fused_render/claude_artifacts.py
+++ b/fused_render/claude_artifacts.py
@@ -48,6 +48,8 @@ import json
 import os
 from datetime import datetime, timezone
 
+from fused_render._view_url_codec import canonical_fs_path
+
 # CLAUDE_CONFIG_DIR wins where set — same rule (and same deliberate local
 # duplication) as server/routers/claude_sessions.py, user_skills.py and the
 # claude template's CLAUDE_DIR.
@@ -133,10 +135,13 @@ def artifact_dict(
     per-transcript cache the rest of these fields do.
     """
     return {
-        # The local file that was published. Reported exactly as the transcript
-        # recorded it — that string is what the publish actually used, and it is
-        # already absolute — rather than re-resolved through the filesystem.
-        "file_path": file_path,
+        # The local file that was published, in the shell's canonical form
+        # (forward slashes — see canonical_fs_path, and the same call in the
+        # sessions router): a Windows transcript records the backslashed form,
+        # and frontend helpers like `basename` split on "/" only. Not otherwise
+        # re-resolved: that string is what the publish actually used, and it is
+        # already absolute.
+        "file_path": canonical_fs_path(file_path),
         "exists": os.path.isfile(file_path),
         "remote_url": remote_url,
         "title": title,
@@ -152,8 +157,12 @@ def artifact_dict(
     }
 
 
-def _artifact_tool_input(obj) -> dict | None:
-    """The Artifact tool call's `input` from an assistant record, or None.
+def _artifact_tool_inputs(obj) -> list[dict]:
+    """Every Artifact tool call `input` in an assistant record, in call order.
+
+    ALL of them, not the first: one assistant message can carry several
+    parallel tool calls, and taking only the first would strip the later
+    publishes of their description and favicon.
 
     Rejects the calls that published nothing: a missing/blank `file_path` (an
     incomplete streamed call, or one that errored before it had a target) and
@@ -162,10 +171,11 @@ def _artifact_tool_input(obj) -> dict | None:
     """
     message = obj.get("message")
     if not isinstance(message, dict):
-        return None
+        return []
     content = message.get("content")
     if not isinstance(content, list):
-        return None
+        return []
+    inputs = []
     for item in content:
         if not isinstance(item, dict) or item.get("type") != "tool_use":
             continue
@@ -176,8 +186,8 @@ def _artifact_tool_input(obj) -> dict | None:
             continue
         if not _text(data.get("file_path")):
             continue
-        return data
-    return None
+        inputs.append(data)
+    return inputs
 
 
 def _parse_transcript(jsonl_path: str) -> list[dict]:
@@ -240,8 +250,7 @@ def _parse_transcript(jsonl_path: str) -> list[dict]:
                     frame["session_id"] = _text(obj.get("sessionId"))
                     _widen(frame, stamp)
                 elif is_tool:
-                    data = _artifact_tool_input(obj)
-                    if data is not None:
+                    for data in _artifact_tool_inputs(obj):
                         path = _text(data.get("file_path"))
                         prior = tool_inputs.get(path)
                         if prior is None or order >= prior[0]:
@@ -341,8 +350,11 @@ def list_artifacts() -> list[dict]:
         seen.add(os.path.abspath(jsonl_path))
         for record in _transcript_artifacts(jsonl_path):
             _absorb(merged, record)
+    # pop(), not del: two overlapping listings can both see the same stale key,
+    # and the second del would KeyError. FastAPI serves sync routes from a
+    # threadpool, so overlapping is normal, not exotic.
     for stale in set(_CACHE) - seen:
-        del _CACHE[stale]
+        _CACHE.pop(stale, None)
     # Undated artifacts sort last rather than first: `reverse` would otherwise
     # promote the ones we know least about to the top of the page.
     artifacts = [artifact_dict(**record) for record in merged.values()]

--- a/fused_render/claude_artifacts.py
+++ b/fused_render/claude_artifacts.py
@@ -1,0 +1,353 @@
+"""Every Artifact this machine has published, recovered from Claude Code's own
+session transcripts — the entry contract behind `GET /api/claude-artifacts`.
+
+There is no artifacts index on disk to read. Publishing an Artifact is a tool
+call inside a Claude Code session, and the only durable trace it leaves locally
+is in the session transcript at ~/.claude/projects/<encoded-cwd>/<id>.jsonl.
+Two kinds of line there matter, and BOTH are needed:
+
+  * a top-level `{"type": "frame-link", ...}` record — one per successful
+    publish, carrying the four facts that make an artifact addressable: the
+    local `path` that was published, the hosted `frameUrl`, the `title`, and a
+    `timestamp`. This is the authoritative publish record; if it isn't there,
+    the publish didn't land, which is why an artifact with no frame-link is not
+    listed at all.
+  * the assistant's `tool_use` record for the Artifact call, which is the only
+    place the `description` and `favicon` the author chose ever appear. The
+    frame-link doesn't echo them back.
+
+So the shape below is a JOIN, keyed on the local file path within a session,
+between "what got published" and "how the author described it".
+
+Identity is the `frameUrl`, not the file path. One page is redeployed many
+times — a `.html` in a scratchpad gets published, edited, published again — and
+every redeploy writes another frame-link for the SAME url. Those are one
+artifact with a history, not N artifacts: latest publish wins for what to show
+(title, path, description), `created_at` is the first publish and `updated_at`
+the last. The dedupe also has to run ACROSS transcripts, because an artifact
+can be updated from a different session later via the tool's `url` parameter —
+a per-session merge alone would list that page twice.
+
+Cost is the reason for the two-stage prefilter and the per-file cache. Real
+transcript stores run to hundreds of megabytes; `json.loads` on every line of
+that per request is not viable, and neither is re-reading unchanged files. So
+lines are substring-screened before parsing (a cheap `in` test rejects
+virtually all of them), and each transcript's merged result is cached against
+its (mtime, size) so a repeat request only re-reads the transcripts that
+actually moved.
+
+Nothing in here raises for input it cannot read: an unreadable transcript, a
+truncated JSON line, a timestamp in an unexpected format, a missing projects
+dir — each degrades to "no artifacts from that", never to a failed listing.
+`exists` is deliberately the one fact NOT cached: scratchpad files are
+temporary and the caller needs to know, right now, whether the local source is
+still openable.
+"""
+import glob
+import json
+import os
+from datetime import datetime, timezone
+
+# CLAUDE_CONFIG_DIR wins where set — same rule (and same deliberate local
+# duplication) as server/routers/claude_sessions.py, user_skills.py and the
+# claude template's CLAUDE_DIR.
+CLAUDE_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+PROJECTS_DIR = os.path.join(CLAUDE_DIR, "projects")
+
+# Substring screens applied to a raw line BEFORE json.loads. Cheap enough to run
+# over every line of a multi-hundred-MB store; a line that passes is one of the
+# few thousand we actually care about. Written as the JSON-encoded field values so
+# they can't match a stray mention in prose — but only as a *filter*, so a false
+# positive costs one wasted parse and a future format change (spaces after the
+# colons, say) still matches on the bare tokens.
+_FRAME_LINK_HINT = "frame-link"
+_TOOL_USE_HINTS = ("Artifact", "tool_use")
+
+# How far into a transcript to hunt for its `cwd` when no line we parse for
+# other reasons happens to carry one. It is normally on the very FIRST record
+# (claude_sessions._session_cwd relies on the same thing), so this is a bound on
+# a pathological file rather than a real budget — without it, a transcript that
+# never records a cwd would cost a full json.loads of every line.
+_CWD_PROBE_LINES = 20
+
+# path -> (mtime, size, merged-artifacts-for-that-transcript). Keyed by absolute
+# path, so a monkeypatched PROJECTS_DIR under tmp can never collide with a real
+# transcript's entry. Pruned to the transcripts currently on disk on each
+# listing, so a deleted session doesn't pin its result for the process lifetime.
+_CACHE: dict[str, tuple[float, int, list[dict]]] = {}
+
+
+def reset_cache() -> None:
+    """Forget every cached transcript. For tests, and for any caller that wants
+    the next listing to re-read from disk unconditionally."""
+    _CACHE.clear()
+
+
+def _epoch(value) -> float | None:
+    """A transcript's ISO-8601 timestamp as an epoch float, or None.
+
+    The trailing "Z" is rewritten rather than passed through: `fromisoformat`
+    only learned to accept it in 3.11, and this package still runs on 3.10. A
+    timestamp with no zone at all is read as UTC — every writer of these records
+    emits UTC, and guessing local time would silently shift an artifact's
+    position in a listing sorted by time.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00" if value.endswith("Z") else value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _text(value) -> str | None:
+    """A transcript string field, or None for anything unusable — absent, the
+    wrong type, or empty. Empty and absent are the same claim here ("no title
+    was recorded"), and collapsing them keeps the UI from having to know."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def artifact_dict(
+    file_path: str,
+    remote_url: str,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+    favicon: str | None = None,
+    session_id: str | None = None,
+    cwd: str | None = None,
+    created_at: float | None = None,
+    updated_at: float | None = None,
+) -> dict:
+    """One listed artifact — the single place the entry shape is built.
+
+    `exists` is resolved HERE and nowhere else, on every call: it is the only
+    field that can change without any transcript changing (the published file
+    was in a scratchpad and got cleaned up), so it must never come out of the
+    per-transcript cache the rest of these fields do.
+    """
+    return {
+        # The local file that was published. Reported exactly as the transcript
+        # recorded it — that string is what the publish actually used, and it is
+        # already absolute — rather than re-resolved through the filesystem.
+        "file_path": file_path,
+        "exists": os.path.isfile(file_path),
+        "remote_url": remote_url,
+        "title": title,
+        "description": description,
+        "favicon": favicon,
+        # The session of the LATEST publish, not the first: it is offered as
+        # "where this artifact is being worked on", and for an artifact updated
+        # from a second session the first one is the stale answer.
+        "session_id": session_id,
+        "cwd": cwd,
+        "created_at": created_at,
+        "updated_at": updated_at,
+    }
+
+
+def _artifact_tool_input(obj) -> dict | None:
+    """The Artifact tool call's `input` from an assistant record, or None.
+
+    Rejects the calls that published nothing: a missing/blank `file_path` (an
+    incomplete streamed call, or one that errored before it had a target) and
+    `action: "list"`, which only enumerates existing artifacts. Either would
+    otherwise contribute a description to whichever artifact shared its path.
+    """
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return None
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "tool_use":
+            continue
+        if item.get("name") != "Artifact":
+            continue
+        data = item.get("input")
+        if not isinstance(data, dict) or data.get("action") == "list":
+            continue
+        if not _text(data.get("file_path")):
+            continue
+        return data
+    return None
+
+
+def _parse_transcript(jsonl_path: str) -> list[dict]:
+    """One transcript's artifacts, already merged within the session.
+
+    Returns raw records (the `artifact_dict` keyword set minus `exists`) rather
+    than finished entries, because this is exactly what gets cached and merged
+    again across sessions — see the module docstring.
+
+    Line order is the tiebreaker for "latest" wherever a timestamp is missing,
+    which is the right fallback: a transcript is append-only, so later in the
+    file IS later in time.
+    """
+    frames: dict[str, dict] = {}
+    # file_path -> (rank, input). The metadata join is per file path within the
+    # session; the frame-link is what turns it into a url.
+    tool_inputs: dict[str, tuple[int, dict]] = {}
+    cwd: str | None = None
+    order = 0
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                order += 1
+                is_frame = _FRAME_LINK_HINT in line
+                is_tool = all(hint in line for hint in _TOOL_USE_HINTS)
+                # The cwd probe is the only reason to parse an uninteresting
+                # line at all, and only near the top of the file.
+                if not is_frame and not is_tool and (
+                    cwd is not None or order > _CWD_PROBE_LINES
+                ):
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue  # truncated / partially-written line: skip it
+                if not isinstance(obj, dict):
+                    continue
+                if cwd is None:
+                    cwd = _text(obj.get("cwd"))
+                if is_frame and obj.get("type") == "frame-link":
+                    url = _text(obj.get("frameUrl"))
+                    path = _text(obj.get("path"))
+                    if not url or not path:
+                        continue
+                    stamp = _epoch(obj.get("timestamp"))
+                    rank = (stamp if stamp is not None else -1.0, order)
+                    frame = frames.get(url)
+                    if frame is None:
+                        frames[url] = frame = {"rank": rank, "created_at": stamp,
+                                               "updated_at": stamp}
+                    elif rank >= frame["rank"]:
+                        frame["rank"] = rank
+                    else:
+                        # An out-of-order record still moves the time span, but
+                        # must not overwrite the newer display fields.
+                        _widen(frame, stamp)
+                        continue
+                    frame["path"] = path
+                    frame["title"] = _text(obj.get("title"))
+                    frame["session_id"] = _text(obj.get("sessionId"))
+                    _widen(frame, stamp)
+                elif is_tool:
+                    data = _artifact_tool_input(obj)
+                    if data is not None:
+                        path = _text(data.get("file_path"))
+                        prior = tool_inputs.get(path)
+                        if prior is None or order >= prior[0]:
+                            tool_inputs[path] = (order, data)
+    except OSError:
+        return []  # unreadable/vanished transcript: contributes nothing
+
+    records = []
+    for url, frame in frames.items():
+        _, data = tool_inputs.get(frame["path"], (0, {}))
+        records.append({
+            "file_path": frame["path"],
+            "remote_url": url,
+            # The frame-link's title is what the page actually published under;
+            # the tool input's is only a fallback for the publish that let the
+            # HTML's own <title> supply it and got nothing echoed back.
+            "title": frame["title"] or _text(data.get("title")),
+            "description": _text(data.get("description")),
+            "favicon": _text(data.get("favicon")),
+            "session_id": frame["session_id"],
+            "cwd": cwd,
+            "created_at": frame["created_at"],
+            "updated_at": frame["updated_at"],
+        })
+    return records
+
+
+def _widen(frame: dict, stamp: float | None) -> None:
+    """Grow a frame's [created_at, updated_at] span to include `stamp`. A
+    timestamp we couldn't read contributes nothing rather than a zero."""
+    if stamp is None:
+        return
+    if frame["created_at"] is None or stamp < frame["created_at"]:
+        frame["created_at"] = stamp
+    if frame["updated_at"] is None or stamp > frame["updated_at"]:
+        frame["updated_at"] = stamp
+
+
+def _transcript_artifacts(jsonl_path: str) -> list[dict]:
+    """`_parse_transcript` behind the (mtime, size) cache. A transcript that
+    cannot even be stat'ed contributes nothing."""
+    try:
+        st = os.stat(jsonl_path)
+    except OSError:
+        return []
+    key = os.path.abspath(jsonl_path)
+    cached = _CACHE.get(key)
+    if cached is not None and cached[0] == st.st_mtime and cached[1] == st.st_size:
+        return cached[2]
+    records = _parse_transcript(jsonl_path)
+    _CACHE[key] = (st.st_mtime, st.st_size, records)
+    return records
+
+
+def _absorb(merged: dict[str, dict], record: dict) -> None:
+    """Fold one transcript's record into the global by-url index.
+
+    Newest publish owns the display fields; the span always widens. This is the
+    across-session half of the dedupe — the same page updated from a second
+    session is one row, dated from its first publish to its last.
+    """
+    url = record["remote_url"]
+    existing = merged.get(url)
+    if existing is None:
+        merged[url] = dict(record)
+        return
+    newer = _is_newer(record.get("updated_at"), existing.get("updated_at"))
+    created = _min_stamp(existing.get("created_at"), record.get("created_at"))
+    updated = _max_stamp(existing.get("updated_at"), record.get("updated_at"))
+    if newer:
+        merged[url] = dict(record)
+    merged[url]["created_at"] = created
+    merged[url]["updated_at"] = updated
+
+
+def _is_newer(candidate: float | None, current: float | None) -> bool:
+    if candidate is None:
+        return False
+    return current is None or candidate > current
+
+
+def _min_stamp(a: float | None, b: float | None) -> float | None:
+    return b if a is None else a if b is None else min(a, b)
+
+
+def _max_stamp(a: float | None, b: float | None) -> float | None:
+    return b if a is None else a if b is None else max(a, b)
+
+
+def list_artifacts() -> list[dict]:
+    """Every artifact published from this machine's Claude Code sessions,
+    newest update first. [] when there are no transcripts at all — a listing
+    degrades to what it could see and never fails."""
+    merged: dict[str, dict] = {}
+    seen: set[str] = set()
+    for jsonl_path in sorted(glob.glob(os.path.join(PROJECTS_DIR, "*", "*.jsonl"))):
+        seen.add(os.path.abspath(jsonl_path))
+        for record in _transcript_artifacts(jsonl_path):
+            _absorb(merged, record)
+    for stale in set(_CACHE) - seen:
+        del _CACHE[stale]
+    # Undated artifacts sort last rather than first: `reverse` would otherwise
+    # promote the ones we know least about to the top of the page.
+    artifacts = [artifact_dict(**record) for record in merged.values()]
+    artifacts.sort(
+        key=lambda a: (a["updated_at"] is not None, a["updated_at"] or 0.0),
+        reverse=True,
+    )
+    return artifacts

--- a/fused_render/claude_artifacts.py
+++ b/fused_render/claude_artifacts.py
@@ -133,7 +133,20 @@ def artifact_dict(
     field that can change without any transcript changing (the published file
     was in a scratchpad and got cleaned up), so it must never come out of the
     per-transcript cache the rest of these fields do.
+
+    A mount-backed path is never stat'ed and reports `exists: False`. The
+    kernel os.stat is the GETATTR that wedges a dead mount (see
+    server/mount.py), and this runs once per artifact on every listing — one
+    bad mount would hang the whole page. False is also the SAFE answer, not
+    just the cheap one: `exists: True` would make the UI render a live iframe
+    preview per card, each of which is a read through the same mount. The card
+    falls back to its hosted claude.ai link, which is always openable.
     """
+    # Lazy import, following server/mount.py's own use of this helper: the
+    # mounts machinery would be a heavy top-level dependency for a module that
+    # is otherwise pure transcript parsing.
+    from fused_render.shell.mounts import is_mount_backed
+
     return {
         # The local file that was published, in the shell's canonical form
         # (forward slashes — see canonical_fs_path, and the same call in the
@@ -142,7 +155,7 @@ def artifact_dict(
         # re-resolved: that string is what the publish actually used, and it is
         # already absolute.
         "file_path": canonical_fs_path(file_path),
-        "exists": os.path.isfile(file_path),
+        "exists": not is_mount_backed(file_path) and os.path.isfile(file_path),
         "remote_url": remote_url,
         "title": title,
         "description": description,
@@ -253,8 +266,14 @@ def _parse_transcript(jsonl_path: str) -> list[dict]:
                     for data in _artifact_tool_inputs(obj):
                         path = _text(data.get("file_path"))
                         prior = tool_inputs.get(path)
-                        if prior is None or order >= prior[0]:
+                        if prior is None:
                             tool_inputs[path] = (order, data)
+                        elif order >= prior[0]:
+                            # Merged, not replaced: a republish routinely omits
+                            # the optional description (it means "unchanged",
+                            # not "cleared"), and losing it would strip the
+                            # card of its summary after every update.
+                            tool_inputs[path] = (order, {**prior[1], **data})
     except OSError:
         return []  # unreadable/vanished transcript: contributes nothing
 
@@ -311,6 +330,12 @@ def _absorb(merged: dict[str, dict], record: dict) -> None:
     Newest publish owns the display fields; the span always widens. This is the
     across-session half of the dedupe — the same page updated from a second
     session is one row, dated from its first publish to its last.
+
+    Owning is not wiping: a display field the newer publish DIDN'T carry
+    (an update via the tool's `url` parameter states no description/favicon,
+    and its title can fail to join) falls back to the older publish's value.
+    Metadata only ever gets more complete; a plain republish can't blank a
+    card that used to have a summary and an emoji.
     """
     url = record["remote_url"]
     existing = merged.get(url)
@@ -320,8 +345,15 @@ def _absorb(merged: dict[str, dict], record: dict) -> None:
     newer = _is_newer(record.get("updated_at"), existing.get("updated_at"))
     created = _min_stamp(existing.get("created_at"), record.get("created_at"))
     updated = _max_stamp(existing.get("updated_at"), record.get("updated_at"))
+    # Whichever publish ends up owning the row, fill its gaps from the loser —
+    # transcripts arrive in glob order, not time order, so the older publish
+    # can just as well be the SECOND one absorbed.
+    loser = existing if newer else record
     if newer:
         merged[url] = dict(record)
+    for field in ("title", "description", "favicon"):
+        if merged[url][field] is None:
+            merged[url][field] = loser[field]
     merged[url]["created_at"] = created
     merged[url]["updated_at"] = updated
 

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -40,6 +40,7 @@ from fused_render.server.common import (
     _forced_engine,
 )
 from fused_render.server.routers.apps import router as apps_router
+from fused_render.server.routers.claude_artifacts import router as claude_artifacts_router
 from fused_render.server.routers.claude_config import router as claude_config_router
 from fused_render.server.routers.claude_sessions import router as claude_sessions_router
 from fused_render.server.routers.clipboard import router as clipboard_router
@@ -337,6 +338,9 @@ def create_app(start_dir: str) -> FastAPI:
     # Claude Code project folders for the Explorer homepage's "Claude
     # sessions" tab (routers/claude_sessions.py) — read-only, no auth guard.
     app.include_router(claude_sessions_router)
+    # Artifacts published from those sessions, recovered from the same
+    # transcripts (routers/claude_artifacts.py) — read-only, no auth guard.
+    app.include_router(claude_artifacts_router)
     # Git repositories on this machine for the Explorer homepage's "Repos" tab
     # (routers/git_repos.py) — candidates come from the file index, never a
     # fresh walk, so it cannot touch a mount. Read-only, no auth guard.

--- a/fused_render/server/routers/claude_artifacts.py
+++ b/fused_render/server/routers/claude_artifacts.py
@@ -1,0 +1,26 @@
+"""GET /api/claude-artifacts — every Artifact published from this machine's
+Claude Code sessions, for the Explorer homepage's artifacts index.
+
+A publish leaves no index behind, only a `frame-link` record inside the session
+transcript it happened in, so the listing is recovered by scanning
+~/.claude/projects/<encoded-cwd>/*.jsonl and joining those records to the
+Artifact tool calls that carry the author's description and favicon. All of that
+— the scan, the dedupe by hosted url across sessions, and what one listed
+artifact IS — lives in `fused_render/claude_artifacts.py` rather than in this
+handler, for the same reason the apps walk lives in `app_listing.py`: those are
+the rules worth testing and reusing directly, and a route is not the place for
+them.
+
+Read-only and unguarded, like the neighbouring /api/claude-sessions: it reads
+transcripts and touches nothing.
+"""
+from fastapi import APIRouter
+
+from fused_render import claude_artifacts
+
+router = APIRouter()
+
+
+@router.get("/api/claude-artifacts")
+def api_claude_artifacts():
+    return {"artifacts": claude_artifacts.list_artifacts()}

--- a/fused_render/server/routers/shell.py
+++ b/fused_render/server/routers/shell.py
@@ -36,6 +36,7 @@ def shell_explorer(path: str = "", shell_path: str = Depends(get_shell_path)):
 # URLs is a real GET the server has to answer with the shell.
 @router.get("/claude-config")
 @router.get("/claude-artifacts")
+@router.get("/claude-published")
 @router.get("/claude-md")
 @router.get("/preferences")
 @router.get("/templates")

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -1,0 +1,225 @@
+"""GET /api/claude-artifacts (server/routers/claude_artifacts.py): the Artifacts
+published from this machine's Claude Code sessions, recovered from the session
+transcripts at ~/.claude/projects/<encoded-cwd>/*.jsonl — one row per hosted
+url no matter how many times it was republished (or from how many sessions),
+newest update first, with the author's description/favicon joined in from the
+Artifact tool call and `exists` reporting whether the published local file is
+still there.
+"""
+import json
+import shutil
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import claude_artifacts as claude_artifacts_mod
+from fused_render.server import create_app
+
+URL_A = "https://claude.ai/code/artifact/aaaaaaaa-0000-0000-0000-000000000000"
+URL_B = "https://claude.ai/code/artifact/bbbbbbbb-0000-0000-0000-000000000000"
+
+
+@pytest.fixture()
+def projects_dir(tmp_path, monkeypatch):
+    d = tmp_path / "claude-projects"
+    d.mkdir()
+    monkeypatch.setattr(claude_artifacts_mod, "PROJECTS_DIR", str(d))
+    # The per-transcript cache is module-level and keyed by absolute path, so a
+    # tmp path can't collide with another test's — but reset it anyway so a test
+    # that rewrites a transcript in place (same size, same mtime second) can't
+    # be served a stale parse.
+    claude_artifacts_mod.reset_cache()
+    return d
+
+
+@pytest.fixture()
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _frame_link(session_id, path, url, title, timestamp):
+    return {"type": "frame-link", "sessionId": session_id, "path": str(path),
+            "frameUrl": url, "title": title, "timestamp": timestamp}
+
+
+def _publish(path, **extra):
+    """An assistant record carrying one Artifact tool call, the only place the
+    author's description/favicon appear."""
+    return {"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(path), **extra}}]}}
+
+
+def _session(projects_dir, encoded_dir, session_id, cwd, records):
+    d = projects_dir / encoded_dir
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{session_id}.jsonl"
+    lines = [json.dumps({"cwd": cwd, "sessionId": session_id,
+                         "timestamp": "2026-01-01T00:00:00Z"})]
+    lines += [r if isinstance(r, str) else json.dumps(r) for r in records]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_lists_publish_with_tool_call_metadata_merged(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("<title>Bali</title>")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, favicon="\U0001f93f", description="Course picker."),
+        _frame_link("s1", page, URL_A, "Bali Open Water", "2026-07-16T09:43:32.223Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["file_path"] == str(page)
+    assert entry["remote_url"] == URL_A
+    assert entry["title"] == "Bali Open Water"
+    assert entry["description"] == "Course picker."
+    assert entry["favicon"] == "\U0001f93f"
+    assert entry["session_id"] == "s1"
+    assert entry["cwd"] == "/tmp/proj"
+    assert entry["exists"] is True
+    assert entry["created_at"] == entry["updated_at"] == pytest.approx(1784195012.223)
+
+
+def test_republished_page_is_one_row_with_latest_title_and_full_span(
+    client, projects_dir, tmp_path
+):
+    # Every redeploy writes another frame-link for the same frameUrl. That is one
+    # artifact with a history: newest publish wins for what's shown, and the
+    # dates span first publish to last.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, description="first pass"),
+        _frame_link("s1", page, URL_A, "First Title", "2026-07-16T09:00:00.000Z"),
+        _publish(page, description="second pass", favicon="\U0001f422"),
+        _frame_link("s1", page, URL_A, "Latest Title", "2026-07-16T11:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["title"] == "Latest Title"
+    # Latest tool call wins for the metadata too.
+    assert entry["description"] == "second pass"
+    assert entry["favicon"] == "\U0001f422"
+    assert entry["created_at"] == pytest.approx(1784192400.0)
+    assert entry["updated_at"] == pytest.approx(1784199600.0)
+
+
+def test_exists_reports_whether_the_published_file_is_still_there(
+    client, projects_dir, tmp_path
+):
+    # Artifacts are routinely published from scratchpads that get cleaned up.
+    here = tmp_path / "here.html"
+    here.write_text("<title>here</title>")
+    gone = tmp_path / "gone.html"  # never created
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", here, URL_A, "Here", "2026-07-16T10:00:00.000Z"),
+        _frame_link("s1", gone, URL_B, "Gone", "2026-07-16T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert {a["file_path"]: a["exists"] for a in artifacts} == {
+        str(here): True, str(gone): False}
+
+
+def test_missing_projects_dir_is_empty_not_an_error(client, projects_dir):
+    shutil.rmtree(projects_dir)
+    assert client.get("/api/claude-artifacts").json() == {"artifacts": []}
+
+
+def test_malformed_lines_and_list_calls_are_skipped(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        '{"type": "frame-link", "path": "/x", truncated',  # unparseable, skipped
+        # An `action: "list"` call publishes nothing, and neither does a call
+        # with no file_path — neither may contribute metadata.
+        _publish(page, description="from a list call", action="list"),
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "name": "Artifact",
+             "input": {"action": "list", "description": "no file_path"}}]}},
+        _publish(page, description="real publish"),
+        _frame_link("s1", page, URL_A, "Real", "2026-07-16T10:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert [(a["remote_url"], a["description"]) for a in artifacts] == [
+        (URL_A, "real publish")]
+
+
+def test_tool_call_without_a_frame_link_is_not_listed(client, projects_dir, tmp_path):
+    # The frame-link is the authoritative publish record; without one there is
+    # no hosted url, so there is nothing to list.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, description="never landed"),
+    ])
+    assert client.get("/api/claude-artifacts").json() == {"artifacts": []}
+
+
+def test_same_url_published_from_two_sessions_collapses_to_one_row(
+    client, projects_dir, tmp_path
+):
+    # An artifact can be updated from a later session via the tool's `url`
+    # param, so the dedupe has to run across transcripts, not just within one.
+    first = tmp_path / "first.html"
+    first.write_text("x")
+    second = tmp_path / "second.html"
+    second.write_text("x")
+    _session(projects_dir, "-tmp-a", "old", "/tmp/a", [
+        _publish(first, description="original"),
+        _frame_link("old", first, URL_A, "Original", "2026-07-16T09:00:00.000Z"),
+    ])
+    _session(projects_dir, "-tmp-b", "new", "/tmp/b", [
+        _publish(second, description="updated elsewhere"),
+        _frame_link("new", second, URL_A, "Updated", "2026-07-17T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    # Latest publish owns every display field, including which session/cwd it
+    # is now being worked on from; created_at is still the first publish.
+    assert entry["title"] == "Updated"
+    assert entry["description"] == "updated elsewhere"
+    assert entry["file_path"] == str(second)
+    assert entry["session_id"] == "new"
+    assert entry["cwd"] == "/tmp/b"
+    assert entry["created_at"] == pytest.approx(1784192400.0)
+    assert entry["updated_at"] == pytest.approx(1784278800.0)
+
+
+def test_sorted_newest_update_first(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-a", "s1", "/tmp/a", [
+        _frame_link("s1", page, URL_A, "Older", "2026-07-16T09:00:00.000Z"),
+    ])
+    _session(projects_dir, "-tmp-b", "s2", "/tmp/b", [
+        _frame_link("s2", page, URL_B, "Newer", "2026-07-20T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert [a["title"] for a in artifacts] == ["Newer", "Older"]
+
+
+def test_unchanged_transcript_is_not_reparsed_but_exists_stays_live(
+    client, projects_dir, tmp_path, monkeypatch
+):
+    # The per-file cache is what makes a repeat request cheap against a
+    # hundreds-of-MB transcript store; `exists` is deliberately outside it.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", page, URL_A, "Cached", "2026-07-16T10:00:00.000Z"),
+    ])
+    assert client.get("/api/claude-artifacts").json()["artifacts"][0]["exists"] is True
+
+    calls = []
+    real_parse = claude_artifacts_mod._parse_transcript
+    monkeypatch.setattr(
+        claude_artifacts_mod, "_parse_transcript",
+        lambda p: (calls.append(p), real_parse(p))[1])
+    page.unlink()
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert calls == []
+    assert artifacts[0]["exists"] is False

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -223,3 +223,29 @@ def test_unchanged_transcript_is_not_reparsed_but_exists_stays_live(
     artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
     assert calls == []
     assert artifacts[0]["exists"] is False
+
+
+def test_parallel_publishes_in_one_message_all_keep_their_metadata(
+    client, projects_dir, tmp_path
+):
+    # One assistant message can carry several Artifact tool calls (parallel tool
+    # use). Each publish keeps its own description/favicon — taking only the
+    # message's first call would strip the later ones.
+    page_a, page_b = tmp_path / "a.html", tmp_path / "b.html"
+    both = {"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(page_a), "favicon": "🅰️", "description": "First."}},
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(page_b), "favicon": "🅱️", "description": "Second."}},
+    ]}}
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        both,
+        _frame_link("s1", page_a, URL_A, "A", "2026-07-16T09:00:00Z"),
+        _frame_link("s1", page_b, URL_B, "B", "2026-07-16T09:00:01Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    by_url = {a["remote_url"]: a for a in artifacts}
+    assert by_url[URL_A]["description"] == "First."
+    assert by_url[URL_A]["favicon"] == "🅰️"
+    assert by_url[URL_B]["description"] == "Second."
+    assert by_url[URL_B]["favicon"] == "🅱️"

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -249,3 +249,56 @@ def test_parallel_publishes_in_one_message_all_keep_their_metadata(
     assert by_url[URL_A]["favicon"] == "🅰️"
     assert by_url[URL_B]["description"] == "Second."
     assert by_url[URL_B]["favicon"] == "🅱️"
+
+
+def test_republish_without_description_keeps_the_earlier_metadata(
+    client, projects_dir, tmp_path
+):
+    # A republish routinely omits the optional description/favicon — that means
+    # "unchanged", not "cleared". Within a session the tool inputs merge; across
+    # sessions the newer row inherits any display field it didn't carry.
+    page = tmp_path / "page.html"
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, favicon="🐢", description="The summary."),
+        _frame_link("s1", page, URL_A, "First", "2026-07-16T09:00:00Z"),
+        _publish(page),  # update: no description, no favicon
+        _frame_link("s1", page, URL_A, "Second", "2026-07-16T10:00:00Z"),
+    ])
+    # And an update from a DIFFERENT session (via the tool's url parameter),
+    # whose transcript never carried the original metadata at all.
+    _session(projects_dir, "-tmp-other", "s2", "/tmp/other", [
+        _publish(page, url=URL_A),
+        _frame_link("s2", page, URL_A, "Third", "2026-07-16T11:00:00Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["title"] == "Third"
+    assert entry["description"] == "The summary."
+    assert entry["favicon"] == "🐢"
+    assert entry["session_id"] == "s2"
+
+
+def test_mount_backed_file_is_not_stated_and_reports_not_local(
+    client, projects_dir, tmp_path, monkeypatch
+):
+    # A path under the mounts dir must never reach the kernel stat — that
+    # GETATTR is what wedges a dead mount, once per card per listing. The card
+    # falls back to its hosted link, so False is the safe answer even when the
+    # remote file is really there.
+    from fused_render.shell.mounts import access as mounts_access
+
+    page = tmp_path / "mounts-root" / "s3" / "page.html"
+    page.parent.mkdir(parents=True)
+    page.write_text("<title>On a mount</title>")
+    monkeypatch.setattr(mounts_access, "mounts_dir", lambda: str(tmp_path / "mounts-root"))
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", page, URL_A, "Mounted", "2026-07-16T09:00:00Z"),
+    ])
+    stats = []
+    real_isfile = claude_artifacts_mod.os.path.isfile
+    monkeypatch.setattr(claude_artifacts_mod.os.path, "isfile",
+                        lambda p: (stats.append(p), real_isfile(p))[1])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert artifacts[0]["exists"] is False
+    assert str(page) not in stats


### PR DESCRIPTION
## What

A new **Published** page (`/claude-published`, sidebar CLAUDE group) that lists every artifact Claude Code has published from this machine, as an apps-hub-style grid of preview cards. The existing `/claude-artifacts` session-folder list is untouched.

## How

Claude Code writes a `frame-link` record into the session transcript on every Artifact publish — local file path, hosted `claude.ai/code/artifact/...` URL, title, timestamp. The new `fused_render/claude_artifacts.py` scans `~/.claude/projects/*/*.jsonl` for those records, merges in the Artifact tool-call inputs (favicon, description), dedupes by hosted URL across sessions, and serves `GET /api/claude-artifacts`.

- Per-transcript `(mtime, size)` cache: cold scan of 800MB of real transcripts ~0.6s, warm ~3ms
- `exists` re-stat'ed per request — scratchpad cleanup flips a card to "file removed" on next refresh
- Card primary link: local file while it exists (in-app), the published claude.ai page once it doesn't (new tab); footer always carries the published-page link

## Testing

- 9 new API tests (`tests/test_claude_artifacts_api.py`), house style of `test_claude_sessions_api.py`; full targeted run green
- `tsc --noEmit`, boundaries check, `bun test` (825) all pass
- Verified live against real `~/.claude`: publish → appears on refresh; file deletion → remote-only card; both themes screenshotted, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New transcript scan on every API hit can be costly on large stores (mitigated by caching), and listing touches many local paths plus iframe previews—mount paths are deliberately not stat'd to avoid hangs.
> 
> **Overview**
> Adds a **Published** page at `/claude-published` that lists every page Claude Code published with its Artifact tool from this machine, as a searchable apps-hub-style card grid. `/claude-artifacts` (session folders) is unchanged.
> 
> **Backend:** New read-only `GET /api/claude-artifacts` scans `~/.claude/projects/*/*.jsonl`, joins `frame-link` publish records with Artifact `tool_use` metadata (description, favicon), dedupes by hosted `claude.ai` URL across sessions and republishes, caches per-transcript parses by `(mtime, size)`, and recomputes `exists` on each request (skips stat on mount-backed paths).
> 
> **Frontend:** `ClaudePublished` loads the API, filters client-side, and renders cards that preview local `.html` via `/render` when the file still exists, otherwise fall back to the remote URL; a footer link always opens the published page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d24137d6d2065a1d1fc5c8951f4fe3dd36c8665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->