### PR TITLE
Showcase cards open the cloned app's page, not its folder

### DIFF
--- a/frontend/src/apps/builder/CommunityGrid.tsx
+++ b/frontend/src/apps/builder/CommunityGrid.tsx
@@ -138,10 +138,10 @@ function basename(p: string): string {
 // -- open behavior ---------------------------------------------------------
 
 function hrefForCommunity(app: CommunityApp, cacheRoot: string | undefined): string {
-  // A cloned app opens its workspace folder in the explorer — same rule as a
-  // workspace card (appEntry.ts, D262: no app route, the listing is the
-  // destination).
-  if (app.installed && app.path) return urlForFsPath(app.path);
+  // A cloned app opens its PAGE, like every other app card (appEntry.ts, D269) —
+  // and like the uncloned branch just below, which has always opened the
+  // catalog's index.html rather than the folder it sits in.
+  if (app.installed && app.path) return urlForFsPath(`${app.path}/index.html`);
   // Uncloned: the preview page from the catalog cache, in the explorer's own
   // view route. Best-effort for middle-click/new-tab — the folder may not be
   // materialized yet (the left-click path materializes it via `detail` first).
@@ -151,7 +151,7 @@ function hrefForCommunity(app: CommunityApp, cacheRoot: string | undefined): str
 async function openCommunityApp(app: CommunityApp, cacheRoot: string | undefined): Promise<void> {
   touch(app.slug);
   if (app.installed && app.path) {
-    navigate(app.path, { isDir: true });
+    navigate(`${app.path}/index.html`, { isDir: false });
     return;
   }
   // Materialize the app folder in the cache (sparse checkout) before loading


### PR DESCRIPTION
## Summary

- Clicking a **cloned** showcase card on the /apps page dropped you into the app's folder listing instead of its page. It now opens `<app>/index.html`.
- This was the last card on /apps still on the old rule: D269 ("a folder with a top-level `.html` IS that page, at every surface") reached the workspace grid in f9de829b, but never `CommunityGrid`, which has its own open path because the community payload carries no `entry` field to run `openTargetFor` against.
- The *uncloned* branch of the very same function already opened `<slug>/index.html` — so a showcase app changed destination the moment you cloned it. The two branches now agree.

## Visuals

```mermaid
flowchart TD
    A[Click showcase card] --> B{Cloned?}
    B -->|no| C[cache/slug/index.html]
    B -->|yes, before| D[Workspace folder listing]
    B -->|yes, after| E[app path/index.html]
```

Both the `href` and the click handler changed together, so middle-click and Cmd-click land where a plain click does.

## Usage

Not separately invocable. /apps → **showcase** tab → click a card marked cloned; it opens the app's page. The context menu's "Open in Explorer" still goes to the folder, unchanged.

## Test Plan

- [x] `bunx tsc --noEmit` clean.
- [ ] Clone a showcase app, then click its card in the showcase tab → lands on the app's page, not a listing.
- [ ] Middle-click / Cmd-click that card → same destination in a new tab.
- [ ] An uncloned showcase card still opens its catalog preview page (unchanged path).
- [ ] The same app's card in the workspace grid still opens its page (unchanged).
- [ ] Right-click → "Open in Explorer" still opens the folder listing.

Note: no automated test was added — this is a two-line destination change in a module with no existing test file, and it was made under an explicit "do it quick, no TDD" instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
