### PR TITLE
Rename sidebar menu entry from Config to Claude Config

### DIFF
--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -236,7 +236,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   // pages. Same gates as before — an entry a machine can't use stays hidden.
   const menuEntries: (PrefsMenuEntry | "separator")[] = [
     ...(claudeConfigAvailable
-      ? [{ href: "/claude-config", label: "Config", icon: CLAUDE_CONFIG_ICON }]
+      ? [{ href: "/claude-config", label: "Claude Config", icon: CLAUDE_CONFIG_ICON }]
       : []),
     ...(learnMountReady ? [{ href: "/learn", label: "App Basics", icon: <LearnIcon /> }] : []),
   ];


### PR DESCRIPTION
The bottom-menu entry for the Claude Config panel was labeled just "Config", which is ambiguous next to Preferences/Settings. Renames it to "Claude Config" to match the panel's page title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 68be0434ea9dc87fa81016131f69088bc34b51db. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->