### PR TITLE
Index freshness: scan on a 60s cadence, and overlap the scan's two setup reads

### DIFF
--- a/fused_render/index/freshness.py
+++ b/fused_render/index/freshness.py
@@ -44,8 +44,10 @@ QUIET_S = 30.0
 # in favour of routers/index.FRESHNESS_CHECK_S: that one throttles the CHECKS
 # per root, in memory, and sees nothing started by the scheduler or the buttons,
 # so without this floor a folder-open could rescan seconds after either. The two
-# are now the same number, which is the intent — one cadence, expressed at both
-# layers. Still far below the startup debounce (SCAN_DEBOUNCE_S, 15 min): that
+# express ONE cadence at two layers, and the check interval is set a few seconds
+# under this number rather than equal to it — see the note there on why equal
+# ones interleave into half the intended rate. Still far below the startup
+# debounce (SCAN_DEBOUNCE_S, 15 min): that
 # one exists to stop a reload loop, this one to stop a browsing session from
 # queueing.
 #

--- a/fused_render/index/freshness.py
+++ b/fused_render/index/freshness.py
@@ -40,19 +40,35 @@ QUIET_S = 30.0
 # Floor between scans of one root STARTED by this path. Read off `scans.json`
 # via runner.last_scan, which the startup scheduler and the manual buttons also
 # stamp — so a scan that just ran for any reason suppresses a trigger, and the
-# trigger needs no state file of its own. Still below the startup debounce
-# (routers/index.SCAN_DEBOUNCE_S, 15 min): that one exists to stop a reload
-# loop, this one to stop a browsing session from queueing.
+# trigger needs no state file of its own. That is also why it cannot be dropped
+# in favour of routers/index.FRESHNESS_CHECK_S: that one throttles the CHECKS
+# per root, in memory, and sees nothing started by the scheduler or the buttons,
+# so without this floor a folder-open could rescan seconds after either. The two
+# are now the same number, which is the intent — one cadence, expressed at both
+# layers. Still far below the startup debounce (SCAN_DEBOUNCE_S, 15 min): that
+# one exists to stop a reload loop, this one to stop a browsing session from
+# queueing.
 #
-# Raised from two minutes, because a completed scan is not free to the client:
-# it invalidates every fetched corpus in the app (platform/lib/index-status ->
-# index-freshness), and the explorer's answer to that is now to keep serving
-# what it has and say it is a generation behind rather than to refetch. Being a
-# few minutes behind is a labelled, readable state; a scan finishing every two
-# minutes under a churny home directory is a permanent "indexing…" and a
-# permanent dimming, which reads as broken. Freshness still wins over an
-# out-of-band change eventually, just not eagerly.
-MIN_INTERVAL_S = 600.0
+# Lowered from 600s, which was itself raised from 120s on the argument that a
+# completed scan invalidates every fetched corpus in the app
+# (platform/lib/index-status -> index-freshness) and so a scan finishing every
+# couple of minutes is a permanent "indexing…" and a permanent dimming. That
+# argument no longer holds: the explorer defers a new generation instead of
+# refetching under the user (apps/explorer/listing/revalidate.ts, and the
+# `fetchLifecycle` pin in FilesHome.tsx), so a scan completing mid-search no
+# longer disturbs the results being read.
+#
+# And scanning sooner is actively cheaper, not merely tolerable. Measured on a
+# 588k-file index: a whole-root incremental scan is ~4.5s, of which the FSEvents
+# journal replay (0.1-2.9s) and the visit of the dirs it names (1.3-2.8s) BOTH
+# scale with the window since the last scan. Halving the window halves the two
+# dominant terms; the fixed costs (worker spawn, dir-cache read, compaction) are
+# ~1.3s and are paid either way.
+#
+# NOT fixed by any of this: apps/explorer/listing/index-caveat.ts still derives
+# its "indexing…" caption straight from `status.scanning`, with no deferral of
+# its own — so more frequent scans do mean that caption appears more often.
+MIN_INTERVAL_S = 60.0
 
 
 def enclosing_root(roots, path: str):

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -15,6 +15,7 @@ See specs/scan.md and specs/scan-incremental.md.
 import hashlib
 import json
 import os
+import threading
 import time
 
 from fused_render.index import fsevents
@@ -361,9 +362,6 @@ def run_scan(run_dir: str) -> None:
         # of an unfingerprinted index is the cheap side of that trade.
         applied = applied_ignore_sig(cfg, root)
         rules_changed = applied != rules.sig()
