### PR TITLE
Add joblib_model template for previewing .joblib/.pkl/.pickle files

### DIFF
--- a/fused_render/_env_install_worker.py
+++ b/fused_render/_env_install_worker.py
@@ -210,7 +210,12 @@ def _acquire_python(version):
     # dir-qualified here (it comes from `shutil.which`), which posix_spawn also
     # requires; a bare command name forks despite the flag.
     proc = subprocess.run([uv, "python", "install", version], env=_uv_env(),
-                          capture_output=True, text=True, close_fds=False)
+                          capture_output=True, text=True, close_fds=False,
+                          # This worker is itself spawned with DETACHED_PROCESS
+                          # (envinstall._spawn), so it has no console of its own to
+                          # hand a console-subsystem child like uv.exe — without
+                          # this, Windows allocates a fresh, visible one for it.
+                          creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
     if proc.returncode != 0:
         # Verbatim, exactly like the requirements install below: uv's own text names
         # the real problem (an offline machine, a proxy refusing the download, no
@@ -334,8 +339,12 @@ def _build(project_dir, venv_dir, uv_cache_dir, python_executable):
     os.makedirs(uv_cache_dir, exist_ok=True)
     # close_fds=False for posix_spawn rather than fork()+exec — the same discipline
     # every other spawn in this codebase follows; see `_acquire_python` above.
+    # creationflags: see `_acquire_python` above — this worker has no console of
+    # its own to hand `uv sync` (a console-subsystem binary), so Windows would
+    # otherwise pop a fresh one for it.
     proc = subprocess.run(cmd, cwd=project_dir, env=env,
-                          capture_output=True, text=True, close_fds=False)
+                          capture_output=True, text=True, close_fds=False,
+                          creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
     if proc.returncode != 0:
         # Verbatim: uv's own text names the real problem (no wheel for this
         # platform, a bad pin, no network, a lock that no longer matches the

--- a/fused_render/_env_install_worker.py
+++ b/fused_render/_env_install_worker.py
@@ -209,12 +209,10 @@ def _acquire_python(version):
     # handle and SIGSEGVs before exec — a bare returncode -11 with no stderr. `uv` is
     # dir-qualified here (it comes from `shutil.which`), which posix_spawn also
     # requires; a bare command name forks despite the flag.
+    # This worker runs detached with no console of its own, so Windows would
+    # otherwise pop a fresh one for a console-subsystem child like uv.exe.
     proc = subprocess.run([uv, "python", "install", version], env=_uv_env(),
                           capture_output=True, text=True, close_fds=False,
-                          # This worker is itself spawned with DETACHED_PROCESS
-                          # (envinstall._spawn), so it has no console of its own to
-                          # hand a console-subsystem child like uv.exe — without
-                          # this, Windows allocates a fresh, visible one for it.
                           creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
     if proc.returncode != 0:
         # Verbatim, exactly like the requirements install below: uv's own text names
@@ -339,9 +337,6 @@ def _build(project_dir, venv_dir, uv_cache_dir, python_executable):
     os.makedirs(uv_cache_dir, exist_ok=True)
     # close_fds=False for posix_spawn rather than fork()+exec — the same discipline
     # every other spawn in this codebase follows; see `_acquire_python` above.
-    # creationflags: see `_acquire_python` above — this worker has no console of
-    # its own to hand `uv sync` (a console-subsystem binary), so Windows would
-    # otherwise pop a fresh one for it.
     proc = subprocess.run(cmd, cwd=project_dir, env=env,
                           capture_output=True, text=True, close_fds=False,
                           creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)

--- a/fused_render/templates/joblib_model/icon.svg
+++ b/fused_render/templates/joblib_model/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="4" r="2"/><circle cx="5" cy="20" r="2"/><circle cx="19" cy="20" r="2"/><path d="M12 6v3"/><path d="M12 9 5 18"/><path d="M12 9 19 18"/></svg>

--- a/fused_render/templates/joblib_model/pyproject.toml
+++ b/fused_render/templates/joblib_model/pyproject.toml
@@ -1,0 +1,26 @@
+# This template's environment (SPEC PY-16). Unlike most readers, this one
+# genuinely has to unpickle real estimators to introspect them (hyperparams,
+# feature importances, tree structure) rather than reading raw bytes/headers —
+# so, unlike model_card's stdlib-only inspect_model.py, it needs the actual
+# ML libraries installed.
+#
+# `catboost` is deliberately NOT declared here: it is heavier and less common
+# than the other three, and a pickle referencing it still resolves to a clear
+# "unavailable" verdict (reader.py's allowlist trusts the package without
+# requiring it to be bundled) rather than failing outright.
+[project]
+name = "fused-render-template-joblib-model"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "joblib>=1.5",
+    "scikit-learn>=1.3",
+    "xgboost>=2.0",
+    "lightgbm>=4.0",
+    "pandas>=2.0",
+]
+
+# Not a distribution — this folder is a set of scripts, not something to build
+# and install.
+[tool.uv]
+package = false

--- a/fused_render/templates/joblib_model/pyproject.toml
+++ b/fused_render/templates/joblib_model/pyproject.toml
@@ -1,19 +1,12 @@
-# This template's environment (SPEC PY-16). Unlike most readers, this one
-# genuinely has to unpickle real estimators to introspect them (hyperparams,
-# feature importances, tree structure) rather than reading raw bytes/headers —
-# so, unlike model_card's stdlib-only inspect_model.py, it needs the actual
-# ML libraries installed.
-#
-# `catboost` is deliberately NOT declared here: it is heavier and less common
-# than the other three, and a pickle referencing it still resolves to a clear
-# "unavailable" verdict (reader.py's allowlist trusts the package without
-# requiring it to be bundled) rather than failing outright.
+# catboost is intentionally not declared: a pickle referencing it still
+# resolves to an "unavailable" verdict instead of failing outright.
 [project]
 name = "fused-render-template-joblib-model"
 version = "0.1.0"
 requires-python = ">=3.12"
 dependencies = [
     "joblib>=1.5",
+    "numpy",
     "scikit-learn>=1.3",
     "xgboost>=2.0",
     "lightgbm>=4.0",

--- a/fused_render/templates/joblib_model/reader.py
+++ b/fused_render/templates/joblib_model/reader.py
@@ -5,6 +5,7 @@ class/callable is confirmed trusted. Self-contained — templates are scripts
 run by the engine, not part of the package (SPEC PY-15/D166).
 """
 import io
+import itertools
 import json
 import math
 import os
@@ -12,6 +13,7 @@ import pickle
 import zlib
 
 import joblib.numpy_pickle
+import numpy as np
 
 _RAW_SIZE_CAP = 2 * 1024 * 1024 * 1024
 _DECOMPRESSED_CAP = 512 * 1024 * 1024
@@ -106,20 +108,80 @@ def _classify(module: str, name: str) -> bool:
     return any(module == prefix.rstrip(".") or module.startswith(prefix) for prefix in _PREFIX_ALLOW)
 
 
-class _DelegatingUnpickler(pickle.Unpickler):
-    """Plain Unpickler with externally supplied find_class/persistent_load
-    (the C-accelerated Unpickler won't allow find_class as an instance attribute)."""
+def _refuse_unsafe_call(target, unsafe_to_call, refs_by_key, blocked):
+    """None if `target` is safe to call. Otherwise records the block against the
+    (module, name) find_class resolved it from and returns a substitute _Stub().
+    refs_by_key is an O(1) lookup (not a scan) so an attacker can't turn repeated,
+    memo-reused REDUCE/INST calls to the same blocked target into O(n*m) work."""
+    origin = unsafe_to_call.get(id(target))
+    if origin is None:
+        return None
+    ref = refs_by_key.get(origin)
+    if ref is not None:
+        ref["allowed"] = False
+    blocked.append({"module": origin[0], "name": origin[1]})
+    return _Stub()
 
-    def __init__(self, file_handle, find_class, persistent_load):
+
+def _guarded_reduce(unpickler, unsafe_to_call, refs_by_key, blocked):
+    """Gates the REDUCE opcode: mirrors pickle._Unpickler.load_reduce exactly,
+    except a call target find_class flagged unsafe-to-call is never invoked.
+    Used by both _RestrictedUnpickler and _DelegatingUnpickler (the object-dtype
+    array delegate) so neither stream can call an unvetted function."""
+    args = unpickler.stack.pop()
+    func = unpickler.stack[-1]
+    stub = _refuse_unsafe_call(func, unsafe_to_call, refs_by_key, blocked)
+    unpickler.stack[-1] = stub if stub is not None else func(*args)
+
+
+def _guarded_instantiate(unpickler, klass, args, unsafe_to_call, refs_by_key, blocked):
+    """Gates the legacy INST/OBJ opcodes: mirrors pickle._Unpickler._instantiate
+    exactly. Like REDUCE, this can call an arbitrary resolved callable with
+    attacker-chosen args -- through an opcode pair load_reduce alone doesn't cover,
+    since load_inst/load_obj call self._instantiate(...) directly, not REDUCE."""
+    stub = _refuse_unsafe_call(klass, unsafe_to_call, refs_by_key, blocked)
+    if stub is not None:
+        unpickler.append(stub)
+        return
+    if args or not isinstance(klass, type) or hasattr(klass, "__getinitargs__"):
+        try:
+            value = klass(*args)
+        except TypeError as err:
+            raise TypeError("in constructor for %s: %s" % (klass.__name__, str(err)), err.__traceback__)
+    else:
+        value = klass.__new__(klass)
+    unpickler.append(value)
+
+
+class _DelegatingUnpickler(pickle._Unpickler):
+    """Delegates find_class/persistent_load to the enclosing _RestrictedUnpickler
+    and shares its _unsafe_to_call/refs/blocked bookkeeping, so a function call
+    reached through an object-dtype array's embedded stream is gated exactly
+    like one reached through the top-level stream. Explicitly the pure-Python
+    Unpickler (not the C-accelerated one `pickle.Unpickler` aliases to) because
+    only the pure-Python one exposes an overridable `dispatch` table for
+    load_reduce -- the same reason NumpyUnpickler itself is built on it."""
+
+    def __init__(self, file_handle, restricted):
         super().__init__(file_handle)
-        self._find_class = find_class
-        self._persistent_load = persistent_load
+        self._restricted = restricted
 
     def find_class(self, module, name):
-        return self._find_class(module, name)
+        return self._restricted.find_class(module, name)
 
     def persistent_load(self, pid):
-        return self._persistent_load(pid)
+        return self._restricted.persistent_load(pid)
+
+    def load_reduce(self):
+        r = self._restricted
+        _guarded_reduce(self, r._unsafe_to_call, r.refs_by_key, r.blocked)
+
+    def _instantiate(self, klass, args):
+        r = self._restricted
+        _guarded_instantiate(self, klass, args, r._unsafe_to_call, r.refs_by_key, r.blocked)
+
+    dispatch = dict(pickle._Unpickler.dispatch)
+    dispatch[pickle.REDUCE[0]] = load_reduce
 
 
 class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
@@ -131,7 +193,7 @@ class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
 
     def read_array(self, unpickler, ensure_native_byte_order):
         if self.dtype.hasobject:
-            embedded = _DelegatingUnpickler(unpickler.file_handle, unpickler.find_class, unpickler.persistent_load)
+            embedded = _DelegatingUnpickler(unpickler.file_handle, unpickler)
             return embedded.load()
         count = 1
         for dim in self.shape:
@@ -145,6 +207,13 @@ class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
             )
         return super().read_array(unpickler, ensure_native_byte_order)
 
+    def read_mmap(self, unpickler):
+        # Unreachable today (this reader never sets mmap_mode), but read_mmap
+        # memory-maps unpickler.filename at an attacker-controlled offset/shape/
+        # dtype/order with none of read_array's checks -- refuse outright rather
+        # than rely on that staying true.
+        raise pickle.UnpicklingError("refusing to memory-map an array")
+
 
 class _SafeNDArrayWrapper(joblib.numpy_pickle.NDArrayWrapper):
     """Legacy joblib<=0.9 wrapper: loads an attacker-named sibling file via
@@ -157,72 +226,54 @@ class _SafeNDArrayWrapper(joblib.numpy_pickle.NDArrayWrapper):
 
 
 class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
-    """find_class is the sole gate: allowed references resolve for real,
-    everything else becomes an inert _Stub and is recorded as blocked."""
+    """find_class is the reference gate (disallowed names never resolve); REDUCE
+    and the legacy INST/OBJ opcodes -- the only ways a resolved reference is ever
+    actually CALLED, each with attacker-chosen args -- are gated separately below,
+    since find_class alone can't tell which resolved names will go on to be called."""
 
     def __init__(self, filename, file_obj):
         super().__init__(filename, file_obj, ensure_native_byte_order=True)
-        self.refs = []  # [{"module", "name", "allowed"}], first-seen order, deduped
-        self._seen = set()
+        self.refs_by_key = {}  # (module, name) -> {"module", "name", "allowed"}, first-seen order
         self.blocked = []
         self.missing = set()
         # A prefix-trusted name may resolve to a real, uncalled reference (e.g. a
         # FunctionTransformer merely storing numpy.log1p as an attribute) -- that's
-        # harmless, so find_class doesn't block it. What IS dangerous is REDUCE
-        # actually CALLING an unvetted function with attacker-chosen args (e.g.
-        # joblib.load). load_reduce below is the real gate for that; this maps
-        # id(resolved) -> (module, name) for anything it must refuse to call.
+        # harmless, so find_class doesn't block it. This maps id(resolved) -> the
+        # (module, name) it must refuse to actually CALL, for load_reduce/_instantiate.
         self._unsafe_to_call = {}
 
     def find_class(self, module, name):
         key = (module, name)
-        first_seen = key not in self._seen
-        self._seen.add(key)
-
-        def record(final_allowed):
-            if first_seen:
-                self.refs.append({"module": module, "name": name, "allowed": final_allowed})
+        ref = self.refs_by_key.get(key)
+        if ref is None:
+            ref = {"module": module, "name": name, "allowed": True}
+            self.refs_by_key[key] = ref
 
         if not _classify(module, name):
-            record(False)
+            ref["allowed"] = False
             self.blocked.append({"module": module, "name": name})
             return _Stub
         try:
             resolved = super().find_class(module, name)
         except (ImportError, AttributeError):
-            record(True)
             self.missing.add(module.split(".", 1)[0])
             return _Stub
         if resolved is joblib.numpy_pickle.NumpyArrayWrapper:
-            record(True)
             return _SafeNumpyArrayWrapper
         if resolved is joblib.numpy_pickle.NDArrayWrapper:
-            record(True)
             return _SafeNDArrayWrapper
         exact = _EXACT_ALLOW.get(module)
         prefix_trusted = exact is None or name not in exact
         is_safe_function = key in _PREFIX_FUNCTION_ALLOW or _is_pyx_unpickle_helper(name)
         if prefix_trusted and not isinstance(resolved, type) and not is_safe_function:
             self._unsafe_to_call[id(resolved)] = key
-        record(True)
         return resolved
 
     def load_reduce(self):
-        # Mirrors pickle._Unpickler.load_reduce exactly, except a call target
-        # find_class flagged unsafe-to-call is never actually invoked.
-        args = self.stack.pop()
-        func = self.stack[-1]
-        origin = self._unsafe_to_call.get(id(func))
-        if origin is not None:
-            module, name = origin
-            for ref in self.refs:
-                if ref["module"] == module and ref["name"] == name:
-                    ref["allowed"] = False
-                    break
-            self.blocked.append({"module": module, "name": name})
-            self.stack[-1] = _Stub()
-        else:
-            self.stack[-1] = func(*args)
+        _guarded_reduce(self, self._unsafe_to_call, self.refs_by_key, self.blocked)
+
+    def _instantiate(self, klass, args):
+        _guarded_instantiate(self, klass, args, self._unsafe_to_call, self.refs_by_key, self.blocked)
 
     dispatch = dict(joblib.numpy_pickle.NumpyUnpickler.dispatch)
     dispatch[pickle.REDUCE[0]] = load_reduce
@@ -286,11 +337,12 @@ def _restricted_load(path: str, data: bytes):
     except Exception as exc:  # noqa: BLE001 - any failure here means "not proven safe"
         return "blocked", [], f"could not parse as a pickle stream: {exc}", None
 
+    refs = list(unpickler.refs_by_key.values())
     if unpickler.blocked:
-        return "blocked", unpickler.refs, None, None
+        return "blocked", refs, None, None
     if unpickler.missing:
-        return "unavailable", unpickler.refs, ", ".join(sorted(unpickler.missing)), None
-    return "safe", unpickler.refs, None, obj
+        return "unavailable", refs, ", ".join(sorted(unpickler.missing)), None
+    return "safe", refs, None, obj
 
 
 def _sibling_chunks(path: str):
@@ -330,23 +382,33 @@ def _escape_path_key(key) -> str:
     return str(key).replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[").replace("]", "\\]")
 
 
-def _describe(obj, path="", depth=0, max_depth=4):
+def _describe(obj, path="", depth=0, max_depth=4, seen=None):
+    if seen is None:
+        seen = set()
     if depth >= max_depth:
         return {"path": path, "kind": "truncated"}
+    if isinstance(obj, (dict, list, tuple)):
+        # Pickle's memo lets a tiny file declare the SAME object many times over
+        # (shared references) -- without this, a handful of nested lists sharing
+        # one inner list produces branch^depth walk work from a few hundred bytes.
+        obj_id = id(obj)
+        if obj_id in seen:
+            return {"path": path, "kind": "shared"}
+        seen.add(obj_id)
     if isinstance(obj, dict):
         return {
             "path": path, "kind": "dict",
             "length": len(obj),
             "items": [
-                {"key": str(k), **_describe(v, f"{path}.{_escape_path_key(k)}" if path else _escape_path_key(k), depth + 1, max_depth)}
-                for k, v in list(obj.items())[:50]
+                {"key": str(k), **_describe(v, f"{path}.{_escape_path_key(k)}" if path else _escape_path_key(k), depth + 1, max_depth, seen)}
+                for k, v in itertools.islice(obj.items(), 50)
             ],
         }
     if isinstance(obj, (list, tuple)):
         return {
             "path": path, "kind": "list",
             "length": len(obj),
-            "items": [_describe(v, f"{path}[{i}]", depth + 1, max_depth) for i, v in enumerate(obj[:50])],
+            "items": [_describe(v, f"{path}[{i}]", depth + 1, max_depth, seen) for i, v in enumerate(obj[:50])],
         }
     if _is_ndarray(obj):
         return {"path": path, "kind": "ndarray", "shape": list(obj.shape), "dtype": str(obj.dtype)}
@@ -354,12 +416,19 @@ def _describe(obj, path="", depth=0, max_depth=4):
         return {"path": path, "kind": "estimator", "type": type(obj).__name__, "module": type(obj).__module__}
     if isinstance(obj, (str, int, float, bool)) or obj is None:
         value = _json_float(obj) if isinstance(obj, float) else obj
-        return {"path": path, "kind": "scalar", "value": value if not isinstance(value, str) or len(value) <= 200 else value[:200] + "…"}
+        # "type" carries the ORIGINAL Python type, since a NaN/Infinity float is
+        # sent as the JSON string "NaN" -- indistinguishable from a real string
+        # that happens to say "NaN" unless the view knows it started as a float.
+        py_type = "none" if obj is None else type(obj).__name__
+        return {
+            "path": path, "kind": "scalar", "type": py_type,
+            "value": value if not isinstance(value, str) or len(value) <= 200 else value[:200] + "…",
+        }
     return {"path": path, "kind": "object", "type": type(obj).__name__, "repr": _short_repr(obj)}
 
 
 def _is_ndarray(obj) -> bool:
-    return type(obj).__module__.startswith("numpy") and type(obj).__name__ == "ndarray"
+    return isinstance(obj, np.ndarray)
 
 
 _FIND_ESTIMATORS_MAX_DEPTH = 12  # a dict-wrapped Pipeline alone needs dict->Pipeline->steps->tuple->estimator
@@ -374,23 +443,27 @@ def _find_estimators(obj, path="", depth=0, max_depth=_FIND_ESTIMATORS_MAX_DEPTH
     obj_id = id(obj)
     if obj_id in seen:
         return []
+    # Marked as seen for EVERY object, not just estimators: pickle's memo lets a
+    # tiny file declare the same (large) container many times over via shared
+    # references, which would otherwise blow up recursive work exponentially
+    # with depth (see _describe's identical guard).
+    seen.add(obj_id)
     found = []
     is_estimator = hasattr(obj, "get_params") and callable(obj.get_params)
     if is_estimator:
-        seen.add(obj_id)
         found.append((path, obj))
     if isinstance(obj, dict):
-        for key, value in list(obj.items())[:50]:
+        for key, value in itertools.islice(obj.items(), 50):
             child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
             found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))
     elif isinstance(obj, (list, tuple)):
         for index, value in enumerate(obj[:50]):
             found.extend(_find_estimators(value, f"{path}[{index}]", depth + 1, max_depth, seen))
-    elif is_estimator and _tree_kind(obj) is None and hasattr(obj, "__dict__"):
-        # Composite estimators (Pipeline, VotingClassifier, ...) hold sub-estimators as
-        # plain attributes. Skipped once _tree_kind recognises obj as an ensemble itself
-        # (RandomForest, Bagging, ...): its members are already covered by the tree
-        # viewer, not independent top-level models.
+    elif is_estimator and not _is_tree_ensemble(obj) and hasattr(obj, "__dict__"):
+        # Composite estimators (Pipeline, VotingClassifier, ...) hold sub-estimators
+        # as plain attributes. Skipped for a tree ensemble itself (RandomForest,
+        # Bagging, ...): its members are already covered by the tree viewer, not
+        # independent top-level models.
         for key, value in list(vars(obj).items())[:50]:
             child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
             found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))
@@ -420,7 +493,10 @@ def _estimator_summary(path: str, est) -> dict:
         summary["n_features_in"] = int(est.n_features_in_)
     if hasattr(est, "classes_"):
         try:
-            summary["classes"] = [c.item() if hasattr(c, "item") else c for c in list(est.classes_)]
+            summary["classes"] = [
+                _json_float(v) if isinstance(v, float) else v
+                for v in (c.item() if hasattr(c, "item") else c for c in list(est.classes_))
+            ]
         except Exception:  # noqa: BLE001 - best-effort, never fatal to the view
             pass
     return summary
@@ -438,9 +514,12 @@ def _feature_importance(path: str, est):
             values = [abs(float(v)) for v in coef]
     if values is None:
         return None
+    # NaN compares False against everything, so sorting by a raw NaN key leaves it
+    # in an arbitrary position (even rank 0) instead of last, where "can't rank
+    # this" belongs.
     ranked = sorted(
         ({"feature": i, "importance": float(v)} for i, v in enumerate(values)),
-        key=lambda row: -row["importance"],
+        key=lambda row: math.inf if math.isnan(row["importance"]) else -row["importance"],
     )
     for row in ranked:
         row["importance"] = _json_float(row["importance"])
@@ -459,6 +538,13 @@ def _tree_kind(est):
     if hasattr(est, "tree_") and hasattr(est.tree_, "children_left"):
         return "sklearn_tree"
     return None
+
+
+def _is_tree_ensemble(est) -> bool:
+    """True if _tree_kind can render est's own trees -- so _find_estimators must
+    not also treat its individual members (e.g. a RandomForest's per-tree
+    estimators_) as separate, independently-listed top-level models."""
+    return _tree_kind(est) is not None
 
 
 def _sklearn_tree_node(tree, node_id, depth=0):
@@ -541,8 +627,10 @@ def _tree_ensemble(path: str, est, tree_index):
             round_idx, class_idx = divmod(idx, n_classes)
             return _sklearn_tree_node(est.estimators_[round_idx, class_idx].tree_, 0)
     elif kind == "xgboost":
-        # num_boosted_rounds() is cheap; get_dump() (needed only for the one
-        # requested tree) costs seconds on a large model.
+        # num_boosted_rounds() is cheap; a full get_dump() costs seconds on a large
+        # model. booster[i:i+1] slices by ROUND (all classes' trees for that round),
+        # not by flat tree index, so the round is sliced out and the class picked
+        # from it -- dumping one round instead of dumping every tree in the model.
         booster = est.get_booster()
         n_classes = len(est.classes_) if hasattr(est, "classes_") and len(est.classes_) > 2 else 1
         count = booster.num_boosted_rounds() * n_classes
@@ -550,14 +638,17 @@ def _tree_ensemble(path: str, est, tree_index):
         idx = tree_index if tree_index is not None else 0
 
         def node_builder():
-            return _xgboost_tree_node(json.loads(booster.get_dump(dump_format="json")[idx]))
+            round_idx, class_idx = divmod(idx, n_classes)
+            round_dump = booster[round_idx:round_idx + 1].get_dump(dump_format="json")
+            return _xgboost_tree_node(json.loads(round_dump[class_idx]))
     elif kind == "lightgbm":
         count = est.booster_.num_trees()
         meta = [{"index": i} for i in range(count)]
         idx = tree_index if tree_index is not None else 0
 
         def node_builder():
-            return _lightgbm_tree_node(est.booster_.dump_model()["tree_info"][idx]["tree_structure"])
+            tree_info = est.booster_.dump_model(num_iteration=1, start_iteration=idx)["tree_info"]
+            return _lightgbm_tree_node(tree_info[0]["tree_structure"])
     else:
         return None
 
@@ -588,7 +679,8 @@ def main(file: str, tree_index=None) -> dict:
         size = os.path.getsize(file)
         mtime = os.path.getmtime(file)
     except OSError as exc:
-        return {"file": {"error": str(exc)}, "scan": {"verdict": "blocked", "refs": [], "message": str(exc)}}
+        file_info = {"size": None, "mtime": None, "sibling_files": []}
+        return {"file": file_info, "scan": {"verdict": "blocked", "refs": [], "message": str(exc)}}
 
     data, error = _bounded_bytes(file)
     file_info = {"size": size, "mtime": mtime, "sibling_files": _sibling_chunks(file)}

--- a/fused_render/templates/joblib_model/reader.py
+++ b/fused_render/templates/joblib_model/reader.py
@@ -464,7 +464,14 @@ def _find_estimators(obj, path="", depth=0, max_depth=_FIND_ESTIMATORS_MAX_DEPTH
         # as plain attributes. Skipped for a tree ensemble itself (RandomForest,
         # Bagging, ...): its members are already covered by the tree viewer, not
         # independent top-level models.
-        for key, value in list(vars(obj).items())[:50]:
+        attrs = vars(obj)
+        for key, value in itertools.islice(attrs.items(), 50):
+            # `estimators` next to `estimators_` is the pre-fit copy of the same
+            # models (sklearn's trailing-underscore convention); listing both would
+            # show every sub-model twice, once untrained. Pipeline has no `steps_`,
+            # so its `steps` is still walked.
+            if f"{key}_" in attrs:
+                continue
             child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
             found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))
     return found
@@ -526,16 +533,29 @@ def _feature_importance(path: str, est):
     return {"path": path, "features": ranked}
 
 
+def _has_tree(obj) -> bool:
+    tree = getattr(obj, "tree_", None)
+    return tree is not None and hasattr(tree, "children_left")
+
+
 def _tree_kind(est):
     if hasattr(est, "get_booster"):
         return "xgboost"
     if hasattr(est, "booster_") and hasattr(est.booster_, "dump_model"):
         return "lightgbm"
