### PR TITLE
dev.sh: reap the whole process tree, and any dev.sh already running

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ cmux-assets/
 # dev.sh's staged builtin-mount zips (learn.zip / sessions.zip) — build
 # artifacts, freshly rebuilt on every dev.sh run, never committed
 .dev-zips/
+# dev.sh's per-worktree pidfile (one file per branch ref) — how a re-run finds
+# and reaps the dev.sh tree already running for this worktree
+.dev-pids/
 # dev.sh's core_apps reload poke (scripts/dev.sh core_apps watcher)
 core_apps/.dev-reload-trigger.py
 docs/superpowers/plans/

--- a/.gitignore
+++ b/.gitignore
@@ -53,8 +53,10 @@ cmux-assets/
 # dev.sh's staged builtin-mount zips (learn.zip / sessions.zip) — build
 # artifacts, freshly rebuilt on every dev.sh run, never committed
 .dev-zips/
-# dev.sh's per-worktree pidfile (one file per branch ref) — how a re-run finds
-# and reaps the dev.sh tree already running for this worktree
+# dev.sh's per-worktree pidfile (one fixed file per checkout; the dir itself is
+# what makes it worktree-unique) — how a re-run finds and reaps the dev.sh tree
+# already running for this worktree. May also hold leftovers from the older
+# branch-keyed naming, which dev.sh sweeps on startup.
 .dev-pids/
 # dev.sh's core_apps reload poke (scripts/dev.sh core_apps watcher)
 core_apps/.dev-reload-trigger.py

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -66,10 +66,12 @@ set -- ${_ARGS[@]+"${_ARGS[@]}"}
 # baseline, so this is a no-op there. Respect an already-set value so the caller
 # can override (including to "" to force baseline).
 #
-# Resolved this early (before any of the setup below) because the pidfile is
-# keyed on the same ref: the reap has to happen before dev.sh starts rebuilding
-# the shell, or the old run's `vite build --watch` is still writing shell-dist/
-# while this one builds into it.
+# Resolved this early (before any of the setup below) because the port it feeds
+# is what the startup reap waits on for the old server to let go of the bind, and
+# that reap has to happen before dev.sh starts rebuilding the shell — otherwise
+# the old run's `vite build --watch` is still writing shell-dist/ while this one
+# builds into it. (The pidfile deliberately does NOT depend on this ref; see
+# dev_pidfile_path.)
 #
 # NOTE: on main/master this mirrors baseline (port 1777 + the shared
 # ~/.fused-render state), which is exactly what the installed macOS desktop app
@@ -224,19 +226,30 @@ dev_python() {
   fi
 }
 
-# Where this worktree records its dev.sh pid. Keyed on the SANITIZED branch ref
-# — the same key _branch.py already derives the port and state dir from, reused
-# rather than reimplemented so the pidfile name can never drift away from the
-# port it is supposed to describe. Baseline (main/master/detached, which
-# sanitize to "") still needs a filename, hence the literal fallback.
+# Where this worktree records its dev.sh pid. Keyed on the WORKTREE — one fixed
+# filename — because the worktree is what the record actually protects:
+# shell-dist/, node_modules, and the `vite build --watch` writing into them are
+# per-checkout, not per-branch. `.dev-pids/` lives inside $REPO_ROOT, so the
+# directory is already worktree-unique by construction and a branch component in
+# the name would add nothing but two ways to MISS a live process:
+#
+#   * this function used to shell out to dev_python() to sanitize the ref, and
+#     dev_python() legitimately returns "" on the machine the venv bootstrap
+#     below exists to serve (no $VIRTUAL_ENV, no .venv yet, only a versioned
+#     python3.12 that is not on PATH as `python3`). The name silently fell back
+#     to a literal `_baseline` even on a feature branch, so the FIRST run
+#     recorded itself under one name and the next — bootstrap done, interpreter
+#     now resolvable — read another, found nothing, and stacked a second tree;
+#   * `git checkout` while dev.sh is running changed the derived ref, so the next
+#     run looked up a different file and left the old tree alive, with two vite
+#     watchers writing the same shell-dist/.
+#
+# Keying on the path also drops the interpreter dependency entirely, which is
+# what makes `--cleanup` and the startup reap work before any venv exists.
+# Distinguishing one worktree's record from another's is now solely the job of
+# the recorded repo root in dev_pidfile_is_ours — see the note there.
 dev_pidfile_path() {
-  local py ref
-  py="$(dev_python)"
-  ref=""
-  if [[ -n "$py" ]]; then
-    ref="$(cd "$REPO_ROOT" && "$py" -c 'from fused_render._branch import branch_ref; print(branch_ref())' 2>/dev/null || true)"
-  fi
-  printf '%s/.dev-pids/%s\n' "$REPO_ROOT" "${ref:-_baseline}"
+  printf '%s/.dev-pids/dev.sh.pid\n' "$REPO_ROOT"
 }
 
 # Is pid $1 really the dev.sh this pidfile was written for? Four checks, ALL