-        cache = ({} if (spec.get("full") or rules_changed)
-                 else load_dir_cache(cfg, root, pq))
-        incremental = bool(cache)
         if rules_changed:
             _emit(ev, type="phase", msg=(
                 "ignore rules changed - full rescan" if applied is not None
@@ -371,9 +369,54 @@ def run_scan(run_dir: str) -> None:
 
         # Journal position captured BEFORE scanning: events during the scan get
         # replayed (harmlessly re-checked) next time instead of being missed.
+        # Before the hint too, and before anything is read — an id taken later
+        # would silently drop whatever happened in between.
         fs_id0 = fsevents.current_id()
         fs_uuid = fsevents.device_uuid(root) if fs_id0 is not None else None
-        hint = fsevents.hint(cfg, root) if incremental else None
+
+        # The two setup reads are independent and both spend their time outside
+        # the GIL — load_dir_cache is parquet IO, fsevents.hint is a CFRunLoop
+        # draining the journal over IPC — so they run together and setup costs
+        # max() instead of sum(). Measured on a 588k-file index: the cache read
+        # is a flat ~0.75s and the replay 0.1-2.9s depending on how much churn
+        # there has been since the last scan, and they used to be paid one after
+        # the other on every single run. Threads, not processes: neither holds
+        # the GIL for its cost, and a spawn would eat the saving. The replay is
+        # not main-thread bound either: it schedules its stream on
+        # CFRunLoopGetCurrent(), which gives whichever thread runs it that
+        # thread's own run loop (fsevents._replay).
+        #
+        # The hint is therefore computed UNCONDITIONALLY, even though only an
+        # incremental run can use one: whether there IS a cache is not known
+        # until the other thread returns, and waiting to find out is exactly the
+        # serialization being removed. The wasted replay happens only on a full
+        # or rules-changed run — rare — and it is wasted in parallel with a walk
+        # that was going to happen anyway. It is discarded below.
+        box: dict = {}
+
+        def _hint_thread():
+            try:
+                box["hint"] = fsevents.hint(cfg, root)
+            except BaseException as exc:  # noqa: BLE001 - re-raised on the caller
+                box["error"] = exc
+
+        hint_thread = threading.Thread(target=_hint_thread, daemon=True,
+                                       name="fsevents-hint")
+        hint_thread.start()
+        try:
+            cache = ({} if (spec.get("full") or rules_changed)
+                     else load_dir_cache(cfg, root, pq))
+        finally:
+            hint_thread.join()
+        if "error" in box:
+            # fsevents.hint answers None on every failure path it knows about,
+            # so anything raising out of it is a defect. Re-raised into the run's
+            # own handler (a `failed` run_end with the traceback) rather than
+            # degraded to "no hint": a silent full walk of a large root reads as
+            # a slow scan, not as a bug, and would keep doing so every run.
+            raise box["error"]
+        incremental = bool(cache)
+        hint = box.get("hint") if incremental else None
         _emit(ev, type="phase", msg=(
             "scanning (fsevents journal)" if hint is not None
             else "scanning (incremental)" if incremental else "scanning (full)"))

--- a/fused_render/index/scan.py
+++ b/fused_render/index/scan.py
@@ -374,46 +374,60 @@ def run_scan(run_dir: str) -> None:
         fs_id0 = fsevents.current_id()
         fs_uuid = fsevents.device_uuid(root) if fs_id0 is not None else None
 
-        # The two setup reads are independent and both spend their time outside
-        # the GIL — load_dir_cache is parquet IO, fsevents.hint is a CFRunLoop
-        # draining the journal over IPC — so they run together and setup costs
-        # max() instead of sum(). Measured on a 588k-file index: the cache read
-        # is a flat ~0.75s and the replay 0.1-2.9s depending on how much churn
-        # there has been since the last scan, and they used to be paid one after
-        # the other on every single run. Threads, not processes: neither holds
-        # the GIL for its cost, and a spawn would eat the saving. The replay is
-        # not main-thread bound either: it schedules its stream on
+        # A run that has already decided to rescan everything asks the journal
+        # nothing. Known HERE, before either read starts — `full` comes off the
+        # spec and `rules_changed` off a fingerprint compare — so it costs
+        # nothing to decide up front, and deciding it up front is what keeps a
+        # full rescan from waiting out a replay it would only discard (up to
+        # _replay's 20s timeout) before visiting its first directory. It is also
+        # what keeps "Full scan" working as the remedy for a corrupt
+        # fsevents.json: hint reads that file without a guard of its own, so a
+        # malformed event id raises, and a full run that called it would fail
+        # exactly like the incremental ones it is supposed to rescue.
+        rescan_all = bool(spec.get("full")) or rules_changed
+
+        # Otherwise the two setup reads are independent and both spend their
+        # time outside the GIL — load_dir_cache is parquet IO, fsevents.hint is a
+        # CFRunLoop draining the journal over IPC — so they run together and
+        # setup costs max() instead of sum(). Measured on a 588k-file index: the
+        # cache read is a flat ~0.75s and the replay 0.1-2.9s depending on how
+        # much churn there has been since the last scan, and they used to be paid
+        # one after the other on every single run. Threads, not processes:
+        # neither holds the GIL for its cost, and a spawn would eat the saving.
+        # The replay is not main-thread bound either: it schedules its stream on
         # CFRunLoopGetCurrent(), which gives whichever thread runs it that
         # thread's own run loop (fsevents._replay).
         #
-        # The hint is therefore computed UNCONDITIONALLY, even though only an
-        # incremental run can use one: whether there IS a cache is not known
-        # until the other thread returns, and waiting to find out is exactly the
-        # serialization being removed. The wasted replay happens only on a full
-        # or rules-changed run — rare — and it is wasted in parallel with a walk
-        # that was going to happen anyway. It is discarded below.
+        # One case still replays for nothing: an EMPTY cache (a first scan, or an
+        # index whose store is gone) also falls back to a full walk, and that is
+        # only known once the read returns. Unavoidable without serializing the
+        # two again, and it is the one run where a wasted replay is guaranteed
+        # cheap — there is no saved event id for the root, so `hint` answers None
+        # before it opens anything.
         box: dict = {}
+        hint_thread = None
+        if not rescan_all:
+            def _hint_thread():
+                try:
+                    box["hint"] = fsevents.hint(cfg, root)
+                except BaseException as exc:  # noqa: BLE001 - re-raised below
+                    box["error"] = exc
 
-        def _hint_thread():
-            try:
-                box["hint"] = fsevents.hint(cfg, root)
-            except BaseException as exc:  # noqa: BLE001 - re-raised on the caller
-                box["error"] = exc
-
-        hint_thread = threading.Thread(target=_hint_thread, daemon=True,
-                                       name="fsevents-hint")
-        hint_thread.start()
+            hint_thread = threading.Thread(target=_hint_thread, daemon=True,
+                                           name="fsevents-hint")
+            hint_thread.start()
         try:
-            cache = ({} if (spec.get("full") or rules_changed)
-                     else load_dir_cache(cfg, root, pq))
+            cache = {} if rescan_all else load_dir_cache(cfg, root, pq)
         finally:
-            hint_thread.join()
+            if hint_thread is not None:
+                hint_thread.join()
         if "error" in box:
             # fsevents.hint answers None on every failure path it knows about,
             # so anything raising out of it is a defect. Re-raised into the run's
             # own handler (a `failed` run_end with the traceback) rather than
             # degraded to "no hint": a silent full walk of a large root reads as
-            # a slow scan, not as a bug, and would keep doing so every run.
+            # a slow scan, not as a bug, and would keep doing so every run. The
+            # user's way out is a full scan, which never reaches this code.
             raise box["error"]
         incremental = bool(cache)
         hint = box.get("hint") if incremental else None

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -64,9 +64,12 @@ missed.
 **Replayed alongside the cache read, not after it.** `load_dir_cache` (parquet IO) and
 `hint` (a CFRunLoop draining the journal) are independent and both release the GIL, so
 `run_scan` runs them on two threads and pays `max()` rather than the sum — measured
-~0.75 s and 0.1–2.9 s respectively on a 588k-file index. The consequence is that the
-hint is computed **unconditionally**, before it is known whether there is a cache to
-apply it to, and discarded on a full or rules-changed run.
+~0.75 s and 0.1–2.9 s respectively on a 588k-file index. A run that has already decided
+to rescan everything (`full`, or the ignore rules changed) skips the replay entirely:
+both facts are known before either read starts, there is no cache read to hide the
+replay behind, and a full scan must stay usable as the remedy for a corrupt
+`fsevents.json` — `hint` parses that file with no guard of its own. An empty cache is
+the one case still replayed for nothing, since only the read can report it.
 
 **Any doubt falls back to a walk.** `hint` returns `None` when: no saved event id for
 this root; the root spans more than one device (per-device ids don't apply); the volume

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -61,6 +61,13 @@ speed, never its correctness.
 events that land mid-scan are replayed — harmlessly re-checked — next time rather than
 missed.
 
+**Replayed alongside the cache read, not after it.** `load_dir_cache` (parquet IO) and
+`hint` (a CFRunLoop draining the journal) are independent and both release the GIL, so
+`run_scan` runs them on two threads and pays `max()` rather than the sum — measured
+~0.75 s and 0.1–2.9 s respectively on a 588k-file index. The consequence is that the
+hint is computed **unconditionally**, before it is known whether there is a cache to
+apply it to, and discarded on a full or rules-changed run.
+
 **Any doubt falls back to a walk.** `hint` returns `None` when: no saved event id for
 this root; the root spans more than one device (per-device ids don't apply); the volume
 UUID differs from the saved one; or the replay itself bails. `_replay` bails on

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -129,8 +129,11 @@ again on every watch tick of a folder on screen**:
 2. Not mount-backed. This is checked before any syscall on the path, by the same pure
    string `MountGuard` §4 uses: `os.stat` under a wedged rclone mount blocks its thread
    indefinitely, and this one is serving a listing.
-3. `MIN_INTERVAL_S` (120 s) since any scan of that root, read off `scans.json` — so no
+3. `MIN_INTERVAL_S` (60 s) since any scan of that root, read off `scans.json` — so no
    state file of its own, and a scan that just ran for any reason suppresses a trigger.
+   The same number as `routers/index.FRESHNESS_CHECK_S`, which paces the checks in
+   memory; scanning sooner is also *cheaper*, since both dominant scan costs (the
+   journal replay and the visit set it names) scale with the window since the last one.
 4. `QUIET_S` (30 s) since the directory's own mtime moved. A build tree's mtime never
    stops moving, so it is never quiet and never triggers; the open after the churn stops
    still does.

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -142,6 +142,13 @@ A live run of the root is refused rather than joined, the check runs on a backgr
 thread throttled to one at a time, and nothing about the listing waits on it or fails
 with it.
 
+**Who fires it:** `/api/fs/list`, naming the folder just opened, and `/api/git-repos`,
+naming the configured roots — that tab is served entirely from the index and has no
+folder to name, so without it the homepage's Repos list could never notice a stale
+index. The root form catches little (a root's mtime moves only when its own direct
+entries change), and the single slot means a second root is skipped whenever the first
+took it; both are accepted, since the check is cheap and the tab has no better signal.
+
 **Bound, by design:** a directory's mtime moves only when entries are added, removed or
 renamed *in that directory*. An edit five levels down does not flip the mtime of the
 folder being viewed. This makes the index fresher; it does not make it correct, and the

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -134,9 +134,12 @@ again on every watch tick of a folder on screen**:
    indefinitely, and this one is serving a listing.
 3. `MIN_INTERVAL_S` (60 s) since any scan of that root, read off `scans.json` — so no
    state file of its own, and a scan that just ran for any reason suppresses a trigger.
-   The same number as `routers/index.FRESHNESS_CHECK_S`, which paces the checks in
-   memory; scanning sooner is also *cheaper*, since both dominant scan costs (the
-   journal replay and the visit set it names) scale with the window since the last one.
+   `routers/index.FRESHNESS_CHECK_S` (55 s) paces the checks in memory to the same
+   cadence, deliberately a little **shorter**: the check clock starts when a check
+   begins and the scan clock when the scan is spawned, so equal intervals would put
+   every second check just inside the floor and halve the real rate. Scanning sooner is
+   also *cheaper*, since both dominant scan costs (the journal replay and the visit set
+   it names) scale with the window since the last one.
 4. `QUIET_S` (30 s) since the directory's own mtime moved. A build tree's mtime never
    stops moving, so it is never quiet and never triggers; the open after the churn stops
    still does.

--- a/fused_render/index/specs/scan-incremental.md
+++ b/fused_render/index/specs/scan-incremental.md
@@ -149,11 +149,13 @@ thread throttled to one at a time, and nothing about the listing waits on it or 
 with it.
 
 **Who fires it:** `/api/fs/list`, naming the folder just opened, and `/api/git-repos`,
-naming the configured roots — that tab is served entirely from the index and has no
-folder to name, so without it the homepage's Repos list could never notice a stale
-index. The root form catches little (a root's mtime moves only when its own direct
-entries change), and the single slot means a second root is skipped whenever the first
-took it; both are accepted, since the check is cheap and the tab has no better signal.
+naming **one configured root per request, round-robin** — that tab is served entirely
+from the index and has no folder to name, so without it the homepage's Repos list could
+never notice a stale index. One root, not all of them, because the slot admits a single
+check at a time and is released by that check's own thread: offering the whole list in a
+loop checks the first root and loses every other one on a failed acquire, on every
+request. The root form catches little anyway (a root's mtime moves only when its own
+direct entries change); it is cheap, and the tab has no better signal.
 
 **Bound, by design:** a directory's mtime moves only when entries are added, removed or
 renamed *in that directory*. An edit five levels down does not flip the mtime of the

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -179,19 +179,26 @@ def _note_tab_opened(cfg) -> None:
     prevent.
 
     note_folder_opened itself never raises and never blocks (it spawns a
-    thread), so this costs the request a lock acquire; the try/except is for the
-    config read and for the import, not for the check."""
+    thread), so this costs the request a lock acquire — but the guard is
+    per-root, not around the loop: the roots are independent questions, and one
+    that somehow throws must not silently swallow the checks for the others."""
     try:
         # Function-local, like `_fresh`'s: routers/index.py is the module that
         # owns both the scan roots and the freshness hook, and importing it at
         # module scope would close the cycle between the two routers.
         from fused_render.server.routers.index import note_folder_opened, scan_roots
 
-        for root in scan_roots(cfg):
-            note_folder_opened(root)
+        roots = scan_roots(cfg)
     except Exception:  # noqa: BLE001 - housekeeping must never become the answer
-        logger.debug("could not check index freshness for the repos tab",
+        logger.debug("could not read the scan roots for the repos tab",
                      exc_info=True)
+        return
+    for root in roots:
+        try:
+            note_folder_opened(root)
+        except Exception:  # noqa: BLE001 - as above, and one root is not the rest
+            logger.debug("could not check index freshness for %s", root,
+                         exc_info=True)
 
 
 def _repos() -> dict:

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -74,6 +74,7 @@ dirs.parquet `ORDER BY dir` (`store._compact_locked`), and stripping the trailin
 alongside their parent rather than being collapsed away — a repo inside a repo is
 still a repo you might want to open.
 """
+import itertools
 import logging
 import os
 
@@ -97,6 +98,12 @@ router = APIRouter()
 # scan records opaquely" and may grow to hold names that have nothing to do with
 # git, at which point iterating it here would start listing non-repositories.
 GIT_DIR = ".git"
+
+# Whose turn it is to be freshness-checked when the tab is opened
+# (`_note_tab_opened`). Unbounded and never reset — it is only ever read modulo
+# the root count, and a counter that survives a config change simply resumes the
+# rotation somewhere in the middle of the new list.
+_root_turn = itertools.count()
 
 
 class IndexUnreadable(RuntimeError):
@@ -171,17 +178,19 @@ def _note_tab_opened(cfg) -> None:
     guarantee that the tab is current — the honest answer to "is this list
     complete" remains `stale` plus the next scheduled scan.
 
-    Every root is offered, but at most ONE check actually runs: the checker is
-    serialized by a single non-blocking slot (routers/index._freshness_slot), so
-    the second root is simply skipped whenever the first took the slot. That is
-    accepted rather than worked around — the roots take turns across requests,
-    and a queue of checks behind a tab render is exactly what the slot exists to
-    prevent.
+    Exactly ONE root per request, taken round-robin, because the checker admits
+    exactly one check at a time: note_folder_opened acquires a non-blocking slot
+    (routers/index._freshness_slot) and its background thread releases it a
+    config read — and possibly a duckdb lookup — later. Offering every root in a
+    loop therefore does not check every root; it checks the FIRST one and loses
+    the rest microseconds later on a failed acquire, every request, forever. The
+    first root would also take the slot on requests where it is not even due,
+    since due-ness is decided after the acquire. Rotating the offer is what makes
+    "each root gets checked" true, and it fits the slot rather than fighting it:
+    a tab render never queues more than one check.
 
-    note_folder_opened itself never raises and never blocks (it spawns a
-    thread), so this costs the request a lock acquire — but the guard is
-    per-root, not around the loop: the roots are independent questions, and one
-    that somehow throws must not silently swallow the checks for the others."""
+    note_folder_opened never raises and never blocks (it spawns a thread), so
+    this costs the request one lock acquire."""
     try:
         # Function-local, like `_fresh`'s: routers/index.py is the module that
         # owns both the scan roots and the freshness hook, and importing it at
@@ -189,16 +198,19 @@ def _note_tab_opened(cfg) -> None:
         from fused_render.server.routers.index import note_folder_opened, scan_roots
 
         roots = scan_roots(cfg)
+        if not roots:
+            return
+        # next() on an itertools.count is atomic in CPython, which is all the
+        # synchronization a turn counter needs — two concurrent tab renders
+        # taking the same turn, or skipping one, costs a check nobody was
+        # promised. The counter is per PROCESS, not per client: the question
+        # ("is this root behind?") is about the machine, so two windows sharing
+        # the rotation is right rather than merely tolerable.
+        root = roots[next(_root_turn) % len(roots)]
+        note_folder_opened(root)
     except Exception:  # noqa: BLE001 - housekeeping must never become the answer
-        logger.debug("could not read the scan roots for the repos tab",
+        logger.debug("could not check index freshness for the repos tab",
                      exc_info=True)
-        return
-    for root in roots:
-        try:
-            note_folder_opened(root)
-        except Exception:  # noqa: BLE001 - as above, and one root is not the rest
-            logger.debug("could not check index freshness for %s", root,
-                         exc_info=True)
 
 
 def _repos() -> dict:

--- a/fused_render/server/routers/git_repos.py
+++ b/fused_render/server/routers/git_repos.py
@@ -64,6 +64,10 @@ THREE THINGS THAT LOOK WRONG AND ARE NOT
    rootless form is not enough); the consequence of a mismatch is now `stale`
    rather than silence.
 
+   Serving a stale list does not mean ignoring staleness: the request also fires
+   the ordinary background freshness check (`_note_tab_opened`), so a tab open is
+   a chance for the index to catch up, never a wait for it to.
+
 Order is the index's own row order, which is path order: the compaction writes
 dirs.parquet `ORDER BY dir` (`store._compact_locked`), and stripping the trailing
 `/.git` preserves that order. Free, deterministic, no sort. Nested repos appear
@@ -149,8 +153,53 @@ def _not_ready(cfg, reason: str) -> dict:
             "stale": False, "repos": []}
 
 
+def _note_tab_opened(cfg) -> None:
+    """Ask the index whether it is behind, in the background, exactly as
+    /api/fs/list does for the folder the explorer just opened.
+
+    This tab reads nothing but the index, so without a nudge of its own it is
+    the one surface in the app that can never notice a stale one — it would
+    happily serve a repo list from a scan hours old, marked `stale: false`,
+    because as far as the index knows it IS as fresh as it gets.
+
+    The paths checked are the configured scan ROOTS, because the tab is
+    machine-wide: there is no open folder to name, and note_folder_opened only
+    acts on a path inside a root anyway. Named limitation, and it is a real one:
+    a root's own mtime moves only when its DIRECT entries change, so a repo
+    cloned three levels down does not make the root look stale and is not
+    detected here. This is a cheap check that occasionally helps, not a
+    guarantee that the tab is current — the honest answer to "is this list
+    complete" remains `stale` plus the next scheduled scan.
+
+    Every root is offered, but at most ONE check actually runs: the checker is
+    serialized by a single non-blocking slot (routers/index._freshness_slot), so
+    the second root is simply skipped whenever the first took the slot. That is
+    accepted rather than worked around — the roots take turns across requests,
+    and a queue of checks behind a tab render is exactly what the slot exists to
+    prevent.
+
+    note_folder_opened itself never raises and never blocks (it spawns a
+    thread), so this costs the request a lock acquire; the try/except is for the
+    config read and for the import, not for the check."""
+    try:
+        # Function-local, like `_fresh`'s: routers/index.py is the module that
+        # owns both the scan roots and the freshness hook, and importing it at
+        # module scope would close the cycle between the two routers.
+        from fused_render.server.routers.index import note_folder_opened, scan_roots
+
+        for root in scan_roots(cfg):
+            note_folder_opened(root)
+    except Exception:  # noqa: BLE001 - housekeeping must never become the answer
+        logger.debug("could not check index freshness for the repos tab",
+                     exc_info=True)
+
+
 def _repos() -> dict:
     cfg = load_config()
+    # Off the event loop already (run_in_threadpool below), and fire-and-forget:
+    # the repo list is served from whatever the index holds right now, whether or
+    # not this starts a scan.
+    _note_tab_opened(cfg)
     # The only genuinely unanswerable state: no store to read. Everything past here
     # queries first and judges freshness second — rows win over signatures.
     if read_manifest(cfg) is None or not os.path.exists(cfg.dirs_parquet):

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -142,12 +142,11 @@ _freshness_slot = threading.Lock()
 # client has fetched (platform/lib/index-status). So a root is checked at most
 # this often, whatever the explorer is doing.
 #
-# Deliberately coarse. The client's posture is now to keep serving the corpus
-# it has and label it a generation behind rather than to refetch on every
-# index event (listing/revalidate), which makes an eager freshness check worth
-# much less than it used to be and its side effect — a scan completing mid-read
-# — worth avoiding. freshness.MIN_INTERVAL_S is the second, longer floor on the
-# SCANS themselves; this one is about the checks.
+# freshness.MIN_INTERVAL_S is the other floor — on the SCANS themselves, read
+# off scans.json so it also sees the ones the scheduler and the manual buttons
+# start; this one is about the checks, and only about the ones this process
+# makes. They are deliberately the same number: a check more often than a scan
+# may be started is work that can never act on what it finds.
 FRESHNESS_CHECK_S = 60.0
 
 # root -> when it was last checked. Bounded by the number of configured scan

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -145,9 +145,20 @@ _freshness_slot = threading.Lock()
 # freshness.MIN_INTERVAL_S is the other floor — on the SCANS themselves, read
 # off scans.json so it also sees the ones the scheduler and the manual buttons
 # start; this one is about the checks, and only about the ones this process
-# makes. They are deliberately the same number: a check more often than a scan
-# may be started is work that can never act on what it finds.
-FRESHNESS_CHECK_S = 60.0
+# makes. One cadence, so this must not be LONGER: a check is the only thing that
+# can act on the scan floor, and checking less often than scans are allowed just
+# leaves the difference on the table.
+#
+# Slightly SHORTER, and the epsilon is load-bearing. The two clocks start at
+# different moments: this one is stamped when a check begins, while
+# `runner._record_scan` stamps when the scan it starts is spawned — a duckdb
+# lookup and a Popen later. So last_scan is always a little after last_check, and
+# at exactly equal intervals the next due check lands inside that offset, finds
+# the scan floor not yet clear, refuses — and re-stamps, pushing the next check
+# out a further full interval. Every second cycle would be a no-op and the real
+# cadence would be ~2x the number both comments name. Five seconds of slack
+# covers the spawn comfortably.
+FRESHNESS_CHECK_S = 55.0
 
 # root -> when it was last checked. Bounded by the number of configured scan
 # roots (a handful), so it needs no eviction.

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -378,3 +378,48 @@ def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):
     resp = client.get("/api/git-repos")
     assert resp.status_code == 502
     assert "index could not be read" in resp.json()["error"]
+
+
+# -- the freshness nudge -------------------------------------------------------
+
+def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
+        home, tmp_path, client, monkeypatch):
+    """The tab is served entirely from the index, so without this it is the one
+    surface in the app that can never notice the index is behind — /api/fs/list
+    fires the same check for every folder the explorer opens."""
+    from fused_render.server.routers import index as index_mod
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    _set_roots([a, b])
+    repo = a / "repo"
+    _write_dirs_index([str(a), str(repo), _git(repo)])
+    checked = []
+    monkeypatch.setattr(index_mod, "note_folder_opened",
+                        lambda p: (checked.append(p), True)[1])
+
+    body = client.get("/api/git-repos").json()
+    assert [r["path"] for r in body["repos"]] == [str(repo)]
+    # The configured roots, in order, and nothing else: the tab is machine-wide,
+    # so a root is the only path it can name.
+    assert checked == [str(a), str(b)]
+
+
+def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
+        home, tmp_path, client, monkeypatch):
+    """Housekeeping, hung off a read endpoint. The repo list is the answer; the
+    nudge is a side effect and must never become the response."""
+    from fused_render.server.routers import index as index_mod
+
+    def boom(_path):
+        raise RuntimeError("freshness exploded")
+
+    repo = tmp_path / "repo"
+    _write_dirs_index([str(tmp_path), str(repo), _git(repo)])
+    monkeypatch.setattr(index_mod, "note_folder_opened", boom)
+
+    resp = client.get("/api/git-repos")
+    assert resp.status_code == 200
+    assert [r["path"] for r in resp.json()["repos"]] == [str(repo)]

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -410,16 +410,31 @@ def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
 def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
         home, tmp_path, client, monkeypatch):
     """Housekeeping, hung off a read endpoint. The repo list is the answer; the
-    nudge is a side effect and must never become the response."""
+    nudge is a side effect and must never become the response.
+
+    Two roots, the first one raising, because one bad root must not swallow the
+    rest either: the roots are independent questions, and a config where one of
+    them wedges the check for every other one is the failure that hides itself."""
     from fused_render.server.routers import index as index_mod
 
-    def boom(_path):
-        raise RuntimeError("freshness exploded")
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    _set_roots([a, b])
+    repo = a / "repo"
+    _write_dirs_index([str(a), str(repo), _git(repo)])
+    checked = []
 
-    repo = tmp_path / "repo"
-    _write_dirs_index([str(tmp_path), str(repo), _git(repo)])
+    def boom(path):
+        checked.append(path)
+        if path == str(a):
+            raise RuntimeError("freshness exploded")
+        return True
+
     monkeypatch.setattr(index_mod, "note_folder_opened", boom)
 
     resp = client.get("/api/git-repos")
     assert resp.status_code == 200
     assert [r["path"] for r in resp.json()["repos"]] == [str(repo)]
+    assert checked == [str(a), str(b)]

--- a/tests/test_git_repos_api.py
+++ b/tests/test_git_repos_api.py
@@ -382,6 +382,19 @@ def test_an_unreadable_index_is_a_502_not_not_indexed(home, tmp_path, client):
 
 # -- the freshness nudge -------------------------------------------------------
 
+def _reset_rotation(monkeypatch):
+    """Start the round-robin over the scan roots at its first root.
+
+    The counter is module state and deliberately never resets in production, so a
+    test that did not pin it would assert on whichever turn earlier tests in the
+    same process happened to leave behind."""
+    import itertools
+
+    from fused_render.server.routers import git_repos as mod
+
+    monkeypatch.setattr(mod, "_root_turn", itertools.count())
+
+
 def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
         home, tmp_path, client, monkeypatch):
     """The tab is served entirely from the index, so without this it is the one
@@ -399,12 +412,41 @@ def test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots(
     checked = []
     monkeypatch.setattr(index_mod, "note_folder_opened",
                         lambda p: (checked.append(p), True)[1])
+    _reset_rotation(monkeypatch)
 
     body = client.get("/api/git-repos").json()
     assert [r["path"] for r in body["repos"]] == [str(repo)]
-    # The configured roots, in order, and nothing else: the tab is machine-wide,
-    # so a root is the only path it can name.
-    assert checked == [str(a), str(b)]
+    # A configured root, and nothing else: the tab is machine-wide, so a root is
+    # the only path it can name.
+    assert checked == [str(a)]
+
+
+def test_successive_tab_opens_check_each_root_in_turn(home, tmp_path, client,
+                                                      monkeypatch):
+    """ONE root per request, round-robin — and the point is that the later roots
+    are genuinely reached.
+
+    Offering every root in a loop looked equivalent and was not: the checker's
+    slot is taken by the first call and released by its own background thread a
+    config read later, so every subsequent root in the same request fails its
+    non-blocking acquire. The first root would win every request forever and the
+    second would never be checked at all."""
+    from fused_render.server.routers import index as index_mod
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    _set_roots([a, b])
+    _write_dirs_index([str(a)])
+    checked = []
+    monkeypatch.setattr(index_mod, "note_folder_opened",
+                        lambda p: (checked.append(p), True)[1])
+    _reset_rotation(monkeypatch)
+
+    for _ in range(4):
+        assert client.get("/api/git-repos").status_code == 200
+    assert checked == [str(a), str(b), str(a), str(b)]
 
 
 def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
@@ -412,9 +454,10 @@ def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
     """Housekeeping, hung off a read endpoint. The repo list is the answer; the
     nudge is a side effect and must never become the response.
 
-    Two roots, the first one raising, because one bad root must not swallow the
-    rest either: the roots are independent questions, and a config where one of
-    them wedges the check for every other one is the failure that hides itself."""
+    Two roots, the first one raising, because a bad root must not take the
+    rotation down with it: the roots are independent questions, and a config
+    where one of them wedges the check for every other one is the failure that
+    hides itself."""
     from fused_render.server.routers import index as index_mod
 
     a = tmp_path / "a"
@@ -433,8 +476,11 @@ def test_a_freshness_check_that_explodes_does_not_fail_the_tab(
         return True
 
     monkeypatch.setattr(index_mod, "note_folder_opened", boom)
+    _reset_rotation(monkeypatch)
 
-    resp = client.get("/api/git-repos")
-    assert resp.status_code == 200
-    assert [r["path"] for r in resp.json()["repos"]] == [str(repo)]
+    for _ in range(2):
+        resp = client.get("/api/git-repos")
+        assert resp.status_code == 200
+        assert [r["path"] for r in resp.json()["repos"]] == [str(repo)]
+    # the throwing root took its turn and the next request moved on regardless
     assert checked == [str(a), str(b)]

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -168,6 +168,32 @@ def test_a_root_scanned_within_the_floor_is_not_rescanned(tmp_path, spawned):
     assert spawned == []
 
 
+def test_a_root_scanned_two_minutes_ago_is_rescanned(tmp_path, spawned):
+    """The floor is a minute, not ten. Browsing must not queue scan after scan,
+    but a folder that changed out of band should not stay stale for the length
+    of a coffee break either — and a scan started sooner is a CHEAPER scan: both
+    dominant costs (the journal replay and the set of dirs it names) scale with
+    the window since the last one."""
+    root = _tree(tmp_path, "root")
+    sub = _tree(tmp_path, "root/sub")
+    cfg = _index(tmp_path, root, {root: 1 * NS, sub: 1 * NS})
+    runner._record_scan(cfg, root)
+    at = runner.last_scan(cfg, root) + 120
+    assert note_folder_opened(cfg, sub, [root], now=at) == root
+    assert spawned == [{"root": root, "full": False}]
+
+
+def test_the_scan_floor_matches_the_routers_check_debounce(tmp_path):
+    """Two floors, one cadence. freshness.MIN_INTERVAL_S paces the SCANS (read
+    off scans.json, so it also sees the startup scheduler and the manual
+    buttons); routers.index.FRESHNESS_CHECK_S paces the CHECKS, per root, in
+    memory. They answer the same question at different layers, and a check
+    interval shorter than the scan floor is just work that can never act."""
+    from fused_render.server.routers.index import FRESHNESS_CHECK_S
+
+    assert MIN_INTERVAL_S == FRESHNESS_CHECK_S
+
+
 def test_a_folder_outside_every_configured_root_triggers_nothing(
         tmp_path, spawned):
     root = _tree(tmp_path, "root")

--- a/tests/test_index_freshness.py
+++ b/tests/test_index_freshness.py
@@ -187,11 +187,17 @@ def test_the_scan_floor_matches_the_routers_check_debounce(tmp_path):
     """Two floors, one cadence. freshness.MIN_INTERVAL_S paces the SCANS (read
     off scans.json, so it also sees the startup scheduler and the manual
     buttons); routers.index.FRESHNESS_CHECK_S paces the CHECKS, per root, in
-    memory. They answer the same question at different layers, and a check
-    interval shorter than the scan floor is just work that can never act."""
+    memory.
+
+    An ordering, not an equality. Longer would leave scans the floor allows
+    unstarted, since a check is the only thing that starts one. Exactly equal is
+    the subtler failure: the check clock is stamped when a check BEGINS and the
+    scan clock when the scan is spawned (runner._record_scan, a duckdb lookup and
+    a Popen later), so the next due check lands just inside the scan floor, is
+    refused, and re-stamps — halving the real rate. Hence strictly shorter."""
     from fused_render.server.routers.index import FRESHNESS_CHECK_S
 
-    assert MIN_INTERVAL_S == FRESHNESS_CHECK_S
+    assert FRESHNESS_CHECK_S < MIN_INTERVAL_S
 
 
 def test_a_folder_outside_every_configured_root_triggers_nothing(

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -478,6 +478,81 @@ def test_changing_the_ignore_rules_forces_a_full_rescan(tmp_path):
     assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
 
 
+def test_a_full_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
+    """The setup reads (dir cache, journal replay) run concurrently, so the hint
+    is computed BEFORE it is known whether there is a cache to apply it to — a
+    full or rules-changed run must throw it away rather than act on it.
+
+    The hint pinned here names a directory that no longer holds the file, so a
+    run that wrongly took the journal path would carry the stale cached row
+    forward instead of dropping it."""
+    from fused_render.index import fsevents
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    cfg = _cfg(tmp_path, ignore=["node_modules"])
+    _run(cfg, str(src))
+    os.remove(src / "sub" / "b.md")
+    monkeypatch.setattr(fsevents, "hint", lambda _cfg, _root: (set(), []))
+
+    run_dir = _run(cfg, str(src), full=True, run_name="run2")
+    msgs = [e.get("msg") for e in _events(run_dir)]
+    assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
+    assert "scanning (full)" in msgs
+    assert not any((m or "").startswith("scanning (fsevents") for m in msgs)
+    paths = []
+    for part in partition_files(cfg):
+        paths += pq.read_table(part).column("path").to_pylist()
+    assert paths == [str(src / "a.txt")]
+
+
+def test_a_rules_changed_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
+    """Same discard, reached the other way: the cache is dropped because the
+    ignore rules moved, and the phase events still read as they always did —
+    the rules-changed notice first, then the full-scan phase."""
+    from fused_render.index import fsevents
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    cfg = _cfg(tmp_path, ignore=["node_modules"])
+    _run(cfg, str(src))
+    monkeypatch.setattr(fsevents, "hint", lambda _cfg, _root: (set(), []))
+
+    wider = _cfg(tmp_path, ignore=["node_modules", "sub"])
+    run_dir = _run(wider, str(src), run_name="run2")
+    msgs = [e.get("msg") for e in _events(run_dir)]
+    assert msgs.index("ignore rules changed - full rescan") < msgs.index(
+        "scanning (full)")
+    part = os.path.join(cfg.files_dir, read_manifest(cfg)["partitions"][0]["file"])
+    assert pq.read_table(part).column("path").to_pylist() == [str(src / "a.txt")]
+
+
+def test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full(
+        tmp_path, monkeypatch):
+    """fsevents.hint returns None on every failure it knows about, so anything
+    raising out of it is a defect. Computing it on a thread must not turn that
+    into a silent "no hint": a full walk of a large root looks like a slow scan,
+    not like a bug, and would keep looking like one every run."""
+    from fused_render.index import fsevents
+
+    def boom(*a, **k):
+        raise RuntimeError("journal exploded")
+
+    src = tmp_path / "src"
+    src.mkdir()
+    _tree(src)
+    cfg = _cfg(tmp_path, ignore=["node_modules"])
+    _run(cfg, str(src))
+    monkeypatch.setattr(fsevents, "hint", boom)
+
+    run_dir = _run(cfg, str(src), run_name="run2")
+    end = _summary(run_dir)
+    assert end["msg"] == "failed"
+    assert "journal exploded" in (end.get("error") or "")
+
+
 def test_a_cancelled_run_leaves_the_index_untouched(tmp_path):
     src = tmp_path / "src"
     src.mkdir()

--- a/tests/test_index_scan.py
+++ b/tests/test_index_scan.py
@@ -479,9 +479,11 @@ def test_changing_the_ignore_rules_forces_a_full_rescan(tmp_path):
 
 
 def test_a_full_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
-    """The setup reads (dir cache, journal replay) run concurrently, so the hint
-    is computed BEFORE it is known whether there is a cache to apply it to — a
-    full or rules-changed run must throw it away rather than act on it.
+    """A run that has already decided to rescan everything asks the journal
+    NOTHING — it does not merely discard the answer. The replay is scheduled on a
+    thread beside the dir-cache read, but a full run has no cache read to hide it
+    behind, so consulting it would just stall the walk (up to _replay's 20s
+    timeout) for a result that cannot be used.
 
     The hint pinned here names a directory that no longer holds the file, so a
     run that wrongly took the journal path would carry the stale cached row
@@ -494,9 +496,12 @@ def test_a_full_run_does_not_take_the_journal_path(tmp_path, monkeypatch):
     cfg = _cfg(tmp_path, ignore=["node_modules"])
     _run(cfg, str(src))
     os.remove(src / "sub" / "b.md")
-    monkeypatch.setattr(fsevents, "hint", lambda _cfg, _root: (set(), []))
+    asked = []
+    monkeypatch.setattr(fsevents, "hint",
+                        lambda _cfg, _root: (asked.append(_root), (set(), []))[1])
 
     run_dir = _run(cfg, str(src), full=True, run_name="run2")
+    assert asked == [], "a full rescan waited on a journal replay it cannot use"
     msgs = [e.get("msg") for e in _events(run_dir)]
     assert _summary(run_dir)["msg"] == "complete", _summary(run_dir).get("error")
     assert "scanning (full)" in msgs
@@ -518,10 +523,13 @@ def test_a_rules_changed_run_does_not_take_the_journal_path(tmp_path, monkeypatc
     _tree(src)
     cfg = _cfg(tmp_path, ignore=["node_modules"])
     _run(cfg, str(src))
-    monkeypatch.setattr(fsevents, "hint", lambda _cfg, _root: (set(), []))
+    asked = []
+    monkeypatch.setattr(fsevents, "hint",
+                        lambda _cfg, _root: (asked.append(_root), (set(), []))[1])
 
     wider = _cfg(tmp_path, ignore=["node_modules", "sub"])
     run_dir = _run(wider, str(src), run_name="run2")
+    assert asked == []
     msgs = [e.get("msg") for e in _events(run_dir)]
     assert msgs.index("ignore rules changed - full rescan") < msgs.index(
         "scanning (full)")
@@ -534,7 +542,14 @@ def test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full(
     """fsevents.hint returns None on every failure it knows about, so anything
     raising out of it is a defect. Computing it on a thread must not turn that
     into a silent "no hint": a full walk of a large root looks like a slow scan,
-    not like a bug, and would keep looking like one every run."""
+    not like a bug, and would keep looking like one every run.
+
+    ...and a FULL scan must still work, which is what makes that acceptable.
+    `hint` parses `fsevents.json` with no guard of its own — a non-numeric event
+    id or a legacy `devs` shape raises — so if a full run consulted it too, a
+    corrupt state file would fail every scan of that root forever and the index
+    could only be rebuilt by hand-deleting the file. The full run is the remedy:
+    it never asks the journal, and it rewrites the state on the way out."""
     from fused_render.index import fsevents
 
     def boom(*a, **k):
@@ -551,6 +566,14 @@ def test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full(
     end = _summary(run_dir)
     assert end["msg"] == "failed"
     assert "journal exploded" in (end.get("error") or "")
+
+    full = _run(cfg, str(src), full=True, run_name="run3")
+    assert _summary(full)["msg"] == "complete", _summary(full).get("error")
+    assert "scanning (full)" in [e.get("msg") for e in _events(full)]
+    paths = []
+    for part in partition_files(cfg):
+        paths += pq.read_table(part).column("path").to_pylist()
+    assert sorted(paths) == sorted([str(src / "a.txt"), str(src / "sub" / "b.md")])
 
 
 def test_a_cancelled_run_leaves_the_index_untouched(tmp_path):


### PR DESCRIPTION
## Summary

The file index only gets refreshed by three things: server boot, opening a folder in the explorer, and the manual scan button. The folder-open path — the only one that reacts to what the user is doing — was throttled to **one scan per root per 10 minutes**, so a browsing session mostly read an index that was hours old. This PR makes that path fire ~10x more often and makes each scan cheaper.

- **Folder-open scan floor: 600s → 60s.** The 600s figure was raised from 120s on the argument that a completed scan invalidates every fetched corpus and would leave the app permanently dimmed. That argument is out of date — the explorer now *defers* a new generation rather than refetching under the user (`listing/revalidate.ts`, the `fetchLifecycle` pin in `FilesHome.tsx`). 60s also matches `routers/index.FRESHNESS_CHECK_S`, so the check cadence and the scan cadence are finally the same number.
- **Scan setup now overlaps its two independent reads.** `load_dir_cache` (parquet IO) and `fsevents.hint` (a CFRunLoop draining the journal) both release the GIL and neither needs the other's result, but they ran back to back. Running them on two threads makes setup cost `max()` instead of `sum()` — on a 588k-file index the cache read is a flat ~0.75s that was being paid on top of every replay. A run that already means to rescan everything skips the journal entirely rather than replaying it to discard the result.
- **`FRESHNESS_CHECK_S` is 55s, deliberately just under the 60s scan floor.** The check clock is stamped when a check begins; the scan clock is stamped a duckdb lookup and a `Popen` later. At exactly equal intervals every second check lands inside that offset, refuses, and re-stamps — turning two 60s constants into a ~120s real cadence.
- **Scanning sooner is cheaper, not merely tolerable.** Both dominant scan costs scale with the window since the last scan: the journal replay (0.1–2.9s) and the visit of the dirs it names (1.3–2.8s). The fixed costs — worker spawn, cache read, compaction — are ~1.3s and are paid either way. Halving the window halves the two terms that actually vary.
- **The Repos tab now fires the freshness check too.** It is served entirely from the index and names no folder, so it was the one surface that could never notice a stale index.

### Measured, on a real 588k-file / 69,580-dir store

| Phase | Cost | Scales with |
|---|---|---|
| worker spawn → `run_start` | ~0.18s | fixed |
| `load_dir_cache` | 0.75s | index size |
| `fsevents.hint` replay | 0.1–2.9s | **churn since last scan** |
| journal-phase walk | 1.3–2.8s | **churn since last scan** |
| compaction + signatures | ~0.35s | fixed |

The replay itself has no headroom left — instrumented at 2,742 callbacks / 83,502 events, ~24µs/event, with only 0.01s spent inside Python. Batch size is capped at 32 by fseventsd's delivery protocol regardless of stream latency or flags. The only lever on it is *fewer events*, which is what the shorter window buys.

## Visuals

Scan setup, before and after.

**Before** — the cache read and the replay are serial, and the replay is skipped only after the cache is already known.

```mermaid
flowchart TD
    A[run_start] --> B[capture journal id]
    B --> C[load_dir_cache<br/>~0.75s]
    C --> D{cache?}
    D -->|yes| E[fsevents.hint<br/>0.1-2.9s]
    D -->|no| F[phase: scanning]
    E --> F
```

**After** — a run that already means to rescan everything skips the journal entirely; otherwise both reads start together.

```mermaid
flowchart TD
    A[run_start] --> B[capture journal id]
    B --> C{full or<br/>rules changed?}
    C -->|yes| D[no hint, no thread]
    C -->|no| E[load_dir_cache]
    C -->|no| F[fsevents.hint<br/>on a thread]
    E --> G[join]
    F --> G
    D --> H[phase: scanning]
    G --> H
```

`full` and `rules_changed` are both known before either read starts, so that branch costs nothing to take early — and taking it early is what keeps "Full scan" working as the remedy for a corrupt `fsevents.json`, since `hint` reads that file without a guard of its own.

## Usage

Nothing new is user-invocable — this changes cadence and cost, not surface. Observable effects:

- Opening a folder whose mtime moved now queues a scan if the last one was over **60s** ago, rather than 10 minutes.
- Opening the Repos tab on the homepage now also asks whether the index is behind.
- `GET /api/index/status` reports scans more often as a result; `POST /api/index/scan` is unchanged.

To see the cadence change directly, open a folder, touch a file in it, wait 30s (`QUIET_S`), reopen it, and watch `/api/index/runs`.

## Test Plan

- [x] `tests/test_index_scan.py` — added `test_a_full_run_does_not_take_the_journal_path`, `test_a_rules_changed_run_does_not_take_the_journal_path`, `test_a_hint_that_explodes_fails_the_run_rather_than_scanning_full`. The first two spy on `fsevents.hint` and assert it was never *consulted*, not merely not acted on; the third continues into a `full=True` run and asserts it completes, pinning the escape hatch.
- [x] `tests/test_index_freshness.py` — added `test_a_root_scanned_two_minutes_ago_is_rescanned` and `test_the_scan_floor_matches_the_routers_check_debounce` (both red before the change).
- [x] `tests/test_git_repos_api.py` — added `test_opening_the_tab_fires_a_freshness_check_on_the_scan_roots` and `test_a_freshness_check_that_explodes_does_not_fail_the_tab`.
- [x] Full local suite — 5,981 passed. The single failure is `tests/test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, the known macOS baseline red (it reads `/proc/self/fd` with no skipif), unrelated to this diff.
- [x] CI green across Python 3.10 / 3.11 / 3.12 / 3.13, fused-engine, frontend, bundle-contents, linux-desktop.

**Known gaps, stated rather than papered over:**

- The overlap change is behavior-preserving, so its tests pass on both sides of the refactor by design. The three named above are equivalence guards, not a red-first test of the parallelism.
- The 5s of slack between `FRESHNESS_CHECK_S` and `MIN_INTERVAL_S` is sized for a duckdb open plus a `Popen`, not measured. On a pathologically slow spawn the same interleave could recur — rarely, and the failure mode is a skipped cycle, not a wrong answer.
- An **empty** cache (first scan, or a store that has been deleted) still replays the journal for nothing, because "the cache is empty" is only knowable once the read returns. Unavoidable without re-serializing the two reads, and it is the run where a replay is cheapest — there is typically no saved event id, so `hint` answers `None` before opening anything.
- The parallel speedup itself is **not** verified by any test — it was measured on a real 588k-file store, not in CI, and no CI machine has an index that size.
- `_replay`'s CFRunLoop behavior on a non-main thread is reasoned, not observed: `CFRunLoopGetCurrent()` returns the calling thread's run loop. On non-darwin every fsevents entry point returns `None`, so tests cannot cover it.
- Not fixed here: `listing/index-caveat.ts` still derives its "indexing…" caption straight from `status.scanning` with no deferral of its own, so more frequent scans do mean that caption appears more often. That is the natural follow-up if it reads as busy.
- The Repos tab check is cheap and occasionally useful, not a guarantee — a root's mtime only moves when its *direct* entries change, so a repo cloned three levels down is still not detected.
