### PR TITLE
Home search: warm the corpus at startup, persist gitignore verdicts, ship it compact

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -343,14 +343,42 @@ export interface IndexSearchResult {
   age_s: number | null;
 }
 
-export function indexSearch(
+// The same corpus as parallel arrays — what `fmt=columns` answers with. Every
+// entry carries the same four keys, so the object-per-entry shape spends a
+// third of its bytes spelling those keys out again: 25.7 MB on a 164k-entry
+// home, fetched in one shot on the user's first keystroke.
+//
+// The decode back to WalkEntry[] happens HERE, at the API-client boundary, so
+// the corpus consumers (listing/index-corpus.ts, FilesHome, useWalkSearch)
+// never learn about the wire format. `is_dir` travels as 0/1; `size` and
+// `mtime` stay nullable — a directory legitimately has neither.
+interface IndexSearchColumns extends Omit<IndexSearchResult, "entries"> {
+  fmt: "columns";
+  rels: string[];
+  dirs: number[];
+  sizes: (number | null)[];
+  mtimes: (number | null)[];
+}
+
+export async function indexSearch(
   fsPath: string,
   opts: { signal?: AbortSignal } = {},
 ): Promise<IndexSearchResult> {
-  return getJson<IndexSearchResult>(
-    "/api/index/search?root=" + encodeURIComponent(fsPath),
+  const body = await getJson<IndexSearchColumns>(
+    "/api/index/search?fmt=columns&root=" + encodeURIComponent(fsPath),
     { signal: opts.signal },
   );
+  const { fmt, rels, dirs, sizes, mtimes, ...rest } = body;
+  const entries: WalkEntry[] = new Array(rels.length);
+  for (let i = 0; i < rels.length; i++) {
+    entries[i] = {
+      rel: rels[i],
+      is_dir: dirs[i] === 1,
+      size: sizes[i],
+      mtime: mtimes[i],
+    };
+  }
+  return { ...rest, entries };
 }
 
 // GET /api/index/status with no run id — the state of the most recent scan,

--- a/fused_render/index/runner.py
+++ b/fused_render/index/runner.py
@@ -215,6 +215,45 @@ def read_events(run_dir: str, since: int = 0):
     return events, new, cursor
 
 
+def has_ended(run_dir: str, since: int = 0):
+    """`(ended, cursor)` for a run, parsing only the lines after `since`.
+
+    For a caller that wants one bit — "is this run over yet" — and polls for
+    it. `read_events` cannot serve that: its callers need the whole folded
+    state, so it `json.loads` every line from 0 on every call, and a poller
+    would re-parse a log that grows by ~2 events a second (scan.py emits
+    progress twice a second) once per poll — quadratic in the length of the
+    very scan it is waiting on. Here the lines before the cursor are only
+    counted, never decoded, so a poll costs a read of the file and a parse of
+    what is genuinely new.
+
+    A run whose log does not exist yet has not ended; `False` is also the
+    honest answer for an unreadable one (the caller's own liveness check is
+    what covers a worker that died without writing `run_end`).
+    """
+    path = os.path.join(run_dir, "events.jsonl")
+    ended, seen = False, 0
+    try:
+        with open(path) as f:
+            for i, line in enumerate(f):
+                if i < since:
+                    seen = i + 1
+                    continue
+                try:
+                    ev = json.loads(line)
+                except ValueError:
+                    # A half-written last line: do NOT move the cursor past
+                    # it, or the completed version — which may be the
+                    # `run_end` this call exists to find — is never read.
+                    break
+                seen = i + 1
+                if ev.get("type") == "run_end":
+                    ended = True
+    except OSError:
+        return False, since
+    return ended, max(seen, since)
+
+
 def derive_state(events) -> dict:
     """Fold the whole log into the flat state a client renders. Folding is
     idempotent, which is what makes resume-after-reload work."""

--- a/fused_render/index/specs/index-store.md
+++ b/fused_render/index/specs/index-store.md
@@ -21,7 +21,7 @@ nesting come for free, and no test can write into a real home.
 | `<index>/ignore_applied.json` | ignore fingerprint the index was built with (`scan-ignore.md §4`) |
 | `<index>/config.json` | user config: ignore list + scan roots (`server-api.md §3`) |
 | `<index>/scans.json` | last scan start per root — the startup debounce (`server-api.md §2`) |
-| `<index>/gitignore/<digest>.json` | one index root's pooled `git check-ignore` verdicts, so a restart does not re-sweep — a SERVER-layer cache that only lodges here, age-bounded by `VERDICT_MAX_AGE_S` and untouched by `POST /api/index/delete` (`server/index_gitignore.py`) |
+| `<index>/gitignore/<digest>.json` | one index root's pooled `git check-ignore` verdicts, so a restart does not re-sweep — a SERVER-layer cache that only lodges here, age-bounded by `VERDICT_MAX_AGE_S` and untouched by `POST /api/index/delete` (`server/index_gitignore.py`). Written only for an actual **index root**, which is what bounds this directory: a folder outside every configured scan root gets a pool too, but an in-memory one, because nothing ever reclaims a file here and one per folder ever searched would grow without limit. A `<digest>.json.<pid>.new` is a write in progress; one left by a process that died mid-write is swept on the next save. |
 | `<index>/runs/<run_id>/` | per-run scratch: spec, event log, shards (`scan.md §2`) |
 
 OpenIndex had a relocatable index folder (`OpenIndex.location` + a `move_index`

--- a/fused_render/index/specs/index-store.md
+++ b/fused_render/index/specs/index-store.md
@@ -21,6 +21,7 @@ nesting come for free, and no test can write into a real home.
 | `<index>/ignore_applied.json` | ignore fingerprint the index was built with (`scan-ignore.md §4`) |
 | `<index>/config.json` | user config: ignore list + scan roots (`server-api.md §3`) |
 | `<index>/scans.json` | last scan start per root — the startup debounce (`server-api.md §2`) |
+| `<index>/gitignore/<digest>.json` | one index root's pooled `git check-ignore` verdicts, so a restart does not re-sweep — a SERVER-layer cache that only lodges here, age-bounded by `VERDICT_MAX_AGE_S` and untouched by `POST /api/index/delete` (`server/index_gitignore.py`) |
 | `<index>/runs/<run_id>/` | per-run scratch: spec, event log, shards (`scan.md §2`) |
 
 OpenIndex had a relocatable index folder (`OpenIndex.location` + a `move_index`

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -167,6 +167,11 @@ all of it billed to a keystroke. The warm moves it to idle.
   A root whose scan was **debounce-skipped** has no entry and is not waited on: no new
   run is coming and its index is already on disk. The persisted verdict pool
   (`server/index_gitignore.py`) is what covers restarts.
+- The warm and the **first keystroke overlap by design** — the warm runs for ~2.2 s and
+  the user is typing inside it — so `server/index_gitignore.py` coordinates them: the
+  second caller to want verdicts for the same base waits on the sweep already in flight
+  (`_inflight`, `SWEEP_WAIT_MAX_S`) and reads the pool it produced, instead of shelling
+  out to `git check-ignore` over the same 200k entries a second time.
 - It **never raises**: nobody joins the thread.
 
 Patched out in tests by the same fixture, and its own tests call `run_startup_warm()`

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -149,9 +149,12 @@ all of it billed to a keystroke. The warm moves it to idle.
 
 - A **thread**, not `asyncio.to_thread`: a startup hook must complete before the app
   serves, and this is seconds of work.
-- A **mount-backed** home is skipped on the string check alone (`MountGuard.blocks_root`),
-  never a syscall: the index refuses to scan mounts, so the warm could only answer
-  `covered: false` after aiming kernel I/O at a mount.
+- A **mount-backed** home is skipped by `MountGuard.blocks_root`, the same check
+  `runner.start` makes, before anything touches the path: the index refuses to scan
+  mounts, so the warm could only answer `covered: false` after aiming kernel I/O at a
+  mount. The guarantee is about the mount, not about cost — a path under the mounts dir
+  matches on `abspath` alone, while a local home falls through to `is_mount_backed` and
+  pays two `realpath`s, neither of them on the mount.
 - **One bounded wait on a first boot.** Usually the index is already there, the search
   answers `covered: true`, and the warm is those two calls and nothing else. When it
   answers `covered: false` — first-ever boot, nothing to sweep — the warm waits for the

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -19,7 +19,7 @@ unguarded like every other read endpoint and none of them can write.
 | `GET /api/index/runs` | — | the 20 most recent runs with their folded state |
 | `GET /api/index/stats?root=` | — | totals + per-extension breakdown (`query.md §2`) |
 | `GET /api/index/lookup?q=&limit=&offset=&sort=` | — | path lookup (`query.md §3`) |
-| `GET /api/index/search?root=&q=&limit=` | — | the explorer's in-folder corpus (`query.md §6`) |
+| `GET /api/index/search?root=&q=&limit=&fmt=` | — | the explorer's in-folder corpus (`query.md §6`); `fmt=columns` for the compact encoding (§6) |
 | `POST /api/index/query` `{sql, limit?}` | X-Fused | run ONE read-only statement over `files`/`dirs`; `{columns, rows, truncated}` (`query.md §5`) |
 | `POST /api/index/ask` `{prompt, limit?}` | X-Fused | compile a question to SQL through the AI relay, run it under the same guard, echo the `sql` (`query.md §5`) |
 | `GET /api/index/config` · `POST /api/index/config` | X-Fused on write | scan roots + ignore list (§3) |
@@ -161,6 +161,44 @@ all of it billed to a keystroke. The warm moves it to idle.
 
 Patched out in tests by the same fixture, and its own tests call `run_startup_warm()`
 directly.
+
+## 6. The compact corpus — `fmt=columns`
+
+`GET /api/index/search` answers with one object per entry
+(`{rel, is_dir, size, mtime}`), which is the shape `/api/fs/walk` streams and the
+shape every existing caller — including the JS bridge `fused.fileIndex.search`
+(`static/runtime.js`) — reads. That shape stays the default, and an unrecognized
+`fmt` falls back to it rather than 400ing: a format nobody asked for must not be able
+to break a page someone wrote.
+
+`fmt=columns` re-cuts the same corpus as index-aligned parallel arrays —
+`rels`, `dirs` (0/1), `sizes`, `mtimes`, plus `fmt: "columns"` — and leaves every other
+field (`covered`, `fresh`, `truncated`, `total`, `updated`, `age_s`, …) exactly as it is.
+`size`/`mtime` stay nullable: a directory legitimately has neither. The explorer asks
+for it and decodes back to the walk's entry shape at the API-client boundary
+(`platform/lib/api.ts`), so the corpus consumers never learn the wire format.
+
+Why, measured on the 164k-entry home corpus this route exists for (25.7 MB, fetched in
+one shot on the user's **first keystroke**):
+
+| Body | Bytes |
+|---|---|
+| `entries` objects | 27.7 MB |
+| `fmt=columns` | 21.1 MB |
+| `fmt=columns`, gzip level 1 | 5.0 MB |
+
+The compact response is therefore also **gzipped** — level 1, and only when
+`Accept-Encoding` says the caller can take it. Level 1 costs 0.06 s, less than the JSON
+encoding itself (0.07 s); the higher levels spend seconds to shave a few percent off a
+body that is read once. It is done per-route rather than with a GZip middleware because
+this app also streams the live walk and serves file bytes raw, and compressing those on
+a **local** server is CPU spent against loopback for nothing — this one response is the
+outlier.
+
+Rejected: front-coding the rels (they arrive depth-then-path ordered, so neighbours
+share long prefixes). It takes the body to 12.4 MB, but costs 0.45 s of Python per
+corpus — more of the first search's budget than it saves, and gzip finds most of the
+same redundancy for an eighth of the time.
 
 ## Non-goals
 

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -134,6 +134,34 @@ failure to read the config aborts the scheduling rather than the server.
 `_no_startup_index_scan`) — a suite that ran it would spawn a worker over the
 developer's real home. The scheduler's own tests call `run_startup_scan()` directly.
 
+### 4.1 The startup warm
+
+The same hook then calls `startup_warm()`, which spawns one detached daemon thread
+running `run_startup_warm()`: `search_under` + `filter_corpus` over `expanduser("~")`
+— exactly the request the explorer's home page makes on the first keystroke, under
+exactly the same pool key.
+
+Everything that path caches is **per process** and starts empty: the gitignore verdict
+pool has no verdicts until some request sweeps `git check-ignore` over the whole corpus,
+and `duckdb` is not imported until the first query. Measured on a 164k-entry home,
+that made the first search of a fresh process ~2.2 s against ~0.8 s for the next one,
+all of it billed to a keystroke. The warm moves it to idle.
+
+- A **thread**, not `asyncio.to_thread`: a startup hook must complete before the app
+  serves, and this is seconds of work.
+- A **mount-backed** home is skipped on the string check alone (`MountGuard.blocks_root`),
+  never a syscall: the index refuses to scan mounts, so the warm could only answer
+  `covered: false` after aiming kernel I/O at a mount.
+- **One shot, never polled.** If the index has not covered home yet — first-ever boot —
+  the warm answers `covered: false` cheaply and pools nothing, so the first search after
+  that boot's scan still pays the sweep. A loop chasing the scan would be a second
+  scheduler; the persisted verdict pool (`server/index_gitignore.py`) is what covers
+  restarts instead.
+- It **never raises**: nobody joins the thread.
+
+Patched out in tests by the same fixture, and its own tests call `run_startup_warm()`
+directly.
+
 ## Non-goals
 
 - **Watching the filesystem** — there is no daemon. Freshness comes from the startup

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -163,7 +163,10 @@ all of it billed to a keystroke. The warm moves it to idle.
   `WARM_WAIT_POLL_S` (0.5 s, the worker's heartbeat cadence) with a hard
   `WARM_WAIT_DEADLINE_S` ceiling (6 min — just past `runner.ABANDONED_RUN_S`, so a dead
   worker is reported not-running before the ceiling is reached), on a daemon thread that
-  cannot hold the process open. Giving up is logged once and the corpus stays cold.
+  cannot hold the process open. The search and the sweep then run **whatever ended the
+  wait** — a finished scan, a dead worker, a pruned run dir, the ceiling — because how a
+  scan ended does not tell you whether the index covers the root, and an uncovered one
+  costs one cheap `covered: false`. Giving up is logged once.
   A root whose scan was **debounce-skipped** has no entry and is not waited on: no new
   run is coming and its index is already on disk. The persisted verdict pool
   (`server/index_gitignore.py`) is what covers restarts.

--- a/fused_render/index/specs/server-api.md
+++ b/fused_render/index/specs/server-api.md
@@ -152,11 +152,18 @@ all of it billed to a keystroke. The warm moves it to idle.
 - A **mount-backed** home is skipped on the string check alone (`MountGuard.blocks_root`),
   never a syscall: the index refuses to scan mounts, so the warm could only answer
   `covered: false` after aiming kernel I/O at a mount.
-- **One shot, never polled.** If the index has not covered home yet — first-ever boot —
-  the warm answers `covered: false` cheaply and pools nothing, so the first search after
-  that boot's scan still pays the sweep. A loop chasing the scan would be a second
-  scheduler; the persisted verdict pool (`server/index_gitignore.py`) is what covers
-  restarts instead.
+- **One bounded wait on a first boot.** Usually the index is already there, the search
+  answers `covered: true`, and the warm is those two calls and nothing else. When it
+  answers `covered: false` — first-ever boot, nothing to sweep — the warm waits for the
+  one scan `run_startup_scan` just spawned for that root (recorded in `_startup_runs`)
+  and then searches again. It is not a scheduler: one named run, polled every
+  `WARM_WAIT_POLL_S` (0.5 s, the worker's heartbeat cadence) with a hard
+  `WARM_WAIT_DEADLINE_S` ceiling (6 min — just past `runner.ABANDONED_RUN_S`, so a dead
+  worker is reported not-running before the ceiling is reached), on a daemon thread that
+  cannot hold the process open. Giving up is logged once and the corpus stays cold.
+  A root whose scan was **debounce-skipped** has no entry and is not waited on: no new
+  run is coming and its index is already on disk. The persisted verdict pool
+  (`server/index_gitignore.py`) is what covers restarts.
 - It **never raises**: nobody joins the thread.
 
 Patched out in tests by the same fixture, and its own tests call `run_startup_warm()`

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -463,5 +463,10 @@ def create_app(start_dir: str) -> FastAPI:
     @app.on_event("startup")
     async def _startup_index_scan():
         await index_routes.startup_scan(start_dir)
+        # ...and warm the corpus path the explorer's home search reads, on a
+        # detached thread, so the gitignore sweep and the duckdb import are
+        # paid at idle rather than by the user's first keystroke
+        # (index/specs/server-api.md §4).
+        index_routes.startup_warm()
 
     return app

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -80,6 +80,7 @@ import logging
 import os
 import time
 from collections import OrderedDict
+from threading import Event as _Event
 from threading import Lock
 
 from fused_render.server.gitignore import _IgnoreOracle, _repo_toplevel
@@ -92,6 +93,21 @@ logger = logging.getLogger(__name__)
 _CACHE_ROOTS = 4
 _cache: "OrderedDict[str, _Verdicts]" = OrderedDict()
 _cache_lock = Lock()
+
+# base -> an Event set when the sweep currently running for that base has
+# folded its verdicts into the pool. One entry per base being swept, removed by
+# the sweeper itself (in a `finally`, so a raising sweep releases its waiters).
+# This is NOT the lock the docstring below refuses to hold across git: it
+# serializes callers asking for the SAME base's verdicts, and leaves every
+# other base free.
+_inflight: dict = {}
+
+# How long a caller may wait on someone else's sweep before doing its own. The
+# floor under a sweeper that dies in a way its `finally` cannot see (a killed
+# daemon thread at interpreter exit): the cost of being wrong is one duplicate
+# sweep — what every caller did before this existed — so it is set generously
+# against the ~1.5 s a home-sized sweep takes rather than tightly.
+SWEEP_WAIT_MAX_S = 30.0
 
 # How long a pool may live before it is discarded and git is re-asked about
 # everything.
@@ -123,9 +139,11 @@ _UNDECIDED = ""
 # can exit.
 _SAVE_MIN_INTERVAL_S = 60.0
 
-# root -> when THIS process last wrote its pool. Bounded by _CACHE_ROOTS in
-# practice; entries for evicted roots are harmless (a stale stamp only delays
-# one write).
+# root -> when THIS process last wrote its pool. Only ever keyed on an actual
+# index root (filter_corpus refuses to persist anything else, and that is the
+# reason it refuses), so it is bounded by the number of configured scan roots —
+# a handful — and needs no eviction. Entries for roots evicted from `_cache`
+# are harmless: a stale stamp only delays one write.
 _saved_at: dict = {}
 
 
@@ -169,12 +187,22 @@ def filter_corpus(out: dict, index_root: str | None = None) -> dict:
         return out
     base = index_root or root
     prefix = _rel_prefix(base, root)
+    # Only a base the CALLER identified as an index root is written to disk.
+    # The fallbacks below are not roots and not bounded: a folder outside every
+    # configured scan root gets a pool of its own, and persisting those would
+    # grow `_saved_at` and the gitignore/ directory by one entry per such
+    # folder ever searched, forever — the in-memory pool is LRU-capped at
+    # _CACHE_ROOTS, but nothing reclaims either of those (prune_runs touches
+    # run dirs only, and delete_store deliberately leaves gitignore/ alone).
+    # In memory is all such a folder ever needed: the restart-warm case is
+    # about the home page's root, which always arrives here as one.
+    persist = index_root is not None and prefix is not None
     if prefix is None:
         base, prefix = root, ""
     # Indexes, not rels: a corpus may legitimately repeat a rel (it cannot
     # today, but nothing here should depend on that) and the decider is
     # per-entry.
-    drop = _pooled_verdicts(base, prefix, root, entries)
+    drop = _pooled_verdicts(base, prefix, root, entries, persist=persist)
     if not drop:
         return {**out, "total": len(entries)}
     kept = [e for i, e in enumerate(entries) if i not in drop]
@@ -194,54 +222,96 @@ def _rel_prefix(base: str, root: str):
     return None
 
 
-def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
+def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
+                     persist: bool = True) -> set:
     """The INDEXES into `entries` that git calls ignored.
 
     Reads what the pool already decided UNDER THE SAME ORACLE, queries git for
-    the rest, and folds the answers back in. The git work happens OUTSIDE the
-    lock: it is the second (or the ten-second) part, and holding a lock across
-    it would serialize every search in the app behind one folder's first sweep.
+    the rest, and folds the answers back in.
+
+    Three kinds of work are kept OUT of `_cache_lock`, for one reason: it is a
+    module-global, so anything held across it stops every search in the app —
+    including ones for entirely different roots — behind this one. The git
+    sweep is seconds; the disk load is a multi-megabyte `json.load` plus a few
+    hundred thousand inserts; the snapshot is a full pass over up to 200k rels.
+    The lock covers only the pool bookkeeping around them.
+
+    What IS coordinated is duplicate work on the SAME base: `_inflight` makes a
+    second caller wait for the sweep already running rather than start an
+    identical one. That is the opposite of holding the lock — one base's
+    callers queue for one sweep, and other bases are never touched. The race is
+    not hypothetical: the startup warm sweeps on a detached thread for exactly
+    the ~2.2 s in which the user's first keystroke arrives, and both used to
+    build the same 200k-entry query set and shell out to git for it twice.
     """
     # Pure string work, no git: which oracle this request would consult for
     # each entry. Computed for the WHOLE corpus every time — a few tens of
     # milliseconds — because it is half of the cache key.
     top, deciders = _deciders(root, entries, prefix)
     rels = [prefix + e["rel"] for e in entries]
-    now = time.time()
+    # A process that has never held this root's pool asks disk before it asks
+    # git: the file is a sweep of this same root, by this process before a
+    # restart or by another one, and it is age-checked exactly as an in-memory
+    # pool is. Speculative and outside the lock — if another thread has landed
+    # a pool by the time we look, this one is simply dropped. An EXPIRED
+    # in-memory pool deliberately does NOT come back through here: its own
+    # saved copy is never newer than it, so reloading it would put the pool
+    # back to the age it just aged out of and VERDICT_MAX_AGE_S would never be
+    # reachable.
     with _cache_lock:
-        pool = _cache.get(base)
-        if pool is None:
-            # A process that has never held this root's pool asks disk before
-            # it asks git: the file is a sweep of this same root, by this
-            # process before a restart or by another one, and it is age-checked
-            # exactly as an in-memory pool is. An EXPIRED in-memory pool
-            # deliberately does NOT come back through here — its own saved copy
-            # is never newer than it, so reloading it would put the pool back
-            # to the age it just aged out of and VERDICT_MAX_AGE_S would never
-            # be reachable.
-            pool = _load_verdicts(base)
-        if pool is None or (now - pool.swept_at) >= VERDICT_MAX_AGE_S:
-            pool = _Verdicts(now)
-        _cache[base] = pool
-        _cache.move_to_end(base)
-        while len(_cache) > _CACHE_ROOTS:
-            _cache.popitem(last=False)
-        drop, want = set(), set()
-        for i, (name, _marker) in enumerate(deciders):
-            # Nothing in this request's scope can decide this entry. Pass it
-            # through (the under-filtering bias) and, crucially, do not record
-            # that as a verdict: a wider request must still get to ask.
-            if name == _UNDECIDED:
-                continue
-            if pool.decider.get(rels[i]) == name:
-                if rels[i] in pool.ignored:
-                    drop.add(i)
-            else:
-                want.add(i)
-    if not want:
-        return drop
-    fresh = _ignored(root, entries, top, deciders, want)
-    snapshot = None
+        known = base in _cache
+    loaded = None if known else _load_verdicts(base)
+
+    mine, waited = None, False
+    while True:
+        now = time.time()
+        with _cache_lock:
+            pool = _cache.get(base) or loaded
+            if pool is None or (now - pool.swept_at) >= VERDICT_MAX_AGE_S:
+                pool = _Verdicts(now)
+            _cache[base] = pool
+            _cache.move_to_end(base)
+            while len(_cache) > _CACHE_ROOTS:
+                _cache.popitem(last=False)
+            drop, want = set(), set()
+            for i, (name, _marker) in enumerate(deciders):
+                # Nothing in this request's scope can decide this entry. Pass
+                # it through (the under-filtering bias) and, crucially, do not
+                # record that as a verdict: a wider request must still get to
+                # ask.
+                if name == _UNDECIDED:
+                    continue
+                if pool.decider.get(rels[i]) == name:
+                    if rels[i] in pool.ignored:
+                        drop.add(i)
+                else:
+                    want.add(i)
+            if not want:
+                return drop
+            waiter = _inflight.get(base)
+            if waiter is None or waited:
+                # Ours to sweep. `waited` is the second time round:
+                # whoever we waited for did not decide our entries (a narrower
+                # corpus), so we sweep the remainder rather than queueing
+                # behind sweep after sweep for a verdict that is never coming.
+                mine = _inflight[base] = _Event()
+                break
+        # Someone else is asking git for this very base. Their answers land in
+        # the pool we just read, so wait and read it again. The timeout is the
+        # floor under a sweeper that somehow never finishes: worst case we do
+        # what the old code always did and sweep concurrently.
+        waiter.wait(timeout=SWEEP_WAIT_MAX_S)
+        waited = True
+
+    try:
+        fresh = _ignored(root, entries, top, deciders, want)
+    finally:
+        with _cache_lock:
+            if _inflight.get(base) is mine:
+                del _inflight[base]
+        mine.set()
+
+    swept_at = decider = ignored = None
     with _cache_lock:
         # A concurrent request may have swept the pool out from under us; its
         # verdicts are no less true, but they belong to the pool that asked for
@@ -256,10 +326,16 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
                     # It may have been ignored under a DIFFERENT oracle before;
                     # this request's answer supersedes it, in both directions.
                     pool.ignored.discard(rel)
-            if _save_due(base, now):
-                snapshot = _snapshot(base, pool)
-    if snapshot is not None:
-        _save_verdicts(base, snapshot)
+            if persist and _save_due(base, now):
+                # Copied, not snapshotted, under the lock: `dict(...)` and
+                # `set(...)` are one C-level pass each, while `_snapshot` is a
+                # Python loop over every rel. The copy is also what makes the
+                # snapshot safe to build outside — the pool itself keeps being
+                # mutated, by this module, only under this lock.
+                swept_at = pool.swept_at
+                decider, ignored = dict(pool.decider), set(pool.ignored)
+    if decider is not None:
+        _save_verdicts(base, _snapshot(base, swept_at, decider, ignored))
     return drop | fresh
 
 
@@ -279,8 +355,12 @@ def _verdicts_path(base: str) -> str:
     return os.path.join(load_config().dir, "gitignore", digest[:16] + ".json")
 
 
-def _snapshot(base: str, pool: "_Verdicts") -> dict:
+def _snapshot(base: str, swept_at: float, decider: dict, ignored: set) -> dict:
     """The pool as a JSON-able document, grouped by deciding oracle.
+
+    Takes the pool's parts rather than the pool, because it runs OUTSIDE
+    `_cache_lock` (a Python pass over up to 200k rels) and the live pool keeps
+    being mutated under that lock. The caller copies; this only reads.
 
     Grouping IS the compaction: `decider` maps every rel to an oracle name, and
     there are a handful of distinct names against up to 200k rels, so writing
@@ -289,12 +369,12 @@ def _snapshot(base: str, pool: "_Verdicts") -> dict:
     which of them it called ignored — because reuse is conditional on the
     decider and a lossy `ignored`-only file would silently widen it."""
     groups: dict = {}
-    for rel, name in pool.decider.items():
+    for rel, name in decider.items():
         g = groups.get(name)
         if g is None:
             g = groups[name] = ([], [])
-        g[0 if rel in pool.ignored else 1].append(rel)
-    return {"root": base, "swept_at": pool.swept_at,
+        g[0 if rel in ignored else 1].append(rel)
+    return {"root": base, "swept_at": swept_at,
             "verdicts": [[name, ig, kept] for name, (ig, kept) in groups.items()]}
 
 
@@ -360,14 +440,51 @@ def _save_verdicts(base: str, data: dict) -> None:
     tmp = f"{path}.{os.getpid()}.new"
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
+        _sweep_tmp(os.path.dirname(path), tmp)
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(data, f)
         os.replace(tmp, path)
     except Exception:  # noqa: BLE001 - a cache that cannot be saved is still a cache
         logger.debug("could not save the gitignore verdict pool for %s", base,
                      exc_info=True)
+    finally:
+        # In a `finally`, not just on the error path: the write can also be
+        # abandoned mid-`json.dump` — this runs on the warm's daemon thread,
+        # which the interpreter kills outright at exit — and nothing else ever
+        # reclaims this directory. A no-op after a successful `os.replace`.
         try:
             os.unlink(tmp)
+        except OSError:
+            pass
+
+
+# A `.new` this old cannot belong to a write still in progress: the dump is a
+# fraction of a second even for a home-sized pool, and the writer would have
+# renamed it. Anything older is the residue of a process that died mid-write.
+_TMP_STALE_S = 3600.0
+
+
+def _sweep_tmp(dirname: str, keep: str) -> None:
+    """Reclaim `.new` files left by processes that died mid-write.
+
+    The `finally` above cannot cover a daemon thread killed at interpreter
+    exit, and a pid is reused, so a stale tmp can even carry OUR pid. One
+    listdir of a directory holding a handful of files, on the save path only.
+    Never raises: a cache that cannot tidy up is still a cache."""
+    now = time.time()
+    try:
+        names = os.listdir(dirname)
+    except OSError:
+        return
+    for name in names:
+        if not name.endswith(".new"):
+            continue
+        p = os.path.join(dirname, name)
+        if p == keep:
+            continue
+        try:
+            if (now - os.stat(p).st_mtime) > _TMP_STALE_S:
+                os.unlink(p)
         except OSError:
             pass
 

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -311,7 +311,11 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
                 del _inflight[base]
         mine.set()
 
-    swept_at = decider = ignored = None
+    # The pool's parts to write back, or None for "nothing to write". One
+    # value, not three: they are only ever meaningful together, and three
+    # separate optionals let a later edit assign one without the others — a
+    # half-built snapshot nothing in the signature would object to.
+    to_save: tuple | None = None
     with _cache_lock:
         # A concurrent request may have swept the pool out from under us; its
         # verdicts are no less true, but they belong to the pool that asked for
@@ -332,10 +336,10 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list,
                 # Python loop over every rel. The copy is also what makes the
                 # snapshot safe to build outside — the pool itself keeps being
                 # mutated, by this module, only under this lock.
-                swept_at = pool.swept_at
-                decider, ignored = dict(pool.decider), set(pool.ignored)
-    if decider is not None:
-        _save_verdicts(base, _snapshot(base, swept_at, decider, ignored))
+                to_save = (pool.swept_at, dict(pool.decider),
+                           set(pool.ignored))
+    if to_save is not None:
+        _save_verdicts(base, _snapshot(base, *to_save))
     return drop | fresh
 
 

--- a/fused_render/server/index_gitignore.py
+++ b/fused_render/server/index_gitignore.py
@@ -50,6 +50,16 @@ of the machinery here, so time is the only thing that can bound it, and the
 sweep therefore happens on age whatever the index is doing. Newly-appeared
 paths are never stale — they are exactly the ones that get queried.
 
+The pool is also PERSISTED, one file per index root under the index state
+dir. A sweep of a home-sized corpus is ~1.5s of check-ignore, and it used to
+be re-bought on the first keystroke after every server start — a cost with no
+cause, since a verdict is a fact about a path and an oracle, not about a
+process. What does NOT change is the bound: `swept_at` is stored and the
+loaded pool is discarded on age exactly as an in-memory one is, so
+persistence alone only helps a restart within VERDICT_MAX_AGE_S. The other
+half of the design is the startup warm (server/routers/index.py), which
+re-sweeps at idle; together they mean no keystroke pays for a sweep.
+
 Scope is an approximation of the walk's online discovery, biased to
 under-filter (pruning is an optimization, never a hard dependency — the
 walk takes the same posture when git is missing):
@@ -64,12 +74,17 @@ walk takes the same posture when git is missing):
 Mount-backed roots never get here: the index refuses to scan them, so they
 are never `covered` — no check-ignore (kernel I/O) can be aimed at a mount.
 """
+import hashlib
+import json
+import logging
 import os
 import time
 from collections import OrderedDict
 from threading import Lock
 
 from fused_render.server.gitignore import _IgnoreOracle, _repo_toplevel
+
+logger = logging.getLogger(__name__)
 
 # Verdict pools kept per INDEX ROOT. Four is generous now that folders share
 # their root's pool: a machine with more than four configured scan roots is
@@ -99,6 +114,19 @@ VERDICT_MAX_AGE_S = 300.0
 # The name of "no oracle in this request's scope can decide this entry". Not a
 # verdict: such an entry is passed through unfiltered and left out of the pool.
 _UNDECIDED = ""
+
+# How often one root's pool may be written back. A sweep tops the pool up on
+# every request that sees new paths, and the file is the whole pool each time
+# (~200k rels on a home dir), so writing per top-up would put a multi-megabyte
+# serialize on the search path. The FIRST save of a root is not debounced —
+# that is the big one the warm buys, and it must reach disk before the process
+# can exit.
+_SAVE_MIN_INTERVAL_S = 60.0
+
+# root -> when THIS process last wrote its pool. Bounded by _CACHE_ROOTS in
+# practice; entries for evicted roots are harmless (a stale stamp only delays
+# one write).
+_saved_at: dict = {}
 
 
 class _Verdicts:
@@ -182,9 +210,19 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
     now = time.time()
     with _cache_lock:
         pool = _cache.get(base)
+        if pool is None:
+            # A process that has never held this root's pool asks disk before
+            # it asks git: the file is a sweep of this same root, by this
+            # process before a restart or by another one, and it is age-checked
+            # exactly as an in-memory pool is. An EXPIRED in-memory pool
+            # deliberately does NOT come back through here — its own saved copy
+            # is never newer than it, so reloading it would put the pool back
+            # to the age it just aged out of and VERDICT_MAX_AGE_S would never
+            # be reachable.
+            pool = _load_verdicts(base)
         if pool is None or (now - pool.swept_at) >= VERDICT_MAX_AGE_S:
             pool = _Verdicts(now)
-            _cache[base] = pool
+        _cache[base] = pool
         _cache.move_to_end(base)
         while len(_cache) > _CACHE_ROOTS:
             _cache.popitem(last=False)
@@ -203,6 +241,7 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
     if not want:
         return drop
     fresh = _ignored(root, entries, top, deciders, want)
+    snapshot = None
     with _cache_lock:
         # A concurrent request may have swept the pool out from under us; its
         # verdicts are no less true, but they belong to the pool that asked for
@@ -217,7 +256,120 @@ def _pooled_verdicts(base: str, prefix: str, root: str, entries: list) -> set:
                     # It may have been ignored under a DIFFERENT oracle before;
                     # this request's answer supersedes it, in both directions.
                     pool.ignored.discard(rel)
+            if _save_due(base, now):
+                snapshot = _snapshot(base, pool)
+    if snapshot is not None:
+        _save_verdicts(base, snapshot)
     return drop | fresh
+
+
+# ------------------------------------------------------------ the pool on disk
+
+def _verdicts_path(base: str) -> str:
+    """Where one index root's pool lives, under the index state dir.
+
+    A digest rather than the root path itself: a root is an absolute path with
+    separators, spaces and any unicode the filesystem allows, and none of that
+    belongs in a filename. The root is stored INSIDE the file and checked on
+    load, so a truncated digest costs a re-sweep at worst, never another
+    tree's verdicts."""
+    from fused_render.index.config import load_config
+
+    digest = hashlib.sha1(base.encode("utf-8", "surrogateescape")).hexdigest()
+    return os.path.join(load_config().dir, "gitignore", digest[:16] + ".json")
+
+
+def _snapshot(base: str, pool: "_Verdicts") -> dict:
+    """The pool as a JSON-able document, grouped by deciding oracle.
+
+    Grouping IS the compaction: `decider` maps every rel to an oracle name, and
+    there are a handful of distinct names against up to 200k rels, so writing
+    the name once per group instead of once per rel is most of the file. Both
+    halves of a verdict round trip exactly — which rels the oracle decided, and
+    which of them it called ignored — because reuse is conditional on the
+    decider and a lossy `ignored`-only file would silently widen it."""
+    groups: dict = {}
+    for rel, name in pool.decider.items():
+        g = groups.get(name)
+        if g is None:
+            g = groups[name] = ([], [])
+        g[0 if rel in pool.ignored else 1].append(rel)
+    return {"root": base, "swept_at": pool.swept_at,
+            "verdicts": [[name, ig, kept] for name, (ig, kept) in groups.items()]}
+
+
+def _load_verdicts(base: str):
+    """The persisted pool for `base`, or None — missing, too old, for another
+    root, or unreadable in any way. Never raises: this runs on the path that
+    answers a search box, and a pool is an optimization."""
+    try:
+        with open(_verdicts_path(base), encoding="utf-8") as f:
+            data = json.load(f)
+        if data.get("root") != base:
+            return None
+        swept_at = float(data["swept_at"])
+        # The same bound an in-memory pool lives under, anchored on the sweep
+        # that produced these verdicts rather than on the process that read
+        # them: an edited .gitignore is invisible to everything here, so age is
+        # the only thing that can bound the staleness, restart or no restart.
+        if (time.time() - swept_at) >= VERDICT_MAX_AGE_S:
+            return None
+        pool = _Verdicts(swept_at)
+        for name, ignored, kept in data["verdicts"]:
+            if not name:  # _UNDECIDED is not a verdict and is never written
+                return None
+            for rel in ignored:
+                pool.decider[rel] = name
+                pool.ignored.add(rel)
+            for rel in kept:
+                pool.decider[rel] = name
+        return pool
+    except FileNotFoundError:
+        return None
+    except Exception:  # noqa: BLE001 - corrupt, truncated, hand-edited: re-sweep
+        logger.debug("unreadable gitignore verdict pool for %s", base,
+                     exc_info=True)
+        return None
+
+
+def _save_due(base: str, now: float) -> bool:
+    """Whether `base`'s pool may be written back now, stamping it when it may.
+
+    Called under `_cache_lock`. The FIRST save of a root is never debounced —
+    it is the full sweep the startup warm buys, and the whole point is that the
+    next process finds it — while later top-ups are, because the file is the
+    whole pool every time and a search must not serialize megabytes per
+    keystroke."""
+    last = _saved_at.get(base)
+    if last is not None and (now - last) < _SAVE_MIN_INTERVAL_S:
+        return False
+    _saved_at[base] = now
+    return True
+
+
+def _save_verdicts(base: str, data: dict) -> None:
+    """Write the pool atomically (tmp + rename, as `index/store._write_manifest`
+    does) so a reader never sees half of one, and never raise.
+
+    Inline on the thread that swept, not a background one: the sweep this
+    follows is seconds of `git check-ignore` and the dump is a fraction of it,
+    and in the normal case both are paid by the startup warm rather than by a
+    request. The tmp name carries the pid so two processes writing the same
+    root cannot land in each other's file."""
+    path = _verdicts_path(base)
+    tmp = f"{path}.{os.getpid()}.new"
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001 - a cache that cannot be saved is still a cache
+        logger.debug("could not save the gitignore verdict pool for %s", base,
+                     exc_info=True)
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def _deciders(root: str, entries: list, prefix: str):

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -32,7 +32,7 @@ from fused_render.index import freshness, runner
 from fused_render.index.freshness import enclosing_root
 from fused_render.index.config import IndexConfig, load_config, save_config
 from fused_render.index.guarded_query import MAX_LIMIT, run_guarded
-from fused_render.index.ignore import default_ignore, norm
+from fused_render.index.ignore import MountGuard, default_ignore, norm
 from fused_render.index.query import MAX_CORPUS
 from fused_render.index.query import lookup as index_lookup
 from fused_render.index.query import search_under as index_search
@@ -124,6 +124,63 @@ def run_startup_scan(start_dir: str | None = None) -> None:
 async def startup_scan(start_dir: str | None = None) -> None:
     """The create_app hook. Off the event loop because it touches the disk."""
     await asyncio.to_thread(run_startup_scan, start_dir)
+
+
+# ------------------------------------------------------------- startup warm
+
+def warm_root() -> str:
+    """The root the explorer's home page will search.
+
+    FilesHome searches `config.home` — `expanduser("~")` from
+    routers/config.py — and NOT the folder the app was opened on, so a warm
+    aimed anywhere else fills a pool the first keystroke never reads. In
+    `canonical_root` spelling because that is the spelling every store key and
+    every scan-root comparison uses (see `scan_roots`)."""
+    return runner.canonical_root("~")
+
+
+def run_startup_warm() -> None:
+    """Pay the first search's cold cost at idle instead of on a keystroke.
+
+    Everything the corpus path caches is PER PROCESS and starts empty: the
+    gitignore verdict pool (server/index_gitignore.py) knows nothing until
+    some request sweeps `git check-ignore` over the whole corpus, and duckdb
+    is not even imported until the first query. Measured on a 164k-entry home:
+    ~2.2 s for the first search of a fresh process against ~0.8 s for the next
+    one — and all of it was billed to the user's first keystroke.
+
+    So it runs exactly the pair of calls `api_index_search` makes, with the
+    same root and the same pool key. An index that has not covered the home
+    root yet answers `covered: false` cheaply and pools nothing; a scan that
+    completes later therefore still leaves the first search paying the sweep.
+    Deliberately NOT polled or retried: a loop chasing the scan would be a
+    second scheduler, and the persisted pool (index_gitignore) is what covers
+    the restart case.
+
+    Never raises: it runs on a thread nobody joins."""
+    try:
+        root = warm_root()
+        # A mount-backed home is refused by the index anyway, so the warm
+        # could only answer `covered: false` — after aiming kernel I/O at a
+        # mount path, which is the one thing this codebase never does
+        # speculatively. Pure string work, exactly as in `runner.start`.
+        if MountGuard(mounts_dir=runner._mounts_dir()).blocks_root(root):
+            return
+        cfg = load_config()
+        out = index_search(cfg, root)
+        filter_corpus(out, index_root=enclosing_root(scan_roots(cfg),
+                                                     out.get("root") or root))
+    except Exception:  # noqa: BLE001 - a warm must never take the server down
+        logger.exception("could not warm the index search path")
+
+
+def startup_warm() -> None:
+    """The create_app hook. A detached daemon thread, not `to_thread`: the
+    startup hook must COMPLETE before the app serves, and this is seconds of
+    duckdb and `git check-ignore` — the very cost the warm exists to move off
+    the request path. Nobody joins it and it cannot raise (above)."""
+    threading.Thread(target=run_startup_warm, name="index-warm",
+                     daemon=True).start()
 
 
 # ------------------------------------------------------ open-folder freshness

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -85,13 +85,25 @@ def scan_roots(cfg: IndexConfig, start_dir: str | None = None) -> list:
     return [runner.canonical_root("~")]
 
 
+# root -> the run id this process started for it at startup, for the warm
+# below to wait on. Only the runs THIS boot spawned: a root that was
+# debounce-skipped, refused, or failed leaves no entry, which is exactly the
+# "there is nothing to wait for" signal the warm needs. Bounded by the number
+# of scan roots (a handful), and rewritten from scratch on every call.
+_startup_runs: dict = {}
+
+
 def run_startup_scan(start_dir: str | None = None) -> None:
     """Reclaim old run dirs and kick off one incremental scan per root.
 
     Never raises and never blocks: the scan itself is a detached worker, so
     this is a `Popen` per root and nothing more. A scan that ran recently is
     skipped (SCAN_DEBOUNCE_S), and a root that no longer exists is ignored
-    rather than reported — the config outlives the folders it names."""
+    rather than reported — the config outlives the folders it names.
+
+    Records each started run in `_startup_runs` for `run_startup_warm`, which
+    warms only after the run covering its root has finished."""
+    _startup_runs.clear()
     try:
         cfg = load_config()
         runner.prune_runs(cfg, keep=KEEP_RUNS)
@@ -109,8 +121,11 @@ def run_startup_scan(start_dir: str | None = None) -> None:
                             root, now - last)
                 continue
             started = runner.start(cfg, root)
+            run_id = (started or {}).get("run_id")
+            if run_id:
+                _startup_runs[root] = run_id
             logger.info("index: started background scan of %s (run %s)",
-                        root, (started or {}).get("run_id"))
+                        root, run_id)
         except ValueError as e:
             # A root that no longer exists, or one that turned out to be
             # mount-backed — skip it quietly; the config outlives the folders
@@ -140,6 +155,50 @@ def warm_root() -> str:
     return runner.canonical_root("~")
 
 
+# How often the warm re-reads the status of the one scan it is waiting for.
+# Nothing signals this thread when a detached worker finishes, so the wait is
+# a stat of that run's event log (runner.status folds it, and re-folds only
+# when the log moves). Half a second is the worker's own heartbeat cadence, so
+# a finer poll would mostly re-read an unchanged file, and half a second of
+# latency is nothing against the ~2.2 s the warm is saving.
+WARM_WAIT_POLL_S = 0.5
+# ...and the hard ceiling on that wait. The first-ever whole-home scan that
+# motivated this took 9.2 s (570k files, 74k dirs); six minutes is ~40x that,
+# so even a much larger home on a much slower disk still gets warmed. The
+# ceiling exists for the scan that never reports at all: a worker killed
+# mid-walk is reported not-running by runner's own liveness check after
+# ABANDONED_RUN_S (5 min), so this must sit just PAST that — otherwise the
+# common death gives up here instead of taking the (correct) finished path —
+# while still guaranteeing the thread cannot poll for the process lifetime.
+WARM_WAIT_DEADLINE_S = 6 * 60.0
+
+
+def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
+    """Block until `run_id` stops running; False if the deadline beat it.
+
+    One-shot and bounded, on a daemon thread nobody joins: it waits for one
+    named run and then it is done, whichever way that run ended."""
+    import time
+
+    deadline = time.monotonic() + WARM_WAIT_DEADLINE_S
+    while True:
+        try:
+            state = runner.status(cfg, run_id)["state"]
+        except ValueError:
+            # The run dir is gone (pruned, or a stubbed start that never made
+            # one). Nothing left to wait for, and the index is whatever it is.
+            return True
+        if not state.get("running"):
+            return True
+        if time.monotonic() >= deadline:
+            # Once, at info: this is a diagnosis of a stuck scan, not a
+            # failure of the warm — the next search just pays the old cost.
+            logger.info("index: gave up waiting %.0fs for scan %s; the search "
+                        "corpus stays cold", WARM_WAIT_DEADLINE_S, run_id)
+            return False
+        time.sleep(WARM_WAIT_POLL_S)
+
+
 def run_startup_warm() -> None:
     """Pay the first search's cold cost at idle instead of on a keystroke.
 
@@ -151,12 +210,19 @@ def run_startup_warm() -> None:
     one — and all of it was billed to the user's first keystroke.
 
     So it runs exactly the pair of calls `api_index_search` makes, with the
-    same root and the same pool key. An index that has not covered the home
-    root yet answers `covered: false` cheaply and pools nothing; a scan that
-    completes later therefore still leaves the first search paying the sweep.
-    Deliberately NOT polled or retried: a loop chasing the scan would be a
-    second scheduler, and the persisted pool (index_gitignore) is what covers
-    the restart case.
+    same root and the same pool key. Usually that is all: an index is already
+    on disk, the search answers `covered: true`, and the sweep lands in the
+    pool immediately.
+
+    On a first-ever boot it is not. The index has not covered home yet, the
+    search answers `covered: false` cheaply, and there is nothing to sweep —
+    which is exactly the boot the warm exists for. So when that happens it
+    waits for the ONE scan `run_startup_scan` just spawned for this root
+    (`_startup_runs`) and then warms. That is not the general "poll for scans"
+    scheduler this deliberately is not: it is one bounded wait on one named
+    run, with a definite end (WARM_WAIT_DEADLINE_S) on a thread nobody joins.
+    A root whose scan was debounce-skipped has no entry and is not waited on —
+    there is no new run coming, and its index is already there.
 
     Never raises: it runs on a thread nobody joins."""
     try:
@@ -169,6 +235,13 @@ def run_startup_warm() -> None:
             return
         cfg = load_config()
         out = index_search(cfg, root)
+        if not out.get("covered"):
+            run_id = _startup_runs.get(root)
+            if run_id is not None and _wait_for_scan(cfg, run_id):
+                out = index_search(cfg, root)
+        # Unconditional, including the uncovered cases: filter_corpus is a
+        # no-op on a response that is not covered, and the point is to run
+        # precisely what the route runs.
         filter_corpus(out, index_root=enclosing_root(scan_roots(cfg),
                                                      out.get("root") or root))
     except Exception:  # noqa: BLE001 - a warm must never take the server down
@@ -179,7 +252,9 @@ def startup_warm() -> None:
     """The create_app hook. A detached daemon thread, not `to_thread`: the
     startup hook must COMPLETE before the app serves, and this is seconds of
     duckdb and `git check-ignore` — the very cost the warm exists to move off
-    the request path. Nobody joins it and it cannot raise (above)."""
+    the request path — and, on a first boot, a bounded wait for the startup
+    scan on top of that. Nobody joins it and it cannot raise (above); `daemon`
+    is what guarantees a warm still waiting cannot hold the process open."""
     threading.Thread(target=run_startup_warm, name="index-warm",
                      daemon=True).start()
 

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -18,6 +18,7 @@ X-Fused-guarded despite being reads: they execute a caller-shaped statement, so
 neither should be reachable from a crafted link.
 """
 import asyncio
+import gzip
 import json
 import logging
 import os
@@ -26,7 +27,7 @@ import threading
 
 from fastapi import APIRouter, Body, Header, Query
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 
 from fused_render.index import freshness, runner
 from fused_render.index.freshness import enclosing_root
@@ -397,9 +398,19 @@ def api_index_lookup(q: str = Query(default=""), limit: int = Query(default=100)
                            sort=sort)}
 
 
+# The one value of `fmt` that means anything. Anything else — including the
+# empty default every existing caller sends — is the classic `entries` shape:
+# the JS bridge (`fused.fileIndex.search`, static/runtime.js) and any page a
+# user has written against it must not change under them, and a 400 on an
+# unknown format would break exactly the callers that never asked.
+COLUMNS_FMT = "columns"
+
+
 @router.get("/api/index/search")
 def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
-                     limit: int = Query(default=MAX_CORPUS)):
+                     limit: int = Query(default=MAX_CORPUS),
+                     fmt: str = Query(default=""),
+                     accept_encoding: str | None = Header(default=None)):
     """The explorer's in-folder corpus, index-backed.
 
     Same entry shape as /api/fs/walk, plus `covered`/`fresh` so the client can
@@ -410,7 +421,12 @@ def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
 
     Entries pass through the gitignore filter before leaving: the walk this
     corpus replaces prunes gitignored entries, and the swap must not change
-    what search shows (server/index_gitignore.py)."""
+    what search shows (server/index_gitignore.py).
+
+    `fmt=columns` asks for the same corpus as parallel arrays instead of one
+    object per entry (§6 of index/specs/server-api.md) — the home page's
+    corpus is the whole ranking set, 25.7 MB on a 164k-entry home, and it is
+    fetched in one shot on the user's first keystroke."""
     if not root.strip():
         return _error("'root' is required")
     cfg = load_config()
@@ -422,7 +438,59 @@ def api_index_search(root: str = Query(default=""), q: str = Query(default=""),
     # canonical spelling the corpus rels are relative to.
     index_root = enclosing_root(scan_roots(cfg), out.get("root") or root)
     out = filter_corpus(out, index_root=index_root)
-    return {"ok": True, **out}
+    if fmt != COLUMNS_FMT:
+        return {"ok": True, **out}
+    return _corpus_response(_columnar({"ok": True, **out}), accept_encoding)
+
+
+def _columnar(out: dict) -> dict:
+    """`entries` re-cut as parallel arrays; everything else untouched.
+
+    Every entry carries the same four keys, so the classic shape spends ~40
+    bytes per entry spelling `rel`/`is_dir`/`size`/`mtime` out again — a third
+    of a 164k-entry corpus. The arrays are index-aligned and the same length;
+    `size`/`mtime` stay nullable (a directory legitimately has neither) and
+    `is_dir` travels as 0/1 because `false` costs three more bytes 164k times.
+
+    Deliberately NOT a cleverer packing. Front-coding the rels (they arrive
+    depth-then-path ordered, so neighbours share long prefixes) takes the body
+    from 21 MB to 12 MB — but costs 0.45 s of Python per corpus against the
+    0.07 s the whole serialization takes, so it spends more of the first
+    search's budget than it saves. Compression buys more for a fraction of
+    that (below)."""
+    entries = out.get("entries") or []
+    body = {k: v for k, v in out.items() if k != "entries"}
+    body["fmt"] = COLUMNS_FMT
+    body["rels"] = [e["rel"] for e in entries]
+    body["dirs"] = [1 if e["is_dir"] else 0 for e in entries]
+    body["sizes"] = [e["size"] for e in entries]
+    body["mtimes"] = [e["mtime"] for e in entries]
+    return body
+
+
+def _corpus_response(body: dict, accept_encoding: str | None) -> Response:
+    """The compact corpus, gzipped when the caller says it can take it.
+
+    Level 1, not the default 9: measured on the 164k-entry corpus this route
+    exists for, level 1 takes the compact body from 21 MB to 5.0 MB in 0.06 s
+    — a fifth of the bytes for less CPU than the JSON encoding itself. Higher
+    levels spend several seconds to shave a few percent off a body that is
+    read once and thrown away.
+
+    Per-route rather than a GZip middleware: this app also streams the live
+    walk and serves file bytes raw, and compressing those on a LOCAL server
+    would be CPU spent against loopback for nothing. This one response is the
+    outlier — a single 25 MB read on a keystroke.
+
+    `Accept-Encoding` is honoured rather than assumed: browsers and the JS
+    bridge all send gzip, but a client that cannot decompress must still be
+    able to read the corpus."""
+    payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
+    if "gzip" not in (accept_encoding or "").lower():
+        return Response(content=payload, media_type="application/json")
+    return Response(content=gzip.compress(payload, 1),
+                    media_type="application/json",
+                    headers={"Content-Encoding": "gzip"})
 
 
 # ------------------------------------------------------------------ user SQL

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -180,6 +180,11 @@ def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
     One-shot and bounded, on a daemon thread nobody joins: it waits for one
     named run and then it is done, whichever way that run ended.
 
+    The return value says how the WAIT ended, and nothing more — the caller
+    warms either way, because how a scan ended does not tell you whether the
+    index covers the root. It exists so the two ways of not-finishing can be
+    told apart in a log and in a test.
+
     Deliberately NOT `runner.status`, which is the status panel's call: it
     folds the whole event log from line 0 every time, so polling it would
     re-parse a log the waited-on scan is appending to twice a second — work
@@ -194,7 +199,8 @@ def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
         run_dir = runner._run_dir(cfg, run_id)
     except ValueError:
         # The run dir is gone (pruned, or a stubbed start that never made
-        # one). Nothing left to wait for, and the index is whatever it is.
+        # one). Nothing left to wait for; whether the index covers the root is
+        # a question for the search that follows, not for this.
         return True
     deadline = time.monotonic() + WARM_WAIT_DEADLINE_S
     cursor = 0
@@ -203,14 +209,15 @@ def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
         if ended:
             return True
         if runner._looks_abandoned(run_dir, time.time(), runner.ABANDONED_RUN_S):
-            logger.info("index: scan %s died without finishing; the search "
-                        "corpus stays cold", run_id)
+            logger.info("index: scan %s stopped reporting; warming with "
+                        "whatever the index holds", run_id)
             return False
         if time.monotonic() >= deadline:
             # Once, at info: this is a diagnosis of a stuck scan, not a
-            # failure of the warm — the next search just pays the old cost.
-            logger.info("index: gave up waiting %.0fs for scan %s; the search "
-                        "corpus stays cold", WARM_WAIT_DEADLINE_S, run_id)
+            # failure of the warm, which goes ahead regardless.
+            logger.info("index: gave up waiting %.0fs for scan %s; warming "
+                        "with whatever the index holds",
+                        WARM_WAIT_DEADLINE_S, run_id)
             return False
         time.sleep(WARM_WAIT_POLL_S)
 
@@ -234,11 +241,12 @@ def run_startup_warm() -> None:
     search answers `covered: false` cheaply, and there is nothing to sweep —
     which is exactly the boot the warm exists for. So when that happens it
     waits for the ONE scan `run_startup_scan` just spawned for this root
-    (`_startup_runs`) and then warms. That is not the general "poll for scans"
-    scheduler this deliberately is not: it is one bounded wait on one named
-    run, with a definite end (WARM_WAIT_DEADLINE_S) on a thread nobody joins.
-    A root whose scan was debounce-skipped has no entry and is not waited on —
-    there is no new run coming, and its index is already there.
+    (`_startup_runs`) and then warms — warms unconditionally, however that wait
+    ended. That is not the general "poll for scans" scheduler this deliberately
+    is not: it is one bounded wait on one named run, with a definite end
+    (WARM_WAIT_DEADLINE_S) on a thread nobody joins. A root whose scan was
+    debounce-skipped has no entry and is not waited on — there is no new run
+    coming, and its index is already there.
 
     Never raises: it runs on a thread nobody joins."""
     try:
@@ -258,7 +266,15 @@ def run_startup_warm() -> None:
         out = index_search(cfg, root)
         if not out.get("covered"):
             run_id = _startup_runs.get(root)
-            if run_id is not None and _wait_for_scan(cfg, run_id):
+            if run_id is not None:
+                # Searching again is unconditional — how the wait ENDED does
+                # not tell us whether the index covers the root. A run dir
+                # pruned mid-wait reads as a dead scan here, but `prune_runs`
+                # only removes run dirs and never touches the store, so the
+                # index may well be complete. A still-uncovered index costs
+                # one cheap `covered: false`, which is exactly what the
+                # original single-shot warm already paid.
+                _wait_for_scan(cfg, run_id)
                 out = index_search(cfg, root)
         # Unconditional, including the uncovered cases: filter_corpus is a
         # no-op on a response that is not covered, and the point is to run

--- a/fused_render/server/routers/index.py
+++ b/fused_render/server/routers/index.py
@@ -155,21 +155,22 @@ def warm_root() -> str:
     return runner.canonical_root("~")
 
 
-# How often the warm re-reads the status of the one scan it is waiting for.
-# Nothing signals this thread when a detached worker finishes, so the wait is
-# a stat of that run's event log (runner.status folds it, and re-folds only
-# when the log moves). Half a second is the worker's own heartbeat cadence, so
-# a finer poll would mostly re-read an unchanged file, and half a second of
-# latency is nothing against the ~2.2 s the warm is saving.
+# How often the warm re-reads the event log of the one scan it is waiting for.
+# Nothing signals this thread when a detached worker finishes, so the wait
+# reads that log (`runner.has_ended`, cursored so only new lines are decoded).
+# Half a second is the worker's own progress cadence, so a finer poll would
+# mostly re-read a file with nothing new in it, and half a second of latency is
+# nothing against the ~2.2 s the warm is saving.
 WARM_WAIT_POLL_S = 0.5
 # ...and the hard ceiling on that wait. The first-ever whole-home scan that
 # motivated this took 9.2 s (570k files, 74k dirs); six minutes is ~40x that,
-# so even a much larger home on a much slower disk still gets warmed. The
-# ceiling exists for the scan that never reports at all: a worker killed
-# mid-walk is reported not-running by runner's own liveness check after
-# ABANDONED_RUN_S (5 min), so this must sit just PAST that — otherwise the
-# common death gives up here instead of taking the (correct) finished path —
-# while still guaranteeing the thread cannot poll for the process lifetime.
+# so even a much larger home on a much slower disk still gets warmed. This is
+# the LAST resort, not the usual exit: a worker killed mid-walk never writes
+# `run_end`, and the wait spots that within ABANDONED_RUN_S (5 min) through the
+# same mtime check `runner.status` uses. The ceiling sits just past that so the
+# common death takes the specific path, and covers only the pathological rest —
+# a worker alive but wedged — so the thread can never poll for the process
+# lifetime.
 WARM_WAIT_DEADLINE_S = 6 * 60.0
 
 
@@ -177,19 +178,34 @@ def _wait_for_scan(cfg: IndexConfig, run_id: str) -> bool:
     """Block until `run_id` stops running; False if the deadline beat it.
 
     One-shot and bounded, on a daemon thread nobody joins: it waits for one
-    named run and then it is done, whichever way that run ended."""
+    named run and then it is done, whichever way that run ended.
+
+    Deliberately NOT `runner.status`, which is the status panel's call: it
+    folds the whole event log from line 0 every time, so polling it would
+    re-parse a log the waited-on scan is appending to twice a second — work
+    quadratic in that scan's length, spent competing with it for the disk.
+    `runner.has_ended` carries a cursor and decodes only what is new, and the
+    dead-worker case is the same `_looks_abandoned` mtime check `status`
+    applies (a worker killed mid-walk never writes `run_end`, so without it
+    this would wait out the whole deadline for the most common death)."""
     import time
 
+    try:
+        run_dir = runner._run_dir(cfg, run_id)
+    except ValueError:
+        # The run dir is gone (pruned, or a stubbed start that never made
+        # one). Nothing left to wait for, and the index is whatever it is.
+        return True
     deadline = time.monotonic() + WARM_WAIT_DEADLINE_S
+    cursor = 0
     while True:
-        try:
-            state = runner.status(cfg, run_id)["state"]
-        except ValueError:
-            # The run dir is gone (pruned, or a stubbed start that never made
-            # one). Nothing left to wait for, and the index is whatever it is.
+        ended, cursor = runner.has_ended(run_dir, cursor)
+        if ended:
             return True
-        if not state.get("running"):
-            return True
+        if runner._looks_abandoned(run_dir, time.time(), runner.ABANDONED_RUN_S):
+            logger.info("index: scan %s died without finishing; the search "
+                        "corpus stays cold", run_id)
+            return False
         if time.monotonic() >= deadline:
             # Once, at info: this is a diagnosis of a stuck scan, not a
             # failure of the warm — the next search just pays the old cost.
@@ -230,7 +246,12 @@ def run_startup_warm() -> None:
         # A mount-backed home is refused by the index anyway, so the warm
         # could only answer `covered: false` — after aiming kernel I/O at a
         # mount path, which is the one thing this codebase never does
-        # speculatively. Pure string work, exactly as in `runner.start`.
+        # speculatively. Exactly the check `runner.start` makes, and what it
+        # guarantees is what matters here: a path INSIDE the mounts dir matches
+        # on `abspath` alone and is refused before any syscall touches it. It
+        # is not free for everyone else — a local home falls through to
+        # `is_mount_backed`, which realpaths the mounts dir and the path — but
+        # those two realpaths are off the mount by construction.
         if MountGuard(mounts_dir=runner._mounts_dir()).blocks_root(root):
             return
         cfg = load_config()
@@ -559,13 +580,48 @@ def _corpus_response(body: dict, accept_encoding: str | None) -> Response:
 
     `Accept-Encoding` is honoured rather than assumed: browsers and the JS
     bridge all send gzip, but a client that cannot decompress must still be
-    able to read the corpus."""
+    able to read the corpus. `Vary` goes on both answers because both live at
+    the same URL — an intermediary keyed on the URL alone would otherwise hand
+    a gzipped body to the client that asked for identity, or the reverse."""
     payload = json.dumps(body, separators=(",", ":")).encode("utf-8")
-    if "gzip" not in (accept_encoding or "").lower():
-        return Response(content=payload, media_type="application/json")
+    headers = {"Vary": "Accept-Encoding"}
+    if not _accepts_gzip(accept_encoding):
+        return Response(content=payload, media_type="application/json",
+                        headers=headers)
     return Response(content=gzip.compress(payload, 1),
                     media_type="application/json",
-                    headers={"Content-Encoding": "gzip"})
+                    headers={**headers, "Content-Encoding": "gzip"})
+
+
+def _accepts_gzip(accept_encoding: str | None) -> bool:
+    """Whether the caller will take a gzipped body, per RFC 9110 §12.5.3.
+
+    A substring test for "gzip" is not that test: `gzip;q=0` is the explicit
+    spelling of "I cannot decode this", and reading it as consent hands such a
+    client 5 MB it has no way to open. So the qvalue is parsed, an explicit
+    `gzip` (or the legacy `x-gzip`) beats the `*` wildcard, and anything
+    unparseable is treated as a refusal — being wrong the safe way costs a
+    bigger body, not an unreadable one."""
+    explicit = star = None
+    for part in (accept_encoding or "").split(","):
+        token, _, params = part.strip().partition(";")
+        token = token.strip().lower()
+        if token not in ("gzip", "x-gzip", "*"):
+            continue
+        q = 1.0
+        for param in params.split(";"):
+            key, _, value = param.partition("=")
+            if key.strip().lower() == "q":
+                try:
+                    q = float(value.strip())
+                except ValueError:
+                    q = 0.0
+        if token == "*":
+            star = q if star is None else max(star, q)
+        else:
+            explicit = q if explicit is None else max(explicit, q)
+    q = explicit if explicit is not None else star
+    return q is not None and q > 0
 
 
 # ------------------------------------------------------------------ user SQL

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -353,6 +353,11 @@ def _no_startup_index_scan(monkeypatch):
         return None
 
     monkeypatch.setattr(index_routes, "startup_scan", _skip)
+    # The same hook also warms the home page's search corpus on a detached
+    # thread. Harmless to the index, but it sweeps `git check-ignore` over the
+    # developer's real home and outlives the test that spawned it — so it goes
+    # too. Its own tests call `run_startup_warm()` directly.
+    monkeypatch.setattr(index_routes, "startup_warm", lambda: None)
     # Same hazard by a second door: GET /api/fs/list notes the folder for the
     # index freshness check (scan-incremental.md §5), which runs on a background
     # thread and can call runner.start. A test listing any path under the

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -655,6 +655,88 @@ def test_startup_scan_skips_a_root_that_is_gone(home, tmp_path, monkeypatch):
     assert started == [str(ok)]
 
 
+# -- the startup warm ----------------------------------------------------------
+
+def test_startup_warm_runs_the_home_pages_first_search(home, tmp_path, monkeypatch):
+    """The warm must ask for exactly what the home page asks for.
+
+    FilesHome searches `config.home` (routers/config.py — `expanduser("~")`),
+    not the folder the app was opened on, so a warm aimed anywhere else fills
+    a pool the first keystroke never reads."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    seen = []
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: seen.append(("search", root))
+                        or {"covered": True, "root": root, "entries": []})
+    monkeypatch.setattr(index_router, "filter_corpus",
+                        lambda out, index_root=None:
+                        seen.append(("filter", index_root)) or out)
+    cfg = load_config()
+    cfg.roots = [str(tmp_path)]
+    index_router.save_config(cfg)
+    index_router.run_startup_warm()
+    # Same pair of calls the route makes, and pooled under the same index root:
+    # a warm that filtered under a different key would fill a second pool.
+    assert seen == [("search", index_router.runner.canonical_root("~")),
+                    ("filter", str(tmp_path))]
+
+
+def test_startup_warm_never_raises(home, tmp_path, monkeypatch):
+    """It runs on a background thread nobody joins: a raise here would be an
+    unhandled exception in the log and a permanently cold pool."""
+    def boom(*a, **k):
+        raise RuntimeError("duckdb on fire")
+
+    monkeypatch.setattr(index_router, "index_search", boom)
+    index_router.run_startup_warm()  # no exception
+
+
+def test_startup_warm_refuses_a_mount_backed_home(home, tmp_path, monkeypatch):
+    """The index refuses to scan mounts, so a warm aimed at one could only
+    ever answer `covered: false` — after paying kernel I/O on a mount path,
+    which is the one thing this codebase never does speculatively."""
+    monkeypatch.setattr(index_router.MountGuard, "blocks_root",
+                        lambda self, root: True)
+    called = []
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: called.append(root) or {})
+    index_router.run_startup_warm()
+    assert called == []
+
+
+def test_startup_warm_fills_the_gitignore_verdict_pool(home, tmp_path, monkeypatch):
+    """The point of the warm, end to end: after a real scan the first search
+    pays a full check-ignore sweep of the whole corpus (~1.5 s on a home dir).
+    Once the warm has run, that sweep is already in the pool."""
+    from fused_render.server import index_gitignore
+
+    src = _tree(tmp_path)
+    (src / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (src / "noise.log").write_text("x", encoding="utf-8")
+    client = _client(tmp_path)
+    started = client.post("/api/index/scan", json={"root": str(src)},
+                          headers={"X-Fused": "1"})
+    run_id = started.json()["run_id"]
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        if not client.get("/api/index/status",
+                          params={"run_id": run_id}).json()["running"]:
+            break
+        time.sleep(0.2)
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_gitignore._cache.clear()
+    # HOME is what the warm aims at; point it at the scanned tree so the warm
+    # answers `covered` and actually sweeps.
+    monkeypatch.setenv("HOME", str(src))
+    index_router.run_startup_warm()
+    pool = index_gitignore._cache.get(str(src))
+    assert pool is not None
+    assert "noise.log" in pool.ignored
+    assert "alpha.txt" in pool.decider
+
+
 def test_a_root_of_slash_survives_the_config_write(home, tmp_path):
     """Roots are paths, not ignore patterns: clean_patterns rstrips '/' into
     the empty string and silently drops the root."""

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -942,7 +942,10 @@ def test_startup_warm_gives_up_when_the_scan_never_finishes(home, tmp_path,
     began = time.monotonic()
     index_router.run_startup_warm()
     assert time.monotonic() - began < 5, "the wait is not deadline-bounded"
-    assert len(calls) == 1, "it searched again after giving up"
+    # It still searches: how the wait ended says nothing about whether the
+    # index covers the root, and an uncovered one costs a cheap `covered:
+    # false` — exactly what the original single-shot warm already paid.
+    assert len(calls) == 2
 
 
 def test_startup_warm_stops_waiting_on_a_worker_that_died(home, tmp_path,
@@ -966,7 +969,38 @@ def test_startup_warm_stops_waiting_on_a_worker_that_died(home, tmp_path,
     began = time.monotonic()
     index_router.run_startup_warm()
     assert time.monotonic() - began < 5
-    assert len(calls) == 1
+    assert len(calls) == 2
+
+
+def test_startup_warm_searches_again_when_the_run_dir_vanishes_mid_wait(
+        home, tmp_path, monkeypatch):
+    """`prune_runs` reclaims run DIRS; it never touches the store. So a run
+    dir that disappears while the warm is waiting on it says nothing about
+    whether the index covers the root — reading it as "the scan died, skip the
+    warm" silently left the pool cold for an index that was complete."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    run_dir = tmp_path / "pruned-run"
+    run_dir.mkdir()
+    calls, filtered = [], []
+
+    def search(cfg, root, **kw):
+        calls.append(root)
+        if len(calls) == 1:
+            run_dir.rmdir()  # pruned out from under the wait
+            return {"covered": False, "root": root}
+        return {"covered": True, "root": root, "entries": []}
+
+    monkeypatch.setattr(index_router, "index_search", search)
+    monkeypatch.setattr(index_router, "filter_corpus",
+                        lambda out, index_root=None: filtered.append(out) or out)
+    monkeypatch.setattr(index_router.runner, "_run_dir",
+                        lambda cfg, run_id: str(run_dir))
+    monkeypatch.setattr(index_router, "WARM_WAIT_POLL_S", 0.01)
+    monkeypatch.setitem(index_router._startup_runs, index_router.warm_root(),
+                        "run-that-was-pruned")
+    index_router.run_startup_warm()
+    assert len(calls) == 2
+    assert [out.get("covered") for out in filtered] == [True]
 
 
 def test_startup_warm_does_not_wait_when_the_root_is_covered(home, tmp_path,

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -736,6 +736,35 @@ def test_columns_are_several_times_smaller_on_the_wire(home, tmp_path, monkeypat
     assert wire[0] / wire[1] >= 3.0, wire
 
 
+@pytest.mark.parametrize("accept,gzipped", [
+    ("gzip", True),
+    ("gzip, deflate, br", True),
+    ("x-gzip", True),
+    ("gzip;q=0.5", True),
+    ("*", True),
+    # `q=0` is the explicit "I cannot take this encoding" spelling, and a
+    # substring match read it as consent — handing a client a 5 MB body it
+    # just said it could not decode.
+    ("gzip;q=0", False),
+    ("gzip; q=0.0", False),
+    ("*;q=0", False),
+    ("identity", False),
+    ("", False),
+])
+def test_gzip_is_negotiated_by_q_value_not_by_substring(home, tmp_path,
+                                                        monkeypatch, accept,
+                                                        gzipped):
+    _stub_corpus(monkeypatch, _corpus())
+    resp = _client(tmp_path).get("/api/index/search",
+                                 params={"root": "/r", "fmt": "columns"},
+                                 headers={"Accept-Encoding": accept})
+    assert (resp.headers.get("content-encoding") == "gzip") is gzipped
+    # Both bodies live at one URL, so an intermediary keyed on the URL alone
+    # would otherwise serve either one to either client.
+    assert resp.headers["vary"] == "Accept-Encoding"
+    assert resp.json()["rels"] == ["d", "d/f0.txt", "d/f1.txt", "d/f2.txt"]
+
+
 def test_a_client_that_cannot_gunzip_still_gets_the_columns(home, tmp_path,
                                                             monkeypatch):
     """Encoding is negotiated, not assumed: `Accept-Encoding` decides whether
@@ -891,16 +920,21 @@ def test_startup_warm_waits_for_the_scan_it_started(home, tmp_path, monkeypatch)
 
 def test_startup_warm_gives_up_when_the_scan_never_finishes(home, tmp_path,
                                                              monkeypatch):
-    """A worker that hangs (or a status that never flips) must not leave a
-    thread polling for the process lifetime: the wait is deadline-bounded and
-    the warm simply does not happen."""
+    """A worker alive but wedged — writing nothing, dying never — must not
+    leave a thread polling for the process lifetime: the wait is
+    deadline-bounded and the warm simply does not happen."""
     monkeypatch.setenv("HOME", str(tmp_path))
+    run_dir = tmp_path / "wedged-run"
+    run_dir.mkdir()
     calls = []
     monkeypatch.setattr(index_router, "index_search",
                         lambda cfg, root, **kw: calls.append(root)
                         or {"covered": False, "root": root})
-    monkeypatch.setattr(index_router.runner, "status",
-                        lambda cfg, run_id, since=0: {"state": {"running": True}})
+    monkeypatch.setattr(index_router.runner, "_run_dir",
+                        lambda cfg, run_id: str(run_dir))
+    # Alive, so the dead-worker exit cannot fire: only the deadline can end it.
+    monkeypatch.setattr(index_router.runner, "_looks_abandoned",
+                        lambda run_dir, now, threshold_s: False)
     monkeypatch.setattr(index_router, "WARM_WAIT_DEADLINE_S", 0.05)
     monkeypatch.setattr(index_router, "WARM_WAIT_POLL_S", 0.01)
     monkeypatch.setitem(index_router._startup_runs, index_router.warm_root(),
@@ -909,6 +943,30 @@ def test_startup_warm_gives_up_when_the_scan_never_finishes(home, tmp_path,
     index_router.run_startup_warm()
     assert time.monotonic() - began < 5, "the wait is not deadline-bounded"
     assert len(calls) == 1, "it searched again after giving up"
+
+
+def test_startup_warm_stops_waiting_on_a_worker_that_died(home, tmp_path,
+                                                          monkeypatch):
+    """A worker killed mid-walk never writes `run_end`, so the log alone would
+    keep the wait going until the deadline. runner's own mtime liveness check
+    is what ends it in seconds instead."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    run_dir = tmp_path / "dead-run"
+    run_dir.mkdir()
+    calls = []
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: calls.append(root)
+                        or {"covered": False, "root": root})
+    monkeypatch.setattr(index_router.runner, "_run_dir",
+                        lambda cfg, run_id: str(run_dir))
+    monkeypatch.setattr(index_router.runner, "_looks_abandoned",
+                        lambda run_dir, now, threshold_s: True)
+    monkeypatch.setitem(index_router._startup_runs, index_router.warm_root(),
+                        "run-that-died")
+    began = time.monotonic()
+    index_router.run_startup_warm()
+    assert time.monotonic() - began < 5
+    assert len(calls) == 1
 
 
 def test_startup_warm_does_not_wait_when_the_root_is_covered(home, tmp_path,

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -655,6 +655,99 @@ def test_startup_scan_skips_a_root_that_is_gone(home, tmp_path, monkeypatch):
     assert started == [str(ok)]
 
 
+# -- the compact corpus --------------------------------------------------------
+
+def _corpus(n=3):
+    """A corpus in the shape search_under answers with, nulls included."""
+    entries = [{"rel": "d", "is_dir": True, "size": None, "mtime": None}]
+    entries += [{"rel": f"d/f{i}.txt", "is_dir": False, "size": i,
+                 "mtime": 1700000000.5 + i} for i in range(n)]
+    return {"covered": True, "fresh": True, "updated": 1.0, "age_s": 2.0,
+            "root": "/r", "entries": entries, "truncated": False,
+            "total": len(entries), "scanned_partitions": 1,
+            "of_partitions": 1}
+
+
+def _stub_corpus(monkeypatch, out):
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: dict(out))
+    monkeypatch.setattr(index_router, "filter_corpus",
+                        lambda out, index_root=None: out)
+
+
+def test_search_answers_in_columns_when_asked(home, tmp_path, monkeypatch):
+    """The corpus is the home page's whole ranking set — 25.7 MB of
+    `{rel,is_dir,size,mtime}` objects on a 164k-entry home, most of it repeated
+    key names. `fmt=columns` sends parallel arrays instead."""
+    _stub_corpus(monkeypatch, _corpus())
+    body = _client(tmp_path).get("/api/index/search",
+                                 params={"root": "/r", "fmt": "columns"}).json()
+    assert body["fmt"] == "columns"
+    assert "entries" not in body
+    assert body["rels"] == ["d", "d/f0.txt", "d/f1.txt", "d/f2.txt"]
+    assert body["dirs"] == [1, 0, 0, 0]
+    # Nulls are entries a directory legitimately has, not missing data.
+    assert body["sizes"] == [None, 0, 1, 2]
+    assert body["mtimes"] == [None, 1700000000.5, 1700000001.5, 1700000002.5]
+
+
+def test_the_two_formats_carry_the_same_corpus_and_metadata(home, tmp_path,
+                                                            monkeypatch):
+    """`fmt` changes the encoding of the entries and nothing else: every
+    client decision (covered/fresh/truncated/…) reads the same fields."""
+    _stub_corpus(monkeypatch, _corpus())
+    client = _client(tmp_path)
+    classic = client.get("/api/index/search", params={"root": "/r"}).json()
+    columns = client.get("/api/index/search",
+                         params={"root": "/r", "fmt": "columns"}).json()
+    assert "fmt" not in classic and classic["entries"] == _corpus()["entries"]
+    decoded = [{"rel": r, "is_dir": bool(d), "size": s, "mtime": m}
+               for r, d, s, m in zip(columns["rels"], columns["dirs"],
+                                     columns["sizes"], columns["mtimes"])]
+    assert decoded == classic["entries"]
+    assert ({k: v for k, v in classic.items() if k != "entries"}
+            == {k: v for k, v in columns.items()
+                if k not in ("fmt", "rels", "dirs", "sizes", "mtimes")})
+
+
+def test_an_unknown_fmt_answers_in_the_classic_shape(home, tmp_path, monkeypatch):
+    """The bridge (`fused.fileIndex.search`, static/runtime.js) and every other
+    caller ask with no `fmt` at all, so anything but the one known value has to
+    be the old shape rather than an error."""
+    _stub_corpus(monkeypatch, _corpus())
+    body = _client(tmp_path).get("/api/index/search",
+                                 params={"root": "/r", "fmt": "parquet"}).json()
+    assert [e["rel"] for e in body["entries"]] == ["d", "d/f0.txt", "d/f1.txt",
+                                                   "d/f2.txt"]
+
+
+def test_columns_are_several_times_smaller_on_the_wire(home, tmp_path, monkeypatch):
+    """The transfer is the third of the three costs of the first search (25.7 MB
+    on a 164k-entry home). Content-Length, not the decoded body: the compact
+    format is also gzipped, and both halves are the win."""
+    _stub_corpus(monkeypatch, _corpus(n=2000))
+    client = _client(tmp_path)
+    classic = client.get("/api/index/search", params={"root": "/r"})
+    columns = client.get("/api/index/search",
+                         params={"root": "/r", "fmt": "columns"})
+    assert columns.headers["content-encoding"] == "gzip"
+    wire = (int(classic.headers["content-length"]),
+            int(columns.headers["content-length"]))
+    assert wire[0] / wire[1] >= 3.0, wire
+
+
+def test_a_client_that_cannot_gunzip_still_gets_the_columns(home, tmp_path,
+                                                            monkeypatch):
+    """Encoding is negotiated, not assumed: `Accept-Encoding` decides whether
+    the body is compressed, and the document inside it is the same either way."""
+    _stub_corpus(monkeypatch, _corpus())
+    resp = _client(tmp_path).get("/api/index/search",
+                                 params={"root": "/r", "fmt": "columns"},
+                                 headers={"Accept-Encoding": "identity"})
+    assert "content-encoding" not in resp.headers
+    assert resp.json()["rels"] == ["d", "d/f0.txt", "d/f1.txt", "d/f2.txt"]
+
+
 # -- the startup warm ----------------------------------------------------------
 
 def test_startup_warm_runs_the_home_pages_first_search(home, tmp_path, monkeypatch):

--- a/tests/test_index_api.py
+++ b/tests/test_index_api.py
@@ -830,6 +830,134 @@ def test_startup_warm_fills_the_gitignore_verdict_pool(home, tmp_path, monkeypat
     assert "alpha.txt" in pool.decider
 
 
+def test_startup_scan_records_the_run_the_warm_waits_on(home, tmp_path, monkeypatch):
+    """The warm waits on the run THIS process started, so the scheduler has to
+    hand it over — `run_startup_scan` used to drop `runner.start`'s run id on
+    the floor."""
+    src = _tree(tmp_path)
+    monkeypatch.setattr(index_router.runner, "start",
+                        lambda cfg, root, full=False: {"run_id": "r-42",
+                                                       "root": root})
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_router.run_startup_scan(start_dir=str(tmp_path))
+    assert index_router._startup_runs == {runner.canonical_root(str(src)): "r-42"}
+
+
+def test_startup_warm_waits_for_the_scan_it_started(home, tmp_path, monkeypatch):
+    """The first-ever boot, end to end — the case the warm exists for.
+
+    On a fresh index the warm's first search answers `covered: false` cheaply
+    and there is nothing to sweep; the scan this process just spawned finishes
+    seconds later. Sampling once left the user's first keystroke paying the
+    whole cold cost anyway (2.3 s, observed). Waiting for that one run and
+    warming after it is what fills the pool."""
+    from fused_render.server import index_gitignore
+
+    src = _tree(tmp_path)
+    (src / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    (src / "noise.log").write_text("x", encoding="utf-8")
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    index_gitignore._cache.clear()
+    # HOME is what the warm aims at, and what the scheduler scans.
+    monkeypatch.setenv("HOME", str(src))
+    index_router.run_startup_scan(start_dir=str(tmp_path))
+
+    # Force the uncovered branch rather than racing the worker: the first
+    # search must answer `covered: false` for this to be the boot being tested.
+    real_search = index_router.index_search
+    calls = []
+
+    def uncovered_once(cfg, root, **kw):
+        calls.append(root)
+        if len(calls) == 1:
+            return {"covered": False, "root": root}
+        return real_search(cfg, root, **kw)
+
+    monkeypatch.setattr(index_router, "index_search", uncovered_once)
+    monkeypatch.setattr(index_router, "WARM_WAIT_POLL_S", 0.05)
+    monkeypatch.setattr(index_router, "WARM_WAIT_DEADLINE_S", 60.0)
+    index_router.run_startup_warm()
+
+    assert len(calls) == 2, "the warm did not search again after the scan"
+    pool = index_gitignore._cache.get(str(src))
+    assert pool is not None
+    assert "noise.log" in pool.ignored
+    assert "alpha.txt" in pool.decider
+
+
+def test_startup_warm_gives_up_when_the_scan_never_finishes(home, tmp_path,
+                                                             monkeypatch):
+    """A worker that hangs (or a status that never flips) must not leave a
+    thread polling for the process lifetime: the wait is deadline-bounded and
+    the warm simply does not happen."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    calls = []
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: calls.append(root)
+                        or {"covered": False, "root": root})
+    monkeypatch.setattr(index_router.runner, "status",
+                        lambda cfg, run_id, since=0: {"state": {"running": True}})
+    monkeypatch.setattr(index_router, "WARM_WAIT_DEADLINE_S", 0.05)
+    monkeypatch.setattr(index_router, "WARM_WAIT_POLL_S", 0.01)
+    monkeypatch.setitem(index_router._startup_runs, index_router.warm_root(),
+                        "run-that-hangs")
+    began = time.monotonic()
+    index_router.run_startup_warm()
+    assert time.monotonic() - began < 5, "the wait is not deadline-bounded"
+    assert len(calls) == 1, "it searched again after giving up"
+
+
+def test_startup_warm_does_not_wait_when_the_root_is_covered(home, tmp_path,
+                                                             monkeypatch):
+    """The overwhelmingly common boot: an index is already there, so the warm
+    is the same two calls it always was, with no wait in the way."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    waited, filtered = [], []
+    monkeypatch.setattr(index_router, "_wait_for_scan",
+                        lambda cfg, run_id: waited.append(run_id) or True)
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: {"covered": True, "root": root,
+                                                 "entries": []})
+    monkeypatch.setattr(index_router, "filter_corpus",
+                        lambda out, index_root=None: filtered.append(out) or out)
+    monkeypatch.setitem(index_router._startup_runs, index_router.warm_root(),
+                        "run-1")
+    index_router.run_startup_warm()
+    assert waited == []
+    assert len(filtered) == 1
+
+
+def test_startup_warm_does_not_wait_when_the_scan_was_debounced(home, tmp_path,
+                                                                monkeypatch):
+    """No run was started, so there is nothing to wait for — and a debounced
+    root was scanned within SCAN_DEBOUNCE_S, so the index is already there.
+    Waiting here would block the warm on a run that never comes."""
+    src = _tree(tmp_path)
+    monkeypatch.setenv("HOME", str(src))
+    monkeypatch.setattr(
+        index_router.runner, "start",
+        lambda cfg, root, full=False: pytest.fail("debounced root was scanned"))
+    cfg = load_config()
+    cfg.roots = [str(src)]
+    index_router.save_config(cfg)
+    runner._record_scan(cfg, runner.canonical_root(str(src)))
+    index_router.run_startup_scan(start_dir=str(tmp_path))
+
+    waited, calls = [], []
+    monkeypatch.setattr(index_router, "_wait_for_scan",
+                        lambda cfg, run_id: waited.append(run_id) or True)
+    monkeypatch.setattr(index_router, "index_search",
+                        lambda cfg, root, **kw: calls.append(root)
+                        or {"covered": False, "root": root})
+    index_router.run_startup_warm()
+    assert waited == []
+    assert len(calls) == 1
+
+
 def test_a_root_of_slash_survives_the_config_write(home, tmp_path):
     """Roots are paths, not ignore patterns: clean_patterns rstrips '/' into
     the empty string and silently drops the root."""

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -3,6 +3,7 @@ and the index-first swap must not change what search shows.
 
 See fused_render/server/index_gitignore.py.
 """
+import json
 import os
 import subprocess
 
@@ -270,6 +271,149 @@ def test_a_narrowed_payload_cannot_masquerade_as_the_corpus(tmp_path, monkeypatc
         "proj/.gitignore", "proj/a.log", "proj/a.py"]))
     assert [e["rel"] for e in full["entries"]] == ["proj/.gitignore", "proj/a.py"]
     assert full["total"] == len(full["entries"])
+
+
+# -- the pool on disk ----------------------------------------------------------
+
+def _restart(monkeypatch):
+    """A NEW server process: same disk, no in-memory state at all."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+
+
+def _no_git(monkeypatch):
+    """Make asking git impossible, so a filtered result can only have come out
+    of the persisted pool."""
+    def boom(*a, **k):
+        raise AssertionError("git was asked; the pool was not reused")
+
+    monkeypatch.setattr(index_gitignore, "_ignored", boom)
+
+
+def test_the_pool_survives_a_restart(tmp_path, monkeypatch):
+    """The verdicts a sweep bought are a per-INDEX-ROOT fact, not a per-process
+    one: a server restart used to throw ~1.5s of check-ignore away and re-buy
+    it on the user's next keystroke."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    rels = ["proj/.gitignore", "proj/a.log", "proj/a.py"]
+    filter_corpus(_out(root, rels), index_root=root)
+
+    _restart(monkeypatch)
+    _no_git(monkeypatch)
+    out = filter_corpus(_out(root, rels), index_root=root)
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py"]
+
+
+def test_the_loaded_pool_round_trips_the_decider_map(tmp_path, monkeypatch):
+    """The decider map is the correctness half of the pool — a verdict is only
+    reusable under the ORACLE that produced it — so it has to come back exactly
+    as it went out, not merely "the ignored set survived"."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    (proj / "sub").mkdir(parents=True)
+    (proj / ".gitignore").write_text("*.outer\n", encoding="utf-8")
+    (proj / "sub" / ".gitignore").write_text("*.inner\n", encoding="utf-8")
+    root = str(tmp_path)
+    rels = ["proj/.gitignore", "proj/sub/.gitignore", "proj/x.outer",
+            "proj/sub/y.inner", "proj/sub/keep.py"]
+    filter_corpus(_out(root, rels), index_root=root)
+    before = index_gitignore._cache[root]
+
+    _restart(monkeypatch)
+    loaded = index_gitignore._load_verdicts(root)
+    assert loaded is not None
+    assert loaded.decider == before.decider
+    assert loaded.ignored == before.ignored
+    assert loaded.swept_at == before.swept_at
+
+
+def test_a_pool_too_old_on_disk_is_discarded(tmp_path, monkeypatch):
+    """VERDICT_MAX_AGE_S is the ONLY bound on the staleness verdict reuse
+    introduces (an edited .gitignore moves nothing observable), so it has to
+    hold across restarts too — `swept_at` from the file is the age anchor."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    rels = ["proj/.gitignore", "proj/a.log"]
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 1
+
+    path = index_gitignore._verdicts_path(root)
+    with open(path, encoding="utf-8") as f:
+        stored = json.load(f)
+    stored["swept_at"] -= index_gitignore.VERDICT_MAX_AGE_S + 1
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(stored, f)
+
+    _restart(monkeypatch)
+    assert index_gitignore._load_verdicts(root) is None
+    # ...and the rule that changed while the server was down is seen again.
+    (proj / ".gitignore").write_text("nothing-here\n", encoding="utf-8")
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 2
+
+
+def test_a_corrupt_pool_file_is_ignored(tmp_path, monkeypatch):
+    """A half-written or hand-edited file re-sweeps; it never raises. This runs
+    on the path that answers a search box."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    rels = ["proj/.gitignore", "proj/a.log", "proj/a.py"]
+    filter_corpus(_out(root, rels), index_root=root)
+    with open(index_gitignore._verdicts_path(root), "w", encoding="utf-8") as f:
+        f.write('{"root": "' + root + '", "swept_at": 1.0, "verdicts": [[')
+
+    _restart(monkeypatch)
+    assert index_gitignore._load_verdicts(root) is None
+    out = filter_corpus(_out(root, rels), index_root=root)
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py"]
+
+
+def test_a_file_written_for_another_root_is_not_reused(tmp_path, monkeypatch):
+    """The filename is a digest of the root; the root itself is stored inside
+    and checked, so a digest collision (or a file left by a renamed root)
+    re-sweeps instead of answering with another tree's verdicts."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    filter_corpus(_out(root, ["proj/.gitignore", "proj/a.log"]), index_root=root)
+    path = index_gitignore._verdicts_path(root)
+    with open(path, encoding="utf-8") as f:
+        stored = json.load(f)
+    stored["root"] = root + "-elsewhere"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(stored, f)
+
+    _restart(monkeypatch)
+    assert index_gitignore._load_verdicts(root) is None
+
+
+def test_an_expired_in_memory_pool_does_not_reload_itself_from_disk(
+        tmp_path, monkeypatch):
+    """Disk is consulted only when this process has NO pool for the root. An
+    expired pool means the process has already decided to re-sweep, and its own
+    saved copy is never newer than it — reloading it would make
+    VERDICT_MAX_AGE_S unreachable."""
+    _fresh_cache(monkeypatch)
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    root = str(tmp_path)
+    rels = ["proj/.gitignore", "proj/a.log"]
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 1
+    (proj / ".gitignore").write_text("nothing-here\n", encoding="utf-8")
+    for pool in index_gitignore._cache.values():
+        pool.swept_at -= index_gitignore.VERDICT_MAX_AGE_S + 1
+    assert len(filter_corpus(_out(root, rels), index_root=root)["entries"]) == 2
 
 
 def test_nested_markers_defer_to_the_outermost(tmp_path, monkeypatch):

--- a/tests/test_index_gitignore.py
+++ b/tests/test_index_gitignore.py
@@ -6,6 +6,8 @@ See fused_render/server/index_gitignore.py.
 import json
 import os
 import subprocess
+import time
+from threading import Event, Thread
 
 from fused_render.server import index_gitignore
 from fused_render.server.index_gitignore import filter_corpus
@@ -431,3 +433,180 @@ def test_nested_markers_defer_to_the_outermost(tmp_path, monkeypatch):
     assert "proj/x.outer" not in rels
     assert "proj/sub/y.inner" not in rels
     assert "proj/sub/z.py" in rels
+
+
+# -- concurrency and cost ------------------------------------------------------
+
+def _proj_with_a_log(tmp_path):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (proj / ".gitignore").write_text("*.log\n", encoding="utf-8")
+    return str(tmp_path), ["proj/.gitignore", "proj/a.log", "proj/a.py"]
+
+
+def test_two_callers_of_the_same_base_share_one_sweep(tmp_path, monkeypatch):
+    """The startup warm and the user's first keystroke are exactly this race:
+    the warm is a detached thread and the keystroke arrives inside the ~2.2 s
+    it takes. Both used to read the same empty pool and spawn the same full
+    check-ignore sweep, so the keystroke paid the whole cold cost AND competed
+    with the warm for the CPU. The second caller now waits on the sweep already
+    in flight and reads the pool it produced."""
+    _fresh_cache(monkeypatch)
+    root, rels = _proj_with_a_log(tmp_path)
+    real = index_gitignore._ignored
+    sweeps = []
+
+    def slow(*a, **k):
+        sweeps.append(1)
+        time.sleep(0.3)
+        return real(*a, **k)
+
+    monkeypatch.setattr(index_gitignore, "_ignored", slow)
+    results = []
+
+    def go():
+        results.append([e["rel"] for e in filter_corpus(
+            _out(root, rels), index_root=root)["entries"]])
+
+    threads = [Thread(target=go) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+    assert sweeps == [1], "the same sweep ran twice"
+    assert results == [["proj/.gitignore", "proj/a.py"]] * 2
+
+
+def test_a_waiting_caller_still_sweeps_what_the_other_did_not_cover(tmp_path,
+                                                                    monkeypatch):
+    """Waiting is not deferring: two concurrent requests can carry different
+    corpora, so the second one must sweep the remainder rather than silently
+    accept a pool that never decided its entries."""
+    _fresh_cache(monkeypatch)
+    root, rels = _proj_with_a_log(tmp_path)
+    real = index_gitignore._ignored
+    started = Event()
+
+    def slow(*a, **k):
+        started.set()
+        time.sleep(0.3)
+        return real(*a, **k)
+
+    monkeypatch.setattr(index_gitignore, "_ignored", slow)
+    first = Thread(target=lambda: filter_corpus(_out(root, rels),
+                                                index_root=root))
+    first.start()
+    started.wait(timeout=10)
+    out = filter_corpus(_out(root, rels + ["proj/b.log", "proj/b.py"]),
+                        index_root=root)
+    first.join(timeout=30)
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore",
+                                                  "proj/a.py", "proj/b.py"]
+
+
+def test_the_disk_load_does_not_hold_the_cache_lock(tmp_path, monkeypatch):
+    """A home-sized pool is a multi-megabyte json.load plus ~400k inserts.
+    Under the module-global lock that blocks every concurrent search and the
+    freshness thread — the very thing `_pooled_verdicts` documents it does not
+    do for the git work."""
+    _fresh_cache(monkeypatch)
+    root, rels = _proj_with_a_log(tmp_path)
+    held = []
+    real = index_gitignore._load_verdicts
+
+    def watched(base):
+        free = index_gitignore._cache_lock.acquire(blocking=False)
+        if free:
+            index_gitignore._cache_lock.release()
+        held.append(not free)
+        return real(base)
+
+    monkeypatch.setattr(index_gitignore, "_load_verdicts", watched)
+    filter_corpus(_out(root, rels), index_root=root)
+    assert held and not any(held), "_load_verdicts ran under _cache_lock"
+
+
+def test_the_snapshot_does_not_hold_the_cache_lock(tmp_path, monkeypatch):
+    """Same rule for the write side: `_snapshot` is a full pass over up to
+    200k rels."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+    root, rels = _proj_with_a_log(tmp_path)
+    held = []
+    real = index_gitignore._snapshot
+
+    def watched(*a, **k):
+        free = index_gitignore._cache_lock.acquire(blocking=False)
+        if free:
+            index_gitignore._cache_lock.release()
+        held.append(not free)
+        return real(*a, **k)
+
+    monkeypatch.setattr(index_gitignore, "_snapshot", watched)
+    filter_corpus(_out(root, rels), index_root=root)
+    assert held and not any(held), "_snapshot ran under _cache_lock"
+
+
+# -- what may be persisted -----------------------------------------------------
+
+def test_a_folder_outside_every_index_root_is_not_persisted(tmp_path, monkeypatch):
+    """`filter_corpus` falls back to the REQUESTED root whenever the folder
+    lives under no configured scan root, and that fallback base is unbounded:
+    searching N such folders would leave N `_saved_at` entries forever (the
+    in-memory pool is LRU-capped at four) and write N files that nothing ever
+    reclaims — `prune_runs` only touches run dirs and `delete_store` leaves
+    `gitignore/` alone. Such a pool stays in memory only."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+    root, rels = _proj_with_a_log(tmp_path)
+    out = filter_corpus(_out(root, rels))  # no index_root: out-of-root folder
+    assert [e["rel"] for e in out["entries"]] == ["proj/.gitignore", "proj/a.py"]
+    assert index_gitignore._saved_at == {}
+    assert index_gitignore._load_verdicts(root) is None
+    # ...but it is still pooled in memory, which is what a second keystroke
+    # in the same folder reads.
+    assert index_gitignore._cache[root].ignored == {"proj/a.log"}
+
+
+def test_an_index_root_is_still_persisted(tmp_path, monkeypatch):
+    """The counterpart: a real scan root — the home page's search, and the
+    startup warm's — is exactly the pool the restart case needs on disk."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+    root, rels = _proj_with_a_log(tmp_path)
+    filter_corpus(_out(root, rels), index_root=root)
+    assert list(index_gitignore._saved_at) == [root]
+    assert index_gitignore._load_verdicts(root) is not None
+
+
+def test_a_save_leaves_no_temp_file_behind(tmp_path, monkeypatch):
+    """`_save_verdicts` unlinked its tmp only on the exception path."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+    root, rels = _proj_with_a_log(tmp_path)
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(index_gitignore.json, "dump", boom)
+    filter_corpus(_out(root, rels), index_root=root)  # never raises
+    # This root's tmp specifically: the state dir is shared by every test in
+    # the run (one FUSED_RENDER_HOME per process, inherited by every xdist
+    # worker), so a listdir would see other tests' files too.
+    path = index_gitignore._verdicts_path(root)
+    assert not os.path.exists(f"{path}.{os.getpid()}.new")
+
+
+def test_an_orphaned_temp_file_is_swept_on_the_next_save(tmp_path, monkeypatch):
+    """The warm is a daemon thread: killed mid-`json.dump` at interpreter exit
+    it leaves a `.new` behind, and nothing else ever reclaims that directory."""
+    _fresh_cache(monkeypatch)
+    monkeypatch.setattr(index_gitignore, "_saved_at", {})
+    root, rels = _proj_with_a_log(tmp_path)
+    path = index_gitignore._verdicts_path(root)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    orphan = f"{path}.999999.new"
+    open(orphan, "w").close()
+    os.utime(orphan, (0, 0))  # from a long-dead process
+    filter_corpus(_out(root, rels), index_root=root)
+    assert not os.path.exists(orphan)

--- a/tests/test_index_runner.py
+++ b/tests/test_index_runner.py
@@ -466,3 +466,54 @@ def test_start_checks_the_mount_guard_before_touching_the_kernel(tmp_path, spawn
     with pytest.raises(ValueError, match="mount"):
         runner.start(_cfg(tmp_path), str(mounts / "m1"))
     assert spawned == []
+
+
+# -- has_ended (the startup warm's poll) ---------------------------------------
+
+def _log(tmp_path, *lines):
+    run_dir = tmp_path / "run"
+    run_dir.mkdir(exist_ok=True)
+    (run_dir / "events.jsonl").write_text("".join(lines), encoding="utf-8")
+    return str(run_dir)
+
+
+def test_has_ended_reports_the_end_and_carries_a_cursor(tmp_path):
+    run_dir = _log(tmp_path, '{"type": "progress", "files": 1}\n')
+    ended, cursor = runner.has_ended(run_dir)
+    assert (ended, cursor) == (False, 1)
+    ended, cursor = runner.has_ended(run_dir, cursor)
+    assert (ended, cursor) == (False, 1)  # nothing new, nothing re-decoded
+    _log(tmp_path, '{"type": "progress", "files": 1}\n',
+         '{"type": "run_end", "msg": "complete"}\n')
+    assert runner.has_ended(run_dir, cursor) == (True, 2)
+
+
+def test_has_ended_decodes_only_the_lines_after_the_cursor(tmp_path):
+    """The whole point of it: `read_events` json.loads from line 0 every call,
+    so a poller re-parsed the growing log once per poll — quadratic in the
+    length of the very scan it waits on."""
+    run_dir = _log(tmp_path, *['{"type": "progress"}\n'] * 5)
+    decoded = []
+    real = json.loads
+    monkeypatched = lambda s, *a, **k: decoded.append(s) or real(s, *a, **k)
+    runner.json.loads = monkeypatched
+    try:
+        runner.has_ended(run_dir, 4)
+    finally:
+        runner.json.loads = real
+    assert len(decoded) == 1
+
+
+def test_has_ended_does_not_step_over_a_half_written_line(tmp_path):
+    """The worker appends line by line; a cursor moved past a truncated line
+    would skip its completed version — which may be the `run_end` itself."""
+    run_dir = _log(tmp_path, '{"type": "progress"}\n', '{"type": "run_')
+    assert runner.has_ended(run_dir) == (False, 1)
+    _log(tmp_path, '{"type": "progress"}\n', '{"type": "run_end"}\n')
+    assert runner.has_ended(run_dir, 1) == (True, 2)
+
+
+def test_has_ended_on_a_run_that_has_not_written_a_log_yet(tmp_path):
+    run_dir = tmp_path / "fresh"
+    run_dir.mkdir()
+    assert runner.has_ended(str(run_dir)) == (False, 0)


### PR DESCRIPTION
## Summary

- The explorer home search's first keystroke paid 3–4 s (measured: 2198 ms server-side + a 27.7 MB JSON parse) because the corpus fetch was deferred to the first search and every server start began with a cold gitignore verdict pool. Repeat searches were already fast (~0.8 s fetch, then local ranking).
- **Warm at startup**: a detached daemon thread runs the exact `search_under` + `filter_corpus` pair the route uses, for the canonical home root, right after the startup scan is spawned — the `git check-ignore` sweep and the duckdb import now happen during idle seconds, never on a keystroke. Never blocks startup, never raises, skips mount-backed homes.
- **Persist the verdict pool**: each index root's gitignore verdicts round-trip through `<index>/gitignore/<sha1(root)[:16]>.json` (atomic tmp+rename, saves debounced to 60 s after the first). `VERDICT_MAX_AGE_S` (300 s) is honored across restarts via the stored `swept_at`; disk is only consulted when the process has no pool, so the age bound stays reachable. Corrupt/foreign/expired files are ignored and re-swept.
- **Compact transfer**: `GET /api/index/search?fmt=columns` returns the corpus as parallel arrays and gzips (level 1) when the client accepts it — **27.7 MB → 5.0 MB (5.5×)** on the real 164k-entry corpus. Any other `fmt` (including absent) keeps the classic shape, so the `runtime.js` bridge is untouched; the frontend decodes back to `WalkEntry[]` inside `api.ts`, so no consumer changes.

## Visuals

**Before**
```mermaid
flowchart TD
    A[Server start] --> B[Index rescan spawned]
    C[First keystroke] --> D[Cold gitignore sweep + duckdb import]
    D --> E[27.7 MB JSON corpus]
    E --> F[First results after 3-4 s]
```

**After**
```mermaid
flowchart TD
    A[Server start] --> B[Index rescan spawned]
    A --> C[index-warm thread]
    C --> D[Load persisted verdicts / sweep once]
    E[First keystroke] --> F[Warm corpus, fmt=columns + gzip: 5 MB]
    F --> G[First results]
```

## Usage

Nothing new is user-invocable — the explorer home search simply gets fast on the first keystroke. For other API clients, `GET /api/index/search?root=...&fmt=columns` opts into the columnar shape (`rels/dirs/sizes/mtimes` parallel arrays + `fmt: "columns"`); omitting `fmt` keeps the classic `entries` list.

## Test Plan

- [x] Unit A: 9 tests in `tests/test_index_api.py`, incl. two end-to-end warms over a real scan + real `.gitignore` asserting the verdict pool is populated (one of them through the first-boot wait), the deadline give-up, the already-covered fast path, and the debounce-skipped case; `_no_startup_index_scan` autouse fixture extended to also neutralize the warm for every other test.
- [x] Unit B: 6 tests in `tests/test_index_gitignore.py` — round-trip, age expiry on load, corrupt-file tolerance, foreign-root rejection, in-memory-expiry-does-not-reload, debounced saves.
- [x] Unit C: server tests for shape/null equivalence between classic and columnar formats; `cd frontend && npm run build` (boundary check + tsc + vite) green.
- [x] Scoped suites green during build: `test_index_api`, `test_index_gitignore`, `test_index_query`, `test_index_search`, `test_search_index`, `test_index_store`, `test_server_gitignore`, `test_index_freshness`.
- [ ] Full local suite (`pytest -n auto`) — running; known macOS baseline failure in `test_calls.py` (/proc read) is expected.
- [ ] Manual: `scripts/dev.sh`, wait ~10 s, first home-search keystroke should return in well under a second (was 3–4 s).

**First-ever boot** (the case that matters most, since it is the first impression): the index hasn't covered home yet, so the warm's first search answers `covered:false` and there is nothing to sweep. Rather than giving up, the warm makes **one bounded wait** on the specific scan run this process just spawned for that root, then searches and sweeps once. It is not a second scheduler: one named run, polled every 0.5 s (the worker's own heartbeat cadence) with a hard 6-minute ceiling — just past `runner.ABANDONED_RUN_S`, so a dead worker is reported not-running before the ceiling — on a daemon thread that can never hold the process open. Giving up is logged once. A root whose startup scan was debounce-skipped has no new run to wait on, so it takes the immediate path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
