### PR TITLE
Rename Move to Bin to Delete, sticky Bookmarks heading, remove engine prefs

### DIFF
--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -270,7 +270,7 @@ function usePreviewFileMenu(
       } else if (r.status === "unsupported") {
         startDelete();
       } else {
-        pushToast({ msg: friendlyFsError(r.message, { verb: "move to Bin", name: stat.name }), tone: "error" });
+        pushToast({ msg: friendlyFsError(r.message, { verb: "delete", name: stat.name }), tone: "error" });
       }
     });
   };
@@ -330,7 +330,7 @@ function usePreviewFileMenu(
   const buildMenu = (): MenuEntry[] => [
     { label: "Open With", icon: MenuIcons.openWith, submenu: loadOpenWith },
     "separator",
-    { label: "Move to Bin", icon: MenuIcons.trash, onClick: doTrash },
+    { label: "Delete", icon: MenuIcons.trash, onClick: doTrash },
     "separator",
     { label: "Rename…", icon: MenuIcons.rename, onClick: startRename },
     { label: "Duplicate", icon: MenuIcons.duplicate, onClick: doDuplicate },

--- a/frontend/src/apps/explorer/lib/fs-actions.ts
+++ b/frontend/src/apps/explorer/lib/fs-actions.ts
@@ -286,7 +286,7 @@ export function friendlyFsError(err: unknown, ctx: { verb: string; name: string 
   return `Couldn't ${verb} "${name}". ${raw}`;
 }
 
-// Outcome of a Move to Bin attempt. "unsupported" is the non-macOS 501 case
+// Outcome of a Delete (trash) attempt. "unsupported" is the non-macOS 501 case
 // where the caller should fall back to a hard-delete confirm; "error" is any
 // other failure (surface it as a toast).
 export type TrashOutcome =
@@ -294,7 +294,7 @@ export type TrashOutcome =
   | { status: "unsupported" }
   | { status: "error"; message: string };
 
-// Move to Bin: a recoverable delete (macOS Trash). Where the server can't trash
+// Delete: a recoverable delete (moves to the macOS Trash). Where the server can't trash
 // (non-macOS → 501 "trash unsupported") this reports "unsupported" so the
 // caller can fall back to the irreversible confirm-then-hard-delete flow.
 export async function trashEntry(path: string, isDir: boolean): Promise<TrashOutcome> {

--- a/frontend/src/apps/explorer/lib/fs-actions.ts
+++ b/frontend/src/apps/explorer/lib/fs-actions.ts
@@ -280,7 +280,7 @@ export function friendlyFsError(err: unknown, ctx: { verb: string; name: string 
   // Trash move failed after we'd already committed to the recoverable path —
   // reassure that nothing was hard-deleted.
   if (msg.includes("cannot move to trash"))
-    return `Couldn't move "${name}" to the Bin. Nothing was deleted.`;
+    return `Couldn't delete "${name}". It's still in place — nothing was removed.`;
 
   // Network / unknown: keep the original message so it isn't hidden.
   return `Couldn't ${verb} "${name}". ${raw}`;

--- a/frontend/src/apps/explorer/lib/recents.ts
+++ b/frontend/src/apps/explorer/lib/recents.ts
@@ -93,7 +93,7 @@ export function displayRecents(): RecentEntry[] {
   return slotPaths.flatMap((p) => byPath.get(p) ?? []);
 }
 
-// Drop the rows for a path the user just DELETED (or moved to the Bin), and for
+// Drop the rows for a path the user just DELETED (trashed or hard-deleted), and for
 // everything inside it when that path was a folder — the same prefix + "/"
 // containment test `clearClipboardIfDeleted` uses.
 //

--- a/frontend/src/apps/explorer/listing/useFileOps.ts
+++ b/frontend/src/apps/explorer/listing/useFileOps.ts
@@ -522,7 +522,7 @@ export function useFileOps({
     });
   };
 
-  // Move to Bin: a recoverable delete (macOS Trash), so no confirm dialog.
+  // Delete: a recoverable delete (moves to the macOS Trash), so no confirm dialog.
   // Acts on every row passed in (the whole selection). Where the server can't
   // trash (non-macOS → "unsupported") those rows fall back to the existing
   // confirm-then-hard-delete flow, which IS irreversible and so keeps its
@@ -531,7 +531,7 @@ export function useFileOps({
     // As in startDelete: trashing a folder takes everything inside it, so a
     // selection that also holds rows from within that folder must not trash them
     // individually — the second call would hit a vanished path and be counted as
-    // a real failure, replacing the "Moved to Bin" toast with a bogus error.
+    // a real failure, replacing the "Deleted" toast with a bogus error.
     const rows = pruneDescendantRows(allRows);
     if (!rows.length) return;
     void (async () => {
@@ -551,7 +551,7 @@ export function useFileOps({
       }
       if (trashed.length) {
         pushToast({
-          msg: trashed.length === 1 ? "Moved to Bin" : `Moved ${trashed.length} items to Bin`,
+          msg: trashed.length === 1 ? "Deleted" : `Deleted ${trashed.length} items`,
           tone: "info",
         });
         refetch();
@@ -563,7 +563,7 @@ export function useFileOps({
       // nothing errored.
       if (failed !== null) {
         pushToast({
-          msg: friendlyFsError(failed.message, { verb: "move to Bin", name: failed.row.name }),
+          msg: friendlyFsError(failed.message, { verb: "delete", name: failed.row.name }),
           tone: "error",
         });
       } else if (unsupported.length) {
@@ -597,7 +597,7 @@ export function useFileOps({
     const n = rows.length;
     if (n > 1) {
       return [
-        { label: `Move ${n} items to Bin`, icon: MenuIcons.trash, onClick: () => doTrash(rows) },
+        { label: `Delete ${n} items`, icon: MenuIcons.trash, onClick: () => doTrash(rows) },
         "separator",
         { label: `Duplicate ${n} items`, icon: MenuIcons.duplicate, onClick: () => doDuplicate(rows) },
         "separator",
@@ -624,7 +624,7 @@ export function useFileOps({
       { label: "Open", icon: MenuIcons.open, onClick: () => navigate(row.path, { isDir: row.isDir }) },
       { label: "Open With", icon: MenuIcons.openWith, submenu: loadOpenWith(row.path) },
       "separator",
-      { label: "Move to Bin", icon: MenuIcons.trash, onClick: () => doTrash([row]) },
+      { label: "Delete", icon: MenuIcons.trash, onClick: () => doTrash([row]) },
       "separator",
       { label: "Rename…", icon: MenuIcons.rename, onClick: () => startRename(row) },
       { label: "Duplicate", icon: MenuIcons.duplicate, onClick: () => doDuplicate([row]) },

--- a/frontend/src/platform/ui/MenuIcons.tsx
+++ b/frontend/src/platform/ui/MenuIcons.tsx
@@ -48,7 +48,7 @@ export const MenuIcons: Record<string, ReactNode> = {
       <path d="M4 8V6a2 2 0 0 1 2-2h3l2 2h7a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V8z" />
     </svg>
   ),
-  // Move to Bin — trash can with lid + two ribs.
+  // Delete — trash can with lid + two ribs.
   trash: (
     <svg {...svgProps}>
       <path d="M4 7h16" />

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -247,10 +247,11 @@ export default function GlobalSidebar({ config }: { config: Config }) {
     />
   ) : undefined;
 
-  // The Explorer row is "home" to every fs route: the homepage, any
-  // /explorer/view|embed path (files, panel, tabs, bookmark sentinels).
+  // Only the Explorer HOMEPAGE lights the row. Viewing a file
+  // (/explorer/view|embed/...) is "being somewhere", not "being on Explorer" —
+  // highlighting both the row and the thing you opened read as two selections.
   const pathname = location.pathname;
-  const explorerActive = pathname === "/explorer" || pathname.startsWith("/explorer/");
+  const explorerActive = pathname === "/explorer";
 
   // Everything that is not primary nav lives in the bottom menu for now:
   // the former sidebar entries (Showcase / Artifacts / Config / App Basics),

--- a/frontend/src/shell/Preferences.tsx
+++ b/frontend/src/shell/Preferences.tsx
@@ -4,7 +4,7 @@
 //     chat and fused.ai reach for when nothing else has said), Call log
 //     (capture/redaction/retention for
 //     fused_render/calls.py), Deploy to Fused account (the opt-in Deploy-button
-//     toggle), Accessibility, and last Execution engine. Always present; the
+//     toggle), and Accessibility. Always present; the
 //     default (clean URL). No Tour button — the tour still runs itself on a
 //     first visit (App.tsx's maybeAutoStartTour); it is onboarding, not a
 //     preference. The app's OWN log is not here either: it is disposable
@@ -30,7 +30,6 @@ import {
   putCallsRetentionDays,
   putDefaultModel,
   putDeployEnabled,
-  putEnginePref,
   putReaderEnabled,
 } from "@platform/lib/api";
 import type { CallsParamsMode, Prefs } from "@platform/lib/api";
@@ -93,97 +92,6 @@ function AppearanceSection() {
           <b>Dark</b> — always dark, whatever your desktop is set to.
         </span>
       </label>
-    </section>
-  );
-}
-
-function EngineSection({ prefs, onChange }: { prefs: Prefs; onChange: (p: Prefs) => void }) {
-  const [busy, setBusy] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const engine = prefs.engine;
-  const locked = engine.forced_by !== null;
-
-  const select = async (value: "builtin" | "fused") => {
-    if (busy || value === engine.selected) return;
-    setBusy(true);
-    setError(null);
-    try {
-      onChange(await putEnginePref(value));
-    } catch (e) {
-      setError((e as Error).message);
-    } finally {
-      setBusy(false);
-    }
-  };
-
-  return (
-    <section className="prefs-section">
-      <h2>Execution engine</h2>
-      <p className="deploy-muted">
-        How <code>fused.runPython</code> runs a page's Python. <b>Both engines run on this
-        machine</b> — neither uses your configured Fused environments (those are only deploy
-        targets, chosen in a page's Deploy dialog). Changes apply to the next run — no restart
-        needed. With nothing chosen here the <b>Fused engine</b> is used when its package is
-        importable, and Local otherwise (D204).
-      </p>
-      <label className={"prefs-radio" + (locked ? " locked" : "")}>
-        <input
-          type="radio"
-          name="engine"
-          checked={engine.selected === "builtin"}
-          disabled={locked || busy}
-          onChange={() => select("builtin")}
-        />
-        <span>
-          <b>Local (built-in)</b> — a fresh subprocess per call, in the environment that
-          launched this server.
-        </span>
-      </label>
-      {/* Since D204 an unset pref reports `selected: "fused"`, so on a machine
-          without the package this radio renders CHECKED and disabled — the common
-          case now, not an edge one. It is not left unexplained: the inline
-          "(unavailable…)" span below, the title, and the "Currently running: Local
-          (built-in) — falling back…" line together say what is running and why,
-          and the Local radio stays live so the choice can still be pinned. */}
-      <label
-        className={"prefs-radio" + (locked || !engine.fused_available ? " locked" : "")}
-        title={
-          engine.fused_available
-            ? undefined
-            : "The fused package is not importable in the server's environment — install it from a page's Deploy dialog, or pip install \"fused-render[fused]\""
-        }
-      >
-        <input
-          type="radio"
-          name="engine"
-          checked={engine.selected === "fused"}
-          disabled={locked || busy || !engine.fused_available}
-          onChange={() => select("fused")}
-        />
-        <span>
-          <b>Fused engine (default)</b> — the fused package's local runner: a folder's{" "}
-          <code>pyproject.toml</code> dependencies resolved into cached venvs
-          (<code>~/.fused-render/venvs</code>), plus{" "}
-          <code>@fused.udf</code> / <code>result</code> entrypoints.
-          {!engine.fused_available && (
-            <span className="deploy-muted"> (unavailable — the fused package isn't installed)</span>
-          )}
-        </span>
-      </label>
-      <div className="deploy-muted">
-        Currently running: <b>{engine.effective === "fused" ? "Fused engine" : "Local (built-in)"}</b>
-        {locked && (
-          <>
-            {" "}
-            — locked by <code>FUSED_RENDER_ENGINE={engine.forced_by}</code> for this process; the
-            switch applies once the variable is removed.
-          </>
-        )}
-        {!locked && engine.selected === "fused" && engine.effective === "builtin" && (
-          <> — falling back to Local while the fused package is unavailable.</>
-        )}
-      </div>
-      {error && <ErrorBanner>{error}</ErrorBanner>}
     </section>
   );
 }
@@ -573,11 +481,6 @@ export default function Preferences() {
                   onOpenAccount={() => setTab("account")}
                 />
                 <AccessibilitySection prefs={prefs} onChange={setPrefs} />
-                {/* Last: the engine is the setting a user is least likely to
-                    come here to change (builtin is right for almost everyone,
-                    and an env var pins it in the cases that matter), so it does
-                    not deserve the position above the ones they do. */}
-                <EngineSection prefs={prefs} onChange={setPrefs} />
               </>
             )}
             {tab === "indexing" && <IndexingPanel />}

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -299,6 +299,25 @@ button.sidebar-prefs-trigger {
   gap: 1px;
 }
 
+/* The section is its own scroll container, so the heading must pin itself or
+   it rides out of view with the rows. The section's 8px top padding moves INTO
+   the heading: sticky pins to the content box, so padding on the container is
+   an uncovered strip the rows would scroll through above the heading. The
+   box-shadow paints over the flex gap below the heading for the same reason. */
+.sidebar-bookmarks {
+  padding-top: 0;
+}
+.sidebar-bookmarks > .sidebar-heading {
+  position: sticky;
+  top: 0;
+  background: var(--bg-alt);
+  /* Above the rows' own stacking contexts (.bookmark-glyph/.bookmark-badge
+     are position:relative + z-index:1, and later in the DOM). */
+  z-index: 2;
+  padding-top: 18px;
+  box-shadow: 0 1px 0 var(--bg-alt);
+}
+
 .sidebar-empty {
   padding: 6px 10px;
   color: var(--fg-muted);


### PR DESCRIPTION
## Changes

- **"Move to Bin" → "Delete"** across the platform: listing row menu, multi-select (`Delete N items`), Preview file menu, and toasts (`Deleted` / `Deleted N items`). Behavior unchanged — still a recoverable move to the macOS Trash, with the existing confirm-then-hard-delete fallback where trashing is unsupported.
- **Bookmarks heading stays pinned** while the bookmark list scrolls. The section is its own scroll container, so the heading is now `position: sticky`; the section's top padding moved into the heading (sticky pins to the content box, so container padding was an uncovered strip rows scrolled through), and the heading sits above the glyph/badge stacking contexts (`z-index: 2`).
- **Removed the Execution engine section** from Preferences (component + render slot + unused import).
- **Sidebar Explorer row highlights only on the `/explorer` homepage** — opening a file (`/explorer/view/...`, e.g. via Recents) no longer lights the Explorer row at the same time.

## Verification

- Playwright against the live dev server: context menu shows "Delete", prefs page has no engine section, heading computed sticky and rows never paint above it after scrolling, Explorer row inactive on file views / active on `/explorer`.
- `npm run build` (check-boundaries + tsc + vite) green, `bun test` 847 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly copy and CSS; removing the engine prefs UI is a product change but does not alter runtime engine selection via env or API.
> 
> **Overview**
> User-facing **delete** wording replaces **Move to Bin** in listing menus, Preview, batch actions, success toasts, and `friendlyFsError` messages. Trash behavior is unchanged: recoverable macOS Trash with the same hard-delete fallback when trashing is unsupported.
> 
> The **Bookmarks** section heading is **sticky** inside the scrollable bookmark list (padding and `z-index` adjusted so rows do not scroll over the title).
> 
> **Preferences** no longer shows the **Execution engine** section (`EngineSection` removed from the UI; backend prefs API is untouched).
> 
> The sidebar **Explorer** nav item is **active only on** `/explorer`, not when viewing files under `/explorer/view` or embed routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12759526706a783b6c18e241317b8e16a8f5ed79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->