### PR TITLE
Collapsed sidebar: settings icon opens the Settings popover

### DIFF
--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -30,8 +30,13 @@ export interface SidebarRailItem {
   label: string;
   icon: React.ReactNode;
   /** Navigate here on click. Highlights as active on exact pathname match,
-      like NavItem. */
+      like NavItem. Still set even when `onClick` overrides the click, so
+      middle-click/copy-link keeps working. */
   href: string;
+  /** Overrides the click instead of navigating to `href` — for a rail icon
+      that opens a menu (e.g. Settings) rather than going straight to a page.
+      Receives the anchor so the caller can anchor a popover off its rect. */
+  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
   /** Hairline above this item — a group boundary, mirroring the expanded
       sidebar's headings. */
   dividerBefore?: boolean;
@@ -193,7 +198,8 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
                   title={item.label}
                   onClick={(e) => {
                     e.preventDefault();
-                    navigateUrl(item.href);
+                    if (item.onClick) item.onClick(e);
+                    else navigateUrl(item.href);
                   }}
                 >
                   {item.icon}

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -152,16 +152,26 @@ function PreferencesPopover({
   pos,
   entries,
   onClose,
+  triggerRef,
 }: {
   pos: { left: number; bottom: number };
   entries: (PrefsMenuEntry | "separator")[];
   onClose: () => void;
+  /** The element that opened this popover. A click there is NOT an outside
+      click — it's the trigger's own toggle-closed, and must be left to that
+      handler. Otherwise pointerdown closes it here first, and by the time
+      the paired click re-checks "is it open" (React 18 batches the setState
+      before that click fires), it sees closed and reopens it right back. */
+  triggerRef: React.RefObject<HTMLElement | null>;
 }) {
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const onDown = (e: PointerEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) onClose();
+      const target = e.target as Node;
+      if (rootRef.current?.contains(target)) return;
+      if (triggerRef.current?.contains(target)) return;
+      onClose();
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
@@ -276,11 +286,15 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   // mounted whichever trigger (expanded row vs. collapsed rail icon) opened
   // it — the two live in subtrees SidebarFrame never renders together.
   const [prefsPos, setPrefsPos] = useState<{ left: number; bottom: number } | null>(null);
+  // Which trigger opened it — the popover's outside-click check must not
+  // treat a re-click on this element as "outside" (see PreferencesPopover).
+  const prefsTriggerRef = useRef<HTMLElement | null>(null);
   const togglePrefsMenu = (el: HTMLElement) => {
     if (prefsPos) {
       setPrefsPos(null);
       return;
     }
+    prefsTriggerRef.current = el;
     const r = el.getBoundingClientRect();
     // Grows upward: pinned by its bottom edge just above the trigger.
     setPrefsPos({ left: r.left, bottom: window.innerHeight - r.top + 4 });
@@ -341,6 +355,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
           pos={prefsPos}
           entries={menuEntries}
           onClose={() => setPrefsPos(null)}
+          triggerRef={prefsTriggerRef}
         />
       )}
     </>

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -106,95 +106,103 @@ interface PrefsMenuEntry {
   extra?: React.ReactNode;
 }
 
-// The bottom Settings trigger + its pop-up menu. A NavItem-shaped row that
-// opens a fixed-position menu growing UP from the row (the row sits on the
-// sidebar's bottom edge). Closes on outside pointerdown / Escape / navigation.
-function PreferencesMenu({
-  entries,
+// The bottom Settings trigger (a NavItem-shaped row in the expanded sidebar,
+// an icon on the collapsed rail) and its pop-up menu. Split in two because the
+// two triggers live in different, mutually-exclusive subtrees — SidebarFrame
+// renders either its rail or its `children`, never both — while the popover
+// itself must stay mounted regardless of collapse state, so its open/closed
+// position lives in GlobalSidebar and the popover renders as a sibling of
+// SidebarFrame rather than nested inside one trigger's markup.
+
+// The expanded-sidebar trigger row.
+function PreferencesTrigger({
+  open,
   dot,
   active,
+  onToggle,
 }: {
-  entries: (PrefsMenuEntry | "separator")[];
+  open: boolean;
   dot?: React.ReactNode;
   /** The current route is one of the menu's destinations — the trigger is
       the only sidebar chrome that can show it. */
   active: boolean;
+  onToggle: (el: HTMLElement) => void;
 }) {
-  const [pos, setPos] = useState<{ left: number; bottom: number } | null>(null);
+  return (
+    <button
+      type="button"
+      className={"sidebar-item sidebar-prefs-trigger" + (active ? " active" : "")}
+      aria-haspopup="menu"
+      aria-expanded={open}
+      onClick={(e) => onToggle(e.currentTarget)}
+    >
+      <span className="icon">
+        {PREFERENCES_ICON}
+        {dot}
+      </span>{" "}
+      Settings
+    </button>
+  );
+}
+
+// The floating menu itself — a fixed-position panel growing UP from whichever
+// trigger opened it (that row/icon sits on the sidebar's bottom edge). Closes
+// on outside pointerdown / Escape / blur, or on picking an entry.
+function PreferencesPopover({
+  pos,
+  entries,
+  onClose,
+}: {
+  pos: { left: number; bottom: number };
+  entries: (PrefsMenuEntry | "separator")[];
+  onClose: () => void;
+}) {
   const rootRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    if (!pos) return;
     const onDown = (e: PointerEvent) => {
-      if (!rootRef.current?.contains(e.target as Node)) setPos(null);
+      if (!rootRef.current?.contains(e.target as Node)) onClose();
     };
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setPos(null);
+      if (e.key === "Escape") onClose();
     };
-    const onBlur = () => setPos(null);
     document.addEventListener("pointerdown", onDown);
     document.addEventListener("keydown", onKey);
-    window.addEventListener("blur", onBlur);
+    window.addEventListener("blur", onClose);
     return () => {
       document.removeEventListener("pointerdown", onDown);
       document.removeEventListener("keydown", onKey);
-      window.removeEventListener("blur", onBlur);
+      window.removeEventListener("blur", onClose);
     };
-  }, [pos]);
+  }, [onClose]);
 
   return (
-    <div ref={rootRef}>
-      <button
-        type="button"
-        className={"sidebar-item sidebar-prefs-trigger" + (active ? " active" : "")}
-        aria-haspopup="menu"
-        aria-expanded={pos !== null}
-        onClick={(e) => {
-          if (pos) {
-            setPos(null);
-            return;
-          }
-          const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-          // Grows upward: pinned by its bottom edge just above the trigger.
-          setPos({ left: r.left, bottom: window.innerHeight - r.top + 4 });
-        }}
-      >
-        <span className="icon">
-          {PREFERENCES_ICON}
-          {dot}
-        </span>{" "}
-        Settings
-      </button>
-      {pos && (
-        <div
-          className="context-menu placed sidebar-prefs-menu"
-          role="menu"
-          style={{ left: pos.left, bottom: pos.bottom }}
-        >
-          {entries.map((entry, i) =>
-            entry === "separator" ? (
-              <div key={"sep" + i} className="context-menu-sep" role="separator" />
-            ) : (
-              <div
-                key={entry.href}
-                role="menuitem"
-                className={
-                  "context-menu-item" + (location.pathname === entry.href ? " active" : "")
-                }
-                onClick={() => {
-                  setPos(null);
-                  navigateUrl(entry.href);
-                }}
-              >
-                <span className="context-menu-icon" aria-hidden="true">
-                  {entry.icon}
-                </span>
-                <span className="context-menu-label">{entry.label}</span>
-                {entry.extra}
-              </div>
-            )
-          )}
-        </div>
+    <div
+      ref={rootRef}
+      className="context-menu placed sidebar-prefs-menu"
+      role="menu"
+      style={{ left: pos.left, bottom: pos.bottom }}
+    >
+      {entries.map((entry, i) =>
+        entry === "separator" ? (
+          <div key={"sep" + i} className="context-menu-sep" role="separator" />
+        ) : (
+          <div
+            key={entry.href}
+            role="menuitem"
+            className={"context-menu-item" + (location.pathname === entry.href ? " active" : "")}
+            onClick={() => {
+              onClose();
+              navigateUrl(entry.href);
+            }}
+          >
+            <span className="context-menu-icon" aria-hidden="true">
+              {entry.icon}
+            </span>
+            <span className="context-menu-label">{entry.label}</span>
+            {entry.extra}
+          </div>
+        )
       )}
     </div>
   );
@@ -264,12 +272,36 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   // "you are on one of the menu's pages" — highlight it on any of them.
   const prefsActive = menuEntries.some((e) => e !== "separator" && e.href === pathname);
 
+  // Owned here, not inside either trigger, because the popover must stay
+  // mounted whichever trigger (expanded row vs. collapsed rail icon) opened
+  // it — the two live in subtrees SidebarFrame never renders together.
+  const [prefsPos, setPrefsPos] = useState<{ left: number; bottom: number } | null>(null);
+  const togglePrefsMenu = (el: HTMLElement) => {
+    if (prefsPos) {
+      setPrefsPos(null);
+      return;
+    }
+    const r = el.getBoundingClientRect();
+    // Grows upward: pinned by its bottom edge just above the trigger.
+    setPrefsPos({ left: r.left, bottom: window.innerHeight - r.top + 4 });
+  };
+
   const rail: SidebarRailItem[] = [
     { key: "home", label: "Home", icon: HOME_ICON, href: "/home", active: homeActive },
     ...(sessionsMountReady
       ? [{ key: "sessions", label: "Inbox", icon: SESSIONS_ICON, href: "/sessions" }]
       : []),
-    { key: "preferences", label: "Preferences", icon: PREFERENCES_ICON, href: "/preferences", pinBottom: true, active: prefsActive },
+    {
+      key: "preferences",
+      label: "Preferences",
+      icon: PREFERENCES_ICON,
+      href: "/preferences",
+      pinBottom: true,
+      active: prefsActive,
+      // Same Settings popover as the expanded row, not a straight nav — the
+      // collapsed rail otherwise has no way to reach Templates/Mounts/etc.
+      onClick: (e) => togglePrefsMenu(e.currentTarget),
+    },
   ];
 
   // The trigger's own dot mirrors the strongest signal inside the menu, so
@@ -279,24 +311,38 @@ export default function GlobalSidebar({ config }: { config: Config }) {
     (deployEnabled && accountLoggedIn ? <span className="account-signedin-dot" /> : undefined);
 
   return (
-    <SidebarFrame title="Render" version={config.version} homeHref="/home" rail={rail}>
-      <div className="sidebar-section sidebar-group">
-        <NavItem
-          href="/home"
-          id="home-link"
-          label="Home"
-          icon={HOME_ICON}
-          active={homeActive}
+    <>
+      <SidebarFrame title="Render" version={config.version} homeHref="/home" rail={rail}>
+        <div className="sidebar-section sidebar-group">
+          <NavItem
+            href="/home"
+            id="home-link"
+            label="Home"
+            icon={HOME_ICON}
+            active={homeActive}
+          />
+          {sessionsMountReady && (
+            <NavItem href="/sessions" id="sessions-link" label="Inbox" icon={SESSIONS_ICON} />
+          )}
+        </div>
+        <BookmarksSection />
+        <div className="sidebar-section sidebar-settings">
+          <UpdateBadge />
+          <PreferencesTrigger
+            open={prefsPos !== null}
+            dot={triggerDot}
+            active={prefsActive}
+            onToggle={togglePrefsMenu}
+          />
+        </div>
+      </SidebarFrame>
+      {prefsPos && (
+        <PreferencesPopover
+          pos={prefsPos}
+          entries={menuEntries}
+          onClose={() => setPrefsPos(null)}
         />
-        {sessionsMountReady && (
-          <NavItem href="/sessions" id="sessions-link" label="Inbox" icon={SESSIONS_ICON} />
-        )}
-      </div>
-      <BookmarksSection />
-      <div className="sidebar-section sidebar-settings">
-        <UpdateBadge />
-        <PreferencesMenu entries={menuEntries} dot={triggerDot} active={prefsActive} />
-      </div>
-    </SidebarFrame>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Collapsed-sidebar Settings icon navigated straight to `/preferences`, bypassing the popover (Templates, Mounts, Schedule, AI Models, Preferences) that the expanded row's Settings button opens.
- Lifted the popover's open/position state from the per-trigger component up to `GlobalSidebar`, since the expanded trigger and the collapsed rail icon live in mutually-exclusive subtrees (`SidebarFrame` renders either its rail or its `children`, never both) — the popover now renders as a sibling so it stays mounted regardless of collapse state.
- Added an optional `onClick` to `SidebarRailItem` so a rail icon can override navigation (used here to open the popover instead); `href` is kept for middle-click/copy-link.

## Test plan
- [x] `bunx tsc --noEmit` clean
- [x] `node scripts/check-boundaries.mjs` — OK
- [x] Manually verified in the running app: expanded sidebar Settings button and collapsed rail Settings icon both open the identical popover with the same entries; confirmed working by user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized sidebar UI and navigation behavior with no auth, data, or API changes.
> 
> **Overview**
> **Collapsed sidebar Settings** now opens the same multi-entry Settings popover as the expanded row, instead of navigating straight to `/preferences`.
> 
> `SidebarRailItem` gains an optional **`onClick`** so a rail icon can override primary navigation while **`href`** stays for middle-click and copy-link. **`SidebarFrame`** invokes `onClick` when set; otherwise it still navigates.
> 
> In **`GlobalSidebar`**, preferences UI is split into a trigger (`PreferencesTrigger` / rail `onClick`) and a sibling **`PreferencesPopover`**, with open/position state lifted to `GlobalSidebar` so one menu works whether the sidebar is expanded or collapsed (`SidebarFrame` only shows rail *or* children). Outside-click handling ignores the opening trigger via **`triggerRef`**, avoiding a React 18 toggle bug where the menu closes and immediately reopens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 001988a51fb600cb12b79e91df833984c71fdf5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->