@@ -253,8 +266,14 @@ dev_pidfile_path() {
 # failed at write time), a recycled pid landing on ANY process whose argv
 # mentions dev.sh — another worktree's dev.sh included — would be reaped.
 # Failing closed costs a missed auto-restart; failing open kills someone's work.
-# The recorded repo root is compared too; the pidfile already lives inside this
-# worktree, so this only catches a file copied between checkouts.
+# The recorded repo root is compared too, and that check carries more weight now
+# that the filename is fixed rather than branch-derived: it is the ONLY thing in
+# the record that names a worktree. It catches a pidfile that arrived from
+# another checkout by any route — copied by hand, restored from a backup, or
+# (the realistic one) a $REPO_ROOT that moved because the directory was renamed
+# or a worktree was re-created at a new path while a dev.sh from the old path was
+# still running. Never drop it on the grounds that the file's location already
+# implies the root.
 dev_pidfile_is_ours() {
   local pid="$1" want_start="$2" want_root="$3" cmd cur_start
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
@@ -364,27 +383,46 @@ fi
 # a second full tree whose vite watch fights this one over shell-dist/.
 DEV_PIDFILE="$(dev_pidfile_path)"
 REAPED=0
-if [[ -f "$DEV_PIDFILE" ]]; then
+# Every record in .dev-pids/, not just the current filename. The pidfile used to
+# be named after the sanitized branch ref, so a dev.sh started before this change
+# — or before a `git checkout` — left its record in this same directory under a
+# different name, and honouring only the new name would leave those trees running
+# forever with nothing but a pattern kill able to find them.
+#
+# Reading the leftovers is safe, and reading them is not a weaker check than
+# reading the current one: .dev-pids/ lives inside $REPO_ROOT, so every file in
+# it describes a process started from THIS worktree, and each one still has to
+# pass all of dev_pidfile_is_ours (live, argv says dev.sh, start time matches,
+# recorded root == $REPO_ROOT) before anything is signalled. A leftover that
+# cannot be verified is simply deleted, so the directory does not accumulate dead
+# branch names. The glob is second so the current name is handled first and the
+# messages come out in the order the developer expects; the `-f` test skips the
+# repeat (already removed) and the no-match literal when the dir does not exist.
+for _pf in "$DEV_PIDFILE" "$REPO_ROOT"/.dev-pids/*; do
+  [[ -f "$_pf" ]] || continue
   rec_pid="" rec_start="" rec_root=""
-  { read -r rec_pid || true; read -r rec_start || true; read -r rec_root || true; } < "$DEV_PIDFILE"
+  { read -r rec_pid || true; read -r rec_start || true; read -r rec_root || true; } < "$_pf"
   if dev_pidfile_is_ours "$rec_pid" "$rec_start" "$rec_root"; then
     echo "==> reaping the dev.sh already running for this worktree (pid $rec_pid)"
     kill_tree_hard "$rec_pid"
     REAPED=1
-    # Wait for the port to actually free: the old server holds the bind for a
-    # beat after its process dies, and cli.py's port guard would SystemExit on
-    # it. Bounded — a port still busy after this belongs to something else, and
-    # the guard should say so loudly rather than have dev.sh hang here.
-    if [[ -n "$PORT" ]]; then
-      for _ in $(seq 1 40); do
-        port_is_open "$PORT" || break
-        sleep 0.25
-      done
-    fi
   else
     echo "==> ignoring a stale dev.sh pidfile (pid ${rec_pid:-?} is gone or is not ours)"
   fi
-  rm -f "$DEV_PIDFILE"
+  rm -f "$_pf"
+done
+
+# Wait for the port to actually free: the old server holds the bind for a beat
+# after its process dies, and cli.py's port guard would SystemExit on it.
+# Bounded — a port still busy after this belongs to something else, and the guard
+# should say so loudly rather than have dev.sh hang here. Done once, after the
+# whole loop, because every record above belongs to this worktree and so every
+# reaped server was contending for the same port.
+if [[ "$REAPED" -eq 1 && -n "$PORT" ]]; then
+  for _ in $(seq 1 40); do
+    port_is_open "$PORT" || break
+    sleep 0.25
+  done
 fi
 
 if [[ "$CLEANUP_ONLY" -eq 1 ]]; then

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -41,7 +41,19 @@
 # dev.sh falls back to the original single-launch behavior.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# PHYSICAL, not logical: `cd -P` + `pwd -P` resolve every symlink, so this is
+# the same string no matter how the developer spelled the path they invoked
+# (a symlinked checkout, /tmp vs /private/tmp on macOS, an alias into a worktree).
+# That matters because $REPO_ROOT is what dev_pidfile_is_ours compares the
+# recorded root against, and it is the only field in the record that names a
+# worktree at all. With a logical `pwd`, one run through a symlink and the next
+# through the real path derived two different roots for the SAME .dev-pids/
+# directory: the second called the live record not-ours, deleted it, and started
+# a second tree — the duplicate-vite bug, now with no record left to find it by.
+# `cd -P` twice rather than `cd "…/.."` because a logical `..` is applied
+# textually and would jump to the wrong parent when it is `scripts` itself that
+# is the symlink.
+REPO_ROOT="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && cd -P .. && pwd -P)"
 FRONTEND="$REPO_ROOT/frontend"
 
 # --cleanup is dev.sh's own flag and must not reach the server: cli.py's parser
@@ -208,10 +220,13 @@ kill_tree_hard() {
 }
 
 # A python that can import this worktree's fused_render._branch. Deliberately
-# NOT the $PY resolved further down: the pidfile has to be readable before the
-# venv bootstrap runs (and by `--cleanup`, which bootstraps nothing). _branch is
-# stdlib-only and is imported from the source tree via cwd, so any python3 gives
-# the same answer the server will.
+# NOT the $PY resolved further down: its two callers — dev_effective_port and
+# port_is_open — both run BEFORE the venv bootstrap, because the reap has to know
+# which port to wait on before this run starts rebuilding anything, and because
+# `--cleanup` bootstraps nothing at all. _branch is stdlib-only and is imported
+# from the source tree via cwd, so any python3 gives the same answer the server
+# will. (The pidfile used to be a third caller; it no longer resolves an
+# interpreter for anything — see dev_pidfile_path.)
 dev_python() {
   if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then
     printf '%s\n' "$VIRTUAL_ENV/bin/python"
@@ -393,11 +408,33 @@ REAPED=0
 # reading the current one: .dev-pids/ lives inside $REPO_ROOT, so every file in
 # it describes a process started from THIS worktree, and each one still has to
 # pass all of dev_pidfile_is_ours (live, argv says dev.sh, start time matches,
-# recorded root == $REPO_ROOT) before anything is signalled. A leftover that
-# cannot be verified is simply deleted, so the directory does not accumulate dead
-# branch names. The glob is second so the current name is handled first and the
-# messages come out in the order the developer expects; the `-f` test skips the
-# repeat (already removed) and the no-match literal when the dir does not exist.
+# recorded root == $REPO_ROOT) before anything is signalled. The glob is second
+# so the current name is handled first and the messages come out in the order the
+# developer expects; the `-f` test skips the repeat (already handled) and the
+# no-match literal when the dir does not exist.
+#
+# What gets DELETED is a separate question from what gets reaped, and the two
+# must not be conflated. dev_pidfile_is_ours fails closed, so "not ours" also
+# covers recoverable answers — a `ps` that failed under load, a start time that
+# read back empty, a $REPO_ROOT that skewed. Deleting on that answer throws away
+# the only handle on a tree that may well be alive, and the sole way back would
+# be the pattern kill this section forbids. So only two kinds of record are
+# removed: one we just reaped (its process is now gone), and one whose recorded
+# pid is not alive at all (definitively dead — nothing can be lost with it).
+# Anything else stays on disk for a later run to re-evaluate, and is named in the
+# output so the developer can look at it. (One record cannot actually be kept:
+# the CURRENT filename is where this run has to write its own pid a few lines
+# down, so an unverifiable record there is overwritten regardless. That is why
+# the note below is loud and names the pid — it is the developer's only chance to
+# act on it.)
+#
+# `!= $$` in the alive test is not redundant with the same check inside
+# dev_pidfile_is_ours: a record carrying THIS pid means our pid was recycled from
+# the dev.sh that wrote it, so that process is gone and the record is genuinely
+# dead. Without the guard `pid_alive` would answer yes about ourselves and the
+# file would be kept forever.
+STALE_DEAD=0
+STALE_KEPT=""
 for _pf in "$DEV_PIDFILE" "$REPO_ROOT"/.dev-pids/*; do
   [[ -f "$_pf" ]] || continue
   rec_pid="" rec_start="" rec_root=""
@@ -406,18 +443,38 @@ for _pf in "$DEV_PIDFILE" "$REPO_ROOT"/.dev-pids/*; do
     echo "==> reaping the dev.sh already running for this worktree (pid $rec_pid)"
     kill_tree_hard "$rec_pid"
     REAPED=1
+    rm -f "$_pf"
+  elif [[ "$rec_pid" =~ ^[0-9]+$ ]] && [[ "$rec_pid" != "$$" ]] && pid_alive "$rec_pid"; then
+    STALE_KEPT="$STALE_KEPT $(basename "$_pf")(pid $rec_pid)"
   else
-    echo "==> ignoring a stale dev.sh pidfile (pid ${rec_pid:-?} is gone or is not ours)"
+    STALE_DEAD=$((STALE_DEAD + 1))
+    rm -f "$_pf"
   fi
-  rm -f "$_pf"
 done
+
+# One line per OUTCOME, not one per file: a worktree upgraded from the
+# branch-keyed naming can hold several leftovers at once, and a burst of
+# identical "stale pidfile" lines reads as several stale processes when it is
+# really one directory being tidied.
+if [[ "$STALE_DEAD" -gt 0 ]]; then
+  echo "==> discarded $STALE_DEAD stale dev.sh pidfile(s) — their processes are gone"
+fi
+if [[ -n "${STALE_KEPT// /}" ]]; then
+  echo "==> NOTE: pidfile(s) naming a LIVE pid this run could not verify:$STALE_KEPT" >&2
+  echo "    left in place rather than deleted (verification fails closed, so this" >&2
+  echo "    can be a transient ps failure as easily as a foreign process). Check" >&2
+  echo "    with: pgrep -laf dev.sh — and stop it yourself if it is a dev.sh for" >&2
+  echo "    this worktree, because this run will not signal it." >&2
+fi
 
 # Wait for the port to actually free: the old server holds the bind for a beat
 # after its process dies, and cli.py's port guard would SystemExit on it.
 # Bounded — a port still busy after this belongs to something else, and the guard
 # should say so loudly rather than have dev.sh hang here. Done once, after the
-# whole loop, because every record above belongs to this worktree and so every
-# reaped server was contending for the same port.
+# whole loop, and deliberately only for $PORT: a leftover record written before a
+# `git checkout` names a server on the OTHER branch's port, which this run is not
+# about to bind and therefore need not wait on. $PORT is the only port whose
+# release can block us.
 if [[ "$REAPED" -eq 1 && -n "$PORT" ]]; then
   for _ in $(seq 1 40); do
     port_is_open "$PORT" || break

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -26,6 +26,8 @@
 #
 # Knobs:
 #   * --no-browser (passed through): dev.sh won't open a tab either.
+#   * --cleanup: reap this worktree's running dev.sh tree and exit, starting
+#     nothing. Consumed here, never forwarded to the server.
 #   * FUSED_RENDER_NO_RELOAD=1: disable Python auto-reload; run the server once
 #     exactly as before (server opens its own browser tab).
 # watchfiles is auto-installed into the venv if missing; if the install fails,
@@ -34,6 +36,308 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FRONTEND="$REPO_ROOT/frontend"
+
+# --cleanup is dev.sh's own flag and must not reach the server: cli.py's parser
+# rejects unknown options, so leaving it in "$@" would turn a cleanup into a
+# usage error. Strip it here, before either passthrough site (the watchfiles
+# CMD builder and the single-launch argv) reads "$@".
+CLEANUP_ONLY=0
+_ARGS=()
+for _a in "$@"; do
+  if [[ "$_a" == "--cleanup" ]]; then CLEANUP_ONLY=1; else _ARGS+=("$_a"); fi
+done
+# `${_ARGS[@]+…}` because bash 3.2 (what macOS ships) treats an empty array as
+# unset under `set -u` and would abort on a bare `"${_ARGS[@]}"`.
+set -- ${_ARGS[@]+"${_ARGS[@]}"}
+
+# Isolate each branch/worktree onto its own port + state dir. Without this every
+# dev.sh run (main checkout and every worktree) defaults to the baseline port
+# 1777 and clobbers the same ~/.fused-render state, so a server left running in
+# one worktree collides with — or gets served stale to — another. Deriving the
+# ref from the current branch gives each branch a deterministic port of its own
+# (see fused_render/_branch.py). main/master and detached HEAD sanitize to the
+# baseline, so this is a no-op there. Respect an already-set value so the caller
+# can override (including to "" to force baseline).
+#
+# Resolved this early (before any of the setup below) because the pidfile is
+# keyed on the same ref: the reap has to happen before dev.sh starts rebuilding
+# the shell, or the old run's `vite build --watch` is still writing shell-dist/
+# while this one builds into it.
+#
+# NOTE: on main/master this mirrors baseline (port 1777 + the shared
+# ~/.fused-render state), which is exactly what the installed macOS desktop app
+# uses. Running dev.sh on main alongside the installed app therefore collides:
+# the port bind fails loudly (see cli.py _check_port_free) and, more subtly,
+# both read/write the same baseline state dir. Work on a feature branch (or pass
+# FUSED_RENDER_BRANCH / --port) to run dev fully isolated from the desktop app.
+if [[ -z "${FUSED_RENDER_BRANCH+x}" ]]; then
+  export FUSED_RENDER_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
+fi
+
+# ---------------------------------------------------------------------------
+# Process cleanup: kill_tree, the per-worktree pidfile, and the one shutdown
+# handler every trap installs.
+#
+# dev.sh used to leak entire process trees. Eleven orphans were hand-killed off
+# one machine, some 10-20 days old, from three separate holes:
+#
+#   1. `(cd "$FRONTEND" && npm run watch) &` makes $! the SUBSHELL, not vite.
+#      The observed chain was dev.sh -> subshell -> npm -> node vite; the trap
+#      killed the subshell, and npm + vite reparented to init and kept
+#      rebuilding into shell-dist/ forever. Same shape for the core_apps poll
+#      loop (which has a `sleep` child) and the browser opener.
+#   2. The watchfiles-supervised server ran in the FOREGROUND and appeared in no
+#      trap at all — and bash defers a trap handler until the current foreground
+#      command returns, so `kill <dev.sh>` was merely queued. Those trees only
+#      collapsed once the watchfiles children were signalled directly.
+#   3. Nothing noticed an already-running dev.sh for the same worktree. cli.py's
+#      port guard catches a second SERVER, but two vite watchers coexist happily
+#      while both write the same shell-dist/ — which is how one worktree ended
+#      up with two complete dev.sh trees.
+#
+# Everything below reaps ONLY the pids this run owns, or the tree the pidfile
+# names. Never a pattern kill: other worktrees on this machine run their own
+# dev servers and orphans that are none of our business.
+# ---------------------------------------------------------------------------
+
+# macOS ships bash 3.2 and has no `setsid`, so there is no process group to
+# signal — walk the tree by hand. `pgrep -P` exists on both macOS and Linux
+# (CI runs linux-desktop), unlike the BSD-only ps flags. Depth-first: children
+# die before their parent, so nothing reparents to init mid-kill and escapes.
+kill_tree() {
+  local pid="$1" child
+  [[ -n "$pid" ]] || return 0
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    kill_tree "$child"
+  done
+  kill -TERM "$pid" 2>/dev/null || true
+}
+
+# The same walk, but only collecting pids. Snapshotting BEFORE the kill is what
+# makes the KILL escalation possible at all: once TERM lands, the parent links
+# are gone and the tree can no longer be rediscovered.
+tree_pids() {
+  local pid="$1" child
+  [[ -n "$pid" ]] || return 0
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    tree_pids "$child"
+  done
+  printf '%s\n' "$pid"
+}
+
+# Alive AND not a zombie. `kill -0` answers yes for a zombie (it exists until
+# it is waited for), which would make every shutdown burn the full grace period
+# on our own just-TERMed children.
+pid_alive() {
+  local st
+  st="$(ps -o stat= -p "$1" 2>/dev/null | tr -d '[:space:]')"
+  [[ -n "$st" && "${st:0:1}" != "Z" ]]
+}
+
+# TERM the tree, then KILL whatever is still standing. The grace period is
+# bounded (~2s) rather than a wait-until-gone loop: a child that traps TERM must
+# not be able to hang the Ctrl-C the developer just pressed.
+kill_tree_hard() {
+  local pid="$1" pids p i alive
+  [[ -n "$pid" ]] || return 0
+  pids="$(tree_pids "$pid")"
+  kill_tree "$pid"
+  for i in $(seq 1 10); do
+    alive=0
+    for p in $pids; do
+      if pid_alive "$p"; then alive=1; break; fi
+    done
+    [[ "$alive" -eq 0 ]] && return 0
+    sleep 0.2
+  done
+  for p in $pids; do
+    kill -KILL "$p" 2>/dev/null || true
+  done
+}
+
+# A python that can import this worktree's fused_render._branch. Deliberately
+# NOT the $PY resolved further down: the pidfile has to be readable before the
+# venv bootstrap runs (and by `--cleanup`, which bootstraps nothing). _branch is
+# stdlib-only and is imported from the source tree via cwd, so any python3 gives
+# the same answer the server will.
+dev_python() {
+  if [[ -n "${VIRTUAL_ENV:-}" && -x "$VIRTUAL_ENV/bin/python" ]]; then
+    printf '%s\n' "$VIRTUAL_ENV/bin/python"
+  elif [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
+    printf '%s\n' "$REPO_ROOT/.venv/bin/python"
+  else
+    command -v python3 || true
+  fi
+}
+
+# Where this worktree records its dev.sh pid. Keyed on the SANITIZED branch ref
+# — the same key _branch.py already derives the port and state dir from, reused
+# rather than reimplemented so the pidfile name can never drift away from the
+# port it is supposed to describe. Baseline (main/master/detached, which
+# sanitize to "") still needs a filename, hence the literal fallback.
+dev_pidfile_path() {
+  local py ref
+  py="$(dev_python)"
+  ref=""
+  if [[ -n "$py" ]]; then
+    ref="$(cd "$REPO_ROOT" && "$py" -c 'from fused_render._branch import branch_ref; print(branch_ref())' 2>/dev/null || true)"
+  fi
+  printf '%s/.dev-pids/%s\n' "$REPO_ROOT" "${ref:-_baseline}"
+}
+
+# Is pid $1 really the dev.sh this pidfile was written for? Three independent
+# checks, because getting this wrong means killing an innocent process:
+#   * it is alive at all;
+#   * its command line still mentions dev.sh (a recycled pid almost never will);
+#   * its start time matches the one recorded alongside the pid — the only check
+#     that actually rules out pid reuse, since a *new* dev.sh in another
+#     worktree could otherwise satisfy the first two.
+# The recorded repo root is compared too; the pidfile already lives inside this
+# worktree, so this only catches a file copied between checkouts.
+# Any doubt resolves to "not ours" — a stale pidfile is a no-op plus a delete,
+# never a guess.
+dev_pidfile_is_ours() {
+  local pid="$1" want_start="$2" want_root="$3" cmd cur_start
+  [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+  [[ "$pid" != "$$" ]] || return 1
+  [[ "$want_root" == "$REPO_ROOT" ]] || return 1
+  pid_alive "$pid" || return 1
+  cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+  case "$cmd" in
+    *dev.sh*) ;;
+    *) return 1 ;;
+  esac
+  if [[ -n "$want_start" ]]; then
+    cur_start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')"
+    [[ "$cur_start" == "$want_start" ]] || return 1
+  fi
+  return 0
+}
+
+# Every background pid this run owns. Set before the traps so the handler can
+# read them lazily under `set -u` no matter how early we die.
+WATCH_PID=""
+CORE_WATCH_PID=""
+OPENER_PID=""
+SERVER_PID=""
+DEV_PIDFILE=""
+
+# The single shutdown handler — one function, installed by every trap, so the
+# two trap sites that used to carry DIFFERENT pid lists (and neither of them the
+# server) cannot drift apart again.
+dev_shutdown() {
+  # Disarm first: the INT/TERM handlers exit, which re-enters via EXIT.
+  trap - EXIT INT TERM
+  local pids="" p i alive
+  for p in "$WATCH_PID" "$CORE_WATCH_PID" "$OPENER_PID" "$SERVER_PID"; do
+    [[ -n "$p" ]] || continue
+    pids="$pids $(tree_pids "$p")"
+    kill_tree "$p"
+  done
+  if [[ -n "${pids// /}" ]]; then
+    for i in $(seq 1 10); do
+      alive=0
+      for p in $pids; do
+        if pid_alive "$p"; then alive=1; break; fi
+      done
+      [[ "$alive" -eq 0 ]] && break
+      sleep 0.2
+    done
+    for p in $pids; do
+      pid_alive "$p" && kill -KILL "$p" 2>/dev/null || true
+    done
+    # Reap our own children rather than leaving zombies parked on this shell.
+    # Safe from hanging: anything that ignored TERM has just been KILLed.
+    wait 2>/dev/null || true
+  fi
+  [[ -n "$DEV_PIDFILE" ]] && rm -f "$DEV_PIDFILE"
+  return 0
+}
+
+# Library mode: define the helpers, then stop before doing anything. Lets the
+# tests drive kill_tree and the stale-pidfile decision against the real code
+# instead of a copy that can rot (tests/test_dev_sh_process_cleanup.py).
+if [[ -n "${FUSED_RENDER_DEV_SH_LIB:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# The port this run will use, for the post-reap wait below and for the browser
+# opener further down (computed once so the two cannot disagree). An explicit
+# --port wins; otherwise it is the per-branch default the server derives.
+dev_effective_port() {
+  local a want=0 port="" py
+  for a in "$@"; do
+    if [[ "$want" -eq 1 ]]; then port="$a"; want=0; continue; fi
+    case "$a" in
+      --port=*) port="${a#--port=}" ;;
+      --port)   want=1 ;;
+    esac
+  done
+  if [[ -z "$port" ]]; then
+    py="$(dev_python)"
+    if [[ -n "$py" ]]; then
+      port="$(cd "$REPO_ROOT" && "$py" -c 'from fused_render._branch import branch_port; print(branch_port())' 2>/dev/null || true)"
+    fi
+  fi
+  printf '%s\n' "$port"
+}
+PORT="$(dev_effective_port "$@")"
+
+# Is $1 accepting connections? Same probe the browser opener uses.
+port_is_open() {
+  local py
+  py="$(dev_python)"
+  [[ -n "$py" && -n "$1" ]] || return 1
+  "$py" -c "import socket,sys; s=socket.socket(); s.settimeout(0.5); sys.exit(0 if s.connect_ex(('127.0.0.1', int(sys.argv[1])))==0 else 1)" "$1" 2>/dev/null
+}
+
+# Reap a previous dev.sh for THIS worktree. Restarting is nearly always what the
+# developer meant by running dev.sh again — and the alternative is hole 3 above:
+# a second full tree whose vite watch fights this one over shell-dist/.
+DEV_PIDFILE="$(dev_pidfile_path)"
+if [[ -f "$DEV_PIDFILE" ]]; then
+  rec_pid="" rec_start="" rec_root=""
+  { read -r rec_pid || true; read -r rec_start || true; read -r rec_root || true; } < "$DEV_PIDFILE"
+  if dev_pidfile_is_ours "$rec_pid" "$rec_start" "$rec_root"; then
+    echo "==> reaping the dev.sh already running for this worktree (pid $rec_pid)"
+    kill_tree_hard "$rec_pid"
+    # Wait for the port to actually free: the old server holds the bind for a
+    # beat after its process dies, and cli.py's port guard would SystemExit on
+    # it. Bounded — a port still busy after this belongs to something else, and
+    # the guard should say so loudly rather than have dev.sh hang here.
+    if [[ -n "$PORT" ]]; then
+      for _ in $(seq 1 40); do
+        port_is_open "$PORT" || break
+        sleep 0.25
+      done
+    fi
+  else
+    echo "==> ignoring a stale dev.sh pidfile (pid ${rec_pid:-?} is gone or is not ours)"
+  fi
+  rm -f "$DEV_PIDFILE"
+fi
+
+if [[ "$CLEANUP_ONLY" -eq 1 ]]; then
+  echo "==> --cleanup: nothing left to start"
+  exit 0
+fi
+
+# Record this run. Written after the reap so the dying predecessor's own EXIT
+# trap (which removes the pidfile) cannot delete the entry we just made —
+# kill_tree_hard does not return until that process is gone. The start time goes
+# in alongside the pid so a recycled pid can be recognized and left alone.
+mkdir -p "$REPO_ROOT/.dev-pids"
+printf '%s\n%s\n%s\n' \
+  "$$" \
+  "$(ps -o lstart= -p $$ 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')" \
+  "$REPO_ROOT" > "$DEV_PIDFILE"
+
+# Armed from here on, so an abort anywhere in the setup below (a failed npm
+# install, a Ctrl-C during the venv bootstrap) still clears the pidfile and
+# reaps whatever had started.
+trap 'dev_shutdown' EXIT
+trap 'dev_shutdown; exit 130' INT
+trap 'dev_shutdown; exit 143' TERM
 
 # Read core templates straight from the repo, skipping the stage-into-home copy
 # (~/.fused-render/.core-templates). Without this the server serves the last
@@ -71,25 +375,6 @@ done
 # already-set value so the caller can override (including to "0" to force the
 # production dies-with-server behavior).
 export FUSED_RENDER_RCLONE_PERSIST="${FUSED_RENDER_RCLONE_PERSIST:-1}"
-
-# Isolate each branch/worktree onto its own port + state dir. Without this every
-# dev.sh run (main checkout and every worktree) defaults to the baseline port
-# 1777 and clobbers the same ~/.fused-render state, so a server left running in
-# one worktree collides with — or gets served stale to — another. Deriving the
-# ref from the current branch gives each branch a deterministic port of its own
-# (see fused_render/_branch.py). main/master and detached HEAD sanitize to the
-# baseline, so this is a no-op there. Respect an already-set value so the caller
-# can override (including to "" to force baseline).
-#
-# NOTE: on main/master this mirrors baseline (port 1777 + the shared
-# ~/.fused-render state), which is exactly what the installed macOS desktop app
-# uses. Running dev.sh on main alongside the installed app therefore collides:
-# the port bind fails loudly (see cli.py _check_port_free) and, more subtly,
-# both read/write the same baseline state dir. Work on a feature branch (or pass
-# FUSED_RENDER_BRANCH / --port) to run dev fully isolated from the desktop app.
-if [[ -z "${FUSED_RENDER_BRANCH+x}" ]]; then
-  export FUSED_RENDER_BRANCH="$(git -C "$REPO_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-fi
 
 # Python: active venv first, then the repo-local .venv. With neither, bootstrap
 # a repo-local .venv (with the `dev` + `fused` + `bundled` extras) so a fresh
@@ -277,11 +562,12 @@ rm -f "$DIST_INDEX"
 
 echo "==> starting vite watch + fused-render server (Ctrl-C stops both)"
 (cd "$FRONTEND" && npm run watch) &
+# $! is the SUBSHELL, not vite: the real chain is subshell -> npm -> node vite.
+# dev_shutdown walks down from here with kill_tree; killing this pid alone is
+# exactly what left three `vite build --watch` nodes running under init for
+# weeks. The traps are already armed (see the cleanup section at the top) and
+# read WATCH_PID lazily, so there is nothing to re-install here.
 WATCH_PID=$!
-# OPENER_PID is the one-shot browser opener (set below, reload path only). The
-# trap references it lazily so it's harmless while still unset.
-OPENER_PID=""
-trap 'kill "$WATCH_PID" 2>/dev/null || true; [[ -n "$OPENER_PID" ]] && kill "$OPENER_PID" 2>/dev/null || true' EXIT INT TERM
 
 echo "==> waiting for the vite watch to emit the shell bundle"
 for _ in $(seq 1 60); do
@@ -315,23 +601,16 @@ if [[ "$RELOAD" -eq 1 ]]; then
 fi
 
 if [[ "$RELOAD" -eq 1 ]]; then
-  # Decide whether to open a browser tab, and on which port. The server runs
-  # with --no-browser under the reloader, so dev.sh opens the tab exactly once.
+  # Decide whether to open a browser tab. The server runs with --no-browser
+  # under the reloader, so dev.sh opens the tab exactly once. $PORT is already
+  # resolved (dev_effective_port, at the top) — the startup reap needs the same
+  # number to wait on, and deriving it twice is how the two would drift.
   NO_BROWSER=0
-  PORT=""
-  want_port=0
   for a in "$@"; do
-    if [[ "$want_port" -eq 1 ]]; then PORT="$a"; want_port=0; continue; fi
     case "$a" in
       --no-browser) NO_BROWSER=1 ;;
-      --port=*)     PORT="${a#--port=}" ;;
-      --port)       want_port=1 ;;
     esac
   done
-  # No explicit --port: fall back to the per-branch default the server derives.
-  if [[ -z "$PORT" ]]; then
-    PORT="$("$PY" -c 'from fused_render._branch import branch_port; print(branch_port())' 2>/dev/null || true)"
-  fi
 
   # One-shot opener: wait for the port to accept a connection, then open the tab.
   if [[ "$NO_BROWSER" -eq 0 && -n "$PORT" ]]; then
@@ -399,8 +678,9 @@ if [[ "$RELOAD" -eq 1 ]]; then
       fi
     done
   ) &
+  # Another subshell pid, and this one has a `sleep` child of its own — same
+  # kill_tree treatment as the vite watch above.
   CORE_WATCH_PID=$!
-  trap 'kill "$WATCH_PID" "$CORE_WATCH_PID" 2>/dev/null || true; [[ -n "$OPENER_PID" ]] && kill "$OPENER_PID" 2>/dev/null || true' EXIT INT TERM
 
   # The restart target is dev_server_run.sh (re-stage builtin zips, then exec
   # the server) so every restart mounts current core_apps content — not the
@@ -408,8 +688,33 @@ if [[ "$RELOAD" -eq 1 ]]; then
   CMD="bash $(printf '%q' "$REPO_ROOT/scripts/dev_server_run.sh") $(printf '%q' "$PY")"
   for a in "$@"; do CMD+=" $(printf '%q' "$a")"; done
   CMD+=" --no-browser"
-  "$PY" -m watchfiles --filter python "$CMD" "$REPO_ROOT/fused_render" "$REPO_ROOT/core_apps"
+  # BACKGROUNDED, then waited on — not run in the foreground, which is how this
+  # whole tree used to survive `kill <dev.sh>`: bash defers a trap handler until
+  # the current foreground command returns, so the signal only queued a handler
+  # that never got to run, and watchfiles + the server it supervises were in no
+  # trap anyway. `wait` is interruptible, so the handler fires immediately.
+  "$PY" -m watchfiles --filter python "$CMD" "$REPO_ROOT/fused_render" "$REPO_ROOT/core_apps" &
+  SERVER_PID=$!
+  # `wait` returns the child's status and a signalled child returns non-zero, so
+  # `set -e` would abort here on an ordinary Ctrl-C; the status is captured
+  # instead and re-raised below, which keeps a genuinely failing server failing.
+  set +e
+  wait "$SERVER_PID"
+  SERVER_STATUS=$?
+  set -e
+  SERVER_PID=""
+  exit "$SERVER_STATUS"
 else
   # Original single-launch behavior: the server opens its own browser tab.
-  "$PY" -m fused_render.cli "$@"
+  # Backgrounded + waited on for the same reason as the reload path above: a
+  # foreground server defers the trap, and the vite watch started earlier would
+  # be left running.
+  "$PY" -m fused_render.cli "$@" &
+  SERVER_PID=$!
+  set +e
+  wait "$SERVER_PID"
+  SERVER_STATUS=$?
+  set -e
+  SERVER_PID=""
+  exit "$SERVER_STATUS"
 fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -483,8 +483,25 @@ if [[ "$REAPED" -eq 1 && -n "$PORT" ]]; then
 fi
 
 if [[ "$CLEANUP_ONLY" -eq 1 ]]; then
-  if [[ "$REAPED" -eq 1 ]]; then
+  # The summary is a function of ALL THREE sweep outcomes, not just the reap
+  # flag. --cleanup exists to answer one question — "is anything still running
+  # for this worktree?" — so a kept record has to outrank everything else: it
+  # names a pid that is alive right now and that this run deliberately did not
+  # signal. Reporting "nothing left running" or "nothing reaped" alongside it
+  # would contradict the NOTE printed a few lines above, in the one command whose
+  # entire output is that answer.
+  if [[ -n "${STALE_KEPT// /}" ]]; then
+    echo "==> --cleanup: NOT clean — see the unverified pidfile(s) noted above"
+    if [[ "$REAPED" -eq 1 ]]; then
+      echo "    (the dev.sh this worktree recorded WAS reaped; what is left is"
+      echo "     the record(s) above, whose pids are alive but unverifiable)"
+    fi
+  elif [[ "$REAPED" -eq 1 ]]; then
     echo "==> --cleanup: done, nothing left running for this worktree"
+  elif [[ "$STALE_DEAD" -gt 0 ]]; then
+    # Distinct from the case below: records DID exist, so this worktree is not a
+    # fresh one — their processes had simply already exited. Nothing to hunt for.
+    echo "==> --cleanup: nothing was running — only dead records to tidy up"
   else
     # Say what was NOT done, and why. A dev.sh started before this change wrote
     # no pidfile at all, which is the common case on the first upgrade — and

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -262,7 +262,17 @@ dev_pidfile_is_ours() {
   [[ -n "$want_start" ]] || return 1
   [[ "$want_root" == "$REPO_ROOT" ]] || return 1
   pid_alive "$pid" || return 1
-  cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+  # `-ww` is load-bearing on Linux and NOT cosmetic: GNU procps truncates the
+  # command column to 80 chars whenever stdout is not a terminal (it is a pipe
+  # here), and dev.sh lives at the END of its own command line. Any checkout
+  # deeper than ~74 characters — e.g. a git worktree under
+  # <repo>/.claude/worktrees/<name>/scripts/dev.sh — would lose the "dev.sh"
+  # suffix, this check would reject the pidfile forever, and the startup reap
+  # would silently do nothing while dev.sh went back to stacking duplicate
+  # trees. Exactly the invisible failure this whole section exists to remove.
+  # BSD ps (macOS) accepts -ww too and never truncated a piped -o in the first
+  # place, so this needs no platform branch.
+  cmd="$(ps -ww -o command= -p "$pid" 2>/dev/null || true)"
   case "$cmd" in
     *dev.sh*) ;;
     *) return 1 ;;

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -5,8 +5,15 @@
 #
 # Pipeline: npm install (if needed) -> one gated build (tsc + vite, so type
 # errors surface before anything starts) -> `vite build --watch` in the
-# background -> fused-render server in the foreground, supervised by
-# watchfiles for Python auto-reload. Ctrl-C stops everything.
+# background -> fused-render server (supervised by watchfiles for Python
+# auto-reload) ALSO in the background, with dev.sh parked on `wait` for it.
+# Ctrl-C — or a plain `kill` of this script — stops everything.
+#
+# The server is deliberately not a foreground child: bash defers a trap handler
+# until the current foreground command returns, so while it ran in the
+# foreground a signal to dev.sh merely QUEUED the handler and the whole tree
+# survived. `wait` is interruptible, so the handler runs at once. See the
+# process-cleanup section below, which owns the teardown for every pid.
 #
 # Two independent reload paths:
 #   * Frontend: `vite build --watch` rebuilds into fused_render/static/
@@ -100,6 +107,15 @@ fi
 # dev servers and orphans that are none of our business.
 # ---------------------------------------------------------------------------
 
+# Every walk below is `pgrep -P`, so a machine without pgrep would degrade
+# silently back to the exact orphan bug this section exists to fix (the walks
+# swallow the failure with `|| true` and only the root pid gets signalled). Say
+# so once, loudly, rather than leaking vite watchers for another three weeks.
+if ! command -v pgrep >/dev/null 2>&1; then
+  echo "==> WARNING: pgrep not found — dev.sh can only signal its direct" >&2
+  echo "    children, so a vite watch or server may be left running after exit." >&2
+fi
+
 # macOS ships bash 3.2 and has no `setsid`, so there is no process group to
 # signal — walk the tree by hand. `pgrep -P` exists on both macOS and Linux
 # (CI runs linux-desktop), unlike the BSD-only ps flags. Depth-first: children
@@ -134,15 +150,42 @@ pid_alive() {
   [[ -n "$st" && "${st:0:1}" != "Z" ]]
 }
 
-# TERM the tree, then KILL whatever is still standing. The grace period is
-# bounded (~2s) rather than a wait-until-gone loop: a child that traps TERM must
-# not be able to hang the Ctrl-C the developer just pressed.
-kill_tree_hard() {
-  local pid="$1" pids p i alive
-  [[ -n "$pid" ]] || return 0
-  pids="$(tree_pids "$pid")"
-  kill_tree "$pid"
+# TERM every tree rooted at the (space-separated) pids in $1, then KILL whatever
+# is still standing. The grace period is bounded (~2s) rather than a
+# wait-until-gone loop: a child that traps TERM must not be able to hang the
+# Ctrl-C the developer just pressed.
+#
+# One function for both callers (the startup reap and dev_shutdown) so the
+# escalation policy cannot differ between "reap the previous run" and "reap this
+# one" — the two trap sites already drifted apart once.
+reap_trees() {
+  local roots="$1" pids="" p i alive newpid
+  for p in $roots; do
+    [[ -n "$p" ]] || continue
+    pids="$pids $(tree_pids "$p")"
+    kill_tree "$p"
+  done
+  [[ -n "${pids// /}" ]] || return 0
   for i in $(seq 1 10); do
+    # Re-walk from the roots on every pass: a tree can GROW mid-teardown. The
+    # core_apps poll loop touches a *.py trigger, which is exactly what makes
+    # watchfiles spawn a REPLACEMENT server — so a restart can land between the
+    # walk above and the TERM, and that new server would inherit the port with
+    # nothing supervising it. Anything that appears is TERMed and joins the
+    # escalation list. (A root that is already gone contributes nothing, which is
+    # why this cannot chase a pid we never owned.)
+    for p in $roots; do
+      [[ -n "$p" ]] || continue
+      for newpid in $(tree_pids "$p"); do
+        case " $pids " in
+          *" $newpid "*) ;;
+          *)
+            pids="$pids $newpid"
+            kill -TERM "$newpid" 2>/dev/null || true
+            ;;
+        esac
+      done
+    done
     alive=0
     for p in $pids; do
       if pid_alive "$p"; then alive=1; break; fi
@@ -151,8 +194,15 @@ kill_tree_hard() {
     sleep 0.2
   done
   for p in $pids; do
-    kill -KILL "$p" 2>/dev/null || true
+    if pid_alive "$p"; then kill -KILL "$p" 2>/dev/null || true; fi
   done
+  return 0
+}
+
+# Single-tree convenience wrapper (the startup reap has exactly one root).
+kill_tree_hard() {
+  [[ -n "$1" ]] || return 0
+  reap_trees "$1"
 }
 
 # A python that can import this worktree's fused_render._branch. Deliberately
@@ -166,7 +216,11 @@ dev_python() {
   elif [[ -x "$REPO_ROOT/.venv/bin/python" ]]; then
     printf '%s\n' "$REPO_ROOT/.venv/bin/python"
   else
-    command -v python3 || true
+    # Last resort, and it CAN come up empty: on a machine with no venv yet and
+    # only a versioned `python3.12` on PATH (the setup the venv bootstrap below
+    # exists to serve) there is no bare python3 to find. Callers must treat ""
+    # as "not yet resolvable" and say so — see the PORT note below.
+    command -v python3 || command -v python || true
   fi
 }
 
@@ -185,21 +239,27 @@ dev_pidfile_path() {
   printf '%s/.dev-pids/%s\n' "$REPO_ROOT" "${ref:-_baseline}"
 }
 
-# Is pid $1 really the dev.sh this pidfile was written for? Three independent
-# checks, because getting this wrong means killing an innocent process:
-#   * it is alive at all;
-#   * its command line still mentions dev.sh (a recycled pid almost never will);
+# Is pid $1 really the dev.sh this pidfile was written for? Four checks, ALL
+# mandatory, because getting this wrong means kill_tree_hard on an innocent
+# process:
+#   * a recorded start time exists at all;
+#   * it is alive;
+#   * its command line still mentions dev.sh;
 #   * its start time matches the one recorded alongside the pid — the only check
 #     that actually rules out pid reuse, since a *new* dev.sh in another
-#     worktree could otherwise satisfy the first two.
+#     worktree satisfies the other two just as well as ours does.
+# The start-time check is required rather than best-effort for exactly that
+# reason: were it skipped when the record is empty (a `ps -o lstart=` that
+# failed at write time), a recycled pid landing on ANY process whose argv
+# mentions dev.sh — another worktree's dev.sh included — would be reaped.
+# Failing closed costs a missed auto-restart; failing open kills someone's work.
 # The recorded repo root is compared too; the pidfile already lives inside this
 # worktree, so this only catches a file copied between checkouts.
-# Any doubt resolves to "not ours" — a stale pidfile is a no-op plus a delete,
-# never a guess.
 dev_pidfile_is_ours() {
   local pid="$1" want_start="$2" want_root="$3" cmd cur_start
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
   [[ "$pid" != "$$" ]] || return 1
+  [[ -n "$want_start" ]] || return 1
   [[ "$want_root" == "$REPO_ROOT" ]] || return 1
   pid_alive "$pid" || return 1
   cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
@@ -207,10 +267,8 @@ dev_pidfile_is_ours() {
     *dev.sh*) ;;
     *) return 1 ;;
   esac
-  if [[ -n "$want_start" ]]; then
-    cur_start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')"
-    [[ "$cur_start" == "$want_start" ]] || return 1
-  fi
+  cur_start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')"
+  [[ "$cur_start" == "$want_start" ]] || return 1
   return 0
 }
 
@@ -228,24 +286,9 @@ DEV_PIDFILE=""
 dev_shutdown() {
   # Disarm first: the INT/TERM handlers exit, which re-enters via EXIT.
   trap - EXIT INT TERM
-  local pids="" p i alive
-  for p in "$WATCH_PID" "$CORE_WATCH_PID" "$OPENER_PID" "$SERVER_PID"; do
-    [[ -n "$p" ]] || continue
-    pids="$pids $(tree_pids "$p")"
-    kill_tree "$p"
-  done
-  if [[ -n "${pids// /}" ]]; then
-    for i in $(seq 1 10); do
-      alive=0
-      for p in $pids; do
-        if pid_alive "$p"; then alive=1; break; fi
-      done
-      [[ "$alive" -eq 0 ]] && break
-      sleep 0.2
-    done
-    for p in $pids; do
-      pid_alive "$p" && kill -KILL "$p" 2>/dev/null || true
-    done
+  local roots="$WATCH_PID $CORE_WATCH_PID $OPENER_PID $SERVER_PID"
+  if [[ -n "${roots// /}" ]]; then
+    reap_trees "$roots"
     # Reap our own children rather than leaving zombies parked on this shell.
     # Safe from hanging: anything that ignored TERM has just been KILLed.
     wait 2>/dev/null || true
@@ -254,16 +297,11 @@ dev_shutdown() {
   return 0
 }
 
-# Library mode: define the helpers, then stop before doing anything. Lets the
-# tests drive kill_tree and the stale-pidfile decision against the real code
-# instead of a copy that can rot (tests/test_dev_sh_process_cleanup.py).
-if [[ -n "${FUSED_RENDER_DEV_SH_LIB:-}" ]]; then
-  return 0 2>/dev/null || exit 0
-fi
-
 # The port this run will use, for the post-reap wait below and for the browser
-# opener further down (computed once so the two cannot disagree). An explicit
-# --port wins; otherwise it is the per-branch default the server derives.
+# opener further down (derived in one place so the two cannot disagree). An
+# explicit --port wins — in either spelling — otherwise it is the per-branch
+# default the server derives. Returns "" when no interpreter is resolvable yet;
+# every caller checks.
 dev_effective_port() {
   local a want=0 port="" py
   for a in "$@"; do
@@ -281,7 +319,6 @@ dev_effective_port() {
   fi
   printf '%s\n' "$port"
 }
-PORT="$(dev_effective_port "$@")"
 
 # Is $1 accepting connections? Same probe the browser opener uses.
 port_is_open() {
@@ -291,16 +328,39 @@ port_is_open() {
   "$py" -c "import socket,sys; s=socket.socket(); s.settimeout(0.5); sys.exit(0 if s.connect_ex(('127.0.0.1', int(sys.argv[1])))==0 else 1)" "$1" 2>/dev/null
 }
 
+# Library mode: define the helpers, then stop before doing anything. Lets the
+# tests drive kill_tree, the stale-pidfile decision and the --port extraction
+# against the real code instead of a copy that can rot
+# (tests/test_dev_sh_process_cleanup.py). Everything testable belongs ABOVE
+# this line.
+if [[ -n "${FUSED_RENDER_DEV_SH_LIB:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# Best effort at this point in the script: the reap has to run before the venv
+# bootstrap (it must stop the old vite watch before this run rebuilds
+# shell-dist/), so on a machine whose only interpreter is the versioned
+# python3.12 that the bootstrap is about to use, there is nothing to ask yet.
+# That is not fatal — it costs the post-reap port wait, and PORT is re-derived
+# once $PY exists — but it is never silent.
+PORT="$(dev_effective_port "$@")"
+if [[ -z "$PORT" ]]; then
+  echo "==> NOTE: no interpreter on PATH yet, so the dev port is still unknown;" >&2
+  echo "    skipping the post-reap port wait (re-derived after the venv is ready)." >&2
+fi
+
 # Reap a previous dev.sh for THIS worktree. Restarting is nearly always what the
 # developer meant by running dev.sh again — and the alternative is hole 3 above:
 # a second full tree whose vite watch fights this one over shell-dist/.
 DEV_PIDFILE="$(dev_pidfile_path)"
+REAPED=0
 if [[ -f "$DEV_PIDFILE" ]]; then
   rec_pid="" rec_start="" rec_root=""
   { read -r rec_pid || true; read -r rec_start || true; read -r rec_root || true; } < "$DEV_PIDFILE"
   if dev_pidfile_is_ours "$rec_pid" "$rec_start" "$rec_root"; then
     echo "==> reaping the dev.sh already running for this worktree (pid $rec_pid)"
     kill_tree_hard "$rec_pid"
+    REAPED=1
     # Wait for the port to actually free: the old server holds the bind for a
     # beat after its process dies, and cli.py's port guard would SystemExit on
     # it. Bounded — a port still busy after this belongs to something else, and
@@ -318,7 +378,19 @@ if [[ -f "$DEV_PIDFILE" ]]; then
 fi
 
 if [[ "$CLEANUP_ONLY" -eq 1 ]]; then
-  echo "==> --cleanup: nothing left to start"
+  if [[ "$REAPED" -eq 1 ]]; then
+    echo "==> --cleanup: done, nothing left running for this worktree"
+  else
+    # Say what was NOT done, and why. A dev.sh started before this change wrote
+    # no pidfile at all, which is the common case on the first upgrade — and
+    # finding it would take a pattern match over every process on the machine,
+    # which is precisely what must never happen here (other worktrees run their
+    # own servers, and at least one deliberate orphan). Hand the developer the
+    # search instead of guessing on their behalf.
+    echo "==> --cleanup: no dev.sh recorded for this worktree — nothing reaped"
+    echo "    (a dev.sh started before this pidfile existed leaves no record;"
+    echo "     find it with: pgrep -laf dev.sh, and check its worktree first)"
+  fi
   exit 0
 fi
 
@@ -327,10 +399,18 @@ fi
 # kill_tree_hard does not return until that process is gone. The start time goes
 # in alongside the pid so a recycled pid can be recognized and left alone.
 mkdir -p "$REPO_ROOT/.dev-pids"
-printf '%s\n%s\n%s\n' \
-  "$$" \
-  "$(ps -o lstart= -p $$ 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')" \
-  "$REPO_ROOT" > "$DEV_PIDFILE"
+SELF_START="$(ps -o lstart= -p $$ 2>/dev/null | sed -e 's/^ *//' -e 's/ *$//')"
+if [[ -z "$SELF_START" ]]; then
+  # dev_pidfile_is_ours fails closed without a start time, so the record would
+  # be inert: the next run would call it stale and start a second tree instead
+  # of restarting. Better to lose the auto-restart than to reap on two weaker
+  # checks, but the developer should know why `dev.sh` stopped replacing itself.
+  echo "==> WARNING: could not read this process's start time (ps -o lstart=)," >&2
+  echo "    so a later run will not be able to verify this pidfile and will not" >&2
+  echo "    reap this dev.sh. Stop it with Ctrl-C, or scripts/dev.sh --cleanup" >&2
+  echo "    will report nothing to do." >&2
+fi
+printf '%s\n%s\n%s\n' "$$" "$SELF_START" "$REPO_ROOT" > "$DEV_PIDFILE"
 
 # Armed from here on, so an abort anywhere in the setup below (a failed npm
 # install, a Ctrl-C during the venv bootstrap) still clears the pidfile and
@@ -611,6 +691,19 @@ if [[ "$RELOAD" -eq 1 ]]; then
       --no-browser) NO_BROWSER=1 ;;
     esac
   done
+  # Second attempt for the case the early derivation warned about: back then
+  # there may have been no interpreter at all, and by now the venv bootstrap has
+  # made one. Without this the opener would silently never fire on a
+  # freshly-created checkout.
+  if [[ -z "$PORT" ]]; then
+    PORT="$(dev_effective_port "$@")"
+    # Spelled as an `if`, not `[[ … ]] && echo`: under `set -e` that idiom
+    # aborts the script whenever the test is false and it is the last command
+    # in the enclosing block.
+    if [[ -z "$PORT" ]]; then
+      echo "==> NOTE: dev port still unresolved — not opening a browser tab" >&2
+    fi
+  fi
 
   # One-shot opener: wait for the port to accept a connection, then open the tab.
   if [[ "$NO_BROWSER" -eq 0 && -n "$PORT" ]]; then

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -181,6 +181,47 @@ def _lstart(pid):
     ).stdout.strip()
 
 
