### PR TITLE
Refresh AI runtime state when returning to AI Models tab

### DIFF
--- a/frontend/src/shell/AiModels.tsx
+++ b/frontend/src/shell/AiModels.tsx
@@ -35,7 +35,7 @@ import {
   type AiLoadedModel,
   type AiModelsResult,
 } from "@platform/lib/api";
-import { useNavEpoch } from "@platform/lib/hooks";
+import { useNavEpoch, useRefreshOnReturn } from "@platform/lib/hooks";
 import { fetchJobs, type Job } from "@platform/lib/jobs";
 import { formatSize, formatMtimeFull, formatParams, timeAgo } from "@platform/lib/format";
 import { navigate, navigateUrl, urlForFsPath } from "@platform/lib/router";
@@ -556,6 +556,13 @@ export default function AiModels() {
   // one); the job rows are read here because only this page joins them onto
   // cards, and only while something is actually running.
   const runtime = useAiRuntime();
+  // Returning to this tab re-checks what's loaded RIGHT NOW rather than
+  // waiting out the idle poll's 10s (aiRuntime.ts) — the same "cheap state,
+  // re-read on return" posture as the deploy dot and account status
+  // (lib/hooks.ts). Deliberately narrower than the disk walk below: that scan
+  // is a filesystem crawl over every blob and stays gated on a KNOWN change
+  // (a delete or a finished download), never on a focus tick.
+  useRefreshOnReturn(refreshAiRuntime);
   const [jobs, setJobs] = useState<Job[]>([]);
   const [runtimeError, setRuntimeError] = useState<string | null>(null);
   // Per-target refusals from the last delete (a symlinked repo, a row that was


### PR DESCRIPTION
## Summary
Added automatic refresh of AI runtime state when the user returns to the AI Models tab, ensuring the UI reflects the current state of loaded models without waiting for the idle polling interval.

## Changes
- Imported `useRefreshOnReturn` hook from `@platform/lib/hooks`
- Added `useRefreshOnReturn(refreshAiRuntime)` call in the `AiModels` component to trigger a refresh when the tab regains focus

## Implementation Details
The refresh on return is intentionally scoped narrowly to just the AI runtime state check. This follows the same pattern used elsewhere in the codebase (deploy dot, account status) for "cheap state, re-read on return" behavior. Unlike the broader filesystem walk that scans every blob and is gated on known changes (deletes, finished downloads), this refresh simply re-checks what models are currently loaded without waiting for the 10-second idle polling interval defined in `aiRuntime.ts`.

https://claude.ai/code/session_01HLw7bmYWhCsYEKFXuJsQWv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only freshness hook on an existing refresh function; no auth, data, or API contract changes.
> 
> **Overview**
> When users return to the **AI Models** page, loaded-model state now refreshes immediately instead of waiting on the shared runtime poll (~10s).
> 
> The page wires **`useRefreshOnReturn(refreshAiRuntime)`**, matching the existing “cheap state, re-read on return” pattern used for deploy status and account info. The heavy Hugging Face cache disk walk is unchanged—it still runs only when the disk is known to have changed (deletes, finished downloads), not on every focus event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1417851f60361a3dd5ae306ad6b141f8d88aa7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->