-    if hasattr(est, "estimators_"):
-        if getattr(est.estimators_, "ndim", 1) > 1:
-            return "sklearn_gradient_boosting"  # 2-D: one row of trees per round
-        return "sklearn_forest"
-    if hasattr(est, "tree_") and hasattr(est.tree_, "children_left"):
+    # `estimators_` alone is not enough: composite meta-estimators (VotingClassifier,
+    # StackingClassifier, ...) have one too, holding arbitrary models rather than
+    # trees. Only claim the ensemble if its members really are trees, otherwise
+    # _tree_ensemble's `estimators_[i].tree_` has nothing to read and
+    # _find_estimators would skip walking into a composite it should descend.
+    members = getattr(est, "estimators_", None)
+    if members is not None and len(members):
+        if getattr(members, "ndim", 1) > 1:
+            if _has_tree(members[0][0]):
+                return "sklearn_gradient_boosting"  # 2-D: one row of trees per round
+        elif _has_tree(members[0]):
+            return "sklearn_forest"
+    if _has_tree(est):
         return "sklearn_tree"
     return None
 
@@ -602,6 +622,15 @@ def _lightgbm_tree_node(node, depth=0):
     }
 
 
+def _tree_meta(count, n_classes):
+    """Per-tree labels. A boosting round holds one tree per class, so the flat
+    index splits into round/class -- meaningless (and noise in the picker) when
+    a round holds a single tree, so it's omitted there."""
+    if n_classes <= 1:
+        return [{"index": i} for i in range(count)]
+    return [{"index": i, "round": i // n_classes, "class": i % n_classes} for i in range(count)]
+
+
 def _tree_ensemble(path: str, est, tree_index):
     kind = _tree_kind(est)
     if kind is None:
@@ -620,7 +649,7 @@ def _tree_ensemble(path: str, est, tree_index):
     elif kind == "sklearn_gradient_boosting":
         n_rounds, n_classes = est.estimators_.shape
         count = n_rounds * n_classes
-        meta = [{"index": i, "round": i // n_classes, "class": i % n_classes} for i in range(count)]
+        meta = _tree_meta(count, n_classes)
         idx = tree_index if tree_index is not None else 0
 
         def node_builder():
@@ -634,7 +663,7 @@ def _tree_ensemble(path: str, est, tree_index):
         booster = est.get_booster()
         n_classes = len(est.classes_) if hasattr(est, "classes_") and len(est.classes_) > 2 else 1
         count = booster.num_boosted_rounds() * n_classes
-        meta = [{"index": i, "round": i // n_classes, "class": i % n_classes} for i in range(count)]
+        meta = _tree_meta(count, n_classes)
         idx = tree_index if tree_index is not None else 0
 
         def node_builder():
@@ -642,13 +671,20 @@ def _tree_ensemble(path: str, est, tree_index):
             round_dump = booster[round_idx:round_idx + 1].get_dump(dump_format="json")
             return _xgboost_tree_node(json.loads(round_dump[class_idx]))
     elif kind == "lightgbm":
-        count = est.booster_.num_trees()
-        meta = [{"index": i} for i in range(count)]
+        # num_trees() counts trees FLAT, but dump_model's num_iteration/
+        # start_iteration select boosting ROUNDS -- and a multiclass round holds
+        # one tree per class, so the flat index has to be split the same way the
+        # xgboost branch splits it.
+        booster = est.booster_
+        n_classes = len(est.classes_) if hasattr(est, "classes_") and len(est.classes_) > 2 else 1
+        count = booster.num_trees()
+        meta = _tree_meta(count, n_classes)
         idx = tree_index if tree_index is not None else 0
 
         def node_builder():
-            tree_info = est.booster_.dump_model(num_iteration=1, start_iteration=idx)["tree_info"]
-            return _lightgbm_tree_node(tree_info[0]["tree_structure"])
+            round_idx, class_idx = divmod(idx, n_classes)
+            round_dump = booster.dump_model(num_iteration=1, start_iteration=round_idx)["tree_info"]
+            return _lightgbm_tree_node(round_dump[class_idx]["tree_structure"])
     else:
         return None
 

--- a/fused_render/templates/joblib_model/reader.py
+++ b/fused_render/templates/joblib_model/reader.py
@@ -1,0 +1,682 @@
+"""Reader backing joblib_model/template.html: a restricted, allowlisted load
+of a `.joblib`/`.pkl`/`.pickle` file, and — only when every referenced class
+turned out to be trusted — real introspection of what's inside (estimator
+hyperparameters, feature importances, and tree-ensemble structure).
+
+`pickle.load()`/`joblib.load()` is arbitrary code execution: a crafted
+`__reduce__` calls any importable callable with attacker-chosen arguments the
+moment it's unpickled, and this template is offered on any `.joblib`/`.pkl`
+a user opens — including downloaded files. So the object is never
+reconstructed except through a single restricted pass that resolves every
+referenced class/callable against an explicit allowlist *before* it is ever
+invoked.
+
+The restriction uses the "Restricting Globals" pattern from the `pickle`
+module's own docs — subclassing `Unpickler` and overriding `find_class` —
+rather than hand-parsing opcodes: CPython's Unpickler already gets the
+stack/memo bookkeeping right (GET/BINGET can make a class reference arrive
+via a memo slot rather than an adjacent literal, which a naive "last two
+strings seen" opcode-stream heuristic would get wrong), and, just as
+importantly, joblib's own on-disk format for numpy arrays isn't plain
+pickle: `joblib.numpy_pickle.NumpyUnpickler.load_build` reads raw array
+bytes directly off the file handle immediately after a genuine
+`NumpyArrayWrapper` is built, bypassing normal opcode parsing entirely. A
+naive scanner that replaces every class — including that wrapper — with an
+inert stand-in desyncs from the byte stream the moment it hits the first
+array (confirmed by hand: it throws "invalid load key" a few opcodes later,
+reading array bytes as if they were opcodes). So `_RestrictedUnpickler`
+subclasses `NumpyUnpickler` itself to inherit its framing, and
+`find_class(module, name)` resolves the REAL class via the normal
+`super().find_class()` for anything on the allowlist (needed both for
+correct framing and because the object has to be genuinely usable
+afterwards) and substitutes `_Stub` — an inert class that swallows any
+constructor/state/append/etc. call as a no-op — for anything that is not.
+`EXT1`/`EXT2`/`EXT4` and `INST`/`OBJ` all route through the same
+`find_class` call as `GLOBAL`/`STACK_GLOBAL`, so nothing bypasses this.
+
+The one guarantee this preserves absolutely: a disallowed class or callable
+is never instantiated or invoked — `find_class` simply never returns it.
+What it does NOT try to prevent is an allowlisted class (real numpy/sklearn/
+xgboost/etc.) being constructed with adversarial arguments before a later,
+disallowed reference is reached and blocks the overall verdict — that
+residual resource-exhaustion risk is the same one a from-scratch pure-opcode
+scan would still face for the eventually-safe case, and it is bounded the
+same way: the byte cap in `_bounded_bytes` (a pickle stream can only encode
+as many opcodes as it has bytes, so the cap bounds the restricted load's own
+work too), and this reader's process — like every template reader not
+listed in `fused_render/executor.py`'s `INPROCESS_HELPERS` — already runs in
+a fresh, timeout-killed subprocess per call.
+
+One allowlisted class needs a carve-out from "find_class resolves the real
+class": `NumpyArrayWrapper.read_array` (the same joblib method this reader
+depends on for framing, see above) calls a bare `pickle.load()` directly on
+the file handle when the array's dtype is `object` — entirely outside
+`find_class`, so an object-dtype array can smuggle in any callable regardless
+of the allowlist. Its declared `shape` is also used to size a `np.empty(...)`
+allocation before any array bytes are even read, so a tiny pickle can still
+declare a huge shape. `find_class` handles this by substituting
+`_SafeNumpyArrayWrapper` (and, for the joblib<=0.9 on-disk format,
+`_SafeNDArrayWrapper`) for the real wrapper class: same fields, same framing,
+but the oversized-shape case is refused outright, and the object-dtype case
+is re-read with a fresh `pickle.Unpickler` wired to the *same* restricted
+`find_class` rather than a plain one — real ensembles (GradientBoosting,
+AdaBoost, bagging, ...) genuinely store their per-round estimators in an
+object-dtype array, so it can't simply be refused without breaking ordinary
+models.
+
+A module that resolves but is not actually importable (e.g. a pickle
+referencing `catboost.*`, which is allowlisted-by-policy but not bundled
+with this template) is reported as "unavailable" rather than "blocked" —
+trusted, just absent.
+
+Self-contained on purpose: a template is a set of scripts run by the engine,
+not part of the package (SPEC PY-15/D166), so it never imports
+`fused_render`.
+"""
+import io
+import json
+import math
+import os
+import pickle
+import zlib
+
+import joblib.numpy_pickle
+
+_RAW_SIZE_CAP = 2 * 1024 * 1024 * 1024  # refuse to even open a pickle bigger than this
+_DECOMPRESSED_CAP = 512 * 1024 * 1024  # cap on the decompressed byte stream handed to the loader
+_MAX_ARRAY_BYTES = _DECOMPRESSED_CAP  # cap on a single array's declared size; see _SafeNumpyArrayWrapper
+_MAX_TREE_DEPTH = 200  # real trees rarely exceed depth 30-40; this only bounds pathological/adversarial state
+
+# Exact-symbol allow: the handful of builtin/stdlib names a pickled ML object
+# routinely needs to reconstruct plain containers and numpy scalars. Never
+# widened to a prefix — "builtins" as a prefix would allow eval/exec/open.
+_EXACT_ALLOW = {
+    "builtins": {"dict", "list", "tuple", "set", "frozenset", "complex",
+                 "bytes", "bytearray", "str", "int", "float", "bool", "slice"},
+    "collections": {"OrderedDict", "defaultdict"},
+    "copyreg": {"_reconstructor", "__newobj__", "__newobj_ex__"},
+    "_codecs": {"encode"},  # numpy scalars round-trip through latin1 via this
+}
+
+# Prefix allow: trust-the-package, not its internal module layout (a name
+# like "sklearn.tree._tree" breaks silently on every version bump; the real
+# security boundary is which packages are trusted, not where their classes
+# happen to live this release).
+_PREFIX_ALLOW = (
+    "numpy.", "numpy._core.", "numpy.core.",
+    "scipy.", "sklearn.", "xgboost.", "lightgbm.", "catboost.",
+    "pandas.", "joblib.",
+)
+
+
+class _Stub:
+    """Stands in for every disallowed class a scanned pickle references.
+    Swallows any constructor call, state, or container mutation as a no-op,
+    so a mixed object graph (some allowed, some not) can still finish
+    loading — the disallowed branches just come out inert."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __call__(self, *args, **kwargs):
+        return _Stub()
+
+    def __setstate__(self, state):
+        pass
+
+    def __reduce__(self):
+        return (_Stub, ())
+
+    def __setitem__(self, key, value):
+        pass
+
+    def __getitem__(self, key):
+        return _Stub()
+
+    def append(self, value):
+        pass
+
+    def extend(self, values):
+        pass
+
+    def update(self, *args, **kwargs):
+        pass
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+
+def _classify(module: str, name: str) -> bool:
+    """True if (module, name) is on the allowlist. Fail closed: anything not
+    explicitly recognised is unsafe by default."""
+    allowed_names = _EXACT_ALLOW.get(module)
+    if allowed_names is not None and name in allowed_names:
+        return True
+    return any(module == prefix.rstrip(".") or module.startswith(prefix) for prefix in _PREFIX_ALLOW)
+
+
+class _DelegatingUnpickler(pickle.Unpickler):
+    """A plain `pickle.Unpickler` whose `find_class`/`persistent_load`
+    delegate to externally supplied callables. Needed because the
+    C-accelerated `pickle.Unpickler` refuses to have `find_class` set as an
+    instance attribute ("object attribute 'find_class' is read-only") — it
+    has to be overridden by subclassing, even though the callable itself is
+    just forwarded straight through unchanged."""
+
+    def __init__(self, file_handle, find_class, persistent_load):
+        super().__init__(file_handle)
+        self._find_class = find_class
+        self._persistent_load = persistent_load
+
+    def find_class(self, module, name):
+        return self._find_class(module, name)
+
+    def persistent_load(self, pid):
+        return self._persistent_load(pid)
+
+
+class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
+    """Same fields and on-disk framing as the real `NumpyArrayWrapper`, but
+    `read_array` closes the two ways it escapes the restricted-unpickle
+    guarantee entirely (module docstring): an object-dtype array is read via
+    a bare `pickle.load()` on the file handle, and the element count comes
+    from this wrapper's own declared `shape`/`dtype`, otherwise never
+    checked against anything before `np.empty(count, dtype)` allocates it.
+
+    Real ensembles (GradientBoostingClassifier, AdaBoost, bagging, ...)
+    genuinely store their per-round estimators in an object-dtype array, so
+    the object-dtype case can't simply be refused outright without breaking
+    ordinary models — instead it's re-read with a fresh `pickle.Unpickler`
+    whose `find_class` is `unpickler.find_class` itself (the enclosing
+    `_RestrictedUnpickler`), so every reference inside still goes through the
+    same allowlist and is recorded in the same refs/blocked/missing
+    bookkeeping."""
+
+    def read_array(self, unpickler, ensure_native_byte_order):
+        if self.dtype.hasobject:
+            # (no native-byte-order fixup needed here: that only ever matters
+            # for numeric dtypes, never for "|O" object arrays)
+            embedded = _DelegatingUnpickler(unpickler.file_handle, unpickler.find_class, unpickler.persistent_load)
+            return embedded.load()
+        count = 1
+        for dim in self.shape:
+            count *= int(dim)
+        declared_bytes = count * self.dtype.itemsize
+        if declared_bytes > _MAX_ARRAY_BYTES:
+            raise pickle.UnpicklingError(
+                f"refusing to allocate a {declared_bytes:,}-byte array "
+                f"(declared shape {tuple(self.shape)!r}), above the "
+                f"{_MAX_ARRAY_BYTES:,}-byte safety cap"
+            )
+        return super().read_array(unpickler, ensure_native_byte_order)
+
+
+class _SafeNDArrayWrapper(joblib.numpy_pickle.NDArrayWrapper):
+    """The joblib<=0.9 compat wrapper: `read` loads an attacker-named sibling
+    file via `np.load(..., allow_pickle=True)`, the same bare-pickle escape
+    as `_SafeNumpyArrayWrapper` above, plus an attacker-controlled filename.
+    Nothing produced by any joblib in the last decade uses this format, so
+    refuse it outright rather than re-deriving numpy's own dtype sniffing."""
+
+    def read(self, unpickler):
+        raise pickle.UnpicklingError(
+            "refusing to load a legacy (joblib<=0.9) NDArrayWrapper array"
+        )
+
+
+class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
+    """`NumpyUnpickler` (not plain `pickle.Unpickler`) so joblib's own
+    array-wrapper framing (see module docstring) still works. `find_class`
+    is the sole gate: allowed references resolve for real, everything else
+    becomes an inert `_Stub` and is recorded as blocked."""
+
+    def __init__(self, filename, file_obj):
+        super().__init__(filename, file_obj, ensure_native_byte_order=True)
+        self.refs = []  # [{"module", "name", "allowed"}], first-seen order, deduped
+        self._seen = set()
+        self.blocked = []
+        self.missing = set()
+
+    def find_class(self, module, name):
+        allowed = _classify(module, name)
+        key = (module, name)
+        if key not in self._seen:
+            self._seen.add(key)
+            self.refs.append({"module": module, "name": name, "allowed": allowed})
+        if not allowed:
+            self.blocked.append({"module": module, "name": name})
+            return _Stub
+        try:
+            resolved = super().find_class(module, name)
+        except (ImportError, AttributeError):
+            self.missing.add(module.split(".", 1)[0])
+            return _Stub
+        if resolved is joblib.numpy_pickle.NumpyArrayWrapper:
+            return _SafeNumpyArrayWrapper
+        if resolved is joblib.numpy_pickle.NDArrayWrapper:
+            return _SafeNDArrayWrapper
+        return resolved
+
+    def persistent_load(self, pid):
+        # Out-of-band persistent references have no callable to allowlist —
+        # refuse rather than guess at what they'd resolve to.
+        raise pickle.UnpicklingError(f"unsupported persistent reference: {pid!r}")
+
+
+def _decompress_capped(raw: bytes, cap: int):
+    """None on cap exceeded. Recognises joblib's own zlib/gzip wrapping;
+    anything else (lz4, xz, or genuinely raw pickle bytes) passes through
+    unchanged — an unrecognised compressed format simply fails to parse as
+    pickle opcodes later, which is already treated as blocked."""
+    if raw[:2] == b"\x1f\x8b":
+        decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
+    elif raw[:1] == b"\x78":
+        decompressor = zlib.decompressobj()
+    else:
+        return raw
+
+    out = bytearray()
+    pending = raw
+    while pending or decompressor.unconsumed_tail:
+        chunk = decompressor.unconsumed_tail or pending
+        pending = b""
+        piece = decompressor.decompress(chunk, max(1, cap - len(out)))
+        out.extend(piece)
+        if len(out) > cap:
+            return None
+        if not piece and not decompressor.unconsumed_tail:
+            break
+    out.extend(decompressor.flush())
+    return bytes(out) if len(out) <= cap else None
+
+
+def _bounded_bytes(path: str):
+    """(bytes, error) — error is a human-readable string on failure, bytes is
+    None in that case. Never raises: a bound that can itself throw defeats
+    the point of having one."""
+    try:
+        size = os.path.getsize(path)
+    except OSError as exc:
+        return None, f"could not stat file: {exc}"
+    if size > _RAW_SIZE_CAP:
+        return None, f"file is {size:,} bytes, above the {_RAW_SIZE_CAP:,}-byte safety cap"
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    except OSError as exc:
+        return None, f"could not read file: {exc}"
+    try:
+        data = _decompress_capped(raw, _DECOMPRESSED_CAP)
+    except zlib.error as exc:
+        return None, f"could not decompress: {exc}"
+    if data is None:
+        return None, f"decompressed content exceeds the {_DECOMPRESSED_CAP:,}-byte safety cap"
+    return data, None
+
+
+def _restricted_load(path: str, data: bytes):
+    """(verdict, refs, message, obj). verdict is "safe" | "unavailable" |
+    "blocked"; obj is the real reconstructed object only when verdict is
+    "safe" — a partially-stubbed object from a blocked/unavailable file is
+    never handed to the introspection helpers below."""
+    unpickler = _RestrictedUnpickler(path, io.BytesIO(data))
+    try:
+        obj = unpickler.load()
+    except Exception as exc:  # noqa: BLE001 - any failure here means "not
+        # proven safe", never "safe by default".
+        return "blocked", [], f"could not parse as a pickle stream: {exc}", None
+
+    if unpickler.blocked:
+        return "blocked", unpickler.refs, None, None
+    if unpickler.missing:
+        return "unavailable", unpickler.refs, ", ".join(sorted(unpickler.missing)), None
+    return "safe", unpickler.refs, None, obj
+
+
+def _sibling_chunks(path: str):
+    """joblib's memmap-backing sibling files, when `joblib.dump` split large
+    arrays out of the main pickle (`name.pkl_01.npy`, `_02.npy`, ...)."""
+    base = os.path.basename(path)
+    directory = os.path.dirname(path) or "."
+    try:
+        entries = os.listdir(directory)
+    except OSError:
+        return []
+    prefix = base + "_"
+    return sorted(
+        name for name in entries
+        if name.startswith(prefix) and name.endswith(".npy")
+    )
+
+
+def _short_repr(value, limit=120) -> str:
+    text = repr(value)
+    return text if len(text) <= limit else text[:limit] + "…"
+
+
+def _json_float(v):
+    """float, or a JSON-safe string sentinel for nan/inf. The production
+    response path (fused_render/executor.py's dumps_result, `allow_nan:
+    False`) rejects non-finite floats outright with an uncaught ValueError —
+    and nan is not an exotic edge case here: XGBClassifier's default
+    `missing` param IS nan, so almost every real fitted XGBoost model has one
+    in its params."""
+    f = float(v)
+    if math.isnan(f):
+        return "NaN"
+    if math.isinf(f):
+        return "Infinity" if f > 0 else "-Infinity"
+    return f
+
+
+def _escape_path_key(key) -> str:
+    """A dict key, escaped for splicing into a synthesized dotted/bracketed
+    path. Without this, a dict key containing a literal "." (or "[]") could
+    collide with a path built from actually-nested dicts — e.g.
+    {"sensor.temp": a, "sensor": {"temp": b}} would otherwise both produce
+    the path "sensor.temp" — and template.html's
+    `data.trees.find(x => x.path === t.path)` would then silently pick the
+    wrong one."""
+    return str(key).replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[").replace("]", "\\]")
+
+
+def _describe(obj, path="", depth=0, max_depth=4):
+    """Bounded recursive structure walk: what _describe returns is also how
+    plain training-provenance metadata (dataset name, dropped-sample ids, ...)
+    surfaces for a bundle like {"classifier": ..., "dataset": "...", ...} —
+    it's just dict values the walk already shows, no separate "model card"
+    merge step needed for that part."""
+    if depth >= max_depth:
+        return {"path": path, "kind": "truncated"}
+    if isinstance(obj, dict):
+        return {
+            "path": path, "kind": "dict",
+            "length": len(obj),
+            "items": [
+                {"key": str(k), **_describe(v, f"{path}.{_escape_path_key(k)}" if path else _escape_path_key(k), depth + 1, max_depth)}
+                for k, v in list(obj.items())[:50]
+            ],
+        }
+    if isinstance(obj, (list, tuple)):
+        return {
+            "path": path, "kind": "list",
+            "length": len(obj),
+            "items": [_describe(v, f"{path}[{i}]", depth + 1, max_depth) for i, v in enumerate(obj[:50])],
+        }
+    if _is_ndarray(obj):
+        return {"path": path, "kind": "ndarray", "shape": list(obj.shape), "dtype": str(obj.dtype)}
+    if hasattr(obj, "get_params") and callable(obj.get_params):
+        return {"path": path, "kind": "estimator", "type": type(obj).__name__, "module": type(obj).__module__}
+    if isinstance(obj, (str, int, float, bool)) or obj is None:
+        value = _json_float(obj) if isinstance(obj, float) else obj
+        return {"path": path, "kind": "scalar", "value": value if not isinstance(value, str) or len(value) <= 200 else value[:200] + "…"}
+    return {"path": path, "kind": "object", "type": type(obj).__name__, "repr": _short_repr(obj)}
+
+
+def _is_ndarray(obj) -> bool:
+    return type(obj).__module__.startswith("numpy") and type(obj).__name__ == "ndarray"
+
+
+def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
+    """All objects with a scikit-learn-style get_params(), anywhere in the
+    (bounded-depth) structure, tagged with their path."""
+    if seen is None:
+        seen = set()
+    if depth >= max_depth:
+        return []
+    obj_id = id(obj)
+    if obj_id in seen:
+        return []
+    found = []
+    if hasattr(obj, "get_params") and callable(obj.get_params):
+        seen.add(obj_id)
+        found.append((path, obj))
+    if isinstance(obj, dict):
+        for key, value in list(obj.items())[:50]:
+            child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
+            found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj[:50]):
+            found.extend(_find_estimators(value, f"{path}[{index}]", depth + 1, max_depth, seen))
+    return found
+
+
+def _jsonable_params(params: dict) -> dict:
+    out = {}
+    for key, value in params.items():
+        if isinstance(value, float):
+            out[key] = _json_float(value)
+        elif isinstance(value, (str, int, bool)) or value is None:
+            out[key] = value
+        else:
+            out[key] = _short_repr(value, 80)
+    return out
+
+
+def _estimator_summary(path: str, est) -> dict:
+    summary = {
+        "path": path,
+        "type": type(est).__name__,
+        "module": type(est).__module__,
+        "params": _jsonable_params(est.get_params(deep=False)),
+    }
+    if hasattr(est, "n_features_in_"):
+        summary["n_features_in"] = int(est.n_features_in_)
+    if hasattr(est, "classes_"):
+        try:
+            summary["classes"] = [c.item() if hasattr(c, "item") else c for c in list(est.classes_)]
+        except Exception:  # noqa: BLE001 - best-effort, never fatal to the view
+            pass
+    return summary
+
+
+def _feature_importance(path: str, est):
+    values = None
+    if hasattr(est, "feature_importances_"):
+        values = list(est.feature_importances_)
+    elif hasattr(est, "coef_"):
+        coef = est.coef_
+        if getattr(coef, "ndim", 1) > 1:
+            # multi-class: one coefficient row per class. Mean of absolute
+            # values across classes is a standard, defensible way to
+            # summarize importance in one ranking, rather than arbitrarily
+            # picking class 0 and silently discarding the rest.
+            values = list(abs(coef).mean(axis=0))
+        else:
+            values = [abs(float(v)) for v in coef]
+    if values is None:
+        return None
+    ranked = sorted(
+        ({"feature": i, "importance": float(v)} for i, v in enumerate(values)),
+        key=lambda row: -row["importance"],
+    )
+    for row in ranked:
+        row["importance"] = _json_float(row["importance"])
+    return {"path": path, "features": ranked}
+
+
+def _tree_kind(est):
+    if hasattr(est, "get_booster"):
+        return "xgboost"
+    if hasattr(est, "booster_") and hasattr(est.booster_, "dump_model"):
+        return "lightgbm"
+    if hasattr(est, "estimators_"):
+        # GradientBoostingClassifier/Regressor's estimators_ is 2-D — one row
+        # of trees per boosting round, one column per class (a single column
+        # for binary/regression) — not a flat list of one tree each like a
+        # RandomForest/AdaBoost's estimators_.
+        if getattr(est.estimators_, "ndim", 1) > 1:
+            return "sklearn_gradient_boosting"
+        return "sklearn_forest"
+    if hasattr(est, "tree_") and hasattr(est.tree_, "children_left"):
+        return "sklearn_tree"
+    return None
+
+
+def _sklearn_tree_node(tree, node_id, depth=0):
+    if depth >= _MAX_TREE_DEPTH:
+        return {"leaf": [], "truncated": True}
+    if tree.children_left[node_id] == -1:
+        value = tree.value[node_id]
+        return {"leaf": [_json_float(v) for v in value.reshape(-1)]}
+    return {
+        "feature": int(tree.feature[node_id]),
+        "threshold": _json_float(tree.threshold[node_id]),
+        "left": _sklearn_tree_node(tree, tree.children_left[node_id], depth + 1),
+        "right": _sklearn_tree_node(tree, tree.children_right[node_id], depth + 1),
+    }
+
+
+def _xgboost_feature_index(split: str):
+    # xgboost's JSON dump names an unnamed feature "f<index>" (a string) where
+    # sklearn/lightgbm give a bare int — normalized back to an int here so the
+    # three libraries agree on what "feature" means and the view can format it
+    # uniformly. A booster trained with real feature_names keeps its own name
+    # — including one that happens to look like "f<something>" (e.g. "f007",
+    # or "f²" whose "²" is a Unicode digit str.isdigit() accepts but int()
+    # can't parse) — so this only treats it as an auto-generated index if it
+    # round-trips exactly back to the original string.
+    if split.startswith("f"):
+        try:
+            index = int(split[1:])
+        except ValueError:
+            return split
+        if f"f{index}" == split:
+            return index
+    return split
+
+
+def _xgboost_tree_node(node, depth=0):
+    if depth >= _MAX_TREE_DEPTH:
+        return {"leaf": [], "truncated": True}
+    if "leaf" in node:
+        return {"leaf": [_json_float(node["leaf"])]}
+    children = {child["nodeid"]: child for child in node.get("children", [])}
+    return {
+        "feature": _xgboost_feature_index(node["split"]),
+        "threshold": _json_float(node["split_condition"]),
+        "left": _xgboost_tree_node(children[node["yes"]], depth + 1),
+        "right": _xgboost_tree_node(children[node["no"]], depth + 1),
+    }
+
+
+def _lightgbm_tree_node(node, depth=0):
+    if depth >= _MAX_TREE_DEPTH:
+        return {"leaf": [], "truncated": True}
+    if "leaf_value" in node:
+        return {"leaf": [_json_float(node["leaf_value"])]}
+    return {
+        "feature": int(node["split_feature"]),
+        "threshold": _json_float(node["threshold"]),
+        "left": _lightgbm_tree_node(node["left_child"], depth + 1),
+        "right": _lightgbm_tree_node(node["right_child"], depth + 1),
+    }
+
+
+def _tree_ensemble(path: str, est, tree_index):
+    kind = _tree_kind(est)
+    if kind is None:
+        return None
+
+    if kind == "sklearn_tree":
+        count = 1
+        meta = [{"index": 0}]
+        tree = est.tree_
+        node_builder = lambda: _sklearn_tree_node(tree, 0)  # noqa: E731
+    elif kind == "sklearn_forest":
+        count = len(est.estimators_)
+        meta = [{"index": i} for i in range(count)]
+        idx = tree_index if tree_index is not None else 0
+        node_builder = lambda: _sklearn_tree_node(est.estimators_[idx].tree_, 0)  # noqa: E731
+    elif kind == "sklearn_gradient_boosting":
+        n_rounds, n_classes = est.estimators_.shape
+        count = n_rounds * n_classes
+        meta = [{"index": i, "round": i // n_classes, "class": i % n_classes} for i in range(count)]
+        idx = tree_index if tree_index is not None else 0
+
+        def node_builder():
+            round_idx, class_idx = divmod(idx, n_classes)
+            return _sklearn_tree_node(est.estimators_[round_idx, class_idx].tree_, 0)
+    elif kind == "xgboost":
+        # Tree count comes from num_boosted_rounds() (cheap: no dump), not
+        # len(get_dump()) — dumping every tree as JSON text just to count them
+        # cost 6+ seconds on a 992-tree model; get_dump() only ever runs, lazily,
+        # for the one tree actually requested.
+        booster = est.get_booster()
+        n_classes = len(est.classes_) if hasattr(est, "classes_") and len(est.classes_) > 2 else 1
+        count = booster.num_boosted_rounds() * n_classes
+        meta = [{"index": i, "round": i // n_classes, "class": i % n_classes} for i in range(count)]
+        idx = tree_index if tree_index is not None else 0
+
+        def node_builder():
+            return _xgboost_tree_node(json.loads(booster.get_dump(dump_format="json")[idx]))
+    elif kind == "lightgbm":
+        count = est.booster_.num_trees()  # cheap: dump_model() only runs lazily below
+        meta = [{"index": i} for i in range(count)]
+        idx = tree_index if tree_index is not None else 0
+
+        def node_builder():
+            return _lightgbm_tree_node(est.booster_.dump_model()["tree_info"][idx]["tree_structure"])
+    else:
+        return None
+
+    result = {"path": path, "library": kind, "count": count, "trees": meta}
+    if tree_index is not None or count == 1:
+        try:
+            result["tree"] = node_builder()
+        except Exception as exc:  # noqa: BLE001 - a bad index still returns a usable summary
+            result["tree_error"] = str(exc)
+    return result
+
+
+def _safe(fn, *args):
+    """None on any failure. The estimator being introspected here came
+    through __reduce__/__setstate__ rather than a normal constructor, so a
+    real allowlisted class with adversarial internal state can raise from
+    these getters in ways hasattr()'s AttributeError-only suppression won't
+    catch — and one bad estimator anywhere in a multi-model bundle must not
+    kill every other estimator's data too."""
+    try:
+        return fn(*args)
+    except Exception:  # noqa: BLE001 - best-effort, isolated per estimator
+        return None
+
+
+def main(file: str, tree_index=None) -> dict:
+    # tree_index is intentionally unannotated (matches structure/reader.py's
+    # row_group convention): a param round-tripped through the URL arrives
+    # as a string or JS null, and an `int` annotation would blow up on null.
+    try:
+        idx = int(tree_index) if tree_index not in (None, "") else None
+    except (TypeError, ValueError):
+        idx = None
+
+    try:
+        size = os.path.getsize(file)
+        mtime = os.path.getmtime(file)
+    except OSError as exc:
+        return {"file": {"error": str(exc)}, "scan": {"verdict": "blocked", "refs": [], "message": str(exc)}}
+
+    data, error = _bounded_bytes(file)
+    file_info = {"size": size, "mtime": mtime, "sibling_files": _sibling_chunks(file)}
+    if error is not None:
+        return {"file": file_info, "scan": {"verdict": "blocked", "refs": [], "message": error}}
+
+    verdict, refs, message, obj = _restricted_load(file, data)
+    scan_info = {"verdict": verdict, "refs": refs, "message": message}
+    if verdict != "safe":
+        return {"file": file_info, "scan": scan_info}
+
+    found = _find_estimators(obj)
+
+    return {
+        "file": file_info,
+        "scan": scan_info,
+        "structure": _describe(obj),
+        "estimators": [s for s in (_safe(_estimator_summary, p, e) for p, e in found) if s],
+        "feature_importance": [fi for fi in (_safe(_feature_importance, p, e) for p, e in found) if fi],
+        "trees": [t for t in (_safe(_tree_ensemble, p, e, idx) for p, e in found) if t],
+    }

--- a/fused_render/templates/joblib_model/reader.py
+++ b/fused_render/templates/joblib_model/reader.py
@@ -1,77 +1,8 @@
-"""Reader backing joblib_model/template.html: a restricted, allowlisted load
-of a `.joblib`/`.pkl`/`.pickle` file, and — only when every referenced class
-turned out to be trusted — real introspection of what's inside (estimator
-hyperparameters, feature importances, and tree-ensemble structure).
-
-`pickle.load()`/`joblib.load()` is arbitrary code execution: a crafted
-`__reduce__` calls any importable callable with attacker-chosen arguments the
-moment it's unpickled, and this template is offered on any `.joblib`/`.pkl`
-a user opens — including downloaded files. So the object is never
-reconstructed except through a single restricted pass that resolves every
-referenced class/callable against an explicit allowlist *before* it is ever
-invoked.
-
-The restriction uses the "Restricting Globals" pattern from the `pickle`
-module's own docs — subclassing `Unpickler` and overriding `find_class` —
-rather than hand-parsing opcodes: CPython's Unpickler already gets the
-stack/memo bookkeeping right (GET/BINGET can make a class reference arrive
-via a memo slot rather than an adjacent literal, which a naive "last two
-strings seen" opcode-stream heuristic would get wrong), and, just as
-importantly, joblib's own on-disk format for numpy arrays isn't plain
-pickle: `joblib.numpy_pickle.NumpyUnpickler.load_build` reads raw array
-bytes directly off the file handle immediately after a genuine
-`NumpyArrayWrapper` is built, bypassing normal opcode parsing entirely. A
-naive scanner that replaces every class — including that wrapper — with an
-inert stand-in desyncs from the byte stream the moment it hits the first
-array (confirmed by hand: it throws "invalid load key" a few opcodes later,
-reading array bytes as if they were opcodes). So `_RestrictedUnpickler`
-subclasses `NumpyUnpickler` itself to inherit its framing, and
-`find_class(module, name)` resolves the REAL class via the normal
-`super().find_class()` for anything on the allowlist (needed both for
-correct framing and because the object has to be genuinely usable
-afterwards) and substitutes `_Stub` — an inert class that swallows any
-constructor/state/append/etc. call as a no-op — for anything that is not.
-`EXT1`/`EXT2`/`EXT4` and `INST`/`OBJ` all route through the same
-`find_class` call as `GLOBAL`/`STACK_GLOBAL`, so nothing bypasses this.
-
-The one guarantee this preserves absolutely: a disallowed class or callable
-is never instantiated or invoked — `find_class` simply never returns it.
-What it does NOT try to prevent is an allowlisted class (real numpy/sklearn/
-xgboost/etc.) being constructed with adversarial arguments before a later,
-disallowed reference is reached and blocks the overall verdict — that
-residual resource-exhaustion risk is the same one a from-scratch pure-opcode
-scan would still face for the eventually-safe case, and it is bounded the
-same way: the byte cap in `_bounded_bytes` (a pickle stream can only encode
-as many opcodes as it has bytes, so the cap bounds the restricted load's own
-work too), and this reader's process — like every template reader not
-listed in `fused_render/executor.py`'s `INPROCESS_HELPERS` — already runs in
-a fresh, timeout-killed subprocess per call.
-
-One allowlisted class needs a carve-out from "find_class resolves the real
-class": `NumpyArrayWrapper.read_array` (the same joblib method this reader
-depends on for framing, see above) calls a bare `pickle.load()` directly on
-the file handle when the array's dtype is `object` — entirely outside
-`find_class`, so an object-dtype array can smuggle in any callable regardless
-of the allowlist. Its declared `shape` is also used to size a `np.empty(...)`
-allocation before any array bytes are even read, so a tiny pickle can still
-declare a huge shape. `find_class` handles this by substituting
-`_SafeNumpyArrayWrapper` (and, for the joblib<=0.9 on-disk format,
-`_SafeNDArrayWrapper`) for the real wrapper class: same fields, same framing,
-but the oversized-shape case is refused outright, and the object-dtype case
-is re-read with a fresh `pickle.Unpickler` wired to the *same* restricted
-`find_class` rather than a plain one — real ensembles (GradientBoosting,
-AdaBoost, bagging, ...) genuinely store their per-round estimators in an
-object-dtype array, so it can't simply be refused without breaking ordinary
-models.
-
-A module that resolves but is not actually importable (e.g. a pickle
-referencing `catboost.*`, which is allowlisted-by-policy but not bundled
-with this template) is reported as "unavailable" rather than "blocked" —
-trusted, just absent.
-
-Self-contained on purpose: a template is a set of scripts run by the engine,
-not part of the package (SPEC PY-15/D166), so it never imports
-`fused_render`.
+"""Reader backing joblib_model/template.html: restricted, allowlist-based
+loading of untrusted `.joblib`/`.pkl`/`.pickle` files, then introspection
+(hyperparameters, feature importances, tree structure) once every referenced
+class/callable is confirmed trusted. Self-contained — templates are scripts
+run by the engine, not part of the package (SPEC PY-15/D166).
 """
 import io
 import json
@@ -82,38 +13,51 @@ import zlib
 
 import joblib.numpy_pickle
 
-_RAW_SIZE_CAP = 2 * 1024 * 1024 * 1024  # refuse to even open a pickle bigger than this
-_DECOMPRESSED_CAP = 512 * 1024 * 1024  # cap on the decompressed byte stream handed to the loader
-_MAX_ARRAY_BYTES = _DECOMPRESSED_CAP  # cap on a single array's declared size; see _SafeNumpyArrayWrapper
-_MAX_TREE_DEPTH = 200  # real trees rarely exceed depth 30-40; this only bounds pathological/adversarial state
+_RAW_SIZE_CAP = 2 * 1024 * 1024 * 1024
+_DECOMPRESSED_CAP = 512 * 1024 * 1024
+_MAX_ARRAY_BYTES = _DECOMPRESSED_CAP
+_MAX_TREE_DEPTH = 200  # real trees rarely exceed depth 30-40
 
-# Exact-symbol allow: the handful of builtin/stdlib names a pickled ML object
-# routinely needs to reconstruct plain containers and numpy scalars. Never
-# widened to a prefix — "builtins" as a prefix would allow eval/exec/open.
+# Exact-symbol allow: never widened to a prefix ("builtins" would allow eval/exec/open).
 _EXACT_ALLOW = {
     "builtins": {"dict", "list", "tuple", "set", "frozenset", "complex",
                  "bytes", "bytearray", "str", "int", "float", "bool", "slice"},
     "collections": {"OrderedDict", "defaultdict"},
     "copyreg": {"_reconstructor", "__newobj__", "__newobj_ex__"},
-    "_codecs": {"encode"},  # numpy scalars round-trip through latin1 via this
+    "_codecs": {"encode"},
 }
 
-# Prefix allow: trust-the-package, not its internal module layout (a name
-# like "sklearn.tree._tree" breaks silently on every version bump; the real
-# security boundary is which packages are trusted, not where their classes
-# happen to live this release).
+# Prefix allow: trust the package, not its internal module layout.
 _PREFIX_ALLOW = (
     "numpy.", "numpy._core.", "numpy.core.",
     "scipy.", "sklearn.", "xgboost.", "lightgbm.", "catboost.",
     "pandas.", "joblib.",
 )
 
+# A prefix-trusted FUNCTION (unlike a class) is called directly with
+# attacker-chosen arguments the moment REDUCE runs (e.g. joblib.load itself
+# would re-enter an unrestricted load) — so only these known reconstruction
+# helpers may resolve as functions; see find_class.
+_PREFIX_FUNCTION_ALLOW = {
+    ("numpy.core.multiarray", "_reconstruct"),
+    ("numpy.core.multiarray", "scalar"),
+    ("numpy._core.multiarray", "_reconstruct"),
+    ("numpy._core.multiarray", "scalar"),
+    ("numpy.core.numeric", "_frombuffer"),
+    ("numpy._core.numeric", "_frombuffer"),
+    ("numpy.random._pickle", "__randomstate_ctor"),
+    ("numpy.random._pickle", "__bit_generator_ctor"),
+    ("numpy.random._pickle", "__generator_ctor"),
+}
+
+
+def _is_pyx_unpickle_helper(name: str) -> bool:
+    """Cython's auto-generated `__pyx_unpickle_<Class>` reconstruction helpers."""
+    return name.startswith("__pyx_unpickle_")
+
 
 class _Stub:
-    """Stands in for every disallowed class a scanned pickle references.
-    Swallows any constructor call, state, or container mutation as a no-op,
-    so a mixed object graph (some allowed, some not) can still finish
-    loading — the disallowed branches just come out inert."""
+    """Inert stand-in for every disallowed class; swallows any call as a no-op."""
 
     def __init__(self, *args, **kwargs):
         pass
@@ -150,8 +94,7 @@ class _Stub:
 
 
 def _classify(module: str, name: str) -> bool:
-    """True if (module, name) is on the allowlist. Fail closed: anything not
-    explicitly recognised is unsafe by default."""
+    """Fail closed: anything not explicitly recognised is unsafe by default."""
     allowed_names = _EXACT_ALLOW.get(module)
     if allowed_names is not None and name in allowed_names:
         return True
@@ -159,12 +102,8 @@ def _classify(module: str, name: str) -> bool:
 
 
 class _DelegatingUnpickler(pickle.Unpickler):
-    """A plain `pickle.Unpickler` whose `find_class`/`persistent_load`
-    delegate to externally supplied callables. Needed because the
-    C-accelerated `pickle.Unpickler` refuses to have `find_class` set as an
-    instance attribute ("object attribute 'find_class' is read-only") — it
-    has to be overridden by subclassing, even though the callable itself is
-    just forwarded straight through unchanged."""
+    """Plain Unpickler with externally supplied find_class/persistent_load
+    (the C-accelerated Unpickler won't allow find_class as an instance attribute)."""
 
     def __init__(self, file_handle, find_class, persistent_load):
         super().__init__(file_handle)
@@ -179,26 +118,14 @@ class _DelegatingUnpickler(pickle.Unpickler):
 
 
 class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
-    """Same fields and on-disk framing as the real `NumpyArrayWrapper`, but
-    `read_array` closes the two ways it escapes the restricted-unpickle
-    guarantee entirely (module docstring): an object-dtype array is read via
-    a bare `pickle.load()` on the file handle, and the element count comes
-    from this wrapper's own declared `shape`/`dtype`, otherwise never
-    checked against anything before `np.empty(count, dtype)` allocates it.
-
-    Real ensembles (GradientBoostingClassifier, AdaBoost, bagging, ...)
-    genuinely store their per-round estimators in an object-dtype array, so
-    the object-dtype case can't simply be refused outright without breaking
-    ordinary models — instead it's re-read with a fresh `pickle.Unpickler`
-    whose `find_class` is `unpickler.find_class` itself (the enclosing
-    `_RestrictedUnpickler`), so every reference inside still goes through the
-    same allowlist and is recorded in the same refs/blocked/missing
-    bookkeeping."""
+    """NumpyArrayWrapper.read_array bypasses find_class entirely for
+    object-dtype arrays (a bare pickle.load()) and sizes its allocation from
+    its own declared shape before reading a single byte. This closes both:
+    object-dtype content is re-read through the same restricted find_class,
+    and an oversized declared shape is refused before allocating."""
 
     def read_array(self, unpickler, ensure_native_byte_order):
         if self.dtype.hasobject:
-            # (no native-byte-order fixup needed here: that only ever matters
-            # for numeric dtypes, never for "|O" object arrays)
             embedded = _DelegatingUnpickler(unpickler.file_handle, unpickler.find_class, unpickler.persistent_load)
             return embedded.load()
         count = 1
@@ -215,11 +142,8 @@ class _SafeNumpyArrayWrapper(joblib.numpy_pickle.NumpyArrayWrapper):
 
 
 class _SafeNDArrayWrapper(joblib.numpy_pickle.NDArrayWrapper):
-    """The joblib<=0.9 compat wrapper: `read` loads an attacker-named sibling
-    file via `np.load(..., allow_pickle=True)`, the same bare-pickle escape
-    as `_SafeNumpyArrayWrapper` above, plus an attacker-controlled filename.
-    Nothing produced by any joblib in the last decade uses this format, so
-    refuse it outright rather than re-deriving numpy's own dtype sniffing."""
+    """Legacy joblib<=0.9 wrapper: loads an attacker-named sibling file via
+    np.load(allow_pickle=True). Nothing recent uses this format — refuse outright."""
 
     def read(self, unpickler):
         raise pickle.UnpicklingError(
@@ -228,10 +152,8 @@ class _SafeNDArrayWrapper(joblib.numpy_pickle.NDArrayWrapper):
 
 
 class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
-    """`NumpyUnpickler` (not plain `pickle.Unpickler`) so joblib's own
-    array-wrapper framing (see module docstring) still works. `find_class`
-    is the sole gate: allowed references resolve for real, everything else
-    becomes an inert `_Stub` and is recorded as blocked."""
+    """find_class is the sole gate: allowed references resolve for real,
+    everything else becomes an inert _Stub and is recorded as blocked."""
 
     def __init__(self, filename, file_obj):
         super().__init__(filename, file_obj, ensure_native_byte_order=True)
@@ -241,36 +163,47 @@ class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
         self.missing = set()
 
     def find_class(self, module, name):
-        allowed = _classify(module, name)
         key = (module, name)
-        if key not in self._seen:
-            self._seen.add(key)
-            self.refs.append({"module": module, "name": name, "allowed": allowed})
-        if not allowed:
+        first_seen = key not in self._seen
+        self._seen.add(key)
+
+        def record(final_allowed):
+            if first_seen:
+                self.refs.append({"module": module, "name": name, "allowed": final_allowed})
+
+        if not _classify(module, name):
+            record(False)
             self.blocked.append({"module": module, "name": name})
             return _Stub
         try:
             resolved = super().find_class(module, name)
         except (ImportError, AttributeError):
+            record(True)
             self.missing.add(module.split(".", 1)[0])
             return _Stub
         if resolved is joblib.numpy_pickle.NumpyArrayWrapper:
+            record(True)
             return _SafeNumpyArrayWrapper
         if resolved is joblib.numpy_pickle.NDArrayWrapper:
+            record(True)
             return _SafeNDArrayWrapper
+        exact = _EXACT_ALLOW.get(module)
+        prefix_trusted = exact is None or name not in exact
+        is_safe_function = key in _PREFIX_FUNCTION_ALLOW or _is_pyx_unpickle_helper(name)
+        if prefix_trusted and not isinstance(resolved, type) and not is_safe_function:
+            record(False)
+            self.blocked.append({"module": module, "name": name})
+            return _Stub
+        record(True)
         return resolved
 
     def persistent_load(self, pid):
-        # Out-of-band persistent references have no callable to allowlist —
-        # refuse rather than guess at what they'd resolve to.
         raise pickle.UnpicklingError(f"unsupported persistent reference: {pid!r}")
 
 
 def _decompress_capped(raw: bytes, cap: int):
     """None on cap exceeded. Recognises joblib's own zlib/gzip wrapping;
-    anything else (lz4, xz, or genuinely raw pickle bytes) passes through
-    unchanged — an unrecognised compressed format simply fails to parse as
-    pickle opcodes later, which is already treated as blocked."""
+    anything else passes through unchanged (fails to parse later, already treated as blocked)."""
     if raw[:2] == b"\x1f\x8b":
         decompressor = zlib.decompressobj(16 + zlib.MAX_WBITS)
     elif raw[:1] == b"\x78":
@@ -294,9 +227,7 @@ def _decompress_capped(raw: bytes, cap: int):
 
 
 def _bounded_bytes(path: str):
-    """(bytes, error) — error is a human-readable string on failure, bytes is
-    None in that case. Never raises: a bound that can itself throw defeats
-    the point of having one."""
+    """(bytes, error); never raises."""
     try:
         size = os.path.getsize(path)
     except OSError as exc:
@@ -318,15 +249,11 @@ def _bounded_bytes(path: str):
 
 
 def _restricted_load(path: str, data: bytes):
-    """(verdict, refs, message, obj). verdict is "safe" | "unavailable" |
-    "blocked"; obj is the real reconstructed object only when verdict is
-    "safe" — a partially-stubbed object from a blocked/unavailable file is
-    never handed to the introspection helpers below."""
+    """(verdict, refs, message, obj); obj is real only when verdict is "safe"."""
     unpickler = _RestrictedUnpickler(path, io.BytesIO(data))
     try:
         obj = unpickler.load()
-    except Exception as exc:  # noqa: BLE001 - any failure here means "not
-        # proven safe", never "safe by default".
+    except Exception as exc:  # noqa: BLE001 - any failure here means "not proven safe"
         return "blocked", [], f"could not parse as a pickle stream: {exc}", None
 
     if unpickler.blocked:
@@ -337,8 +264,7 @@ def _restricted_load(path: str, data: bytes):
 
 
 def _sibling_chunks(path: str):
-    """joblib's memmap-backing sibling files, when `joblib.dump` split large
-    arrays out of the main pickle (`name.pkl_01.npy`, `_02.npy`, ...)."""
+    """joblib's memmap sibling files (`name.pkl_01.npy`, `_02.npy`, ...)."""
     base = os.path.basename(path)
     directory = os.path.dirname(path) or "."
     try:
@@ -358,12 +284,8 @@ def _short_repr(value, limit=120) -> str:
 
 
 def _json_float(v):
-    """float, or a JSON-safe string sentinel for nan/inf. The production
-    response path (fused_render/executor.py's dumps_result, `allow_nan:
-    False`) rejects non-finite floats outright with an uncaught ValueError —
-    and nan is not an exotic edge case here: XGBClassifier's default
-    `missing` param IS nan, so almost every real fitted XGBoost model has one
-    in its params."""
+    """float, or a JSON-safe string sentinel for nan/inf (XGBClassifier's
+    default `missing` param is nan, so this is common, not exotic)."""
     f = float(v)
     if math.isnan(f):
         return "NaN"
@@ -373,22 +295,12 @@ def _json_float(v):
 
 
 def _escape_path_key(key) -> str:
-    """A dict key, escaped for splicing into a synthesized dotted/bracketed
-    path. Without this, a dict key containing a literal "." (or "[]") could
-    collide with a path built from actually-nested dicts — e.g.
-    {"sensor.temp": a, "sensor": {"temp": b}} would otherwise both produce
-    the path "sensor.temp" — and template.html's
-    `data.trees.find(x => x.path === t.path)` would then silently pick the
-    wrong one."""
+    """Escapes a dict key before splicing into a synthesized dotted path, so a
+    literal "." in a key can't collide with an actually-nested path."""
     return str(key).replace("\\", "\\\\").replace(".", "\\.").replace("[", "\\[").replace("]", "\\]")
 
 
 def _describe(obj, path="", depth=0, max_depth=4):
-    """Bounded recursive structure walk: what _describe returns is also how
-    plain training-provenance metadata (dataset name, dropped-sample ids, ...)
-    surfaces for a bundle like {"classifier": ..., "dataset": "...", ...} —
-    it's just dict values the walk already shows, no separate "model card"
-    merge step needed for that part."""
     if depth >= max_depth:
         return {"path": path, "kind": "truncated"}
     if isinstance(obj, dict):
@@ -421,8 +333,7 @@ def _is_ndarray(obj) -> bool:
 
 
 def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
-    """All objects with a scikit-learn-style get_params(), anywhere in the
-    (bounded-depth) structure, tagged with their path."""
+    """All objects with a scikit-learn-style get_params(), tagged with their path."""
     if seen is None:
         seen = set()
     if depth >= max_depth:
@@ -431,7 +342,8 @@ def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
     if obj_id in seen:
         return []
     found = []
-    if hasattr(obj, "get_params") and callable(obj.get_params):
+    is_estimator = hasattr(obj, "get_params") and callable(obj.get_params)
+    if is_estimator:
         seen.add(obj_id)
         found.append((path, obj))
     if isinstance(obj, dict):
@@ -441,6 +353,12 @@ def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
     elif isinstance(obj, (list, tuple)):
         for index, value in enumerate(obj[:50]):
             found.extend(_find_estimators(value, f"{path}[{index}]", depth + 1, max_depth, seen))
+    elif is_estimator and hasattr(obj, "__dict__"):
+        # Composite estimators (Pipeline, VotingClassifier, ...) hold sub-estimators
+        # as plain attributes, not get_params() values.
+        for key, value in list(vars(obj).items())[:50]:
+            child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
+            found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))
     return found
 
 
@@ -480,11 +398,7 @@ def _feature_importance(path: str, est):
     elif hasattr(est, "coef_"):
         coef = est.coef_
         if getattr(coef, "ndim", 1) > 1:
-            # multi-class: one coefficient row per class. Mean of absolute
-            # values across classes is a standard, defensible way to
-            # summarize importance in one ranking, rather than arbitrarily
-            # picking class 0 and silently discarding the rest.
-            values = list(abs(coef).mean(axis=0))
+            values = list(abs(coef).mean(axis=0))  # multi-class: mean |coef| across classes
         else:
             values = [abs(float(v)) for v in coef]
     if values is None:
@@ -504,12 +418,8 @@ def _tree_kind(est):
     if hasattr(est, "booster_") and hasattr(est.booster_, "dump_model"):
         return "lightgbm"
     if hasattr(est, "estimators_"):
-        # GradientBoostingClassifier/Regressor's estimators_ is 2-D — one row
-        # of trees per boosting round, one column per class (a single column
-        # for binary/regression) — not a flat list of one tree each like a
-        # RandomForest/AdaBoost's estimators_.
         if getattr(est.estimators_, "ndim", 1) > 1:
-            return "sklearn_gradient_boosting"
+            return "sklearn_gradient_boosting"  # 2-D: one row of trees per round
         return "sklearn_forest"
     if hasattr(est, "tree_") and hasattr(est.tree_, "children_left"):
         return "sklearn_tree"
@@ -531,14 +441,9 @@ def _sklearn_tree_node(tree, node_id, depth=0):
 
 
 def _xgboost_feature_index(split: str):
-    # xgboost's JSON dump names an unnamed feature "f<index>" (a string) where
-    # sklearn/lightgbm give a bare int — normalized back to an int here so the
-    # three libraries agree on what "feature" means and the view can format it
-    # uniformly. A booster trained with real feature_names keeps its own name
-    # — including one that happens to look like "f<something>" (e.g. "f007",
-    # or "f²" whose "²" is a Unicode digit str.isdigit() accepts but int()
-    # can't parse) — so this only treats it as an auto-generated index if it
-    # round-trips exactly back to the original string.
+    """xgboost names an unnamed feature "f<index>" (a string); normalized to
+    an int only when it round-trips exactly, so a real feature literally
+    named "f007" isn't corrupted."""
     if split.startswith("f"):
         try:
             index = int(split[1:])
@@ -601,10 +506,8 @@ def _tree_ensemble(path: str, est, tree_index):
             round_idx, class_idx = divmod(idx, n_classes)
             return _sklearn_tree_node(est.estimators_[round_idx, class_idx].tree_, 0)
     elif kind == "xgboost":
-        # Tree count comes from num_boosted_rounds() (cheap: no dump), not
-        # len(get_dump()) — dumping every tree as JSON text just to count them
-        # cost 6+ seconds on a 992-tree model; get_dump() only ever runs, lazily,
-        # for the one tree actually requested.
+        # num_boosted_rounds() is cheap; get_dump() (needed only for the one
+        # requested tree) costs seconds on a large model.
         booster = est.get_booster()
         n_classes = len(est.classes_) if hasattr(est, "classes_") and len(est.classes_) > 2 else 1
         count = booster.num_boosted_rounds() * n_classes
@@ -614,7 +517,7 @@ def _tree_ensemble(path: str, est, tree_index):
         def node_builder():
             return _xgboost_tree_node(json.loads(booster.get_dump(dump_format="json")[idx]))
     elif kind == "lightgbm":
-        count = est.booster_.num_trees()  # cheap: dump_model() only runs lazily below
+        count = est.booster_.num_trees()
         meta = [{"index": i} for i in range(count)]
         idx = tree_index if tree_index is not None else 0
 
@@ -633,12 +536,7 @@ def _tree_ensemble(path: str, est, tree_index):
 
 
 def _safe(fn, *args):
-    """None on any failure. The estimator being introspected here came
-    through __reduce__/__setstate__ rather than a normal constructor, so a
-    real allowlisted class with adversarial internal state can raise from
-    these getters in ways hasattr()'s AttributeError-only suppression won't
-    catch — and one bad estimator anywhere in a multi-model bundle must not
-    kill every other estimator's data too."""
+    """None on any failure, isolating one bad estimator from the rest of the bundle."""
     try:
         return fn(*args)
     except Exception:  # noqa: BLE001 - best-effort, isolated per estimator
@@ -646,9 +544,6 @@ def _safe(fn, *args):
 
 
 def main(file: str, tree_index=None) -> dict:
-    # tree_index is intentionally unannotated (matches structure/reader.py's
-    # row_group convention): a param round-tripped through the URL arrives
-    # as a string or JS null, and an `int` annotation would blow up on null.
     try:
         idx = int(tree_index) if tree_index not in (None, "") else None
     except (TypeError, ValueError):

--- a/fused_render/templates/joblib_model/reader.py
+++ b/fused_render/templates/joblib_model/reader.py
@@ -34,10 +34,11 @@ _PREFIX_ALLOW = (
     "pandas.", "joblib.",
 )
 
-# A prefix-trusted FUNCTION (unlike a class) is called directly with
-# attacker-chosen arguments the moment REDUCE runs (e.g. joblib.load itself
-# would re-enter an unrestricted load) — so only these known reconstruction
-# helpers may resolve as functions; see find_class.
+# A prefix-trusted FUNCTION (unlike a class) is DANGEROUS ONLY once REDUCE
+# actually calls it with attacker-chosen args (e.g. joblib.load would re-enter
+# an unrestricted load) -- merely resolving/storing a reference is harmless, so
+# find_class allows that freely and _RestrictedUnpickler.load_reduce is the
+# real gate. These are the known-safe functions real pickles need to CALL.
 _PREFIX_FUNCTION_ALLOW = {
     ("numpy.core.multiarray", "_reconstruct"),
     ("numpy.core.multiarray", "scalar"),
@@ -48,6 +49,10 @@ _PREFIX_FUNCTION_ALLOW = {
     ("numpy.random._pickle", "__randomstate_ctor"),
     ("numpy.random._pickle", "__bit_generator_ctor"),
     ("numpy.random._pickle", "__generator_ctor"),
+    ("pandas._libs.internals", "_unpickle_block"),
+    ("pandas.core.indexes.base", "_new_Index"),
+    ("pandas.core.internals.blocks", "new_block"),
+    ("pandas.core.series", "_new_Series"),
 }
 
 
@@ -161,6 +166,13 @@ class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
         self._seen = set()
         self.blocked = []
         self.missing = set()
+        # A prefix-trusted name may resolve to a real, uncalled reference (e.g. a
+        # FunctionTransformer merely storing numpy.log1p as an attribute) -- that's
+        # harmless, so find_class doesn't block it. What IS dangerous is REDUCE
+        # actually CALLING an unvetted function with attacker-chosen args (e.g.
+        # joblib.load). load_reduce below is the real gate for that; this maps
+        # id(resolved) -> (module, name) for anything it must refuse to call.
+        self._unsafe_to_call = {}
 
     def find_class(self, module, name):
         key = (module, name)
@@ -191,11 +203,29 @@ class _RestrictedUnpickler(joblib.numpy_pickle.NumpyUnpickler):
         prefix_trusted = exact is None or name not in exact
         is_safe_function = key in _PREFIX_FUNCTION_ALLOW or _is_pyx_unpickle_helper(name)
         if prefix_trusted and not isinstance(resolved, type) and not is_safe_function:
-            record(False)
-            self.blocked.append({"module": module, "name": name})
-            return _Stub
+            self._unsafe_to_call[id(resolved)] = key
         record(True)
         return resolved
+
+    def load_reduce(self):
+        # Mirrors pickle._Unpickler.load_reduce exactly, except a call target
+        # find_class flagged unsafe-to-call is never actually invoked.
+        args = self.stack.pop()
+        func = self.stack[-1]
+        origin = self._unsafe_to_call.get(id(func))
+        if origin is not None:
+            module, name = origin
+            for ref in self.refs:
+                if ref["module"] == module and ref["name"] == name:
+                    ref["allowed"] = False
+                    break
+            self.blocked.append({"module": module, "name": name})
+            self.stack[-1] = _Stub()
+        else:
+            self.stack[-1] = func(*args)
+
+    dispatch = dict(joblib.numpy_pickle.NumpyUnpickler.dispatch)
+    dispatch[pickle.REDUCE[0]] = load_reduce
 
     def persistent_load(self, pid):
         raise pickle.UnpicklingError(f"unsupported persistent reference: {pid!r}")
@@ -332,7 +362,10 @@ def _is_ndarray(obj) -> bool:
     return type(obj).__module__.startswith("numpy") and type(obj).__name__ == "ndarray"
 
 
-def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
+_FIND_ESTIMATORS_MAX_DEPTH = 12  # a dict-wrapped Pipeline alone needs dict->Pipeline->steps->tuple->estimator
+
+
+def _find_estimators(obj, path="", depth=0, max_depth=_FIND_ESTIMATORS_MAX_DEPTH, seen=None):
     """All objects with a scikit-learn-style get_params(), tagged with their path."""
     if seen is None:
         seen = set()
@@ -353,9 +386,11 @@ def _find_estimators(obj, path="", depth=0, max_depth=4, seen=None):
     elif isinstance(obj, (list, tuple)):
         for index, value in enumerate(obj[:50]):
             found.extend(_find_estimators(value, f"{path}[{index}]", depth + 1, max_depth, seen))
-    elif is_estimator and hasattr(obj, "__dict__"):
-        # Composite estimators (Pipeline, VotingClassifier, ...) hold sub-estimators
-        # as plain attributes, not get_params() values.
+    elif is_estimator and _tree_kind(obj) is None and hasattr(obj, "__dict__"):
+        # Composite estimators (Pipeline, VotingClassifier, ...) hold sub-estimators as
+        # plain attributes. Skipped once _tree_kind recognises obj as an ensemble itself
+        # (RandomForest, Bagging, ...): its members are already covered by the tree
+        # viewer, not independent top-level models.
         for key, value in list(vars(obj).items())[:50]:
             child_path = f"{path}.{_escape_path_key(key)}" if path else _escape_path_key(key)
             found.extend(_find_estimators(value, child_path, depth + 1, max_depth, seen))

--- a/fused_render/templates/joblib_model/template.html
+++ b/fused_render/templates/joblib_model/template.html
@@ -175,6 +175,7 @@ function bytes(n) {
 }
 
 function dateStr(epochSeconds) {
+  if (typeof epochSeconds !== "number") return "—";
   return new Date(epochSeconds * 1000).toLocaleString();
 }
 
@@ -211,9 +212,11 @@ function scanNote(scan) {
 function structPrimitive(item) {
   if (item.kind === "scalar") {
     const v = item.value;
-    if (v === null || v === undefined) return `<span class="null">None</span>`;
-    if (typeof v === "string") return `<span class="str">"${esc(v)}"</span>`;
-    if (typeof v === "boolean") return `<span class="bool">${v}</span>`;
+    // Dispatch on the ORIGINAL Python type, not typeof v -- a NaN/Infinity float
+    // arrives as the JS string "NaN", indistinguishable by typeof from a real string.
+    if (item.type === "none") return `<span class="null">None</span>`;
+    if (item.type === "str") return `<span class="str">"${esc(v)}"</span>`;
+    if (item.type === "bool") return `<span class="bool">${v}</span>`;
     return `<span class="num">${esc(v)}</span>`;
   }
   if (item.kind === "ndarray") {
@@ -223,6 +226,7 @@ function structPrimitive(item) {
     return `<span class="type">${esc(item.type)}</span> <span class="muted mono">${esc(item.module)}</span>`;
   }
   if (item.kind === "truncated") return `<span class="muted">… (nesting limit reached)</span>`;
+  if (item.kind === "shared") return `<span class="muted">↩ (shared reference, shown elsewhere)</span>`;
   return `<span class="type">${esc(item.type || "")}</span> <span class="muted mono">${esc(item.repr || "")}</span>`;
 }
 
@@ -400,7 +404,9 @@ function renderFeatureImportance(list) {
   return list.map((fi) => {
     const top = fi.features.slice(0, 40);
     const numOr0 = (v) => (typeof v === "number" ? v : 0);
-    const biggest = top.length ? numOr0(top[0].importance) : 0;
+    // Max across the whole page, not just top[0] -- a NaN/non-numeric entry
+    // ranked first (e.g. every importance is NaN) must not collapse every bar.
+    const biggest = top.length ? Math.max(...top.map((f) => numOr0(f.importance))) : 0;
     return `<section><h2>Feature importance — ${esc(fi.path || "(root)")}</h2>
       <div class="scroll"><table>
         <tr><th>Feature</th><th class="num">Importance</th><th></th></tr>
@@ -428,6 +434,7 @@ function renderTreeSections(treesList) {
 }
 
 function wireTreeSections(treesList) {
+  const redraws = [];
   treesList.forEach((t, ti) => {
     // Section-qualified key: each estimator's tree section has its own selection.
     const paramKey = `tree_${ti}`;
@@ -460,6 +467,7 @@ function wireTreeSections(treesList) {
       const btn = document.getElementById(`treeexpand-${ti}`);
       if (btn) btn.addEventListener("click", () => { extraDepth += 4; draw(); });
     }
+    redraws.push(draw);
 
     async function loadTree(index) {
       const box = document.getElementById(`treebox-${ti}`);
@@ -493,6 +501,10 @@ function wireTreeSections(treesList) {
       });
     }
   });
+  // Colours are baked into the SVG via getComputedStyle at draw time (SPEC §30),
+  // so a theme change alone doesn't repaint an already-drawn tree.
+  new MutationObserver(() => redraws.forEach((fn) => fn()))
+    .observe(document.documentElement, { attributeFilter: ["data-theme"] });
 }
 
 function render(d) {

--- a/fused_render/templates/joblib_model/template.html
+++ b/fused_render/templates/joblib_model/template.html
@@ -1,0 +1,545 @@
+<!DOCTYPE html>
+<html data-fused-theme="shell">
+<head>
+<meta charset="utf-8" />
+<title>Model file</title>
+<style>
+  /* Palette pair (SPEC §30): this view follows the shell's appearance because
+     it opted in with `data-fused-theme` on <html> above — the runtime then
+     keeps `data-theme` in step. Every colour below is a token defined in these
+     two blocks and nowhere else. */
+  :root {
+    color-scheme: dark;
+    --fg: #e8eaed;
+    --fg-muted: #9aa0a6;
+    --border: #2a2d33;
+    --bg: #131417;
+    --bg-alt: #1b1d21;
+    --accent: #E5FF44;
+    --error: #ff6b6b;
+    --warn: #e8b339;
+    --ok: #5fd97a;
+    --bar: #3a6ee8;
+    --json-str: #98c379;
+    --json-num: #d19a66;
+    --json-bool: #c678dd;
+  }
+  :root[data-theme="light"] {
+    color-scheme: light;
+    --fg: #1f2023;
+    --fg-muted: #61656c;
+    --border: #d8dade;
+    --bg: #ffffff;
+    --bg-alt: #f4f5f7;
+    --accent: #5f7300;
+    --error: #c62828;
+    --warn: #9a6a00;
+    --ok: #237a3c;
+    --bar: #2b5fd9;
+    --json-str: #2f7d32;
+    --json-num: #9a5b00;
+    --json-bool: #7c4dbd;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    padding: 22px 26px 40px;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--fg);
+    background: var(--bg);
+  }
+  .mono { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+  h1 { margin: 0; font-size: 20px; font-weight: 600; overflow-wrap: anywhere; }
+  .sub { margin-top: 3px; font-size: 12px; color: var(--fg-muted); overflow-wrap: anywhere; }
+  .facts { display: flex; flex-wrap: wrap; gap: 8px; margin: 14px 0 20px; }
+  .fact {
+    padding: 8px 12px;
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    min-width: 100px;
+  }
+  .fact .k { font-size: 11px; text-transform: uppercase; letter-spacing: .05em; color: var(--fg-muted); }
+  .fact .v { font-size: 15px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .pill {
+    display: inline-block;
+    padding: 2px 7px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    border-radius: 4px;
+    background: var(--border);
+    color: var(--fg-muted);
+  }
+  .pill.ok { background: color-mix(in srgb, var(--ok) 22%, transparent); color: var(--ok); }
+  .pill.warn { background: color-mix(in srgb, var(--warn) 22%, transparent); color: var(--warn); }
+  .pill.danger { background: color-mix(in srgb, var(--error) 22%, transparent); color: var(--error); }
+  section { margin-bottom: 24px; }
+  h2 {
+    margin: 0 0 8px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: .06em;
+    color: var(--fg-muted);
+  }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  td, th { padding: 5px 8px; text-align: left; border-bottom: 1px solid var(--border); vertical-align: top; }
+  th { font-weight: 500; color: var(--fg-muted); }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  td.name { overflow-wrap: anywhere; }
+  .bar { height: 3px; background: var(--bar); border-radius: 2px; min-width: 1px; }
+  .muted { color: var(--fg-muted); }
+  .err { color: var(--error); }
+  .scroll { max-height: 340px; overflow: auto; border: 1px solid var(--border); border-radius: 8px; }
+  .scroll table td:first-child, .scroll table th:first-child { padding-left: 12px; }
+  .note {
+    padding: 10px 12px;
+    font-size: 12px;
+    color: var(--fg);
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    max-width: 80ch;
+  }
+  .note.danger { border-color: var(--error); }
+  .note.warn { border-color: var(--warn); }
+  .note ul { margin: 6px 0 0; padding-left: 18px; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+
+  /* Structure-walk collapsible tree — same visual language as the tree/ template. */
+  #struct { padding: 10px 12px; white-space: nowrap; overflow-x: auto; }
+  #struct .row { cursor: default; padding-left: 0; }
+  #struct .row.foldable { cursor: pointer; }
+  #struct .toggle { display: inline-block; width: 1em; color: var(--fg-muted); user-select: none; }
+  #struct .node { padding-left: 16px; }
+  #struct .collapsed > .node { display: none; }
+  #struct .collapsed > .row .preview { color: var(--fg-muted); }
+  #struct .key { color: var(--accent); }
+  #struct .punct, #struct .count { color: var(--fg-muted); }
+  #struct .count { font-style: italic; }
+  #struct .type { color: var(--json-bool); }
+  #struct .str { color: var(--json-str); }
+  #struct .num { color: var(--json-num); }
+  #struct .bool { color: var(--json-bool); }
+  #struct .null { color: var(--fg-muted); }
+
+  select {
+    font: inherit;
+    color: var(--fg);
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 8px;
+    margin: 4px 0 10px;
+  }
+  button {
+    font: inherit;
+    color: var(--fg);
+    background: var(--bg-alt);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 5px 10px;
+    cursor: pointer;
+  }
+  button:hover { border-color: var(--fg-muted); }
+  .treebox {
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: auto;
+    background: var(--bg-alt);
+    padding: 8px;
+  }
+  .treebox .placeholder { padding: 20px; color: var(--fg-muted); }
+</style>
+</head>
+<body>
+<div id="root" class="muted">Reading the file…</div>
+
+<script>
+const FILE = fused.params.get("_file");
+
+const esc = (s) => String(s ?? "").replace(/[&<>"']/g, (c) => (
+  { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]
+));
+
+function bytes(n) {
+  if (!n && n !== 0) return "—";
+  if (n === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let v = n, u = 0;
+  while (v >= 1024 && u < units.length - 1) { v /= 1024; u++; }
+  return `${u === 0 ? v : v.toFixed(v < 10 ? 1 : 0)} ${units[u]}`;
+}
+
+function dateStr(epochSeconds) {
+  return new Date(epochSeconds * 1000).toLocaleString();
+}
+
+function rows(items, cells) {
+  return items.map((item) => `<tr>${cells(item)}</tr>`).join("");
+}
+
+// ------------------------------------------------------------ safety panel
+
+const VERDICT_LABEL = { safe: "Loaded", unavailable: "Partially available", blocked: "Blocked" };
+const VERDICT_CLASS = { safe: "ok", unavailable: "warn", blocked: "danger" };
+
+function scanNote(scan) {
+  if (scan.verdict === "blocked") {
+    const offending = scan.refs.filter((r) => !r.allowed);
+    return `<div class="note danger">
+      This file references code this viewer does not trust, so it was not loaded.
+      ${scan.message ? `<div class="mono" style="margin-top:6px">${esc(scan.message)}</div>` : ""}
+      ${offending.length ? `<ul class="mono">${offending.map((r) =>
+        `<li>${esc(r.module)}.${esc(r.name)}</li>`).join("")}</ul>` : ""}
+    </div>`;
+  }
+  if (scan.verdict === "unavailable") {
+    return `<div class="note warn">
+      This file's classes are trusted, but a library it needs isn't available to this
+      template: <span class="mono">${esc(scan.message)}</span>. Nothing was loaded.
+    </div>`;
+  }
+  return "";
+}
+
+// ------------------------------------------------------------ structure walk
+
+function structPrimitive(item) {
+  if (item.kind === "scalar") {
+    const v = item.value;
+    if (v === null || v === undefined) return `<span class="null">None</span>`;
+    if (typeof v === "string") return `<span class="str">"${esc(v)}"</span>`;
+    if (typeof v === "boolean") return `<span class="bool">${v}</span>`;
+    return `<span class="num">${esc(v)}</span>`;
+  }
+  if (item.kind === "ndarray") {
+    return `<span class="type">ndarray</span> <span class="muted">shape=(${item.shape.join(", ")}) dtype=${esc(item.dtype)}</span>`;
+  }
+  if (item.kind === "estimator") {
+    return `<span class="type">${esc(item.type)}</span> <span class="muted mono">${esc(item.module)}</span>`;
+  }
+  if (item.kind === "truncated") return `<span class="muted">… (nesting limit reached)</span>`;
+  return `<span class="type">${esc(item.type || "")}</span> <span class="muted mono">${esc(item.repr || "")}</span>`;
+}
+
+function buildStructNode(item, keyHtml, depth) {
+  if (item.kind !== "dict" && item.kind !== "list") {
+    const el = document.createElement("div");
+    el.className = "row";
+    el.innerHTML = `${keyHtml}${structPrimitive(item)}`;
+    return el;
+  }
+  const entries = item.kind === "dict"
+    ? item.items.map((it) => [it.key, it])
+    : item.items.map((it, i) => [String(i), it]);
+  const open = item.kind === "dict" ? "{" : "[";
+  const close = item.kind === "dict" ? "}" : "]";
+  // item.length is the true count server-side; item.items is capped at 50 —
+  // they can diverge, so the label (and the "+N more" row below) reflect the
+  // true count rather than just what was actually walked.
+  const total = item.length !== undefined ? item.length : entries.length;
+  const countLabel = `${total} ${item.kind === "dict" ? "key" : "item"}${total === 1 ? "" : "s"}`;
+
+  const container = document.createElement("div");
+  const row = document.createElement("div");
+  row.className = "row foldable";
+  row.innerHTML =
+    `<span class="toggle">▾</span>${keyHtml}` +
+    `<span class="punct">${open}</span>` +
+    `<span class="count preview"> ${countLabel} </span>` +
+    `<span class="punct">${close}</span>`;
+  container.appendChild(row);
+
+  const children = document.createElement("div");
+  children.className = "node";
+  for (const [k, child] of entries) {
+    const childKey = item.kind === "dict"
+      ? `<span class="key">"${esc(k)}"</span><span class="punct">: </span>`
+      : "";
+    children.appendChild(buildStructNode(child, childKey, depth + 1));
+  }
+  if (total > entries.length) {
+    const moreRow = document.createElement("div");
+    moreRow.className = "row";
+    moreRow.innerHTML = `<span class="muted">… +${total - entries.length} more ${item.kind === "dict" ? "keys" : "items"}</span>`;
+    children.appendChild(moreRow);
+  }
+  container.appendChild(children);
+
+  function setCollapsed(collapsed) {
+    container.classList.toggle("collapsed", collapsed);
+    row.querySelector(".toggle").textContent = collapsed ? "▸" : "▾";
+  }
+  row.addEventListener("click", (e) => {
+    e.stopPropagation();
+    setCollapsed(!container.classList.contains("collapsed"));
+  });
+  if (entries.length > 0 && depth >= 1) setCollapsed(true); // default-open only the root
+
+  return container;
+}
+
+// reader.py sends nan/inf as the strings "NaN"/"Infinity"/"-Infinity" (the
+// production response path rejects literal non-finite floats) -- format
+// those as-is instead of crashing a bare .toFixed() call on a string.
+function fmtNum(v, digits) {
+  return typeof v === "number" ? v.toFixed(digits) : String(v);
+}
+
+// -------------------------------------------------------- tree SVG renderer
+
+const BASE_RENDER_DEPTH = 6;
+const COL_WIDTH = 92, ROW_HEIGHT = 58, PADDING = 26;
+
+function countNodes(node) {
+  if (node.leaf !== undefined) return 1;
+  return 1 + countNodes(node.left) + countNodes(node.right);
+}
+
+function layoutTree(node, depth, maxDepth, counter) {
+  const isRealLeaf = node.leaf !== undefined;
+  const truncate = !isRealLeaf && depth >= maxDepth;
+  if (isRealLeaf || truncate) {
+    const x = counter.n++;
+    return { x, depth, node, isLeaf: isRealLeaf, truncatedCount: truncate ? countNodes(node) - 1 : 0, children: [] };
+  }
+  const left = layoutTree(node.left, depth + 1, maxDepth, counter);
+  const right = layoutTree(node.right, depth + 1, maxDepth, counter);
+  return { x: (left.x + right.x) / 2, depth, node, isLeaf: false, children: [left, right] };
+}
+
+function maxDepthOf(l) {
+  return l.children.length ? Math.max(...l.children.map(maxDepthOf)) : l.depth;
+}
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+function svgEl(tag, attrs) {
+  const el = document.createElementNS(SVG_NS, tag);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  return el;
+}
+
+function renderTreeSvg(container, root, maxDepth) {
+  const counter = { n: 0 };
+  const layout = layoutTree(root, 0, maxDepth, counter);
+  const depthShown = maxDepthOf(layout);
+  const width = Math.max(220, counter.n * COL_WIDTH + PADDING * 2);
+  const height = (depthShown + 1) * ROW_HEIGHT + PADDING * 2;
+
+  // Colours read live via getComputedStyle (SPEC §30): CSS var() does not
+  // resolve for values set through JS/SVG attributes, only through CSS itself.
+  const cs = getComputedStyle(document.documentElement);
+  const fg = cs.getPropertyValue("--fg").trim();
+  const border = cs.getPropertyValue("--border").trim();
+  const accent = cs.getPropertyValue("--accent").trim();
+  const bg = cs.getPropertyValue("--bg").trim();
+
+  const px = (x) => PADDING + x * COL_WIDTH + COL_WIDTH / 2;
+  const py = (depth) => PADDING + depth * ROW_HEIGHT;
+
+  const svg = svgEl("svg", { width, height, viewBox: `0 0 ${width} ${height}` });
+
+  function draw(l) {
+    for (const child of l.children) {
+      svg.appendChild(svgEl("line", {
+        x1: px(l.x), y1: py(l.depth) + 13, x2: px(child.x), y2: py(child.depth) - 13,
+        stroke: border, "stroke-width": 1.4,
+      }));
+      draw(child);
+    }
+    const truncated = !l.isLeaf && l.children.length === 0;
+    const featureLabel = typeof l.node.feature === "number" ? `f${l.node.feature}` : l.node.feature;
+    const label = l.isLeaf
+      ? `leaf ${l.node.leaf.map((v) => fmtNum(v, 3)).join(", ")}`
+      : truncated
+        ? `+${l.truncatedCount} more`
+        : `${featureLabel} < ${fmtNum(l.node.threshold, 3)}`;
+    const w = Math.min(COL_WIDTH - 8, Math.max(46, label.length * 6.4));
+    svg.appendChild(svgEl("rect", {
+      x: px(l.x) - w / 2, y: py(l.depth) - 12, width: w, height: 24, rx: 5,
+      fill: l.isLeaf ? accent : truncated ? "none" : bg,
+      "fill-opacity": l.isLeaf ? 0.16 : 1,
+      stroke: l.isLeaf ? accent : border,
+      "stroke-dasharray": truncated ? "3,2" : "none",
+    }));
+    const text = svgEl("text", {
+      x: px(l.x), y: py(l.depth) + 4, "text-anchor": "middle",
+      "font-size": 10.5, "font-family": "ui-monospace, monospace", fill: fg,
+    });
+    text.textContent = label;
+    svg.appendChild(text);
+  }
+  draw(layout);
+
+  container.innerHTML = "";
+  container.appendChild(svg);
+  return depthShown;
+}
+
+// ------------------------------------------------------------------ render
+
+function renderEstimators(estimators) {
+  if (!estimators.length) return "";
+  return `<section><h2>Model summary</h2>${estimators.map((e) => `
+    <div style="margin-bottom:16px">
+      <div><b>${esc(e.path || "(root)")}</b> <span class="pill">${esc(e.type)}</span></div>
+      <div class="sub mono">${esc(e.module)}</div>
+      <div class="facts">
+        ${e.n_features_in !== undefined ? `<div class="fact"><div class="k">Features</div><div class="v">${e.n_features_in}</div></div>` : ""}
+        ${e.classes ? `<div class="fact"><div class="k">Classes</div><div class="v">${e.classes.length}</div></div>` : ""}
+      </div>
+      <div class="scroll"><table>
+        ${rows(Object.entries(e.params), ([k, v]) => `<th>${esc(k)}</th><td class="mono">${esc(v)}</td>`)}
+      </table></div>
+    </div>`).join("")}
+  </section>`;
+}
+
+function renderFeatureImportance(list) {
+  if (!list.length) return "";
+  return list.map((fi) => {
+    const top = fi.features.slice(0, 40);
+    const numOr0 = (v) => (typeof v === "number" ? v : 0);
+    const biggest = top.length ? numOr0(top[0].importance) : 0;
+    return `<section><h2>Feature importance — ${esc(fi.path || "(root)")}</h2>
+      <div class="scroll"><table>
+        <tr><th>Feature</th><th class="num">Importance</th><th></th></tr>
+        ${rows(top, (f) => `
+          <td class="mono">#${f.feature}</td>
+          <td class="num">${fmtNum(f.importance, 4)}</td>
+          <td style="width:120px"><div class="bar" style="width:${
+            biggest ? Math.max(1, Math.round((numOr0(f.importance) / biggest) * 100)) : 1}%"></div></td>`)}
+      </table></div>
+      ${fi.features.length > top.length ? `<div class="sub">+${fi.features.length - top.length} more features</div>` : ""}
+    </section>`;
+  }).join("");
+}
+
+function renderTreeSections(treesList) {
+  if (!treesList.length) return "";
+  return treesList.map((t, ti) => `
+    <section>
+      <h2>Trees — ${esc(t.path || "(root)")} <span class="pill">${esc(t.library)}</span></h2>
+      <div class="sub">${t.count} tree${t.count === 1 ? "" : "s"}</div>
+      ${t.count > 1 ? `<div><select id="treesel-${ti}" class="mono"></select></div>` : ""}
+      <div id="treebox-${ti}" class="treebox"><div class="placeholder">Loading tree…</div></div>
+      <div id="treemore-${ti}"></div>
+    </section>`).join("");
+}
+
+function wireTreeSections(treesList) {
+  treesList.forEach((t, ti) => {
+    // Section-qualified key: each estimator's tree section has its own
+    // independent selection, same idea as structure/template.html's "view"
+    // tab param but keyed per section since there can be several here.
+    const paramKey = `tree_${ti}`;
+    const select = document.getElementById(`treesel-${ti}`);
+    let initialIndex = 0;
+    if (select) {
+      select.innerHTML = t.trees.map((m) => {
+        const label = m.round !== undefined ? `Tree ${m.index} (round ${m.round}, class ${m.class})` : `Tree ${m.index}`;
+        return `<option value="${m.index}">${esc(label)}</option>`;
+      }).join("");
+      const saved = Number(fused.params.get(paramKey));
+      if (Number.isInteger(saved) && saved >= 0 && saved < t.trees.length) {
+        initialIndex = saved;
+        select.value = String(saved);
+      }
+    }
+
+    let extraDepth = 0;
+    let currentTreeData = null;
+
+    function draw() {
+      if (!currentTreeData) return;
+      const box = document.getElementById(`treebox-${ti}`);
+      const shown = renderTreeSvg(box, currentTreeData, BASE_RENDER_DEPTH + extraDepth);
+      const more = document.getElementById(`treemore-${ti}`);
+      const totalDepth = maxDepthOf(layoutTree(currentTreeData, 0, Infinity, { n: 0 }));
+      more.innerHTML = shown < totalDepth
+        ? `<button type="button" id="treeexpand-${ti}">Show deeper levels</button>`
+        : "";
+      const btn = document.getElementById(`treeexpand-${ti}`);
+      if (btn) btn.addEventListener("click", () => { extraDepth += 4; draw(); });
+    }
+
+    async function loadTree(index) {
+      const box = document.getElementById(`treebox-${ti}`);
+      box.innerHTML = `<div class="placeholder">Loading tree…</div>`;
+      extraDepth = 0;
+      try {
+        const data = await fused.runPython("./reader.py", { file: FILE, tree_index: index }, { key: `tree-${ti}` });
+        const entry = data.trees.find((x) => x.path === t.path);
+        if (!entry || !entry.tree) {
+          box.innerHTML = `<div class="placeholder err">${esc(entry && entry.tree_error || "This tree could not be rendered.")}</div>`;
+          return;
+        }
+        currentTreeData = entry.tree;
+        draw();
+      } catch (err) {
+        box.innerHTML = `<div class="placeholder err">${esc((err && err.message) || err)}</div>`;
+      }
+    }
+
+    if (t.tree && initialIndex === 0) {
+      currentTreeData = t.tree;
+      draw();
+    } else {
+      loadTree(initialIndex);
+    }
+    if (select) {
+      select.addEventListener("change", () => {
+        const index = Number(select.value);
+        fused.params.set(paramKey, String(index));
+        loadTree(index);
+      });
+    }
+  });
+}
+
+function render(d) {
+  const scan = d.scan;
+  const facts = [
+    ["Size", bytes(d.file.size)],
+    ["Modified", dateStr(d.file.mtime)],
+    ["Files", String(1 + (d.file.sibling_files || []).length)],
+  ];
+
+  document.getElementById("root").innerHTML = `
+    <h1>${esc(FILE.split(/[\\/]/).pop())} <span class="pill ${VERDICT_CLASS[scan.verdict] || ""}">${
+      esc(VERDICT_LABEL[scan.verdict] || scan.verdict)}</span></h1>
+    <div class="sub mono">${esc(FILE)}</div>
+    <div class="facts">${facts.map(([k, v]) => `
+      <div class="fact"><div class="k">${esc(k)}</div><div class="v">${esc(v)}</div></div>`).join("")}
+    </div>
+    ${scanNote(scan)}
+    ${scan.verdict === "safe" ? `
+      <section><h2>Structure</h2><div id="struct" class="scroll"></div></section>
+      ${renderEstimators(d.estimators)}
+      ${renderFeatureImportance(d.feature_importance)}
+      ${renderTreeSections(d.trees)}
+    ` : ""}
+  `;
+
+  if (scan.verdict === "safe") {
+    document.getElementById("struct").appendChild(buildStructNode(d.structure, "", 0));
+    wireTreeSections(d.trees);
+  }
+}
+
+async function load() {
+  try {
+    render(await fused.runPython("./reader.py", { file: FILE }));
+  } catch (err) {
+    document.getElementById("root").innerHTML =
+      `<div class="err">Could not read this file: ${esc((err && err.message) || err)}</div>`;
+  }
+}
+load();
+</script>
+</body>
+</html>

--- a/fused_render/templates/joblib_model/template.html
+++ b/fused_render/templates/joblib_model/template.html
@@ -238,9 +238,7 @@ function buildStructNode(item, keyHtml, depth) {
     : item.items.map((it, i) => [String(i), it]);
   const open = item.kind === "dict" ? "{" : "[";
   const close = item.kind === "dict" ? "}" : "]";
-  // item.length is the true count server-side; item.items is capped at 50 —
-  // they can diverge, so the label (and the "+N more" row below) reflect the
-  // true count rather than just what was actually walked.
+  // item.length is the true count; item.items is capped at 50 and can diverge.
   const total = item.length !== undefined ? item.length : entries.length;
   const countLabel = `${total} ${item.kind === "dict" ? "key" : "item"}${total === 1 ? "" : "s"}`;
 
@@ -283,9 +281,7 @@ function buildStructNode(item, keyHtml, depth) {
   return container;
 }
 
-// reader.py sends nan/inf as the strings "NaN"/"Infinity"/"-Infinity" (the
-// production response path rejects literal non-finite floats) -- format
-// those as-is instead of crashing a bare .toFixed() call on a string.
+// reader.py sends nan/inf as the strings "NaN"/"Infinity"/"-Infinity"; format as-is.
 function fmtNum(v, digits) {
   return typeof v === "number" ? v.toFixed(digits) : String(v);
 }
@@ -433,9 +429,7 @@ function renderTreeSections(treesList) {
 
 function wireTreeSections(treesList) {
   treesList.forEach((t, ti) => {
-    // Section-qualified key: each estimator's tree section has its own
-    // independent selection, same idea as structure/template.html's "view"
-    // tab param but keyed per section since there can be several here.
+    // Section-qualified key: each estimator's tree section has its own selection.
     const paramKey = `tree_${ti}`;
     const select = document.getElementById(`treesel-${ti}`);
     let initialIndex = 0;

--- a/fused_render/templates/joblib_model/tests/test_reader.py
+++ b/fused_render/templates/joblib_model/tests/test_reader.py
@@ -15,6 +15,7 @@ import os
 import pickle
 import random
 import sys
+import time
 
 import joblib
 import joblib.numpy_pickle
@@ -92,6 +93,50 @@ def test_object_dtype_array_bypass_is_blocked_and_never_executed(tmp_path, monke
     assert out["scan"]["verdict"] != "safe"
     assert calls == []  # the real os.system (nt.system/posix.system) was never reached
     assert "structure" not in out
+
+
+def test_object_dtype_array_gates_the_call_not_just_the_reference(tmp_path, monkeypatch):
+    # _DelegatingUnpickler (used for object-dtype array content) used to be built on
+    # pickle.Unpickler, the C-accelerated one with no overridable dispatch table --
+    # so load_reduce's unsafe-to-call gate silently never applied inside it, and a
+    # prefix-trusted function reached only through an object-dtype array (unlike a
+    # top-level REDUCE) was called for real.
+    class _Reducer:
+        def __reduce__(self):
+            return (joblib.load, ("/etc/passwd",))
+
+    path = os.path.join(str(tmp_path), "evil_array2.joblib")
+    joblib.dump({"arr": np.array([_Reducer()], dtype=object)}, path)
+
+    calls = []
+    monkeypatch.setattr(joblib.numpy_pickle, "load", lambda *a, **k: calls.append(a))
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "blocked"
+    offending = [r for r in out["scan"]["refs"] if not r["allowed"]]
+    assert any(r["name"] == "load" for r in offending)
+    assert calls == []
+
+
+def test_legacy_inst_opcode_gates_the_call_too(tmp_path, monkeypatch):
+    # The legacy INST/OBJ opcodes (pickle._Unpickler._instantiate) call a resolved
+    # reference directly, the same as REDUCE, but through a completely different
+    # code path load_reduce alone does not cover.
+    path = os.path.join(str(tmp_path), "inst_gadget.pkl")
+    with open(path, "wb") as handle:
+        handle.write(pickle.MARK)
+        handle.write(pickle.SHORT_BINSTRING + bytes([1]) + b"x")
+        handle.write(pickle.INST + b"joblib.numpy_pickle\nload\n")
+        handle.write(pickle.STOP)
+
+    calls = []
+    monkeypatch.setattr(joblib.numpy_pickle, "load", lambda *a, **k: calls.append(a))
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "blocked"
+    offending = [r for r in out["scan"]["refs"] if not r["allowed"]]
+    assert any(r["name"] == "load" for r in offending)
+    assert calls == []
 
 
 def test_prefix_trusted_function_gadget_is_blocked_and_never_executed(tmp_path, monkeypatch):
@@ -213,6 +258,22 @@ def test_array_with_huge_declared_shape_is_blocked_before_allocating(tmp_path):
     assert out["scan"]["verdict"] != "safe"
 
 
+def test_shared_references_do_not_blow_up_the_walk(tmp_path):
+    # Pickle's memo lets a tiny file declare the SAME (large) list many times over.
+    # Without identity-based dedup, a walk that recurses per-occurrence rather than
+    # per-object does branch**depth work from a file of a few hundred bytes.
+    level = 0
+    for _ in range(24):
+        level = [level] * 20
+    path = _dump(level, tmp_path, name="shared_refs.joblib")
+    assert os.path.getsize(path) < 2000
+
+    start = time.time()
+    out = reader.main(file=path)
+    assert time.time() - start < 10
+    assert out["scan"]["verdict"] == "safe"
+
+
 def test_unrecognised_but_allowlist_prefixed_library_is_unavailable(tmp_path):
     # catboost isn't a bundled dependency; a real reference to it must resolve
     # to "unavailable" (trusted, just absent), not "blocked".
@@ -295,6 +356,35 @@ def test_multiclass_linear_model_feature_importance_uses_all_classes(tmp_path):
     assert got != {i: class0_only[i] for i in range(len(class0_only))}
     for i, v in enumerate(expected):
         assert got[i] == pytest.approx(float(v))
+
+
+def test_feature_importance_sorts_nan_last_not_arbitrarily(tmp_path):
+    # NaN compares False against everything, so sorting by a raw NaN key can leave
+    # it anywhere -- including rank 0, displayed as the MOST important feature.
+    class _FakeEstimator:
+        feature_importances_ = [0.2, float("nan"), 0.5, 0.1]
+
+        def get_params(self, deep=True):
+            return {}
+
+    result = reader._feature_importance("", _FakeEstimator())
+    order = [row["feature"] for row in result["features"]]
+    assert order == [2, 0, 3, 1]  # descending by value, NaN (feature 1) last
+    assert result["features"][-1]["importance"] == "NaN"
+
+
+def test_classes_containing_nan_stay_json_safe(tmp_path):
+    # classes_ used to bypass _json_float entirely -- a NaN there broke the whole
+    # response's allow_nan=False serialization instead of degrading gracefully.
+    class _FakeEstimator:
+        classes_ = np.array([0.0, float("nan"), 2.0])
+
+        def get_params(self, deep=False):
+            return {}
+
+    summary = reader._estimator_summary("", _FakeEstimator())
+    assert summary["classes"] == [0.0, "NaN", 2.0]
+    json.dumps(summary, allow_nan=False)
 
 
 def test_one_bad_estimator_does_not_crash_the_others(tmp_path, monkeypatch):
@@ -502,3 +592,6 @@ def test_dict_traversal_is_capped_like_list_traversal(tmp_path):
 def test_missing_file_reports_blocked_without_raising(tmp_path):
     out = reader.main(file=os.path.join(str(tmp_path), "does_not_exist.joblib"))
     assert out["scan"]["verdict"] == "blocked"
+    # Same file_info shape as every other return path -- template.html always
+    # reads file.size/file.mtime/file.sibling_files unconditionally.
+    assert set(out["file"]) == {"size", "mtime", "sibling_files"}

--- a/fused_render/templates/joblib_model/tests/test_reader.py
+++ b/fused_render/templates/joblib_model/tests/test_reader.py
@@ -1,0 +1,459 @@
+"""Unit tests for joblib_model/reader.py.
+
+Needs joblib/scikit-learn/xgboost/lightgbm at test time (unlike every other
+template's tests, since this reader genuinely has to unpickle real estimators
+to introspect them — confirmed there's no existing wiring in this repo that
+installs a template's own pyproject.toml deps into the pytest env, so this is
+self-documented rather than added to CI):
+
+    uv run --with joblib --with scikit-learn --with xgboost --with lightgbm \
+        pytest fused_render/templates/joblib_model/tests/test_reader.py -v
+"""
+import io
+import json
+import os
+import pickle
+import random
+import sys
+
+import joblib
+import joblib.numpy_pickle
+import numpy as np
+import pytest
+from sklearn.ensemble import GradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.preprocessing import StandardScaler
+from xgboost import XGBClassifier
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))  # import the sibling reader.py
+
+import reader  # noqa: E402
+
+
+def _dump(obj, tmp_path, name="model.joblib"):
+    path = os.path.join(str(tmp_path), name)
+    joblib.dump(obj, path)
+    return path
+
+
+def _make_bundle():
+    rng = np.random.RandomState(0)
+    x = rng.rand(200, 6)
+    y = rng.randint(0, 3, size=200)
+    scaler = StandardScaler().fit(x)
+    clf = XGBClassifier(n_estimators=5, max_depth=2, eval_metric="mlogloss")
+    clf.fit(scaler.transform(x), y)
+    return {
+        "scaler": scaler,
+        "classifier": clf,
+        "dataset": "synthetic_test_v1",
+        "dropped_polygons": ["abc-123"],
+    }
+
+
+# --------------------------------------------------------------- safety scan
+
+
+def test_dangerous_reduce_is_blocked_and_never_executed(tmp_path, monkeypatch):
+    class _Reducer:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    path = os.path.join(str(tmp_path), "evil.pkl")
+    with open(path, "wb") as handle:
+        pickle.dump(_Reducer(), handle)  # dumped BEFORE patching os.system below
+
+    calls = []
+    monkeypatch.setattr(os, "system", lambda cmd: calls.append(cmd))
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "blocked"
+    offending = [r for r in out["scan"]["refs"] if not r["allowed"]]
+    assert any(r["name"] == "system" for r in offending)
+    assert calls == []  # the real os.system was never reached
+    assert "structure" not in out
+
+
+def test_object_dtype_array_bypass_is_blocked_and_never_executed(tmp_path, monkeypatch):
+    # joblib's own NumpyArrayWrapper.read_array calls a bare pickle.load()
+    # directly on the file handle for object-dtype arrays -- entirely
+    # outside find_class's allowlist gate -- so np.array([...], dtype=object)
+    # can smuggle in a dangerous __reduce__ payload even though every class
+    # the scanner sees looks safe. Same technique as
+    # test_dangerous_reduce_is_blocked_and_never_executed, but patched on
+    # os.system's actual defining module: os.system is a re-export (e.g. of
+    # nt.system on Windows) and pickle serialises a global by
+    # __module__/__qualname__, not by the name it happens to be imported
+    # under, so patching os.system itself doesn't intercept the real call.
+    class _Reducer:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    path = os.path.join(str(tmp_path), "evil_array.joblib")
+    joblib.dump({"arr": np.array([_Reducer()], dtype=object)}, path)
+
+    calls = []
+    monkeypatch.setattr(sys.modules[os.system.__module__], "system", lambda cmd: calls.append(cmd))
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] != "safe"
+    assert calls == []  # the real os.system (nt.system/posix.system) was never reached
+    assert "structure" not in out
+
+
+def test_array_with_huge_declared_shape_is_blocked_before_allocating(tmp_path):
+    # NumpyArrayWrapper.read_array computes `count` from the wrapper's own
+    # (attacker-controlled) shape and calls np.empty(count, dtype) before
+    # reading a single array byte -- unbounded by _RAW_SIZE_CAP or
+    # _DECOMPRESSED_CAP, which only bound the pickle byte *stream*, not
+    # values encoded inside it. A few bytes of shape can declare a
+    # petabyte-sized array.
+    wrapper = joblib.numpy_pickle.NumpyArrayWrapper(
+        subclass=np.ndarray, shape=(10**15,), order="C",
+        dtype=np.dtype("float64"), allow_mmap=False,
+    )
+    buf = io.BytesIO()
+    joblib.numpy_pickle.NumpyPickler(buf).dump(wrapper)
+    # No array bytes follow -- a real allocation attempt would blow up long
+    # before it ever got to reading (or failing to read) them.
+    path = os.path.join(str(tmp_path), "huge_shape.joblib")
+    with open(path, "wb") as handle:
+        handle.write(buf.getvalue())
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] != "safe"
+
+
+def test_unrecognised_but_allowlist_prefixed_library_is_unavailable(tmp_path):
+    # catboost is deliberately not a declared dependency of this template, so
+    # a real pickle referencing it (hand-built: GLOBAL + EMPTY_TUPLE + REDUCE
+    # is enough for our scanner, which never actually imports the module) must
+    # report "unavailable", not "blocked" — the class is trusted, just absent.
+    payload = (
+        pickle.PROTO + bytes([2])
+        + pickle.GLOBAL + b"catboost.core\nCatBoostClassifier\n"
+        + pickle.EMPTY_TUPLE
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+    path = os.path.join(str(tmp_path), "catboost_ref.pkl")
+    with open(path, "wb") as handle:
+        handle.write(payload)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "unavailable"
+    assert "catboost" in out["scan"]["message"]
+
+
+def test_truncated_compressed_file_reports_blocked_without_raising(tmp_path):
+    # _decompress_capped isn't wrapped in try/except in _bounded_bytes:
+    # zlib.decompressobj(...).decompress(...) raises zlib.error on malformed/
+    # truncated compressed data (e.g. a .joblib file that's mid-download,
+    # with valid gzip magic bytes but corrupt content) -- this used to
+    # propagate uncaught out of main().
+    path = os.path.join(str(tmp_path), "truncated.joblib")
+    with open(path, "wb") as handle:
+        handle.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00" + random.Random(0).randbytes(64))
+
+    out = reader.main(file=path)  # must not raise
+    assert out["scan"]["verdict"] == "blocked"
+    assert "decompress" in out["scan"]["message"]
+
+
+def test_json_serializable_on_every_verdict(tmp_path):
+    # allow_nan=False mirrors fused_render/executor.py's dumps_result, whose
+    # _JSON_KW rejects non-finite floats outright -- json.dumps' lenient
+    # defaults (allow_nan=True) would pass a nan/inf straight through and
+    # never catch that class of bug.
+    bundle_path = _dump(_make_bundle(), tmp_path)
+    json.dumps(reader.main(file=bundle_path), allow_nan=False)
+
+    class _Reducer:
+        def __reduce__(self):
+            return (eval, ("1+1",))
+
+    evil_path = os.path.join(str(tmp_path), "evil2.pkl")
+    with open(evil_path, "wb") as handle:
+        pickle.dump(_Reducer(), handle)
+    json.dumps(reader.main(file=evil_path), allow_nan=False)
+
+
+def test_xgboost_default_missing_nan_param_is_json_safe(tmp_path):
+    # XGBClassifier's default `missing` param IS float('nan') -- virtually
+    # every fitted XGBoost model has one -- and the production response path
+    # rejects non-finite floats with allow_nan=False. This used to raise
+    # ValueError for almost any real XGBoost file.
+    rng = np.random.RandomState(3)
+    x = rng.rand(50, 4)
+    y = rng.randint(0, 2, size=50)
+    clf = XGBClassifier(n_estimators=3, max_depth=2).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    summary = next(e for e in out["estimators"] if e["path"] == "")
+    assert summary["params"]["missing"] == "NaN"
+    json.dumps(out, allow_nan=False)
+
+
+# ------------------------------------------------------------- introspection
+
+
+def test_multiclass_linear_model_feature_importance_uses_all_classes(tmp_path):
+    # coef_ for a multi-class linear model is 2-D (one row per class); the
+    # old code took coef[0] and silently discarded every other class's
+    # coefficients with no indication in the output. It should reflect all
+    # classes -- mean of absolute values, a standard one-ranking summary --
+    # not arbitrarily just class 0.
+    rng = np.random.RandomState(4)
+    x = rng.rand(150, 5)
+    y = rng.randint(0, 3, size=150)  # 3 classes
+    clf = LogisticRegression(max_iter=500).fit(x, y)
+    assert clf.coef_.shape[0] == 3  # sanity: genuinely multi-class
+
+    path = _dump(clf, tmp_path)
+    out = reader.main(file=path)
+    fi = next(f for f in out["feature_importance"] if f["path"] == "")
+    got = {row["feature"]: row["importance"] for row in fi["features"]}
+
+    expected = np.abs(clf.coef_).mean(axis=0)
+    class0_only = np.abs(clf.coef_[0])
+    assert got != {i: class0_only[i] for i in range(len(class0_only))}
+    for i, v in enumerate(expected):
+        assert got[i] == pytest.approx(float(v))
+
+
+def test_one_bad_estimator_does_not_crash_the_others(tmp_path, monkeypatch):
+    # _estimator_summary/_feature_importance/_tree_ensemble call attributes
+    # and methods on an object that came through __reduce__/__setstate__
+    # rather than a normal constructor, with no exception isolation -- one
+    # real allowlisted estimator raising from a getter used to take down
+    # every other estimator's data in the same bundle, not just its own.
+    rng = np.random.RandomState(7)
+    x, y = rng.rand(20, 3), rng.randint(0, 2, size=20)
+    good = StandardScaler().fit(x)
+    bad = LogisticRegression().fit(x, y)
+    path = _dump({"good": good, "bad": bad}, tmp_path)
+
+    def rigged_get_params(self, deep=True):
+        raise RuntimeError("rigged failure")
+
+    monkeypatch.setattr(LogisticRegression, "get_params", rigged_get_params)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    paths = {e["path"] for e in out["estimators"]}
+    assert "good" in paths
+    assert "bad" not in paths
+
+
+def test_dotted_dict_key_does_not_collide_with_a_nested_path(tmp_path):
+    # _describe/_find_estimators build paths via f"{path}.{key}" with no
+    # escaping -- a dict key containing a literal dot collides with the path
+    # a genuinely nested dict would produce, and
+    # template.html's `data.trees.find(x => x.path === t.path)` would then
+    # silently pick the wrong one.
+    rng = np.random.RandomState(9)
+    x, y = rng.rand(20, 2), rng.randint(0, 2, size=20)
+    est_a = LogisticRegression().fit(x, y)
+    est_b = StandardScaler().fit(x)
+    # Both "sensor.temp" (a literal dotted key) and nested sensor -> temp
+    # would naively synthesize the same path "sensor.temp".
+    bundle = {"sensor.temp": est_a, "sensor": {"temp": est_b}}
+    path = _dump(bundle, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    paths = [e["path"] for e in out["estimators"]]
+    assert len(paths) == 2
+    assert len(set(paths)) == 2  # distinct paths -- no collision
+
+
+def test_safe_dict_bundle_like_real_file(tmp_path):
+    path = _dump(_make_bundle(), tmp_path)
+    out = reader.main(file=path)
+
+    assert out["scan"]["verdict"] == "safe"
+    assert out["file"]["size"] == os.path.getsize(path)
+
+    paths = {e["path"] for e in out["estimators"]}
+    assert "scaler" in paths and "classifier" in paths
+
+    clf_summary = next(e for e in out["estimators"] if e["path"] == "classifier")
+    assert clf_summary["type"] == "XGBClassifier"
+    assert clf_summary["params"]["max_depth"] == 2
+    assert clf_summary["n_features_in"] == 6
+
+    fi = next(f for f in out["feature_importance"] if f["path"] == "classifier")
+    assert len(fi["features"]) == 6
+    assert fi["features"] == sorted(fi["features"], key=lambda r: -r["importance"])
+
+    trees = next(t for t in out["trees"] if t["path"] == "classifier")
+    assert trees["library"] == "xgboost"
+    assert trees["count"] == 15  # 5 rounds x one tree per class (3 classes) for multiclass softmax
+
+    # plain training-provenance metadata surfaces via the structure walk,
+    # with no separate sidecar-merge step
+    top_keys = {item["key"] for item in out["structure"]["items"]}
+    assert "dataset" in top_keys and "dropped_polygons" in top_keys
+
+
+def test_tree_detail_lazy_fetch_matches_count(tmp_path):
+    path = _dump(_make_bundle(), tmp_path)
+    overview = reader.main(file=path)
+    trees = next(t for t in overview["trees"] if t["path"] == "classifier")
+
+    detail = reader.main(file=path, tree_index=trees["count"] - 1)
+    detail_trees = next(t for t in detail["trees"] if t["path"] == "classifier")
+    assert "tree" in detail_trees
+    node = detail_trees["tree"]
+    assert "leaf" in node or ("feature" in node and "left" in node and "right" in node)
+
+
+def test_bare_random_forest(tmp_path):
+    rng = np.random.RandomState(1)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    clf = RandomForestClassifier(n_estimators=3, max_depth=2, random_state=0).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    out = reader.main(file=path, tree_index=0)
+    assert out["scan"]["verdict"] == "safe"
+    trees = next(t for t in out["trees"] if t["path"] == "")
+    assert trees["library"] == "sklearn_forest"
+    assert trees["count"] == 3
+    assert "tree" in trees
+
+
+def test_gradient_boosting_binary(tmp_path):
+    # GradientBoostingClassifier's estimators_ is 2-D (n_rounds, n_classes) --
+    # a row of trees, not one tree each -- unlike RandomForest's flat
+    # estimators_. _tree_kind used to misclassify it as "sklearn_forest",
+    # and est.estimators_[idx].tree_ raised AttributeError since
+    # est.estimators_[idx] is itself a sub-array, not a single tree.
+    rng = np.random.RandomState(5)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    clf = GradientBoostingClassifier(n_estimators=4, max_depth=2, random_state=0).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    out = reader.main(file=path, tree_index=0)
+    assert out["scan"]["verdict"] == "safe"
+    trees = next(t for t in out["trees"] if t["path"] == "")
+    assert trees["library"] == "sklearn_gradient_boosting"
+    assert trees["count"] == 4  # 4 rounds x 1 tree (binary => single column)
+    assert "tree" in trees
+    assert "feature" in trees["tree"] or "leaf" in trees["tree"]
+
+
+def test_gradient_boosting_multiclass(tmp_path):
+    rng = np.random.RandomState(6)
+    x = rng.rand(120, 4)
+    y = rng.randint(0, 3, size=120)  # 3 classes
+    clf = GradientBoostingClassifier(n_estimators=3, max_depth=2, random_state=0).fit(x, y)
+    assert clf.estimators_.shape == (3, 3)
+    path = _dump(clf, tmp_path)
+
+    # Fetch the last tree (round 2, class 2) -- genuinely reachable, not just
+    # tree_index=0 which the 1-D fallback would already have gotten "right".
+    out = reader.main(file=path, tree_index=8)
+    trees = next(t for t in out["trees"] if t["path"] == "")
+    assert trees["library"] == "sklearn_gradient_boosting"
+    assert trees["count"] == 9  # 3 rounds x 3 classes
+    assert trees["trees"][8] == {"index": 8, "round": 2, "class": 2}
+    assert "tree" in trees
+    assert "feature" in trees["tree"] or "leaf" in trees["tree"]
+
+
+def test_xgboost_unicode_digit_feature_name_does_not_crash():
+    # split[1:].isdigit() is True for non-ASCII Unicode "digit" characters
+    # int() can't parse (e.g. superscript "²"), which used to crash this
+    # tree's render entirely.
+    node = {
+        "nodeid": 0, "split": "f²", "split_condition": 0.5,
+        "yes": 1, "no": 2,
+        "children": [{"nodeid": 1, "leaf": 0.1}, {"nodeid": 2, "leaf": -0.1}],
+    }
+    result = reader._xgboost_tree_node(node)
+    assert result["feature"] == "f²"  # preserved as-is, not silently coerced
+
+
+def test_xgboost_leading_zero_feature_name_is_preserved_literally():
+    # A real feature literally named "f007" used to be silently misread as
+    # index 7 with no warning -- it doesn't round-trip back to "f007", so it
+    # must be kept as the literal name.
+    node = {
+        "nodeid": 0, "split": "f007", "split_condition": 0.5,
+        "yes": 1, "no": 2,
+        "children": [{"nodeid": 1, "leaf": 0.1}, {"nodeid": 2, "leaf": -0.1}],
+    }
+    result = reader._xgboost_tree_node(node)
+    assert result["feature"] == "f007"  # not silently turned into 7 or "f7"
+
+
+def test_tree_node_recursion_has_a_depth_guard():
+    # _sklearn_tree_node/_xgboost_tree_node/_lightgbm_tree_node recurse on the
+    # tree's own child links with no depth cap, unlike _describe's max_depth=4
+    # -- a manufactured (or corrupted) tree with an excessive chain of nodes
+    # would hit RecursionError instead of terminating gracefully.
+    node = {"leaf_value": 0.0}
+    for _ in range(300):
+        node = {"split_feature": 0, "threshold": 0.5, "left_child": node, "right_child": {"leaf_value": 0.0}}
+
+    result = reader._lightgbm_tree_node(node)  # must not raise RecursionError
+
+    walked, depth_walked = result, 0
+    while "left" in walked and depth_walked < 250:
+        walked = walked["left"]
+        depth_walked += 1
+    assert "leaf" in walked  # terminated with a (possibly truncated) leaf, not a RecursionError
+    assert depth_walked <= reader._MAX_TREE_DEPTH + 1  # guard fired well before the full 300-deep chain
+
+
+def test_lightgbm_model(tmp_path):
+    lgb = pytest.importorskip("lightgbm")
+    rng = np.random.RandomState(2)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    clf = lgb.LGBMClassifier(n_estimators=3, max_depth=2, min_child_samples=5).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    out = reader.main(file=path, tree_index=0)
+    assert out["scan"]["verdict"] == "safe"
+    trees = next(t for t in out["trees"] if t["path"] == "")
+    assert trees["library"] == "lightgbm"
+    assert trees["count"] == 3
+    assert "tree" in trees
+
+
+def test_file_stats_and_sibling_npy_chunks(tmp_path):
+    path = _dump(_make_bundle(), tmp_path, name="chunked.joblib")
+    # Simulate joblib's own memmap-split sibling files.
+    for suffix in ("_01.npy", "_02.npy"):
+        open(path + suffix, "wb").close()
+
+    out = reader.main(file=path)
+    assert out["file"]["size"] == os.path.getsize(path)
+    assert sorted(out["file"]["sibling_files"]) == ["chunked.joblib_01.npy", "chunked.joblib_02.npy"]
+
+
+def test_dict_traversal_is_capped_like_list_traversal(tmp_path):
+    # _describe/_find_estimators cap list/tuple iteration at obj[:50], but
+    # dict iteration was unbounded -- a dict with many keys (attacker- or
+    # just carelessly-constructed) could blow up the structure walk's work
+    # with no cap, unlike its list/tuple sibling branches.
+    big_dict = {f"key_{i}": i for i in range(200)}
+    path = _dump(big_dict, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    structure = out["structure"]
+    assert structure["kind"] == "dict"
+    assert structure["length"] == 200
+    assert len(structure["items"]) == 50
+
+
+def test_missing_file_reports_blocked_without_raising(tmp_path):
+    out = reader.main(file=os.path.join(str(tmp_path), "does_not_exist.joblib"))
+    assert out["scan"]["verdict"] == "blocked"

--- a/fused_render/templates/joblib_model/tests/test_reader.py
+++ b/fused_render/templates/joblib_model/tests/test_reader.py
@@ -565,6 +565,54 @@ def test_lightgbm_model(tmp_path):
     assert "tree" in trees
 
 
+def test_lightgbm_multiclass_tree_index_is_flat_not_a_round(tmp_path):
+    # num_trees() counts trees flat, but dump_model's start_iteration selects a
+    # boosting ROUND. Fetching by the flat index without splitting it by class
+    # returns the wrong tree (idx=1) or nothing at all (idx >= n_rounds).
+    lgb = pytest.importorskip("lightgbm")
+    rng = np.random.RandomState(11)
+    x = rng.rand(300, 5)
+    y = rng.randint(0, 3, size=300)  # 3 classes -> 3 trees per round
+    clf = lgb.LGBMClassifier(n_estimators=4, max_depth=2, min_child_samples=5, verbose=-1).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    expected = clf.booster_.dump_model()["tree_info"]
+    overview = next(t for t in reader.main(file=path)["trees"] if t["path"] == "")
+    assert overview["count"] == 12
+    assert overview["trees"][5] == {"index": 5, "round": 1, "class": 2}
+
+    for idx in (1, 5, 11):  # every one of these was wrong or missing before
+        trees = next(t for t in reader.main(file=path, tree_index=idx)["trees"] if t["path"] == "")
+        assert "tree_error" not in trees
+        assert trees["tree"] == reader._lightgbm_tree_node(expected[idx]["tree_structure"])
+
+
+def test_voting_classifier_is_not_mistaken_for_a_tree_ensemble(tmp_path):
+    # _tree_kind used to call anything with `estimators_` a forest, so a composite
+    # was skipped by the walk that exists to descend into it -- hiding its models.
+    from sklearn.ensemble import VotingClassifier
+
+    rng = np.random.RandomState(12)
+    x = rng.rand(120, 4)
+    y = rng.randint(0, 2, size=120)
+    vc = VotingClassifier([
+        ("lr", LogisticRegression()),
+        ("rf", RandomForestClassifier(n_estimators=3, max_depth=2, random_state=0)),
+    ]).fit(x, y)
+    assert reader._tree_kind(vc) is None
+    path = _dump(vc, tmp_path)
+
+    out = reader.main(file=path)
+    types = [e["type"] for e in out["estimators"]]
+    assert "VotingClassifier" in types
+    assert "LogisticRegression" in types
+    assert "RandomForestClassifier" in types
+    # The pre-fit copies in the `estimators` param must not double every sub-model.
+    assert types.count("RandomForestClassifier") == 1
+    assert types.count("LogisticRegression") == 1
+    assert [t["library"] for t in out["trees"]] == ["sklearn_forest"]
+
+
 def test_file_stats_and_sibling_npy_chunks(tmp_path):
     path = _dump(_make_bundle(), tmp_path, name="chunked.joblib")
     # Simulate joblib's own memmap-split sibling files.

--- a/fused_render/templates/joblib_model/tests/test_reader.py
+++ b/fused_render/templates/joblib_model/tests/test_reader.py
@@ -76,16 +76,8 @@ def test_dangerous_reduce_is_blocked_and_never_executed(tmp_path, monkeypatch):
 
 
 def test_object_dtype_array_bypass_is_blocked_and_never_executed(tmp_path, monkeypatch):
-    # joblib's own NumpyArrayWrapper.read_array calls a bare pickle.load()
-    # directly on the file handle for object-dtype arrays -- entirely
-    # outside find_class's allowlist gate -- so np.array([...], dtype=object)
-    # can smuggle in a dangerous __reduce__ payload even though every class
-    # the scanner sees looks safe. Same technique as
-    # test_dangerous_reduce_is_blocked_and_never_executed, but patched on
-    # os.system's actual defining module: os.system is a re-export (e.g. of
-    # nt.system on Windows) and pickle serialises a global by
-    # __module__/__qualname__, not by the name it happens to be imported
-    # under, so patching os.system itself doesn't intercept the real call.
+    # Same os.system gadget via joblib's bare pickle.load() escape for object-dtype
+    # arrays; patched on os.system's real module since pickle serializes by __module__.
     class _Reducer:
         def __reduce__(self):
             return (os.system, ("echo pwned",))
@@ -102,21 +94,54 @@ def test_object_dtype_array_bypass_is_blocked_and_never_executed(tmp_path, monke
     assert "structure" not in out
 
 
+def test_prefix_trusted_function_gadget_is_blocked_and_never_executed(tmp_path, monkeypatch):
+    # joblib.load is a real function under the trusted "joblib." prefix.
+    class _Reducer:
+        def __reduce__(self):
+            return (joblib.load, ("/etc/passwd",))
+
+    path = os.path.join(str(tmp_path), "gadget.pkl")
+    with open(path, "wb") as handle:
+        pickle.dump(_Reducer(), handle)
+
+    calls = []
+    monkeypatch.setattr(joblib.numpy_pickle, "load", lambda *a, **k: calls.append(a))
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "blocked"
+    offending = [r for r in out["scan"]["refs"] if not r["allowed"]]
+    assert any(r["name"] == "load" for r in offending)
+    assert calls == []
+
+
+def test_pipeline_surfaces_the_inner_estimators_it_wraps(tmp_path):
+    # Pipeline's inner scaler/classifier are attributes, not get_params() values.
+    from sklearn.pipeline import Pipeline
+
+    rng = np.random.RandomState(0)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    pipe = Pipeline([
+        ("scale", StandardScaler()),
+        ("clf", RandomForestClassifier(n_estimators=3, max_depth=2, random_state=0)),
+    ]).fit(x, y)
+    path = _dump(pipe, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    types = {e["type"] for e in out["estimators"]}
+    assert types == {"Pipeline", "StandardScaler", "RandomForestClassifier"}
+    assert out["trees"]  # the wrapped RandomForestClassifier's trees surfaced
+
+
 def test_array_with_huge_declared_shape_is_blocked_before_allocating(tmp_path):
-    # NumpyArrayWrapper.read_array computes `count` from the wrapper's own
-    # (attacker-controlled) shape and calls np.empty(count, dtype) before
-    # reading a single array byte -- unbounded by _RAW_SIZE_CAP or
-    # _DECOMPRESSED_CAP, which only bound the pickle byte *stream*, not
-    # values encoded inside it. A few bytes of shape can declare a
-    # petabyte-sized array.
+    # shape is attacker-controlled and sizes np.empty(...) before any array byte is read.
     wrapper = joblib.numpy_pickle.NumpyArrayWrapper(
         subclass=np.ndarray, shape=(10**15,), order="C",
         dtype=np.dtype("float64"), allow_mmap=False,
     )
     buf = io.BytesIO()
-    joblib.numpy_pickle.NumpyPickler(buf).dump(wrapper)
-    # No array bytes follow -- a real allocation attempt would blow up long
-    # before it ever got to reading (or failing to read) them.
+    joblib.numpy_pickle.NumpyPickler(buf).dump(wrapper)  # no array bytes follow, on purpose
     path = os.path.join(str(tmp_path), "huge_shape.joblib")
     with open(path, "wb") as handle:
         handle.write(buf.getvalue())
@@ -126,10 +151,8 @@ def test_array_with_huge_declared_shape_is_blocked_before_allocating(tmp_path):
 
 
 def test_unrecognised_but_allowlist_prefixed_library_is_unavailable(tmp_path):
-    # catboost is deliberately not a declared dependency of this template, so
-    # a real pickle referencing it (hand-built: GLOBAL + EMPTY_TUPLE + REDUCE
-    # is enough for our scanner, which never actually imports the module) must
-    # report "unavailable", not "blocked" — the class is trusted, just absent.
+    # catboost isn't a bundled dependency; a real reference to it must resolve
+    # to "unavailable" (trusted, just absent), not "blocked".
     payload = (
         pickle.PROTO + bytes([2])
         + pickle.GLOBAL + b"catboost.core\nCatBoostClassifier\n"
@@ -147,11 +170,7 @@ def test_unrecognised_but_allowlist_prefixed_library_is_unavailable(tmp_path):
 
 
 def test_truncated_compressed_file_reports_blocked_without_raising(tmp_path):
-    # _decompress_capped isn't wrapped in try/except in _bounded_bytes:
-    # zlib.decompressobj(...).decompress(...) raises zlib.error on malformed/
-    # truncated compressed data (e.g. a .joblib file that's mid-download,
-    # with valid gzip magic bytes but corrupt content) -- this used to
-    # propagate uncaught out of main().
+    # Malformed gzip magic + truncated body must not raise zlib.error out of main().
     path = os.path.join(str(tmp_path), "truncated.joblib")
     with open(path, "wb") as handle:
         handle.write(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x00" + random.Random(0).randbytes(64))
@@ -162,10 +181,7 @@ def test_truncated_compressed_file_reports_blocked_without_raising(tmp_path):
 
 
 def test_json_serializable_on_every_verdict(tmp_path):
-    # allow_nan=False mirrors fused_render/executor.py's dumps_result, whose
-    # _JSON_KW rejects non-finite floats outright -- json.dumps' lenient
-    # defaults (allow_nan=True) would pass a nan/inf straight through and
-    # never catch that class of bug.
+    # allow_nan=False mirrors the production response path's JSON encoder.
     bundle_path = _dump(_make_bundle(), tmp_path)
     json.dumps(reader.main(file=bundle_path), allow_nan=False)
 
@@ -180,10 +196,8 @@ def test_json_serializable_on_every_verdict(tmp_path):
 
 
 def test_xgboost_default_missing_nan_param_is_json_safe(tmp_path):
-    # XGBClassifier's default `missing` param IS float('nan') -- virtually
-    # every fitted XGBoost model has one -- and the production response path
-    # rejects non-finite floats with allow_nan=False. This used to raise
-    # ValueError for almost any real XGBoost file.
+    # XGBClassifier's default `missing` param is float('nan'), which the
+    # production response path's allow_nan=False would otherwise reject.
     rng = np.random.RandomState(3)
     x = rng.rand(50, 4)
     y = rng.randint(0, 2, size=50)
@@ -201,11 +215,7 @@ def test_xgboost_default_missing_nan_param_is_json_safe(tmp_path):
 
 
 def test_multiclass_linear_model_feature_importance_uses_all_classes(tmp_path):
-    # coef_ for a multi-class linear model is 2-D (one row per class); the
-    # old code took coef[0] and silently discarded every other class's
-    # coefficients with no indication in the output. It should reflect all
-    # classes -- mean of absolute values, a standard one-ranking summary --
-    # not arbitrarily just class 0.
+    # coef_ is 2-D for multi-class; importance must reflect all classes, not just class 0.
     rng = np.random.RandomState(4)
     x = rng.rand(150, 5)
     y = rng.randint(0, 3, size=150)  # 3 classes
@@ -225,11 +235,7 @@ def test_multiclass_linear_model_feature_importance_uses_all_classes(tmp_path):
 
 
 def test_one_bad_estimator_does_not_crash_the_others(tmp_path, monkeypatch):
-    # _estimator_summary/_feature_importance/_tree_ensemble call attributes
-    # and methods on an object that came through __reduce__/__setstate__
-    # rather than a normal constructor, with no exception isolation -- one
-    # real allowlisted estimator raising from a getter used to take down
-    # every other estimator's data in the same bundle, not just its own.
+    # One estimator raising from a getter must not take down the others in the bundle.
     rng = np.random.RandomState(7)
     x, y = rng.rand(20, 3), rng.randint(0, 2, size=20)
     good = StandardScaler().fit(x)
@@ -249,17 +255,11 @@ def test_one_bad_estimator_does_not_crash_the_others(tmp_path, monkeypatch):
 
 
 def test_dotted_dict_key_does_not_collide_with_a_nested_path(tmp_path):
-    # _describe/_find_estimators build paths via f"{path}.{key}" with no
-    # escaping -- a dict key containing a literal dot collides with the path
-    # a genuinely nested dict would produce, and
-    # template.html's `data.trees.find(x => x.path === t.path)` would then
-    # silently pick the wrong one.
+    # A literal dotted key must not collide with the path a nested dict would produce.
     rng = np.random.RandomState(9)
     x, y = rng.rand(20, 2), rng.randint(0, 2, size=20)
     est_a = LogisticRegression().fit(x, y)
     est_b = StandardScaler().fit(x)
-    # Both "sensor.temp" (a literal dotted key) and nested sensor -> temp
-    # would naively synthesize the same path "sensor.temp".
     bundle = {"sensor.temp": est_a, "sensor": {"temp": est_b}}
     path = _dump(bundle, tmp_path)
 
@@ -293,8 +293,6 @@ def test_safe_dict_bundle_like_real_file(tmp_path):
     assert trees["library"] == "xgboost"
     assert trees["count"] == 15  # 5 rounds x one tree per class (3 classes) for multiclass softmax
 
-    # plain training-provenance metadata surfaces via the structure walk,
-    # with no separate sidecar-merge step
     top_keys = {item["key"] for item in out["structure"]["items"]}
     assert "dataset" in top_keys and "dropped_polygons" in top_keys
 
@@ -327,11 +325,7 @@ def test_bare_random_forest(tmp_path):
 
 
 def test_gradient_boosting_binary(tmp_path):
-    # GradientBoostingClassifier's estimators_ is 2-D (n_rounds, n_classes) --
-    # a row of trees, not one tree each -- unlike RandomForest's flat
-    # estimators_. _tree_kind used to misclassify it as "sklearn_forest",
-    # and est.estimators_[idx].tree_ raised AttributeError since
-    # est.estimators_[idx] is itself a sub-array, not a single tree.
+    # estimators_ is 2-D (rounds x classes), unlike RandomForest's flat estimators_.
     rng = np.random.RandomState(5)
     x = rng.rand(100, 4)
     y = rng.randint(0, 2, size=100)
@@ -355,9 +349,7 @@ def test_gradient_boosting_multiclass(tmp_path):
     assert clf.estimators_.shape == (3, 3)
     path = _dump(clf, tmp_path)
 
-    # Fetch the last tree (round 2, class 2) -- genuinely reachable, not just
-    # tree_index=0 which the 1-D fallback would already have gotten "right".
-    out = reader.main(file=path, tree_index=8)
+    out = reader.main(file=path, tree_index=8)  # round 2, class 2
     trees = next(t for t in out["trees"] if t["path"] == "")
     assert trees["library"] == "sklearn_gradient_boosting"
     assert trees["count"] == 9  # 3 rounds x 3 classes
@@ -367,9 +359,7 @@ def test_gradient_boosting_multiclass(tmp_path):
 
 
 def test_xgboost_unicode_digit_feature_name_does_not_crash():
-    # split[1:].isdigit() is True for non-ASCII Unicode "digit" characters
-    # int() can't parse (e.g. superscript "²"), which used to crash this
-    # tree's render entirely.
+    # str.isdigit() accepts Unicode digits like "²" that int() can't parse.
     node = {
         "nodeid": 0, "split": "f²", "split_condition": 0.5,
         "yes": 1, "no": 2,
@@ -380,9 +370,7 @@ def test_xgboost_unicode_digit_feature_name_does_not_crash():
 
 
 def test_xgboost_leading_zero_feature_name_is_preserved_literally():
-    # A real feature literally named "f007" used to be silently misread as
-    # index 7 with no warning -- it doesn't round-trip back to "f007", so it
-    # must be kept as the literal name.
+    # "f007" doesn't round-trip back from int(), so it must stay a literal name.
     node = {
         "nodeid": 0, "split": "f007", "split_condition": 0.5,
         "yes": 1, "no": 2,
@@ -393,10 +381,7 @@ def test_xgboost_leading_zero_feature_name_is_preserved_literally():
 
 
 def test_tree_node_recursion_has_a_depth_guard():
-    # _sklearn_tree_node/_xgboost_tree_node/_lightgbm_tree_node recurse on the
-    # tree's own child links with no depth cap, unlike _describe's max_depth=4
-    # -- a manufactured (or corrupted) tree with an excessive chain of nodes
-    # would hit RecursionError instead of terminating gracefully.
+    # An excessively deep tree must terminate gracefully, not hit RecursionError.
     node = {"leaf_value": 0.0}
     for _ in range(300):
         node = {"split_feature": 0, "threshold": 0.5, "left_child": node, "right_child": {"leaf_value": 0.0}}
@@ -439,10 +424,7 @@ def test_file_stats_and_sibling_npy_chunks(tmp_path):
 
 
 def test_dict_traversal_is_capped_like_list_traversal(tmp_path):
-    # _describe/_find_estimators cap list/tuple iteration at obj[:50], but
-    # dict iteration was unbounded -- a dict with many keys (attacker- or
-    # just carelessly-constructed) could blow up the structure walk's work
-    # with no cap, unlike its list/tuple sibling branches.
+    # Dict iteration must be capped at 50 like list/tuple iteration already is.
     big_dict = {f"key_{i}": i for i in range(200)}
     path = _dump(big_dict, tmp_path)
 

--- a/fused_render/templates/joblib_model/tests/test_reader.py
+++ b/fused_render/templates/joblib_model/tests/test_reader.py
@@ -6,7 +6,7 @@ to introspect them — confirmed there's no existing wiring in this repo that
 installs a template's own pyproject.toml deps into the pytest env, so this is
 self-documented rather than added to CI):
 
-    uv run --with joblib --with scikit-learn --with xgboost --with lightgbm \
+    uv run --with joblib --with scikit-learn --with xgboost --with lightgbm --with pandas \
         pytest fused_render/templates/joblib_model/tests/test_reader.py -v
 """
 import io
@@ -132,6 +132,69 @@ def test_pipeline_surfaces_the_inner_estimators_it_wraps(tmp_path):
     types = {e["type"] for e in out["estimators"]}
     assert types == {"Pipeline", "StandardScaler", "RandomForestClassifier"}
     assert out["trees"]  # the wrapped RandomForestClassifier's trees surfaced
+
+
+def test_pipeline_nested_in_a_dict_is_still_discovered(tmp_path):
+    # joblib.dump({"model": pipe}) is the realistic layout (matches _make_bundle's
+    # own shape) -- one extra depth level must not exhaust the traversal budget.
+    from sklearn.pipeline import Pipeline
+
+    rng = np.random.RandomState(0)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    pipe = Pipeline([
+        ("scale", StandardScaler()),
+        ("clf", RandomForestClassifier(n_estimators=3, max_depth=2, random_state=0)),
+    ]).fit(x, y)
+    path = _dump({"model": pipe}, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    types = {e["type"] for e in out["estimators"]}
+    assert types == {"Pipeline", "StandardScaler", "RandomForestClassifier"}
+    assert out["trees"]
+
+
+def test_random_forest_members_are_not_treated_as_separate_models(tmp_path):
+    # Each DecisionTreeClassifier inside estimators_ also has get_params(); walking
+    # into it as if it were a nested composite estimator would duplicate the forest
+    # once per tree instead of showing the forest as a single ensemble.
+    rng = np.random.RandomState(1)
+    x = rng.rand(100, 4)
+    y = rng.randint(0, 2, size=100)
+    clf = RandomForestClassifier(n_estimators=5, max_depth=2, random_state=0).fit(x, y)
+    path = _dump(clf, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+    assert [e["type"] for e in out["estimators"]] == ["RandomForestClassifier"]
+    assert len(out["trees"]) == 1
+
+
+def test_pandas_dataframe_bundle_is_safe(tmp_path):
+    # pandas' own Block/Index reconstruction is via module-level functions
+    # (_unpickle_block, _new_Index), not classes -- any DataFrame/Index in a bundle
+    # used to be misreported as "blocked".
+    pd = pytest.importorskip("pandas")
+    rng = np.random.RandomState(2)
+    df = pd.DataFrame({"a": rng.rand(20), "b": pd.Categorical(["x", "y"] * 10)})
+    path = _dump({"data": df, "cols": df.columns}, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
+
+
+def test_function_transformer_wrapping_a_trusted_ufunc_is_safe(tmp_path):
+    # A numpy ufunc reference is only ever STORED as an attribute here, never
+    # called -- treating every non-class reference as unsafe over-blocked this.
+    from sklearn.preprocessing import FunctionTransformer
+
+    rng = np.random.RandomState(3)
+    ft = FunctionTransformer(np.log1p).fit(rng.rand(20, 2))
+    path = _dump(ft, tmp_path)
+
+    out = reader.main(file=path)
+    assert out["scan"]["verdict"] == "safe"
 
 
 def test_array_with_huge_declared_shape_is_blocked_before_allocating(tmp_path):

--- a/fused_render/templates/joblib_model/tests/test_viewer_e2e.py
+++ b/fused_render/templates/joblib_model/tests/test_viewer_e2e.py
@@ -1,23 +1,7 @@
-"""End-to-end tests for the joblib model viewer template, driven through
-Playwright against a real fused-render server (FUSED_RENDER_CORE_TEMPLATES
-points at this checkout's templates so edits are served live).
+"""End-to-end tests for the joblib model viewer template (Playwright, real server).
 
-Unlike every other template's e2e test, this one also needs the optional
-`fused` local-compute-backend package importable in the SAME interpreter that
-runs the server: reader.py's dependencies (joblib/scikit-learn/xgboost/
-lightgbm) only ever get installed through that engine's per-folder project-env
-mechanism (SPEC PY-16) — without it, the built-in executor runs reader.py on
-the app's own interpreter with no per-template venv at all, and every open
-reports "No module named 'joblib'". This mirrors model_card's own note about
-needing the engine switched for its tokenizer section, except here it's not
-optional: verified manually against the running app (fused package installed
-via `uv pip install fused==2.9.3b3`) before this test was written.
-
-First run downloads scikit-learn/xgboost/lightgbm into a fresh per-template
-venv (SPEC PY-16/18), which can take a minute or more and needs network
-access — this is why it is skipped by default rather than wired into CI (no
-existing template test needs extra deps at pytest time; this is the first).
-Run explicitly:
+First run downloads scikit-learn/xgboost/lightgbm into a fresh per-template venv
+and needs the "fused" engine active, so it's opt-in, not wired into CI. Run explicitly:
     PYTHONPATH=<checkout> python -m pytest \
         fused_render/templates/joblib_model/tests/test_viewer_e2e.py -o addopts=""
 """
@@ -149,18 +133,12 @@ def _open(browser, port, path):
 
 def test_safe_bundle_renders_all_sections(server, browser):
     page, frame = _open(browser, server["port"], os.path.join(server["work"], "bundle.joblib"))
-    # timeout=240: a cold run pays for a real `uv sync` of scikit-learn/xgboost/
-    # lightgbm/pandas into this template's own venv (SPEC PY-16/18) before the
-    # first render can happen at all — confirmed via the server log the one time
-    # this legitimately took over 90s. A warm venv (every run after the first on
-    # this machine) returns in a few seconds, same as the reader.py unit tests.
+    # timeout=240: a cold run pays for a real `uv sync` of the template's venv first.
     state = _wait(lambda: frame.evaluate(
         """() => {
             const pill = document.querySelector('h1 .pill');
             if (!pill || pill.textContent !== 'Loaded') return null;
-            // The tree diagram is a SEPARATE lazily-fetched runPython call made
-            // after the initial render (a 15-tree ensemble isn't eagerly
-            // included), so it can still be loading after the pill flips.
+            // Tree diagram is a separate, lazily-fetched runPython call.
             const svgRects = document.querySelectorAll('.treebox svg rect').length;
             if (svgRects === 0) return null;
             return {

--- a/fused_render/templates/joblib_model/tests/test_viewer_e2e.py
+++ b/fused_render/templates/joblib_model/tests/test_viewer_e2e.py
@@ -1,0 +1,189 @@
+"""End-to-end tests for the joblib model viewer template, driven through
+Playwright against a real fused-render server (FUSED_RENDER_CORE_TEMPLATES
+points at this checkout's templates so edits are served live).
+
+Unlike every other template's e2e test, this one also needs the optional
+`fused` local-compute-backend package importable in the SAME interpreter that
+runs the server: reader.py's dependencies (joblib/scikit-learn/xgboost/
+lightgbm) only ever get installed through that engine's per-folder project-env
+mechanism (SPEC PY-16) — without it, the built-in executor runs reader.py on
+the app's own interpreter with no per-template venv at all, and every open
+reports "No module named 'joblib'". This mirrors model_card's own note about
+needing the engine switched for its tokenizer section, except here it's not
+optional: verified manually against the running app (fused package installed
+via `uv pip install fused==2.9.3b3`) before this test was written.
+
+First run downloads scikit-learn/xgboost/lightgbm into a fresh per-template
+venv (SPEC PY-16/18), which can take a minute or more and needs network
+access — this is why it is skipped by default rather than wired into CI (no
+existing template test needs extra deps at pytest time; this is the first).
+Run explicitly:
+    PYTHONPATH=<checkout> python -m pytest \
+        fused_render/templates/joblib_model/tests/test_viewer_e2e.py -o addopts=""
+"""
+import os
+import pickle
+import socket
+import subprocess
+import sys
+import time
+import urllib.request
+from urllib.parse import quote
+
+import pytest
+
+pytest.importorskip("playwright.sync_api")
+from playwright.sync_api import sync_playwright  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+# repo root: joblib_model/tests -> joblib_model -> templates -> fused_render -> root
+ROOT = os.path.abspath(os.path.join(HERE, "..", "..", "..", ".."))
+SHELL = os.path.join(ROOT, "fused_render", "static", "shell-dist", "index.html")
+
+pytestmark = [
+    pytest.mark.skipif(not os.path.exists(SHELL), reason="React shell not built"),
+    pytest.mark.skipif(
+        os.environ.get("FUSED_RENDER_E2E_JOBLIB") != "1",
+        reason="downloads a real ML env on first run; set FUSED_RENDER_E2E_JOBLIB=1 to opt in",
+    ),
+]
+
+
+def _free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _make_fixtures(work_dir):
+    import joblib
+    import numpy as np
+    from sklearn.preprocessing import StandardScaler
+    from xgboost import XGBClassifier
+
+    rng = np.random.RandomState(0)
+    x = rng.rand(200, 6)
+    y = rng.randint(0, 3, size=200)
+    scaler = StandardScaler().fit(x)
+    clf = XGBClassifier(n_estimators=5, max_depth=2, eval_metric="mlogloss")
+    clf.fit(scaler.transform(x), y)
+    bundle = {"scaler": scaler, "classifier": clf, "dataset": "synthetic_e2e_v1"}
+    joblib.dump(bundle, os.path.join(work_dir, "bundle.joblib"))
+
+    class _Reducer:
+        def __reduce__(self):
+            return (os.system, ("echo pwned",))
+
+    with open(os.path.join(work_dir, "evil.pkl"), "wb") as handle:
+        pickle.dump(_Reducer(), handle)
+
+
+@pytest.fixture(scope="module")
+def server(tmp_path_factory):
+    home = tmp_path_factory.mktemp("joblib-home")
+    work = tmp_path_factory.mktemp("joblib-work")
+    _make_fixtures(str(work))
+    port = _free_port()
+    env = dict(os.environ)
+    env["PYTHONPATH"] = ROOT
+    env["FUSED_RENDER_HOME"] = str(home)
+    env["FUSED_RENDER_CORE_TEMPLATES"] = os.path.join(ROOT, "fused_render", "templates")
+    log_path = home / "server.log"
+    with open(log_path, "ab") as log:
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "fused_render.cli", "serve",
+             "--port", str(port), "--no-browser", "--start-dir", str(work)],
+            env=env, stdout=log, stderr=subprocess.STDOUT)
+    deadline = time.time() + 60
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(f"http://127.0.0.1:{port}/api/config", timeout=2).read()
+            break
+        except OSError:
+            if proc.poll() is not None:
+                raise RuntimeError("server exited:\n" +
+                                   log_path.read_text("utf-8", errors="replace")[-2000:])
+            time.sleep(0.3)
+    else:
+        proc.kill()
+        raise RuntimeError("server did not come up")
+    yield {"port": port, "work": str(work)}
+    proc.kill()
+    proc.wait(timeout=15)
+
+
+@pytest.fixture(scope="module")
+def browser():
+    with sync_playwright() as p:
+        b = p.chromium.launch()
+        yield b
+        b.close()
+
+
+def _embed_url(port, path):
+    return f"http://127.0.0.1:{port}/explorer/embed/" + quote(path.replace("\\", "/"), safe="/:")
+
+
+def _wait(fn, timeout=90, step=0.5):
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        last = fn()
+        if last:
+            return last
+        time.sleep(step)
+    raise AssertionError(f"condition not met within {timeout}s (last={last!r})")
+
+
+def _open(browser, port, path):
+    page = browser.new_page(viewport={"width": 1280, "height": 900})
+    page.goto(_embed_url(port, path), wait_until="domcontentloaded")
+
+    def find_frame():
+        page.keyboard.press("Escape")
+        return next((f for f in page.frames if "/render" in f.url), None)
+
+    frame = _wait(find_frame, timeout=30, step=0.5)
+    return page, frame
+
+
+def test_safe_bundle_renders_all_sections(server, browser):
+    page, frame = _open(browser, server["port"], os.path.join(server["work"], "bundle.joblib"))
+    # timeout=240: a cold run pays for a real `uv sync` of scikit-learn/xgboost/
+    # lightgbm/pandas into this template's own venv (SPEC PY-16/18) before the
+    # first render can happen at all — confirmed via the server log the one time
+    # this legitimately took over 90s. A warm venv (every run after the first on
+    # this machine) returns in a few seconds, same as the reader.py unit tests.
+    state = _wait(lambda: frame.evaluate(
+        """() => {
+            const pill = document.querySelector('h1 .pill');
+            if (!pill || pill.textContent !== 'Loaded') return null;
+            // The tree diagram is a SEPARATE lazily-fetched runPython call made
+            // after the initial render (a 15-tree ensemble isn't eagerly
+            // included), so it can still be loading after the pill flips.
+            const svgRects = document.querySelectorAll('.treebox svg rect').length;
+            if (svgRects === 0) return null;
+            return {
+              h2s: [...document.querySelectorAll('h2')].map(h => h.textContent),
+              treeOptions: (document.querySelector('select') || {}).options?.length,
+              svgRects,
+            };
+        }""") or None, timeout=240)
+    assert "Structure" in state["h2s"]
+    assert any(h.startswith("Feature importance") for h in state["h2s"])
+    assert any(h.startswith("Trees") for h in state["h2s"])
+    assert state["svgRects"] > 0, "tree diagram should have drawn at least one node"
+    page.close()
+
+
+def test_dangerous_pickle_shows_blocked_banner_not_a_crash(server, browser):
+    page, frame = _open(browser, server["port"], os.path.join(server["work"], "evil.pkl"))
+    state = _wait(lambda: frame.evaluate(
+        """() => {
+            const pill = document.querySelector('h1 .pill');
+            const note = document.querySelector('.note.danger');
+            if (!pill || pill.textContent !== 'Blocked' || !note) return null;
+            return { noteText: note.textContent, hasErrOverlay: !!document.querySelector('.err') };
+        }""") or None, timeout=30)
+    assert "nt.system" in state["noteText"] or "os.system" in state["noteText"] or "system" in state["noteText"]
+    page.close()

--- a/fused_render/templates/joblib_model/uv.lock
+++ b/fused_render/templates/joblib_model/uv.lock
@@ -1,0 +1,344 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "fused-render-template-joblib-model"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "joblib" },
+    { name = "lightgbm" },
+    { name = "pandas" },
+    { name = "scikit-learn" },
+    { name = "xgboost" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "joblib", specifier = ">=1.5" },
+    { name = "lightgbm", specifier = ">=4.0" },
+    { name = "pandas", specifier = ">=2.0" },
+    { name = "scikit-learn", specifier = ">=1.3" },
+    { name = "xgboost", specifier = ">=2.0" },
+]
+
+[[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "lightgbm"
+version = "4.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/8e/4db5e29290d7e619c307fdb8dab0a0514090af2ce3ec483050e024ec6126/lightgbm-4.7.0.tar.gz", hash = "sha256:f8e20f682c9aabd000bcf4a7ed8aa6f473c1adfecccae34ec24e823d156f4af0", size = 1792896, upload-time = "2026-07-18T21:00:56.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/05/7213965863cba1ed0150ad045bceed6276a1afaaaedbaeff4699ec4f0ccb/lightgbm-4.7.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:dfc1cfe8e760387be1e7ba7a214688be21fdff96e4ed9749188f83e1877c2477", size = 1877851, upload-time = "2026-07-18T21:00:35.225Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/86/f4fe714f2e0bf3941705a20d7f6849dc476276d71236e82ea6b0d6539b86/lightgbm-4.7.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:129535462686f274df179133643118c5c5c5667167fe6c3a28d955f0b3c8e868", size = 1498914, upload-time = "2026-07-18T21:00:36.549Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/b29580948b92e8c2f84dea70118ac702ff067dc52ec4ffb5d73c953536a5/lightgbm-4.7.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d4529acec5c6fefe4768302a529707d0ead90f6a6f42df694b856212e09695b8", size = 3349492, upload-time = "2026-07-18T21:00:37.943Z" },
+    { url = "https://files.pythonhosted.org/packages/15/eb/837ea3b40cc36e22eeebb9785c01e42b2c255d033eea1d2d9ee8e2540e55/lightgbm-4.7.0-py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d23e922acd891e77212e4d0fbcee9ba973c96dee479491341d05ba595357ebb7", size = 3476028, upload-time = "2026-07-18T21:00:39.331Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0b/c5c17d862b12ce292f24cd85d40f2f8f8981668fbdbd43fdc2625eccbc79/lightgbm-4.7.0-py3-none-win_amd64.whl", hash = "sha256:f42d1e5b32b6f170e606d7c689c6165671da98d7bf37f1addec2623efc8740c9", size = 1360833, upload-time = "2026-07-18T21:00:40.865Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.24.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/1d/58946e5aab18393e793bd4add6985b95d0e01c3a2d832f38f54468b10dcd/narwhals-2.24.0.tar.gz", hash = "sha256:b5c0f684ccd9d7475b564111e319a4964abcf2baf79d3cf6b1003d06ac9b828d", size = 661143, upload-time = "2026-07-13T10:49:19.086Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/85/a5bfaebfd305ac18b57b0854d74e37e586809061a91fda62f0bd50c8518e/narwhals-2.24.0-py3-none-any.whl", hash = "sha256:42fdedf44e5b2ca7505630d45b4ac3058f38d8485cba9fe1652ca23152df7489", size = 461030, upload-time = "2026-07-13T10:49:17.571Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/80/db0b4559e57ec36362bedbb05530a87fafbcb6067708c946967a41d449e7/numpy-2.5.2.tar.gz", hash = "sha256:d482d171c406ae88c5b19cad3b6a1c4c5209f886ab74bc44c2c865c23f52d860", size = 20773161, upload-time = "2026-08-09T13:48:27.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/72/dccb0aaf40972777283303919f613964227266d0c13adebb79ac124f1c3e/numpy-2.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:14e373cfc6387177e8409dac3c7159be8eb05cd77096cd7c950268b86f62831c", size = 16891693, upload-time = "2026-08-09T13:44:51.702Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2e/b5aee50a1f74ac815cf8331812cb8251e29024025de462e0c047641c614c/numpy-2.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbd96c833ecc8cc069ce518078fc8c60cb9cbfb0fea5b7a803ad65035596d03", size = 11903109, upload-time = "2026-08-09T13:44:55.501Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f4/29e78102a80601cf034d4e9767022cffeca2c3b4c926e1754572ca95593d/numpy-2.5.2-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:6e8172ddfcf5cf74b811d372b570b83c60bd2de87a6fbfbebdadb4a9bd9c6cbb", size = 5350202, upload-time = "2026-08-09T13:44:58.401Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4b/dcd3b7eadaf4035d2c7a4289d232523a6964f602598ef7674e4bd7291f93/numpy-2.5.2-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:65f188481f1669e26f62b701e8205d19e460fa4a9b52a1414ba382330e4a3414", size = 6687736, upload-time = "2026-08-09T13:45:00.813Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/21/4947e0e9d6c9fc2e2ff15b8949049ee44f63adb9cacc729ab8793f97e712/numpy-2.5.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8ee9c4eeb8454b3660a8b53493563c3e121c2fc94fbd72b848ef814ed7b676a9", size = 15612696, upload-time = "2026-08-09T13:45:04.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/5f/62d28cf019460c7f1394105b4d49d9911a9c444cb77ab0bd95a204c5a6de/numpy-2.5.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3cdec01fa790a186d430433fdd4d4ffb70eed6f0eeb4bf05c8dbe2dce0a9bcb8", size = 16722264, upload-time = "2026-08-09T13:45:07.714Z" },
+    { url = "https://files.pythonhosted.org/packages/14/25/3f0be4c1b9fdf5dd5e708a6806978564d7c46a055c000496309ff2a2f8af/numpy-2.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7999d4ddb0c4025018373fd787510d46e04c769467af22869707b3c1cfd459ab", size = 16974396, upload-time = "2026-08-09T13:45:11.316Z" },
+    { url = "https://files.pythonhosted.org/packages/22/72/6262cbdeeb45da9d971e40715f579d791603ba8ec0b5e2db1ac55454421d/numpy-2.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c1f017dc0875c9209d219f97feceb7d54c2661bb243deb4114478e1295808af7", size = 18476044, upload-time = "2026-08-09T13:45:14.869Z" },
+    { url = "https://files.pythonhosted.org/packages/36/33/29208b8b075bde62d26a81d14b358c42b0f69b6cabd98d4ff97f37f22b05/numpy-2.5.2-cp312-cp312-win32.whl", hash = "sha256:d6a48072864e3324e194a8fbb3c657bcc5b5c869dbc64c9537b1d5c862572c0a", size = 6072817, upload-time = "2026-08-09T13:45:17.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/87fea2769fe1c47c1b5b01d8310772c9d1a85d485de7cf386ef7a3332b02/numpy-2.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:28ac63476ec7651484215ee7fa15a1f78b57c14621f01e392afe17b9a1390ce4", size = 12464674, upload-time = "2026-08-09T13:45:20.734Z" },
+    { url = "https://files.pythonhosted.org/packages/14/52/032b97e00461ab0809bbe4c588b035620e5a14b8cdee47ecddefc7b17d33/numpy-2.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:27650bb0e7140fa3d37b9923b4803645e0b125d190f326eecfd3f4dad8e8ade1", size = 10397131, upload-time = "2026-08-09T13:45:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/6b24738a0ef4557d189b150046cd07823c50e4273e8aebd651222e24306f/numpy-2.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8e4cb9a754c8a0c62eaa88273a5fba3391f4a610d1dee893c0755da31c083f15", size = 16886595, upload-time = "2026-08-09T13:45:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/65/60/f2d208d366f263f39c6e69ed309290717aab41078b6d04c9be2a84fa2a07/numpy-2.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:52c808f96484f5571a5cc863775ce50247c17dfb3b0361f8ed6b4b0456f80080", size = 11896845, upload-time = "2026-08-09T13:45:31.638Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/79/81e0bf24f4d020a2b1d5cd297a9f60c3f24eeb116f9bba5870443f7b6a4a/numpy-2.5.2-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:29d81e97f668489cba8ebfd796b9bdd453525d35dd9e162e2daec94bf3fc7740", size = 5343880, upload-time = "2026-08-09T13:45:34.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/cc/e3141cf06d1a8a2c7e107543fe1269c1d1af760d4d683c0794a4ee1127c2/numpy-2.5.2-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:afb3f0632d6b2e3ba04dbce8d1e48d321b369138b73830b5ca371a0e8d479d56", size = 6682264, upload-time = "2026-08-09T13:45:36.7Z" },
+    { url = "https://files.pythonhosted.org/packages/29/f1/2a64a307d92c5d98f5255a4014eb43bb6103ee477087b61ecae44a3aa9b9/numpy-2.5.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0aadf13b60048d501e05fa699efaf7734e2494f3498a4c2a5521d822640324f3", size = 15609566, upload-time = "2026-08-09T13:45:39.518Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/44/59a1eb68e773c4098d107ef34a0dbdeca501d72ffcfbff9a7707343921ce/numpy-2.5.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:29b86ff8a6cc556b47ec6b64b194815cc80e6bf5eedcc6cddfd65318cb0b4eee", size = 16709995, upload-time = "2026-08-09T13:45:43.661Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4c/3e54d4ddbc359a1295f8b633e8106bcd4d7d4a206e82df051bdfb3058755/numpy-2.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6950c4b7dd562453090548ba7f5da7e59f57f85663f15d5dcc60e249192f7e59", size = 16972511, upload-time = "2026-08-09T13:45:47.094Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9f/02e371638ebf19b66d46231e4be52999e87f32d1961b113bc45656608b22/numpy-2.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b9727f472d2f3888053b8a75ab0cb94745a9de224bb5846dbadc0092101bc71d", size = 18465609, upload-time = "2026-08-09T13:45:50.808Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/ad6645abc7a3510fe48e8ea1ab4598166f500057ef4ebf38bfad4f1577de/numpy-2.5.2-cp313-cp313-win32.whl", hash = "sha256:4f9744f9fbdcea0bc552e8f19e1f141f811a3f9bc2be2cc6e86d982cab23e3f4", size = 6070204, upload-time = "2026-08-09T13:45:54.111Z" },
+    { url = "https://files.pythonhosted.org/packages/15/20/f3489f86d81ea460b2bcdceaed094142ca6579f6be0ec527b781d39afe68/numpy-2.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:85aaccb24182c25df891ad0ec333585967e115269d5f1b17f2c9ae005bc96657", size = 12460532, upload-time = "2026-08-09T13:45:57.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/21/35b31dde1b283b79de828b80f876afd8c94e28fe1e9c375f89e261cc4c0d/numpy-2.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:bd68ece1553d2023c09a4226d9e41c586ad2d20594d1a456186c33513d2cb3f2", size = 10396725, upload-time = "2026-08-09T13:46:00.478Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/f8/c3b222bf075b50afd8e949a07a15c4b312a4a84bd8102a332bcd953cbbb4/numpy-2.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d787cf769c3baeb5f6235e778edb52c08dfa923789b5958f28e6450f96107cb1", size = 16885180, upload-time = "2026-08-09T13:46:03.939Z" },
+    { url = "https://files.pythonhosted.org/packages/17/e1/2c1d4b1987795a92b5bbf7c24fe249ab96aa2573ab0d7604802c189d7b86/numpy-2.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:24b9dc2e3d84aa58523798805194e23e736f3f6ce2d1a5b92583ae734e6dbda8", size = 11907878, upload-time = "2026-08-09T13:46:07.045Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ee/d08226fc858044355983a6e5b94f08ff6f3969e0a2b160a4a89f0ddb3445/numpy-2.5.2-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:9e9413326d726c2545bfa65d2c0876871e8d8386e77f992c1d426e180bbd4323", size = 5354922, upload-time = "2026-08-09T13:46:10.04Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f0/6d3d933056440ebbc5e6bad92065fc6c26a48a84a36b1208580e94eea76c/numpy-2.5.2-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:60e902ac295855348a5ca2ea4c89108989a9f5fddfad3dfc0a8f36b10358567e", size = 6679168, upload-time = "2026-08-09T13:46:12.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3b/ecd49dd90033cceb2704d88ca905d4d7d89b0e8c739608754ffd325fa820/numpy-2.5.2-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50e500dc868e9313530ce12ba470fe50ff3afe3d62993ed6eff652dacd555b65", size = 15624501, upload-time = "2026-08-09T13:46:15.322Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/99/461bd36dbdfac6c1c53efa370bd55a83227542d0d118f1677dbf1a3dacd5/numpy-2.5.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:318b9a4c845dbea06708a29c84ee429cc3065048db34cdb799047643492050ee", size = 16713701, upload-time = "2026-08-09T13:46:18.949Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/9c/2b251df9e8a5d647b62b0cbc1b90a91850c1cf4859ecb532fd0b4eacff6c/numpy-2.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:34c319e2963be042673fb46570501b2f06c41924e17e3563d58646b4380dfb68", size = 16986065, upload-time = "2026-08-09T13:46:23.006Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/25/20de43f53ff1390534a124475055a19f01fe10c920a0fd11b8e18d6d6052/numpy-2.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f06571a052127dc1b4e8b83029b4d1b20daa2b64a31cdd181fc6bc774e9000eb", size = 18470031, upload-time = "2026-08-09T13:46:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5e/0c577ca308d6da5eb79b546ba10bbe5b60148192194e2da060913b1de4f1/numpy-2.5.2-cp314-cp314-win32.whl", hash = "sha256:2cc779226e476d1e1f08c74068c419e60f41a9e0e069c92f6671d31d5c985e98", size = 6121028, upload-time = "2026-08-09T13:46:30.046Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5c/7bcbd5b11f94199073320410cddcbb80cee62415bfeb540874b265c2d922/numpy-2.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:7587f53dfbd5edc0f7b87c6217b4c6d2d1f2ef9c3da70bc1315e7db5f8d7ec9d", size = 12597627, upload-time = "2026-08-09T13:46:32.886Z" },
+    { url = "https://files.pythonhosted.org/packages/87/bc/4d0b06fba0da90ccc75af62823cb9dcedb6c9ea0cffa058cb2c9ee773a77/numpy-2.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:3e4c367352d3747784248a227fbec218e193b56f7e6692e3b64fc805478ecfdf", size = 10680414, upload-time = "2026-08-09T13:46:36.036Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/17/f429aac9dc08833a0d0f188eba38c532a751b1a1f2ca6018a37b455cb321/numpy-2.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b879fb674276e331513fb136b78dbc6bd3c848309e0d841cfd63be3896c4cfc1", size = 12026967, upload-time = "2026-08-09T13:46:39.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/9f/d0849de96a2a4ceaa16662f18ee13eaa9c0aa418269fdc8c4857c56b11da/numpy-2.5.2-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:fd0d703772bba096843785bd38371e31bb4a0c1151497ad5739d182114a73f7f", size = 5473874, upload-time = "2026-08-09T13:46:42.075Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/8df216d4a4a5422a3de045301cf7df8ea47286d76f5cb7160b0128ac26b7/numpy-2.5.2-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:3a2f061cebd9e3d23bdcfaaded5e2293a4c6a5b60fa42df85d410a725ce621bf", size = 6789276, upload-time = "2026-08-09T13:46:44.387Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/20d7e9891c4ddfadd6ff8d95bf4b29f353d8e1770553de2099880551dfb9/numpy-2.5.2-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6df895598c0edcb41030126c89e0f353b07d93238116143b7405e937359736c4", size = 15659154, upload-time = "2026-08-09T13:46:47.538Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d6/f3aa3d2688bf501b858835c6bd087ae9b51a56ae6fca8e2b0990abd177af/numpy-2.5.2-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1ab3d4a901f844ea836c3e80bf463c6a27d7f3c14e8e292fcf28d348b25b9bce", size = 16748909, upload-time = "2026-08-09T13:46:51.442Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8f/1c5cae8d2baf86ab802ae97a00be55bc7e21ebc11b12bbc33376c5f05342/numpy-2.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cebc2d6dbb605a7703d59751dea4bd6b0ab127a5a4338a6f432df1936fef8b26", size = 17027685, upload-time = "2026-08-09T13:46:55.095Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/27/71d3467404aedc1c24ce79610f91b52b0b0f466c43a701aa56fc75c145ab/numpy-2.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eaca7ff36f0f52e2111ec71f169d8fd3e889e7ddc0d2592e0d703fd8d3ce8fac", size = 18501181, upload-time = "2026-08-09T13:46:59.09Z" },
+    { url = "https://files.pythonhosted.org/packages/14/2f/42921d27c40aea7e077f4a423ae509fd9220b028cd787bafefd8ab2b3a5f/numpy-2.5.2-cp314-cp314t-win32.whl", hash = "sha256:ddf47472af2e4280d79bac82304f5e80150211f1b9e614b760061d5fdfbb6eba", size = 6271085, upload-time = "2026-08-09T13:47:01.903Z" },
+    { url = "https://files.pythonhosted.org/packages/75/e6/bad5f5d56de9b1971bac959963dda276d35c40f1854475005434bbe08692/numpy-2.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:44ef9675d908e65f9953063837c3277730f3f4437615a4cdab67b366cabaf884", size = 12787971, upload-time = "2026-08-09T13:47:04.963Z" },
+    { url = "https://files.pythonhosted.org/packages/df/05/f608795cb34391acd67e38d94a3c36abd8d8576293a3a80727d7595c372c/numpy-2.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:eaa088384c46f519dacb93b7ec483a6d6b19a4a2085ae4f25ab9b1c43d387d1e", size = 10750306, upload-time = "2026-08-09T13:47:07.976Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c6/28de0191c5f82b7d42a0a51390ba98587048aa93a39fafb05bdbe6e8d00c/numpy-2.5.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:078f9b027b478c9379b9677babbf0f8b8f1ecfada27636d7b9a93990c638739f", size = 16885274, upload-time = "2026-08-09T13:47:11.439Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/973ca116000d244897e468ea1aff30b589e5022e3c8744b71706fe33bd57/numpy-2.5.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:50a68f4bacd8a2b33d8da3d2269d0d78500f86ea582e4786dc10f5ef2c2c6842", size = 11907846, upload-time = "2026-08-09T13:47:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d9/8c4b3937ef204cb2fd88d389ccd0f265a2ffb11f35a01d2064cf46714bd6/numpy-2.5.2-cp315-cp315-macosx_14_0_arm64.whl", hash = "sha256:e79aba74ffaf5f78a050d777c184cddf8fdffabab38acf5f3ef1fecbc17895d6", size = 5354892, upload-time = "2026-08-09T13:47:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/b6ee65ea2999fdb7023935e108e6fb776ee4082aa15f159acfa857e578c8/numpy-2.5.2-cp315-cp315-macosx_14_0_x86_64.whl", hash = "sha256:9a0731745a72a184490a582fb4af2533512bd071ace67785b5fdffc0ae58dce8", size = 6679309, upload-time = "2026-08-09T13:47:20.456Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f3/acb18d8b137a393c8e7803a8c994c9e64bde3930692a69d826993113a159/numpy-2.5.2-cp315-cp315-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ec954036759bcee3aa484f8603bd9c14f3e776293b85578b8734c2d72777c69", size = 15625850, upload-time = "2026-08-09T13:47:24.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bf/a8e9bb0db815a0e265b5744ebedd3af0bd5faad8604e5b50a1cd012f3c91/numpy-2.5.2-cp315-cp315-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dc649493697006bc90614a5f0bbc8cb3cb1866715c474e473694968d7e6b99ab", size = 16713664, upload-time = "2026-08-09T13:47:27.965Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c3/6e913736b3dd6582344af32418b5fb9dab34282e8a8174ae1d54ceb0fc13/numpy-2.5.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:cf7de32f486e4ac9e2d93b810f9e9ac72a728dd46a32a0bb403222f27f653514", size = 16986749, upload-time = "2026-08-09T13:47:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/80/09/7d3b23eff5c7428ef6c01e6f7052bb60d504c4d33e317b36b8959c24ad97/numpy-2.5.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2ffa7bacab3e2ee1b19ed31766bb60bb380b68c23f051e199c5cc598afd68710", size = 18470495, upload-time = "2026-08-09T13:47:35.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a4/68a321d825374f6eb677ffe8ef8c6b9a328304e6fd2e39d9530822776607/numpy-2.5.2-cp315-cp315-win32.whl", hash = "sha256:6b588cc8f902d6bff201c19fd00c43ab8545671e3554d014e12e14139e5e8617", size = 6120696, upload-time = "2026-08-09T13:47:38.561Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/23/deafbb1700f79fae9cd1e91220f133d124cc267de1b584da3fbf6db2f6cd/numpy-2.5.2-cp315-cp315-win_amd64.whl", hash = "sha256:07d4e89f3a9ab0a9ba24264ccdb642b3dd951b2281e8883a5481a4aa79cc31a7", size = 12597324, upload-time = "2026-08-09T13:47:41.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cd/3272ba105e3bbbdaeb11357eda31e7a6825ffe159e8171665660299a948f/numpy-2.5.2-cp315-cp315-win_arm64.whl", hash = "sha256:a610dc7e3c52edd39c2bc2375ff9c3fd59cb3ad00e4472d36f83bc1457145788", size = 10680466, upload-time = "2026-08-09T13:47:44.873Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/0e/58370637b1bb70a5c9ce2b43f4b521ccb224e36ccb76a6596b17ae4b447c/numpy-2.5.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:40f4d451aed46a8046a1aae41c4e55fb3612273df9c502480135e1501576a34b", size = 16993947, upload-time = "2026-08-09T13:47:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/10/93/2abcb807712b289d6d60fe4cf30532f98974a8396d885650f3ba5a13026e/numpy-2.5.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:c081cbe16ba1ab53078e5ff29013621e33c509eedab055775d956427712c236e", size = 12025331, upload-time = "2026-08-09T13:47:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3a/2898e003a5fbaf87e76c039b4ee1f5eb390471b4ffe74887c1f34c4e791e/numpy-2.5.2-cp315-cp315t-macosx_14_0_arm64.whl", hash = "sha256:0090ccdd57ec2703e9b49d0bf554767370581c1dd0a6b2bb2b2d9def317d042a", size = 5472336, upload-time = "2026-08-09T13:47:55.403Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/23f69d07c544597b29758b31b55c27dc9d541012a2c1496189fef702aec2/numpy-2.5.2-cp315-cp315t-macosx_14_0_x86_64.whl", hash = "sha256:6a9bb119fb8dd21ba30b3f0e555b7e2b081bd9883af21ec9c1c633d161cda3a8", size = 6788387, upload-time = "2026-08-09T13:47:58.192Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ea/c0dbdbcf22f43782510a3e492dd3da73c6112b69cac8929d16d127536fc4/numpy-2.5.2-cp315-cp315t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a839318485284a6fb31be4f8f2c91c8f2cb22f4543c4a8903f12b0671ffe07cc", size = 15667096, upload-time = "2026-08-09T13:48:01.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5e/29c73c31748cdb0f7566642125ba17fd5b56780cddf891b085dab27e4466/numpy-2.5.2-cp315-cp315t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba0a474801b8dc67b66bf465548abc90e82b44d2611b5770f33008dcabffe8ec", size = 16751730, upload-time = "2026-08-09T13:48:05.706Z" },
+    { url = "https://files.pythonhosted.org/packages/47/95/02501e8454796bb58dadf7a99d3181e0b464bf264e1003039572f9779fac/numpy-2.5.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0a4035ae1129ff8777f08bfbd44f1e5d8e9c049ce0c2dd78fc0d92c13e7251c0", size = 17038686, upload-time = "2026-08-09T13:48:09.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b5/53a681d91b5c82687067d8ea5035e02d917b5509d6f334cb06484a954714/numpy-2.5.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:77843ca236b777e67f8d6b3660ea116e499612703a0ecd7093f316201eb9d8e2", size = 18507727, upload-time = "2026-08-09T13:48:13.744Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.31.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a0/530efd7db8857c0436868bb7df9764f09fde2bd4d1f0bae546eec9fc40d0/nvidia_nccl_cu13-2.31.2-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:b5563f8e2534f363d93ace022670ba016d3717e190ac4eba564d05fbbe8495b1", size = 252479893, upload-time = "2026-08-11T23:22:01.53Z" },
+    { url = "https://files.pythonhosted.org/packages/14/fb/94933e00bb3dcfdf66ea3456739c6a51d322353f7cc64fa1f5f660e695ac/nvidia_nccl_cu13-2.31.2-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:0bcaf0308854cb55fcc35af72e2c83143f3b71e65a4e865e2c586b1cdcdb5ae0", size = 252442223, upload-time = "2026-08-11T23:22:40.341Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/54/1dc810ea558d1320b597aa140a514f2fdf1d2ea09c38cf556f13ea712ec9/pandas-3.0.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fa290c16964d4963fbfbc358928239cf3bd755b20e988ce944877def2f44471d", size = 10411717, upload-time = "2026-07-22T22:18:08.307Z" },
+    { url = "https://files.pythonhosted.org/packages/68/56/fbe81c09195924d8b7b8d4461a20458fe80a6a5ed6b24f0314da684277e1/pandas-3.0.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2e26bb46934b8a2ca0c3de1d3d606fc5f6746584791b2db264d58cf370e08dc", size = 9957095, upload-time = "2026-07-22T22:18:10.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/51/fac252f4a913ed5eabf3c11b880a9e8d5a6c10f0b2129d0462212d238b4d/pandas-3.0.5-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73fa87b08a7ef706f8aafda39ddaccf2a99047bea62d8c88a0361bcafb2237bc", size = 10485458, upload-time = "2026-07-22T22:18:12.834Z" },
+    { url = "https://files.pythonhosted.org/packages/12/98/e976540c1addf70442be7842a18cf70884a964abbf69442504f4d2939989/pandas-3.0.5-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d373ce03ffd84010ed9839fa73672a9c8256990532e158440c0085db7d914b34", size = 10998091, upload-time = "2026-07-22T22:18:15.209Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/8c/1f29b5be8d3fc47dd7567eb167fabba2085879b31e0287ce7cba6d3d2ff4/pandas-3.0.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2a29c53d85ea98c5e792c59ef82ee9fbe6ca902c0d0adb6b23f45ef894cd7bf6", size = 11499501, upload-time = "2026-07-22T22:18:17.689Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e2/bd9c98ad2df7b38bde002adde4cdf353519da51881634323b126c55997f9/pandas-3.0.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a5ad3b02ed6bc7d7ae9b70804b2c6aa31827489d150f8e623ce82491b82085d7", size = 12060559, upload-time = "2026-07-22T22:18:20.147Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/9a/ffbd852d58bd74a617fe2f8ee6a58a96982271ce41cf981eab22190b4a4b/pandas-3.0.5-cp312-cp312-pyemscripten_2024_0_wasm32.whl", hash = "sha256:b2acb4650527eec6822c3dadb2b771277b65e7dae7a267d4bccf65fd1bb3fbce", size = 7197652, upload-time = "2026-07-22T22:18:22.502Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b5/d2d3e9ae73362ba4229651b0ee1455cf78073a1ce585f6ff693782ce263e/pandas-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:80a611068e8a3ac23f7398c6c14eb46dc974e5cc9997f653e2dcfd1da74edd41", size = 9831691, upload-time = "2026-07-22T22:18:24.534Z" },
+    { url = "https://files.pythonhosted.org/packages/52/51/dea1e89d6a6796b9c43f85a09b484ee03edb8a4c4842e73e200a8c11301c/pandas-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:25ff585b972a18ef1fe9ffa3ac6544d9950508aa76832e5147640b6022821e49", size = 9105796, upload-time = "2026-07-22T22:18:27.064Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/7b95c4a0025227d6f118c4039b423412ac6a982db02864166185d812fbc7/pandas-3.0.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c1c05a767fe8e5b4fe9e1c29806829c582052eaedb9120a3da83ba3f69e24a5b", size = 10385742, upload-time = "2026-07-22T22:18:29.346Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0c/dc78fd8c4da477b4b5e8ad37295af352190d21ef63a9ee1bc071753074cc/pandas-3.0.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b86765f268b56f7e665b93bce9d5df69dee7f99e595cf8fb839483ab315942a3", size = 9932067, upload-time = "2026-07-22T22:18:31.833Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/71/3592c055cf44df9808550f9368ceda80ff2b224d355ef73fe251dcda1802/pandas-3.0.5-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c597ecf5616b5c420372c1d4d4c00dbbfba7398bea857dcc984347e1ea48417b", size = 10466756, upload-time = "2026-07-22T22:18:34.195Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/70/4363150359f95b4cb4bcbb34ca23572bb5495749a621a8f3d5a1ddfd293c/pandas-3.0.5-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4b11c36e218331d0387cbe3a0a5f75162357a1d92d57b2b08a336ff94b19b2be", size = 10938525, upload-time = "2026-07-22T22:18:36.81Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d0/317e7a0c67c0e69fa905a0161409397a7dc2d46ff611f6ca4803352c042b/pandas-3.0.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cf52e1f61d229496da17dc7ab54acdee627357e7008fd4fecba3d0ba2937fa58", size = 11489303, upload-time = "2026-07-22T22:18:39.287Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/8d/36dade89b49e4f9d5cbdbe863772581f98c0c6d78fc39ad4c557f6f2e17e/pandas-3.0.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db172144bb56422bd157812f3b021eacc255451470b31e2c633c349490a1cfee", size = 11989004, upload-time = "2026-07-22T22:18:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ba/18c4ec8a746e177da05a9e7a7963781d8ea195780724f854601b6ebd6b78/pandas-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:0d298e951f23016ce4699951d044ae6418dbc91bf68cefca0f77666fcbb4e5c6", size = 9826896, upload-time = "2026-07-22T22:18:44.539Z" },
+    { url = "https://files.pythonhosted.org/packages/de/ec/28a57266b753799a87b8bc79e7887ac6fd981b8c6d2978a0b7e7b6bd708c/pandas-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:66266d3442a5e8b3c90274c2b8b230bee42dd1c286bc822cc2f9f2c7e12b883e", size = 9094790, upload-time = "2026-07-22T22:18:47.468Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2f/cf6aae281264f4463f0875bcbb15fd2bb6d291cc535187dad1732475e4a9/pandas-3.0.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2f264fc46911cc8131a7322a16199bbf8e353d27c10bb211f5bd0c814324dc36", size = 10390034, upload-time = "2026-07-22T22:18:49.818Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ec/5189518c7a7659c4bdcc6b1eb32c46c6f3c86b0661ffd84143d1112c7732/pandas-3.0.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:53730687fcd161883b24e10411c06d6a4c0f2275d2faf3bb2bc25deb4ba8007c", size = 9980065, upload-time = "2026-07-22T22:18:52.249Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f1/598503ce8d7e3c35601e0747ba288c7864baae66380725bc12f13f884dfe/pandas-3.0.5-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:960d3ebcf249f75206899fcd2c6de53f736b7265759ced0d3e559df0b8b709b0", size = 10545532, upload-time = "2026-07-22T22:18:54.813Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/de/ceae2adf7034e07e9910299fe412e1819c4f0dd520700a888bcb03625448/pandas-3.0.5-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e94c2c5ca43bd3ca32bf64d32308887b65e5f9bfd8023ea52755107a999f93b", size = 10963120, upload-time = "2026-07-22T22:18:57.42Z" },
+    { url = "https://files.pythonhosted.org/packages/66/25/86e0f4451874eb79e688deeebe3c451fec4557f8952005818d800ee8ac7e/pandas-3.0.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e819dd5f62966b481a8cb649d3299ebd886a1ea91ed5a99bf7ce77c98d18ab94", size = 11563178, upload-time = "2026-07-22T22:18:59.729Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/45/8643daa3b4147e433adfcccefdd0380d3aad79d86b15d8999730fe1944d5/pandas-3.0.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:3c5ed2e7c06e91d340dfd091d7934f9bc82e4a36b95f647f090b9d1c9ac649da", size = 12028708, upload-time = "2026-07-22T22:19:02.164Z" },
+    { url = "https://files.pythonhosted.org/packages/96/58/ad979ae617615576e8aafd569c9d4b62f1191d896e38f51d66ba06f3b89a/pandas-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:cd8f7c6dc98527058ee6264219343f5392240a6f1bfa654fc5d79023020d0c92", size = 9951806, upload-time = "2026-07-22T22:19:04.596Z" },
+    { url = "https://files.pythonhosted.org/packages/69/32/7ac03886b304049a9d2625ee88f59af760d8a93bd30ed9239bce7b9869a8/pandas-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:5183427f5a8156d480f30333777bc978be93650a49a7c01db26adffe95b31e85", size = 9238297, upload-time = "2026-07-22T22:19:06.836Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ed/1d1f2ee5547d5167face2376d11c8b2a4c7bfff5a416ee7a9046891fab1e/pandas-3.0.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:303da736987d481074ca720ada325f8bd80c64ebc2d45ed79b29df3aaa4a26ca", size = 10849690, upload-time = "2026-07-22T22:19:09.391Z" },
+    { url = "https://files.pythonhosted.org/packages/57/55/17e17152e98fbb0c4b1e562bc65387a2f20a80db0f4a86bf8d3a0e4248d4/pandas-3.0.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3b2801bbb049d0136f6c213eae02b5fca969384fc2064dd728d8620552aa49da", size = 10509945, upload-time = "2026-07-22T22:19:11.773Z" },
+    { url = "https://files.pythonhosted.org/packages/88/90/817d44dbf83facf9556f33576d9af0a241981e7bb5c00606c0bcb5df8dda/pandas-3.0.5-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cce3a9d11d2b1f82c69a27ec1f4948a170e2c403c4bbfa8cca62e3fdebe2ef3a", size = 10392197, upload-time = "2026-07-22T22:19:14.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/da/889f00c0a6f5aa1545add70abbf01502dff87ab577adb855bd631c54d2f2/pandas-3.0.5-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ef01af4d8dc6cd2c8d6c7736f149574ef93fe043811eeb5e445f2647154b5040", size = 10862726, upload-time = "2026-07-22T22:19:16.351Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/98/f1e934fb3c98fce859c6147c6785816c7b5b9ab7821115c5d8c4de9842b9/pandas-3.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e2759e890db96dfcffdbd9b86c3c2cb6afaf58def482820317e06163ec1066cd", size = 11414864, upload-time = "2026-07-22T22:19:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/be/d448af7d657d82e1888dd8551f79c6d6fb161080b5b9752d84d910ec2319/pandas-3.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b58b1b39d46a5862e3fb18f50d1a201398619d16a0f9f73f57eea5583cf0e63c", size = 11925105, upload-time = "2026-07-22T22:19:21.515Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c1/ccb4238212c8c4f496c584f3044d94e0c030ed8e1d68999db46c91c2242f/pandas-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:1c10461f6eeb35d8f05b6184c65c8b9991663b66c46b1d559b682cb34ae7c6ea", size = 10387612, upload-time = "2026-07-22T22:19:24.257Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cf/6a51b2c38980e04c279fd2fa908a1b0982064e860444acfca4ec2e2c8359/pandas-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3c5015fd1730fbf883647e88068176c839c102cea883ba1769a6f4593bfc1f8c", size = 9509776, upload-time = "2026-07-22T22:19:26.694Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "scikit-learn"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/20/75f915ff375d6249e6550ac740fdbbd66159a068fd3af1400ff62036b07a/scikit_learn-1.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2bd41b0d201bc81575531b96b713d3eb5e5f50fb0b82101ff0f92294fdc236ac", size = 8741122, upload-time = "2026-06-02T11:53:24.08Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d5/2b5148f2279196775e1db2aeb85d14b70ac80e7e32b3b28e7ebeafb0901d/scikit_learn-1.9.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5be45aa4a42a68a533913a6ed736cf309de2226411c79ef8d609a5456f1939b1", size = 8261512, upload-time = "2026-06-02T11:53:27.183Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/ee/5adbc77656b71f9456a2f5a7a9fdb4bcf9207a6b962889f1c2f9323afa4e/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e50ed4da51974e86e940690e9a3d82e729b62b5a49f7c9bac534d515d39d86f", size = 8837603, upload-time = "2026-06-02T11:53:30.328Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c2/63fdda36c56437eeb44aaf9493c8bcd62ce230ab1598924fc626ffbfa943/scikit_learn-1.9.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:056c92bb67ad4c28463c2f2653d9701449201e7e7a9e94e321be0f71c4fef2b8", size = 9132097, upload-time = "2026-06-02T11:53:33.456Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a4/c8e67227c680e2259c8864ae72ff48b06e16a6f51253a22167aa02a8aa4e/scikit_learn-1.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:4306775fad04cc4b472a1b15af1ae9cede1540fbfcc17fbce3767cd8dc7ae283", size = 8211173, upload-time = "2026-06-02T11:53:36.602Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/fd/3c0863792e98e67e9184aa4029288a175935eb65443afcd30d4f143450cf/scikit_learn-1.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:26e22435f63bcdcf396b574273f29f13dd531f5ea035801f5be10ba1540a4e60", size = 7867451, upload-time = "2026-06-02T11:53:39.075Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
+]
+
+[[package]]
+name = "xgboost"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/11/2b1de4cb9b7eeb042ca49c7d3b3ed2b77e7645ee6c0f99cf616716f3e8d7/xgboost-3.4.0.tar.gz", hash = "sha256:a6b5d114e7186b5a68c5b08b42297fc76c8c5d7292294220cdb12a6efd59977e", size = 1231819, upload-time = "2026-08-04T11:14:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/27/3172bd833a41815ffed3757be5077bbb66a34afb389393606518b1889741/xgboost-3.4.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:bc7aeee7c72e827f6406e8dc1f56c4c13d2ff2470fc6b4093b07c1e84b6c3920", size = 2541629, upload-time = "2026-08-04T11:13:50.234Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0f/a4628c03bcc85b16dced3854af2bcb8f3bb8deac718c1bcb5e12740ec5d5/xgboost-3.4.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:7c328ab0fe446883271aab194ce1e4f49b37b4bd919a258a3ca74fb83e64029c", size = 2365529, upload-time = "2026-08-04T11:13:53.05Z" },
+    { url = "https://files.pythonhosted.org/packages/69/49/49d43a6244877904eb3df40d064303114a7f921d4bf730ab55b169e1f9dc/xgboost-3.4.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:1aaf7fb7af8ab306b1ef20f9576dbc1a06a7a42d2a366169650d024138d39638", size = 57196337, upload-time = "2026-08-04T11:14:09.981Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/1b/d631cf47b046ba9fae9c86bf2dba88bec3c2f42173d5216fe81fb9be729c/xgboost-3.4.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:ba132153e3c696f090be808bc42b8e4248932ab9a4ee66441154c954789b507c", size = 57615296, upload-time = "2026-08-04T11:14:30.855Z" },
+    { url = "https://files.pythonhosted.org/packages/89/97/838165ec9399aa5e6add044f05b64d877d45125adeda15869021b9e625ce/xgboost-3.4.0-py3-none-win_amd64.whl", hash = "sha256:23c62770c38fb9acd8b40d6c7df6de8fa077ef7afcb84aafd898faabbec639f9", size = 48935508, upload-time = "2026-08-04T11:14:50.954Z" },
+    { url = "https://files.pythonhosted.org/packages/56/84/92c3af9c167815a15cfa09e5579d6cc604dc6f08b1ae061b3756274cf530/xgboost-3.4.0-py3-none-win_arm64.whl", hash = "sha256:9cdc68b992e55717438122174e2b3d9527c59882818fb954a329a62786012709", size = 2094191, upload-time = "2026-08-04T11:14:55.472Z" },
+]

--- a/fused_render/templates/joblib_model/uv.lock
+++ b/fused_render/templates/joblib_model/uv.lock
@@ -17,6 +17,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "joblib" },
     { name = "lightgbm" },
+    { name = "numpy" },
     { name = "pandas" },
     { name = "scikit-learn" },
     { name = "xgboost" },
@@ -26,6 +27,7 @@ dependencies = [
 requires-dist = [
     { name = "joblib", specifier = ">=1.5" },
     { name = "lightgbm", specifier = ">=4.0" },
+    { name = "numpy" },
     { name = "pandas", specifier = ">=2.0" },
     { name = "scikit-learn", specifier = ">=1.3" },
     { name = "xgboost", specifier = ">=2.0" },

--- a/fused_render/templates/registry.json
+++ b/fused_render/templates/registry.json
@@ -565,5 +565,14 @@
     "code",
     "claude",
     "reader"
+  ],
+  ".joblib": [
+    "joblib_model"
+  ],
+  ".pkl": [
+    "joblib_model"
+  ],
+  ".pickle": [
+    "joblib_model"
   ]
 }

--- a/scripts/file_associations.json
+++ b/scripts/file_associations.json
@@ -196,6 +196,11 @@
       "standard_mime": "application/x-java-archive"
     },
     {
+      "extension": ".joblib",
+      "icon": "file",
+      "standard_mime": null
+    },
+    {
       "extension": ".jpeg",
       "icon": "image",
       "standard_mime": "image/jpeg"
@@ -349,6 +354,16 @@
       "extension": ".pdf",
       "icon": "doc",
       "standard_mime": "application/pdf"
+    },
+    {
+      "extension": ".pickle",
+      "icon": "file",
+      "standard_mime": null
+    },
+    {
+      "extension": ".pkl",
+      "icon": "file",
+      "standard_mime": null
     },
     {
       "extension": ".plist",

--- a/tests/_theme_sources.py
+++ b/tests/_theme_sources.py
@@ -35,6 +35,7 @@ TIER_ONE_TEMPLATES = (
     "duckdb",
     "git",
     "graph",
+    "joblib_model",
     "log_studio",
     "markdown",
     "model_card",


### PR DESCRIPTION
## Summary
- New built-in template (`fused_render/templates/joblib_model/`) that previews `.joblib`/`.pkl`/`.pickle` files: file/model summary, hyperparameters, a feature-importance chart, and an interactive SVG decision-tree diagram for sklearn/XGBoost/LightGBM models.
- The core design problem: `pickle.load()`/`joblib.load()` is arbitrary code execution, and this template is offered on any file a user opens, including downloaded ones. `reader.py` never unpickles blindly — it subclasses `joblib`'s own `NumpyUnpickler` and overrides `find_class` so every referenced class either resolves for real (only if it matches an explicit numpy/scipy/sklearn/xgboost/lightgbm/catboost/pandas/joblib allowlist) or becomes an inert stand-in that swallows any call as a no-op. Verdicts are `safe` / `unavailable` (trusted library just not installed) / `blocked` (with the exact offending references shown). This includes a targeted fix for a bypass where joblib's own array-wrapper framing calls a bare, unrestricted `pickle.load()` internally for object-dtype numpy arrays — closed by substituting a wrapper subclass that routes that nested read back through the same restricted `find_class` instead of refusing it outright (which would have broken legitimate GradientBoosting/AdaBoost/bagging models that store real estimators in object-dtype arrays).
- Registers `.joblib`/`.pkl`/`.pickle` in `fused_render/templates/registry.json`.
- Also fixes a pre-existing gap in `fused_render/_env_install_worker.py`: its `uv sync`/`uv python install` subprocess calls were missing the `CREATE_NO_WINDOW` flag that every other subprocess spawn in this codebase carries, so a template's first-time dependency install popped a visible console window on Windows (that worker runs detached with no console of its own to hand a console-subsystem child). This template is the first with mandatory (not opt-in) declared dependencies, which is what surfaced it.

## Test plan
- [x] `uv run --with joblib --with scikit-learn --with xgboost --with lightgbm --with pytest pytest fused_render/templates/joblib_model/tests/test_reader.py -v` — 22 unit tests covering the safety scan (blocked/unavailable/safe verdicts, the object-dtype bypass, oversized declared array shapes, truncated compressed files), and introspection (sklearn/XGBoost/LightGBM/GradientBoosting tree extraction, multi-class feature importance, NaN/Infinity JSON-safety, per-estimator failure isolation, dict/list traversal caps, path-collision escaping).
- [x] Playwright e2e smoke tests (`tests/test_viewer_e2e.py`, opt-in via `FUSED_RENDER_E2E_JOBLIB=1` since it needs a real `uv sync` on first run): safe-bundle renders all sections including the tree diagram; a malicious pickle shows the blocked banner instead of a crash.
- [x] Manually verified end-to-end in a running app against a real-world 1MB XGBoost model (992 trees): loads `safe`, tree diagram matches the raw file's actual leaf values, `json.dumps(..., allow_nan=False)` succeeds (this used to raise for any XGBoost model, since `missing=nan` is XGBoost's default param).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces security-critical unpickling of user-supplied files; risk is mitigated by explicit allowlists and broad safety tests, but any gap would be arbitrary code execution.
> 
> **Overview**
> Adds a **`joblib_model`** built-in template so `.joblib`, `.pkl`, and `.pickle` open in the explorer with model summary, hyperparameters, feature importance, structure walk, and lazy-loaded SVG decision trees (sklearn / XGBoost / LightGBM). **`reader.py`** loads files through a custom restricted unpickler (allowlisted modules, gated `REDUCE`/`INST`, safe numpy array wrappers, size/decompression caps) and returns **`safe` / `unavailable` / `blocked`** before any introspection runs.
> 
> Wires the template in **`registry.json`**, **`scripts/file_associations.json`**, and theme tier-one sources; ships **`pyproject.toml`**, **`uv.lock`**, unit tests, and opt-in Playwright e2e.
> 
> Also sets **`CREATE_NO_WINDOW`** on `uv python install` and `uv sync` in **`_env_install_worker.py`** so first-time template env installs on Windows no longer flash a console (this template is the first with mandatory template deps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8cd88deb8f29f2f5e46c1a9a2ee093cc7c5389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->