### PR TITLE
Title first, description second, both the main field

### DIFF
--- a/core_apps/sessions/inbox.html
+++ b/core_apps/sessions/inbox.html
@@ -337,22 +337,33 @@ function reload() {
   return load();
 }
 
-// running session → In Progress; a session this page saw running that has now
-// stopped → Done + unread, so finished work surfaces in the Inbox as news
+// A run this page watched END → Done + unread, so finished work surfaces in the
+// Inbox as news. That is the only thing written down here, and the missing half
+// is the point: the in-progress lane is DERIVED, not recorded.
+//
+// This used to also write `{status: "in_progress"}` for every session it saw
+// running, and it could only take that back while this very tab stayed open —
+// the clear-back below gates on `RUNNING`, an in-memory Set that is empty on
+// every page load. So any run whose finish no Inbox tab witnessed left an
+// `in_progress` on disk that nothing would ever clear, and the Tasks board read
+// those pins as cards the user had dragged there (five sat in In Progress for a
+// day). triage.json holds filing DECISIONS; a lane that inbox.py can compute
+// from the same activity this function reads is not one of them, so it computes
+// it — for a session with an older done/archived record too, which is the one
+// case the write used to earn.
 const RUNNING = new Set();
 let PROJECTS_EXPANDED = false;
 function autoFlow() {
-  const started = [], finished = [];
+  const finished = [];
   for (const s of DATA.sessions) {
-    if (isRunning(s.mtime)) {
-      RUNNING.add(s.sessionId);
-      if (s.status !== "in_progress") started.push(s.sessionId);
-    } else if (RUNNING.has(s.sessionId)) {
-      RUNNING.delete(s.sessionId);
-      if (s.status === "in_progress") finished.push(s.sessionId);
-    }
+    if (isRunning(s.mtime)) RUNNING.add(s.sessionId);
+    // `delete` reports whether it was there: this page saw the run, and now
+    // sees it stopped. Gated on what it OBSERVED rather than on `s.status`,
+    // because only a full load() recomputes that — a session that was quiet at
+    // load and ran afterwards (the poll updates mtime alone) still carries its
+    // old lane, and a status gate would let that finish go unrecorded.
+    else if (RUNNING.delete(s.sessionId)) finished.push(s.sessionId);
   }
-  if (started.length) saveMany(started, {status: "in_progress"});
   if (finished.length) saveMany(finished, {status: "done", read: ""});
 }
 

--- a/core_apps/sessions/inbox.py
+++ b/core_apps/sessions/inbox.py
@@ -71,13 +71,25 @@ def main(limit: int = 500) -> dict:
     tag_counts = {}
     for s in base["sessions"]:
         t = triage.get(s["sessionId"], {})
-        # untriaged: running sessions are in progress, stopped ones are done —
-        # a session that finished while the page wasn't watching shouldn't sit
-        # in "In Progress" forever
-        default = "in_progress" if _is_running(s.get("mtime")) else "done"
-        status = t.get("status") or default
-        if status not in STATUSES:
-            status = default
+        # THE IN-PROGRESS LANE IS DERIVED, NOT RECORDED. "Something is running in
+        # this conversation" is a fact about the present, so it outranks every
+        # pin — a session filed as done or archived that has been resumed belongs
+        # in In Progress, and a run that finished while nothing was watching
+        # belongs back wherever the user filed it (or in Done, untriaged). Both
+        # answers come out of the same activity read, so neither needs a record.
+        #
+        # That is why inbox.html's autoFlow no longer writes the in-progress
+        # claim: it could only retract one while its own tab stayed open, so
+        # every unwitnessed finish left a pin on disk that nothing would clear
+        # and the Tasks board honoured it as a card the user had dragged. The
+        # pin the user DOES make survives here untouched, because deriving reads
+        # the record instead of overwriting it.
+        if _is_running(s.get("mtime")):
+            status = "in_progress"
+        else:
+            status = t.get("status") or "done"
+            if status not in STATUSES:
+                status = "done"  # a hand-edited record costs the pin, not the row
         s["status"] = status
         s["read"] = bool(t.get("read"))
         # the Inbox holds unread work that still matters — archived is filed away

--- a/core_apps/sessions/set_triage.py
+++ b/core_apps/sessions/set_triage.py
@@ -3,9 +3,14 @@
 `patch` is a JSON object; keys present are written, empty-string values
 clear the key. A record whose fields are all cleared (and status back to
 "inbox") is removed, so the session returns to the Inbox pile.
+
+A status write is also STAMPED with `at` — see main(). The Tasks board treats an
+`in_progress` pin as falsifiable and needs to know when the status was chosen;
+the shell's own writer (`/api/claude-sessions/triage`) stamps the same field.
 """
 import json
 import os
+import time
 
 try:
     import fcntl  # POSIX only — Windows falls back to no inter-process lock
@@ -22,6 +27,9 @@ _STATE_DIR = os.path.join(
 TRIAGE_FILE = os.path.join(_STATE_DIR, "triage.json")
 LOCK_FILE = TRIAGE_FILE + ".lock"
 
+# What a patch may write. `at` is deliberately absent: it is stamped below from
+# this process's clock, and a pin whose lifetime the browser could set would be
+# a pin the browser could make immortal.
 FIELDS = {"status", "note", "tags", "read"}
 
 
@@ -57,6 +65,29 @@ def main(session: str = "", patch: str = "{}") -> dict:
                 rec[key] = value
             else:
                 rec.pop(key, None)
+
+        # Stamp WHEN THE STATUS WAS CHOSEN, and only then — restamping on a note
+        # edit would let a thought typed today revive a pin from last week's run.
+        #
+        # `in_progress` is the one triage word that is a claim about the present,
+        # so the Tasks board reaps one whose run has demonstrably ended
+        # (tasks.py `_pin_holds`); a stamp later than the session's last activity
+        # is what marks it as a decision no run has contradicted. Every
+        # `in_progress` that reaches this file is now a person pressing the
+        # button — inbox.html's autoFlow stopped writing the automatic one — and
+        # the one automatic write left (`done` on a finish it watched) is a
+        # timeless filing decision nothing reaps, so stamping every status rather
+        # than sniffing which one is simpler and costs nothing. Epoch seconds as
+        # a string: the same value and shape the shell's writer records, and the
+        # same coercion every field above gets.
+        #
+        # Cleared with the status: an orphan `at` would keep an otherwise empty
+        # record alive, and it is emptiness that returns a session to the Inbox.
+        if "status" in changes:
+            if rec.get("status"):
+                rec["at"] = str(time.time())
+            else:
+                rec.pop("at", None)
 
         if rec:
             triage[session] = rec

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2129,9 +2129,13 @@ export interface Task {
   target: string; // what the task actually points at (may be that file)
   session_id: string; // "" until the first run
   title: string;
-  // Which of the three sources won: the user's own title, Claude Code's own
-  // `ai-title` record, or the first line of the first message.
-  title_source: "user" | "ai" | "message";
+  // Which source won: the user's own title, Claude Code's own `ai-title`
+  // record, the first line of the session's own first prompt (`message`), or —
+  // with no readable transcript to take that from — the first line of a message
+  // merely SCHEDULED at the session (`entry`). The last two are named apart
+  // because only `entry` can be the message a form is composing right now; see
+  // sessionTitleOf and tasks.py `_title`.
+  title_source: "user" | "ai" | "message" | "entry";
   description: string;
   // Decided by the SERVER, once, for every view — List, Board and Calendar all
   // read this rather than each deriving a column from the newest message.

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1148,11 +1148,12 @@ export function deleteFailureText(err: unknown, series: boolean): string {
 }
 
 // ---- Naming the task -----------------------------------------------------
-// Title is REQUIRED (Akshil, 2026-08-17), which is a change of kind and not
-// just of copy: a required field the form opens BLANK is a form that refuses to
-// save until the user does clerical work, so every path that can name the task
-// arrives with a name in the box. The field is then a name to accept or edit,
-// never a name to invent.
+// Title is REQUIRED (Akshil, 2026-08-17), and it opens prefilled wherever the
+// app honestly knows a name — which is any path with a SESSION behind it (see
+// the precedence below). Where it does not, the field opens blank and the
+// requirement is what asks for a name. That is the trade, stated plainly: a
+// blank required field costs the user one line of typing, while a field
+// prefilled with a guess costs them a task named after its own description.
 //
 // The placeholder is left with only the job a placeholder can honestly do —
 // saying which field this is. It used to say "optional, filled in
@@ -1161,48 +1162,106 @@ export function deleteFailureText(err: unknown, series: boolean): string {
 // accept is the worst of the three states.
 export const TITLE_PLACEHOLDER = "Title";
 
-// The precedence the server uses (tasks.py `_title`): the user's own title,
-// then Claude Code's `ai-title` for the session, then the first line of the
-// message. The form now mirrors it, because it has to show what the task would
-// have been called — this function is the last of the three steps, shared by
-// the two paths that need it (a chat handoff's draft, an Edit's stored prose).
-//
-// One line, and never the whole thing: an <input> would strip the newlines
-// anyway, and the first line is what `_title` itself takes.
+// One line of a block of prose, trimmed. Used to reduce a multi-line value to
+// something an <input> can hold (it would strip the newlines anyway) and to ask
+// "is this string the message I am about to send?" below.
 export function firstLine(text: string): string {
   return text.trim().split("\n")[0]?.trim() ?? "";
 }
 
-// What Title OPENS on, synchronously — so the field is never blank on arrival
-// even on the first paint, before the tasks lookup below has answered.
+// -- The title names the SESSION, never the message ---------------------------
+// The bug this replaced (Akshil, 2026-08-17): scheduling from a Claude chat
+// prefilled Title with `firstLine(ask)` — the very message being scheduled — so
+// a long message came out duplicated, once as the title and once as the
+// description. "The description is what we type in the chat box"; the title is
+// what the CONVERSATION is called.
 //
-// A stored title wins outright (it is the top of the precedence, and an edit
-// that quietly replaced it would be a data loss). Otherwise the first line of
-// the ask, which is `_title`'s own last resort: it is what the server would
-// have named this task, so it is the honest thing to show — and it means an
-// UNTITLED task can still be edited and saved, which a blank required field
-// would make impossible.
-export function initialTitleOf(
-  entry?: ScheduledMessage | null,
-  chatDraft?: string | null,
-): string {
-  return (entry?.title ?? "").trim() || firstLine(initialAskOf(entry, chatDraft));
+// So the precedence is now, in order:
+//   1. the task's own stored title, if a user ever set one;
+//   2. the SESSION's resolved title — Claude Code's `ai-title` record, which is
+//      the "cloud summarised it" case, served on /api/tasks as `title` with
+//      `title_source: "ai"`;
+//   3. the session's FIRST user message, shortened — "the first message that we
+//      had". Also /api/tasks, as `title_source: "message"`: the server's own
+//      last resort is the first line of the transcript's first user prompt
+//      (tasks.py `_title` reading `tasks_store.head`);
+//   4. nothing. The field opens blank and the user types a name.
+// Never the composed message, at any step. Steps 2 and 3 need a fetch, so they
+// live in the /api/tasks effect; 1 and 4 are what `initialTitleOf` decides
+// synchronously.
+
+// How long a title derived from a first message is allowed to be. A name, not a
+// summary: this is the whole point of step 3 — a 200-char first line (the
+// server's own cap) is the duplication bug again in a longer field.
+export const TITLE_MAX = 60;
+
+// A first message reduced to a name: one line, clamped, cut on a word boundary.
+// No ellipsis — the field is a NAME the user can edit, and "…" is punctuation
+// they would have to delete. A single word longer than the clamp has no boundary
+// to cut on, so it is cut hard; that is the only mid-word cut here.
+export function shortTitle(text: string, max = TITLE_MAX): string {
+  const line = firstLine(text);
+  if (line.length <= max) return line;
+  // max + 1 so a value whose max'th character is the space gets the whole word
+  // before it rather than losing it.
+  const boundary = line.slice(0, max + 1).lastIndexOf(" ");
+  return (boundary > 0 ? line.slice(0, boundary) : line.slice(0, max)).trimEnd();
 }
 
-// …and the middle step, which only /api/tasks can answer: the name the session
-// this form was opened from already carries. Only a real NAME counts — the
-// session's own `ai-title`, or a title the user has already given the thread. A
-// `message`-sourced title is the first line of the first prompt echoed back,
-// which is the same answer `initialTitleOf` already derived locally, so
-// replacing one with the other would be motion without meaning.
+// What Title OPENS on, synchronously. Only step 1 and step 4: a stored title
+// wins outright (an edit that quietly replaced it would be data loss), and
+// otherwise the field is BLANK until the /api/tasks lookup answers.
+//
+// It used to derive `firstLine(initialAskOf(...))` here, which is what put the
+// scheduled message in the title. Blank is the honest synchronous answer instead
+// — the form has nothing to say about the session yet — and blank is safe even
+// though Title is required: the requirement bites at Save, by which time either
+// the lookup has filled the field or the user has.
+export function initialTitleOf(entry?: ScheduledMessage | null): string {
+  return (entry?.title ?? "").trim();
+}
+
+// Steps 2 and 3, which only /api/tasks can answer: the name the session this
+// form was opened from already carries. A session IS a task there, so the row
+// keyed on it has both the resolved `title` and the `title_source` saying which
+// branch produced it — and that provenance is the whole reason this reads the
+// API instead of a string in the deep link.
+//
+// `ask` is the message being composed or edited, and it is here to be REFUSED.
+// A `message`-sourced title used to be dropped outright, on the grounds that it
+// was the first line of the first prompt echoed back and therefore byte-identical
+// to what the form had already derived locally. That reasoning inverted with the
+// bug above: the local derivation is now the thing we are removing, so a
+// `message`-sourced title is the ONLY way to reach step 3 — "the first message
+// that we had" — and dropping it would leave a session with no `ai-title` yet
+// falling straight through to blank.
+//
+// It cannot be accepted blind, though, because `_title`'s message branch has a
+// second source: when the session has no readable transcript, it falls back to
+// the first line of the earliest schedule ENTRY's message. On a task scheduled
+// from this very form that is the message being scheduled — the duplication,
+// arriving by way of the server. So the branch is accepted only when it is not
+// the head of `ask`. Checked in one direction on purpose: a stored title that
+// begins the message being sent is that message, while a longer title that
+// merely starts with it is a real first prompt the composer's draft happens to
+// echo.
+//
+// Steps 1 and 2 are taken verbatim — a name a human typed and a name Claude
+// wrote are both already names, and shortening either would edit someone's
+// words. Only step 3 is a message being reduced to one.
 export function sessionTitleOf(
   tasks: readonly { session_id: string; title: string; title_source: string }[],
   sessionId: string,
+  ask = "",
 ): string {
   if (!sessionId) return "";
   const task = tasks.find((t) => t.session_id === sessionId);
-  if (!task || task.title_source === "message") return "";
-  return task.title.trim();
+  const title = (task?.title ?? "").trim();
+  if (!title) return "";
+  if (task?.title_source !== "message") return title;
+  const composed = firstLine(ask);
+  if (composed !== "" && composed.startsWith(title)) return "";
+  return shortTitle(title);
 }
 
 // What the Repeat checkbox does to the repeat state. Unticking CLEARS: the key
@@ -1320,11 +1379,10 @@ export function buildSchedulePayload(form: {
   // refuses Save on an empty one.
   message: string;
   // The FIRST field on the card, and REQUIRED as of 2026-08-17: `saveEnabled`
-  // refuses Save on a blank one, and every path that opens the form arrives with
-  // a name already in it (initialTitleOf). The wire contract is unchanged — the
-  // server still names an untitled task from the transcript's `ai-title` (design
-  // §4) — so the empty branch below stays as the honest fallback for a caller
-  // this form's gate never saw.
+  // refuses Save on a blank one, so what reaches here is a name a human accepted
+  // or typed. The wire contract is unchanged — the server still names an untitled
+  // task from the transcript's `ai-title` (design §4) — so the empty branch below
+  // stays as the honest fallback for a caller this form's gate never saw.
   title: string;
   when: string;
   // The structured rule the current choice means; null for a one-off and for
@@ -1409,10 +1467,12 @@ export function buildSchedulePayload(form: {
 // nothing to do is not a task, and Title because a task nobody can name in a
 // list is not much better (Akshil, 2026-08-17).
 //
-// Title being required costs the user nothing, and that is the condition on
-// which it was made required: the form opens with a name in the field on every
-// path that has one to offer (initialTitleOf, and the /api/tasks lookup behind
-// it), so the gate only ever fires on a title the user deliberately cleared.
+// Title being required is not softened by the field sometimes opening blank —
+// that is the point of the requirement rather than a hole in it. The form fills
+// the field from the session wherever a session has a name (initialTitleOf plus
+// the /api/tasks lookup behind it); where nothing honest is available it asks,
+// which is strictly better than the alternative it replaced — naming the task
+// after the message it is scheduling.
 //
 // Both use `.trim()`, because a textarea full of newlines is not an instruction
 // and a title of spaces is not a name. Save is `disabled` on a false — nothing
@@ -1496,17 +1556,17 @@ export default function NewJobModal({
   // modal (QA 2026-08-14).
   const initialAsk = initialAskOf(editing, initialMessage);
   const [message, setMessage] = useState(initialAsk);
-  // The FIRST field on the card, and REQUIRED (Akshil, 2026-08-17) — which is
-  // only reasonable because it opens PREFILLED. `initialTitleOf` is the
-  // synchronous part of the server's own precedence: a stored title, else the
-  // first line of the ask. The `ai-title` step needs a fetch and lands later
-  // (the /api/tasks effect below), which is exactly why the local derivation
-  // exists — a required field must not be blank on the first paint, and an entry
-  // written before this field existed still has to be editable.
+  // The FIRST field on the card, and REQUIRED (Akshil, 2026-08-17).
+  // `initialTitleOf` is only the synchronous half of the precedence: a stored
+  // title, else blank. The two SESSION steps — the thread's `ai-title`, then its
+  // first user message — need a fetch and land in the /api/tasks effect below.
+  // Blank on the first paint is deliberate now: the alternative was deriving a
+  // name from the ask, which is exactly how a long scheduled message ended up
+  // duplicated into the title.
   //
   // Held in a const for the same reason `initialAsk` is: the BASELINE (`initial`)
   // has to be the identical value or an untouched Edit reads as dirty.
-  const derivedTitle = initialTitleOf(editing, initialMessage);
+  const derivedTitle = initialTitleOf(editing);
   const [title, setTitle] = useState(derivedTitle);
   const [target, setTarget] = useState(editing?.target ?? initialTarget ?? "");
   // ONE date-time drives everything: a one-off runs at it, and every derived
@@ -1876,13 +1936,19 @@ export default function NewJobModal({
   const [replaced, setReplaced] = useState(false);
 
   // ---- The session's own name, prefilled into Title ----------------------
+  // Steps 2 and 3 of the precedence (see sessionTitleOf): what the CONVERSATION
+  // is called — its `ai-title`, else its first user message — never the message
+  // being scheduled.
+  //
   // Sourced from /api/tasks rather than from the deep link or a new endpoint:
   // a session IS a task there (tasks.py `_collect`), so the row keyed on it
   // already carries the resolved title AND `title_source`, which is what says
-  // whether the name is a real one. The alternative — having the chat template
-  // put its title in the URL beside `message`, `target`, `session_id` and
-  // `back` — would hand us a string with no provenance, and one that is stale
-  // from the moment the link is built.
+  // WHICH of the two steps produced it — and the first user message is only
+  // reachable that way, since the server resolves it (`tasks_store.head`) but
+  // does not put it on the wire under a name of its own. The alternative —
+  // having the chat template put its title in the URL beside `message`,
+  // `target`, `session_id` and `back` — would hand us a string with no
+  // provenance, and one that is stale from the moment the link is built.
   //
   // BOTH paths that have a session use it, and for the same reason: the chat
   // this form was deep-linked from (?new=1&session_id=…), and whatever session
@@ -1893,10 +1959,13 @@ export default function NewJobModal({
   // only name that exists. Refusing to look it up would leave the user retyping
   // a name the app already knows.
   //
-  // It only ever replaces the DERIVED title, never a typed one and never a
-  // stored one — same discipline as the getConfig effect above, and for the same
-  // bug: `initial` moves with it, because a value the user did not type must not
-  // read as dirty and arm the close-twice guard.
+  // It only ever replaces the SYNCHRONOUS title (usually the empty string),
+  // never a typed one and never a stored one — same discipline as the getConfig
+  // effect above, and for the same bug: `initial` moves with it, because a value
+  // the user did not type must not read as dirty and arm the close-twice guard.
+  // That pairing matters more now that the field starts blank: without it, every
+  // form opened from a chat would arrive already dirty and its ✕ would need two
+  // presses before the user had touched anything.
   const nameSession = (editing?.session_id || chatSessionId) ?? "";
   useEffect(() => {
     // A stored title is the top of the precedence — nothing may outrank it.
@@ -1904,20 +1973,25 @@ export default function NewJobModal({
     let alive = true;
     getTasks()
       .then(({ tasks }) => {
-        const resolved = sessionTitleOf(tasks, nameSession);
+        // `initialAsk`, not the live `message`: the question is whether the
+        // resolved name is the message being SCHEDULED, which is what the form
+        // opened on. Reading the live value would also refetch the whole task
+        // list on every keystroke in the description.
+        const resolved = sessionTitleOf(tasks, nameSession, initialAsk);
         if (!alive || !resolved) return;
         setTitle((prev) => (prev === derivedTitle ? resolved : prev));
         setInitial((prev) =>
           prev.title === derivedTitle ? { ...prev, title: resolved } : prev,
         );
       })
-      // A failed lookup is not worth reporting: the derived title is already a
-      // complete, saveable answer, so the form simply keeps it.
+      // A failed lookup is not worth reporting: the field is either already
+      // showing a stored title or blank with Save asking for one, and neither
+      // state is improved by an error banner about a name.
       .catch(() => {});
     return () => {
       alive = false;
     };
-  }, [editing, nameSession, derivedTitle]);
+  }, [editing, nameSession, derivedTitle, initialAsk]);
 
   // ---- Delete ------------------------------------------------------------
   // Only when EDITING, and only for something the server will actually
@@ -2132,16 +2206,16 @@ export default function NewJobModal({
             leading icon, because a 14px glyph beside a 20px face read as
             debris and the gutter is what says "this is a detail".
 
-            REQUIRED, and PREFILLED — the two together, because either alone
-            would be worse than what was here before (Akshil, 2026-08-17). Every
-            task the user can see in a list has a name, so the field is filled
-            from the same precedence the server uses: a stored title, this
-            session's own `ai-title`, else the first line of the ask
-            (initialTitleOf, plus the /api/tasks lookup above). What the user
-            does here is accept or edit a name, never invent one — so `ready`
-            can refuse a blank one without ever making the form feel like
-            paperwork, and `aria-required` says so rather than leaving a
-            disabled Save as the only hint.
+            REQUIRED, and prefilled from the SESSION where there is one to read
+            (Akshil, 2026-08-17): its `ai-title`, else its first user message —
+            see sessionTitleOf for the whole precedence and for what it refuses.
+            What it will never be again is the first line of the ask: that named
+            every chat-scheduled task after the message it was scheduling, so a
+            long message arrived duplicated into both fields. Opened from the New
+            task button, or from a session with nothing to say for itself, the
+            field is blank and the requirement is what asks for a name —
+            `aria-required` says so rather than leaving a disabled Save as the
+            only hint.
 
             An <input>, not a textarea, and that is the whole overflow answer:
             one line that never wraps and never grows. Long text scrolls

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -128,16 +128,10 @@ const ICON_FILE = (
   </svg>
 );
 
-// lucide "type" — the serif T of a title field. Inline, like every other glyph
-// in this file: no icon package in this repo.
-const ICON_TITLE = (
-  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-       strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-    <polyline points="4 7 4 4 20 4 20 7" />
-    <line x1="9" y1="20" x2="15" y2="20" />
-    <line x1="12" y1="4" x2="12" y2="20" />
-  </svg>
-);
+// There was a lucide "type" glyph here — the serif T that led the Title row
+// while Title was one of the form's quiet icon rows. Title is a prominent
+// peer of the ask now and neither of the two takes an icon, so the glyph went
+// with the row (see the form's markup for why).
 
 // lucide "check", at tick scale.
 const ICON_CHECK = (
@@ -1285,15 +1279,17 @@ export type SchedulePayload = Parameters<typeof scheduleMessage>[0];
 
 export function buildSchedulePayload(form: {
   target: string;
-  // The big field, and the ONLY prose the form asks for: what Claude is sent,
-  // and — same text, no second field — the task's description (Akshil,
+  // The SECOND field on the card and the required one: what Claude is sent,
+  // and — same text, no third field — the task's description (Akshil,
   // 2026-08-17: "the big field is the description, that is the first message").
   // It rides the wire twice, once as each, because the server stores them as
   // two things and a task page that showed nothing under a task would be the
-  // only alternative.
+  // only alternative. Never blank by the time it gets here: `saveEnabled`
+  // refuses Save on an empty one.
   message: string;
-  // Optional, and empty is the ordinary case: the server fills a missing title
-  // in from the transcript's `ai-title` (design §4).
+  // The FIRST field on the card, and still optional: empty is the ordinary case
+  // and the server fills a missing title in from the transcript's `ai-title`
+  // (design §4). Its position and its prominence changed; the contract did not.
   title: string;
   when: string;
   // The structured rule the current choice means; null for a one-off and for
@@ -1371,6 +1367,46 @@ export function buildSchedulePayload(form: {
   };
 }
 
+// WHAT SAVE REFUSES. Pulled out of the component (it was an inline `ready`
+// expression) so the one rule this pass added is assertable: the description —
+// the big second field, the text Claude is actually sent — is REQUIRED, and
+// Title, first field though it now is, is not (design §4: left blank, the
+// server names the task from the transcript's `ai-title`, then the message's
+// first line).
+//
+// It is the SAME gate as before, deliberately: the form has always refused a
+// blank ask, and this change only moved that field down one row and gave it the
+// other field's clothes. `.trim()`, because a textarea full of newlines is not
+// an instruction. Save is `disabled` on a false — nothing here is a submit
+// handler that could be reached another way.
+export function saveEnabled(f: {
+  // The ask / description. Required.
+  message: string;
+  // Where it runs. Required, and the async existence check must not be failing.
+  target: string;
+  pathError: string | null;
+  // A "custom" repeat is only a choice once the recurrence dialog produced a
+  // rule; a legacy cron template needs its line; everything else needs a
+  // parseable date-time.
+  repeatOn: boolean;
+  repeat: string;
+  customRule: RecurrenceRule | null;
+  legacyCron: string;
+  pickedOk: boolean;
+  // The entry has already been re-created by this modal — saving twice would
+  // schedule it twice.
+  replaced: boolean;
+}): boolean {
+  return (
+    !f.replaced &&
+    f.message.trim() !== "" &&
+    f.target.trim() !== "" &&
+    f.pathError === null &&
+    (f.repeatOn && f.repeat === "custom" ? f.customRule !== null : true) &&
+    (f.repeat === "cron" ? f.legacyCron !== "" : f.pickedOk)
+  );
+}
+
 export default function NewJobModal({
   initialTime,
   initialTarget,
@@ -1418,11 +1454,13 @@ export default function NewJobModal({
   // modal (QA 2026-08-14).
   const initialAsk = initialAskOf(editing, initialMessage);
   const [message, setMessage] = useState(initialAsk);
-  // Optional and new (design §4), and normally left blank — Claude Code writes
-  // its own one-liner into the transcript and the server prefers that — so the
-  // field asks for nothing and the placeholder says so. Absent on the stored
-  // entry reads as empty, which is what an entry written before this field
-  // existed means.
+  // The FIRST field on the card now (Akshil, 2026-08-17) but still optional and
+  // still normally left blank — Claude Code writes its own one-liner into the
+  // transcript and the server prefers that (design §4) — so the field asks for
+  // nothing and the placeholder says so. Being first changed where it sits and
+  // what it looks like, not what it means. Absent on the stored entry reads as
+  // empty, which is what an entry written before this field existed means, and
+  // is what makes the Edit round trip work either way.
   const [title, setTitle] = useState(editing?.title ?? "");
   const [target, setTarget] = useState(editing?.target ?? initialTarget ?? "");
   // ONE date-time drives everything: a one-off runs at it, and every derived
@@ -1616,10 +1654,12 @@ export default function NewJobModal({
     };
   }, [target]);
 
-  // The ask wears the title's clothes but grows like a note: with the text, up
-  // to the CSS max-height (~5 lines), then scrolls. Measured on every change
-  // because "auto then scrollHeight" is the one reflow-safe way to shrink back
-  // when lines are deleted.
+  // The ask wears the SAME clothes as Title above it and grows like a note:
+  // with the text, up to the CSS max-height (~5 lines), then scrolls. This
+  // measuring is the whole difference between the two fields — Title is an
+  // <input> and has no height to measure. Measured on every change because
+  // "auto then scrollHeight" is the one reflow-safe way to shrink back when
+  // lines are deleted.
   const askRef = useRef<HTMLTextAreaElement>(null);
   const pathRef = useRef<HTMLInputElement>(null);
   // Escape-from-a-row hands focus back to the field WITHOUT reopening the
@@ -1946,13 +1986,18 @@ export default function NewJobModal({
   // the two wordings differ rather than one covering both. See pastNoteFor.
   const pastNote = pastNoteFor(pickedOk ? picked : null, repeatOn, rule, new Date());
 
-  const ready =
-    !replaced &&
-    message.trim() !== "" &&
-    target.trim() !== "" &&
-    pathError === null &&
-    (repeatOn && repeat === "custom" ? customRule !== null : true) &&
-    (repeat === "cron" ? legacyCron !== "" : pickedOk);
+  // See saveEnabled: the description is required, Title is not.
+  const ready = saveEnabled({
+    message,
+    target,
+    pathError,
+    repeatOn,
+    repeat,
+    customRule,
+    legacyCron,
+    pickedOk,
+    replaced,
+  });
 
   return (
     <Modal
@@ -2000,45 +2045,66 @@ export default function NewJobModal({
       }
     >
       <div className="schedule-form">
-        {/* The ask leads, wearing the title's clothes, and it is now the ONLY
-            prose the form collects: what the user types here is what Claude is
-            sent AND what the task is described as (Akshil, 2026-08-17 — three
-            text fields for one thought did not make sense). The separate
-            "Description (optional)" textarea that used to sit a row below is
-            gone; Title, still optional, is the one field left under it.
-            The placeholder stays "What should Claude do?": the field's job did
-            not change — you type the instruction — and "Description" is what
-            the server calls that text, not a second thing to write. */}
+        {/* TITLE FIRST, and as prominent as the ask below it (Akshil,
+            2026-08-17: "title will be the first field and then description will
+            be the second field… make both of those like the main field that we
+            have"). It swapped places with the ask and put on the same clothes —
+            same 20px face, same weight, same underline — because the two of
+            them are what the task IS; the folder and the time are facts about
+            it and stay quiet beneath.
+
+            NEITHER of the two carries a leading icon now. The 26px icon gutter
+            is the QUIET rows' vocabulary (📁 folder, 🕐 when) and a 14px glyph
+            beside a 20px face read as debris; Title used to wear a `T` only
+            because it was one of those rows. Peers wear the same clothes, so
+            the choice was both or neither, and neither is what keeps the
+            gutter meaning "this is a detail".
+
+            Still OPTIONAL, and normally left alone: Claude Code writes its own
+            one-line title into the transcript and the server prefers that,
+            falling back to the first line of the message (design §4). The
+            placeholder says so, because a blank prominent field reads as
+            something you owe the form — and when this form was opened from a
+            chat it says it by showing that conversation's CURRENT name (see
+            titlePlaceholderFor: a preview, deliberately not a value, because a
+            value would freeze the name).
+
+            An <input>, not a textarea, and that is the whole overflow answer:
+            one line that never wraps and never grows. Long text scrolls
+            horizontally under the caret while the field has focus and ellipses
+            when it does not — see `.new-task-title` in new-task.css. */}
+        <input
+          type="text"
+          className="schedule-form-title new-task-title"
+          aria-label="Title"
+          placeholder={titlePlaceholderFor(sessionTitle, repeatOn)}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          autoFocus
+        />
+
+        {/* …and the ask SECOND, still the only other prose the form collects:
+            what the user types here is what Claude is sent AND what the task is
+            described as (design §4 — three text fields for one thought did not
+            make sense, so `description` and `message` are one field). Which is
+            also why it is REQUIRED where Title is not: an empty one is a task
+            with nothing to do. `ready` below refuses Save on it, and
+            aria-required says so to a screen reader rather than leaving a
+            disabled button as the only hint.
+
+            It keeps the growth Title deliberately does not have: multi-line,
+            autogrowing with the text up to the CSS max-height (~5 lines), then
+            scrolling. */}
         <textarea
           ref={askRef}
           className="schedule-form-title"
           rows={2}
           aria-label="What should Claude do?"
+          aria-required="true"
           placeholder="What should Claude do?"
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          autoFocus
         />
-
-        {/* Optional, and normally left alone: Claude Code writes its own
-            one-line title into the transcript and the server prefers that,
-            falling back to the first line of the message. The placeholder says
-            so, because a blank field with a "Title" label reads as something
-            you owe the form — and when this form was opened from a chat, it
-            says it by showing that conversation's CURRENT name (see
-            titlePlaceholderFor: a preview, deliberately not a value, because a
-            value would freeze the name). */}
-        <div className="schedule-form-line">
-          {ICON_TITLE}
-          <input
-            type="text"
-            className="field-control new-task-title"
-            aria-label="Title"
-            placeholder={titlePlaceholderFor(sessionTitle, repeatOn)}
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-          />
-        </div>
 
         {/* The path is a combobox, Google-style: focusing it drops the last
             few folders the user scheduled against, with Browse as the

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -749,6 +749,15 @@ function CustomRecurrence({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const [freq, setFreq] = useState<RecurrenceRule["freq"]>(initial?.freq ?? "week");
+  // How often, as a list of units. `year` is NOT one of them any more (Akshil,
+  // 2026-08-17 — the annual preset went with it), with one exception: a rule
+  // that is ALREADY yearly keeps the row while it is being edited. That rule
+  // opens here (keyOfRule finds no preset for a yearly freq, so the modal opens
+  // it as Custom), and a unit dropdown that could not say "year" would show a
+  // value with no matching row — and would turn any other edit on the panel,
+  // the interval or the end date, into a silent change of frequency. Read off
+  // `initial` rather than the live `freq` so the row does not vanish mid-edit.
+  const units = initial?.freq === "year" ? LEGACY_RECUR_UNITS : RECUR_UNITS;
   const [interval, setIntervalN] = useState(initial?.interval ?? 1);
   const [byday, setByday] = useState<number[]>(
     initial?.byday?.length ? initial.byday : [anchor.getDay()],
@@ -812,7 +821,7 @@ function CustomRecurrence({
           ariaLabel="Repeat unit"
           className="schedule-recur-unit"
           value={interval > 1 ? `${freq}s` : freq}
-          options={(["hour", "day", "week", "month", "year"] as const).map((u) => ({
+          options={units.map((u) => ({
             key: u,
             label: interval > 1 ? `${u}s` : u,
           }))}
@@ -960,6 +969,13 @@ function untilLabel(ymd: string): string {
 }
 
 const NTH_LABELS = ["first", "second", "third", "fourth", "fifth"];
+
+// The custom panel's "repeat every N ___" units. Shortest first, the order
+// recur.FREQUENCIES is written in — and without `year`, which is off the menu
+// for anything new (see `units` in CustomRecurrence for the one exception, and
+// repeatChoicesFor for the preset row that went with it).
+const RECUR_UNITS: readonly RecurrenceRule["freq"][] = ["hour", "day", "week", "month"];
+const LEGACY_RECUR_UNITS: readonly RecurrenceRule["freq"][] = [...RECUR_UNITS, "year"];
 
 // How a permission mode is SAID. The keys are the server's contract and stay
 // exactly as they are on the wire; only the reading changes. A mode this map
@@ -1654,12 +1670,15 @@ export default function NewJobModal({
     };
   }, [target]);
 
-  // The ask wears the SAME clothes as Title above it and grows like a note:
-  // with the text, up to the CSS max-height (~5 lines), then scrolls. This
-  // measuring is the whole difference between the two fields — Title is an
-  // <input> and has no height to measure. Measured on every change because
-  // "auto then scrollHeight" is the one reflow-safe way to shrink back when
-  // lines are deleted.
+  // The ask shares Title's borderless surface but not its face, and it grows
+  // like a note: with the text, from the CSS floor (`.new-task-ask`'s
+  // min-height, which is what hands it the card's slack) up to the CSS
+  // max-height, then it scrolls. Both clamps hold against the inline height set
+  // here — min-/max-height bound the used value whatever `style.height` says —
+  // so this measuring only ever picks the size BETWEEN them. It is the whole
+  // difference between the two fields: Title is an <input> and has no height to
+  // measure. Measured on every change because "auto then scrollHeight" is the
+  // one reflow-safe way to shrink back when lines are deleted.
   const askRef = useRef<HTMLTextAreaElement>(null);
   const pathRef = useRef<HTMLInputElement>(null);
   // Escape-from-a-row hands focus back to the field WITHOUT reopening the
@@ -2045,20 +2064,25 @@ export default function NewJobModal({
       }
     >
       <div className="schedule-form">
-        {/* TITLE FIRST, and as prominent as the ask below it (Akshil,
-            2026-08-17: "title will be the first field and then description will
-            be the second field… make both of those like the main field that we
-            have"). It swapped places with the ask and put on the same clothes —
-            same 20px face, same weight, same underline — because the two of
-            them are what the task IS; the folder and the time are facts about
-            it and stay quiet beneath.
+        {/* ONE WRITING SURFACE, not two controls (Akshil, 2026-08-17, reference
+            image): the title and the description share a single borderless
+            area running from the header rule to the rows below it, the title
+            set large and the description quieter beneath it. Neither field
+            looks like an input — no border, no underline, no filled box — so
+            the top of the card reads as a document you type into rather than a
+            form with two fields in it. The wrapper is what makes that ONE
+            surface: it owns the block's vertical space and hands the slack to
+            the description, so a two-word entry does not leave the card
+            top-heavy. See `.new-task-write` in new-task.css for the whole
+            treatment, including what focus looks like when there is no box to
+            recolour.
 
-            NEITHER of the two carries a leading icon now. The 26px icon gutter
-            is the QUIET rows' vocabulary (📁 folder, 🕐 when) and a 14px glyph
-            beside a 20px face read as debris; Title used to wear a `T` only
-            because it was one of those rows. Peers wear the same clothes, so
-            the choice was both or neither, and neither is what keeps the
-            gutter meaning "this is a detail".
+            TITLE FIRST, and the prominent one (Akshil, 2026-08-17: "title will
+            be the first field and then description will be the second field").
+            The folder and the time are facts ABOUT the task and stay quiet
+            beneath in the 26px icon gutter; neither of these two carries a
+            leading icon, because a 14px glyph beside a 20px face read as
+            debris and the gutter is what says "this is a detail".
 
             Still OPTIONAL, and normally left alone: Claude Code writes its own
             one-line title into the transcript and the server prefers that,
@@ -2073,38 +2097,41 @@ export default function NewJobModal({
             one line that never wraps and never grows. Long text scrolls
             horizontally under the caret while the field has focus and ellipses
             when it does not — see `.new-task-title` in new-task.css. */}
-        <input
-          type="text"
-          className="schedule-form-title new-task-title"
-          aria-label="Title"
-          placeholder={titlePlaceholderFor(sessionTitle, repeatOn)}
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          autoFocus
-        />
+        <div className="new-task-write">
+          <input
+            type="text"
+            className="new-task-field new-task-title"
+            aria-label="Title"
+            placeholder={titlePlaceholderFor(sessionTitle, repeatOn)}
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+          />
 
-        {/* …and the ask SECOND, still the only other prose the form collects:
-            what the user types here is what Claude is sent AND what the task is
-            described as (design §4 — three text fields for one thought did not
-            make sense, so `description` and `message` are one field). Which is
-            also why it is REQUIRED where Title is not: an empty one is a task
-            with nothing to do. `ready` below refuses Save on it, and
-            aria-required says so to a screen reader rather than leaving a
-            disabled button as the only hint.
+          {/* …and the ask SECOND, still the only other prose the form collects:
+              what the user types here is what Claude is sent AND what the task
+              is described as (design §4 — three text fields for one thought did
+              not make sense, so `description` and `message` are one field).
+              Which is also why it is REQUIRED where Title is not: an empty one
+              is a task with nothing to do. `ready` below refuses Save on it,
+              and aria-required says so to a screen reader rather than leaving a
+              disabled button as the only hint.
 
-            It keeps the growth Title deliberately does not have: multi-line,
-            autogrowing with the text up to the CSS max-height (~5 lines), then
-            scrolling. */}
-        <textarea
-          ref={askRef}
-          className="schedule-form-title"
-          rows={2}
-          aria-label="What should Claude do?"
-          aria-required="true"
-          placeholder="What should Claude do?"
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-        />
+              Quieter and smaller than the title, and it keeps the growth Title
+              deliberately does not have: multi-line, autogrowing with the text
+              from the floor `.new-task-ask` sets up to its max-height, then
+              scrolling. */}
+          <textarea
+            ref={askRef}
+            className="new-task-field new-task-ask"
+            rows={2}
+            aria-label="What should Claude do?"
+            aria-required="true"
+            placeholder="What should Claude do?"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+          />
+        </div>
 
         {/* The path is a combobox, Google-style: focusing it drops the last
             few folders the user scheduled against, with Browse as the

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1163,8 +1163,10 @@ export function deleteFailureText(err: unknown, series: boolean): string {
 export const TITLE_PLACEHOLDER = "Title";
 
 // One line of a block of prose, trimmed. Used to reduce a multi-line value to
-// something an <input> can hold (it would strip the newlines anyway) and to ask
-// "is this string the message I am about to send?" below.
+// something an <input> can hold — it would strip the newlines anyway. It also
+// used to answer "is this string the message I am about to send?" for
+// sessionTitleOf; that question is the server's now, and answered by provenance
+// rather than by comparing strings.
 export function firstLine(text: string): string {
   return text.trim().split("\n")[0]?.trim() ?? "";
 }
@@ -1182,9 +1184,11 @@ export function firstLine(text: string): string {
 //      the "cloud summarised it" case, served on /api/tasks as `title` with
 //      `title_source: "ai"`;
 //   3. the session's FIRST user message, shortened — "the first message that we
-//      had". Also /api/tasks, as `title_source: "message"`: the server's own
-//      last resort is the first line of the transcript's first user prompt
-//      (tasks.py `_title` reading `tasks_store.head`);
+//      had". Also /api/tasks, as `title_source: "message"`: the first line of the
+//      transcript's first user prompt (tasks.py `_title` reading
+//      `tasks_store.head`). Its sibling `title_source: "entry"` — a row named
+//      from a message merely SCHEDULED at the session, because the transcript
+//      could not be read — is not a step here at all; see sessionTitleOf;
 //   4. nothing. The field opens blank and the user types a name.
 // Never the composed message, at any step. Steps 2 and 3 need a fetch, so they
 // live in the /api/tasks effect; 1 and 4 are what `initialTitleOf` decides
@@ -1227,24 +1231,23 @@ export function initialTitleOf(entry?: ScheduledMessage | null): string {
 // branch produced it — and that provenance is the whole reason this reads the
 // API instead of a string in the deep link.
 //
-// `ask` is the message being composed or edited, and it is here to be REFUSED.
-// A `message`-sourced title used to be dropped outright, on the grounds that it
-// was the first line of the first prompt echoed back and therefore byte-identical
-// to what the form had already derived locally. That reasoning inverted with the
-// bug above: the local derivation is now the thing we are removing, so a
-// `message`-sourced title is the ONLY way to reach step 3 — "the first message
-// that we had" — and dropping it would leave a session with no `ai-title` yet
-// falling straight through to blank.
+// The server's step 3 has TWO sources and only one of them is a name, so the
+// row says which it read (tasks.py `_title`):
 //
-// It cannot be accepted blind, though, because `_title`'s message branch has a
-// second source: when the session has no readable transcript, it falls back to
-// the first line of the earliest schedule ENTRY's message. On a task scheduled
-// from this very form that is the message being scheduled — the duplication,
-// arriving by way of the server. So the branch is accepted only when it is not
-// the head of `ask`. Checked in one direction on purpose: a stored title that
-// begins the message being sent is that message, while a longer title that
-// merely starts with it is a real first prompt the composer's draft happens to
-// echo.
+//   * `message` — the session's own first prompt, out of the transcript. Step 3
+//     itself, "the first message that we had", and taken as a name (shortened).
+//   * `entry` — no readable transcript, so the row is named from the earliest
+//     message SCHEDULED at that session. On a task made in this form that is the
+//     ask itself, which is the duplication bug arriving by way of the server, so
+//     it is refused and Title stays blank for the user to fill.
+//
+// This used to be one value, and the composed ask was passed in so the client
+// could GUESS which of the two it had: a `message` title was dropped whenever
+// the ask's first line began with it. A guess cannot tell an echo from a
+// continuation — "pull today's news and file it" begins with the session's real
+// first prompt "pull today's news" — so a session lost the name the app already
+// knew and Save sat disabled until the user retyped it. The server knows the
+// answer for certain, so it says it, and no draft is an input here at all.
 //
 // Steps 1 and 2 are taken verbatim — a name a human typed and a name Claude
 // wrote are both already names, and shortening either would edit someone's
@@ -1252,16 +1255,14 @@ export function initialTitleOf(entry?: ScheduledMessage | null): string {
 export function sessionTitleOf(
   tasks: readonly { session_id: string; title: string; title_source: string }[],
   sessionId: string,
-  ask = "",
 ): string {
   if (!sessionId) return "";
   const task = tasks.find((t) => t.session_id === sessionId);
   const title = (task?.title ?? "").trim();
   if (!title) return "";
-  if (task?.title_source !== "message") return title;
-  const composed = firstLine(ask);
-  if (composed !== "" && composed.startsWith(title)) return "";
-  return shortTitle(title);
+  if (task?.title_source === "entry") return "";
+  if (task?.title_source === "message") return shortTitle(title);
+  return title;
 }
 
 // What the Repeat checkbox does to the repeat state. Unticking CLEARS: the key
@@ -1973,11 +1974,7 @@ export default function NewJobModal({
     let alive = true;
     getTasks()
       .then(({ tasks }) => {
-        // `initialAsk`, not the live `message`: the question is whether the
-        // resolved name is the message being SCHEDULED, which is what the form
-        // opened on. Reading the live value would also refetch the whole task
-        // list on every keystroke in the description.
-        const resolved = sessionTitleOf(tasks, nameSession, initialAsk);
+        const resolved = sessionTitleOf(tasks, nameSession);
         if (!alive || !resolved) return;
         setTitle((prev) => (prev === derivedTitle ? resolved : prev));
         setInitial((prev) =>
@@ -1991,7 +1988,7 @@ export default function NewJobModal({
     return () => {
       alive = false;
     };
-  }, [editing, nameSession, derivedTitle, initialAsk]);
+  }, [editing, nameSession, derivedTitle]);
 
   // ---- Delete ------------------------------------------------------------
   // Only when EDITING, and only for something the server will actually

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1147,28 +1147,54 @@ export function deleteFailureText(err: unknown, series: boolean): string {
   return (err as Error | null)?.message || "The task could not be deleted.";
 }
 
-// ---- The Title field's placeholder ---------------------------------------
-// Blank is the RIGHT value for Title on a task scheduled from a chat, and this
-// is why (Akshil, 2026-08-17). Title precedence is: the user's own title, then
-// Claude Code's `ai-title` for the session, then the first line of the message
-// (tasks.py `_title`). Claude Code re-emits `ai-title` every turn, so a task
-// that leaves Title blank keeps tracking what the conversation is actually
-// about. Writing the chat's current title into the input would FREEZE it — an
-// explicit title beats `ai-title` for ever — so the task would keep the name it
-// had at the moment it was scheduled while the conversation moved on, and it
-// would be invisible because the field would look like something the user
-// typed.
+// ---- Naming the task -----------------------------------------------------
+// Title is REQUIRED (Akshil, 2026-08-17), which is a change of kind and not
+// just of copy: a required field the form opens BLANK is a form that refuses to
+// save until the user does clerical work, so every path that can name the task
+// arrives with a name in the box. The field is then a name to accept or edit,
+// never a name to invent.
 //
-// So the name is previewed as a PLACEHOLDER instead: you can see what the task
-// will be called, leaving it alone keeps the name live, and typing makes it
-// explicit and frozen — which is exactly what typing should mean.
-export const TITLE_PLACEHOLDER = "Title — optional, filled in automatically";
+// The placeholder is left with only the job a placeholder can honestly do —
+// saying which field this is. It used to say "optional, filled in
+// automatically", and it used to double as a PREVIEW of the chat's own name;
+// both went with the requirement. A previewed name that Save then refuses to
+// accept is the worst of the three states.
+export const TITLE_PLACEHOLDER = "Title";
 
-// Which title is worth previewing. Only a task's real NAME is: the session's
-// own `ai-title`, or a title the user has already given this thread. A
-// `message`-sourced title is just the first line of the conversation's first
-// prompt echoed back, which says nothing the generic placeholder doesn't
-// already say and reads like the wrong field.
+// The precedence the server uses (tasks.py `_title`): the user's own title,
+// then Claude Code's `ai-title` for the session, then the first line of the
+// message. The form now mirrors it, because it has to show what the task would
+// have been called — this function is the last of the three steps, shared by
+// the two paths that need it (a chat handoff's draft, an Edit's stored prose).
+//
+// One line, and never the whole thing: an <input> would strip the newlines
+// anyway, and the first line is what `_title` itself takes.
+export function firstLine(text: string): string {
+  return text.trim().split("\n")[0]?.trim() ?? "";
+}
+
+// What Title OPENS on, synchronously — so the field is never blank on arrival
+// even on the first paint, before the tasks lookup below has answered.
+//
+// A stored title wins outright (it is the top of the precedence, and an edit
+// that quietly replaced it would be a data loss). Otherwise the first line of
+// the ask, which is `_title`'s own last resort: it is what the server would
+// have named this task, so it is the honest thing to show — and it means an
+// UNTITLED task can still be edited and saved, which a blank required field
+// would make impossible.
+export function initialTitleOf(
+  entry?: ScheduledMessage | null,
+  chatDraft?: string | null,
+): string {
+  return (entry?.title ?? "").trim() || firstLine(initialAskOf(entry, chatDraft));
+}
+
+// …and the middle step, which only /api/tasks can answer: the name the session
+// this form was opened from already carries. Only a real NAME counts — the
+// session's own `ai-title`, or a title the user has already given the thread. A
+// `message`-sourced title is the first line of the first prompt echoed back,
+// which is the same answer `initialTitleOf` already derived locally, so
+// replacing one with the other would be motion without meaning.
 export function sessionTitleOf(
   tasks: readonly { session_id: string; title: string; title_source: string }[],
   sessionId: string,
@@ -1177,16 +1203,6 @@ export function sessionTitleOf(
   const task = tasks.find((t) => t.session_id === sessionId);
   if (!task || task.title_source === "message") return "";
   return task.title.trim();
-}
-
-// …and REPEAT takes the preview away, because a repeat takes the session away.
-// A repeating task always refuses the chat's session and opens its own thread
-// (buildSchedulePayload, and learnedSessionOf's note), so there is no
-// conversation whose name would carry over — previewing one would be a lie the
-// moment the checkbox is ticked.
-export function titlePlaceholderFor(sessionTitle: string, repeating: boolean): string {
-  if (repeating) return TITLE_PLACEHOLDER;
-  return sessionTitle.trim() || TITLE_PLACEHOLDER;
 }
 
 // What the Repeat checkbox does to the repeat state. Unticking CLEARS: the key
@@ -1303,9 +1319,12 @@ export function buildSchedulePayload(form: {
   // only alternative. Never blank by the time it gets here: `saveEnabled`
   // refuses Save on an empty one.
   message: string;
-  // The FIRST field on the card, and still optional: empty is the ordinary case
-  // and the server fills a missing title in from the transcript's `ai-title`
-  // (design §4). Its position and its prominence changed; the contract did not.
+  // The FIRST field on the card, and REQUIRED as of 2026-08-17: `saveEnabled`
+  // refuses Save on a blank one, and every path that opens the form arrives with
+  // a name already in it (initialTitleOf). The wire contract is unchanged — the
+  // server still names an untitled task from the transcript's `ai-title` (design
+  // §4) — so the empty branch below stays as the honest fallback for a caller
+  // this form's gate never saw.
   title: string;
   when: string;
   // The structured rule the current choice means; null for a one-off and for
@@ -1373,8 +1392,9 @@ export function buildSchedulePayload(form: {
     ...(continued && carriesLearned ? { session_learned: true } : {}),
     // Empty means "the server decides" for the title and "there isn't one" for
     // the description — in both cases the key is better left off the wire than
-    // sent as "". A blank description only happens if `message` is blank, which
-    // the Save button already refuses.
+    // sent as "". Neither branch is reachable from the form any more: Save
+    // refuses a blank on either field. They stay because the wire contract still
+    // allows both to be absent, and a builder that sent "" would be lying.
     ...(trimmedTitle ? { title: trimmedTitle } : {}),
     ...(trimmedDescription ? { description: trimmedDescription } : {}),
     // Only ever sent on a repeating task: on a one-off there is no "each run"
@@ -1384,20 +1404,25 @@ export function buildSchedulePayload(form: {
 }
 
 // WHAT SAVE REFUSES. Pulled out of the component (it was an inline `ready`
-// expression) so the one rule this pass added is assertable: the description —
-// the big second field, the text Claude is actually sent — is REQUIRED, and
-// Title, first field though it now is, is not (design §4: left blank, the
-// server names the task from the transcript's `ai-title`, then the message's
-// first line).
+// expression) so the rules are assertable: BOTH prose fields are required — the
+// description because it is the text Claude is actually sent and a task with
+// nothing to do is not a task, and Title because a task nobody can name in a
+// list is not much better (Akshil, 2026-08-17).
 //
-// It is the SAME gate as before, deliberately: the form has always refused a
-// blank ask, and this change only moved that field down one row and gave it the
-// other field's clothes. `.trim()`, because a textarea full of newlines is not
-// an instruction. Save is `disabled` on a false — nothing here is a submit
-// handler that could be reached another way.
+// Title being required costs the user nothing, and that is the condition on
+// which it was made required: the form opens with a name in the field on every
+// path that has one to offer (initialTitleOf, and the /api/tasks lookup behind
+// it), so the gate only ever fires on a title the user deliberately cleared.
+//
+// Both use `.trim()`, because a textarea full of newlines is not an instruction
+// and a title of spaces is not a name. Save is `disabled` on a false — nothing
+// here is a submit handler that could be reached another way — and both fields
+// carry `aria-required` so the disabled button is not the only hint.
 export function saveEnabled(f: {
   // The ask / description. Required.
   message: string;
+  // The task's name. Required, and prefilled rather than asked for.
+  title: string;
   // Where it runs. Required, and the async existence check must not be failing.
   target: string;
   pathError: string | null;
@@ -1416,6 +1441,7 @@ export function saveEnabled(f: {
   return (
     !f.replaced &&
     f.message.trim() !== "" &&
+    f.title.trim() !== "" &&
     f.target.trim() !== "" &&
     f.pathError === null &&
     (f.repeatOn && f.repeat === "custom" ? f.customRule !== null : true) &&
@@ -1470,14 +1496,18 @@ export default function NewJobModal({
   // modal (QA 2026-08-14).
   const initialAsk = initialAskOf(editing, initialMessage);
   const [message, setMessage] = useState(initialAsk);
-  // The FIRST field on the card now (Akshil, 2026-08-17) but still optional and
-  // still normally left blank — Claude Code writes its own one-liner into the
-  // transcript and the server prefers that (design §4) — so the field asks for
-  // nothing and the placeholder says so. Being first changed where it sits and
-  // what it looks like, not what it means. Absent on the stored entry reads as
-  // empty, which is what an entry written before this field existed means, and
-  // is what makes the Edit round trip work either way.
-  const [title, setTitle] = useState(editing?.title ?? "");
+  // The FIRST field on the card, and REQUIRED (Akshil, 2026-08-17) — which is
+  // only reasonable because it opens PREFILLED. `initialTitleOf` is the
+  // synchronous part of the server's own precedence: a stored title, else the
+  // first line of the ask. The `ai-title` step needs a fetch and lands later
+  // (the /api/tasks effect below), which is exactly why the local derivation
+  // exists — a required field must not be blank on the first paint, and an entry
+  // written before this field existed still has to be editable.
+  //
+  // Held in a const for the same reason `initialAsk` is: the BASELINE (`initial`)
+  // has to be the identical value or an untouched Edit reads as dirty.
+  const derivedTitle = initialTitleOf(editing, initialMessage);
+  const [title, setTitle] = useState(derivedTitle);
   const [target, setTarget] = useState(editing?.target ?? initialTarget ?? "");
   // ONE date-time drives everything: a one-off runs at it, and every derived
   // repeat choice reads its parts (minute, time, weekday) — Google's model.
@@ -1845,32 +1875,49 @@ export default function NewJobModal({
   // disables the button outright and the error says what to do by hand.
   const [replaced, setReplaced] = useState(false);
 
-  // ---- The chat's name, previewed on Title -------------------------------
+  // ---- The session's own name, prefilled into Title ----------------------
   // Sourced from /api/tasks rather than from the deep link or a new endpoint:
-  // a chat session IS a task there (tasks.py `_collect`), so the row keyed on
-  // this session already carries the resolved title AND `title_source`, which
-  // is what says whether the name is worth previewing at all. The alternative
-  // — having the chat template put its title in the URL beside `message`,
-  // `target`, `session_id` and `back` — would hand us a string with no
-  // provenance, and one that is stale from the moment the link is built.
+  // a session IS a task there (tasks.py `_collect`), so the row keyed on it
+  // already carries the resolved title AND `title_source`, which is what says
+  // whether the name is a real one. The alternative — having the chat template
+  // put its title in the URL beside `message`, `target`, `session_id` and
+  // `back` — would hand us a string with no provenance, and one that is stale
+  // from the moment the link is built.
   //
-  // Only on a NEW task from a chat: an Edit has its own stored title, and a
-  // form opened from anywhere else has no session to name.
-  const [sessionTitle, setSessionTitle] = useState("");
+  // BOTH paths that have a session use it, and for the same reason: the chat
+  // this form was deep-linked from (?new=1&session_id=…), and whatever session
+  // an edited entry carries — the thread it learned, or the chat it was
+  // scheduled from. The provenance that matters elsewhere (learnedSessionOf)
+  // does not matter here: either way that conversation is where this task's name
+  // comes from, and an untitled task is exactly the case where `ai-title` is the
+  // only name that exists. Refusing to look it up would leave the user retyping
+  // a name the app already knows.
+  //
+  // It only ever replaces the DERIVED title, never a typed one and never a
+  // stored one — same discipline as the getConfig effect above, and for the same
+  // bug: `initial` moves with it, because a value the user did not type must not
+  // read as dirty and arm the close-twice guard.
+  const nameSession = (editing?.session_id || chatSessionId) ?? "";
   useEffect(() => {
-    if (editing || !chatSessionId) return;
+    // A stored title is the top of the precedence — nothing may outrank it.
+    if ((editing?.title ?? "").trim() || !nameSession) return;
     let alive = true;
     getTasks()
       .then(({ tasks }) => {
-        if (alive) setSessionTitle(sessionTitleOf(tasks, chatSessionId));
+        const resolved = sessionTitleOf(tasks, nameSession);
+        if (!alive || !resolved) return;
+        setTitle((prev) => (prev === derivedTitle ? resolved : prev));
+        setInitial((prev) =>
+          prev.title === derivedTitle ? { ...prev, title: resolved } : prev,
+        );
       })
-      // A failed lookup is not worth reporting: the generic placeholder is a
-      // complete answer, and half a preview would be worse than none.
+      // A failed lookup is not worth reporting: the derived title is already a
+      // complete, saveable answer, so the form simply keeps it.
       .catch(() => {});
     return () => {
       alive = false;
     };
-  }, [editing, chatSessionId]);
+  }, [editing, nameSession, derivedTitle]);
 
   // ---- Delete ------------------------------------------------------------
   // Only when EDITING, and only for something the server will actually
@@ -2005,9 +2052,10 @@ export default function NewJobModal({
   // the two wordings differ rather than one covering both. See pastNoteFor.
   const pastNote = pastNoteFor(pickedOk ? picked : null, repeatOn, rule, new Date());
 
-  // See saveEnabled: the description is required, Title is not.
+  // See saveEnabled: both prose fields are required now, Title included.
   const ready = saveEnabled({
     message,
+    title,
     target,
     pathError,
     repeatOn,
@@ -2084,14 +2132,16 @@ export default function NewJobModal({
             leading icon, because a 14px glyph beside a 20px face read as
             debris and the gutter is what says "this is a detail".
 
-            Still OPTIONAL, and normally left alone: Claude Code writes its own
-            one-line title into the transcript and the server prefers that,
-            falling back to the first line of the message (design §4). The
-            placeholder says so, because a blank prominent field reads as
-            something you owe the form — and when this form was opened from a
-            chat it says it by showing that conversation's CURRENT name (see
-            titlePlaceholderFor: a preview, deliberately not a value, because a
-            value would freeze the name).
+            REQUIRED, and PREFILLED — the two together, because either alone
+            would be worse than what was here before (Akshil, 2026-08-17). Every
+            task the user can see in a list has a name, so the field is filled
+            from the same precedence the server uses: a stored title, this
+            session's own `ai-title`, else the first line of the ask
+            (initialTitleOf, plus the /api/tasks lookup above). What the user
+            does here is accept or edit a name, never invent one — so `ready`
+            can refuse a blank one without ever making the form feel like
+            paperwork, and `aria-required` says so rather than leaving a
+            disabled Save as the only hint.
 
             An <input>, not a textarea, and that is the whole overflow answer:
             one line that never wraps and never grows. Long text scrolls
@@ -2102,7 +2152,8 @@ export default function NewJobModal({
             type="text"
             className="new-task-field new-task-title"
             aria-label="Title"
-            placeholder={titlePlaceholderFor(sessionTitle, repeatOn)}
+            aria-required="true"
+            placeholder={TITLE_PLACEHOLDER}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             autoFocus
@@ -2112,10 +2163,12 @@ export default function NewJobModal({
               what the user types here is what Claude is sent AND what the task
               is described as (design §4 — three text fields for one thought did
               not make sense, so `description` and `message` are one field).
-              Which is also why it is REQUIRED where Title is not: an empty one
-              is a task with nothing to do. `ready` below refuses Save on it,
-              and aria-required says so to a screen reader rather than leaving a
-              disabled button as the only hint.
+              REQUIRED, as Title above now is, and for a sharper reason: an empty
+              one is a task with nothing to do. `ready` refuses Save on it, and
+              aria-required says so to a screen reader rather than leaving a
+              disabled button as the only hint. Unlike Title there is nothing
+              honest to prefill it from, so this is the one field the user really
+              does have to write.
 
               Quieter and smaller than the title, and it keeps the growth Title
               deliberately does not have: multi-line, autogrowing with the text

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -19,8 +19,9 @@
 // so there is nothing for a variable height to encode — the same reason Google
 // Calendar draws a short event as one line. Do not size chips by duration.
 //
-// Colour is per TASK, derived from its key (schedule-lib.taskColour) so five
-// days of a daily task read as one thing across the grid.
+// Colour is per PROJECT, hashed from the task's folder (schedule-lib.taskColour):
+// five days of a daily task read as one thing across the grid, AND every task out
+// of one repo carries that repo's hue (Akshil, 2026-08-17).
 //
 // AN ARCHIVED TASK DRAWS NOTHING. The grid is for what is going to happen and
 // what did; a task that was cancelled or skipped outright is filed away, and
@@ -1029,7 +1030,7 @@ export default function ScheduleCalendar({
                         left: `calc(${(chip.lane * 100) / chip.lanes}% + 1px)`,
                         width: `calc(${100 / chip.lanes}% - 3px)`,
                         ["--lane" as string]: chip.lane,
-                        // Same task, same colour, right across the grid.
+                        // Same FOLDER, same colour, right across the grid.
                         ["--chip" as string]: `var(--task-c${chip.colour})`,
                       } as React.CSSProperties}
                       title={name}

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1683,25 +1683,33 @@ function TaskCard({
             The unread count is NOT one of the head's marks either: it belongs to
             the title, exactly as it does on a List row, and the same objection
             applies to a card's head as to a row's start (Akshil, 2026-08-17 — the
-            count in front broke the reading priority).
-
-            So title and count are wrapped TOGETHER, as one shrink-wrapped line
-            the count trails. It cannot go INSIDE the title element: that is a
-            two-line `-webkit-box` clamp with `overflow: hidden`, so a title long
-            enough to fill both lines would clip the count away — losing it on
-            exactly the cards that have the most to say. Nor can it be a bare
-            sibling of the head, which parks it in a corner of the card, the
-            placement this is undoing. The wrapper shrink-wraps the title, so a
-            short one keeps the count right after its last word, and a title that
-            fills its clamp pushes the count onto a line of its own, where it is
-            still there to read. */}
+            count in front broke the reading priority). See the title below for
+            where it went and why it took three tries. */}
         <span className="schedule-tv-card-head">
           {failedOffLane && <StatusIcon status={lane} failed />}
           <IdChip id={task.task_id} kind="task" />
           {task.live && <LivePulse />}
         </span>
-        <span className="schedule-tv-card-name">
-          <span className="schedule-tv-card-title">{firstLine(task.title) || "(untitled)"}</span>
+        {/* The count sits INSIDE the title, in its text flow, so it follows the
+            last word wherever the last word ends up.
+
+            Two arrangements before this one were wrong, and both were wrong
+            because the title was a two-line `-webkit-box` clamp that hid its
+            overflow. Inside that clamp, a title long enough to fill both lines
+            clipped the count away — gone on exactly the busiest cards. Lifted out
+            of it into a `flex-wrap` wrapper (`.schedule-tv-card-name`, now
+            deleted), the count survived but any two-line title pushed it onto a
+            line of its own beneath the words, orphaned — which is the screenshot
+            Akshil sent on 2026-08-17, and it looks broken.
+
+            The clamp was the cause of both: nothing can flow after the last word
+            of a clipped box and also stay outside the clip. So schedule.css
+            dropped it, the title wraps freely, and the pill needs no wrapper and
+            no alignment — it is an inline atom in the same flow. Long titles make
+            taller cards, which is accepted; a card's title is the session's own
+            short name rather than the message it sends, so most are one line. */}
+        <span className="schedule-tv-card-title">
+          {firstLine(task.title) || "(untitled)"}
           <UnreadPill count={unread} />
         </span>
         <span className="schedule-tv-card-foot">

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -214,33 +214,19 @@ function IdChip({ id, kind }: { id: string; kind: "task" | "message" }) {
   return <span className={`tasks-id tasks-id--${kind}`}>{id}</span>;
 }
 
-/** A task's unread count as the DOT CARRYING THE NUMBER (§7,
- * tasks-lib.unreadCount): the message dot's own hue, filled, grown from a
- * circle into a short pill only as far as the digits need. It reads as the same
- * mark the thread below it uses, one size up, rather than as a second badge
- * with its own vocabulary. The true count is always the accessible name, even
- * when the pill prints "99+". */
+/** A task's unread count, drawn immediately AFTER its title (§7,
+ * tasks-lib.unreadCount) and in a quiet neutral rather than the thread's blue.
+ * It is the task's total, which is metadata about the row — the per-message dots
+ * are the alert — so it trails the words instead of leading them and it does not
+ * compete with them. Nothing is drawn at all when there is nothing unread; a
+ * trailing chip has no column to hold open, unlike the message rail. The true
+ * count is always the accessible name, even when the pill prints "99+". */
 function UnreadPill({ count }: { count: number }) {
   const c = unreadCount(count);
   if (!c) return null;
   return (
     <span className="tasks-count" role="img" aria-label={c.label} title={c.label}>
       {c.text}
-    </span>
-  );
-}
-
-/** The LEADING rail slot on a task row — the same column, the same width and
- * the same centre line as the `.tasks-rail` at the head of every message row
- * under it, so one straight rail runs down the whole node. Drawn on every task,
- * filled or not: a slot that appeared only on unread tasks would shift the rest
- * of those rows sideways, which is the ragged edge this change exists to
- * remove. */
-function UnreadRail({ count }: { count: number }) {
-  if (count <= 0) return <span className="tasks-rail" aria-hidden />;
-  return (
-    <span className="tasks-rail">
-      <UnreadPill count={count} />
     </span>
   );
 }
@@ -1001,15 +987,21 @@ function TaskNode({
         <span className={"tasks-caret" + (open ? " is-open" : "")} aria-hidden>
           {ICON_CHEVRON}
         </span>
-        {/* Unread LEADS this row too, on the very column the thread's own dots
-            sit on (tasks-lib.unreadCount). The caret stays outside that column,
-            in the gutter to its left, because it is the accordion's control and
-            not part of the rail — which leaves one straight line of markers
-            running from the task down through every message it holds. */}
-        <UnreadRail count={unread} />
+        {/* The ring opens the row, and it stands in the very column the thread's
+            own dots sit on (tasks.css `--tasks-rail-x`) — same width, same centre
+            line, so one straight column runs from the task down through every
+            message it holds. The caret stays outside that column, in the gutter to
+            its left, because it is the accordion's control and not part of it.
+
+            The unread COUNT deliberately does NOT lead here. It did for a day and
+            it inverted the row's priority: the title is what a list is scanned
+            for, and a number in front of it announced the messages before the work
+            they are about (Akshil, 2026-08-17). So the title leads and the count
+            trails it — one gap of separation, then the total, then the live ping. */}
         <StatusIcon status={taskColumn(task)} failed={task.failed} />
         <IdChip id={task.task_id} kind="task" />
         <span className="tasks-title">{label}</span>
+        <UnreadPill count={unread} />
         {task.live && <LivePulse />}
 
         {/* Exactly ONE auto margin in this row: flex distributes free space
@@ -1629,21 +1621,25 @@ function TaskCard({
           if (open) onOpen(open);
         }}
       >
-        {/* Unread leads here too — it sat at the far end of the head, which is
-            the same objection the List's task row just answered. What the card
-            does NOT take from the List is the always-drawn empty slot: a card's
-            head is one line above a title and a folder chip that both start at
-            the card's own edge, so reserving a permanent rail would indent the
-            ring away from the two lines under it — a worse misalignment than the
-            one it fixes. On a card the pill is simply first when there is one. */}
+        {/* The head is the card's marks — ring, id, live ping — and nothing else.
+            The unread count is NOT one of them: it belongs to the title, exactly
+            as it does on a List row, and the same objection applies to a card's
+            head as to a row's start (Akshil, 2026-08-17 — the count in front broke
+            the reading priority).
+
+            So it goes INSIDE the title element rather than beside it. That is not
+            decoration: the title is a two-line `-webkit-box` clamp, and only a
+            child that flows with the words can end up after the last one. A flex
+            sibling would sit in a corner of the card instead, which is the very
+            placement being undone. */}
         <span className="schedule-tv-card-head">
-          <UnreadPill count={unread} />
           <StatusIcon status={taskColumn(task)} failed={task.failed} />
           <IdChip id={task.task_id} kind="task" />
           {task.live && <LivePulse />}
         </span>
         <span className="schedule-tv-card-title">
           {firstLine(task.title) || "(untitled)"}
+          <UnreadPill count={unread} />
         </span>
         <span className="schedule-tv-card-foot">
           <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -51,6 +51,7 @@ import {
   groupByColumn,
   heldMessages,
   isDraggable,
+  isFailedTask,
   markAllRead,
   markRead,
   markReadIntent,
@@ -987,11 +988,13 @@ function TaskNode({
         <span className={"tasks-caret" + (open ? " is-open" : "")} aria-hidden>
           {ICON_CHEVRON}
         </span>
-        {/* The ring opens the row, and it stands in the very column the thread's
-            own dots sit on (tasks.css `--tasks-rail-x`) — same width, same centre
-            line, so one straight column runs from the task down through every
-            message it holds. The caret stays outside that column, in the gutter to
-            its left, because it is the accordion's control and not part of it.
+        {/* The ring opens the row, and it stands in the column every task row's
+            ring stands in (tasks.css `--tasks-rail-x`), which is also the column
+            the thread below is measured from — its own rings hang exactly one ring
+            slot to the right of this one, so the indent that says "these belong to
+            that" is a whole mark wide rather than an arbitrary gap. The caret stays
+            outside the column, in the gutter to its left, because it is the
+            accordion's control and not part of it.
 
             The unread COUNT deliberately does NOT lead here. It did for a day and
             it inverted the row's priority: the title is what a list is scanned
@@ -1132,25 +1135,6 @@ function TaskNode({
                     }
                   }}
                 >
-                  {/* Unread LEADS the row (tasks-lib.unreadMarker). The slot is
-                      drawn on every row, filled or not, so the dots line up in
-                      one column down the left edge instead of shunting the
-                      rest of each unread row sideways. The word that used to
-                      follow it is gone; the dot carries the name itself. It is
-                      the same `.tasks-rail` the task row above opens with —
-                      one class, therefore one column. */}
-                  {mark.unread ? (
-                    <span
-                      className="tasks-rail"
-                      role="img"
-                      aria-label={mark.label}
-                      title={mark.label}
-                    >
-                      <span className="tasks-dot" aria-hidden />
-                    </span>
-                  ) : (
-                    <span className="tasks-rail" aria-hidden />
-                  )}
                   <StatusIcon status={tone.column} failed={tone.failed} label={tone.label} />
                   <span
                     className="tasks-msg-kind"
@@ -1161,6 +1145,38 @@ function TaskNode({
                   </span>
                   <IdChip id={m.message_id} kind="message" />
                   <span className="tasks-msg-body">{firstLine(m.body) || "(empty)"}</span>
+                  {/* Unread TRAILS the title (tasks-lib.unreadMarker), exactly as
+                      the task row's count trails its own. It led the row in a
+                      reserved slot for a day, and that was the same inverted
+                      reading priority the count had: a mark in front of every
+                      unread line announced the marks before the words they are
+                      about, and the task row above having already been fixed made
+                      the thread under it read as a different dialect of the same
+                      page (Akshil, 2026-08-17).
+
+                      Only the POSITION moved. It still means unread and it is
+                      still `--activity`, the loud per-message half of the pair —
+                      the task's neutral total is the quiet half. Drawn only when
+                      the message IS unread: trailing the title there is no column
+                      to hold open, so the empty slot the old head needed is gone
+                      with it.
+
+                      A sibling of the title, never inside it: `.tasks-msg-body`
+                      ellipsises its overflow, so a dot inside a long line would be
+                      truncated away on exactly the rows that have most to say —
+                      the same trap the Board card's clamp set for the count.
+
+                      No margin of its own: the row's `gap` is the separation, and
+                      free space here is split equally between every `auto` margin,
+                      so one more would re-centre the trailing group. */}
+                  {mark.unread && (
+                    <span
+                      className="tasks-dot"
+                      role="img"
+                      aria-label={mark.label}
+                      title={mark.label}
+                    />
+                  )}
                   <span className="tasks-grow" />
                   {/* The one thing about a message a person can still CHANGE:
                       its time or its wording, before it goes out. Quiet and on
@@ -1577,6 +1593,17 @@ function TaskCard({
   // In Progress can never fire different messages. Nothing about which message
   // or which call is re-derived on this side.
   const run = taskRunIntent(task);
+  // The lane this card is IN. Not passed down: `groupByColumn` files every card
+  // by `taskColumn`, so asking it here is asking the same function that decided
+  // which lane header the card is sitting under — a prop would be a second
+  // opinion about a fact the board has already settled.
+  const lane = taskColumn(task);
+  // Whether the ring would SAY anything on this card. See the head below: the
+  // ring is drawn only when it disagrees with the lane, and `isFailedTask` is the
+  // one place that knows what "reads as failed" means (the failed lane, or the
+  // flag that repaints a Done ring red). The lane check is what turns that into
+  // "disagrees": in the failed lane the two agree and the header has said it.
+  const failedOffLane = isFailedTask(task) && lane !== "failed";
   const [busy, setBusy] = useState(false);
   const triage = async (status: ArchiveStatus) => {
     setBusy(true);
@@ -1621,11 +1648,42 @@ function TaskCard({
           if (open) onOpen(open);
         }}
       >
-        {/* The head is the card's marks — ring, id, live ping — and nothing else.
-            The unread count is NOT one of them: it belongs to the title, exactly
-            as it does on a List row, and the same objection applies to a card's
-            head as to a row's start (Akshil, 2026-08-17 — the count in front broke
-            the reading priority).
+        {/* The head is the card's marks — the id, the live ping, and a status ring
+            only when that ring has something to say.
+
+            The ring earns its place on a card by DISAGREEING with the lane, and is
+            silent when it would only repeat it. A card is never read outside the
+            lane it was filed into, and that lane's header already carries the ring
+            and the word ("◯ UPCOMING 9"), so on the common card — status and lane
+            being the same fact — the ring next to the id was the column saying its
+            own name a second time (Akshil, 2026-08-17: "that is just repetitive
+            here").
+
+            Which leaves the one card where they are NOT the same fact. `failed` is
+            a flag beside `status`, not a value of it, and the two disagree in
+            exactly one direction (server routers/tasks.py `_failed`): a broken run
+            triaged to Done or Archive, or one whose session is live again, keeps
+            the flag while the lane says something else. Those cards sit under a
+            header that does not mention the failure, and the red ring is the only
+            thing on them at rest that does — the hover-revealed Re-send is not a
+            signal, it is a control. So the ring is conditional, not absent, and
+            `failedOffLane` above is the whole rule.
+
+            Nothing about the ring itself changes: same component, same
+            `--status-failed` token, same 16px. And the head holds
+            `--tasks-card-head-h` whether or not the ring is in it (tasks.css), so a
+            card does not change height when it gains or loses one — a lane of cards
+            that jittered by the width of a glyph would be a worse tell than the
+            repetition this removed.
+
+            List and Calendar keep their ring unconditionally: a row in a flat list
+            and a chip in a day cell have no lane above them, so there the ring is
+            the only thing that files them at all.
+
+            The unread count is NOT one of the head's marks either: it belongs to
+            the title, exactly as it does on a List row, and the same objection
+            applies to a card's head as to a row's start (Akshil, 2026-08-17 — the
+            count in front broke the reading priority).
 
             So title and count are wrapped TOGETHER, as one shrink-wrapped line
             the count trails. It cannot go INSIDE the title element: that is a
@@ -1638,7 +1696,7 @@ function TaskCard({
             fills its clamp pushes the count onto a line of its own, where it is
             still there to read. */}
         <span className="schedule-tv-card-head">
-          <StatusIcon status={taskColumn(task)} failed={task.failed} />
+          {failedOffLane && <StatusIcon status={lane} failed />}
           <IdChip id={task.task_id} kind="task" />
           {task.live && <LivePulse />}
         </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -51,6 +51,7 @@ import {
   groupByColumn,
   heldMessages,
   isDraggable,
+  isExpandable,
   isFailedTask,
   markAllRead,
   markRead,
@@ -725,7 +726,7 @@ export function TaskList({
 function TaskNode({
   task,
   home,
-  open,
+  open: requested,
   onToggle,
   loaded,
   loading,
@@ -741,6 +742,8 @@ function TaskNode({
 }: {
   task: Task;
   home: string;
+  /** What the List's expanded set says about this row. Whether it is honoured is
+   * this component's decision — see `expandable` below. */
   open: boolean;
   onToggle: () => void;
   loaded?: TaskMessage[];
@@ -765,6 +768,17 @@ function TaskNode({
     answer: { unread: number },
   ) => void;
 }) {
+  // Is this row an accordion at all? tasks-lib.isExpandable asks the server's
+  // message_count, because a thread of one message has nothing under it but a
+  // restatement of this row's own title.
+  //
+  // `open` is DERIVED from it rather than merely rendered around it: the guard
+  // belongs in the predicate, so a row that is in the List's expanded set and then
+  // stops being expandable closes itself instead of being stuck open with no
+  // control to close it. That cannot happen today (a thread never shrinks), but
+  // "cannot happen" is not a thing to leave a render depending on.
+  const expandable = isExpandable(task);
+  const open = expandable && requested;
   const view = threadView(task, loaded);
   // Everything this thread holds, one list: the listing window before Show more,
   // the whole fetched thread after it, and either way the listing's fresher copy
@@ -975,18 +989,38 @@ function TaskNode({
         className={"tasks-row" + (open ? " is-open" : "")}
         role="button"
         tabIndex={0}
-        aria-expanded={open}
+        // Only a row that HAS a disclosure claims one. `undefined` rather than
+        // `false`: false says "collapsed, press to expand", which is a promise a
+        // one-message row cannot keep.
+        aria-expanded={expandable ? open : undefined}
         title={task.title}
-        onClick={onToggle}
+        // Still the row's own click, still onToggle, and still nothing else: this
+        // gesture expands the accordion and deliberately does NOT open the chat
+        // (see the Open chat button below — that one is the gesture that opens, so
+        // that one is the gesture that clears the thread). On a row with nothing to
+        // reveal the press simply has no work to do. The row stays a focusable
+        // control either way, because focus on it is what reveals the hover group
+        // of actions (`.tasks-row:focus-within .tasks-act`) — the keyboard's only
+        // way to reach Run now, Archive and Open chat on this task.
+        onClick={() => {
+          if (expandable) onToggle();
+        }}
         onKeyDown={(e) => {
           if (e.key === "Enter" || e.key === " ") {
             e.preventDefault();
-            onToggle();
+            if (expandable) onToggle();
           }
         }}
       >
+        {/* The disclosure gutter is drawn WHETHER OR NOT there is a chevron in it.
+            `--tasks-caret-w` is the first term of `--tasks-rail-x`, which every
+            indent on this page is measured from (tasks.css), so dropping the
+            element on a one-message row would slide that row's status ring — and
+            the whole rail it stands in — a mark and a gap to the left of its
+            neighbours' and turn a column of rings into a zigzag. So the box stays
+            and only the glyph goes. */}
         <span className={"tasks-caret" + (open ? " is-open" : "")} aria-hidden>
-          {ICON_CHEVRON}
+          {expandable ? ICON_CHEVRON : null}
         </span>
         {/* The ring opens the row, and it stands in the column every task row's
             ring stands in (tasks.css `--tasks-rail-x`), which is also the column

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1627,18 +1627,23 @@ function TaskCard({
             head as to a row's start (Akshil, 2026-08-17 — the count in front broke
             the reading priority).
 
-            So it goes INSIDE the title element rather than beside it. That is not
-            decoration: the title is a two-line `-webkit-box` clamp, and only a
-            child that flows with the words can end up after the last one. A flex
-            sibling would sit in a corner of the card instead, which is the very
-            placement being undone. */}
+            So title and count are wrapped TOGETHER, as one shrink-wrapped line
+            the count trails. It cannot go INSIDE the title element: that is a
+            two-line `-webkit-box` clamp with `overflow: hidden`, so a title long
+            enough to fill both lines would clip the count away — losing it on
+            exactly the cards that have the most to say. Nor can it be a bare
+            sibling of the head, which parks it in a corner of the card, the
+            placement this is undoing. The wrapper shrink-wraps the title, so a
+            short one keeps the count right after its last word, and a title that
+            fills its clamp pushes the count onto a line of its own, where it is
+            still there to read. */}
         <span className="schedule-tv-card-head">
           <StatusIcon status={taskColumn(task)} failed={task.failed} />
           <IdChip id={task.task_id} kind="task" />
           {task.live && <LivePulse />}
         </span>
-        <span className="schedule-tv-card-title">
-          {firstLine(task.title) || "(untitled)"}
+        <span className="schedule-tv-card-name">
+          <span className="schedule-tv-card-title">{firstLine(task.title) || "(untitled)"}</span>
           <UnreadPill count={unread} />
         </span>
         <span className="schedule-tv-card-foot">

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -28,6 +28,7 @@ let deleteFailureText: typeof import("./NewJobModal").deleteFailureText;
 let sessionTitleOf: typeof import("./NewJobModal").sessionTitleOf;
 let titlePlaceholderFor: typeof import("./NewJobModal").titlePlaceholderFor;
 let deletePress: typeof import("./NewJobModal").deletePress;
+let saveEnabled: typeof import("./NewJobModal").saveEnabled;
 let TITLE_PLACEHOLDER: typeof import("./NewJobModal").TITLE_PLACEHOLDER;
 let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
@@ -45,6 +46,7 @@ beforeAll(async () => {
   sessionTitleOf = mod.sessionTitleOf;
   titlePlaceholderFor = mod.titlePlaceholderFor;
   deletePress = mod.deletePress;
+  saveEnabled = mod.saveEnabled;
   TITLE_PLACEHOLDER = mod.TITLE_PLACEHOLDER;
   pastNoteFor = mod.pastNoteFor;
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
@@ -73,9 +75,11 @@ const DAILY: RecurrenceRule = { freq: "day" };
 
 const form = (over: Partial<Form> = {}): Form => ({
   target: " /tmp/work ",
-  // The big field: the message AND the description. There is no third text
-  // field on the form any more (Akshil, 2026-08-17).
+  // The SECOND field, and the required one: the message AND the description.
+  // There is no third text field on the form (Akshil, 2026-08-17).
   message: "pull today's news",
+  // The FIRST field, and optional — blank is the ordinary case, which is why
+  // that is the default here.
   title: "",
   when: "2026-08-17T09:00",
   rule: null,
@@ -208,6 +212,65 @@ describe("the payload", () => {
     expect(
       buildSchedulePayload(form({ sessionId: "abc", rule: DAILY, repeat: "daily" })).session_id,
     ).toBeUndefined();
+  });
+});
+
+// The two prominent fields are NOT equally optional, and this is where that
+// asymmetry lives (Akshil, 2026-08-17): Title is first and optional — the
+// server names the task from the transcript when it is blank (design §4) — and
+// the description below it is second and REQUIRED, because it is the text
+// Claude is actually sent and a task with nothing to do is not a task.
+describe("what Save refuses", () => {
+  // Everything Save wants, so each test can take exactly one thing away.
+  const gate = (over: Partial<Parameters<typeof saveEnabled>[0]> = {}) => ({
+    message: "pull today's news",
+    target: "/tmp/work",
+    pathError: null,
+    repeatOn: false,
+    repeat: "none",
+    customRule: null,
+    legacyCron: "",
+    pickedOk: true,
+    replaced: false,
+    ...over,
+  });
+
+  test("a filled form saves", () => {
+    expect(saveEnabled(gate())).toBe(true);
+  });
+
+  test("an EMPTY description is refused — it is the one required text field", () => {
+    expect(saveEnabled(gate({ message: "" }))).toBe(false);
+    // Whitespace is not an instruction, and a textarea collects plenty of it.
+    expect(saveEnabled(gate({ message: "   " }))).toBe(false);
+    expect(saveEnabled(gate({ message: "\n\n  \t\n" }))).toBe(false);
+  });
+
+  test("…and an empty TITLE is not, because the server names the task", () => {
+    // The whole point of the precedence in design §4: blank Title is the
+    // ordinary case, so it cannot be a reason to refuse. There is no `title` in
+    // the gate at all — Save does not read it.
+    expect(saveEnabled(gate())).toBe(true);
+    expect("title" in gate()).toBe(false);
+    // …and the payload agrees: no title key, and Save was still available.
+    expect("title" in buildSchedulePayload(form({ title: "" }))).toBe(false);
+  });
+
+  test("the rest of the gate is unchanged by the swap", () => {
+    // These were the other refusals before this pass and they still are — the
+    // change moved a field, it did not loosen anything.
+    expect(saveEnabled(gate({ target: "  " }))).toBe(false);
+    expect(saveEnabled(gate({ pathError: "This folder or file doesn't exist" }))).toBe(false);
+    expect(saveEnabled(gate({ replaced: true }))).toBe(false);
+    expect(saveEnabled(gate({ pickedOk: false }))).toBe(false);
+    // A "custom" repeat is only a choice once the dialog produced a rule…
+    expect(saveEnabled(gate({ repeatOn: true, repeat: "custom", customRule: null }))).toBe(false);
+    expect(saveEnabled(gate({ repeatOn: true, repeat: "custom", customRule: DAILY }))).toBe(true);
+    // …and a legacy cron template needs its line, but not a parseable date.
+    expect(saveEnabled(gate({ repeat: "cron", legacyCron: "" }))).toBe(false);
+    expect(saveEnabled(gate({ repeat: "cron", legacyCron: "0 9 * * *", pickedOk: false }))).toBe(
+      true,
+    );
   });
 });
 

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -645,11 +645,11 @@ describe("naming the task", () => {
   });
 
   test("step 2: the session's own `ai-title` is what the form prefills", () => {
-    expect(sessionTitleOf([task()], "sess-1", LONG)).toBe("Porting the parquet reader");
+    expect(sessionTitleOf([task()], "sess-1")).toBe("Porting the parquet reader");
   });
 
   test("step 1 via the API: a title the user gave this thread is a name too", () => {
-    expect(sessionTitleOf([task({ title_source: "user" })], "sess-1", LONG)).toBe(
+    expect(sessionTitleOf([task({ title_source: "user" })], "sess-1")).toBe(
       "Porting the parquet reader",
     );
   });
@@ -661,55 +661,42 @@ describe("naming the task", () => {
     // message that we had", and refusing it would send a session with no
     // `ai-title` yet straight to blank.
     expect(
-      sessionTitleOf(
-        [task({ title: "port the parquet reader", title_source: "message" })],
-        "sess-1",
-        LONG,
-      ),
+      sessionTitleOf([task({ title: "port the parquet reader", title_source: "message" })], "sess-1"),
     ).toBe("port the parquet reader");
   });
 
-  test("…but not when that title IS the message being scheduled", () => {
-    // The server's message branch has a second source: with no readable
-    // transcript it falls back to the first line of the earliest schedule
-    // entry's message, which on a task scheduled from this form is the message
-    // being scheduled. Accepting that is the duplication bug arriving from the
-    // server instead of from the form.
-    const echoed = task({ title: LONG.slice(0, 200), title_source: "message" });
-    expect(sessionTitleOf([echoed], "sess-1", LONG)).toBe("");
-    // Multi-line asks too: the server takes the first line, so that is what
-    // comes back and what has to be recognised.
-    const firstLineEcho = task({ title: "summarise the inbox", title_source: "message" });
-    expect(
-      sessionTitleOf([firstLineEcho], "sess-1", "summarise the inbox\nthen file it"),
-    ).toBe("");
+  test("…but not a title the server read off a SCHEDULED ENTRY", () => {
+    // The server's second source, and the one this refuses. With no readable
+    // transcript, `_title` names the row from the earliest message scheduled at
+    // the session — which on a task made in this form is the ask itself, so
+    // taking it would be the duplication bug arriving by way of the server.
+    // `title_source: "entry"` is the server saying so, which is why nothing here
+    // has to compare strings.
+    expect(sessionTitleOf([task({ title: LONG.slice(0, 200), title_source: "entry" })], "sess-1"))
+      .toBe("");
+    expect(sessionTitleOf([task({ title: "summarise the inbox", title_source: "entry" })], "sess-1"))
+      .toBe("");
   });
 
-  test("the refusal is one-directional — a longer first prompt still counts", () => {
-    // A title that merely STARTS WITH the draft is a real first prompt the
-    // composer happens to echo the opening of; a draft that starts with the
-    // title is that title being sent back.
-    const longer = task({
-      title: "pull today's news and summarise every thread",
-      title_source: "message",
-    });
-    expect(sessionTitleOf([longer], "sess-1", "pull today's news")).toBe(
-      "pull today's news and summarise every thread",
-    );
-  });
-
-  test("and with no ask to compare against, a first message is taken as it stands", () => {
-    // The New task button reaches the form with no draft at all.
-    expect(
-      sessionTitleOf([task({ title: "port the reader", title_source: "message" })], "sess-1"),
-    ).toBe("port the reader");
+  test("a first prompt the new ask CONTINUES keeps its name", () => {
+    // THE 2026-08-17 review finding. This was refused while the client guessed
+    // at provenance: it dropped a `message` title whenever the composed ask's
+    // first line began with it, and "pull today's news and file it" begins with
+    // "pull today's news" — a real session first prompt the draft merely carries
+    // on from. Title came out blank and Save stayed disabled until the user
+    // retyped a name the app already had.
+    // The draft is not an input any more — the ask this call used to take is
+    // gone from the signature, so no composer text can take a session's own name
+    // away and the type checker is what enforces it.
+    const first = task({ title: "pull today's news", title_source: "message" });
+    expect(sessionTitleOf([first], "sess-1")).toBe("pull today's news");
   });
 
   test("no session, no match and a blank title all resolve to nothing", () => {
-    expect(sessionTitleOf([task()], "", LONG)).toBe("");
-    expect(sessionTitleOf([task()], "sess-2", LONG)).toBe("");
-    expect(sessionTitleOf([task({ title: "   " })], "sess-1", LONG)).toBe("");
-    expect(sessionTitleOf([], "sess-1", LONG)).toBe("");
+    expect(sessionTitleOf([task()], "")).toBe("");
+    expect(sessionTitleOf([task()], "sess-2")).toBe("");
+    expect(sessionTitleOf([task({ title: "   " })], "sess-1")).toBe("");
+    expect(sessionTitleOf([], "sess-1")).toBe("");
   });
 
   test("REPEAT no longer takes the name away — it only takes the session away", () => {
@@ -762,20 +749,18 @@ describe("naming the task", () => {
     expect(initialTitleOf(stored)).toBe("");
     expect(initialAskOf(stored)).toBe(LONG);
 
-    // Nor by way of the session lookup, when the server echoes it back.
+    // Nor by way of the session lookup, when the server hands the entry's own
+    // message back as the row's name (`title_source: "entry"` — the only branch
+    // that can be the message being scheduled).
     expect(
-      sessionTitleOf(
-        [task({ title: LONG.slice(0, 200), title_source: "message" })],
-        "sess-1",
-        LONG,
-      ),
+      sessionTitleOf([task({ title: LONG.slice(0, 200), title_source: "entry" })], "sess-1"),
     ).toBe("");
 
     // And nothing anywhere in the resolved chain is that long.
     for (const resolved of [
       initialTitleOf(stored),
-      sessionTitleOf([task()], "sess-1", LONG),
-      sessionTitleOf([task({ title: LONG.slice(0, 200), title_source: "message" })], "sess-1", LONG),
+      sessionTitleOf([task()], "sess-1"),
+      sessionTitleOf([task({ title: LONG.slice(0, 200), title_source: "entry" })], "sess-1"),
     ]) {
       expect(resolved.length).toBeLessThanOrEqual(TITLE_MAX);
       expect(LONG.startsWith(resolved) && resolved !== "").toBe(false);

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -28,6 +28,8 @@ let deleteFailureText: typeof import("./NewJobModal").deleteFailureText;
 let sessionTitleOf: typeof import("./NewJobModal").sessionTitleOf;
 let initialTitleOf: typeof import("./NewJobModal").initialTitleOf;
 let firstLine: typeof import("./NewJobModal").firstLine;
+let shortTitle: typeof import("./NewJobModal").shortTitle;
+let TITLE_MAX: typeof import("./NewJobModal").TITLE_MAX;
 let deletePress: typeof import("./NewJobModal").deletePress;
 let saveEnabled: typeof import("./NewJobModal").saveEnabled;
 let TITLE_PLACEHOLDER: typeof import("./NewJobModal").TITLE_PLACEHOLDER;
@@ -47,6 +49,8 @@ beforeAll(async () => {
   sessionTitleOf = mod.sessionTitleOf;
   initialTitleOf = mod.initialTitleOf;
   firstLine = mod.firstLine;
+  shortTitle = mod.shortTitle;
+  TITLE_MAX = mod.TITLE_MAX;
   deletePress = mod.deletePress;
   saveEnabled = mod.saveEnabled;
   TITLE_PLACEHOLDER = mod.TITLE_PLACEHOLDER;
@@ -324,22 +328,18 @@ describe("what an Edit opens the big field on", () => {
     expect(again.title).toBe("Morning news");
   });
 
-  test("an UNTITLED task is still editable — it opens on a derived name, not blank", () => {
-    // The regression the required Title could have caused, pinned: every task
-    // stored before this field existed, and every one saved while it was
-    // optional, has no title. Opening one on a blank required field would lock
-    // the user out of saving an edit to a field they never filled in.
+  test("an UNTITLED task opens its title BLANK, not on a copy of its message", () => {
+    // Every task stored before the field existed, and every one saved while it
+    // was optional, has no title. Editing one used to derive the first line of
+    // the stored message — which is the duplication bug arriving by the back
+    // door, since that message is also what fills the description below it.
+    // Blank is the synchronous answer; the session lookup fills it if the thread
+    // has a name, and Save asks if it does not.
     const stored = entry({ message: "pull today's news" });
     expect(stored.title).toBeUndefined();
-    const opensOn = initialTitleOf(stored);
-    expect(opensOn).toBe("pull today's news");
-    // Which is the server's own last resort (tasks.py `_title`), so the edit
-    // saves under the name the task was already showing in the list.
-    const again = buildSchedulePayload(
-      form({ message: initialAskOf(stored), title: opensOn }),
-    );
-    expect(again.title).toBe("pull today's news");
-    expect(again.description).toBe("pull today's news");
+    expect(initialTitleOf(stored)).toBe("");
+    // The description is untouched by any of it — the ask still opens filled.
+    expect(initialAskOf(stored)).toBe("pull today's news");
   });
 });
 
@@ -611,16 +611,19 @@ describe("what a failed Delete says", () => {
   });
 });
 
-// Title is required (see "what Save refuses"), and this block is the reason
-// that is fair: the form mirrors the server's own naming precedence (tasks.py
-// `_title` — the user's own title, then the session's `ai-title`, then the first
-// line of the message) so the field arrives FILLED on every path that has a name
-// to offer. The user accepts or edits a name; they never invent one.
+// Title is required (see "what Save refuses"), and this block is what makes that
+// fair — and what the 2026-08-17 review rewrote. The title now names the
+// SESSION, in this order:
 //
-// It used to be a placeholder-only PREVIEW, on the argument that a value would
-// freeze the name — an explicit title beats `ai-title` for ever. Requiring the
-// field settled that trade the other way: a name the user can see and Save
-// cannot accept is worse than a name that stops tracking the conversation.
+//   1. the task's stored title, if a user set one;
+//   2. the session's own resolved name — Claude Code's `ai-title`;
+//   3. the session's FIRST user message, shortened to a name;
+//   4. blank, and Save asks.
+//
+// Never the message being scheduled. That was the bug: `firstLine(ask)` filled
+// Title from the composer's draft, so scheduling a long message from a chat
+// duplicated it — once as the title, once as the description. "The description
+// is what we type in the chat box" (Akshil, 2026-08-17).
 describe("naming the task", () => {
   const task = (over: Record<string, unknown> = {}) => ({
     session_id: "sess-1",
@@ -629,32 +632,84 @@ describe("naming the task", () => {
     ...over,
   });
 
+  // The message the user is scheduling: long, one line, and the thing that must
+  // never become a name.
+  const LONG =
+    "Go through the whole scheduling stack and work out why a recurring task "
+    + "that has already learned a session id stops resuming that thread after "
+    + "an edit, then fix it and add a regression test for it";
+
   test("the placeholder is a field label now, and says nothing about optional", () => {
     expect(TITLE_PLACEHOLDER).toBe("Title");
     expect(TITLE_PLACEHOLDER).not.toContain("optional");
   });
 
-  test("a chat session's own name is what the form prefills", () => {
-    expect(sessionTitleOf([task()], "sess-1")).toBe("Porting the parquet reader");
+  test("step 2: the session's own `ai-title` is what the form prefills", () => {
+    expect(sessionTitleOf([task()], "sess-1", LONG)).toBe("Porting the parquet reader");
   });
 
-  test("a title the user already gave this thread is a name too", () => {
-    expect(sessionTitleOf([task({ title_source: "user" })], "sess-1")).toBe(
+  test("step 1 via the API: a title the user gave this thread is a name too", () => {
+    expect(sessionTitleOf([task({ title_source: "user" })], "sess-1", LONG)).toBe(
       "Porting the parquet reader",
     );
   });
 
-  test("but a message-sourced title is not news — the local derivation has it", () => {
-    // `message`-sourced is the first line of the first prompt echoed back, which
-    // is exactly what initialTitleOf already derived without a round trip.
-    expect(sessionTitleOf([task({ title_source: "message" })], "sess-1")).toBe("");
-    expect(initialTitleOf(null, "pull today's news")).toBe("pull today's news");
+  test("step 3: a message-sourced title IS the session's first message, so it counts", () => {
+    // The reversal of 2026-08-17. This branch used to be dropped on the grounds
+    // that it echoed a derivation the form already had locally. That derivation
+    // is gone — it was the bug — so this is now the ONLY route to "the first
+    // message that we had", and refusing it would send a session with no
+    // `ai-title` yet straight to blank.
+    expect(
+      sessionTitleOf(
+        [task({ title: "port the parquet reader", title_source: "message" })],
+        "sess-1",
+        LONG,
+      ),
+    ).toBe("port the parquet reader");
   });
 
-  test("no session, no match and a blank title all leave the derived name alone", () => {
-    expect(sessionTitleOf([task()], "")).toBe("");
-    expect(sessionTitleOf([task()], "sess-2")).toBe("");
-    expect(sessionTitleOf([task({ title: "   " })], "sess-1")).toBe("");
+  test("…but not when that title IS the message being scheduled", () => {
+    // The server's message branch has a second source: with no readable
+    // transcript it falls back to the first line of the earliest schedule
+    // entry's message, which on a task scheduled from this form is the message
+    // being scheduled. Accepting that is the duplication bug arriving from the
+    // server instead of from the form.
+    const echoed = task({ title: LONG.slice(0, 200), title_source: "message" });
+    expect(sessionTitleOf([echoed], "sess-1", LONG)).toBe("");
+    // Multi-line asks too: the server takes the first line, so that is what
+    // comes back and what has to be recognised.
+    const firstLineEcho = task({ title: "summarise the inbox", title_source: "message" });
+    expect(
+      sessionTitleOf([firstLineEcho], "sess-1", "summarise the inbox\nthen file it"),
+    ).toBe("");
+  });
+
+  test("the refusal is one-directional — a longer first prompt still counts", () => {
+    // A title that merely STARTS WITH the draft is a real first prompt the
+    // composer happens to echo the opening of; a draft that starts with the
+    // title is that title being sent back.
+    const longer = task({
+      title: "pull today's news and summarise every thread",
+      title_source: "message",
+    });
+    expect(sessionTitleOf([longer], "sess-1", "pull today's news")).toBe(
+      "pull today's news and summarise every thread",
+    );
+  });
+
+  test("and with no ask to compare against, a first message is taken as it stands", () => {
+    // The New task button reaches the form with no draft at all.
+    expect(
+      sessionTitleOf([task({ title: "port the reader", title_source: "message" })], "sess-1"),
+    ).toBe("port the reader");
+  });
+
+  test("no session, no match and a blank title all resolve to nothing", () => {
+    expect(sessionTitleOf([task()], "", LONG)).toBe("");
+    expect(sessionTitleOf([task()], "sess-2", LONG)).toBe("");
+    expect(sessionTitleOf([task({ title: "   " })], "sess-1", LONG)).toBe("");
+    expect(sessionTitleOf([], "sess-1", LONG)).toBe("");
   });
 
   test("REPEAT no longer takes the name away — it only takes the session away", () => {
@@ -680,27 +735,97 @@ describe("naming the task", () => {
     })).toBe(true);
   });
 
-  test("a stored title outranks everything, and an edit never loses it", () => {
+  test("step 1: a stored title outranks everything, and an edit never loses it", () => {
     expect(initialTitleOf(entry({ title: "Morning news" }))).toBe("Morning news");
-    // Even against an ask that would have derived something else…
+    // Even against a message that would once have derived something else…
     expect(initialTitleOf(entry({ title: "Morning news", message: "pull the news" }))).toBe(
       "Morning news",
     );
-    // …and a stored title of spaces is not one, so the derivation takes over.
-    expect(initialTitleOf(entry({ title: "   " }))).toBe("pull today's news");
+    // …and a stored title of spaces is not one, so it falls through to blank and
+    // the session lookup gets its turn.
+    expect(initialTitleOf(entry({ title: "   " }))).toBe("");
   });
 
-  test("the last resort is ONE line of the ask, never the whole thing", () => {
-    // `_title`'s own final step. An <input> would strip the newlines anyway, so
-    // taking the first line is both what the server does and what fits.
+  // THE regression, stated as plainly as it can be: the message being scheduled
+  // does not become the task's name, however the form was opened.
+  test("a long scheduled message never becomes the title", () => {
+    expect(LONG.length).toBeGreaterThan(150);
+
+    // From a chat: the draft is the description, and Title has nothing
+    // synchronous to say. The old code returned firstLine(LONG) here.
+    expect(initialTitleOf(null)).toBe("");
+    expect(initialAskOf(null, LONG)).toBe(LONG);
+
+    // Editing the task that draft created: the message is stored, and it is
+    // still not a name.
+    const stored = entry({ message: LONG });
+    expect(initialTitleOf(stored)).toBe("");
+    expect(initialAskOf(stored)).toBe(LONG);
+
+    // Nor by way of the session lookup, when the server echoes it back.
+    expect(
+      sessionTitleOf(
+        [task({ title: LONG.slice(0, 200), title_source: "message" })],
+        "sess-1",
+        LONG,
+      ),
+    ).toBe("");
+
+    // And nothing anywhere in the resolved chain is that long.
+    for (const resolved of [
+      initialTitleOf(stored),
+      sessionTitleOf([task()], "sess-1", LONG),
+      sessionTitleOf([task({ title: LONG.slice(0, 200), title_source: "message" })], "sess-1", LONG),
+    ]) {
+      expect(resolved.length).toBeLessThanOrEqual(TITLE_MAX);
+      expect(LONG.startsWith(resolved) && resolved !== "").toBe(false);
+    }
+  });
+
+  // Step 3 is a message being turned into a NAME, so it is clamped. Steps 1 and 2
+  // are names already and are taken verbatim — shortening them would edit either
+  // the user's words or Claude's.
+  describe("shortening a first message into a name", () => {
+    test("a short one is left exactly alone", () => {
+      expect(shortTitle("port the parquet reader")).toBe("port the parquet reader");
+      expect(shortTitle("x".repeat(TITLE_MAX))).toBe("x".repeat(TITLE_MAX));
+    });
+
+    test("a long one is cut on a word boundary, with no ellipsis", () => {
+      const line = "one two three four five six seven eight nine ten eleven twelve";
+      expect(line.length).toBeGreaterThan(TITLE_MAX);
+      expect(shortTitle(line)).toBe("one two three four five six seven eight nine ten eleven");
+      expect(shortTitle(line)).not.toContain("…");
+      expect(shortTitle(line)).not.toContain("...");
+      // Cut on a boundary means the next character in the original is the space
+      // the cut replaced — never the middle of "twelve".
+      expect(line[shortTitle(line).length]).toBe(" ");
+    });
+
+    test("the word straddling the limit is kept whole when the limit IS the space", () => {
+      const line = "x".repeat(TITLE_MAX) + " tail";
+      expect(shortTitle(line)).toBe("x".repeat(TITLE_MAX));
+    });
+
+    test("one unbroken word has no boundary, so it is cut hard", () => {
+      // The only mid-word cut, and unavoidable: there is nowhere else to cut.
+      expect(shortTitle("a".repeat(200))).toBe("a".repeat(TITLE_MAX));
+    });
+
+    test("it takes one line, and never trails whitespace", () => {
+      expect(shortTitle("summarise the inbox\nthen file it")).toBe("summarise the inbox");
+      expect(shortTitle("   ")).toBe("");
+      expect(shortTitle("")).toBe("");
+      expect(shortTitle("word ".repeat(40))).toBe(shortTitle("word ".repeat(40)).trimEnd());
+    });
+  });
+
+  test("firstLine reduces prose to something an <input> can hold", () => {
     expect(firstLine("summarise the inbox\nthen file it\nand report")).toBe(
       "summarise the inbox",
     );
     expect(firstLine("  padded  \n more ")).toBe("padded");
     expect(firstLine("   ")).toBe("");
-    expect(initialTitleOf(entry({ message: "summarise the inbox\nthen file it" }))).toBe(
-      "summarise the inbox",
-    );
   });
 
   test("with nothing to go on it IS blank — and Save says so", () => {

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -26,7 +26,8 @@ let initialAskOf: typeof import("./NewJobModal").initialAskOf;
 let deleteActionFor: typeof import("./NewJobModal").deleteActionFor;
 let deleteFailureText: typeof import("./NewJobModal").deleteFailureText;
 let sessionTitleOf: typeof import("./NewJobModal").sessionTitleOf;
-let titlePlaceholderFor: typeof import("./NewJobModal").titlePlaceholderFor;
+let initialTitleOf: typeof import("./NewJobModal").initialTitleOf;
+let firstLine: typeof import("./NewJobModal").firstLine;
 let deletePress: typeof import("./NewJobModal").deletePress;
 let saveEnabled: typeof import("./NewJobModal").saveEnabled;
 let TITLE_PLACEHOLDER: typeof import("./NewJobModal").TITLE_PLACEHOLDER;
@@ -44,7 +45,8 @@ beforeAll(async () => {
   deleteActionFor = mod.deleteActionFor;
   deleteFailureText = mod.deleteFailureText;
   sessionTitleOf = mod.sessionTitleOf;
-  titlePlaceholderFor = mod.titlePlaceholderFor;
+  initialTitleOf = mod.initialTitleOf;
+  firstLine = mod.firstLine;
   deletePress = mod.deletePress;
   saveEnabled = mod.saveEnabled;
   TITLE_PLACEHOLDER = mod.TITLE_PLACEHOLDER;
@@ -78,9 +80,10 @@ const form = (over: Partial<Form> = {}): Form => ({
   // The SECOND field, and the required one: the message AND the description.
   // There is no third text field on the form (Akshil, 2026-08-17).
   message: "pull today's news",
-  // The FIRST field, and optional — blank is the ordinary case, which is why
-  // that is the default here.
-  title: "",
+  // The FIRST field, and required as of 2026-08-17 — so a filled one is the
+  // ordinary case here. `title: ""` is still passed explicitly by the tests that
+  // are about the WIRE contract, which still allows the key to be absent.
+  title: "Morning news",
   when: "2026-08-17T09:00",
   rule: null,
   repeat: "none",
@@ -155,12 +158,13 @@ describe("the Repeat checkbox", () => {
 });
 
 describe("the payload", () => {
-  test("a one-off is target, the ask (twice), due and permission", () => {
+  test("a one-off is target, the ask (twice), the title, due and permission", () => {
     expect(buildSchedulePayload(form())).toEqual({
       target: "/tmp/work",
       message: "pull today's news",
       // Same text, second key: the one big field is the description too.
       description: "pull today's news",
+      title: "Morning news",
       due: "2026-08-17T09:00",
       permission_mode: "auto",
     });
@@ -215,15 +219,16 @@ describe("the payload", () => {
   });
 });
 
-// The two prominent fields are NOT equally optional, and this is where that
-// asymmetry lives (Akshil, 2026-08-17): Title is first and optional — the
-// server names the task from the transcript when it is blank (design §4) — and
-// the description below it is second and REQUIRED, because it is the text
-// Claude is actually sent and a task with nothing to do is not a task.
+// BOTH prominent fields are required now (Akshil, 2026-08-17): the description
+// because it is the text Claude is actually sent, and Title because a task
+// nobody can name in a list is not much better. Title only became a legitimate
+// refusal once the form stopped opening it blank — see the naming block below,
+// which is the other half of this one.
 describe("what Save refuses", () => {
   // Everything Save wants, so each test can take exactly one thing away.
   const gate = (over: Partial<Parameters<typeof saveEnabled>[0]> = {}) => ({
     message: "pull today's news",
+    title: "Morning news",
     target: "/tmp/work",
     pathError: null,
     repeatOn: false,
@@ -246,14 +251,16 @@ describe("what Save refuses", () => {
     expect(saveEnabled(gate({ message: "\n\n  \t\n" }))).toBe(false);
   });
 
-  test("…and an empty TITLE is not, because the server names the task", () => {
-    // The whole point of the precedence in design §4: blank Title is the
-    // ordinary case, so it cannot be a reason to refuse. There is no `title` in
-    // the gate at all — Save does not read it.
-    expect(saveEnabled(gate())).toBe(true);
-    expect("title" in gate()).toBe(false);
-    // …and the payload agrees: no title key, and Save was still available.
-    expect("title" in buildSchedulePayload(form({ title: "" }))).toBe(false);
+  test("…and an EMPTY title is refused too — it used to be the optional one", () => {
+    // The change of 2026-08-17. A blank Title used to save (the server named the
+    // task from the transcript); it now refuses, because the field arrives
+    // prefilled and a blank one means the user deliberately cleared it.
+    expect(saveEnabled(gate({ title: "" }))).toBe(false);
+    // Spaces are not a name, exactly as newlines are not an instruction.
+    expect(saveEnabled(gate({ title: "   " }))).toBe(false);
+    // The two are independent refusals, not one rule read twice.
+    expect(saveEnabled(gate({ title: "", message: "pull today's news" }))).toBe(false);
+    expect(saveEnabled(gate({ title: "Morning news", message: "" }))).toBe(false);
   });
 
   test("the rest of the gate is unchanged by the swap", () => {
@@ -317,14 +324,21 @@ describe("what an Edit opens the big field on", () => {
     expect(again.title).toBe("Morning news");
   });
 
-  test("an untitled task edits back untitled — the server keeps naming it", () => {
-    const saved = buildSchedulePayload(form({ title: "" }));
-    expect("title" in saved).toBe(false);
-    const stored = entry({ message: saved.message, description: saved.description });
+  test("an UNTITLED task is still editable — it opens on a derived name, not blank", () => {
+    // The regression the required Title could have caused, pinned: every task
+    // stored before this field existed, and every one saved while it was
+    // optional, has no title. Opening one on a blank required field would lock
+    // the user out of saving an edit to a field they never filled in.
+    const stored = entry({ message: "pull today's news" });
+    expect(stored.title).toBeUndefined();
+    const opensOn = initialTitleOf(stored);
+    expect(opensOn).toBe("pull today's news");
+    // Which is the server's own last resort (tasks.py `_title`), so the edit
+    // saves under the name the task was already showing in the list.
     const again = buildSchedulePayload(
-      form({ message: initialAskOf(stored), title: stored.title ?? "" }),
+      form({ message: initialAskOf(stored), title: opensOn }),
     );
-    expect("title" in again).toBe(false);
+    expect(again.title).toBe("pull today's news");
     expect(again.description).toBe("pull today's news");
   });
 });
@@ -597,11 +611,17 @@ describe("what a failed Delete says", () => {
   });
 });
 
-// Scheduling from an open chat: the session already has a name, so the form
-// PREVIEWS it on Title instead of prefilling it. Prefilling would freeze the
-// name — an explicit title beats Claude Code's per-turn `ai-title` for ever —
-// and it would look like something the user typed (Akshil, 2026-08-17).
-describe("the Title placeholder", () => {
+// Title is required (see "what Save refuses"), and this block is the reason
+// that is fair: the form mirrors the server's own naming precedence (tasks.py
+// `_title` — the user's own title, then the session's `ai-title`, then the first
+// line of the message) so the field arrives FILLED on every path that has a name
+// to offer. The user accepts or edits a name; they never invent one.
+//
+// It used to be a placeholder-only PREVIEW, on the argument that a value would
+// freeze the name — an explicit title beats `ai-title` for ever. Requiring the
+// field settled that trade the other way: a name the user can see and Save
+// cannot accept is worse than a name that stops tracking the conversation.
+describe("naming the task", () => {
   const task = (over: Record<string, unknown> = {}) => ({
     session_id: "sess-1",
     title: "Porting the parquet reader",
@@ -609,11 +629,13 @@ describe("the Title placeholder", () => {
     ...over,
   });
 
-  test("previews the session's own name", () => {
+  test("the placeholder is a field label now, and says nothing about optional", () => {
+    expect(TITLE_PLACEHOLDER).toBe("Title");
+    expect(TITLE_PLACEHOLDER).not.toContain("optional");
+  });
+
+  test("a chat session's own name is what the form prefills", () => {
     expect(sessionTitleOf([task()], "sess-1")).toBe("Porting the parquet reader");
-    expect(titlePlaceholderFor("Porting the parquet reader", false)).toBe(
-      "Porting the parquet reader",
-    );
   });
 
   test("a title the user already gave this thread is a name too", () => {
@@ -622,31 +644,84 @@ describe("the Title placeholder", () => {
     );
   });
 
-  test("but the first line of a message is not a name", () => {
-    // `message`-sourced is the message echoed back; the generic placeholder
-    // already says the title fills itself in, so this adds nothing and reads
-    // like the wrong field.
+  test("but a message-sourced title is not news — the local derivation has it", () => {
+    // `message`-sourced is the first line of the first prompt echoed back, which
+    // is exactly what initialTitleOf already derived without a round trip.
     expect(sessionTitleOf([task({ title_source: "message" })], "sess-1")).toBe("");
+    expect(initialTitleOf(null, "pull today's news")).toBe("pull today's news");
   });
 
-  test("no session, no match and no title all fall back to the generic line", () => {
+  test("no session, no match and a blank title all leave the derived name alone", () => {
     expect(sessionTitleOf([task()], "")).toBe("");
     expect(sessionTitleOf([task()], "sess-2")).toBe("");
     expect(sessionTitleOf([task({ title: "   " })], "sess-1")).toBe("");
-    expect(titlePlaceholderFor("", false)).toBe(TITLE_PLACEHOLDER);
-    expect(titlePlaceholderFor("   ", false)).toBe(TITLE_PLACEHOLDER);
-    expect(TITLE_PLACEHOLDER).toBe("Title — optional, filled in automatically");
   });
 
-  test("ticking Repeat takes the preview away, because it takes the session away", () => {
-    // A repeat refuses the chat's session and opens its own thread, so there is
-    // no conversation whose name would carry over — the preview would be a lie
-    // from the moment the box is ticked.
-    expect(titlePlaceholderFor("Porting the parquet reader", true)).toBe(TITLE_PLACEHOLDER);
-    // …and this is the payload rule it mirrors, asserted above too.
+  test("REPEAT no longer takes the name away — it only takes the session away", () => {
+    // The old preview was suppressed under a ticked Repeat, because a repeat
+    // refuses the chat's session and the preview would have been a lie. A VALUE
+    // in a required field cannot be withdrawn like that: the user still has to
+    // name the task, and the conversation it came from is still the best name
+    // anyone has. The payload rule it used to mirror is unchanged.
     expect(
       buildSchedulePayload(form({ sessionId: "sess-1", rule: DAILY, repeat: "daily" })).session_id,
     ).toBeUndefined();
+    expect(saveEnabled({
+      message: "pull today's news",
+      title: "Porting the parquet reader",
+      target: "/tmp/work",
+      pathError: null,
+      repeatOn: true,
+      repeat: "daily",
+      customRule: null,
+      legacyCron: "",
+      pickedOk: true,
+      replaced: false,
+    })).toBe(true);
+  });
+
+  test("a stored title outranks everything, and an edit never loses it", () => {
+    expect(initialTitleOf(entry({ title: "Morning news" }))).toBe("Morning news");
+    // Even against an ask that would have derived something else…
+    expect(initialTitleOf(entry({ title: "Morning news", message: "pull the news" }))).toBe(
+      "Morning news",
+    );
+    // …and a stored title of spaces is not one, so the derivation takes over.
+    expect(initialTitleOf(entry({ title: "   " }))).toBe("pull today's news");
+  });
+
+  test("the last resort is ONE line of the ask, never the whole thing", () => {
+    // `_title`'s own final step. An <input> would strip the newlines anyway, so
+    // taking the first line is both what the server does and what fits.
+    expect(firstLine("summarise the inbox\nthen file it\nand report")).toBe(
+      "summarise the inbox",
+    );
+    expect(firstLine("  padded  \n more ")).toBe("padded");
+    expect(firstLine("   ")).toBe("");
+    expect(initialTitleOf(entry({ message: "summarise the inbox\nthen file it" }))).toBe(
+      "summarise the inbox",
+    );
+  });
+
+  test("with nothing to go on it IS blank — and Save says so", () => {
+    // The New task button with an empty form: there is no honest name to
+    // derive, so the field opens empty and the requirement bites. That is the
+    // one path where the user must type a title, and it is the path where they
+    // are typing everything else anyway.
+    expect(initialTitleOf(null)).toBe("");
+    expect(initialTitleOf(undefined)).toBe("");
+    expect(saveEnabled({
+      message: "pull today's news",
+      title: initialTitleOf(null),
+      target: "/tmp/work",
+      pathError: null,
+      repeatOn: false,
+      repeat: "none",
+      customRule: null,
+      legacyCron: "",
+      pickedOk: true,
+      replaced: false,
+    })).toBe(false);
   });
 });
 

--- a/frontend/src/shell/schedule-lib.test.ts
+++ b/frontend/src/shell/schedule-lib.test.ts
@@ -2260,9 +2260,11 @@ describe("where the popover's run action is drawn", () => {
     expect(rest).not.toContain("color:");
     expect(rest).not.toContain("border-color:");
     expect(block).not.toContain("transition: all");
-    // The same hue the List's own run button uses, at the same mixes.
-    expect(block).toContain("color: var(--status-upcoming);");
-    expect(TASKS_CSS_SRC).toContain("color: var(--status-upcoming);");
+    // The same hue the List's own run button uses, at the same mixes. `--activity`
+    // rather than `--status-upcoming` since 2026-08-17: Upcoming went grey and the
+    // blue was renamed for the job it was actually doing (live / unread / run).
+    expect(block).toContain("color: var(--activity);");
+    expect(TASKS_CSS_SRC).toContain("color: var(--activity);");
     for (const mix of ["12%", "32%"]) expect(block).toContain(mix);
     // Armoured against the page's two hover skins.
     expect(block).toContain(".prefs-section .schedule-cal-pop-run:hover:not(:disabled)");

--- a/frontend/src/shell/schedule-lib.test.ts
+++ b/frontend/src/shell/schedule-lib.test.ts
@@ -247,7 +247,7 @@ describe("describeRule", () => {
 });
 
 describe("repeatChoicesFor", () => {
-  it("is Google's list, derived from the picked date", () => {
+  it("is Google's list less the annual row, derived from the picked date", () => {
     expect(repeatChoicesFor(AUG12).map((c) => c.label)).toEqual([
       "Does not repeat",
       // Shortest first: Hourly sits above Daily, the order recur.FREQUENCIES
@@ -256,10 +256,26 @@ describe("repeatChoicesFor", () => {
       "Daily",
       "Weekly on Wednesday",
       "Monthly on the second Wednesday",
-      "Annually on August 12",
       "Every weekday (Monday to Friday)",
       "Custom…",
     ]);
+  });
+  it("offers no annual choice, and still leaves a yearly rule readable", () => {
+    // Dropped from the PICKER (Akshil, 2026-08-17) — not from the model. Nothing
+    // here can produce `freq: "year"` any more…
+    expect(repeatChoicesFor(AUG12).some((c) => c.rule?.freq === "year")).toBe(false);
+    // …and an entry already stored as yearly still describes itself in full and
+    // still walks, which is what keeps it editable: the modal finds no preset
+    // for it, opens it as Custom, and shows this sentence on that row.
+    expect(describeRule({ freq: "year" }, AUG12)).toBe("Annually on August 12");
+    expect(
+      ruleOccurrences(
+        { freq: "year" },
+        AUG12,
+        new Date(2026, 7, 12, 12),
+        new Date(2028, 0, 1),
+      ).map((d) => d.getFullYear()),
+    ).toEqual([2027]);
   });
   it("nthOfMonth counts the way the label reads", () => {
     expect(nthOfMonth(new Date(2026, 7, 1))).toBe(1);
@@ -717,20 +733,103 @@ describe("dayTone", () => {
 // ---- colour --------------------------------------------------------------------
 
 describe("taskColour", () => {
-  it("is stable, in range, and does not put every task on one hue", () => {
-    expect(taskColour("sess-abc")).toBe(taskColour("sess-abc"));
-    const keys = Array.from({ length: 40 }, (_, i) => `pending:entry-${i}`);
-    for (const k of keys) {
-      const c = taskColour(k);
+  it("is stable, in range, and does not put every folder on one hue", () => {
+    expect(taskColour("/Users/a/repo")).toBe(taskColour("/Users/a/repo"));
+    const folders = Array.from({ length: 40 }, (_, i) => `/Users/a/proj-${i}`);
+    for (const f of folders) {
+      const c = taskColour(f);
       expect(c).toBeGreaterThanOrEqual(0);
       expect(c).toBeLessThan(8);
     }
     // Not a perfect spread — a hash never is — but every hue gets used.
-    expect(new Set(keys.map(taskColour)).size).toBe(8);
+    expect(new Set(folders.map(taskColour)).size).toBe(8);
   });
 
-  it("does not collide on the anagrams task keys are full of", () => {
-    expect(taskColour("ab")).not.toBe(taskColour("ba"));
+  // The real corpus, measured: the 28 distinct `project` paths on the machine
+  // this was built for. Deep shared prefixes are the case that would cluster a
+  // weak mixer, and the assertion is what a clustered mixer would fail —
+  // every hue used, and no hue holding a quarter of the projects.
+  it("spreads the real project paths across the whole palette", () => {
+    const projects = [
+      "/Users/akshilthumar",
+      "/Users/akshilthumar/Desktop",
+      "/Users/akshilthumar/Desktop/claude-token-wrapped",
+      "/Users/akshilthumar/Desktop/fused",
+      "/Users/akshilthumar/Desktop/fused/annotate-test/claude-plugin-test",
+      "/Users/akshilthumar/Desktop/fused/annotate-test/preview-btn-demo",
+      "/Users/akshilthumar/Desktop/fused/flightdeck",
+      "/Users/akshilthumar/Desktop/fused/fused-render",
+      "/Users/akshilthumar/Desktop/fused/fused-render-wt-claude-select",
+      "/Users/akshilthumar/Desktop/fused/fused-render-wt/annotation-leak",
+      "/Users/akshilthumar/Desktop/fused/fused-render-worktrees/claude-template-view",
+      "/Users/akshilthumar/Desktop/fused/fused-render/docs",
+      "/Users/akshilthumar/Desktop/fused/fused-render/examples",
+      "/Users/akshilthumar/Desktop/fused/fused-render/frontend",
+      "/Users/akshilthumar/Desktop/fused/fused-render/scripts/vendor-sci",
+      "/Users/akshilthumar/Desktop/tribal-talk",
+      "/Users/akshilthumar/Desktop/tribal-talk-immersive",
+      "/Users/akshilthumar/Desktop/weekend proj/content-engine",
+      "/Users/akshilthumar/Documents/Fused",
+      "/Users/akshilthumar/Documents/Fused/showcase/sine-starter",
+      "/Users/akshilthumar/timepass/bali 07:26",
+      "/private/tmp",
+      "/private/tmp/ppt_ai_smoke",
+      "/private/tmp/ppt_ai_smoke2",
+    ];
+    const counts = new Array(8).fill(0);
+    for (const p of projects) counts[taskColour(p)] += 1;
+    expect(counts.filter((n) => n > 0).length).toBe(8);
+    expect(Math.max(...counts)).toBeLessThanOrEqual(6);
+  });
+
+  it("does not collide on the anagrams paths are full of", () => {
+    expect(taskColour("/x/a/b")).not.toBe(taskColour("/x/b/a"));
+  });
+});
+
+// Colour means "which project", so it has to hold across TASKS: two tasks in one
+// folder draw the same hue, and a task in another folder is free to differ (and
+// on these two paths, does).
+describe("chip colour is the folder's, not the task's", () => {
+  const at = (h: number) => new Date(2026, 7, 17, h, 0).getTime() / 1000;
+  const chipTask = (key: string, project: string, hour: number) =>
+    ({
+      key,
+      task_id: key,
+      project,
+      target: project,
+      session_id: key,
+      title: key,
+      title_source: "user",
+      description: "",
+      status: "upcoming",
+      failed: false,
+      live: false,
+      messages: [
+        {
+          message_id: `${key}-m`,
+          kind: "scheduled",
+          at: at(hour),
+          state: "pending",
+          turn: "",
+        },
+      ],
+    }) as never;
+
+  it("gives two tasks in one folder one colour", () => {
+    const day = new Date(2026, 7, 17);
+    const chips = taskChips(
+      [
+        chipTask("t1", "/Users/a/repo", 9),
+        chipTask("t2", "/Users/a/repo", 10),
+        chipTask("t3", "/Users/a/other", 11),
+      ],
+      [day],
+    ).get(dayKey(day))!;
+    expect(chips.length).toBe(3);
+    const [a, b, c] = chips;
+    expect(a.colour).toBe(b.colour);
+    expect(c.colour).not.toBe(a.colour);
   });
 });
 
@@ -1928,9 +2027,11 @@ describe("projection ownership", () => {
     expect(out["pending:t1"].length).toBe(2);
   });
 
-  it("the already-run occurrence keeps its own chip and its own colour", () => {
+  it("the already-run occurrence keeps its own chip, and its folder's colour", () => {
     // Two chips on the day the rule both ran and is still due — they are two
     // TASKS, which is exactly what "unrelated tasks are unrelated chips" means.
+    // Their COLOUR is the folder's, though (2026-08-17), and these two are the
+    // same rule in the same folder: one hue, told apart by tone, not by hue.
     const days = rangeDays(rangeStart(new Date(2026, 7, 17), "week"), "week");
     const done = ran("sess-1", "sess-1", 17);
     const pending = task({
@@ -1942,7 +2043,7 @@ describe("projection ownership", () => {
       calendarThreads([pending, done], [rule()], null)).get("2026-08-17")!;
     expect(chips.length).toBe(2);
     expect(chips.map((c) => c.task.key)).toEqual(["sess-1", "pending:occ-9"]);
-    expect(chips[0].colour).not.toBe(chips[1].colour);
+    expect(chips[0].colour).toBe(chips[1].colour);
     expect(chips[0].tone).toBe("ran");
     expect(chips[1].tone).toBe("upcoming");
   });

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -405,10 +405,10 @@ export function entryRepeatText(entry: ScheduledMessage): string {
   return describeRepeats(entry.repeats || "");
 }
 
-// The repeat select's derived choices, Google's list verbatim: every label is
-// read off the picked date, so recurrence needs no fields of its own until
-// Custom. Returned as data so the modal renders and the tests read the same
-// list.
+// The repeat select's derived choices, Google's list less the annual row: every
+// label is read off the picked date, so recurrence needs no fields of its own
+// until Custom. Returned as data so the modal renders and the tests read the
+// same list.
 export interface RepeatChoice {
   key: string;
   label: string;
@@ -434,11 +434,15 @@ export function repeatChoicesFor(picked: Date): RepeatChoice[] {
       label: `Monthly on the ${NTH_NAMES[nthOfMonth(picked) - 1]} ${DAY_NAMES[dow]}`,
       rule: { freq: "month", monthly: "nth-weekday" },
     },
-    {
-      key: "annually",
-      label: `Annually on ${MONTH_NAMES[picked.getMonth()]} ${picked.getDate()}`,
-      rule: { freq: "year" },
-    },
+    // No ANNUAL row (Akshil, 2026-08-17): nothing anybody schedules here runs
+    // once a year, and the preset only ever cost a line in the menu. Note what
+    // is NOT done — `year` stays a freq the rest of the app can read: recur.py
+    // supports it, describeRule still says "Annually on August 12", and
+    // ruleOccurrences still walks it. So a rule already stored as yearly keeps
+    // working: keyOfRule finds no preset for it and answers "custom", which is
+    // how the modal opens it — the repeat menu shows describeRule's own
+    // "Annually on …" wording on the Custom row, and Saving without touching it
+    // writes the same rule back. Dropped from the picker, never from the model.
     {
       key: "weekday",
       label: "Every weekday (Monday to Friday)",
@@ -597,22 +601,40 @@ export function rangeLabel(days: Date[]): string {
 }
 
 // ---- Task colour ---------------------------------------------------------------
-// Same task, same colour, everywhere on the grid — that is what makes five days
-// of a daily task read as ONE thing rather than five unrelated boxes. The colour
-// is derived from the task key so it needs no storage and cannot drift between
-// renders, and it indexes a small HAND-PICKED palette (styles/tokens.css,
-// --task-c0…--task-c7) rather than generating an hsl(): an arbitrary hue clashes
+// Colour says WHICH PROJECT a task belongs to (Akshil, 2026-08-17: "let's have it
+// deterministic based on folder name… so tasks from same folder will have same
+// color"). It is hashed from the task's FOLDER, not its key: hashing the key gave
+// two tasks in one repo two unrelated hues, which made the calendar look busier
+// than the week actually was and told the reader nothing. Now a glance at the
+// grid groups by project, and five days of a daily task still land as ONE thing —
+// the folder does not change between renders any more than the key did.
+//
+// `task.project` is the folder and is decided server-side (the task's own
+// directory, not its target file), so a file and the folder it sits in cannot
+// diverge. It needs no storage and cannot drift between renders.
+//
+// The index lands in a small HAND-PICKED palette (styles/tokens.css,
+// --task-c0…--task-c7) rather than a generated hsl(): an arbitrary hue clashes
 // with the theme in one mode or the other, and the eight tuned ones do not.
+// Eight hues for a machine with more folders than that means collisions by
+// pigeonhole — two unrelated projects sharing a hue is the accepted cost; the
+// thing that must hold is the converse, that one folder is always one colour.
 
 export const TASK_COLOURS = 8;
 
-export function taskColour(key: string): number {
-  // FNV-1a, 32-bit. Cheap, well spread over short ASCII keys, and — unlike
-  // summing char codes — it does not collide on anagrams, which task keys
-  // (session uuids, `pending:<id>`) are full of.
+export function taskColour(folder: string): number {
+  // FNV-1a, 32-bit. Cheap, and — unlike summing char codes — it does not collide
+  // on anagrams, which paths are full of (…/a/b vs …/b/a).
+  //
+  // MEASURED on the real corpus rather than assumed, because a mixer that piles
+  // half the projects onto one hue would be worse than random here: over the 28
+  // distinct `project` paths on this machine it fills all 8 buckets, 1–5 folders
+  // each (χ²=5.1 on 7 df — an ordinary uniform draw), so the deep shared
+  // prefixes those paths have do not cluster it. A final avalanche step was
+  // tried on the same corpus and moved nothing worth the code.
   let h = 2166136261;
-  for (let i = 0; i < key.length; i++) {
-    h ^= key.charCodeAt(i);
+  for (let i = 0; i < folder.length; i++) {
+    h ^= folder.charCodeAt(i);
     h = Math.imul(h, 16777619);
   }
   return (h >>> 0) % TASK_COLOURS;
@@ -778,7 +800,11 @@ export function taskChips(
         extra: list.length - 1,
         recurring: !!templateId,
         templateId,
-        colour: taskColour(task.key),
+        // The FOLDER, so every task in one project draws the same hue. The key
+        // is the fallback for the (server-side impossible, client-side
+        // unprovable) case of a task with no project: a stable arbitrary colour
+        // beats every project-less task piling onto hash("").
+        colour: taskColour(task.project || task.key),
         tone: dayTone(list),
         projected: list.every(isProjected),
       });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1366,26 +1366,71 @@ describe("the unread count's position", () => {
     expect(VIEWS).not.toContain("function UnreadRail");
   });
 
-  it("trails the board card's title too, and cannot be clipped by its clamp", () => {
-    const head = VIEWS.slice(
+  it("sits INSIDE the board card's title, after the last word, on any number of lines", () => {
+    const card = VIEWS.slice(
       VIEWS.indexOf('<span className="schedule-tv-card-head">'),
       VIEWS.indexOf('<span className="schedule-tv-card-foot">'),
     );
-    // Not in the head any more — the head is the card's id and live ping only.
-    const headOnly = head.slice(0, head.indexOf('className="schedule-tv-card-name"'));
+    // Not in the head — the head is the card's id, its live ping and (only when it
+    // disagrees with the lane) a status ring.
+    const headOnly = card.slice(0, card.indexOf('className="schedule-tv-card-title"'));
     expect(headOnly).toContain("<IdChip");
     expect(headOnly).not.toContain("<UnreadPill");
-    // After the title, and OUTSIDE it. Inside was the first attempt, so that the
-    // count would flow after the title's last word — but that element clamps to
-    // two lines and hides its overflow, so a title long enough to fill it took
-    // the count with it. The count vanished on exactly the busiest cards.
-    expect(head.indexOf("<UnreadPill")).toBeGreaterThan(head.indexOf("firstLine(task.title)"));
-    expect(head).toMatch(
-      /className="schedule-tv-card-title">\{firstLine\(task\.title\)[^}]*\}<\/span>/,
+    // Inside the title element, and after the words: the pill is a sibling of the
+    // TEXT, in the same inline flow, which is the only arrangement that puts it
+    // after the last word of a title that wraps.
+    expect(card).toMatch(
+      /className="schedule-tv-card-title">\s*\{firstLine\(task\.title\)[^}]*\}\s*<UnreadPill count=\{unread\} \/>\s*<\/span>/,
     );
-    // The wrapper is what keeps it visible: it wraps, and the clamp does not.
-    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*flex-wrap: wrap/);
-    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*align-items: flex-end/);
+    // The wrapper that used to hold the two as flex siblings is GONE, along with
+    // both of its bugs. It existed because the title clipped its overflow, so a
+    // pill inside was eaten by a long title; out here it wrapped instead, which
+    // orphaned it on a line of its own under any two-line title (the screenshot,
+    // Akshil 2026-08-17). Neither the element nor its rule may come back — only
+    // the note explaining why, which is why the stylesheet is read stripped.
+    expect(VIEWS).not.toContain('className="schedule-tv-card-name"');
+    expect(SCHEDULE_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain(
+      "schedule-tv-card-name",
+    );
+  });
+
+  it("cannot be clipped, because the card's title no longer clamps at all", () => {
+    // The clamp was the cause of both earlier failures: nothing can flow after the
+    // last word of a clipped box AND stay outside the clip, so it had to go rather
+    // than be worked around a third time. A title now takes as many lines as it
+    // needs and the card grows — accepted, and rare, because a card's title is the
+    // session's short name and not the message it sends.
+    const title = SCHEDULE_CSS.slice(
+      SCHEDULE_CSS.indexOf(".schedule-tv-card-title {"),
+      SCHEDULE_CSS.indexOf("}", SCHEDULE_CSS.indexOf(".schedule-tv-card-title {")),
+    );
+    expect(title).toBeTruthy();
+    expect(title).not.toContain("line-clamp");
+    expect(title).not.toContain("-webkit-box");
+    expect(title).not.toContain("overflow: hidden");
+    expect(title).not.toContain("text-overflow");
+    expect(title).not.toContain("white-space");
+    // Nothing between the pill and the card hides overflow either — a clip one
+    // level out would lose the pill exactly as the clamp did. The chain is the
+    // title, the card, and the wrapper the action strip is pinned against.
+    for (const rule of [
+      /\.schedule-tv-board \.schedule-tv-card,[\s\S]*?\n\}/,
+      /\.tasks-card-wrap \{[\s\S]*?\n\}/,
+    ] as const) {
+      const src = rule.source.includes("card-wrap") ? TASKS_CSS : SCHEDULE_CSS;
+      const block = src.match(rule)?.[0];
+      expect(block).toBeTruthy();
+      expect(block).not.toContain("overflow");
+    }
+    // The one guard kept from the clamped version, and now the only thing standing
+    // between a 200-character unbroken token and a blown-out 260px column.
+    expect(title).toContain("overflow-wrap: anywhere");
+    // What makes it read as part of the line rather than as a box hanging off the
+    // baseline. `inline-flex` comes from `.tasks-count` itself, shared with the row.
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*vertical-align: middle/,
+    );
+    expect(TASKS_CSS).toMatch(/\.tasks-count\s*\{[^}]*display: inline-flex/);
   });
 
   it("keeps the row's ONE flex spacer and adds no auto margin", () => {
@@ -1399,10 +1444,15 @@ describe("the unread count's position", () => {
     expect(TASKS_CSS).toMatch(/\.tasks-msg\s*\{[^}]*gap: var\(--tasks-row-gap\)/);
     expect(TASKS_CSS).toMatch(/\.tasks-dot\s*\{[^}]*flex: 0 0 7px/);
     expect(TASKS_CSS).not.toMatch(/\.tasks-dot\s*\{[^}]*margin/);
-    // Not on the card either: its own wrapper carries a `gap`, so the pill needs
-    // no margin of its own anywhere.
-    expect(TASKS_CSS).not.toMatch(/\.schedule-tv-card-title \.tasks-count\s*\{/);
-    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*gap: 6px/);
+    // The board card is the one place the pill carries a margin, and it is a FIXED
+    // one: inside the title's text flow there is no flex parent to provide a `gap`,
+    // and `auto` has no meaning in inline layout anyway. It must not leak onto the
+    // List row's pill, which takes its spacing from the row's own `gap` — hence the
+    // rule is scoped to the card's title.
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*margin-left: 6px/,
+    );
+    expect(TASKS_CSS).not.toMatch(/\.tasks-count\s*\{[^}]*margin/);
   });
 
   it("trails every MESSAGE row's title too, in the same order as the task row", () => {
@@ -1597,6 +1647,126 @@ describe("the board card's status ring", () => {
       /\.tasks-card-wrap \.schedule-tv-card-head\s*\{[^}]*min-height: var\(--tasks-card-head-h\)/,
     );
     expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*height: 16px/);
+  });
+});
+
+// ---- which thing on the board is a surface -------------------------------------
+// The lane used to paint a fill at rest, so an empty lane was a grey slab and every
+// card competed with the box around it (Akshil, 2026-08-17, against flow side by
+// side). The fill is gone; the CARD is the only surface. Three things then have to
+// stay true, and all three were nearly broken by the same change, so all three are
+// read out of the stylesheets: the card still lifts off the PAGE (not off a lane
+// fill that no longer exists) in both themes, a drop target still announces itself
+// on a box that is painting nothing, and no rule quietly puts the lane's plate back.
+
+describe("the board's surfaces", () => {
+  /** A rule's declarations, found by WHOLE selector rather than by substring:
+   *  every rule here is written twice over (`.x` and `.prefs-section .x`, because
+   *  `.prefs-section button` repaints unarmored buttons on this page), and half of
+   *  them are named in the prose above themselves. Comments go first so a mention
+   *  cannot be mistaken for the rule. */
+  const block = (css: string, selector: string) => {
+    const bare = css.replace(/\/\*[\s\S]*?\*\//g, "");
+    for (const [, list, body] of bare.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      if (list.split(",").some((s) => s.trim() === selector)) return body;
+    }
+    throw new Error(`no rule whose selector list holds exactly "${selector}"`);
+  };
+
+  it("gives the lane no resting fill, and nothing else in its place", () => {
+    const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
+    expect(lane).not.toContain("background");
+    // Not a border or a rule either: the board's `gap` plus the cards' own edges
+    // are what make the columns read as columns, which is what was asked for and
+    // what was tried first.
+    expect(lane).not.toContain("border:");
+    expect(lane).not.toContain("border-left");
+    expect(lane).not.toContain("border-right");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane")).not.toContain("background");
+    // The collapsed lane is a lane too. One painted slab beside four transparent
+    // columns would have made the closed one the loudest thing on the board — but
+    // it keeps its hairline, because unlike the open lane it is a button.
+    const rail = block(SCHEDULE_CSS, ".schedule-tv-rail");
+    expect(rail).toContain("background: transparent");
+    expect(rail).toContain("border: 1px solid var(--border)");
+  });
+
+  it("makes the card lift off the PAGE, in both themes, from tokens", () => {
+    const card = block(SCHEDULE_CSS, ".schedule-tv-board .schedule-tv-card");
+    // `--bg` was the old fill and is also what the page ground is painted in
+    // (base.css `body`), so keeping it would have made the card vanish against the
+    // page — most obviously in light mode, where both are plain white.
+    expect(card).not.toMatch(/background: var\(--bg\);/);
+    // `--bg-panel` is the app's "surface floating above the page" token: it steps
+    // lighter than the ground in dark and stays white in light, where the hairline
+    // and the shadow do the lifting instead.
+    expect(card).toContain("background: var(--bg-panel)");
+    expect(card).toContain("border: 1px solid var(--border)");
+    expect(card).toContain("box-shadow: 0 1px 2px var(--shadow-sm)");
+    // Both halves of the lift are theme-tuned tokens with a value in BOTH blocks,
+    // never a colour defined only under `[data-theme]` — a light-only definition is
+    // how one theme ends up with no card surface at all.
+    for (const token of ["--bg-panel", "--shadow-sm"]) {
+      expect(TOKENS_CSS.slice(0, TOKENS_CSS.indexOf(':root[data-theme="light"]'))).toContain(
+        `${token}:`,
+      );
+      expect(TOKENS_CSS.slice(TOKENS_CSS.indexOf(':root[data-theme="light"]'))).toContain(
+        `${token}:`,
+      );
+    }
+    // The hover-revealed action strip is painted in the card's surface so it reads
+    // as floating over the head; it has to track the card or it is a patch on it.
+    expect(block(TASKS_CSS, ".tasks-card-act")).toContain("background: var(--bg-panel)");
+  });
+
+  it("lets a drop target announce itself by ADDING paint, not by changing it", () => {
+    // This is why removing the resting fill cost the drag nothing: every drop state
+    // goes from nothing to something. A legal lane outlines dashed the moment a drag
+    // starts, the lane under the pointer takes the accent wash, and the one drop
+    // that SENDS rather than files swaps the hue for `--activity` and says so in
+    // words. On a transparent lane all four are more legible than they were on a
+    // tinted one, not less.
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-lane-body\.is-drop-legal\s*\{[^}]*outline: 1px dashed color-mix\(in srgb, var\(--accent\)/,
+    );
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-lane-body\.is-drop-over,[\s\S]*?background: color-mix\(in srgb, var\(--accent\) 14%/,
+    );
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-rail\.is-drop-legal,[\s\S]*?outline: 1px dashed color-mix\(in srgb, var\(--accent\)/,
+    );
+    expect(TASKS_CSS).toMatch(
+      /\.schedule-tv-lane-body\.is-drop-run,[\s\S]*?outline: 1px dashed color-mix\(in srgb, var\(--activity\)/,
+    );
+    expect(TASKS_CSS).toMatch(/\.tasks-run-hint\s*\{[^}]*background: color-mix/);
+    // The lane keeps the geometry those states are drawn with — the padding that
+    // insets the outline off the top card, and the radius the wash takes. Dead at
+    // rest, which is the point.
+    const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
+    expect(lane).toContain("padding: 4px");
+    expect(lane).toContain("border-radius: 8px");
+    // And it keeps a floor, so an EMPTY lane — which now shows its header and
+    // nothing else, because "nothing scheduled" should look like nothing — is still
+    // something a card can be dragged into.
+    expect(lane).toContain("min-height: 120px");
+    // All three classes are still applied to both forms of the lane.
+    for (const state of ["is-drop-legal", "is-drop-over", "is-drop-run"]) {
+      expect((VIEWS.match(new RegExp(`" ${state}"`, "g")) ?? []).length).toBe(2);
+    }
+  });
+
+  it("gives the card the reference's breathing room, and the strip follows it", () => {
+    const card = block(SCHEDULE_CSS, ".schedule-tv-board .schedule-tv-card");
+    // Looser than the 8px/10px and 5px it shipped with, which is what made three
+    // short lines feel crowded. On the repo's even scale, and the three lines keep
+    // their relative hierarchy — no type size moved.
+    expect(card).toContain("padding: 10px 12px");
+    expect(card).toContain("gap: 6px");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane-body")).toContain("gap: 8px");
+    // The action strip is centred on the head off the card's TOP PADDING (plus half
+    // the head's line, less half a 22px button), so loosening the card without
+    // moving this leaves the strip riding high over the head: 10 + 8 - 11 = 7.
+    expect(TASKS_CSS).toMatch(/\.tasks-card-acts\s*\{[^}]*top: 7px/);
   });
 });
 

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1371,9 +1371,9 @@ describe("the unread count's position", () => {
       VIEWS.indexOf('<span className="schedule-tv-card-head">'),
       VIEWS.indexOf('<span className="schedule-tv-card-foot">'),
     );
-    // Not in the head any more — the head is the card's marks only.
+    // Not in the head any more — the head is the card's id and live ping only.
     const headOnly = head.slice(0, head.indexOf('className="schedule-tv-card-name"'));
-    expect(headOnly).toContain("<StatusIcon");
+    expect(headOnly).toContain("<IdChip");
     expect(headOnly).not.toContain("<UnreadPill");
     // After the title, and OUTSIDE it. Inside was the first attempt, so that the
     // count would flow after the title's last word — but that element clamps to
@@ -1390,41 +1390,70 @@ describe("the unread count's position", () => {
 
   it("keeps the row's ONE flex spacer and adds no auto margin", () => {
     // Free space is split equally between every `auto` margin, so a second one
-    // centres the right-hand group instead of pushing it to the end. Moving the
-    // pill across the row must not smuggle one in: the separation comes from the
-    // row's `gap`, and `.tasks-grow` stays the only spacer.
+    // centres the right-hand group instead of pushing it to the end. Neither mark
+    // may smuggle one in as it crosses the row: the separation comes from the row's
+    // `gap`, and `.tasks-grow` stays the only spacer on both kinds of row.
     expect((TASKS_CSS.match(/margin-left: auto/g) ?? []).length).toBe(0);
     expect(TASKS_CSS).toMatch(/\.tasks-grow\s*\{[^}]*flex: 1 1 auto/);
     expect(TASKS_CSS).toMatch(/\.tasks-row\s*\{[^}]*gap: var\(--tasks-row-gap\)/);
+    expect(TASKS_CSS).toMatch(/\.tasks-msg\s*\{[^}]*gap: var\(--tasks-row-gap\)/);
+    expect(TASKS_CSS).toMatch(/\.tasks-dot\s*\{[^}]*flex: 0 0 7px/);
+    expect(TASKS_CSS).not.toMatch(/\.tasks-dot\s*\{[^}]*margin/);
     // Not on the card either: its own wrapper carries a `gap`, so the pill needs
     // no margin of its own anywhere.
     expect(TASKS_CSS).not.toMatch(/\.schedule-tv-card-title \.tasks-count\s*\{/);
     expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*gap: 6px/);
   });
 
-  it("still leads every MESSAGE row, which is the one that is scanned", () => {
-    // The dot's move to the left edge is not undone by any of this: a thread IS
-    // read down its left edge. Only the task's total moved.
-    expect((VIEWS.match(/className="tasks-rail"/g) ?? []).length).toBeGreaterThan(1);
-    expect(VIEWS).not.toContain("tasks-msg-flag");
+  it("trails every MESSAGE row's title too, in the same order as the task row", () => {
+    // The dot used to LEAD its row, in a reserved slot on the rail, and that was
+    // the count's own bug one indent in: the mark announced before the words it is
+    // about. Worse, the task row above had already been fixed, so the thread read
+    // as a different dialect of the same page (Akshil, 2026-08-17). Both halves of
+    // unread now trail their titles; only the position moved.
     const thread = VIEWS.slice(VIEWS.indexOf('className={"tasks-msg"'));
-    expect(thread.indexOf('className="tasks-rail"')).toBeLessThan(
-      thread.indexOf("<StatusIcon"),
+    const body = thread.indexOf('className="tasks-msg-body"');
+    const dot = thread.indexOf('className="tasks-dot"');
+    expect(body).toBeGreaterThan(-1);
+    expect(dot).toBeGreaterThan(body);
+    // ...and therefore after the ring, the kind glyph and the id too.
+    expect(dot).toBeGreaterThan(thread.indexOf("<StatusIcon"));
+    expect(dot).toBeGreaterThan(thread.indexOf('className="tasks-msg-kind"'));
+    expect(dot).toBeGreaterThan(thread.indexOf("<IdChip"));
+    // Before the spacer, so it hugs the title rather than joining the trailing
+    // metadata group — the same placement the task row's count has.
+    expect(dot).toBeLessThan(thread.indexOf('className="tasks-grow"'));
+    // The reserved head slot is gone with it: nothing renders `.tasks-rail` and the
+    // rule itself is no longer in the stylesheet.
+    expect(VIEWS).not.toContain('className="tasks-rail"');
+    expect(TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain(".tasks-rail");
+    expect(VIEWS).not.toContain("tasks-msg-flag");
+    // A SIBLING of the title, never inside it: the body ellipsises its overflow,
+    // so a dot in there would vanish on exactly the longest lines.
+    expect(thread).toMatch(
+      /className="tasks-msg-body">\{firstLine\(m\.body\)[^}]*\}<\/span>/,
     );
   });
 
-  it("derives the thread's indent from the rail rather than typing it twice", () => {
-    // The column is placed once (--tasks-rail-x) and the thread reaches it by
-    // subtracting a message row's own indent. Hand-tune either side separately
-    // and the column bends — which is the bug that geometry fixed.
+  it("derives every indent from the rail rather than typing it twice", () => {
+    // The rail is placed once (--tasks-rail-x): it is where a TASK row's ring
+    // stands. A MESSAGE row's ring stands one ring slot and one gap to its right,
+    // and THAT is derived too, then the thread's padding is derived from it by
+    // subtracting a message row's own left padding. Hand-tune any of the three
+    // separately and the columns part company, which is the bug this geometry
+    // exists to prevent.
     expect(TASKS_CSS).toContain("--tasks-rail-x: calc(");
-    expect(TASKS_CSS).toContain(
-      "calc(var(--tasks-rail-x) - var(--tasks-msg-indent))",
+    expect(TASKS_CSS).toMatch(
+      /--tasks-msg-ring-x: calc\(\s*var\(--tasks-rail-x\) \+ var\(--tasks-rail-w\) \+ var\(--tasks-row-gap\)\s*\);/,
     );
-    // ...and the rail slot is the RING's width, centred, which is what puts a 7px
-    // dot on the exact centre line of the ring on the task row above it.
-    expect(TASKS_CSS).toMatch(/\.tasks-rail\s*\{[^}]*justify-content:\s*center/);
-    expect(TASKS_CSS).toMatch(/\.tasks-rail\s*\{[^}]*flex:\s*0 0 var\(--tasks-rail-w\)/);
+    expect(TASKS_CSS).toContain(
+      "calc(var(--tasks-msg-ring-x) - var(--tasks-msg-indent))",
+    );
+    // The slot the derivation is made of is the RING's width. This is the whole
+    // reason the offset survived the dot leaving the head: the empty slot used to
+    // push the thread's rings into their column, so its width had to be written
+    // down before it could be deleted, or every message row would have slid left
+    // into the task row's own column.
     expect(TASKS_CSS).toMatch(/--tasks-rail-w: 16px/);
     expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*flex: 0 0 16px/);
   });
@@ -1464,6 +1493,112 @@ function statusHues(selector: string): Record<string, string> {
   }
   return out;
 }
+
+// ---- where the status ring is drawn, and where it is not -----------------------
+// The ring is the page's status vocabulary, so the question is not whether it is
+// good but whether each place it appears is SAYING something there. On a board card
+// it usually was not: the lane header states the lane, and every card in that lane
+// then said it again next to its id (Akshil, 2026-08-17 — "just repetitive here").
+//
+// But "repetitive" is a claim about AGREEMENT, and `failed` is a flag beside
+// `status` rather than a value of it, so the two can disagree — a broken run triaged
+// to Done, or live again (server routers/tasks.py `_failed`). On those cards the
+// ring was the only at-rest mark saying the run broke, and deleting it outright lost
+// a signal rather than a repetition. So the rule is conditional, and it is pinned
+// from both ends: the RULE as logic over `isFailedTask` and `taskColumn`, which is
+// what the card asks, and the CALL SITE as source, because "only when it disagrees
+// with the lane" is a claim about markup no unit of pure logic can hold.
+
+describe("the board card's status ring", () => {
+  /** The card's markup, from its head down to the action strip beside it. */
+  const CARD = VIEWS.slice(
+    VIEWS.indexOf('<span className="schedule-tv-card-head">'),
+    VIEWS.indexOf('className="tasks-card-acts"'),
+  );
+
+  /** Exactly what the card asks: does the ring say anything the lane has not? */
+  const saysSomething = (t: Task) => isFailedTask(t) && taskColumn(t) !== "failed";
+
+  it("says nothing extra on a card whose status IS its lane", () => {
+    // The common card, and the whole of what was asked for. Every lane, including
+    // Failed itself — a failed card in the Failed lane is the agreement case, and
+    // its header has already said the word.
+    for (const status of ["upcoming", "in_progress", "done", "archived"] as const) {
+      expect(saysSomething(task({ status }))).toBe(false);
+    }
+    expect(saysSomething(task({ status: "failed", failed: true }))).toBe(false);
+    // A lane the client does not recognise is filed under Done (taskColumn), and it
+    // agrees with the lane it was filed into, so it draws nothing either.
+    expect(saysSomething(task({ status: "invented-later" as Task["status"] }))).toBe(false);
+  });
+
+  it("draws on a failed task filed somewhere other than Failed", () => {
+    // The two directions `_failed` documents: a broken run the user triaged away,
+    // and one whose session is live again. Both sit under a header that says nothing
+    // about the failure, so the ring is the card's only at-rest tell — the Re-send
+    // button is hover-revealed, and a control is not a signal.
+    expect(saysSomething(task({ status: "done", failed: true }))).toBe(true);
+    expect(saysSomething(task({ status: "in_progress", failed: true }))).toBe(true);
+    expect(saysSomething(task({ status: "archived", failed: true }))).toBe(true);
+  });
+
+  it("asks that rule at the call site, through the one helper that knows it", () => {
+    // `isFailedTask` is the single notion of "reads as failed" (the failed lane, or
+    // the flag that repaints a Done ring red). A second inline reading of
+    // `task.failed` here is how the card and the List row would drift apart.
+    expect(CARD).toContain("{failedOffLane && <StatusIcon status={lane} failed />}");
+    expect(CARD).toContain("<IdChip");
+    const card = VIEWS.slice(VIEWS.indexOf("function TaskCard("));
+    expect(card).toContain('isFailedTask(task) && lane !== "failed"');
+    expect(card).toContain("const lane = taskColumn(task)");
+  });
+
+  it("changes nothing about the ring itself — same component, hue and size", () => {
+    // Conditional, not restyled: a second failure marker with its own look would be
+    // a new word in a vocabulary this round was pruning.
+    expect(CARD).not.toContain("schedule-ring");
+    expect(SCHEDULE_CSS).toContain(".schedule-ring--failed,");
+    expect(SCHEDULE_CSS).toContain("color: var(--status-failed);");
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*flex: 0 0 16px/);
+  });
+
+  it("stays on the lane header, which is the one place it always says something", () => {
+    // Both forms of the header: the open lane, and the collapsed rail it becomes.
+    for (const cls of ["schedule-tv-lane-head", "schedule-tv-rail"]) {
+      const at = VIEWS.indexOf(`"${cls}"`);
+      expect(at).toBeGreaterThan(-1);
+      expect(VIEWS.slice(at, VIEWS.indexOf("</button>", at))).toContain(
+        "<StatusIcon status={col.key} />",
+      );
+    }
+  });
+
+  it("stays UNconditional on a List row and in the Calendar, which have no lane", () => {
+    const from = VIEWS.indexOf('className={"tasks-row"');
+    const row = VIEWS.slice(from, VIEWS.indexOf("{open && (", from));
+    // Not gated on anything: a flat row and a day cell have no header above them, so
+    // the ring is the only thing that files them at all.
+    expect(row).toContain("<StatusIcon status={taskColumn(task)} failed={task.failed} />");
+    expect(VIEWS.slice(VIEWS.indexOf('className={"tasks-msg"'))).toContain("<StatusIcon");
+    expect(SCHEDULE_CSS).toContain(".schedule-cal-popover .schedule-ring");
+  });
+
+  it("holds the head's line whether or not a ring is standing in it", () => {
+    // Two failures this prevents. The strip is pinned over the head and centred on
+    // it, and the title starts one card `gap` below — clearance that came free while
+    // EVERY head held a 16px ring; a ringless head is one 11px id chip and the
+    // strip's opaque buttons reach over the title's first line on hover. And with
+    // the ring conditional, a head left to its contents would stand 16px on a
+    // failed-off-lane card and 13px on its neighbour, so a lane would jitter by the
+    // width of a glyph. One stated line answers both, and it is the ring's own
+    // height, so the two cases are exactly the same size.
+    expect(TASKS_CSS).toMatch(/--tasks-card-head-h: 16px/);
+    expect(TASKS_CSS).toMatch(
+      /\.tasks-card-wrap \.schedule-tv-card-head\s*\{[^}]*min-height: var\(--tasks-card-head-h\)/,
+    );
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*height: 16px/);
+  });
+});
 
 describe("the status ring's five hues", () => {
   const LANES = [

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1331,55 +1331,247 @@ describe("archiveIntent", () => {
 });
 
 // ---- where the marks are drawn -------------------------------------------------
-// Two claims the pure half cannot hold on its own: WHICH END of a row the
-// unread mark is at, and whether the task row's rail and its thread's dots are
-// one column. Both were the bug, so both are read out of the source rather than
-// left to a screenshot.
+// Three claims the pure half cannot hold on its own: WHICH END of a row the
+// unread count is at, whether the task row's ring and its thread's dots are one
+// column, and what each mark is painted in. All three were the bug at some point,
+// so all three are read out of the source rather than left to a screenshot.
 
 const SHELL = import.meta.dir;
 const VIEWS = readFileSync(join(SHELL, "ScheduleTaskViews.tsx"), "utf8");
 const TASKS_CSS = readFileSync(join(SHELL, "../styles/tasks.css"), "utf8");
+const SCHEDULE_CSS = readFileSync(join(SHELL, "../styles/schedule.css"), "utf8");
+const TOKENS_CSS = readFileSync(join(SHELL, "../styles/tokens.css"), "utf8");
+const REDUCED_MOTION_CSS = readFileSync(
+  join(SHELL, "../styles/reduced-motion.css"),
+  "utf8",
+);
 
-describe("the unread rail", () => {
-  it("draws the TASK row's unread leading, not out by the folder chip", () => {
+describe("the unread count's position", () => {
+  it("trails the TASK row's title instead of leading the row", () => {
     const from = VIEWS.indexOf('className={"tasks-row"');
     expect(from).toBeGreaterThan(-1);
     // The row ends where the thread it can open begins.
     const row = VIEWS.slice(from, VIEWS.indexOf("{open && (", from));
-    const rail = row.indexOf("<UnreadRail");
-    expect(rail).toBeGreaterThan(-1);
-    // Before the ring, the id, the title and the folder chip it used to trail.
-    expect(rail).toBeLessThan(row.indexOf("<StatusIcon"));
-    expect(rail).toBeLessThan(row.indexOf("<IdChip"));
-    expect(rail).toBeLessThan(row.indexOf("<IdentityChip"));
+    const pill = row.indexOf("<UnreadPill");
+    expect(pill).toBeGreaterThan(-1);
+    // AFTER the title — that is the whole point of this round: the title is what
+    // the list is scanned for, so it must be the first thing the row says.
+    expect(pill).toBeGreaterThan(row.indexOf('className="tasks-title"'));
+    // ...and therefore after the ring and the id too.
+    expect(pill).toBeGreaterThan(row.indexOf("<StatusIcon"));
+    expect(pill).toBeGreaterThan(row.indexOf("<IdChip"));
+    // The leading rail slot is gone from the task row: the ring stands in that
+    // column now, and there is no second component reserving it.
+    expect(row).not.toContain("<UnreadRail");
+    expect(VIEWS).not.toContain("function UnreadRail");
   });
 
-  it("leads the board card too, where it also used to trail", () => {
+  it("trails the board card's title too, inside the clamped title element", () => {
     const head = VIEWS.slice(
       VIEWS.indexOf('<span className="schedule-tv-card-head">'),
-      VIEWS.indexOf('<span className="schedule-tv-card-title">'),
+      VIEWS.indexOf('<span className="schedule-tv-card-foot">'),
     );
-    expect(head.indexOf("<UnreadPill")).toBeLessThan(head.indexOf("<StatusIcon"));
+    // Not in the head any more — the head is the card's marks only.
+    const headOnly = head.slice(0, head.indexOf('className="schedule-tv-card-title"'));
+    expect(headOnly).toContain("<StatusIcon");
+    expect(headOnly).not.toContain("<UnreadPill");
+    // In the title, after the words: the title is a two-line -webkit-box clamp,
+    // so only a child that flows with the text lands after the last word.
+    expect(head.indexOf("<UnreadPill")).toBeGreaterThan(head.indexOf("firstLine(task.title)"));
+    // And the pill knows how to sit on a text line there.
+    expect(TASKS_CSS).toMatch(
+      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*vertical-align: middle/,
+    );
   });
 
-  it("puts a task row and its messages in ONE class, so it is one column", () => {
-    // Both slots are `.tasks-rail`; the old per-view class is gone.
-    expect(VIEWS).not.toContain("tasks-msg-flag");
+  it("keeps the row's ONE flex spacer and adds no auto margin", () => {
+    // Free space is split equally between every `auto` margin, so a second one
+    // centres the right-hand group instead of pushing it to the end. Moving the
+    // pill across the row must not smuggle one in: the separation comes from the
+    // row's `gap`, and `.tasks-grow` stays the only spacer.
+    expect((TASKS_CSS.match(/margin-left: auto/g) ?? []).length).toBe(0);
+    expect(TASKS_CSS).toMatch(/\.tasks-grow\s*\{[^}]*flex: 1 1 auto/);
+    expect(TASKS_CSS).toMatch(/\.tasks-row\s*\{[^}]*gap: var\(--tasks-row-gap\)/);
+    // The one margin the pill does get is on the CARD, where it is an inline box
+    // in a text line rather than a flex item with a gap.
+    expect(TASKS_CSS).toMatch(
+      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*margin-left: 6px/,
+    );
+  });
+
+  it("still leads every MESSAGE row, which is the one that is scanned", () => {
+    // The dot's move to the left edge is not undone by any of this: a thread IS
+    // read down its left edge. Only the task's total moved.
     expect((VIEWS.match(/className="tasks-rail"/g) ?? []).length).toBeGreaterThan(1);
+    expect(VIEWS).not.toContain("tasks-msg-flag");
+    const thread = VIEWS.slice(VIEWS.indexOf('className={"tasks-msg"'));
+    expect(thread.indexOf('className="tasks-rail"')).toBeLessThan(
+      thread.indexOf("<StatusIcon"),
+    );
   });
 
   it("derives the thread's indent from the rail rather than typing it twice", () => {
-    // The rail is placed once (--tasks-rail-x) and the thread reaches it by
+    // The column is placed once (--tasks-rail-x) and the thread reaches it by
     // subtracting a message row's own indent. Hand-tune either side separately
-    // and the column bends — which is the bug this round fixed.
+    // and the column bends — which is the bug that geometry fixed.
     expect(TASKS_CSS).toContain("--tasks-rail-x: calc(");
     expect(TASKS_CSS).toContain(
       "calc(var(--tasks-rail-x) - var(--tasks-msg-indent))",
     );
-    // ...and the rail slot itself is one fixed, centred width, which is what
-    // puts a 7px dot and a count pill on the same centre line.
+    // ...and the rail slot is the RING's width, centred, which is what puts a 7px
+    // dot on the exact centre line of the ring on the task row above it.
     expect(TASKS_CSS).toMatch(/\.tasks-rail\s*\{[^}]*justify-content:\s*center/);
     expect(TASKS_CSS).toMatch(/\.tasks-rail\s*\{[^}]*flex:\s*0 0 var\(--tasks-rail-w\)/);
+    expect(TASKS_CSS).toMatch(/--tasks-rail-w: 16px/);
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*flex: 0 0 16px/);
+  });
+});
+
+// ---- the status vocabulary's five hues ------------------------------------------
+// Upcoming · In Progress · Done · Failed · Archive. Read out of tokens.css because
+// the whole vocabulary only works if the five stay DISTINCT in both themes, and
+// two of them were swapped on 2026-08-17 (Upcoming to grey, Archive off grey to a
+// muted violet). A colour test cannot judge taste; what it can pin is that the
+// five are five, that neither theme was left behind, and that the two that moved
+// did not move onto each other or onto a neighbour.
+
+/** The `--status-*` and `--activity` values of one palette block. */
+function statusHues(selector: string): Record<string, string> {
+  const at = TOKENS_CSS.indexOf(selector + " {");
+  expect(at).toBeGreaterThan(-1);
+  const block = TOKENS_CSS.slice(at, TOKENS_CSS.indexOf("\n}", at));
+  const out: Record<string, string> = {};
+  for (const [, name, value] of block.matchAll(
+    /--(status-[a-z_]+|activity):\s*([^;]+);/g,
+  )) {
+    out[name] = value.trim();
+  }
+  return out;
+}
+
+describe("the status ring's five hues", () => {
+  const LANES = [
+    "status-upcoming",
+    "status-progress",
+    "status-done",
+    "status-failed",
+    "status-archived",
+  ];
+
+  for (const [theme, selector] of [
+    ["dark", ":root"],
+    ["light", ':root[data-theme="light"]'],
+  ] as const) {
+    it(`gives ${theme} all five lanes, and five different values`, () => {
+      const hues = statusHues(selector);
+      for (const lane of LANES) expect(hues[lane]).toBeTruthy();
+      // Five lanes, five hues. A duplicate is a vocabulary with a word missing.
+      expect(new Set(LANES.map((l) => hues[l])).size).toBe(5);
+    });
+
+    it(`paints ${theme}'s Upcoming with an existing neutral, not a hue`, () => {
+      // Blue was the loudest thing on a page about what is happening NOW, so
+      // Upcoming recedes into the row's own metadata colour. It borrows the token
+      // rather than restating a grey, which is what keeps the two in step.
+      expect(statusHues(selector)["status-upcoming"]).toBe("var(--fg-muted)");
+    });
+
+    it(`keeps ${theme}'s Archive off grey and off every live lane`, () => {
+      const hues = statusHues(selector);
+      const archive = hues["status-archived"];
+      // Not the grey Upcoming took, and not the blue either.
+      expect(archive).not.toBe(hues["status-upcoming"]);
+      expect(archive).not.toBe(hues["activity"]);
+      // A literal, and a violet: red and blue channels above green, which is what
+      // separates it from yellow/green/red and from a neutral (r == g == b).
+      expect(archive).toMatch(/^#[0-9a-f]{6}$/);
+      const [r, g, b] = [1, 3, 5].map((i) => parseInt(archive.slice(i, i + 2), 16));
+      expect(b).toBeGreaterThan(g);
+      expect(r).toBeGreaterThan(g);
+      // Low-saturation, so a filed lane never out-shouts a live one: the spread
+      // between the strongest and weakest channel stays modest.
+      expect(Math.max(r, g, b) - Math.min(r, g, b)).toBeLessThan(90);
+    });
+  }
+
+  it("wears each lane's token on the ring, and nothing hardcoded", () => {
+    for (const [lane, token] of [
+      ["upcoming", "--status-upcoming"],
+      ["in_progress", "--status-progress"],
+      ["done", "--status-done"],
+      ["archived", "--status-archived"],
+    ] as const) {
+      expect(SCHEDULE_CSS).toContain(
+        `.schedule-ring--${lane} { color: var(${token}); }`,
+      );
+    }
+    expect(SCHEDULE_CSS).toContain("color: var(--status-failed);");
+  });
+
+  it("moves the surviving blue onto a token named for what it does", () => {
+    // The blue was never the Upcoming hue; it was the page's activity hue, worn by
+    // the live ping, the unread dot and the Run now affordance. Naming it that is
+    // what let Upcoming go grey without repainting the three.
+    for (const theme of [":root", ':root[data-theme="light"]']) {
+      expect(statusHues(theme)["activity"]).toMatch(/^#[0-9a-f]{6}$/);
+    }
+    expect(TASKS_CSS).toMatch(/\.tasks-dot\s*\{[^}]*background: var\(--activity\)/);
+    expect(SCHEDULE_CSS).toMatch(
+      /\.schedule-tv-pulse::before,\n\.schedule-tv-pulse::after \{[^}]*background: var\(--activity\)/,
+    );
+    expect(TASKS_CSS).toMatch(
+      /\.tasks-act--run:hover:not\(:disabled\),\n\.prefs-section \.tasks-act--run:hover:not\(:disabled\) \{[^}]*color: var\(--activity\)/,
+    );
+    // Nothing paints with the old name any more except the ring it belongs to.
+    expect(TASKS_CSS).not.toContain("var(--status-upcoming)");
+  });
+
+  it("de-emphasises the unread count to a neutral, not the dot's blue", () => {
+    const at = TASKS_CSS.indexOf(".tasks-count {");
+    expect(at).toBeGreaterThan(-1);
+    const rule = TASKS_CSS.slice(at, TASKS_CSS.indexOf("}", at));
+    // Metadata after a title, not a badge demanding a press: the FILL is a
+    // neutral wash and no hue is involved at all.
+    expect(rule).toContain("background: color-mix(in srgb, var(--fg-muted)");
+    expect(rule).not.toContain("--activity");
+    expect(rule).not.toContain("--status-upcoming");
+    expect(rule).not.toContain("--on-accent");
+    // ...but the digits are full ink. Muted ink on a muted wash is under AA at
+    // 10px in light mode, and a chip that is quiet by being unreadable is a bug.
+    expect(rule).toContain("color: var(--fg);");
+  });
+});
+
+describe("the In Progress ring", () => {
+  it("does not blink", () => {
+    // A lane is a COLUMN of these, so a 2s breathing loop on each made a full
+    // board flicker; the ring is already the only yellow one on the page.
+    expect(SCHEDULE_CSS).not.toMatch(/\.schedule-ring--in_progress\s*\{[^}]*animation/);
+    expect(SCHEDULE_CSS).not.toContain(".schedule-ring--in_progress {\n    animation");
+    // Static yellow is all it is.
+    expect(SCHEDULE_CSS).toContain(
+      ".schedule-ring--in_progress { color: var(--status-progress); }",
+    );
+  });
+
+  it("leaves the live ping — and only the live ping — moving", () => {
+    // The ping is a single mark on the handful of tasks with a turn actually in
+    // flight, which is a fact about right now rather than about a lane. Its
+    // keyframes therefore stay, and stay motion-gated.
+    expect(SCHEDULE_CSS).toContain("@keyframes schedule-tv-pulse");
+    const at = SCHEDULE_CSS.indexOf("@media (prefers-reduced-motion: no-preference) {");
+    expect(at).toBeGreaterThan(-1);
+    const guard = SCHEDULE_CSS.slice(at, SCHEDULE_CSS.indexOf("\n}", at));
+    expect(guard).toContain(".schedule-tv-pulse::before");
+    expect(guard).not.toContain("schedule-ring--in_progress");
+  });
+
+  it("leaves nothing dangling in reduced-motion.css", () => {
+    // That file names the individual animations it has to override by hand; it
+    // never named this one (the blanket duration rule covered it), so removing the
+    // rule leaves no counterpart behind.
+    expect(REDUCED_MOTION_CSS).not.toContain("schedule-ring");
+    expect(REDUCED_MOTION_CSS).not.toContain("schedule-tv-pulse");
   });
 });
 
@@ -1586,12 +1778,12 @@ describe("the mark-read action", () => {
   });
 
   it("never wears the unread dot's own hue", () => {
-    // --status-upcoming is what the dot and the count pill are painted in, and
-    // what Run now takes on hover — the button directly beside this one.
+    // --activity is what the thread's dots are painted in, and what Run now takes
+    // on hover — the button directly beside this one.
     const at = TASKS_CSS.indexOf(".tasks-act--seen:hover");
     expect(at).toBeGreaterThan(-1);
     const rule = TASKS_CSS.slice(at, TASKS_CSS.indexOf("}", at));
-    expect(rule).not.toContain("--status-upcoming");
+    expect(rule).not.toContain("--activity");
     expect(rule).not.toContain("--error");
   });
 });
@@ -1687,7 +1879,7 @@ describe("opening a thread, from either view", () => {
     // The List asks with the count the row is drawing (local marks included),
     // which is what stops a second press from posting again.
     expect(NODE).toContain("taskUnread(task, read, held)");
-    expect(ROW).toContain("<UnreadRail count={unread} />");
+    expect(ROW).toContain("<UnreadPill count={unread} />");
   });
 
   it("keeps the card's actions OUT of the click, by being siblings of it", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1425,6 +1425,19 @@ describe("the unread count's position", () => {
     expect(TASKS_CSS).toMatch(/--tasks-rail-w: 16px/);
     expect(SCHEDULE_CSS).toMatch(/\.schedule-ring\s*\{[^}]*flex: 0 0 16px/);
   });
+
+  it("draws no vertical rule down the thread", () => {
+    // The indent is the whole signal. A rule beside it read as a stray line
+    // sitting in front of the indentation rather than as a guide belonging to
+    // it, and nothing else in this list is fenced. Pinned because the geometry
+    // above depends on it: the message row's left padding was written as
+    // indent-minus-1 to make room for the rule's own width, so re-adding the
+    // border without re-doing the subtraction would shift every message row a
+    // pixel off the column it is supposed to share with the task above.
+    const body = TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(body).not.toContain("border-left");
+    expect(body).toMatch(/\.tasks-msg\s*\{[^}]*padding: 5px 8px 5px var\(--tasks-msg-indent\)/);
+  });
 });
 
 // ---- the status vocabulary's five hues ------------------------------------------

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1366,22 +1366,26 @@ describe("the unread count's position", () => {
     expect(VIEWS).not.toContain("function UnreadRail");
   });
 
-  it("trails the board card's title too, inside the clamped title element", () => {
+  it("trails the board card's title too, and cannot be clipped by its clamp", () => {
     const head = VIEWS.slice(
       VIEWS.indexOf('<span className="schedule-tv-card-head">'),
       VIEWS.indexOf('<span className="schedule-tv-card-foot">'),
     );
     // Not in the head any more — the head is the card's marks only.
-    const headOnly = head.slice(0, head.indexOf('className="schedule-tv-card-title"'));
+    const headOnly = head.slice(0, head.indexOf('className="schedule-tv-card-name"'));
     expect(headOnly).toContain("<StatusIcon");
     expect(headOnly).not.toContain("<UnreadPill");
-    // In the title, after the words: the title is a two-line -webkit-box clamp,
-    // so only a child that flows with the text lands after the last word.
+    // After the title, and OUTSIDE it. Inside was the first attempt, so that the
+    // count would flow after the title's last word — but that element clamps to
+    // two lines and hides its overflow, so a title long enough to fill it took
+    // the count with it. The count vanished on exactly the busiest cards.
     expect(head.indexOf("<UnreadPill")).toBeGreaterThan(head.indexOf("firstLine(task.title)"));
-    // And the pill knows how to sit on a text line there.
-    expect(TASKS_CSS).toMatch(
-      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*vertical-align: middle/,
+    expect(head).toMatch(
+      /className="schedule-tv-card-title">\{firstLine\(task\.title\)[^}]*\}<\/span>/,
     );
+    // The wrapper is what keeps it visible: it wraps, and the clamp does not.
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*flex-wrap: wrap/);
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*align-items: flex-end/);
   });
 
   it("keeps the row's ONE flex spacer and adds no auto margin", () => {
@@ -1392,11 +1396,10 @@ describe("the unread count's position", () => {
     expect((TASKS_CSS.match(/margin-left: auto/g) ?? []).length).toBe(0);
     expect(TASKS_CSS).toMatch(/\.tasks-grow\s*\{[^}]*flex: 1 1 auto/);
     expect(TASKS_CSS).toMatch(/\.tasks-row\s*\{[^}]*gap: var\(--tasks-row-gap\)/);
-    // The one margin the pill does get is on the CARD, where it is an inline box
-    // in a text line rather than a flex item with a gap.
-    expect(TASKS_CSS).toMatch(
-      /\.schedule-tv-card-title \.tasks-count\s*\{[^}]*margin-left: 6px/,
-    );
+    // Not on the card either: its own wrapper carries a `gap`, so the pill needs
+    // no margin of its own anywhere.
+    expect(TASKS_CSS).not.toMatch(/\.schedule-tv-card-title \.tasks-count\s*\{/);
+    expect(SCHEDULE_CSS).toMatch(/\.schedule-tv-card-name\s*\{[^}]*gap: 6px/);
   });
 
   it("still leads every MESSAGE row, which is the one that is scanned", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -30,6 +30,7 @@ import {
   heldMessages,
   isAllRead,
   isDraggable,
+  isExpandable,
   isFailedTask,
   isPastDue,
   isUnread,
@@ -216,6 +217,43 @@ describe("threadView", () => {
     expect(threadView({ ...task({}, 1), message_count: 4 }).more).toBe(true);
     // ...and one that claims fewer than it sent never goes negative.
     expect(threadView({ ...task({}, 3), message_count: 1 }).hidden).toBe(0);
+  });
+});
+
+// ---- which rows are accordions at all ----------------------------------------
+// "empty task (1 msg only) should not have dropdown" (Akshil, 2026-08-17). A
+// thread of one drew a single message row under the task row whose title was the
+// same words, so the chevron offered a press that revealed a restatement. Zero is
+// the same case. The number asked has to be the SERVER's, or the answer is wrong
+// on precisely the tasks with most to show.
+
+describe("isExpandable", () => {
+  it("offers no disclosure at zero or one message, and one from two up", () => {
+    // Nothing to reveal: a pending task that has never run, and a thread whose one
+    // message the row above is already showing.
+    expect(isExpandable(task({}, 0))).toBe(false);
+    expect(isExpandable(task({}, 1))).toBe(false);
+    // Two is a thread.
+    expect(isExpandable(task({}, 2))).toBe(true);
+    expect(isExpandable(task({}, 3))).toBe(true);
+    expect(isExpandable(task({}, 40))).toBe(true);
+  });
+
+  it("asks message_count, never the tail the client happens to hold", () => {
+    // The listing sends at most PREVIEW_MESSAGES, and can send fewer or none at
+    // all. Counting what we hold would call this forty-message task a leaf and
+    // hide the chevron on the row with the most to open.
+    expect(isExpandable({ ...task({}, 40), messages: [] })).toBe(true);
+    expect(isExpandable({ ...task({}, 40), messages: [msg({})] })).toBe(true);
+    // And the same number the Show more button is arithmetic over, so the chevron
+    // and "Show N more" cannot disagree about the thread's length.
+    const long = { ...task({}, 40), messages: [msg({})] };
+    expect(threadView(long).more).toBe(true);
+    // The converse: a tail longer than the count claims is still not a thread, so
+    // the two never contradict each other in that direction either.
+    const shrunk = { ...task({}, 3), message_count: 1 };
+    expect(isExpandable(shrunk)).toBe(false);
+    expect(threadView(shrunk).more).toBe(false);
   });
 });
 
@@ -1526,9 +1564,14 @@ describe("the unread count's position", () => {
 // Upcoming · In Progress · Done · Failed · Archive. Read out of tokens.css because
 // the whole vocabulary only works if the five stay DISTINCT in both themes, and
 // two of them were swapped on 2026-08-17 (Upcoming to grey, Archive off grey to a
-// muted violet). A colour test cannot judge taste; what it can pin is that the
-// five are five, that neither theme was left behind, and that the two that moved
-// did not move onto each other or onto a neighbour.
+// muted violet — and then, the same day, off that violet to a dusty rose, because
+// at ring size a low-chroma violet beside a grey is two greys).
+//
+// A colour test cannot judge taste. What it can pin is that the five are five, that
+// neither theme was left behind, that the two that moved did not move onto each
+// other or onto a neighbour — and, since the violet cleared every one of those and
+// still failed, that Archive is far enough from Upcoming in CHROMA to be told apart
+// at a glance rather than merely under a picker.
 
 /** The `--status-*` and `--activity` values of one palette block. */
 function statusHues(selector: string): Record<string, string> {
@@ -1542,6 +1585,26 @@ function statusHues(selector: string): Record<string, string> {
     out[name] = value.trim();
   }
   return out;
+}
+
+/** Any single token's value out of one palette block — for the ones Upcoming
+ *  borrows rather than restates (`var(--fg-muted)`), which have to be RESOLVED
+ *  before two colours can be compared as colours. */
+function paletteHex(selector: string, token: string): string {
+  const at = TOKENS_CSS.indexOf(selector + " {");
+  expect(at).toBeGreaterThan(-1);
+  const block = TOKENS_CSS.slice(at, TOKENS_CSS.indexOf("\n}", at));
+  const found = block.match(new RegExp(`--${token}:\\s*(#[0-9a-f]{6});`));
+  expect(found).toBeTruthy();
+  return found![1];
+}
+
+/** `#rrggbb` as three 0-255 numbers, so a claim about a hue can be arithmetic
+ *  over the actual channels rather than a string comparison — two colours that
+ *  differ by one bit are different strings and the same colour. */
+function channels(hex: string): number[] {
+  expect(hex).toMatch(/^#[0-9a-f]{6}$/);
+  return [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16));
 }
 
 // ---- where the status ring is drawn, and where it is not -----------------------
@@ -1650,45 +1713,66 @@ describe("the board card's status ring", () => {
   });
 });
 
+/** A rule's declarations, found by WHOLE selector rather than by substring: many
+ *  rules on this page are written twice over (`.x` and `.prefs-section .x`, because
+ *  `.prefs-section button` repaints unarmored buttons here), and half of them are
+ *  named in the prose above themselves. Comments are stripped first so a mention
+ *  cannot be mistaken for the rule. */
+function block(css: string, selector: string): string {
+  for (const rule of rules(css)) {
+    if (rule.selectors.includes(selector)) return rule.body;
+  }
+  throw new Error(`no rule whose selector list holds exactly "${selector}"`);
+}
+
+/** Every rule in a stylesheet, as its selector list and its declarations. A
+ *  selector can appear in more than one rule (a resting rule and a state rule),
+ *  which `block` above cannot express — it answers with the first. */
+function rules(css: string): { selectors: string[]; body: string }[] {
+  const bare = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  return [...bare.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(([, list, body]) => ({
+    selectors: list.split(",").map((s) => s.trim()),
+    body,
+  }));
+}
+
 // ---- which thing on the board is a surface -------------------------------------
 // The lane used to paint a fill at rest, so an empty lane was a grey slab and every
 // card competed with the box around it (Akshil, 2026-08-17, against flow side by
-// side). The fill is gone; the CARD is the only surface. Three things then have to
-// stay true, and all three were nearly broken by the same change, so all three are
-// read out of the stylesheets: the card still lifts off the PAGE (not off a lane
-// fill that no longer exists) in both themes, a drop target still announces itself
-// on a box that is painting nothing, and no rule quietly puts the lane's plate back.
+// side). The fill is gone and the CARD is the only surface — but the lane is still
+// BOUNDED, by the same hairline the collapsed rail wears, because unfilled and
+// unbounded a column had no edge of its own at all (Akshil, same day: "at least
+// they should have an outline when they're expanded"). Four things then have to stay
+// true, and each was nearly broken by one of those two changes, so all four are read
+// out of the stylesheets: no fill comes back, the edge is there and is the rail's
+// edge, the card still lifts off the PAGE in both themes, and a drop target still
+// announces itself on a box that paints almost nothing — without its dashed line
+// stacking onto the hairline that is now underneath it.
 
 describe("the board's surfaces", () => {
-  /** A rule's declarations, found by WHOLE selector rather than by substring:
-   *  every rule here is written twice over (`.x` and `.prefs-section .x`, because
-   *  `.prefs-section button` repaints unarmored buttons on this page), and half of
-   *  them are named in the prose above themselves. Comments go first so a mention
-   *  cannot be mistaken for the rule. */
-  const block = (css: string, selector: string) => {
-    const bare = css.replace(/\/\*[\s\S]*?\*\//g, "");
-    for (const [, list, body] of bare.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-      if (list.split(",").some((s) => s.trim() === selector)) return body;
-    }
-    throw new Error(`no rule whose selector list holds exactly "${selector}"`);
-  };
-
-  it("gives the lane no resting fill, and nothing else in its place", () => {
+  it("gives the lane no resting fill, but does give it an edge", () => {
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
+    // No FILL: a filled lane is a surface competing with the cards on it, which is
+    // the whole reason the plate came off.
     expect(lane).not.toContain("background");
-    // Not a border or a rule either: the board's `gap` plus the cards' own edges
-    // are what make the columns read as columns, which is what was asked for and
-    // what was tried first.
-    expect(lane).not.toContain("border:");
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane")).not.toContain("background");
+    // But BOUNDED — "at least they should have an outline when they're expanded".
+    // Unfilled and unbounded, the column's only edge was the widest card's ragged
+    // right-hand end.
+    expect(lane).toContain("border: 1px solid var(--border)");
+    expect(lane).toContain("border-radius: 8px");
+    // Stated with it, so `min-height: 120px` stays the floor the board actually has.
+    expect(lane).toContain("box-sizing: border-box");
+    // One hairline all the way round, not a rule down one side.
     expect(lane).not.toContain("border-left");
     expect(lane).not.toContain("border-right");
-    expect(block(SCHEDULE_CSS, ".schedule-tv-lane")).not.toContain("background");
-    // The collapsed lane is a lane too. One painted slab beside four transparent
-    // columns would have made the closed one the loudest thing on the board — but
-    // it keeps its hairline, because unlike the open lane it is a button.
+    // The collapsed lane is a lane too, and since 2026-08-17 the two wear the SAME
+    // edge — same width, same token, same radius, both unfilled — so the open and
+    // closed forms read as one family rather than as two ideas about a lane's edge.
     const rail = block(SCHEDULE_CSS, ".schedule-tv-rail");
     expect(rail).toContain("background: transparent");
     expect(rail).toContain("border: 1px solid var(--border)");
+    expect(rail).toContain("border-radius: 8px");
   });
 
   it("makes the card lift off the PAGE, in both themes, from tokens", () => {
@@ -1740,8 +1824,7 @@ describe("the board's surfaces", () => {
     );
     expect(TASKS_CSS).toMatch(/\.tasks-run-hint\s*\{[^}]*background: color-mix/);
     // The lane keeps the geometry those states are drawn with — the padding that
-    // insets the outline off the top card, and the radius the wash takes. Dead at
-    // rest, which is the point.
+    // insets the outline off the top card, and the radius the wash takes.
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
     expect(lane).toContain("padding: 4px");
     expect(lane).toContain("border-radius: 8px");
@@ -1753,6 +1836,52 @@ describe("the board's surfaces", () => {
     for (const state of ["is-drop-legal", "is-drop-over", "is-drop-run"]) {
       expect((VIEWS.match(new RegExp(`" ${state}"`, "g")) ?? []).length).toBe(2);
     }
+  });
+
+  it("does not let the dashed drop line double up on the lane's own hairline", () => {
+    // The outline is drawn at `outline-offset: -1px`, which since the lane grew a
+    // border is exactly where that border is: left alone, the two stack into one
+    // muddy 2px edge, half grey and half accent, which reads as "thicker" rather
+    // than as "here". So a lane being dropped into takes its hairline to transparent
+    // and the dashed line stands in its place — one line, same position, same
+    // weight, state carried by colour and dashes.
+    // ONE rule does it, and its selector list has to hold all six forms of "a lane
+    // being dropped into" — both drop hues, and both the open lane and the rail.
+    const swap = rules(SCHEDULE_CSS).find(
+      (r) =>
+        r.body.includes("border-color: transparent") &&
+        r.selectors.includes(".schedule-tv-lane-body.is-drop-legal"),
+    );
+    expect(swap).toBeTruthy();
+    for (const selector of [
+      ".schedule-tv-lane-body.is-drop-legal",
+      ".schedule-tv-lane-body.is-drop-run",
+      ".schedule-tv-rail.is-drop-legal:not(:disabled)",
+      ".schedule-tv-rail.is-drop-run:not(:disabled)",
+      ".prefs-section .schedule-tv-rail.is-drop-legal:not(:disabled)",
+      ".prefs-section .schedule-tv-rail.is-drop-run:not(:disabled)",
+    ]) {
+      expect(swap!.selectors).toContain(selector);
+    }
+    // The border-WIDTH never changes, so nothing shifts by a pixel when a drag
+    // starts: the box the cards sit in is the size it was.
+    expect(swap!.body).not.toContain("border-width");
+    expect(swap!.body).not.toContain("border:");
+    // And the rail's drop states have to OUTRANK its hover rule, which restates
+    // `border-color` because `.prefs-section button:hover` would otherwise paint the
+    // edge accent. Same specificity, so the swap has to come later in the file — or
+    // the hairline returns on exactly the rail the pointer is over.
+    const hover = SCHEDULE_CSS.indexOf(
+      ".prefs-section .schedule-tv-rail:hover:not(:disabled)",
+    );
+    const dropped = SCHEDULE_CSS.indexOf(
+      ".prefs-section .schedule-tv-rail.is-drop-legal:not(:disabled)",
+    );
+    expect(hover).toBeGreaterThan(-1);
+    expect(dropped).toBeGreaterThan(hover);
+    expect(block(SCHEDULE_CSS, ".prefs-section .schedule-tv-rail:hover:not(:disabled)")).toContain(
+      "border-color: var(--border)",
+    );
   });
 
   it("gives the card the reference's breathing room, and the strip follows it", () => {
@@ -1803,15 +1932,46 @@ describe("the status ring's five hues", () => {
       // Not the grey Upcoming took, and not the blue either.
       expect(archive).not.toBe(hues["status-upcoming"]);
       expect(archive).not.toBe(hues["activity"]);
-      // A literal, and a violet: red and blue channels above green, which is what
-      // separates it from yellow/green/red and from a neutral (r == g == b).
+      // A literal, and a ROSE: red leads, and blue stands well clear of green.
       expect(archive).toMatch(/^#[0-9a-f]{6}$/);
-      const [r, g, b] = [1, 3, 5].map((i) => parseInt(archive.slice(i, i + 2), 16));
-      expect(b).toBeGreaterThan(g);
+      const [r, g, b] = channels(archive);
       expect(r).toBeGreaterThan(g);
+      expect(r).toBeGreaterThan(b);
+      // The blue-over-green margin is what separates a rose from a RED: on
+      // --status-failed those two channels are equal, so a warm hue with b == g is
+      // the failed lane wearing a different lightness. It is also what keeps it off
+      // the dull bronze that was tried and lost, which reads as a dimmer In
+      // Progress for exactly the opposite reason (b below g).
+      expect(b - g).toBeGreaterThanOrEqual(25);
       // Low-saturation, so a filed lane never out-shouts a live one: the spread
       // between the strongest and weakest channel stays modest.
       expect(Math.max(r, g, b) - Math.min(r, g, b)).toBeLessThan(90);
+    });
+
+    it(`makes ${theme}'s Archive read as a colour beside Upcoming's grey`, () => {
+      // The one thing the old muted violet got wrong, and the reason this test is
+      // about CHANNELS rather than about the two values differing: #a898cb was a
+      // different string from --fg-muted and still read as barely-tinted grey at
+      // ring size — "quite similar" (Akshil, 2026-08-17). Distinguishable means the
+      // two are far apart in CHROMA, so a reader can tell them apart at a glance and
+      // not merely under a colour picker.
+      const hues = statusHues(selector);
+      // Upcoming is `var(--fg-muted)`, so resolve it: the grey it borrows is the
+      // thing Archive has to be told apart from, not the token's spelling.
+      const grey = channels(paletteHex(selector, "fg-muted"));
+      const archive = channels(hues["status-archived"]);
+      const chroma = (c: number[]) => Math.max(...c) - Math.min(...c);
+      // A near-neutral, as a grey must be — this is what Archive is up against.
+      expect(chroma(grey)).toBeLessThanOrEqual(15);
+      // ...and Archive carries real chroma, several times the grey's. The old violet
+      // cleared this by hue but not by margin, which is why the margin is the pin.
+      expect(chroma(archive)).toBeGreaterThanOrEqual(40);
+      expect(chroma(archive) - chroma(grey)).toBeGreaterThanOrEqual(30);
+      // And it is WARM: at this saturation a cool hue collapses into "cool grey",
+      // which is the mistake being corrected. Red leads on the rose and does not on
+      // the grey (whose channels only ever climb towards blue).
+      expect(archive.indexOf(Math.max(...archive))).toBe(0);
+      expect(grey.indexOf(Math.max(...grey))).toBe(2);
     });
   }
 
@@ -1893,6 +2053,78 @@ describe("the In Progress ring", () => {
     // rule leaves no counterpart behind.
     expect(REDUCED_MOTION_CSS).not.toContain("schedule-ring");
     expect(REDUCED_MOTION_CSS).not.toContain("schedule-tv-pulse");
+  });
+});
+
+// ---- the List row's disclosure -------------------------------------------------
+// isExpandable decides whether a row is an accordion; these are the claims about
+// MARKUP that no unit of pure logic can hold — that the chevron is behind that
+// predicate, that the row keeps everything else it does, and above all that the
+// glyph goes without the GUTTER going. `--tasks-caret-w` is the first term of
+// `--tasks-rail-x`, which every indent on the page is derived from, so a chevron
+// removed by deleting its element takes that row's status ring and the whole rail
+// with it and turns a column of rings into a zigzag.
+
+describe("the one-message row's missing chevron", () => {
+  /** The task row's markup, head to thread. */
+  const ROW = VIEWS.slice(
+    VIEWS.indexOf('className={"tasks-row"'),
+    VIEWS.indexOf("{open && (", VIEWS.indexOf('className={"tasks-row"')),
+  );
+
+  it("puts the glyph behind the predicate and the gutter in front of it", () => {
+    // The SPAN is unconditional — no `{expandable && (` around it — so the gutter is
+    // drawn on every row...
+    expect(ROW).toContain('<span className={"tasks-caret" + (open ? " is-open" : "")}');
+    expect(ROW).not.toMatch(/expandable &&\s*\(?\s*<span className=\{"tasks-caret"/);
+    // ...and only its CONTENTS are conditional.
+    expect(ROW).toContain("{expandable ? ICON_CHEVRON : null}");
+    // The gutter's width is the element's own, not the glyph's, or an empty span
+    // would collapse and undo the whole point.
+    const caret = block(TASKS_CSS, ".tasks-caret");
+    expect(caret).toContain("flex: 0 0 var(--tasks-caret-w)");
+    expect(caret).toContain("width: var(--tasks-caret-w)");
+    // And that is the term every indent is measured from, still.
+    expect(TASKS_CSS).toContain("--tasks-caret-w: 16px");
+    expect(TASKS_CSS).toMatch(
+      /--tasks-rail-x: calc\(\s*var\(--tasks-row-pad\) \+ var\(--tasks-caret-w\) \+ var\(--tasks-row-gap\)/,
+    );
+  });
+
+  it("makes the row unexpandable rather than only chevron-less", () => {
+    // The guard is in the derived value, not in the render: a row in the List's
+    // expanded set that stops being expandable closes, instead of being stuck open
+    // with nothing left to close it.
+    expect(VIEWS).toContain("const expandable = isExpandable(task);");
+    expect(VIEWS).toContain("const open = expandable && requested;");
+    // Both ways in are guarded — the click and the keyboard.
+    expect((ROW.match(/if \(expandable\) onToggle\(\);/g) ?? []).length).toBe(2);
+    // A row with no disclosure does not claim one. `false` would say "collapsed,
+    // press to expand", which is a promise it cannot keep.
+    expect(ROW).toContain("aria-expanded={expandable ? open : undefined}");
+  });
+
+  it("leaves every other thing the row does alone", () => {
+    // Still a focusable control, which is how the keyboard reaches the hover-revealed
+    // actions at all (`.tasks-row:focus-within .tasks-act`).
+    expect(ROW).toContain('role="button"');
+    expect(ROW).toContain("tabIndex={0}");
+    expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-act");
+    // Still the same one gesture that OPENS the conversation, and it is still a
+    // button of its own rather than the row's click — a one-message row keeps it,
+    // and pressing it still goes through the shared performer, so it still clears
+    // the thread on the way out.
+    expect(ROW).toContain("{chat && (");
+    expect(ROW).toContain("openChat(chat)");
+    expect(VIEWS).toContain("const chat = openThreadIntent(task, unread);");
+    expect(VIEWS).toMatch(/const openChat = \(intent: OpenThreadIntent\) => \{[\s\S]*?performOpen\(/);
+    // Its own presence is decided by openThreadIntent — a session, not a message
+    // count — so shortening the thread cannot take the button away.
+    expect(VIEWS).not.toMatch(/\{chat && expandable/);
+    // And the row's own click still opens NOTHING: it toggles, or on a leaf it does
+    // nothing at all. If it ever started opening the chat it would start clearing
+    // unread on a plain click, which is the trap that button exists to avoid.
+    expect(ROW).not.toMatch(/onClick=\{\(\) => \{\s*openChat/);
   });
 });
 
@@ -2226,9 +2458,13 @@ describe("opening a thread, from either view", () => {
     // Marking a whole task read on a press that merely expands it would clear
     // messages nobody has seen. Read off the row div's OWN handlers, so a comment
     // naming the intent cannot make this pass.
-    const gesture = ROW.slice(0, ROW.indexOf('<span className={"tasks-caret"'));
-    expect(gesture).toContain("onClick={onToggle}");
-    expect(gesture).toContain("onToggle();");
+    //
+    // Since 2026-08-17 the toggle is guarded rather than bare — a row with one
+    // message has nothing to expand — which changes what the press does on a leaf
+    // (nothing) but not what it can ever do (open a conversation, silently).
+    const gesture = ROW.slice(0, ROW.indexOf('{/* The disclosure gutter'));
+    expect(gesture).toContain("onClick={() => {");
+    expect((gesture.match(/if \(expandable\) onToggle\(\);/g) ?? []).length).toBe(2);
     expect(gesture).not.toContain("openChat");
     expect(gesture).not.toContain("performOpen");
     expect(gesture).not.toContain("navigateUrl");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -607,24 +607,31 @@ export function taskUnread(
 }
 
 /**
- * What the LEADING slot of a TASK row draws — the counterpart of unreadMarker,
- * in the same column.
+ * What a TASK row says about its whole thread — the counterpart of unreadMarker,
+ * which speaks for one message.
  *
- * The dot moved to the head of every MESSAGE row last round and the task's own
- * unread did not move with it: it stayed a pill at the far right of the row,
- * beside the folder chip, while the dots of its own thread led theirs. One
- * marker in two places, and a rail that started halfway down the task (Akshil,
- * 2026-08-17: "for the tasks you didn't bring this on the left side, only for
- * the messages you brought. This looks odd").
+ * The two are drawn in deliberately different places and registers, and it took
+ * three passes to land there:
  *
- * So it leads too. A count cannot be a bare dot, so the DOT CARRIES THE NUMBER
- * — same hue, filled, grown from a circle into a short pill as the digits need
- * it, and centred on the very column the message dots sit in, so the rail is
- * straight whatever it says. Past the cap it prints "99+": the pill is a
- * marker, not a readout, and a three-digit number in a 16px slot is neither.
+ *   * The dot moved to the head of every MESSAGE row, because a thread is scanned
+ *     down its left edge and a marker at the right end is missed entirely
+ *     (Akshil, 2026-08-16: "on the right hand I missed it").
+ *   * The task's count followed it to the left, so the rail would not start
+ *     halfway down the node.
+ *   * And that was wrong, because the two rows are not the same question. A list
+ *     is scanned for its TITLES, and a number in front of every one of them
+ *     announced the messages before the work they are about — it "breaks the
+ *     reading priority" (Akshil, 2026-08-17).
  *
- * `label` is the accessible name and the tooltip, and it always carries the
- * TRUE count — the cap is a drawing decision, not a rounding of the fact.
+ * So the count trails the title now, in a quiet neutral rather than the dot's
+ * blue. Title leads, total follows, and the visible break between them is the
+ * point: the row is the task, the number is a note about it. The per-message dots
+ * keep the alerting; nothing else needs to.
+ *
+ * Past the cap it prints "99+": the pill is a marker, not a readout, and a
+ * three-digit number in a 16px chip is neither. `label` is the accessible name
+ * and the tooltip, and it always carries the TRUE count — the cap is a drawing
+ * decision, not a rounding of the fact.
  */
 export const UNREAD_COUNT_CAP = 99;
 
@@ -635,8 +642,11 @@ export interface UnreadCount {
   label: string;
 }
 
-/** The task row's leading count, or null when there is nothing unread — in
- * which case the slot is still drawn, empty, exactly as a read message's is. */
+/** The count that trails a task's title, or null when there is nothing unread —
+ * and then nothing is drawn at all. That is the difference from unreadMarker: a
+ * LEADING slot has a column to hold open and so exists even when empty, while a
+ * chip after the words holds nothing open and an empty one would just be a gap
+ * between the title and whatever follows it. */
 export function unreadCount(count: number): UnreadCount | null {
   if (count <= 0) return null;
   return {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -719,6 +719,27 @@ export function threadView(task: Task, loaded?: TaskMessage[]): ThreadView {
   return { messages, more: hidden > 0, hidden };
 }
 
+/**
+ * Whether this task is an ACCORDION at all — i.e. whether expanding it would
+ * reveal anything the row has not already said.
+ *
+ * A thread of one message is not a thread. Expanding it drew exactly one message
+ * row, whose title is the same text the task row above it was already showing, so
+ * the disclosure offered a press that told the reader nothing ("empty task (1 msg
+ * only) should not have dropdown", Akshil, 2026-08-17). A task of ZERO — a pending
+ * one that has never run — is the same case and the same answer.
+ *
+ * Asked of `message_count`, the SERVER's total, and never of the tail this client
+ * happens to be holding. `task.messages` is a preview window (PREVIEW_MESSAGES),
+ * so a busy thread can arrive with a short tail or none at all, and counting what
+ * we hold would call a forty-message task unexpandable. It is the same number
+ * threadView already trusts for "is there more?", so the chevron and the "Show N
+ * more" button under it cannot disagree about how long the thread is.
+ */
+export function isExpandable(task: Task): boolean {
+  return task.message_count > 1;
+}
+
 /** Collapsed by default, so the expanded set is what is OPEN (an empty set is
  * the resting state and needs no seeding from a task list that changes on
  * every poll). */

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -129,10 +129,13 @@
 
    What survives from the boxed treatment is the INTERACTION, deliberately
    ("the input box style copy that"): the same generous vertical padding and hit
-   area a `.field-control` has, the ordinary caret every other field in the app
-   draws, and a focus state you can see. What is dropped is only the chrome —
-   including, since 2026-08-17, the accent rule that used to mark the focused
-   field: a stripe in a gutter of its own is chrome too.
+   area a `.field-control` has, and the ordinary caret every other field in the
+   app draws. What is dropped is all of the chrome — the accent rule that used
+   to mark the focused field (a stripe in a gutter of its own is chrome too),
+   and then the focus WASH that replaced it, because a fill is a box drawn in
+   one colour (Akshil, 2026-08-17: "don't do this background highlight thing for
+   the input fields of title and description"). See the focus block below for
+   what is left doing that job.
 
    Every property below is DECLARED rather than inherited, and every selector
    carries the wrapper class as well as the field's own. deploy.css's
@@ -159,7 +162,11 @@
 .new-task-write .new-task-field {
   font: inherit;
   color: var(--fg);
-  /* No box, in either theme: the card's own --bg-alt shows through. */
+  /* No box and no fill, in either theme and in EVERY state — at rest, on hover
+     and on focus. The card's own --bg-alt shows through, which is what makes the
+     two fields read as one surface rather than as two tinted rectangles sitting
+     on it. Declared here rather than merely omitted, because deploy.css paints
+     `background: var(--bg)` onto any unarmored field in a modal. */
   background: transparent;
   border: none;
   border-radius: 0;
@@ -187,27 +194,35 @@
   color: var(--fg-muted);
 }
 
-/* FOCUS, decided — and it had to be decided, because there is no border left to
-   recolour and a caret alone is not a focus indicator (it is 1px, it blinks, and
-   it is invisible on an empty field with a placeholder).
-   So: a whisper of --ctl-quiet-bg across the whole field, and nothing else. It
-   says WHICH of the two fields has the caret, it covers the full line-box so it
-   is unmissable on either face, and a background means nothing reflows when it
-   appears — an `outline` would ring the field and put the box straight back.
-   There was a 2px accent bar down the left edge here too, drawn in the strip the
-   old negative margin opened; it went with that strip (Akshil, 2026-08-17), so
-   the wash is now the whole signal.
-   `:focus`, not `:focus-visible`: a text field matches :focus-visible on a mouse
-   click anyway (the UA heuristic for anything that takes keyboard input), so the
-   two select the same thing here and the plain one does not read as if the mouse
-   case were an accident. */
+/* FOCUS: the CARET, and deliberately nothing else.
+   The third answer this surface has had, and the quietest one that is still
+   honest. It was a 2px accent bar in a gutter; then a --ctl-quiet-bg wash across
+   the field, on the argument that a borderless field leaves a keyboard user
+   nothing. Both are gone: the bar went with the gutter it hung in, and the wash
+   is a filled box wearing a quieter colour — which is precisely the thing the
+   surface exists not to have (Akshil, 2026-08-17).
+   Nothing replaces it, and that is the decision rather than an omission. A text
+   caret IS the focus indicator for a text field — it is what WCAG 2.4.7 accepts
+   for one, and what every borderless writing surface (Notes, Notion, the
+   reference image this card copies) relies on. Here it is unusually legible: the
+   two fields are the only text inputs on this part of the card, Title is a 20px
+   face, and the form opens with the caret already in it. An `outline` or a ring
+   would put the box straight back, and a second wash-by-another-name would only
+   rename the thing that was removed.
+   `outline: none` is still DECLARED, not left to chance: deploy.css's
+   `.modal-body :where(input…, textarea):focus` already suppresses the UA ring at
+   (0,2,0), so this states the same intent at the specificity the rest of the
+   block is written at instead of depending on another file for it. */
 .new-task-write .new-task-field:focus {
   outline: none;
-  background: var(--ctl-quiet-bg);
 }
 
-/* Forced-colours mode drops the background this focus state is made of, so the
-   one place a ring is the right answer is the one place the wash cannot land. */
+/* …with ONE exception, and the reason it survives the wash's removal: in
+   forced-colours mode the caret is the single cue, drawn by the OS in a palette
+   this stylesheet cannot see or check. A ring is the right answer exactly where
+   the quiet answer cannot be verified, and the system Highlight keyword is the
+   one colour guaranteed to read against a forced background. Inset, so it
+   cannot reopen the gutter. */
 @media (forced-colors: active) {
   .new-task-write .new-task-field:focus {
     outline: 2px solid Highlight;

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -1,8 +1,10 @@
 /* -- New task modal: the parts added by the tasks/threads pass ----------------
  * Everything else the form wears comes from schedule.css (.schedule-form-*,
- * .schedule-when-*). This file holds only what that pass introduced: the two
- * quiet checkboxes (Repeat / New task each run), the optional title row, and
- * the past-time note that used to be a refusal.
+ * .schedule-when-*). This file holds what that pass introduced — the two quiet
+ * checkboxes (Repeat / New task each run) and the past-time note that used to
+ * be a refusal — plus the card's WRITING SURFACE: the borderless title and
+ * description, which moved here from schedule.css when they stopped being
+ * boxed controls (2026-08-17).
  *
  * Imported from NewJobModal.tsx rather than the shell.css barrel, so it lands
  * after schedule.css in the cascade — which is what lets these rules armor
@@ -118,17 +120,106 @@
   color: var(--fg-muted);
 }
 
-/* -- Title -------------------------------------------------------------------
-   FIRST field on the card, and a prominent peer of the ask below it (Akshil,
-   2026-08-17). It is not a row in the icon gutter any more and not a
-   `.field-control`: it wears `.schedule-form-title`, the shared prominence
-   defined in schedule.css, so the 20px face, the weight, the transparent
-   background and the 2px underline are one definition worn by both fields
-   rather than two that can drift apart.
+/* -- The writing surface -----------------------------------------------------
+   Title and description are ONE borderless area, not two controls (Akshil,
+   2026-08-17, reference image): a single continuous surface between the card's
+   header rule and the rows beneath it, the title set large and the description
+   quieter under it. NEITHER field has a border, an underline or a filled box —
+   the point is that the top of the card reads as a document you type into.
 
-   What is left for this file is the ONE thing Title does differently: it is a
-   single line, for ever. Never wraps, never grows, and a 200-character title
-   does not push the folder and time rows off the card.
+   What survives from the boxed treatment is the INTERACTION, deliberately
+   ("the input box style copy that"): the same generous padding and hit area a
+   `.field-control` has, the same caret, and a focus state you can see. What is
+   dropped is only the chrome.
+
+   Every property below is DECLARED rather than inherited, and every selector
+   carries the wrapper class as well as the field's own. deploy.css's
+   `.modal-body :where(input…, textarea)` block paints a background, a border, a
+   radius and a padding onto any unarmored field in a modal, and it has the same
+   one-class specificity as a bare `.new-task-field` would — so these rules win
+   on specificity (0,2,0) rather than on import order.
+
+   Both themes come from tokens.css, so there is one set of rules here. */
+
+.new-task-write {
+  display: flex;
+  flex-direction: column;
+  /* Tight, and tighter than the form's own 12px rhythm: the description hangs
+     off the title as its second line, not as the next row of a form. */
+  gap: 2px;
+  /* The block's vertical space belongs to the two fields, and the description
+     is the one that stretches into whatever is spare (see .new-task-ask). */
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* The shared half: the surface, the hit area and the caret. */
+.new-task-write .new-task-field {
+  font: inherit;
+  color: var(--fg);
+  /* No box, in either theme: the card's own --bg-alt shows through. */
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
+  /* The hit area a `.field-control` has (7px 10px), kept — a borderless field
+     still has to be easy to click into. The horizontal padding is cancelled by
+     an equal negative margin so the TEXT stays flush with the card's 16px
+     gutter (the header title and the rows below it hang off the same line)
+     while the clickable box reaches out past it. The negative margin is also
+     what puts the focus bar below in the gutter rather than over the text. */
+  padding: 6px 10px;
+  margin-inline: -10px;
+  /* Both fields are stretched flex children, but an <input> carries an
+     intrinsic `size` width that would otherwise fight a 460px card. */
+  min-width: 0;
+  width: auto;
+  /* The accent caret is half of the "you are typing here" signal; the bar in
+     the :focus rule below is the half that a keyboard user can actually see. */
+  caret-color: var(--accent);
+}
+
+.new-task-write .new-task-field::placeholder {
+  color: var(--fg-muted);
+}
+
+/* FOCUS, decided — and it had to be decided, because there is no border left to
+   recolour and a caret alone is not a focus indicator (it is 1px, it blinks, and
+   it is invisible on an empty field with a placeholder).
+   So: a 2px accent bar down the field's left edge, sitting in the 10px gutter
+   the negative margin opens up, plus a whisper of --ctl-quiet-bg across the
+   field. An editor's active-block marker rather than a form control's ring: it
+   says WHICH of the two fields has the caret, it is full-height so it is
+   unmissable on either face, and the accent against --bg-alt clears 3:1 in both
+   themes. Drawn with an inset box-shadow and a background, so nothing reflows
+   when it appears — an `outline` would ring the whole field and put the box
+   straight back.
+   `:focus`, not `:focus-visible`: a text field matches :focus-visible on a mouse
+   click anyway (the UA heuristic for anything that takes keyboard input), so the
+   two select the same thing here and the plain one does not read as if the mouse
+   case were an accident. */
+.new-task-write .new-task-field:focus {
+  outline: none;
+  background: var(--ctl-quiet-bg);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
+/* A box-shadow is dropped in forced-colours mode, so the one place a ring is the
+   right answer is the one place the bar cannot be drawn. */
+@media (forced-colors: active) {
+  .new-task-write .new-task-field:focus {
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
+}
+
+/* -- Title -------------------------------------------------------------------
+   FIRST field on the card and the large one (Akshil, 2026-08-17). It is not a
+   row in the icon gutter and not a `.field-control`.
+
+   The ONE thing Title does differently from the ask: it is a single line, for
+   ever. Never wraps, never grows, and a 200-character title does not push the
+   folder and time rows off the card.
 
    OVERFLOW, decided: the value SCROLLS horizontally under the caret while the
    field has focus — that is the native <input> behaviour and the only one that
@@ -139,27 +230,53 @@
    already forces `overflow: clip` on a text input — measured: the computed
    value is `clip`, not the `hidden` declared here — so this declaration is
    belt-and-braces for engines that do not, not the thing doing the work.)
-   Measured at 200 characters in both themes: height 41px either way, scrollLeft
-   2558 while focused and 0 once blurred, and the card the same 373px tall as
-   with a one-word title.
-
-   Every property is declared, not inherited: this file lands after deploy.css's
-   `.modal-body :where(input…, textarea)` block, which is the same specificity
-   and would otherwise repaint an unarmored input back into a boxed control.
 
    (There used to be a second row in this section too, a
    "Description (optional)" textarea — .new-task-desc / .new-task-desc-line —
    and its rules went with it: the big field IS the description, so there is no
    third piece of prose to style.) */
-.new-task-title {
+.new-task-write .new-task-title {
+  font-size: 20px;
+  font-weight: 500;
+  line-height: 1.35;
   /* One line. `pre` rather than `nowrap` so a pasted value's own spacing is not
      collapsed on the way in — an <input> strips the newlines either way. */
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
-  /* No autogrow and no drag-grow: the height is one line of the shared 20px
-     face plus the shared padding, and it never changes. */
+  /* No autogrow and no drag-grow: the height is one line of the 20px face plus
+     the shared padding, and it never changes. */
   resize: none;
+  flex: none;
+}
+
+/* -- The ask -----------------------------------------------------------------
+   SECOND, and deliberately quieter than the title: smaller face, book weight,
+   ordinary line height. It is the longer piece of writing of the two, so it
+   reads as body text under a heading — which is also what stops two 20px fields
+   from shouting at each other in a 460px card.
+
+   It GROWS like a note: JS sets height from scrollHeight on every change
+   (NewJobModal), and the two clamps here bound it at both ends. The FLOOR is
+   what keeps the card from being top-heavy — the description owns the slack in
+   the block, so a two-word entry still shows a surface to write on rather than a
+   single line under a big title. The CEILING is what keeps a long brief from
+   shoving the when/where rows off the card (Akshil, 2026-08-15); past it, it
+   scrolls. Both clamp the inline height JS writes, so the measured value only
+   ever picks a size between them. */
+.new-task-write .new-task-ask {
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 1.55;
+  resize: none;
+  overflow-wrap: anywhere;
+  /* Six lines of the 14px face plus the shared padding: the block the reference
+     image gives the description, and the slack it takes. */
+  min-height: calc(14px * 1.55 * 6 + 12px);
+  /* Ten, then it scrolls. */
+  max-height: calc(14px * 1.55 * 10 + 12px);
+  overflow-y: auto;
+  flex: 1 1 auto;
 }
 
 /* -- The past-time note ------------------------------------------------------

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -128,9 +128,11 @@
    the point is that the top of the card reads as a document you type into.
 
    What survives from the boxed treatment is the INTERACTION, deliberately
-   ("the input box style copy that"): the same generous padding and hit area a
-   `.field-control` has, the same caret, and a focus state you can see. What is
-   dropped is only the chrome.
+   ("the input box style copy that"): the same generous vertical padding and hit
+   area a `.field-control` has, the ordinary caret every other field in the app
+   draws, and a focus state you can see. What is dropped is only the chrome —
+   including, since 2026-08-17, the accent rule that used to mark the focused
+   field: a stripe in a gutter of its own is chrome too.
 
    Every property below is DECLARED rather than inherited, and every selector
    carries the wrapper class as well as the field's own. deploy.css's
@@ -153,7 +155,7 @@
   min-height: 0;
 }
 
-/* The shared half: the surface, the hit area and the caret. */
+/* The shared half: the surface and the hit area. */
 .new-task-write .new-task-field {
   font: inherit;
   color: var(--fg);
@@ -162,21 +164,23 @@
   border: none;
   border-radius: 0;
   box-shadow: none;
-  /* The hit area a `.field-control` has (7px 10px), kept — a borderless field
-     still has to be easy to click into. The horizontal padding is cancelled by
-     an equal negative margin so the TEXT stays flush with the card's 16px
-     gutter (the header title and the rows below it hang off the same line)
-     while the clickable box reaches out past it. The negative margin is also
-     what puts the focus bar below in the gutter rather than over the text. */
-  padding: 6px 10px;
-  margin-inline: -10px;
+  /* VERTICAL padding only, and no negative margin cancelling a horizontal one:
+     the surface starts FLUSH with the card's 16px gutter, on the line the header
+     title and the rows below already hang off. It used to be `6px 10px` pulled
+     back by `margin-inline: -10px`, which bought a hit area reaching past the
+     gutter and a strip to draw a focus bar in — and read as a left gutter
+     nothing else on the card has (Akshil, 2026-08-17). The click target is
+     unharmed: both fields are stretched flex children, so the box still spans
+     the whole content column.
+
+     No `caret-color` either. The caret takes `color` — var(--fg) above — which
+     is what every other field in the app gets, `.field-control` included; the
+     --accent override drew a yellow-green cursor found nowhere else. */
+  padding: 6px 0;
   /* Both fields are stretched flex children, but an <input> carries an
      intrinsic `size` width that would otherwise fight a 460px card. */
   min-width: 0;
   width: auto;
-  /* The accent caret is half of the "you are typing here" signal; the bar in
-     the :focus rule below is the half that a keyboard user can actually see. */
-  caret-color: var(--accent);
 }
 
 .new-task-write .new-task-field::placeholder {
@@ -186,14 +190,13 @@
 /* FOCUS, decided — and it had to be decided, because there is no border left to
    recolour and a caret alone is not a focus indicator (it is 1px, it blinks, and
    it is invisible on an empty field with a placeholder).
-   So: a 2px accent bar down the field's left edge, sitting in the 10px gutter
-   the negative margin opens up, plus a whisper of --ctl-quiet-bg across the
-   field. An editor's active-block marker rather than a form control's ring: it
-   says WHICH of the two fields has the caret, it is full-height so it is
-   unmissable on either face, and the accent against --bg-alt clears 3:1 in both
-   themes. Drawn with an inset box-shadow and a background, so nothing reflows
-   when it appears — an `outline` would ring the whole field and put the box
-   straight back.
+   So: a whisper of --ctl-quiet-bg across the whole field, and nothing else. It
+   says WHICH of the two fields has the caret, it covers the full line-box so it
+   is unmissable on either face, and a background means nothing reflows when it
+   appears — an `outline` would ring the field and put the box straight back.
+   There was a 2px accent bar down the left edge here too, drawn in the strip the
+   old negative margin opened; it went with that strip (Akshil, 2026-08-17), so
+   the wash is now the whole signal.
    `:focus`, not `:focus-visible`: a text field matches :focus-visible on a mouse
    click anyway (the UA heuristic for anything that takes keyboard input), so the
    two select the same thing here and the plain one does not read as if the mouse
@@ -201,11 +204,10 @@
 .new-task-write .new-task-field:focus {
   outline: none;
   background: var(--ctl-quiet-bg);
-  box-shadow: inset 2px 0 0 var(--accent);
 }
 
-/* A box-shadow is dropped in forced-colours mode, so the one place a ring is the
-   right answer is the one place the bar cannot be drawn. */
+/* Forced-colours mode drops the background this focus state is made of, so the
+   one place a ring is the right answer is the one place the wash cannot land. */
 @media (forced-colors: active) {
   .new-task-write .new-task-field:focus {
     outline: 2px solid Highlight;
@@ -256,6 +258,14 @@
    reads as body text under a heading — which is also what stops two 20px fields
    from shouting at each other in a 460px card.
 
+   13px, which is not a size picked for this card: it is the repo's BODY size —
+   what `.field-control` sets for every field in the app, and what the two
+   checkboxes and the rows further down this same form already use. So the pair
+   reads as 20px heading over body copy, and the description is the same face as
+   the facts beneath it rather than a third size of its own. It was 14px, one
+   step off the title and close enough that the two looked like one field set
+   twice (Akshil, 2026-08-17).
+
    It GROWS like a note: JS sets height from scrollHeight on every change
    (NewJobModal), and the two clamps here bound it at both ends. The FLOOR is
    what keeps the card from being top-heavy — the description owns the slack in
@@ -265,16 +275,16 @@
    scrolls. Both clamp the inline height JS writes, so the measured value only
    ever picks a size between them. */
 .new-task-write .new-task-ask {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 400;
   line-height: 1.55;
   resize: none;
   overflow-wrap: anywhere;
-  /* Six lines of the 14px face plus the shared padding: the block the reference
+  /* Six lines of the 13px face plus the shared padding: the block the reference
      image gives the description, and the slack it takes. */
-  min-height: calc(14px * 1.55 * 6 + 12px);
+  min-height: calc(13px * 1.55 * 6 + 12px);
   /* Ten, then it scrolls. */
-  max-height: calc(14px * 1.55 * 10 + 12px);
+  max-height: calc(13px * 1.55 * 10 + 12px);
   overflow-y: auto;
   flex: 1 1 auto;
 }

--- a/frontend/src/styles/new-task.css
+++ b/frontend/src/styles/new-task.css
@@ -119,13 +119,48 @@
 }
 
 /* -- Title -------------------------------------------------------------------
-   One optional row under the ask, a plain field-control in the icon gutter
-   every other row hangs from.
+   FIRST field on the card, and a prominent peer of the ask below it (Akshil,
+   2026-08-17). It is not a row in the icon gutter any more and not a
+   `.field-control`: it wears `.schedule-form-title`, the shared prominence
+   defined in schedule.css, so the 20px face, the weight, the transparent
+   background and the 2px underline are one definition worn by both fields
+   rather than two that can drift apart.
 
-   There used to be a second row here, a "Description (optional)" textarea
-   (.new-task-desc / .new-task-desc-line), and its rules went with it: the big
-   field IS the description now (Akshil, 2026-08-17), so there is no second
-   piece of prose to style. */
+   What is left for this file is the ONE thing Title does differently: it is a
+   single line, for ever. Never wraps, never grows, and a 200-character title
+   does not push the folder and time rows off the card.
+
+   OVERFLOW, decided: the value SCROLLS horizontally under the caret while the
+   field has focus — that is the native <input> behaviour and the only one that
+   lets you edit the far end of a long title — and ELLIPSES when focus leaves,
+   so a title too long to show says so instead of appearing to end mid-word.
+   `text-overflow` is what buys the second half, and it only takes effect on an
+   unfocused input, which is exactly the split we want. (Chrome's UA sheet
+   already forces `overflow: clip` on a text input — measured: the computed
+   value is `clip`, not the `hidden` declared here — so this declaration is
+   belt-and-braces for engines that do not, not the thing doing the work.)
+   Measured at 200 characters in both themes: height 41px either way, scrollLeft
+   2558 while focused and 0 once blurred, and the card the same 373px tall as
+   with a one-word title.
+
+   Every property is declared, not inherited: this file lands after deploy.css's
+   `.modal-body :where(input…, textarea)` block, which is the same specificity
+   and would otherwise repaint an unarmored input back into a boxed control.
+
+   (There used to be a second row in this section too, a
+   "Description (optional)" textarea — .new-task-desc / .new-task-desc-line —
+   and its rules went with it: the big field IS the description, so there is no
+   third piece of prose to style.) */
+.new-task-title {
+  /* One line. `pre` rather than `nowrap` so a pasted value's own spacing is not
+     collapsed on the way in — an <input> strips the newlines either way. */
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* No autogrow and no drag-grow: the height is one line of the shared 20px
+     face plus the shared padding, and it never changes. */
+  resize: none;
+}
 
 /* -- The past-time note ------------------------------------------------------
    Was a refusal in the error voice; scheduling into the past is now a

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2303,7 +2303,7 @@ input.schedule-when-field {
    Bordered circle, hue by column, and an inner dot on the terminal state so
    "done" is legible without colour (flow StatusIcon). The five hues are
    styles/tokens.css's `--status-*`; two of them moved on 2026-08-17 (Upcoming to
-   grey, Archive to a muted violet) and the reasoning lives with the tokens,
+   grey, Archive to a dusty rose) and the reasoning lives with the tokens,
    because the ring is only one of the places they are worn. */
 .schedule-ring {
   position: relative;
@@ -2799,22 +2799,29 @@ input.schedule-when-field {
    this board against flow's side by side — there the lanes are transparent and
    the cards are the only surface).
 
-   So the fill is gone and nothing replaced it: the board's 12px `gap` and the
-   cards' own edges are what make four columns read as four columns. No hairline
-   rule between them either — tried the gap alone first, as asked, and the column
-   of card edges is already a stronger vertical than a 1px line would be.
+   So the FILL is gone and nothing filled in for it — but the lane is still
+   BOUNDED ("at least they should have an outline when they're expanded", Akshil,
+   2026-08-17). Unfilled and unbounded, an open lane's only edge was the ragged
+   right-hand end of whatever card happened to be widest, so the column had no
+   bottom at all and a short lane beside a full one read as loose cards on the
+   page. A hairline answers that without putting the plate back: an outline says
+   where the column is, a fill says the column is a surface, and only the second
+   one was ever competing with the cards.
 
-   What the padding and the radius are still for is the DROP states below, which
-   are the only things this element ever paints. `padding` insets the dashed
-   legal-drop outline off the cards so it reads as the lane's edge rather than as
-   a second border on the top card; the radius is the shape the `is-drop-over`
-   wash takes. Both are dead geometry at rest, which is the point.
+   Deliberately the SAME hairline the collapsed rail wears — 1px, `--border`, and
+   the 8px radius this element already had for the drop wash — so the two forms of
+   a lane read as one family and not as two ideas about what a lane's edge is. The
+   rail's is doing extra work (it is a button you press), but it is the same line.
 
-   An EMPTY lane therefore shows its header and nothing else — the label, the
-   ring and a `0`. That is deliberate: "nothing scheduled" should look like
-   nothing, and the header is what says which column the nothing belongs to. The
-   `min-height` is what keeps the empty lane a droppable target anyway, so a card
-   can still be dragged into a column that has never held one. */
+   What the padding is for, on top of insetting the cards off that new edge, is
+   the DROP states below: it holds the dashed legal-drop outline off the top card
+   so it reads as the lane's own edge rather than as a second border on the card.
+
+   An EMPTY lane therefore shows its header and an empty bounded column — the
+   label, the ring, a `0` and the box the cards would go in. That is still
+   "nothing scheduled looks like nothing": an empty outline is not a filled slab.
+   The `min-height` is what keeps it a droppable target, so a card can still be
+   dragged into a column that has never held one. */
 .schedule-tv-lane-body {
   flex: 1 1 auto;
   min-height: 120px;
@@ -2825,12 +2832,19 @@ input.schedule-when-field {
      rather than as separate objects, which is half of what made the lane look
      like a panel full of rows. */
   gap: 8px;
+  /* Stated with the border, as everywhere else on this page: the width is safe
+     either way (a stretched flex item fits its margin box to the 260px lane, so
+     the edge lands inside), but `min-height` below is not — content-box would
+     make the floor 122px and the number here would stop being the number the
+     board actually has. */
+  box-sizing: border-box;
   padding: 4px;
+  border: 1px solid var(--border);
   border-radius: 8px;
 }
 
-/* The card is the board's ONLY surface now that the lane paints nothing, so it
-   has to carry the whole separation from the page ground on its own — and the
+/* The card is the board's ONLY surface now that the lane is an outline rather than
+   a plate, so it has to carry the whole separation from the page ground — and the
    ground is `--bg` in both themes (base.css `body`), which is exactly what the
    card used to be painted in. Against a lane fill that was enough; against the
    page it was the card disappearing, most obviously in light mode where both are
@@ -2885,14 +2899,26 @@ input.schedule-when-field {
    dropdowns speak. The card left behind ghosts.
 
    None of this depended on the lane's resting fill, which is why removing that
-   fill above cost the drop nothing. A drop target announces itself by ADDING
-   paint to an empty box, never by changing paint it was already wearing: legal
-   lanes take a dashed accent outline the moment a drag starts, the lane under
-   the pointer fills with the accent wash, and the one drop that is not filing
-   (Upcoming → In Progress, which sends) swaps the outline for `--activity` and
-   writes the sentence out (tasks.css `.is-drop-run` / `.tasks-run-hint`). All
-   three go from nothing to something, so they are more legible on a transparent
-   lane than they were on a tinted one. */
+   fill cost the drop nothing. A drop target announces itself by ADDING paint to
+   an unfilled box: legal lanes take a dashed accent outline the moment a drag
+   starts, the lane under the pointer fills with the accent wash, and the one drop
+   that is not filing (Upcoming → In Progress, which sends) swaps the outline for
+   `--activity` and writes the sentence out (tasks.css `.is-drop-run` /
+   `.tasks-run-hint`). The wash and the sentence still go from nothing to
+   something, so they are more legible on an unfilled lane than on a tinted one.
+
+   The dashed OUTLINE is the one thing the lane's new hairline changed. It is drawn
+   at `outline-offset: -1px`, i.e. exactly where that hairline now is, so left
+   alone the two stack into a single muddy 2px edge that is half grey and half
+   accent — legible as "thicker", not as "here". So a lane being dropped into
+   takes its own hairline to `transparent` for as long as the drag lasts and the
+   dashed accent line stands in its place: one line either way, in the same
+   position and at the same weight, and the STATE is read off its colour and its
+   dashes rather than off a second concentric line. Nothing moves — the border is
+   still 1px, so the box is the size it was — and the added paint is still what
+   carries the signal; the resting line only steps out of its way.
+
+   Both forms of the lane do this, because both wear the hairline now. */
 .schedule-tv-board .schedule-tv-card.is-draggable,
 .prefs-section .schedule-tv-board .schedule-tv-card.is-draggable {
   cursor: grab;
@@ -3041,12 +3067,14 @@ input.schedule-when-field {
    nobody opens this page to read — and clicking the rail opens it again.
 
    Its resting fill went with the open lane's on 2026-08-17: a rail is a lane, and
-   leaving one lane painted as a slab beside four transparent ones would have made
-   the collapsed column the loudest thing on the board. The hairline stays, and it
-   is doing more work here than on the open lane — the rail is a BUTTON you press
-   to expand, so it has to look like an object rather than a strip of page. Hover
-   still fills (`--row-bg-hover` below), and so do the drop states, which is the
-   same "add paint to an empty box" the lane body relies on. */
+   leaving one lane painted as a slab beside four unfilled ones would have made the
+   collapsed column the loudest thing on the board. The hairline stayed — and later
+   the same day the open lane grew the identical one, so the pair now read as one
+   family: 1px, `--border`, 8px radius, unfilled, in both forms. It is still doing
+   more work here, because the rail is a BUTTON you press to expand and has to look
+   like an object rather than a strip of page; it is the same line either way.
+   Hover fills (`--row-bg-hover` below) and so does the drop wash, which is the
+   same "add paint to an unfilled box" the lane body relies on. */
 .schedule-tv-rail,
 .prefs-section .schedule-tv-rail {
   display: flex;
@@ -3067,10 +3095,32 @@ input.schedule-when-field {
   transition: background-color 0.08s ease;
 }
 
+/* `border-color` is restated here and it is NOT redundant: `.prefs-section
+   button:hover:not(:disabled)` (preferences.css) paints an accent border on any
+   unarmored button on this page, so a hover rule that only set the background
+   would let the rail's edge go accent on hover. It states its own colour, per the
+   page's house rule. */
 .schedule-tv-rail:hover:not(:disabled),
 .prefs-section .schedule-tv-rail:hover:not(:disabled) {
   background: var(--row-bg-hover);
   border-color: var(--border);
+}
+
+/* The hairline gets out of the dashed drop outline's way — see the drag note
+   above, where the reasoning lives. Both forms of the lane, one rule.
+
+   It sits AFTER the hover rule above, and the rail's selectors carry that rule's
+   `:not(:disabled)`, on purpose: hover restates `border-color` (it has to, see
+   above) at the same specificity, so a drop state written any shorter or any
+   earlier would be undone on precisely the rail the pointer is over — the one
+   being dropped into. The lane body has no hover rule and needs neither. */
+.schedule-tv-lane-body.is-drop-legal,
+.schedule-tv-lane-body.is-drop-run,
+.schedule-tv-rail.is-drop-legal:not(:disabled),
+.schedule-tv-rail.is-drop-run:not(:disabled),
+.prefs-section .schedule-tv-rail.is-drop-legal:not(:disabled),
+.prefs-section .schedule-tv-rail.is-drop-run:not(:disabled) {
+  border-color: transparent;
 }
 
 .schedule-tv-rail-label {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1107,10 +1107,12 @@
    must not read as the default press — which rules out .btn-primary and is why
    nothing here touches the resting box at all.
 
-   The hue arrives only under the pointer, and it is the same "upcoming" blue
+   The hue arrives only under the pointer, and it is the same `--activity` blue
    tasks.css gives `.tasks-act--run`, at the same 12%/32% mixes: one action, one
    colour, across List, Board and Calendar. Blue rather than Cancel's red because
-   this one starts work instead of withdrawing it.
+   this one starts work instead of withdrawing it — and `--activity` rather than
+   `--status-upcoming` since 2026-08-17, when Upcoming went grey and the blue was
+   renamed for the job it was actually doing.
 
    Properties are named individually — never `transition: all`, which would also
    animate the border-colour a hover skin sets and leave the edge lagging behind
@@ -1127,9 +1129,9 @@
 
 .schedule-cal-pop-run:hover:not(:disabled),
 .prefs-section .schedule-cal-pop-run:hover:not(:disabled) {
-  color: var(--status-upcoming);
-  background: color-mix(in srgb, var(--status-upcoming) 12%, transparent);
-  border-color: color-mix(in srgb, var(--status-upcoming) 32%, transparent);
+  color: var(--activity);
+  background: color-mix(in srgb, var(--activity) 12%, transparent);
+  border-color: color-mix(in srgb, var(--activity) 32%, transparent);
 }
 
 /* The recurring rule's own pill (list view) and a projected run's (popover). */
@@ -2299,7 +2301,10 @@ input.schedule-when-field {
 
 /* -- The status ring — the vocabulary both views are read by ------------------
    Bordered circle, hue by column, and an inner dot on the terminal state so
-   "done" is legible without colour (flow StatusIcon). */
+   "done" is legible without colour (flow StatusIcon). The five hues are
+   styles/tokens.css's `--status-*`; two of them moved on 2026-08-17 (Upcoming to
+   grey, Archive to a muted violet) and the reasoning lives with the tokens,
+   because the ring is only one of the places they are worn. */
 .schedule-ring {
   position: relative;
   display: inline-block;
@@ -2337,18 +2342,23 @@ input.schedule-when-field {
   background: currentColor;
 }
 
-/* Work happening NOW is the one state that moves. Motion-safe: the pulse is
-   decoration, and reduced-motion users get the hue alone. */
+/* The In Progress ring is STATIC yellow. It used to breathe on a 2s loop, and
+   that was one blink too many (Akshil, 2026-08-17): the lane is a column of
+   them, so a full board flickered, and the ring already says "in progress" by
+   being the only yellow one on the page. The one thing still allowed to move is
+   the live ping below — that is a single mark on the handful of tasks with a turn
+   actually in flight, which is a fact about right now rather than a lane.
+   Nothing to undo in styles/reduced-motion.css: that file never named this
+   animation (its blanket `animation-duration: 0.01ms` covered it), so removing
+   the rule leaves nothing dangling. */
 @keyframes schedule-tv-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.45; }
 }
 
+/* Motion-safe: the ping's halo is decoration, and reduced-motion users get the
+   solid dot alone. */
 @media (prefers-reduced-motion: no-preference) {
-  .schedule-ring--in_progress {
-    animation: schedule-tv-pulse 2s ease-in-out infinite;
-  }
-
   .schedule-tv-pulse::before {
     animation: schedule-tv-pulse 1.6s ease-in-out infinite;
   }
@@ -2368,7 +2378,7 @@ input.schedule-when-field {
   content: "";
   position: absolute;
   border-radius: 999px;
-  background: var(--status-upcoming);
+  background: var(--activity);
 }
 
 .schedule-tv-pulse::before {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2874,6 +2874,19 @@ input.schedule-when-field {
   min-width: 0;
 }
 
+/* Title and its unread count on one line, the count trailing. `flex-wrap` is
+   the whole point: the title below is a clamp that HIDES its overflow, so the
+   count can never live inside it — a two-line title would eat it. Out here it
+   drops to its own line instead of disappearing. `align-items: flex-end` keeps
+   it sitting with the title's last line rather than floating beside line one. */
+.schedule-tv-card-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
 .schedule-tv-card-title {
   font-size: 12.5px;
   line-height: 1.35;
@@ -2882,6 +2895,7 @@ input.schedule-when-field {
   -webkit-box-orient: vertical;
   overflow: hidden;
   overflow-wrap: anywhere;
+  min-width: 0;
 }
 
 .schedule-tv-card-next {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2867,6 +2867,17 @@ input.schedule-when-field {
   outline-offset: -1px;
 }
 
+/* The card's id line. Its status ring became CONDITIONAL on 2026-08-17: the lane
+   header directly above already carries that lane's ring, so on a card whose status
+   IS its lane the ring only repeated a mark the column had just made. It is still
+   drawn where the two disagree — a `failed` task filed under Done, whose header
+   says nothing about the failure — and which cards those are is decided in
+   ScheduleTaskViews.TaskCard, not here.
+
+   The `gap` therefore has up to three things to space, and the height this line has
+   to keep — the same with a ring in it as without, or a lane of cards jitters by
+   the width of a glyph — is tasks.css's `--tasks-card-head-h`, stated there because
+   the action strip that depends on it is defined there. */
 .schedule-tv-card-head {
   display: flex;
   align-items: center;

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1180,9 +1180,18 @@
 }
 
 /* -- New task modal: Google Calendar's event card ------------------------------
-   A big borderless title, icon-led rows, everything else behind More options.
-   The title underlines on focus the way Google's does — the field reads as a
-   place to type, not a boxed form control. */
+   Two big borderless fields, then icon-led rows, then everything else behind
+   More options. Both big fields underline on focus the way Google's title does
+   — they read as places to type, not as boxed form controls.
+
+   `.schedule-form-title` is the SHARED prominence, worn by both of the two
+   fields that matter: Title (first, an <input>) and the ask/description
+   (second, a <textarea>). It was one field's class; it is a vocabulary now
+   (Akshil, 2026-08-17: "the first field CSS should be similar for the title and
+   the description field because both of them are important"). What differs
+   between the two is only how they handle a long value, and that is why the
+   element-qualified blocks below exist rather than a second class: one line vs
+   many is a property of the ELEMENT each field is. */
 
 .schedule-form-title {
   font: inherit;
@@ -1195,13 +1204,21 @@
   border-bottom: 1px solid var(--border);
   border-radius: 0;
   padding: 4px 2px 8px;
+  /* Both fields are direct children of the column-flex .schedule-form, so
+     `align-items: stretch` gives them the card's width — but an <input> carries
+     an intrinsic `size` width that would otherwise fight a narrow card. */
+  min-width: 0;
+}
+
+/* The ask only: it GROWS like a note. JS sets height from scrollHeight on every
+   change, up to five lines of the 20px face, then it scrolls — the cap is what
+   keeps a long brief from shoving the when/where rows off the card (Akshil,
+   2026-08-15). The face came DOWN from 24px: at 24 the description shouted over
+   every other row in a 460px card (audit 2026-08-16), and the calc has to
+   follow it. `resize: none` because the grow is measured, not dragged. */
+textarea.schedule-form-title {
   resize: none;
   overflow-wrap: anywhere;
-  /* Grows with the text (JS sets height from scrollHeight) to five lines of
-     the 20px face, then scrolls — the cap is what keeps a long brief from
-     shoving the when/where rows off the card (Akshil, 2026-08-15). The face
-     came DOWN from 24px: at 24 the description shouted over every other row
-     in a 460px card (audit 2026-08-16), and the calc has to follow it. */
   max-height: calc(20px * 1.35 * 5 + 14px);
   overflow-y: auto;
 }

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -471,9 +471,9 @@
 
 /* -- The chip: one task, one day ------------------------------------------------
    A coloured bar plus a tint of the same colour, not a solid fill: the colour
-   here identifies the TASK (eight hues, --task-c0…7, indexed off the task key),
-   and eight solid fills would each need their own readable text colour in two
-   themes. A bar and a wash keep the text at --fg throughout, so a hue only has
+   here identifies the PROJECT the task belongs to (eight hues, --task-c0…7,
+   indexed off the task's folder by schedule-lib.taskColour), and eight solid
+   fills would each need their own readable text colour in two themes. A bar and a wash keep the text at --fg throughout, so a hue only has
    to be distinguishable — which is what it is for.
 
    FIXED one line tall, always. A message has a start time and no duration, so
@@ -1180,59 +1180,19 @@
 }
 
 /* -- New task modal: Google Calendar's event card ------------------------------
-   Two big borderless fields, then icon-led rows, then everything else behind
-   More options. Both big fields underline on focus the way Google's title does
-   — they read as places to type, not as boxed form controls.
+   One borderless writing surface (title + description), then icon-led rows,
+   then everything else behind More options.
 
-   `.schedule-form-title` is the SHARED prominence, worn by both of the two
-   fields that matter: Title (first, an <input>) and the ask/description
-   (second, a <textarea>). It was one field's class; it is a vocabulary now
-   (Akshil, 2026-08-17: "the first field CSS should be similar for the title and
-   the description field because both of them are important"). What differs
-   between the two is only how they handle a long value, and that is why the
-   element-qualified blocks below exist rather than a second class: one line vs
-   many is a property of the ELEMENT each field is. */
+   The writing surface itself lives in new-task.css (`.new-task-write` and the
+   two `.new-task-field`s inside it) rather than here: it is no longer a
+   "form title" that the schedule page shares, it is the New task card's own
+   top block, and every property it needs has to be declared in a file that
+   lands after deploy.css's `.modal-body :where(input…, textarea)` block. What
+   used to be `.schedule-form-title` in this file went with it (Akshil,
+   2026-08-17: neither field looks like an input any more, so there is no
+   underline and no shared box left to define).
 
-.schedule-form-title {
-  font: inherit;
-  font-size: 20px;
-  font-weight: 500;
-  line-height: 1.35;
-  color: var(--fg);
-  background: transparent;
-  border: none;
-  border-bottom: 1px solid var(--border);
-  border-radius: 0;
-  padding: 4px 2px 8px;
-  /* Both fields are direct children of the column-flex .schedule-form, so
-     `align-items: stretch` gives them the card's width — but an <input> carries
-     an intrinsic `size` width that would otherwise fight a narrow card. */
-  min-width: 0;
-}
-
-/* The ask only: it GROWS like a note. JS sets height from scrollHeight on every
-   change, up to five lines of the 20px face, then it scrolls — the cap is what
-   keeps a long brief from shoving the when/where rows off the card (Akshil,
-   2026-08-15). The face came DOWN from 24px: at 24 the description shouted over
-   every other row in a 460px card (audit 2026-08-16), and the calc has to
-   follow it. `resize: none` because the grow is measured, not dragged. */
-textarea.schedule-form-title {
-  resize: none;
-  overflow-wrap: anywhere;
-  max-height: calc(20px * 1.35 * 5 + 14px);
-  overflow-y: auto;
-}
-
-.schedule-form-title:focus {
-  outline: none;
-  border-bottom-color: var(--accent);
-}
-
-.schedule-form-title::placeholder {
-  color: var(--fg-muted);
-}
-
-/* One icon-led row: the icon column is fixed so rows align, like the popover's
+   One icon-led row: the icon column is fixed so rows align, like the popover's
    fact rows — the modal and the popover describe the same object. */
 .schedule-form-line {
   display: flex;
@@ -1296,12 +1256,9 @@ textarea.schedule-form-title {
 }
 
 /* Reference-card refinements (Akshil, 2026-08-14, Google new-event screenshot):
-   thick accent bar under the title, quiet text-like controls that surface on
-   hover, a pill Save. */
-
-.schedule-form-title {
-  border-bottom-width: 2px;
-}
+   quiet text-like controls that surface on hover, a pill Save. (The thick accent
+   bar this section used to put under the title is gone with the box — see the
+   note above.) */
 
 /* Controls stay VISIBLY controls. The first pass borrowed Google's
    text-until-hovered treatment and it read as "not an input" (Akshil,

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2792,41 +2792,89 @@ input.schedule-when-field {
   color: var(--fg-muted);
 }
 
+/* The lane is not a PANEL. It used to paint `rgba(var(--tint), 0.05)` at rest,
+   which made every lane a filled slab: an empty Upcoming read as a large grey
+   plate with nothing in it, and every card competed with the box it was sitting
+   in rather than being the thing you looked at (Akshil, 2026-08-17, comparing
+   this board against flow's side by side — there the lanes are transparent and
+   the cards are the only surface).
+
+   So the fill is gone and nothing replaced it: the board's 12px `gap` and the
+   cards' own edges are what make four columns read as four columns. No hairline
+   rule between them either — tried the gap alone first, as asked, and the column
+   of card edges is already a stronger vertical than a 1px line would be.
+
+   What the padding and the radius are still for is the DROP states below, which
+   are the only things this element ever paints. `padding` insets the dashed
+   legal-drop outline off the cards so it reads as the lane's edge rather than as
+   a second border on the top card; the radius is the shape the `is-drop-over`
+   wash takes. Both are dead geometry at rest, which is the point.
+
+   An EMPTY lane therefore shows its header and nothing else — the label, the
+   ring and a `0`. That is deliberate: "nothing scheduled" should look like
+   nothing, and the header is what says which column the nothing belongs to. The
+   `min-height` is what keeps the empty lane a droppable target anyway, so a card
+   can still be dragged into a column that has never held one. */
 .schedule-tv-lane-body {
   flex: 1 1 auto;
   min-height: 120px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 4px;
-  padding: 5px;
+  /* Loosened from 4px on 2026-08-17: at 4px the cards read as one ribbed strip
+     rather than as separate objects, which is half of what made the lane look
+     like a panel full of rows. */
+  gap: 8px;
+  padding: 4px;
   border-radius: 8px;
-  background: rgba(var(--tint), 0.05);
 }
 
+/* The card is the board's ONLY surface now that the lane paints nothing, so it
+   has to carry the whole separation from the page ground on its own — and the
+   ground is `--bg` in both themes (base.css `body`), which is exactly what the
+   card used to be painted in. Against a lane fill that was enough; against the
+   page it was the card disappearing, most obviously in light mode where both are
+   plain white.
+
+   `--bg-panel` is the app's existing answer to "a surface floating above the
+   page", and it is tuned per theme for precisely this: in dark it steps LIGHTER
+   than the ground (#202329 over #131417), and in light it stays white and lets
+   the hairline plus a shadow do the lifting (tokens.css says so in as many
+   words). The shadow is the same `0 1px 2px var(--shadow-sm)` the settings
+   page's own cards use — one step of lift, not a drop shadow — and its token is
+   theme-tuned too, so it reads as depth in dark instead of as dirt in light.
+
+   Loosened on 2026-08-17 along with the lane: 8px/10px padding and a 5px gap
+   were tighter than flow's cards, which is what made three short lines feel
+   crowded. The three lines keep their hierarchy — the id small and muted, the
+   title the loudest thing on the card, the folder chip quiet — so nothing about
+   the type had to move, only the air around it. `.tasks-card-acts` (tasks.css)
+   is centred on the head using this `padding-top`, so the two are stated
+   together or the hover strip drifts off the head's line. */
 .schedule-tv-board .schedule-tv-card,
 .prefs-section .schedule-tv-board .schedule-tv-card {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   align-self: stretch;
-  gap: 5px;
+  gap: 6px;
   width: 100%;
   box-sizing: border-box;
-  padding: 8px 10px;
+  padding: 10px 12px;
   font: inherit;
   text-align: left;
   color: var(--fg);
-  background: var(--bg);
+  background: var(--bg-panel);
   border: 1px solid var(--border);
   border-radius: 8px;
+  box-shadow: 0 1px 2px var(--shadow-sm);
   cursor: pointer;
   transition: border-color 0.08s ease;
 }
 
 .schedule-tv-board .schedule-tv-card:hover:not(:disabled),
 .prefs-section .schedule-tv-board .schedule-tv-card:hover:not(:disabled) {
-  background: var(--bg);
+  background: var(--bg-panel);
   border-color: color-mix(in srgb, var(--fg-muted) 40%, var(--border));
 }
 
@@ -2834,7 +2882,17 @@ input.schedule-when-field {
    Native HTML5 drag. A draggable card says so with the grab cursor; while one
    is in flight, every lane that would accept it lifts slightly, and the lane
    under the pointer says "here" with the accent — the same 14% wash the
-   dropdowns speak. The card left behind ghosts. */
+   dropdowns speak. The card left behind ghosts.
+
+   None of this depended on the lane's resting fill, which is why removing that
+   fill above cost the drop nothing. A drop target announces itself by ADDING
+   paint to an empty box, never by changing paint it was already wearing: legal
+   lanes take a dashed accent outline the moment a drag starts, the lane under
+   the pointer fills with the accent wash, and the one drop that is not filing
+   (Upcoming → In Progress, which sends) swaps the outline for `--activity` and
+   writes the sentence out (tasks.css `.is-drop-run` / `.tasks-run-hint`). All
+   three go from nothing to something, so they are more legible on a transparent
+   lane than they were on a tinted one. */
 .schedule-tv-board .schedule-tv-card.is-draggable,
 .prefs-section .schedule-tv-board .schedule-tv-card.is-draggable {
   cursor: grab;
@@ -2885,28 +2943,53 @@ input.schedule-when-field {
   min-width: 0;
 }
 
-/* Title and its unread count on one line, the count trailing. `flex-wrap` is
-   the whole point: the title below is a clamp that HIDES its overflow, so the
-   count can never live inside it — a two-line title would eat it. Out here it
-   drops to its own line instead of disappearing. `align-items: flex-end` keeps
-   it sitting with the title's last line rather than floating beside line one. */
-.schedule-tv-card-name {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  gap: 6px;
-  min-width: 0;
-}
+/* The title, and the unread count INSIDE it, in the text flow, immediately after
+   the last word.
 
+   Two earlier arrangements failed, and both failed because of the clamp this rule
+   no longer has. The title was a two-line `-webkit-box` with `overflow: hidden`;
+   with the pill inside, a title long enough to fill both lines clipped the count
+   away entirely — lost on exactly the cards with the most to say. Moving the pill
+   OUT, into a `flex-wrap` wrapper beside the title, stopped the clipping and
+   bought a worse look: on any two-line title the pill dropped to a line of its
+   own under the words, orphaned, which is what the screenshot showed (Akshil,
+   2026-08-17).
+
+   There is no arrangement that fixes both while the clamp exists: nothing can
+   flow after the last word of a clipped box AND stay outside the clip. So the
+   clamp goes. The title wraps to as many lines as it needs, the pill is an inline
+   atom in the same flow, and it lands after the final word on the final line by
+   ordinary text layout rather than by anything being aligned to anything.
+
+   The cost is accepted: a long title makes a taller card, and lanes of cards will
+   not all be the same height. That is rarer than it sounds — a card's title is
+   the session's own short name now, not the scheduled message it sends — so
+   multi-line is the exception.
+
+   `overflow-wrap: anywhere` is the one guard kept from the old rule and it is the
+   only one still needed: it is what stops a single unbroken 200-character token
+   from widening the 260px column, now that no `overflow: hidden` is standing
+   behind it to catch that. Nothing in the chain from here up to the card hides
+   overflow, deliberately; the lane body's `overflow-y` is a scroller for the
+   column, which is a different thing and further out. */
 .schedule-tv-card-title {
   font-size: 12.5px;
   line-height: 1.35;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
   overflow-wrap: anywhere;
   min-width: 0;
+}
+
+/* The pill as an inline atom. `inline-flex` (it is already that in tasks.css) so
+   it centres its own digits while sitting in the line like a word;
+   `vertical-align: middle` so it rides the ink rather than the baseline, which on
+   a 16px pill against a 12.5px line is the difference between "after the word"
+   and "hanging below it". The gap is a `margin` and not the parent's `gap`
+   because there is no flex parent any more — that wrapper was the bug. Scoped to
+   the board card: the List row keeps the pill as a flex sibling and takes its
+   spacing from the row's own `gap`. */
+.schedule-tv-card-title .tasks-count {
+  margin-left: 6px;
+  vertical-align: middle;
 }
 
 .schedule-tv-card-next {
@@ -2955,7 +3038,15 @@ input.schedule-when-field {
 
 /* The collapsed lane: flow's 52px rail, with the label set vertically and the
    count pinned to the foot. Archive is closed by default — it is the one lane
-   nobody opens this page to read — and clicking the rail opens it again. */
+   nobody opens this page to read — and clicking the rail opens it again.
+
+   Its resting fill went with the open lane's on 2026-08-17: a rail is a lane, and
+   leaving one lane painted as a slab beside four transparent ones would have made
+   the collapsed column the loudest thing on the board. The hairline stays, and it
+   is doing more work here than on the open lane — the rail is a BUTTON you press
+   to expand, so it has to look like an object rather than a strip of page. Hover
+   still fills (`--row-bg-hover` below), and so do the drop states, which is the
+   same "add paint to an empty box" the lane body relies on. */
 .schedule-tv-rail,
 .prefs-section .schedule-tv-rail {
   display: flex;
@@ -2969,7 +3060,7 @@ input.schedule-when-field {
   align-self: stretch;
   font: inherit;
   color: var(--fg);
-  background: rgba(var(--tint), 0.05);
+  background: transparent;
   border: 1px solid var(--border);
   border-radius: 8px;
   cursor: pointer;
@@ -2993,11 +3084,17 @@ input.schedule-when-field {
   color: var(--fg-muted);
 }
 
+/* The count at the rail's foot. Its fill was `--bg` — a plate cut out of the
+   rail's own tint — which the rail no longer has, so on the page ground that was
+   a pill painted the colour of what is behind it, i.e. no pill at all. It takes
+   the app's chip wash instead (the same 18% muted `.tasks-count` wears), which is
+   translucent and therefore still reads over the rail's hover fill and over the
+   accent wash a drop puts under it. */
 .schedule-tv-rail-count {
   margin-top: auto;
   padding: 1px 6px;
   border-radius: 999px;
-  background: var(--bg);
+  background: color-mix(in srgb, var(--fg-muted) 18%, transparent);
   font-size: 10px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -45,18 +45,22 @@
   border-top: 1px solid var(--border);
 }
 
-/* -- The unread rail's geometry ------------------------------------------------
-   ONE column, shared by a task row and every message row beneath it. The dot
-   moved to the head of the message rows last round and the task's own count did
-   not move with it — it stayed at the far right beside the folder chip, so the
-   rail started halfway down the task (Akshil, 2026-08-17: "for the tasks you
-   didn't bring this on the left side, only for the messages you brought. This
-   looks odd").
+/* -- The leading rail's geometry ------------------------------------------------
+   ONE column down the whole node. On a MESSAGE row the thing standing in it is
+   the unread dot; on the TASK row above it is the status ring — the same 16px
+   slot on the same centre line, so the node still reads as one column even
+   though the two rows say different things in it.
+
+   The task row's own unread COUNT is no longer in this column. It led the row
+   for a day and that was a day too long: a number at the very start of a row
+   made the messages outrank the task they belong to (Akshil, 2026-08-17). It
+   trails the title now — see `.tasks-count` — and the rail loses nothing by it,
+   because the ring that took its place is exactly as wide.
 
    The two rows are indented differently on purpose — the thread hangs under its
    task — so the column can only stay straight if ONE number decides where it
    is and the other indents are derived from it. That number is
-   `--tasks-rail-x`: how far the rail sits from the node's left edge. The task
+   `--tasks-rail-x`: how far the column sits from the node's left edge. The task
    row reaches it by its own padding plus the caret gutter; the thread reaches it
    by subtracting a message row's indent from it. Retune any part and both move
    together; hand-tune one and they part company, which is the whole bug. */
@@ -64,7 +68,7 @@
   --tasks-row-pad: 12px; /* the task row's left padding */
   --tasks-caret-w: 16px; /* the disclosure gutter, OUTSIDE the rail */
   --tasks-row-gap: 8px; /* the flex gap every row here uses */
-  --tasks-rail-w: 16px; /* wide enough for a two-digit pill to centre in */
+  --tasks-rail-w: 16px; /* the status ring's width — what the column is sized to */
   --tasks-msg-indent: 13px; /* a message row's 1px rule + its own padding */
   --tasks-rail-x: calc(
     var(--tasks-row-pad) + var(--tasks-caret-w) + var(--tasks-row-gap)
@@ -147,23 +151,25 @@
 }
 
 /* -- Unread ------------------------------------------------------------------
-   A dot, in the one hue the page reserves for "not finished with yet". A
-   message row shows the dot; the task row above shows the SAME dot carrying its
-   count, which is the only way a number reads in a leading slot without either
-   shrinking to nothing or breaking the column it sits in. */
+   The MESSAGE row's dot, in `--activity` — the hue the page reserves for
+   something happening or waiting to be seen, and the same one the live ping
+   wears. This is the alert half of unread: one mark per message, leading the row
+   it is about, so a thread is scanned down its left edge. The task row's COUNT is
+   the other half and is deliberately not this colour any more; see
+   `.tasks-count`. */
 .tasks-dot {
   display: inline-block;
   width: 7px;
   height: 7px;
   flex: 0 0 7px;
   border-radius: 999px;
-  background: var(--status-upcoming);
+  background: var(--activity);
 }
 
-/* The rail slot itself, at the head of a task row and of every message row.
-   Fixed width and centred contents: that is what puts a 7px dot and a 16px
-   count pill on one centre line, so the rail stays straight whatever each row
-   has to say. Drawn even when empty — a slot that appeared only on unread rows
+/* The rail slot itself, at the head of every MESSAGE row. Its width is the status
+   ring's, and its contents are centred: that is what puts a 7px dot on the exact
+   centre line of the ring on the task row above, so the column stays straight
+   down the node. Drawn even when empty — a slot that appeared only on unread rows
    would shift every cell of those rows sideways, and a ragged left edge is
    exactly what a scan cannot follow. */
 .tasks-rail {
@@ -174,37 +180,60 @@
   flex: 0 0 var(--tasks-rail-w);
 }
 
-/* The count. FILLED rather than the tinted pill it used to be at the far right
-   of the row: at the head of the rail it has to read as the same mark the dots
-   below it are, and a 16%-tint chip beside a run of solid dots reads as a
-   different thing entirely. --on-accent is the page's glyph-on-a-fill token and
-   holds in both themes (near-black on the lighter dark-theme blue, white on the
-   darker light-theme one).
+/* The count — the task row's "and there are N of them", sitting immediately
+   AFTER the title text (2026-08-17). Two things changed together and they are one
+   decision:
 
-   min-width is the rail's own width, so one digit is a circle exactly filling
-   the slot; two grow it into a short pill that bleeds ~2px each side into the
-   8px gaps and never reaches its neighbours (measured: even "99+" keeps ~2px
-   clear). Past 99 the text is capped at "99+" (tasks-lib.unreadCount) and the
-   true number stays in the label.
+   POSITION. It used to lead the row, on the rail, and that inverted the reading
+   priority: a reader scanning a list wants the titles, and a bold number in front
+   of every one of them announced the messages before the work they are about.
+   Title first, count after — the indentation break the page needed.
 
-   The fallback in that min-width is not decoration: the Board's card wears this
-   same pill from OUTSIDE `.tasks-node`, where the rail's variables do not
-   resolve. Inside the List it tracks the rail; on a card it keeps the shape. */
+   WEIGHT. Leading, it had to be a solid fill to read as the same mark as the dots
+   under it. Trailing the title it is metadata, not an alert, so the FILL is a
+   quiet neutral wash of --fg-muted instead of a hue. The dots in the thread keep
+   the blue and keep the alerting — one loud mark per unread MESSAGE, one quiet
+   total on the TASK. Deliberately not `--activity`: a blue pill beside a title is
+   a badge demanding a press, which is exactly what it stopped being.
+
+   The INK is --fg rather than --fg-muted, and that is a legibility decision, not
+   a loudness one. Muted ink on an 18% muted wash lands at 3.8:1 in light mode,
+   which is under AA for 10px digits — the chip would be quiet by being unreadable.
+   Full ink on the same wash clears 11:1 in both themes, and the chip still reads
+   as subordinate because it is 10px against a 13px title. Quiet comes from the
+   size and the fill; the number itself still has to be readable.
+
+   min-width keeps one digit a circle; two grow it into a short pill. Past 99 the
+   text is capped at "99+" (tasks-lib.unreadCount) and the true number stays in
+   the label. 16px flat rather than the rail's variable, because the pill is no
+   longer in the rail and the Board's card wears it from outside `.tasks-node`
+   where that variable does not resolve at all. */
 .tasks-count {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
-  min-width: var(--tasks-rail-w, 16px);
+  min-width: 16px;
   height: 16px;
   padding: 0 4px;
   border-radius: 999px;
-  background: var(--status-upcoming);
-  color: var(--on-accent);
+  background: color-mix(in srgb, var(--fg-muted) 18%, transparent);
+  color: var(--fg);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1;
   font-variant-numeric: tabular-nums;
+}
+
+/* On a Board card the pill trails the title's TEXT rather than a flex sibling of
+   it: the card's title is a two-line `-webkit-box` clamp, so the count has to
+   flow with the words to end up after the last one instead of pinned to a corner.
+   That makes it an inline box in a text line, which is the one place the flex
+   row's `align-items: center` cannot centre it — hence the explicit alignment
+   and the gap that `.tasks-row`'s `gap` provides on the List side. */
+.schedule-tv-card-title .tasks-count {
+  margin-left: 6px;
+  vertical-align: middle;
 }
 
 /* -- Quiet row action (Open chat) ---------------------------------------------
@@ -258,22 +287,22 @@
 
 /* Run now / Re-run. Same group, same size, same silence at rest as Edit and
    Cancel — the hue only arrives under the pointer, and it is the page's
-   "upcoming" blue rather than Cancel's red: this one STARTS something. */
+   `--activity` blue rather than Cancel's red: this one STARTS something. */
 .tasks-act--run:hover:not(:disabled),
 .prefs-section .tasks-act--run:hover:not(:disabled) {
-  color: var(--status-upcoming);
-  background: color-mix(in srgb, var(--status-upcoming) 12%, transparent);
-  border-color: color-mix(in srgb, var(--status-upcoming) 32%, transparent);
+  color: var(--activity);
+  background: color-mix(in srgb, var(--activity) 12%, transparent);
+  border-color: color-mix(in srgb, var(--activity) 32%, transparent);
 }
 
 /* Mark read. Same group, same size, same silence at rest — and NEUTRAL under the
-   pointer, not the unread dot's own `--status-upcoming`. That hue is already
-   spoken for twice over: it is what the dot and the count pill are painted in, so
-   wearing it here would read as "this IS unread" rather than "clear it"; and it is
-   also the hue Run now takes on hover, which sits directly beside this button on
-   every row that offers both. Two adjacent buttons in one colour, one of which
-   starts a Claude turn, is the confusion worth spending a hue to avoid. The glyph
-   carries the meaning; the skin only has to say "this is a control". */
+   pointer, not the unread dot's own `--activity`. That hue is already spoken for
+   twice over: it is what the thread's dots are painted in, so wearing it here
+   would read as "this IS unread" rather than "clear it"; and it is also the hue
+   Run now takes on hover, which sits directly beside this button on every row that
+   offers both. Two adjacent buttons in one colour, one of which starts a Claude
+   turn, is the confusion worth spending a hue to avoid. The glyph carries the
+   meaning; the skin only has to say "this is a control". */
 .tasks-act--seen:hover:not(:disabled),
 .prefs-section .tasks-act--seen:hover:not(:disabled) {
   color: var(--fg);
@@ -604,7 +633,7 @@
 .schedule-tv-lane-body.is-drop-run,
 .schedule-tv-rail.is-drop-run,
 .prefs-section .schedule-tv-rail.is-drop-run {
-  outline: 1px dashed color-mix(in srgb, var(--status-upcoming) 60%, transparent);
+  outline: 1px dashed color-mix(in srgb, var(--activity) 60%, transparent);
   outline-offset: -1px;
 }
 
@@ -612,8 +641,8 @@
   margin: 0 0 2px;
   padding: 3px 8px;
   border-radius: 6px;
-  background: color-mix(in srgb, var(--status-upcoming) 14%, transparent);
-  color: var(--status-upcoming);
+  background: color-mix(in srgb, var(--activity) 14%, transparent);
+  color: var(--activity);
   font-size: 11px;
   font-weight: 600;
   text-align: center;

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -45,33 +45,45 @@
   border-top: 1px solid var(--border);
 }
 
-/* -- The leading rail's geometry ------------------------------------------------
-   ONE column down the whole node. On a MESSAGE row the thing standing in it is
-   the unread dot; on the TASK row above it is the status ring — the same 16px
-   slot on the same centre line, so the node still reads as one column even
-   though the two rows say different things in it.
+/* -- The rail's geometry --------------------------------------------------------
+   TWO columns down the node, one ring slot apart, and every indent on the page is
+   derived from the first of them.
 
-   The task row's own unread COUNT is no longer in this column. It led the row
-   for a day and that was a day too long: a number at the very start of a row
-   made the messages outrank the task they belong to (Akshil, 2026-08-17). It
-   trails the title now — see `.tasks-count` — and the rail loses nothing by it,
-   because the ring that took its place is exactly as wide.
+   `--tasks-rail-x` is the rail: where the TASK row's status ring stands. Every
+   task row in the list opens on it, which is what makes the list scannable down
+   its left edge.
 
-   The two rows are indented differently on purpose — the thread hangs under its
-   task — so the column can only stay straight if ONE number decides where it
-   is and the other indents are derived from it. That number is
-   `--tasks-rail-x`: how far the column sits from the node's left edge. The task
-   row reaches it by its own padding plus the caret gutter; the thread reaches it
-   by subtracting a message row's indent from it. Retune any part and both move
-   together; hand-tune one and they part company, which is the whole bug. */
+   `--tasks-msg-ring-x` is where a MESSAGE row's own ring stands — exactly one ring
+   slot plus one gap to the right of the rail, so the thread is visibly indented
+   under the task it belongs to by the width of a whole mark rather than by a
+   number someone liked.
+
+   Two marks have left the rail, and both for the same reason. The task row's
+   unread COUNT led it first, and a number at the very start of a row made the
+   messages outrank the task they belong to; then the message row's unread DOT was
+   found doing the identical thing one indent in, which also left the thread
+   reading as a different dialect from the row above it (Akshil, 2026-08-17). Both
+   trail their titles now — `.tasks-count` and `.tasks-dot`.
+
+   The dot's departure is why `--tasks-msg-ring-x` is written down. The message
+   row's ring used to be pushed into its column by the empty slot the dot reserved
+   at the head of the row; with that slot gone the offset has to be stated, or the
+   whole thread slides left into the task's own column and the indent that says
+   "these belong to that" disappears. So the offset is DERIVED from the rail and
+   the ring slot it used to be made of, and the thread's padding is derived from
+   THAT — never typed. Retune any part and every indent moves together; hand-tune
+   one and they part company, which is the whole bug. */
 .tasks-node {
   --tasks-row-pad: 12px; /* the task row's left padding */
   --tasks-caret-w: 16px; /* the disclosure gutter, OUTSIDE the rail */
   --tasks-row-gap: 8px; /* the flex gap every row here uses */
-  --tasks-rail-w: 16px; /* the status ring's width — what the column is sized to */
-  --tasks-msg-indent: 13px; /* a message row's 1px rule + its own padding */
+  --tasks-rail-w: 16px; /* the status ring's width — what a rail slot is sized to */
+  --tasks-msg-indent: 13px; /* a message row's own left padding */
   --tasks-rail-x: calc(
     var(--tasks-row-pad) + var(--tasks-caret-w) + var(--tasks-row-gap)
+  );
+  --tasks-msg-ring-x: calc(
+    var(--tasks-rail-x) + var(--tasks-rail-w) + var(--tasks-row-gap)
   );
 }
 
@@ -153,10 +165,24 @@
 /* -- Unread ------------------------------------------------------------------
    The MESSAGE row's dot, in `--activity` — the hue the page reserves for
    something happening or waiting to be seen, and the same one the live ping
-   wears. This is the alert half of unread: one mark per message, leading the row
-   it is about, so a thread is scanned down its left edge. The task row's COUNT is
-   the other half and is deliberately not this colour any more; see
-   `.tasks-count`. */
+   wears. This is the alert half of unread: one loud mark per unread message. The
+   task row's COUNT is the quiet half — a total rather than an alert — and is
+   deliberately not this colour any more; see `.tasks-count`.
+
+   It sits immediately AFTER the message's title (2026-08-17), where the count sits
+   on the row above. Leading the row, in a reserved slot on the rail, it was the
+   same inverted priority the count had — the mark announced before the words it is
+   about — and it was that on the one page whose other half had already been fixed,
+   so a thread read as a different dialect from the task it hangs under. Only the
+   position moved: same hue, same meaning.
+
+   `flex: 0 0 7px` and no margin. The row's `gap` is the separation; an `auto`
+   margin here would be the second one in the row, and flex answers two by
+   splitting the free space between them, which re-centres the trailing group
+   instead of pushing it to the end.
+
+   Nothing is drawn at all on a read message. Trailing a title there is no column
+   to hold open — which is the whole reason the empty rail slot could go with it. */
 .tasks-dot {
   display: inline-block;
   width: 7px;
@@ -166,19 +192,14 @@
   background: var(--activity);
 }
 
-/* The rail slot itself, at the head of every MESSAGE row. Its width is the status
-   ring's, and its contents are centred: that is what puts a 7px dot on the exact
-   centre line of the ring on the task row above, so the column stays straight
-   down the node. Drawn even when empty — a slot that appeared only on unread rows
-   would shift every cell of those rows sideways, and a ragged left edge is
-   exactly what a scan cannot follow. */
-.tasks-rail {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--tasks-rail-w);
-  flex: 0 0 var(--tasks-rail-w);
-}
+/* No reserved slot at the head of a MESSAGE row any more. There was one — the ring
+   slot's width, contents centred, drawn even when empty so the dots could not
+   shunt the unread rows sideways — and the dot's move to the end of the title is
+   what retired it. The width it used to contribute has NOT been dropped, only
+   moved into the geometry: `--tasks-msg-ring-x` above is the rail plus that slot
+   plus a gap, so the thread's rings stay in the column the slot used to push them
+   into. Deleting the slot without that would have slid every message row 24px left
+   into the task row's own column. */
 
 /* The count — the task row's "and there are N of them", sitting immediately
    AFTER the title text (2026-08-17). Two things changed together and they are one
@@ -328,13 +349,39 @@
    card still stretches to fill it.
 
    They sit over the card HEAD's right end, which is empty on every card: the head
-   holds the unread pill, the ring, the id and the live ping, all left-aligned
-   and none of them growing. The title below is clamped to two lines and starts
-   on the next line down, so nothing is covered. */
+   holds the id, the live ping and — on the minority of cards where it disagrees
+   with the lane — a status ring, all left-aligned and none of them growing. The
+   title below starts on the next line down, so nothing is covered, and that
+   clearance is what `--tasks-card-head-h` exists to keep true. */
 .tasks-card-wrap {
+  /* The head's line. It was 16px tall by accident until 2026-08-17, because every
+     card's head held a 16px status ring, and the `top` on `.tasks-card-acts` below
+     was quietly measured off that — the strip's 22px buttons are centred on the
+     head and their lower edge stops just short of the title.
+
+     The ring is CONDITIONAL now (ScheduleTaskViews.TaskCard: it is drawn only when
+     it says something the lane header has not), so that accident holds on some
+     cards and not others. Both failures matter. Without the ring the head is one
+     11px id chip, about 13px, and the strip reaches over the title's first line on
+     hover, where its opaque `--bg` skin sits on the words. And a head that were
+     simply left to its contents would stand 16px on a failed-off-lane card and
+     13px on its neighbour, so a lane of cards would jitter by the width of a glyph
+     — a worse tell than the repetition the ring's removal was undoing.
+
+     So the line is stated once here rather than being a side effect of a glyph,
+     and the head holds it whether or not a ring is standing in it. */
+  --tasks-card-head-h: 16px;
   position: relative;
   display: flex;
   align-self: stretch;
+}
+
+/* Board cards only: `.schedule-tv-card-head` is schedule.css's, and this is the
+   one place it has a strip pinned over it. `min-height`, not `height`: the ring is
+   sized to exactly this line, so holding the floor is all that is needed and a
+   fixed height would clip anything the head is given later. */
+.tasks-card-wrap .schedule-tv-card-head {
+  min-height: var(--tasks-card-head-h);
 }
 
 /* One STRIP, pinned once, holding however many actions this card offers — Run
@@ -348,6 +395,9 @@
    press that opens the chat. Only the buttons take them back. */
 .tasks-card-acts {
   position: absolute;
+  /* Centred on the head's line: the card's own 8px top padding plus half of
+     `--tasks-card-head-h`, less half a 22px button. Which is why the head has to
+     keep that height even now that nothing 16px tall stands in it. */
   top: 5px;
   right: 6px;
   /* Above the card it overlays; the card sets no z-index of its own. */
@@ -430,13 +480,15 @@
    than as a thread guide. Nothing else in the list is fenced, so this isn't
    either.
 
-   The left padding is DERIVED, never typed: it is where the rail is, less a
-   message row's own indent, so the thread's dots land on the task row's rail
-   above them. See the geometry block at the top of this file. */
+   The left padding is DERIVED, never typed: it is where a message row's ring
+   belongs, less the row's own indent, so every ring in the thread lands one ring
+   slot to the right of the task row's — the indent the screenshot of this thread
+   was taken with, and the one the dot's old head slot used to provide by
+   accident. See the geometry block at the top of this file. */
 .tasks-thread {
   display: flex;
   flex-direction: column;
-  padding: 2px 12px 8px calc(var(--tasks-rail-x) - var(--tasks-msg-indent));
+  padding: 2px 12px 8px calc(var(--tasks-msg-ring-x) - var(--tasks-msg-indent));
 }
 
 .tasks-msg {
@@ -508,9 +560,9 @@
   white-space: nowrap;
 }
 
-/* The message row's own unread slot is `.tasks-rail`, defined with the rest of
-   the rail's geometry near the top of this file — one class for the task row
-   and its messages, because they are one column. */
+/* The message row's own unread mark is `.tasks-dot`, defined with the rest of the
+   unread vocabulary near the top of this file — beside the task row's count,
+   because the two are one decision and have to keep answering to it together. */
 
 .tasks-thread-error {
   margin: 4px 0 0;

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -225,16 +225,11 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* On a Board card the pill trails the title's TEXT rather than a flex sibling of
-   it: the card's title is a two-line `-webkit-box` clamp, so the count has to
-   flow with the words to end up after the last one instead of pinned to a corner.
-   That makes it an inline box in a text line, which is the one place the flex
-   row's `align-items: center` cannot centre it — hence the explicit alignment
-   and the gap that `.tasks-row`'s `gap` provides on the List side. */
-.schedule-tv-card-title .tasks-count {
-  margin-left: 6px;
-  vertical-align: middle;
-}
+/* No Board-card special case any more: the pill is a flex sibling of the card's
+   title inside `.schedule-tv-card-name` (schedule.css), which provides the gap
+   the List row's own `gap` provides here. It USED to sit inside the title, to
+   flow after its last word — but that title is a clamp with `overflow: hidden`,
+   so a title long enough to fill it clipped the count away entirely. */
 
 /* -- Quiet row action (Open chat) ---------------------------------------------
    Hidden until the row is pointed at: it applies to every task that has run,

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -246,11 +246,13 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* No Board-card special case any more: the pill is a flex sibling of the card's
-   title inside `.schedule-tv-card-name` (schedule.css), which provides the gap
-   the List row's own `gap` provides here. It USED to sit inside the title, to
-   flow after its last word — but that title is a clamp with `overflow: hidden`,
-   so a title long enough to fill it clipped the count away entirely. */
+/* `inline-flex` is what lets the Board card put this pill INSIDE its title, in
+   the text flow, where it lands after the last word however many lines that title
+   takes. The two lines it needs on top of this — the leading margin and
+   `vertical-align` — are stated next to that title in schedule.css, because they
+   are true of the card and not of the List row: the row keeps the pill as a flex
+   sibling on a single ellipsised line and takes its spacing from the row's own
+   `gap`. */
 
 /* -- Quiet row action (Open chat) ---------------------------------------------
    Hidden until the row is pointed at: it applies to every task that has run,
@@ -395,11 +397,13 @@
    press that opens the chat. Only the buttons take them back. */
 .tasks-card-acts {
   position: absolute;
-  /* Centred on the head's line: the card's own 8px top padding plus half of
+  /* Centred on the head's line: the card's own top padding plus half of
      `--tasks-card-head-h`, less half a 22px button. Which is why the head has to
-     keep that height even now that nothing 16px tall stands in it. */
-  top: 5px;
-  right: 6px;
+     keep that height even now that nothing 16px tall stands in it — and why this
+     moved from 5px to 7px on 2026-08-17, when the card's padding was loosened from
+     8px to 10px (schedule.css). Left at 5px the strip rides high on the head. */
+  top: 7px;
+  right: 8px;
   /* Above the card it overlays; the card sets no z-index of its own. */
   z-index: 1;
   display: flex;
@@ -411,9 +415,12 @@
 .tasks-card-act,
 .prefs-section .tasks-card-act {
   pointer-events: auto;
-  /* The card paints `--bg`, and a transparent glyph sitting on it would read as
-     part of the head's own row of marks. */
-  background: var(--bg);
+  /* An opaque skin in the card's OWN surface colour, so the strip reads as
+     floating over the head rather than as part of the head's row of marks. It
+     tracks the card: that surface became `--bg-panel` when the lane's fill was
+     removed and the card had to lift off the page by itself (schedule.css), and a
+     button still painted `--bg` would have been a visible patch on it in dark. */
+  background: var(--bg-panel);
 }
 
 .tasks-card-wrap:hover .tasks-card-act,

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -424,14 +424,16 @@
 .tasks-msg-error {
   margin: 0 0 2px;
   padding: 2px 8px 4px 12px;
-  border-left: 1px solid var(--border);
   font-size: 11px;
   color: var(--error);
 }
 
 /* -- The thread ----------------------------------------------------------------
-   Indented under its task, with a rule running down the left so a long thread
-   still reads as belonging to the row above it.
+   Indented under its task. The indent alone says the messages belong to the row
+   above them — a vertical rule down the left said it a second time, and at the
+   depth these rows sit it read as a stray line before the indentation rather
+   than as a thread guide. Nothing else in the list is fenced, so this isn't
+   either.
 
    The left padding is DERIVED, never typed: it is where the rail is, less a
    message row's own indent, so the thread's dots land on the task row's rail
@@ -446,10 +448,10 @@
   display: flex;
   align-items: center;
   gap: var(--tasks-row-gap);
-  /* 1px rule + this padding = --tasks-msg-indent, the number the thread's own
-     padding subtracts. Written as the subtraction so the two cannot drift. */
-  padding: 5px 8px 5px calc(var(--tasks-msg-indent) - 1px);
-  border-left: 1px solid var(--border);
+  /* The full indent, not indent-minus-1: the 1px used to be the rule's own
+     width, and the row has to keep landing in the same column now that the
+     rule is gone. */
+  padding: 5px 8px 5px var(--tasks-msg-indent);
   font-size: 12.5px;
   cursor: pointer;
   transition: background-color 0.08s ease;
@@ -518,7 +520,6 @@
 .tasks-thread-error {
   margin: 4px 0 0;
   padding-left: 12px;
-  border-left: 1px solid var(--border);
   font-size: 11px;
   color: var(--error);
 }

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -93,18 +93,40 @@
   --tour-dim: #7c7f88;
   --tour-next-hover: #d8f238;
 
-  /* Task status hues — the Schedule page's tree/board rings and the live pulse
+  /* Task status hues — the Schedule page's tree/board/calendar rings
      (shell/ScheduleTaskViews.tsx, ported from the flow app's task board). Own
-     tokens rather than --accent/--success/--warning because these four are a
-     VOCABULARY: a reader learns blue-yellow-green-grey once and then reads any
-     row by its ring, which only holds if the four keep their relative hues in
-     both themes. Dark values first, as everywhere here; light darkens each to
-     the same weight against white. */
-  --status-upcoming: #60a5fa;
+     tokens rather than --accent/--success/--warning because these five are a
+     VOCABULARY: a reader learns the ring hues once and then reads any row by its
+     ring, which only holds if they keep their relative weights in both themes.
+     Dark values first, as everywhere here; light darkens each to the same weight
+     against white.
+     Two of the five moved on 2026-08-17 (Akshil):
+     * Upcoming is GREY. It was blue, which is the loudest thing on a page whose
+       whole point is what is happening now — a lane of "nothing has happened
+       yet" was out-shouting In Progress. It borrows --fg-muted outright rather
+       than a grey of its own: the row's id and folder chips are already that
+       colour, so Upcoming recedes into its own row's metadata, which is exactly
+       what "not started" should look like. Restated in the light block only
+       because test_theme.py requires every dark token to have a light value —
+       the value is deliberately the same expression, not a second grey.
+     * Archive is a MUTED VIOLET, because Upcoming took the grey and two lanes
+       cannot share a hue. Violet is the one direction left: it collides with
+       none of yellow/green/red/grey, and desaturated it reads as "put away"
+       rather than as a live lane. The pair is --icon-data's violet, already
+       tuned in this file for the same weight in both themes, so the palette
+       gains a role rather than a colour. */
+  --status-upcoming: var(--fg-muted);
   --status-progress: #facc15;
   --status-done: #4ade80;
   --status-failed: #f87171;
-  --status-archived: #8b8f96;
+  --status-archived: #a898cb;
+
+  /* The blue Upcoming used to own, which outlived it: it was never really the
+     status hue, it was the page's ACTIVITY hue, and three things still need it —
+     the live ping on a turn in flight, the unread dot on a message row, and the
+     Run now / drag-to-run affordance that puts a task into flight. Naming it for
+     that is what let Upcoming go grey without repainting any of the three. */
+  --activity: #60a5fa;
 
   /* File-type icon hues (FileIcons.tsx). Tuned bright for a dark listing;
      the light palette darkens each one to the same relative weight. */
@@ -201,11 +223,15 @@
   --tour-dim: #6f747c;
   --tour-next-hover: #4e5f00;
 
-  --status-upcoming: #2563eb;
+  /* Upcoming tracks --fg-muted in both themes (see the dark block) — the same
+     expression, restated because the light palette must redefine every token. */
+  --status-upcoming: var(--fg-muted);
   --status-progress: #ca8a04;
   --status-done: #16a34a;
   --status-failed: #dc2626;
-  --status-archived: #737373;
+  --status-archived: #6b57a0;
+
+  --activity: #2563eb;
 
   --icon-folder: #45689e;
   --icon-code: #2f7a6b;

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -121,11 +121,12 @@
   --icon-db: #82abbf;
   --icon-file: #868c93;
 
-  /* Task chip hues — the Calendar's per-task colour (shell/ScheduleCalendar.tsx,
-     indexed by schedule-lib.taskColour). Eight, hand-picked and evenly spread
-     around the wheel, because the calendar's whole read depends on "same task,
-     same colour": five days of a daily task must land as ONE thing, and two
-     unrelated tasks in the same hour must not. A generated hsl() would give
+  /* Task chip hues — the Calendar's per-PROJECT colour (shell/ScheduleCalendar.tsx,
+     indexed by schedule-lib.taskColour, which hashes the task's folder). Eight,
+     hand-picked and evenly spread around the wheel, because the calendar's whole
+     read depends on "same folder, same colour": five days of a daily task must
+     land as ONE thing, two tasks out of one repo must land as that repo, and two
+     unrelated projects in the same hour must not. A generated hsl() would give
      that too, and would also give hues that fight the theme in one mode or the
      other — so the palette is picked, not computed. Dark values first; light
      deepens each to the same weight against white, where they are read as a

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -109,17 +109,28 @@
        what "not started" should look like. Restated in the light block only
        because test_theme.py requires every dark token to have a light value —
        the value is deliberately the same expression, not a second grey.
-     * Archive is a MUTED VIOLET, because Upcoming took the grey and two lanes
-       cannot share a hue. Violet is the one direction left: it collides with
-       none of yellow/green/red/grey, and desaturated it reads as "put away"
-       rather than as a live lane. The pair is --icon-data's violet, already
-       tuned in this file for the same weight in both themes, so the palette
-       gains a role rather than a colour. */
+     * Archive is a DUSTY ROSE, because Upcoming took the grey and two lanes
+       cannot share a hue. It was a muted violet for a day and that failed on the
+       one thing it had to do: at 16px, beside Upcoming's actual grey, a
+       low-chroma violet reads as barely-tinted grey rather than as a colour —
+       "quite similar" (Akshil, 2026-08-17). The lesson is about temperature, not
+       about that particular violet: at the low saturation this lane needs, COOL
+       hues are the ones that collapse into neutral, and a warm hue at the same
+       chroma still announces itself as a colour. So the replacement is warm.
+       Rose rather than the other two warm candidates because of where the live
+       lanes already sit: a rose keeps its blue channel well clear of its green,
+       which is what stops it reading as Failed's red (where those two are
+       equal), whereas a dull bronze reads as a dimmer In Progress and a muted
+       teal sits between Done's green and --activity's blue and reads as a dimmer
+       Done. Rose is the one direction with no live lane already in it, and it is
+       nowhere near yellow, green or blue. The pair is --icon-image's rose,
+       already tuned in this file for the same weight in both themes, so the
+       palette gains a role rather than a colour. */
   --status-upcoming: var(--fg-muted);
   --status-progress: #facc15;
   --status-done: #4ade80;
   --status-failed: #f87171;
-  --status-archived: #a898cb;
+  --status-archived: #cd93b6;
 
   /* The blue Upcoming used to own, which outlived it: it was never really the
      status hue, it was the page's ACTIVITY hue, and three things still need it —
@@ -229,7 +240,10 @@
   --status-progress: #ca8a04;
   --status-done: #16a34a;
   --status-failed: #dc2626;
-  --status-archived: #6b57a0;
+  /* The rose deepened for white (see the dark block). Still warm, still low
+     enough in chroma to stay quiet, and its blue channel still stands well above
+     its green so it cannot be mistaken for the red above it. */
+  --status-archived: #9c4d78;
 
   --activity: #2563eb;
 

--- a/fused_render/schedule.py
+++ b/fused_render/schedule.py
@@ -1391,6 +1391,20 @@ def _busy_sessions(entries: list[dict]) -> set[str]:
     return busy
 
 
+def busy_sessions(entries: list[dict]) -> set[str]:
+    """`_busy_sessions` for readers outside the loop.
+
+    The Tasks router asks the scheduler's own question — "is there a send in
+    this conversation I have not heard back from?" — when it decides whether an
+    `in_progress` pin is still describing something. It has to be the SAME
+    answer, for the reason `session_liveness`'s docstring gives about the
+    liveness rule: a second, nearly-identical notion of "still running" that
+    disagreed by one state would put a card in a lane the scheduler does not
+    believe in. So this is a re-export and deliberately not a reimplementation.
+    """
+    return _busy_sessions(entries)
+
+
 def _session_live(session_id: str, now: datetime, seen: dict | None = None) -> bool:
     """Is a HUMAN (or anything else) mid-turn in this session right now?
 

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -298,14 +298,28 @@ def _summarize(path: str, now: float, names: dict, triage: dict) -> dict | None:
     running = (now - activity) < _RUNNING_WINDOW_SEC
     last_active = last or datetime.fromtimestamp(stat.st_mtime, timezone.utc)
 
-    # Untriaged: running sessions are in progress, stopped ones are done — a
-    # session that finished while nothing was watching shouldn't sit in
-    # "in_progress" forever.
-    default = "in_progress" if running else "done"
-    record = triage.get(session_id)
-    status = (record.get("status") if isinstance(record, dict) else None) or default
-    if status not in STATUSES:
-        status = default
+    # THE IN-PROGRESS LANE IS DERIVED, NOT RECORDED — the same rule as the Inbox
+    # this module mirrors (core_apps/sessions/inbox.py). "Something is running in
+    # this conversation" is a fact about the present, so it outranks the record:
+    # a session filed as done or archived and then resumed belongs in In Progress,
+    # and one that finished while nothing was watching drops back to whatever the
+    # user filed it as (or Done, untriaged) without anything having to notice.
+    #
+    # The guard used to cover only the untriaged default, which was the half that
+    # was never the problem. The Inbox's `autoFlow` bought the other half by
+    # OVERWRITING the record whenever it saw a run — and could only retract that
+    # while its own tab stayed open, so every unwitnessed finish left an
+    # `in_progress` pin on disk that nothing would ever clear (tasks.py
+    # `_pin_holds` is the reap that made the leftovers harmless). autoFlow stopped
+    # writing it, so the lane is computed here instead and the user's own pin is
+    # still in the file when the run stops.
+    if running:
+        status = "in_progress"
+    else:
+        record = triage.get(session_id)
+        status = (record.get("status") if isinstance(record, dict) else None) or "done"
+        if status not in STATUSES:
+            status = "done"  # a hand-edited record costs the pin, not the row
 
     custom = names.get(session_id)
     if isinstance(custom, str) and custom.strip():

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -358,6 +358,15 @@ def api_claude_session_triage(patch: TriagePatch):
     Board drags cards between the same three columns the Inbox uses. Same
     file, same locking, same merge semantics: only `status` changes, and the
     record's other keys (note, tags, read) survive untouched.
+
+    **The write is stamped.** `at` is when this status was chosen, and the Tasks
+    router's `_pin_holds` needs it to tell a deliberate `in_progress` — the
+    reopen drag — from the ones `autoFlow` writes automatically and cannot take
+    back once its page is closed. A pin with no stamp reads as older than
+    anything that has happened and is reapable, which is the right answer for
+    every automatic one: `autoFlow` sends `{status}` alone, and this is the only
+    writer that knows the status came from a person. Stringified because that is
+    the shape of the record — `set_triage.py` coerces every field it writes.
     """
     session_id = patch.session_id.strip()
     if not session_id:
@@ -376,6 +385,7 @@ def api_claude_session_triage(patch: TriagePatch):
         if not isinstance(rec, dict):
             rec = {}
         rec["status"] = patch.status
+        rec["at"] = str(datetime.now(timezone.utc).timestamp())
         triage[session_id] = rec
         with open(triage_path, "w", encoding="utf-8") as f:
             json.dump(triage, f, indent=2, ensure_ascii=False)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -495,7 +495,77 @@ def _board_column(message: dict | None) -> str:
     return "upcoming"
 
 
-def _status(newest: dict | None, session_id: str, triage: dict, live: bool) -> str:
+def _pin_at(record: dict) -> float:
+    """When an `in_progress` pin was placed, or 0.0 for one that does not say.
+
+    0.0 is the answer for every pin the Inbox's `autoFlow` wrote — it sends
+    `{status}` and nothing else — and for every pin written before the stamp
+    existed. Both are exactly the pins that have to be reapable, so the absence
+    reads as "older than anything that has happened", which is what 0.0 is.
+
+    Stored as a string because that is the shape of the record: `set_triage.py`
+    coerces every field it writes with `str(value).strip()`, so `read` is "1"
+    and not 1. Parsed defensively for the same reason — a hand-edited file must
+    cost a pin, not the page."""
+    try:
+        return float(record.get("at") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _pin_holds(record: dict, session_id: str, live: bool, busy: set[str],
+               active: float) -> bool:
+    """Is a recorded `in_progress` still describing something?
+
+    This is the one triage word that is a CLAIM ABOUT THE PRESENT. `done` and
+    `archived` are filing decisions and are timeless — they stay true however
+    long the card sits in the lane — so they are never asked this question and
+    never reaped. "Something is running in this conversation" is falsifiable,
+    and nothing was falsifying it.
+
+    Why it had to be: the sessions Inbox's `autoFlow` writes `in_progress` for
+    every session it sees running, and only writes it back to `done` if THAT
+    SAME PAGE is still open to witness the stop — it gates on an in-memory
+    `RUNNING` set that is empty on every load. So every run whose finish no
+    Inbox tab watched leaves a pin on disk that outlives it forever, and
+    `_status` honoured them unconditionally as "the user's own act". The board
+    held five cards in In Progress for days over runs that had recorded `done`
+    hours or a day earlier. The Inbox's own `_summarize` names this exact
+    failure ("a session that finished while nothing was watching shouldn't sit
+    in in_progress forever") and then only guards the untriaged default, which
+    is the half that was never the problem.
+
+    THREE independent reasons to hold, and a pin needs only one. They are
+    independent on purpose, because each one is wrong on its own in a different
+    direction:
+
+    * **`live`** — the shared liveness rule says the transcript is mid-turn.
+      Not sufficient alone: a turn thinking through a long tool call appends
+      nothing for minutes and reads as not-live while genuinely running.
+    * **`busy`** — `schedule.busy_sessions`, the scheduler's own record of a
+      send it has not heard back from (`sending`, or `sent` with no verdict).
+      This is what covers the liveness gap above for a scheduled run, and it is
+      the scheduler's answer rather than a second one of ours. Not sufficient
+      alone either: a session a human is typing into has no entry at all.
+    * **a stamp later than the session's last activity** — a deliberate pin
+      that no run has contradicted. This is what keeps the reopen drag (a
+      `done` card dropped back on In Progress, which `dropLanes` offers) from
+      being undone on the next 20s poll.
+
+    A turn is therefore only reaped when the session is quiet, the scheduler is
+    waiting on nothing in it, and the pin predates the last thing that happened
+    — three ways of being over, all at once. What is NOT relied on is the
+    rendered message's `turn`: `_entry_turn` folds liveness into that field and
+    has no word for "sent, no verdict, not live" (it says `idle`), so reading it
+    would have collapsed the second guard into the first.
+    """
+    if live or session_id in busy:
+        return True
+    return _pin_at(record) > active
+
+
+def _status(newest: dict | None, session_id: str, triage: dict, live: bool,
+            busy: set[str], active: float) -> str:
     """The status a task sits in — ONE decision, made here, for every view.
 
     Derived from the newest message, then overridden by an explicit triage
@@ -506,6 +576,10 @@ def _status(newest: dict | None, session_id: str, triage: dict, live: bool) -> s
     a derivation too, and a weaker one than the message's own state. Triage has
     only three words, so a user cannot file a task as `failed`; that is a fact
     about the run, not a place to put it.
+
+    The one exception to triage winning is a stale `in_progress` — a pin whose
+    run has ended, which is not the user's act at all but a claim the Inbox
+    wrote automatically and had no way to take back. See `_pin_holds`.
 
     `failed` is decided here rather than left to the `failed` boolean beside it
     because a broken run is not a kind of `done`, and a status every view reads
@@ -520,7 +594,9 @@ def _status(newest: dict | None, session_id: str, triage: dict, live: bool) -> s
     record = triage.get(session_id) if session_id else None
     if isinstance(record, dict):
         status = record.get("status")
-        if status in _TRIAGE_STATUSES:
+        if status in _TRIAGE_STATUSES and (
+                status != "in_progress"
+                or _pin_holds(record, session_id, live, busy, active)):
             return status
     if live and newest is not None:
         return "in_progress"
@@ -834,8 +910,15 @@ def _next_run(entries: list[dict]) -> tuple[float, str]:
     return best_at, best_id
 
 
-def _row(task: dict, number: str, triage: dict, read: dict, now: float) -> dict:
-    """One listing row. The tail parse only: three messages, and a count."""
+def _row(task: dict, number: str, triage: dict, read: dict, now: float,
+         busy: set[str]) -> dict:
+    """One listing row. The tail parse only: three messages, and a count.
+
+    `busy` is `schedule.busy_sessions` over the WHOLE store, computed once by
+    the caller — see `_pin_holds`. Over the whole store rather than this task's
+    own entries because a resume that forked is filed under the session it RAN
+    in (`_entry_session` reads the answer first) while it still holds the
+    session it NAMED busy, and that one is another row."""
     rec = _scan(task["path"]) if task["path"] else None
     live, active = _live(task["path"], now)
     prompts = list(rec["tail"]) if rec else []
@@ -887,7 +970,10 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float) -> dict:
         # an LLM call. Read from the entry so a store that grows the field later
         # starts working without a change here.
         "description": _description(task),
-        "status": _status(newest, task["session_id"], triage, live),
+        # `active` is finalised above and feeds the status as well as the sort:
+        # a pin is stale exactly when it predates the last thing that happened.
+        "status": _status(newest, task["session_id"], triage, live, busy,
+                          active),
         "failed": _failed(newest),
         "live": live,
         "unread": _unread_count(task, total, unfired, read),
@@ -971,13 +1057,17 @@ def api_tasks():
     read = tasks_store.read_state()
     now = time.time()
     tasks = _collect()
+    # One pass over the store for every row: which conversations the scheduler
+    # is still waiting on. See `_pin_holds`.
+    busy = schedule.busy_sessions(schedule.list_entries())
     for task in tasks.values():
         _place(task)
     numbers = _numbers(tasks)
     rows = []
     for task in tasks.values():
         try:
-            row = _row(task, numbers.get(task["key"], ""), triage, read, now)
+            row = _row(task, numbers.get(task["key"], ""), triage, read, now,
+                       busy)
         except (OSError, ValueError, KeyError, TypeError):
             continue  # one unreadable task, not an unreadable page
         rows.append(row)

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -550,7 +550,10 @@ def _pin_holds(record: dict, session_id: str, live: bool, busy: set[str],
     * **a stamp later than the session's last activity** — a deliberate pin
       that no run has contradicted. This is what keeps the reopen drag (a
       `done` card dropped back on In Progress, which `dropLanes` offers) from
-      being undone on the next 20s poll.
+      being undone on the next 20s poll. `active` is therefore what HAPPENED
+      and only that: a due time in the future is later than any stamp a user
+      can make, so admitting one here inverts this guard for exactly the tasks
+      that have work coming. `_row` keeps the two apart.
 
     A turn is therefore only reaped when the session is quiet, the scheduler is
     waiting on nothing in it, and the pin predates the last thing that happened
@@ -622,23 +625,43 @@ def _failed(newest: dict | None) -> bool:
 
 def _title(task: dict, rec: dict | None, first_prompt: str) -> tuple[str, str]:
     """(title, where it came from). The precedence is §4's: what the user called
-    it, then Claude Code's own one-liner for the session, then the first line of
-    the first message. No summarisation call anywhere — the title we want is
-    already written into the transcript once per turn."""
+    it (`user`), then Claude Code's own one-liner for the session (`ai`), then
+    the first line of the first message. No summarisation call anywhere — the
+    title we want is already written into the transcript once per turn.
+
+    FOUR sources, because the last step has two and they are not equally
+    trustworthy:
+
+    * `message` — the session's own first prompt, read out of the transcript
+      (`tasks_store.head`). This is the step §4 asks for: "the first message
+      that we had", a line the session actually opened with.
+    * `entry` — the earliest scheduled message asked OF this session, used only
+      when there is no readable transcript to take the line above from. It is
+      still the best name here, but for a task scheduled from the New task form
+      it is the very message being scheduled, so a client prefilling a Title
+      field from it writes the description into the name.
+
+    The two are the same shape of string and the client has no way to tell them
+    apart by looking. It used to guess — refusing a `message` title whenever the
+    composed ask began with it — and a guess cannot tell a continuation ("pull
+    today's news" as the session's real first prompt, "pull today's news and file
+    it" as the new ask) from an echo, so a session lost the name the app already
+    knew. Naming the source is the same information without the guess."""
     for entry in reversed(task["entries"]):
         title = str(entry.get("title") or "").strip()
         if title:
             return title[:200], "user"
     if rec is not None and rec.get("title"):
         return str(rec["title"])[:200], "ai"
-    body = first_prompt
+    body, source = first_prompt, "message"
     if not body:
         for entry in task["entries"]:
-            body = str(entry.get("message") or "").strip()
-            if body:
+            text = str(entry.get("message") or "").strip()
+            if text:
+                body, source = text, "entry"
                 break
     line = body.strip().splitlines()[0].strip() if body.strip() else ""
-    return line[:200], "message"
+    return line[:200], source
 
 
 # ------------------------------------------------------------ task collection
@@ -945,16 +968,33 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     _mark_unread(tail, task["key"], read)
 
     newest = tail[-1] if tail else None
+    # TWO times, because "recent" is two questions here and one number could
+    # only answer them by lying to one of them.
+    #
+    # `active` is the last thing that actually HAPPENED in this session, and
+    # nothing that has not happened may enter it — it is the clock `_pin_holds`
+    # measures a deliberate `in_progress` stamp against. `ran_at` is when a
+    # message ran (a caught-up run is news today, whatever day it was due) and
+    # 0.0 until it does; `at` is the due time, which never moves and can be in
+    # the FUTURE (see `_entry_at`). Reading `at` here was reaping every pin on a
+    # task with a message still to come, because no stamp a user can make is
+    # later than tomorrow — the exact reopen the stamp exists to protect.
     if newest is not None:
-        # BOTH stamps, because the list sorts on this and the two answer
-        # different halves of "recent": `ran_at` is when the task last did
-        # something (a caught-up run is news today, whatever day it was due),
-        # and `at` is what keeps a message scheduled for tomorrow near the top
-        # where it can be seen before it fires.
-        active = max(active, newest["at"] or 0.0, newest["ran_at"] or 0.0)
+        active = max(active, newest["ran_at"] or 0.0)
     if not active and task["entries"]:
-        active = (tasks_store.epoch(task["entries"][-1].get("created"))
-                  or _entry_at(task["entries"][-1]))
+        # Nothing has run and there is no transcript to date: what happened is
+        # that the message was ASKED for, and `created` is when. Deliberately
+        # not `_entry_at` — a due time is the other question, below — and `or
+        # 0.0` because `epoch` answers None for a stamp it cannot read, while
+        # every time on this row is a float and 0.0 is how it says "never".
+        active = tasks_store.epoch(task["entries"][-1].get("created")) or 0.0
+    # The sort's question is the other one: the List is read newest-first, and a
+    # message scheduled for tomorrow belongs near the top where it can be seen
+    # BEFORE it fires. So the row's `last_active` keeps the due time — only the
+    # pin's clock stops at what has happened.
+    surfaced = max(active, (newest["at"] or 0.0) if newest is not None else 0.0)
+    if not surfaced and task["entries"]:
+        surfaced = _entry_at(task["entries"][-1])
     title, source = _title(task, rec, task["first_prompt"])
     return {
         "key": task["key"],
@@ -970,14 +1010,14 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # an LLM call. Read from the entry so a store that grows the field later
         # starts working without a change here.
         "description": _description(task),
-        # `active` is finalised above and feeds the status as well as the sort:
-        # a pin is stale exactly when it predates the last thing that happened.
+        # `active`, not `surfaced`: a pin is stale exactly when it predates the
+        # last thing that HAPPENED, and a run still ahead has not happened.
         "status": _status(newest, task["session_id"], triage, live, busy,
                           active),
         "failed": _failed(newest),
         "live": live,
         "unread": _unread_count(task, total, unfired, read),
-        "last_active": active,
+        "last_active": surfaced,
         "message_count": total,
         # The next run, and the entry it belongs to — `min(at)` over every
         # pending entry, not over the window below. 0.0 / "" when the task has

--- a/fused_render/templates/claude/template.html
+++ b/fused_render/templates/claude/template.html
@@ -1203,8 +1203,7 @@
      quiet as its neighbours, and `.pill`'s own padding kept so the hover paints
      the shape the rest of the row paints. Spelled out rather than folded into
      the .viewshot selector: the two buttons share a look, not a fate, and
-     .viewshot's other two rules (hidden with the pane, disabled mid-capture) are
-     about photographing something this one never touches. */
+     .viewshot's `[hidden]` rule is about a pane this one never touches. */
   .schedbtn {
     display: inline-flex;
     align-items: center;
@@ -1212,6 +1211,18 @@
     min-height: 1.65em;
   }
   .schedbtn svg { display: block; }
+  /* Dead for as long as a scheduled message is pending in this session — the same
+     refusal as the disabled textarea above it, because a task queued from here is
+     input into that message's context exactly as a typed reply would be (see
+     applyComposerBlockState). The hover that would have contradicted the dim is
+     excluded on `.pill:hover` itself, where source order can no longer undo it.
+
+     `not-allowed`, which is #box:disabled's cursor and not .viewshot's `default`:
+     these two are the SAME refusal and should feel like one, while .viewshot's
+     disable is a one-second capture that is nobody's mistake to make. Dimmer than
+     the box (.45 against .6) because an 14px monochrome glyph at .6 still reads
+     as a live icon, where a whole greyed textarea does not. */
+  .schedbtn:disabled { opacity: .45; cursor: not-allowed; }
   .user .bubble {
     background: var(--bubble-user);
     border-radius: 18px 18px 4px 18px;
@@ -1985,8 +1996,17 @@
      the "this is on" receipt disappearing under the cursor at exactly the moment
      the user is deciding whether to click. Relying on rule order for that is one
      reshuffle away from the bug coming back, and the next pressable pill in this
-     row inherits the fix rather than rediscovering it. */
-  .pill:hover:not([aria-pressed="true"]) { background-color: var(--surface-2); color: var(--fg); }
+     row inherits the fix rather than rediscovering it.
+
+     `:not(:disabled)` for the second half of the same argument. A dimmed pill that
+     still lights up under the cursor is a control saying two things at once, and
+     the reader believes the one that moves — this row now has a pill that goes dead
+     for as long as a scheduled message is pending (.schedbtn), so the exclusion is
+     spelled here rather than fought locally: at (0,2,0) a `.schedbtn:disabled`
+     override would lose to this rule on source order, which is the bug above with
+     the roles swapped. It is also the idiom the rest of this file already uses
+     (.stop, .perm button, .sb-acts button all hover `:not(:disabled)`). */
+  .pill:hover:not([aria-pressed="true"]):not(:disabled) { background-color: var(--surface-2); color: var(--fg); }
   .pill[aria-pressed="true"]:hover { filter: brightness(1.1); }
   /* Still styled, because the native popup is only SUPPRESSED for the pointer
      (openSelPop): a keyboard user who presses Space still gets the platform
@@ -3133,7 +3153,13 @@
                  selects that only describe how a run behaves.
                  A calendar and not a clock: what it opens is a task with a date
                  on it, not a delay on this message (see openScheduler for what
-                 the composer stopped trying to do on its own). -->
+                 the composer stopped trying to do on its own).
+
+                 The title and aria-label here are the PRISTINE pair, and they are
+                 also the only place this button's wording lives: a pending
+                 scheduled message disables it along with the textarea and swaps
+                 both for the banner's reason, then puts these back when the block
+                 lifts (applyComposerBlockState reads them at boot). -->
             <button id="schedbtn" class="pill schedbtn" type="button"
                     aria-label="Schedule this as a task"
                     title="Schedule this as a task"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true"><rect x="2" y="3.2" width="12" height="10.6" rx="1.6" stroke="currentColor" stroke-width="1.3"/><path d="M2 6.6h12M5.4 1.8v2.6M10.6 1.8v2.6" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></svg></button>
@@ -8040,6 +8066,12 @@ function openSchedConfirm(btn) {
 
 document.querySelectorAll(".schedbtn").forEach((btn) => {
   btn.addEventListener("click", () => {
+    // A pending scheduled message shuts this door as well as the composer's:
+    // a session that is already holding queued work takes no further input, and
+    // a task is input the same way a typed reply is (see applyComposerBlockState,
+    // which is what actually disables the button). Guarded here anyway, the same
+    // discipline `submitChat` keeps — disabled for the eye, guarded for the hand.
+    if (schedBlocked()) return;
     // A second press on the same button closes, rather than closing on the
     // document handler below and reopening here.
     const same = schedPopFor === btn;
@@ -8049,6 +8081,12 @@ document.querySelectorAll(".schedbtn").forEach((btn) => {
 });
 
 document.getElementById("schedpop-go").addEventListener("click", () => {
+  // The confirm can OUTLIVE the press that opened it: the 15s schedule poll may
+  // block this chat while the question is still on screen, and this is the only
+  // caller of openScheduler — so the last word on whether a task may be made from
+  // here is read here, not at open time. The block also closes the confirm
+  // (applyComposerBlockState), which makes this the race and not the ordinary path.
+  if (schedBlocked()) return;
   // The box belonging to the composer that was clicked, not "the visible one":
   // only one composer is on screen at a time, but reading the button's own form
   // is what keeps that a fact about the layout rather than an assumption here.
@@ -11290,7 +11328,25 @@ const schedBlockName = schedBlockEl.querySelector(".sb-name");
 const schedBlockMeta = schedBlockEl.querySelector(".sb-meta");
 const schedBlockNote = schedBlockEl.querySelector(".sb-note");
 const schedBlockStop = document.getElementById("sb-stop");
+// THE CHAT COMPOSER'S CALENDAR BUTTON, which goes dead with the box it sits in
+// (Akshil, 2026-08-17 — "when we have a blocked panel we don't allow to type…
+// we should not allow to schedule the task as well"). A session already holding
+// pending scheduled work takes no further input of ANY kind: queuing a second
+// message into a context that is spoken for is the same pollution the block
+// exists to prevent, one step later. See applyComposerBlockState.
+//
+// The HOME card's copy (#hschedbtn) is deliberately not touched, for the same
+// reason `homebox` is not: there is no session on the landing page, so nothing
+// can be pending in the conversation it is about to start (schedPendingHere
+// returns [] without one) and a handle to it here would be dead wiring.
+const schedBtn = document.getElementById("schedbtn");
 const BOX_PLACEHOLDER = box.placeholder;
+// The pristine wording, read off the markup rather than retyped, which is what
+// BOX_PLACEHOLDER above is doing too: the button's own attributes stay the one
+// place its name lives, so a re-word there cannot leave this file restoring a
+// tooltip nobody writes any more.
+const SCHED_BTN_TITLE = schedBtn.title;
+const SCHED_BTN_LABEL = schedBtn.getAttribute("aria-label");
 
 // The pending messages that would land in this conversation, soonest first.
 // EMPTY is the only state in which the composer works — and it is also the state
@@ -11501,6 +11557,21 @@ function schedStopTarget(entry) {
     ? String(entry.template_id) : String((entry && entry.id) || "");
 }
 
+// WHY THE BOX IS SHUT, in one sentence, and it has one author. The banner shows
+// it as its only line of prose and the calendar button carries it as its tooltip
+// and its spoken name — the two things the block switches off — so a reader
+// refused by the button reads the same words as the card six pixels above it.
+// Two literals would be two things to re-word, and the one that got missed would
+// be the one under the pointer.
+//
+// The repeat gets its own wording because the ESCAPE differs (see schedStopTarget):
+// "scheduled" is a message you can cancel, "repeating" is a job you have to stop.
+function schedBlockReason(entry) {
+  return schedIsRepeat(entry)
+    ? "Blocked — a repeating message runs in this chat."
+    : "Blocked — a scheduled message runs in this chat.";
+}
+
 function renderSchedBlock() {
   const next = schedBlockers[0];
   // Nothing blocking: hide it, and put the button back cold. A hidden card left
@@ -11523,9 +11594,7 @@ function renderSchedBlock() {
   // The SOONEST is named by the row and the rest are counted here, because naming
   // one is what answers "what is coming?" and a list of five would be the Tasks
   // page in a strip above a chat.
-  let why = repeat
-    ? "Blocked — a repeating message runs in this chat."
-    : "Blocked — a scheduled message runs in this chat.";
+  let why = schedBlockReason(next);
   if (others > 0) why += " " + others + " more after it.";
   schedBlockWhen.textContent = why;
   // ── the row ──
@@ -11635,6 +11704,33 @@ function applyComposerBlockState() {
   // simply clipped. The banner above carries the explanation; this only has to
   // say the box is not broken.
   box.placeholder = blocked ? "Waiting on a scheduled message…" : BOX_PLACEHOLDER;
+  // THE CALENDAR BUTTON GOES WITH THE BOX, off the SAME `blocked` — not off a
+  // second read of the schedule. A parallel notion of "is this session blocked"
+  // is two answers to one question, and the day they disagree one of them is
+  // lying to the user about what their chat is doing.
+  //
+  // The real `disabled` attribute rather than a class that merely looks it: it
+  // stops the pointer AND the keyboard in one stroke, since a disabled <button>
+  // fires no click for Enter or Space either — a control that paints itself dead
+  // and still navigates is worse than one that never dimmed. The click handler
+  // guards as well, the same belt-and-braces `submitChat` uses.
+  const why = blocked ? schedBlockReason(schedBlockers[0]) : "";
+  schedBtn.disabled = blocked;
+  schedBtn.title = blocked ? why : SCHED_BTN_TITLE;
+  // And the SPOKEN name says it too, the way the box's placeholder does above:
+  // `disabled` takes the button out of tab order, so the title is unreachable by
+  // keyboard and the name is all a reader browsing this row will hear. The name
+  // stays first — what the control is, then why it is off — so the button is
+  // still identifiable while it is refusing.
+  schedBtn.setAttribute("aria-label", blocked ? SCHED_BTN_LABEL + " — " + why
+                                              : SCHED_BTN_LABEL);
+  // A confirm can already be up when the poll lands: "Schedule this as a task?"
+  // is a question about a button that has just died, and its Continue would hit
+  // the guard and do nothing visible. Take it down instead, so what the reader
+  // ends up looking at is the banner. Only on the way IN — closing a confirm the
+  // user opened the moment the block lifted would be the block reaching past its
+  // own end.
+  if (blocked) closeSchedConfirm();
   // The row's number and name, fetched AFTER the card is on screen and never
   // before the block: what shuts the composer is the schedule, and the listing
   // only decorates the row (see schedLoadTaskRow). Guarded there against refetching

--- a/tests/test_claude_composer_block.py
+++ b/tests/test_claude_composer_block.py
@@ -29,6 +29,15 @@ session ID because you are already there" — and the row is the LINK to the tas
 which is what let "Edit schedule" go: two doors to one room, and the banner's own
 door could not unblock.
 
+IT IS NOT ONLY THE BOX. The composer's calendar button — the hop that hands this
+draft to the Schedule page — goes dead with it (Akshil, 2026-08-17: "when we have
+a blocked panel we don't allow to type… we should not allow to schedule the task
+as well"). A session already holding pending scheduled work accepts no further
+input of ANY kind: queuing a second message into a context that is spoken for is
+the same pollution one step later. Both controls read the ONE `schedBlocked()`
+this file already had, because two notions of "is this session blocked" is two
+answers to one question.
+
 Structural assertions over the template source, the same approach
 test_claude_message_anchor.py and test_claude_schedule_pill.py take: inline
 vanilla JS in a 12000-line document, so what can be pinned is that the wiring
@@ -36,9 +45,17 @@ exists and that the properties it would be easy to get wrong stay true. Here
 those are: it blocks on a pending entry naming THIS session, it does NOT block
 when the schedule cannot be read, the row carries four facts and no fifth, it
 sits against the composer it is shutting, and its one action actually unblocks.
+
+Where a direction could be backwards rather than absent, the page's own function
+is LIFTED OUT AND RUN under node instead (`_node` below, the harness
+test_claude_shots.py established): "blocked ⇒ shut" and "unblocked ⇒ open again"
+are both `= blocked`, and a source read cannot tell them apart.
 """
+import json
 import os
 import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -65,6 +82,89 @@ def code(source) -> str:
 def _fn(code: str, opening: str) -> str:
     body = code[code.index(opening):]
     return body[:body.index("\n}")]
+
+
+# --------------------------------------------- the page's own JS, under node
+#
+# Structure says the wiring is there; it cannot say which way round it points.
+# "Blocked ⇒ shut" and "unblocked ⇒ open again" are the two directions a
+# `= blocked` assignment could have backwards, so applyComposerBlockState is
+# lifted out of the page and RUN, against stubs for the DOM it touches. Same
+# extraction as tests/test_claude_shots.py's `_node`, kept as its own copy for
+# the reason that one gives: the suites are independent and a shared harness
+# would couple them.
+
+def _node(fn_names, call, html, prelude=""):
+    if not shutil.which("node"):
+        pytest.skip("node is needed to run the page's own composer-block helpers")
+    chunks = []
+    for name in fn_names:
+        start = html.index(name)
+        if name.startswith("function") or name.startswith("async function"):
+            end = html.index("\n}\n", start) + 3      # closing brace at column 0
+            chunks.append(html[start:end])
+            continue
+        taken = []
+        for line in html[start:].split("\n"):
+            taken.append(line)
+            if line.split("//")[0].rstrip().endswith(";"):
+                break
+        chunks.append("\n".join(taken))
+    script = prelude + "\n" + "\n".join(chunks) + "\n" + call
+    out = subprocess.run(["node", "-e", script], capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+# The pristine strings come out of the TEMPLATE (the three `const`s below), so a
+# rename or a re-word on either the box or the button is caught here rather than
+# being quietly mirrored into the stub.
+_STATE_FNS = ["let schedBlockers", "const BOX_PLACEHOLDER",
+              "const SCHED_BTN_TITLE", "const SCHED_BTN_LABEL",
+              "function schedBlocked(", "function schedIsRepeat(",
+              "function schedBlockReason(", "function applyComposerBlockState(",
+              "function applyComposerBlock(", "function clearComposerBlock("]
+
+# Only the session matters to schedPendingHere, and the block exists only when
+# there is one. Everything else here is a surface the state function writes to.
+_STATE_STUBS = """
+const fused = { params: { get: (k) => (k === "session_id" ? "S1" : "") } };
+function nearBottom() { return false; }
+function scrollBottom() {}
+function schedLoadTaskRow() {}
+let confirmClosed = 0;
+function closeSchedConfirm() { confirmClosed += 1; }
+const schedBlockEl = { hidden: true };
+function renderSchedBlock() { schedBlockEl.hidden = !schedBlockers[0]; }
+const box = { disabled: false, placeholder: "Reply to Claude…" };
+const schedBtn = {
+  disabled: false,
+  title: "Schedule this as a task",
+  attrs: { "aria-label": "Schedule this as a task" },
+  setAttribute(k, v) { this.attrs[k] = v; },
+  getAttribute(k) { return this.attrs[k]; },
+};
+function snap() {
+  return {
+    disabled: schedBtn.disabled,
+    title: schedBtn.title,
+    label: schedBtn.getAttribute("aria-label"),
+    box_disabled: box.disabled,
+    placeholder: box.placeholder,
+    hidden: schedBlockEl.hidden,
+    confirm_closed: confirmClosed,
+  };
+}
+"""
+
+
+def _run(source, body):
+    return _node(_STATE_FNS, body, source, prelude=_STATE_STUBS)
+
+
+_ONE_OFF = '{ id: "e1", state: "pending", session_id: "S1", due: "2026-08-18T09:00:00" }'
+_REPEAT = ('{ id: "e2", state: "pending", session_id: "S1", template_id: "t9",'
+           ' due: "2026-08-18T09:00:00" }')
 
 
 # ------------------------------------------------------- what blocks the box
@@ -100,10 +200,172 @@ def test_the_box_is_shut_and_the_send_path_is_guarded(code):
 
 def test_the_send_button_is_never_disabled(code):
     """While a run is live that button is the STOP button, and a chat that cannot
-    stop its own running turn is a worse state than the one this prevents."""
+    stop its own running turn is a worse state than the one this prevents. The two
+    things that DO go dead are the textarea and the calendar button — everything
+    else in the row (the three selects, the screenshot, Send) stays live."""
     state = _fn(code, "function applyComposerBlockState(")
-    assert "disabled = blocked" in state
-    assert state.count("disabled = blocked") == 1, "only the textarea"
+    assert "box.disabled = blocked" in state
+    assert "schedBtn.disabled = blocked" in state
+    assert state.count("disabled = blocked") == 2, "the textarea and the calendar"
+    for live in (".send", "sendBtn", "viewshot", "model", "effort", "perm"):
+        assert live not in state, f"{live} has no business going dead here"
+
+
+# ------------------------------------------- the calendar button goes with it
+
+
+def test_the_calendar_button_is_shut_by_the_SAME_state_as_the_box(code):
+    """"When we have a blocked panel we don't allow to type… we should not allow to
+    schedule the task as well" (Akshil, 2026-08-17). A session holding pending
+    scheduled work takes no further input of ANY kind — typed or queued — because
+    queuing a second message into a context that is already spoken for is the same
+    pollution one keystroke later.
+
+    ONE state, not two. Both reads are `blocked`, the single `schedBlocked()` this
+    function already computed: a second notion of "is this session blocked" is two
+    answers to one question, and the day they disagree one of them is lying to the
+    user about what their chat is doing."""
+    state = _fn(code, "function applyComposerBlockState(")
+    assert "const blocked = schedBlocked();" in state
+    assert "box.disabled = blocked" in state
+    assert "schedBtn.disabled = blocked" in state
+    # no second predicate: nothing here re-derives the block from the entries
+    assert "schedPendingHere(" not in state
+    assert state.count("schedBlocked()") == 1
+
+
+def test_a_blocked_calendar_button_is_disabled_and_says_why(source):
+    """`disabled` for real, not a class that looks it: a control that paints itself
+    dead and still navigates on the click is worse than one that never dimmed.
+
+    And it says WHY in the banner's own sentence — schedBlockReason, the same
+    function that writes the card's one line — because the reader is being refused
+    by a button whose explanation is six pixels above it, and a second phrasing of
+    one fact is how the two drift apart."""
+    out = _run(source, "applyComposerBlock([" + _ONE_OFF
+               + "]); console.log(JSON.stringify(snap()));")
+    assert out["disabled"] is True
+    assert out["box_disabled"] is True, "the box and the button go together"
+    assert out["title"] == "Blocked — a scheduled message runs in this chat."
+    # the spoken name carries the reason too: `disabled` takes the button out of
+    # tab order, so the title is unreachable by keyboard
+    assert out["label"] == ("Schedule this as a task"
+                           " — Blocked — a scheduled message runs in this chat.")
+
+
+def test_a_repeat_is_refused_in_the_repeats_own_words(source):
+    """The banner distinguishes the two cases because the ESCAPE differs; the
+    button borrows whichever sentence the card is showing, so the tooltip never
+    disagrees with the notice directly above it."""
+    out = _run(source, "applyComposerBlock([" + _REPEAT
+               + "]); console.log(JSON.stringify(snap()));")
+    assert out["disabled"] is True
+    assert out["title"] == "Blocked — a repeating message runs in this chat."
+
+
+def test_the_calendar_button_comes_back_the_moment_the_block_lifts(source):
+    """The other direction, and it is the one an `= blocked` assignment can have
+    backwards. It re-enables through the path that reopens the BOX and no other:
+    the cancel, the stop, a queued turn completing and the switch of session all
+    land on applyComposerBlockState, so there is nothing here to refresh
+    separately — and the pristine title and name come back with it, or the button
+    would keep explaining a block that has gone."""
+    out = _run(source, "applyComposerBlock([" + _ONE_OFF + "]);"
+               " clearComposerBlock();"
+               " console.log(JSON.stringify(snap()));")
+    assert out["disabled"] is False
+    assert out["box_disabled"] is False
+    assert out["title"] == "Schedule this as a task"
+    assert out["label"] == "Schedule this as a task"
+    assert out["placeholder"] == "Reply to Claude…"
+
+
+def test_a_blocked_calendar_button_also_LOOKS_dead(source):
+    """`disabled` alone paints nothing on a pill: every background in that row is
+    transparent, so a live and a dead calendar are the same picture until the
+    cursor arrives — and then `.pill:hover` lights the dead one up. The hover is
+    excluded on `.pill:hover` itself rather than overridden locally: both selectors
+    sit at (0,2,0), so a `.schedbtn:disabled` background would lose on source
+    order — the exact bug the aria-pressed comment beside it records, with the
+    roles swapped.
+
+    The CURSOR is the box's, not .viewshot's: this button and that textarea are the
+    same refusal for the same reason and should feel like one under the hand, where
+    .viewshot's disable is a one-second capture nobody could have got wrong."""
+    rule = re.search(r"^  \.schedbtn:disabled \{[^\n]*$", source, flags=re.M).group(0)
+    assert "opacity:" in rule
+    assert "cursor: not-allowed;" in rule
+    box = source[source.index("  #box:disabled {"):]
+    assert "cursor: not-allowed;" in box[:box.index("\n  }")]
+    hover = re.search(r"^  \.pill:hover[^\n]*$", source, flags=re.M).group(0)
+    assert ":not(:disabled)" in hover
+    assert "!important" not in source, "specificity, not force (D146)"
+
+
+def test_the_pristine_title_and_name_are_captured_and_not_retyped(code):
+    """The same idiom as BOX_PLACEHOLDER beside them: read off the element at boot,
+    so the markup stays the one place the button's wording lives. Retyping the
+    strings here is how the restored tooltip ends up being last week's copy."""
+    assert 'const schedBtn = document.getElementById("schedbtn");' in code
+    assert "const SCHED_BTN_TITLE = schedBtn.title;" in code
+    assert 'const SCHED_BTN_LABEL = schedBtn.getAttribute("aria-label");' in code
+
+
+def test_every_route_to_the_scheduler_is_closed_while_blocked(code):
+    """Grepped, not assumed. Three ways in and all three are shut:
+
+    * the two `.schedbtn` clicks — `disabled` stops the pointer AND the keyboard,
+      since a disabled <button> fires no click for Enter or Space either, and the
+      handler guards anyway (`submitChat`'s discipline: disabled for the eye,
+      guarded for the hand);
+    * the confirm's Continue, which is the only caller of openScheduler and can
+      outlive the press — the 15s poll may block the chat while the question is
+      still on screen.
+
+    There is no shortcut key and no kebab item: the menu's schedule entry was
+    deleted on 2026-08-16 (see test_claude_schedule_button.py) and nothing else in
+    this template opens the Schedule page with a draft."""
+    clicks = code[code.index('document.querySelectorAll(".schedbtn")'):]
+    clicks = clicks[:clicks.index("\n});")]
+    assert "if (schedBlocked()) return;" in clicks
+    go = code[code.index('document.getElementById("schedpop-go").addEventListener'):]
+    go = go[:go.index("\n});")]
+    assert "if (schedBlocked()) return;" in go
+    assert go.index("schedBlocked()") < go.index("openScheduler("), \
+        "the guard has to come before the hop"
+    # and only those two: no third entry point grew one
+    assert code.count("openSchedConfirm(") == 2   # the definition and the click
+    assert code.count("openScheduler(") == 2      # the definition and Continue
+
+
+def test_a_confirm_already_open_is_taken_down_by_the_block(source):
+    """The poll arrives every 15s, so "Schedule this as a task?" can be on screen
+    when the block lands. Left standing it is a question about a button that has
+    just died, with a Continue that the guard above would silently ignore — so the
+    block closes it, and the reader sees the banner instead of a dead dialog."""
+    out = _run(source, "applyComposerBlock([" + _ONE_OFF
+               + "]); console.log(JSON.stringify(snap()));")
+    assert out["confirm_closed"] == 1
+    # and NOT on the way out: closing a confirm the user opened the moment the
+    # block lifted would be the block reaching past its own end
+    out = _run(source, "clearComposerBlock(); console.log(JSON.stringify(snap()));")
+    assert out["confirm_closed"] == 0
+
+
+def test_the_reason_line_has_one_author(code):
+    """The banner and the button read the same sentence from the same function.
+    Two literals would be two things to re-word, and the one that got missed would
+    be the one under the pointer."""
+    reason = _fn(code, "function schedBlockReason(")
+    assert '"Blocked — a repeating message runs in this chat."' in reason
+    assert '"Blocked — a scheduled message runs in this chat."' in reason
+    assert "schedIsRepeat(" in reason
+    # nobody else spells them
+    assert code.count("runs in this chat.") == 2, "the sentences live in one place"
+    render = _fn(code, "function renderSchedBlock(")
+    assert "schedBlockReason(next)" in render
+    state = _fn(code, "function applyComposerBlockState(")
+    assert "schedBlockReason(schedBlockers[0])" in state
 
 
 def test_there_is_no_time_window_anywhere(code):
@@ -350,8 +612,10 @@ def test_the_reason_is_one_short_line_and_nothing_else_in_words(code):
     second still spent a sentence on it. The state and the time live on the row now,
     so the line only has to say the box is shut and why."""
     render = _fn(code, "function renderSchedBlock(")
-    assert '"Blocked — a scheduled message runs in this chat."' in render
-    assert '"Blocked — a repeating message runs in this chat."' in render
+    assert "let why = schedBlockReason(next);" in render
+    reason = _fn(code, "function schedBlockReason(")
+    assert '"Blocked — a scheduled message runs in this chat."' in reason
+    assert '"Blocked — a repeating message runs in this chat."' in reason
     # the sentences it replaced are gone, in both generations
     for gone in ("read-only for as long as", "moves the block to the next one",
                  "would join this task's context", "Reschedule to change",

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -158,6 +158,35 @@ def test_the_click_confirms_before_it_navigates(code):
     assert "openScheduler(" in go
 
 
+def test_no_route_through_this_button_survives_a_blocked_composer(code):
+    """"When we have a blocked panel we don't allow to type… we should not allow to
+    schedule the task as well" (Akshil, 2026-08-17). A session already holding a
+    pending scheduled message takes no further input, and a task queued from here
+    lands in that message's context exactly as a typed reply would.
+
+    What this suite owns is the ROUTE COUNT: the handoff is two clicks and one
+    Continue, and the block has to reach all three — the `disabled` attribute plus
+    the click guard for the buttons, and a guard on Continue because the 15s poll
+    can shut the chat while the confirm is still on screen. The state itself, both
+    directions and the wording live in tests/test_claude_composer_block.py; there
+    is exactly ONE of them and this reads the same one."""
+    state = code[code.index("function applyComposerBlockState("):]
+    state = state[:state.index("\n}")]
+    assert "schedBtn.disabled = blocked" in state
+    assert "const blocked = schedBlocked();" in state
+    clicks = code[code.index('document.querySelectorAll(".schedbtn")'):]
+    clicks = clicks[:clicks.index("\n});")]
+    assert "if (schedBlocked()) return;" in clicks
+    go = code[code.index('document.getElementById("schedpop-go").addEventListener'):]
+    go = go[:go.index("\n});")]
+    assert "if (schedBlocked()) return;" in go
+    assert go.index("schedBlocked()") < go.index("openScheduler(")
+    # and there is no fourth way in for it to have missed: no shortcut key, no
+    # kebab item (deleted 2026-08-16, above), and only these two callers
+    assert code.count("openSchedConfirm(") == 2
+    assert code.count("openScheduler(") == 2
+
+
 def test_the_confirm_says_what_travels(source):
     """The one thing the icon cannot say. A user who does not know the draft comes
     along will retype it on the other side, which is the failure the whole handoff

--- a/tests/test_claude_session_summaries.py
+++ b/tests/test_claude_session_summaries.py
@@ -192,6 +192,52 @@ def test_fresh_activity_is_running_and_defaults_to_in_progress(
     assert session["status"] == "in_progress"
 
 
+@pytest.mark.parametrize("pinned", ["done", "archived"])
+def test_a_running_session_outranks_a_stale_filing_decision(
+        client, projects_dir, state_dir, tmp_path, pinned):
+    """The in-progress lane is DERIVED, not recorded — and this module mirrors
+    the Inbox (see the module docstring), so it derives it the same way.
+
+    "Something is running in this conversation" is a fact about the present, and
+    a record filed during an earlier run does not outvote it: a session the user
+    marked done or archived and then resumed belongs in In Progress. The Inbox
+    used to buy that by having `autoFlow` OVERWRITE the record whenever it saw a
+    run — a write it could only retract while that same tab stayed open, so every
+    finish nothing witnessed left an `in_progress` on disk that nothing would ever
+    clear. It stopped writing, so both readers of triage.json compute the lane,
+    and the pin the user made is still in the file when the run stops.
+    """
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _write(projects_dir, "proj", "s1", [
+        {"cwd": str(proj), **_user("hi", "2026-08-16T08:00:00Z")},
+        _assistant("working", now_iso),
+    ])
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"s1": {"status": pinned, "note": "keep me"}}))
+
+    assert _get(client)[0]["status"] == "in_progress"
+    # derived, not cached: nothing rewrote the user's record to get here
+    rec = json.loads((state_dir / "triage.json").read_text())["s1"]
+    assert rec == {"status": pinned, "note": "keep me"}
+
+
+def test_a_filing_decision_still_wins_once_the_run_is_over(
+        client, projects_dir, state_dir, tmp_path):
+    """The other side of it. Only `in_progress` is a claim about the present;
+    `done` and `archived` are decisions, and a quiet session is where they hold.
+    """
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    _write(projects_dir, "proj", "s1", [
+        {"cwd": str(proj), **_user("hi", "2026-08-16T08:00:00Z")},
+    ], mtime=STALE)
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"s1": {"status": "archived"}}))
+    assert _get(client)[0]["status"] == "archived"
+
+
 def test_housekeeping_tail_is_not_activity_even_with_a_fresh_file(
         client, projects_dir, state_dir, tmp_path):
     """A turn_duration entry appended after the turn ends bumps the file mtime

--- a/tests/test_claude_session_summaries.py
+++ b/tests/test_claude_session_summaries.py
@@ -318,6 +318,8 @@ def test_triage_write_sets_status_and_reads_back(projects_dir, state_dir, client
 
 
 def test_triage_write_preserves_the_records_other_keys(state_dir, client):
+    """`status` and its stamp are the only fields this endpoint touches — a note
+    the user typed in the Inbox must survive a drag on the Board."""
     path = os.path.join(str(state_dir), "triage.json")
     with open(path, "w", encoding="utf-8") as f:
         json.dump({"s1": {"status": "done", "note": "keep me", "read": "1"}}, f)
@@ -326,7 +328,14 @@ def test_triage_write_preserves_the_records_other_keys(state_dir, client):
     assert r.status_code == 200
     with open(path, encoding="utf-8") as f:
         rec = json.load(f)["s1"]
-    assert rec == {"status": "in_progress", "note": "keep me", "read": "1"}
+    assert rec["note"] == "keep me"
+    assert rec["read"] == "1"
+    assert rec["status"] == "in_progress"
+    # Stamped, so `_pin_holds` can tell this deliberate pin from an automatic
+    # one. The set of keys is asserted whole so a future field has to be a
+    # decision rather than a leak.
+    assert set(rec) == {"status", "note", "read", "at"}
+    assert float(rec["at"]) > 0
 
 
 def test_triage_write_refuses_a_status_it_does_not_speak(state_dir, client):

--- a/tests/test_claude_shots.py
+++ b/tests/test_claude_shots.py
@@ -1754,8 +1754,13 @@ def test_hover_never_eats_an_active_state_in_either_control(html):
     button with no pressed state at all (it captures on click, and the chip above
     the composer is the receipt, so there is nothing to keep painted). The RULE
     stays, stated in the selectors rather than left to source order, so the next
-    pressable pill in that row inherits the fix rather than rediscovering it."""
-    pairs = [('.pill:hover:not([aria-pressed="true"])',
+    pressable pill in that row inherits the fix rather than rediscovering it.
+
+    `:not(:disabled)` joined it for the same argument on a second state: the row
+    now has a pill that goes dead while a scheduled message is pending (.schedbtn,
+    see tests/test_claude_composer_block.py), and a dimmed control that still
+    lights up under the cursor is this bug with the roles swapped."""
+    pairs = [('.pill:hover:not([aria-pressed="true"]):not(:disabled)',
               '.pill[aria-pressed="true"]:hover')]
     for neutral, active in pairs:
         assert neutral + " {" in html, neutral

--- a/tests/test_new_task_css.py
+++ b/tests/test_new_task_css.py
@@ -8,18 +8,29 @@ pinned by reading the stylesheet's own numbers rather than restating them:
 retuning a value keeps these tests honest, and only breaking the *invariant*
 fails one.
 
-Three invariants, all from the same review (Akshil, 2026-08-17):
+Four invariants, all from the same run of reviews (Akshil, 2026-08-17):
 
 1. **The surface starts FLUSH.** There is no left gutter and no accent rule
    standing in one. The pair used to sit 10px in behind a 2px accent bar drawn
    in a strip a negative margin opened up; that read as a gutter nothing else on
    the card has.
 
-2. **The caret is the ordinary one.** No `caret-color` override anywhere on this
+2. **Neither field has a fill.** Not at rest, not on hover, and — the last one
+   to go — not on focus: "don't do this background highlight thing for the input
+   fields of title and description". A tinted rectangle is a box drawn in one
+   colour, so a `--ctl-quiet-bg` wash undid the borderlessness the rest of this
+   file buys. Focus is the caret now, which is what WCAG 2.4.7 accepts for a text
+   field; the one ring left is the forced-colours one, where the caret is drawn in
+   a palette this stylesheet cannot check. Pinned as "no background", not as
+   "no rules" — the whole point is that removing the wash did not quietly bring
+   back a border, a shadow or a second fill under another name.
+
+3. **The caret is the ordinary one.** No `caret-color` override anywhere on this
    surface — a text cursor takes `color`, the way `.field-control` leaves it, and
    the accent override drew a yellow-green cursor found nowhere else in the app.
+   Load-bearing twice over now that the caret is the entire focus signal.
 
-3. **The description reads as body text under a heading.** Two faces, not two
+4. **The description reads as body text under a heading.** Two faces, not two
    sizes of the same face: the numbers are read out of the file and compared, so
    the test says "clearly smaller" rather than "13px".
 
@@ -64,6 +75,28 @@ def _decl(css: str, selector: str, prop: str) -> str | None:
     return found.group(1).strip() if found else None
 
 
+def _fills(css: str) -> list[tuple[str, str]]:
+    """Every background declaration in the file, paired with the selector of the
+    rule it sits in.
+
+    Broader than `_decl` on purpose: invariant 2 is about the whole surface, so a
+    fill smuggled in under `:hover`, under a grouped selector or inside an
+    at-rule has to be caught as readily as one on the plain rule. The selector is
+    the text between the rule's own `{` and whatever ended the thing before it —
+    the previous rule's `}` or an enclosing at-rule's `{`, whichever is nearer,
+    which is what makes a rule nested in `@media` report its own selector rather
+    than the media query's."""
+    out = []
+    for found in re.finditer(r"(?<![\w-])background(?:-color|-image)?\s*:\s*([^;}]+)", css):
+        brace = css.rfind("{", 0, found.start())
+        start = max(css.rfind("}", 0, brace), css.rfind("{", 0, brace)) + 1
+        out.append((" ".join(css[start:brace].split()), found.group(1).strip()))
+    return out
+
+
+_SURFACE = ("new-task-field", "new-task-title", "new-task-ask")
+
+
 def _px(value: str) -> int:
     """A length in px. A bare `0` is a length too — CSS drops the unit on zero,
     and `padding: 6px 0` is exactly how "no horizontal padding" is written."""
@@ -99,22 +132,66 @@ def test_nothing_pulls_the_fields_back_out_into_a_gutter():
             f"{prop} on the writing surface reintroduces the left gutter")
 
 
-def test_focus_is_a_wash_and_not_an_accent_rule():
+# -- 2. no fill, in any state -------------------------------------------------
+
+def test_the_fields_declare_themselves_unfilled():
+    # `transparent` is DECLARED rather than left off: deploy.css paints
+    # `background: var(--bg)` onto every unarmored field in a modal, so silence
+    # here is a recessed box, not a bare surface.
+    css = _source()
+    assert _decl(css, _FIELD, "background") == "transparent", (
+        "the writing surface must declare `background: transparent` — omitting it "
+        "lets deploy.css's modal-field fill through")
+    assert _decl(css, _FIELD, "background-color") is None, (
+        "one background declaration, not two arguing")
+
+
+def test_focus_is_not_a_background():
     css = _source()
     focus = _block(css, _FIELD + ":focus")
-    assert focus, "the focused field must still say it is focused somehow"
-    # The wash IS the signal now, so it has to be there…
-    assert re.search(r"(?<![\w-])background\s*:", focus), (
-        "focus is a --ctl-quiet-bg wash across the field; without it a borderless "
-        "field gives a keyboard user nothing")
-    # …and the bar it replaced must not come back, in any of its spellings.
+    # The rule still exists — it declares `outline: none`, which is the statement
+    # that this surface does not ring. What it must not declare is a fill.
+    assert focus, (
+        "the :focus rule states outline:none deliberately; deleting it hands the "
+        "decision to whatever deploy.css says")
+    for prop in ("background", "background-color", "background-image"):
+        assert _decl(css, _FIELD + ":focus", prop) is None, (
+            f"{prop} on focus is the --ctl-quiet-bg wash coming back: a tinted "
+            "rectangle is a box, which is the one thing these fields must not "
+            "grow when you type in them")
+    # And the chrome the wash itself replaced stays gone — a removed fill must not
+    # be swapped for the bar, a shadow or an underline.
     assert _decl(css, _FIELD + ":focus", "box-shadow") is None, (
         "the 2px accent bar down the left edge was removed with the gutter it "
-        "was drawn in")
-    for prop in ("border-left", "border-inline-start", "border"):
+        "was drawn in; a box-shadow is how it would come back")
+    for prop in ("border-left", "border-inline-start", "border", "border-bottom"):
         assert _decl(css, _FIELD + ":focus", prop) is None, (
             f"{prop} puts the box back on a surface whose whole point is not "
             "having one")
+
+
+def test_no_rule_anywhere_fills_the_writing_surface():
+    # The broad form of the two above, so a fill cannot slip in under `:hover`, a
+    # grouped selector, or a state nobody thought to write a test for.
+    for selector, value in _fills(_source()):
+        if not any(name in selector for name in _SURFACE):
+            continue
+        assert value in ("transparent", "none"), (
+            f"{selector} fills a writing-surface field ({value}); title and "
+            "description sit directly on the card in every state")
+
+
+def test_forced_colours_still_rings_the_focused_field():
+    # The one ring that survives, and the only state where a ring is right: the
+    # caret carries focus everywhere else, but in forced-colours mode it is drawn
+    # by the OS in a palette this stylesheet cannot see, let alone verify.
+    css = _source()
+    cut = css.find("@media (forced-colors: active)")
+    assert cut != -1, "the forced-colours handling for this surface went missing"
+    outline = _decl(css[cut:], _FIELD + ":focus", "outline")
+    assert outline and "Highlight" in outline, (
+        "forced-colours focus must ring the field in the system Highlight colour, "
+        f"not in a token the mode discards (outline: {outline})")
 
 
 def test_no_accent_is_painted_on_the_writing_surface_at_all():

--- a/tests/test_new_task_css.py
+++ b/tests/test_new_task_css.py
@@ -1,0 +1,167 @@
+"""Things about the New task card's WRITING SURFACE that only CSS can get wrong.
+
+The title and the description share one borderless area (`.new-task-write` in
+`frontend/src/styles/new-task.css`), which means the usual signals a field has —
+a border, a box, a focus ring — are deliberately absent and the few that remain
+carry the whole design. Nothing in the suite renders CSS, so the invariants are
+pinned by reading the stylesheet's own numbers rather than restating them:
+retuning a value keeps these tests honest, and only breaking the *invariant*
+fails one.
+
+Three invariants, all from the same review (Akshil, 2026-08-17):
+
+1. **The surface starts FLUSH.** There is no left gutter and no accent rule
+   standing in one. The pair used to sit 10px in behind a 2px accent bar drawn
+   in a strip a negative margin opened up; that read as a gutter nothing else on
+   the card has.
+
+2. **The caret is the ordinary one.** No `caret-color` override anywhere on this
+   surface — a text cursor takes `color`, the way `.field-control` leaves it, and
+   the accent override drew a yellow-green cursor found nowhere else in the app.
+
+3. **The description reads as body text under a heading.** Two faces, not two
+   sizes of the same face: the numbers are read out of the file and compared, so
+   the test says "clearly smaller" rather than "13px".
+
+`tests/test_theme.py` established reading stylesheet source this way, and
+`tests/test_schedule_css.py` is the sibling suite for the list page.
+"""
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_CSS = os.path.join(REPO_ROOT, "frontend", "src", "styles", "new-task.css")
+
+_FIELD = ".new-task-write .new-task-field"
+_TITLE = ".new-task-write .new-task-title"
+_ASK = ".new-task-write .new-task-ask"
+
+
+def _source() -> str:
+    """The stylesheet with its comments removed.
+
+    Not optional here: this file's comments quote the very declarations these
+    tests assert are gone (they explain what replaced `margin-inline: -10px` and
+    why `caret-color` went), so a parser that read comments would find every
+    removed property still present."""
+    with open(_CSS, encoding="utf-8") as f:
+        return re.sub(r"/\*.*?\*/", "", f.read(), flags=re.S)
+
+
+def _block(css: str, selector: str) -> str:
+    """The body of the rule for exactly `selector`, or "".
+
+    Deliberately literal, like test_schedule_css._decl: `…new-task-field` and
+    `…new-task-field:focus` are two different blocks and neither can be found
+    by accident through the other."""
+    found = re.search(re.escape(selector) + r"\s*\{([^}]*)\}", css)
+    return found.group(1) if found else ""
+
+
+def _decl(css: str, selector: str, prop: str) -> str | None:
+    body = _block(css, selector)
+    found = re.search(rf"(?<![\w-]){re.escape(prop)}\s*:\s*([^;]+);", body)
+    return found.group(1).strip() if found else None
+
+
+def _px(value: str) -> int:
+    """A length in px. A bare `0` is a length too — CSS drops the unit on zero,
+    and `padding: 6px 0` is exactly how "no horizontal padding" is written."""
+    found = re.fullmatch(r"(\d+)(?:px)?", value.strip())
+    assert found, f"not a px length: {value!r}"
+    return int(found.group(1))
+
+
+# -- 1. no gutter, and nothing standing in one --------------------------------
+
+def test_the_surface_has_no_horizontal_padding_to_hang_a_rule_in():
+    padding = _decl(_source(), _FIELD, "padding")
+    assert padding, "the writing surface must still declare its own padding"
+    parts = padding.split()
+    # One value is symmetric and fine; two means "vertical horizontal", and the
+    # horizontal half has to be zero for the text to sit on the card's gutter.
+    assert len(parts) <= 2, f"unexpected padding shorthand: {padding!r}"
+    if len(parts) == 2:
+        assert _px(parts[1]) == 0, (
+            "the fields must start flush with the card's 16px gutter; horizontal "
+            f"padding here reopens the left gutter (padding: {padding})")
+
+
+def test_nothing_pulls_the_fields_back_out_into_a_gutter():
+    css = _source()
+    body = _block(css, _FIELD)
+    assert body, "the shared field rule went missing"
+    # The negative margin existed only to cancel the horizontal padding above and
+    # to open a strip for the focus bar. Both are gone; a negative inline margin
+    # now would push the text off the card's own line.
+    for prop in ("margin-inline", "margin-left", "margin-inline-start"):
+        assert _decl(css, _FIELD, prop) is None, (
+            f"{prop} on the writing surface reintroduces the left gutter")
+
+
+def test_focus_is_a_wash_and_not_an_accent_rule():
+    css = _source()
+    focus = _block(css, _FIELD + ":focus")
+    assert focus, "the focused field must still say it is focused somehow"
+    # The wash IS the signal now, so it has to be there…
+    assert re.search(r"(?<![\w-])background\s*:", focus), (
+        "focus is a --ctl-quiet-bg wash across the field; without it a borderless "
+        "field gives a keyboard user nothing")
+    # …and the bar it replaced must not come back, in any of its spellings.
+    assert _decl(css, _FIELD + ":focus", "box-shadow") is None, (
+        "the 2px accent bar down the left edge was removed with the gutter it "
+        "was drawn in")
+    for prop in ("border-left", "border-inline-start", "border"):
+        assert _decl(css, _FIELD + ":focus", prop) is None, (
+            f"{prop} puts the box back on a surface whose whole point is not "
+            "having one")
+
+
+def test_no_accent_is_painted_on_the_writing_surface_at_all():
+    # The broad version of the three above: the surface used to be the one place
+    # in the app that wore --accent as chrome rather than as a control's fill.
+    css = _source()
+    for selector in (_FIELD, _FIELD + ":focus", _TITLE, _ASK):
+        assert "--accent" not in _block(css, selector), (
+            f"{selector} paints the accent colour; the writing surface is quiet "
+            "now — the accent belongs to the checkboxes and the Save button")
+
+
+# -- 2. the ordinary caret ----------------------------------------------------
+
+def test_the_caret_is_whatever_every_other_field_gets():
+    # `.field-control` never sets caret-color, so a caret takes `color` — and the
+    # writing surface declares `color: var(--fg)`. Any override here is a cursor
+    # this app has in exactly one place.
+    assert "caret-color" not in _source(), (
+        "no caret-color override on the New task fields: the caret follows "
+        "`color`, the way every other input in the app leaves it")
+
+
+# -- 3. a heading and body text, not two headings -----------------------------
+
+def test_the_description_is_clearly_smaller_than_the_title():
+    css = _source()
+    title = _decl(css, _TITLE, "font-size")
+    ask = _decl(css, _ASK, "font-size")
+    assert title and ask, "both fields declare their own face; one stopped"
+    # Read, not restated: retuning either size keeps this passing as long as the
+    # hierarchy survives. A couple of steps down the repo's ladder — the title is
+    # a heading, the description is body copy at the same size as the rest of the
+    # form's controls — which is comfortably more than a single step.
+    assert _px(ask) <= _px(title) - 5, (
+        f"the description ({ask}) has to read as body text under the title "
+        f"({title}), not as a second heading")
+
+
+def test_the_ask_clamps_are_expressed_in_its_own_face():
+    # The floor and the ceiling are line counts of the description's face, so
+    # they have to move WITH the font-size — a stale 14px in the calc would size
+    # the block for a face the field no longer has.
+    css = _source()
+    ask_size = _decl(css, _ASK, "font-size")
+    for prop in ("min-height", "max-height"):
+        clamp = _decl(css, _ASK, prop)
+        assert clamp and ask_size in clamp, (
+            f"{prop} on the description must be computed from its own "
+            f"{ask_size} face, not from whatever it used to be ({clamp!r})")

--- a/tests/test_sessions_triage_pins.py
+++ b/tests/test_sessions_triage_pins.py
@@ -1,0 +1,394 @@
+"""triage.json holds the user's FILING DECISIONS, not a cache of who is running.
+
+The bug these tests exist for: `core_apps/sessions/inbox.html`'s `autoFlow`
+wrote `{status: "in_progress"}` to triage.json for every session it saw running,
+and only wrote it back to `done` when THAT SAME PAGE INSTANCE observed the stop
+— it gated the clear-back on `RUNNING`, an in-memory `Set` that is empty on
+every page load. So every run whose finish no Inbox tab was open to witness left
+a pin on disk that nothing would ever clear, and the Tasks board honoured those
+pins as the user's own act: five cards sat in In Progress for a day over runs
+that had finished hours earlier.
+
+`tasks.py::_pin_holds` now reaps an `in_progress` pin whose run has demonstrably
+ended, which makes the stale pins harmless. It does not make them right, and it
+is not the fix these tests pin. TWO writer-side rules are:
+
+1. **Nothing mints a pin it cannot take back.** The automatic in-progress claim
+   is not persisted at all, because it was never needed: `inbox.py` already
+   DERIVES the lane from the session's own activity, and deriving it for a
+   pinned session too covers the one case the write used to cover (a `done` or
+   `archived` session that started running again). One rule, no pin — so an
+   unwitnessed finish leaves nothing behind to be stale.
+
+2. **A deliberate pin is stamped.** `set_triage.py` is the Inbox's writer and
+   the shell's `/api/claude-sessions/triage` is the Board's; both now record
+   `at`, because `_pin_holds` reads a stamp later than the session's last
+   activity as "a decision no run has contradicted". Unstamped meant reapable,
+   so without this the user pressing In Progress in the Inbox on purpose lost
+   the choice on the next 20s poll.
+
+Rule 1 is checked by running the page's REAL `autoFlow` under node — the
+`_js_block` posture of test_sessions_inbox_layout.py / test_sessions_inbox_open_dir.py,
+because a copy of the flow logic in the test would keep passing after the
+shipping code regressed. Rules about disk are checked against the actual
+modules, exec'd standalone the way the fused engine execs them.
+"""
+import datetime
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.dirname(_HERE)
+_APP = os.path.join(_ROOT, "core_apps", "sessions")
+
+
+# --------------------------------------------------------------- loading
+
+def _load(name):
+    """A core_apps script exec'd standalone, the way runPython runs it."""
+    path = os.path.join(_APP, name)
+    spec = importlib.util.spec_from_file_location("core_" + name[:-3], path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _home(tmp_path, monkeypatch):
+    # Both modules resolve their state dir off FUSED_RENDER_HOME at import time,
+    # so this has to be set before `_load` — never the developer's real store.
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+
+
+@pytest.fixture()
+def triage_path(tmp_path):
+    return tmp_path / "home" / "claude-sessions" / "triage.json"
+
+
+@pytest.fixture()
+def set_triage():
+    return _load("set_triage.py")
+
+
+@pytest.fixture()
+def inbox(tmp_path, monkeypatch):
+    """`inbox.py` with the transcript store pointed at tmp."""
+    monkeypatch.syspath_prepend(os.path.join(_APP, "sessions"))
+    sys.modules.pop("sessions", None)
+    mod = _load("inbox.py")
+    projects = tmp_path / "projects"
+    projects.mkdir()
+    monkeypatch.setattr(mod._sessions, "PROJECTS_DIR", str(projects))
+    monkeypatch.setattr(mod._sessions, "NAMES_FILE", str(tmp_path / "names.json"))
+    mod.projects = projects
+    yield mod
+    sys.modules.pop("sessions", None)
+
+
+def _transcript(inbox, session_id, *, quiet=False):
+    """One session on disk, running or finished.
+
+    Running = a real (non-housekeeping) entry timestamped inside the 45s window,
+    which is what `_activity_mtime` reports and what `_is_running` tests. `quiet`
+    is a finished run: an old entry, and an old file mtime so the tail read is
+    skipped the way it is on a store full of yesterday's sessions.
+    """
+    d = inbox.projects / "-tmp-proj"
+    d.mkdir(exist_ok=True)
+    path = d / (session_id + ".jsonl")
+    when = datetime.datetime.now(datetime.timezone.utc)
+    if quiet:
+        when -= datetime.timedelta(hours=1)
+    path.write_text(json.dumps({
+        "type": "user", "timestamp": when.isoformat().replace("+00:00", "Z"),
+        "cwd": "/tmp/proj", "message": {"content": "hi"}}) + "\n",
+        encoding="utf-8")
+    if quiet:
+        _quieten(path)
+    return path
+
+
+def _quieten(path):
+    """Backdate the file, so the run reads as over. Separate from `_transcript`
+    because one test has to watch a session STOP without rewriting it."""
+    old = time.time() - 3600
+    os.utime(path, (old, old))
+
+
+def _pin(triage_path, record):
+    triage_path.parent.mkdir(parents=True, exist_ok=True)
+    triage_path.write_text(json.dumps(record), encoding="utf-8")
+
+
+def _status(inbox, session_id):
+    rows = {s["sessionId"]: s for s in inbox.main()["sessions"]}
+    return rows[session_id]["status"]
+
+
+# ------------------------------------------------- the page's real autoFlow
+
+@pytest.fixture(scope="module")
+def source():
+    with open(os.path.join(_APP, "inbox.html"), encoding="utf-8") as f:
+        return f.read()
+
+
+def _auto_flow_block(src):
+    """`RUNNING` and `autoFlow`, verbatim — the shipping flow logic."""
+    start = src.find("const RUNNING = new Set();")
+    assert start != -1, "inbox.html no longer keeps a RUNNING set"
+    end = src.find("\n}", src.index("function autoFlow()", start))
+    assert end != -1, "autoFlow is no longer a single function body"
+    return src[start:end + 2]
+
+
+def _flow(tmp_path, src, sessions, frames):
+    """Drive `autoFlow` over a sequence of ticks and report what it SAVED.
+
+    `sessions` is the rows as `inbox.py` handed them over (id + the status it
+    derived); `frames` is one dict per tick of id -> "run"/"stop", which is what
+    the status poll does to `s.mtime` in place. `saveMany` is stubbed to record
+    the call AND to apply it locally, because the shipping one does (`applyLocal`)
+    and a stub that didn't would hide a flow that depends on its own writes.
+    """
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - node is preinstalled on the CI runners
+        pytest.skip("node is required to drive the page's JS")
+    harness = tmp_path / "flow.mjs"
+    harness.write_text(
+        f"const sessions = {json.dumps(sessions)};\n"
+        f"const frames = {json.dumps(frames)};\n"
+        "const DATA = { sessions };\n"
+        'function isRunning(m) { return m === "run"; }\n'
+        "const calls = [];\n"
+        "function saveMany(ids, patch) {\n"
+        "  calls.push({ ids, patch });\n"
+        "  for (const s of sessions)\n"
+        "    if (ids.includes(s.sessionId) && patch.status !== undefined)\n"
+        "      s.status = patch.status;\n"
+        "}\n"
+        f"{_auto_flow_block(src)}\n"
+        "for (const frame of frames) {\n"
+        '  for (const s of sessions) s.mtime = frame[s.sessionId] || "stop";\n'
+        "  autoFlow();\n"
+        "}\n"
+        "console.log(JSON.stringify(calls));\n",
+        encoding="utf-8")
+    out = subprocess.run([node, str(harness)], capture_output=True, text=True,
+                         timeout=60)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout.strip())
+
+
+def _pins(calls):
+    """Just the `in_progress` writes — the ones that must not exist."""
+    return [c for c in calls if c["patch"].get("status") == "in_progress"]
+
+
+# ============================ 1. nothing mints a pin it cannot take back
+
+def test_a_running_session_gets_no_pin_written_for_it(tmp_path, source):
+    """The whole bug in one tick. The page sees a run, and writes nothing: the
+    lane it wants is the one `inbox.py` already derived from the same activity,
+    so the write bought a duplicate of a derived fact and a permanent lie in the
+    file that outlived the run."""
+    calls = _flow(tmp_path, source,
+                  [{"sessionId": "s1", "status": "in_progress"}],
+                  [{"s1": "run"}, {"s1": "run"}])
+    assert _pins(calls) == []
+
+
+def test_a_done_session_that_starts_running_still_gets_no_pin(tmp_path, source):
+    """The one case the write used to earn its keep — a session with an older
+    `done` record that got resumed, which `t.get("status") or default` would
+    otherwise leave sitting in Done while its dot pulses. It is `inbox.py`'s job
+    now (see the derivation tests below), so the write is still not needed."""
+    calls = _flow(tmp_path, source, [{"sessionId": "s1", "status": "done"}],
+                  [{"s1": "run"}])
+    assert _pins(calls) == []
+
+
+def test_an_unwitnessed_finish_writes_nothing_at_all(tmp_path, source):
+    """A page that was never open while the session ran has nothing to say about
+    it. This is the tick that used to be the ONLY thing keeping the file honest,
+    and now there is nothing for it to clean up."""
+    calls = _flow(tmp_path, source, [{"sessionId": "s1", "status": "done"}],
+                  [{"s1": "stop"}, {"s1": "stop"}])
+    assert calls == []
+
+
+def test_a_witnessed_finish_still_files_the_run_as_unread_news(tmp_path, source):
+    """The half of `autoFlow` that is a real observation rather than a cache: a
+    run this page watched END is a fact, `done` is a timeless filing decision,
+    and clearing `read` is how finished work surfaces in the Inbox as news."""
+    calls = _flow(tmp_path, source, [{"sessionId": "s1", "status": "in_progress"}],
+                  [{"s1": "run"}, {"s1": "stop"}])
+    assert [c["patch"] for c in calls] == [{"status": "done", "read": ""}]
+    assert calls[0]["ids"] == ["s1"]
+
+
+def test_the_finish_is_noticed_even_when_the_row_was_loaded_as_done(
+        tmp_path, source):
+    """The regression that removing the pin write would otherwise cause.
+
+    `s.status` is only recomputed by a full `load()`; the 5s poll updates
+    `s.mtime` alone. So a session that was quiet at load and started running
+    afterwards carries a stale `done` in `DATA`, and the finish branch used to
+    reach that status only because the pin write had just set it locally. With
+    the write gone the gate has to be what this page OBSERVED — `RUNNING` — and
+    not the status the last scan happened to render."""
+    calls = _flow(tmp_path, source, [{"sessionId": "s1", "status": "done"}],
+                  [{"s1": "run"}, {"s1": "stop"}])
+    assert [c["patch"] for c in calls] == [{"status": "done", "read": ""}]
+
+
+def test_a_finish_is_filed_once_and_not_on_every_later_tick(tmp_path, source):
+    """`RUNNING.delete` is what makes it once. A write per poll would rewrite
+    `read: ""` forever and no session could ever be marked read."""
+    calls = _flow(tmp_path, source, [{"sessionId": "s1", "status": "in_progress"}],
+                  [{"s1": "run"}, {"s1": "stop"}, {"s1": "stop"}, {"s1": "stop"}])
+    assert len(calls) == 1
+
+
+# =========================== 2. the Inbox derives the lane instead of pinning
+
+def test_a_running_session_is_in_progress_with_no_record_at_all(inbox):
+    """Already true before this change, and it is the reason the pin was
+    redundant: the untriaged default is derived from the session's activity."""
+    _transcript(inbox, "s1")
+    assert _status(inbox, "s1") == "in_progress"
+
+
+def test_a_quiet_session_is_done_with_no_record_at_all(inbox, triage_path):
+    """The other end of the derivation, and the answer an unwitnessed finish now
+    gets for free. Nothing wrote a file to get here."""
+    _transcript(inbox, "s1", quiet=True)
+    assert _status(inbox, "s1") == "done"
+    assert not triage_path.exists(), "the Inbox invented a record for a quiet run"
+
+
+@pytest.mark.parametrize("pinned", ["done", "archived"])
+def test_a_running_session_outranks_a_stale_filing_decision(
+        inbox, triage_path, pinned):
+    """A resumed session belongs in In Progress even though it was filed away
+    earlier, because "running" is a fact about the present and the pin is a
+    decision about a run that has since been superseded. `autoFlow` used to buy
+    this by overwriting the record; the derivation buys it without touching disk,
+    so the pin the user made is still there when the run stops."""
+    _transcript(inbox, "s1")
+    _pin(triage_path, {"s1": {"status": pinned}})
+    assert _status(inbox, "s1") == "in_progress"
+
+
+def test_the_filing_decision_comes_back_when_the_run_stops(inbox, triage_path):
+    """Because it was never overwritten. This is the difference between deriving
+    and caching: the record still says what the user said."""
+    path = _transcript(inbox, "s1")
+    _pin(triage_path, {"s1": {"status": "archived", "note": "keep me"}})
+    assert _status(inbox, "s1") == "in_progress"
+    _quieten(path)
+    assert _status(inbox, "s1") == "archived"
+    assert json.loads(triage_path.read_text())["s1"]["note"] == "keep me"
+
+
+def test_a_deliberate_in_progress_pin_holds_on_a_quiet_session(inbox, triage_path):
+    """The Inbox honours the pin it is given — the reap that tells a deliberate
+    pin from an automatic one lives in the Tasks board, and after this change
+    every `in_progress` in the file IS deliberate."""
+    _transcript(inbox, "s1", quiet=True)
+    _pin(triage_path, {"s1": {"status": "in_progress", "at": str(time.time())}})
+    assert _status(inbox, "s1") == "in_progress"
+
+
+def test_a_status_the_page_cannot_render_falls_back_to_the_derivation(
+        inbox, triage_path):
+    _transcript(inbox, "s1", quiet=True)
+    _pin(triage_path, {"s1": {"status": "nonsense"}})
+    assert _status(inbox, "s1") == "done"
+
+
+# =============================== 3. the manual path stamps its pin
+
+def test_a_status_write_from_the_inbox_is_stamped(set_triage, triage_path):
+    """Every `in_progress` that reaches disk through here is now a person
+    pressing In Progress — `autoFlow` no longer writes one — and `_pin_holds`
+    reads the absence of a stamp as "older than anything that has happened", so
+    an unstamped write would be reaped on the Board's next 20s poll."""
+    before = time.time()
+    out = set_triage.main("s1", json.dumps({"status": "in_progress"}))
+    assert out["ok"] is True
+    rec = json.loads(triage_path.read_text())["s1"]
+    assert rec["status"] == "in_progress"
+    # the shape `tasks.py::_pin_at` parses: a stringified epoch, like every
+    # other field this writer coerces
+    assert isinstance(rec["at"], str)
+    assert float(rec["at"]) >= before
+
+
+def test_the_stamp_is_the_servers_clock_and_not_the_pages(set_triage, triage_path):
+    """`at` is not in `FIELDS`, so a patch cannot set it. The browser clock is
+    the one thing that must not decide whether a pin outlives a run."""
+    set_triage.main("s1", json.dumps({"status": "in_progress", "at": "1.0"}))
+    rec = json.loads(triage_path.read_text())["s1"]
+    assert float(rec["at"]) > 1.0
+
+
+def test_a_note_edit_does_not_refresh_the_stamp(set_triage, triage_path):
+    """The stamp answers "when was this STATUS chosen". Restamping on any write
+    would let a note typed today resurrect a pin from a run that ended last
+    week."""
+    _pin(triage_path, {"s1": {"status": "in_progress", "at": "1.0"}})
+    set_triage.main("s1", json.dumps({"note": "later thought"}))
+    rec = json.loads(triage_path.read_text())["s1"]
+    assert rec["at"] == "1.0"
+    assert rec["note"] == "later thought"
+
+
+def test_clearing_the_status_takes_the_stamp_with_it(set_triage, triage_path):
+    """A record with no status has no pin to stamp, and an orphan `at` would
+    keep the record non-empty — which is what returns a session to the Inbox
+    pile (`if rec: ... else: pop`)."""
+    _pin(triage_path, {"s1": {"status": "in_progress", "at": "1.0"}})
+    set_triage.main("s1", json.dumps({"status": ""}))
+    assert json.loads(triage_path.read_text()) == {}
+
+
+def test_the_stamp_does_not_disturb_the_records_other_keys(set_triage,
+                                                           triage_path):
+    _pin(triage_path, {"s1": {"status": "done", "note": "n", "tags": "a,b",
+                              "read": "1"}})
+    set_triage.main("s1", json.dumps({"status": "in_progress"}))
+    rec = json.loads(triage_path.read_text())["s1"]
+    assert rec["note"] == "n" and rec["tags"] == "a,b" and rec["read"] == "1"
+    assert set(rec) == {"status", "note", "tags", "read", "at"}
+
+
+def _fields(src):
+    """The writer's `FIELDS` set, read out of the source."""
+    line = next(ln for ln in src.splitlines() if ln.startswith("FIELDS"))
+    return {w.strip().strip('"\'') for w in
+            line.split("{", 1)[1].split("}", 1)[0].split(",")}
+
+
+def test_both_writers_of_triage_json_stamp_the_same_field():
+    """A duplicated rule needs a test rather than a comment (D146): the Inbox
+    writes triage.json directly through `set_triage.py` while the Board goes
+    through `/api/claude-sessions/triage`, and a pin only survives if BOTH of
+    them stamp the field `_pin_at` reads."""
+    with open(os.path.join(_APP, "set_triage.py"), encoding="utf-8") as f:
+        writer = f.read()
+    router = os.path.join(_ROOT, "fused_render", "server", "routers",
+                          "claude_sessions.py")
+    with open(router, encoding="utf-8") as f:
+        shell = f.read()
+    for src, who in ((writer, "set_triage.py"), (shell, "claude_sessions.py")):
+        assert '"at"' in src or "'at'" in src, f"{who} no longer stamps the pin"
+    assert "at" not in _fields(writer), (
+        "`at` became a patchable field: the page's clock must not set it")

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -13,6 +13,7 @@ Nothing here reads the real ~/.claude — every path is under tmp_path.
 """
 import json
 import os
+import time
 
 import pytest
 from fastapi.testclient import TestClient
@@ -1104,6 +1105,167 @@ def test_triage_wins_where_it_disagrees(client, projects_dir, state_dir):
     (state_dir / "triage.json").write_text(
         json.dumps({"sess-a": {"status": "archived"}}))
     assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
+def test_a_stale_in_progress_pin_does_not_outlive_its_run(client, projects_dir,
+                                                          state_dir):
+    """The pin is a claim about the present, and the run it named has ended.
+
+    The Inbox's `autoFlow` writes `in_progress` for every session it sees
+    running and only writes it back to `done` if that same page is still open
+    to witness the stop, so a run nobody watched finish leaves the pin behind
+    forever. Honouring it was five cards stuck in In Progress for days over
+    entries whose turns were recorded `done`."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "in_progress"}}))
+
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is False
+    assert task["messages"][0]["turn"] == "done"
+    assert task["status"] == "done"
+
+
+def test_a_stale_in_progress_pin_on_an_empty_thread_is_dropped(client,
+                                                               projects_dir,
+                                                               state_dir):
+    """The one the board showed with no messages at all. Nothing is running and
+    there is no turn to still be open, so the pin is the only thing holding it
+    in the lane."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.CANCELLED,
+                           claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "in_progress"}}))
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
+def test_an_in_progress_pin_holds_while_the_turn_is_still_open(client,
+                                                               projects_dir,
+                                                               state_dir):
+    """The guard that protects a genuinely running turn from the reap above.
+
+    A turn thinking through a long tool call appends nothing to its transcript
+    for minutes and reads as NOT live, so liveness alone would reap it. The
+    store still has the send in flight — spawned, no `turn` verdict — which is
+    `_busy_sessions`, the second guard, and the one that is right here.
+
+    Note what this asserts about the RENDERED turn: it is `idle`, because
+    `_entry_turn` folds liveness in and has no word for "sent, no verdict, not
+    live". So the message the row carries cannot be the guard; the store's own
+    claim has to be."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "in_progress"}}))
+
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is False
+    assert task["messages"][0]["turn"] == "idle"
+    assert task["status"] == "in_progress"
+
+
+def test_an_in_progress_pin_holds_over_a_send_in_flight(client, projects_dir,
+                                                        state_dir):
+    """A `sending` claim has not reached a transcript at all, so there is no
+    turn to have settled and nothing to reap."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENDING,
+                           claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "in_progress"}}))
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
+def test_a_stale_pin_does_not_hide_the_next_occurrence(client, projects_dir,
+                                                       state_dir):
+    """A recurring task whose last run left a pin behind, and whose next
+    occurrence has since materialised. The card belongs in Upcoming — the pin
+    is describing a run that is over, and honouring it hides the fact that this
+    task is due again.
+
+    Note that a user cannot have MEANT this pin: dropping an upcoming card on
+    In Progress is `dropAction`'s run-now move, not a triage write, so the only
+    thing that puts an `in_progress` pin on an upcoming task is a stale one."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([
+        _entry("e1", "every day", T9, state=schedule.SENT, fired=T9, turn="ok",
+               template_id="tpl", claude_session_id="sess-a"),
+        _entry("e2", "every day", T12, template_id="tpl", session_id="sess-a"),
+    ])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "in_progress"}}))
+
+    task = _by_key(client)["sess-a"]
+    assert task["status"] == "upcoming"
+    assert task["next_run_entry"] == "e2"
+
+
+def test_a_pin_placed_after_the_run_ended_is_the_users_own_and_sticks(
+        client, projects_dir, state_dir):
+    """The reopen drag: a `done` card dropped back on In Progress. `dropLanes`
+    offers that lane for a done task, so it is a real gesture, and a derivation
+    that undid it on the next 20s poll would make the board unusable.
+
+    A stamp is what tells it apart from the Inbox's automatic pin. `autoFlow`
+    writes `{status}` and nothing else, so its pins carry no `at` and are
+    reapable; the shell stamps its own writes, and a stamp later than anything
+    that has happened in the session is a decision no run has contradicted."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    assert _by_key(client)["sess-a"]["status"] == "done"
+
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
+def test_a_pin_placed_before_the_run_ended_is_reaped(client, projects_dir,
+                                                     state_dir):
+    """The other side of the stamp. A pin from before the last run finished is
+    describing that run, and the run answered it."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"sess-a": {"status": "in_progress", "at": "1.0"}}))
+    assert _by_key(client)["sess-a"]["status"] == "done"
+
+
+def test_the_triage_write_stamps_the_pin(client, projects_dir, state_dir):
+    """The stamp the reap above reads has to actually be written, or every pin
+    the shell makes is reaped on the next poll."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    r = client.post("/api/claude-sessions/triage",
+                    json={"session_id": "sess-a", "status": "in_progress"})
+    assert r.status_code == 200, r.text
+
+    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
+    assert float(rec["at"]) > 0
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
+@pytest.mark.parametrize("pinned", ["done", "archived"])
+def test_the_timeless_pins_still_win_over_a_settled_run(client, projects_dir,
+                                                        state_dir, pinned):
+    """Only `in_progress` is falsifiable. `done` and `archived` are filing
+    decisions that stay true however long the card sits there, so the reap must
+    not touch them — the user dragged the card and a derivation that undid it on
+    the next poll would make the board unusable."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.ERROR,
+                           error="target vanished", claude_session_id="sess-a")])
+    assert _by_key(client)["sess-a"]["status"] == "failed"
+
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": pinned}}))
+    assert _by_key(client)["sess-a"]["status"] == pinned
 
 
 def test_a_dead_turn_is_reported_as_a_failure(client, projects_dir):

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -208,6 +208,37 @@ def test_the_title_falls_back_to_the_first_message(client, projects_dir):
     assert task["title_source"] == "message"
 
 
+def test_a_title_read_off_a_scheduled_entry_says_which_message_it_read(
+        client, tmp_path):
+    """The message branch has TWO sources and only one of them is a name.
+
+    With no transcript to read a first prompt from, the earliest scheduled
+    entry's message is the best the server has — but on a task scheduled from
+    the New task form that message IS what the user typed into the ask box, so a
+    client prefilling Title from it duplicates the description into the name.
+    `entry` is the row saying which of the two it read, because the client cannot
+    tell them apart by looking at the string."""
+    _seed_schedule([_entry("e1", "pull today's news\nand file it", T12,
+                           target=str(tmp_path))])
+    task = _tasks(client)[0]
+    assert task["title"] == "pull today's news"
+    assert task["title_source"] == "entry"
+
+
+def test_the_sessions_own_first_prompt_outranks_the_entry_that_asked_it(
+        client, projects_dir, tmp_path):
+    """Both sources present. The transcript's first prompt is the session's own
+    opening line and stays `message`; the entry fallback is only for a session
+    whose transcript says nothing."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("check the deploy",
+                                                          T9)])
+    _seed_schedule([_entry("e1", "pull today's news", T9, state=schedule.SENT,
+                           fired=T9, turn="ok", claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["title"] == "check the deploy"
+    assert task["title_source"] == "message"
+
+
 def test_an_explicit_user_title_beats_the_ai_one(client, projects_dir):
     """What the user called it wins over what Claude Code called it."""
     _write_transcript(projects_dir, "sess-a", "/p", [
@@ -1222,6 +1253,56 @@ def test_a_pin_placed_after_the_run_ended_is_the_users_own_and_sticks(
     (state_dir / "triage.json").write_text(json.dumps(
         {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
     assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
+def test_a_pin_holds_on_a_task_that_still_has_work_ahead_of_it(
+        client, projects_dir, state_dir):
+    """The same deliberate pin, on a task whose next run has not happened yet.
+
+    This is where measuring the stamp against "the last activity" went wrong.
+    The row's newest message is one due TOMORROW, and a scheduled message's `at`
+    is the time it was ASKED FOR — it never moves and it is not a thing that has
+    occurred (see `_entry_at`). Folded into the activity the pin is compared
+    against, it made every stamp a user could make look older than the session,
+    so the reap fired on the next 20s poll for exactly the tasks that have work
+    coming.
+
+    The gesture is reachable: `archiveIntent` and `dropLanes` both put a card
+    coming back out of Archive into In Progress, whatever it has scheduled, and
+    that write is stamped by the triage endpoint.
+
+    `last_active` deliberately still reads the due time — the List surfaces a
+    message due tomorrow near the top so it can be seen BEFORE it fires — which
+    is why the two are separate values and this asserts both."""
+    soon = time.strftime("%Y-%m-%dT%H:%M:%SZ",
+                         time.gmtime(time.time() + 86400))
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([
+        _entry("e1", "every day", T9, state=schedule.SENT, fired=T9, turn="ok",
+               template_id="tpl", claude_session_id="sess-a"),
+        _entry("e2", "every day", soon, template_id="tpl",
+               session_id="sess-a"),
+    ])
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
+
+    task = _by_key(client)["sess-a"]
+    assert task["next_run"] > time.time(), "the upcoming run is the whole case"
+    assert task["status"] == "in_progress"
+    assert task["last_active"] == task["next_run"], \
+        "the sort still surfaces the run ahead; only the pin's clock changed"
+
+
+def test_an_unreadable_created_stamp_still_leaves_a_row(client, tmp_path):
+    """The dates on this row are floats and 0.0 is how they say "never", so the
+    one place a stamp is parsed for activity has to answer in floats too. A None
+    reaching the arithmetic raises `TypeError`, which `api_tasks` catches per
+    task — the row would not be wrong, it would be GONE."""
+    _seed_schedule([_entry("e1", "x", T12, target=str(tmp_path),
+                           created="whenever")])
+    task = _tasks(client)[0]
+    assert task["status"] == "upcoming"
+    assert task["last_active"] > 0, "the due time still surfaces it"
 
 
 def test_a_pin_placed_before_the_run_ended_is_reaped(client, projects_dir,


### PR DESCRIPTION
## Title first, Description second, both the main field

The New task modal opened with one big field placeholdered *"What should Claude do?"* — the message **and** the description — followed by a small optional Title input. Akshil, 2026-08-17:

> *"title will be the first field and then description will be the second field for a new task. Title will still be optional but description will have to be filled. And make both of those like the main field that we have… The first field CSS should be similar for the title and the description field because both of them are important. Title may not overflow, it will only be one line, but description will be as the first field that will go through multiple lines."*

So they swap places and become peers:

```
New task
  Title — optional, filled in automatically   ← first, optional, ONE line
  ─────────────────────────
  What should Claude do?                      ← second, REQUIRED, autogrows
  ─────────────────────────
  📁 /Users/…/Fused
  🕐 Mon Aug 17   4:02pm   ☐ Repeat
```

### Both get the prominent treatment

`.schedule-form-title` stops being one field's class and becomes the **shared prominence** both wear — same 20px face, same 500 weight, same transparent ground, same 2px underline — one definition rather than two that drift apart. Computed styles measured side by side in both themes: identical on every prominence property (the only difference is `border-bottom-color`, and only because one of them has focus).

What actually differs between the two is only how each handles a long value, and that is a property of the element each field is — so those rules are element-qualified rather than hidden behind a second class:

* `textarea.schedule-form-title` keeps the measured autogrow (~5 lines of the 20px face, then scrolls).
* `.new-task-title` is one line, for ever.

### The icons: neither

The 26px icon gutter is the **quiet** rows' vocabulary (📁 folder, 🕐 when), and a 14px glyph beside a 20px face reads as debris. Title wore a lucide `T` only because it used to be one of those rows; the ask never had one. Peers wear the same clothes, so the choice was both or neither — and *neither* is what keeps the gutter meaning "this is a detail". The `ICON_TITLE` constant went with the row.

### Title overflow: scrolls focused, ellipses blurred

It is an `<input>`, so it never wraps and never grows. Long text **scrolls horizontally under the caret while the field has focus** — native behaviour, and the only one that lets you edit the far end of a long title — and **ellipses once focus leaves**, so a truncated title says it is truncated instead of appearing to end mid-word. (Chrome's UA sheet already forces `overflow: clip` on a text input — the computed value is `clip`, not the `hidden` declared — so the declaration is belt-and-braces, and `text-overflow` is what does the work.)

Measured at exactly 200 characters, both themes: **41px tall either way**, `scrollHeight` ≤ `clientHeight` (one line), `scrollLeft` 2558 while focused and 0 once blurred, and the card the **same 373px** as with a one-word title — the folder and time rows never move.

### Description is required, Title is not

Same gate as before — the form has always refused a blank ask — but the inline `ready` expression came out of the component as `saveEnabled()` so the rule is assertable in `new-task-form.test.ts`:

* empty **or whitespace-only** description → Save disabled, with or without a title;
* empty **title** → Save enabled, because the server goes on naming the task from the transcript's `ai-title`, then the message's first line (design §4 precedence, untouched — and the placeholder still says the field fills itself in).

`aria-required="true"` on the description says so to a screen reader rather than leaving a disabled button as the only hint.

### Contract untouched

`description` carries the big field trimmed, `message` goes verbatim, `title` is omitted when blank, and the whole `session_id` / `session_learned` provenance logic is byte-for-byte what it was. Every provenance test and the chat-handoff test pass **unchanged**.

## Verified

`bun test` (1268 pass), `npm run build`, `npx tsc --noEmit`, `pytest tests/` (7135 pass). Known-not-mine, confirmed failing on the base branch by stashing: `tests/test_calls.py::test_an_abandoned_merge…`, `tests/test_deploy.py::test_config_reports_missing_cli_as_installable`, `tests/test_deploy.py::test_install_invokes_pip_with_the_pinned_requirement`, and the 4 `test_notebook_e2e.py` (no playwright).

On a running server in both light and dark, driven with Playwright:

* field order — `input.new-task-title`, then `textarea.schedule-form-title`, then the two quiet rows;
* zero leading glyphs on either big field;
* Save refused with both empty, with a title and no description, and with a whitespace-only description; enabled once the description has text and with the title cleared again;
* the 200-character title above;
* Tab order: **Title → Description → path → Browse → time**;
* the accent underline as a visible focus indicator on both fields, in both themes (light `#5F7300`, dark `#E5FF44`);
* an **Edit round trip** through the task row's pencil: both fields repopulate, the modal does not open dirty, and saving it untouched sends both values back through the cancel-and-re-create — plus clearing the description inside an Edit disables Save there too.

## Base

**Base is `main` deliberately.** This branch sits on top of the unmerged `agent/20260816-next`, so the PR shows that branch's commits as well as this one. Expected — only the last commit ("Title first, description second, both the main field") is this change.

## Not in scope, noticed while verifying

`/scheduled?new=1&edit=<id>` opens a modal headed **"Edit task" with both fields empty**: `setCreating` fires immediately so `NewJobModal` mounts with `editing=null`, and the later `setEditing` never reaches its `useState` initialisers because the component carries no `key`. Reproduced on the base branch with this change stashed, so it is pre-existing and untouched here. The path users actually take (the row's pencil, which sets `creating=null` and mounts fresh) works correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Why there is no CI run on this PR

`.github/workflows/test.yml` triggers on `push: branches: [main]` and `pull_request: {}`. Because the base is `main` while the branch is stacked on the unmerged `agent/20260816-next`, GitHub reports the PR as `CONFLICTING` and cannot compute a merge ref — so it schedules no `pull_request` run. Waited 10 minutes; none appeared. The full gate was therefore run locally instead (`bun test`, `npm run build`, `npx tsc --noEmit`, `pytest tests/` — results above). CI will run normally once `agent/20260816-next` lands and this rebases cleanly, or immediately if the base is retargeted to that branch.

Cursor Bugbot's one finding (`frontend/src/platform/lib/jobs.ts`, "Header counts waiting as running") is against a file this PR does not touch — it comes from the stacked base branch, and is [answered inline](https://github.com/fusedio/fused-render/pull/564#discussion_r3795674554).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches triage persistence and inbox status derivation (can affect Tasks board lanes and stale pins), plus required-title scheduling UX; frontend-heavy with coordinated CSS/token changes across list, board, and calendar.
> 
> **Overview**
> **New task modal** puts **Title** above the ask in a single borderless writing surface (`new-task.css`), makes **both** fields required via `saveEnabled`, and prefills titles from the **session** (`/api/tasks` + `title_source`)—never from the message being scheduled (`entry` titles are refused). Adds `title_source: "entry"` on the API type and extensive `new-task-form.test.ts` coverage.
> 
> **Inbox / triage:** **In Progress** is now **derived** from recent session activity (`inbox.py` `_is_running`); `inbox.html` `autoFlow` no longer writes `in_progress` pins (only watched finishes → `done`). **`set_triage.py`** stamps **`at`** on status changes so manual `in_progress` pins can be reaped on the Tasks board.
> 
> **Tasks & schedule UI:** Calendar/board **chip color** hashes **`task.project`** (folder), not task key. **Unread** counts trail titles (neutral pill); per-message dots trail message text. **List** rows with ≤1 message hide the chevron but keep gutter alignment (`isExpandable`). **Board** cards lose lane-redundant status rings (except **failed-off-lane**), drop lane fill for hairline outlines + `--bg-panel` cards, and fix unread pill placement by removing title line-clamp. **Status tokens:** Upcoming → grey (`--fg-muted`), activity blue → **`--activity`**; Archive rose; In Progress ring no longer pulses. **Repeat** picker drops the annual preset (year still supported for existing rules).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadba3b95a84bbcfbecfce1cf21100f2311bb9d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->