### PR TITLE
Sort /home and /apps by last-opened recency

### DIFF
--- a/frontend/src/apps/builder/AppPreviewCard.tsx
+++ b/frontend/src/apps/builder/AppPreviewCard.tsx
@@ -23,7 +23,7 @@
 import { useState } from "react";
 import type { AppInfo } from "@platform/lib/api";
 import { rawUrl } from "@platform/lib/api";
-import { hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
+import { appRecency, hrefFor, onAppCardClick, openTargetFor } from "@platform/lib/appEntry";
 import { hueFor } from "@apps/builder/AppCard";
 
 import { timeAgo } from "@platform/lib/format";
@@ -47,7 +47,11 @@ export function AppPreviewCard({
   badge?: string;
 }) {
   const title = app.title || app.name;
-  const ago = timeAgo(app.updated_at);
+  // The same timestamp the grid SORTS by (last opened, modified standing in) —
+  // a card ranked first for being opened just now must not label itself with a
+  // stale modified time. appRecency's 0-for-neither is falsy, so timeAgo still
+  // returns null and the label hides.
+  const ago = timeAgo(appRecency(app));
   // Set when the authored thumbnail fails to decode — see the fallback chain in
   // the module comment. One-way: a retry would loop on a file that is broken.
   const [shotFailed, setShotFailed] = useState(false);

--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -5,12 +5,14 @@
 // filter row — a Category/Repo mode selector with chips derived from the apps
 // themselves (categories from each folder's metadata.json, repos from the
 // top-level tag dirs) — and a search box (name/title/tag/category,
-// case-insensitive). Order is always recently-modified; filtering never
-// reorders cards relative to each other.
+// case-insensitive). Order is always recently-opened (modified time stands in
+// for an app never opened — appEntry.sortApps); filtering never reorders cards
+// relative to each other.
 import { useEffect, useMemo, useState } from "react";
 import { getApps } from "@platform/lib/api";
 import type { AppInfo, Config } from "@platform/lib/api";
 import { appCardMenu } from "@platform/lib/appCardMenu";
+import { sortApps } from "@platform/lib/appEntry";
 import { runCommunity, SHOWCASE_TAG } from "@platform/lib/community";
 import { requestCloneApp } from "@platform/cloud/cloneApp";
 import { useDeployEnabled } from "@platform/lib/prefs";
@@ -33,14 +35,6 @@ const MODES: { key: FilterMode; label: string }[] = [
   { key: "category", label: "Category" },
   { key: "repo", label: "Repo" },
 ];
-
-// Always recently-modified desc; apps without a timestamp sink to the end,
-// name breaks ties so the order is stable.
-function sortApps(apps: AppInfo[]): AppInfo[] {
-  const byName = (a: AppInfo, b: AppInfo) =>
-    (a.title || a.name).localeCompare(b.title || b.name) || a.name.localeCompare(b.name);
-  return apps.slice().sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0) || byName(a, b));
-}
 
 type ShowcaseCatalog = { status?: string; apps?: { slug: string; installed?: boolean }[] };
 

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1891,16 +1891,18 @@ export function getApps(): Promise<{ apps: AppInfo[] }> {
 }
 
 // Record that an app was opened (feeds opened_at above, which is what /home
-// and /apps sort by). Server no-ops (recorded: false) for an app whose folder
-// is gone, so callers need not pre-check.
+// and /apps sort by). `path` is the app's absolute folder path from the
+// listing — the identity the store keys on (workspace-relative server-side),
+// unique at every depth where (tag, name) is not. Server no-ops
+// (recorded: false) for an app whose folder is gone, so callers need not
+// pre-check.
 export function postAppOpen(
-  tag: string,
-  name: string,
+  path: string,
   title?: string | null,
 ): Promise<{ recorded: boolean }> {
   return postJson<{ recorded: boolean }>(
     "/api/apps/recents/open",
-    title ? { tag, name, title } : { tag, name },
+    title ? { path, title } : { path },
   );
 }
 

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1880,10 +1880,28 @@ export interface AppInfo {
   // Last-modified time, epoch seconds. Optional/null for servers that don't
   // report it (older backends) — those sort last in the Home grid.
   updated_at?: number | null;
+  // Last-opened time, epoch seconds, from the app recents store
+  // (~/.fused-render/app_recents.json). Null for an app never opened, and
+  // undefined on older backends — both fall back to updated_at in sortApps.
+  opened_at?: number | null;
 }
 
 export function getApps(): Promise<{ apps: AppInfo[] }> {
   return getJson<{ apps: AppInfo[] }>("/api/apps");
+}
+
+// Record that an app was opened (feeds opened_at above, which is what /home
+// and /apps sort by). Server no-ops (recorded: false) for an app whose folder
+// is gone, so callers need not pre-check.
+export function postAppOpen(
+  tag: string,
+  name: string,
+  title?: string | null,
+): Promise<{ recorded: boolean }> {
+  return postJson<{ recorded: boolean }>(
+    "/api/apps/recents/open",
+    title ? { tag, name, title } : { tag, name },
+  );
 }
 
 // Scaffold a new app folder and (optionally) kick off a Claude session seeded

