### PR TITLE
Claude template: per-target artifacts, tabbed home lists, in-flow receipts

### DIFF
--- a/fused_render/claude_artifacts.py
+++ b/fused_render/claude_artifacts.py
@@ -1,0 +1,397 @@
+"""Every Artifact this machine has published, recovered from Claude Code's own
+session transcripts — the entry contract behind `GET /api/claude-artifacts`.
+
+There is no artifacts index on disk to read. Publishing an Artifact is a tool
+call inside a Claude Code session, and the only durable trace it leaves locally
+is in the session transcript at ~/.claude/projects/<encoded-cwd>/<id>.jsonl.
+Two kinds of line there matter, and BOTH are needed:
+
+  * a top-level `{"type": "frame-link", ...}` record — one per successful
+    publish, carrying the four facts that make an artifact addressable: the
+    local `path` that was published, the hosted `frameUrl`, the `title`, and a
+    `timestamp`. This is the authoritative publish record; if it isn't there,
+    the publish didn't land, which is why an artifact with no frame-link is not
+    listed at all.
+  * the assistant's `tool_use` record for the Artifact call, which is the only
+    place the `description` and `favicon` the author chose ever appear. The
+    frame-link doesn't echo them back.
+
+So the shape below is a JOIN, keyed on the local file path within a session,
+between "what got published" and "how the author described it".
+
+Identity is the `frameUrl`, not the file path. One page is redeployed many
+times — a `.html` in a scratchpad gets published, edited, published again — and
+every redeploy writes another frame-link for the SAME url. Those are one
+artifact with a history, not N artifacts: latest publish wins for what to show
+(title, path, description), `created_at` is the first publish and `updated_at`
+the last. The dedupe also has to run ACROSS transcripts, because an artifact
+can be updated from a different session later via the tool's `url` parameter —
+a per-session merge alone would list that page twice.
+
+Cost is the reason for the two-stage prefilter and the per-file cache. Real
+transcript stores run to hundreds of megabytes; `json.loads` on every line of
+that per request is not viable, and neither is re-reading unchanged files. So
+lines are substring-screened before parsing (a cheap `in` test rejects
+virtually all of them), and each transcript's merged result is cached against
+its (mtime, size) so a repeat request only re-reads the transcripts that
+actually moved.
+
+Nothing in here raises for input it cannot read: an unreadable transcript, a
+truncated JSON line, a timestamp in an unexpected format, a missing projects
+dir — each degrades to "no artifacts from that", never to a failed listing.
+`exists` is deliberately the one fact NOT cached: scratchpad files are
+temporary and the caller needs to know, right now, whether the local source is
+still openable.
+"""
+import glob
+import json
+import os
+from datetime import datetime, timezone
+
+from fused_render._view_url_codec import canonical_fs_path
+
+# CLAUDE_CONFIG_DIR wins where set — same rule (and same deliberate local
+# duplication) as server/routers/claude_sessions.py, user_skills.py and the
+# claude template's CLAUDE_DIR.
+CLAUDE_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+PROJECTS_DIR = os.path.join(CLAUDE_DIR, "projects")
+
+# Substring screens applied to a raw line BEFORE json.loads. Cheap enough to run
+# over every line of a multi-hundred-MB store; a line that passes is one of the
+# few thousand we actually care about. Written as the JSON-encoded field values so
+# they can't match a stray mention in prose — but only as a *filter*, so a false
+# positive costs one wasted parse and a future format change (spaces after the
+# colons, say) still matches on the bare tokens.
+_FRAME_LINK_HINT = "frame-link"
+_TOOL_USE_HINTS = ("Artifact", "tool_use")
+
+# How far into a transcript to hunt for its `cwd` when no line we parse for
+# other reasons happens to carry one. It is normally on the very FIRST record
+# (claude_sessions._session_cwd relies on the same thing), so this is a bound on
+# a pathological file rather than a real budget — without it, a transcript that
+# never records a cwd would cost a full json.loads of every line.
+_CWD_PROBE_LINES = 20
+
+# path -> (mtime, size, merged-artifacts-for-that-transcript). Keyed by absolute
+# path, so a monkeypatched PROJECTS_DIR under tmp can never collide with a real
+# transcript's entry. Pruned to the transcripts currently on disk on each
+# listing, so a deleted session doesn't pin its result for the process lifetime.
+_CACHE: dict[str, tuple[float, int, list[dict]]] = {}
+
+
+def reset_cache() -> None:
+    """Forget every cached transcript. For tests, and for any caller that wants
+    the next listing to re-read from disk unconditionally."""
+    _CACHE.clear()
+
+
+def _epoch(value) -> float | None:
+    """A transcript's ISO-8601 timestamp as an epoch float, or None.
+
+    The trailing "Z" is rewritten rather than passed through: `fromisoformat`
+    only learned to accept it in 3.11, and this package still runs on 3.10. A
+    timestamp with no zone at all is read as UTC — every writer of these records
+    emits UTC, and guessing local time would silently shift an artifact's
+    position in a listing sorted by time.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value[:-1] + "+00:00" if value.endswith("Z") else value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _text(value) -> str | None:
+    """A transcript string field, or None for anything unusable — absent, the
+    wrong type, or empty. Empty and absent are the same claim here ("no title
+    was recorded"), and collapsing them keeps the UI from having to know."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+def artifact_dict(
+    file_path: str,
+    remote_url: str,
+    *,
+    title: str | None = None,
+    description: str | None = None,
+    favicon: str | None = None,
+    session_id: str | None = None,
+    cwd: str | None = None,
+    created_at: float | None = None,
+    updated_at: float | None = None,
+) -> dict:
+    """One listed artifact — the single place the entry shape is built.
+
+    `exists` is resolved HERE and nowhere else, on every call: it is the only
+    field that can change without any transcript changing (the published file
+    was in a scratchpad and got cleaned up), so it must never come out of the
+    per-transcript cache the rest of these fields do.
+
+    A mount-backed path is never stat'ed and reports `exists: False`. The
+    kernel os.stat is the GETATTR that wedges a dead mount (see
+    server/mount.py), and this runs once per artifact on every listing — one
+    bad mount would hang the whole page. False is also the SAFE answer, not
+    just the cheap one: `exists: True` would make the UI render a live iframe
+    preview per card, each of which is a read through the same mount. The card
+    falls back to its hosted claude.ai link, which is always openable.
+    """
+    # Lazy import, following server/mount.py's own use of this helper: the
+    # mounts machinery would be a heavy top-level dependency for a module that
+    # is otherwise pure transcript parsing.
+    from fused_render.shell.mounts import is_mount_backed
+
+    return {
+        # The local file that was published, in the shell's canonical form
+        # (forward slashes — see canonical_fs_path, and the same call in the
+        # sessions router): a Windows transcript records the backslashed form,
+        # and frontend helpers like `basename` split on "/" only. Not otherwise
+        # re-resolved: that string is what the publish actually used, and it is
+        # already absolute.
+        "file_path": canonical_fs_path(file_path),
+        "exists": not is_mount_backed(file_path) and os.path.isfile(file_path),
+        "remote_url": remote_url,
+        "title": title,
+        "description": description,
+        "favicon": favicon,
+        # The session of the LATEST publish, not the first: it is offered as
+        # "where this artifact is being worked on", and for an artifact updated
+        # from a second session the first one is the stale answer.
+        "session_id": session_id,
+        "cwd": cwd,
+        "created_at": created_at,
+        "updated_at": updated_at,
+    }
+
+
+def _artifact_tool_inputs(obj) -> list[dict]:
+    """Every Artifact tool call `input` in an assistant record, in call order.
+
+    ALL of them, not the first: one assistant message can carry several
+    parallel tool calls, and taking only the first would strip the later
+    publishes of their description and favicon.
+
+    Rejects the calls that published nothing: a missing/blank `file_path` (an
+    incomplete streamed call, or one that errored before it had a target) and
+    `action: "list"`, which only enumerates existing artifacts. Either would
+    otherwise contribute a description to whichever artifact shared its path.
+    """
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    inputs = []
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "tool_use":
+            continue
+        if item.get("name") != "Artifact":
+            continue
+        data = item.get("input")
+        if not isinstance(data, dict) or data.get("action") == "list":
+            continue
+        if not _text(data.get("file_path")):
+            continue
+        inputs.append(data)
+    return inputs
+
+
+def _parse_transcript(jsonl_path: str) -> list[dict]:
+    """One transcript's artifacts, already merged within the session.
+
+    Returns raw records (the `artifact_dict` keyword set minus `exists`) rather
+    than finished entries, because this is exactly what gets cached and merged
+    again across sessions — see the module docstring.
+
+    Line order is the tiebreaker for "latest" wherever a timestamp is missing,
+    which is the right fallback: a transcript is append-only, so later in the
+    file IS later in time.
+    """
+    frames: dict[str, dict] = {}
+    # file_path -> (rank, input). The metadata join is per file path within the
+    # session; the frame-link is what turns it into a url.
+    tool_inputs: dict[str, tuple[int, dict]] = {}
+    cwd: str | None = None
+    order = 0
+    try:
+        with open(jsonl_path, "r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                order += 1
+                is_frame = _FRAME_LINK_HINT in line
+                is_tool = all(hint in line for hint in _TOOL_USE_HINTS)
+                # The cwd probe is the only reason to parse an uninteresting
+                # line at all, and only near the top of the file.
+                if not is_frame and not is_tool and (
+                    cwd is not None or order > _CWD_PROBE_LINES
+                ):
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue  # truncated / partially-written line: skip it
+                if not isinstance(obj, dict):
+                    continue
+                if cwd is None:
+                    cwd = _text(obj.get("cwd"))
+                if is_frame and obj.get("type") == "frame-link":
+                    url = _text(obj.get("frameUrl"))
+                    path = _text(obj.get("path"))
+                    if not url or not path:
+                        continue
+                    stamp = _epoch(obj.get("timestamp"))
+                    rank = (stamp if stamp is not None else -1.0, order)
+                    frame = frames.get(url)
+                    if frame is None:
+                        frames[url] = frame = {"rank": rank, "created_at": stamp,
+                                               "updated_at": stamp}
+                    elif rank >= frame["rank"]:
+                        frame["rank"] = rank
+                    else:
+                        # An out-of-order record still moves the time span, but
+                        # must not overwrite the newer display fields.
+                        _widen(frame, stamp)
+                        continue
+                    frame["path"] = path
+                    frame["title"] = _text(obj.get("title"))
+                    frame["session_id"] = _text(obj.get("sessionId"))
+                    _widen(frame, stamp)
+                elif is_tool:
+                    for data in _artifact_tool_inputs(obj):
+                        path = _text(data.get("file_path"))
+                        prior = tool_inputs.get(path)
+                        if prior is None:
+                            tool_inputs[path] = (order, data)
+                        elif order >= prior[0]:
+                            # Merged, not replaced: a republish routinely omits
+                            # the optional description (it means "unchanged",
+                            # not "cleared"), and losing it would strip the
+                            # card of its summary after every update.
+                            tool_inputs[path] = (order, {**prior[1], **data})
+    except OSError:
+        return []  # unreadable/vanished transcript: contributes nothing
+
+    records = []
+    for url, frame in frames.items():
+        _, data = tool_inputs.get(frame["path"], (0, {}))
+        records.append({
+            "file_path": frame["path"],
+            "remote_url": url,
+            # The frame-link's title is what the page actually published under;
+            # the tool input's is only a fallback for the publish that let the
+            # HTML's own <title> supply it and got nothing echoed back.
+            "title": frame["title"] or _text(data.get("title")),
+            "description": _text(data.get("description")),
+            "favicon": _text(data.get("favicon")),
+            "session_id": frame["session_id"],
+            "cwd": cwd,
+            "created_at": frame["created_at"],
+            "updated_at": frame["updated_at"],
+        })
+    return records
+
+
+def _widen(frame: dict, stamp: float | None) -> None:
+    """Grow a frame's [created_at, updated_at] span to include `stamp`. A
+    timestamp we couldn't read contributes nothing rather than a zero."""
+    if stamp is None:
+        return
+    if frame["created_at"] is None or stamp < frame["created_at"]:
+        frame["created_at"] = stamp
+    if frame["updated_at"] is None or stamp > frame["updated_at"]:
+        frame["updated_at"] = stamp
+
+
+def _transcript_artifacts(jsonl_path: str) -> list[dict]:
+    """`_parse_transcript` behind the (mtime, size) cache. A transcript that
+    cannot even be stat'ed contributes nothing."""
+    try:
+        st = os.stat(jsonl_path)
+    except OSError:
+        return []
+    key = os.path.abspath(jsonl_path)
+    cached = _CACHE.get(key)
+    if cached is not None and cached[0] == st.st_mtime and cached[1] == st.st_size:
+        return cached[2]
+    records = _parse_transcript(jsonl_path)
+    _CACHE[key] = (st.st_mtime, st.st_size, records)
+    return records
+
+
+def _absorb(merged: dict[str, dict], record: dict) -> None:
+    """Fold one transcript's record into the global by-url index.
+
+    Newest publish owns the display fields; the span always widens. This is the
+    across-session half of the dedupe — the same page updated from a second
+    session is one row, dated from its first publish to its last.
+
+    Owning is not wiping: a display field the newer publish DIDN'T carry
+    (an update via the tool's `url` parameter states no description/favicon,
+    and its title can fail to join) falls back to the older publish's value.
+    Metadata only ever gets more complete; a plain republish can't blank a
+    card that used to have a summary and an emoji.
+    """
+    url = record["remote_url"]
+    existing = merged.get(url)
+    if existing is None:
+        merged[url] = dict(record)
+        return
+    newer = _is_newer(record.get("updated_at"), existing.get("updated_at"))
+    created = _min_stamp(existing.get("created_at"), record.get("created_at"))
+    updated = _max_stamp(existing.get("updated_at"), record.get("updated_at"))
+    # Whichever publish ends up owning the row, fill its gaps from the loser —
+    # transcripts arrive in glob order, not time order, so the older publish
+    # can just as well be the SECOND one absorbed.
+    loser = existing if newer else record
+    if newer:
+        merged[url] = dict(record)
+    for field in ("title", "description", "favicon"):
+        if merged[url][field] is None:
+            merged[url][field] = loser[field]
+    merged[url]["created_at"] = created
+    merged[url]["updated_at"] = updated
+
+
+def _is_newer(candidate: float | None, current: float | None) -> bool:
+    if candidate is None:
+        return False
+    return current is None or candidate > current
+
+
+def _min_stamp(a: float | None, b: float | None) -> float | None:
+    return b if a is None else a if b is None else min(a, b)
+
+
+def _max_stamp(a: float | None, b: float | None) -> float | None:
+    return b if a is None else a if b is None else max(a, b)
+
+
+def list_artifacts() -> list[dict]:
+    """Every artifact published from this machine's Claude Code sessions,
+    newest update first. [] when there are no transcripts at all — a listing
+    degrades to what it could see and never fails."""
+    merged: dict[str, dict] = {}
+    seen: set[str] = set()
+    for jsonl_path in sorted(glob.glob(os.path.join(PROJECTS_DIR, "*", "*.jsonl"))):
+        seen.add(os.path.abspath(jsonl_path))
+        for record in _transcript_artifacts(jsonl_path):
+            _absorb(merged, record)
+    # pop(), not del: two overlapping listings can both see the same stale key,
+    # and the second del would KeyError. FastAPI serves sync routes from a
+    # threadpool, so overlapping is normal, not exotic.
+    for stale in set(_CACHE) - seen:
+        _CACHE.pop(stale, None)
+    # Undated artifacts sort last rather than first: `reverse` would otherwise
+    # promote the ones we know least about to the top of the page.
+    artifacts = [artifact_dict(**record) for record in merged.values()]
+    artifacts.sort(
+        key=lambda a: (a["updated_at"] is not None, a["updated_at"] or 0.0),
+        reverse=True,
+    )
+    return artifacts

--- a/fused_render/claude_artifacts.py
+++ b/fused_render/claude_artifacts.py
@@ -155,7 +155,13 @@ def artifact_dict(
         # re-resolved: that string is what the publish actually used, and it is
         # already absolute.
         "file_path": canonical_fs_path(file_path),
-        "exists": not is_mount_backed(file_path) and os.path.isfile(file_path),
+        # Tri-state: True/False are real answers from a local stat; None means
+        # "not checked" — the path sits on a managed mount, where the kernel
+        # stat is the GETATTR that wedges a dead mount (see server/mount.py),
+        # once per artifact per listing. None rather than False because the two
+        # claims differ: False is "gone from disk" and a UI may hide it; None
+        # is "unknowable cheaply" and the hosted page is still the safe door.
+        "exists": None if is_mount_backed(file_path) else os.path.isfile(file_path),
         "remote_url": remote_url,
         "title": title,
         "description": description,

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -40,6 +40,7 @@ from fused_render.server.common import (
     _forced_engine,
 )
 from fused_render.server.routers.apps import router as apps_router
+from fused_render.server.routers.claude_artifacts import router as claude_artifacts_router
 from fused_render.server.routers.claude_config import router as claude_config_router
 from fused_render.server.routers.claude_sessions import router as claude_sessions_router
 from fused_render.server.routers.community import router as community_router
@@ -339,6 +340,9 @@ def create_app(start_dir: str) -> FastAPI:
     # Claude Code project folders for the Explorer homepage's "Claude
     # sessions" tab (routers/claude_sessions.py) — read-only, no auth guard.
     app.include_router(claude_sessions_router)
+    # Artifacts published from those sessions, recovered from the same
+    # transcripts (routers/claude_artifacts.py) — read-only, no auth guard.
+    app.include_router(claude_artifacts_router)
     # Community marketplace backend for the /apps hub's Showcase tab and the
     # explorer preview's Clone button (routers/community.py).
     app.include_router(community_router)

--- a/fused_render/server/routers/claude_artifacts.py
+++ b/fused_render/server/routers/claude_artifacts.py
@@ -1,0 +1,34 @@
+"""GET /api/claude-artifacts — every Artifact published from this machine's
+Claude Code sessions, for the Explorer homepage's artifacts index.
+
+A publish leaves no index behind, only a `frame-link` record inside the session
+transcript it happened in, so the listing is recovered by scanning
+~/.claude/projects/<encoded-cwd>/*.jsonl and joining those records to the
+Artifact tool calls that carry the author's description and favicon. All of that
+— the scan, the dedupe by hosted url across sessions, and what one listed
+artifact IS — lives in `fused_render/claude_artifacts.py` rather than in this
+handler, for the same reason the apps walk lives in `app_listing.py`: those are
+the rules worth testing and reusing directly, and a route is not the place for
+them.
+
+Read-only and unguarded, like the neighbouring /api/claude-sessions: it reads
+transcripts and touches nothing.
+"""
+from fastapi import APIRouter
+
+from fused_render import claude_artifacts
+from fused_render._view_url_codec import canonical_fs_path
+
+router = APIRouter()
+
+
+@router.get("/api/claude-artifacts")
+def api_claude_artifacts(cwd: str | None = None):
+    # `cwd` scopes the listing to sessions run in one directory — the claude
+    # template's "artifacts for this file/folder" section. Compared in the
+    # shell's canonical form, the same form the entries themselves carry.
+    artifacts = claude_artifacts.list_artifacts()
+    if cwd is not None:
+        want = canonical_fs_path(cwd)
+        artifacts = [a for a in artifacts if a["cwd"] and canonical_fs_path(a["cwd"]) == want]
+    return {"artifacts": artifacts}

--- a/fused_render/templates/claude/artifacts.py
+++ b/fused_render/templates/claude/artifacts.py
@@ -200,11 +200,12 @@ def _list(file: str) -> dict:
     The server answers per DIRECTORY (`cwd`), which is one step coarser than
     what the screen means, so two filters run on top of its answer:
 
-    ONE, only artifacts whose local source is still on disk (`exists`). A page
+    ONE, no artifacts whose local source is KNOWN gone (`exists` False). A page
     published from a scratchpad that has since been cleaned up is still live at
     its url, but it is not something this target has any hold on any more, and
     a landing screen listing four dead scratchpads above three real pages reads
-    as noise.
+    as noise. `exists` None (a mount-backed path the server refuses to stat) is
+    not "gone" — those rows stay and open their hosted page.
 
     TWO, strict per-target scoping, in the two directions a target can be:
 
@@ -243,7 +244,11 @@ def _list(file: str) -> dict:
     artifacts = payload.get("artifacts")
     if not isinstance(artifacts, list):
         return {"artifacts": [], "error": "unexpected response"}
-    artifacts = [a for a in artifacts if isinstance(a, dict) and a.get("exists")]
+    # Drop only the KNOWN-gone (exists is False). None means the server did
+    # not stat the path (mount-backed, hang-avoidance) — those rows stay, and
+    # the page opens their hosted url instead of claiming a local file.
+    artifacts = [a for a in artifacts
+                 if isinstance(a, dict) and a.get("exists") is not False]
 
     if os.path.isdir(file):
         own = _sidecar_sessions(file)

--- a/fused_render/templates/claude/artifacts.py
+++ b/fused_render/templates/claude/artifacts.py
@@ -1,0 +1,366 @@
+"""runPython target for claude/template.html's Artifacts section: the pages
+Claude PUBLISHED while working on this target.
+
+An artifact is the one thing a chat produces that outlives the chat and does not
+live on disk — a hosted page on claude.ai. The transcript records it and then
+scrolls away, so a folder someone has published five pages from looks, on the
+landing screen, exactly like one that has published none. This module is what
+the landing screen asks so it can say otherwise, and what the live chat asks so
+a page announces itself the moment it is published rather than at the next
+reload.
+
+TWO readers, because the two questions are genuinely different and only one of
+them is cheap:
+
+* **`list`** — the artifacts published while working on THIS target, across
+  every session, whose local source is still on disk. The cross-session scan
+  (every transcript under ~/.claude/projects, plus a per-url merge of
+  redeploys) is the SERVER's job and already done there
+  (`/api/claude-artifacts`, cached): this action is an HTTP call to it, scoped
+  by `cwd`, and then two filters the server cannot apply because they are about
+  the TARGET rather than the directory — see `_list`. It deliberately does not
+  reimplement the scan: a second implementation of "which artifacts exist" is
+  how the two grow apart, and the server's is the one with the cache, the
+  `exists` probe and the description/favicon join.
+* **`live`** — the artifacts in ONE session's transcript, read straight off
+  disk. Called on a timer while a run streams, which is exactly when the server
+  cannot help: its answer is cached, and the frame-link that a publish just
+  appended is a single line in a file whose name we already know. One `open()`
+  of one transcript is cheaper than a cache invalidation would be, and it is
+  never stale by construction.
+
+The server is reached the sanctioned way — `../shared/appenv.origin()`, i.e. the
+`FUSED_RENDER_ORIGIN` the app exports — because a template may not import
+`fused_render` (SPEC PY-15). Stdlib otherwise.
+
+NOTHING HERE RAISES. Both actions are decoration on a screen whose subject is a
+conversation: an unset origin, a refused connection, a transcript that was
+rotated away are all ordinary, and the honest answer to every one of them is an
+empty list (plus `error` for the console) rather than the red traceback overlay
+over a working chat.
+
+Actions:
+  main(action="list", file=...)                  -> {"artifacts": [...]}
+      newest first, the server's own order. Entries carry file_path, exists
+      (always true — see `_list`), remote_url, title, description, favicon,
+      session_id, cwd, created_at, updated_at.
+  main(action="live", session_id=..., file=...)  -> {"artifacts": [...]}
+      oldest first (publish order), one session only. Entries carry
+      remote_url, title, file_path, favicon, timestamp.
+"""
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+# The fused engine execs this script without setting __file__; it puts the
+# script's own directory first on sys.path, so rebuild __file__ from it. Under
+# the built-in executor __file__ is already set, so this is a no-op. (Same
+# preamble as agent.py, for the same reason.)
+if "__file__" not in globals():
+    __file__ = os.path.join(sys.path[0], "artifacts.py")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+_SHARED = os.path.join(os.path.dirname(HERE), "shared")
+# Guarded insert: /api/run may exec this module repeatedly in one worker.
+if _SHARED not in sys.path:
+    sys.path.insert(0, _SHARED)
+from appenv import origin as _origin
+from appenv import sidecar_path as _sidecar_path
+
+# Claude Code's own data dir, and it must be the SAME one the CLI writes to or
+# `live` reads a transcript that does not exist. CLAUDE_CONFIG_DIR wins where
+# the user set it — see agent.py's CLAUDE_DIR, which this mirrors deliberately
+# rather than importing: `live` is the only reader here and one env lookup is
+# cheaper than making this module depend on the whole agent.
+CLAUDE_DIR = os.environ.get("CLAUDE_CONFIG_DIR") or os.path.expanduser("~/.claude")
+PROJECTS = os.path.join(CLAUDE_DIR, "projects")
+
+# The listing is a landing-screen decoration behind a localhost hop. Long enough
+# that a cold scan of a big ~/.claude/projects still lands, short enough that a
+# server which is not answering does not hold the section's spinner for a screen
+# the user is already typing into.
+_TIMEOUT = 5.0
+
+# Substring screens applied to a raw line BEFORE json.loads — a transcript is
+# megabytes of tool output and assistant prose, and parsing all of it is the
+# whole cost of this read. The same two screens the server's scanner uses, for
+# the same two records: the `frame-link` is the publish that landed, and the
+# Artifact `tool_use` beside it is the only place the favicon the author chose
+# ever appears (the frame-link does not echo it back).
+_FRAME_LINK_HINT = "frame-link"
+_TOOL_USE_HINTS = ("Artifact", "tool_use")
+
+
+def _workdir(file: str) -> str:
+    """Claude's cwd for a target: a directory target IS the working directory, a
+    file target's is its parent.
+
+    The SAME rule as agent.py's `_workdir`, replicated rather than imported.
+    Importing it would drag agent.py's whole module body (subprocess discovery,
+    run-dir creation at import time) into a call that only wants a path, and a
+    template may not add a sibling to sys.path just to borrow four words. The
+    rule is one line and it is pinned by the thing that matters: the `cwd` the
+    server stores comes from claude's own report of where it ran, so a drift
+    here shows up immediately as an empty section, not as wrong data.
+    """
+    return file if os.path.isdir(file) else os.path.dirname(file)
+
+
+def _munge(path: str) -> str:
+    """A cwd's project-dir name under ~/.claude/projects: every non-alphanumeric
+    char becomes '-' (claude-code's own rule — see agent.py `_munge`)."""
+    return re.sub(r"[^A-Za-z0-9]", "-", os.path.abspath(path))
+
+
+def _bad_id(value: str) -> bool:
+    """Whether a session id from the page is unsafe to join into a path. It
+    arrives as a URL param and gets joined onto a directory we own, so it may
+    carry no separator and no leading dot — and on Windows a drive prefix
+    ("d:x") makes os.path.join drop our directory entirely."""
+    return not value or value.startswith(".") or any(c in value for c in "/\\:")
+
+
+def _text(value):
+    """A non-empty string, or None. Guards against a record whose field is
+    present but null/numeric — the page renders these straight into the DOM."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value or None
+
+
+# ------------------------------------------------------------------ list
+
+def _sidecar_sessions(target: str) -> set:
+    """The claude session ids recorded against EXACTLY this file-or-folder.
+
+    The claude template writes one entry per chat it starts into the target's
+    sidecar (`agent.py:_record_session` -> `appenv.sidecar_path(target)` ->
+    `{"claudeSessions": [{"id": ...}, ...]}`), which makes the sidecar the only
+    record of WHICH TARGET a conversation was opened on. `cwd` cannot answer
+    that — a chat on a file and a chat on its folder run in the same directory
+    and are indistinguishable by cwd alone.
+
+    Same helper the writer uses, so the mapping can never drift. An absent,
+    unreadable or malformed sidecar is an ordinary "no chats here": the empty
+    set, never an exception.
+    """
+    try:
+        with open(_sidecar_path(target), encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, ValueError):
+        return set()
+    if not isinstance(data, dict):
+        return set()
+    entries = data.get("claudeSessions")
+    if not isinstance(entries, list):
+        return set()
+    found = set()
+    for entry in entries:
+        if isinstance(entry, dict):
+            found.add(_text(entry.get("id")))
+    found.discard(None)
+    return found
+
+
+def _claimed_by_child_files(folder: str) -> set:
+    """Session ids that belong to a FILE inside this folder — the chats a folder
+    listing must not absorb.
+
+    Direct children only, and only non-directories: a chat on a subfolder runs
+    with that subfolder as its cwd, so the server's `cwd` scoping has already
+    excluded it and there is nothing left here to exclude. Recursing would turn
+    one landing-screen read into a walk of the tree for no change in the answer.
+
+    Best-effort per entry: an unreadable directory or a `DT_UNKNOWN` stat that
+    fails contributes nothing rather than failing the listing.
+    """
+    claimed = set()
+    try:
+        entries = list(os.scandir(folder))
+    except OSError:
+        return claimed
+    for entry in entries:
+        try:
+            if entry.is_dir():
+                continue
+        except OSError:
+            continue
+        claimed |= _sidecar_sessions(entry.path)
+    return claimed
+
+
+def _list(file: str) -> dict:
+    """The artifacts published while working on THIS target, newest first.
+
+    The server answers per DIRECTORY (`cwd`), which is one step coarser than
+    what the screen means, so two filters run on top of its answer:
+
+    ONE, only artifacts whose local source is still on disk (`exists`). A page
+    published from a scratchpad that has since been cleaned up is still live at
+    its url, but it is not something this target has any hold on any more, and
+    a landing screen listing four dead scratchpads above three real pages reads
+    as noise.
+
+    TWO, strict per-target scoping, in the two directions a target can be:
+
+    * a FILE shows only the chats started ON that file (its own sidecar's
+      session ids). It never inherits its folder's artifacts — the folder's
+      chats were about the folder, and a file that has published nothing must
+      say so even when its neighbours have published plenty.
+    * a FOLDER shows the chats that are about the folder: everything running in
+      it EXCEPT the sessions some child file has claimed as its own. Its own
+      sidecar's sessions are re-admitted unconditionally, because a chat can be
+      recorded against both (a session resumed onto the folder), and the
+      folder's own record is the more specific fact here. A session in nobody's
+      sidecar — a chat started from a terminal in this directory — is
+      folder-related by default and stays: the alternative is hiding real work
+      for the sole reason that it did not come through this template.
+    """
+    workdir = _workdir(file)
+    if not workdir:
+        return {"artifacts": [], "error": "no target"}
+    base = _origin()
+    if not base:
+        # Nothing published this page's server location, so there is nowhere to
+        # ask. Stated rather than swallowed: it means "the app did not export
+        # FUSED_RENDER_ORIGIN", which is a deployment fact worth seeing in the
+        # console, not an empty history.
+        return {"artifacts": [], "error": "FUSED_RENDER_ORIGIN is not set"}
+    url = (base.rstrip("/") + "/api/claude-artifacts?cwd="
+           + urllib.parse.quote(workdir, safe=""))
+    try:
+        with urllib.request.urlopen(url, timeout=_TIMEOUT) as response:
+            payload = json.loads(response.read().decode("utf-8", "replace"))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        # A server that is starting, restarting or gone. The section simply has
+        # nothing to show; the message is for the console.
+        return {"artifacts": [], "error": "%s: %s" % (type(exc).__name__, exc)}
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        return {"artifacts": [], "error": "unexpected response"}
+    artifacts = [a for a in artifacts if isinstance(a, dict) and a.get("exists")]
+
+    if os.path.isdir(file):
+        own = _sidecar_sessions(file)
+        claimed = _claimed_by_child_files(file) - own
+        return {"artifacts": [a for a in artifacts
+                              if a.get("session_id") not in claimed]}
+    mine = _sidecar_sessions(file)
+    # `mine` never holds None, so an artifact whose transcript did not state a
+    # sessionId simply is not this file's.
+    return {"artifacts": [a for a in artifacts if a.get("session_id") in mine]}
+
+
+# ------------------------------------------------------------------ live
+
+def _favicons(obj, into: dict) -> None:
+    """Record `file_path -> favicon` for every Artifact tool call in an assistant
+    record. ALL of them, not the first: one message can carry several parallel
+    publishes. `action: "list"` and a call with no target published nothing and
+    would otherwise donate an emoji to whichever artifact shared its path.
+
+    A LATER call overwrites an earlier one for the same path, but only when it
+    states a favicon — a republish routinely omits the optional field, and that
+    means "unchanged", not "cleared"."""
+    message = obj.get("message")
+    if not isinstance(message, dict):
+        return
+    content = message.get("content")
+    if not isinstance(content, list):
+        return
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "tool_use":
+            continue
+        if item.get("name") != "Artifact":
+            continue
+        data = item.get("input")
+        if not isinstance(data, dict) or data.get("action") == "list":
+            continue
+        target = _text(data.get("file_path"))
+        icon = _text(data.get("favicon"))
+        if target and icon:
+            into[target] = icon
+
+
+def _live(session_id: str, file: str, cwd: str = "") -> dict:
+    """The artifacts in ONE session's transcript, in publish order.
+
+    `cwd` is an override for the caller that already knows it; otherwise it is
+    derived from the target by the same rule everything else here uses, so the
+    page never has to do path arithmetic to ask this question.
+
+    Redeploys collapse by `frameUrl` — a page republished four times is ONE
+    artifact — and the LAST record wins the display fields, because the last
+    publish is what is at that url now. Identity is the url and not the file
+    path for the same reason the server does it that way: two different local
+    files can be published to the same page, and one file republished under a
+    new url is a new page.
+
+    The favicon join is per file path within this one session, which is all the
+    strip needs: the emoji is stated by the tool call that published, and both
+    records are in the same transcript a few lines apart.
+    """
+    if _bad_id(session_id):
+        return {"artifacts": []}
+    ground = cwd or _workdir(file)
+    if not ground:
+        return {"artifacts": []}
+    path = os.path.join(PROJECTS, _munge(ground), session_id + ".jsonl")
+
+    found = {}
+    icons = {}
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as handle:
+            for line in handle:
+                is_frame = _FRAME_LINK_HINT in line
+                is_tool = all(hint in line for hint in _TOOL_USE_HINTS)
+                if not is_frame and not is_tool:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except ValueError:
+                    continue  # a partially-written tail line: skip it
+                if not isinstance(obj, dict):
+                    continue
+                if is_tool:
+                    _favicons(obj, icons)
+                if not is_frame or obj.get("type") != "frame-link":
+                    continue
+                url = _text(obj.get("frameUrl"))
+                if not url:
+                    continue
+                # dict order IS publish order: a transcript is append-only, so
+                # first-seen is first-published, and re-assigning an existing key
+                # updates the value without moving it. That keeps a republished
+                # page where the user first saw it in the strip instead of
+                # jumping it to the end mid-run.
+                found[url] = {
+                    "remote_url": url,
+                    "title": _text(obj.get("title")),
+                    "file_path": _text(obj.get("path")),
+                    "timestamp": _text(obj.get("timestamp")),
+                }
+    except OSError:
+        return {"artifacts": []}  # no transcript yet, or unreadable
+
+    # Joined at the end, not inline: the tool call can be written EITHER side of
+    # its frame-link (the publish is what the call produces, but a streamed
+    # assistant record can be flushed after it), so the emoji is only reliably
+    # known once the whole file has been read.
+    for record in found.values():
+        record["favicon"] = icons.get(record["file_path"])
+    return {"artifacts": list(found.values())}
+
+
+def main(action: str = "list", file: str = "", session_id: str = "",
+         cwd: str = "") -> dict:
+    if action == "list":
+        return _list(file)
+    if action == "live":
+        return _live(session_id, file, cwd)
+    return {"artifacts": [], "error": "unknown action: %s" % action}

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -6161,6 +6161,10 @@ document.getElementById("back").onclick = () => {
 
 function enterChat() {
   chatEl.classList.remove("home");
+  // The strip belongs to ONE conversation. Chips from the previous chat are
+  // hidden on the home screen but still in the map — a new chat must not
+  // inherit them (nor a late poll's leftovers).
+  clearArtStrip();
   focusBox(box);
 }
 
@@ -8900,8 +8904,7 @@ function renderRecentSkeleton(list) {
 let recentCount = null;
 let artCount = null;
 // Which list is showing, and it is the BLOCK's state rather than the page's:
-// leaving for a chat and coming back keeps the tab you were on, the same way
-// `snapExpanded` survives that round trip.
+// leaving for a chat and coming back keeps the tab you were on.
 let listTab = "recent";
 
 function syncLists() {
@@ -8971,9 +8974,14 @@ async function loadRecent() {
     // names, or no panel yet) costs nothing, and it repaints from the cached
     // timeline rather than re-reading anything.
     if (named && snapTimeline) renderSnapshots(snapTimeline);
-    // No early return and no inline display write for the empty case: the count
-    // drives the section's visibility through syncLists (hidden/classes), the
-    // same way the artifacts list is shown and hidden.
+    if (!sessions.length) {
+      // Empty is an answer, not an error — but there is nothing to draw, and
+      // the count is what hides the section (syncLists; hidden/classes, never
+      // an inline display write).
+      recentCount = 0;
+      syncLists();
+      return;
+    }
     recentCount = sessions.length;
     for (const s of sessions) addChatRow(list, s);
   } catch (err) {
@@ -9035,17 +9043,19 @@ function addArtifactRow(list, a) {
   // count as a click on the row (which opens the local file instead).
   row.querySelector(".art-go").onclick = (e) => e.stopPropagation();
   // The row's own subject is the LOCAL file — the thing this window can show.
-  // Always pressable: `list` returns only artifacts whose source is still on
-  // disk (artifacts.py filters on `exists`), so there is no unpressable row to
-  // style or explain here any more. The guard stays on `file_path` alone,
-  // because a row with no local path has nothing for a press to open.
-  if (a.file_path) {
+  // `list` drops the KNOWN-gone, so what reaches here is exists true (a real
+  // local file) or exists null: a mount-backed path the server refuses to
+  // stat, where the hosted page is the one door that cannot hang. The press
+  // follows that split; either way a row is always pressable.
+  const local = a.exists === true && a.file_path;
+  if (local || a.remote_url) {
     row.setAttribute("role", "button");
     row.tabIndex = 0;
-    row.title = a.file_path;
+    row.title = local ? a.file_path : a.remote_url;
     // A new tab, not this frame: this window is a chat (often a pane of a
     // split), and navigating it away would end the conversation.
-    const open = () => window.open(artOpenHref(a.file_path), "_blank", "noopener");
+    const open = () => window.open(
+      local ? artOpenHref(a.file_path) : a.remote_url, "_blank", "noopener");
     row.onclick = open;
     row.onkeydown = (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); open(); } };
   }
@@ -9127,6 +9137,10 @@ async function pollArtifacts() {
   try {
     const { artifacts } = await fused.runPython(
       ARTIFACTS, { action: "live", session_id, file: FILE }, { key: null });
+    // The await straddles navigation: Back may have cleared the strip (and the
+    // session param) while this read was in flight, and a fresh chat may even
+    // be underway. A stale answer must evaporate, not repopulate the strip.
+    if (fused.params.get("session_id") !== session_id) return;
     if (!artifacts || !artifacts.length) return;
     // Change detection is by CONTENT, not by count: the favicon/title join can
     // land a poll or two after the frame-link (the tool_use streams later in

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -840,6 +840,12 @@
     padding: 8px 12px;
     border-radius: 10px;
   }
+  /* ...and once it IS history it is parked inside the turn it belongs to
+     (parkResolvedCard), where it is a sibling of the segment views rather than a
+     top-level turn — so it takes their vertical rhythm instead of a turn's 20px
+     gutter, and sits on the reply's text column because `.assistant` is a flex
+     row and the body is its second item. */
+  .assistant .body > .perm { margin: 8px 0; }
   .perm.resolved .plan-body,
   .perm.resolved .qtext,
   .perm.resolved .perm-sub { color: var(--dim); }
@@ -851,7 +857,15 @@
   .perm .perm-head { font-size: 13px; color: var(--dim); }
   .perm .perm-head .tool { color: var(--accent-text); font-weight: 600; }
   .perm .perm-sub { color: var(--dim); word-break: break-word; font-size: 12px; margin-top: 2px; }
-  .perm pre {
+  /* The second selector is the SAME rule one class richer, for a card that has
+     been parked back into its turn (parkResolvedCard): inside `.assistant` the
+     `.assistant pre` rule far below matches too, at equal specificity and later
+     in the sheet — so it would win and hand the card's payload box `white-space:
+     pre` and no height cap, i.e. a long Bash command that scrolls sideways
+     instead of wrapping and a 400-line body with no ceiling. Restating the
+     selector is enough to outrank it wherever the card sits. */
+  .perm pre,
+  .assistant .perm pre {
     /* Anchors .copybtn, top-right — attachCodeCopy runs on a plan card's body
        too (buildPlanCard), and without this its absolutely-positioned button
        escapes to the nearest positioned ancestor instead of its own pre. */
@@ -1549,6 +1563,50 @@
     margin: 0 auto;
     padding: 8px 20px 6px;
   }
+  /* The live artifacts strip: a page Claude publishes DURING a turn, announced
+     while the turn is still going. It sits under the composer rather than in the
+     transcript because it is not part of what was said — the transcript's own
+     record of a publish is a tool chip that scrolls away, and the thing the user
+     wants afterwards ("open the page you just made") must not scroll with it.
+     A chip row, not the landing page's stacked rows: this is an accumulating
+     count of small identical things beside a live conversation, which is the
+     same job .annchips does two elements up, so it takes that shape.
+     `hidden` rather than an inline `display`, because a child of #chat may not
+     carry an inline display — see the #inputbox rule (D146, and
+     tests/test_claude_narrow.py pins it). The [hidden] rule below is needed for
+     the same reason .annchips-style flex boxes need one: `display: flex`
+     outranks the UA's `[hidden]`. */
+  #artstrip {
+    flex-shrink: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    max-width: 720px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2px 24px 6px;
+  }
+  #artstrip[hidden] { display: none; }
+  #chat.home #artstrip { display: none; }
+  .art-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    max-width: 220px;
+    padding: 3px 9px;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--fg);
+    font-size: 11.5px;
+    text-decoration: none;
+  }
+  .art-chip:hover { border-color: var(--accent); color: var(--accent); }
+  .art-chip .art-chip-lbl { overflow: hidden; text-overflow: ellipsis;
+                            white-space: nowrap; }
+  .art-chip .art-chip-go { color: var(--faint); flex-shrink: 0; }
+  .art-chip:hover .art-chip-go { color: var(--accent); }
+
   #footnote {
     max-width: 720px;
     margin: 0 auto;
@@ -1727,7 +1785,12 @@
     align-items: center;
     padding-top: 14vh;
   }
-  #home .inner { width: 100%; max-width: 620px; padding: 0 24px; }
+  /* The bottom breathing room belongs to the COLUMN, not to each section: every
+     landing section used to end in its own `padding-bottom: 32px`, which only
+     the last one needed and which added itself to the next one's `margin-top`
+     for a 60px gutter between blocks that read as three unrelated screens
+     stacked. One 32px here, one margin per block below. */
+  #home .inner { width: 100%; max-width: 620px; padding: 0 24px 32px; }
   .home-title {
     font-size: 26px;
     font-weight: 600;
@@ -1746,7 +1809,51 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  #recent { margin-top: 28px; padding-bottom: 32px; }
+  /* ONE block for the two cross-session lists — past chats and published
+     artifacts — because they are two answers to the same question ("what has
+     happened here before?") and stacking them cost the landing page two
+     headings, two 60px gutters and an artifacts section pushed so far down it
+     was below the fold on a short pane. Where there is something in both, the
+     block wears a TAB BAR and shows one list at a time; where only one of them
+     exists it is just that list under its own heading, exactly as before, since
+     a tab bar with one tab is a label pretending to be a control. */
+  #lists { margin-top: 28px; }
+  #listtabs {
+    display: flex;
+    align-items: baseline;
+    gap: 16px;
+    margin-bottom: 8px;
+    padding: 0 4px;
+  }
+  /* `display: flex` outranks the UA's `[hidden]` rule. */
+  #listtabs[hidden] { display: none; }
+  /* The tabs ARE the section headings — same 11px uppercase letter-spaced
+     micro-type as every other label on this page (.head below), so switching
+     lists never changes the shape of the screen. The only thing that marks the
+     active one is ink plus a hairline under it; a pair of pills here would be
+     the loudest object on a landing page whose subject is the composer. */
+  .list-tab {
+    font: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .8px;
+    text-transform: uppercase;
+    color: var(--faint);
+    background: none;
+    border: 0;
+    border-bottom: 1.5px solid transparent;
+    border-radius: 0;
+    padding: 0 0 4px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .list-tab:hover { color: var(--fg); }
+  .list-tab[aria-selected="true"] { color: var(--fg); border-bottom-color: var(--accent); }
+  .list-tab:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .list-tab .tab-count { font-weight: 400; letter-spacing: 0; }
+  /* Tabbed: the bar names both lists, so the per-list headings would say the
+     active tab's label twice. */
+  #lists.tabbed #recent .head, #lists.tabbed #artifacts .head { display: none; }
   #recent .head {
     color: var(--faint);
     font-size: 11px;
@@ -1902,6 +2009,68 @@
   .snap-note { color: var(--faint); flex-basis: 100%; }
   .snap-err { color: var(--error); }
   #snapsnote { color: var(--faint); font-size: 11.5px; padding: 4px; }
+
+  /* Artifacts: the pages Claude PUBLISHED from this target's working directory.
+     Now the SECOND HALF of #lists rather than a third stack of its own, and
+     styled as the same thing — the same quiet uppercase label (when it is alone
+     and has to carry one) over the same bordered pressable rows as #recent and
+     #snaps, because it answers the same shape of question and a fourth visual
+     idiom on one screen would only make the other three look accidental.
+     ALWAYS EXPANDED: the read is one localhost call made with the landing page,
+     so by the time the section exists the rows are already in hand and
+     collapsing them would hide what was just paid for. The `hide ▾` that used
+     to sit on the head line is GONE — in the tabbed case the tab bar is already
+     the control for which list shows (a second one for the same box, in a
+     different type system, beside a label that is itself a control), and in the
+     single-list case the section is high in a tighter column now, so the thing
+     it was protecting — the composer's own history below it — is no longer
+     below it. */
+  #artifacts { margin-top: 0; }
+  #artifacts .head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--faint);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: .8px;
+    text-transform: uppercase;
+    margin-bottom: 8px;
+    padding: 0 4px;
+  }
+  .art-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 14px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    margin-bottom: 6px;
+    font-size: 12.5px;
+    cursor: pointer;
+    background: transparent;
+    transition: background .12s, border-color .12s;
+  }
+  .art-row:hover { background: var(--surface); border-color: var(--border-strong); }
+  .art-row:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+  /* The favicon, in BOTH places an artifact is drawn (a landing row and a live
+     chip) — one rule, because it is one thing: the emoji the author chose, sized
+     to sit on the text baseline without stretching the line. */
+  .art-ic { flex-shrink: 0; font-size: 13px; line-height: 1; }
+  .art-chip .art-ic { font-size: 12px; }
+  .art-row .art-title { color: var(--fg); flex: 1; overflow: hidden;
+                        text-overflow: ellipsis; white-space: nowrap; }
+  .art-row .art-when { color: var(--faint); flex-shrink: 0; }
+  /* The hosted-page opener reads as a small BUTTON, not a bare glyph: it is
+     the one control on the row that leaves the app (deployed preview), so it
+     gets a bordered hit target — globe icon inside. */
+  .art-row .art-go { color: var(--faint); flex-shrink: 0; text-decoration: none;
+                     display: inline-flex; align-items: center; justify-content: center;
+                     width: 24px; height: 24px; border: 1px solid var(--border);
+                     border-radius: 6px; }
+  .art-row .art-go svg { display: block; }
+  .art-row .art-go:hover { color: var(--link); border-color: var(--link); }
+  #artifactscount { font-weight: 400; letter-spacing: 0; }
 
   .chat-row {
     display: flex;
@@ -2268,6 +2437,11 @@
         </div>
       </div>
     </form>
+    <!-- Pages published during this conversation, above the footnote so a chip
+         appearing never moves the composer the user is typing into. Empty (and
+         `hidden`) until a publish is seen — see the #artstrip rule for why the
+         attribute and not a style. -->
+    <div id="artstrip" hidden aria-label="Pages Claude published in this chat"></div>
     <!-- The second piece of chrome that names the target (the composer
          placeholder is the first), and it ships the kind-FREE wording for the
          same reason: the kind is not known until stat answers, and a sentence
@@ -2304,9 +2478,39 @@
             </button>
           </div>
         </form>
-        <div id="recent">
-          <div class="head">Recent chats</div>
-          <div id="recentlist"></div>
+        <!-- The two cross-session lists for this target, in ONE block: past
+             chats and every page published from here. Both are read as the
+             landing page mounts, so switching between them is a class change
+             and never a round trip.
+             The TAB BAR only exists when both lists have something in them
+             (syncLists) — with one list it would be a single tab, which is a
+             heading that can be clicked, and the plain .head below is the
+             honest version of that. -->
+        <div id="lists">
+          <div id="listtabs" hidden role="tablist" aria-label="Past chats and published pages">
+            <button class="list-tab" type="button" role="tab" id="tab-recent"
+                    aria-selected="true" aria-controls="recent">Recent chats</button>
+            <button class="list-tab" type="button" role="tab" id="tab-artifacts"
+                    aria-selected="false" aria-controls="artifacts">Artifacts<span
+                    class="tab-count" id="tabartcount"></span></button>
+          </div>
+          <!-- Both ship `hidden`: which of them shows (and whether either does)
+               is not known until the two reads answer, and a section that
+               appears and then empties is worse than one that arrives late. -->
+          <div id="recent" hidden>
+            <div class="head">Recent chats</div>
+            <div id="recentlist"></div>
+          </div>
+          <!-- Every page Claude has published from this target's working
+               directory, across every past session — the one product of a chat
+               that outlives it and is not on disk. -->
+          <div id="artifacts" hidden>
+            <div class="head">
+              <span>Artifacts</span>
+              <span id="artifactscount"></span>
+            </div>
+            <div id="artifactslist"></div>
+          </div>
         </div>
         <!-- Claude Code's own file-history checkpoints for this file (SPEC
              §34). Ported from the superseded `annotate` template, whose reader
@@ -5930,13 +6134,21 @@ document.getElementById("back").onclick = () => {
   resetCardPolicy();  // ...and the collapse overrides: that transcript is gone
   chatEl.classList.add("home");
   document.getElementById("recentlist").innerHTML = "";
-  document.getElementById("recent").style.display = "";
   // Deliberately NOT awaited in sequence with the mount below: these are two
   // independent reads and neither should hold the other's section blank. What
   // makes that safe is that `loadRecent` repaints the run headings itself once it
   // has names — see the tail of that function — rather than this call site being
   // ordered so it happens to win.
+  // The two counts are deliberately NOT reset here, unlike the log above: both
+  // reads are about to run again and land within a few hundred ms, and clearing
+  // them first would take the tab bar off screen and put it back for the trip —
+  // a stale count for a moment is quieter than a section that blinks. Boot is
+  // the only place the "not read yet" state is real.
   loadRecent();
+  // The chips belonged to the conversation being left; the section below the
+  // composer is the cross-session view and is re-read from the index instead.
+  clearArtStrip();
+  loadArtifacts();
   // The snapshots panel belongs to the LANDING page, so it is offered on every
   // path onto it — not just the boot with no session. A page opened straight
   // into a resumed chat (`?session_id=`) never ran the boot's landing branch, so
@@ -6828,6 +7040,52 @@ function showPermissionCard(card, working) {
   scrollBottom();
 }
 
+// An ANSWERED card belongs where it was answered. While a card is open it lives
+// at the bottom of the log, right above the working line, because that is where
+// a control the run is blocked on has to be — but the turn's prose and tool
+// chips all render INSIDE the one streaming `reply` bubble, which sits above it.
+// So every segment produced after the click appended above the card, and a
+// decision the user made in the middle of a turn slid down the page and stuck to
+// the bottom of the log for the rest of it: a receipt filed after everything it
+// came before. (See `.perm.resolved` — the card was always meant to "keep its
+// place in the transcript"; the pinning was an artifact of where it was mounted,
+// not a decision.)
+//
+// So on resolve the card moves once, into the live turn's segment container at
+// its current tail. renderSegments only ever appends its own views and removes
+// its own views (tracked by index in segStates), so a foreign child at the tail
+// keeps its spot and everything rendered afterwards lands below it — which is
+// exactly chronological order. The container is published by pollLoop only AFTER
+// the one `segBody.replaceChildren()` of the legacy→segment flip, so that sweep
+// can never take a parked card with it.
+//
+// Two things are deliberately left alone:
+//   * no live turn (a decision that landed after the run ended, or a card
+//     re-attached with its verdict already on disk) leaves the card where it is,
+//     i.e. today's behaviour;
+//   * an errored run drops its whole bubble (keepText false) and a parked card
+//     goes with it. The chip-ask tool chip is the durable record of the exchange
+//     and is already in the transcript, so nothing is lost that a reload would
+//     have kept.
+function parkResolvedCard(card) {
+  const seg = activeSegBody;
+  const el = card && card.el;
+  if (!seg || !seg.isConnected || !el || !el.isConnected) return;
+  if (el.parentNode === seg) return;   // already filed; do not drag it to the tail again
+  // The move reflows everything between the card's old and new home, so read the
+  // viewport first. Sticking to the bottom is the log's own rule while a run
+  // streams (see the typer's nearBottom check); otherwise the most this may do
+  // is keep the card the user was just looking at on screen — scrolling a reader
+  // who is somewhere else entirely would be the move yanking the page.
+  const atBottom = nearBottom();
+  const box = el.getBoundingClientRect();
+  const port = logwrap.getBoundingClientRect();
+  const wasVisible = box.bottom > port.top && box.top < port.bottom;
+  seg.appendChild(el);
+  if (atBottom) scrollBottom();
+  else if (wasVisible) el.scrollIntoView({ block: "nearest" });
+}
+
 // Reconcile the poll's request list with what is on screen. Idempotent — poll
 // replays the whole list every 400 ms.
 function syncPermissions(list, run_id, working, liveMode) {
@@ -6844,7 +7102,14 @@ function syncPermissions(list, run_id, working, liveMode) {
     // `answers` is only ever set on a question card, and it is why poll carries
     // it: a frame that re-attaches after the click has to be able to show what
     // was chosen, not just that something was.
-    if (p.decision) card.resolve(p.decision, p.scope, p.mode, p.answers);
+    if (p.decision) {
+      card.resolve(p.decision, p.scope, p.mode, p.answers);
+      // Filed here rather than inside the card's own click handler: `decision` on
+      // the poll is the verdict that LANDED on disk, and the poll is also the only
+      // thing that reports a card the run expired or a decision this frame did not
+      // make. One move, from whichever of those settles the card first.
+      parkResolvedCard(card);
+    }
   }
 }
 
@@ -7778,6 +8043,12 @@ async function answerAppState(list, run_id, working) {
 // button and Escape have something to aim at, which covers a re-attached run too.
 let activeRun = null;
 let activeWorking = null;
+// The live turn's segment container, or null between turns. Published by pollLoop
+// once the segment path owns the bubble, and read by parkResolvedCard — which is
+// the one thing outside the loop that has to put something INTO the turn being
+// streamed. Nulled in the loop's `finally`, so a decision that arrives after the
+// run is over cannot file itself into a finished (or removed) bubble.
+let activeSegBody = null;
 // Keyed by id, not a bare boolean: it is read when a run ENDS, and a stale flag
 // would label the next turn's ending as a stop too.
 let stoppedRun = "";
@@ -8114,10 +8385,17 @@ async function pollLoop(run_id) {
   let segBody = null;    // the element the segment views are rendered into
   let segMode = false;   // this turn returned segments, so they are the truth
   let tailText = null;   // the trailing text segment, for typer.finish()
+  // Ticks of THIS loop, so the artifacts read below is one in every eight polls
+  // (~3.2s) rather than one every 400ms: a publish is a rare event in a turn and
+  // a transcript read is an open() of a file that is being appended to.
+  let tick = 0;
   try {
     while (true) {
       const data = await fused.runPython(AGENT, { action: "poll", run_id }, { key: null });
       if (data.session_id) { fused.params.set("session_id", String(data.session_id)); showSession(); }
+      // Not awaited, for the same reason the app-state answer below is not: a
+      // strip of chips may never hold up the streaming reply by a single frame.
+      if (tick++ % 8 === 0) pollArtifacts();
       // usage arrives only at message end; estimate from streamed text meanwhile
       const tokens = Math.max(data.tokens || 0, Math.round((data.text || "").length / 4));
       w.setStats(tokens, data.phase || "thinking", data.retry);
@@ -8150,6 +8428,11 @@ async function pollLoop(run_id) {
             segMode = true;
             typer.retarget(null);
             segBody.replaceChildren();
+            // Published only NOW, and this is the reason: the line above is the
+            // one and only sweep this container ever sees, so a resolved card
+            // parked into it afterwards (parkResolvedCard) can never be swept
+            // away. Before the flip there is nothing to park into anyway.
+            activeSegBody = segBody;
           }
           tailText = renderSegments(segBody, segs, { typer });
         } else if (!data.done) typer.update(data.text);
@@ -8166,6 +8449,9 @@ async function pollLoop(run_id) {
         // The turn may have edited the file, and Claude Code checkpoints what it
         // edits — so the snapshots panel's cached timeline is now behind.
         snapInvalidate();
+        // One last read: a page published in the final seconds of the turn would
+        // otherwise sit unmentioned until the user went back to the landing page.
+        pollArtifacts();
         const end = runEnding(data, stoppedRun === run_id);
         if (!end.keepText) {
           if (typer) typer.abort();
@@ -8208,6 +8494,7 @@ async function pollLoop(run_id) {
     // the NEXT turn's ending as a stop.
     activeRun = null;
     activeWorking = null;
+    activeSegBody = null;
     setRunningUi(false);
   }
 }
@@ -8600,15 +8887,72 @@ function renderRecentSkeleton(list) {
   });
 }
 
+// ── the landing page's two cross-session lists, and the tab bar over them ──
+//
+// #recent and #artifacts answer the same question about the same target — what
+// has happened here before — from two different stores, so they share one block
+// and, when both have something to say, one tab bar. Neither is the page's
+// subject (the composer is), so the whole thing is allowed to be absent.
+//
+// The counts are the state: `null` means the read has not answered yet, which is
+// NOT the same as zero — a skeleton is drawn into #recent while the sessions
+// read is in flight, and it has to be on screen to be a skeleton of anything.
+let recentCount = null;
+let artCount = null;
+// Which list is showing, and it is the BLOCK's state rather than the page's:
+// leaving for a chat and coming back keeps the tab you were on, the same way
+// `snapExpanded` survives that round trip.
+let listTab = "recent";
+
+function syncLists() {
+  // Tabs only when BOTH lists really have rows: one tab is a heading with a
+  // pointer cursor, and the plain .head each section carries is the honest
+  // version of it.
+  const tabbed = recentCount > 0 && artCount > 0;
+  document.getElementById("lists").classList.toggle("tabbed", tabbed);
+  document.getElementById("listtabs").hidden = !tabbed;
+  // `null > 0` is false, which is why the loading case is spelled out: unread
+  // recent chats still show (the skeleton), unread artifacts do not (there is
+  // nothing to stand in for, and the section may well never exist).
+  document.getElementById("recent").hidden =
+    tabbed ? listTab !== "recent" : !(recentCount === null || recentCount > 0);
+  document.getElementById("artifacts").hidden =
+    tabbed ? listTab !== "artifacts" : !(artCount > 0);
+  for (const [name, id] of [["recent", "tab-recent"], ["artifacts", "tab-artifacts"]]) {
+    const tab = document.getElementById(id);
+    tab.setAttribute("aria-selected", listTab === name ? "true" : "false");
+    // Only the selected tab is in the tab order, which is what a tablist means:
+    // Tab enters the bar, arrows move inside it.
+    tab.tabIndex = listTab === name ? 0 : -1;
+  }
+}
+
+function selectListTab(name) {
+  listTab = name;
+  syncLists();
+}
+for (const [name, id] of [["recent", "tab-recent"], ["artifacts", "tab-artifacts"]]) {
+  const tab = document.getElementById(id);
+  tab.onclick = () => selectListTab(name);
+  tab.onkeydown = (e) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    e.preventDefault();
+    const other = name === "recent" ? "artifacts" : "recent";
+    selectListTab(other);
+    document.getElementById(other === "recent" ? "tab-recent" : "tab-artifacts").focus();
+  };
+}
+
 async function loadRecent() {
   const list = document.getElementById("recentlist");
   renderRecentSkeleton(list);
+  syncLists();  // the skeleton needs its section shown
   try {
     const { sessions, error } = await fused.runPython(AGENT, { action: "sessions", file: FILE }, { key: null });
     if (error) throw new Error(error);
     list.innerHTML = "";  // drop the skeleton now that we know the real state
     // Name the snapshot runs from the SAME strings these rows are labelled with,
-    // before the early return: a file can have chains in the store and no chats in
+    // even for an empty list: a file can have chains in the store and no chats in
     // its sidecar, and the reverse — an empty session list is still an answer the
     // snapshots panel wants (it means "name nothing"), not a reason to skip.
     let named = false;
@@ -8627,14 +8971,177 @@ async function loadRecent() {
     // names, or no panel yet) costs nothing, and it repaints from the cached
     // timeline rather than re-reading anything.
     if (named && snapTimeline) renderSnapshots(snapTimeline);
-    if (!sessions.length) {
-      document.getElementById("recent").style.display = "none";
-      return;
-    }
+    // No early return and no inline display write for the empty case: the count
+    // drives the section's visibility through syncLists (hidden/classes), the
+    // same way the artifacts list is shown and hidden.
+    recentCount = sessions.length;
     for (const s of sessions) addChatRow(list, s);
   } catch (err) {
     list.innerHTML = "";
+    // A list that could not be read is not a list with nothing in it, but it
+    // renders the same way here: no heading, no empty state, no error.
+    recentCount = 0;
     console.warn("session list failed:", err.message);
+  }
+  syncLists();
+}
+
+// ── Artifacts: the pages Claude published from this target ──
+//
+// TWO views of one thing, from one backend (./artifacts.py):
+//   * the landing page's #artifacts section — every artifact ever published from
+//     this target's workdir, from the server's cross-session index ("list");
+//   * the live #artstrip during a turn — the CURRENT session's transcript, read
+//     straight off disk ("live"), so a page announces itself seconds after it is
+//     published instead of at the next landing.
+// Neither is load-bearing: every failure below is a console warning and an
+// absent section, never the error overlay. A chat whose artifacts cannot be
+// listed is still a working chat.
+const ARTIFACTS = "./artifacts.py";
+
+// Mirrors the shell codec (router.ts urlForFsPath), same as the peer templates
+// that link out to the explorer: normalize ONLY drive-letter paths, because a
+// backslash is a legal POSIX filename char and must round-trip.
+function artOpenHref(path) {
+  const norm = /^[A-Za-z]:[\\/]/.test(path) ? String(path).replace(/\\/g, "/") : String(path);
+  const segs = norm.replace(/^\/+/, "").split("/").filter(Boolean).map(encodeURIComponent);
+  return "/explorer/view/" + segs.join("/");
+}
+
+// The title the page published under, falling back to the file's basename: a
+// publish that let the HTML's own <title> name it gets nothing echoed back, and
+// an untitled row is worse than a filename.
+function artLabel(a) {
+  return a.title || String(a.file_path || "").split(/[\\/]/).pop() || a.remote_url;
+}
+
+function addArtifactRow(list, a) {
+  const row = document.createElement("div");
+  row.className = "art-row";
+  row.innerHTML =
+    '<span class="art-ic"></span><span class="art-title"></span>' +
+    '<span class="art-when"></span>' +
+    '<a class="art-go" target="_blank" rel="noopener noreferrer" title="Open the published page" aria-label="Open the published page">' +
+    '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+    '<circle cx="12" cy="12" r="10"/><path d="M2 12h20"/>' +
+    '<path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></a>';
+  // Emoji, not markup: the favicon is author-chosen text from a transcript, so
+  // it goes in through textContent like every other field on this row.
+  row.querySelector(".art-ic").textContent = a.favicon || "◻";
+  row.querySelector(".art-title").textContent = artLabel(a);
+  row.querySelector(".art-when").textContent = ago(a.updated_at || a.created_at || 0);
+  row.querySelector(".art-go").href = a.remote_url;
+  // The ↗ is the ONE place the hosted page opens; a click on it must not also
+  // count as a click on the row (which opens the local file instead).
+  row.querySelector(".art-go").onclick = (e) => e.stopPropagation();
+  // The row's own subject is the LOCAL file — the thing this window can show.
+  // Always pressable: `list` returns only artifacts whose source is still on
+  // disk (artifacts.py filters on `exists`), so there is no unpressable row to
+  // style or explain here any more. The guard stays on `file_path` alone,
+  // because a row with no local path has nothing for a press to open.
+  if (a.file_path) {
+    row.setAttribute("role", "button");
+    row.tabIndex = 0;
+    row.title = a.file_path;
+    // A new tab, not this frame: this window is a chat (often a pane of a
+    // split), and navigating it away would end the conversation.
+    const open = () => window.open(artOpenHref(a.file_path), "_blank", "noopener");
+    row.onclick = open;
+    row.onkeydown = (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); open(); } };
+  }
+  list.appendChild(row);
+}
+
+// The landing page's read. Called on every path ONTO the landing page (boot and
+// the back button), not once per page life: a turn that just published a page
+// must be able to leave it behind here.
+//
+// Whether the rows end up under a heading or behind a tab is syncLists's call —
+// this function only ever reports how many there are. It never collapses them:
+// the read is one localhost call made with the landing page, so by the time
+// there is anything to draw it is already paid for.
+async function loadArtifacts() {
+  const list = document.getElementById("artifactslist");
+  try {
+    const { artifacts, error } = await fused.runPython(
+      ARTIFACTS, { action: "list", file: FILE }, { key: null });
+    if (error) throw new Error(error);
+    list.innerHTML = "";
+    // Nothing published from here is the common case — so no heading, no tab, no
+    // empty state, no row saying so. The section simply is not there.
+    artCount = (artifacts || []).length;
+    for (const a of artifacts || []) addArtifactRow(list, a);
+    const count = "· " + artCount;
+    document.getElementById("artifactscount").textContent = count;
+    // The tab carries the count too, because in the tabbed case the heading that
+    // used to carry it is not drawn.
+    document.getElementById("tabartcount").textContent = " " + count;
+  } catch (err) {
+    // No visible failure: an unreachable index is not news on a landing page
+    // whose subject is the composer above it.
+    console.warn("artifacts list failed:", err.message);
+    artCount = 0;
+  }
+  syncLists();
+}
+
+// ── the live strip ──
+//
+// ACCUMULATING, keyed by url: the poll below reads the transcript of whichever
+// session is current, and a chip must not vanish because a turn ended or a
+// later read raced. Cleared only by leaving for the landing page (a different
+// conversation's pages are not this one's) or by a reload.
+const artChips = new Map();
+
+function renderArtStrip() {
+  const strip = document.getElementById("artstrip");
+  strip.replaceChildren();
+  for (const a of artChips.values()) {
+    const chip = document.createElement("a");
+    chip.className = "art-chip";
+    chip.href = a.remote_url;
+    chip.target = "_blank";
+    chip.rel = "noopener noreferrer";
+    chip.title = "Open " + artLabel(a);
+    chip.innerHTML = '<span class="art-ic"></span><span class="art-chip-lbl"></span>' +
+                     '<span class="art-chip-go">↗</span>';
+    chip.querySelector(".art-ic").textContent = a.favicon || "◻";
+    chip.querySelector(".art-chip-lbl").textContent = artLabel(a);
+    strip.appendChild(chip);
+  }
+  strip.hidden = artChips.size === 0;
+}
+
+function clearArtStrip() {
+  artChips.clear();
+  renderArtStrip();
+}
+
+// One transcript read. Deliberately dumb: re-absorb the whole returned list
+// every time and let the Map dedupe, rather than tracking what was already
+// seen — the list is a handful of entries and a publish that arrives twice must
+// be idempotent anyway (a redeploy reports the same url again).
+async function pollArtifacts() {
+  const session_id = fused.params.get("session_id");
+  if (!session_id) return;  // no session yet: nothing has been written to read
+  try {
+    const { artifacts } = await fused.runPython(
+      ARTIFACTS, { action: "live", session_id, file: FILE }, { key: null });
+    if (!artifacts || !artifacts.length) return;
+    // Change detection is by CONTENT, not by count: the favicon/title join can
+    // land a poll or two after the frame-link (the tool_use streams later in
+    // the transcript), so an already-seen url can gain metadata without the
+    // set growing. Still no rebuild when nothing changed — this runs every few
+    // seconds beside a streaming reply, and rebuilding an unchanged strip
+    // would drop the user's mid-click on a chip.
+    const sig = (m) => Array.from(m.values(), (a) =>
+      a.remote_url + "\u0000" + (a.title || "") + "\u0000" + (a.favicon || "")).join("\u0001");
+    const before = sig(artChips);
+    for (const a of artifacts) artChips.set(a.remote_url, a);
+    if (sig(artChips) !== before) renderArtStrip();
+  } catch (err) {
+    // A poll for decoration must never interrupt the poll for the reply.
+    console.warn("artifacts poll failed:", err.message);
   }
 }
 
@@ -9166,6 +9673,10 @@ async function loadSnapshots() {
     // re-attach nothing.
     restoreQueue(session_id, run_id);
     if (session_id) await loadHistory(session_id);
+    // The chips this session already earned. The poll loop rebuilds them while a
+    // run streams, but a resumed conversation with nothing in flight never
+    // reaches that loop — and its pages are no less published for it.
+    if (session_id) pollArtifacts();
     if (run_id) await resumeRun(run_id);
     // The run this queue was parked behind may have finished while no frame was
     // attached (`resumeRun` takes the done branch and never polls), and then
@@ -9183,6 +9694,10 @@ async function loadSnapshots() {
     focusBox(homebox);
     await loadRecent();
     await mountSnapshots();
+    // Last of the three landing reads, and unawaited by nothing above it on
+    // purpose: it is the only one that leaves the machine (a localhost call to
+    // the artifacts index), so it must not sit in front of the session list.
+    loadArtifacts();
   }
 })();
 </script>

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -283,9 +283,9 @@ def test_mount_backed_file_is_not_stated_and_reports_not_local(
     client, projects_dir, tmp_path, monkeypatch
 ):
     # A path under the mounts dir must never reach the kernel stat — that
-    # GETATTR is what wedges a dead mount, once per card per listing. The card
-    # falls back to its hosted link, so False is the safe answer even when the
-    # remote file is really there.
+    # GETATTR is what wedges a dead mount, once per card per listing. `exists`
+    # is None there, not False: "not checked" is a different claim from "gone
+    # from disk", and a UI that hides the known-gone must not also hide these.
     from fused_render.shell.mounts import access as mounts_access
 
     page = tmp_path / "mounts-root" / "s3" / "page.html"
@@ -300,7 +300,7 @@ def test_mount_backed_file_is_not_stated_and_reports_not_local(
     monkeypatch.setattr(claude_artifacts_mod.os.path, "isfile",
                         lambda p: (stats.append(p), real_isfile(p))[1])
     artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
-    assert artifacts[0]["exists"] is False
+    assert artifacts[0]["exists"] is None
     assert str(page) not in stats
 
 

--- a/tests/test_claude_artifacts_api.py
+++ b/tests/test_claude_artifacts_api.py
@@ -1,0 +1,324 @@
+"""GET /api/claude-artifacts (server/routers/claude_artifacts.py): the Artifacts
+published from this machine's Claude Code sessions, recovered from the session
+transcripts at ~/.claude/projects/<encoded-cwd>/*.jsonl — one row per hosted
+url no matter how many times it was republished (or from how many sessions),
+newest update first, with the author's description/favicon joined in from the
+Artifact tool call and `exists` reporting whether the published local file is
+still there.
+"""
+import json
+import shutil
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fused_render import claude_artifacts as claude_artifacts_mod
+from fused_render.server import create_app
+
+URL_A = "https://claude.ai/code/artifact/aaaaaaaa-0000-0000-0000-000000000000"
+URL_B = "https://claude.ai/code/artifact/bbbbbbbb-0000-0000-0000-000000000000"
+
+
+@pytest.fixture()
+def projects_dir(tmp_path, monkeypatch):
+    d = tmp_path / "claude-projects"
+    d.mkdir()
+    monkeypatch.setattr(claude_artifacts_mod, "PROJECTS_DIR", str(d))
+    # The per-transcript cache is module-level and keyed by absolute path, so a
+    # tmp path can't collide with another test's — but reset it anyway so a test
+    # that rewrites a transcript in place (same size, same mtime second) can't
+    # be served a stale parse.
+    claude_artifacts_mod.reset_cache()
+    return d
+
+
+@pytest.fixture()
+def client(tmp_path):
+    return TestClient(create_app(start_dir=str(tmp_path)))
+
+
+def _frame_link(session_id, path, url, title, timestamp):
+    return {"type": "frame-link", "sessionId": session_id, "path": str(path),
+            "frameUrl": url, "title": title, "timestamp": timestamp}
+
+
+def _publish(path, **extra):
+    """An assistant record carrying one Artifact tool call, the only place the
+    author's description/favicon appear."""
+    return {"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(path), **extra}}]}}
+
+
+def _session(projects_dir, encoded_dir, session_id, cwd, records):
+    d = projects_dir / encoded_dir
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{session_id}.jsonl"
+    lines = [json.dumps({"cwd": cwd, "sessionId": session_id,
+                         "timestamp": "2026-01-01T00:00:00Z"})]
+    lines += [r if isinstance(r, str) else json.dumps(r) for r in records]
+    path.write_text("\n".join(lines) + "\n")
+    return path
+
+
+def test_lists_publish_with_tool_call_metadata_merged(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("<title>Bali</title>")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, favicon="\U0001f93f", description="Course picker."),
+        _frame_link("s1", page, URL_A, "Bali Open Water", "2026-07-16T09:43:32.223Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["file_path"] == str(page)
+    assert entry["remote_url"] == URL_A
+    assert entry["title"] == "Bali Open Water"
+    assert entry["description"] == "Course picker."
+    assert entry["favicon"] == "\U0001f93f"
+    assert entry["session_id"] == "s1"
+    assert entry["cwd"] == "/tmp/proj"
+    assert entry["exists"] is True
+    assert entry["created_at"] == entry["updated_at"] == pytest.approx(1784195012.223)
+
+
+def test_republished_page_is_one_row_with_latest_title_and_full_span(
+    client, projects_dir, tmp_path
+):
+    # Every redeploy writes another frame-link for the same frameUrl. That is one
+    # artifact with a history: newest publish wins for what's shown, and the
+    # dates span first publish to last.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, description="first pass"),
+        _frame_link("s1", page, URL_A, "First Title", "2026-07-16T09:00:00.000Z"),
+        _publish(page, description="second pass", favicon="\U0001f422"),
+        _frame_link("s1", page, URL_A, "Latest Title", "2026-07-16T11:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["title"] == "Latest Title"
+    # Latest tool call wins for the metadata too.
+    assert entry["description"] == "second pass"
+    assert entry["favicon"] == "\U0001f422"
+    assert entry["created_at"] == pytest.approx(1784192400.0)
+    assert entry["updated_at"] == pytest.approx(1784199600.0)
+
+
+def test_exists_reports_whether_the_published_file_is_still_there(
+    client, projects_dir, tmp_path
+):
+    # Artifacts are routinely published from scratchpads that get cleaned up.
+    here = tmp_path / "here.html"
+    here.write_text("<title>here</title>")
+    gone = tmp_path / "gone.html"  # never created
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", here, URL_A, "Here", "2026-07-16T10:00:00.000Z"),
+        _frame_link("s1", gone, URL_B, "Gone", "2026-07-16T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert {a["file_path"]: a["exists"] for a in artifacts} == {
+        str(here): True, str(gone): False}
+
+
+def test_missing_projects_dir_is_empty_not_an_error(client, projects_dir):
+    shutil.rmtree(projects_dir)
+    assert client.get("/api/claude-artifacts").json() == {"artifacts": []}
+
+
+def test_malformed_lines_and_list_calls_are_skipped(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        '{"type": "frame-link", "path": "/x", truncated',  # unparseable, skipped
+        # An `action: "list"` call publishes nothing, and neither does a call
+        # with no file_path — neither may contribute metadata.
+        _publish(page, description="from a list call", action="list"),
+        {"type": "assistant", "message": {"role": "assistant", "content": [
+            {"type": "tool_use", "name": "Artifact",
+             "input": {"action": "list", "description": "no file_path"}}]}},
+        _publish(page, description="real publish"),
+        _frame_link("s1", page, URL_A, "Real", "2026-07-16T10:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert [(a["remote_url"], a["description"]) for a in artifacts] == [
+        (URL_A, "real publish")]
+
+
+def test_tool_call_without_a_frame_link_is_not_listed(client, projects_dir, tmp_path):
+    # The frame-link is the authoritative publish record; without one there is
+    # no hosted url, so there is nothing to list.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, description="never landed"),
+    ])
+    assert client.get("/api/claude-artifacts").json() == {"artifacts": []}
+
+
+def test_same_url_published_from_two_sessions_collapses_to_one_row(
+    client, projects_dir, tmp_path
+):
+    # An artifact can be updated from a later session via the tool's `url`
+    # param, so the dedupe has to run across transcripts, not just within one.
+    first = tmp_path / "first.html"
+    first.write_text("x")
+    second = tmp_path / "second.html"
+    second.write_text("x")
+    _session(projects_dir, "-tmp-a", "old", "/tmp/a", [
+        _publish(first, description="original"),
+        _frame_link("old", first, URL_A, "Original", "2026-07-16T09:00:00.000Z"),
+    ])
+    _session(projects_dir, "-tmp-b", "new", "/tmp/b", [
+        _publish(second, description="updated elsewhere"),
+        _frame_link("new", second, URL_A, "Updated", "2026-07-17T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    # Latest publish owns every display field, including which session/cwd it
+    # is now being worked on from; created_at is still the first publish.
+    assert entry["title"] == "Updated"
+    assert entry["description"] == "updated elsewhere"
+    assert entry["file_path"] == str(second)
+    assert entry["session_id"] == "new"
+    assert entry["cwd"] == "/tmp/b"
+    assert entry["created_at"] == pytest.approx(1784192400.0)
+    assert entry["updated_at"] == pytest.approx(1784278800.0)
+
+
+def test_sorted_newest_update_first(client, projects_dir, tmp_path):
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-a", "s1", "/tmp/a", [
+        _frame_link("s1", page, URL_A, "Older", "2026-07-16T09:00:00.000Z"),
+    ])
+    _session(projects_dir, "-tmp-b", "s2", "/tmp/b", [
+        _frame_link("s2", page, URL_B, "Newer", "2026-07-20T09:00:00.000Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert [a["title"] for a in artifacts] == ["Newer", "Older"]
+
+
+def test_unchanged_transcript_is_not_reparsed_but_exists_stays_live(
+    client, projects_dir, tmp_path, monkeypatch
+):
+    # The per-file cache is what makes a repeat request cheap against a
+    # hundreds-of-MB transcript store; `exists` is deliberately outside it.
+    page = tmp_path / "page.html"
+    page.write_text("x")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", page, URL_A, "Cached", "2026-07-16T10:00:00.000Z"),
+    ])
+    assert client.get("/api/claude-artifacts").json()["artifacts"][0]["exists"] is True
+
+    calls = []
+    real_parse = claude_artifacts_mod._parse_transcript
+    monkeypatch.setattr(
+        claude_artifacts_mod, "_parse_transcript",
+        lambda p: (calls.append(p), real_parse(p))[1])
+    page.unlink()
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert calls == []
+    assert artifacts[0]["exists"] is False
+
+
+def test_parallel_publishes_in_one_message_all_keep_their_metadata(
+    client, projects_dir, tmp_path
+):
+    # One assistant message can carry several Artifact tool calls (parallel tool
+    # use). Each publish keeps its own description/favicon — taking only the
+    # message's first call would strip the later ones.
+    page_a, page_b = tmp_path / "a.html", tmp_path / "b.html"
+    both = {"type": "assistant", "message": {"role": "assistant", "content": [
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(page_a), "favicon": "🅰️", "description": "First."}},
+        {"type": "tool_use", "name": "Artifact",
+         "input": {"file_path": str(page_b), "favicon": "🅱️", "description": "Second."}},
+    ]}}
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        both,
+        _frame_link("s1", page_a, URL_A, "A", "2026-07-16T09:00:00Z"),
+        _frame_link("s1", page_b, URL_B, "B", "2026-07-16T09:00:01Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    by_url = {a["remote_url"]: a for a in artifacts}
+    assert by_url[URL_A]["description"] == "First."
+    assert by_url[URL_A]["favicon"] == "🅰️"
+    assert by_url[URL_B]["description"] == "Second."
+    assert by_url[URL_B]["favicon"] == "🅱️"
+
+
+def test_republish_without_description_keeps_the_earlier_metadata(
+    client, projects_dir, tmp_path
+):
+    # A republish routinely omits the optional description/favicon — that means
+    # "unchanged", not "cleared". Within a session the tool inputs merge; across
+    # sessions the newer row inherits any display field it didn't carry.
+    page = tmp_path / "page.html"
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _publish(page, favicon="🐢", description="The summary."),
+        _frame_link("s1", page, URL_A, "First", "2026-07-16T09:00:00Z"),
+        _publish(page),  # update: no description, no favicon
+        _frame_link("s1", page, URL_A, "Second", "2026-07-16T10:00:00Z"),
+    ])
+    # And an update from a DIFFERENT session (via the tool's url parameter),
+    # whose transcript never carried the original metadata at all.
+    _session(projects_dir, "-tmp-other", "s2", "/tmp/other", [
+        _publish(page, url=URL_A),
+        _frame_link("s2", page, URL_A, "Third", "2026-07-16T11:00:00Z"),
+    ])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert len(artifacts) == 1
+    entry = artifacts[0]
+    assert entry["title"] == "Third"
+    assert entry["description"] == "The summary."
+    assert entry["favicon"] == "🐢"
+    assert entry["session_id"] == "s2"
+
+
+def test_mount_backed_file_is_not_stated_and_reports_not_local(
+    client, projects_dir, tmp_path, monkeypatch
+):
+    # A path under the mounts dir must never reach the kernel stat — that
+    # GETATTR is what wedges a dead mount, once per card per listing. The card
+    # falls back to its hosted link, so False is the safe answer even when the
+    # remote file is really there.
+    from fused_render.shell.mounts import access as mounts_access
+
+    page = tmp_path / "mounts-root" / "s3" / "page.html"
+    page.parent.mkdir(parents=True)
+    page.write_text("<title>On a mount</title>")
+    monkeypatch.setattr(mounts_access, "mounts_dir", lambda: str(tmp_path / "mounts-root"))
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", page, URL_A, "Mounted", "2026-07-16T09:00:00Z"),
+    ])
+    stats = []
+    real_isfile = claude_artifacts_mod.os.path.isfile
+    monkeypatch.setattr(claude_artifacts_mod.os.path, "isfile",
+                        lambda p: (stats.append(p), real_isfile(p))[1])
+    artifacts = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert artifacts[0]["exists"] is False
+    assert str(page) not in stats
+
+
+def test_cwd_param_scopes_listing_to_one_directory(client, projects_dir, tmp_path):
+    # ?cwd= narrows the listing to sessions run in that directory — the claude
+    # template's "artifacts for this file/folder" section. Comparison is on the
+    # canonical form, so a caller may pass either spelling of the path.
+    page_a, page_b = tmp_path / "a.html", tmp_path / "b.html"
+    page_a.write_text("<title>A</title>")
+    page_b.write_text("<title>B</title>")
+    _session(projects_dir, "-tmp-proj", "s1", "/tmp/proj", [
+        _frame_link("s1", page_a, URL_A, "A", "2026-07-16T09:00:00Z"),
+    ])
+    _session(projects_dir, "-tmp-other", "s2", "/tmp/other", [
+        _frame_link("s2", page_b, URL_B, "B", "2026-07-16T09:00:01Z"),
+    ])
+    scoped = client.get("/api/claude-artifacts", params={"cwd": "/tmp/proj"}).json()["artifacts"]
+    assert [a["remote_url"] for a in scoped] == [URL_A]
+    unfiltered = client.get("/api/claude-artifacts").json()["artifacts"]
+    assert {a["remote_url"] for a in unfiltered} == {URL_A, URL_B}
+    assert client.get("/api/claude-artifacts", params={"cwd": "/nowhere"}).json()["artifacts"] == []


### PR DESCRIPTION
Self-contained on main. Absorbs the transcript-scanner backend from #488, which is closed — the standalone /claude-published page it carried is dropped; the claude template is the artifacts surface now.

## What

Four pieces on the claude preview template:

1. **`?cwd=` filter** on `GET /api/claude-artifacts` — listing scoped to sessions run in one directory (canonical path comparison). Test added.
2. **`templates/claude/artifacts.py`** (new sidecar, stdlib + `shared/appenv` only): `list` fetches the scoped API and applies the template's visibility rules — local-only (`exists`), and strict per-item scoping: a file shows only artifacts from chats started on that file (its sidecar sessions); a folder shows its cwd's artifacts minus those claimed by a child file's chats. `live` tails the active session's transcript for `frame-link` publishes.
3. **Home screen**: Recent chats + Artifacts merged into one block above Claude snapshots with a tab bar shown only when both are non-empty; single list keeps its plain heading. Spacing tightened (block gap 60px → 26px). Artifact rows end in a bordered globe button (opens the hosted claude.ai page). During a chat, a chip strip under the composer surfaces pages published live.
4. **In-flow receipts**: answered question/approval cards move into the turn's segment container on resolve, keeping their chronological place in the transcript instead of riding the log bottom. Pending cards stay put (a live control belongs at the bottom). Investigation showed the pinned behavior was an emergent artifact, not a decision — the `.perm.resolved` comment always described the card as part of the transcript.

## Screenshots

*(hosted on the never-merging `assets/pr-520-screenshots` branch)*

### Tabbed home block (tabs only when both lists non-empty)
| Recent chats tab | Artifacts tab + globe buttons |
|---|---|
| ![recent](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/tabs-recent.png) | ![artifacts](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/tabs-artifacts-globe.png) |

| Dark theme | Single list → plain heading, no tabs |
|---|---|
| ![dark](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/artifacts-dark.png) | ![chats only](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/chats-only.png) |

| Folder target (artifacts only) | Narrow split pane (~400px) |
|---|---|
| ![folder](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/folder-artifacts-only.png) | ![narrow](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/narrow-pane.png) |

### Live publish chips during a chat
![live chips](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/live-chips.png)

### Question/approval cards fold into the transcript
| Pending — card at bottom (unchanged) | Answered — card holds its place, reply continues below |
|---|---|
| ![pending](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/question-pending.png) | ![folded](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/question-folded.png) |

Approval (Write) card, same treatment:

![approval](https://raw.githubusercontent.com/fusedio/fused-render/6d82145c58c32bd8f2b7d110c6a59281a3638c55/approval-folded.png)

## Testing

- `pytest -k claude`: 880 passed, 8 skipped (includes the template lint suites: segments, narrow, kind, theme)
- Live E2E with real claude runs: AskUserQuestion card and Write approval card both verified folding into the flow; artifacts tabs/scoping/live-strip screenshotted across folder, file, empty, narrow-pane, light/dark cases — zero console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New read-only API scans large local transcript trees on each cold request (mitigated by cache), and template.html changes touch live chat polling and permission-card layout—high user visibility but no auth or mutation paths.
> 
> **Overview**
> Adds **`GET /api/claude-artifacts`** backed by a new transcript scanner (`claude_artifacts.py`) that joins `frame-link` publishes with Artifact tool metadata, dedupes by hosted URL across sessions, caches per transcript, and exposes live `exists` checks (skipping mount-backed paths). Optional **`?cwd=`** scopes the index to one working directory.
> 
> The **Claude template** gains **`artifacts.py`** (`list` via the API plus sidecar-based file/folder scoping; `live` tails the active session) and **UI**: Recent chats and Artifacts share one **`#lists`** block with a tab bar when both are non-empty, artifact rows with a globe opener, and a **`#artstrip`** under the composer updated during streaming polls.
> 
> **UX fixes:** resolved permission/question cards **`parkResolvedCard`** into the active turn’s segment body so they stay in chronological order; CSS tweaks for parked cards and home spacing.
> 
> **Tests:** `test_claude_artifacts_api.py` covers merge, dedupe, cache, mounts, and `cwd` filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca35a3eea013ff295639eefa8f8723c07a5a0323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->