+def _argv(pid):
+    return subprocess.run(
+        ["ps", "-ww", "-o", "command=", "-p", str(pid)], capture_output=True, text=True
+    ).stdout.strip()
+
+
+# A stand-in for dev.sh: a script whose *argv* is what the identity check reads.
+#
+# The trailing `exit 0` and the trap are not decoration. Bash replaces itself
+# with the last command of a script when nothing can follow it — verified here:
+# `bash -c 'sleep 30'` already shows up as `sleep 30`, with no shell in argv, on
+# bash 3.2 — and bash 5.x (every Linux runner) applies that optimization to
+# script files too. A stub that was only `sleep 60` therefore became a bare
+# `sleep` on Linux, its argv lost the "dev.sh" the check looks for, and two
+# tests that should read OURS read STALE. The real dev.sh installs traps and has
+# hundreds of commands after any given one, so it is never exec-replaced; the
+# stub has to be equally unoptimizable or it is not standing in for anything.
+_STUB = "#!/usr/bin/env bash\ntrap 'exit 0' TERM\nsleep 60\nexit 0\n"
+
+
+def _spawn_stub(path):
+    """Start `path` (named dev.sh) and assert it really is identifiable.
+
+    Checking the argv here rather than letting the OURS assertion fail turns a
+    platform quirk in the *fixture* into a message that names it, instead of a
+    bare "STALE" that looks identical to the production bug.
+    """
+    path.write_text(_STUB)
+    proc = subprocess.Popen(["bash", str(path)], close_fds=False)
+    time.sleep(0.5)
+    argv = _argv(proc.pid)
+    if "dev.sh" not in argv:
+        proc.kill()
+        proc.wait(timeout=10)
+        raise AssertionError(
+            f"stub was exec-replaced by its own last command; argv={argv!r}. "
+            "The fixture, not dev.sh, is what needs fixing."
+        )
+    return proc
+
+
 def test_a_dead_pid_is_stale():
     """The common case: the machine rebooted, or dev.sh was SIGKILLed.
 
@@ -231,17 +272,17 @@ def test_a_missing_start_time_fails_closed(tmp_path):
     empty record as "skip that check" would make a recycled pid landing on a
     colleague's dev.sh reapable. Failing closed costs one missed auto-restart.
     """