--- a/frontend/src/platform/lib/appEntry.test.ts
+++ b/frontend/src/platform/lib/appEntry.test.ts
@@ -35,7 +35,7 @@ import type { AppInfo } from "./api";
   clearTimeout: globalThis.clearTimeout.bind(globalThis),
 };
 
-const { entryOf, hrefFor, isBrowserHandledClick, onAppCardClick, openTargetFor } =
+const { entryOf, hrefFor, isBrowserHandledClick, onAppCardClick, openTargetFor, sortApps } =
   await import("./appEntry");
 
 function app(over: Partial<AppInfo> = {}): AppInfo {
@@ -188,4 +188,23 @@ test("a click something else already handled is not hijacked", () => {
   const handled = click({ defaultPrevented: true });
   onAppCardClick(handled, app());
   expect(handled.prevented).toBe(false);
+});
+
+// ------------------------------------------------------------------ ordering
+
+test("sortApps orders by last-opened, modified time standing in", () => {
+  // The one grid order (/home and /apps): opened_at desc; an app never opened
+  // ranks by updated_at; one with neither sinks to the end.
+  const opened = app({ name: "opened", opened_at: 300, updated_at: 10 });
+  const editedButUnopened = app({ name: "edited", opened_at: null, updated_at: 200 });
+  const stale = app({ name: "stale", opened_at: 100, updated_at: 400 });
+  const bare = app({ name: "bare" }); // older backend: neither key at all
+  expect(sortApps([bare, stale, editedButUnopened, opened]).map((a) => a.name))
+    .toEqual(["opened", "edited", "stale", "bare"]);
+});
+
+test("sortApps breaks timestamp ties by display name, stably", () => {
+  const b = app({ name: "b", title: "Beta", opened_at: 100 });
+  const a = app({ name: "a", title: "Alpha", opened_at: 100 });
+  expect(sortApps([b, a]).map((x) => x.name)).toEqual(["a", "b"]);
 });

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -54,7 +54,7 @@ export function sortApps(apps: AppInfo[]): AppInfo[] {
 // sort above) is fed by. Fire-and-forget: recording must never delay or fail
 // the navigation itself.
 function recordAppOpen(app: AppInfo): void {
-  void postAppOpen(app.tag, app.name, app.title).catch(() => undefined);
+  void postAppOpen(app.path, app.title).catch(() => undefined);
 }
 
 // The file this card is about, tolerating a backend that predates `entry`.

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -170,10 +170,18 @@ export function isBrowserHandledClick(e: CardClickEvent): boolean {
 export function onAppCardClick(e: CardClickEvent, app: AppInfo): void {
   if (e.defaultPrevented) return;
   if (isBrowserHandledClick(e)) {
-    // The browser owns the navigation (new tab/window via the href), but the
-    // open still happened — record it so the recency sort sees it too. No
-    // preventDefault: recording rides alongside the browser's own handling.
-    recordAppOpen(app);
+    // The browser owns the click, but SOME of these gestures still open the
+    // app — record those so the recency sort sees them. Only the unambiguous
+    // ones: middle-click, Cmd-click and Shift-click all navigate. Ctrl-click
+    // is the context menu on macOS (no navigation) and Alt-click is a
+    // download — a false record would scramble the sort, where a missed one
+    // just falls back to the modified time, so both are skipped even though
+    // Ctrl-click does open a tab on other platforms. No preventDefault:
+    // recording rides alongside the browser's own handling.
+    const opens =
+      e.button === 1 ||
+      (e.button === 0 && (e.metaKey || e.shiftKey) && !e.ctrlKey && !e.altKey);
+    if (opens) recordAppOpen(app);
     return;
   }
   e.preventDefault();

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -36,8 +36,26 @@
 // click handler — which is the second reason this module exists: `hrefFor` and
 // `openTargetFor` resolve the same target, so a new tab and a left click can't
 // land in different places.
-import type { AppInfo } from "./api";
+import { postAppOpen, type AppInfo } from "./api";
 import { navigate, urlForFsPath } from "./router";
+
+// The ONE ordering every app grid uses (/home's strip, the /apps hub):
+// recently-OPENED desc; an app never opened falls back to its modified time,
+// and one with neither sinks to the end. Name breaks ties so the order is
+// stable. Lives here so the two surfaces can't drift.
+export function sortApps(apps: AppInfo[]): AppInfo[] {
+  const byName = (a: AppInfo, b: AppInfo) =>
+    (a.title || a.name).localeCompare(b.title || b.name) || a.name.localeCompare(b.name);
+  const recency = (a: AppInfo) => a.opened_at ?? a.updated_at ?? 0;
+  return apps.slice().sort((a, b) => recency(b) - recency(a) || byName(a, b));
+}
+
+// Record the open in the app recents store — what `opened_at` (and so the
+// sort above) is fed by. Fire-and-forget: recording must never delay or fail
+// the navigation itself.
+function recordAppOpen(app: AppInfo): void {
+  void postAppOpen(app.tag, app.name, app.title).catch(() => undefined);
+}
 
 // The file this card is about, tolerating a backend that predates `entry`.
 // `entry` is "the file a card opens and previews"; `entry_html` is the narrower
@@ -107,6 +125,7 @@ export function hrefFor(app: AppInfo): string {
 }
 
 export function openApp(app: AppInfo): void {
+  recordAppOpen(app);
   const { path, opts } = openTargetFor(app);
   navigate(path, opts);
 }
@@ -143,7 +162,14 @@ export function isBrowserHandledClick(e: CardClickEvent): boolean {
 // in-app navigation (no page reload, no lost state); everything else is left to
 // the href, which is why the anchor must always carry one.
 export function onAppCardClick(e: CardClickEvent, app: AppInfo): void {
-  if (e.defaultPrevented || isBrowserHandledClick(e)) return;
+  if (e.defaultPrevented) return;
+  if (isBrowserHandledClick(e)) {
+    // The browser owns the navigation (new tab/window via the href), but the
+    // open still happened — record it so the recency sort sees it too. No
+    // preventDefault: recording rides alongside the browser's own handling.
+    recordAppOpen(app);
+    return;
+  }
   e.preventDefault();
   openApp(app);
 }

--- a/frontend/src/platform/lib/appEntry.ts
+++ b/frontend/src/platform/lib/appEntry.ts
@@ -46,8 +46,14 @@ import { navigate, urlForFsPath } from "./router";
 export function sortApps(apps: AppInfo[]): AppInfo[] {
   const byName = (a: AppInfo, b: AppInfo) =>
     (a.title || a.name).localeCompare(b.title || b.name) || a.name.localeCompare(b.name);
-  const recency = (a: AppInfo) => a.opened_at ?? a.updated_at ?? 0;
-  return apps.slice().sort((a, b) => recency(b) - recency(a) || byName(a, b));
+  return apps.slice().sort((a, b) => appRecency(b) - appRecency(a) || byName(a, b));
+}
+
+// The timestamp the sort above ranks by — exported so the card's "…ago" label
+// (AppPreviewCard) shows the SAME time the ordering used; a card sorted first
+// for being opened just now must not say "1d ago" off its modified time.
+export function appRecency(app: AppInfo): number {
+  return app.opened_at ?? app.updated_at ?? 0;
 }
 
 // Record the open in the app recents store — what `opened_at` (and so the

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -16,6 +16,7 @@ import {
   type ClaudeSessionFolder,
   type Config,
 } from "@platform/lib/api";
+import { sortApps } from "@platform/lib/appEntry";
 import { useIndexStatus } from "@platform/lib/index-status";
 import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@apps/explorer/lib/recents";
 import { FilesSearch } from "@apps/explorer/FilesHome";
@@ -47,14 +48,6 @@ function useStripCount() {
     return () => ro.disconnect();
   }, []);
   return { ref, count };
-}
-
-// Same order the /apps hub uses (Apps.tsx sortApps): recently-modified desc,
-// apps without a timestamp sink to the end, name breaks ties.
-function sortApps(apps: AppInfo[]): AppInfo[] {
-  const byName = (a: AppInfo, b: AppInfo) =>
-    (a.title || a.name).localeCompare(b.title || b.name) || a.name.localeCompare(b.name);
-  return apps.slice().sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0) || byName(a, b));
 }
 
 // Section chrome: title row with the "See all" action on the right edge.

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -76,22 +76,35 @@ def api_apps():
     apps = list(app_listing.workspace_apps(fused_dir()))
     apps.sort(key=lambda a: (a["tag"].lower(), a["name"].lower()))
     opened = _opened_at_by_app()
+    root = fused_dir()
     for a in apps:
-        a["opened_at"] = opened.get((a["tag"], a["name"]))
+        a["opened_at"] = opened.get(_workspace_rel(root, a["path"]))
     return {"apps": apps}
 
 
-def _opened_at_by_app() -> dict[tuple[str, str], float]:
-    """(tag, name) → last-open time as epoch seconds (updated_at's unit), from
-    the recents store. The file is user-writable, so a malformed openedAt just
-    drops that entry — a bad timestamp must never fail the listing."""
-    out: dict[tuple[str, str], float] = {}
+def _workspace_rel(root: str, path: str) -> str | None:
+    """`path` as a workspace-relative key, or None when it isn't inside the
+    workspace. The store's identity: unique at every depth the walk lists
+    (1-3), where (tag, name) is not — two depth-3 apps under different shelves
+    of one tag share both."""
+    rel = os.path.relpath(os.path.abspath(path), os.path.abspath(root))
+    if rel == "." or rel.startswith(".."):
+        return None
+    return rel
+
+
+def _opened_at_by_app() -> dict[str, float]:
+    """Workspace-relative app path → last-open time as epoch seconds
+    (updated_at's unit), from the recents store. The file is user-writable, so
+    a malformed openedAt just drops that entry — a bad timestamp must never
+    fail the listing."""
+    out: dict[str, float] = {}
     for e in _read_app_recents()["entries"]:
         ts = e.get("openedAt")
         if not isinstance(ts, str):
             continue
         try:
-            out[(e["tag"], e["name"])] = datetime.fromisoformat(ts).timestamp()
+            out[e["path"]] = datetime.fromisoformat(ts).timestamp()
         except ValueError:
             continue
     return out
@@ -101,9 +114,11 @@ def _opened_at_by_app() -> dict[tuple[str, str], float]:
 #
 # App-builder recents at ~/.fused-render/app_recents.json — its OWN store,
 # fully independent of the explorer's recents.json (shell/recents.py). Entries
-# identify an app by (tag, name), newest-first, deduped, capped. GET filters
-# entries whose app folder is gone (read-only — the folder may come back).
-# The workspace is always local, so plain isdir checks are safe here.
+# identify an app by its WORKSPACE-RELATIVE path (`path`, e.g. "local/demo" or
+# "tag/shelf/app") — unique at every depth the walk lists, where the previous
+# (tag, name) key was not — newest-first, deduped, capped. GET filters entries
+# whose app folder is gone (read-only — the folder may come back). The
+# workspace is always local, so plain isdir checks are safe here.
 
 # The store is the sort input for /home and /apps (opened_at in GET /api/apps),
 # not just a short recents row — so the cap must comfortably exceed the number
@@ -128,25 +143,24 @@ def _read_app_recents() -> dict:
         "entries": [
             e
             for e in (entries if isinstance(entries, list) else [])
-            if isinstance(e, dict)
-            and isinstance(e.get("tag"), str)
-            and isinstance(e.get("name"), str)
+            if isinstance(e, dict) and isinstance(e.get("path"), str)
         ]
     }
 
 
