### PR TITLE
Bump fused pin to 2.9.3b4

### DIFF
--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -151,7 +151,7 @@ def _now_iso() -> str:
 # `==` is what makes pip install a pre-release at all. Move it to `2.9.3` when that
 # lands; the string is duplicated in pyproject's `[fused]` extra and its bundled-deps
 # list, and tests hold all three equal.
-PINNED_FUSED_REQUIREMENT = "fused==2.9.3b3"
+PINNED_FUSED_REQUIREMENT = "fused==2.9.3b4"
 # The release's own environment marker (python_version >= "3.11"), enforced here
 # because pip is handed the marker-free requirement above.
 FUSED_MIN_PYTHON = (3, 11)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,7 +213,7 @@ bundled = [
     # The requirement string must stay byte-identical to `[fused]`'s — see the
     # comment there and
     # tests/test_bundle_contents.py::test_the_bundled_and_fused_extras_pin_the_same_wheel.
-    'fused==2.9.3b3 ; python_version >= "3.11"',
+    'fused==2.9.3b4 ; python_version >= "3.11"',
 ]
 # Private-cloud credential chains (optional). botocore buys the AWS provider
 # chain (SSO / credential_process / assume-role / IMDS) for s3sign's resolver
@@ -250,7 +250,7 @@ app = [
 # (README, docs/usage.md) and CI's `fused-engine` job (`.[dev,fused]`), both of
 # which want the engine WITHOUT the ~650 MB scientific stack.
 fused = [
-    'fused==2.9.3b3 ; python_version >= "3.11"',
+    'fused==2.9.3b4 ; python_version >= "3.11"',
 ]
 # Windows desktop supervisor backend (fused_render/supervisor/_win32,
 # docs/DESKTOP_SUPERVISOR.md). Windows-only; not a core dependency so


### PR DESCRIPTION
## Summary

Moves the `fused` engine pin from `2.9.3b3` to `2.9.3b4`, the newest pre-release on PyPI. The version string is duplicated in three places by design (D78/D232), and the bump touches all three so the equality tests stay green:

- `fused_render/deploy.py` — `PINNED_FUSED_REQUIREMENT`
- `pyproject.toml` — `[bundled]` deps list
- `pyproject.toml` — `[fused]` extra

The `==` stays exact: a range specifier would exclude the pre-release outright.

## Visual

```mermaid
graph LR
  A["fused==2.9.3b3"] --> B["fused==2.9.3b4"]
  B --> C["deploy.PINNED_FUSED_REQUIREMENT"]
  B --> D["pyproject [bundled]"]
  B --> E["pyproject [fused] extra"]
  C -.->|held equal by| T["test_bundle_contents.py"]
  D -.->|held equal by| T
  E -.->|held equal by| T
```

## Usage

No API change. Fresh installs resolve the new pre-release:

```bash
pip install "fused-render[fused]"
```

Existing dev checkouts pick it up on the next `uv sync` / reinstall.

## Test plan

- [x] `uv run pytest tests/test_bundle_contents.py -k fused` — 2 passed (asserts the bundled and `[fused]` extras pin the same wheel, and that `deploy.py` agrees)
- [ ] CI's `fused-engine` job (`.[dev,fused]`) confirms 2.9.3b4 installs and the engine path still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)