### PR TITLE
Card peeks must not record app opens (_preview=1 through the embed shell)

### DIFF
--- a/frontend/src/apps/explorer/BookmarkCards.tsx
+++ b/frontend/src/apps/explorer/BookmarkCards.tsx
@@ -10,7 +10,7 @@
 // bookmark exactly like the sidebar row would.
 import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
-import { navigate, navigateUrl, urlForFsPath, EMBED_PREFIX, VIEW_PREFIX } from "@platform/lib/router";
+import { navigate, navigateUrl, urlForFsPath, withPreviewFlag, EMBED_PREFIX, VIEW_PREFIX } from "@platform/lib/router";
 import { listDir, rawUrl, statPath } from "@platform/lib/api";
 import type { FsEntry } from "@platform/lib/api";
 import { basename } from "@platform/lib/format";
@@ -57,8 +57,14 @@ function joinPath(dir: string, name: string): string {
   return (dir.endsWith("/") ? dir : dir + "/") + name;
 }
 
-// Display-only live preview: scaled iframe + a shield keeping clicks on the card.
+// Display-only live preview: scaled iframe + a shield keeping clicks on the
+// card. The `_preview=1` stamp is what keeps a peek from counting as an OPEN:
+// the embed shell reads it once at load (router.IS_PREVIEW) and forwards it
+// onto every /render it builds, so a card peeking at an app's entry page never
+// records the app open (GET /render records by default, D301) — without it,
+// scrolling a folder card into view reshuffles the /apps hub's recency order.
 export function LivePreview({ src }: { src: string }) {
+  src = withPreviewFlag(src);
   return (
     <span className="fhb-preview" aria-hidden="true">
       <iframe

--- a/frontend/src/apps/explorer/Preview.tsx
+++ b/frontend/src/apps/explorer/Preview.tsx
@@ -15,7 +15,7 @@ import {
   deleteEntry,
 } from "@platform/lib/api";
 import type { Deployment, StatResult, TemplateEntry } from "@platform/lib/api";
-import { navigate, navigateUrl, urlForFsPath, replaceSearch, IS_EMBED } from "@platform/lib/router";
+import { navigate, navigateUrl, urlForFsPath, replaceSearch, IS_EMBED, IS_PREVIEW } from "@platform/lib/router";
 import { formatSize, formatMtimeFull, basename } from "@platform/lib/format";
 import { useRefreshOnReturn } from "@platform/lib/hooks";
 import { useDeployEnabled } from "@platform/lib/prefs";
@@ -1009,13 +1009,18 @@ function TemplatePreview({
   // page makes through `fused.*` does resolve to the revision, and the write gate
   // applies.
   const remote = stat.remote ? "&_remote=1" : "";
+  // A shell loaded as a card thumbnail (IS_PREVIEW) forwards the flag onto
+  // every render it triggers, so peeking at an app's entry page is not
+  // recorded as opening the app (D301 records on GET /render by default).
+  const preview = IS_PREVIEW ? "&_preview=1" : "";
   const srcFor = (m: string): string | null => {
     if (m === "_listing") return null;
-    if (m === "_render") return revSrc(`/render?path=${encodeURIComponent(fsPath)}`, rev);
+    if (m === "_render")
+      return revSrc(`/render?path=${encodeURIComponent(fsPath)}${preview}`, rev);
     const t = templates.find((x) => x.mode === m);
     return t
       ? revSrc(
-          `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(fsPath)}${remote}`,
+          `/render?path=${encodeURIComponent(t.path as string)}&_file=${encodeURIComponent(fsPath)}${remote}${preview}`,
           rev
         )
       : null;
@@ -1055,7 +1060,7 @@ function TemplatePreview({
     const chatOnly = m === "claude" ? "&chat_only=1" : "";
     return (
       `/render?path=${encodeURIComponent(t.path)}` +
-      `&_file=${encodeURIComponent(target)}${rem}${chatOnly}`
+      `&_file=${encodeURIComponent(target)}${rem}${chatOnly}${preview}`
     );
   };
 

--- a/frontend/src/platform/lib/router.test.ts
+++ b/frontend/src/platform/lib/router.test.ts
@@ -22,7 +22,7 @@ import { describe, expect, test } from "bun:test";
   clearTimeout: globalThis.clearTimeout.bind(globalThis),
 };
 
-const { navigate, rewriteLegacyUrl } = await import("./router");
+const { navigate, rewriteLegacyUrl, withPreviewFlag } = await import("./router");
 
 // The url navigate() pushed, with the page sitting on `search` when it ran.
 // navigate reads location.search live (the framing flag is carried FORWARD, not
@@ -125,4 +125,20 @@ test("current urls pass through untouched", () => {
   );
   // A file legitimately named view/ deeper in the path must not rewrite.
   expect(rewriteLegacyUrl("/explorer/view/w/view/f")).toBe("/explorer/view/w/view/f");
+});
+
+// The `_preview=1` thumbnail stamp (D301: GET /render records an app open by
+// default; a card peek must say "I am a picture"). A miss here is invisible
+// until the /apps hub's recency order rearranges itself as cards scroll by.
+test("withPreviewFlag stamps the thumbnail param", () => {
+  expect(withPreviewFlag("/explorer/embed/w/app/index.html")).toBe(
+    "/explorer/embed/w/app/index.html?_preview=1",
+  );
+  // A bookmark's stored query (the saved view params) rides along.
+  expect(withPreviewFlag("/explorer/embed/w/d?sort=size")).toBe(
+    "/explorer/embed/w/d?sort=size&_preview=1",
+  );
+  // Idempotent: cards rebuild src every render; accumulating would reload.
+  const once = withPreviewFlag("/render?path=x");
+  expect(withPreviewFlag(once)).toBe(once);
 });

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -48,6 +48,30 @@ export const IS_EMBED =
   location.pathname.startsWith(EMBED_PREFIX) ||
   location.pathname === "/explorer/embed";
 
+// The param a display-only card peek stamps on its embed URL (BookmarkCards'
+// LivePreview), and the flag GET /render takes to skip open recording (D301).
+// One name end to end: the card marks the embed shell, the shell forwards it
+// onto every /render URL it builds (Preview.tsx), the server skips the record.
+export const PREVIEW_PARAM = "_preview";
+
+// AM I A THUMBNAIL? Read once at module init like IS_EMBED — navigate() drops
+// the query on every in-app hop, but a card peek never navigates (its pointer
+// shield keeps every click on the card), so the load-time value is the truth
+// for the document's whole life. Without this, a folder card peeking at an
+// app's entry page RECORDS AN OPEN of that app every time the card scrolls
+// into view, and the /apps recency order rearranges itself.
+export const IS_PREVIEW =
+  IS_EMBED && new URLSearchParams(location.search).get(PREVIEW_PARAM) === "1";
+
+// Mark an embed/render URL as a thumbnail. Idempotent (a bookmark's stored
+// url may carry any query, and cards rebuild their src every render — an
+// accumulating param would reload the frame for nothing), same shape as
+// frame-focus's withNoFocus.
+export function withPreviewFlag(src: string): string {
+  if (new URLSearchParams(src.split("?")[1] ?? "").get(PREVIEW_PARAM) === "1") return src;
+  return src + (src.includes("?") ? "&" : "?") + PREVIEW_PARAM + "=1";
+}
+
 // A FROZEN TREE, not a live folder: the framing a view uses when it embeds a
 // materialised historical snapshot — a commit extracted into
 // ~/.fused-render/app-versions/<key>/<sha>/ with that directory framed.

--- a/frontend/src/platform/lib/router.ts
+++ b/frontend/src/platform/lib/router.ts
@@ -54,6 +54,26 @@ export const IS_EMBED =
 // onto every /render URL it builds (Preview.tsx), the server skips the record.
 export const PREVIEW_PARAM = "_preview";
 
+// A same-origin ancestor frame carrying the thumbnail stamp. Inheritance is
+// the point: a PREVIEWED page may itself embed other apps (the tutorial
+// example iframes the sine app via /embed/ and the full shell via /view/),
+// and those nested shells load with no flag of their own — so a card peek at
+// the tutorial recorded opens of the apps INSIDE it. Any ancestor being a
+// thumbnail makes this whole subtree a thumbnail, whatever prefix it loaded
+// under. Cross-origin ancestors (or no DOM at all, in tests) read as "no".
+function ancestorIsPreview(): boolean {
+  try {
+    let w: Window = window;
+    while (w.parent && w.parent !== w) {
+      w = w.parent;
+      if (new URLSearchParams(w.location.search).get(PREVIEW_PARAM) === "1") return true;
+    }
+  } catch {
+    /* cross-origin frame — not ours, so not our thumbnail */
+  }
+  return false;
+}
+
 // AM I A THUMBNAIL? Read once at module init like IS_EMBED — navigate() drops
 // the query on every in-app hop, but a card peek never navigates (its pointer
 // shield keeps every click on the card), so the load-time value is the truth
@@ -61,7 +81,8 @@ export const PREVIEW_PARAM = "_preview";
 // app's entry page RECORDS AN OPEN of that app every time the card scrolls
 // into view, and the /apps recency order rearranges itself.
 export const IS_PREVIEW =
-  IS_EMBED && new URLSearchParams(location.search).get(PREVIEW_PARAM) === "1";
+  (IS_EMBED && new URLSearchParams(location.search).get(PREVIEW_PARAM) === "1") ||
+  ancestorIsPreview();
 
 // Mark an embed/render URL as a thumbnail. Idempotent (a bookmark's stored
 // url may carry any query, and cards rebuild their src every render — an

--- a/fused_render/server/routers/render.py
+++ b/fused_render/server/routers/render.py
@@ -3,7 +3,9 @@ import os
 import urllib.error
 import urllib.request
 
-from fastapi import APIRouter
+from urllib.parse import parse_qs, urlsplit
+
+from fastapi import APIRouter, Header
 from fastapi.responses import HTMLResponse
 
 from fused_render.server.common import _error
@@ -15,8 +17,28 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
+def _referred_by_preview(referer: str | None) -> bool:
+    """True when the DOCUMENT that requested this render is itself a preview
+    (`_preview=1` in the referring URL's query). Covers the flag's one gap: a
+    previewed page that directly iframes another `/render?path=...` URL — its
+    author never wrote the flag, but same-origin requests carry a full-URL
+    Referer, so the parent's stamp is visible here. Shell-mediated nesting
+    (/embed/, /view/) is covered client-side instead (router.IS_PREVIEW walks
+    ancestor frames), because there the referrer is the unflagged shell URL."""
+    if not referer:
+        return False
+    try:
+        return parse_qs(urlsplit(referer).query).get("_preview") == ["1"]
+    except ValueError:
+        return False
+
+
 @router.get("/render")
-def render(path: str, _preview: str | None = None):
+def render(
+    path: str,
+    _preview: str | None = None,
+    referer: str | None = Header(default=None),
+):
     if not _is_file_mount_safe(path):
         return _error(f"no such file: {path}", status=404)
     # Mount-backed pages read through the rclone serve like /api/fs/raw:
@@ -50,7 +72,7 @@ def render(path: str, _preview: str | None = None):
     # flagged never registers an external app (breaks the only path in).
     # Templates render through here too and carry no marker, so they never
     # record. Best-effort: recording must never fail the render.
-    if _preview != "1":
+    if _preview != "1" and not _referred_by_preview(referer):
         from fused_render.app_listing import text_has_fused_meta
         from fused_render.server.routers.apps import record_app_open
 

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -813,6 +813,29 @@ def test_a_preview_render_records_nothing(client, workspace, recents_home):
     assert _opened_at(client, "sine") is None
 
 
+def test_a_render_referred_by_a_preview_records_nothing(client, workspace, recents_home):
+    # A previewed page may itself iframe another app's /render URL directly —
+    # its author never wrote _preview=1, but the same-origin Referer carries
+    # the parent's stamp, so the nested render is a thumbnail too. Without
+    # this, previewing a page that embeds other apps re-records THOSE apps.
+    d = _app_dir(workspace, "sine")
+    r = client.get(
+        "/render",
+        params={"path": str(d / "index.html")},
+        headers={"Referer": "http://x/render?path=%2Fw%2Ftutorial.html&_preview=1"},
+    )
+    assert r.status_code == 200
+    assert _opened_at(client, "sine") is None
+    # An ordinary referer (a real open navigated from anywhere) still records.
+    r = client.get(
+        "/render",
+        params={"path": str(d / "index.html")},
+        headers={"Referer": "http://x/explorer/view/w/sine"},
+    )
+    assert r.status_code == 200
+    assert _opened_at(client, "sine") is not None
+
+
 def test_rendering_an_unmarked_page_records_nothing(client, workspace, tmp_path, recents_home):
     # Templates and plain html render through /render too; no marker, no record.
     p = tmp_path / "plain.html"


### PR DESCRIPTION
## Problem
Two leaks made preview renders count as app opens (GET /render records by default, D301), reshuffling the /apps hub's recency order:

1. **Folder-card peeks** (BookmarkCards' `LivePreview`) load through `/explorer/embed/`, and the embed shell built its `/render` URLs without `_preview=1`.
2. **Nested embeds inside a previewed page**: a previewed app can itself iframe other apps (the tutorial example embeds sine via `/embed/` and showcase via `/view/`) — those nested documents carried no flag, so scrolling the /apps hub re-recorded `examples/sine` and `examples/showcase` through the tutorial card's live preview (reproduced with a CDP-driven Chrome against the dev server).

## Fix
- `LivePreview` stamps `_preview=1` on its embed src via idempotent `withPreviewFlag` (router.ts).
- `router.IS_PREVIEW` (read once at module init, beside `IS_EMBED`): true when the shell's own URL carries the flag, **or when any same-origin ancestor frame does** — a thumbnail's whole subtree is a thumbnail, whatever prefix it loaded under. Preview.tsx forwards the flag onto every `/render` it builds (`srcFor`, `sideSrcFor`).
- Server belt: GET /render also skips recording when the **Referer's query carries `_preview=1`** — covers a previewed page that directly iframes another `/render` URL, where no shell runs client-side.
- Panel/tab panes untouched: no flag anywhere in their ancestry, opens still record.

## Verification
- Live repro before fix: CDP-driven Chrome on the dev server — scrolling /apps re-recorded sine+showcase via tutorial's nested embeds. After fix (rebuilt shell): loading /home and /apps with all previews rendered leaves `app_recents.json` untouched; confirmed working by the user.
- `bun test` 924 pass, `tsc --noEmit` clean, `pytest tests/test_apps_api.py` 55 pass (new referer test included). Two pre-existing failures (`test_deploy`, `test_calls`) reproduce on a clean tree — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)