### PR TITLE
Make a dead git visible, stop orphaning rcd, and add Resolve with AI for conflicts (GT-19)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4554,6 +4554,75 @@ caller that wants the log on purpose.
   never the traceback overlay — and `ai_unavailable` reads as *"AI is not
   available on this server."*
 
+- **GT-19** **A merge conflict, and a failed operation, can be taken to an AI —
+  and NOTHING it says reaches the working tree without a confirmation.** Two
+  situations, one button (the same sparkle as GT-18), one panel, and one model:
+  **`claude-sonnet-5`**, named explicitly rather than left on the cheap default,
+  because reconciling two versions of a file is not the shape of work the default
+  is for. `effort` stays low — the thinking budget is not what decides whether a
+  merge is understood, and it is the latency the user waits through.
+
+  **The conflict case is the primary one.** A conflicted row in the change lists
+  carries the sparkle, ahead of Stage — on a conflicted file the resolution is
+  what the user came for, and Stage is the act that ENDS the conflict, so
+  offering them the other way round invites a `git add` of a file that still has
+  markers in it. Which rows are conflicted is the READER's answer
+  (`_status`'s `conflicted`, git's own porcelain rule: a `U` on either side, plus
+  `AA`/`DD`) and never re-derived in the view — a seven-case mirror with no way
+  to notice it drifting is how the button appears on the wrong rows.
+
+  The context the model gets is `log.py op="conflicts"`: the unmerged paths with
+  their **working-tree marker text** (the index's three stages are not the text a
+  resolution replaces), the operation in flight — merge / rebase / cherry-pick /
+  revert, read from the git dir's marker files rather than parsed out of `git
+  status`'s localised prose — and the branch. The read is deliberately
+  **UNSCOPED**, unlike almost every other read in §33: a merge is not
+  half-finished for one folder, so hiding the conflicts outside the open scope
+  would describe a state that does not exist. Each entry carries `in_scope`
+  instead, so the view SHOWS every conflict and offers to write only the ones
+  `ops.py` would accept (GT-13). Capped in file count and total bytes with the
+  truncation reported, so a prompt built from it is bounded and the panel can say
+  the model saw only part of the file. A binary or unreadable unmerged file is
+  NAMED and never read — the answer there is `git checkout --ours/--theirs`, not
+  a model.
+
+  **Nothing is applied by the button that asked.** The answer streams into a
+  review panel above the toolbar; Apply asks (GT-16's `ask` mechanism, and
+  `resolve` is in `DESTRUCTIVE_OPS` for exactly that reason: it overwrites the
+  only copy of what git left behind), and the confirmation is rendered INSIDE the
+  panel rather than in a list section — the question belongs next to the text it
+  writes, and a conflicted file is listed in both the staged and the changes
+  section, so there is no single row to attach it to. A pending `ask=resolve:…`
+  that survived a refresh is dropped rather than answered: the resolved text
+  lives in memory, so its Yes could only fail.
+
+  `ops.py op="resolve"` writes ONE file's text and does **nothing else** — no
+  `git add`, no commit. Marking a conflict resolved is a separate act the user did
+  not press, so the file lands unmerged-in-the-index and the ordinary Stage
+  button is still what resolves it. It refuses: a path that is not currently
+  unmerged (`--diff-filter=U` is the authority, which is what stops this being a
+  general-purpose "overwrite any file" write), more than one path, empty content,
+  oversized content, and — the refusal that makes the feature safe to point at a
+  model — content that still carries conflict markers. Written through a temp
+  file and `os.replace`, because a half-overwritten conflicted file is worse than
+  no write. A model that declines answers `UNRESOLVABLE` and gets **no Apply at
+  all**.
+
+  **The operation-error case is secondary and produces advice only.** A failed
+  mutation's `flash` carries the sparkle; the model gets the error text plus the
+  repository's branch/upstream/ahead-behind/dirty state and returns what it means
+  and what to run. There is no Apply, and this view will not run a command a
+  model picked — that is a different feature and a much larger one.
+
+  Every `fused.ai` rejection is this view's own sentence, never the traceback
+  overlay: `ai_unavailable`, `model_loading`, `unavailable`, `cancelled`,
+  `timeout` and `bad_request` each read as an ordinary answer. The button is
+  disabled while a call is in flight and while a proposal is on screen (one panel,
+  one subject), and Cancel drops the panel — honestly, since `fused.ai.cancel`
+  only reaches a LOCAL generation and this asks for a Claude model. Mount-backed
+  targets never reach any of it: `_locate` refuses a mount in both modules and the
+  gate never offers the view (GT-4 / MD-11).
+
 **See also §34** (`file_history`), the other history view. It is complementary
 rather than an alternative: this one drives the repository's own commit graph and
 index, i.e. everything git already knows about; that one reads Claude Code's

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -44,6 +44,23 @@ import time
 
 from fused_render.shell.seed import fused_dir
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 logger = logging.getLogger(__name__)
 
 _GIT_TIMEOUT = 30
@@ -80,7 +97,7 @@ def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
     _GIT_TIMEOUT; every caller in this file is already wrapped in a broad
     except Exception, so a hung git never escapes as an unhandled error."""
     return subprocess.run(
-        ["git", "-C", app_dir, *_IDENTITY, *args],
+        [_git_bin(), "-C", app_dir, *_IDENTITY, *args],
         capture_output=True, text=True, timeout=_GIT_TIMEOUT,
         close_fds=False,
         creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,

--- a/fused_render/claude_config/lib.py
+++ b/fused_render/claude_config/lib.py
@@ -24,6 +24,23 @@ from typing import Any, Generator, Optional
 
 from fused_render.shell.storage import home_dir
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 # flock is POSIX-only and this module is imported at server-startup time (the
 # router is registered unconditionally in server/app.py), so a bare
 # `import fcntl` would take the WHOLE server down on Windows over a lock that
@@ -253,7 +270,7 @@ def git(*args: str, check: bool = True) -> str:
     spawn instead of inside git, and a forking spawn dies rc=-11 the moment
     PROJ is resident in this process."""
     res = subprocess.run(
-        ["git", "-C", CLAUDE_DIR, *args],
+        [_git_bin(), "-C", CLAUDE_DIR, *args],
         capture_output=True,
         **SUBPROCESS_KWARGS,
     )
@@ -705,7 +722,7 @@ def archive_zip(name: str) -> bytes:
     ~/.claude.json, or secrets."""
     ensure_repo()
     res = subprocess.run(
-        ["git", "-C", CLAUDE_DIR, "archive", "--format=zip", name],
+        [_git_bin(), "-C", CLAUDE_DIR, "archive", "--format=zip", name],
         capture_output=True,
         close_fds=False,
     )

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -49,6 +49,23 @@ import sys
 import tempfile
 import time
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 REPO_URL = os.environ.get(
     "FUSED_RENDER_COMMUNITY_REPO",
     "https://github.com/fusedio/fused-render-community-apps.git",
@@ -129,7 +146,7 @@ def _git(cwd, *args, timeout=GIT_TIMEOUT):
     env = dict(os.environ, GIT_TERMINAL_PROMPT="0")
     try:
         return subprocess.run(
-            ["git", "-C", cwd, *IDENTITY, *args],
+            [_git_bin(), "-C", cwd, *IDENTITY, *args],
             capture_output=True, text=True, timeout=timeout, env=env,
             close_fds=False,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,

--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -37,6 +37,23 @@ from fused_render._view_url_codec import view_url_path as _view_url_path
 
 from fused_render.shell.seed import fused_dir
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 logger = logging.getLogger("fused_render")
 
 router = APIRouter()
@@ -226,7 +243,7 @@ def _git(args: list[str], cwd: str | None = None, timeout: int = 300) -> str:
     """Run git, raise DeeplinkError carrying git's stderr on failure."""
     try:
         proc = subprocess.run(
-            ["git", *args],
+            [_git_bin(), *args],
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,

--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -239,12 +239,19 @@ def _git_env() -> dict:
     return env
 
 
-def _git(args: list[str], cwd: str | None = None, timeout: int = 300) -> str:
-    """Run git, raise DeeplinkError carrying git's stderr on failure."""
+def _git(args: list[str], timeout: int = 300) -> str:
+    """Run git, raise DeeplinkError carrying git's stderr on failure.
+
+    Takes no `cwd`: it had one, no caller ever passed it (every call already
+    carries its own `-C <dest>`), and a `cwd=` kwarg forces CPython onto the fork
+    path — where a process with libproj resident dies in PROJ's atfork handler
+    before exec, rc -11 and silent. Removed rather than defaulted so it cannot be
+    reintroduced by a caller that does not know that.
+    """
     try:
         proc = subprocess.run(
             [_git_bin(), *args],
-            cwd=cwd,
+            close_fds=False,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -24,6 +24,23 @@ from fused_render.server.mount import _invalidate_stat_cache, _is_under_snapshot
 from fused_render.server.walk import _mount_list_error_response
 from fused_render.shell import storage as shell_storage
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 router = APIRouter()
 
 
@@ -378,7 +395,7 @@ def _run_git(args: list[str], cwd: str):
     Returns the CompletedProcess, or None when git is missing/hung."""
     try:
         return subprocess.run(
-            ["git", "--no-pager", *args],
+            [_git_bin(), "--no-pager", *args],
             cwd=cwd,
             env={**os.environ, **_GIT_ENV},
             stdin=subprocess.DEVNULL,

--- a/fused_render/server/fs_mutate.py
+++ b/fused_render/server/fs_mutate.py
@@ -392,11 +392,19 @@ _GIT_ENV = {
 
 def _run_git(args: list[str], cwd: str):
     """Run git with an argv list (never a shell), no stdin, and a timeout.
-    Returns the CompletedProcess, or None when git is missing/hung."""
+    Returns the CompletedProcess, or None when git is missing/hung.
+
+    `cwd` becomes `-C <cwd>` in the argv rather than a `cwd=` kwarg, and that is
+    load-bearing: `cwd=` forces CPython onto the fork path, where a process with
+    libproj resident dies in PROJ's atfork handler before exec (rc -11, silently).
+    `-C` is also stricter — git chdirs there itself, so this process's working
+    directory cannot change the answer. Callers therefore pass their own args
+    WITHOUT a leading `-C`.
+    """
     try:
         return subprocess.run(
-            [_git_bin(), "--no-pager", *args],
-            cwd=cwd,
+            [_git_bin(), "--no-pager", "-C", cwd, *args],
+            close_fds=False,
             env={**os.environ, **_GIT_ENV},
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -414,7 +422,7 @@ def _has_any_ref(src: str) -> bool:
     actually needs. `for-each-ref --count=1` exits 0 whether or not anything
     matches and prints a refname only when one exists, so emptiness is read off
     stdout rather than the exit code."""
-    refs = _run_git(["-C", src, "for-each-ref", "--count=1",
+    refs = _run_git(["for-each-ref", "--count=1",
                      "--format=%(refname)"], src)
     return refs is not None and refs.returncode == 0 and bool(refs.stdout.strip())
 
@@ -553,7 +561,7 @@ def _fs_compress(body: dict, x_fused: str | None):
             if not _has_any_ref(src):
                 return _error(f"{src} has no commits yet")
         else:
-            head = _run_git(["-C", src, "rev-parse", "--verify", "HEAD"], src)
+            head = _run_git(["rev-parse", "--verify", "HEAD"], src)
             if head is None or head.returncode != 0:
                 # A repo with no refs at all really has no commits; one whose
                 # HEAD alone is unborn is full of history that just isn't
@@ -571,8 +579,8 @@ def _fs_compress(body: dict, x_fused: str | None):
             except OSError as e:
                 return _error(f"cannot compress {src}: {e}")
         else:
-            args = (["-C", src, "bundle", "create", tmp, "--all"] if fmt == "git-bundle"
-                    else ["-C", src, "archive", "--format=tar.gz", "-o", tmp, "HEAD"])
+            args = (["bundle", "create", tmp, "--all"] if fmt == "git-bundle"
+                    else ["archive", "--format=tar.gz", "-o", tmp, "HEAD"])
             proc = _run_git(args, src)
             if proc is None:
                 return _error(f"cannot compress {src}: git is unavailable or timed out")

--- a/fused_render/server/gitignore.py
+++ b/fused_render/server/gitignore.py
@@ -8,6 +8,60 @@ import time
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------- how git is run
+#
+# THE bug behind "the Git side panel is disabled for every repository". With
+# libproj resident in this process — and it becomes resident the moment any map /
+# geotiff / zarr template or daemon imports rasterio or pyproj — a plain `fork()`
+# runs PROJ's pthread_atfork child handler straight into a SIGSEGV, *before*
+# exec. The child dies with signal 11, so `returncode == -11` with empty stdout
+# and stderr and NO exception, because the spawn itself worked. Every call site
+# here then fails closed on a git that never ran, for every repository at once,
+# and it looks exactly like "not a repository".
+#
+# `close_fds=False` is the well-known half of the fix and it is NOT sufficient.
+# CPython reaches posix_spawn only when every clause of this holds
+# (`subprocess.py::_execute_child`):
+#
+#     _USE_POSIX_SPAWN and os.path.dirname(executable) and preexec_fn is None
+#     and not close_fds and not pass_fds and cwd is None and ... and umask < 0
+#
+# Two were being violated across the whole codebase: argv[0] was the BARE NAME
+# "git" (dirname "" — falsy), and some callers passed `cwd=`. Either one alone
+# forces the fork path however carefully close_fds is set. So all three parts are
+# required together, and `tests/test_git_posix_spawn.py` pins them as behaviour.
+_GIT_BIN: str | None = None
+
+
+def git_bin() -> str:
+    """An ABSOLUTE path to git, so CPython can posix_spawn it.
+
+    Resolved once and cached: `shutil.which` walks PATH, and these calls run on
+    every directory the user opens. Falling back to the bare name keeps a
+    PATH-less environment behaving as it did before (a fork, and a
+    FileNotFoundError we already report) rather than raising from here.
+    """
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
+def _spawn_kwargs() -> dict:
+    """The kwargs every git spawn here shares. See the note above.
+
+    `cwd` is deliberately absent, not None-by-omission: adding one silently
+    reintroduces the fork. Every caller passes `-C <path>` to git instead, which
+    is stricter anyway — it cannot be changed by this process's cwd.
+    """
+    return {
+        "close_fds": False,
+        "creationflags": (subprocess.CREATE_NO_WINDOW
+                          if sys.platform == "win32" else 0),
+    }
+
+
 # Every git call site here fails CLOSED, which is right — but "git said no" and
 # "git could not be run at all" are very different facts and used to look
 # identical from the outside AND leave nothing in the log. A spawn failure (no
@@ -186,12 +240,12 @@ def _empty_git_dir():
         try:
             root = tempfile.mkdtemp(prefix="fused-render-emptygit-")
             subprocess.run(
-                ["git", "init", "-q", root],
+                [git_bin(), "init", "-q", root],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
                 timeout=5,
-                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+                **_spawn_kwargs(),
             )
             _EMPTY_GIT_DIR = os.path.join(root, ".git")
         except (OSError, subprocess.SubprocessError):
@@ -237,12 +291,16 @@ class _IgnoreOracle:
             env = {**os.environ, "GIT_DIR": empty, "GIT_WORK_TREE": repo_root}
         try:
             self.proc = subprocess.Popen(
-                ["git", "-C", repo_root, "check-ignore", "--stdin", "-z", "-v", "-n"],
+                [git_bin(), "-C", repo_root,
+                 "check-ignore", "--stdin", "-z", "-v", "-n"],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
+                # DEVNULL, unlike the one-shot calls: this co-process outlives
+                # the call, and an unread stderr PIPE on a long-lived child can
+                # fill and deadlock it. Its failures surface through `broken`.
                 stderr=subprocess.DEVNULL,
                 env=env,
-                creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+                **_spawn_kwargs(),
             )
         except OSError as e:
             _warn_git_unusable("check-ignore co-process", e)
@@ -307,7 +365,7 @@ def _repo_toplevel(path):
     seen during the walk itself."""
     try:
         proc = subprocess.run(
-            ["git", "-C", path, "rev-parse", "--show-toplevel"],
+            [git_bin(), "-C", path, "rev-parse", "--show-toplevel"],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             # CAPTURED, not discarded: this is the only place git says WHY it
@@ -316,7 +374,7 @@ def _repo_toplevel(path):
             # pipe-filling risk (unlike the long-lived oracle below).
             stderr=subprocess.PIPE,
             timeout=5,
-            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+            **_spawn_kwargs(),
         )
     except (OSError, subprocess.TimeoutExpired) as e:
         _warn_git_unusable("rev-parse --show-toplevel", e)
@@ -398,12 +456,12 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
         # failure incl. "not a git repository".
         payload = b"".join(os.fsencode(n) + b"\0" for n in rel_names)
         proc = subprocess.run(
-            ["git", "-C", cwd, "check-ignore", "--stdin", "-z"],
+            [git_bin(), "-C", cwd, "check-ignore", "--stdin", "-z"],
             input=payload,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,       # captured for the same reason as above
             timeout=5,
-            creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+            **_spawn_kwargs(),
         )
     except (OSError, subprocess.SubprocessError) as e:
         _warn_git_unusable("check-ignore", e)

--- a/fused_render/server/gitignore.py
+++ b/fused_render/server/gitignore.py
@@ -1,7 +1,57 @@
+import logging
 import os
 import subprocess
 import sys
 import tempfile
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+# Every git call site here fails CLOSED, which is right — but "git said no" and
+# "git could not be run at all" are very different facts and used to look
+# identical from the outside AND leave nothing in the log. A spawn failure (no
+# binary on PATH, EMFILE/EAGAIN under fd or process pressure) or a timeout
+# disables every git-backed feature in the app at once, for every repository:
+# /api/fs/conditions reports "git": false with no error key, /api/fs/git-repo
+# reports is_repo_root false for a real root, and /api/fs/list stops dimming
+# .git — all of it indistinguishable from "not a repository". So the
+# CANNOT-RUN case gets a WARNING while the ordinary negative stays silent.
+#
+# Throttled, because these run on every directory the user opens: a broken git
+# would otherwise write one line per stat and bury the signal it is meant to be.
+_SPAWN_WARN_INTERVAL_S = 60.0
+_spawn_warn_lock = threading.Lock()
+_spawn_warn_at = 0.0
+
+
+def _reset_spawn_failure_throttle() -> None:
+    """Forget the last-warned timestamp. For tests."""
+    global _spawn_warn_at
+    with _spawn_warn_lock:
+        _spawn_warn_at = 0.0
+
+
+def _warn_git_unusable(what: str, exc: BaseException) -> None:
+    """Record that a git subprocess could not be RUN (not that git said no).
+
+    Never raises and never changes a caller's answer: the callers all fail
+    closed either side of this call.
+    """
+    global _spawn_warn_at
+    now = time.monotonic()
+    with _spawn_warn_lock:
+        if _spawn_warn_at and now - _spawn_warn_at < _SPAWN_WARN_INTERVAL_S:
+            return
+        _spawn_warn_at = now
+    logger.warning(
+        "git could not be run (%s): %s: %s — every git-backed feature "
+        "(the git side panel, repo-root detection, .gitignore dimming) is "
+        "failing closed until this clears. Check that `git` is on the server "
+        "process's PATH and that the process is not out of file descriptors or "
+        "child-process slots.",
+        what, type(exc).__name__, exc,
+    )
 
 
 
@@ -78,7 +128,8 @@ class _IgnoreOracle:
                 env=env,
                 creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
             )
-        except OSError:
+        except OSError as e:
+            _warn_git_unusable("check-ignore co-process", e)
             self.proc = None
             self.broken = True
         self._buf = b""
@@ -147,7 +198,8 @@ def _repo_toplevel(path):
             timeout=5,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired) as e:
+        _warn_git_unusable("rev-parse --show-toplevel", e)
         return None
     if proc.returncode != 0:
         return None
@@ -214,7 +266,8 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
             timeout=5,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError) as e:
+        _warn_git_unusable("check-ignore", e)
         return set()
     if proc.returncode not in (0, 1):
         return set()

--- a/fused_render/server/gitignore.py
+++ b/fused_render/server/gitignore.py
@@ -18,18 +18,88 @@ logger = logging.getLogger(__name__)
 # .git — all of it indistinguishable from "not a repository". So the
 # CANNOT-RUN case gets a WARNING while the ordinary negative stays silent.
 #
+# There is a SECOND, harder half, and it is the one that let a real
+# investigation reach the wrong conclusion. A git that is spawned fine and
+# answers in the NEGATIVE is also indistinguishable from "not a repository", and
+# every call site here used to throw git's stderr away, so there was nothing to
+# read. The absence of a "could not be run" warning was then taken as proof that
+# git was healthy — when in fact git had run and refused. Two negative shapes
+# therefore have to be visible, because they have different causes:
+#
+#   * a NON-ZERO exit whose stderr is not the ordinary "not a git repository":
+#     `detected dubious ownership`, a bad config, an unreadable object store, a
+#     working directory deleted under the process.
+#   * exit ZERO with a negative ANSWER, which is what a polluted `GIT_DIR` /
+#     `GIT_WORK_TREE` / `GIT_CEILING_DIRECTORIES` in this process produces.
+#     There is no stderr at all in that case, so stderr capture alone cannot
+#     explain it and the inherited git environment has to be in the report.
+#
+# What stays silent is the ORDINARY negative — a folder that genuinely is not a
+# repository, which is most folders a user opens.
+#
 # Throttled, because these run on every directory the user opens: a broken git
 # would otherwise write one line per stat and bury the signal it is meant to be.
+# One throttle PER KIND, so a storm of one cannot hide the first of the other.
 _SPAWN_WARN_INTERVAL_S = 60.0
-_spawn_warn_lock = threading.Lock()
-_spawn_warn_at = 0.0
+_warn_lock = threading.Lock()
+_warned_at: dict[str, float] = {}
+
+# git's own words for "this is not a repository", the one negative that is
+# ordinary. Matched as a substring, case-folded, against stderr — the exact
+# sentence carries the searched path and varies by subcommand.
+_ORDINARY_NEGATIVES = (
+    "not a git repository",
+    "does not have a commit checked out",   # a fresh clone with no HEAD
+)
+
+# The environment that can make a healthy git answer about the WRONG repository,
+# plus the two that decide which config it reads. Reported on a contradiction
+# because a stray value here is invisible from the outside and instantly
+# explains one: `git -C <repo> rev-parse` honours `GIT_DIR` over `-C`.
+_GIT_ENV_KEYS = (
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+    "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM",
+    "HOME", "XDG_CONFIG_HOME",
+)
 
 
 def _reset_spawn_failure_throttle() -> None:
-    """Forget the last-warned timestamp. For tests."""
-    global _spawn_warn_at
-    with _spawn_warn_lock:
-        _spawn_warn_at = 0.0
+    """Forget every last-warned timestamp. For tests."""
+    with _warn_lock:
+        _warned_at.clear()
+
+
+def _throttled(kind: str) -> bool:
+    """True when `kind` has been warned about too recently to warn again."""
+    now = time.monotonic()
+    with _warn_lock:
+        last = _warned_at.get(kind)
+        if last is not None and now - last < _SPAWN_WARN_INTERVAL_S:
+            return True
+        _warned_at[kind] = now
+    return False
+
+
+def _git_context() -> str:
+    """The process facts that explain a git answering about the wrong thing.
+
+    Only variables that are SET are named — a list of eleven `None`s buries the
+    one that matters. The working directory is included because a git whose
+    inherited cwd has been deleted fails even with `-C` (it calls `getcwd()`
+    before anything else).
+    """
+    parts = [f"{k}={os.environ[k]!r}" for k in _GIT_ENV_KEYS if os.environ.get(k)]
+    try:
+        parts.append(f"cwd={os.getcwd()!r}")
+    except OSError as exc:      # the cwd has been removed under this process
+        parts.append(f"cwd=UNAVAILABLE ({exc})")
+    return ", ".join(parts) or "no git-related environment set"
+
+
+def _is_ordinary_negative(stderr: bytes) -> bool:
+    text = stderr.decode("utf-8", "replace").lower()
+    return any(phrase in text for phrase in _ORDINARY_NEGATIVES)
 
 
 def _warn_git_unusable(what: str, exc: BaseException) -> None:
@@ -38,12 +108,8 @@ def _warn_git_unusable(what: str, exc: BaseException) -> None:
     Never raises and never changes a caller's answer: the callers all fail
     closed either side of this call.
     """
-    global _spawn_warn_at
-    now = time.monotonic()
-    with _spawn_warn_lock:
-        if _spawn_warn_at and now - _spawn_warn_at < _SPAWN_WARN_INTERVAL_S:
-            return
-        _spawn_warn_at = now
+    if _throttled("unusable"):
+        return
     logger.warning(
         "git could not be run (%s): %s: %s — every git-backed feature "
         "(the git side panel, repo-root detection, .gitignore dimming) is "
@@ -52,6 +118,56 @@ def _warn_git_unusable(what: str, exc: BaseException) -> None:
         "child-process slots.",
         what, type(exc).__name__, exc,
     )
+
+
+def _warn_git_refused(what: str, path: str, rc: int, stderr: bytes) -> None:
+    """Record that git RAN and failed for a reason that is not "not a repo".
+
+    The ordinary negative is filtered out by the CALLER (it has the context to
+    know what ordinary means for its own subcommand); anything reaching here is
+    a refusal worth a human's attention.
+    """
+    if _throttled("refused"):
+        return
+    logger.warning(
+        "git refused (%s) for %s: exit %s: %s [%s] — git ran fine, so this is "
+        "not a spawn problem; the git-backed features are failing closed on "
+        "git's own answer.",
+        what, path, rc,
+        stderr.decode("utf-8", "replace").strip() or "(no stderr)",
+        _git_context(),
+    )
+
+
+def _warn_git_contradicted(what: str, path: str, answer: str) -> None:
+    """Record that git answered NEGATIVELY about a path that has a `.git`.
+
+    Exit zero, nothing on stderr, and an answer that disagrees with the
+    filesystem — the shape a stray `GIT_DIR` in this process produces, and the
+    one shape stderr capture cannot explain. So the report is the environment.
+    """
+    if _throttled("contradicted"):
+        return
+    logger.warning(
+        "git contradicted the filesystem (%s): %s has a .git entry but git "
+        "answered %s — the git-backed features are failing closed on that. "
+        "This process's git environment is: %s",
+        what, path, answer, _git_context(),
+    )
+
+
+def _has_dot_git(path: str) -> bool:
+    """Whether a `.git` entry sits directly in `path` — one stat, no walk.
+
+    Only ever consulted on a NEGATIVE answer, and only to decide whether that
+    negative deserves a log line, so it never influences a verdict. `exists`
+    rather than `isdir` because a linked worktree and a submodule carry a `.git`
+    FILE, and both are cases where git answering "no" would be just as wrong.
+    """
+    try:
+        return os.path.exists(os.path.join(path, ".git"))
+    except OSError:
+        return False
 
 
 
@@ -194,7 +310,11 @@ def _repo_toplevel(path):
             ["git", "-C", path, "rev-parse", "--show-toplevel"],
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            # CAPTURED, not discarded: this is the only place git says WHY it
+            # refused, and without it a refusal is indistinguishable from "not a
+            # repository". `rev-parse` writes one short line, so there is no
+            # pipe-filling risk (unlike the long-lived oracle below).
+            stderr=subprocess.PIPE,
             timeout=5,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
@@ -202,6 +322,14 @@ def _repo_toplevel(path):
         _warn_git_unusable("rev-parse --show-toplevel", e)
         return None
     if proc.returncode != 0:
+        # Exit 128 is BOTH "not a git repository" (ordinary, silent, and the
+        # answer for most folders) and "detected dubious ownership" / "bad
+        # config" / "cannot get current working directory" (abnormal, and the
+        # reason every git-backed feature just went dark). The exit code cannot
+        # tell them apart; git's words can.
+        if not _is_ordinary_negative(proc.stderr):
+            _warn_git_refused("rev-parse --show-toplevel", path,
+                              proc.returncode, proc.stderr)
         return None
     top = os.fsdecode(proc.stdout.strip())
     return top or None
@@ -233,7 +361,18 @@ def _is_repo_root(path: str) -> bool:
     top = _repo_toplevel(path)
     if top is None:
         return False
-    return _canonical(top) == _canonical(path)
+    if _canonical(top) == _canonical(path):
+        return True
+    # A different toplevel is the ORDINARY answer for a subdirectory of a repo —
+    # that is the whole reason this function is stricter than
+    # `--is-inside-work-tree`. It is NOT ordinary for a directory that has a
+    # `.git` of its own: git exited zero and pointed elsewhere, which is what a
+    # stray GIT_DIR in this process does, and it leaves no stderr to read. One
+    # stat, only on the negative, and it never changes the verdict.
+    if _has_dot_git(path):
+        _warn_git_contradicted("rev-parse --show-toplevel", path,
+                               f"toplevel {top!r}")
+    return False
 
 
 def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
@@ -262,7 +401,7 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
             ["git", "-C", cwd, "check-ignore", "--stdin", "-z"],
             input=payload,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,       # captured for the same reason as above
             timeout=5,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )
@@ -270,6 +409,8 @@ def _git_ignored(cwd: str, rel_names: list[str]) -> set[str]:
         _warn_git_unusable("check-ignore", e)
         return set()
     if proc.returncode not in (0, 1):
+        if not _is_ordinary_negative(proc.stderr):
+            _warn_git_refused("check-ignore", cwd, proc.returncode, proc.stderr)
         return set()
     ignored = {os.fsdecode(chunk) for chunk in proc.stdout.split(b"\0") if chunk}
     # Return code 0/1 (not 128) proves this is a work tree with git available,

--- a/fused_render/server/routers/git_show.py
+++ b/fused_render/server/routers/git_show.py
@@ -62,6 +62,23 @@ from fused_render.server.common import _error
 from fused_render.server.proxy import _harden_raw
 from fused_render.shell import mounts as shell_mounts
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
@@ -177,7 +194,7 @@ def _git(root: str, *args: str, allow=(0,)) -> bytes:
     so no caller has to branch on a raw CalledProcessError."""
     try:
         proc = subprocess.run(
-            ["git", "--no-pager", "-C", root, *args],
+            [_git_bin(), "--no-pager", "-C", root, *args],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             timeout=TIMEOUT_S, **_popen_kwargs())
     except FileNotFoundError as exc:
@@ -206,7 +223,7 @@ def _show(root: str, rel: str, sha: str) -> bytes:
     spec = f"{sha}:{rel}"
     try:
         proc = subprocess.Popen(
-            ["git", "--no-pager", "-C", root, "show", spec],
+            [_git_bin(), "--no-pager", "-C", root, "show", spec],
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, **_popen_kwargs())
     except FileNotFoundError as exc:
         raise _Refused("git is not installed, or not on this app's PATH",

--- a/fused_render/server/routers/git_show.py
+++ b/fused_render/server/routers/git_show.py
@@ -131,6 +131,11 @@ def _popen_kwargs():
     return {
         "env": {**os.environ, **_ENV},
         "stdin": subprocess.DEVNULL,
+        # Required, together with the absolute argv[0] and the ABSENCE of `cwd=`,
+        # to reach posix_spawn — see the note above _git_bin. Missing it here made
+        # both calls below fork, so opening a commit in the git view died with a
+        # silent rc -11 whenever libproj was resident.
+        "close_fds": False,
         "creationflags": (subprocess.CREATE_NO_WINDOW
                           if sys.platform == "win32" else 0),
     }

--- a/fused_render/shell/mounts/rcd.py
+++ b/fused_render/shell/mounts/rcd.py
@@ -636,6 +636,13 @@ def _rclone_should_persist() -> bool:
 
 _rcd_lock = threading.Lock()
 
+# How long a freshly spawned rcd gets to answer `core/pid` before we give up on
+# it (and tear it down — see _terminate_child). Named rather than inline so a
+# test can reach the give-up path without waiting out the real budget.
+_RCD_STARTUP_TIMEOUT_S = 10.0
+# Grace between SIGTERM and SIGKILL when tearing that daemon down.
+_RCD_TERMINATE_GRACE_S = 2.0
+
 
 def ensure_rcd() -> int:
     """Port of a live rcd daemon, spawning one (detached) if none answers.
@@ -695,7 +702,7 @@ def _ensure_rcd_locked() -> int:
     # clears the inherited RCLONE_RC_* namespace, which could otherwise
     # reconfigure the interface out from under us.
     auth = (_RCD_RC_USER, secrets.token_urlsafe(32))
-    subprocess.Popen(
+    child = subprocess.Popen(
         [bin_, "rcd", "--use-server-modtime",
          f"--rc-addr=127.0.0.1:{port}",
          f"--log-file={log_path}", "--log-level", "INFO"],
@@ -709,15 +716,58 @@ def _ensure_rcd_locked() -> int:
         # Job either way; on macOS app.py SIGTERMs it explicitly on quit).
         start_new_session=_rclone_should_persist(),
     )
-    deadline = time.time() + 10
-    while time.time() < deadline:
+    deadline = time.time() + _RCD_STARTUP_TIMEOUT_S
+    while True:
         try:
             pid = _rc(port, "core/pid", timeout=2, auth=auth).get("pid", 0)
             write_rcd_state(port, pid, log_path, auth)
             return port
         except RuntimeError:
+            if time.time() >= deadline:
+                break
             time.sleep(0.2)
-    raise RuntimeError("rclone rcd did not come up within 10s")
+    # Give up — but do NOT walk away from the child we just started. The mount
+    # health loop retries automount on a timer, once per mount record, so
+    # orphaning the daemon here leaks one abandoned `rclone rcd` per mount per
+    # cycle, forever (in dev it is setsid-detached, so nothing else ever reaps
+    # it either). Measured on a real machine as 14 orphans spanning eight days.
+    # That process/fd pressure inside the long-lived server process is what
+    # starves unrelated `subprocess.run` calls in the same process — and every
+    # git call site in the app fails CLOSED and silently when its subprocess
+    # cannot be spawned or overruns its timeout, which is how "the Git side
+    # panel is disabled for every repository" presents.
+    _terminate_child(child)
+    raise RuntimeError(
+        f"rclone rcd did not come up within {_RCD_STARTUP_TIMEOUT_S:g}s")
+
+
+def _terminate_child(child) -> None:
+    """Best-effort teardown of a spawned rcd that never became usable.
+
+    SIGTERM first (rclone flushes its log and exits), escalating to SIGKILL if
+    it is still alive after a short grace — the same escalation the mount
+    lifecycle uses elsewhere. Every step is guarded: this runs on an error path
+    whose own exception (the RuntimeError the caller is about to raise) is the
+    one that matters, and a child that died on its own already raises
+    ProcessLookupError/OSError here.
+    """
+    try:
+        child.terminate()
+    except Exception:  # noqa: BLE001 — already gone, or no signal to send
+        pass
+    try:
+        child.wait(timeout=_RCD_TERMINATE_GRACE_S)
+        return
+    except Exception:  # noqa: BLE001 — TimeoutExpired, or a fake with no wait
+        pass
+    try:
+        child.kill()
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        child.wait(timeout=_RCD_TERMINATE_GRACE_S)
+    except Exception:  # noqa: BLE001 — reaping is best-effort
+        pass
 
 
 _KILL_TIMEOUT_S = 5.0

--- a/fused_render/templates/bundle/reader.py
+++ b/fused_render/templates/bundle/reader.py
@@ -40,6 +40,23 @@ import subprocess
 import sys
 import tempfile
 
+
+# An ABSOLUTE git path is required to reach posix_spawn, not merely tidy: CPython
+# forks unless `os.path.dirname(executable)` is truthy, and a fork in a process
+# with libproj resident dies with SIGSEGV before exec (rc -11, no output, no
+# exception). `close_fds=False` alone does NOT achieve this — see
+# fused_render/server/gitignore.py and tests/test_git_posix_spawn.py.
+_GIT_BIN = None
+
+
+def _git_bin():
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 # The fused engine execs this script without setting __file__; it puts the
 # script's own directory first on sys.path, so rebuild __file__ from it. Under
 # the built-in executor __file__ is already set, so this is a no-op. (The
@@ -110,7 +127,7 @@ def _run(args, cwd, timeout=TIMEOUT_S, allow=(0,)):
     """
     try:
         proc = subprocess.run(
-            ["git", "--no-pager", *_CONFIG, *args],
+            [_git_bin(), "--no-pager", *_CONFIG, *args],
             cwd=cwd,
             env={**os.environ, **_ENV},
             stdin=subprocess.DEVNULL,

--- a/fused_render/templates/bundle/reader.py
+++ b/fused_render/templates/bundle/reader.py
@@ -118,8 +118,33 @@ class _Refused(Exception):
 # ------------------------------------------------------------------ invocation
 
 
+def _popen_kwargs():
+    """The spawn discipline, shared with every other git caller in this repo.
+
+    `close_fds=False` is one of THREE things that together reach posix_spawn: an
+    absolute argv[0] and the absence of a `cwd=` kwarg are the other two, and any
+    one of them missing puts the call back on fork(), where a process with libproj
+    resident dies in PROJ's atfork handler before exec — rc -11, no output, no
+    exception. A plain dict literal on purpose: tests/test_git_posix_spawn.py
+    reads it statically to verify the call sites that spread it.
+    """
+    return {
+        "env": {**os.environ, **_ENV},
+        "stdin": subprocess.DEVNULL,
+        "close_fds": False,
+        "creationflags": (subprocess.CREATE_NO_WINDOW
+                          if sys.platform == "win32" else 0),
+    }
+
+
 def _run(args, cwd, timeout=TIMEOUT_S, allow=(0,)):
     """One bounded git call. Returns (stdout_text, stderr_text, returncode).
+
+    `cwd` becomes `-C <cwd>` in the argv rather than a `cwd=` kwarg (see
+    _popen_kwargs). git chdirs there itself before the subcommand runs, so every
+    relative path in `args` resolves exactly as it did before — and `dest` is
+    already required to be absolute by _check_dest, so the clone is unaffected
+    either way.
 
     `allow` is the set of exit codes that are ANSWERS rather than failures —
     `bundle verify` exits 1 for "this bundle needs commits you don't have",
@@ -127,15 +152,11 @@ def _run(args, cwd, timeout=TIMEOUT_S, allow=(0,)):
     """
     try:
         proc = subprocess.run(
-            [_git_bin(), "--no-pager", *_CONFIG, *args],
-            cwd=cwd,
-            env={**os.environ, **_ENV},
-            stdin=subprocess.DEVNULL,
+            [_git_bin(), "--no-pager", *_CONFIG, "-C", cwd, *args],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             timeout=timeout,
-            creationflags=(subprocess.CREATE_NO_WINDOW
-                           if sys.platform == "win32" else 0),
+            **_popen_kwargs(),
         )
     except FileNotFoundError as exc:
         raise _Refused("no-git", "git is not installed, or not on this app's PATH.") from exc

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1560,6 +1560,10 @@ def _start(file: str, message: str, session_id: str, model: str,
     try:
         with _private_open(os.path.join(run_dir, "out.jsonl")) as out, \
              _private_open(os.path.join(run_dir, "err.log")) as err:
+            # posix-spawn-exempt: `cmd` is the CLAUDE CLI argv (built by
+            # _claude_argv), never git — checked by hand. The git spawn in this
+            # file is the `git()` helper above, which resolves an absolute
+            # argv[0] and passes close_fds=False like every other one.
             proc = subprocess.Popen(cmd, stdout=out, stderr=err,
                                     cwd=_workdir(file),
                                     stdin=stdin_fh or subprocess.DEVNULL,

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1612,8 +1612,12 @@ def _commit_turn(file: str, message: str) -> None:
         if subject else "Claude turn"
 
     def git(*args):
+        # ABSOLUTE argv[0]: close_fds=False alone does NOT reach posix_spawn —
+        # CPython forks unless os.path.dirname(executable) is truthy, and a fork
+        # with libproj resident dies with SIGSEGV before exec (rc -11, silently).
+        import shutil
         return subprocess.run(
-            ["git", "-C", app_dir, "-c", "user.name=Fused",
+            [shutil.which("git") or "git", "-C", app_dir, "-c", "user.name=Fused",
              "-c", "user.email=apps@fused.io", *args],
             capture_output=True, text=True, timeout=30, close_fds=False)
 

--- a/fused_render/templates/git/condition.py
+++ b/fused_render/templates/git/condition.py
@@ -79,6 +79,18 @@ offered-then-broken.
 
 Fails closed: a missing git binary, a timeout, a non-zero exit, stdout that
 isn't literally `true`, an unreadable path, any exception at all → False.
+
+Fails closed but no longer SILENTLY. Answering False for both "this is not a
+repository" (the common, correct case) and "git ran and refused" made the two
+indistinguishable, and the second one hides the Git panel on EVERY repository at
+once with nothing in the log — a real investigation concluded "not reproducible"
+from that silence. So git's stderr is captured, and a negative that CONTRADICTS
+the filesystem (a non-zero exit whose words are not "not a git repository", or
+exit zero with a negative answer for a directory that has a `.git`) is logged
+once a minute with the process's git environment, which is where a stray
+`GIT_DIR` — invisible from outside — would show up. The verdict is unchanged;
+only the silence is. See `_warn_suspicious_negative`.
+
 Self-contained apart from `../shared/appenv.py` (itself stdlib-only, env vars
 only) — the module is exec'd standalone (not imported as part of a package), so
 nothing here imports fused_render.
@@ -107,6 +119,73 @@ _ENV = {
     "GCM_INTERACTIVE": "Never",   # git-credential-manager
     "GIT_LFS_SKIP_SMUDGE": "1",   # never fetch an LFS object to answer this
 }
+
+# How often a negative that looks WRONG may be logged. The gate answers on every
+# directory the user opens, so an unthrottled line would be one per stat.
+_WARN_INTERVAL_S = 60.0
+
+# The environment that can make a healthy git answer about the WRONG repository,
+# plus the two that decide which config it reads. `git -C <repo> rev-parse`
+# honours `GIT_DIR` over `-C`, so a stray value here silently redirects the
+# question — and it is invisible from outside the process, which is exactly why
+# it belongs in the log line.
+_REPORT_ENV = (
+    "GIT_DIR", "GIT_WORK_TREE", "GIT_COMMON_DIR", "GIT_INDEX_FILE",
+    "GIT_CEILING_DIRECTORIES", "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+    "GIT_CONFIG_GLOBAL", "GIT_CONFIG_SYSTEM", "GIT_CONFIG_NOSYSTEM",
+    "HOME", "XDG_CONFIG_HOME",
+)
+
+# git's own words for the one negative that is ORDINARY. Everything else it can
+# say on the way to a non-zero exit — `detected dubious ownership`, a bad config,
+# `cannot get current working directory` — is a reason the mode disappeared that
+# a human needs to see. The exit code cannot tell them apart (all 128); the words
+# can.
+_ORDINARY_NEGATIVES = ("not a git repository",)
+
+
+def _warn_suspicious_negative(kind, path, detail):
+    """Log a negative that contradicts the filesystem, at most once a minute.
+
+    Why this exists: a gate that answers False both for "this is not a
+    repository" (the common, correct case) and for "git ran and refused" is
+    undiagnosable, and it disables the Git side panel for EVERY repository with
+    nothing whatsoever in the log. A real investigation concluded "not
+    reproducible" from that silence.
+
+    The throttle state cannot live in a module global: `_run_condition` re-execs
+    this file on every stat, so a global would be reset before it was ever read.
+    It rides on the `logging.Logger` object instead, which the logging manager
+    caches for the life of the PROCESS — the lifetime the throttle is about.
+
+    stdlib only, like the rest of this module (SPEC PY-15), and it never changes
+    the verdict: every caller has already decided to fail closed.
+    """
+    try:
+        import logging
+        import os
+        import time
+
+        log = logging.getLogger("fused_render.templates.git.condition")
+        attr = "_fused_warned_" + kind
+        now = time.monotonic()
+        last = getattr(log, attr, None)
+        if last is not None and now - last < _WARN_INTERVAL_S:
+            return
+        setattr(log, attr, now)
+
+        env = [f"{k}={os.environ[k]!r}" for k in _REPORT_ENV if os.environ.get(k)]
+        try:
+            env.append(f"cwd={os.getcwd()!r}")
+        except OSError as exc:   # the cwd was removed under this process
+            env.append(f"cwd=UNAVAILABLE ({exc})")
+        log.warning(
+            "the git mode is being hidden for %s and it looks wrong: %s — git "
+            "ran, so this is not a spawn problem. This process's git "
+            "environment is: %s",
+            path, detail, ", ".join(env) or "no git-related environment set")
+    except Exception:  # noqa: BLE001 — a gate must never fail because of its log
+        pass
 
 
 def main(path: str) -> bool:
@@ -167,14 +246,43 @@ def main(path: str) -> bool:
             env={**os.environ, **_ENV},
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
+            # CAPTURED, not discarded. This is the only place git says WHY it
+            # refused, and discarding it is what made "the Git panel is gone for
+            # every repository" indistinguishable from "this is not a
+            # repository". `rev-parse` writes one short line, so there is no
+            # pipe-filling risk.
+            stderr=subprocess.PIPE,
             timeout=_TIMEOUT_S,
             creationflags=(subprocess.CREATE_NO_WINDOW
                            if sys.platform == "win32" else 0),
             close_fds=False,
         )
         if proc.returncode != 0:
+            said = proc.stderr.decode("utf-8", "replace").lower()
+            if not any(phrase in said for phrase in _ORDINARY_NEGATIVES):
+                _warn_suspicious_negative(
+                    "refused", path,
+                    "git exited %s saying %r" % (
+                        proc.returncode,
+                        proc.stderr.decode("utf-8", "replace").strip()
+                        or "(nothing)"))
             return False
-        return proc.stdout.strip() == b"true"
+        if proc.stdout.strip() == b"true":
+            return True
+        # Exit ZERO with a negative answer. Ordinary for a bare repo and inside
+        # `.git`; NOT ordinary for a directory carrying a `.git` of its own,
+        # which is the shape a stray GIT_DIR produces — and it leaves no stderr
+        # at all, so the environment is the only thing that can explain it. One
+        # stat, only on the negative, and it never changes the verdict.
+        try:
+            has_git = os.path.exists(os.path.join(path, ".git"))
+        except OSError:
+            has_git = False
+        if has_git:
+            _warn_suspicious_negative(
+                "contradicted", path,
+                "it has a .git entry but `rev-parse --is-inside-work-tree` "
+                "answered %r" % proc.stdout.decode("utf-8", "replace").strip())
+        return False
     except Exception:  # noqa: BLE001 — any probe error: fail closed, quietly
         return False

--- a/fused_render/templates/git/condition.py
+++ b/fused_render/templates/git/condition.py
@@ -143,6 +143,41 @@ _REPORT_ENV = (
 # can.
 _ORDINARY_NEGATIVES = ("not a git repository",)
 
+# THE bug this gate shipped, and the reason the Git panel vanished for every
+# repository at once. With libproj resident in the host process — and it becomes
+# resident the moment any map / geotiff / zarr template or daemon imports
+# rasterio or pyproj — a plain fork() runs PROJ's pthread_atfork child handler
+# into a SIGSEGV *before* exec. The child dies with signal 11: `returncode ==
+# -11`, empty stdout, empty stderr, and NO exception, because the spawn itself
+# succeeded. This gate then answered False on a git that never ran.
+#
+# CPython avoids fork only when EVERY clause of this holds
+# (`subprocess.py::_execute_child`):
+#
+#     _USE_POSIX_SPAWN and os.path.dirname(executable) and preexec_fn is None
+#     and not close_fds and not pass_fds and cwd is None and ... and umask < 0
+#
+# This gate already passed `close_fds=False`, which is why it looked correct. It
+# was violating two other clauses: argv[0] was the bare name "git" (dirname "" —
+# falsy) and it passed `cwd=`. Either one alone forces the fork path. All three
+# parts are required together; `tests/test_git_posix_spawn.py` pins them.
+_GIT_BIN = None
+
+
+def _git_bin():
+    """An absolute path to git, resolved once per exec of this module.
+
+    The module is re-exec'd per stat so the cache is short-lived, and that is
+    fine: `shutil.which` is a handful of stats and the alternative — a bare name
+    — is what forks. The bare-name fallback keeps a PATH-less environment raising
+    the FileNotFoundError the caller already handles.
+    """
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
 
 def _warn_suspicious_negative(kind, path, detail):
     """Log a negative that contradicts the filesystem, at most once a minute.
@@ -240,9 +275,12 @@ def main(path: str) -> bool:
         # (3) git is the authority. `--is-inside-work-tree` is false for a bare
         # repo and inside `.git`, which is what we want; exit 128 ("not a git
         # repository") is the ordinary negative and lands in the same False.
+        # argv[0] ABSOLUTE and NO `cwd=`, both load-bearing — see _git_bin.
+        # `-C cwd` already pins the repository, and it is stricter than `cwd=`
+        # was: it cannot be changed by this process's working directory.
         proc = subprocess.run(
-            ["git", "--no-pager", "-C", cwd, "rev-parse", "--is-inside-work-tree"],
-            cwd=cwd,
+            [_git_bin(), "--no-pager", "-C", cwd,
+             "rev-parse", "--is-inside-work-tree"],
             env={**os.environ, **_ENV},
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,

--- a/fused_render/templates/git/log.py
+++ b/fused_render/templates/git/log.py
@@ -567,6 +567,14 @@ def _status(root, rel, is_dir):
             "path": path,
             "orig": orig,
             "moved": moved,
+            # Whether this entry is UNMERGED, answered from git's own porcelain
+            # rule rather than left for the view to re-derive: any code with a
+            # `U` on either side, plus `AA` and `DD` (both-added / both-deleted
+            # carry no U at all). A mirror of this in the view would be a second
+            # copy of a rule with seven cases and no way to notice it drifting —
+            # and getting it wrong means offering to resolve a file that is not
+            # conflicted, or hiding the button on one that is.
+            "conflicted": "U" in (x, y) or code in ("AA", "DD"),
             "staged": not untracked and x not in (" ", "?"),
             "unstaged": not untracked and y not in (" ", "?"),
             "untracked": untracked,

--- a/fused_render/templates/git/log.py
+++ b/fused_render/templates/git/log.py
@@ -105,6 +105,21 @@ MAX_PROMPT_DIFF_BYTES = 80_000
 MAX_PROMPT_DIFF_LINES = 1_500
 MAX_PROMPT_FILES = 100
 
+# The `conflicts` read has its own pair of budgets, and they are smaller again
+# than the `pending` ones for a different reason: a conflicted file is sent WHOLE
+# (the markers only mean something in their surroundings), so the bound is on how
+# much whole-file text one prompt may carry, not on how much of a patch. Ten
+# files is already an unusual merge; a repository-wide conflict of hundreds is a
+# situation to hand back to the command line rather than to a model, and the
+# payload says so instead of quietly sending the first few as if they were all.
+MAX_CONFLICT_FILES = 10
+MAX_CONFLICT_BYTES = 60_000
+
+# The three lines git writes into a conflicted file. Recognised here so a binary
+# or marker-less unmerged file can be reported as such, and mirrored in ops.py,
+# which refuses to APPLY content that still contains them.
+CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")
+
 # `git status` is unbounded in principle (a build tree can hold 100k untracked
 # files). Bounded on the way in — bytes off the pipe — and again on the way out.
 MAX_STATUS_BYTES = 4_000_000
@@ -813,7 +828,7 @@ def _check_op(op, sha, entry):
     (with the target's cwd) to run. Cheap string checks come first, always.
     """
     if op not in ("overview", "log", "commit", "worktree", "branches", "stashes",
-                  "pending"):
+                  "pending", "conflicts"):
         raise _Refused("bad-op", f"Unknown operation: {op}")
     if op == "commit" and not _SHA_RE.match(sha or ""):
         raise _Refused("bad-sha", "That is not a commit id.")
