### PR TITLE
Rename sidebar bottom trigger from Preferences to Settings

### DIFF
--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -1,7 +1,7 @@
 // THE sidebar — one for the whole app, on every route. Replaces the old pair
 // (ShellSidebar app-switcher on shell routes, ExplorerSidebar on fs routes):
 // primary nav on top (Explorer / Build App / Inbox), the explorer's Recents
-// and Bookmarks below it, and a single Preferences trigger pinned to the
+// and Bookmarks below it, and a single Settings trigger pinned to the
 // bottom that opens a menu holding everything else (Showcase / Artifacts /
 // Config / App Basics for now, plus Templates / Mounts / AI Models /
 // Preferences).
@@ -127,7 +127,7 @@ interface PrefsMenuEntry {
   extra?: React.ReactNode;
 }
 
-// The bottom Preferences trigger + its pop-up menu. A NavItem-shaped row that
+// The bottom Settings trigger + its pop-up menu. A NavItem-shaped row that
 // opens a fixed-position menu growing UP from the row (the row sits on the
 // sidebar's bottom edge). Closes on outside pointerdown / Escape / navigation.
 function PreferencesMenu({
@@ -184,7 +184,7 @@ function PreferencesMenu({
           {PREFERENCES_ICON}
           {dot}
         </span>{" "}
-        Preferences
+        Settings
       </button>
       {pos && (
         <div


### PR DESCRIPTION
The bottom sidebar button opens a navigation menu (Showcase, Artifacts, Config, App Basics, Templates, Mounts, AI Models, Preferences), so labeling it "Preferences" was misleading. Renamed the trigger to "Settings"; the Preferences menu item and page keep their name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only label change in sidebar UI with no routing, logic, or API impact.
> 
> **Overview**
> Renames the **bottom sidebar control** in `GlobalSidebar` from **Preferences** to **Settings** so the label matches what it does: open a multi-destination menu (Showcase, Artifacts, Config, Templates, Mounts, AI Models, and a separate **Preferences** item), not the Preferences page alone.
> 
> Only user-visible copy and nearby comments change; menu entries, routes, icons, and `PreferencesMenu` behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af1acf891edc1194bf59beed159c6d9814c06201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->