-    stub = tmp_path / "dev.sh"
-    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
-    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
+    proc = _spawn_stub(tmp_path / "dev.sh")
     try:
-        time.sleep(0.5)
         # Same process that IS recognized when the start time is supplied.
         res = _run_lib(
             f'dev_pidfile_is_ours {proc.pid} {_lstart(proc.pid)!r} {_ROOT!r}'
             " && echo OURS || echo STALE"
         )
-        assert res.stdout.strip() == "OURS", res.stdout + res.stderr
+        assert res.stdout.strip() == "OURS", (
+            f"{res.stdout}{res.stderr} argv={_argv(proc.pid)!r} "
+            f"lstart={_lstart(proc.pid)!r}"
+        )
         res = _run_lib(
             f'dev_pidfile_is_ours {proc.pid} "" {_ROOT!r} && echo OURS || echo STALE'
         )
@@ -259,20 +300,15 @@ def test_a_live_dev_sh_for_this_worktree_is_recognized(tmp_path):
     under test is the identification (command line + start time + recorded
     root), and that sees only what `ps` reports.
     """
-    stub = tmp_path / "dev.sh"
-    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
-    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
+    proc = _spawn_stub(tmp_path / "dev.sh")
     try:
-        time.sleep(0.5)
-        start = subprocess.run(
-            ["ps", "-o", "lstart=", "-p", str(proc.pid)],
-            capture_output=True,
-            text=True,
-        ).stdout.strip()
+        start = _lstart(proc.pid)
         res = _run_lib(
             f'dev_pidfile_is_ours {proc.pid} {start!r} {_ROOT!r} && echo OURS || echo STALE'
         )
-        assert res.stdout.strip() == "OURS", res.stdout + res.stderr
+        assert res.stdout.strip() == "OURS", (
+            f"{res.stdout}{res.stderr} argv={_argv(proc.pid)!r} start={start!r}"
+        )
 
         # ...and the same pid with a start time from a different process (i.e. a
         # recycled pid) must not be.
@@ -292,16 +328,48 @@ def test_a_pidfile_from_another_worktree_root_is_stale(tmp_path):
     Uses a live process that passes every OTHER check (named dev.sh, real start
     time), so the recorded root is the only thing that can reject it.
     """