@@ -1048,6 +1063,137 @@ def _pending(root, rel, branch):
     }
 
 
+def _operation_in_flight(root):
+    """Which multi-step operation git is part-way through, and against what.
+
+    Returns `(operation, theirs, summary)` — all three `None` when the tree is
+    not mid-anything. Read from the ref/marker files in the git dir rather than
+    parsed out of `git status`'s prose, because that prose is localised and
+    reworded between releases while the marker names are plumbing.
+
+    Only the operations that can leave an unmerged index are recognised, which is
+    the same set that can produce the conflict this read exists to describe. A
+    `None` operation with unmerged paths is a real state, not a bug: `git
+    checkout --merge` and a conflicted `stash pop` both leave one with no
+    operation to continue.
+    """
+    gitdir = _git(root, "rev-parse", "--absolute-git-dir",
+                  allow=(0, 128)).decode("utf-8", "replace").strip()
+    if not gitdir or not os.path.isdir(gitdir):
+        return None, None, None
+
+    def head_of(name):
+        raw = _git(root, "rev-parse", "--short", name, allow=(0, 128, 1))
+        sha = raw.decode("utf-8", "replace").strip()
+        return sha or None
+
+    def first_line(*parts):
+        path = os.path.join(gitdir, *parts)
+        try:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                return handle.readline(500).strip() or None
+        except OSError:
+            return None
+
+    # A rebase is a directory, not a ref, and it is checked FIRST: a conflicted
+    # rebase step also writes REBASE_HEAD, so asking about single refs first
+    # would report the step's parent instead of the rebase.
+    for sub in ("rebase-merge", "rebase-apply"):
+        if os.path.isdir(os.path.join(gitdir, sub)):
+            onto = first_line(sub, "head-name")
+            if onto and onto.startswith("refs/heads/"):
+                onto = onto[len("refs/heads/"):]
+            return "rebase", onto, first_line(sub, "message")
+    for marker, name in (("MERGE_HEAD", "merge"),
+                         ("CHERRY_PICK_HEAD", "cherry-pick"),
+                         ("REVERT_HEAD", "revert")):
+        if os.path.exists(os.path.join(gitdir, marker)):
+            return name, head_of(marker), first_line("MERGE_MSG")
+    return None, None, None
+
+
+def _conflict_body(root, rel, budget):
+    """One unmerged file as text-with-markers, or a flag saying it is not text.
+
+    The file is read from the WORKING TREE, which is where git wrote the markers —
+    the index holds the three unmerged stages separately and none of them is the
+    marked-up text a resolution has to replace.
+
+    `budget` is the bytes left for this file across the whole payload, so a merge
+    of one enormous file and a merge of many small ones share one ceiling.
+    Truncated on a CHARACTER boundary after decoding (a byte slice can split a
+    UTF-8 sequence) and reported, so the prompt can say the file was cut rather
+    than let a model resolve a hunk whose closing marker it never saw.
+    """
+    full = os.path.join(root, *rel.split("/"))
+    try:
+        with open(full, "rb") as handle:
+            raw = handle.read(budget + 1)
+    except OSError:
+        return "", False, True          # unreadable: named, not read
+    truncated = len(raw) > budget
+    if truncated:
+        raw = raw[:budget]
+    if b"\0" in raw:
+        return "", True, False          # binary: named, never sent to a model
+    text = raw.decode("utf-8", "replace")
+    while truncated and text and len(text.encode("utf-8")) > budget:
+        text = text[:-1]
+    return text, False, truncated
+
+
+def _conflicts(root, rel, branch):
+    """The unmerged paths and their marker text — the model's context (GT-19).
+
+    A READ, and it lives here for the same reason `_pending` does: it forks
+    `git diff --diff-filter=U` and reads files, changes no ref, no index and
+    nothing on disk. The write half is `ops.py`'s `resolve`, which is where the
+    confirmation-and-refusal machinery belongs.
+
+    Deliberately **UNSCOPED**, unlike almost every other read here. A conflict is
+    a state of the whole repository and of the operation in flight: a merge is not
+    half-finished for `pkg/` and finished elsewhere, so a view scoped to a folder
+    that hid the conflicts outside it would describe a situation that does not
+    exist. Each entry carries `in_scope` instead, which is what the view needs —
+    it may SHOW every conflict and may only offer to write the ones `ops.py`
+    would accept (GT-13).
+
+    `empty` is the first-class "there is nothing to resolve" answer (GT-9), and it
+    is about the CONFLICT, not about how many files were listed: a cap reached
+    reports `files_truncated` with `empty` false, because "we showed you none of
+    them" must never read as "there are none".
+    """
+    operation, theirs, summary = _operation_in_flight(root)
+    names, name_capped = _name_list(
+        root, ("diff", "--name-only", "--diff-filter=U", "-z", *_pathspec("")))
+    shown = names[:MAX_CONFLICT_FILES]
+    files = []
+    budget = MAX_CONFLICT_BYTES
+    for name in shown:
+        content, binary, truncated = _conflict_body(root, name, max(budget, 0))
+        budget -= len(content.encode("utf-8"))
+        files.append({
+            "path": name,
+            "in_scope": (not rel) or name == rel or name.startswith(rel + "/"),
+            "binary": binary,
+            "content": content,
+            "truncated": truncated,
+        })
+    return {
+        "ok": True,
+        "operation": operation,
+        "theirs": theirs,
+        "summary": summary,
+        "branch": branch,
+        "scope": rel,
+        "files": files,
+        "files_truncated": name_capped or len(names) > len(shown),
+        "empty": not names,
+        "max_files": MAX_CONFLICT_FILES,
+        "max_bytes": MAX_CONFLICT_BYTES,
+    }
+
+
 def main(
     file: str,
     op: str = "overview",
@@ -1091,6 +1237,10 @@ def main(
             branch, detached, head, _ = _head(root)
             return _pending(root, rel,
                             branch or (("detached at " + head) if head else None))
+        if op == "conflicts":
+            branch, detached, head, _ = _head(root)
+            return _conflicts(root, rel,
+                              branch or (("detached at " + head) if head else None))
         if op == "stashes":
             stashes, truncated = _stashes(root)
             return {"ok": True, "stashes": stashes, "truncated": truncated}

--- a/fused_render/templates/git/log.py
+++ b/fused_render/templates/git/log.py
@@ -250,14 +250,44 @@ class _Refused(Exception):
 # ------------------------------------------------------------------ invocation
 
 
+
+# ---------------------------------------------------------------- how git is run
+#
+# argv[0] is an ABSOLUTE path, and that is load-bearing rather than tidy. With
+# libproj resident in the host process a plain fork() runs PROJ's pthread_atfork
+# child handler into a SIGSEGV before exec, so the child dies with signal 11 and
+# empty output and NO exception — every git answer becomes a silent negative.
+# CPython avoids fork only when EVERY clause holds
+# (`subprocess.py::_execute_child`): `os.path.dirname(executable)` truthy,
+# `close_fds` false, `cwd is None`, no preexec_fn/pass_fds/start_new_session.
+# `close_fds=False` alone is NOT enough, which is what the previous version of
+# this comment got wrong: a bare "git" has dirname "" and forks regardless, and
+# so does any call that passes `cwd=`. All three parts together, or none of them
+# work. `-C <root>` is what replaces `cwd=`.
+_GIT_BIN = None
+
+
+def _git_bin():
+    """An absolute path to git, resolved once. Bare name as a last resort so a
+    PATH-less environment still raises the FileNotFoundError callers expect."""
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 def _argv(root, args):
-    return ["git", "--no-pager", *_CONFIG, "-C", root, *args]
+    return [_git_bin(), "--no-pager", *_CONFIG, "-C", root, *args]
 
 
 def _popen_kwargs():
     return {
         "env": {**os.environ, **_ENV},
         "stdin": subprocess.DEVNULL,
+        # See the note above _argv: required to reach posix_spawn, and only in
+        # combination with the absolute argv[0] and no `cwd=`.
+        "close_fds": False,
         "creationflags": (subprocess.CREATE_NO_WINDOW
                           if sys.platform == "win32" else 0),
     }

--- a/fused_render/templates/git/ops.py
+++ b/fused_render/templates/git/ops.py
@@ -220,24 +220,50 @@ class _Refused(Exception):
 # ------------------------------------------------------------------ invocation
 
 
+
+# ---------------------------------------------------------------- how git is run
+#
+# argv[0] is an ABSOLUTE path, and that is load-bearing rather than tidy. With
+# libproj resident in the host process a plain fork() runs PROJ's pthread_atfork
+# child handler into a SIGSEGV before exec, so the child dies with signal 11 and
+# empty output and NO exception — every git answer becomes a silent negative.
+# CPython avoids fork only when EVERY clause holds
+# (`subprocess.py::_execute_child`): `os.path.dirname(executable)` truthy,
+# `close_fds` false, `cwd is None`, no preexec_fn/pass_fds/start_new_session.
+# `close_fds=False` alone is NOT enough, which is what the previous version of
+# this comment got wrong: a bare "git" has dirname "" and forks regardless, and
+# so does any call that passes `cwd=`. All three parts together, or none of them
+# work. `-C <root>` is what replaces `cwd=`.
+_GIT_BIN = None
+
+
+def _git_bin():
+    """An absolute path to git, resolved once. Bare name as a last resort so a
+    PATH-less environment still raises the FileNotFoundError callers expect."""
+    global _GIT_BIN
+    if _GIT_BIN is None:
+        import shutil
+        _GIT_BIN = shutil.which("git") or "git"
+    return _GIT_BIN
+
+
 def _argv(root, args):
     """log.py's twin. `-C <root>` on everything, so a relative pathspec means
     exactly one thing and no `cd` can change it."""
-    return ["git", "--no-pager", *_CONFIG, "-C", root, *args]
+    return [_git_bin(), "--no-pager", *_CONFIG, "-C", root, *args]
 
 
 def _popen_kwargs():
     return {
         "env": {**os.environ, **_ENV},
         "stdin": subprocess.DEVNULL,
-        # close_fds=False matches every other subprocess spawn in this codebase
-        # (app_git.py documents the crash at length): with libproj resident, a
-        # plain fork() runs PROJ's pthread_atfork child handler into a SIGSEGV
-        # before exec, and close_fds=False is what makes CPython take the
-        # posix_spawn path that runs no atfork handlers. It matters more here
-        # than in the reader: a read that dies before exec is a refused read,
-        # while a `git commit` that dies before exec is work the user believes
-        # they recorded.
+        # close_fds=False is NECESSARY for the posix_spawn path and, on its own,
+        # NOT SUFFICIENT — the older version of this comment claimed otherwise
+        # and the whole app shipped forking anyway. See the note above _argv:
+        # argv[0] must also be absolute and no `cwd=` may be passed. It matters
+        # more here than in the reader: a read that dies before exec is a
+        # refused read, while a `git commit` that dies before exec is work the
+        # user believes they recorded.
         "close_fds": False,
         "creationflags": (subprocess.CREATE_NO_WINDOW
                           if sys.platform == "win32" else 0),

--- a/fused_render/templates/git/ops.py
+++ b/fused_render/templates/git/ops.py
@@ -177,12 +177,18 @@ _SAFE_OPS = (
     "stash_push", "stash_apply", "stash_pop",
     "fetch", "pull", "push",
 )
-DESTRUCTIVE_OPS = ("discard", "discard_all", "stash_drop")
+#
+# `resolve` is here rather than in `_SAFE_OPS` because it OVERWRITES a file in
+# the working tree: the marked-up conflicted text is the only copy of "what git
+# left me", and once it is replaced the only way back is `git checkout --merge`.
+# So it gets the confirmation step every other work-losing op gets, and the
+# proposed-resolution panel in front of it is a review surface, not the consent.
+DESTRUCTIVE_OPS = ("discard", "discard_all", "stash_drop", "resolve")
 _OPS = _SAFE_OPS + DESTRUCTIVE_OPS
 
 # Ops that take an explicit `paths` list, and ops that operate on the whole open
 # scope instead. Everything else takes neither.
-_PATH_OPS = ("stage", "unstage", "discard")
+_PATH_OPS = ("stage", "unstage", "discard", "resolve")
 _SCOPE_OPS = ("stage_all", "unstage_all", "discard_all")
 
 # git's own words for the two situations we have to recognise in its output
@@ -190,6 +196,17 @@ _SCOPE_OPS = ("stage_all", "unstage_all", "discard_all")
 # failure. Matched case-insensitively against stderr+stdout.
 _NOTHING_TO_STASH = "no local changes to save"
 _NOT_FF = "not possible to fast-forward"
+
+# The lines git writes into a conflicted file. Mirrors log.py's CONFLICT_MARKERS
+# (the two modules are exec'd standalone, so neither may import the other) and is
+# used for the opposite purpose: there to recognise a conflict, here to REFUSE
+# content that still contains one.
+CONFLICT_MARKERS = ("<<<<<<< ", "=======", ">>>>>>> ")
+
+# A resolved file is one file's text. The bound is generous — it has to hold
+# whatever the conflicted file held — and exists so a hand-written request cannot
+# ask this module to write an arbitrary amount of data.
+MAX_CONTENT_BYTES = 2_000_000
 
 
 class _Refused(Exception):
@@ -422,7 +439,91 @@ def _scope_spec(rel):
 # ----------------------------------------------------------------- validation
 
 
-def _check_strings(op, paths, message, name, index):
+def _check_resolve_content(paths, content):
+    """Everything about a `resolve` that is decidable from the strings alone.
+
+    All three refusals are this module's own rather than git's, because git is
+    never asked: `resolve` writes a file and stages nothing, so there is no git
+    command whose error could stand in for any of them.
+
+    * **one path.** A resolution is one file's text; a `paths` list of two with
+      one `content` cannot mean anything, and picking the first would write the
+      wrong file.
+    * **not empty.** Truncating a conflicted file to nothing is never a
+      resolution, and it is exactly what an AI answer that arrived empty (a
+      cancelled stream, a refusal, a fenced reply that cleaned to "") would do.
+    * **no markers left.** Content that still carries `<<<<<<<` has not resolved
+      the conflict, it has copied it — and writing it back makes the file look
+      resolved-and-saved to everything downstream while leaving the markers in the
+      source. This is the check that makes the feature safe to point at a model.
+    """
+    if len(paths) != 1:
+        raise _Refused(
+            "one-path",
+            f"A resolution applies to ONE file; {len(paths)} were given.")
+    if not isinstance(content, str) or not content.strip():
+        raise _Refused("empty-content",
+                       "There is no resolved content to write.")
+    if len(content.encode("utf-8", "replace")) > MAX_CONTENT_BYTES:
+        raise _Refused(
+            "too-large",
+            f"That resolution is larger than {MAX_CONTENT_BYTES} bytes.")
+    if any(any(line.startswith(m) or line == m.strip() for m in CONFLICT_MARKERS)
+           for line in content.splitlines()):
+        raise _Refused(
+            "unresolved",
+            "That text still contains conflict markers, so it is not a "
+            "resolution. Nothing was written.")
+
+
+def _resolve(root, rel, content):
+    """Write the resolved text of ONE conflicted file, and do nothing else.
+
+    Deliberately NOT followed by `git add`. Marking a conflict resolved is the
+    act that lets the merge be committed, and it is not what the user pressed:
+    they pressed "apply this proposal so I can look at it". So the file lands in
+    the working tree, still unmerged as far as the index is concerned, and the
+    ordinary Stage button — which the view already has, and which git's own
+    `add` semantics make the resolve — is how it becomes resolved. No commit
+    either, for the same reason and more so.
+
+    The path must currently be UNMERGED. That is not a courtesy check: without it
+    this op is a general-purpose "overwrite any file in the repo" write, which is
+    not something this module offers. `--diff-filter=U` is git's own answer to
+    "is this file conflicted", so the question is not re-implemented here.
+
+    Written through a temporary file in the same directory and `os.replace`d, so
+    an interrupted write cannot leave the conflicted file half-overwritten — the
+    one outcome worse than not writing at all.
+    """
+    out = _git_ok(root, "diff", "--name-only", "--diff-filter=U", "-z",
+                  *_spec([rel]), allow=(0, 1))
+    unmerged = [c for c in out.decode("utf-8", "replace").split("\0") if c]
+    if rel not in unmerged:
+        raise _Refused(
+            "not-conflicted",
+            f"{rel} is not a conflicted file, so there is nothing to resolve "
+            "in it. Nothing was written.")
+
+    full = os.path.join(root, *rel.split("/"))
+    tmp = full + ".fused-resolve.tmp"
+    try:
+        with open(tmp, "w", encoding="utf-8", newline="") as handle:
+            handle.write(content)
+        os.replace(tmp, full)
+    except OSError as exc:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise _Refused("write-failed", f"Could not write {rel}: {exc}") from exc
+    return _ok("resolve",
+               f"Wrote the resolved {rel}. It is NOT staged and NOT committed — "
+               "review it, then stage and commit as usual.",
+               path=rel)
+
+
+def _check_strings(op, paths, message, name, index, content=""):
     """Everything that can be decided WITHOUT touching the filesystem or git.
 
     Ordering, not just validation. `_locate` is itself a git call, so validating
@@ -461,6 +562,9 @@ def _check_strings(op, paths, message, name, index):
             if os.path.isabs(raw) or any(part == ".." for part in rel.split("/")):
                 raise _Refused("outside-repo",
                                f"{raw} is outside the repository.")
+
+    if op == "resolve":
+        _check_resolve_content(paths, content)
 
     if op == "commit" and not (message or "").strip():
         # Our own refusal, not git's: `git commit -m ""` fails with "Aborting
@@ -1028,6 +1132,7 @@ def main(
     include_untracked: bool = False,
     checkout: bool = True,
     sha: str = "",
+    content: str = "",
 ) -> dict:
     """One mutation, or a refusal payload.
 
@@ -1037,12 +1142,14 @@ def main(
     try:
         # Strings first, always — `_locate` forks git, so nothing malformed may
         # get that far.
-        _check_strings(op, paths, message, name, index)
+        _check_strings(op, paths, message, name, index, content)
         root, scope, scope_is_dir = _locate(file)
 
         if op in _PATH_OPS:
             rels = _resolve_paths(root, scope, scope_is_dir, paths)
             label = _n(len(rels), "path")
+            if op == "resolve":
+                return _resolve(root, rels[0], content)
             if op == "stage":
                 return _stage(root, rels, label)
             if op == "unstage":

--- a/fused_render/templates/git/template.html
+++ b/fused_render/templates/git/template.html
@@ -439,6 +439,9 @@
      and never as the runtime's red traceback overlay: a git refusal is an
      ordinary answer, not a bug in this view. */
   .flash {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
     margin: 0 0 10px;
     padding: 8px 11px;
     border: 1px solid var(--good-line);
@@ -449,6 +452,8 @@
     white-space: pre-wrap;
     overflow-wrap: anywhere;
   }
+  /* The message takes the width and the (failure-only) sparkle sits beside it. */
+  .flash > span { flex: 1; min-width: 0; }
   .flash.bad { border-color: var(--bad-line); background: var(--bad-bg); color: var(--bad-fg); }
 
   /* ================= confirmation ================= */
@@ -468,6 +473,56 @@
     font-size: 12px;
   }
   .confirm .q { flex: 1; min-width: 12ch; }
+
+  /* ================= AI resolution (GT-19) =================
+     The proposed resolution, before anything is written. Built out of the
+     surfaces already here — `.panel` for the frame, `.panel-head` for its bar,
+     the `.diff` scroll container for the text — because it is a REVIEW surface
+     like the diff pane and reading as a new kind of thing would be the wrong
+     signal for something whose whole job is "look at this before it lands". */
+  .proposal { margin: 0 0 10px; }
+  .proposal .panel-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  /* A path is not a label: `.panel-head`'s uppercase + letter-spacing is right
+     for "BRANCHES" and wrong for `pkg/mod.py`, which has to be readable as the
+     literal name it is. */
+  .proposal .what {
+    flex: 1;
+    min-width: 12ch;
+    color: var(--ink-2);
+    font-size: 11px;
+    letter-spacing: 0;
+    text-transform: none;
+    overflow-wrap: anywhere;
+  }
+  .proposal .text {
+    margin: 0;
+    padding: 10px 12px;
+    max-height: 46vh;
+    overflow: auto;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    font-size: 12px;
+    line-height: 1.5;
+    tab-size: 4;
+    color: var(--ink);
+  }
+  .proposal .foot {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    padding: 8px 12px;
+    border-top: 1px solid var(--line);
+    background: var(--surface-2);
+    font-size: 11px;
+    color: var(--ink-3);
+  }
+  .proposal .foot .note { flex: 1; min-width: 12ch; }
 
   /* ================= dropdown panels ================= */
   .panel {
@@ -866,7 +921,7 @@ const OPS = "./ops.py";
 /* The ops that can lose uncommitted work. Mirrors ops.py's DESTRUCTIVE_OPS, and
  * the mirroring is the safety property: an op named here gets the inline
  * confirmation step, and one that is not gets called on the first click. */
-const DESTRUCTIVE = new Set(["discard", "discard_all", "stash_drop"]);
+const DESTRUCTIVE = new Set(["discard", "discard_all", "stash_drop", "resolve"]);
 
 const file = fused.params.get("_file") || "";
 const skeleton = document.getElementById("skeleton");
@@ -1712,6 +1767,344 @@ async function generateMessage() {
   }
 }
 
+/* ------------------------------------------- AI conflict resolution (GT-19)
+ *
+ * Two situations, one button, one panel, and NOTHING is written by any of it.
+ *
+ *   a merge/rebase CONFLICT — the primary case. The model is given the
+ *     conflicted file with its markers and asked for the resolved file. What
+ *     comes back is shown, and `ops.py resolve` writes it only after the
+ *     confirmation every destructive op in this view gets.
+ *   a failed git OPERATION — the secondary case. There is no file to write, so
+ *     the model is asked for the next command instead, and the panel has no
+ *     Apply at all. Advice is not an action; offering to run a command a model
+ *     picked is a different feature, and a much larger one.
+ *
+ * The model is Sonnet, not the default: a resolution has to be READ out of two
+ * versions of a file and reconciled, which is the kind of work the cheap default
+ * is wrong for. `effort` stays low — the thinking budget is not what decides
+ * whether a merge is understood, and it is the latency the user waits through.
+ */
+
+const RESOLVE_MODEL = "claude-sonnet-5";
+
+/* Reply-shape rules as a SYSTEM prompt, for the same reason AI_SYSTEM is one:
+   they are not something the model should have to notice inside a conflicted
+   file. The hard rule is the last one — the reply IS the file, so a preamble or
+   a fence would be written into the user's source. `cleanMessage` strips a fence
+   as a backstop, and a preamble it cannot strip at all. */
+const RESOLVE_SYSTEM = [
+  "You resolve git merge conflicts. You are given a file exactly as git left",
+  "it, with conflict markers. Reply with the COMPLETE resolved contents of that",
+  "file and nothing else — no preamble, no explanation, no code fences, no",
+  "line numbers. Your reply is written to the file verbatim.",
+  "Keep BOTH sides' intent whenever they are compatible; that is what a merge",
+  "is. Remove every conflict marker. Change nothing outside the conflicted",
+  "regions — not formatting, not imports, not unrelated lines.",
+  "If the file was truncated before you saw all of it, or the two sides",
+  "genuinely cannot be reconciled without a decision only the author can make,",
+  "reply with exactly UNRESOLVABLE and one short sentence saying why.",
+].join(" ");
+
+const ADVISE_SYSTEM = [
+  "You are a git expert helping someone whose git command just failed inside a",
+  "GUI. Explain in one or two sentences what the error means, then give the",
+  "exact command(s) to run in a terminal, one per line, to get out of it.",
+  "Be concrete and brief. Never suggest a force push, a hard reset, or",
+  "anything that rewrites published history unless the error leaves no",
+  "alternative — and say so explicitly if it does.",
+].join(" ");
+
+/* The model's answer for exactly one situation, awaiting review. One at a time,
+   like `busy`: two proposals on screen would make "Apply" ambiguous.
+     { path: <repo-relative> | null, text, note, unresolvable }
+   `path` null = advice for a failed operation (no Apply). Module-level, and read
+   at BUILD time like `aiBusy`, so a repaint cannot hand out a second click. */
+let proposal = null;
+/* What has arrived from the stream so far. Kept out of `proposal` because a
+   partial answer is not a proposal — it has no Apply and must not get one. */
+let streamed = "";
+/* The subject of the call in flight — a path, or "" for the error case — or null
+   when nothing is in flight. A string (not a boolean) so the busy row can be the
+   one being resolved rather than every row at once. */
+let resolving = null;
+
+function resolveButton(path, label) {
+  const busyHere = resolving === path;
+  return action("resolve-ai:" + path, icon(SPARK_GLYPH, 14), {
+    className: "icon ai" + (busyHere ? " working" : ""),
+    disabled: resolving !== null || aiBusy || proposal !== null,
+    label: label,
+    title: busyHere ? "Asking the AI…"
+                    : proposal !== null
+                      ? "Review the proposal above first."
+                      : label,
+    onClick: () => resolveWithAI(path),
+  });
+}
+
+function proposalPanel() {
+  if (resolving === null && proposal === null) return null;
+  const wrap = el("div", { className: "panel proposal" });
+  const head = el("div", { className: "panel-head" },
+    el("span", { className: "what",
+                 textContent: proposal
+                   ? (proposal.path ? "Proposed resolution — " + proposal.path
+                                    : "What to do about that error")
+                   : (resolving ? "Resolving " + resolving + "…"
+                                : "Asking the AI…") }));
+  /* Cancel is offered while a call is in flight, and it is a real cancel: it
+     stops the generation as well as dropping the panel. */
+  if (resolving !== null) {
+    head.append(action("resolve-cancel", "Cancel", {
+      className: "icon", label: "Stop asking the AI", onClick: cancelResolve,
+    }));
+  }
+  wrap.append(head);
+  wrap.append(el("pre", { className: "text",
+                          textContent: (proposal ? proposal.text : streamed) || "" }));
+  if (proposal) {
+    const pending = resolveConfirmBar();
+    if (pending) {
+      wrap.append(pending);
+    } else {
+      const foot = el("div", { className: "foot" });
+      foot.append(el("span", { className: "note", textContent: proposal.note }));
+      /* An Apply exists ONLY for a file, and only when the model produced
+         something it called a resolution. Advice has nothing to apply, and an
+         UNRESOLVABLE answer is the model declining — offering to write that
+         sentence into the user's source would be the worst button in the view. */
+      if (proposal.path && !proposal.unresolvable) {
+        foot.append(confirmable("resolve:" + proposal.path, "Apply to file",
+          "Overwrite " + proposal.path + " with the proposed resolution.",
+          { label: "Apply the proposed resolution to " + proposal.path }));
+      }
+      foot.append(action("resolve-dismiss", "Dismiss", {
+        onClick: () => { proposal = null; streamed = ""; draw(true); },
+      }));
+      wrap.append(foot);
+    }
+  }
+  return wrap;
+}
+
+/* The confirmation for an Apply, when one is pending. Answered here rather than
+   through `pendingConfirm` (which returns null for `resolve`) because the panel
+   is where the text being written is.
+
+   Only ever built when the ON-SCREEN proposal is the one the question names: the
+   resolved text lives in memory, not in the URL, so an `ask=resolve:…` that
+   survived a refresh has nothing to apply, and rendering the question anyway
+   would offer a Yes that could only fail. */
+function resolveConfirmBar() {
+  const ask = param("ask");
+  if (!proposal || !proposal.path || proposal.unresolvable) return null;
+  if (ask !== "resolve:" + proposal.path) return null;
+  const path = proposal.path;
+  return confirmBar(
+    "Overwrite " + path + " with the proposed resolution? The conflicted version "
+    + "git left there is replaced, and getting it back means `git checkout "
+    + "--merge " + path + "`. Nothing is staged and nothing is committed.",
+    () => {
+      const content = proposal.text;
+      run("resolve:" + path, { op: "resolve", paths: [path], content },
+          () => { proposal = null; streamed = ""; });
+    });
+}
+
+function resolveFailed(message) {
+  resolving = null;
+  streamed = "";
+  proposal = null;
+  flash = { ok: false, message };
+  announce(message);
+  draw(true);
+}
+
+/* Every rejection `fused.ai` can produce, in this view's own words. A server
+   with no AI configured is an ordinary answer here, not a bug in the view, so
+   none of these reaches the runtime's red traceback overlay. */
+function aiErrorText(err) {
+  const type = err && err.type;
+  const detail = (err && err.message) || "the request failed.";
+  if (type === "ai_unavailable") return "AI is not available on this server.";
+  if (type === "model_loading") return "A model is still loading. Try again in a moment.";
+  if (type === "unavailable") return "AI cannot run here: " + detail;
+  if (type === "cancelled") return "Cancelled.";
+  if (type === "timeout") return "The AI did not answer in time. Try again.";
+  if (type === "bad_request") return "The AI rejected that request: " + detail;
+  return "The AI could not help with that: " + detail;
+}
+
+function cancelResolve() {
+  /* Best-effort and deliberately not awaited: `cancel` only reaches a LOCAL
+     generation, and this view asks for a Claude model, so the honest thing is to
+     stop showing the panel immediately rather than to imply the tokens stopped.
+     The in-flight promise's continuations see `resolving === null` and bail. */
+  try { if (fused.ai && fused.ai.cancel) fused.ai.cancel(); } catch (err) { /* nothing to stop */ }
+  resolving = null;
+  streamed = "";
+  proposal = null;
+  announce("Stopped.");
+  draw(true);
+}
+
+/* One conflicted file -> a proposed resolution. `path` is repo-relative. */
+async function resolveWithAI(path) {
+  if (resolving !== null || aiBusy || busy !== null) return;
+  resolving = path;
+  streamed = "";
+  proposal = null;
+  flash = null;
+  draw(true);
+
+  let payload;
+  try {
+    payload = await fused.runPython(READER, { file, op: "conflicts" },
+                                    chan("conflicts"));
+  } catch (err) {
+    payload = { ok: false, message: err && err.message ? err.message : String(err) };
+  }
+  if (resolving !== path) return;              // cancelled while reading
+  if (!payload.ok) {
+    resolveFailed("Could not read the conflict: "
+                  + (payload.message || "git refused that."));
+    return;
+  }
+  const entry = (payload.files || []).find((f) => f.path === path);
+  if (!entry) {
+    /* The conflict went away between the click and the read — someone resolved
+       it in a terminal, or the operation was aborted. Not an error. */
+    resolveFailed(path + " is no longer conflicted.");
+    return;
+  }
+  if (entry.binary) {
+    resolveFailed(path + " is a binary file — pick a side with `git checkout "
+                  + "--ours`/`--theirs` instead.");
+    return;
+  }
+  if (!entry.content) {
+    resolveFailed("Could not read " + path + " to resolve it.");
+    return;
+  }
+
+  try {
+    const result = await fused.ai(conflictPrompt(payload, entry), {
+      systemPrompt: RESOLVE_SYSTEM,
+      model: RESOLVE_MODEL,
+      effort: "low",
+      onChunk: (text) => {
+        if (resolving !== path) return;
+        streamed += text;
+        const body = document.querySelector(".proposal .text");
+        if (body) body.textContent = streamed;
+      },
+    });
+    if (resolving !== path) return;
+    const text = cleanMessage(result.text);
+    if (!text) throw new Error("The AI returned nothing.");
+    const unresolvable = /^UNRESOLVABLE\b/.test(text);
+    resolving = null;
+    streamed = "";
+    proposal = {
+      path: path,
+      text: text,
+      unresolvable: unresolvable,
+      note: unresolvable
+        ? "The AI declined to resolve this one, so there is nothing to apply."
+        : "Nothing has been written yet. Applying replaces " + path
+          + " in your working tree; it is not staged and not committed."
+          + (entry.truncated
+             ? " NOTE: the file was longer than this view sends, so the AI saw"
+               + " only part of it — read the whole file before applying."
+             : ""),
+    };
+    announce(unresolvable ? "The AI could not resolve " + path
+                          : "A resolution for " + path + " is ready to review.");
+    draw(true);
+  } catch (err) {
+    if (resolving !== path) return;            // already cancelled
+    resolveFailed(aiErrorText(err));
+  }
+}
+
+function conflictPrompt(payload, entry) {
+  const parts = [];
+  const op = payload.operation
+    ? "git is part-way through a " + payload.operation + "."
+    : "The working tree has an unmerged file with no operation in flight "
+      + "(a conflicted `checkout --merge` or `stash pop`).";
+  parts.push(op);
+  if (payload.branch) parts.push("Current branch: " + payload.branch);
+  if (payload.theirs) parts.push("Merging in: " + payload.theirs);
+  if (payload.summary) parts.push("Operation summary: " + payload.summary);
+  const others = (payload.files || []).filter((f) => f.path !== entry.path);
+  if (others.length) {
+    parts.push("Other conflicted files in this repository (do NOT resolve them, "
+      + "they are context):\n" + others.map((f) => "- " + f.path).join("\n"));
+  }
+  parts.push("Resolve THIS file only: " + entry.path);
+  parts.push("Contents of " + entry.path + " as git left it:\n"
+    + entry.content
+    + (entry.truncated
+       ? "\n(The file was cut off at this view's size cap. If you cannot see the "
+         + "whole of every conflicted region, reply UNRESOLVABLE.)"
+       : ""));
+  parts.push("Reply with the complete resolved contents of " + entry.path + ".");
+  return parts.join("\n\n");
+}
+
+/* The secondary case: a git operation failed and the message is all the user
+   has. No file is involved, so this can only ever produce advice. */
+async function adviseOnError(message) {
+  if (resolving !== null || aiBusy || busy !== null) return;
+  resolving = "";
+  streamed = "";
+  proposal = null;
+  draw(true);
+
+  const repo = snapshot && snapshot.repo;
+  const parts = ["A git operation failed in a GUI. The error was:\n" + message];
+  if (repo) {
+    parts.push("Repository state: branch " + (repo.branch || "(detached)")
+      + (repo.upstream ? ", tracking " + repo.upstream : ", no upstream")
+      + ", " + (repo.ahead || 0) + " ahead / " + (repo.behind || 0) + " behind"
+      + ", working tree " + (repo.dirty ? "dirty" : "clean") + ".");
+  }
+  parts.push("What does this mean, and what should I run next?");
+
+  try {
+    const result = await fused.ai(parts.join("\n\n"), {
+      systemPrompt: ADVISE_SYSTEM,
+      model: RESOLVE_MODEL,
+      effort: "low",
+      onChunk: (text) => {
+        if (resolving !== "") return;
+        streamed += text;
+        const body = document.querySelector(".proposal .text");
+        if (body) body.textContent = streamed;
+      },
+    });
+    if (resolving !== "") return;
+    const text = cleanMessage(result.text);
+    if (!text) throw new Error("The AI returned nothing.");
+    resolving = null;
+    streamed = "";
+    proposal = {
+      path: null,
+      text: text,
+      unresolvable: false,
+      note: "Advice only — nothing here has been run, and this view will not "
+            + "run it. Copy what you need into a terminal.",
+    };
+    announce("The AI answered. Read it before running anything.");
+    draw(true);
+  } catch (err) {
+    if (resolving !== "") return;
+    resolveFailed(aiErrorText(err));
+  }
+}
+
 function commit(message) {
   if (!message.trim()) {
     flash = { ok: false, message: "Write a commit message before committing." };
@@ -1769,6 +2162,14 @@ function changeLine(repo, change, selected, kind) {
   const acts = el("div", { className: "acts" });
   const path = change.path;
   if (writable(repo, path)) {
+    /* A conflicted row gets the sparkle FIRST, because on a conflicted file it
+       is the action the user came for and Stage is the one that ends the
+       conflict — offering them the other way round invites a `git add` of a file
+       that still has markers in it. `change.conflicted` is the reader's answer
+       (git's porcelain rule), never re-derived from the status letters here. */
+    if (change.conflicted) {
+      acts.append(resolveButton(path, "Resolve " + path + " with AI"));
+    }
     if (kind === "staged") {
       acts.append(action("unstage:" + path, "−", {
         className: "icon", label: "Unstage " + path,
@@ -2157,6 +2558,16 @@ function pendingConfirm(data) {
         () => run("discard_all", { op: "discard_all" })),
     };
   }
+  if (op === "resolve") {
+    /* Answered inside the PROPOSAL PANEL, not in a list section, so this returns
+       nothing here — see `resolveConfirmBar`. Every other question in this view
+       belongs to a row, and the principle behind that ("the question sits next to
+       the thing it is about") points at the panel for this one: the thing it is
+       about is the proposed text, which is in the panel and nowhere else. A
+       conflicted file is also listed in BOTH the staged and the changes section,
+       so there is no single row to attach it to. */
+    return null;
+  }
   if (op === "stash_drop") {
     const split = rest.indexOf(":");
     if (split === -1) return null;
@@ -2400,9 +2811,29 @@ function render(data, stashes, diff) {
 
   const page = el("div", null);
   if (flash) {
-    page.append(el("div", { className: "flash" + (flash.ok ? "" : " bad"),
-                            textContent: flash.message }));
+    const note = el("div", { className: "flash" + (flash.ok ? "" : " bad") },
+                    el("span", { textContent: flash.message }));
+    /* The secondary case (GT-19): a git operation just failed and the message is
+       all the user has. The sparkle turns it into an explanation and a next
+       command — advice only, never a run. Offered on FAILURES alone, and not
+       while a proposal is already on screen or another call is in flight, so the
+       one panel below always has one subject. */
+    if (!flash.ok && resolving === null && proposal === null && !aiBusy) {
+      note.append(action("advise", icon(SPARK_GLYPH, 14), {
+        className: "icon ai",
+        label: "Ask AI what to do about this error",
+        title: "Ask AI what this error means and what to run next",
+        onClick: () => adviseOnError(flash.message),
+      }));
+    }
+    page.append(note);
   }
+  /* The proposal (or the call that will become one) sits above the toolbar: it is
+     the thing the user is being asked to read, and it must not be below the lists
+     it is about. One panel for both cases, so there is never a question about
+     which Apply belongs to which answer. */
+  const panel = proposalPanel();
+  if (panel) page.append(panel);
   page.append(toolbar(data));
   /* Guarded, not appended blind: `commitBox` returns null when nothing is
      staged, and `Node.append(null)` inserts the literal text "null". */

--- a/tests/_git_view_probe.mjs
+++ b/tests/_git_view_probe.mjs
@@ -1,0 +1,232 @@
+/* Run the git template's REAL script against a DOM stub, and report whether the
+ * view actually painted.
+ *
+ * Why this exists: the full-page git view shipped BLANK on a branch whose whole
+ * pytest suite was green, and it was invisible to every check we had.
+ * `node --check` passes (it is not a parse error), the source-contract tests pass
+ * (the source is fine to read), and `window.onerror` never fires — because
+ * `draw()` is async, so a throw inside `render()` becomes an unhandled REJECTION,
+ * which the page-error hook does not observe. The page calls Python, gets good
+ * data, records no error, and paints nothing.
+ *
+ * So the only thing that catches it is running the render for real and asserting
+ * the DOM is not empty. Same idea as the `_DOM_STUB` harnesses in
+ * test_annotate_revert.py, sized up for this template: a stub just large enough
+ * to run the shipping code verbatim, with no copy of the logic under test.
+ *
+ * Usage: node _git_view_probe.mjs <template.html> <fixture.json>
+ * Prints one JSON object: { painted, viewChildren, error, unhandled, calls }.
+ */
+import { readFileSync } from "node:fs";
+
+const [templatePath, fixturePath] = process.argv.slice(2);
+const html = readFileSync(templatePath, "utf8");
+const fixture = JSON.parse(readFileSync(fixturePath, "utf8"));
+
+// ---------------------------------------------------------------- DOM stub
+class ClassList {
+  constructor(node) { this.node = node; this.set = new Set(); }
+  add(...c) { c.forEach((x) => x && this.set.add(x)); }
+  remove(...c) { c.forEach((x) => this.set.delete(x)); }
+  toggle(c, on) { (on === undefined ? !this.set.has(c) : on) ? this.set.add(c) : this.set.delete(c); }
+  contains(c) { return this.set.has(c); }
+}
+
+class El {
+  constructor(tag) {
+    this.tagName = String(tag || "div").toUpperCase();
+    this.children = [];
+    this.attrs = {};
+    this.classList = new ClassList(this);
+    this._text = "";
+    this.style = {};
+    this.dataset = {};
+    this.hidden = false;
+    this.disabled = false;
+    this.value = "";
+    this.parentNode = null;
+  }
+  get className() { return [...this.classList.set].join(" "); }
+  set className(v) {
+    this.classList.set = new Set(String(v || "").split(/\s+/).filter(Boolean));
+  }
+  get textContent() {
+    return this._text || this.children.map((c) => (c.textContent ?? String(c))).join("");
+  }
+  set textContent(v) { this._text = v === null || v === undefined ? "" : String(v); this.children = []; }
+  append(...kids) {
+    for (const k of kids.flat()) {
+      if (k === null || k === undefined || k === false) continue;
+      const node = typeof k === "object" ? k : Object.assign(new El("span"), { _text: String(k) });
+      if (node instanceof Frag) { this.append(...node.children); continue; }
+      node.parentNode = this;
+      this.children.push(node);
+    }
+  }
+  appendChild(k) { this.append(k); return k; }
+  prepend(...kids) { const old = this.children; this.children = []; this.append(...kids); this.children.push(...old); }
+  replaceChildren(...kids) { this.children = []; this._text = ""; this.append(...kids); }
+  remove() { if (this.parentNode) this.parentNode.children = this.parentNode.children.filter((c) => c !== this); }
+  setAttribute(k, v) { this.attrs[k] = String(v); }
+  getAttribute(k) { return k in this.attrs ? this.attrs[k] : null; }
+  removeAttribute(k) { delete this.attrs[k]; }
+  addEventListener() {}
+  removeEventListener() {}
+  focus() {}
+  scrollIntoView() {}
+  closest() { return null; }
+  contains() { return false; }
+  // Depth-first descendant search over class/tag selectors, enough for the
+  // template's three querySelector calls.
+  querySelector(sel) {
+    for (const kid of this.children) {
+      if (matches(kid, sel)) return kid;
+      const deep = kid.querySelector ? kid.querySelector(sel) : null;
+      if (deep) return deep;
+    }
+    return null;
+  }
+  querySelectorAll(sel) {
+    const out = [];
+    for (const kid of this.children) {
+      if (matches(kid, sel)) out.push(kid);
+      if (kid.querySelectorAll) out.push(...kid.querySelectorAll(sel));
+    }
+    return out;
+  }
+  get firstChild() { return this.children[0] || null; }
+  get lastChild() { return this.children[this.children.length - 1] || null; }
+  get childElementCount() { return this.children.length; }
+}
+
+class Frag extends El {}
+
+function matches(node, sel) {
+  return String(sel).split(/\s+/).every((part) => {
+    if (part.startsWith(".")) return node.classList && node.classList.contains(part.slice(1));
+    if (part.startsWith("#")) return node.attrs && node.attrs.id === part.slice(1);
+    return node.tagName === part.toUpperCase();
+  });
+}
+
+const byId = {};
+for (const id of ["skeleton", "view", "live", "msg"]) {
+  byId[id] = new El("div");
+  byId[id].attrs.id = id;
+}
+
+const document = {
+  getElementById: (id) => byId[id] || null,
+  createElement: (t) => new El(t),
+  createElementNS: (_ns, t) => new El(t),
+  createDocumentFragment: () => new Frag("fragment"),
+  createTextNode: (t) => Object.assign(new El("span"), { _text: String(t) }),
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  activeElement: null,
+  body: new El("body"),
+  documentElement: new El("html"),
+  querySelector: (sel) => byId.view.querySelector(sel) || byId.skeleton.querySelector(sel),
+  querySelectorAll: (sel) => byId.view.querySelectorAll(sel),
+  title: "",
+};
+
+// ------------------------------------------------------------- fused stub
+const calls = [];
+const params = new Map(Object.entries(fixture.params || {}));
+let onChange = () => {};
+
+const fused = {
+  env: "local",
+  params: {
+    get: (k) => (params.has(k) ? params.get(k) : undefined),
+    getAll: () => Object.fromEntries(params),
+    set: (k, v) => {
+      if (typeof v !== "string" && v !== null) throw new TypeError("params must be strings");
+      if (v === null) params.delete(k); else params.set(k, v);
+      onChange(Object.fromEntries(params));
+    },
+    onChange: (cb) => { onChange = cb; return () => {}; },
+  },
+  runPython: (py, p) => {
+    calls.push({ py, op: p && p.op });
+    const op = (p && p.op) || "overview";
+    if (!(op in fixture.payloads)) {
+      return Promise.reject(Object.assign(new Error("no fixture for op " + op), { type: "probe" }));
+    }
+    return Promise.resolve(fixture.payloads[op]);
+  },
+  ai: Object.assign(() => Promise.reject(Object.assign(new Error("no AI in the probe"),
+                                                      { type: "ai_unavailable" })),
+                    { cancel: () => Promise.resolve(false) }),
+  readFile: () => Promise.resolve(""),
+  writeFile: () => Promise.resolve({ mtime: 1 }),
+  stat: () => Promise.resolve({ writable: true, mtime: 1 }),
+  rawUrl: (p) => "raw:" + p,
+  trackJob: () => ({ update() {}, finish() {}, fail() {}, cancelled() {} }),
+  autoReload: () => {},
+};
+
+// --------------------------------------------------------------- window stub
+let fatal = null;
+const unhandled = [];
+process.on("unhandledRejection", (err) => {
+  unhandled.push(err && err.stack ? String(err.stack).split("\n").slice(0, 4).join(" | ")
+                                  : String(err));
+});
+
+const location = { href: "http://127.0.0.1/probe", search: "", pathname: "/probe" };
+const history = { replaceState() {}, pushState() {} };
+const window = {
+  fused, document, location, history,
+  addEventListener: () => {}, removeEventListener: () => {},
+  parent: null, frameElement: null, top: null,
+  requestAnimationFrame: (fn) => setTimeout(fn, 0),
+  setInterval: () => 0, setTimeout, clearInterval: () => {}, clearTimeout,
+  matchMedia: () => ({ matches: false, addEventListener() {} }),
+  getComputedStyle: () => ({ getPropertyValue: () => "" }),
+  localStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+  sessionStorage: { getItem: () => null, setItem() {}, removeItem() {} },
+  postMessage: () => {},
+  scrollTo: () => {},
+};
+window.self = window;
+window.window = window;
+
+// ----------------------------------------------------------------- run it
+const scripts = [...html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/g)].map((m) => m[1]);
+const source = scripts.join("\n");
+
+try {
+  // COMPILING is inside the try, not just calling: a duplicate top-level `let`
+  // — the exact failure that shipped — is a SyntaxError raised when the function
+  // is CONSTRUCTED. With this outside the try it escaped, node died with empty
+  // stdout, and the probe reported nothing at all rather than the error. Which
+  // is the same "unverifiable reads as fine" trap this whole harness is for.
+  const runner = new Function(
+    "window", "document", "fused", "location", "history", "navigator",
+    "requestAnimationFrame", "setInterval", "clearInterval", "matchMedia",
+    "getComputedStyle", "localStorage", "sessionStorage", "self",
+    '"use strict";\n' + source);
+  runner(window, document, fused, location, history, { platform: "probe", clipboard: {} },
+         window.requestAnimationFrame, window.setInterval, window.clearInterval,
+         window.matchMedia, window.getComputedStyle, window.localStorage,
+         window.sessionStorage, window);
+} catch (err) {
+  fatal = err && err.stack ? String(err.stack).split("\n").slice(0, 5).join(" | ") : String(err);
+}
+
+// Let the async draw() settle.
+await new Promise((r) => setTimeout(r, 60));
+await new Promise((r) => setTimeout(r, 60));
+
+const view = byId.view;
+process.stdout.write(JSON.stringify({
+  painted: view.children.length > 0,
+  viewChildren: view.children.length,
+  viewText: view.textContent.slice(0, 400),
+  skeletonHidden: byId.skeleton.hidden,
+  error: fatal,
+  unhandled,
+  calls,
+}, null, 1));

--- a/tests/test_bundle_reader.py
+++ b/tests/test_bundle_reader.py
@@ -634,9 +634,18 @@ def test_every_git_call_is_an_argv_list_with_no_shell_and_a_timeout(
     reader.main(full_bundle, action="history", ref="refs/heads/main")
     assert seen
     for cmd, kw in seen:
-        # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+        # argv[0] is the ABSOLUTE git path, and the absoluteness is the
+        # point: CPython only reaches posix_spawn when
+        # os.path.dirname(executable) is truthy, and a fork with libproj
+        # resident SIGSEGVs before exec (tests/test_git_posix_spawn.py).
+        # basename alone would pass a regression to a bare "git".
         assert isinstance(cmd, list)
+        assert os.path.isabs(cmd[0])
         assert os.path.basename(cmd[0]) in ("git", "git.exe")
+        # The other two thirds of the same rule — this module forked until
+        # they were added, and this test passed the whole time.
+        assert kw.get("close_fds") is False
+        assert kw.get("cwd") is None
         assert kw.get("shell", False) is False
         assert kw.get("stdin") is subprocess.DEVNULL
         assert kw.get("timeout") or kw.get("stdout") is subprocess.PIPE

--- a/tests/test_bundle_reader.py
+++ b/tests/test_bundle_reader.py
@@ -634,7 +634,9 @@ def test_every_git_call_is_an_argv_list_with_no_shell_and_a_timeout(
     reader.main(full_bundle, action="history", ref="refs/heads/main")
     assert seen
     for cmd, kw in seen:
-        assert isinstance(cmd, list) and cmd[0] == "git"
+        # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+        assert isinstance(cmd, list)
+        assert os.path.basename(cmd[0]) in ("git", "git.exe")
         assert kw.get("shell", False) is False
         assert kw.get("stdin") is subprocess.DEVNULL
         assert kw.get("timeout") or kw.get("stdout") is subprocess.PIPE

--- a/tests/test_claude_config_api.py
+++ b/tests/test_claude_config_api.py
@@ -732,7 +732,12 @@ def test_git_runs_with_dash_c_rather_than_cwd():
     with mock.patch.object(subprocess, "run", fake_run):
         lib.git("status", "--porcelain")
 
-    # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+    # argv[0] is the ABSOLUTE git path, and the absoluteness is the point:
+    # CPython only reaches posix_spawn when os.path.dirname(executable) is
+    # truthy, and a fork with libproj resident SIGSEGVs before exec
+    # (tests/test_git_posix_spawn.py). basename alone would pass a
+    # regression to a bare "git".
+    assert os.path.isabs(seen["argv"][0])
     assert os.path.basename(seen["argv"][0]) in ("git", "git.exe")
     assert seen["argv"][1:3] == ["-C", lib.CLAUDE_DIR]
     assert "cwd" not in seen["kwargs"]

--- a/tests/test_claude_config_api.py
+++ b/tests/test_claude_config_api.py
@@ -732,7 +732,9 @@ def test_git_runs_with_dash_c_rather_than_cwd():
     with mock.patch.object(subprocess, "run", fake_run):
         lib.git("status", "--porcelain")
 
-    assert seen["argv"][:3] == ["git", "-C", lib.CLAUDE_DIR]
+    # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+    assert os.path.basename(seen["argv"][0]) in ("git", "git.exe")
+    assert seen["argv"][1:3] == ["-C", lib.CLAUDE_DIR]
     assert "cwd" not in seen["kwargs"]
     assert seen["kwargs"]["close_fds"] is False
 

--- a/tests/test_git_condition.py
+++ b/tests/test_git_condition.py
@@ -291,7 +291,14 @@ def test_git_is_invoked_non_interactively(gate, repo, monkeypatch):
     monkeypatch.setattr(subprocess, "run", spy)
     assert gate(repo) is True
     env = seen["kwargs"].get("env") or {}
-    assert seen["argv"][0] == "git"
+    # argv[0] is the ABSOLUTE path to git, not the bare name, and the
+    # absoluteness is required rather than cosmetic: CPython only reaches
+    # posix_spawn when os.path.dirname(executable) is truthy, and a fork in a
+    # process with libproj resident dies with SIGSEGV before exec (see
+    # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
+    # still no shell — which is what this assertion is really about.
+    assert os.path.isabs(seen["argv"][0])
+    assert os.path.basename(seen["argv"][0]) in ("git", "git.exe")
     assert "--no-pager" in seen["argv"]
     assert env.get("GIT_TERMINAL_PROMPT") == "0"
     assert env.get("GIT_OPTIONAL_LOCKS") == "0"

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -1,0 +1,248 @@
+"""Conflict support in the `git` template: the `conflicts` READ and the
+`resolve` WRITE (the two halves behind the view's "Resolve with AI" button).
+
+Driven against a REAL conflicted repository, like the rest of this template's
+suite: the modules' whole job is to ask git and parse what git says, so a mocked
+subprocess would test our fiction of the porcelain format instead of the format.
+
+What is pinned here:
+
+* `log.py op="conflicts"` reports the unmerged paths WITH their conflict markers
+  (that text is the model's only real context), names the operation in flight,
+  and says `empty` — a first-class answer, not an error — when there is no
+  conflict.
+* Content is CAPPED per file and in file count, and the truncation is reported,
+  so a prompt built from it cannot be unbounded.
+* Binary conflicts are named and NOT read.
+* `ops.py op="resolve"` writes one resolved file and does **nothing else**: it
+  never stages and never commits, so the user reviews the working tree before
+  anything enters the index. Asserted by checking the index directly.
+* Every way `resolve` must refuse: a path that is not conflicted, a path outside
+  the view's scope, empty content, and content that still carries conflict
+  markers (a "resolution" that resolved nothing).
+* `resolve` is DESTRUCTIVE — it overwrites a file in the working tree — so it
+  must be in `DESTRUCTIVE_OPS`, which is what gives it the view's confirmation.
+"""
+import importlib.util
+import os
+
+import pytest
+
+from _git_repo import git, git_available
+
+_TPL = os.path.join(
+    os.path.dirname(__file__), "..", "fused_render", "templates", "git")
+
+pytestmark = pytest.mark.skipif(not git_available(), reason="git binary not installed")
+
+
+def _load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def reader():
+    return _load("git_log_conflicts", os.path.join(_TPL, "log.py"))
+
+
+@pytest.fixture(scope="module")
+def ops():
+    return _load("git_ops_conflicts", os.path.join(_TPL, "ops.py"))
+
+
+def _put(root, rel, payload):
+    full = os.path.join(root, *rel.split("/"))
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    mode = "wb" if isinstance(payload, bytes) else "w"
+    with open(full, mode) as fh:
+        fh.write(payload)
+
+
+def conflicted_repo(root, path="pkg/mod.py", binary=False):
+    """A repo mid-merge with exactly one unmerged path."""
+    os.makedirs(root, exist_ok=True)
+    git(root, "init", "-q", root)
+    _put(root, path, b"\x00base\x00" if binary else "one\ntwo\nthree\n")
+    _put(root, "README.md", "readme\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "base")
+    git(root, "branch", "other")
+
+    _put(root, path, b"\x00ours\x00\x01" if binary else "one\nOURS\nthree\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "ours")
+
+    git(root, "checkout", "-q", "other")
+    _put(root, path, b"\x00theirs\x00\x02" if binary else "one\nTHEIRS\nthree\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "theirs")
+
+    git(root, "checkout", "-q", "-")
+    git(root, "merge", "other", check=False)     # conflicts on purpose
+    return root
+
+
+def unmerged(root):
+    return [n for n in git(
+        root, "diff", "--name-only", "--diff-filter=U").splitlines() if n]
+
+
+def index_stages(root, path):
+    """How many unmerged stages the INDEX still holds for `path`.
+
+    This, not `git diff --cached`, is the honest "was it staged" question for a
+    conflicted file: an unmerged path always differs from HEAD, so it shows up in
+    `--cached` whether or not anyone added it. `git add` is what COLLAPSES the
+    three stages to one, so a non-zero count here proves the index was untouched.
+    """
+    return len([n for n in git(root, "ls-files", "-u", "--", path).splitlines() if n])
+
+
+# ------------------------------------------------------------------- the read
+
+
+def test_conflicts_reports_the_unmerged_file_with_its_markers(reader, tmp_path):
+    root = conflicted_repo(str(tmp_path / "repo"))
+    payload = reader.main(file=root, op="conflicts")
+    assert payload["ok"] is True
+    assert payload["empty"] is False
+    assert payload["operation"] == "merge"
+    paths = [f["path"] for f in payload["files"]]
+    assert paths == ["pkg/mod.py"]
+    body = payload["files"][0]["content"]
+    # The markers ARE the context — a payload without them is useless to a model.
+    assert "<<<<<<<" in body and "=======" in body and ">>>>>>>" in body
+    assert "OURS" in body and "THEIRS" in body
+
+
+def test_conflicts_is_empty_on_a_clean_repo(reader, tmp_path):
+    root = str(tmp_path / "clean")
+    os.makedirs(root)
+    git(root, "init", "-q", root)
+    _put(root, "a.txt", "a\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "only")
+    payload = reader.main(file=root, op="conflicts")
+    assert payload["ok"] is True          # not an error — an answer (GT-9)
+    assert payload["empty"] is True
+    assert payload["files"] == []
+    assert payload["operation"] is None
+
+
+def test_conflicts_marks_what_is_outside_the_open_scope(reader, tmp_path):
+    root = conflicted_repo(str(tmp_path / "scoped"))
+    payload = reader.main(file=os.path.join(root, "README.md"), op="conflicts")
+    # A conflict is repository-wide, so it is still LISTED from a scoped view —
+    # but the view may not write outside its scope and has to know that.
+    assert [f["path"] for f in payload["files"]] == ["pkg/mod.py"]
+    assert payload["files"][0]["in_scope"] is False
+
+
+def test_conflicts_caps_file_content_and_reports_it(reader, tmp_path, monkeypatch):
+    root = conflicted_repo(str(tmp_path / "big"))
+    monkeypatch.setattr(reader, "MAX_CONFLICT_BYTES", 40)
+    payload = reader.main(file=root, op="conflicts")
+    entry = payload["files"][0]
+    assert len(entry["content"].encode("utf-8")) <= 40
+    assert entry["truncated"] is True
+
+
+def test_conflicts_caps_the_file_count_and_reports_it(reader, tmp_path, monkeypatch):
+    root = conflicted_repo(str(tmp_path / "many"))
+    monkeypatch.setattr(reader, "MAX_CONFLICT_FILES", 0)
+    payload = reader.main(file=root, op="conflicts")
+    assert payload["files"] == []
+    assert payload["files_truncated"] is True
+    assert payload["empty"] is False      # there IS a conflict; we just showed none
+
+
+def test_conflicts_names_a_binary_conflict_without_reading_it(reader, tmp_path):
+    root = conflicted_repo(str(tmp_path / "bin"), binary=True)
+    entry = reader.main(file=root, op="conflicts")["files"][0]
+    assert entry["binary"] is True
+    assert entry["content"] == ""
+
+
+def test_conflicts_refuses_a_non_repository(reader, tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    payload = reader.main(file=str(plain), op="conflicts")
+    assert payload["ok"] is False
+    assert payload["reason"] == "not-a-repo"
+
+
+# ------------------------------------------------------------------ the write
+
+
+def test_resolve_is_declared_destructive(ops):
+    # It overwrites a file in the working tree; the view keys its confirmation
+    # step off this tuple, so omitting it ships the op without one.
+    assert "resolve" in ops.DESTRUCTIVE_OPS
+
+
+def test_resolve_writes_the_file_and_stages_nothing(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "apply"))
+    payload = ops.main(file=root, op="resolve", paths=["pkg/mod.py"],
+                       content="one\nMERGED\nthree\n")
+    assert payload["ok"] is True, payload
+    with open(os.path.join(root, "pkg/mod.py")) as fh:
+        assert fh.read() == "one\nMERGED\nthree\n"
+    # The point of the whole feature: the user reviews the working tree. Nothing
+    # was added to the index and nothing was committed.
+    assert unmerged(root) == ["pkg/mod.py"]
+    assert index_stages(root, "pkg/mod.py") == 3            # never `git add`ed
+    assert git(root, "log", "--oneline").count("\n") == 2   # base + ours only
+
+
+def test_resolve_refuses_a_path_that_is_not_conflicted(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "notconf"))
+    payload = ops.main(file=root, op="resolve", paths=["README.md"],
+                       content="rewritten\n")
+    assert payload["ok"] is False
+    assert payload["reason"] == "not-conflicted"
+    with open(os.path.join(root, "README.md")) as fh:
+        assert fh.read() == "readme\n"          # untouched
+
+
+def test_resolve_refuses_outside_the_open_scope(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "outscope"))
+    os.makedirs(os.path.join(root, "docs"), exist_ok=True)
+    _put(root, "docs/x.md", "x\n")
+    payload = ops.main(file=os.path.join(root, "docs"), op="resolve",
+                       paths=["pkg/mod.py"], content="one\nMERGED\nthree\n")
+    assert payload["ok"] is False
+    assert payload["reason"] == "outside-scope"
+
+
+def test_resolve_refuses_empty_content(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "empty"))
+    payload = ops.main(file=root, op="resolve", paths=["pkg/mod.py"], content="")
+    assert payload["ok"] is False
+    assert payload["reason"] == "empty-content"
+
+
+def test_resolve_refuses_content_that_still_has_conflict_markers(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "markers"))
+    payload = ops.main(
+        file=root, op="resolve", paths=["pkg/mod.py"],
+        content="one\n<<<<<<< HEAD\nOURS\n=======\nTHEIRS\n>>>>>>> other\nthree\n")
+    assert payload["ok"] is False
+    assert payload["reason"] == "unresolved"
+
+
+def test_resolve_refuses_more_than_one_path(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "multi"))
+    payload = ops.main(file=root, op="resolve",
+                       paths=["pkg/mod.py", "README.md"], content="x\n")
+    assert payload["ok"] is False
+    assert payload["reason"] == "one-path"
+
+
+def test_resolve_refuses_an_unknown_op_shape(ops, tmp_path):
+    root = conflicted_repo(str(tmp_path / "noop"))
+    payload = ops.main(file=root, op="resolve", paths=[], content="x\n")
+    assert payload["ok"] is False
+    assert payload["reason"] == "missing"

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -39,6 +39,10 @@ pytestmark = pytest.mark.skipif(not git_available(), reason="git binary not inst
 
 def _load(name, path):
     spec = importlib.util.spec_from_file_location(name, path)
+    # Asserted, never ignored: a None spec or loader means the module did not
+    # load, so every assertion below would be checking a module that was never
+    # executed — a green test over nothing.
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod

--- a/tests/test_git_conflicts.py
+++ b/tests/test_git_conflicts.py
@@ -24,6 +24,7 @@ What is pinned here:
   must be in `DESTRUCTIVE_OPS`, which is what gives it the view's confirmation.
 """
 import importlib.util
+import re
 import os
 
 import pytest
@@ -246,3 +247,92 @@ def test_resolve_refuses_an_unknown_op_shape(ops, tmp_path):
     payload = ops.main(file=root, op="resolve", paths=[], content="x\n")
     assert payload["ok"] is False
     assert payload["reason"] == "missing"
+
+
+# ------------------------------------------------- source contract (the view)
+#
+# The view is a browser document; nothing here executes its JavaScript. What CAN
+# be pinned from a test is the handful of cross-file contracts whose breakage is
+# silent — each of these is a bug that ships looking fine.
+
+_TEMPLATE = os.path.join(_TPL, "template.html")
+
+
+def _view_source():
+    with open(_TEMPLATE, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def test_view_destructive_set_mirrors_ops_module(ops):
+    """The template's DESTRUCTIVE set IS ops.py's DESTRUCTIVE_OPS.
+
+    ops.py says it in a comment ("a new op that can lose work must be added here
+    or it silently ships without a confirmation") and the view says it again. Two
+    hand-maintained copies of one list is exactly the thing that drifts, and the
+    drift is invisible: the op simply stops asking before it destroys something.
+    """
+    found = re.search(r"const DESTRUCTIVE = new Set\(\[([^\]]*)\]\)", _view_source())
+    assert found, "the view no longer declares a DESTRUCTIVE set"
+    listed = set(re.findall(r'"([^"]+)"', found.group(1)))
+    assert listed == set(ops.DESTRUCTIVE_OPS)
+
+
+def test_view_asks_sonnet_for_a_resolution():
+    src = _view_source()
+    assert 'const RESOLVE_MODEL = "claude-sonnet-5"' in src
+    # And it is the model actually passed, not just declared.
+    assert src.count("model: RESOLVE_MODEL") == 2      # conflict + error advice
+
+
+def test_view_reads_conflicts_on_its_own_channel():
+    """Same rule as every other reader call here (see test_git_view.py): a call
+    sharing log.py's default channel supersedes an in-flight overview and hangs
+    it forever."""
+    src = _view_source()
+    assert 'op: "conflicts" }, \n' not in src            # no channel-less form
+    assert re.search(r'op:\s*"conflicts"\s*\}\s*,\s*chan\("conflicts"\)', src)
+
+
+def test_view_never_applies_a_resolution_without_the_confirmation():
+    """The only `op: "resolve"` call site is inside the confirmation bar.
+
+    The proposal panel's Apply button must go through `confirmable`, which writes
+    `ask` to the URL and renders a question — never straight to `run`. A second
+    call site is how that guarantee gets bypassed by a later edit.
+    """
+    src = _view_source()
+    assert src.count('{ op: "resolve"') == 1
+    assert 'confirmable("resolve:" + proposal.path' in src
+    # And the one call site sits inside the confirmation bar's continuation.
+    bar = src.index("function resolveConfirmBar()")
+    after = src.index("\n}", src.index("return confirmBar(", bar))
+    assert bar < src.index('{ op: "resolve"') < after
+    # `pendingConfirm` must NOT also render this question (two Yes buttons for one
+    # proposal, one of them in a list section far from the text it writes).
+    assert 'if (op === "resolve") {\n    /*' in src
+    assert src.count('confirmBar(\n    "Overwrite ') == 1
+
+
+def test_view_handles_every_ai_rejection_code():
+    """`fused.ai` rejects with these `.type`s; an unhandled one falls through to
+    a message that names the code at the user instead of explaining it."""
+    src = _view_source()
+    for code in ("ai_unavailable", "model_loading", "unavailable",
+                 "cancelled", "timeout", "bad_request"):
+        assert '"' + code + '"' in src, code
+
+
+def test_view_offers_the_button_only_on_a_conflicted_row():
+    src = _view_source()
+    assert "if (change.conflicted) {" in src
+    assert "resolveButton(path," in src
+
+
+def test_resolve_never_stages_or_commits(ops):
+    """ops.py's resolve path runs exactly one git command, and it is a READ."""
+    import inspect
+
+    body = inspect.getsource(ops._resolve)
+    for forbidden in ('"add"', '"commit"', '"checkout"', '"merge"', '"restore"'):
+        assert forbidden not in body, forbidden
+    assert body.count("_git_ok(") == 1

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -877,7 +877,14 @@ def test_every_mutating_invocation_is_pinned_hardened_and_bounded(
     for argv, kwargs in seen:
         assert isinstance(argv, list), "argv list only — never a shell string"
         assert kwargs.get("shell") in (None, False)
-        assert argv[0] == "git"
+        # argv[0] is the ABSOLUTE path to git, not the bare name, and the
+        # absoluteness is required rather than cosmetic: CPython only reaches
+        # posix_spawn when os.path.dirname(executable) is truthy, and a fork in a
+        # process with libproj resident dies with SIGSEGV before exec (see
+        # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
+        # still no shell — which is what this assertion is really about.
+        assert os.path.isabs(argv[0])
+        assert os.path.basename(argv[0]) in ("git", "git.exe")
         assert "--no-pager" in argv
         # Exactly one invocation is pinned to the TARGET rather than the root:
         # the `--show-toplevel` bootstrap that discovers the root in the first

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -213,28 +213,265 @@ def test_a_signal_death_is_not_mistaken_for_a_missing_repo(monkeypatch, caplog,
 # this is pinned by test rather than by comment.
 
 
-def test_no_git_spawn_uses_a_bare_executable_name():
-    """A repo-wide sweep: nothing may spawn git by bare name.
+# ---------------------------------------------------------- the STATIC backstop
+#
+# The behavioural tests above only reach call sites a test can drive. The five
+# sites that shipped forking on this branch were NOT among them, and the first
+# version of this sweep passed anyway because it only looked at argv[0] — a
+# backstop that goes green while the bug is live is worse than no backstop, so
+# this one checks the whole rule.
+#
+# AST-based, and deliberately so. A regex over source lines misses the same
+# violation written multi-line, which is this repo's prevailing style (the git
+# gate's own call is wrapped across lines), and it cannot see a tuple argv or an
+# `executable=` kwarg at all.
+#
+# `**_popen_kwargs()`-style indirection is resolved by reading the helper's dict
+# literal out of the SAME file's AST — no import, so no module side effects. When
+# a spawn's kwargs cannot be determined statically the sweep FAILS rather than
+# skipping: "I could not check this" must never read as "this is fine", which is
+# precisely how five forking sites slipped through.
 
-    Deliberately a source sweep rather than per-site behaviour tests: these sites
-    need repos, remotes and app dirs to reach, and the property being protected —
-    argv[0] is resolved, not bare — is visible in the source and is the one that
-    silently un-fixes itself when someone adds a new call site by copy-paste.
+_SPAWNERS = {"run", "Popen", "call", "check_call", "check_output"}
+_GIT_NAMES = {"git", "git.exe"}
+
+
+def _is_git_argv(node):
+    """Whether this call's program is git, however argv[0] is spelled."""
+    import ast
+
+    def names_git(n):
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            return os.path.basename(n.value) in _GIT_NAMES
+        if isinstance(n, ast.Call):                     # _git_bin() / git_bin()
+            f = n.func
+            name = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", "")
+            if name in ("_git_bin", "git_bin"):
+                return True
+            if name == "which" and n.args:              # shutil.which("git")
+                return names_git(n.args[0])
+        if isinstance(n, ast.BoolOp):                   # which("git") or "git"
+            return any(names_git(v) for v in n.values)
+        return False
+
+    for kw in node.keywords:
+        if kw.arg == "executable" and names_git(kw.value):
+            return True
+    if not node.args:
+        return False
+    argv = node.args[0]
+    if isinstance(argv, (ast.List, ast.Tuple)) and argv.elts:
+        return names_git(argv.elts[0])
+    return names_git(argv)
+
+
+def _dict_literal_of(tree, name):
+    """The keys of a module-level `NAME = {...}` or `def NAME(): return {...}`.
+
+    Returns a dict of key -> ast node, or None when it is not a plain literal we
+    can read (which the caller must treat as a FAILURE, not a pass).
     """
+    import ast
+
+    def keys_of(d):
+        if not isinstance(d, ast.Dict):
+            return None
+        out = {}
+        for k, v in zip(d.keys, d.values):
+            if not (isinstance(k, ast.Constant) and isinstance(k.value, str)):
+                return None
+            out[k.value] = v
+        return out
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == name:
+                    return keys_of(node.value)
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            for sub in node.body:
+                if isinstance(sub, ast.Return):
+                    return keys_of(sub.value)
+    return None
+
+
+def _spawn_keywords(tree, node):
+    """(kwargs as key -> ast node, unresolved) for one spawn call."""
+    import ast
+
+    kwargs, unresolved = {}, []
+    for kw in node.keywords:
+        if kw.arg is not None:
+            kwargs[kw.arg] = kw.value
+            continue
+        # **something
+        target = kw.value
+        name = None
+        if isinstance(target, ast.Call):
+            f = target.func
+            name = f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", None)
+        elif isinstance(target, ast.Name):
+            name = target.id
+        merged = _dict_literal_of(tree, name) if name else None
+        if merged is None:
+            unresolved.append(name or "<expression>")
+        else:
+            kwargs.update(merged)
+    return kwargs, unresolved
+
+
+def _sources():
     import pathlib
-    import re
 
     root = pathlib.Path(__file__).resolve().parent.parent / "fused_render"
-    # argv lists whose first element is the literal string "git".
-    bare = re.compile(r"""\[\s*["']git["']\s*,""")
-    offenders = []
-    for py in root.rglob("*.py"):
-        for n, line in enumerate(py.read_text(errors="replace").splitlines(), 1):
-            if bare.search(line) and "# posix-spawn-exempt" not in line:
-                offenders.append(f"{py.relative_to(root)}:{n}: {line.strip()}")
-    assert not offenders, (
-        "these spawn git by bare name, so CPython forks and the child SIGSEGVs "
-        "before exec whenever libproj is resident:\n  " + "\n  ".join(offenders))
+    return root, sorted(root.rglob("*.py"))
+
+
+def test_every_git_spawn_in_the_repo_can_posix_spawn():
+    """The whole rule, statically, at every git spawn in the package.
+
+    Checks argv[0] is resolved AND `close_fds=False` AND no `cwd=` — the three
+    clauses that must hold together. Checking only the first is what let five
+    sites ship forking with a green suite.
+    """
+    import ast
+
+    root, files = _sources()
+    problems = []
+    for py in files:
+        try:
+            tree = ast.parse(py.read_text(errors="replace"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+                    and node.func.attr in _SPAWNERS):
+                continue
+            if not _is_git_argv(node):
+                continue
+            where = f"{py.relative_to(root)}:{node.lineno}"
+            kwargs, unresolved = _spawn_keywords(tree, node)
+            if unresolved:
+                problems.append(
+                    f"{where}: cannot determine spawn kwargs (**{', **'.join(unresolved)}"
+                    ") — make the helper a plain dict literal in this file so this "
+                    "check can read it, rather than leaving the site unverifiable")
+                continue
+
+            # argv[0] must be resolved, not a bare name.
+            argv = node.args[0] if node.args else None
+            if isinstance(argv, (ast.List, ast.Tuple)) and argv.elts:
+                first = argv.elts[0]
+                if isinstance(first, ast.Constant) and not os.path.dirname(first.value):
+                    problems.append(f"{where}: argv[0] is the bare name "
+                                    f"{first.value!r} — CPython forks")
+
+            cf = kwargs.get("close_fds")
+            if cf is None:
+                problems.append(f"{where}: no close_fds — defaults to True, so "
+                                "CPython forks and the child SIGSEGVs before exec")
+            elif not (isinstance(cf, ast.Constant) and cf.value is False):
+                problems.append(f"{where}: close_fds is not the literal False")
+
+            cwd = kwargs.get("cwd")
+            if cwd is not None and not (isinstance(cwd, ast.Constant)
+                                        and cwd.value is None):
+                problems.append(f"{where}: passes cwd=, which forces the fork "
+                                "path on its own — use `-C <root>` instead")
+
+            for forcer in ("preexec_fn", "pass_fds", "start_new_session"):
+                val = kwargs.get(forcer)
+                if val is not None and not (isinstance(val, ast.Constant)
+                                            and not val.value):
+                    problems.append(f"{where}: {forcer}= forces the fork path")
+
+    assert not problems, (
+        f"{len(problems)} git spawn(s) would fork, and a fork in a process with "
+        "libproj resident dies with SIGSEGV before exec:\n  "
+        + "\n  ".join(problems))
+
+
+def test_the_sweep_actually_catches_each_violation(tmp_path):
+    """The backstop's own regression test.
+
+    A sweep that cannot fail is not a backstop, and this branch shipped one that
+    could not. So the detector is pointed at deliberately broken sources —
+    including the multi-line and tuple spellings the old regex missed — and must
+    object to every one.
+    """
+    import ast
+
+    bad = [
+        # multi-line argv: the spelling the regex version could not see
+        'subprocess.run(\n    ["git", "-C", root,\n     "status"],\n'
+        '    close_fds=False)',
+        # tuple argv
+        'subprocess.run(("git", "status"), close_fds=False)',
+        # absolute argv but no close_fds
+        'subprocess.run([_git_bin(), "status"])',
+        # absolute argv, close_fds ok, but cwd passed
+        'subprocess.run([_git_bin(), "status"], close_fds=False, cwd=root)',
+        # kwargs hidden behind an unreadable helper
+        'subprocess.run([_git_bin(), "status"], **make_kwargs(root))',
+        # executable= spelling
+        'subprocess.run(["x"], executable="git", close_fds=False)',
+    ]
+    for src in bad:
+        tree = ast.parse(src)
+        call = next(n for n in ast.walk(tree)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and n.func.attr in _SPAWNERS)
+        assert _is_git_argv(call), f"not recognised as a git spawn:\n{src}"
+        kwargs, unresolved = _spawn_keywords(tree, call)
+        argv = call.args[0] if call.args else None
+        bare = (isinstance(argv, (ast.List, ast.Tuple)) and argv.elts
+                and isinstance(argv.elts[0], ast.Constant)
+                and not os.path.dirname(argv.elts[0].value))
+        cf = kwargs.get("close_fds")
+        bad_cf = cf is None or not (isinstance(cf, ast.Constant) and cf.value is False)
+        cwd = kwargs.get("cwd")
+        bad_cwd = cwd is not None and not (isinstance(cwd, ast.Constant)
+                                          and cwd.value is None)
+        assert unresolved or bare or bad_cf or bad_cwd, (
+            f"the sweep would have PASSED this:\n{src}")
+
+    # …and must not object to the correct form.
+    good = 'subprocess.run([_git_bin(), "-C", root, "status"], close_fds=False)'
+    tree = ast.parse(good)
+    call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call))
+    kwargs, unresolved = _spawn_keywords(tree, call)
+    assert not unresolved
+    assert isinstance(kwargs["close_fds"], ast.Constant)
+    assert kwargs["close_fds"].value is False
+    assert "cwd" not in kwargs
+
+
+def test_the_sweep_resolves_a_kwargs_helper():
+    """`**_popen_kwargs()` must be READ, not waved through — four modules use it,
+    and that indirection is where the missed sites hid their missing close_fds."""
+    import ast
+
+    src = (
+        'def _popen_kwargs():\n'
+        '    return {"stdin": subprocess.DEVNULL, "close_fds": False}\n'
+        'subprocess.run([_git_bin(), "status"], **_popen_kwargs())\n')
+    tree = ast.parse(src)
+    call = next(n for n in ast.walk(tree)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                and n.func.attr == "run")
+    kwargs, unresolved = _spawn_keywords(tree, call)
+    assert not unresolved, unresolved
+    assert kwargs["close_fds"].value is False
+
+    # The same helper WITHOUT close_fds must be caught, not merged silently.
+    src_bad = src.replace(', "close_fds": False', "")
+    tree_bad = ast.parse(src_bad)
+    call_bad = next(n for n in ast.walk(tree_bad)
+                    if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                    and n.func.attr == "run")
+    kwargs_bad, unresolved_bad = _spawn_keywords(tree_bad, call_bad)
+    assert not unresolved_bad
+    assert "close_fds" not in kwargs_bad
 
 
 def test_git_bin_is_absolute_and_cached():

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -1,0 +1,197 @@
+"""Every git subprocess must reach `posix_spawn`, never `fork()`.
+
+THE ROOT CAUSE of "the Git side panel is disabled for every repository".
+
+With `libproj` resident in the server process — and it becomes resident the
+moment any map / geotiff / zarr template or daemon imports rasterio or pyproj —
+a plain `fork()` runs PROJ's `pthread_atfork` child handler, which SIGSEGVs
+*before* `exec`. The child dies with signal 11, so:
+
+    returncode == -11,  stdout == b"",  stderr == b""
+
+No exception is raised, because the spawn itself succeeded. Every git call site
+in the app fails CLOSED on that: `/api/fs/conditions` reports `"git": false`,
+`/api/fs/git-repo` reports `is_repo_root: false` for a real root, and
+`/api/fs/list` stops dimming `.git`. All of it silent, all of it for every
+repository at once, and all of it indistinguishable from "not a repository" —
+which is exactly how it presented, and why it was mis-diagnosed twice.
+
+Measured in the live server:
+
+    WARNING fused_render.templates.git.condition: the git mode is being hidden
+    for /Users/iamsdas/Documents/Fused and it looks wrong: git exited -11 saying
+    '(nothing)'
+
+`close_fds=False` was believed to be the fix, and three of these modules already
+passed it with a comment saying so. **It is necessary and NOT sufficient.**
+CPython takes the posix_spawn path only when ALL of these hold
+(`subprocess.py::_execute_child`):
+
+    _USE_POSIX_SPAWN and os.path.dirname(executable) and preexec_fn is None
+    and not close_fds and not pass_fds and cwd is None and ... and umask < 0
+
+Two of those were being violated everywhere:
+
+  * `os.path.dirname(executable)` — the argv started with the BARE NAME `"git"`,
+    whose dirname is `""`. Falsy. So every call forked, `close_fds=False` or not.
+  * `cwd is None` — the template gate passed `cwd=<the directory>`, which forces
+    fork on its own even with an absolute executable.
+
+So the rule this file pins is the whole rule, not the half of it that reads
+plausibly: an ABSOLUTE git path, `close_fds=False`, and no `cwd=` (git already
+gets `-C`). It is pinned as a BEHAVIOUR — the recorded kwargs are run through
+CPython's own condition — rather than as a grep, so it cannot pass by accident.
+"""
+import importlib.util
+import os
+import subprocess
+
+import pytest
+
+_TPL = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "git")
+
+
+def assert_posix_spawnable(argv, kwargs, where):
+    """CPython's own preconditions for taking the posix_spawn path.
+
+    Mirrors `subprocess.py::_execute_child`'s condition, minus the parts no
+    caller here sets (uid/gid/umask/process_group). A violation means this call
+    forks — and a fork in a process with libproj resident dies with SIGSEGV
+    before it ever execs git.
+    """
+    executable = argv[0]
+    assert os.path.dirname(executable), (
+        f"{where}: argv[0] is {executable!r} — a bare name has no dirname, so "
+        "CPython forks instead of posix_spawn'ing. Resolve git to an absolute "
+        "path.")
+    assert os.path.isabs(executable), f"{where}: {executable!r} is not absolute"
+    assert kwargs.get("close_fds") is False, (
+        f"{where}: close_fds must be explicitly False to reach posix_spawn")
+    assert kwargs.get("cwd") is None, (
+        f"{where}: cwd={kwargs.get('cwd')!r} forces the fork path on its own — "
+        "git already takes -C, so pass no cwd")
+    assert kwargs.get("preexec_fn") is None, f"{where}: preexec_fn forces fork"
+    assert not kwargs.get("pass_fds"), f"{where}: pass_fds forces fork"
+    assert not kwargs.get("start_new_session"), (
+        f"{where}: start_new_session forces fork")
+
+
+@pytest.fixture
+def recorder(monkeypatch):
+    """Capture every subprocess spawn without running one."""
+    calls = []
+
+    class _Fake:
+        returncode = 0
+        stdout = b""
+        stderr = b""
+
+        def __init__(self):
+            self.stdin = None
+
+        def communicate(self, *a, **k):
+            return b"", b""
+
+    def record(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _Fake()
+
+    monkeypatch.setattr(subprocess, "run", record)
+    monkeypatch.setattr(subprocess, "Popen", record)
+    return calls
+
+
+# ------------------------------------------------------- the server-side sites
+
+
+def test_repo_toplevel_reaches_posix_spawn(recorder, tmp_path):
+    from fused_render.server import gitignore
+
+    gitignore._repo_toplevel(str(tmp_path))
+    assert recorder, "no git call was recorded"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "gitignore._repo_toplevel")
+
+
+def test_git_ignored_reaches_posix_spawn(recorder, tmp_path):
+    from fused_render.server import gitignore
+
+    gitignore._git_ignored(str(tmp_path), ["a", "b"])
+    assert recorder, "no git call was recorded"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "gitignore._git_ignored")
+
+
+def test_ignore_oracle_reaches_posix_spawn(recorder, tmp_path):
+    from fused_render.server import gitignore
+
+    (tmp_path / ".git").mkdir()          # a real repo: no empty-GIT_DIR graft
+    gitignore._IgnoreOracle(str(tmp_path))
+    assert recorder, "no git call was recorded"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "gitignore._IgnoreOracle")
+
+
+# ----------------------------------------------------- the git template's own
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_TPL, filename))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_the_gate_reaches_posix_spawn(recorder, tmp_path):
+    """The gate is the surface the user hit: it decides `"git": false`."""
+    gate = _load("git_condition_spawn", "condition.py")
+    gate.main(str(tmp_path))
+    assert recorder, "the gate made no git call"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "templates/git/condition.py")
+
+
+def test_the_reader_reaches_posix_spawn(recorder, tmp_path):
+    reader = _load("git_log_spawn", "log.py")
+    reader.main(file=str(tmp_path))
+    assert recorder, "the reader made no git call"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "templates/git/log.py")
+
+
+def test_the_writer_reaches_posix_spawn(recorder, tmp_path):
+    ops = _load("git_ops_spawn", "ops.py")
+    ops.main(file=str(tmp_path), op="fetch")
+    assert recorder, "the writer made no git call"
+    for argv, kwargs in recorder:
+        assert_posix_spawnable(argv, kwargs, "templates/git/ops.py")
+
+
+# ------------------------------------------------------------- the real thing
+
+
+def test_a_signal_death_is_not_mistaken_for_a_missing_repo(monkeypatch, caplog,
+                                                           tmp_path):
+    """The symptom, reproduced exactly: rc -11, no output, no exception.
+
+    It must still fail closed (it is not a repo answer we can trust), and it must
+    now be LOUD — a silent -11 is what cost two investigations.
+    """
+    from fused_render.server import gitignore
+
+    (tmp_path / ".git").mkdir()
+    gitignore._reset_spawn_failure_throttle()
+
+    class _Segv:
+        returncode = -11
+        stdout = b""
+        stderr = b""
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _Segv())
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is False
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "-11" in joined, "a SIGSEGV'd git was reported without its exit status"

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -195,3 +195,54 @@ def test_a_signal_death_is_not_mistaken_for_a_missing_repo(monkeypatch, caplog,
         assert gitignore._is_repo_root(str(tmp_path)) is False
     joined = " ".join(r.getMessage() for r in caplog.records)
     assert "-11" in joined, "a SIGSEGV'd git was reported without its exit status"
+
+
+# --------------------------------------------------- every OTHER git spawn too
+#
+# The same latent bug sat at eight more sites. Two of them matter directly to the
+# feature the user reported: `routers/git_show.py` renders a file as of a commit
+# (GT-17, reached from the same git view) and `server/fs_mutate.py` performs the
+# server's git writes. The rest — app_git, community, deeplink, claude_config,
+# the bundle reader, the claude agent — would fail the same silent way.
+#
+# `app_git.py`'s module docstring records this exact crash being diagnosed in
+# August ("every `git add` died rc=-11 with empty output") and being fixed with
+# `close_fds=False`. That fix could never have worked while argv[0] stayed the
+# bare name `"git"`: the posix_spawn path was still unreachable. It only LOOKED
+# fixed because it was validated in a process where libproj was not resident. So
+# this is pinned by test rather than by comment.
+
+
+def test_no_git_spawn_uses_a_bare_executable_name():
+    """A repo-wide sweep: nothing may spawn git by bare name.
+
+    Deliberately a source sweep rather than per-site behaviour tests: these sites
+    need repos, remotes and app dirs to reach, and the property being protected —
+    argv[0] is resolved, not bare — is visible in the source and is the one that
+    silently un-fixes itself when someone adds a new call site by copy-paste.
+    """
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parent.parent / "fused_render"
+    # argv lists whose first element is the literal string "git".
+    bare = re.compile(r"""\[\s*["']git["']\s*,""")
+    offenders = []
+    for py in root.rglob("*.py"):
+        for n, line in enumerate(py.read_text(errors="replace").splitlines(), 1):
+            if bare.search(line) and "# posix-spawn-exempt" not in line:
+                offenders.append(f"{py.relative_to(root)}:{n}: {line.strip()}")
+    assert not offenders, (
+        "these spawn git by bare name, so CPython forks and the child SIGSEGVs "
+        "before exec whenever libproj is resident:\n  " + "\n  ".join(offenders))
+
+
+def test_git_bin_is_absolute_and_cached():
+    from fused_render.server import gitignore
+
+    first = gitignore.git_bin()
+    assert os.path.isabs(first) or first == "git"   # "git" only with no PATH
+    assert gitignore.git_bin() is first             # cached, not re-resolved
+    if first != "git":
+        assert os.path.basename(first) in ("git", "git.exe")
+        assert os.access(first, os.X_OK)

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -320,6 +320,78 @@ def _spawn_keywords(tree, node):
     return kwargs, unresolved
 
 
+# An escape hatch for a spawn whose argv this sweep cannot read but a human HAS
+# read and confirmed is not git. Deliberately a comment on the call rather than a
+# list in this file: the justification belongs next to the code, and adding one is
+# a reviewable diff. Silence is what this whole file exists to prevent — an
+# exemption is not silence, it is a recorded decision.
+_EXEMPT = "posix-spawn-exempt"
+
+
+def _exempted(src_lines, node):
+    """Whether the spawn carries an `# posix-spawn-exempt: <why>` marker.
+
+    Searched across the call itself AND the whole comment block immediately above
+    it, walking up while the lines are comments or blank. A one-line window would
+    force the justification onto the same line as the code, where it cannot say
+    anything useful — and the justification is the point of the mechanism.
+    """
+    end = min(len(src_lines), (node.end_lineno or node.lineno))
+    start = node.lineno - 1
+    while start > 0:
+        above = src_lines[start - 1].strip()
+        if above.startswith("#") or not above:
+            start -= 1
+        else:
+            break
+    return any(_EXEMPT in line for line in src_lines[start:end])
+
+
+def _resolves_git(tree):
+    """Whether this file mentions git resolution at all (`_git_bin`/`git_bin`/
+    `which("git")`/a literal git path). Used only to decide whether an
+    UNRECOGNISABLE argv in this file deserves a complaint — a file with no git
+    anywhere is none of this sweep's business."""
+    import ast
+
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Name) and n.id in ("_git_bin", "git_bin", "_GIT_BIN"):
+            return True
+        if isinstance(n, ast.Attribute) and n.attr in ("_git_bin", "git_bin"):
+            return True
+        if isinstance(n, ast.Constant) and isinstance(n.value, str):
+            if os.path.basename(n.value) in _GIT_NAMES:
+                return True
+    return False
+
+
+def test_no_module_imports_a_spawner_by_bare_name():
+    """`from subprocess import run` would make every call above invisible.
+
+    The sweep matches `subprocess.run(...)` as an ATTRIBUTE call, so a bare
+    imported `run(...)` slips past the whole check. Measured today: zero
+    occurrences in the package. Pinned so it stays that way, because the failure
+    is silent — the sweep simply stops seeing the call site.
+    """
+    import ast
+
+    root, files = _sources()
+    offenders = []
+    for py in files:
+        try:
+            tree = ast.parse(py.read_text(errors="replace"))
+        except SyntaxError:
+            continue
+        for n in ast.walk(tree):
+            if isinstance(n, ast.ImportFrom) and n.module == "subprocess":
+                names = [a.name for a in n.names if a.name in _SPAWNERS]
+                if names:
+                    offenders.append(
+                        f"{py.relative_to(root)}:{n.lineno}: from subprocess "
+                        f"import {', '.join(names)} — invisible to the sweep")
+    assert not offenders, "\n  ".join(offenders)
+
+
 def _sources():
     import pathlib
 
@@ -339,15 +411,36 @@ def test_every_git_spawn_in_the_repo_can_posix_spawn():
     root, files = _sources()
     problems = []
     for py in files:
+        text = py.read_text(errors="replace")
         try:
-            tree = ast.parse(py.read_text(errors="replace"))
+            tree = ast.parse(text)
         except SyntaxError:
             continue
+        src_lines = text.splitlines()
         for node in ast.walk(tree):
             if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
                     and node.func.attr in _SPAWNERS):
                 continue
             if not _is_git_argv(node):
+                # RECOGNITION blind spot, closed here rather than left implicit.
+                # `_is_git_argv` can only see a literal argv; three spellings
+                # defeat it — argv assembled into a local VARIABLE, argv[0] from
+                # an f-string, and a tuple/name spread. In those cases the call
+                # is not recognised as a git spawn at all, so NONE of the three
+                # clauses gets checked: the "could not check reads as fine"
+                # failure, displaced from the kwargs up to the argv. Today no git
+                # spawn is written that way (measured: 17 variable-argv spawns in
+                # the package, none of them git), so flagging it in a file that
+                # resolves git AT ALL costs nothing and fails loudly the day
+                # someone writes one.
+                if (_resolves_git(tree) and node.args
+                        and isinstance(node.args[0], (ast.Name, ast.JoinedStr))
+                        and not _exempted(src_lines, node)):
+                    problems.append(
+                        f"{py.relative_to(root)}:{node.lineno}: argv is a "
+                        f"{type(node.args[0]).__name__}, so this sweep cannot see "
+                        "whether it is git — inline the argv list, or mark the "
+                        f"call `# {_EXEMPT}: <why>` once you have checked it")
                 continue
             where = f"{py.relative_to(root)}:{node.lineno}"
             kwargs, unresolved = _spawn_keywords(tree, node)
@@ -398,6 +491,16 @@ def test_the_sweep_actually_catches_each_violation(tmp_path):
     could not. So the detector is pointed at deliberately broken sources —
     including the multi-line and tuple spellings the old regex missed — and must
     object to every one.
+
+    DRIFT RISK, stated because it is real: the clause checks below are
+    re-implemented inline rather than shared with
+    test_every_git_spawn_in_the_repo_can_posix_spawn, so a bug in THAT test's
+    close_fds/cwd logic would not be caught here. They are kept separate on
+    purpose — sharing the code under test with the test that checks it is how a
+    detector comes to agree with itself and nothing else — and the pair was
+    mutation-tested to confirm it jointly covers the detector (a
+    `_dict_literal_of` mutation survives one of the two and is caught by its
+    sibling). If you change a clause in one, change it in the other.
     """
     import ast
 

--- a/tests/test_git_posix_spawn.py
+++ b/tests/test_git_posix_spawn.py
@@ -140,6 +140,10 @@ def test_ignore_oracle_reaches_posix_spawn(recorder, tmp_path):
 def _load(name, filename):
     spec = importlib.util.spec_from_file_location(
         name, os.path.join(_TPL, filename))
+    # Asserted, never ignored: a None spec or loader means the module did not
+    # load, so every assertion below would be checking a module that was never
+    # executed — a green test over nothing.
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
@@ -455,7 +459,11 @@ def test_every_git_spawn_in_the_repo_can_posix_spawn():
             argv = node.args[0] if node.args else None
             if isinstance(argv, (ast.List, ast.Tuple)) and argv.elts:
                 first = argv.elts[0]
-                if isinstance(first, ast.Constant) and not os.path.dirname(first.value):
+                # `isinstance(..., str)` is a real narrowing, not a type-checker
+                # appeasement: an ast.Constant holds any literal, and only a
+                # STRING argv[0] is a program name to test for a dirname.
+                if (isinstance(first, ast.Constant) and isinstance(first.value, str)
+                        and not os.path.dirname(first.value)):
                     problems.append(f"{where}: argv[0] is the bare name "
                                     f"{first.value!r} — CPython forks")
 
@@ -527,9 +535,10 @@ def test_the_sweep_actually_catches_each_violation(tmp_path):
         assert _is_git_argv(call), f"not recognised as a git spawn:\n{src}"
         kwargs, unresolved = _spawn_keywords(tree, call)
         argv = call.args[0] if call.args else None
-        bare = (isinstance(argv, (ast.List, ast.Tuple)) and argv.elts
-                and isinstance(argv.elts[0], ast.Constant)
-                and not os.path.dirname(argv.elts[0].value))
+        first = (argv.elts[0] if isinstance(argv, (ast.List, ast.Tuple)) and argv.elts
+                 else None)
+        bare = (isinstance(first, ast.Constant) and isinstance(first.value, str)
+                and not os.path.dirname(first.value))
         cf = kwargs.get("close_fds")
         bad_cf = cf is None or not (isinstance(cf, ast.Constant) and cf.value is False)
         cwd = kwargs.get("cwd")

--- a/tests/test_git_reader.py
+++ b/tests/test_git_reader.py
@@ -492,7 +492,14 @@ def test_every_invocation_is_pinned_hardened_and_bounded(reader, repo, monkeypat
     for argv, kwargs in seen:
         assert isinstance(argv, list), "argv list only — never a shell string"
         assert kwargs.get("shell") in (None, False)
-        assert argv[0] == "git"
+        # argv[0] is the ABSOLUTE path to git, not the bare name, and the
+        # absoluteness is required rather than cosmetic: CPython only reaches
+        # posix_spawn when os.path.dirname(executable) is truthy, and a fork in a
+        # process with libproj resident dies with SIGSEGV before exec (see
+        # tests/test_git_posix_spawn.py). Still exactly one basename, still a list,
+        # still no shell — which is what this assertion is really about.
+        assert os.path.isabs(argv[0])
+        assert os.path.basename(argv[0]) in ("git", "git.exe")
         assert "--no-pager" in argv
         assert "-C" in argv
         # Exactly one invocation is pinned to the TARGET rather than the root:

--- a/tests/test_git_spawn_diagnosable.py
+++ b/tests/test_git_spawn_diagnosable.py
@@ -244,6 +244,10 @@ _GATE_LOGGER = "fused_render.templates.git.condition"
 @pytest.fixture
 def gate():
     spec = importlib.util.spec_from_file_location("git_condition_diag", _GATE)
+    # Asserted, never ignored: a None spec or loader means the module did not
+    # load, so every assertion below would be checking a module that was never
+    # executed — a green test over nothing.
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     # The throttle rides on the persistent logger, so it survives between the
@@ -306,6 +310,7 @@ def test_gate_warning_is_throttled_across_re_execs(gate, caplog, tmp_path):
         with caplog.at_level("WARNING", logger=_GATE_LOGGER):
             for _ in range(20):
                 spec = importlib.util.spec_from_file_location("git_cond_re", _GATE)
+                assert spec is not None and spec.loader is not None
                 fresh = importlib.util.module_from_spec(spec)
                 spec.loader.exec_module(fresh)      # a new module object each time
                 fresh.main(str(tmp_path))

--- a/tests/test_git_spawn_diagnosable.py
+++ b/tests/test_git_spawn_diagnosable.py
@@ -1,0 +1,95 @@
+"""A git subprocess that cannot be RUN must leave evidence in the log.
+
+Every git call site in the app fails closed on purpose: `_is_repo_root` returns
+False, `_git_ignored` returns "nothing ignored", the check-ignore oracle marks
+itself broken, and the `git` template gate returns False. That posture is
+deliberate and stays exactly as it is.
+
+What was wrong is that it was also SILENT, and it conflated two very different
+answers:
+
+  * "git ran and said no"  — the ordinary negative, correctly quiet.
+  * "git could not be run" — a spawn failure (no binary, EMFILE/EAGAIN under
+    process-and-fd pressure) or a timeout. This one disables every git-backed
+    feature in the app at once, for every repository, and produced NOTHING in
+    the server log: `/api/fs/conditions` answered `"git": false` with no error
+    key, `/api/fs/git-repo` answered `is_repo_root: false` for a real root, and
+    `/api/fs/list` reported `.git` as not ignored — all indistinguishable from
+    "not a repo". Diagnosing it took a full investigation because the log was
+    empty.
+
+These tests pin the second case to a WARNING. They do NOT relax the fail-closed
+return values, which are asserted here too.
+"""
+import subprocess
+
+import pytest
+
+from fused_render.server import gitignore
+
+
+@pytest.fixture(autouse=True)
+def _reset_throttle():
+    """The warning is throttled per process; each test needs a clean slate."""
+    gitignore._reset_spawn_failure_throttle()
+    yield
+    gitignore._reset_spawn_failure_throttle()
+
+
+def _raise(exc):
+    def _run(*a, **k):
+        raise exc
+    return _run
+
+
+@pytest.mark.parametrize("exc", [
+    FileNotFoundError(2, "No such file or directory: 'git'"),
+    OSError(24, "Too many open files"),
+    OSError(35, "Resource temporarily unavailable"),
+    subprocess.TimeoutExpired("git", 5),
+])
+def test_repo_toplevel_logs_when_git_cannot_run(monkeypatch, caplog, tmp_path, exc):
+    monkeypatch.setattr(gitignore.subprocess, "run", _raise(exc))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._repo_toplevel(str(tmp_path)) is None      # still fails closed
+        assert gitignore._is_repo_root(str(tmp_path)) is False      # still fails closed
+    assert any("git" in r.message for r in caplog.records), \
+        "a git subprocess that could not run left no trace in the log"
+
+
+def test_git_ignored_logs_when_git_cannot_run(monkeypatch, caplog, tmp_path):
+    monkeypatch.setattr(gitignore.subprocess, "run",
+                        _raise(OSError(24, "Too many open files")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._git_ignored(str(tmp_path), [".git", "build"]) == set()
+    assert caplog.records, "a check-ignore spawn failure left no trace in the log"
+
+
+def test_oracle_logs_when_git_cannot_run(monkeypatch, caplog, tmp_path):
+    (tmp_path / ".git").mkdir()  # look like a real repo so no empty-GIT_DIR graft
+    monkeypatch.setattr(gitignore.subprocess, "Popen",
+                        _raise(OSError(35, "Resource temporarily unavailable")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        oracle = gitignore._IgnoreOracle(str(tmp_path))
+    assert oracle.broken is True                                     # fails closed
+    assert oracle.ignored(["build"]) == set()
+    assert caplog.records, "an oracle spawn failure left no trace in the log"
+
+
+def test_ordinary_negative_stays_quiet(caplog, tmp_path):
+    """A directory that is genuinely not a repo must not warn — otherwise the
+    log fills up on every folder the user opens and the real signal is lost."""
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        gitignore._is_repo_root(str(tmp_path))
+    assert not caplog.records
+
+
+def test_warning_is_throttled(monkeypatch, caplog, tmp_path):
+    """The gate runs on every directory the user opens, so a broken git must not
+    emit one warning per stat."""
+    monkeypatch.setattr(gitignore.subprocess, "run",
+                        _raise(OSError(24, "Too many open files")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        for _ in range(50):
+            gitignore._repo_toplevel(str(tmp_path))
+    assert len(caplog.records) == 1, "the git-spawn warning is not throttled"

--- a/tests/test_git_spawn_diagnosable.py
+++ b/tests/test_git_spawn_diagnosable.py
@@ -21,6 +21,7 @@ answers:
 These tests pin the second case to a WARNING. They do NOT relax the fail-closed
 return values, which are asserted here too.
 """
+import os
 import subprocess
 
 import pytest
@@ -93,3 +94,219 @@ def test_warning_is_throttled(monkeypatch, caplog, tmp_path):
         for _ in range(50):
             gitignore._repo_toplevel(str(tmp_path))
     assert len(caplog.records) == 1, "the git-spawn warning is not throttled"
+
+
+# ---------------------------------------------------------------- git RAN and
+# ---------------------------------------------------------------- said no
+#
+# The second, harder half — and the one that let a real investigation reach the
+# wrong conclusion. A `git` that is spawned fine and answers in the NEGATIVE is
+# indistinguishable from "not a repository", and every call site here threw
+# git's stderr away (`stderr=DEVNULL`), so there was nothing to read. The
+# absence of a "could not be run" warning was then taken as proof that git was
+# healthy, when in fact git had run and refused.
+#
+# Two negative shapes have to be visible, because they have different causes:
+#
+#   * a non-zero exit whose stderr is NOT the ordinary "not a git repository" —
+#     `detected dubious ownership`, a bad config, an unreadable object store, a
+#     cwd that has been deleted under the process.
+#   * exit ZERO with a negative ANSWER — which is what a polluted `GIT_DIR` /
+#     `GIT_WORK_TREE` / `GIT_CEILING_DIRECTORIES` in the server process
+#     produces. No stderr at all, so stderr capture alone would not explain it;
+#     the inherited git environment has to be in the report.
+#
+# What must stay silent is the ordinary negative: a folder that is genuinely not
+# a repository, which is most folders a user opens.
+
+
+class _Proc:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _returns(proc):
+    def _run(*a, **k):
+        return proc
+    return _run
+
+
+def test_abnormal_nonzero_exit_is_reported_with_gits_own_words(
+        monkeypatch, caplog, tmp_path):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+        returncode=128,
+        stderr=b"fatal: detected dubious ownership in repository at '/x'\n")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is False   # still fails closed
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "dubious ownership" in joined, \
+        "git's own complaint was thrown away instead of logged"
+
+
+def test_ordinary_not_a_repository_stays_silent(monkeypatch, caplog, tmp_path):
+    """Most folders a user opens are not repositories. Warning on that buries
+    the signal this whole mechanism exists to produce."""
+    monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+        returncode=128,
+        stderr=b"fatal: not a git repository (or any of the parent directories): .git\n")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is False
+    assert not caplog.records
+
+
+def test_a_zero_exit_negative_on_a_dot_git_path_is_reported(
+        monkeypatch, caplog, tmp_path):
+    """git exited 0 and pointed somewhere else — the shape a polluted GIT_DIR
+    produces. There is no stderr to read, so the report has to carry the
+    inherited git environment instead."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+        returncode=0, stdout=b"/somewhere/else\n")))
+    monkeypatch.setenv("GIT_DIR", "/tmp/stray/.git")
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is False
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "GIT_DIR" in joined, "the inherited git environment was not reported"
+    assert "/tmp/stray/.git" in joined
+
+
+def test_a_plain_directory_with_no_dot_git_stays_silent(
+        monkeypatch, caplog, tmp_path):
+    """The contradiction is "git says no but a .git is right there". Without the
+    .git there is no contradiction, and a subdirectory of a repo legitimately
+    reports a different toplevel — that is what _is_repo_root is FOR."""
+    monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+        returncode=0, stdout=b"/somewhere/else\n")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is False
+    assert not caplog.records
+
+
+def test_a_real_repo_root_never_warns(caplog, tmp_path):
+    """The happy path, against real git: no warning, and the right answer."""
+    import subprocess as sp
+    if sp.run(["git", "init", "-q", str(tmp_path)],
+              stdout=sp.DEVNULL, stderr=sp.DEVNULL).returncode != 0:
+        pytest.skip("git init failed")
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        assert gitignore._is_repo_root(str(tmp_path)) is True
+    assert not caplog.records
+
+
+def test_refusal_warning_is_throttled(monkeypatch, caplog, tmp_path):
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+        returncode=128, stderr=b"fatal: detected dubious ownership\n")))
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        for _ in range(50):
+            gitignore._is_repo_root(str(tmp_path))
+    assert len(caplog.records) == 1
+
+
+def test_spawn_and_refusal_throttles_are_independent(monkeypatch, caplog, tmp_path):
+    """A storm of one kind must not hide the first of the other kind — they have
+    different causes and different fixes."""
+    (tmp_path / ".git").mkdir()
+    with caplog.at_level("WARNING", logger="fused_render.server.gitignore"):
+        monkeypatch.setattr(gitignore.subprocess, "run", _returns(_Proc(
+            returncode=128, stderr=b"fatal: detected dubious ownership\n")))
+        gitignore._is_repo_root(str(tmp_path))
+        monkeypatch.setattr(gitignore.subprocess, "run",
+                            _raise(OSError(24, "Too many open files")))
+        gitignore._is_repo_root(str(tmp_path))
+    assert len(caplog.records) == 2
+
+
+# ----------------------------------------------------------------- the GATE
+#
+# `templates/git/condition.py` is the surface the USER hit: it is what makes
+# /api/fs/conditions answer `"git": false`, which is what disables the Git side
+# panel. It had the same blind spot as the package sites above, plus one of its
+# own — `server.templates._run_condition` re-execs the module on every stat, so
+# it cannot hold a throttle in a module global. The throttle therefore lives on
+# the persistent `logging.Logger` object, which the logging manager caches for
+# the life of the process. Still stdlib-only; the template imports no
+# fused_render (SPEC PY-15).
+
+import importlib.util
+import logging
+from unittest import mock
+
+_GATE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "templates", "git", "condition.py")
+_GATE_LOGGER = "fused_render.templates.git.condition"
+
+
+@pytest.fixture
+def gate():
+    spec = importlib.util.spec_from_file_location("git_condition_diag", _GATE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    # The throttle rides on the persistent logger, so it survives between the
+    # re-execs this fixture simulates — and has to be cleared per test.
+    for attr in list(vars(logging.getLogger(_GATE_LOGGER))):
+        if attr.startswith("_fused_warned_"):
+            delattr(logging.getLogger(_GATE_LOGGER), attr)
+    return mod
+
+
+def test_gate_reports_a_refusal_with_gits_words(gate, caplog, tmp_path):
+    (tmp_path / ".git").mkdir()
+    proc = _Proc(returncode=128,
+                 stderr=b"fatal: detected dubious ownership in repository\n")
+    with mock.patch.object(subprocess, "run", return_value=proc):
+        with caplog.at_level("WARNING", logger=_GATE_LOGGER):
+            assert gate.main(str(tmp_path)) is False        # still fails closed
+    assert "dubious ownership" in " ".join(r.getMessage() for r in caplog.records)
+
+
+def test_gate_reports_a_zero_exit_negative_on_a_repo(gate, caplog, tmp_path,
+                                                     monkeypatch):
+    """The exact shape the user saw: git exits 0, prints `false`, and the panel
+    goes away. No stderr, so the environment is the report."""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setenv("GIT_DIR", "/tmp/stray/.git")
+    with mock.patch.object(subprocess, "run",
+                           return_value=_Proc(returncode=0, stdout=b"false\n")):
+        with caplog.at_level("WARNING", logger=_GATE_LOGGER):
+            assert gate.main(str(tmp_path)) is False
+    joined = " ".join(r.getMessage() for r in caplog.records)
+    assert "GIT_DIR" in joined and "/tmp/stray/.git" in joined
+
+
+def test_gate_stays_silent_on_an_ordinary_non_repo(gate, caplog, tmp_path):
+    proc = _Proc(returncode=128,
+                 stderr=b"fatal: not a git repository (or any parent): .git\n")
+    with mock.patch.object(subprocess, "run", return_value=proc):
+        with caplog.at_level("WARNING", logger=_GATE_LOGGER):
+            assert gate.main(str(tmp_path)) is False
+    assert not caplog.records
+
+
+def test_gate_stays_silent_on_a_real_repo(gate, caplog, tmp_path):
+    if subprocess.run(["git", "init", "-q", str(tmp_path)],
+                      stdout=subprocess.DEVNULL,
+                      stderr=subprocess.DEVNULL).returncode != 0:
+        pytest.skip("git init failed")
+    with caplog.at_level("WARNING", logger=_GATE_LOGGER):
+        assert gate.main(str(tmp_path)) is True
+    assert not caplog.records
+
+
+def test_gate_warning_is_throttled_across_re_execs(gate, caplog, tmp_path):
+    """The gate is re-exec'd per stat, so a module-global throttle would reset
+    every call and write one line per directory the user opens."""
+    (tmp_path / ".git").mkdir()
+    proc = _Proc(returncode=128, stderr=b"fatal: detected dubious ownership\n")
+    with mock.patch.object(subprocess, "run", return_value=proc):
+        with caplog.at_level("WARNING", logger=_GATE_LOGGER):
+            for _ in range(20):
+                spec = importlib.util.spec_from_file_location("git_cond_re", _GATE)
+                fresh = importlib.util.module_from_spec(spec)
+                spec.loader.exec_module(fresh)      # a new module object each time
+                fresh.main(str(tmp_path))
+    assert len(caplog.records) == 1

--- a/tests/test_git_view_renders.py
+++ b/tests/test_git_view_renders.py
@@ -54,6 +54,11 @@ pytestmark = pytest.mark.skipif(not git_available(), reason="git binary not inst
 @pytest.fixture(scope="module")
 def reader():
     spec = importlib.util.spec_from_file_location("git_log_render", READER)
+    # Asserted rather than ignored or cast: a None spec/loader means log.py did
+    # not load, and every payload below would then be built from a module that
+    # was never executed — the unverifiable-reads-as-fine shape this whole file
+    # exists to prevent. Same guard as test_git_reader.py's loader.
+    assert spec is not None and spec.loader is not None
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod

--- a/tests/test_git_view_renders.py
+++ b/tests/test_git_view_renders.py
@@ -1,0 +1,222 @@
+"""The git view must actually PAINT — asserted by running its real script.
+
+This closes the last hole this branch went through. Everything else the suite has
+looked at the template's SOURCE: the channel contract, the DESTRUCTIVE mirror, the
+single `op: "resolve"` call site. All of that passes on a template that renders a
+blank page, and one really did: while the "Resolve with AI" work was mid-edit the
+working tree briefly carried two `let streamed` declarations, and because
+templates are served LIVE from the working tree (FUSED_RENDER_CORE_TEMPLATES) the
+full-page git view was a blank document for anyone who loaded it in that window.
+The call log recorded it exactly once:
+
+    kind=page-error  SyntaxError: Cannot declare a let variable twice: 'streamed'
+
+Nothing else could see it:
+
+  * `node --check` on the extracted script — passes. It is a REDECLARATION across
+    the script's top-level lexical scope, which V8 reports at evaluation, and in
+    any case the tree was fixed before it was ever committed, so a source check
+    on HEAD proves nothing about what the server was serving.
+  * `window.onerror` — silent for the OTHER shape of this failure. `draw()` is
+    async, so a throw inside `render()` becomes an unhandled REJECTION, which the
+    page-error hook does not observe: the page calls Python, gets good data,
+    records no error, and paints nothing.
+  * the source-contract tests — all green, because the source reads correctly.
+
+So the only thing that catches "renders blank" is rendering it. The probe
+(`_git_view_probe.mjs`) runs the template's own `<script>` verbatim against a DOM
+stub — the `_DOM_STUB` pattern from test_annotate_revert.py, sized up — with a
+`fused` stub that answers `runPython` from a REAL log.py payload. No copy of the
+view's logic lives in the harness; if the script throws, or finishes without
+filling `#view`, the test fails and says so.
+
+Both states are covered, because the conflicted one is the whole point of the
+feature and it takes a different path through `changeLine`/`resolveButton`.
+"""
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from _git_repo import git, git_available
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEMPLATE = os.path.join(ROOT, "fused_render", "templates", "git", "template.html")
+READER = os.path.join(ROOT, "fused_render", "templates", "git", "log.py")
+PROBE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "_git_view_probe.mjs")
+
+pytestmark = pytest.mark.skipif(not git_available(), reason="git binary not installed")
+
+
+@pytest.fixture(scope="module")
+def reader():
+    spec = importlib.util.spec_from_file_location("git_log_render", READER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _put(root, rel, text):
+    full = os.path.join(root, *rel.split("/"))
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w") as fh:
+        fh.write(text)
+
+
+def clean_repo(root):
+    os.makedirs(root, exist_ok=True)
+    git(root, "init", "-q", root)
+    _put(root, "README.md", "# hi\n")
+    _put(root, "pkg/mod.py", "one\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "first")
+    _put(root, "pkg/mod.py", "one\ntwo\n")       # an unstaged change to list
+    _put(root, "extra.txt", "untracked\n")       # and an untracked one
+    return root
+
+
+def conflicted_repo(root):
+    os.makedirs(root, exist_ok=True)
+    git(root, "init", "-q", root)
+    _put(root, "mod.py", "one\ntwo\nthree\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "base")
+    git(root, "branch", "other")
+    _put(root, "mod.py", "one\nOURS\nthree\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "ours")
+    git(root, "checkout", "-q", "other")
+    _put(root, "mod.py", "one\nTHEIRS\nthree\n")
+    git(root, "add", "-A")
+    git(root, "commit", "-qm", "theirs")
+    git(root, "checkout", "-q", "-")
+    git(root, "merge", "other", check=False)      # conflicts on purpose
+    return root
+
+
+def render(reader, repo, tmp_path, params=None):
+    """Run the template's script against `repo`'s real reader payloads."""
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - node is present on CI runners
+        pytest.skip("node is required to run the git view")
+    payloads = {
+        "overview": reader.main(file=repo, op="overview"),
+        "stashes": reader.main(file=repo, op="stashes"),
+        "conflicts": reader.main(file=repo, op="conflicts"),
+    }
+    assert payloads["overview"]["ok"] is True, payloads["overview"]
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({
+        "params": dict({"_file": repo}, **(params or {})),
+        "payloads": payloads,
+    }))
+    proc = subprocess.run([node, PROBE, TEMPLATE, str(fixture)],
+                          capture_output=True, text=True, timeout=90)
+    assert proc.returncode == 0, f"probe crashed:\n{proc.stderr[-3000:]}"
+    return json.loads(proc.stdout)
+
+
+def _assert_painted(out, what):
+    assert out["error"] is None, f"{what}: the template's script threw:\n{out['error']}"
+    assert not out["unhandled"], (
+        f"{what}: an unhandled promise rejection — this is the shape "
+        f"window.onerror never sees:\n" + "\n".join(out["unhandled"]))
+    assert out["painted"], (
+        f"{what}: the script ran without error and left #view EMPTY — a blank "
+        f"page. calls={out['calls']}")
+
+
+def test_a_clean_repo_paints(reader, tmp_path):
+    out = render(reader, clean_repo(str(tmp_path / "clean")), tmp_path)
+    _assert_painted(out, "clean repo")
+    # Not just "some node" — the things the view exists to show.
+    text = out["viewText"]
+    assert "Commit" in text or "Changes" in text, text
+    assert out["skeletonHidden"] is True, "the loading skeleton was never hidden"
+
+
+def test_a_conflicted_repo_paints(reader, tmp_path):
+    """The feature's own state. `changeLine` takes the `change.conflicted` branch
+    here and builds `resolveButton`, which the clean case never reaches."""
+    out = render(reader, conflicted_repo(str(tmp_path / "conflicted")), tmp_path)
+    _assert_painted(out, "conflicted repo")
+    assert "mod.py" in out["viewText"], out["viewText"]
+
+
+def test_the_view_reads_the_reader_on_distinct_channels(reader, tmp_path):
+    """Both reads happen, which is what proves the render got real data rather
+    than painting an empty state (see test_git_view.py for the channel rule)."""
+    out = render(reader, clean_repo(str(tmp_path / "chan")), tmp_path)
+    ops = [c["op"] for c in out["calls"]]
+    assert "overview" in ops and "stashes" in ops, ops
+
+
+def test_the_probe_fails_on_a_template_that_throws(reader, tmp_path):
+    """The harness's own regression test.
+
+    A render check that cannot fail is worth nothing — that is the lesson this
+    file exists to encode — so the probe is pointed at a deliberately broken copy
+    of the real template and must report the throw instead of a clean paint.
+    """
+    broken = tmp_path / "broken.html"
+    src = open(TEMPLATE, encoding="utf-8").read()
+    # The exact failure that shipped: a second top-level `let streamed`.
+    src = src.replace("let streamed = \"\";",
+                      "let streamed = \"\";\nlet streamed = \"\";", 1)
+    broken.write_text(src)
+
+    payloads = {"overview": reader.main(file=str(tmp_path), op="overview")}
+    fixture = tmp_path / "f.json"
+    fixture.write_text(json.dumps({"params": {"_file": str(tmp_path)},
+                                   "payloads": payloads}))
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node is required")
+    proc = subprocess.run([node, PROBE, str(broken), str(fixture)],
+                          capture_output=True, text=True, timeout=90)
+    out = json.loads(proc.stdout)
+    assert out["error"] is not None, "the probe did not notice a duplicate `let`"
+    assert "streamed" in out["error"], out["error"]
+    assert out["painted"] is False
+
+
+def test_the_probe_fails_on_a_template_that_paints_nothing(reader, tmp_path):
+    """The insidious shape: no error at all, and an empty page.
+
+    A throw is the easy case. The one that actually reached a reviewer's browser
+    on this feature's sibling path is a script that runs clean, calls Python, gets
+    good data — and paints nothing, because the failure happened after an `await`
+    where nothing is watching. `painted` is the assertion that catches it, so it
+    gets its own negative control: suppress the paint, keep everything else, and
+    the probe must still object.
+    """
+    repo = clean_repo(str(tmp_path / "silent"))
+    broken = tmp_path / "silent.html"
+    src = open(TEMPLATE, encoding="utf-8").read()
+    # Neuter the one call that fills #view, leaving the rest of the run intact.
+    assert "function render(data, stashes, diff) {" in src
+    src = src.replace("function render(data, stashes, diff) {",
+                      "function render(data, stashes, diff) {\n  return;", 1)
+    broken.write_text(src)
+
+    fixture = tmp_path / "f2.json"
+    fixture.write_text(json.dumps({
+        "params": {"_file": repo},
+        "payloads": {"overview": reader.main(file=repo, op="overview"),
+                     "stashes": reader.main(file=repo, op="stashes")},
+    }))
+    node = shutil.which("node")
+    if not node:  # pragma: no cover
+        pytest.skip("node is required")
+    proc = subprocess.run([node, PROBE, str(broken), str(fixture)],
+                          capture_output=True, text=True, timeout=90)
+    out = json.loads(proc.stdout)
+    assert out["error"] is None, "this control is about a SILENT blank"
+    assert not out["unhandled"], out["unhandled"]
+    assert out["painted"] is False, "the probe called an empty #view 'painted'"
+    # And the real assertion helper must reject it.
+    with pytest.raises(AssertionError, match="EMPTY"):
+        _assert_painted(out, "suppressed render")

--- a/tests/test_mounts_rcd_orphan.py
+++ b/tests/test_mounts_rcd_orphan.py
@@ -42,10 +42,12 @@ class _FakeChild:
         self.killed += 1
         self._alive = False
 
-    def wait(self, timeout=None):
+    def wait(self, timeout: float | None = None):
         self.waited += 1
         if self._alive:
-            raise mounts_mod.subprocess.TimeoutExpired("rclone", timeout)
+            # TimeoutExpired wants a real number; a bare `wait()` (no timeout)
+            # still has to raise, so 0 stands in for "no budget given".
+            raise mounts_mod.subprocess.TimeoutExpired("rclone", timeout or 0)
         return 0
 
     def poll(self):

--- a/tests/test_mounts_rcd_orphan.py
+++ b/tests/test_mounts_rcd_orphan.py
@@ -1,0 +1,107 @@
+"""A rcd that never comes up must not be left running.
+
+`_ensure_rcd_locked` spawns `rclone rcd` and polls `core/pid` until a deadline.
+Until this test existed the Popen handle was DISCARDED, so the timeout path
+raised `RuntimeError("rclone rcd did not come up within 10s")` and walked away
+from the child it had just started. In dev that child is also `setsid`-detached
+(FUSED_RENDER_RCLONE_PERSIST), so nothing ever reaped it.
+
+That leak is not cosmetic. The mount health loop retries automount on a timer,
+once per mount record, so a store with a dozen mounts leaks a dozen abandoned
+rclone daemons per cycle, indefinitely — measured on a real machine as 14
+orphaned `rclone rcd` processes spanning eight days. The resulting process/fd
+pressure inside the long-lived server process is what starves OTHER
+`subprocess.run` calls in the same process, and every git call site in the app
+fails CLOSED and silently when its subprocess cannot be spawned or overruns its
+timeout (the git gate, `_is_repo_root`, the check-ignore oracle) — which is how
+"the Git side panel is disabled for every repository" presents.
+
+No real rclone is exec'd: rclone_bin, log rotation, the state write and the
+`core/pid` probe are all monkeypatched, and the startup deadline is shortened
+so the failure path is reached immediately.
+"""
+import pytest
+
+import fused_render.shell.mounts as mounts_mod
+
+
+class _FakeChild:
+    """Stands in for the rclone Popen handle and records how it was disposed of."""
+
+    def __init__(self):
+        self.terminated = 0
+        self.killed = 0
+        self.waited = 0
+        self._alive = True
+
+    def terminate(self):
+        self.terminated += 1
+        self._alive = False
+
+    def kill(self):
+        self.killed += 1
+        self._alive = False
+
+    def wait(self, timeout=None):
+        self.waited += 1
+        if self._alive:
+            raise mounts_mod.subprocess.TimeoutExpired("rclone", timeout)
+        return 0
+
+    def poll(self):
+        return None if self._alive else 0
+
+
+@pytest.fixture
+def spawn_never_ready(monkeypatch):
+    """Force the spawn path, make the daemon never answer, and hand back the child."""
+    child = _FakeChild()
+
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda *a, **k: None)
+    monkeypatch.setattr(mounts_mod, "reap_stale_rcd", lambda: None)
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/fake/rclone")
+    monkeypatch.setattr(mounts_mod, "_rotate_rcd_log", lambda: "/fake/rcd.log")
+    monkeypatch.setattr(mounts_mod, "write_rcd_state", lambda *a, **k: None)
+
+    def never(*a, **k):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(mounts_mod, "_rc", never)
+    monkeypatch.setattr(mounts_mod.subprocess, "Popen", lambda args, **kw: child)
+    # Reach the give-up path without waiting out the real startup budget.
+    monkeypatch.setattr(mounts_mod.rcd, "_RCD_STARTUP_TIMEOUT_S", 0.0)
+    return child
+
+
+def test_rcd_that_never_comes_up_is_not_orphaned(spawn_never_ready):
+    with pytest.raises(RuntimeError, match="did not come up"):
+        mounts_mod._ensure_rcd_locked()
+    child = spawn_never_ready
+    assert child.terminated == 1, "the abandoned rclone rcd child was never terminated"
+
+
+def test_rcd_that_ignores_terminate_is_killed(spawn_never_ready):
+    child = spawn_never_ready
+    # A child that refuses SIGTERM (terminate() leaves it alive) must be SIGKILLed
+    # rather than left behind, otherwise the leak survives the fix.
+    child.terminate = lambda: (setattr(child, "terminated", child.terminated + 1))
+    with pytest.raises(RuntimeError, match="did not come up"):
+        mounts_mod._ensure_rcd_locked()
+    assert child.terminated == 1
+    assert child.killed == 1, "a rcd child that ignored terminate() was left running"
+
+
+def test_healthy_rcd_child_is_left_alone(monkeypatch):
+    """The success path must not touch the daemon it just started."""
+    child = _FakeChild()
+    monkeypatch.setattr(mounts_mod, "_live_rcd_port", lambda *a, **k: None)
+    monkeypatch.setattr(mounts_mod, "reap_stale_rcd", lambda: None)
+    monkeypatch.setattr(mounts_mod, "rclone_bin", lambda: "/fake/rclone")
+    monkeypatch.setattr(mounts_mod, "_rotate_rcd_log", lambda: "/fake/rcd.log")
+    monkeypatch.setattr(mounts_mod, "write_rcd_state", lambda *a, **k: None)
+    monkeypatch.setattr(mounts_mod, "_rc", lambda *a, **k: {"pid": 4321})
+    monkeypatch.setattr(mounts_mod.subprocess, "Popen", lambda args, **kw: child)
+
+    assert isinstance(mounts_mod._ensure_rcd_locked(), int)
+    assert child.terminated == 0
+    assert child.killed == 0

--- a/tests/test_server_fs_compress.py
+++ b/tests/test_server_fs_compress.py
@@ -424,7 +424,9 @@ def test_git_is_run_as_an_argv_list_with_no_shell(tmp_path, monkeypatch):
     real_run = mod.subprocess.run
 
     def spy(cmd, **kw):
-        if isinstance(cmd, list) and cmd[:1] == ["git"]:
+        # argv[0] is now the ABSOLUTE git path — required to reach posix_spawn, since CPython forks unless os.path.dirname(executable) is truthy and a fork with libproj resident SIGSEGVs before exec (tests/test_git_posix_spawn.py). Still one basename, still a list, still no shell, which is what this test is about.
+        if isinstance(cmd, list) and cmd and os.path.basename(
+                str(cmd[0])) in ("git", "git.exe"):
             seen.setdefault("calls", []).append((cmd, kw))
         return real_run(cmd, **kw)
 


### PR DESCRIPTION
## Summary

- **Root cause found and fixed: every `git` subprocess was dying with SIGSEGV before it ever ran.** With `libproj` resident in the server process — and it becomes resident the moment any map/geotiff/zarr template or daemon imports `rasterio` or `pyproj` — a plain `fork()` runs PROJ's `pthread_atfork` child handler straight into a segfault. The child died with `returncode == -11`, empty stdout, empty stderr and **no exception**, because the spawn itself succeeded. Every git call site failed closed on that, so `/api/fs/conditions` reported `"git": false`, `/api/fs/git-repo` reported `is_repo_root: false` for a real root, and `/api/fs/list` stopped dimming `.git` — all three at once, for every repository, indistinguishable from "not a repository".
- **`close_fds=False` was believed to be the fix. It is necessary and not sufficient.** Three modules already passed it, with a comment saying it took the `posix_spawn` path. It did not: CPython also requires `os.path.dirname(executable)` to be truthy, and every call started with the **bare name `"git"`** (dirname `""`). The template gate additionally passed `cwd=`, which forces `fork` on its own. Fixed at **every** git spawn site in the repo — 14 argv constructions across 11 modules, guarded by an AST sweep that checks all three clauses: absolute git path, `close_fds=False`, no `cwd=` (`-C <root>` already pins the repo and is stricter).
- **"Resolve with AI" for merge conflicts and failed git operations (GT-19).** A conflicted row and a failed operation now offer a sparkle that sends the real conflict — marker text, the operation in flight, the branch — to `claude-sonnet-5` via `fused.ai` and streams a proposal back.
- **Nothing reaches the working tree without confirmation.** The new `resolve` write touches exactly one file, never stages and never commits, and refuses content that still carries conflict markers. Advice for a *failed operation* gets no Apply at all — the view will not run a command a model chose.
- **Two independent defects fixed on the way:** a `rclone rcd` process leak, and the git sites' total silence on failure.

## How it was found, and two wrong turns

Worth recording, because the failure mode is built to mislead.

1. **First wrong answer: "git could not be spawned."** A throttled `git could not be run` warning was added for `OSError`/timeout. It never fired — the spawn *worked*.
2. **Second wrong answer: "not reproducible."** Every probe of a *fresh* server answered correctly, so the bug looked like accumulated process state. It was: `libproj` becoming resident. Worse, editing any file under `fused_render/` triggers dev.sh's watchfiles restart, so **the instrumentation kept killing the very process that was reproducing it.**
3. **What actually settled it** was widening the diagnostic to the case both attempts had missed — git *ran* and answered negatively — and printing git's exit status. One line ended it:

   ```
   WARNING …templates.git.condition: the git mode is being hidden for
   /Users/iamsdas/Documents/Fused and it looks wrong: git exited -11 saying
   '(nothing)'
   ```

   `-11` is `SIGSEGV`. Not a refusal, not a missing repo — a child that died in the fork.

**A previously-recorded fix was ineffective.** `app_git.py`'s module docstring documents this exact crash being diagnosed in August ("every `git add` died rc=-11 with empty output") and fixed with `close_fds=False`. That fix could never have worked while `argv[0]` stayed a bare name; it only looked fixed because it was validated in a process where `libproj` was not resident. That is why the rule is now pinned by test.

## Visuals

Why `close_fds=False` alone changed nothing. Every clause is `and`-ed in CPython's `subprocess.py::_execute_child`:

```mermaid
flowchart TD
    S["subprocess.run(['git', ...], close_fds=False)"] --> D{"os.path.dirname('git')"}
    D -->|"'' — falsy"| F["fork() + exec"]
    D -->|"absolute path"| C{"cwd is None?"}
    C -->|"cwd= passed (the gate)"| F
    C -->|"no cwd"| P["posix_spawn — no atfork handlers"]
    F --> X["PROJ atfork handler → SIGSEGV<br/>rc -11, no output, no exception"]
    X --> V["every git verdict fails closed, silently"]
    P --> OK["git actually runs"]
```

The AI conflict path. A partial stream is deliberately not a proposal — it has no Apply until the answer completes.

```mermaid
flowchart TD
    A["Resolve with AI (conflicted row)"] --> B["fused.ai · claude-sonnet-5"]
    B -->|rejected| R["Reason shown · no Apply"]
    B --> C["Proposal streams into panel"]
    C --> D{"Apply to file?"}
    D -->|confirmed| E["Writes one file · no add, no commit"]
    D -->|dismissed| F["Nothing written"]
```

## Usage

**The spawn rule**, enforced by `tests/test_git_posix_spawn.py`: absolute `argv[0]` **and** `close_fds=False` **and** no `cwd=`. Two layers — recorded kwargs run through CPython's own precondition set at the six drivable sites, plus an **AST sweep over the whole package** that checks all three clauses at every git spawn.

The sweep is AST-based rather than a regex because a regex misses the same violation written multi-line (this repo's prevailing style), tuple argv, and `executable="git"`. `**_popen_kwargs()` indirection is resolved by reading the helper's dict literal from the same file's AST, and a site whose kwargs cannot be determined statically **fails** rather than being skipped — "I could not check this" must never read as "this is fine". The sweep has its own regression test: it is pointed at six deliberately broken spellings and must object to every one.

**The diagnostic**, if any git-backed feature goes dark again. Three distinct cases, each throttled to one line a minute *independently*, so a storm of one cannot hide the first of another. An ordinary non-repo folder logs **nothing**:

```
git could not be run (…): OSError: …            → spawn failed (PATH, fds, procs)
git refused (…) for /repo: exit 128: fatal: detected dubious ownership …
                                                 → git ran and refused; its words
git contradicted the filesystem (…): /repo has a .git entry but git answered
toplevel '/somewhere/else' … GIT_DIR='/tmp/stray/.git', cwd='/srv'
                                                 → exit 0, wrong answer, no stderr
```

The third case prints the process's git environment because that is the only thing that can explain it — `git -C <repo> rev-parse` honours `GIT_DIR` over `-C`, and a stray value is invisible from outside the process.

**Resolve with AI.** Open a repo with a conflict in the git view (`?_mode=git`). Conflicted rows show a sparkle ahead of *Stage*; a failed operation shows one on its error flash. Click it, watch the proposal stream in, then either **Apply to file** (routes through the existing confirmation) or **Dismiss**.

New template ops, both refusing mount-backed targets via `_locate`:

| Op | Module | Effect |
|---|---|---|
| `conflicts` | `log.py` | Reads unmerged paths + marker text, capped at 10 files / 60 KB, truncation reported; binaries named, never read |
| `resolve` | `ops.py` | Writes one currently-unmerged file (`--diff-filter=U`) via temp file + `os.replace`. In `DESTRUCTIVE_OPS` |

**The rcd leak**, an independent fix: `_ensure_rcd_locked` discarded the `Popen` handle of any `rclone rcd` that failed to come up, so the give-up path walked away from the child it had just spawned — and in dev that child is `setsid`-detached, so nothing reaped it. The health loop retries per mount on a timer, leaking one daemon per mount per cycle. **Measured: 14 orphans, oldest eight days old.** Now torn down (SIGTERM → SIGKILL) before raising.

### Review round: the first fix was incomplete

Worth recording, because it is the same trap one level up. The first pass fixed
argv[0] everywhere but added `close_fds=False`/dropped `cwd=` only where it was
already partly right — leaving **five spawns across four modules still forking**,
two of them in the reported feature (`git_show._git` and `git_show._show`, reached
whenever the git view opens a commit). Independent verification caught it by
running each site's real kwargs through CPython's precondition.

The suite passed the whole time. That is the actual defect: the behavioural tests
only covered the six drivable sites, and the sweep only looked at the program
name. The sweep now checks the whole rule and, run against the pre-fix tree,
independently reproduces exactly the five sites the verifier named. Those five
also carried the new header comment stating the three-part rule, which made the
omission read as deliberate rather than missed.

### The `test_claude_config_api.py` intermittent: identified, and it was this bug

Review flagged that file failing `2 failed, 45 passed` on three consecutive
`-n auto` runs and then passing 24/24 afterwards, with the two identities never
captured. It was not a load flake and not an unrelated pre-existing one — **it was
this branch's own bug, in the last module to get the fix.**

`claude_config/lib.py` on `main` spawned `["git", "-C", CLAUDE_DIR, *args]` with
`close_fds=False` — a bare `argv[0]`, so the fork path, so a SIGSEGV before exec in
any pytest worker with libproj resident (a map/geotiff/zarr test file having loaded
rasterio or pyproj into that same process — hence "while other test files had just
run"). The two tests that depend on `lib.git` producing a real commit are
`test_claude_md_commit_folds_an_edit_into_the_config_repo` and
`test_git_log_round_trips_a_non_ascii_commit_message` — **2 of 47, exactly the
observed split.** Simulating a `-11` git confirms the git-dependent blast radius in
that file is those two plus the two `preferences` tests; with `-n auto` the four are
spread across workers and only the contaminated ones fail, which is why it was 2
and not 4.

It stopped reproducing permanently because commit `e003970b` made that `argv[0]`
absolute. Every replay review attempted was **after** the fix, which is why nothing
reproduced. The `no_spotlight` / `client`-fixture hypothesis is disproven: neither
of those two tests uses `no_spotlight`, and the `client`-only tests never touch
`lib.git`.

I could not reproduce the original red (~80 targeted runs: 12 four-way concurrent,
18 under heavy background load, 20 co-scheduled with related files) — expected,
since the cause is fixed.

**Two genuine bugs found while hunting it, both pre-existing and neither mine to
fix here:**

1. **`tests/test_ai_runtime.py` has the same crash, in the AI worker spawn.** Caught
   live: `assert 'exploded' in 'the worker exited before it started (code -11)'`.
   `fused_render/ai/supervisor.py:508` passes `close_fds=True` **and** `cwd=` —
   deliberately on the fork path. Untouched by this branch (`git diff main..HEAD --
   fused_render/ai/` is empty), so it is pre-existing. Not fixed here: whether that
   worker may drop `close_fds=True` is an isolation decision for that subsystem,
   not a drive-by.
2. **`tests/test_claude_config_api.py` is not hermetic.** `lib.CLAUDE_DIR` reads the
   `CLAUDE_DIR` env var, but conftest redirects `CLAUDE_CONFIG_DIR` — a *different*
   variable — so it resolves to the real `~/.claude`. Separately, five tests in that
   file omit the `no_spotlight` fixture and so run real Spotlight: `_mdfind()`
   returns **12 real CLAUDE.md files from the developer's machine** on this box.
   Their assertions happen to tolerate it today, but conftest's own docstring says
   "no test may touch the real ~/.claude".

### The "blank git view" report: a capture artifact, plus a real coverage gap

Review reported the full-page git view rendering completely blank. **It renders
correctly.** The blank screenshots came from a cmux browser surface opened with
`--focus false`: an unfocused webview does not composite, so its screenshots show
background colour only.

Three controls settle it, two of them on code this branch never touched:

| Page | unfocused | focused |
|---|---|---|
| folder listing (pure shell, untouched) | **blank** | renders fully |
| markdown template (untouched) | **blank** | — |
| full-page git view | **blank** | **renders fully** |

Measured inside the iframe while it looked blank: `readyState: complete`,
`#view` present with 1 child and real text (`main / Fetch / Pull / Push /
COMMITS / …`), skeleton hidden, `#view` at (24, 20) sized 708×1160, `opacity: 1`,
`visibility: visible`, colour `rgb(232,234,237)` on `rgb(19,20,23)`. Nothing was
wrong with the page. `focus-webview` then captures it correctly — see
`cmux-assets/.../browser/13-gitmode-focused-RENDERS.png` and
`14-conflict-gitmode-focused-sparkle.png`, which also shows the new sparkle on
both `UU mod.py` rows.

**But the branch did briefly serve a genuinely blank page, and no test could have
told me.** The call log caught it once, mid-edit:

```
kind=page-error   SyntaxError: Cannot declare a let variable twice: 'streamed'
```

Two top-level `let streamed` declarations existed in the working tree for a few
minutes while I was moving that declaration, and templates are served LIVE from
the working tree. It never reached a commit (every commit here has exactly one),
but the gap was real, and the second shape of it is worse: `draw()` is async, so a
throw inside `render()` becomes an unhandled **rejection**, which the page-error
hook does not observe at all — the page calls Python, gets good data, logs
nothing, and paints nothing.

Closed by `tests/test_git_view_renders.py` + `tests/_git_view_probe.mjs`: the
template's own `<script>` runs verbatim against a DOM stub with a `fused` stub fed
by real `log.py` payloads, and `#view` must be non-empty for both a clean and a
conflicted repo. Two negative controls, because a render check that cannot fail is
worth nothing — a duplicate `let` (the exact failure) and a suppressed `render()`
(the silent shape) must each be caught. Writing the first found a bug in the probe
itself: `new Function` sat outside the try, so the SyntaxError escaped and the
probe reported *nothing*.

## Test Plan

- [x] **The fix, verified in the live server** on the user's exact path, after each round. Before: `git=false`, `root=false`, `ignored=[]`. After:

  ```
  conditions: {'claude': True, 'git': True, ...}
  git-repo  : {'is_repo_root': True}
  ignored   : ['.git', '__pycache__']
  ```

  Nested dirs correctly report `git=true` / `root=false`; genuine non-repos (`~`, `/tmp`, `~/Documents/Fused`) still report `false`; the server log is clean of warnings. `/api/git/show` — one of the two newly-fixed sites in this feature — renders a file at a real sha (91 KB) through the live server.
- [x] **Automated, new:** `tests/test_git_posix_spawn.py` (11), `tests/test_git_spawn_diagnosable.py` (20), `tests/test_git_conflicts.py` (22), `tests/test_mounts_rcd_orphan.py` (3) — each written TDD, red before green. One test reproduces the symptom exactly (rc `-11`, no output, no exception) and asserts it stays fail-closed **and** loud.
- [x] **The verifier's own probe** re-run at HEAD: all 14 sites report `SPAWN`, none `FORKS`.
- [x] **Scoped regression:** 507 passed across the git + newly-touched suites (compress, bundle reader, claude config); 113 passed across deeplink / community / git_show / git_repos.
- [x] **`-C` conversion checked against real git**, not just statically: the bundle and compress suites drive `git init`, `git bundle create`, `git archive` and `git clone` through the converted call sites.
- [x] **Full suite, by the verification agent:** 7000 passed / 85 skipped, with the same 3 failures + 1 collection error as the `main` baseline (`test_deploy.py` ×2, `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`, `joblib_model/tests/test_reader.py`) — **zero regressions**. Pyright: 40 errors on `main`, 40 at HEAD, identical set. No rcd orphans resurrected. Flake check 3/3 green on all four new test files. (Re-verification of the latest two commits is pending.)
- [x] **End-to-end** with a real conflicted repo: `conflicts` returns markers with `operation: merge`; overview carries `('UU', True)`; all three `resolve` refusals fire; Apply wrote the file and the repo stayed at `UU` with 2 commits — nothing staged, nothing committed. `POST /api/ai` confirmed `claude-sonnet-5` responds.

**Not verified — needs a human at a browser.**

- [x] **The git view renders**, verified by screenshot on a focused surface: full-page mode on a clean repo and on a conflicted one, with the sparkle present on both `UU` rows ahead of Stage. The Git side panel renders too (review's own screenshot 01).
- [ ] The *interactive* half of Resolve-with-AI: clicking the sparkle, streaming into the panel, Apply → confirm → write, Cancel and Dismiss, and the failed-operation sparkle on a genuine refusal. I can drive navigation and read the DOM, but I will not claim a verified click/stream I have not watched end to end.
- [ ] Visual polish of the `.proposal` panel and `.flash` layout in both light and dark themes (the panel has not been on screen yet — it needs an AI call to exist).
- [ ] Whether any *other* forked subprocess in the server shares this crash. Only git was swept; `close_fds` is omitted at roughly a hundred other spawn sites, and the same `-11` would be just as silent there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
