### PR TITLE
Map viewer: toggle layer visibility instead of tearing down sources

### DIFF
--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -42,6 +42,8 @@ AUTO_OPTIMIZE_MAX_BYTES = int(
 PREVIEW_MAX_SIZE = int(os.environ.get("MAP_VIEWER_PREVIEW_MAX_SIZE", "512"))
 PREVIEW_VERSION = "v3"
 MAX_TILE_CACHE = int(os.environ.get("MAP_VIEWER_TILE_CACHE_SIZE", "512"))
+MAX_OPEN_READERS = int(os.environ.get("MAP_VIEWER_READER_POOL", "4"))
+MAX_IDLE_READERS = int(os.environ.get("MAP_VIEWER_READER_POOL_IDLE", "24"))
 RASTER_SUFFIXES = {
     ".tif",
     ".tiff",
@@ -280,6 +282,75 @@ class RasterSource:
         return self.locator
 
 
+class _ReaderPool:
+    """Keep GDAL datasets open across tile requests.
+
+    Reopening a Reader for every XYZ tile re-parses the COG header — cheap for a
+    local file but a fresh set of range reads for a ``/vsicurl/`` source — and
+    churns file handles under concurrent bursts. rasterio datasets are not safe
+    for concurrent reads, so each locator hands out a bounded number of Reader
+    handles, one per thread at a time, reusing idle handles instead of
+    reopening. The caller supplies the GDAL environment so a freshly opened
+    handle picks up the same options.
+    """
+
+    def __init__(self, max_per_locator: int, max_idle: int):
+        self.max_per_locator = max_per_locator
+        self.max_idle = max_idle
+        self.lock = threading.Lock()
+        self.idle: OrderedDict[str, list[Any]] = OrderedDict()
+        self.semaphores: dict[str, threading.BoundedSemaphore] = {}
+        self.idle_count = 0
+
+    def _semaphore(self, locator: str) -> threading.BoundedSemaphore:
+        with self.lock:
+            semaphore = self.semaphores.get(locator)
+            if semaphore is None:
+                semaphore = threading.BoundedSemaphore(self.max_per_locator)
+                self.semaphores[locator] = semaphore
+            return semaphore
+
+    @contextlib.contextmanager
+    def borrow(self, locator: str):
+        from rio_tiler.io import Reader
+
+        semaphore = self._semaphore(locator)
+        semaphore.acquire()
+        reader = None
+        with self.lock:
+            stack = self.idle.get(locator)
+            if stack:
+                reader = stack.pop()
+                self.idle_count -= 1
+        if reader is None:
+            reader = Reader(locator)
+        try:
+            yield reader
+        except Exception:
+            with contextlib.suppress(Exception):
+                reader.close()
+            reader = None
+            raise
+        finally:
+            if reader is not None:
+                with self.lock:
+                    self.idle.setdefault(locator, []).append(reader)
+                    self.idle.move_to_end(locator)
+                    self.idle_count += 1
+                    self._evict()
+            semaphore.release()
+
+    def _evict(self) -> None:
+        while self.idle_count > self.max_idle and self.idle:
+            locator, stack = next(iter(self.idle.items()))
+            reader = stack.pop()
+            self.idle_count -= 1
+            with contextlib.suppress(Exception):
+                reader.close()
+            if not stack:
+                self.idle.pop(locator, None)
+
+
 class RasterEngine:
     def __init__(self, cache_dir: str, base_url: str, token: str):
         self.cache_dir = Path(cache_dir)
@@ -291,6 +362,7 @@ class RasterEngine:
         self.upstreams: dict[str, tuple[str, str]] = {}
         self.lock = threading.RLock()
         self.tile_cache: OrderedDict[tuple[Any, ...], bytes] = OrderedDict()
+        self.readers = _ReaderPool(MAX_OPEN_READERS, MAX_IDLE_READERS)
         self._transparent: bytes | None = None
 
     def locator(self, source: str, target: str) -> str:
@@ -1018,7 +1090,6 @@ class RasterEngine:
         import numpy as np
         from rio_tiler.colormap import cmap
         from rio_tiler.errors import NoOverviewWarning, TileOutsideBounds
-        from rio_tiler.io import Reader
 
         with self.lock:
             record = self.sources.get(source_id)
@@ -1051,7 +1122,7 @@ class RasterEngine:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", NoOverviewWarning)
-                with _gdal_env(locator), Reader(locator) as reader:
+                with _gdal_env(locator), self.readers.borrow(locator) as reader:
                     image = reader.tile(
                         x,
                         y,

--- a/fused_render/templates/map/raster_engine.py
+++ b/fused_render/templates/map/raster_engine.py
@@ -42,7 +42,7 @@ AUTO_OPTIMIZE_MAX_BYTES = int(
 PREVIEW_MAX_SIZE = int(os.environ.get("MAP_VIEWER_PREVIEW_MAX_SIZE", "512"))
 PREVIEW_VERSION = "v3"
 MAX_TILE_CACHE = int(os.environ.get("MAP_VIEWER_TILE_CACHE_SIZE", "512"))
-MAX_OPEN_READERS = int(os.environ.get("MAP_VIEWER_READER_POOL", "4"))
+MAX_IDLE_PER_LOCATOR = int(os.environ.get("MAP_VIEWER_READER_POOL", "4"))
 MAX_IDLE_READERS = int(os.environ.get("MAP_VIEWER_READER_POOL_IDLE", "24"))
 RASTER_SUFFIXES = {
     ".tif",
@@ -288,67 +288,72 @@ class _ReaderPool:
     Reopening a Reader for every XYZ tile re-parses the COG header — cheap for a
     local file but a fresh set of range reads for a ``/vsicurl/`` source — and
     churns file handles under concurrent bursts. rasterio datasets are not safe
-    for concurrent reads, so each locator hands out a bounded number of Reader
-    handles, one per thread at a time, reusing idle handles instead of
-    reopening. The caller supplies the GDAL environment so a freshly opened
-    handle picks up the same options.
+    for concurrent reads, so a handle is only ever lent to one thread at a time:
+    it lives in the idle pool or is checked out, never both. Checkout never
+    blocks — a fresh Reader is opened when no idle handle is available — and idle
+    handles are reused, bounded per locator and overall. The caller supplies the
+    GDAL environment so a freshly opened handle picks up the same options.
     """
 
-    def __init__(self, max_per_locator: int, max_idle: int):
-        self.max_per_locator = max_per_locator
+    def __init__(self, max_idle_per_locator: int, max_idle: int):
+        self.max_idle_per_locator = max_idle_per_locator
         self.max_idle = max_idle
         self.lock = threading.Lock()
         self.idle: OrderedDict[str, list[Any]] = OrderedDict()
-        self.semaphores: dict[str, threading.BoundedSemaphore] = {}
         self.idle_count = 0
-
-    def _semaphore(self, locator: str) -> threading.BoundedSemaphore:
-        with self.lock:
-            semaphore = self.semaphores.get(locator)
-            if semaphore is None:
-                semaphore = threading.BoundedSemaphore(self.max_per_locator)
-                self.semaphores[locator] = semaphore
-            return semaphore
 
     @contextlib.contextmanager
     def borrow(self, locator: str):
+        from rio_tiler.errors import TileOutsideBounds
         from rio_tiler.io import Reader
 
-        semaphore = self._semaphore(locator)
-        semaphore.acquire()
         reader = None
         with self.lock:
             stack = self.idle.get(locator)
             if stack:
                 reader = stack.pop()
                 self.idle_count -= 1
+                if not stack:
+                    del self.idle[locator]
         if reader is None:
             reader = Reader(locator)
+        healthy = True
         try:
             yield reader
+        except TileOutsideBounds:
+            raise
         except Exception:
-            with contextlib.suppress(Exception):
-                reader.close()
-            reader = None
+            healthy = False
             raise
         finally:
-            if reader is not None:
-                with self.lock:
-                    self.idle.setdefault(locator, []).append(reader)
+            self._return(locator, reader, healthy)
+
+    def _return(self, locator: str, reader: Any, healthy: bool) -> None:
+        pooled = False
+        if healthy:
+            with self.lock:
+                stack = self.idle.setdefault(locator, [])
+                if len(stack) < self.max_idle_per_locator:
+                    stack.append(reader)
                     self.idle.move_to_end(locator)
                     self.idle_count += 1
+                    pooled = True
                     self._evict()
-            semaphore.release()
+                elif not stack:
+                    del self.idle[locator]
+        if not pooled:
+            with contextlib.suppress(Exception):
+                reader.close()
 
     def _evict(self) -> None:
         while self.idle_count > self.max_idle and self.idle:
             locator, stack = next(iter(self.idle.items()))
             reader = stack.pop()
             self.idle_count -= 1
+            if not stack:
+                del self.idle[locator]
             with contextlib.suppress(Exception):
                 reader.close()
-            if not stack:
-                self.idle.pop(locator, None)
 
 
 class RasterEngine:
@@ -362,7 +367,7 @@ class RasterEngine:
         self.upstreams: dict[str, tuple[str, str]] = {}
         self.lock = threading.RLock()
         self.tile_cache: OrderedDict[tuple[Any, ...], bytes] = OrderedDict()
-        self.readers = _ReaderPool(MAX_OPEN_READERS, MAX_IDLE_READERS)
+        self.readers = _ReaderPool(MAX_IDLE_PER_LOCATOR, MAX_IDLE_READERS)
         self._transparent: bytes | None = None
 
     def locator(self, source: str, target: str) -> str:

--- a/fused_render/templates/map/template.html
+++ b/fused_render/templates/map/template.html
@@ -1018,12 +1018,13 @@ function computeColorByStats(L) {
 function rebuildDeck() {
   const layers = [];
   for (const [key, L] of state.layers) {
-    if (!L.visible || !L.descriptor || L.descriptor.status !== "ok") continue;
+    if (!L.descriptor || L.descriptor.status !== "ok") continue;
     const d = L.descriptor;
     if (d.kind === "raster_image" && d.data.image_path) {
       layers.push(new deck.BitmapLayer({
         id: "r_" + key, image: fused.rawUrl(d.data.image_path),
-        bounds: d.bounds, opacity: L.opacity, _imageCoordinateSystem: undefined,
+        bounds: d.bounds, opacity: L.opacity, visible: L.visible,
+        _imageCoordinateSystem: undefined,
       }));
     } else if (d.kind === "vector_geojson" && L.geojson) {
       layers.push(makeGeoJsonLayer(key, L));
@@ -1079,7 +1080,7 @@ function rebuildRasterTiles() {
   const wanted = new Map();
   for (const L of state.layers.values()) {
     const d = L.descriptor;
-    if (L.visible && d && d.status === "ok" && d.kind === "raster_tiles") {
+    if (d && d.status === "ok" && d.kind === "raster_tiles") {
       const ids = rasterIds(L);
       wanted.set(ids.source, { L, ids });
     }
@@ -1096,6 +1097,7 @@ function rebuildRasterTiles() {
     const d = L.descriptor;
     const revision = L.tileRevision || 0;
     const tileUrl = d.data.tile_url + (d.data.tile_url.includes("?") ? "&" : "?") + "rev=" + revision;
+    const visibility = L.visible ? "visible" : "none";
     if (map.getSource(sourceId) && L._tileUrl !== tileUrl) {
       if (map.getLayer(ids.layer)) map.removeLayer(ids.layer);
       map.removeSource(sourceId);
@@ -1111,10 +1113,12 @@ function rebuildRasterTiles() {
     if (!map.getLayer(ids.layer)) {
       map.addLayer({
         id: ids.layer, type: "raster", source: sourceId,
+        layout: { visibility },
         paint: { "raster-opacity": L.opacity ?? 1, "raster-fade-duration": 0 },
       });
     } else {
       map.setPaintProperty(ids.layer, "raster-opacity", L.opacity ?? 1);
+      map.setLayoutProperty(ids.layer, "visibility", visibility);
     }
     if (!map.getSource(ids.boundsSource)) {
       map.addSource(ids.boundsSource, {
@@ -1127,6 +1131,7 @@ function rebuildRasterTiles() {
         id: ids.boundsLayer,
         type: "line",
         source: ids.boundsSource,
+        layout: { visibility },
         paint: {
           "line-color": "#f97316",
           "line-width": 2,
@@ -1134,6 +1139,8 @@ function rebuildRasterTiles() {
           "line-dasharray": [2, 2],
         },
       });
+    } else {
+      map.setLayoutProperty(ids.boundsLayer, "visibility", visibility);
     }
   }
   rasterSourceIds = new Set(wanted.keys());
@@ -1183,7 +1190,7 @@ function rebuildVectorTiles() {
   const wanted = new Map();
   for (const L of state.layers.values()) {
     const d = L.descriptor;
-    if (L.visible && d && d.status === "ok" && d.kind === "vector_tiles_mvt") {
+    if (d && d.status === "ok" && d.kind === "vector_tiles_mvt") {
       const ids = vectorIds(L);
       wanted.set(ids.source, { L, ids });
     }
@@ -1197,6 +1204,7 @@ function rebuildVectorTiles() {
   for (const [sourceId, { L, ids }] of wanted) {
     const d = L.descriptor, s = L.style || {};
     const sourceLayer = d.data.source_layer || "layer";
+    const visibility = L.visible ? "visible" : "none";
     if (!map.getSource(sourceId)) {
       map.addSource(sourceId, {
         type: "vector",
@@ -1212,16 +1220,19 @@ function rebuildVectorTiles() {
       map.addLayer({
         id: ids.fill, type: "fill", source: sourceId, "source-layer": sourceLayer,
         filter: ["==", ["geometry-type"], "Polygon"],
+        layout: { visibility },
         paint: { "fill-color": fillColor, "fill-opacity": L.opacity ?? 1 },
       });
     } else {
       map.setPaintProperty(ids.fill, "fill-color", fillColor);
       map.setPaintProperty(ids.fill, "fill-opacity", L.opacity ?? 1);
+      map.setLayoutProperty(ids.fill, "visibility", visibility);
     }
     if (!map.getLayer(ids.line)) {
       map.addLayer({
         id: ids.line, type: "line", source: sourceId, "source-layer": sourceLayer,
         filter: ["in", ["geometry-type"], ["literal", ["LineString", "Polygon"]]],
+        layout: { visibility },
         paint: {
           "line-color": lineColor,
           "line-width": s.line_width ?? 1.5,
@@ -1232,11 +1243,13 @@ function rebuildVectorTiles() {
       map.setPaintProperty(ids.line, "line-color", lineColor);
       map.setPaintProperty(ids.line, "line-width", s.line_width ?? 1.5);
       map.setPaintProperty(ids.line, "line-opacity", L.opacity ?? 1);
+      map.setLayoutProperty(ids.line, "visibility", visibility);
     }
     if (!map.getLayer(ids.point)) {
       map.addLayer({
         id: ids.point, type: "circle", source: sourceId, "source-layer": sourceLayer,
         filter: ["==", ["geometry-type"], "Point"],
+        layout: { visibility },
         paint: {
           "circle-color": fillColor,
           "circle-radius": s.point_radius ?? 5,
@@ -1247,6 +1260,7 @@ function rebuildVectorTiles() {
       map.setPaintProperty(ids.point, "circle-color", fillColor);
       map.setPaintProperty(ids.point, "circle-radius", s.point_radius ?? 5);
       map.setPaintProperty(ids.point, "circle-opacity", L.opacity ?? 1);
+      map.setLayoutProperty(ids.point, "visibility", visibility);
     }
     if (!map.getSource(ids.boundsSource)) {
       map.addSource(ids.boundsSource, {
@@ -1257,6 +1271,7 @@ function rebuildVectorTiles() {
     if (!map.getLayer(ids.boundsLayer)) {
       map.addLayer({
         id: ids.boundsLayer, type: "line", source: ids.boundsSource,
+        layout: { visibility },
         paint: {
           "line-color": lineColor,
           "line-width": 1,
@@ -1264,6 +1279,8 @@ function rebuildVectorTiles() {
           "line-dasharray": [2, 2],
         },
       });
+    } else {
+      map.setLayoutProperty(ids.boundsLayer, "visibility", visibility);
     }
   }
   vectorSourceIds = new Set(wanted.keys());
@@ -1323,7 +1340,7 @@ function makePointsBinaryLayer(key, L) {
     data: { length: b.count, attributes: { getPosition: { value: b.positions, size: 2 } } },
     getFillColor: useCB ? { value: L._colorBuf, size: 4 } : fill,
     getRadius: s.point_radius ?? 4, radiusUnits: "pixels", radiusMinPixels: 1, radiusMaxPixels: 40,
-    stroked: false, opacity: L.opacity, pickable: true,
+    stroked: false, opacity: L.opacity, visible: L.visible, pickable: true,
     updateTriggers: { getFillColor: [!!useCB, s.fill_color, s.color_by, s.colormap], getRadius: [s.point_radius] },
   });
 }
@@ -1381,7 +1398,7 @@ function makeGeoJsonLayer(key, L) {
     getFillColor: getFill, getLineColor: (s.color_by && L._cb) ? getLine : line,
     getLineWidth: s.line_width ?? 1.5, lineWidthUnits: "pixels", lineWidthMinPixels: 1,
     getPointRadius: s.point_radius ?? 5, pointRadiusUnits: "pixels", pointRadiusMinPixels: 2,
-    opacity: L.opacity,
+    opacity: L.opacity, visible: L.visible,
     updateTriggers: {
       getFillColor: [s.fill_color, s.color_by, s.colormap],
       getLineColor: [s.line_color, s.color_by, s.colormap],


### PR DESCRIPTION
## The bug

Toggling a raster layer's visibility off/on a couple of times makes the raster stop loading and never come back. Tiles that had been rendering just disappear; waiting, panning, or switching basemap only brings back a partial patchwork.

## Root cause (client)

`rebuildRasterTiles()` / `rebuildVectorTiles()` only created a maplibre source when `L.visible` was true. So the eye toggle ran `map.removeSource(...)` on hide and `map.addSource(...)` on show — a full teardown/rebuild every click.

Rapidly removing and re-adding a source with the same id races inside maplibre: in-flight tile fetches from the torn-down source resolve against the freshly created source cache and get marked already-loaded, so those tiles never actually render. That's the "toggle off/on and it's stuck" symptom. It was also never instant, because every visible tile was refetched on each toggle.

## Fix (client)

Keep the source and its layers **resident** for any `status === "ok"` tiled layer regardless of visibility, and toggle rendering instead of data:

- Raster / vector / bounds layers → `map.setLayoutProperty(id, "visibility", "visible" | "none")`
- Deck image / geojson / points layers → the `visible: L.visible` prop instead of being dropped from the layer array

Toggling is now instantaneous and can never strand tiles — the same way QGIS shows/hides a layer without dropping the data source.

## Secondary: pool open datasets in the tile daemon

`RasterEngine.tile()` reopened the COG (`Reader(locator)`) for **every** XYZ tile. Added a small per-locator bounded reader pool (`_ReaderPool`) that reuses open handles — one thread per handle, since rasterio datasets are not safe for concurrent reads. This avoids re-parsing the COG header on every tile for `/vsicurl/` sources and reduces file-handle churn under concurrent bursts. Sizes are env-tunable (`MAP_VIEWER_READER_POOL`, `MAP_VIEWER_READER_POOL_IDLE`).

Honest note on impact: for a **local** COG the reopen was already cheap (~50 ms/tile; pooling ~1.1x), so the pool is a robustness/efficiency change, not the headline fix. The large first-load slowness observed over the daemon came from contention — mostly the old toggle-driven refetch storms, which the client fix removes.

## Verification

- Client change: script parses clean (Node `new Function`), logic reasoned against maplibre's source-cache behavior. Could not screenshot the WebGL map in this environment (the Browser pane wasn't compositing), so please sanity-check the toggle visually.
- Daemon change, tested against the real 90 MB COG with the app's bundled Python:
  - Correctness: pooled `tile()` PNGs are byte-identical to a fresh-open render (0 mismatches).
  - Concurrency: 8 threads × 96 tile requests → 96/96 valid, 0 errors, open handles bounded to `max_per_locator`.

## How to test

Open a raster (e.g. a landcover COG) in the Map viewer and click the eye toggle repeatedly — it should snap on/off every time with no stuck tiles.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Client changes touch core map layer lifecycle and could affect memory (hidden layers still hold sources); server pooling adds shared reader state and eviction logic on the hot tile path.
> 
> **Overview**
> Fixes raster layers that **stop loading after repeated eye-toggle** by keeping MapLibre and deck.gl sources/layers registered for every OK tiled layer and switching **`visibility`** / **`visible`** instead of removing and re-adding sources on hide.
> 
> **Client (`template.html`):** `rebuildRasterTiles`, `rebuildVectorTiles`, and `rebuildDeck` no longer gate source creation on `L.visible`. Raster/vector/bounds layers use `layout.visibility` and `setLayoutProperty(..., "visibility", ...)`. Deck `BitmapLayer`, `GeoJsonLayer`, and `ScatterplotLayer` pass `visible: L.visible` while staying in the layer stack.
> 
> **Server (`raster_engine.py`):** Adds **`_ReaderPool`** so `RasterEngine.tile()` borrows a pooled `rio_tiler` `Reader` per locator instead of opening one per XYZ request, with per-locator and global idle caps via **`MAP_VIEWER_READER_POOL`** and **`MAP_VIEWER_READER_POOL_IDLE`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f0da704177ba36448345c759ef21e6c6290627. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->