-    stub = tmp_path / "dev.sh"
-    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
-    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
+    proc = _spawn_stub(tmp_path / "dev.sh")
     try:
-        time.sleep(0.5)
         res = _run_lib(
             f'dev_pidfile_is_ours {proc.pid} {_lstart(proc.pid)!r} "/some/other/worktree"'
             " && echo OURS || echo STALE"
         )
         assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_a_long_command_line_is_still_recognized(tmp_path):
+    """`ps` must not truncate dev.sh out of its own command line.
+
+    GNU procps caps the command column at 80 chars when stdout is not a
+    terminal, and dev.sh sits at the END of the line — so on Linux a checkout
+    deeper than ~74 chars (any git worktree under
+    <repo>/.claude/worktrees/<name>/) would make dev_pidfile_is_ours reject its
+    own pidfile forever: no error, no reap, just the duplicate trees this PR
+    exists to prevent. `ps -ww` lifts the cap.
+
+    This can only go red on Linux — BSD ps never truncated a piped `-o` — but it
+    is the check that pins the flag in place, and it is cheap to keep here
+    rather than in a Linux-only file nobody runs locally.
+    """
+    deep = tmp_path
+    for part in ("a-very-deeply-nested", "worktree-style-path", "that-exceeds-eighty"):
+        deep = deep / part
+    deep.mkdir(parents=True)
+    stub = deep / "dev.sh"
+    proc = _spawn_stub(stub)
+    try:
+        argv = _argv(proc.pid)
+        assert len(argv) > 80, f"path too short to exercise the cap: {len(argv)}"
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} {_lstart(proc.pid)!r} {_ROOT!r}'
+            " && echo OURS || echo STALE"
+        )
+        assert res.stdout.strip() == "OURS", (
+            f"{res.stdout}{res.stderr} argv={argv!r} (len {len(argv)})"
+        )
     finally:
         proc.kill()
         proc.wait(timeout=10)
@@ -427,6 +495,20 @@ def test_the_server_is_backgrounded_and_waited_on_in_both_branches():
         )
         assert re.search(pattern, src, re.M), f"{launch} is not backgrounded"
     assert src.count('wait "$SERVER_PID"') == 2, "both launches must be waited on"
+
+
+def test_command_line_reads_are_width_unlimited():
+    """Every `ps … command=` in dev.sh must pass -ww.
+
+    The behavioural test above cannot fail on macOS, where BSD ps does not
+    truncate; this one can, and it is the guard that keeps the flag from being
+    dropped as noise by someone reading the script on a Mac.
+    """
+    src = _script()
+    reads = re.findall(r"ps\s+([^\n|]*?)-o\s+command=", src)
+    assert reads, "the command-line read vanished"
+    for flags in reads:
+        assert "-ww" in flags, f"`ps -o command=` without -ww: {flags!r}"
 
 
 def test_dev_pids_dir_is_gitignored():

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -1,0 +1,320 @@
+"""Guards on scripts/dev.sh's process cleanup: kill_tree, the pidfile, the traps.
+
+dev.sh used to leak whole process trees. Three separate holes, each observed on
+a real machine (eleven orphans hand-killed, some 10-20 days old):
+
+  * the traps killed `$!` of a *subshell* — `(cd frontend && npm run watch) &` —
+    so `npm` and the `vite build --watch` node under it reparented to init and
+    kept rebuilding into shell-dist/ forever;
+  * the watchfiles-supervised server ran in the FOREGROUND and was in no trap at
+    all, and bash defers a trap handler until the current foreground command
+    returns, so `kill <dev.sh>` was queued and did nothing;
+  * nothing detected an already-running dev.sh for the same worktree, so one
+    worktree accumulated two complete dev.sh trees writing the same shell-dist/.
+
+The shell is the only source of truth for all three, so these tests drive the
+real functions out of the script: `FUSED_RENDER_DEV_SH_LIB=1 source dev.sh`
+defines the helpers and returns before dev.sh does any work, which is what makes
+`kill_tree` and the stale-pidfile decision testable without booting a server.
+"""
+import os
+import re
+import subprocess
+import time
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_DEV_SH = os.path.join(_ROOT, "scripts", "dev.sh")
+
+
+def _script():
+    with open(_DEV_SH, encoding="utf-8") as f:
+        return f.read()
+
+
+def _run_lib(snippet, env=None, timeout=60):
+    """Run `snippet` with dev.sh's helper functions sourced (library mode)."""
+    full_env = dict(os.environ)
+    full_env["FUSED_RENDER_DEV_SH_LIB"] = "1"
+    # Deterministic ref unless the test asks for another one: an unset var would
+    # make dev.sh read the checkout's real branch and the assertions would move
+    # with whatever branch the suite runs on.
+    full_env.setdefault("FUSED_RENDER_BRANCH", "test-branch")
+    if env:
+        full_env.update(env)
+    return subprocess.run(
+        ["bash", "-c", f'source {_DEV_SH!r}\n{snippet}'],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        timeout=timeout,
+        close_fds=False,
+    )
+
+
+def _alive(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    # A zombie still answers signal 0; ps is what distinguishes "gone" from
+    # "waiting to be reaped", and only the former is what kill_tree promises.
+    out = subprocess.run(
+        ["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True
+    ).stdout.strip()
+    return bool(out) and not out.startswith("Z")
+
+
+# --------------------------------------------------------------------------
+# kill_tree
+# --------------------------------------------------------------------------
+
+def test_kill_tree_reaps_every_descendant_not_just_the_direct_child():
+    """The orphan-vite bug in one assertion.
+
+    `(...) &` gives back the SUBSHELL's pid; the real work (npm -> node vite)
+    hangs two levels below it. Killing only the pid bash handed you leaves that
+    work running under init. kill_tree must walk down with `pgrep -P` and kill
+    depth-first, so nothing reparents mid-kill.
+    """
+    # bash -c 'sleep 300 & sleep 300' -> a subshell whose children are two sleeps.
+    proc = subprocess.Popen(
+        ["bash", "-c", "bash -c 'sleep 300 & sleep 300' & wait"], close_fds=False
+    )
+    try:
+        # Let the whole tree materialize before snapshotting it.
+        descendants = []
+        for _ in range(50):
+            descendants = _descendants(proc.pid)
+            if len(descendants) >= 3:
+                break
+            time.sleep(0.1)
+        assert len(descendants) >= 3, f"tree never formed: {descendants}"
+
+        res = _run_lib(f"kill_tree_hard {proc.pid}")
+        assert res.returncode == 0, res.stderr
+
+        leftover = list(descendants)
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            leftover = [p for p in descendants if _alive(p)]
+            if not leftover:
+                break
+            time.sleep(0.1)
+        proc.wait(timeout=10)
+        assert not leftover, f"descendants survived kill_tree: {leftover}"
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def test_kill_tree_escalates_to_sigkill_for_a_term_ignoring_process():
+    """A child that traps TERM must not be able to outlive dev.sh.
+
+    Bounded grace, then KILL — never an unbounded wait, which would hang the
+    Ctrl-C the developer just pressed.
+    """
+    proc = subprocess.Popen(
+        ["bash", "-c", "trap '' TERM; sleep 300"], close_fds=False
+    )
+    try:
+        time.sleep(0.3)
+        res = _run_lib(f"kill_tree_hard {proc.pid}", timeout=30)
+        assert res.returncode == 0, res.stderr
+        proc.wait(timeout=10)
+        assert not _alive(proc.pid)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def _descendants(pid):
+    out = []
+    stack = [pid]
+    while stack:
+        cur = stack.pop()
+        kids = subprocess.run(
+            ["pgrep", "-P", str(cur)], capture_output=True, text=True
+        ).stdout.split()
+        for k in kids:
+            out.append(int(k))
+            stack.append(int(k))
+    return out
+
+
+# --------------------------------------------------------------------------
+# pidfile path derivation
+# --------------------------------------------------------------------------
+
+def test_pidfile_is_per_worktree_and_keyed_on_the_sanitized_branch():
+    """Same key the port and state dir already use (_branch.sanitize).
+
+    A second sanitizer would let the pidfile name and the port drift apart, and
+    the whole point of keying on the branch is that one worktree's entry can
+    never be read as another's.
+    """
+    res = _run_lib(
+        'dev_pidfile_path', env={"FUSED_RENDER_BRANCH": "feature/Some_Branch"}
+    )
+    assert res.returncode == 0, res.stderr
+    path = res.stdout.strip()
+    assert path == os.path.join(_ROOT, ".dev-pids", "feature-some"), path
+
+
+def test_pidfile_baseline_ref_still_gets_a_filename():
+    """main/master sanitize to "" (baseline); an empty filename is not a path."""
+    res = _run_lib("dev_pidfile_path", env={"FUSED_RENDER_BRANCH": "main"})
+    assert res.returncode == 0, res.stderr
+    path = res.stdout.strip()
+    assert os.path.dirname(path) == os.path.join(_ROOT, ".dev-pids")
+    assert os.path.basename(path), "baseline produced an empty pidfile name"
+
+
+# --------------------------------------------------------------------------
+# stale vs live
+# --------------------------------------------------------------------------
+
+def test_a_dead_pid_is_stale():
+    """The common case: the machine rebooted, or dev.sh was SIGKILLed."""
+    proc = subprocess.Popen(["sleep", "0.01"], close_fds=False)
+    proc.wait(timeout=10)
+    res = _run_lib(
+        f'dev_pidfile_is_ours {proc.pid} "" {_ROOT!r} && echo OURS || echo STALE'
+    )
+    assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+
+
+def test_a_live_but_unrelated_pid_is_stale():
+    """PID reuse must never turn cleanup into killing someone else's process.
+
+    Other worktrees on this machine run their own servers, and at least one
+    known orphan is deliberately left alone; a recycled pid landing on any of
+    them must read as stale, not as "our dev.sh".
+    """
+    proc = subprocess.Popen(["sleep", "60"], close_fds=False)
+    try:
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} "" {_ROOT!r} && echo OURS || echo STALE'
+        )
+        assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_a_live_dev_sh_for_this_worktree_is_recognized(tmp_path):
+    """The positive case, or the reap would silently never fire.
+
+    Stands in a throwaway script *named* dev.sh for the real thing — booting a
+    server here would be both slow and a way to leave processes behind. What is
+    under test is the identification (command line + start time + recorded
+    root), and that sees only what `ps` reports.
+    """
+    stub = tmp_path / "dev.sh"
+    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
+    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
+    try:
+        time.sleep(0.5)
+        start = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(proc.pid)],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} {start!r} {_ROOT!r} && echo OURS || echo STALE'
+        )
+        assert res.stdout.strip() == "OURS", res.stdout + res.stderr
+
+        # ...and the same pid with a start time from a different process (i.e. a
+        # recycled pid) must not be.
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} "Mon Jan  1 00:00:00 2001" {_ROOT!r}'
+            " && echo OURS || echo STALE"
+        )
+        assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_a_pidfile_from_another_worktree_root_is_stale():
+    """Defence in depth behind the per-worktree path: the root is recorded too."""
+    proc = subprocess.Popen(["sleep", "60"], close_fds=False)
+    try:
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} "" "/some/other/worktree"'
+            " && echo OURS || echo STALE"
+        )
+        assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+# --------------------------------------------------------------------------
+# structural guards
+# --------------------------------------------------------------------------
+
+def test_cleanup_flag_is_consumed_and_never_forwarded_to_the_server():
+    """`--cleanup` is dev.sh's own flag; cli.py would reject it.
+
+    It has to be stripped from `$@` before the passthrough loops build the
+    watchfiles command / the single-launch argv.
+    """
+    src = _script()
+    assert "--cleanup" in src
+    # The strip has to happen before either passthrough site uses "$@".
+    strip_at = src.index("--cleanup")
+    for marker in ('for a in "$@"; do CMD+=', '-m fused_render.cli "$@"'):
+        assert strip_at < src.index(marker), f"--cleanup stripped after {marker}"
+
+
+def test_no_broad_pattern_kill():
+    """Never `pkill -f vite` / `pkill -f dev.sh`.
+
+    Other worktrees on this machine run their own dev servers; a pattern kill
+    would take them out along with ours. Only the pidfile's own tree is fair
+    game.
+    """
+    src = _script()
+    assert not re.search(r"pkill\s+-f", src)
+    assert not re.search(r"killall", src)
+
+
+def test_shutdown_is_a_single_handler_reaping_every_background_pid():
+    """One handler, so the two trap sites cannot drift apart again.
+
+    The old script had two `trap '...' EXIT INT TERM` lines with different pid
+    lists, and neither mentioned the server at all.
+    """
+    src = _script()
+    assert "dev_shutdown" in src
+    handler = src[src.index("dev_shutdown() {") : src.index("dev_shutdown() {") + 2500]
+    for var in ("WATCH_PID", "CORE_WATCH_PID", "OPENER_PID", "SERVER_PID"):
+        assert var in handler, f"{var} is not reaped by dev_shutdown"
+    # Every trap installs the same handler.
+    traps = re.findall(r"^\s*trap\s+'([^']*)'\s+EXIT", src, re.M)
+    assert traps, "no EXIT trap"
+    for body in traps:
+        assert "dev_shutdown" in body, body
+
+
+def test_the_server_is_backgrounded_and_waited_on_in_both_branches():
+    """A FOREGROUND child defers the trap; `wait` is interruptible.
+
+    Both the reload path (watchfiles) and FUSED_RENDER_NO_RELOAD=1 (plain cli)
+    must background + wait, or `kill <dev.sh>` queues a handler that only runs
+    once the child happens to exit on its own.
+    """
+    src = _script()
+    for launch in ("-m watchfiles", "-m fused_render.cli"):
+        idx = src.rindex(launch)
+        tail = src[idx : idx + 400]
+        assert "SERVER_PID=$!" in tail, f"{launch} is not backgrounded"
+        assert 'wait "$SERVER_PID"' in tail, f"{launch} is not waited on"
+
+
+def test_dev_pids_dir_is_gitignored():
+    with open(os.path.join(_ROOT, ".gitignore"), encoding="utf-8") as f:
+        assert ".dev-pids/" in f.read().split("\n")

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -19,6 +19,7 @@ defines the helpers and returns before dev.sh does any work, which is what makes
 """
 import os
 import re
+import shutil
 import subprocess
 import time
 
@@ -147,28 +148,130 @@ def _descendants(pid):
 # pidfile path derivation
 # --------------------------------------------------------------------------
 
-def test_pidfile_is_per_worktree_and_keyed_on_the_sanitized_branch():
-    """Same key the port and state dir already use (_branch.sanitize).
+def _fake_root(tmp_path, name):
+    """A throwaway $REPO_ROOT holding a copy of dev.sh.
 
-    A second sanitizer would let the pidfile name and the port drift apart, and
-    the whole point of keying on the branch is that one worktree's entry can
-    never be read as another's.
+    dev.sh derives REPO_ROOT from `dirname $BASH_SOURCE/..`, so the only way to
+    ask it about a *different* worktree is to source a copy that sits in one.
+    `fused_render` is symlinked in so the pre-fix code path (which imported
+    _branch from the repo root) can still resolve — otherwise "no interpreter"
+    and "no importable package" would be indistinguishable and the regression
+    test below could pass for the wrong reason.
     """
