### PR TITLE
Brew updates: show the command, don't run brew

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -162,16 +162,16 @@ export function getConfig(): Promise<Config> {
 export interface UpdateStatus {
   // idle | checking | available | installing | installed | error
   state: string;
-  // brew: install delegates to `brew upgrade --cask`; dmg: the app downloads
-  // and swaps its own bundle; none: not updatable in place.
+  // brew: the user runs `brew upgrade --cask` themselves (see manual_command);
+  // dmg: the app downloads and swaps its own bundle; none: not updatable.
   method: string;
   latest_version: string | null;
   // Bytes downloaded so far (dmg method only) — the manifest carries no total
   // size, so the UI shows MB downloaded rather than a percentage.
   progress: number | null;
   error: string | null;
-  // Set when the user must run the update themselves (brew failed) — shown
-  // with a copy button, never retried against the DMG path.
+  // Set when the user must run the update themselves (brew-managed installs,
+  // state "available") — shown with a copy button.
   manual_command: string | null;
 }
 

--- a/frontend/src/platform/ui/UpdateBadge.tsx
+++ b/frontend/src/platform/ui/UpdateBadge.tsx
@@ -1,9 +1,9 @@
 // Sidebar self-update affordance. Renders nothing until /api/config's
 // `update` field says a newer version exists (packaged mac app only — the
 // field is absent everywhere else), then shows an "Update available" row that
-// expands into a small panel: install button, download/brew progress, and the
-// brew-failure fallback (the exact command to run by hand — a brew-managed
-// install is never updated behind brew's back).
+// expands into a small panel. DMG installs get an install button with download
+// progress; brew-managed installs get the exact `brew upgrade` command to run
+// by hand — the app never runs brew itself.
 //
 // Owns its own slow poll (60s idle, 2s while installing) instead of riding
 // ServerStatusBanner's 5s one: the two components live in different trees and
@@ -97,12 +97,25 @@ export default function UpdateBadge() {
       </button>
       {open && (
         <div className="update-badge-panel">
-          {status.state === "available" && (
+          {status.state === "available" && status.method === "brew" && (
             <>
               <div className="update-badge-text">
-                {status.method === "brew"
-                  ? "Installed with Homebrew — updating runs brew for you."
-                  : "Downloads the new version and installs it in place."}
+                Installed with Homebrew — run this in your terminal:
+              </div>
+              {status.manual_command && (
+                <div className="update-badge-command">
+                  <code>{status.manual_command}</code>
+                  <button type="button" className="update-badge-copy" onClick={copyCommand}>
+                    {copied ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+          {status.state === "available" && status.method !== "brew" && (
+            <>
+              <div className="update-badge-text">
+                Downloads the new version and installs it in place.
               </div>
               <button type="button" className="update-badge-action" onClick={install}>
                 Update to v{status.latest_version}
@@ -111,9 +124,7 @@ export default function UpdateBadge() {
           )}
           {status.state === "installing" && (
             <div className="update-badge-text">
-              {status.method === "brew"
-                ? "Updating via Homebrew…"
-                : `Downloading… ${formatMb(status.progress)}`}
+              Downloading… {formatMb(status.progress)}
             </div>
           )}
           {status.state === "installed" && (

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -4,13 +4,15 @@ signed manifest and surfaces a newer version only through /api/config's
 `update` field — the shell shows a badge. Downloading and installing happen
 solely on an explicit POST /api/update/install.
 
-Two install methods, decided once per process:
+Two methods, decided once per process:
 
-- "brew": the running bundle is Homebrew-managed. Install delegates to
-  `brew upgrade --cask fused-render` so brew's own bookkeeping (Caskroom
-  metadata, `brew list`) stays truthful. On failure there is NO fallback to
-  the DMG path — swapping the bundle behind brew's back would desync it
-  permanently — the error surfaces the exact command for the user to run.
+- "brew": the running bundle is Homebrew-managed. The app never runs brew
+  itself — swapping the bundle behind brew's back would desync its
+  bookkeeping (Caskroom metadata, `brew list`) permanently. Instead the
+  "available" state carries `manual_command` (`brew upgrade --cask
+  fused-render`) for the user to run in a terminal; POST /api/update/install
+  is a no-op. The next check() tick reads the bundle on disk and flips to
+  "installed" once the user's upgrade lands.
 - "dmg": download the signed DMG, verify, and swap the .app bundle in place.
   Replacing the bundle under a running process is the SUPPORTED existing flow
   (a manual DMG drag does exactly this): installed.installed_version() then
@@ -49,7 +51,7 @@ CASK_NAME = "fused-render"
 # GUI apps launch with a bare PATH, so brew is probed at its two fixed homes
 # (Apple Silicon, then Intel) rather than through the environment.
 BREW_PATHS = ("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
-BREW_TIMEOUT_S = 15 * 60
+BREW_COMMAND = f"brew upgrade --cask {CASK_NAME}"
 _DOWNLOAD_PREFIX = "FusedRender-"
 _DOWNLOAD_SUFFIX = ".dmg"
 # Keep a margin over the DMG itself: the download and the staged .app copy
@@ -196,6 +198,7 @@ class UpdateManager:
                         self._state = "available"
                     else:
                         self._state = "idle"
+                    self._sync_manual_command()
             return self.status()
         # The bundle on disk, not the running __version__, decides "already
         # installed": after a successful swap (ours, brew's, or a manual one
@@ -215,7 +218,17 @@ class UpdateManager:
                 else:
                     self._latest = None
                     self._state = "idle"
+                self._sync_manual_command()
         return self.status()
+
+    def _sync_manual_command(self) -> None:
+        """Brew-managed installs are never updated by the app: "available"
+        carries the terminal command for the user to run instead. Called with
+        the lock held after every check() state transition."""
+        if self._state == "available" and self.method() == "brew":
+            self._manual_command = BREW_COMMAND
+        else:
+            self._manual_command = None
 
     def _disk_version(self) -> str | None:
         """CFBundleShortVersionString of the bundle on disk — what would launch
@@ -240,6 +253,10 @@ class UpdateManager:
                 return self.status()
             if self._latest is None or self._state not in ("available", "error"):
                 return self.status()
+            if self.method() == "brew":
+                # Brew-managed: the user runs manual_command themselves; a
+                # stray POST must not put the manager into "installing".
+                return self.status()
             manifest = self._latest
             self._state = "installing"
             self._error = None
@@ -254,9 +271,7 @@ class UpdateManager:
 
     def _install(self, manifest: dict) -> None:
         try:
-            if self.method() == "brew":
-                self._install_brew(manifest)
-            elif self.method() == "dmg":
+            if self.method() == "dmg":
                 self._install_dmg(manifest)
             else:
                 raise RuntimeError("not running from an installed bundle")
@@ -269,46 +284,6 @@ class UpdateManager:
         with self._lock:
             self._state = "installed"
             self._progress = None
-
-    # -- brew path ------------------------------------------------------------
-
-    def _install_brew(self, manifest: dict) -> None:
-        brew = find_brew()
-        command = f"brew upgrade --cask {CASK_NAME}"
-        if brew is None:
-            with self._lock:
-                self._manual_command = command
-            raise RuntimeError("Homebrew was not found")
-        try:
-            result = subprocess.run(
-                [brew, "upgrade", "--cask", CASK_NAME],
-                capture_output=True, text=True, timeout=BREW_TIMEOUT_S,
-                env={**os.environ, "HOMEBREW_NO_ENV_HINTS": "1"},
-            )
-        except subprocess.TimeoutExpired as error:
-            with self._lock:
-                self._manual_command = command
-            raise RuntimeError("brew upgrade timed out") from error
-        if result.returncode != 0:
-            # No DMG fallback — a brew-managed install must stay brew-managed.
-            # Surface the exact command so the user can run it themselves.
-            tail = (result.stderr or result.stdout or "").strip().splitlines()[-5:]
-            with self._lock:
-                self._manual_command = command
-            raise RuntimeError("brew upgrade failed: " + " / ".join(tail))
-        # brew exits 0 without upgrading anything when it considers the cask
-        # current — which it is whenever the tap bump (release CI's last job)
-        # hasn't landed yet, since the signed manifest publishes first. Only
-        # the bundle on disk proves the install happened.
-        target = manifest["version"]
-        disk = self._disk_version()
-        if disk is None or common.is_newer(target, disk):
-            with self._lock:
-                self._manual_command = command
-            raise RuntimeError(
-                f"brew finished but the installed app is still v{disk or 'unknown'} "
-                f"— v{target} may not have reached the Homebrew tap yet. "
-                "Try again in a few minutes.")
 
     # -- dmg path -------------------------------------------------------------
 

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -135,6 +135,16 @@ class UpdateManager:
 
     def status(self) -> dict:
         with self._lock:
+            # A brew-managed update happens in the user's terminal, outside any
+            # state transition here — so "available" re-checks the bundle on
+            # disk on every read (the UI polls this every minute) rather than
+            # waiting out the next CHECK_INTERVAL_S tick to notice the upgrade.
+            if self._state == "available" and self._latest:
+                disk = self._disk_version()
+                if disk is not None and not common.is_newer(
+                        self._latest["version"], disk):
+                    self._state = "installed"
+                    self._sync_manual_command()
             return {
                 "state": self._state,
                 "method": self.method(),

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -192,6 +192,17 @@ def test_brew_install_is_a_noop(monkeypatch):
     assert manager._install_thread is None
 
 
+def test_status_notices_external_upgrade_without_a_check(monkeypatch):
+    """The badge polls status() every minute; a terminal `brew upgrade` must
+    flip it to "installed" then, not after the next multi-hour check tick."""
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    assert manager.check()["state"] == "available"
+    monkeypatch.setattr(manager, "_disk_version", lambda: "9.9.9")
+    status = manager.status()
+    assert status["state"] == "installed"
+    assert status["manual_command"] is None
+
+
 def test_brew_external_upgrade_flips_check_to_installed(monkeypatch):
     """The user runs brew in a terminal; the next check() sees the new bundle
     on disk, lands on "installed", and drops the manual command."""

--- a/tests/test_mac_update.py
+++ b/tests/test_mac_update.py
@@ -2,8 +2,10 @@
 
 The signed-manifest crypto path is shared with the Windows updater and covered
 by tests/test_win_supervisor_update.py; these tests cover what's new on mac:
-the brew/dmg method decision, the manager's state machine (including the
-no-DMG-fallback-on-brew-failure rule), and the /api/update endpoints' guards.
+the brew/dmg method decision, the manager's state machine (including the rule
+that brew-managed installs are never updated by the app — the user runs the
+surfaced `brew upgrade` command themselves), and the /api/update endpoints'
+guards.
 """
 import subprocess
 import types
@@ -165,70 +167,40 @@ def test_install_retry_allowed_from_error(monkeypatch):
     assert manager.status()["state"] == "installed"
 
 
-# ---- brew path: failure gives the command, never a DMG fallback ---------------
+# ---- brew path: the app never runs brew — the user does -----------------------
 
 
-def test_brew_failure_sets_manual_command_and_no_dmg(monkeypatch):
+def test_brew_available_carries_manual_command(monkeypatch):
     manager = _manager(monkeypatch, method="brew", available="9.9.9")
-    manager.check()
-    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
-
-    def run(cmd, **kwargs):
-        return types.SimpleNamespace(returncode=1, stdout="", stderr="Error: no sudo")
-
-    monkeypatch.setattr(mac.subprocess, "run", run)
-    dmg_calls = []
-    monkeypatch.setattr(manager, "_install_dmg", lambda manifest: dmg_calls.append(1))
-    manager.install()
-    manager._install_thread.join(timeout=5)
-    status = manager.status()
-    assert status["state"] == "error"
-    assert status["manual_command"] == "brew upgrade --cask fused-render"
-    assert "no sudo" in status["error"]
-    assert not dmg_calls
-
-
-def test_brew_missing_at_install_sets_manual_command(monkeypatch):
-    manager = _manager(monkeypatch, method="brew", available="9.9.9")
-    manager.check()
-    monkeypatch.setattr(mac, "find_brew", lambda: None)
-    manager.install()
-    manager._install_thread.join(timeout=5)
-    status = manager.status()
-    assert status["state"] == "error"
+    status = manager.check()
+    assert status["state"] == "available"
     assert status["manual_command"] == "brew upgrade --cask fused-render"
 
 
-def test_brew_success_lands_installed(monkeypatch):
+def test_dmg_available_has_no_manual_command(monkeypatch):
+    manager = _manager(monkeypatch, available="9.9.9")
+    status = manager.check()
+    assert status["state"] == "available"
+    assert status["manual_command"] is None
+
+
+def test_brew_install_is_a_noop(monkeypatch):
     manager = _manager(monkeypatch, method="brew", available="9.9.9")
     manager.check()
-    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
-    monkeypatch.setattr(
-        mac.subprocess, "run",
-        lambda cmd, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""))
-    # brew exit 0 alone must not count — the bundle on disk proves the install.
+    status = manager.install()
+    assert status["state"] == "available"
+    assert manager._install_thread is None
+
+
+def test_brew_external_upgrade_flips_check_to_installed(monkeypatch):
+    """The user runs brew in a terminal; the next check() sees the new bundle
+    on disk, lands on "installed", and drops the manual command."""
+    manager = _manager(monkeypatch, method="brew", available="9.9.9")
+    assert manager.check()["state"] == "available"
     monkeypatch.setattr(manager, "_disk_version", lambda: "9.9.9")
-    manager.install()
-    manager._install_thread.join(timeout=5)
-    assert manager.status()["state"] == "installed"
-
-
-def test_brew_exit_zero_with_stale_tap_is_an_error(monkeypatch):
-    """brew exits 0 without upgrading when the tap bump hasn't landed yet; the
-    manager must not claim "installed" while the bundle on disk is still old."""
-    manager = _manager(monkeypatch, method="brew", available="9.9.9")
-    manager.check()
-    monkeypatch.setattr(mac, "find_brew", lambda: "/fake/brew")
-    monkeypatch.setattr(
-        mac.subprocess, "run",
-        lambda cmd, **kwargs: types.SimpleNamespace(returncode=0, stdout="", stderr=""))
-    monkeypatch.setattr(manager, "_disk_version", lambda: "0.4.10")
-    manager.install()
-    manager._install_thread.join(timeout=5)
-    status = manager.status()
-    assert status["state"] == "error"
-    assert "tap" in status["error"]
-    assert status["manual_command"] == "brew upgrade --cask fused-render"
+    status = manager.check()
+    assert status["state"] == "installed"
+    assert status["manual_command"] is None
 
 
 def test_failed_check_keeps_installed_when_disk_is_current(monkeypatch):


### PR DESCRIPTION
Removes the in-app brew upgrade process. When an update is available and the install is Homebrew-managed, the update badge now shows `brew upgrade --cask fused-render` with a copy button and asks the user to run it themselves.

- `mac.py`: deleted `_install_brew`; `install()` is a no-op for method `brew`; `check()` populates `manual_command` in the "available" state for brew installs (cleared otherwise). The existing disk-version check flips state to "installed" after the user's terminal upgrade.
- `UpdateBadge.tsx`: brew "available" panel shows the command + Copy instead of an install button; dead "Updating via Homebrew…" branch removed.
- Tests rewritten: brew install is a no-op, available carries the command, external upgrade flips to installed. 27 passed; frontend `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes mac self-update behavior for Homebrew users and removes automated brew execution, but DMG path and state machine guards remain; risk is mainly UX/regression on update detection rather than security.
> 
> **Overview**
> **Homebrew-managed macOS installs** no longer trigger an in-app `brew upgrade`. The updater sets `manual_command` (`brew upgrade --cask fused-render`) while state is **available**, treats `POST /api/update/install` as a **no-op** for brew, and drops the entire `_install_brew` subprocess path.
> 
> The **update badge** for brew shows that command with **Copy** instead of an install button; DMG installs still use in-app download/install. **`status()`** re-reads the bundle on disk during **available** so a terminal upgrade flips to **installed** on the next poll without waiting for the next manifest check.
> 
> API comments and mac update tests were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5e7e2cbda8f7bd8992ac806115176ae4210c6ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->