### PR TITLE
In-app self-update for the macOS app (brew + DMG paths)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,27 @@ jobs:
           echo "dmg_url=https://${CDN_DOMAIN}/fused-render-dmgs/$(basename "$DMG_PATH")" >> "$GITHUB_OUTPUT"
           echo "wheel_url=https://${CDN_DOMAIN}/fused-render-wheels/$(basename "$WHL_PATH")" >> "$GITHUB_OUTPUT"
 
+      - name: Publish signed macOS update manifest
+        # The in-app updater (fused_render/update/mac.py) polls this fixed
+        # name — same signing scheme and script as the Windows manifest
+        # (docs/PYTHON_SUPERVISOR_SPEC.md "Software updates"). The manifest
+        # URL points at the already-uploaded DMG, so this runs strictly after
+        # the S3 upload above.
+        env:
+          FUSED_RENDER_UPDATE_SIGNING_KEY: ${{ secrets.FUSED_RENDER_UPDATE_SIGNING_KEY }}
+          MACOS_PREFIX: fused-render-macos
+        run: |
+          set -euo pipefail
+          VERSION="$(basename "$DMG_PATH" .dmg | sed 's/^FusedRender-//')"
+          uv run --no-project --with cryptography \
+            scripts/windows/generate_update_manifest.py \
+            "$VERSION" "$DMG_PATH" "https://${CDN_DOMAIN}/fused-render-dmgs" \
+            dist/macos-latest.json
+          # no-cache: the updater polls this fixed name; a stale CDN copy
+          # would mask a release.
+          aws s3 cp dist/macos-latest.json "s3://${S3_BUCKET}/${MACOS_PREFIX}/latest.json" \
+            --cache-control no-cache
+
       - name: Invalidate CloudFront
         # The root download page (index.html/latest.json/og-image.png) is
         # published once, after every platform build, by the
@@ -203,7 +224,7 @@ jobs:
           set -euo pipefail
           aws cloudfront create-invalidation \
             --distribution-id "$CLOUDFRONT_DISTRIBUTION_ID" \