-    res = _run_lib(
-        'dev_pidfile_path', env={"FUSED_RENDER_BRANCH": "feature/Some_Branch"}
+    root = tmp_path / name
+    (root / "scripts").mkdir(parents=True)
+    shutil.copy2(_DEV_SH, root / "scripts" / "dev.sh")
+    (root / "fused_render").symlink_to(os.path.join(_ROOT, "fused_render"))
+    return root
+
+
+def _run_lib_at(root, snippet, env=None, timeout=60):
+    """`_run_lib`, but sourcing the dev.sh copy inside `root`."""
+    full_env = dict(os.environ)
+    full_env["FUSED_RENDER_DEV_SH_LIB"] = "1"
+    full_env.setdefault("FUSED_RENDER_BRANCH", "test-branch")
+    if env:
+        full_env.update(env)
+    dev_sh = os.path.join(str(root), "scripts", "dev.sh")
+    return subprocess.run(
+        ["bash", "-c", f"source {dev_sh!r}\n{snippet}"],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        timeout=timeout,
+        close_fds=False,
     )
-    assert res.returncode == 0, res.stderr
-    path = res.stdout.strip()
-    assert path == os.path.join(_ROOT, ".dev-pids", "feature-some"), path
 
 
-def test_pidfile_baseline_ref_still_gets_a_filename():
-    """main/master sanitize to "" (baseline); an empty filename is not a path."""
-    res = _run_lib("dev_pidfile_path", env={"FUSED_RENDER_BRANCH": "main"})
-    assert res.returncode == 0, res.stderr
-    path = res.stdout.strip()
-    assert os.path.dirname(path) == os.path.join(_ROOT, ".dev-pids")
-    assert os.path.basename(path), "baseline produced an empty pidfile name"
+def _pathless_bin(tmp_path):
+    """A $PATH with the shell tools dev.sh needs and no python of any spelling.
+
+    Emptying PATH outright is not the same experiment: dev.sh calls `dirname`
+    before it reaches anything under test, so the script would derive a bogus
+    REPO_ROOT and the assertion would be measuring the harness. Symlinking a
+    fixed tool list reproduces exactly the machine dev.sh's venv bootstrap
+    exists for — shell tools present, interpreter not yet installed.
+    """
+    binv = tmp_path / "nopybin"
+    binv.mkdir()
+    for tool in ("bash", "sh", "dirname", "basename", "pgrep", "ps", "sed", "seq",
+                 "tr", "git", "uname", "cat", "grep", "mkdir", "rm", "sleep",
+                 "kill", "env"):
+        real = shutil.which(tool)
+        if real:
+            (binv / tool).symlink_to(real)
+    for spelling in ("python", "python3"):
+        assert shutil.which(spelling, path=str(binv)) is None, spelling
+    return str(binv)
+
+
+def test_pidfile_path_is_the_same_without_an_interpreter(tmp_path):
+    """Finding 1: the key must not be derived by shelling out to python.
+
+    The pidfile used to be named by asking an interpreter to sanitize the branch
+    ref, with a literal `_baseline` fallback when none resolved. On the uv-only
+    machine dev.sh's bootstrap exists to serve — no $VIRTUAL_ENV, no .venv yet,
+    only a versioned python3.12 that is not on PATH as `python3` — that fallback
+    fired on a feature branch, so the first run recorded itself under one name
+    and the next run (bootstrap done, interpreter now resolvable) looked under
+    another, found nothing, and stacked a second tree. Exactly the failure the
+    pidfile exists to prevent.
+    """
+    root = _fake_root(tmp_path, "wt")
+    env_no_venv = {"VIRTUAL_ENV": "", "FUSED_RENDER_BRANCH": "feature/Some_Branch"}
+    with_py = _run_lib_at(root, "dev_pidfile_path", env=env_no_venv)
+    assert with_py.returncode == 0, with_py.stderr
+    assert shutil.which("python3") or shutil.which("python"), "no python to contrast with"
+
+    without_py = _run_lib_at(
+        root, "dev_pidfile_path", env={**env_no_venv, "PATH": _pathless_bin(tmp_path)}
+    )
+    assert without_py.returncode == 0, without_py.stderr
+    assert without_py.stdout.strip() == with_py.stdout.strip(), (
+        f"pidfile key moved when no interpreter was resolvable: "
+        f"{with_py.stdout.strip()!r} vs {without_py.stdout.strip()!r}"
+    )
+
+
+def test_pidfile_path_is_keyed_on_the_worktree_not_the_branch(tmp_path):
+    """Finding 2: `git checkout` must not hide a running dev.sh.
+
+    Switching branches without stopping dev.sh used to change the derived key,
+    so the next run read a different file, left the old tree alive, and two
+    `vite build --watch` processes wrote the same shell-dist/. The resource the
+    pidfile protects (shell-dist/, node_modules, the watcher) is per-worktree,
+    so the key is the worktree — and `.dev-pids/` already lives inside
+    $REPO_ROOT, which is what keeps two worktrees apart with no branch in the
+    name at all.
+    """
+    root = _fake_root(tmp_path, "wt")
+    paths = set()
+    for ref in ("feature/Some_Branch", "main", "other/branch", ""):
+        res = _run_lib_at(root, "dev_pidfile_path", env={"FUSED_RENDER_BRANCH": ref})
+        assert res.returncode == 0, res.stderr
+        path = res.stdout.strip()
+        assert os.path.dirname(path) == os.path.join(str(root), ".dev-pids"), path
+        assert os.path.basename(path), f"ref {ref!r} produced an empty pidfile name"
+        paths.add(path)
+    assert len(paths) == 1, f"the pidfile key still moves with the branch: {paths}"
+
+
+def test_pidfile_path_still_differs_between_worktrees(tmp_path):
+    """The isolation property that must NOT regress with the branch gone.
+
+    Two checkouts of the same branch (the common `git worktree add` case) each
+    have their own shell-dist/ and must each get their own record, or one run
+    would reap the other's tree.
+    """
+    seen = []
+    for name in ("wt-a", "wt-b"):
+        res = _run_lib_at(_fake_root(tmp_path, name), "dev_pidfile_path")
+        assert res.returncode == 0, res.stderr
+        seen.append(res.stdout.strip())
+    assert seen[0] != seen[1], seen
+    assert _run_lib("dev_pidfile_path").stdout.strip() == os.path.join(
+        _ROOT, ".dev-pids", os.path.basename(seen[0])
+    )
 
 
 # --------------------------------------------------------------------------
@@ -441,6 +544,28 @@ def test_cleanup_flag_is_consumed_and_never_forwarded_to_the_server():
         assert hits, f"passthrough site vanished: {marker}"
         for at in hits:
             assert rebuild_at < at, f"--cleanup still reaches {marker}"
+
+
+def test_the_startup_reap_reads_every_record_in_the_dir():
+    """Records written under the OLD branch-keyed name still get honoured.
+
+    The pidfile used to be named after the sanitized branch ref. A dev.sh started
+    before this change — or before a `git checkout` — is still running with its
+    record under that other name, and looking only at the fixed name would strand
+    it: the tree would keep writing shell-dist/ with nothing but a pattern kill
+    (forbidden here) able to find it. So the reap walks the whole directory,
+    which is safe precisely because .dev-pids/ lives inside $REPO_ROOT and every
+    entry still has to pass dev_pidfile_is_ours before anything is signalled.
+    """
+    src = _script()
+    loop = re.search(
+        r"^for _pf in [^\n]*\.dev-pids/\*; do\n(.*?)^done$", src, re.M | re.S
+    )
+    assert loop, "the startup reap no longer walks .dev-pids/"
+    body = loop.group(1)
+    assert "dev_pidfile_is_ours" in body, "a record is reaped without the identity check"
+    assert "kill_tree_hard" in body
+    assert 'rm -f "$_pf"' in body, "an unverifiable leftover is never cleaned up"
 
 
 def test_no_broad_pattern_kill():

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -256,6 +256,33 @@ def test_pidfile_path_is_keyed_on_the_worktree_not_the_branch(tmp_path):
     assert len(paths) == 1, f"the pidfile key still moves with the branch: {paths}"
 
 
+def test_repo_root_is_physical_so_a_symlinked_invocation_agrees(tmp_path):
+    """`pwd`, not `pwd -P`, made the recorded root depend on how you typed it.
+
+    The recorded repo root is now the ONLY field in the record that names a
+    worktree, and it is compared as a string. With a logical `pwd`, running
+    dev.sh once through a symlinked path and once through the physical one gave
+    two different $REPO_ROOT values for the SAME .dev-pids/ directory: the
+    second run read the live record, decided `want_root != REPO_ROOT`, called it
+    not-ours, and started a second tree — with the record gone, unrecoverably.
+    """
+    real = _fake_root(tmp_path, "real")
+    link = tmp_path / "link"
+    link.symlink_to(real)
+
+    via_link = _run_lib_at(link, "dev_pidfile_path")
+    assert via_link.returncode == 0, via_link.stderr
+    via_real = _run_lib_at(real, "dev_pidfile_path")
+    assert via_real.returncode == 0, via_real.stderr
+    assert via_link.stdout.strip() == via_real.stdout.strip(), (
+        f"the recorded root moves with the spelling of the path: "
+        f"{via_link.stdout.strip()!r} vs {via_real.stdout.strip()!r}"
+    )
+    assert via_link.stdout.strip() == os.path.join(
+        os.path.realpath(str(real)), ".dev-pids", "dev.sh.pid"
+    ), via_link.stdout
+
+
 def test_pidfile_path_still_differs_between_worktrees(tmp_path):
     """The isolation property that must NOT regress with the branch gone.
 
@@ -479,6 +506,110 @@ def test_a_long_command_line_is_still_recognized(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# the startup sweep over .dev-pids/
+#
+# These drive the real script end to end — `dev.sh --cleanup` in a throwaway
+# $REPO_ROOT — because the sweep lives BELOW the library-mode return and is the
+# part that actually decides who gets signalled and whose record survives.
+# --cleanup exits before the venv bootstrap, so this costs nothing but the
+# process spawn.
+# --------------------------------------------------------------------------
+
+def _record(root, name, pid, start, rec_root):
+    path = root / ".dev-pids" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{pid}\n{start}\n{rec_root}\n")
+    return path
+
+
+def _run_cleanup_at(root, timeout=120):
+    env = dict(os.environ)
+    env["FUSED_RENDER_BRANCH"] = "test-branch"
+    env.pop("FUSED_RENDER_DEV_SH_LIB", None)
+    return subprocess.run(
+        ["bash", os.path.join(str(root), "scripts", "dev.sh"), "--cleanup"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=timeout,
+        close_fds=False,
+    )
+
+
+def test_the_sweep_reaps_a_record_left_under_the_old_branch_name(tmp_path):
+    """The migration case: a pre-fix dev.sh is still running under its old key.
+
+    Before this change the pidfile was named after the sanitized branch ref, so
+    an upgrade (or a `git checkout` mid-run) leaves a live tree recorded under a
+    name the fixed key never looks at. Honouring only the new name would strand
+    it, and finding it again would take the pattern kill this file forbids.
+    """
+    root = _fake_root(tmp_path, "wt")
+    stub_dir = root / "legacy"
+    stub_dir.mkdir()
+    proc = _spawn_stub(stub_dir / "dev.sh")
+    try:
+        rec = _record(
+            root, "feature-old", proc.pid, _lstart(proc.pid), os.path.realpath(str(root))
+        )
+        res = _run_cleanup_at(root)
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert not _alive(proc.pid), "the legacy record's tree survived the sweep"
+        assert not rec.exists(), "a reaped record must not be left behind"
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_the_sweep_deletes_dead_records_but_keeps_live_unverifiable_ones(tmp_path):
+    """Deleting every file the check rejected threw away the only live handle.
+
+    dev_pidfile_is_ours fails closed, so it says "not ours" for recoverable
+    reasons too — a `ps` that failed under load, a start time that read empty, a
+    $REPO_ROOT skew. If the record is removed on that answer, the tree it names
+    becomes unfindable by anything but a pattern kill. So: a record whose pid is
+    gone is definitively dead and gets cleaned up; a record whose pid is still
+    ALIVE but unverifiable stays on disk for a later run to re-evaluate.
+    """
+    root = _fake_root(tmp_path, "wt")
+    dead = _record(root, "dead-branch", 99999999, "Sat Jan  1 00:00:00 2000",
+                   os.path.realpath(str(root)))
+    # Alive, real start time, right root — rejected only because its argv says
+    # `sleep`, standing in for any of the recoverable rejections above.
+    alien = subprocess.Popen(["sleep", "60"], close_fds=False)
+    time.sleep(0.3)
+    try:
+        live = _record(root, "live-branch", alien.pid, _lstart(alien.pid),
+                       os.path.realpath(str(root)))
+        res = _run_cleanup_at(root)
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert not dead.exists(), "a record whose process is gone was not cleaned up"
+        assert live.exists(), (
+            "an unverifiable record for a LIVE pid was deleted; that is the only "
+            f"handle on that tree.\n{res.stdout}{res.stderr}"
+        )
+        assert _alive(alien.pid), "an unverified pid was signalled"
+        assert str(live.name) in res.stdout + res.stderr, (
+            f"the kept record is not named in the output:\n{res.stdout}{res.stderr}"
+        )
+    finally:
+        alien.kill()
+        alien.wait(timeout=10)
+
+
+def test_the_sweep_reports_stale_records_once_not_once_per_file(tmp_path):
+    """Several leftover branch names must not read as several stale processes."""
+    root = _fake_root(tmp_path, "wt")
+    for name in ("a-branch", "b-branch", "c-branch"):
+        _record(root, name, 99999999, "Sat Jan  1 00:00:00 2000",
+                os.path.realpath(str(root)))
+    res = _run_cleanup_at(root)
+    assert res.returncode == 0, res.stdout + res.stderr
+    stale_lines = [ln for ln in res.stdout.splitlines() if "stale" in ln]
+    assert len(stale_lines) == 1, f"one line per leftover file:\n{res.stdout}"
+
+
+# --------------------------------------------------------------------------
 # --port extraction
 # --------------------------------------------------------------------------
 
@@ -563,9 +694,22 @@ def test_the_startup_reap_reads_every_record_in_the_dir():
     )
     assert loop, "the startup reap no longer walks .dev-pids/"
     body = loop.group(1)
-    assert "dev_pidfile_is_ours" in body, "a record is reaped without the identity check"
-    assert "kill_tree_hard" in body
-    assert 'rm -f "$_pf"' in body, "an unverifiable leftover is never cleaned up"
+    # The kill must sit INSIDE the `if dev_pidfile_is_ours` arm, not merely
+    # somewhere in the same loop: hoisting it out would reap unverified records —
+    # someone else's process, the exact failure this file exists to prevent — and
+    # a "both names appear in the body" assertion would stay green through it.
+    guarded = re.search(
+        r"^  if dev_pidfile_is_ours [^\n]*; then\n(.*?)^  (?:elif|else|fi)\b",
+        body,
+        re.M | re.S,
+    )
+    assert guarded, "the identity check no longer guards the reap"
+    assert "kill_tree_hard" in guarded.group(1), (
+        "kill_tree_hard escaped the dev_pidfile_is_ours guard"
+    )
+    assert body.count("kill_tree_hard") == 1, (
+        "a second kill in the sweep — every signal must be behind the guard"
+    )
 
 
 def test_no_broad_pattern_kill():

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -175,12 +175,29 @@ def test_pidfile_baseline_ref_still_gets_a_filename():
 # stale vs live
 # --------------------------------------------------------------------------
 
+def _lstart(pid):
+    return subprocess.run(
+        ["ps", "-o", "lstart=", "-p", str(pid)], capture_output=True, text=True
+    ).stdout.strip()
+
+
 def test_a_dead_pid_is_stale():
-    """The common case: the machine rebooted, or dev.sh was SIGKILLed."""
-    proc = subprocess.Popen(["sleep", "0.01"], close_fds=False)
+    """The common case: the machine rebooted, or dev.sh was SIGKILLed.
+
+    The recorded start time is the REAL one, captured while the process was
+    alive, so the verdict has to come from the liveness check. Passing "" would
+    make this pass for the wrong reason — and worse, would leave the assertion
+    resting on the command-line check, which under `-n auto` races every
+    concurrent `bash -c "source …/dev.sh"` in this very file: those all have
+    dev.sh in their argv, so a recycled pid would flip the answer to OURS.
+    """
+    proc = subprocess.Popen(["sleep", "30"], close_fds=False)
+    start = _lstart(proc.pid)
+    assert start, "ps -o lstart= gave nothing; the rest of this test is vacuous"
+    proc.kill()
     proc.wait(timeout=10)
     res = _run_lib(
-        f'dev_pidfile_is_ours {proc.pid} "" {_ROOT!r} && echo OURS || echo STALE'
+        f'dev_pidfile_is_ours {proc.pid} {start!r} {_ROOT!r} && echo OURS || echo STALE'
     )
     assert res.stdout.strip() == "STALE", res.stdout + res.stderr
 
@@ -190,10 +207,41 @@ def test_a_live_but_unrelated_pid_is_stale():
 
     Other worktrees on this machine run their own servers, and at least one
     known orphan is deliberately left alone; a recycled pid landing on any of
-    them must read as stale, not as "our dev.sh".
+    them must read as stale, not as "our dev.sh". Its own real start time is
+    passed, so only the command-line check can reject it.
     """
     proc = subprocess.Popen(["sleep", "60"], close_fds=False)
     try:
+        start = _lstart(proc.pid)
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} {start!r} {_ROOT!r} && echo OURS || echo STALE'
+        )
+        assert res.stdout.strip() == "STALE", res.stdout + res.stderr
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_a_missing_start_time_fails_closed(tmp_path):
+    """No recorded start time -> stale, even for a live process named dev.sh.
+
+    `ps -o lstart=` can come back empty at write time, and the start time is the
+    ONLY check that rules out pid reuse — alive + "argv mentions dev.sh" +
+    recorded root are all satisfied by another worktree's dev.sh. Treating the
+    empty record as "skip that check" would make a recycled pid landing on a
+    colleague's dev.sh reapable. Failing closed costs one missed auto-restart.
+    """
+    stub = tmp_path / "dev.sh"
+    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
+    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
+    try:
+        time.sleep(0.5)
+        # Same process that IS recognized when the start time is supplied.
+        res = _run_lib(
+            f'dev_pidfile_is_ours {proc.pid} {_lstart(proc.pid)!r} {_ROOT!r}'
+            " && echo OURS || echo STALE"
+        )
+        assert res.stdout.strip() == "OURS", res.stdout + res.stderr
         res = _run_lib(
             f'dev_pidfile_is_ours {proc.pid} "" {_ROOT!r} && echo OURS || echo STALE'
         )
