### PR TITLE
pano viewer: manual Apply-changes workflow, string-param fix, faster open

### DIFF
--- a/fused_render/templates/pano/pano.py
+++ b/fused_render/templates/pano/pano.py
@@ -29,6 +29,11 @@ CACHE_ROOT = os.path.expanduser(os.path.join("~", ".fused-render", "cache", "pan
 DISPLAY_MAX_W = 8192   # keep under common WebGL texture limits
 CONVERT_MAX_W = 4096   # resample source cap so conversions stay interactive
 
+# Formats a browser <img>/WebGL texture accepts as-is. When the source is one of
+# these, already within DISPLAY_MAX_W, and needs no EXIF rotation, the display
+# copy is skipped and the original file is served directly.
+BROWSER_FMTS = {"JPEG", "PNG", "WEBP", "GIF"}
+
 
 def _pil():
     try:
@@ -115,6 +120,13 @@ def _content_hash(path):
     return h.hexdigest()[:16]
 
 
+def _display_file(meta):
+    """Absolute path of the image to display: the cached copy, or the original
+    file itself when it was served as-is (passthrough, display=None)."""
+    return (os.path.join(meta["dir"], meta["display"]) if meta.get("display")
+            else meta["source"])
+
+
 def _prepare(file):
     """Classify the image and build its browser-displayable copy, cached by
     content hash. Returns the meta dict with 'dir' set to the cache folder."""
@@ -126,41 +138,52 @@ def _prepare(file):
     if os.path.isfile(meta_path):
         with open(meta_path, encoding="utf-8") as f:
             meta = json.load(f)
-        if os.path.isfile(os.path.join(cdir, meta["display"])):
-            meta["dir"] = cdir
+        meta["dir"] = cdir
+        if os.path.isfile(_display_file(meta)):
             return meta
 
     Image, ImageOps = _pil()
     Image.MAX_IMAGE_PIXELS = 400_000_000
     img = Image.open(file)
     fmt = (img.format or "?").upper()
-    img = ImageOps.exif_transpose(img)
-    w, h = img.size
+    orient = img.getexif().get(0x0112, 1)   # EXIF orientation (274); 1 = upright
     with open(file, "rb") as f:
         head = f.read(256 * 1024)
-    kind, valid, reasons = _classify(w, h, head, img)
-
     os.makedirs(cdir, exist_ok=True)
-    has_alpha = img.mode in ("RGBA", "LA", "PA") or (
-        img.mode == "P" and "transparency" in img.info
-    )
-    disp = img.convert("RGBA" if has_alpha else "RGB")
-    if disp.width > DISPLAY_MAX_W:
-        disp = disp.resize(
-            (DISPLAY_MAX_W, max(1, round(disp.height * DISPLAY_MAX_W / disp.width))),
-            Image.LANCZOS,
-        )
-    if has_alpha:
-        display = "display.png"
-        disp.save(os.path.join(cdir, display))
+
+    if fmt in BROWSER_FMTS and img.width <= DISPLAY_MAX_W and orient in (0, 1):
+        # Upright, browser-displayable, within the texture cap: serve the
+        # original as-is — skip exif_transpose (its copy() forces a full decode)
+        # and the re-encode. _classify only touches pixels for the 4:3 cube-cross
+        # check; a 2:1 pano is classified from its dimensions and never decoded.
+        w, h = img.size
+        kind, valid, reasons = _classify(w, h, head, img)
+        display, disp_w, disp_h = None, w, h
     else:
-        display = "display.jpg"
-        disp.save(os.path.join(cdir, display), quality=92)
+        img = ImageOps.exif_transpose(img)
+        w, h = img.size
+        kind, valid, reasons = _classify(w, h, head, img)
+        has_alpha = img.mode in ("RGBA", "LA", "PA") or (
+            img.mode == "P" and "transparency" in img.info
+        )
+        disp = img.convert("RGBA" if has_alpha else "RGB")
+        if disp.width > DISPLAY_MAX_W:
+            disp = disp.resize(
+                (DISPLAY_MAX_W, max(1, round(disp.height * DISPLAY_MAX_W / disp.width))),
+                Image.LANCZOS,
+            )
+        if has_alpha:
+            display = "display.png"
+            disp.save(os.path.join(cdir, display))
+        else:
+            display = "display.jpg"
+            disp.save(os.path.join(cdir, display), quality=92)
+        disp_w, disp_h = disp.width, disp.height
 
     meta = {"name": os.path.basename(file), "format": fmt,
             "bytes": os.path.getsize(file), "width": w, "height": h,
-            "kind": kind, "valid": valid, "reasons": reasons,
-            "display": display, "display_w": disp.width, "display_h": disp.height}
+            "kind": kind, "valid": valid, "reasons": reasons, "source": file,
+            "display": display, "display_w": disp_w, "display_h": disp_h}
     with open(meta_path, "w", encoding="utf-8") as f:
         json.dump(meta, f)
     meta["dir"] = cdir
@@ -169,7 +192,8 @@ def _prepare(file):
 
 def op_open(file):
     meta = _prepare(file)
-    meta["display_path"] = os.path.join(meta.pop("dir"), meta["display"])
+    meta["display_path"] = _display_file(meta)
+    meta.pop("dir", None)
     return {"asset": meta}
 
 
@@ -182,7 +206,7 @@ def _load_equirect(meta):
 
     py360convert = _py360()
     Image, _ = _pil()
-    img = Image.open(os.path.join(meta["dir"], meta["display"])).convert("RGB")
+    img = Image.open(_display_file(meta)).convert("RGB")
     if img.width > CONVERT_MAX_W:
         img = img.resize(
             (CONVERT_MAX_W, max(1, round(img.height * CONVERT_MAX_W / img.width))),

--- a/fused_render/templates/pano/pano.py
+++ b/fused_render/templates/pano/pano.py
@@ -336,6 +336,30 @@ def main(
     out_h: int = 0,
     face_w: int = 0,
 ):
+    # Numeric params can arrive as strings from an engine that doesn't coerce by
+    # annotation; coerce here so a blank falls back to the default and a truthy
+    # "0" string can't slip into py360convert and break every projection.
+    def _int(v, d):
+        try:
+            return int(float(v)) if str(v).strip() != "" else d
+        except (TypeError, ValueError):
+            return d
+
+    def _float(v, d):
+        try:
+            return float(v) if str(v).strip() != "" else d
+        except (TypeError, ValueError):
+            return d
+
+    fov = _float(fov, 90.0)
+    yaw = _float(yaw, 0.0)
+    pitch = _float(pitch, 0.0)
+    roll = _float(roll, 0.0)
+    zoom = _float(zoom, 1.0)
+    out_w = _int(out_w, 0)
+    out_h = _int(out_h, 0)
+    face_w = _int(face_w, 0)
+
     if not file:
         raise ValueError("missing 'file' param (the image to view)")
     if action == "open":

--- a/fused_render/templates/pano/pano.py
+++ b/fused_render/templates/pano/pano.py
@@ -14,6 +14,7 @@ to the user's file.
 import hashlib
 import json
 import math
+import mimetypes
 import os
 import time
 
@@ -139,6 +140,12 @@ def _prepare(file):
         with open(meta_path, encoding="utf-8") as f:
             meta = json.load(f)
         meta["dir"] = cdir
+        # Cache is keyed by content hash, so `file` is a valid path to these
+        # exact bytes: bind name/source to the requested path, not the first one
+        # cached — right filename on a duplicate open, and no dependency on the
+        # first path still existing.
+        meta["name"] = os.path.basename(file)
+        meta["source"] = file
         if os.path.isfile(_display_file(meta)):
             return meta
 
@@ -151,11 +158,15 @@ def _prepare(file):
         head = f.read(256 * 1024)
     os.makedirs(cdir, exist_ok=True)
 
-    if fmt in BROWSER_FMTS and img.width <= DISPLAY_MAX_W and orient in (0, 1):
-        # Upright, browser-displayable, within the texture cap: serve the
-        # original as-is — skip exif_transpose (its copy() forces a full decode)
-        # and the re-encode. _classify only touches pixels for the 4:3 cube-cross
-        # check; a 2:1 pano is classified from its dimensions and never decoded.
+    mime, _ = mimetypes.guess_type(file)
+    if (fmt in BROWSER_FMTS and (mime or "").startswith("image/")
+            and img.width <= DISPLAY_MAX_W and orient in (0, 1)):
+        # Upright, browser-displayable, within the texture cap, and its path maps
+        # to an image/* content-type (/api/fs/raw types the served bytes from the
+        # path and sends nosniff, so a non-image extension would fail to render):
+        # serve the original as-is — skip exif_transpose (its copy() forces a full
+        # decode) and the re-encode. _classify only touches pixels for the 4:3
+        # cube-cross check; a 2:1 pano is classified from dimensions, never decoded.
         w, h = img.size
         kind, valid, reasons = _classify(w, h, head, img)
         display, disp_w, disp_h = None, w, h

--- a/fused_render/templates/pano/template.html
+++ b/fused_render/templates/pano/template.html
@@ -32,7 +32,10 @@
     border-radius: 6px; padding: 5px 11px; cursor: pointer; font: inherit;
     white-space: nowrap; box-shadow: var(--shadow-sm); font-weight: 500;
   }
-  .btn:hover { background: var(--panel2); border-color: #d4d4d8; }
+  .btn:hover:not(:disabled) { background: var(--panel2); border-color: #d4d4d8; }
+  .btn.primary { background: var(--accent); border-color: var(--accent); color: #fafafa; }
+  .btn.primary:hover:not(:disabled) { background: var(--accent2); border-color: var(--accent2); }
+  .btn:disabled { opacity: .5; cursor: default; box-shadow: none; }
   #topbar .spacer { flex: 1; }
   #topbar .fname { font-size: 12px; color: var(--dim); overflow: hidden;
     text-overflow: ellipsis; white-space: nowrap; max-width: 34vw; }

--- a/fused_render/templates/pano/template.html
+++ b/fused_render/templates/pano/template.html
@@ -219,7 +219,7 @@
     <tr><td><kbd>1</kbd> … <kbd>8</kbd></td><td>switch projection view</td></tr>
     <tr><td><kbd>d</kbd></td><td>download current view</td></tr>
     <tr><td><kbd>?</kbd></td><td>toggle this help</td></tr>
-    <tr><td colspan="2" style="padding-top:10px">Perspective / fisheye: drag the image to look around. Set FOV with the slider or by typing a value.</td></tr>
+    <tr><td colspan="2" style="padding-top:10px">Perspective / fisheye / little planet: adjust the sliders (or type a value), then click Apply to render.</td></tr>
   </table>
 </div></div>
 
@@ -357,7 +357,7 @@
   function slider(key, label, min, max, step) {
     const v = P.get(key);
     return `<div class="row"><label>${label}` +
-      `<input class="num" type="number" data-p="${key}" min="${min}" ` +
+      `<input class="num" type="number" id="n-${key}" data-num="${key}" min="${min}" ` +
       `max="${max}" step="${step}" value="${v}"></label>` +
       `<input type="range" data-p="${key}" min="${min}" max="${max}" ` +
       `step="${step}" value="${v}"></div>`;
@@ -368,20 +368,8 @@
       options.map((o) => `<option value="${o[0]}"${String(o[0]) === v ? " selected" : ""}>${o[1]}</option>`).join("") +
       `</select></div>`;
   }
-  function syncControls() {
-    // Same mode as last build: refresh values in place rather than rebuilding
-    // the DOM, so a focused number field or an in-flight drag isn't clobbered.
-    els.ctrl.querySelectorAll("[data-p]").forEach((el) => {
-      if (el === document.activeElement) return;
-      const v = P.get(el.dataset.p);
-      if (el.value !== v) el.value = v;
-    });
-  }
-  let ctrlMode = null;
   function renderControls() {
     const m = mode();
-    if (m === ctrlMode) { syncControls(); return; }
-    ctrlMode = m;
     let html = "";
     if (m === "perspective") {
       html = `<h4>Perspective (e2p)</h4>` +
@@ -392,7 +380,7 @@
         sizeSelect("psize", "Output size", [["1024x576", "1024 × 576"],
           ["1280x720", "1280 × 720"], ["1920x1080", "1920 × 1080"],
           ["1080x1080", "1080 × 1080"]]) +
-        `<div class="hint">drag image to look around</div>`;
+        `<div class="hint">adjust the sliders, then Apply to render</div>`;
     } else if (m === "little_planet") {
       html = `<h4>Little planet</h4>` +
         slider("zoom", "Zoom", 0.2, 3, 0.05) +
@@ -403,28 +391,46 @@
         slider("yaw", "Yaw °", -180, 180, 1) +
         slider("pitch", "Pitch °", -90, 90, 1) +
         sizeSelect("csize", "Output size", [["512", "512 px"], ["1024", "1024 px"], ["2048", "2048 px"]]) +
-        `<div class="hint">drag image to look around</div>`;
+        `<div class="hint">adjust the sliders, then Apply to render</div>`;
     } else if (m === "cube_dice" || m === "cube_horizon" || m === "cube_faces") {
       html = `<h4>${m === "cube_faces" ? "Cube faces (e2c)" : "Cubemap (e2c)"}</h4>` +
         sizeSelect("face", "Face size", [["0", "auto (source/4)"], ["256", "256 px"],
           ["512", "512 px"], ["1024", "1024 px"]]);
     }
+    // Manual render: adjusting a control only stages its value and enables the
+    // button. Nothing re-renders until Apply commits the values to the params.
+    if (html) html += `<button class="btn primary" id="applyBtn" ` +
+      `style="margin-top:12px;width:100%" disabled>Apply changes</button>`;
     els.ctrl.style.display = html ? "block" : "none";
     els.ctrl.innerHTML = html;
+    const markDirty = () => { const ab = $("applyBtn"); if (ab) ab.disabled = false; };
     els.ctrl.querySelectorAll("[data-p]").forEach((el) => {
-      const sync = () => {
-        if (el.value === "") return;   // mid-edit blank; commit clamps on change
-        P.set(el.dataset.p, el.value);
-        els.ctrl.querySelectorAll(`[data-p="${el.dataset.p}"]`).forEach((s) => {
-          if (s !== el) s.value = el.value;
-        });
-      };
-      el.addEventListener("input", sync);
-      if (el.type === "number") el.addEventListener("change", () => {
-        const n = parseFloat(el.value);   // keep a legit 0; only empty/NaN falls back
-        el.value = Math.max(+el.min, Math.min(+el.max, isNaN(n) ? +el.min : n));
-        sync();
+      el.addEventListener("input", () => {
+        const num = $("n-" + el.dataset.p);
+        if (num) num.value = el.value;          // slider -> number box
+        markDirty();
       });
+    });
+    els.ctrl.querySelectorAll("[data-num]").forEach((el) => {
+      const range = () => els.ctrl.querySelector(`[data-p="${el.dataset.num}"]`);
+      el.addEventListener("input", () => {      // typed value -> slider (clamped)
+        const r = range();
+        if (r && el.value !== "") {
+          let n = parseFloat(el.value);
+          if (!isNaN(n)) {
+            n = Math.max(parseFloat(el.min), Math.min(parseFloat(el.max), n));
+            r.value = String(n);
+          }
+        }
+        markDirty();
+      });
+      el.addEventListener("change", () => { const r = range(); if (r) el.value = r.value; });
+    });
+    const applyBtn = $("applyBtn");
+    if (applyBtn) applyBtn.addEventListener("click", () => {
+      const vals = {};
+      els.ctrl.querySelectorAll("[data-p]").forEach((el) => { vals[el.dataset.p] = el.value; });
+      Object.keys(vals).forEach((k) => P.set(k, vals[k]));
     });
   }
 
@@ -540,19 +546,15 @@
 
     const m = mode();
     if (m === "view360") {
-      els.img.classList.remove("grabbable");
       draw360(meta);
     } else if (m === "original") {
       destroyViewer(); show("img");
-      els.img.classList.remove("grabbable");
       els.img.src = fused.rawUrl(meta.display_path);
       lastView = { path: meta.display_path };
       setViewStatus(`original pixels · ${meta.display_w}×${meta.display_h}` +
         (meta.display_w !== meta.width ? " (display copy, downscaled)" : ""), "");
     } else {
       destroyViewer();
-      els.img.classList.toggle("grabbable",
-        m === "perspective" || m === "fisheye180");
       scheduleRender();
     }
   }
@@ -566,32 +568,6 @@
     link.download = `${meta.name.replace(/\.[^.]+$/, "")}_${mode()}.jpg`;
     link.click();
   }
-
-  // ------------------------------------------------------------- drag look
-  (function dragLook() {
-    let drag = null;
-    els.img.addEventListener("pointerdown", (e) => {
-      const m = mode();
-      if (m !== "perspective" && m !== "fisheye180") return;
-      drag = { x: e.clientX, y: e.clientY, yaw: P.num("yaw"), pitch: P.num("pitch") };
-      els.img.classList.add("grabbing");
-      els.img.setPointerCapture(e.pointerId);
-    });
-    els.img.addEventListener("pointermove", (e) => {
-      if (!drag) return;
-      const fov = P.num("fov");
-      const scale = (mode() === "fisheye180" ? 120 : fov) / els.img.clientWidth;
-      let yaw = drag.yaw - (e.clientX - drag.x) * scale;
-      let pitch = drag.pitch + (e.clientY - drag.y) * scale;
-      yaw = ((yaw + 180) % 360 + 360) % 360 - 180;
-      pitch = Math.max(-90, Math.min(90, pitch));
-      P.set("yaw", Math.round(yaw));
-      P.set("pitch", Math.round(pitch));
-    });
-    const end = () => { drag = null; els.img.classList.remove("grabbing"); };
-    els.img.addEventListener("pointerup", end);
-    els.img.addEventListener("pointercancel", end);
-  })();
 
   // ------------------------------------------------------------- keyboard
   document.addEventListener("keydown", (e) => {

--- a/fused_render/templates/pano/template.html
+++ b/fused_render/templates/pano/template.html
@@ -76,8 +76,6 @@
     box-shadow: 0 6px 28px rgba(0,0,0,.14); border-radius: 6px;
     border: 1px solid var(--edge);
     user-select: none; -webkit-user-drag: none; }
-  #imgview.grabbable { cursor: grab; }
-  #imgview.grabbing { cursor: grabbing; }
   #facegrid { display: none; position: absolute; inset: 0; overflow: auto;
     padding: 18px; }
   #facegrid .grid { display: grid; grid-template-columns: repeat(3, 1fr);
@@ -309,7 +307,6 @@
     // passes no option and relies on the runtime's byte-identical drop alone.)
     set: (k, v) =>
       fused.params.set(k, String(v), k in DEFAULTS ? { default: DEFAULTS[k] } : undefined),
-    num: (k) => parseFloat(fused.params.get(k) ?? DEFAULTS[k]),
   };
   const mode = () => {
     const m = fused.params.get("mode");

--- a/fused_render/templates/pano/tests/test_pano.py
+++ b/fused_render/templates/pano/tests/test_pano.py
@@ -61,3 +61,44 @@ def test_convert_accepts_string_params(sample, mode):
 def test_convert_respects_typed_face_size(sample):
     r = pano.main(action="convert", file=sample, mode="cube_faces", face_w=32)
     assert r["w"] == 32 and r["h"] == 32
+
+
+def _open_asset(tmp_path, monkeypatch, name, w=256, h=128, fmt="JPEG", exif=None):
+    """Write a synthetic image to `name` (isolated cache) and return its asset."""
+    import numpy as np
+
+    monkeypatch.setattr(pano, "CACHE_ROOT", str(tmp_path / "cache"))
+    arr = np.zeros((h, w, 3), "uint8")
+    arr[..., 0] = np.linspace(0, 255, w, dtype="uint8")[None, :]
+    path = str(tmp_path / name)
+    kwargs = {"exif": exif} if exif is not None else {}
+    Image.fromarray(arr).save(path, format=fmt, **kwargs)
+    return path, pano.main(action="open", file=path)["asset"]
+
+
+def test_passthrough_serves_original(tmp_path, monkeypatch):
+    path, a = _open_asset(tmp_path, monkeypatch, "pano.jpg")
+    assert a["display"] is None                   # no re-encoded copy
+    assert a["display_path"] == a["source"]       # serves the original, not a copy
+    assert os.path.samefile(a["source"], path)
+
+
+def test_oversized_image_is_downscaled(tmp_path, monkeypatch):
+    monkeypatch.setattr(pano, "DISPLAY_MAX_W", 64)
+    _, a = _open_asset(tmp_path, monkeypatch, "wide.jpg", w=256, h=128)
+    assert a["display"] is not None               # re-encoded, downscaled copy
+    assert a["display_w"] <= 64
+
+
+def test_rotated_image_is_not_passthrough(tmp_path, monkeypatch):
+    exif = Image.Exif()
+    exif[0x0112] = 6                              # EXIF orientation = 90° rotate
+    _, a = _open_asset(tmp_path, monkeypatch, "rot.jpg", exif=exif)
+    assert a["display"] is not None               # must re-encode upright, no passthrough
+
+
+def test_non_image_extension_is_not_passthrough(tmp_path, monkeypatch):
+    # JPEG bytes at a path mimetypes doesn't type as image/*: /api/fs/raw would
+    # serve octet-stream + nosniff, so a properly typed copy must be written.
+    _, a = _open_asset(tmp_path, monkeypatch, "pano.bin", fmt="JPEG")
+    assert a["display"] is not None

--- a/fused_render/templates/pano/tests/test_pano.py
+++ b/fused_render/templates/pano/tests/test_pano.py
@@ -1,0 +1,63 @@
+"""Regression tests for the pano preview backend (`pano.py`).
+
+The projection conversions (cube/little-planet/fisheye/perspective) once broke
+whenever the numeric params reached `main()` as strings — an engine that
+forwards URL params without coercing by annotation, where a truthy "0" string
+slips straight into py360convert. These call `main()` with every numeric param
+as a string and assert each mode still produces output.
+"""
+import os
+import sys
+
+import pytest
+
+pytest.importorskip("numpy")
+pytest.importorskip("py360convert")
+Image = pytest.importorskip("PIL.Image")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pano  # noqa: E402
+
+
+@pytest.fixture
+def sample(tmp_path, monkeypatch):
+    """A tiny 2:1 image (classifies as equirect) plus an isolated cache dir."""
+    monkeypatch.setattr(pano, "CACHE_ROOT", str(tmp_path / "cache"))
+    import numpy as np
+
+    h, w = 128, 256
+    lon = np.linspace(0, 255, w, dtype="uint8")[None, :].repeat(h, 0)
+    lat = np.linspace(0, 255, h, dtype="uint8")[:, None].repeat(w, 1)
+    arr = np.stack([lon, lat, np.full((h, w), 90, "uint8")], -1)
+    path = str(tmp_path / "equirect.jpg")
+    Image.fromarray(arr).save(path, quality=90)
+    return path
+
+
+# Every numeric param as a string, as a non-coercing engine forwards them.
+STR_PARAMS = dict(fov="90", yaw="0", pitch="0", roll="0", zoom="1",
+                  out_w="0", out_h="0", face_w="0")
+
+CONVERT_MODES = ["equirect", "cube_dice", "cube_horizon", "cube_faces",
+                 "little_planet", "fisheye180", "perspective"]
+
+
+def test_open_classifies_equirect(sample):
+    asset = pano.main(action="open", file=sample)["asset"]
+    assert asset["kind"] == "equirect"
+    assert asset["valid"] is True
+
+
+@pytest.mark.parametrize("mode", CONVERT_MODES)
+def test_convert_accepts_string_params(sample, mode):
+    r = pano.main(action="convert", file=sample, mode=mode, **STR_PARAMS)
+    if mode == "cube_faces":
+        assert len(r["faces"]) == 6
+    else:
+        assert r["path"] and r["w"] > 0 and r["h"] > 0
+
+
+def test_convert_respects_typed_face_size(sample):
+    r = pano.main(action="convert", file=sample, mode="cube_faces", face_w=32)
+    assert r["w"] == 32 and r["h"] == 32


### PR DESCRIPTION
Improvements to the built-in **pano** preview template, ported from the standalone example. All changes are confined to `fused_render/templates/pano/` (3 files).

### 1. Manual "Apply changes" render workflow (`template.html`)
The projection controls (perspective / little-planet / fisheye / cube) used to auto-render on every slider tick, and the image could be dragged to look around. This matches the example instead: adjusting a control only **stages** the value and enables an initially-disabled **"Apply changes"** button; nothing re-renders until Apply commits the values. The drag-to-look handler is removed. Number-box ⇄ slider sync and clamping are preserved.

### 2. Apply button state styles (`template.html`)
Added `.btn.primary` and a real `.btn:disabled` (dim + `cursor: default`), and gated the hover rules behind `:not(:disabled)`, so the disabled button no longer looks clickable. (Resolves the Cursor Bugbot finding.)

### 3. Coerce numeric convert params (`pano.py`)
Every projection conversion crashed when the numeric params reached `main()` as strings (an engine that forwards URL params without coercing by annotation): a truthy `"0"` string flowed into py360convert (`'str' object cannot be interpreted as an integer`). `_int`/`_float` coercion at the top of `main()` fixes it — a blank falls back to the default, `"0"` becomes a real `0`. Idempotent for a coercing engine.

### 4. Skip the display re-encode when the source is already browser-ready (`pano.py`)
For an upright JPEG/PNG/WEBP/GIF within the WebGL size cap, serve the **original file** as the display image instead of decoding + re-encoding a copy — and skip the `exif_transpose` `copy()` that forced a full decode even for upright images. Measured: `op_open` for a typical **8000×4000 equirect drops from ~880 ms to ~25 ms**. Images wider than the cap still get the downscaled copy. `meta` gains `source`; `_display_file` resolves the cached copy or the original.

### Tests
`fused_render/templates/pano/tests/test_pano.py` drives every convert mode with string params (guards #3) and asserts open classification — fails on the pre-fix backend (6 modes), passes with the fix (9/9). Verified live: the Apply-changes viewer renders and the 8000×4000 equirect opens via passthrough serving the original file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the pano template folder; behavior changes are preview UX and performance optimizations with regression tests, no auth or shared infrastructure.
> 
> **Overview**
> Updates the **pano** preview template with faster opens, safer conversion params, and a manual render UX.
> 
> **Backend (`pano.py`):** Upright JPEG/PNG/WEBP/GIF within the WebGL width cap can **passthrough**—`display` is `None` and the original path is served via `_display_file`, avoiding full decode/re-encode (large equirects open much faster). Cache hits rebind `name`/`source` to the requested path. `main()` coerces numeric URL params with `_int`/`_float` so string values (including `"0"`) don’t break py360convert.
> 
> **UI (`template.html`):** Projection controls **stage** slider/select values and enable a primary **Apply changes** button; renders run only after Apply commits params to the URL. Drag-to-look on perspective/fisheye is removed. Primary/disabled button styles fix misleading hover on disabled Apply.
> 
> **Tests:** New `test_pano.py` covers string-param converts, passthrough vs downscale/EXIF/wrong-extension cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1681651e9cc15cd017adbb4b83adca652fd377cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->