-            --paths "/fused-render-dmgs/*" "/fused-render-wheels/*"
+            --paths "/fused-render-dmgs/*" "/fused-render-wheels/*" "/fused-render-macos/*"
 
       - name: Upload DMG + wheel to GitHub Release
         env:

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -24,6 +24,10 @@ export interface Config {
   learn_mount_ready: boolean;
   // Same gate for the builtin sessions mount (the Claude Sessions sub-app).
   sessions_mount_ready: boolean;
+  // Self-update state (fused_render/update/mac.py) — present only when the
+  // packaged mac app started the update manager; absent on dev servers and
+  // the Windows/Linux packages (those update through their supervisor).
+  update?: UpdateStatus;
   // No claude_config gate here any more: the Claude Config app stopped being a
   // mounted html+py app and became native React over its own server bridge, so
   // its availability is GET /api/claude-config/status (useClaudeConfigAvailable
@@ -151,6 +155,32 @@ export const postJson = <T>(url: string, body: unknown) => mutateJson<T>("POST",
 
 export function getConfig(): Promise<Config> {
   return getJson<Config>("/api/config");
+}
+
+// -- Self-update (fused_render/server/routers/update.py) ---------------------
+
+export interface UpdateStatus {
+  // idle | checking | available | installing | installed | error
+  state: string;
+  // brew: install delegates to `brew upgrade --cask`; dmg: the app downloads
+  // and swaps its own bundle; none: not updatable in place.
+  method: string;
+  latest_version: string | null;
+  // Bytes downloaded so far (dmg method only) — the manifest carries no total
+  // size, so the UI shows MB downloaded rather than a percentage.
+  progress: number | null;
+  error: string | null;
+  // Set when the user must run the update themselves (brew failed) — shown
+  // with a copy button, never retried against the DMG path.
+  manual_command: string | null;
+}
+
+export function updateCheck(): Promise<UpdateStatus> {
+  return postJson<UpdateStatus>("/api/update/check", {});
+}
+
+export function updateInstall(): Promise<UpdateStatus> {
+  return postJson<UpdateStatus>("/api/update/install", {});
 }
 
 export function listDir(fsPath: string, cursor?: string | null): Promise<ListResult> {

--- a/frontend/src/platform/ui/UpdateBadge.tsx
+++ b/frontend/src/platform/ui/UpdateBadge.tsx
@@ -1,0 +1,149 @@
+// Sidebar self-update affordance. Renders nothing until /api/config's
+// `update` field says a newer version exists (packaged mac app only — the
+// field is absent everywhere else), then shows an "Update available" row that
+// expands into a small panel: install button, download/brew progress, and the
+// brew-failure fallback (the exact command to run by hand — a brew-managed
+// install is never updated behind brew's back).
+//
+// Owns its own slow poll (60s idle, 2s while installing) instead of riding
+// ServerStatusBanner's 5s one: the two components live in different trees and
+// update state changes rarely. Once the install lands, installed_version
+// drifts from the running version and ServerStatusBanner's restart card takes
+// over — this panel just says "restart to finish" and points there.
+import { useEffect, useRef, useState } from "react";
+
+import { getConfig, updateInstall, type UpdateStatus } from "@platform/lib/api";
+
+const POLL_IDLE_MS = 60_000;
+const POLL_BUSY_MS = 2_000;
+
+function formatMb(bytes: number | null): string {
+  if (!bytes) return "";
+  return `${Math.round(bytes / (1024 * 1024))} MB`;
+}
+
+export default function UpdateBadge() {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | undefined>(undefined);
+  const pollRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    let disposed = false;
+
+    async function poll() {
+      let next: UpdateStatus | null | undefined;
+      try {
+        const config = await getConfig();
+        next = config.update ?? null;
+        if (!disposed) setStatus(next);
+      } catch {
+        // Server down — ServerStatusBanner owns that story; keep last state.
+      }
+      if (disposed) return;
+      const busy = next?.state === "installing";
+      timerRef.current = window.setTimeout(poll, busy ? POLL_BUSY_MS : POLL_IDLE_MS);
+    }
+
+    pollRef.current = () => {
+      window.clearTimeout(timerRef.current);
+      poll();
+    };
+    poll();
+    return () => {
+      disposed = true;
+      window.clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  if (!status) return null;
+  const relevant = ["available", "installing", "installed", "error"].includes(status.state);
+  if (!relevant) return null;
+
+  const install = async () => {
+    setOpen(true);
+    try {
+      setStatus(await updateInstall());
+    } catch {
+      // Fall through — the re-armed poll picks up the real state.
+    }
+    // Re-arm the poll now so installing-progress shows within POLL_BUSY_MS
+    // instead of waiting out the idle interval.
+    pollRef.current();
+  };
+
+  const copyCommand = async () => {
+    if (!status.manual_command) return;
+    await navigator.clipboard.writeText(status.manual_command);
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="update-badge">
+      <button
+        type="button"
+        className="update-badge-row"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <span className="update-badge-dot" aria-hidden="true" />
+        {status.state === "installing"
+          ? "Updating…"
+          : status.state === "installed"
+            ? "Update installed"
+            : `Update available${status.latest_version ? ` — v${status.latest_version}` : ""}`}
+      </button>
+      {open && (
+        <div className="update-badge-panel">
+          {status.state === "available" && (
+            <>
+              <div className="update-badge-text">
+                {status.method === "brew"
+                  ? "Installed with Homebrew — updating runs brew for you."
+                  : "Downloads the new version and installs it in place."}
+              </div>
+              <button type="button" className="update-badge-action" onClick={install}>
+                Update to v{status.latest_version}
+              </button>
+            </>
+          )}
+          {status.state === "installing" && (
+            <div className="update-badge-text">
+              {status.method === "brew"
+                ? "Updating via Homebrew…"
+                : `Downloading… ${formatMb(status.progress)}`}
+            </div>
+          )}
+          {status.state === "installed" && (
+            <div className="update-badge-text">
+              Installed. Restart fused-render to finish — the restart card has a
+              button for it.
+            </div>
+          )}
+          {status.state === "error" && (
+            <>
+              <div className="update-badge-text update-badge-error">
+                {status.manual_command
+                  ? "Automatic update failed. Run this in your terminal:"
+                  : `Update failed: ${status.error ?? "unknown error"}`}
+              </div>
+              {status.manual_command && (
+                <div className="update-badge-command">
+                  <code>{status.manual_command}</code>
+                  <button type="button" className="update-badge-copy" onClick={copyCommand}>
+                    {copied ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              )}
+              <button type="button" className="update-badge-action" onClick={install}>
+                Try again
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -10,6 +10,7 @@
 // the shell is allowed to import together (scripts/check-boundaries.mjs).
 import { useEffect, useRef, useState } from "react";
 import { SidebarFrame, NavItem } from "@platform/ui/sidebar/SidebarFrame";
+import UpdateBadge from "@platform/ui/UpdateBadge";
 import type { SidebarRailItem } from "@platform/ui/sidebar/SidebarFrame";
 import { LearnIcon } from "@platform/ui/FileIcons";
 import type { Config } from "@platform/lib/api";
@@ -294,6 +295,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
       <RecentsSection />
       <BookmarksSection />
       <div className="sidebar-section sidebar-settings">
+        <UpdateBadge />
         <PreferencesMenu entries={menuEntries} dot={triggerDot} active={prefsActive} />
       </div>
     </SidebarFrame>

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -822,7 +822,7 @@ a.bookmark-name::after {
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--accent);
-  color: #fff;
+  color: var(--bg);
   font-size: 12px;
   cursor: pointer;
 }

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -765,3 +765,90 @@ a.bookmark-name::after {
   padding: 10px 4px;
 }
 
+
+/* -- Self-update badge (platform/ui/UpdateBadge, packaged mac app only) ----- */
+
+.update-badge {
+  margin: 2px 8px;
+  font-size: 12px;
+}
+
+.update-badge-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px 8px;
+  border: none;
+  border-radius: 6px;
+  background: rgba(var(--tint), 0.07);
+  color: var(--fg);
+  font-size: 12px;
+  cursor: pointer;
+  text-align: left;
+}
+
+.update-badge-row:hover {
+  background: rgba(var(--tint), 0.12);
+}
+
+.update-badge-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  flex: none;
+}
+
+.update-badge-panel {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.update-badge-text {
+  color: var(--fg-muted);
+  line-height: 1.4;
+}
+
+.update-badge-error {
+  color: var(--fg);
+}
+
+.update-badge-action {
+  align-self: flex-start;
+  padding: 4px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--accent);
+  color: #fff;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.update-badge-command {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.update-badge-command code {
+  flex: 1;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: rgba(var(--tint), 0.09);
+  font-size: 11px;
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.update-badge-copy {
+  padding: 3px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+  color: var(--fg-muted);
+  font-size: 11px;
+  cursor: pointer;
+}

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -847,6 +847,15 @@ def main() -> None:
         _write_pidfile(port)
         state["ready"] = True
         logger.info("server ready on port %s", port)
+        # Self-update checks (update/mac.py): a background loop that only
+        # flips /api/config's `update` field — the shell shows the badge and
+        # drives install from there. Never on the startup critical path.
+        try:
+            from fused_render.update import mac as mac_update
+
+            mac_update.start()
+        except Exception:
+            logger.exception("update manager failed to start")
         if state["pin"] is not None:
             # AppKit is main-thread-only; this bootstrap runs on a worker.
             from PyObjCTools import AppHelper

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -61,6 +61,7 @@ from fused_render.server.routers.run import router as run_router
 from fused_render.server.routers.search import router as search_router
 from fused_render.server.session import router as session_router
 from fused_render.server.routers.shell import router as shell_router
+from fused_render.server.routers.update import router as update_router
 # The MODULE, not `from … import TEMPLATES_DIR`: that constant is a live seam
 # (tests repoint it at a staged copy before calling create_app, and
 # core_templates staging is the reason it can move at all), and a by-value
@@ -333,6 +334,10 @@ def create_app(start_dir: str) -> FastAPI:
     # /api/desktop/shutdown — a generic app-info/control grab-bag that doesn't
     # map to any single fs/template/ai concern (_server_config.py).
     app.include_router(config_router)
+    # Self-update triggers (routers/update.py) — POSTs that kick a manifest
+    # check / an install; both carry the D3 X-Fused guard and 404 unless the
+    # mac app started the update manager.
+    app.include_router(update_router)
     # The Home view's apps backend (routers/apps.py): list workspace app
     # folders + scaffold new ones from the app starter kit.
     app.include_router(apps_router)

--- a/fused_render/server/routers/config.py
+++ b/fused_render/server/routers/config.py
@@ -97,6 +97,13 @@ def api_config(
         # not of the build.
         "native_dir_picker": dirpicker.available(),
     }
+    # Self-update state (update/mac.py) — present only when the mac app
+    # started the manager; the shell shows the sidebar badge / install panel
+    # off this. Rides this endpoint so the ServerStatusBanner poll carries it.
+    from fused_render.update import mac as mac_update
+
+    if (update_manager := mac_update.manager()) is not None:
+        config["update"] = update_manager.status()
     if instance := desktop_instance():
         config["desktop_instance"] = {"id": instance[0]}
         if token == instance[1]:

--- a/fused_render/server/routers/update.py
+++ b/fused_render/server/routers/update.py
@@ -1,0 +1,32 @@
+"""Self-update endpoints (update/mac.py). Status itself rides /api/config's
+`update` field so the shell's existing 5s poll carries it — these POSTs only
+trigger work. Both mutate (network + a bundle swap), so they carry the D3
+X-Fused guard; they 404 when no update manager is running (dev server, CLI,
+Windows/Linux packages — those update through the supervisor's own path)."""
+from fastapi import APIRouter, Header, HTTPException
+
+from fused_render.server.common import _require_fused
+from fused_render.update import mac as mac_update
+
+router = APIRouter()
+
+
+def _manager():
+    manager = mac_update.manager()
+    if manager is None:
+        raise HTTPException(status_code=404, detail="self-update is not available here")
+    return manager
+
+
+@router.post("/api/update/check")
+def api_update_check(x_fused: str | None = Header(default=None)):
+    if (error := _require_fused(x_fused)) is not None:
+        return error
+    return _manager().check()
+
+
+@router.post("/api/update/install")
+def api_update_install(x_fused: str | None = Header(default=None)):
+    if (error := _require_fused(x_fused)) is not None:
+        return error
+    return _manager().install()

--- a/fused_render/supervisor/_win32/update.py
+++ b/fused_render/supervisor/_win32/update.py
@@ -6,12 +6,9 @@ clicks the tray item and approves the prompt. Runs on worker threads; never
 raises, so a failed check can't tear down the Job-owned server."""
 from __future__ import annotations
 
-import base64
 import ctypes
 import glob
-import hashlib
 import http.client
-import json
 import os
 import tempfile
 import threading
@@ -19,22 +16,18 @@ import time
 import urllib.error
 import urllib.request
 
-from cryptography.exceptions import InvalidSignature
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-
 from fused_render import __version__
 from fused_render.supervisor.paths import DesktopPaths
+from fused_render.update import common as _common
 
 _MANIFEST_URL = "https://d2ic19jpchjovp.cloudfront.net/fused-render-windows/latest.json"
-_PUBLIC_KEY = base64.b64decode("u4eiDvccdWmsVCN0nifCEXqmU+xVGIDPe8LP5KRlDns=")
-_SIGNING_CONTEXT = "fused-render-update"
-_FETCH_TIMEOUT_S = 15.0
-_DOWNLOAD_TIMEOUT_S = 300.0
-_STARTUP_DELAY_S = 60.0
-_CHECK_INTERVAL_S = 6 * 60 * 60
-_MAX_MANIFEST_BYTES = 64 * 1024
-_MAX_INSTALLER_BYTES = 600 * 1024 * 1024
-_DOWNLOAD_CHUNK = 1024 * 1024
+# Re-exported from update/common so tests can patch them on THIS module (the
+# thin wrappers below read the module globals at call time).
+_PUBLIC_KEY = _common.PUBLIC_KEY
+_SIGNING_CONTEXT = _common.SIGNING_CONTEXT
+_STARTUP_DELAY_S = _common.STARTUP_DELAY_S
+_CHECK_INTERVAL_S = _common.CHECK_INTERVAL_S
+_MAX_INSTALLER_BYTES = _common.MAX_ARTIFACT_BYTES
 _STAGE_PREFIX = "FusedRenderPy-"
 _STAGE_SUFFIX = "-setup.exe"
 
@@ -55,23 +48,10 @@ _check_lock = threading.Lock()
 _install_launched = False
 
 
-class _HttpsOnlyRedirect(urllib.request.HTTPRedirectHandler):
-    """urlopen follows redirects by default; refuse any that leave HTTPS so a
-    compromised CDN can't 302 the download to http and bypass the https-only
-    control (integrity still rests on the signed sha256, but don't ship bytes
-    over cleartext)."""
-
-    def redirect_request(self, req, fp, code, msg, headers, newurl):
-        if not newurl.startswith("https://"):
-            raise urllib.error.URLError("refusing non-https redirect during update")
-        return super().redirect_request(req, fp, code, msg, headers, newurl)
-
-
-_opener = urllib.request.build_opener(_HttpsOnlyRedirect)
-
-
-def _urlopen(url: str, timeout: float):
-    return _opener.open(url, timeout=timeout)
+# Test seam: tests patch this to stub network I/O; the wrappers below pass it
+# through to update/common per call.
+_urlopen = _common.urlopen
+_HttpsOnlyRedirect = _common.HttpsOnlyRedirect
 
 
 def start_auto_checks(paths: DesktopPaths, notify) -> None:
@@ -222,70 +202,25 @@ def _wait_for_exit(handle) -> None:
 
 
 def _fetch_manifest() -> dict:
-    """Fetch, validate, and cryptographically verify the manifest. The
-    ed25519 signature is checked here — before any caller trusts `version` to
-    decide "up to date" or to prompt — so a CDN/bucket compromise can't forge
-    a version to suppress or fake an update."""
-    with _urlopen(_MANIFEST_URL, _FETCH_TIMEOUT_S) as resp:
-        raw = resp.read(_MAX_MANIFEST_BYTES + 1)
-    if len(raw) > _MAX_MANIFEST_BYTES:
-        raise ValueError("update manifest is too large")
-    manifest = json.loads(raw)
-    if not isinstance(manifest, dict) or manifest.get("schema") != 1 or not all(
-        isinstance(manifest.get(key), str)
-        for key in ("version", "url", "sha256", "signature")
-    ):
-        raise ValueError("malformed update manifest")
-    _verify_signature(manifest["version"], manifest["sha256"], manifest["signature"])
-    return manifest
-
-
-def _verify_signature(version: str, sha256: str, signature: str) -> None:
-    message = f"{_SIGNING_CONTEXT}\n{version}\n{sha256}\n".encode("utf-8")
-    try:
-        Ed25519PublicKey.from_public_bytes(_PUBLIC_KEY).verify(
-            base64.b64decode(signature), message
-        )
-    except InvalidSignature as error:
-        raise ValueError("update manifest signature is invalid") from error
+    """Fetch, validate, and cryptographically verify the manifest (see
+    update/common.fetch_manifest). Module globals are passed per call so tests
+    can patch `_urlopen`/`_PUBLIC_KEY` on this module."""
+    return _common.fetch_manifest(_MANIFEST_URL, urlopen_fn=_urlopen,
+                                  public_key=_PUBLIC_KEY)
 
 
 def _is_newer(candidate: str, current: str) -> bool:
-    def parts(version: str) -> tuple[int, ...]:
-        return tuple(int(part) for part in version.split("."))
-
-    return parts(candidate) > parts(current)
+    return _common.is_newer(candidate, current)
 
 
 def _download_verified(manifest: dict) -> str:
     """Stream the installer to %TEMP% (never the supervisor's temp dir, which
     the installer's [InstallDelete] wipes) while hashing it, and confirm its
-    SHA-256 matches the signed value. The manifest signature (over version +
-    sha256) is already verified in _fetch_manifest; the URL is not signed, so
-    require HTTPS."""
-    url = manifest["url"]
-    if not url.startswith("https://"):
-        raise ValueError("update manifest url is not https")
-    sha256 = manifest["sha256"]
-    digest = hashlib.sha256()
-    total = 0
-    fd, path = tempfile.mkstemp(prefix=_STAGE_PREFIX, suffix=_STAGE_SUFFIX)
-    ok = False
-    try:
-        with os.fdopen(fd, "wb") as out, _urlopen(url, _DOWNLOAD_TIMEOUT_S) as resp:
-            while chunk := resp.read(_DOWNLOAD_CHUNK):
-                total += len(chunk)
-                if total > _MAX_INSTALLER_BYTES:
-                    raise ValueError("update installer exceeds the size limit")
-                digest.update(chunk)
-                out.write(chunk)
-        if digest.hexdigest() != sha256:
-            raise ValueError("downloaded installer does not match the signed manifest")
-        ok = True
-        return path
-    finally:
-        if not ok:
-            _discard(path)
+    SHA-256 matches the signed value (see update/common.download_verified)."""
+    return _common.download_verified(
+        manifest, prefix=_STAGE_PREFIX, suffix=_STAGE_SUFFIX,
+        max_bytes=_MAX_INSTALLER_BYTES, urlopen_fn=_urlopen,
+    )
 
 
 def _sweep_stale_downloads() -> bool:
@@ -305,10 +240,7 @@ def _sweep_stale_downloads() -> bool:
 
 
 def _discard(path: str) -> None:
-    try:
-        os.unlink(path)
-    except OSError:
-        pass
+    _common.discard(path)
 
 
 def _alert(text: str, icon: int) -> None:

--- a/fused_render/update/__init__.py
+++ b/fused_render/update/__init__.py
@@ -1,0 +1,6 @@
+"""Self-update machinery shared by the desktop packages.
+
+`common` holds the platform-neutral core (signed-manifest fetch/verify and
+the hash-verified download) that both the Windows supervisor updater
+(supervisor/_win32/update.py) and the macOS in-app updater (`mac`) build on.
+"""

--- a/fused_render/update/common.py
+++ b/fused_render/update/common.py
@@ -1,0 +1,144 @@
+"""Platform-neutral core of the self-updater: fetch + cryptographically
+verify the signed update manifest, and stream-download the artifact it points
+at while checking its SHA-256 against the signed value.
+
+Factored out of supervisor/_win32/update.py so the macOS in-app updater
+(update/mac.py) shares one implementation of the security-critical path. The
+signing scheme is unchanged: an ed25519 signature over a domain-separated
+`version\nsha256` line (scripts/windows/generate_update_manifest.py), so a
+CDN/bucket compromise can't forge a version or point the client at different
+bytes. The artifact URL itself is not signed — its content is pinned by the
+signed sha256 — so downloads additionally require HTTPS end to end.
+
+Note the signing context is shared across platforms: a Windows manifest
+replayed at the macOS manifest URL verifies, but the sha256 then pins the
+Windows installer bytes, which the macOS install path cannot mount — the swap
+never happens. Version downgrade replays are rejected by is_newer().
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import tempfile
+import urllib.error
+import urllib.request
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+PUBLIC_KEY = base64.b64decode("u4eiDvccdWmsVCN0nifCEXqmU+xVGIDPe8LP5KRlDns=")
+SIGNING_CONTEXT = "fused-render-update"
+FETCH_TIMEOUT_S = 15.0
+DOWNLOAD_TIMEOUT_S = 300.0
+STARTUP_DELAY_S = 60.0
+CHECK_INTERVAL_S = 6 * 60 * 60
+MAX_MANIFEST_BYTES = 64 * 1024
+MAX_ARTIFACT_BYTES = 600 * 1024 * 1024
+DOWNLOAD_CHUNK = 1024 * 1024
+
+
+class HttpsOnlyRedirect(urllib.request.HTTPRedirectHandler):
+    """urlopen follows redirects by default; refuse any that leave HTTPS so a
+    compromised CDN can't 302 the download to http and bypass the https-only
+    control (integrity still rests on the signed sha256, but don't ship bytes
+    over cleartext)."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if not newurl.startswith("https://"):
+            raise urllib.error.URLError("refusing non-https redirect during update")
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+_opener = urllib.request.build_opener(HttpsOnlyRedirect)
+
+
+def urlopen(url: str, timeout: float):
+    return _opener.open(url, timeout=timeout)
+
+
+def fetch_manifest(url: str, *, urlopen_fn=None, public_key: bytes = PUBLIC_KEY) -> dict:
+    """Fetch, validate, and cryptographically verify the manifest. The
+    ed25519 signature is checked here — before any caller trusts `version` to
+    decide "up to date" or to prompt — so a CDN/bucket compromise can't forge
+    a version to suppress or fake an update. `urlopen_fn`/`public_key` are
+    injectable for the platform wrappers' test seams."""
+    if urlopen_fn is None:
+        urlopen_fn = urlopen
+    with urlopen_fn(url, FETCH_TIMEOUT_S) as resp:
+        raw = resp.read(MAX_MANIFEST_BYTES + 1)
+    if len(raw) > MAX_MANIFEST_BYTES:
+        raise ValueError("update manifest is too large")
+    manifest = json.loads(raw)
+    if not isinstance(manifest, dict) or manifest.get("schema") != 1 or not all(
+        isinstance(manifest.get(key), str)
+        for key in ("version", "url", "sha256", "signature")
+    ):
+        raise ValueError("malformed update manifest")
+    verify_signature(manifest["version"], manifest["sha256"], manifest["signature"],
+                     public_key=public_key)
+    return manifest
+
+
+def verify_signature(version: str, sha256: str, signature: str, *,
+                     public_key: bytes = PUBLIC_KEY) -> None:
+    message = f"{SIGNING_CONTEXT}\n{version}\n{sha256}\n".encode("utf-8")
+    try:
+        Ed25519PublicKey.from_public_bytes(public_key).verify(
+            base64.b64decode(signature), message
+        )
+    except InvalidSignature as error:
+        raise ValueError("update manifest signature is invalid") from error
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    def parts(version: str) -> tuple[int, ...]:
+        return tuple(int(part) for part in version.split("."))
+
+    return parts(candidate) > parts(current)
+
+
+def download_verified(manifest: dict, *, dir: str | None = None,
+                      prefix: str = "fused-render-update-", suffix: str = "",
+                      max_bytes: int = MAX_ARTIFACT_BYTES,
+                      progress=None, urlopen_fn=None) -> str:
+    """Stream the artifact to a temp file (in `dir`, or the system temp dir)
+    while hashing it, and confirm its SHA-256 matches the signed value. The
+    manifest signature (over version + sha256) is already verified in
+    fetch_manifest; the URL is not signed, so require HTTPS. `progress`
+    (optional) is called with bytes downloaded so far after each chunk."""
+    if urlopen_fn is None:
+        urlopen_fn = urlopen
+    url = manifest["url"]
+    if not url.startswith("https://"):
+        raise ValueError("update manifest url is not https")
+    sha256 = manifest["sha256"]
+    digest = hashlib.sha256()
+    total = 0
+    fd, path = tempfile.mkstemp(prefix=prefix, suffix=suffix, dir=dir)
+    ok = False
+    try:
+        with os.fdopen(fd, "wb") as out, urlopen_fn(url, DOWNLOAD_TIMEOUT_S) as resp:
+            while chunk := resp.read(DOWNLOAD_CHUNK):
+                total += len(chunk)
+                if total > max_bytes:
+                    raise ValueError("update download exceeds the size limit")
+                digest.update(chunk)
+                out.write(chunk)
+                if progress is not None:
+                    progress(total)
+        if digest.hexdigest() != sha256:
+            raise ValueError("downloaded file does not match the signed manifest")
+        ok = True
+        return path
+    finally:
+        if not ok:
+            discard(path)
+
+
+def discard(path: str) -> None:
+    try:
+        os.unlink(path)
+    except OSError:
+        pass

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -39,7 +39,12 @@ from fused_render.update import common
 
 logger = logging.getLogger("fused_render.update")
 
-MANIFEST_URL = "https://d2ic19jpchjovp.cloudfront.net/fused-render-macos/latest.json"
+# Overridable for staging/E2E tests (point a test build at a test manifest).
+# Safe to expose: the manifest must still verify against the pinned ed25519
+# key, so redirecting the URL alone cannot feed the updater different bytes.
+MANIFEST_URL = os.environ.get(
+    "FUSED_RENDER_UPDATE_MANIFEST_URL",
+    "https://d2ic19jpchjovp.cloudfront.net/fused-render-macos/latest.json")
 CASK_NAME = "fused-render"
 # GUI apps launch with a bare PATH, so brew is probed at its two fixed homes
 # (Apple Silicon, then Intel) rather than through the environment.

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -1,0 +1,406 @@
+"""macOS in-app updater (docs/PYTHON_SUPERVISOR_SPEC.md "Software updates"
+gives the Windows design this mirrors). A silent background loop checks the
+signed manifest and surfaces a newer version only through /api/config's
+`update` field — the shell shows a badge. Downloading and installing happen
+solely on an explicit POST /api/update/install.
+
+Two install methods, decided once per process:
+
+- "brew": the running bundle is Homebrew-managed. Install delegates to
+  `brew upgrade --cask fused-render` so brew's own bookkeeping (Caskroom
+  metadata, `brew list`) stays truthful. On failure there is NO fallback to
+  the DMG path — swapping the bundle behind brew's back would desync it
+  permanently — the error surfaces the exact command for the user to run.
+- "dmg": download the signed DMG, verify, and swap the .app bundle in place.
+  Replacing the bundle under a running process is the SUPPORTED existing flow
+  (a manual DMG drag does exactly this): installed.installed_version() then
+  drifts from __version__, ServerStatusBanner shows the restart card, and
+  fused-render://relaunch (app.begin_relaunch) respawns from disk. That
+  relaunch guard REQUIRES the drift, which is why the swap happens on install
+  rather than being deferred to quit.
+
+Everything runs on worker threads and never raises out of the manager: a
+failed check leaves state "idle"/"error", never a dead loop.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import plistlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+
+from fused_render import __version__
+from fused_render.update import common
+
+logger = logging.getLogger("fused_render.update")
+
+MANIFEST_URL = "https://d2ic19jpchjovp.cloudfront.net/fused-render-macos/latest.json"
+CASK_NAME = "fused-render"
+# GUI apps launch with a bare PATH, so brew is probed at its two fixed homes
+# (Apple Silicon, then Intel) rather than through the environment.
+BREW_PATHS = ("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
+BREW_TIMEOUT_S = 15 * 60
+_DOWNLOAD_PREFIX = "FusedRender-"
+_DOWNLOAD_SUFFIX = ".dmg"
+# Keep a margin over the DMG itself: the download and the staged .app copy
+# coexist briefly during the swap.
+_DISK_SPACE_FACTOR = 3
+
+
+def bundle_path() -> str | None:
+    """The .app bundle root when running packaged, None otherwise (same
+    anatomy as app.bundle_path; duplicated here so this module never imports
+    app.py, which needs AppKit)."""
+    if getattr(sys, "frozen", None) != "macosx_app":
+        return None
+    contents = os.path.dirname(os.path.dirname(os.path.abspath(sys.executable)))
+    return os.path.dirname(contents)
+
+
+def find_brew() -> str | None:
+    for path in BREW_PATHS:
+        if os.access(path, os.X_OK):
+            return path
+    return None
+
+
+def detect_method(bundle: str | None, *, brew: str | None = None,
+                  run=subprocess.run) -> str:
+    """"brew" | "dmg" | "none". Brew-managed means `brew list --cask` knows
+    the cask AND its app artifact is the very bundle we are running — a user
+    with stale brew history but a drag-installed copy elsewhere must get the
+    DMG path, not a brew upgrade that replaces a different install."""
+    if bundle is None:
+        return "none"
+    if brew is None:
+        brew = find_brew()
+    if brew is None:
+        return "dmg"
+    try:
+        listed = run([brew, "list", "--cask", CASK_NAME],
+                     capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired):
+        return "dmg"
+    if listed.returncode != 0:
+        return "dmg"
+    bundle_real = os.path.realpath(bundle)
+    for line in listed.stdout.splitlines():
+        candidate = line.strip().split(" -> ")[0].strip()
+        if candidate.endswith(".app") and os.path.realpath(candidate) == bundle_real:
+            return "brew"
+    # The cask's `app` artifact moves the bundle to /Applications; `brew list`
+    # output shapes vary across brew versions, so accept the conventional
+    # target too when the listing didn't name the bundle directly.
+    if bundle_real == os.path.realpath("/Applications/FusedRender.app"):
+        return "brew"
+    return "dmg"
+
+
+class UpdateManager:
+    """State machine behind /api/config's `update` field.
+
+    states: idle -> checking -> (idle | available) -> installing(progress)
+            -> installed | error(message, manual_command?)
+    "installed" means the bundle on disk is the new version; the existing
+    installed_version drift banner drives the restart from there."""
+
+    def __init__(self, *, manifest_url: str = MANIFEST_URL, bundle: str | None = None,
+                 method: str | None = None):
+        self._lock = threading.Lock()
+        self._manifest_url = manifest_url
+        self._bundle = bundle if bundle is not None else bundle_path()
+        self._method = method  # resolved lazily: brew probing costs a subprocess
+        self._state = "idle"
+        self._latest: dict | None = None
+        self._error: str | None = None
+        self._manual_command: str | None = None
+        self._progress: float | None = None
+        self._install_thread: threading.Thread | None = None
+
+    # -- status ---------------------------------------------------------------
+
+    def status(self) -> dict:
+        with self._lock:
+            return {
+                "state": self._state,
+                "method": self.method(),
+                "latest_version": self._latest["version"] if self._latest else None,
+                "progress": self._progress,
+                "error": self._error,
+                "manual_command": self._manual_command,
+            }
+
+    def method(self) -> str:
+        if self._method is None:
+            self._method = detect_method(self._bundle)
+        return self._method
+
+    # -- checking -------------------------------------------------------------
+
+    def start_auto_checks(self) -> None:
+        """Background check loop (startup delay, then every CHECK_INTERVAL_S).
+        Silent: a newer version only flips state to "available"; set
+        FUSED_RENDER_NO_AUTO_UPDATE to a non-empty value to disable."""
+        if os.environ.get("FUSED_RENDER_NO_AUTO_UPDATE"):
+            return
+
+        def loop():
+            time.sleep(common.STARTUP_DELAY_S)
+            self._sweep_stale_downloads()
+            while True:
+                try:
+                    self.check()
+                except Exception:  # noqa: BLE001 - a tick must never kill the loop
+                    logger.exception("auto update tick failed")
+                time.sleep(common.CHECK_INTERVAL_S)
+
+        threading.Thread(target=loop, daemon=True,
+                         name="fused-render-update-auto").start()
+
+    def check(self) -> dict:
+        """Fetch + verify the manifest and update state. Never touches state
+        while an install is running. Returns status()."""
+        with self._lock:
+            if self._state == "installing":
+                return self.status()
+            self._state = "checking"
+            self._error = None
+        try:
+            manifest = common.fetch_manifest(self._manifest_url)
+            newer = common.is_newer(manifest["version"], __version__)
+        except Exception as error:  # noqa: BLE001 - network/manifest failures are routine
+            logger.info("update check failed: %s", error)
+            with self._lock:
+                if self._state == "checking":
+                    # Keep a previously-found update visible over a later
+                    # transient failure.
+                    self._state = "available" if self._latest else "idle"
+            return self.status()
+        with self._lock:
+            if self._state == "checking":
+                if newer:
+                    self._latest = manifest
+                    self._state = "available"
+                else:
+                    self._latest = None
+                    self._state = "idle"
+        return self.status()
+
+    # -- installing -----------------------------------------------------------
+
+    def install(self) -> dict:
+        """Kick the install on a worker thread. One at a time; re-POSTing
+        while installing just reports current state. Allowed from "available"
+        and from "error" (retry)."""
+        with self._lock:
+            if self._state == "installing":
+                return self.status()
+            if self._latest is None or self._state not in ("available", "error"):
+                return self.status()
+            manifest = self._latest
+            self._state = "installing"
+            self._error = None
+            self._manual_command = None
+            self._progress = 0.0
+            thread = threading.Thread(
+                target=self._install, args=(manifest,), daemon=True,
+                name="fused-render-update-install")
+            self._install_thread = thread
+        thread.start()
+        return self.status()
+
+    def _install(self, manifest: dict) -> None:
+        try:
+            if self.method() == "brew":
+                self._install_brew()
+            elif self.method() == "dmg":
+                self._install_dmg(manifest)
+            else:
+                raise RuntimeError("not running from an installed bundle")
+        except Exception as error:  # noqa: BLE001 - reported through state, never raised
+            logger.exception("update install failed")
+            with self._lock:
+                self._state = "error"
+                self._error = str(error)
+            return
+        with self._lock:
+            self._state = "installed"
+            self._progress = None
+
+    # -- brew path ------------------------------------------------------------
+
+    def _install_brew(self) -> None:
+        brew = find_brew()
+        command = f"brew upgrade --cask {CASK_NAME}"
+        if brew is None:
+            with self._lock:
+                self._manual_command = command
+            raise RuntimeError("Homebrew was not found")
+        try:
+            result = subprocess.run(
+                [brew, "upgrade", "--cask", CASK_NAME],
+                capture_output=True, text=True, timeout=BREW_TIMEOUT_S,
+                env={**os.environ, "HOMEBREW_NO_ENV_HINTS": "1"},
+            )
+        except subprocess.TimeoutExpired as error:
+            with self._lock:
+                self._manual_command = command
+            raise RuntimeError("brew upgrade timed out") from error
+        if result.returncode != 0:
+            # No DMG fallback — a brew-managed install must stay brew-managed.
+            # Surface the exact command so the user can run it themselves.
+            tail = (result.stderr or result.stdout or "").strip().splitlines()[-5:]
+            with self._lock:
+                self._manual_command = command
+            raise RuntimeError("brew upgrade failed: " + " / ".join(tail))
+
+    # -- dmg path -------------------------------------------------------------
+
+    def _updates_dir(self) -> str:
+        path = os.path.expanduser("~/Library/Application Support/fused-render/updates")
+        os.makedirs(path, exist_ok=True)
+        return path
+
+    def _sweep_stale_downloads(self) -> None:
+        """Best-effort cleanup of DMGs and staged bundles a previous session
+        left behind (install failed, or the process died mid-download)."""
+        try:
+            updates = self._updates_dir()
+            for name in os.listdir(updates):
+                full = os.path.join(updates, name)
+                try:
+                    if os.path.isdir(full):
+                        shutil.rmtree(full)
+                    else:
+                        os.unlink(full)
+                except OSError:
+                    pass
+        except OSError:
+            pass
+
+    def _install_dmg(self, manifest: dict) -> None:
+        bundle = self._bundle
+        if bundle is None:
+            raise RuntimeError("not running from an installed bundle")
+        parent = os.path.dirname(bundle)
+        if not os.access(parent, os.W_OK):
+            raise RuntimeError(
+                f"cannot write to {parent} — update by downloading the DMG manually")
+
+        updates = self._updates_dir()
+        self._check_disk_space(updates)
+
+        # Manifest carries no size field (schema 1), so progress is a raw byte
+        # count; the UI shows MB downloaded, not a percentage.
+        def on_bytes(done: int) -> None:
+            with self._lock:
+                self._progress = float(done)
+
+        dmg = common.download_verified(
+            manifest, dir=updates, prefix=_DOWNLOAD_PREFIX,
+            suffix=_DOWNLOAD_SUFFIX, progress=on_bytes)
+        mount = None
+        old = None
+        swap_in = os.path.join(parent, ".FusedRender-update.app")
+        try:
+            mount = self._attach(dmg)
+            source = self._find_app(mount)
+            self._verify_app_version(source, manifest["version"])
+            if os.path.exists(swap_in):
+                shutil.rmtree(swap_in)
+            # ditto straight from the mounted image into the bundle's own
+            # parent dir: it preserves the code signature, resource forks and
+            # xattrs a plain copy can drop (a stripped signature would leave a
+            # bundle Gatekeeper refuses to launch), and landing on the target
+            # volume makes the swap below two same-volume renames.
+            subprocess.run(["/usr/bin/ditto", source, swap_in],
+                           check=True, capture_output=True, timeout=600)
+            # The swap: both renames happen inside `parent` so each is atomic
+            # on the volume; the running process keeps its open files on the
+            # old inode (same situation as a manual DMG drag / brew upgrade).
+            old = os.path.join(parent, f".FusedRender-old-{os.getpid()}.app")
+            os.rename(bundle, old)
+            try:
+                os.rename(swap_in, bundle)
+            except OSError:
+                os.rename(old, bundle)  # roll back — never leave no app at all
+                raise
+        finally:
+            if mount is not None:
+                subprocess.run(["/usr/bin/hdiutil", "detach", mount, "-quiet"],
+                               check=False, capture_output=True, timeout=60)
+            common.discard(dmg)
+            if os.path.exists(swap_in):
+                shutil.rmtree(swap_in, ignore_errors=True)
+        # Old bundle: best-effort removal on a worker; open files keep working
+        # on the unlinked inodes until this process exits.
+        if old is not None:
+            threading.Thread(target=shutil.rmtree, args=(old,),
+                             kwargs={"ignore_errors": True}, daemon=True).start()
+
+    def _check_disk_space(self, updates: str) -> None:
+        stat = os.statvfs(updates)
+        free = stat.f_bavail * stat.f_frsize
+        if free < _DISK_SPACE_FACTOR * common.MAX_ARTIFACT_BYTES // 2:
+            raise RuntimeError("not enough free disk space to download the update")
+
+    def _attach(self, dmg: str) -> str:
+        result = subprocess.run(
+            ["/usr/bin/hdiutil", "attach", dmg, "-nobrowse", "-readonly",
+             "-plist", "-mountrandom", tempfile.gettempdir()],
+            capture_output=True, timeout=120)
+        if result.returncode != 0:
+            raise RuntimeError("could not open the downloaded update image")
+        for entity in plistlib.loads(result.stdout).get("system-entities", []):
+            if entity.get("mount-point"):
+                return entity["mount-point"]
+        raise RuntimeError("update image mounted with no volume")
+
+    def _find_app(self, mount: str) -> str:
+        for name in sorted(os.listdir(mount)):
+            if name.endswith(".app"):
+                return os.path.join(mount, name)
+        raise RuntimeError("update image contains no app bundle")
+
+    def _verify_app_version(self, app: str, version: str) -> None:
+        """The DMG's integrity is already pinned by the signed sha256; this
+        guards against a mispublished manifest (right signature, wrong file)
+        swapping in an unexpected version."""
+        try:
+            with open(os.path.join(app, "Contents", "Info.plist"), "rb") as f:
+                found = plistlib.load(f).get("CFBundleShortVersionString")
+        except (OSError, plistlib.InvalidFileException) as error:
+            raise RuntimeError("update app bundle has no readable Info.plist") from error
+        if found != version:
+            raise RuntimeError(
+                f"update image contains version {found}, expected {version}")
+
+
+_manager: UpdateManager | None = None
+_manager_lock = threading.Lock()
+
+
+def manager() -> UpdateManager | None:
+    """The process-wide manager, or None when start() was never called (dev
+    server, CLI, non-mac packages) — /api/config omits `update` then."""
+    return _manager
+
+
+def start() -> UpdateManager | None:
+    """Create the singleton and start its background checks. Called once from
+    the mac app's server bootstrap; idempotent. No-op (returns None) when not
+    running from a bundle — an unpackaged dev run has nothing to swap, so it
+    gets no badge at all rather than an install that can only fail."""
+    global _manager
+    with _manager_lock:
+        if _manager is None:
+            if bundle_path() is None:
+                return None
+            _manager = UpdateManager()
+            _manager.start_auto_checks()
+        return _manager

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -183,15 +183,37 @@ class UpdateManager:
                     # transient failure.
                     self._state = "available" if self._latest else "idle"
             return self.status()
+        # The bundle on disk, not the running __version__, decides "already
+        # installed": after a successful swap (ours, brew's, or a manual one
+        # in a terminal) this process still runs the old code, and comparing
+        # against __version__ alone would flip a completed install back to
+        # "available" — offering a second swap against an already-new bundle.
+        disk = self._disk_version()
         with self._lock:
             if self._state == "checking":
-                if newer:
+                if newer and disk is not None and not common.is_newer(
+                        manifest["version"], disk):
+                    self._latest = manifest
+                    self._state = "installed"
+                elif newer:
                     self._latest = manifest
                     self._state = "available"
                 else:
                     self._latest = None
                     self._state = "idle"
         return self.status()
+
+    def _disk_version(self) -> str | None:
+        """CFBundleShortVersionString of the bundle on disk — what would launch
+        next time (same read as installed.installed_version, but against this
+        manager's bundle path so tests can point it at a fixture)."""
+        if self._bundle is None:
+            return None
+        try:
+            with open(os.path.join(self._bundle, "Contents", "Info.plist"), "rb") as f:
+                return plistlib.load(f).get("CFBundleShortVersionString")
+        except (OSError, plistlib.InvalidFileException):
+            return None
 
     # -- installing -----------------------------------------------------------
 
@@ -219,7 +241,7 @@ class UpdateManager:
     def _install(self, manifest: dict) -> None:
         try:
             if self.method() == "brew":
-                self._install_brew()
+                self._install_brew(manifest)
             elif self.method() == "dmg":
                 self._install_dmg(manifest)
             else:
@@ -236,7 +258,7 @@ class UpdateManager:
 
     # -- brew path ------------------------------------------------------------
 
-    def _install_brew(self) -> None:
+    def _install_brew(self, manifest: dict) -> None:
         brew = find_brew()
         command = f"brew upgrade --cask {CASK_NAME}"
         if brew is None:
@@ -260,6 +282,19 @@ class UpdateManager:
             with self._lock:
                 self._manual_command = command
             raise RuntimeError("brew upgrade failed: " + " / ".join(tail))
+        # brew exits 0 without upgrading anything when it considers the cask
+        # current — which it is whenever the tap bump (release CI's last job)
+        # hasn't landed yet, since the signed manifest publishes first. Only
+        # the bundle on disk proves the install happened.
+        target = manifest["version"]
+        disk = self._disk_version()
+        if disk is None or common.is_newer(target, disk):
+            with self._lock:
+                self._manual_command = command
+            raise RuntimeError(
+                f"brew finished but the installed app is still v{disk or 'unknown'} "
+                f"— v{target} may not have reached the Homebrew tap yet. "
+                "Try again in a few minutes.")
 
     # -- dmg path -------------------------------------------------------------
 

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -177,11 +177,20 @@ class UpdateManager:
             newer = common.is_newer(manifest["version"], __version__)
         except Exception as error:  # noqa: BLE001 - network/manifest failures are routine
             logger.info("update check failed: %s", error)
+            # Keep a previously-found update visible over a transient failure —
+            # but re-derive WHICH state from the bundle on disk, exactly like
+            # the success path below: a network blip after a completed install
+            # must not resurface the install button.
+            disk = self._disk_version()
             with self._lock:
                 if self._state == "checking":
-                    # Keep a previously-found update visible over a later
-                    # transient failure.
-                    self._state = "available" if self._latest else "idle"
+                    if self._latest and disk is not None and not common.is_newer(
+                            self._latest["version"], disk):
+                        self._state = "installed"
+                    elif self._latest:
+                        self._state = "available"
+                    else:
+                        self._state = "idle"
             return self.status()
         # The bundle on disk, not the running __version__, decides "already
         # installed": after a successful swap (ours, brew's, or a manual one

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -111,7 +111,9 @@ class UpdateManager:
 
     def __init__(self, *, manifest_url: str = MANIFEST_URL, bundle: str | None = None,
                  method: str | None = None):
-        self._lock = threading.Lock()
+        # RLock: the early-return paths in check()/install() read status()
+        # while already holding the lock.
+        self._lock = threading.RLock()
         self._manifest_url = manifest_url
         self._bundle = bundle if bundle is not None else bundle_path()
         self._method = method  # resolved lazily: brew probing costs a subprocess

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -71,7 +71,9 @@ def test_detect_method_dmg_when_brew_errors(tmp_path):
 
 
 def _manager(monkeypatch, *, method="dmg", available=None, current="0.4.10"):
-    manager = mac.UpdateManager(bundle="/Applications/FusedRender.app", method=method)
+    # A bundle path that exists on no machine: _disk_version() must read None
+    # so these tests never see the developer's real /Applications install.
+    manager = mac.UpdateManager(bundle="/nonexistent/FusedRender.app", method=method)
     monkeypatch.setattr(mac, "__version__", current)
     if available is not None:
         manifest = {"schema": 1, "version": available, "url": "https://x/y.dmg",
@@ -204,9 +206,40 @@ def test_brew_success_lands_installed(monkeypatch):
     monkeypatch.setattr(
         mac.subprocess, "run",
         lambda cmd, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""))
+    # brew exit 0 alone must not count — the bundle on disk proves the install.
+    monkeypatch.setattr(manager, "_disk_version", lambda: "9.9.9")
     manager.install()
     manager._install_thread.join(timeout=5)
     assert manager.status()["state"] == "installed"
+
+
+def test_brew_exit_zero_with_stale_tap_is_an_error(monkeypatch):
+    """brew exits 0 without upgrading when the tap bump hasn't landed yet; the
+    manager must not claim "installed" while the bundle on disk is still old."""
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    manager.check()
+    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
+    monkeypatch.setattr(
+        mac.subprocess, "run",
+        lambda cmd, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""))
+    monkeypatch.setattr(manager, "_disk_version", lambda: "0.4.10")
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    status = manager.status()
+    assert status["state"] == "error"
+    assert "tap" in status["error"]
+    assert status["manual_command"] == "brew upgrade --cask fused-render"
+
+
+def test_check_reports_installed_once_disk_has_the_update(monkeypatch):
+    """After a swap (ours or a manual brew upgrade) the running __version__ is
+    still old; a later auto-check must land on "installed", not flip back to
+    "available" with a live install button."""
+    manager = _manager(monkeypatch, available="9.9.9")
+    monkeypatch.setattr(manager, "_disk_version", lambda: "9.9.9")
+    status = manager.check()
+    assert status["state"] == "installed"
+    assert status["latest_version"] == "9.9.9"
 
 
 # ---- dmg helpers ---------------------------------------------------------------

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -1,0 +1,273 @@
+"""macOS in-app updater (fused_render/update/mac.py) and its API surface.
+
+The signed-manifest crypto path is shared with the Windows updater and covered
+by tests/test_win_supervisor_update.py; these tests cover what's new on mac:
+the brew/dmg method decision, the manager's state machine (including the
+no-DMG-fallback-on-brew-failure rule), and the /api/update endpoints' guards.
+"""
+import subprocess
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render.server.app import create_app
+from fused_render.update import common, mac
+
+
+# ---- detect_method -----------------------------------------------------------
+
+
+def _run_stub(returncode: int, stdout: str = ""):
+    def run(cmd, **kwargs):
+        return types.SimpleNamespace(returncode=returncode, stdout=stdout, stderr="")
+
+    return run
+
+
+def test_detect_method_none_when_unbundled():
+    assert mac.detect_method(None) == "none"
+
+
+def test_detect_method_dmg_when_brew_probe_missing(monkeypatch):
+    monkeypatch.setattr(mac, "find_brew", lambda: None)
+    assert mac.detect_method("/Applications/FusedRender.app") == "dmg"
+
+
+def test_detect_method_dmg_when_cask_not_installed():
+    method = mac.detect_method("/Applications/FusedRender.app", brew="/fake/brew",
+                               run=_run_stub(1))
+    assert method == "dmg"
+
+
+def test_detect_method_brew_when_listed_artifact_matches(tmp_path):
+    bundle = tmp_path / "FusedRender.app"
+    bundle.mkdir()
+    method = mac.detect_method(str(bundle), brew="/fake/brew",
+                               run=_run_stub(0, f"==> App\n{bundle}\n"))
+    assert method == "brew"
+
+
+def test_detect_method_dmg_when_listed_artifact_elsewhere(tmp_path):
+    bundle = tmp_path / "FusedRender.app"
+    bundle.mkdir()
+    other = tmp_path / "Other.app"
+    other.mkdir()
+    method = mac.detect_method(str(bundle), brew="/fake/brew",
+                               run=_run_stub(0, f"{other}\n"))
+    assert method == "dmg"
+
+
+def test_detect_method_dmg_when_brew_errors(tmp_path):
+    def run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 30)
+
+    bundle = tmp_path / "FusedRender.app"
+    bundle.mkdir()
+    assert mac.detect_method(str(bundle), brew="/fake/brew", run=run) == "dmg"
+
+
+# ---- UpdateManager state machine ----------------------------------------------
+
+
+def _manager(monkeypatch, *, method="dmg", available=None, current="0.4.10"):
+    manager = mac.UpdateManager(bundle="/Applications/FusedRender.app", method=method)
+    monkeypatch.setattr(mac, "__version__", current)
+    if available is not None:
+        manifest = {"schema": 1, "version": available, "url": "https://x/y.dmg",
+                    "sha256": "s", "signature": "g"}
+        monkeypatch.setattr(common, "fetch_manifest",
+                            lambda url, **kwargs: dict(manifest))
+    return manager
+
+
+def test_check_finds_newer(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    status = manager.check()
+    assert status["state"] == "available"
+    assert status["latest_version"] == "9.9.9"
+
+
+def test_check_up_to_date(monkeypatch):
+    manager = _manager(monkeypatch, available="0.0.1")
+    status = manager.check()
+    assert status["state"] == "idle"
+    assert status["latest_version"] is None
+
+
+def test_check_failure_keeps_available(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    assert manager.check()["state"] == "available"
+
+    def boom(url, **kwargs):
+        raise OSError("offline")
+
+    monkeypatch.setattr(common, "fetch_manifest", boom)
+    status = manager.check()
+    assert status["state"] == "available"
+    assert status["latest_version"] == "9.9.9"
+
+
+def test_check_failure_without_prior_update_is_idle(monkeypatch):
+    manager = _manager(monkeypatch)
+
+    def boom(url, **kwargs):
+        raise OSError("offline")
+
+    monkeypatch.setattr(common, "fetch_manifest", boom)
+    assert manager.check()["state"] == "idle"
+
+
+def test_install_requires_available_state(monkeypatch):
+    manager = _manager(monkeypatch)
+    assert manager.install()["state"] == "idle"
+
+
+def test_install_runs_method_and_lands_installed(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    manager.check()
+    done = []
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: done.append(manifest))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert done and done[0]["version"] == "9.9.9"
+    assert manager.status()["state"] == "installed"
+
+
+def test_install_failure_surfaces_error(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    manager.check()
+
+    def boom(manifest):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(manager, "_install_dmg", boom)
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    status = manager.status()
+    assert status["state"] == "error"
+    assert "disk full" in status["error"]
+
+
+def test_install_retry_allowed_from_error(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    manager.check()
+    monkeypatch.setattr(manager, "_install_dmg",
+                        lambda manifest: (_ for _ in ()).throw(RuntimeError("x")))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert manager.status()["state"] == "error"
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: None)
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert manager.status()["state"] == "installed"
+
+
+# ---- brew path: failure gives the command, never a DMG fallback ---------------
+
+
+def test_brew_failure_sets_manual_command_and_no_dmg(monkeypatch):
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    manager.check()
+    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
+
+    def run(cmd, **kwargs):
+        return types.SimpleNamespace(returncode=1, stdout="", stderr="Error: no sudo")
+
+    monkeypatch.setattr(mac.subprocess, "run", run)
+    dmg_calls = []
+    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: dmg_calls.append(1))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    status = manager.status()
+    assert status["state"] == "error"
+    assert status["manual_command"] == "brew upgrade --cask fused-render"
+    assert "no sudo" in status["error"]
+    assert not dmg_calls
+
+
+def test_brew_missing_at_install_sets_manual_command(monkeypatch):
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    manager.check()
+    monkeypatch.setattr(mac, "find_brew", lambda: None)
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    status = manager.status()
+    assert status["state"] == "error"
+    assert status["manual_command"] == "brew upgrade --cask fused-render"
+
+
+def test_brew_success_lands_installed(monkeypatch):
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    manager.check()
+    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
+    monkeypatch.setattr(
+        mac.subprocess, "run",
+        lambda cmd, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""))
+    manager.install()
+    manager._install_thread.join(timeout=5)
+    assert manager.status()["state"] == "installed"
+
+
+# ---- dmg helpers ---------------------------------------------------------------
+
+
+def test_find_app(tmp_path):
+    (tmp_path / "FusedRender.app").mkdir()
+    manager = mac.UpdateManager(bundle="/x.app", method="dmg")
+    assert manager._find_app(str(tmp_path)).endswith("FusedRender.app")
+    with pytest.raises(RuntimeError):
+        manager._find_app(str(tmp_path / "FusedRender.app"))  # empty dir: no .app
+
+
+def test_verify_app_version(tmp_path):
+    import plistlib
+
+    app = tmp_path / "FusedRender.app"
+    (app / "Contents").mkdir(parents=True)
+    with open(app / "Contents" / "Info.plist", "wb") as f:
+        plistlib.dump({"CFBundleShortVersionString": "1.2.3"}, f)
+    manager = mac.UpdateManager(bundle="/x.app", method="dmg")
+    manager._verify_app_version(str(app), "1.2.3")
+    with pytest.raises(RuntimeError):
+        manager._verify_app_version(str(app), "9.9.9")
+
+
+# ---- API surface ---------------------------------------------------------------
+
+
+@pytest.fixture()
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def test_config_omits_update_without_manager(client):
+    assert mac.manager() is None
+    assert "update" not in client.get("/api/config").json()
+
+
+def test_update_endpoints_404_without_manager(client):
+    assert client.post("/api/update/check", headers={"X-Fused": "1"}).status_code == 404
+    assert client.post("/api/update/install", headers={"X-Fused": "1"}).status_code == 404
+
+
+def test_update_endpoints_require_x_fused(client, monkeypatch):
+    monkeypatch.setattr(mac, "_manager",
+                        mac.UpdateManager(bundle="/x.app", method="dmg"))
+    assert client.post("/api/update/check").status_code == 403
+    assert client.post("/api/update/install").status_code == 403
+
+
+def test_config_carries_update_with_manager(client, monkeypatch):
+    monkeypatch.setattr(mac, "_manager",
+                        mac.UpdateManager(bundle="/x.app", method="dmg"))
+    body = client.get("/api/config").json()
+    assert body["update"]["state"] == "idle"
+    assert body["update"]["method"] == "dmg"
+
+
+def test_start_noop_when_unbundled(monkeypatch):
+    monkeypatch.setattr(mac, "_manager", None)
+    monkeypatch.setattr(mac, "bundle_path", lambda: None)
+    assert mac.start() is None
+    assert mac.manager() is None

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -231,6 +231,20 @@ def test_brew_exit_zero_with_stale_tap_is_an_error(monkeypatch):
     assert status["manual_command"] == "brew upgrade --cask fused-render"
 
 
+def test_failed_check_keeps_installed_when_disk_is_current(monkeypatch):
+    """A network blip after a completed install must not resurface the install
+    button — the error path re-derives state from the bundle on disk."""
+    manager = _manager(monkeypatch, available="9.9.9")
+    monkeypatch.setattr(manager, "_disk_version", lambda: "9.9.9")
+    assert manager.check()["state"] == "installed"
+
+    def boom(url, **kwargs):
+        raise OSError("offline")
+
+    monkeypatch.setattr(common, "fetch_manifest", boom)
+    assert manager.check()["state"] == "installed"
+
+
 def test_check_reports_installed_once_disk_has_the_update(monkeypatch):
     """After a swap (ours or a manual brew upgrade) the running __version__ is
     still old; a later auto-check must land on "installed", not flip back to


### PR DESCRIPTION
## What

Adds an in-app updater to the packaged macOS app. A background loop (60s startup delay, then every 6h; `FUSED_RENDER_NO_AUTO_UPDATE` disables) checks a signed manifest and surfaces a newer version through a new `update` field on `/api/config`. The shell shows an **Update available** row above Preferences in the sidebar; clicking it opens a small panel that installs in place.

Two install methods, decided per process:

- **brew** — the running bundle is Homebrew-managed (`brew list --cask fused-render` lists it and its artifact matches the running bundle path). Install delegates to `brew upgrade --cask fused-render`. On failure there is deliberately **no DMG fallback** — the panel shows the exact command (with a copy button) for the user to run themselves, so brew's bookkeeping never desyncs from what's on disk.
- **dmg** — everything else. Downloads the signed DMG, verifies the ed25519 manifest signature + sha256 (same scheme as the Windows updater), mounts it, `ditto`s the new .app next to the target, and swaps via two same-volume renames. Replacing the bundle under the running process is the already-supported manual-DMG-drag flow: `installed_version` drifts, ServerStatusBanner shows the restart card, and `fused-render://relaunch` respawns from disk (that relaunch guard *requires* the drift, which is why the swap happens at install time).

## Pieces

- `fused_render/update/common.py` — signed-manifest fetch/verify + hash-verified download, factored out of `supervisor/_win32/update.py` (Windows behavior unchanged, same test seams; its 29 tests still pass).
- `fused_render/update/mac.py` — method detection, state machine (`idle/checking/available/installing/installed/error`), brew + DMG install paths, stale-download sweep, disk-space check.
- `fused_render/server/routers/update.py` — `POST /api/update/check` and `POST /api/update/install`, D3 X-Fused guarded; 404 when no manager (dev runs, Windows/Linux packages).
- `/api/config` gains `update` (only when the packaged mac app started the manager) — rides the existing poll.
- `frontend/.../UpdateBadge.tsx` — sidebar row + panel (install button, MB progress, brew-failure command with copy, retry).
- `release.yml` — publishes a signed `fused-render-macos/latest.json` next to the DMG upload, using the same signing script/key as Windows.

## Tests

`tests/test_mac_update.py`: method-detection matrix, state machine (incl. no-DMG-fallback-on-brew-failure and retry-from-error), dmg helpers, API guards. Full suite: 5997 passed; 2 failures are pre-existing on macOS hosts (`test_calls` reads `/proc/self/fd`) or fixed here (`test_theme` color literal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> DMG install renames the live app bundle on disk and release signing/CDN paths feed the updater; mistakes could brick installs or serve bad updates despite ed25519 checks.
> 
> **Overview**
> Adds **in-app self-update** for the packaged macOS app: a background manager polls a signed CDN manifest and exposes state on `/api/config`; the sidebar **UpdateBadge** drives install via guarded `POST /api/update/check` and `/api/update/install`.
> 
> **Install paths:** Homebrew-managed bundles use `brew upgrade --cask` only (failures surface a copyable command, no silent DMG fallback). Other installs download a verified DMG, `ditto` the new `.app`, and atomically swap bundles under the running process so the existing restart/relaunch flow applies.
> 
> **Shared crypto:** Signed-manifest fetch/verify and hash-checked downloads move into `fused_render/update/common.py`; the Windows supervisor updater delegates there without behavior change.
> 
> **Release:** macOS release workflow publishes `fused-render-macos/latest.json` (same signing as Windows) and invalidates that CDN prefix.
> 
> **Scope:** Manager starts only from the frozen mac app bundle; dev and Windows/Linux omit `update` and get 404 on update routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c77e7cf28bb8d9ce1bcab189c221131091caa65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->