-def _app_folder_exists(tag: str, name: str) -> bool:
-    """Does the (tag, name) app currently resolve to a folder on disk?
-    Apps resolve under <workspace>/<tag>/<name>."""
-    return os.path.isdir(os.path.join(fused_dir(), tag, name))
+def _app_folder_exists(rel: str) -> bool:
+    """Does the workspace-relative app path currently resolve to a folder on
+    disk? Rejects a key that would escape the workspace — the store is
+    user-writable, so `rel` cannot be trusted to stay under it."""
+    if os.path.isabs(rel) or rel.startswith(".") or ".." in rel.split("/"):
+        return False
+    return os.path.isdir(os.path.join(fused_dir(), rel))
 
 
 @router.get("/api/apps/recents")
 def api_app_recents():
     entries = [
-        e
-        for e in _read_app_recents()["entries"]
-        if _app_folder_exists(e["tag"], e["name"])
+        e for e in _read_app_recents()["entries"] if _app_folder_exists(e["path"])
     ]
     return {"entries": entries}
 
@@ -160,31 +174,31 @@ def api_app_recent_open(
         return guard
     from fused_render.shell import storage
 
-    tag, name = body.get("tag"), body.get("name")
-    if not isinstance(tag, str) or not isinstance(name, str) or not tag or not name:
-        return _error("tag and name required", 400)
-    # Only real app folders are recorded — same benign no-op posture as the
-    # explorer's POST /api/recents/open for a non-file url.
-    if "/" in tag or "/" in name or tag.startswith(".") or name.startswith("."):
-        return {"recorded": False}
-    if not _app_folder_exists(tag, name):
+    path = body.get("path")
+    if not isinstance(path, str) or not path:
+        return _error("path required", 400)
+    # The client sends the app's absolute `path` from the listing; the store
+    # keys on the workspace-relative form. Only real app folders inside the
+    # workspace are recorded — same benign no-op posture as the explorer's
+    # POST /api/recents/open for a non-file url.
+    rel = _workspace_rel(fused_dir(), path)
+    if rel is None or not _app_folder_exists(rel):
         return {"recorded": False}
     title_raw = body.get("title")
     title = title_raw.strip() if isinstance(title_raw, str) and title_raw.strip() else None
     data = _read_app_recents()
-    # Dedupe by (tag, name); a title-less re-record keeps the last known title.
+    # Dedupe by path; a title-less re-record keeps the last known title.
     existing_title = None
     kept = []
     for e in data["entries"]:
-        if e["tag"] == tag and e["name"] == name:
+        if e["path"] == rel:
             t = e.get("title")
             if existing_title is None and isinstance(t, str) and t:
                 existing_title = t
             continue
         kept.append(e)
     entry = {
-        "tag": tag,
-        "name": name,
+        "path": rel,
         "openedAt": datetime.now(timezone.utc).isoformat(),
     }
     if title is not None:

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -160,11 +160,18 @@ def _app_folder_exists(rel: str) -> bool:
     disk? Rejects a key that would escape the workspace — the store is
     user-writable, so `rel` cannot be trusted to stay under it."""
     # Split on the OS separator too: a user-edited backslash key on Windows
-    # must not smuggle `..` past a "/"-only split.
+    # must not smuggle `..` past a "/"-only split. Segments are then vetted
+    # individually — a drive-relative segment like "C:foo" would make a
+    # starred os.path.join discard the workspace base entirely, so anything
+    # carrying a drive or absolute form is rejected, and the join happens as
+    # ONE "/"-joined string (a legal separator on Windows as well) so no
+    # segment can ever reset the base.
     parts = rel.replace(os.sep, "/").split("/")
     if os.path.isabs(rel) or rel.startswith(".") or ".." in parts:
         return False
-    return os.path.isdir(os.path.join(fused_dir(), *parts))
+    if any(not p or os.path.isabs(p) or os.path.splitdrive(p)[0] for p in parts):
+        return False
+    return os.path.isdir(os.path.join(fused_dir(), "/".join(parts)))
 
 
 @router.get("/api/apps/recents")

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -83,14 +83,21 @@ def api_apps():
 
 
 def _workspace_rel(root: str, path: str) -> str | None:
-    """`path` as a workspace-relative key, or None when it isn't inside the
-    workspace. The store's identity: unique at every depth the walk lists
-    (1-3), where (tag, name) is not — two depth-3 apps under different shelves
-    of one tag share both."""
-    rel = os.path.relpath(os.path.abspath(path), os.path.abspath(root))
+    """`path` as a workspace-relative, forward-slash key, or None when it isn't
+    inside the workspace. The store's identity: unique at every depth the walk
+    lists (1-3), where (tag, name) is not — two depth-3 apps under different
+    shelves of one tag share both. Normalized to "/" so a key written on
+    Windows matches the split in _app_folder_exists; the replace is os.sep-
+    conditional because on POSIX a backslash is a legal filename character."""
+    try:
+        rel = os.path.relpath(os.path.abspath(path), os.path.abspath(root))
+    except ValueError:
+        # Windows: relpath across drives has no relative form — that is just
+        # "not inside the workspace", not an error.
+        return None
     if rel == "." or rel.startswith(".."):
         return None
-    return rel
+    return rel.replace(os.sep, "/") if os.sep != "/" else rel
 
 
 def _opened_at_by_app() -> dict[str, float]:
@@ -152,9 +159,12 @@ def _app_folder_exists(rel: str) -> bool:
     """Does the workspace-relative app path currently resolve to a folder on
     disk? Rejects a key that would escape the workspace — the store is
     user-writable, so `rel` cannot be trusted to stay under it."""
-    if os.path.isabs(rel) or rel.startswith(".") or ".." in rel.split("/"):
+    # Split on the OS separator too: a user-edited backslash key on Windows
+    # must not smuggle `..` past a "/"-only split.
+    parts = rel.replace(os.sep, "/").split("/")
+    if os.path.isabs(rel) or rel.startswith(".") or ".." in parts:
         return False
-    return os.path.isdir(os.path.join(fused_dir(), rel))
+    return os.path.isdir(os.path.join(fused_dir(), *parts))
 
 
 @router.get("/api/apps/recents")

--- a/fused_render/server/routers/apps.py
+++ b/fused_render/server/routers/apps.py
@@ -75,7 +75,26 @@ _APP_STARTER_DIR = os.path.join(
 def api_apps():
     apps = list(app_listing.workspace_apps(fused_dir()))
     apps.sort(key=lambda a: (a["tag"].lower(), a["name"].lower()))
+    opened = _opened_at_by_app()
+    for a in apps:
+        a["opened_at"] = opened.get((a["tag"], a["name"]))
     return {"apps": apps}
+
+
+def _opened_at_by_app() -> dict[tuple[str, str], float]:
+    """(tag, name) → last-open time as epoch seconds (updated_at's unit), from
+    the recents store. The file is user-writable, so a malformed openedAt just
+    drops that entry — a bad timestamp must never fail the listing."""
+    out: dict[tuple[str, str], float] = {}
+    for e in _read_app_recents()["entries"]:
+        ts = e.get("openedAt")
+        if not isinstance(ts, str):
+            continue
+        try:
+            out[(e["tag"], e["name"])] = datetime.fromisoformat(ts).timestamp()
+        except ValueError:
+            continue
+    return out
 
 
 # ------------------------------------------------------------------- recents
@@ -86,7 +105,10 @@ def api_apps():
 # entries whose app folder is gone (read-only — the folder may come back).
 # The workspace is always local, so plain isdir checks are safe here.
 
-APP_RECENTS_CAP = 20
+# The store is the sort input for /home and /apps (opened_at in GET /api/apps),
+# not just a short recents row — so the cap must comfortably exceed the number
+# of apps a user actively cycles through, or open #N+1 silently loses its rank.
+APP_RECENTS_CAP = 200
 
 
 def _app_recents_path() -> str:

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -390,6 +390,65 @@ def test_updated_at_is_a_float(client, workspace):
     assert isinstance(apps[0]["updated_at"], float)
 
 
+# ------------------------------------------------- opened_at (recency of open)
+
+@pytest.fixture()
+def recents_home(tmp_path, monkeypatch):
+    """Per-test recents store — the session-wide FUSED_RENDER_HOME is shared,
+    and app_recents.json written by one test must not rank apps in another."""
+    home = tmp_path / "frhome"
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(home))
+    return home
+
+
+def test_opening_an_app_stamps_opened_at_in_the_listing(
+        client, workspace, recents_home):
+    """The recency the shell sorts /home and /apps by: POST recents/open
+    records the open, and GET /api/apps reports it as epoch seconds
+    (updated_at's unit). An app never opened carries null."""
+    _app_dir(workspace, "opened")
+    _app_dir(workspace, "untouched")
+    r = client.post("/api/apps/recents/open",
+                    json={"tag": "local", "name": "opened"},
+                    headers={"X-Fused": "1"})
+    assert r.json() == {"recorded": True}
+    apps = {a["name"]: a for a in client.get("/api/apps").json()["apps"]}
+    assert isinstance(apps["opened"]["opened_at"], float)
+    assert abs(apps["opened"]["opened_at"] - time.time()) < 60
+    assert apps["untouched"]["opened_at"] is None
+
+
+def test_a_malformed_recents_timestamp_never_fails_the_listing(
+        client, workspace, recents_home):
+    """app_recents.json is user-writable: a garbage openedAt drops that
+    entry's opened_at, it must not 500 GET /api/apps."""
+    _app_dir(workspace, "victim")
+    recents_home.mkdir(parents=True, exist_ok=True)
+    (recents_home / "app_recents.json").write_text(json.dumps({
+        "entries": [
+            {"tag": "local", "name": "victim", "openedAt": "not-a-date"},
+            {"tag": "local", "name": "victim2", "openedAt": 12345},
+        ]
+    }))
+    r = client.get("/api/apps")
+    assert r.status_code == 200
+    apps = {a["name"]: a for a in r.json()["apps"]}
+    assert apps["victim"]["opened_at"] is None
+
+
+def test_reopening_updates_opened_at_not_duplicates(
+        client, workspace, recents_home):
+    _app_dir(workspace, "again")
+    for _ in range(2):
+        client.post("/api/apps/recents/open",
+                    json={"tag": "local", "name": "again"},
+                    headers={"X-Fused": "1"})
+    entries = client.get("/api/apps/recents").json()["entries"]
+    assert [e["name"] for e in entries] == ["again"]
+    apps = client.get("/api/apps").json()["apps"]
+    assert isinstance(apps[0]["opened_at"], float)
+
+
 # ---------------------------------------------------- the fork-safe spawn seam
 
 def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -404,18 +404,49 @@ def recents_home(tmp_path, monkeypatch):
 def test_opening_an_app_stamps_opened_at_in_the_listing(
         client, workspace, recents_home):
     """The recency the shell sorts /home and /apps by: POST recents/open
-    records the open, and GET /api/apps reports it as epoch seconds
-    (updated_at's unit). An app never opened carries null."""
+    records the open (keyed on the app's path), and GET /api/apps reports it
+    as epoch seconds (updated_at's unit). An app never opened carries null."""
     _app_dir(workspace, "opened")
     _app_dir(workspace, "untouched")
     r = client.post("/api/apps/recents/open",
-                    json={"tag": "local", "name": "opened"},
+                    json={"path": str(workspace / "local" / "opened")},
                     headers={"X-Fused": "1"})
     assert r.json() == {"recorded": True}
     apps = {a["name"]: a for a in client.get("/api/apps").json()["apps"]}
     assert isinstance(apps["opened"]["opened_at"], float)
     assert abs(apps["opened"]["opened_at"] - time.time()) < 60
     assert apps["untouched"]["opened_at"] is None
+
+
+def test_open_records_at_every_depth_and_shelves_do_not_collide(
+        client, workspace, recents_home):
+    """The path key exists because (tag, name) was ambiguous: two depth-3 apps
+    under different shelves of one tag share both. Each depth the walk lists
+    (1-3) must record, and opening one same-named app must not stamp the other."""
+    # depth 1: the folder is its own tag; depth 3: index.html under tag/shelf/app.
+    (workspace / "solo").mkdir()
+    (workspace / "solo" / "page.html").write_text("<html></html>")
+    for shelf in ("a", "b"):
+        d = workspace / "deep" / shelf / "twin"
+        d.mkdir(parents=True)
+        (d / "index.html").write_text("<html></html>")
+    for p in ("solo", "deep/a/twin"):
+        r = client.post("/api/apps/recents/open",
+                        json={"path": str(workspace / p)},
+                        headers={"X-Fused": "1"})
+        assert r.json() == {"recorded": True}, p
+    apps = {a["path"]: a for a in client.get("/api/apps").json()["apps"]}
+    assert isinstance(apps[str(workspace / "solo")]["opened_at"], float)
+    assert isinstance(apps[str(workspace / "deep" / "a" / "twin")]["opened_at"], float)
+    assert apps[str(workspace / "deep" / "b" / "twin")]["opened_at"] is None
+
+
+def test_open_outside_the_workspace_is_a_no_op(client, workspace, recents_home, tmp_path):
+    outside = tmp_path / "elsewhere"
+    outside.mkdir()
+    r = client.post("/api/apps/recents/open",
+                    json={"path": str(outside)}, headers={"X-Fused": "1"})
+    assert r.json() == {"recorded": False}
 
 
 def test_a_malformed_recents_timestamp_never_fails_the_listing(
@@ -426,8 +457,8 @@ def test_a_malformed_recents_timestamp_never_fails_the_listing(
     recents_home.mkdir(parents=True, exist_ok=True)
     (recents_home / "app_recents.json").write_text(json.dumps({
         "entries": [
-            {"tag": "local", "name": "victim", "openedAt": "not-a-date"},
-            {"tag": "local", "name": "victim2", "openedAt": 12345},
+            {"path": "local/victim", "openedAt": "not-a-date"},
+            {"path": "local/victim2", "openedAt": 12345},
         ]
     }))
     r = client.get("/api/apps")
@@ -441,10 +472,10 @@ def test_reopening_updates_opened_at_not_duplicates(
     _app_dir(workspace, "again")
     for _ in range(2):
         client.post("/api/apps/recents/open",
-                    json={"tag": "local", "name": "again"},
+                    json={"path": str(workspace / "local" / "again")},
                     headers={"X-Fused": "1"})
     entries = client.get("/api/apps/recents").json()["entries"]
-    assert [e["name"] for e in entries] == ["again"]
+    assert [e["path"] for e in entries] == ["local/again"]
     apps = client.get("/api/apps").json()["apps"]
     assert isinstance(apps[0]["opened_at"], float)
 


### PR DESCRIPTION
## What

Tracks when each app was last opened and sorts the /home strip and the /apps hub by that recency.

- Card activation (left click via `openApp`, and new-tab gestures — cmd/middle-click — in `onAppCardClick`) fire-and-forget POSTs to the existing `/api/apps/recents/open` store, which previously had no caller.
- The store is re-keyed on the app's **workspace-relative path** — the old `(tag, name)` key only resolved depth-2 apps: a depth-1 app is its own tag, and two depth-3 apps under different shelves of one tag collide on both fields. The client sends `app.path`; the server derives and validates the relative form (rejects paths outside the workspace).
- `GET /api/apps` merges the store back as `opened_at` (epoch seconds, `updated_at`'s unit); a malformed user-edited timestamp drops that entry instead of failing the listing.
- The two identical `sortApps` copies (Home.tsx, Apps.tsx) are deduped into `@platform/lib/appEntry`: order is `opened_at` desc, `updated_at` stands in for never-opened apps, name breaks ties. Deliberately not `max(opened_at, updated_at)` — an edited-but-unopened app must not leapfrog.
- `APP_RECENTS_CAP` 20 → 200: the store is now the sort input, so the cap must exceed the apps a user cycles through.

## Tests

- Backend: open stamps `opened_at` in the listing; records at every listed depth (1–3) and same-named shelf twins don't collide; outside-workspace path is a no-op; malformed timestamp never 500s; reopen dedupes. `tests/test_apps_api.py` 48 pass.
- Frontend: sortApps ordering + tie-break tests. Full bun suite 890 pass, tsc clean, boundaries OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user-writable `app_recents.json` with path validation and a store key migration from (tag, name); open recording is best-effort and should not block navigation, but sort behavior changes for all app grids.
> 
> **Overview**
> **`/home` and `/apps` now rank apps by last-opened time**, not last-modified. Never-opened apps still sort by `updated_at`; edited-but-unopened apps do not jump ahead of recently opened ones.
> 
> Opening an app **records recency** via fire-and-forget `POST /api/apps/recents/open` from `openApp` and from new-tab gestures (middle-click, Cmd/Shift-click) in `onAppCardClick`. Ctrl/Alt clicks are not recorded so macOS context-menu opens do not scramble the sort.
> 
> The recents store is **re-keyed from `(tag, name)` to workspace-relative `path`** so depth-1 apps and same-named depth-3 shelf twins do not collide. `GET /api/apps` merges `opened_at` (epoch seconds); bad user-edited timestamps are ignored instead of breaking the listing. **`APP_RECENTS_CAP` rises from 20 to 200** because the store drives full-grid ordering.
> 
> Shared **`sortApps` / `appRecency`** live in `appEntry.ts` (replacing duplicate sorters in Home and Apps). Preview cards show the same timestamp used for sorting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5479ab2b8a8a2f05550f92b3d6b5cf7925bf32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->