@@ -238,12 +286,19 @@ def test_a_live_dev_sh_for_this_worktree_is_recognized(tmp_path):
         proc.wait(timeout=10)
 
 
-def test_a_pidfile_from_another_worktree_root_is_stale():
-    """Defence in depth behind the per-worktree path: the root is recorded too."""
-    proc = subprocess.Popen(["sleep", "60"], close_fds=False)
+def test_a_pidfile_from_another_worktree_root_is_stale(tmp_path):
+    """Defence in depth behind the per-worktree path: the root is recorded too.
+
+    Uses a live process that passes every OTHER check (named dev.sh, real start
+    time), so the recorded root is the only thing that can reject it.
+    """
+    stub = tmp_path / "dev.sh"
+    stub.write_text("#!/usr/bin/env bash\nsleep 60\n")
+    proc = subprocess.Popen(["bash", str(stub)], close_fds=False)
     try:
+        time.sleep(0.5)
         res = _run_lib(
-            f'dev_pidfile_is_ours {proc.pid} "" "/some/other/worktree"'
+            f'dev_pidfile_is_ours {proc.pid} {_lstart(proc.pid)!r} "/some/other/worktree"'
             " && echo OURS || echo STALE"
         )
         assert res.stdout.strip() == "STALE", res.stdout + res.stderr
@@ -253,21 +308,71 @@ def test_a_pidfile_from_another_worktree_root_is_stale():
 
 
 # --------------------------------------------------------------------------
+# --port extraction
+# --------------------------------------------------------------------------
+
+def test_effective_port_reads_both_port_spellings():
+    """`--port N` and `--port=N` both have to win over the per-branch default.
+
+    This is what the post-reap port wait blocks on; getting it wrong means
+    waiting on the wrong port and racing cli.py's port guard.
+    """
+    for args, want in (
+        ("--port 9000", "9000"),
+        ("--port=9001", "9001"),
+        ("serve --no-browser --port 9002", "9002"),
+    ):
+        res = _run_lib(f"dev_effective_port {args}")
+        assert res.stdout.strip() == want, (args, res.stdout, res.stderr)
+
+
+def test_effective_port_falls_back_to_the_branch_port():
+    """No --port: the same number the server itself derives from the branch."""
+    import sys
+
+    sys.path.insert(0, _ROOT)
+    from fused_render._branch import branch_port
+
+    res = _run_lib("dev_effective_port --no-browser")
+    assert res.stdout.strip() == str(branch_port("test-branch")), (
+        res.stdout,
+        res.stderr,
+    )
+
+
+# --------------------------------------------------------------------------
 # structural guards
 # --------------------------------------------------------------------------
 
 def test_cleanup_flag_is_consumed_and_never_forwarded_to_the_server():
     """`--cleanup` is dev.sh's own flag; cli.py would reject it.
 
-    It has to be stripped from `$@` before the passthrough loops build the
-    watchfiles command / the single-launch argv.
+    It has to be stripped from `$@`, and `$@` REBUILT from the filtered array,
+    before the passthrough loops build the watchfiles command / the
+    single-launch argv.
+
+    Anchored on the strip statement itself, never on the bare string
+    "--cleanup": that string's first occurrence is the header documentation
+    bullet ~600 chars above, so `src.index("--cleanup")` made this assertion
+    "the header comment precedes line 700" — trivially true, and green even with
+    the whole strip loop deleted.
     """
     src = _script()
-    assert "--cleanup" in src
-    # The strip has to happen before either passthrough site uses "$@".
-    strip_at = src.index("--cleanup")
+    strip = 'if [[ "$_a" == "--cleanup" ]]'
+    rebuild = 'set -- ${_ARGS[@]+"${_ARGS[@]}"}'
+    assert src.count(strip) == 1, "the strip statement moved or was duplicated"
+    assert src.count(rebuild) == 1, "the argv rebuild moved or was duplicated"
+    strip_at = src.index(strip)
+    rebuild_at = src.index(rebuild)
+    assert strip_at < rebuild_at, "$@ is rebuilt before --cleanup is filtered out"
+    # EVERY occurrence of each passthrough site must follow the rebuild — using
+    # index()/rindex() here would reintroduce exactly the first-vs-last trap
+    # this test was rewritten to escape.
     for marker in ('for a in "$@"; do CMD+=', '-m fused_render.cli "$@"'):
-        assert strip_at < src.index(marker), f"--cleanup stripped after {marker}"
+        hits = [m.start() for m in re.finditer(re.escape(marker), src)]
+        assert hits, f"passthrough site vanished: {marker}"
+        for at in hits:
+            assert rebuild_at < at, f"--cleanup still reaches {marker}"
 
 
 def test_no_broad_pattern_kill():
@@ -289,10 +394,13 @@ def test_shutdown_is_a_single_handler_reaping_every_background_pid():
     lists, and neither mentioned the server at all.
     """
     src = _script()
-    assert "dev_shutdown" in src
-    handler = src[src.index("dev_shutdown() {") : src.index("dev_shutdown() {") + 2500]
+    start = src.index("dev_shutdown() {")
+    # Bound the slice at the function's own closing brace rather than by a
+    # character count: a fixed window spills into whatever follows, so the
+    # assertions below could be satisfied by unrelated code further down.
+    body = src[start : src.index("\n}\n", start)]
     for var in ("WATCH_PID", "CORE_WATCH_PID", "OPENER_PID", "SERVER_PID"):
-        assert var in handler, f"{var} is not reaped by dev_shutdown"
+        assert var in body, f"{var} is not reaped by dev_shutdown"
     # Every trap installs the same handler.
     traps = re.findall(r"^\s*trap\s+'([^']*)'\s+EXIT", src, re.M)
     assert traps, "no EXIT trap"
@@ -308,11 +416,17 @@ def test_the_server_is_backgrounded_and_waited_on_in_both_branches():
     once the child happens to exit on its own.
     """
     src = _script()
-    for launch in ("-m watchfiles", "-m fused_render.cli"):
-        idx = src.rindex(launch)
-        tail = src[idx : idx + 400]
-        assert "SERVER_PID=$!" in tail, f"{launch} is not backgrounded"
-        assert 'wait "$SERVER_PID"' in tail, f"{launch} is not waited on"
+    # Matched as code, not by index()/rindex() on a substring that also occurs
+    # in prose: each launch line must literally end in `&` and be followed by
+    # the SERVER_PID capture and the wait.
+    for launch in ("watchfiles", "fused_render\\.cli"):
+        pattern = (
+            r'^\s*"\$PY" -m ' + launch + r'\b[^\n]*&\n'
+            r'(?:\s*#[^\n]*\n)*'
+            r"\s*SERVER_PID=\$!\n"
+        )
+        assert re.search(pattern, src, re.M), f"{launch} is not backgrounded"
+    assert src.count('wait "$SERVER_PID"') == 2, "both launches must be waited on"
 
 
 def test_dev_pids_dir_is_gitignored():

--- a/tests/test_dev_sh_process_cleanup.py
+++ b/tests/test_dev_sh_process_cleanup.py
@@ -18,12 +18,21 @@ defines the helpers and returns before dev.sh does any work, which is what makes
 `kill_tree` and the stale-pidfile decision testable without booting a server.
 """
 import os
+import pathlib
 import re
 import shutil
 import subprocess
 import time
 
-_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+# realpath, NOT abspath: dev.sh derives $REPO_ROOT with `pwd -P` and compares the
+# recorded root to it as a plain string. abspath leaves symlinks in place, so on
+# a symlinked checkout every `want_root=_ROOT` below would differ from what the
+# script computed, every dev_pidfile_is_ours here would flip to STALE, and the
+# suite would go red for a reason that has nothing to do with dev.sh. Worse, it
+# would be red only on the machines where the behaviour under test actually
+# matters — this file would be unable to detect the very bug the physical-root
+# change exists to fix.
+_ROOT = os.path.realpath(os.path.join(os.path.dirname(__file__), ".."))
 _DEV_SH = os.path.join(_ROOT, "scripts", "dev.sh")
 
 
@@ -158,7 +167,13 @@ def _fake_root(tmp_path, name):
     and "no importable package" would be indistinguishable and the regression
     test below could pass for the wrong reason.
     """
-    root = tmp_path / name
+    # Resolved for the same reason as _ROOT: every assertion below compares this
+    # against a path the script derived with `pwd -P`. pytest's tmp_path is
+    # already physical on macOS (/private/var, not /var), but that is a platform
+    # accident, not a guarantee — a test that only passes because of it would go
+    # red somewhere else for a harness reason. Tests that want the UNRESOLVED
+    # spelling build their own symlink and pass it explicitly.
+    root = pathlib.Path(os.path.realpath(str(tmp_path))) / name
     (root / "scripts").mkdir(parents=True)
     shutil.copy2(_DEV_SH, root / "scripts" / "dev.sh")
     (root / "fused_render").symlink_to(os.path.join(_ROOT, "fused_render"))
@@ -595,6 +610,99 @@ def test_the_sweep_deletes_dead_records_but_keeps_live_unverifiable_ones(tmp_pat
     finally:
         alien.kill()
         alien.wait(timeout=10)
+
+
+def test_the_suites_repo_root_is_physical():
+    """Pins the harness invariant the assertions below silently depend on.
+
+    Every `want_root=_ROOT` in this file is compared against a `pwd -P` root
+    computed inside dev.sh. If _ROOT ever goes back to abspath, that comparison
+    holds on an ordinary checkout and breaks on a symlinked one — a failure that
+    would look like a dev.sh bug and appear only on someone else's machine.
+    """
+    assert _ROOT == os.path.realpath(_ROOT)
+
+
+def test_a_record_is_still_ours_when_dev_sh_is_invoked_through_a_symlink(tmp_path):
+    """The symlinked-checkout bug, end to end rather than by path arithmetic.
+
+    dev.sh writes the physical root into the record. Invoked through a symlinked
+    path with a logical `pwd`, the next run computed a DIFFERENT root string for
+    the same worktree, called its own live record not-ours, and (with the sweep's
+    keep rule) left the tree running while reporting nothing to do. Reaping here
+    is the whole chain working: symlinked invocation -> physical $REPO_ROOT ->
+    recorded root matches -> the tree dies.
+    """
+    real = _fake_root(tmp_path, "real")
+    link = pathlib.Path(os.path.realpath(str(tmp_path))) / "link"
+    link.symlink_to(real)
+    (real / "legacy").mkdir()
+    proc = _spawn_stub(real / "legacy" / "dev.sh")
+    try:
+        rec = _record(real, "dev.sh.pid", proc.pid, _lstart(proc.pid),
+                      os.path.realpath(str(real)))
+        res = _run_cleanup_at(link)
+        assert res.returncode == 0, res.stdout + res.stderr
+        assert not _alive(proc.pid), (
+            f"the record was not recognized through the symlink:\n"
+            f"{res.stdout}{res.stderr}"
+        )
+        assert not rec.exists()
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+def test_cleanup_never_reports_clean_while_a_live_record_is_kept(tmp_path):
+    """`--cleanup` exists to answer "is this worktree clean?" — truthfully.
+
+    The summary used to branch on the reap flag alone, so a run that had just
+    left an unverifiable-but-LIVE record on disk still printed "nothing left
+    running for this worktree" (when something was also reaped) or "no dev.sh
+    recorded … nothing reaped" (when nothing was) — both flatly contradicting the
+    NOTE it had printed moments earlier, in the one command whose whole job is
+    that answer.
+    """
+    for also_reap in (False, True):
+        root = _fake_root(tmp_path, f"wt-{int(also_reap)}")
+        alien = subprocess.Popen(["sleep", "60"], close_fds=False)
+        time.sleep(0.3)
+        stub = None
+        try:
+            _record(root, "live-branch", alien.pid, _lstart(alien.pid),
+                    os.path.realpath(str(root)))
+            if also_reap:
+                (root / "legacy").mkdir()
+                stub = _spawn_stub(root / "legacy" / "dev.sh")
+                _record(root, "dev.sh.pid", stub.pid, _lstart(stub.pid),
+                        os.path.realpath(str(root)))
+            res = _run_cleanup_at(root)
+            assert res.returncode == 0, res.stdout + res.stderr
+            out = res.stdout + res.stderr
+            assert "nothing left running" not in out, out
+            assert "no dev.sh recorded" not in out, out
+            assert "could not verify" in out, out
+        finally:
+            alien.kill()
+            alien.wait(timeout=10)
+            if stub is not None:
+                stub.kill()
+                stub.wait(timeout=10)
+
+
+def test_cleanup_still_reports_an_empty_worktree_as_empty(tmp_path):
+    """The genuinely-clean case keeps its guidance: no record is not no process.
+
+    A dev.sh started before the pidfile existed leaves nothing behind, and
+    finding it would take the pattern match this script must never do — so the
+    developer gets the search rather than a guess made on their behalf.
+    """
+    root = _fake_root(tmp_path, "wt")
+    res = _run_cleanup_at(root)
+    assert res.returncode == 0, res.stdout + res.stderr
+    out = res.stdout + res.stderr
+    assert "no dev.sh recorded for this worktree" in out, out
+    assert "pgrep -laf dev.sh" in out, out
 
 
 def test_the_sweep_reports_stale_records_once_not_once_per_file(tmp_path):


### PR DESCRIPTION
## Summary

- **`dev.sh` no longer leaves orphaned processes behind.** Eleven were hand-killed on one machine while writing this, several running 10–20 days: `vite build --watch` nodes reparented to init with no `dev.sh` above them, plus two complete duplicate dev.sh trees on a single worktree.
- **The trap was killing the wrong PID.** `WATCH_PID` was the backgrounded *subshell*, not vite — the live chain is `dev.sh → subshell → npm → node vite → esbuild`, and killing the subshell orphans everything below it. Shutdown now walks descendants by ppid and reaps the whole tree.
- **The server was never in the trap at all**, and bash defers trap handlers until the foreground command returns, so `kill <dev.sh-pid>` did nothing. Both server launches (watchfiles and `FUSED_RENDER_NO_RELOAD=1`) are now backgrounded and `wait`ed, which is what makes shutdown responsive to a plain signal.
- **A second `dev.sh` on the same worktree used to just… run.** `cli.py`'s port guard catches a duplicate *server*, but two vite watchers coexist happily, both writing the same `shell-dist/`. A branch-keyed pidfile now reaps the previous run instead. `--cleanup` reaps and exits.

## Visuals

Shutdown, before and after. The old handler reached three PIDs and none of their children; the new one walks the tree.

**Before**

```mermaid
flowchart TD
    T["trap on EXIT/INT/TERM"] --> W["kill WATCH_PID<br/>(a subshell)"]
    T --> O["kill OPENER_PID"]
    W --> N["npm — survives"]
    N --> V["vite --watch — survives"]
    V --> E["esbuild — survives"]
    S["watchfiles + server<br/>(foreground, not in trap)"] -.->|never signalled| S
```

**After**

```mermaid
flowchart TD
    T["dev_shutdown<br/>(one handler, all three traps)"] --> K["kill_tree each PID"]
    K --> A["WATCH_PID subtree"]
    K --> B["CORE_WATCH_PID subtree"]
    K --> C["SERVER_PID subtree"]
    A --> G["TERM depth-first → 2s grace → KILL<br/>then wait, then drop pidfile"]
    B --> G
    C --> G
```

## Usage

Nothing new is required — the fix applies to the normal `scripts/dev.sh` run. Two additions:

```bash
scripts/dev.sh --cleanup   # reap this worktree's dev.sh tree and exit
scripts/dev.sh             # a second run now reaps the first instead of stacking
```

The pidfile lives at `.dev-pids/<sanitized-branch>` (gitignored), keyed by branch via `fused_render._branch.branch_ref` — the same sanitizer the port and state dir already use, so one worktree can never reap another's.

**Reaping is deliberately narrow**: only the PID the pidfile names and its descendants. No `pkill -f vite`, no `killall`. A pidfile whose PID is dead — or recycled onto an unrelated process — is a no-op plus a file delete. Identity is checked on liveness, command line, `ps -o lstart=` start time, and recorded repo root, because on macOS a bash subshell reports its *parent's* command line and the command line alone is not enough.

## Test Plan

- [x] `tests/test_dev_sh_process_cleanup.py` — 13 tests. Sources `dev.sh` under `FUSED_RENDER_DEV_SH_LIB=1`, which defines the helpers and returns before doing any work, so the tests drive the **real** functions rather than a reimplementation.
- [x] `kill_tree_hard` against a spawned `bash -c 'bash -c "sleep 300 & sleep 300" & wait'` tree — every descendant asserted gone; and against a TERM-ignoring child, asserting KILL escalation.
- [x] Pidfile decisions: dead PID → stale; live-but-unrelated PID → stale; wrong recorded root → stale; foreign start time on a matching PID → stale; real live `dev.sh` → ours.
- [x] Structural guards: no `pkill -f`/`killall` anywhere, `--cleanup` stripped before both passthrough sites, every EXIT trap routes through `dev_shutdown`, both server launches backgrounded and waited, `.dev-pids/` gitignored.
- [x] Manual, verbatim `ps` captured in each case: `kill` the dev.sh PID → exits 143, whole tree gone, pidfile removed. SIGINT → exits 130, same. Double-start → run B reports reaping run A's PID and A exits 143. `--cleanup` with a live tree, with nothing running, and with a pidfile hand-pointed at pid 1 (correctly ignored — launchd survives). `FUSED_RENDER_NO_RELOAD=1` path exercised separately.
- [x] Other worktrees verified untouched across every reap, including a deliberately-kept orphan vite in a sibling worktree.
- [ ] Full suite + CI — running now; PR stays in draft until both are green.

One thing not covered in-suite: trap responsiveness against a live server tree, and the double-start reap, are shell/process behaviour with no harness in this repo. Both were verified by hand with `ps` output recorded in the build report rather than asserted automatically.
