### PR TITLE
Live preview thumbnail per denoising step for fused.ai.image()

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ Any `.html` file can call it and bind the result to the URL:
 - `fused.ai.image({prompt, ...})` — text to image, locally; resolves with the
   PNG's path, a ready-made URL to point an `<img>` at, and the seed used (one is
   chosen for you if you don't pass one, so a render is always repeatable). It
-  runs for minutes, so `onProgress` fires per denoising step and the download
-  manager's ✕ really stops it.
+  runs for minutes, so `onProgress` fires per denoising step — each tick with a
+  `previewUrl` for a thumbnail of the image so far, so there is a picture
+  emerging rather than a number going up — and the download manager's ✕ really
+  stops it.
 - `fused.ai.transcribe({path, ...})` — speech to text, locally: point it at an
   audio or video file on this machine and it resolves with the words plus the
   `{start, end, text}` segments that carry their timestamps. `task` picks

--- a/SPEC.md
+++ b/SPEC.md
@@ -6518,8 +6518,13 @@ an AI Models page that could say what was on disk but not what was *running*.
   no file, no branch in either denoising loop, and no device sync (the latents
   reach the sink as a closure, so a no-op never pulls them off the GPU). Frames
   land by `os.replace` from a temp beside the target, because the page is
-  reading the file through `/api/fs/raw` while the worker rewrites it. And it is
-  removed on success, on cancel AND **on error** — the one place this diverges
+  reading the file through `/api/fs/raw` while the worker rewrites it — and
+  **nothing escapes the sink**, because it is called from the one interruption
+  point in a render that runs for minutes: a full disk, or a Windows lock held
+  by the page's own `<img>` over the destination, must cost the thumbnail and
+  never the picture. A sink that fails three times in a row switches itself off
+  rather than paying a device sync and a doomed syscall per remaining step. And
+  it is removed on success, on cancel AND **on error** — the one place this diverges
   from the progressive transcript (AI-10a), whose file is kept on a failure
   because 80 minutes of words is salvage; a half-denoised 32x32 blur of a
   picture that will never exist is not.

--- a/SPEC.md
+++ b/SPEC.md
@@ -6530,7 +6530,13 @@ an AI Models page that could say what was on disk but not what was *running*.
   it is removed on success, on cancel AND **on error** — the one place this diverges
   from the progressive transcript (AI-10a), whose file is kept on a failure
   because 80 minutes of words is salvage; a half-denoised 32x32 blur of a
-  picture that will never exist is not.
+  picture that will never exist is not. **A kill has no unwind**, so a worker
+  ended by `_terminate` / `_kill_tree` (unload, shutdown, a wedge) leaves its
+  last frame behind — and the next render sweeps `<home>/ai/images` of any
+  preview nothing has touched for an hour. Wired to the request rather than to a
+  timer: the directory grows only when renders happen, the caller is about to
+  wait minutes anyway, and a live preview is rewritten every step so its age is
+  what tells the two apart. The image itself is never swept at any age.
 - **AI-8** **The worker measures its own memory.** Only the process holding the
   weights can; on Apple Silicon the GPU pool IS system memory, so RSS is one
   honest number rather than two that need reconciling. What the supervisor knows

--- a/SPEC.md
+++ b/SPEC.md
@@ -6487,6 +6487,42 @@ an AI Models page that could say what was on disk but not what was *running*.
   `overwrite=True`, because mflux's default resolves a collision by writing
   somewhere else, and the server has already told the caller where the image
   will be.
+- **AI-9e** **A render shows the picture while it is being made, and it is one
+  file rewritten in place.** A FLUX render is minutes long and everything a page
+  could show was a step counter — a progress bar for a process whose whole
+  output is visual. So the worker writes `<out>.preview.png` beside the image
+  the request already named: a ~32x32, ~3KB thumbnail, **overwritten every
+  step**, advertised by the route as `previewPath` and handed to the page by
+  `fused.ai.image` as a `previewUrl` on every `onProgress` tick — cache-busted
+  by the step, because one path rewritten in place is one image as far as a
+  browser is concerned. Blurring and upscaling it is the page's taste, not this
+  API's. **Always on, no flag**: measured at 68ms/step (1.25% of a 512²/16-step
+  render) and dominated by the device sync and the PNG encode rather than the
+  matmul, so it stays roughly flat as resolution grows — a one-percent feature
+  behind an opt-in is a feature most pages never get. **A filmstrip was the
+  other option and is refused**: 100 steps would leave 100 files in a directory
+  the user browses, and the page's `<img>` would have to know which is current.
+  The frame is not the raw latent. FLUX.2 klein is step-wise distilled and its
+  sigma is still ≥ 0.5 at step 14 of 16, so what the callback holds projects to
+  static for almost the whole render; what IS legible from step 2 of 16 is the
+  model's own DENOISED ESTIMATE, recovered from two consecutive latents and
+  their two sigmas. The first step has no predecessor and therefore no preview,
+  which is correct rather than a gap. The latent→RGB map is a 128→3 affine
+  constant fitted once against the VAE's own encodes (R² 0.911/0.912/0.891) —
+  written down rather than derived, because deriving it needs the weights and a
+  preview must not wait for those. **One implementation for both engines**, at
+  the runners root (AI-10c): `runners/preview.py` owns the path rule, the
+  arithmetic, the atomic write and the lifecycle, keyed by the VAE's class name,
+  which the torch runner reads off `pipe.vae` and the MLX one off its variant
+  recipe. A model with no fitted projection renders exactly as it did before —
+  no file, no branch in either denoising loop, and no device sync (the latents
+  reach the sink as a closure, so a no-op never pulls them off the GPU). Frames
+  land by `os.replace` from a temp beside the target, because the page is
+  reading the file through `/api/fs/raw` while the worker rewrites it. And it is
+  removed on success, on cancel AND **on error** — the one place this diverges
+  from the progressive transcript (AI-10a), whose file is kept on a failure
+  because 80 minutes of words is salvage; a half-denoised 32x32 blur of a
+  picture that will never exist is not.
 - **AI-8** **The worker measures its own memory.** Only the process holding the
   weights can; on Apple Silicon the GPU pool IS system memory, so RSS is one
   honest number rather than two that need reconciling. What the supervisor knows

--- a/SPEC.md
+++ b/SPEC.md
@@ -6495,7 +6495,10 @@ an AI Models page that could say what was on disk but not what was *running*.
   step**, advertised by the route as `previewPath` and handed to the page by
   `fused.ai.image` as a `previewUrl` on every `onProgress` tick — cache-busted
   by the step, because one path rewritten in place is one image as far as a
-  browser is concerned. Blurring and upscaling it is the page's taste, not this
+  browser is concerned, and **null on the terminal tick and on the resolved
+  object**, because the file is discarded as the render unwinds and a page that
+  followed the last `previewUrl` would end every render on a 404 exactly where
+  the finished picture belongs. Blurring and upscaling it is the page's taste, not this
   API's. **Always on, no flag**: measured at 68ms/step (1.25% of a 512²/16-step
   render) and dominated by the device sync and the PNG encode rather than the
   matmul, so it stays roughly flat as resolution grows — a one-percent feature

--- a/SPEC.md
+++ b/SPEC.md
@@ -6495,7 +6495,13 @@ an AI Models page that could say what was on disk but not what was *running*.
   step**, advertised by the route as `previewPath` and handed to the page by
   `fused.ai.image` as a `previewUrl` on every `onProgress` tick — cache-busted
   by the step, because one path rewritten in place is one image as far as a
-  browser is concerned, and **null on the terminal tick and on the resolved
+  browser is concerned. **The frame is written before the tick that announces
+  it**, in both runners: `done` is what becomes `&step=N`, and a tick published
+  first can hand a page a URL whose file is still being written — which does not
+  merely 404, it caches the PREVIOUS frame's bytes under a URL that is never
+  requested again, so that step shows a stale picture for its whole duration.
+  The cost is that the ✕ is learned one frame-write later, still on the same
+  callback. `previewUrl` is **null on the terminal tick and on the resolved
   object**, because the file is discarded as the render unwinds and a page that
   followed the last `previewUrl` would end every render on a 404 exactly where
   the finished picture belongs. Blurring and upscaling it is the page's taste, not this

--- a/fused_render/ai/runners/diffusers_image/worker.py
+++ b/fused_render/ai/runners/diffusers_image/worker.py
@@ -301,14 +301,18 @@ def generate(body):
         done = step + 1
         average = sum(step_times) / len(step_times) if step_times else None
         remaining = (steps - done) * average if average else None
-        # `report_or_cancel`, not `report`: this callback is the ONLY point in a
-        # minutes-long `pipe()` call where a stop can be honoured, and the reply
-        # to this tick is how the ✕ gets here.
-        worker_base.report_or_cancel(
-            job=job, kind="task", unit="", done=done, total=steps,
-            detail="Denoising — step %d/%d%s" % (done, steps, _eta(remaining)))
-        if worker_base.CANCEL.is_set():
-            raise worker_base.Cancelled()
+        # **The FRAME comes before the TICK, and the order is load-bearing.**
+        # `done` is what `runtime.js` turns into the cache-busted `&step=N`
+        # preview URL, so a tick published first can hand the page step N's URL
+        # while step N's PNG is still being written — the poll is about every
+        # 700ms and the write about 68ms, so the window is real. The 404 that
+        # produces is survivable; the nastier half is that the URL is keyed by
+        # the step and is never requested twice, so a fetch landing in the
+        # window caches the PREVIOUS frame's bytes under it and that step shows
+        # a stale picture for its whole duration. The cost of this order is that
+        # the ✕ is learned one frame-write later, which is 68ms against a step
+        # measured in seconds — and it is still honoured on THIS callback.
+        #
         # `callback_on_step_end_tensor_inputs` defaults to `["latents"]` and
         # `Flux2KleinPipeline._callback_tensor_inputs` is `["latents",
         # "prompt_embeds"]`, so the latents arrive here without asking for them.
@@ -324,8 +328,20 @@ def generate(body):
                 lambda: callback_kwargs["latents"].detach().to(
                     "cpu", torch.float32).numpy(),
                 sigma=sigma, grid=grid)
+        # `report_or_cancel`, not `report`: this callback is the ONLY point in a
+        # minutes-long `pipe()` call where a stop can be honoured, and the reply
+        # to this tick is how the ✕ gets here.
+        worker_base.report_or_cancel(
+            job=job, kind="task", unit="", done=done, total=steps,
+            detail="Denoising — step %d/%d%s" % (done, steps, _eta(remaining)))
+        if worker_base.CANCEL.is_set():
+            raise worker_base.Cancelled()
         return callback_kwargs
 
+    # Step 0 is the one tick with no frame behind it, and that is not the
+    # ordering bug above: a frame needs two latents, so nothing exists to write
+    # until the second step. `runtime.js` documents that early 404 as ordinary
+    # and tells a page to hide the <img> on error.
     worker_base.report(job=job, state="running", kind="task", unit="",
                        done=0, total=steps, detail="Denoising — step 0/%d" % steps)
     # The sink wraps the SAVE as well as the render: its exit is the lifecycle,

--- a/fused_render/ai/runners/diffusers_image/worker.py
+++ b/fused_render/ai/runners/diffusers_image/worker.py
@@ -40,6 +40,7 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import formats  # noqa: E402 - the shared format checks; see formats.py
+import preview  # noqa: E402 - the ONE live-thumbnail writer; see preview.py
 import worker_base  # noqa: E402 - the path insert above is what makes it importable
 
 #: The loaded pipeline and the device its generator wants. One per process.
@@ -188,6 +189,13 @@ def load(model_id, fetched):
     device, seed_device = _place(pipe)
     _loaded["seed_device"] = seed_device
     _loaded["pipe"] = pipe
+    # The key the live preview's projection table is keyed by, captured HERE
+    # because the VAE is what defines the latent space a fitted matrix belongs
+    # to — not the pipeline and not the repo id, either of which would need a
+    # new table row for every checkpoint that shares one autoencoder. A class
+    # `preview.PROJECTIONS` has no entry for simply gets no preview.
+    vae = getattr(pipe, "vae", None)
+    _loaded["vae"] = None if vae is None else type(vae).__name__
     # See `worker_base.STATE["device"]`: on Windows the PyPI torch wheel is
     # CPU-only, so "this machine has a GPU" and "this pipeline is using one" are
     # different facts and only this process knows the second.
@@ -236,6 +244,26 @@ def memory():
     return total or None
 
 
+def _sigma_after(pipeline, step):
+    """The noise level the scheduler has ARRIVED at, after step index `step`.
+
+    `scheduler.sigmas` is the whole schedule with a trailing zero, and by the
+    time `callback_on_step_end` runs for step `i` the scheduler has already
+    advanced from `sigmas[i]` to `sigmas[i + 1]` — so the latents in the
+    callback are at `i + 1`. That off-by-one is the difference between a
+    preview that converges and one that is permanently one step stale, which is
+    invisible on a 32x32 thumbnail, hence writing it down.
+
+    None when the schedule is not there or is shorter than the loop, which no
+    scheduler in this pipeline does — but a preview must not be able to raise
+    out of a denoising callback and lose a render that was going to succeed.
+    """
+    sigmas = getattr(getattr(pipeline, "scheduler", None), "sigmas", None)
+    if sigmas is None or len(sigmas) <= step + 1:
+        return None
+    return float(sigmas[step + 1])
+
+
 def generate(body):
     """Render one image. Returns `{path, seconds, seed, width, height, steps}`."""
     import torch
@@ -259,6 +287,11 @@ def generate(body):
     started = time.time()
     step_times = []
     last = [started]
+    # The live thumbnail. A no-op when the request named no preview file or when
+    # nothing has been fitted for this VAE, which is what lets the callback below
+    # call it unconditionally — see `preview.sink`.
+    frames = preview.sink(body.get("outPreview"), _loaded.get("vae"))
+    grid = preview.token_grid(width, height)
 
     def on_step_end(pipeline, step, timestep, callback_kwargs):
         now = time.time()
@@ -275,22 +308,41 @@ def generate(body):
             detail="Denoising — step %d/%d%s" % (done, steps, _eta(remaining)))
         if worker_base.CANCEL.is_set():
             raise worker_base.Cancelled()
+        # `callback_on_step_end_tensor_inputs` defaults to `["latents"]` and
+        # `Flux2KleinPipeline._callback_tensor_inputs` is `["latents",
+        # "prompt_embeds"]`, so the latents arrive here without asking for them.
+        #
+        # A CLOSURE, not the array: pulling `(1, H*W, 128)` off the GPU is a
+        # synchronisation, and most of the 68ms this feature was measured at. A
+        # sink that is not writing must not be charged for it, and passing a
+        # thunk is what keeps the `if preview:` branch out of this loop. `.to`
+        # in one call rather than `.float().cpu()` — one transfer, not two.
+        sigma = _sigma_after(pipeline, step)
+        if sigma is not None:
+            frames.add(
+                lambda: callback_kwargs["latents"].detach().to(
+                    "cpu", torch.float32).numpy(),
+                sigma=sigma, grid=grid)
         return callback_kwargs
 
     worker_base.report(job=job, state="running", kind="task", unit="",
                        done=0, total=steps, detail="Denoising — step 0/%d" % steps)
-    image = pipe(
-        prompt=prompt,
-        height=height,
-        width=width,
-        guidance_scale=guidance,
-        num_inference_steps=steps,
-        generator=generator,
-        callback_on_step_end=on_step_end,
-    ).images[0]
+    # The sink wraps the SAVE as well as the render: its exit is the lifecycle,
+    # and a clean one means the real PNG has landed and the preview is now
+    # duplicate bytes. A cancel or a failure discards it too (`preview.Sink`).
+    with frames:
+        image = pipe(
+            prompt=prompt,
+            height=height,
+            width=width,
+            guidance_scale=guidance,
+            num_inference_steps=steps,
+            generator=generator,
+            callback_on_step_end=on_step_end,
+        ).images[0]
 
-    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
-    image.save(out)
+        os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+        image.save(out)
     return {
         "path": out,
         "seconds": round(time.time() - started, 2),

--- a/fused_render/ai/runners/diffusers_image/worker.py
+++ b/fused_render/ai/runners/diffusers_image/worker.py
@@ -192,8 +192,9 @@ def load(model_id, fetched):
     # The key the live preview's projection table is keyed by, captured HERE
     # because the VAE is what defines the latent space a fitted matrix belongs
     # to — not the pipeline and not the repo id, either of which would need a
-    # new table row for every checkpoint that shares one autoencoder. A class
-    # `preview.PROJECTIONS` has no entry for simply gets no preview.
+    # new table row for every checkpoint that shares one autoencoder. A VAE
+    # class that `preview.PROJECTIONS` has no entry for gets no preview at all,
+    # which is what keeps this additive for every other pipeline.
     vae = getattr(pipe, "vae", None)
     _loaded["vae"] = None if vae is None else type(vae).__name__
     # See `worker_base.STATE["device"]`: on Windows the PyPI torch wheel is

--- a/fused_render/ai/runners/formats.py
+++ b/fused_render/ai/runners/formats.py
@@ -68,11 +68,24 @@ MFLUX_COMPONENTS = ("transformer", "text_encoder", "vae")
 #: load this": the components can be perfect and the repo still unbuildable,
 #: and a card that showed the engine off the layout alone would offer a Load
 #: for every MLX diffusion repo on the Hub.
+#:
+#: `vae` names the AUTOENCODER the conversion was made from, which is the key
+#: `preview.PROJECTIONS` is indexed by. It is a class name out of diffusers and
+#: mflux has no such class, so it can look like a stray fact in an MLX table —
+#: it is not. The two image runners have to reach ONE row of ONE projection
+#: table (a page must not be able to tell which engine rendered for it), the
+#: torch one reads it off `type(pipe.vae).__name__`, and this side has no
+#: equivalent to read: an mflux conversion carries the same latent space as the
+#: repo it was converted from, and only this table knows which repo that was.
+#: Verified rather than assumed — `bn.running_mean`/`running_var` are
+#: bit-identical between the two repos (max|diff| = 0.0). A variant with no
+#: `vae` simply gets no preview.
 MFLUX_VARIANTS = {
     "mlx-community/FLUX.2-Klein-4B-4bit": {
         "variant": "Flux2Klein",
         "module": "mflux.models.flux2.variants",
         "config": "flux2_klein_4b",
+        "vae": "AutoencoderKLFlux2",
     },
 }
 

--- a/fused_render/ai/runners/mflux_image/worker.py
+++ b/fused_render/ai/runners/mflux_image/worker.py
@@ -45,6 +45,7 @@ import time
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import formats  # noqa: E402 - the shared format checks; see formats.py
+import preview  # noqa: E402 - the ONE live-thumbnail writer; see preview.py
 import worker_base  # noqa: E402 - the path insert above is what makes it importable
 
 #: The loaded model. One per process.
@@ -160,6 +161,11 @@ def load(model_id, fetched):
     # request out of `_request` instead.
     model.callbacks.register(_StepReporter())
     _loaded["model"] = model
+    # The key the live preview's projection table is keyed by. The torch runner
+    # reads it off `type(pipe.vae).__name__`; there is no such object here, so
+    # it comes out of the recipe — see `formats.MFLUX_VARIANTS` for why an
+    # autoencoder class name is the right thing for an MLX table to carry.
+    _loaded["vae"] = recipe.get("vae")
     # See `worker_base.STATE["device"]`. MLX is Metal or nothing, so unlike the
     # torch runner there is nothing to detect — but the page shows this field to
     # explain a speed, and a user comparing the two engines should be able to
@@ -217,6 +223,44 @@ def _eta(remaining):
 _request = {}
 
 
+def _sigma_after(config, t):
+    """The noise level the schedule has ARRIVED at, after step index `t`.
+
+    `config.scheduler.sigmas` is the whole schedule with a trailing zero, and
+    the latents the callback is handed after step `t` are at `sigmas[t + 1]` —
+    the same indexing `diffusers_image/worker.py` documents against
+    `pipeline.scheduler.sigmas`, because it is the same schedule.
+
+    None when there is no schedule to read, which mflux always has — but a
+    preview must not be able to raise out of the one callback this runner
+    cancels through and lose a render that was going to succeed.
+    """
+    sigmas = getattr(getattr(config, "scheduler", None), "sigmas", None)
+    if sigmas is None or len(sigmas) <= t + 1:
+        return None
+    return float(sigmas[t + 1])
+
+
+def _as_numpy(latents):
+    """The step's latents as numpy, for the preview projection.
+
+    `astype(float32)` first because numpy has no bfloat16 and mflux's loop is
+    free to work in it. Both packed `(B, N, 128)` and unpatchified
+    `(B, 128, h, w)` come through unchanged — `preview` takes either, so the
+    unpack rule is not restated here.
+
+    **This costs the render nothing.** Touching the array forces the same
+    `mx.eval` the generation loop performs immediately after the callback
+    returns, and it happens ON that thread — so there is no unevaluated graph
+    crossing a thread boundary and no `_pin_stream` concern (see `load`'s
+    docstring for the failure mode that would be).
+    """
+    import mlx.core as mx
+    import numpy
+
+    return numpy.asarray(latents.astype(mx.float32))
+
+
 class _StepReporter:
     """mflux's in-loop callback, and this runner's only interruption point.
 
@@ -256,6 +300,16 @@ class _StepReporter:
             # `KeyboardInterrupt`, so this is not swallowed and turned into a
             # half-rendered image — it unwinds the call, which is what a ✕ means.
             raise worker_base.Cancelled()
+        # The live thumbnail, from the SAME hook and for the same reason the
+        # progress tick is here: this is the only place in a minutes-long
+        # `generate_image()` where anything can be seen. A CLOSURE, not the
+        # array — a sink that is not writing must not be charged for the
+        # conversion, which is what keeps the branch out of this loop and the
+        # two runners' callbacks the same shape.
+        sigma = _sigma_after(config, t)
+        if sigma is not None:
+            request["preview"].add(lambda: _as_numpy(latents), sigma=sigma,
+                                   grid=request["grid"])
 
 
 def generate(body):
@@ -283,29 +337,37 @@ def generate(body):
         raise ValueError("'out' must be the path to write the image to")
 
     started = time.time()
+    # The live thumbnail. A no-op when the request named no preview file or when
+    # nothing has been fitted for this model's latent space — see `preview.sink`.
+    frames = preview.sink(body.get("outPreview"), _loaded.get("vae"))
     # Published before the call and cleared after it, so the registered reporter
     # is reporting about THIS request and no other.
     _request.clear()
-    _request.update({"job": job, "steps": steps, "step_times": [], "last": started})
+    _request.update({"job": job, "steps": steps, "step_times": [], "last": started,
+                     "preview": frames, "grid": preview.token_grid(width, height)})
     worker_base.report(job=job, state="running", kind="task", unit="",
                        done=0, total=steps, detail="Denoising — step 0/%d" % steps)
-    try:
-        image = model.generate_image(
-            seed=seed, prompt=prompt, num_inference_steps=steps,
-            height=height, width=width, guidance=guidance)
-    finally:
-        # Even on the cancel path: a reporter left pointing at a finished
-        # request would tick a row that is closed.
-        _request.clear()
+    # The sink wraps the SAVE as well as the render: its exit is the lifecycle,
+    # and a clean one means the real PNG has landed and the preview is now
+    # duplicate bytes. A cancel or a failure discards it too (`preview.Sink`).
+    with frames:
+        try:
+            image = model.generate_image(
+                seed=seed, prompt=prompt, num_inference_steps=steps,
+                height=height, width=width, guidance=guidance)
+        finally:
+            # Even on the cancel path: a reporter left pointing at a finished
+            # request would tick a row that is closed.
+            _request.clear()
 
-    os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
-    # `overwrite=True` is NOT optional. mflux's default resolves a colliding
-    # path by writing somewhere ELSE (`ImageUtil.resolve_output_path`), and the
-    # server has already told the caller where this image will be — so the
-    # default would answer a request with a file at a path nobody was given,
-    # while `out` stayed empty or stale. The server owns the location; this
-    # process owns the pixels.
-    image.save(out, overwrite=True)
+        os.makedirs(os.path.dirname(out) or ".", exist_ok=True)
+        # `overwrite=True` is NOT optional. mflux's default resolves a colliding
+        # path by writing somewhere ELSE (`ImageUtil.resolve_output_path`), and
+        # the server has already told the caller where this image will be — so
+        # the default would answer a request with a file at a path nobody was
+        # given, while `out` stayed empty or stale. The server owns the
+        # location; this process owns the pixels.
+        image.save(out, overwrite=True)
     return {
         "path": out,
         "seconds": round(time.time() - started, 2),

--- a/fused_render/ai/runners/mflux_image/worker.py
+++ b/fused_render/ai/runners/mflux_image/worker.py
@@ -288,6 +288,23 @@ class _StepReporter:
         done = t + 1
         average = sum(started) / len(started) if started else None
         remaining = (steps - done) * average if average else None
+        # The live thumbnail, from the SAME hook and for the same reason the
+        # progress tick is here: this is the only place in a minutes-long
+        # `generate_image()` where anything can be seen. A CLOSURE, not the
+        # array — a sink that is not writing must not be charged for the
+        # conversion, which is what keeps the branch out of this loop and the
+        # two runners' callbacks the same shape.
+        #
+        # **BEFORE the tick, and the order is load-bearing** — the diffusers
+        # runner's `on_step_end` says why at length, and it is the same reason
+        # here because it is the same page reading the same URL: `done` becomes
+        # the cache-busted `&step=N`, and a tick published ahead of its frame can
+        # get the previous frame's bytes cached under this step's URL for the
+        # step's whole duration. It costs the ✕ one frame-write of latency.
+        sigma = _sigma_after(config, t)
+        if sigma is not None:
+            request["preview"].add(lambda: _as_numpy(latents), sigma=sigma,
+                                   grid=request["grid"])
         # `report_or_cancel`, not `report`: this callback is the ONLY point in a
         # minutes-long `generate_image()` where a stop can be honoured, and the
         # reply to this tick is how the ✕ gets here. Same sentence, same fields
@@ -300,16 +317,6 @@ class _StepReporter:
             # `KeyboardInterrupt`, so this is not swallowed and turned into a
             # half-rendered image — it unwinds the call, which is what a ✕ means.
             raise worker_base.Cancelled()
-        # The live thumbnail, from the SAME hook and for the same reason the
-        # progress tick is here: this is the only place in a minutes-long
-        # `generate_image()` where anything can be seen. A CLOSURE, not the
-        # array — a sink that is not writing must not be charged for the
-        # conversion, which is what keeps the branch out of this loop and the
-        # two runners' callbacks the same shape.
-        sigma = _sigma_after(config, t)
-        if sigma is not None:
-            request["preview"].add(lambda: _as_numpy(latents), sigma=sigma,
-                                   grid=request["grid"])
 
 
 def generate(body):
@@ -345,6 +352,9 @@ def generate(body):
     _request.clear()
     _request.update({"job": job, "steps": steps, "step_times": [], "last": started,
                      "preview": frames, "grid": preview.token_grid(width, height)})
+    # Step 0 is the one tick with no frame behind it, and that is not the
+    # ordering rule the reporter documents: a frame needs two latents, so
+    # nothing exists to write until the second step.
     worker_base.report(job=job, state="running", kind="task", unit="",
                        done=0, total=steps, detail="Denoising — step 0/%d" % steps)
     # The sink wraps the SAVE as well as the render: its exit is the lifecycle,

--- a/fused_render/ai/runners/preview.py
+++ b/fused_render/ai/runners/preview.py
@@ -113,6 +113,17 @@ MAX_SIDE = 32
 #: packing would have to move it into the table — worth doing then, not now.
 TOKEN_STRIDE = 16
 
+#: Consecutive failed frames before a sink switches itself off.
+#:
+#: A preview never costs a render (see `Sink.add`), so a failure is swallowed —
+#: but a PERMANENT failure swallowed silently is a device sync plus a doomed
+#: syscall on every one of a hundred steps. Three in a row is the line: the
+#: failure this most expects is a Windows lock held by the page's own `<img>`
+#: over the destination, which is transient by nature, and a sink that gave up
+#: on the first unlucky step would throw the feature away over nothing. The
+#: count resets on any frame that lands.
+MAX_FAILURES = 3
+
 
 def token_grid(width, height) -> tuple:
     """The `(h, w)` token grid a render of `width` x `height` denoises in.
@@ -416,6 +427,7 @@ class Sink:
         #: render with no entry in `PROJECTIONS` pays nothing at all.
         self.wanted = bool(self.path and PROJECTIONS.get(model_key or ""))
         self._previous = None
+        self._failures = 0
 
     def add(self, latents, sigma, grid=None) -> None:
         """Offer the step just taken. Writes a frame from the second one on.
@@ -431,9 +443,48 @@ class Sink:
         index `i`, diffusers' scheduler has moved from `sigmas[i]` to
         `sigmas[i+1]`, and mflux's `config.scheduler.sigmas` indexes the same
         way off the callback's `t`.
+
+        **NOTHING escapes this method, and that is the whole of it.** It is
+        called from inside a denoising callback, which is the one interruption
+        point in a `pipe()` / `generate_image()` call that runs for minutes — so
+        an exception here does not fail a thumbnail, it unwinds the render and
+        destroys work that was going to succeed. The failures are real and are
+        not hypothetical: `save` on a full disk, `os.replace` against a Windows
+        lock held by the page's own `<img>` reading this very file through
+        `/api/fs/raw` (the hazard `discard` already swallows, one line of
+        reasoning below), a device that has fallen over inside `latents()`, a
+        latent shape nobody predicted. Both runners' `_sigma_after` helpers
+        state this invariant; this is where it is actually kept.
+
+        Broad on purpose — a list of expected exception types is a promise
+        about a third-party library's failure modes, and getting that list
+        wrong costs a render. What a failure DOES cost is the temp file it may
+        have left, which is removed here, and eventually the feature: after
+        `MAX_FAILURES` in a row the sink turns itself into the same working
+        no-op an unfitted model gets, rather than paying a device sync and a
+        doomed syscall on every remaining step.
         """
         if not self.wanted:
             return
+        try:
+            self._add(latents, sigma, grid)
+        except Exception:  # noqa: BLE001 - see the docstring; a render is at stake
+            self._failures += 1
+            # A `save` that landed and a `replace` that did not leaves a temp in
+            # a directory the user browses. It is this method's to clean up:
+            # `discard` runs at the end of the render, and until then one per
+            # failed step would accumulate.
+            try:
+                os.remove(self._temp_path())
+            except OSError:
+                pass
+            if self._failures >= MAX_FAILURES:
+                self.wanted = False
+        else:
+            self._failures = 0
+
+    def _add(self, latents, sigma, grid) -> None:
+        """`add` without the guard — everything that is allowed to raise."""
         tokens, grid = _tokens(latents(), grid)
         sigma = float(sigma)
         previous, self._previous = self._previous, (tokens, sigma)

--- a/fused_render/ai/runners/preview.py
+++ b/fused_render/ai/runners/preview.py
@@ -103,6 +103,26 @@ SUFFIX = ".preview.png"
 #: blurring a picture of a picture either way.
 MAX_SIDE = 32
 
+#: Pixels per latent token, per axis: FLUX.2's VAE downsamples 8x and its 2x2
+#: patchify folds another 2. So a 1024² render denoises a 64x64 token grid.
+#:
+#: Here rather than beside the projection because both runners need it to say
+#: what shape the packed tokens they hold are, and one of them (`(B, N, C)`)
+#: cannot tell from the array. Strictly it is a fact about klein's autoencoder
+#: like the matrix is, so a second entry in `PROJECTIONS` with a different
+#: packing would have to move it into the table — worth doing then, not now.
+TOKEN_STRIDE = 16
+
+
+def token_grid(width, height) -> tuple:
+    """The `(h, w)` token grid a render of `width` x `height` denoises in.
+
+    Both workers know their pixel size and neither can read the grid off the
+    packed `(B, N, C)` tokens, so the division lives here — a runner doing its
+    own `// 16` is a second copy of a fact about the VAE.
+    """
+    return (int(height) // TOKEN_STRIDE, int(width) // TOKEN_STRIDE)
+
 
 def preview_path(out: str | None) -> str | None:
     """Where the live preview for `out` goes, or None if there is no out.

--- a/fused_render/ai/runners/preview.py
+++ b/fused_render/ai/runners/preview.py
@@ -1,0 +1,501 @@
+"""The live preview: the picture WHILE it is being denoised (SPEC §40).
+
+`fused.ai.image` writes its PNG once, at the end. A FLUX render is minutes long
+and for all of them the only thing a page can show is a step counter — a
+progress bar for a process whose entire output is visual. This module is the
+fix: a `<out without ext>.preview.png` beside the image the request already
+named, ~32x32 and ~3KB, **overwritten every step**, which a page points an
+`<img>` at. Blurring and upscaling it is the page's business, not this API's.
+
+**Always on, no flag.** Measured at 68ms per step for the projection plus the
+PNG at 512²/16 steps — 1.25% of the render — and dominated by the device->CPU
+sync and the PNG encode rather than by the matmul, so it stays roughly flat as
+the resolution grows. A feature that costs one percent does not need an opt-in;
+an opt-in would only guarantee that most pages never get it.
+
+**This module is the whole of the feature and it sits at the runners ROOT**,
+beside `worker_base.py`, `formats.py`, `diarize.py` and `partial.py`, for the
+reason AI-10c states: two engines serve one capability and a page must not be
+able to tell which one ran. The path rule, the arithmetic, the write and the
+lifecycle exist once, and `tests/test_ai_image_preview.py` pins that
+structurally — a second `preview.py` under either image runner would fail no
+behavioural test, because both copies would pass their own.
+
+**Stdlib only at import time, and no import of `fused_render`.** The same
+constraint `formats.py`, `diarize.py` and `partial.py` document, for the same
+two reasons: each runner runs on its own interpreter with the app's package off
+its path, and the SERVER imports this file too — to derive the path it
+advertises to the page — so reading it must not need either runner venv. numpy
+and Pillow are both present in both image venvs (torch/mlx pull the first,
+`pillow`/`mflux` the second) and both are used, inside the functions that need
+them.
+
+---
+
+## Why the raw latent is not the picture
+
+FLUX.2 klein is step-wise **distilled**, and its sigma schedule is nothing like
+a normal flow-matching one. A real 16-step render walked
+
+    1.0, 0.991, 0.98, 0.968, 0.955, 0.939, 0.921, 0.9, 0.875, 0.845,
+    0.808, 0.761, 0.7, 0.617, 0.5, 0.318, 0.0
+
+— still at sigma 0.5 with two steps to go. What the denoising callback holds is
+therefore mostly noise for almost the whole render, and projecting it gives a
+preview that is grey static until the last frame, which is the frame nobody
+needed. What IS legible from step 2 of 16, and converges visibly to the finished
+image, is the model's own current guess: recover the velocity from two
+consecutive latents and extrapolate it to sigma 0.
+
+    v      = (x_next - x_prev) / (s_next - s_prev)
+    x1_hat = x_next - s_next * v
+
+Step 1 has no predecessor and so gets no preview. That is correct rather than a
+gap to paper over — a first frame projected from the raw latent is exactly the
+static this approach exists to avoid.
+
+## Why the projection is a fitted constant
+
+FLUX.1's published 16-channel latent-RGB factors do not apply here. klein's VAE
+is `AutoencoderKLFlux2`: 32 latent channels, a 2x2 patchify (so 128 channels per
+token), 8x spatial, and a normalisation that is a **BatchNorm**
+(`vae.bn.running_mean` / `running_var` + `vae.config.batch_norm_eps`) rather
+than the usual `scaling_factor`/`shift_factor` pair. A denoising callback holds
+`(1, H*W, 128)` row-major packed tokens with a grid side of `image side / 16`.
+
+So the map was fitted, once, by `fit_factors.py`: encode the three sample jpgs
+that ship in the FLUX.2 repo through the torch VAE, patchify and BN-normalise to
+land in **exactly the space the callback sees**, box-downsample each source
+image 16x to one pixel per token, and least-squares a 128->3 affine map between
+them. R² = 0.911 / 0.912 / 0.891 per channel, residual RMS 0.083 in [0,1]. The
+numbers are written down here rather than derived at runtime because deriving
+them needs the VAE weights, which is the one thing a preview must not wait for.
+
+**One matrix serves both engines.** `bn.running_mean` and `bn.running_var` are
+bit-identical (max|diff| = 0.0) between `black-forest-labs/FLUX.2-klein-4B` and
+`mlx-community/FLUX.2-Klein-4B-4bit`, and mflux's `decode_packed_latents`
+applies the same `packed * bn_std + bn_mean` with the same unpatchify
+permutation that diffusers' id-scatter produces for text2image. That is why the
+table below is keyed by the VAE's class name and not by the repo id: the two
+runners reach the same row from opposite directions (`type(pipe.vae).__name__`
+on one side, `formats.MFLUX_VARIANTS[...]["vae"]` on the other), and a model
+whose latent space nobody has fitted gets **no preview at all** — a working
+no-op sink, so a render without an entry behaves exactly as it did before this
+existed. That is what keeps this additive.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+
+#: What replaces the render's `.png`. A SIBLING of the image, sharing its stem:
+#: `20260101-120000-abc.png` and `20260101-120000-abc.preview.png` sort together
+#: in `ai/images/`, which a user browses, and neither reads like the other.
+#: Appending (`out.png.preview.png`) would leave a name that ends in the same
+#: extension twice and looks like a second render.
+SUFFIX = ".preview.png"
+
+#: The longest side a frame is written at. A 512² render has a 32x32 token grid,
+#: a 1024² one 64x64 and a 2048² one 128x128 — and the cost that was measured is
+#: the cost of a 32x32 PNG. Capping keeps the per-step price flat across
+#: resolutions, and costs nothing a viewer can see: the page is upscaling and
+#: blurring a picture of a picture either way.
+MAX_SIDE = 32
+
+
+def preview_path(out: str | None) -> str | None:
+    """Where the live preview for `out` goes, or None if there is no out.
+
+    Derived in ONE place because three parties have to name the same file: the
+    route advertises it, the worker writes it, and `runtime.js` builds the URL
+    a page's `<img>` points at. A page is never asked to string-munge one path
+    out of another — the rule `partial.partial_path` already follows.
+    """
+    if not out:
+        return None
+    return os.path.splitext(out)[0] + SUFFIX
+
+
+#: FLUX.2 klein's fitted map, exactly as `fit_factors.py` recorded it: three
+#: rows of 128 weights (R, G, B) and the three constants. Written out as a
+#: literal because deriving it needs the VAE weights, which is the one thing a
+#: preview must not wait for. See the module docstring for how it was fitted.
+_FLUX2_FACTORS = (
+    (
+        0.004319765605032444, 0.006642758846282959, -0.0007230047485791147,
+        0.00039216605364345014, 0.0012196688912808895, -0.0032893787138164043,
+        -0.0023591439239680767, -0.0008559596026316285, -0.0028271269984543324,
+        -0.007499493192881346, -0.002115743001922965, -0.0010739217977970839,
+        0.014385404996573925, 0.03257348760962486, 0.028830809518694878,
+        0.03811405226588249, 0.007008147891610861, 0.001040852046571672,
+        0.0034754264634102583, 0.0020419186912477016, 0.0014182536397129297,
+        0.00017251365352422, 0.0003846861363854259, -0.0004692572692874819,
+        -0.006217387039214373, -0.0059965914115309715, -0.005683690309524536,
+        -0.002909251255914569, -0.0026819377671927214, 7.079380156937987e-05,
+        -0.005395818967372179, -0.0052736373618245125, -0.05788913741707802,
+        -0.05462039262056351, -0.056071482598781586, -0.04536673054099083,
+        -0.00048514496302232146, -0.0018123873742297292, -0.005414324812591076,
+        -0.003954681102186441, 0.0017698599258437753, 0.0008416266064159572,
+        0.0006753841880708933, 0.0025590350851416588, 0.005032898858189583,
+        0.005456556100398302, 0.0020204943139106035, 0.004936059936881065,
+        0.0010978523641824722, 0.0009927782230079174, 0.0022764126770198345,
+        -0.0005715248407796025, -0.0019375573610886931, -0.0010985295521095395,
+        -0.00045477927778847516, -0.002286893781274557, 0.00263522588647902,
+        -0.0009740614332258701, 0.0011853392934426665, -0.0018170623807236552,
+        -0.01178462989628315, -0.007736557628959417, -0.011570101603865623,
+        -0.008714784868061543, -0.00375718274153769, -0.003101083217188716,
+        0.002798135858029127, -0.003109609941020608, 0.0022560900542885065,
+        -0.001226974418386817, 0.0012127363588660955, 0.000674975395668298,
+        -0.005696927197277546, -0.0030896333046257496, -0.0019271587952971458,
+        -0.004249103367328644, 0.011104568839073181, 0.010736517608165741,
+        0.013935495167970657, 0.009387445636093616, -0.0006810142658650875,
+        0.0004111784801352769, 0.0002535065868869424, -0.00015048008935991675,
+        0.0014298794558271766, 0.00018491005175746977, -0.0012072670506313443,
+        -0.0033697609324008226, 0.0008210957748815417, 0.001347901183180511,
+        -0.0009010171052068472, 0.0006450305809266865, 0.0025541384238749743,
+        0.0021683203522115946, -0.0012691175797954202, -0.00022639325470663607,
+        -0.002680952427908778, 0.0013456307351589203, -0.0024516519624739885,
+        0.0018459331477060914, 0.0007122131646610796, -0.001650148187763989,
+        -0.004450578708201647, -0.0021670707501471043, 0.006447337567806244,
+        0.007563515566289425, 0.003611154155805707, 0.004609786439687014,
+        0.007319333031773567, 0.0017690816894173622, 0.0009661246440373361,
+        7.226940215332434e-05, -0.005029898136854172, -0.00033574795816093683,
+        0.0016172690084204078, 0.0031301246490329504, -0.00432027131319046,
+        -0.009064449928700924, -0.007024370599538088, -0.004720802418887615,
+        0.00028518948238343, -0.00029789458494633436, -0.0003985691873822361,
+        0.004343509208410978, 0.0022476192098110914, 0.0011696548899635673,
+        0.005508198868483305, 0.002861988265067339,
+    ),
+    (
+        0.0034148988779634237, 0.0070432014763355255, 0.0017529254546388984,
+        0.0028275945223867893, 0.0009609725675545633, -0.004111018031835556,
+        -0.003459643805399537, -0.0025663108099251986, 0.0021073592361062765,
+        -0.0018211830174550414, 0.0013698607217520475, 0.002512849634513259,
+        0.03404124826192856, 0.0444403775036335, 0.0446140430867672,
+        0.049372103065252304, 0.0018090720986947417, -0.0023069174494594336,
+        0.0012175474548712373, 6.446584302466363e-05, -0.002638330915942788,
+        -0.00194084201939404, -0.0007935801986604929, -0.0018358816159889102,
+        0.007274247240275145, 0.005180122330784798, 0.006793948356062174,
+        0.007183389738202095, 0.001261013327166438, 0.0011284986976534128,
+        -0.0042471084743738174, -0.0010458165779709816, -0.04735724627971649,
+        -0.03988916054368019, -0.04207339137792587, -0.027211442589759827,
+        -0.00040315708611160517, -0.0014614894753322005, -0.005677468609064817,
+        -0.0036556359846144915, 0.0010590190067887306, 0.0013988933060318232,
+        -0.0016817450523376465, 0.0024990320671349764, -0.001685467315837741,
+        -0.0005607864004559815, -0.0026659753639250994, -0.000577025581151247,
+        0.002216205932199955, 0.004346057306975126, 0.001112748752348125,
+        0.00014651997480541468, -0.0021955263800919056, 0.0012995416764169931,
+        -0.0026010156143456697, -0.0005221454193815589, 0.005691594909876585,
+        0.0023765326477587223, 0.0036872252821922302, 0.0012299439404159784,
+        0.0001382525806548074, 0.003853888250887394, -0.003670091275125742,
+        0.0010674693621695042, -0.0019302365835756063, -0.0011030228342860937,
+        0.004642413463443518, 0.0007383595802821219, 0.00012394941586535424,
+        -0.002786841243505478, 0.001386596355587244, 8.776979666436091e-05,
+        -0.003786040237173438, -0.000441443087765947, -0.0005074712680652738,
+        -0.0047491067089140415, -0.00640726275742054, -0.005853611044585705,
+        -0.002752845175564289, -0.004113187547773123, -0.0020386073738336563,
+        0.00025124827516265213, -0.0014114718651399016, -0.0023085209541022778,
+        0.002601321553811431, 0.001963091781362891, -0.0008846810669638216,
+        -0.002873504301533103, 0.0007136394851841033, 0.0011142006842419505,
+        0.0036992731038480997, 0.0029123497661203146, 0.0011071143671870232,
+        0.0032149790786206722, 0.00019870192045345902, -0.0005686454242095351,
+        0.005012097768485546, 0.00301953312009573, 0.00218176725320518,
+        0.0028472288977354765, 0.00028534684679470956, -0.0008731617126613855,
+        -0.002721555531024933, -9.343306737719104e-05, -8.250449172919616e-05,
+        0.002428097650408745, -0.0014057522639632225, 0.00019750333740375936,
+        0.003689037635922432, 0.0038317302241921425, -0.0015036027180030942,
+        0.0014431606978178024, -0.004956075455993414, -0.0027192551642656326,
+        0.00043002082384191453, -4.082196392118931e-05, 0.0014737430028617382,
+        -0.00434843497350812, -0.0008810207364149392, 0.00043270873720757663,
+        0.0005371406441554427, 0.00034614658216014504, -0.00025972092407755554,
+        0.0047650146298110485, -0.0009968490339815617, -0.002356966957449913,
+        -0.0014902063412591815, -0.001119957654736936,
+    ),
+    (
+        0.0027692848816514015, 0.00452546076849103, 0.0010614838683977723,
+        0.002304889727383852, 0.004143681842833757, 0.0014532961649820209,
+        -0.00016871534171514213, 0.0021996430587023497, 0.00748686958104372,
+        0.003078680718317628, 0.006122744642198086, 0.007088279817253351,
+        0.05132089555263519, 0.05588889494538307, 0.05816791206598282,
+        0.05842182785272598, 0.003406404284760356, -0.003791265422478318,
+        0.0016819584416225553, -0.0003801948332693428, -0.005580201279371977,
+        -0.004168902989476919, -0.004186726175248623, -0.003993000369518995,
+        -0.005205431953072548, -0.005476972553879023, -0.0045888060703873634,
+        -0.002421777695417404, 0.0027023053262382746, 0.002057417295873165,
+        -0.0032084088306874037, 0.0008731561247259378, -0.03782600909471512,
+        -0.027280563488602638, -0.027297867462038994, -0.01044269185513258,
+        0.002545560011640191, 0.0006769885076209903, -0.004624918103218079,
+        -0.001264780294150114, 0.0008665978675708175, 0.004234627820551395,
+        -0.0009841150604188442, 0.004356895573437214, -0.016789274290204048,
+        -0.011619621887803078, -0.016309170052409172, -0.012541979551315308,
+        0.0011986388126388192, 0.004194409586489201, 0.00017755494627635926,
+        8.217765571316704e-05, -0.004402271471917629, -0.0002598506980575621,
+        -0.002417230047285557, -0.002586920978501439, 0.0018378455424681306,
+        -0.0002395514165982604, 0.002050467301160097, -0.0008707294473424554,
+        0.0028382211457937956, 0.005832775961607695, -0.0011329541448503733,
+        0.0016617453657090664, 1.630527367524337e-05, -0.002697952091693878,
+        0.006262653041630983, 0.003172331489622593, -0.0019500143826007843,
+        -0.0032625049352645874, 0.0006693286122754216, -5.892138506169431e-05,
+        -0.002339741215109825, -0.00015672558220103383, -0.0016881701303645968,
+        -0.008027976378798485, -0.00682775629684329, -0.0041418904438614845,
+        -0.001429605996236205, -0.0023731663823127747, -0.0001982292887987569,
+        0.0028105515521019697, 0.0022730750497430563, -0.0015523541951552033,
+        0.002164091682061553, 0.004002835601568222, -0.002230421407148242,
+        -0.002602699212729931, -0.0012716384371742606, -0.0012002679286524653,
+        0.0048891883343458176, 0.0012911114608868957, 0.0019010730320587754,
+        0.006292331963777542, 0.0001571069296915084, 0.0029545447323471308,
+        0.0037529708351939917, 0.0003842232399620116, 0.0005831393063999712,
+        -0.001189555274322629, -0.0007639620453119278, 0.0005708681419491768,
+        -0.0006069278460927308, 0.001546171260997653, 0.001089361496269703,
+        0.0016942339716479182, 0.0019325121538713574, 0.00027734797913581133,
+        0.0015092457178980112, 0.0035559318494051695, -0.0020400607027113438,
+        0.0015733694890514016, -0.004380906466394663, -0.0026256937999278307,
+        -0.0010093118762597442, -0.0017491326434537768, 0.0036383545957505703,
+        -0.0031859581358730793, 0.0011547106551006436, 0.0035906629636883736,
+        -0.0005358326015993953, 0.0017820722423493862, -0.002990684239193797,
+        0.004044759552925825, -0.001744472305290401, -0.0029976358637213707,
+        -0.0035976916551589966, -0.002255234634503722,
+    ),
+)
+
+_FLUX2_BIAS = (0.4698728024959564, 0.4328208565711975, 0.4053916037082672)
+
+
+#: Model key -> the fitted 128->3 affine map from packed latent tokens to sRGB.
+#:
+#: `rgb = tokens @ factors.T + bias`, then clip to [0, 1]. Keyed by the VAE's
+#: CLASS NAME because that is the thing the two engines can both name (see the
+#: module docstring), and a TABLE rather than a heuristic for the reason
+#: `_GGUF_RECIPES` and `MFLUX_VARIANTS` are: which projection is right for a
+#: latent space is a measurement somebody took, not something to infer.
+#:
+#: A model absent from here is not broken — it renders exactly as it did before
+#: this module existed, with no preview file and no branch in its denoising loop.
+PROJECTIONS = {
+    "AutoencoderKLFlux2": {
+        # FLUX.2 klein 4B. Fitted by `fit_factors.py` against the torch VAE's
+        # own encode of the repo's three sample jpgs; R² 0.911 / 0.912 / 0.891,
+        # residual RMS 0.083 in [0,1]; validated end-to-end on a real GGUF
+        # render. See the module docstring for the derivation in full.
+        "factors": _FLUX2_FACTORS,
+        "bias": _FLUX2_BIAS,
+    },
+}
+
+
+def project(tokens, model_key: str | None):
+    """`(n, 128)` latent tokens -> `(n, 3)` RGB in [0, 1], or None.
+
+    None when nothing has been fitted for `model_key`, which is the same answer
+    the sink turns into "no preview": the caller is never handed a projection
+    computed with somebody else's matrix.
+
+    **Clipped**, and not as tidiness. The map is affine and unbounded, and an
+    early estimate sits well outside the range it was fitted over, so the raw
+    numbers routinely leave [0, 1]. A page is being handed a colour.
+    """
+    entry = PROJECTIONS.get(model_key or "")
+    if entry is None:
+        return None
+    import numpy
+
+    factors = numpy.asarray(entry["factors"], dtype=numpy.float32)
+    bias = numpy.asarray(entry["bias"], dtype=numpy.float32)
+    rgb = numpy.asarray(tokens, dtype=numpy.float32) @ factors.T + bias
+    return numpy.clip(rgb, 0.0, 1.0)
+
+
+def denoised(previous, current, sigma_previous, sigma_current):
+    """The model's guess at the FINISHED image, from two steps of one render.
+
+    `x1_hat = x_next - s_next * (x_next - x_prev) / (s_next - s_prev)` — the
+    velocity between two consecutive latents, extrapolated to sigma 0. This is
+    the whole reason a preview of klein is legible at all; see the module
+    docstring for the sigma schedule that makes the raw latent useless.
+
+    None when the two sigmas are equal, which is a division by zero and not a
+    frame. Nothing in either scheduler repeats a sigma mid-render, so this is a
+    guard rather than a case — but "nothing does that today" is how a NaN
+    thumbnail gets shipped.
+    """
+    gap = float(sigma_current) - float(sigma_previous)
+    if gap == 0.0:
+        return None
+    import numpy
+
+    current = numpy.asarray(current, dtype=numpy.float32)
+    velocity = (current - numpy.asarray(previous, dtype=numpy.float32)) / gap
+    return current - float(sigma_current) * velocity
+
+
+def _tokens(latents, grid):
+    """Whatever a callback holds -> `((n, 128) tokens, (h, w))`.
+
+    Both shapes both engines produce, in one place, because a runner reshaping
+    its own latents first would be a second copy of the unpack rule:
+
+    * `(B, N, C)` — diffusers' packed tokens, and mflux's before its
+      unpatchify. Row-major over the token grid, which is `image side / 16` per
+      axis, so the grid has to be told rather than inferred.
+    * `(B, C, h, w)` — already unpatchified, where the grid IS the shape.
+
+    A grid that cannot be resolved raises rather than silently guessing a
+    square: both workers compute it from the width and height they were given,
+    so this is unreachable in a render, and a wrong-shaped thumbnail is a bug
+    that looks like a picture.
+    """
+    import numpy
+
+    array = numpy.asarray(latents, dtype=numpy.float32)
+    if array.ndim == 4:
+        array = array[0]
+        height, width = int(array.shape[1]), int(array.shape[2])
+        return array.reshape(array.shape[0], height * width).T, (height, width)
+    if array.ndim == 3:
+        array = array[0]
+    if array.ndim != 2:
+        raise ValueError(f"latents of shape {numpy.shape(latents)} are not tokens")
+    count = int(array.shape[0])
+    if grid is None:
+        side = math.isqrt(count)
+        if side * side != count:
+            raise ValueError(
+                f"{count} packed tokens are not a square grid — pass grid=(h, w)")
+        grid = (side, side)
+    height, width = int(grid[0]), int(grid[1])
+    if height * width != count:
+        raise ValueError(f"grid {height}x{width} does not hold {count} tokens")
+    return array, (height, width)
+
+
+class Sink:
+    """A single-frame view of an image being denoised.
+
+    Use it as a context manager around the whole render INCLUDING the final
+    save, because the exit is the lifecycle — and here the lifecycle is simpler
+    than `partial.Sink`'s in the one way that matters: **every exit discards.**
+
+    A clean exit means the real PNG landed, so the preview is duplicate bytes at
+    a thirty-second of the resolution. A cancel means the user pressed ✕ and
+    does not want this picture. And an ERROR discards too, which is where this
+    diverges from the transcript sink — deliberately, and it is the one
+    difference worth stating: a run that died at minute 80 of 90 has 80 minutes
+    of words in its partial file and that file is the only salvage there is,
+    whereas a render that died at step 12 of 16 has a 32x32 blur of a picture
+    that will never exist. Not salvage; just a file in `ai/images/` that no job
+    row explains and nothing will ever clean up. That is also why this class
+    takes no `cancelled=` argument: with all three exits doing the same thing,
+    it never has to tell one exception from another.
+    """
+
+    def __init__(self, path: str | None, model_key: str | None = None):
+        self.path = path or None
+        self.model_key = model_key
+        #: Whether a frame will ever be written. Read by the callers, so a
+        #: render with no entry in `PROJECTIONS` pays nothing at all.
+        self.wanted = bool(self.path and PROJECTIONS.get(model_key or ""))
+        self._previous = None
+
+    def add(self, latents, sigma, grid=None) -> None:
+        """Offer the step just taken. Writes a frame from the second one on.
+
+        `latents` is a **callable returning** the latents, not the latents, and
+        that is the point: reading them off the device is a synchronisation
+        that costs most of the measured 68ms, and a sink that is not writing
+        must not charge the render for it. Passing a closure instead of an
+        array is what lets both denoising loops call this unconditionally —
+        the `if preview:` branch `partial.sink`'s no-op exists to avoid.
+
+        `sigma` is the schedule value the run has just arrived AT: after step
+        index `i`, diffusers' scheduler has moved from `sigmas[i]` to
+        `sigmas[i+1]`, and mflux's `config.scheduler.sigmas` indexes the same
+        way off the callback's `t`.
+        """
+        if not self.wanted:
+            return
+        tokens, grid = _tokens(latents(), grid)
+        sigma = float(sigma)
+        previous, self._previous = self._previous, (tokens, sigma)
+        if previous is None:
+            # Step 1: a velocity needs two points. No frame, by design.
+            return
+        estimate = denoised(previous[0], tokens, previous[1], sigma)
+        if estimate is None:
+            return
+        self._write(project(estimate, self.model_key), grid)
+
+    def _write(self, rgb, grid) -> None:
+        """One frame, complete or not at all.
+
+        **Temp file plus `os.replace`, never a write in place.** The page is
+        reading this path through `/api/fs/raw` at the same time, and a reader
+        that arrives mid-write gets a truncated PNG — the byte-level analogue of
+        the half-a-line hazard `partial.Sink.add` flushes around. `os.replace`
+        is atomic within a filesystem, hence a temp beside the target rather
+        than in `/tmp`. The pid is in its name because a stale temp from a
+        killed worker must not be mistaken for this one's.
+        """
+        import numpy
+        from PIL import Image
+
+        height, width = grid
+        frame = numpy.asarray(rgb, dtype=numpy.float32).reshape(height, width, 3)
+        image = Image.fromarray((frame * 255.0 + 0.5).astype(numpy.uint8), "RGB")
+        if max(height, width) > MAX_SIDE:
+            scale = MAX_SIDE / float(max(height, width))
+            # BOX, i.e. plain averaging: this is a thumbnail of a thumbnail and
+            # a sharpening filter on latent-projected noise invents detail.
+            resample = getattr(Image, "Resampling", Image).BOX
+            image = image.resize((max(1, round(width * scale)),
+                                  max(1, round(height * scale))), resample)
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        temp = self._temp_path()
+        image.save(temp, format="PNG")
+        os.replace(temp, self.path)
+
+    def _temp_path(self) -> str:
+        return f"{self.path}.{os.getpid()}.tmp"
+
+    def discard(self) -> None:
+        """Remove the preview and any temp beside it. Best-effort by design.
+
+        This runs on the way OUT of the context manager, which on the success
+        path is reached only after the real PNG has already been written — so
+        anything raised here reports a finished render as a failed one, in
+        exchange for a tidier directory. That trade is never worth taking, so
+        every `os.remove` failure is swallowed and not just the absent-file one:
+        a render cancelled on its first step arrives having written nothing
+        (FileNotFoundError), and a page holding this file open through
+        `/api/fs/raw` can have a Windows lock on it (PermissionError) at the
+        exact moment the image lands. The temp goes too — a frame that failed
+        between `save` and `replace` is the one thing here that can outlive its
+        writer, and it is in a directory the user browses.
+        """
+        if self.path is None:
+            return
+        for path in (self.path, self._temp_path()):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+    def __enter__(self) -> "Sink":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.discard()
+        return False
+
+
+def sink(path: str | None, model_key: str | None = None) -> Sink:
+    """A `Sink` for `path`, or a working no-op one when there is no preview.
+
+    Two ways to get the no-op and they mean different things, but the caller
+    treats them identically: no `path` is a request from before this feature
+    (and it must run exactly as it did), and no entry in `PROJECTIONS` for
+    `model_key` is a model whose latent space nobody has fitted a matrix for.
+    Neither is an error and neither is a reason for a denoising loop to grow a
+    conditional — that is the argument `partial.sink` makes for its own no-op.
+    """
+    return Sink(path, model_key)

--- a/fused_render/server/routers/ai_runtime.py
+++ b/fused_render/server/routers/ai_runtime.py
@@ -85,6 +85,60 @@ def _images_dir() -> str:
     return directory
 
 
+#: How long a preview frame has to sit untouched before a sweep takes it.
+#:
+#: An hour, which is far longer than it needs to be and deliberately so. A LIVE
+#: preview is rewritten every denoising step, so its mtime is always seconds
+#: old — the threshold is not really a timeout, it is the line between "nobody
+#: is writing this" and "somebody is", and it is what lets the sweep run without
+#: knowing which renders are in flight. Erring long costs an orphan an extra
+#: hour on disk; erring short would delete the picture a user is watching.
+_PREVIEW_TTL = 3600
+
+
+def _sweep_previews(directory: str) -> None:
+    """Remove preview frames that no render is writing any more.
+
+    `preview.Sink.discard` runs on the way out of a render and takes the
+    thumbnail with it — but only on a normal unwind, and a worker does not
+    always get one. `supervisor._terminate` / `_kill_tree` end the process
+    outright when a model is unloaded, the app shuts down, or a worker wedges,
+    and what survives is a `<stem>.preview.png` (plus, if the kill landed
+    between the save and the replace, a `.<pid>.tmp` beside it) in
+    `<home>/ai/images` — a directory the user browses, holding a file with no
+    job row to explain it and nothing that would ever remove it.
+
+    Swept HERE, on the way into a render, rather than by a background timer: it
+    is the moment this is free (the caller is about to wait minutes) and the
+    only moment it is needed (the directory grows only when renders happen), and
+    a timer would be a lifecycle to own for a few kilobytes.
+
+    Matched by `preview.SUFFIX` appearing anywhere in the name, which covers the
+    frame and its temp in one test and cannot match a render's own
+    `<timestamp>-<uid>.png`. **The image itself is never touched at any age** —
+    it is the artefact the whole feature exists to produce.
+
+    Best-effort throughout, for the reason `discard` is: this runs at the front
+    of a request that is about to work, and an untidy folder is worth more than
+    a refused render. A directory that cannot be listed and a file that cannot
+    be removed are both simply left.
+    """
+    cutoff = time.time() - _PREVIEW_TTL
+    try:
+        names = os.listdir(directory)
+    except OSError:
+        return
+    for name in names:
+        if preview.SUFFIX not in name:
+            continue
+        path = os.path.join(directory, name)
+        try:
+            if os.path.getmtime(path) < cutoff:
+                os.remove(path)
+        except OSError:
+            pass
+
+
 def _transcripts_dir() -> str:
     """Where transcripts land: `<home>/ai/transcripts`.
 
@@ -327,9 +381,14 @@ def api_ai_image(body: dict = Body(...), x_fused: str | None = Header(default=No
 
     uid = secrets.token_hex(6)
     job = supervisor.image_job_id(uid)
+    images = _images_dir()
+    # Before the render, not after: a preview orphaned by a killed worker has no
+    # unwind coming that would clean it up, so the next request is the only
+    # thing that will ever look. See `_sweep_previews`.
+    _sweep_previews(images)
     # Time-ordered and unique: the folder sorts chronologically in the explorer,
     # and two renders in the same second still land on different files.
-    path = os.path.join(_images_dir(), f"{time.strftime('%Y%m%d-%H%M%S')}-{uid}.png")
+    path = os.path.join(images, f"{time.strftime('%Y%m%d-%H%M%S')}-{uid}.png")
 
     request = {
         "prompt": prompt.strip(),

--- a/fused_render/server/routers/ai_runtime.py
+++ b/fused_render/server/routers/ai_runtime.py
@@ -43,7 +43,7 @@ from fused_render.ai import catalog, registry, supervisor
 # restated. They are the SAME modules the runners import out of their own venvs
 # — which is why every heavy import inside them is deferred, and why reading a
 # rule here costs nothing.
-from fused_render.ai.runners import diarize, engine_options, partial
+from fused_render.ai.runners import diarize, engine_options, partial, preview
 from fused_render.server.common import _error, _require_fused
 # The AI Models page's reading of the local cache, imported rather than
 # re-derived: see `_inferred_capability`. It imports nothing from here.
@@ -339,6 +339,20 @@ def api_ai_image(body: dict = Body(...), x_fused: str | None = Header(default=No
         "guidance": guidance,
         "seed": seed,
         "out": path,
+        # …and where the picture-in-progress goes while it denoises, so a page
+        # has something to show through a render that takes minutes. Derived
+        # through `preview.preview_path` rather than spelled here, for the
+        # reason `outPartial` is: the worker that writes this file and the reply
+        # that advertises it must name the same one, and a second spelling of
+        # the suffix is how they come to disagree. A sibling of the image for
+        # the same reason the transcript's three are siblings — the server owns
+        # where user files go.
+        #
+        # Sent unconditionally. Whether a preview HAPPENS is the worker's answer
+        # (it needs a fitted projection for the model's latent space), and a
+        # route that tried to predict it would need this process to know what a
+        # runner venv it cannot import has a matrix for.
+        "outPreview": preview.preview_path(path),
     }
     try:
         supervisor.start_image(model, request, job)
@@ -353,6 +367,13 @@ def api_ai_image(body: dict = Body(...), x_fused: str | None = Header(default=No
     return {
         "jobId": job,
         "path": path,
+        # Canonical, because this goes back to a page that will put it in a
+        # `/api/fs/raw` URL — a Windows path that reached it backslashed would
+        # not match what the shell stored for the same file. It is a promise
+        # about a PATH, not about a file: a model with no fitted projection
+        # writes nothing there, and `fused.ai.image` treats a missing preview
+        # as the ordinary case rather than as an error.
+        "previewPath": canonical_fs_path(request["outPreview"]),
         "model": model,
         "prompt": request["prompt"],
         "width": request["width"],

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -33,9 +33,11 @@
  *     ready-made /api/fs/raw url to point an <img> at, plus the seed that was
  *     used — invented server-side when you don't pass one, so a render is
  *     always repeatable. Minutes long: onProgress fires per denoising step with
- *     the download-manager record, and that row's ✕ really stops it. Rejects
- *     with .type "cancelled" | "ai_error" | "unavailable" (no image runner on
- *     this machine — the reason is in the message).
+ *     the download-manager record, and that row's ✕ really stops it. Each tick
+ *     also carries previewUrl — a ~32x32 thumbnail of the image so far, ready
+ *     for an <img> src — so there is a picture to watch rather than a counter;
+ *     swap to url on resolve. Rejects with .type "cancelled" | "ai_error" |
+ *     "unavailable" (no image runner on this machine — reason in the message).
  *   fused.ai.transcribe({path, model, language, task, diarize, speakers,
  *                        onProgress, onSegment})
  *                  -> Promise<{output, url, text, segments, language, ...}>
@@ -2574,7 +2576,7 @@
     return data;
   }
 
-  // fused.ai.image({prompt, ...}) -> Promise<{path, url, seed, ...}>
+  // fused.ai.image({prompt, ...}) -> Promise<{path, url, previewUrl, seed, ...}>
   //
   // The one call in this bridge that RESOLVES WITH A FILE. Text streams, so
   // fused.ai hands back words; an image is an artefact, so this hands back
@@ -2588,6 +2590,22 @@
   //
   // The seed comes back whether or not one was passed, so "make that one again"
   // is always a call away.
+  //
+  // And there is something to LOOK at while it runs: `previewUrl` on every
+  // onProgress tick points at a ~32x32 thumbnail of the image-in-progress that
+  // the worker rewrites each denoising step. A page sets it as an <img> src and
+  // gets a picture emerging out of noise instead of a number going up; blur it
+  // and scale it up with CSS, that part is the page's taste, not this API's.
+  //
+  // The URL is built HERE, cache-busted by step, for the same reason `url` is:
+  // otherwise every page that wants this writes the same two lines, and the one
+  // that forgets the cache-buster gets a browser showing frame 2 for a minute.
+  // It is null until the first frame exists (the first step has no preview —
+  // two latents are needed to estimate a picture) and stays null for a model
+  // whose latent space has no fitted projection, so a page must treat a broken
+  // or missing image as ordinary. On resolve, SWAP TO `url`: the last preview
+  // is the finished picture at a thirtieth of the resolution, and the file it
+  // points at is deleted the moment the real PNG lands.
   function aiImage(opts) {
     opts = opts || {};
     if (typeof opts.prompt !== "string" || !opts.prompt.trim()) {
@@ -2602,8 +2620,24 @@
     }
     return aiPost("/api/ai/image", body).then((started) => {
       const watcher = watchJob(started.jobId);
-      const done = () => ({ ...started, url: rawUrl(started.path) });
-      return watcher.watch(onProgress).then((record) => {
+      // `step` is the cache-buster and nothing more: the preview file is ONE
+      // path overwritten in place, so a browser handed the same URL twice shows
+      // the first frame forever. Keyed on the step rather than on Date.now() so
+      // two ticks of the same step are one image and not two requests.
+      const previewUrl = (step) =>
+        started.previewPath ? rawUrl(started.previewPath) + "&step=" + (step || 0) : null;
+      const done = () => ({
+        ...started,
+        url: rawUrl(started.path),
+        previewUrl: previewUrl(started.steps),
+      });
+      // The record is COPIED rather than annotated: it is the same object the
+      // job manager is drawing from, and a field written onto it here would
+      // travel to every other watcher of that row.
+      const tick = onProgress
+        ? (job) => onProgress({ ...job, previewUrl: previewUrl(job && job.done) })
+        : null;
+      return watcher.watch(tick).then((record) => {
         if (!record) {
           // The row aged out from under us — a backgrounded tab can sleep past
           // its retention on a render this long. The FILE is the other witness,

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -36,8 +36,9 @@
  *     the download-manager record, and that row's ✕ really stops it. Each tick
  *     also carries previewUrl — a ~32x32 thumbnail of the image so far, ready
  *     for an <img> src — so there is a picture to watch rather than a counter.
- *     It can 404 (the first step writes no frame), so hide it on error, and
- *     swap to url on resolve. Rejects with .type "cancelled" | "ai_error" |
+ *     It can 404 early (the first step writes no frame), so hide it on error;
+ *     it is null on the last tick and on resolve, because the preview file is
+ *     deleted then — end on url. Rejects with .type "cancelled" | "ai_error" |
  *     "unavailable" (no image runner on this machine — reason in the message).
  *   fused.ai.transcribe({path, model, language, task, diarize, speakers,
  *                        onProgress, onSegment})
@@ -2601,18 +2602,21 @@
   // The URL is built HERE, cache-busted by step, for the same reason `url` is:
   // otherwise every page that wants this writes the same two lines, and the one
   // that forgets the cache-buster gets a browser showing frame 2 for a minute.
-  // It is null when this render has no preview file at all. When it is a URL,
-  // the file behind it may still be MISSING — the first step writes no frame
-  // (two latents are needed to estimate a picture), and a model whose latent
-  // space has no fitted projection never writes one. So an <img> pointed here
-  // can 404, which is ordinary rather than an error: give it an onerror that
-  // hides it, or start it hidden and show it on load. Predicting that here
-  // would mean this bridge carrying its own copy of a rule that lives in
-  // `runners/preview.py`, and being wrong about it on some future model.
+  // It is null when this render has no preview file at all, and null again on
+  // the LAST tick and on the resolved object — the preview is deleted as the
+  // render finishes, so a URL there would be a guaranteed 404 and a blank flash
+  // exactly where the finished picture belongs. The resolved `url` is what the
+  // <img> should end on.
   //
-  // On resolve, SWAP TO `url`: the last preview is the finished picture at a
-  // thirtieth of the resolution, and the file it points at is deleted the
-  // moment the real PNG lands.
+  // In between, when it is a URL, the file behind it may still be MISSING: the
+  // first step writes no frame (two latents are needed to estimate a picture),
+  // and a model whose latent space has no fitted projection never writes one.
+  // So an <img> pointed here can 404 early, which is ordinary rather than an
+  // error: give it an onerror that hides it, or start it hidden and show it on
+  // load. Predicting THAT here would mean this bridge carrying its own copy of
+  // a rule that lives in `runners/preview.py`, and being wrong about it on some
+  // future model — whereas "the file is gone once the row is terminal" is this
+  // bridge's own fact, and it is the one that would be seen every render.
   function aiImage(opts) {
     opts = opts || {};
     if (typeof opts.prompt !== "string" || !opts.prompt.trim()) {
@@ -2631,18 +2635,26 @@
       // path overwritten in place, so a browser handed the same URL twice shows
       // the first frame forever. Keyed on the step rather than on Date.now() so
       // two ticks of the same step are one image and not two requests.
-      const previewUrl = (step) =>
-        started.previewPath ? rawUrl(started.previewPath) + "&step=" + (step || 0) : null;
-      const done = () => ({
-        ...started,
-        url: rawUrl(started.path),
-        previewUrl: previewUrl(started.steps),
-      });
+      //
+      // NULL once the row is terminal, and that is not tidiness. `watch` calls
+      // back with the terminal record too, and by then the preview file is
+      // ALREADY GONE — the worker's sink discards it as the render unwinds,
+      // which happens before the row can be marked done. A page that keeps its
+      // <img> on the latest previewUrl would therefore end every render on a
+      // guaranteed 404: a blank flash exactly where the finished picture
+      // belongs. `state !== "running"` is `watch`'s own terminal test.
+      const previewUrl = (job) =>
+        started.previewPath && job && job.state === "running"
+          ? rawUrl(started.previewPath) + "&step=" + (job.done || 0)
+          : null;
+      // Same fact on the resolved object: it names the real PNG through `url`,
+      // and `previewUrl` is null because the file it would name is deleted.
+      const done = () => ({ ...started, url: rawUrl(started.path), previewUrl: null });
       // The record is COPIED rather than annotated: it is the same object the
       // job manager is drawing from, and a field written onto it here would
       // travel to every other watcher of that row.
       const tick = onProgress
-        ? (job) => onProgress({ ...job, previewUrl: previewUrl(job && job.done) })
+        ? (job) => onProgress({ ...job, previewUrl: previewUrl(job) })
         : null;
       return watcher.watch(tick).then((record) => {
         if (!record) {

--- a/fused_render/static/runtime.js
+++ b/fused_render/static/runtime.js
@@ -35,7 +35,8 @@
  *     always repeatable. Minutes long: onProgress fires per denoising step with
  *     the download-manager record, and that row's ✕ really stops it. Each tick
  *     also carries previewUrl — a ~32x32 thumbnail of the image so far, ready
- *     for an <img> src — so there is a picture to watch rather than a counter;
+ *     for an <img> src — so there is a picture to watch rather than a counter.
+ *     It can 404 (the first step writes no frame), so hide it on error, and
  *     swap to url on resolve. Rejects with .type "cancelled" | "ai_error" |
  *     "unavailable" (no image runner on this machine — reason in the message).
  *   fused.ai.transcribe({path, model, language, task, diarize, speakers,
@@ -2600,12 +2601,18 @@
   // The URL is built HERE, cache-busted by step, for the same reason `url` is:
   // otherwise every page that wants this writes the same two lines, and the one
   // that forgets the cache-buster gets a browser showing frame 2 for a minute.
-  // It is null until the first frame exists (the first step has no preview —
-  // two latents are needed to estimate a picture) and stays null for a model
-  // whose latent space has no fitted projection, so a page must treat a broken
-  // or missing image as ordinary. On resolve, SWAP TO `url`: the last preview
-  // is the finished picture at a thirtieth of the resolution, and the file it
-  // points at is deleted the moment the real PNG lands.
+  // It is null when this render has no preview file at all. When it is a URL,
+  // the file behind it may still be MISSING — the first step writes no frame
+  // (two latents are needed to estimate a picture), and a model whose latent
+  // space has no fitted projection never writes one. So an <img> pointed here
+  // can 404, which is ordinary rather than an error: give it an onerror that
+  // hides it, or start it hidden and show it on load. Predicting that here
+  // would mean this bridge carrying its own copy of a rule that lives in
+  // `runners/preview.py`, and being wrong about it on some future model.
+  //
+  // On resolve, SWAP TO `url`: the last preview is the finished picture at a
+  // thirtieth of the resolution, and the file it points at is deleted the
+  // moment the real PNG lands.
   function aiImage(opts) {
     opts = opts || {};
     if (typeof opts.prompt !== "string" || !opts.prompt.trim()) {

--- a/skills/fused-render-ai/SKILL.md
+++ b/skills/fused-render-ai/SKILL.md
@@ -162,9 +162,14 @@ Runtime calls reject with `.type` `"unavailable"` (409 — a fact about this mac
 The one call in the bridge that **resolves with a file**. Text streams, so `fused.ai` hands back words; an image is an artefact, so this hands back somewhere to point an `<img>`.
 
 ```js
+el.onerror = () => el.hidden = true;    // an early tick has no frame yet — see below
+
 const img = await fused.ai.image({
   prompt: "a topographic map of an island, engraved",
-  onProgress: (job) => bar.value = job.done / job.total,   // DENOISING STEPS, not bytes
+  onProgress: (job) => {
+    bar.value = job.done / job.total;   // DENOISING STEPS, not bytes
+    if (job.previewUrl) { el.src = job.previewUrl; el.hidden = false; }
+  },
 });
 el.src = img.url;        // ready-made /api/fs/raw url — no need to build it
 el.dataset.seed = img.seed;
@@ -172,8 +177,13 @@ el.dataset.seed = img.seed;
 
 Options: `prompt` (required), `model`, `width`, `height`, `steps`, `guidance`, `seed`, `onProgress`.
 
+Resolves with `{jobId, path, url, previewUrl, previewPath, model, prompt, width, height, steps, guidance, seed}` — the render that will actually happen, not the one you asked for (sides are snapped to a multiple of 16 and clamped, steps and guidance clamped).
+
 - **`seed` comes back whether or not you passed one** — invented server-side, so "make that one again" is always one call away.
 - **Minutes, not seconds.** `onProgress` fires per denoising step with the download-manager record, and that row's ✕ really stops it (the work is the server's, not the page's).
+- **Watch it being made: `job.previewUrl`.** Every tick carries a ready-made URL for a ~32px thumbnail of the image *so far* — the worker rewrites that one file each denoising step, so a page that keeps an `<img>` on it gets a picture emerging out of noise instead of a number going up. It is tiny on purpose (the whole feature costs about 1% of the render); blur it and scale it up in CSS, which is where that decision belongs. `previewPath` is the same file as a path, if you want to read it yourself.
+- **It goes null at the end, and that is the cue to swap.** The preview file is deleted the moment the real PNG lands, so `previewUrl` is null on the last tick and on the resolved object — end on `img.url`, which is the full-resolution picture. It is also null throughout for a model with no preview support.
+- **An early tick can 404**, because the first denoising step writes no frame (two steps are needed to guess at a picture). That is ordinary, not an error: give the `<img>` an `onerror` that hides it, as above.
 - Rejects with `.type` `"cancelled"` | `"ai_error"` | `"unavailable"` (no image runner here — reason in the message).
 - **`model` comes from `catalog()` here too.** The Diffusers and MLX FLUX runners take *different repos for the same model* — `black-forest-labs/FLUX.2-klein-4B` against `mlx-community/FLUX.2-Klein-4B-4bit` — so a hard-coded id becomes an unloadable download the moment the other one is serving.
 
@@ -309,7 +319,7 @@ Don't try to smuggle the call past the textual match by aliasing it — that tra
 
 `fused.trackJob` exports fine — it no-ops on a hosted page. `fused.ai` never will.
 
-**The DOTTED calls are a trap, and in the opposite direction.** The check matches `fused.ai(` specifically, so `fused.ai.image(`, `fused.ai.transcribe(` and `fused.ai.models.*` slip past it: a page using only those **exports cleanly and then fails at the reader**, since a hosted page has no worker, no `<home>/ai/transcripts/`, and no filesystem to read a transcript off. Gate them on `fused.env === "local"` yourself — nothing will stop you at export time. (Whether that gap should be closed is an open question, recorded in `docs/EXPORT.md`; today it is the behaviour.)
+**The DOTTED calls are a trap, and in the opposite direction.** The check matches `fused.ai(` specifically, so `fused.ai.image(`, `fused.ai.transcribe(` and `fused.ai.models.*` slip past it: a page using only those **exports cleanly and then fails at the reader**, since a hosted page has no worker, no `<home>/ai/images/` or `<home>/ai/transcripts/`, and no `/api/fs/raw` — so every `url`, `previewUrl` and `output` those calls hand back is a dead address there too. Gate them on `fused.env === "local"` yourself — nothing will stop you at export time. (Whether that gap should be closed is an open question, recorded in `docs/EXPORT.md`; today it is the behaviour.)
 
 ## Debugging
 

--- a/tests/test_ai_diffusers_worker.py
+++ b/tests/test_ai_diffusers_worker.py
@@ -448,6 +448,66 @@ def test_the_thumbnail_is_the_estimate_at_the_sigma_just_REACHED(
     assert got.tolist() == frame.reshape(-1).tolist()
 
 
+def _order_spies(monkeypatch, worker, base, events):
+    """Record every frame write and every progress tick, in the order they happen."""
+    real_write = worker.preview.Sink._write
+
+    def spy_write(self, rgb, grid):
+        events.append("frame")
+        return real_write(self, rgb, grid)
+
+    real_report = base.report_or_cancel
+
+    def spy_report(job=None, **fields):
+        events.append("tick %d" % fields["done"])
+        return real_report(job=job, **fields)
+
+    monkeypatch.setattr(worker.preview.Sink, "_write", spy_write)
+    monkeypatch.setattr(base, "report_or_cancel", spy_report)
+
+
+def test_the_FRAME_is_written_BEFORE_the_tick_that_announces_it(monkeypatch, base,
+                                                                tmp_path):
+    """The order is load-bearing and reads as arbitrary, so it is pinned rather
+    than left to be tidied up later.
+
+    `done` on the tick is exactly what `runtime.js` turns into the cache-busted
+    `&step=N` preview URL. Report first and a page can be handed step N's URL
+    before step N's PNG exists — `watchJob` polls about every 700ms and the
+    write is about 68ms, so the window is real. The first frame 404s, which is
+    survivable; the nastier half is that the URL is keyed by the step and will
+    never be requested again, so a fetch landing in that window caches the
+    PREVIOUS frame's bytes under step N's URL and that step shows a stale
+    picture for its whole duration.
+
+    Step 1 has no frame at all — a velocity needs two latents — which is the
+    documented early-404 and not this bug.
+    """
+    events = []
+    worker = loaded_worker(monkeypatch, base, FakePipe())
+    _order_spies(monkeypatch, worker, base, events)
+    worker.generate(_request(tmp_path))
+    assert events == ["tick 1", "frame", "tick 2", "frame", "tick 3",
+                      "frame", "tick 4"]
+
+
+def test_a_cancel_is_still_honoured_on_the_tick_it_arrives_on(monkeypatch, base,
+                                                             tmp_path):
+    """The cost of writing the frame first: the ✕ is learned one frame-write
+    later than it was. What must NOT change is which tick honours it — the
+    reply to the report is the only channel a cancel has, so the raise still
+    happens on that same callback and never a step later. A cancelled render
+    writing one extra frame is free; it is discarded on the way out."""
+    worker = loaded_worker(monkeypatch, base, FakePipe())
+    base.cancel_on_tick = 3          # the opening report, then two steps
+    with pytest.raises(base.Cancelled):
+        worker.generate(_request(tmp_path))
+    # Two `report_or_cancel` ticks reached, i.e. it unwound inside the second
+    # step's callback rather than carrying on into a third.
+    assert [tick["done"] for tick in base.ticks] == [0, 1, 2]
+    assert os.listdir(tmp_path) == []
+
+
 def test_a_VAE_with_no_fitted_projection_renders_exactly_as_BEFORE(
         monkeypatch, base, tmp_path):
     """No file, no branch — and no device sync either: the latents are handed

--- a/tests/test_ai_diffusers_worker.py
+++ b/tests/test_ai_diffusers_worker.py
@@ -95,6 +95,17 @@ READ_BY_THE_PIPELINE = {
 TRANSFORMER_BYTES = 7_751_106_000
 
 
+class _Flag:
+    def __init__(self):
+        self._set = False
+
+    def set(self):
+        self._set = True
+
+    def is_set(self):
+        return self._set
+
+
 class FakeBase:
     """`worker_base`, recording what the runner asked it to fetch."""
 
@@ -104,6 +115,18 @@ class FakeBase:
     def __init__(self):
         self.snapshot_calls = []
         self.file_calls = []
+        self.ticks = []
+        self.CANCEL = _Flag()
+        #: Set by a test to have the Nth tick answer "the ✕ was pressed".
+        self.cancel_on_tick = None
+
+    def report(self, job=None, **fields):
+        self.ticks.append({"job": job, **fields})
+
+    def report_or_cancel(self, job=None, **fields):
+        self.ticks.append({"job": job, **fields})
+        if self.cancel_on_tick is not None and len(self.ticks) >= self.cancel_on_tick:
+            self.CANCEL.set()
 
     def download_snapshot(self, model_id, allow_patterns=None,
                           ignore_patterns=None, **kwargs):
@@ -239,3 +262,235 @@ def test_the_gguf_repo_is_a_registered_component(base, monkeypatch):
     entry = formats.COMPONENT_REPOS[call["repo"]]
     assert entry["file"] == call["file"]
     assert entry["of"] == MODEL
+
+
+# -- the live preview (SPEC §40) -------------------------------------------------
+#
+# The second thing this runner does per step, beside reporting: project the
+# model's denoised estimate to a 32x32 PNG the page can point an <img> at. The
+# arithmetic and the file lifecycle belong to `runners/preview.py` and are
+# tested there; what is pinned HERE is the wiring only — that the latents and
+# the sigma this pipeline hands the callback reach that module correctly, and
+# that a pipeline with no fitted projection renders exactly as it did before.
+#
+# No torch and no weights: the pipeline is a fake that drives the callback the
+# way diffusers does, with numpy latents of the shape a real klein render holds.
+
+
+class FakeTensor:
+    """A latent tensor, with the three calls the callback makes on it.
+
+    `.detach().to("cpu", dtype).numpy()` — one transfer rather than
+    `.float().cpu()`'s two, which is the whole reason the worker spells it this
+    way, so the fake insists on it.
+    """
+
+    def __init__(self, array, on_read=None):
+        self._array = array
+        self._on_read = on_read
+
+    def detach(self):
+        return self
+
+    def to(self, device, dtype):
+        assert device == "cpu", device
+        if self._on_read is not None:
+            self._on_read()
+        return self
+
+    def numpy(self):
+        return self._array
+
+
+class FakePipe:
+    """Enough of a diffusers pipeline to run the denoising loop.
+
+    The sigma schedule is klein's shape: one more entry than there are steps and
+    ending at zero, already advanced past `sigmas[step]` by the time the
+    callback runs — which is the off-by-one the worker's `_sigma_after` exists
+    to get right.
+    """
+
+    def __init__(self, vae_class="AutoencoderKLFlux2", sigmas=None, on_read=None,
+                 latents=None):
+        self.vae = type(vae_class, (), {})()
+        self.scheduler = types.SimpleNamespace(
+            sigmas=sigmas or [1.0, 0.9, 0.7, 0.4, 0.0])
+        self.on_read = on_read
+        self.latents = latents
+        self.watch = None
+
+    def __call__(self, prompt=None, height=None, width=None, guidance_scale=None,
+                 num_inference_steps=None, generator=None,
+                 callback_on_step_end=None):
+        import numpy
+
+        tokens = (height // 16) * (width // 16)
+        array = (self.latents if self.latents is not None
+                 else numpy.zeros((1, tokens, 128), dtype=numpy.float32))
+        for step in range(num_inference_steps):
+            callback_on_step_end(self, step, 0, {
+                "latents": FakeTensor(array, on_read=self.on_read)})
+            if self.watch is not None:
+                self.watch(step)
+        return types.SimpleNamespace(images=[FakeSavedImage()])
+
+
+class FakeSavedImage:
+    def save(self, path):
+        with open(path, "wb") as handle:
+            handle.write(b"\x89PNG\r\n\x1a\n")
+
+
+def fake_torch():
+    """`torch`, for the two things `generate` asks of it."""
+    torch = types.ModuleType("torch")
+    torch.float32 = "float32"
+
+    class Generator:
+        def __init__(self, device=None):
+            self.device = device
+
+        def manual_seed(self, seed):
+            self.seed = seed
+            return self
+
+    torch.Generator = Generator
+    return torch
+
+
+def loaded_worker(monkeypatch, base, pipe):
+    """The worker with `pipe` already loaded, as `load` would leave it."""
+    monkeypatch.setitem(sys.modules, "torch", fake_torch())
+    worker = load_worker(monkeypatch, base)
+    worker._loaded.update({"pipe": pipe, "seed_device": "cpu",
+                           "vae": type(pipe.vae).__name__})
+    return worker
+
+
+def _request(tmp_path, **over):
+    from fused_render.ai.runners import preview
+
+    out = str(tmp_path / "fox.png")
+    return {"prompt": "a red fox", "out": out, "job": "sys:ai-image:abc",
+            "width": 512, "height": 512, "steps": 4,
+            "outPreview": preview.preview_path(out), **over}
+
+
+def test_the_vae_CLASS_NAME_is_what_the_projection_table_is_keyed_by(monkeypatch, base):
+    """Captured at load, off the VAE rather than off the repo id or the
+    pipeline: the latent space a fitted matrix belongs to is the autoencoder's,
+    and two checkpoints sharing one VAE share one projection."""
+    pipe = FakePipe()
+    pipe.to = lambda device: None
+    torch = fake_torch()
+    torch.cuda = types.SimpleNamespace(is_available=lambda: False)
+    torch.backends = types.SimpleNamespace(mps=None)
+    torch.bfloat16 = "bfloat16"
+    diffusers = types.ModuleType("diffusers")
+    diffusers.AutoPipelineForText2Image = types.SimpleNamespace(
+        from_pretrained=lambda *a, **k: pipe)
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "diffusers", diffusers)
+
+    worker = load_worker(monkeypatch, base)
+    worker.load("some/other-model", None)
+    assert worker._loaded["vae"] == "AutoencoderKLFlux2"
+
+
+def test_a_thumbnail_appears_from_the_SECOND_step_and_is_GONE_at_the_end(
+        monkeypatch, base, tmp_path):
+    """Step 1 has no predecessor, so it has no velocity and no estimate — and
+    the last frame is duplicate bytes once the real PNG lands."""
+    seen = []
+    pipe = FakePipe()
+    request = _request(tmp_path)
+    pipe.watch = lambda step: seen.append(os.path.exists(request["outPreview"]))
+    worker = loaded_worker(monkeypatch, base, pipe)
+    worker.generate(request)
+
+    assert seen == [False, True, True, True]
+    assert os.listdir(tmp_path) == ["fox.png"]
+
+
+def test_the_thumbnail_is_the_estimate_at_the_sigma_just_REACHED(
+        monkeypatch, base, tmp_path):
+    """The wiring's one real risk: an off-by-one on `scheduler.sigmas` reads the
+    level the run has LEFT rather than the one it arrived at, which is a preview
+    that is permanently one step stale and looks perfectly fine.
+
+    The fake hands every step the same latents, so the velocity is zero and the
+    estimate is the latent itself — at the FINAL sigma of 0.0. Read one entry
+    earlier the last frame would be the estimate at 0.318, which these pixels
+    are not."""
+    import numpy
+    from PIL import Image
+
+    rng = numpy.random.default_rng(7)
+    latents = rng.standard_normal((1, 32 * 32, 128)).astype(numpy.float32)
+    pipe = FakePipe(sigmas=[1.0, 0.9, 0.7, 0.318, 0.0], latents=latents)
+    worker = loaded_worker(monkeypatch, base, pipe)
+    # The worker's OWN reading of `preview.py` — a runner reaches it by path, so
+    # `fused_render.ai.runners.preview` is a second module object with its own
+    # `Sink` class, and patching that one would patch nothing the worker uses.
+    preview = worker.preview
+    request = _request(tmp_path)
+    # Keep the last frame: `generate`'s clean exit removes it, which is the
+    # behaviour the test above is about.
+    monkeypatch.setattr(preview.Sink, "discard", lambda self: None)
+    worker.generate(request)
+
+    expected = preview.project(latents[0], "AutoencoderKLFlux2")
+    frame = numpy.asarray(expected * 255.0 + 0.5, dtype=numpy.uint8)
+    with Image.open(request["outPreview"]) as image:
+        assert image.size == (preview.MAX_SIDE, preview.MAX_SIDE)
+        got = numpy.frombuffer(image.convert("RGB").tobytes(), dtype=numpy.uint8)
+    assert got.tolist() == frame.reshape(-1).tolist()
+
+
+def test_a_VAE_with_no_fitted_projection_renders_exactly_as_BEFORE(
+        monkeypatch, base, tmp_path):
+    """No file, no branch — and no device sync either: the latents are handed
+    over as a closure precisely so a no-op sink never touches them."""
+    def touched():
+        raise AssertionError("a no-op preview pulled the latents off the device")
+
+    pipe = FakePipe(vae_class="AutoencoderKL", on_read=touched)
+    worker = loaded_worker(monkeypatch, base, pipe)
+    worker.generate(_request(tmp_path))
+    assert os.listdir(tmp_path) == ["fox.png"]
+
+
+def test_a_request_that_named_no_preview_file_renders_exactly_as_BEFORE(
+        monkeypatch, base, tmp_path):
+    """A worker request from before this feature carries no `outPreview`."""
+    def touched():
+        raise AssertionError("a no-op preview pulled the latents off the device")
+
+    pipe = FakePipe(on_read=touched)
+    worker = loaded_worker(monkeypatch, base, pipe)
+    request = _request(tmp_path)
+    del request["outPreview"]
+    worker.generate(request)
+    assert os.listdir(tmp_path) == ["fox.png"]
+
+
+def test_the_thumbnail_is_removed_when_the_render_is_CANCELLED(
+        monkeypatch, base, tmp_path):
+    """A ✕ means the user does not want this picture, at any resolution."""
+    pipe = FakePipe()
+    worker = loaded_worker(monkeypatch, base, pipe)
+    base.cancel_on_tick = 4          # the opening report, then three steps
+    with pytest.raises(base.Cancelled):
+        worker.generate(_request(tmp_path))
+    assert os.listdir(tmp_path) == []
+
+
+def test_a_pipeline_with_NO_sigma_schedule_still_RENDERS(monkeypatch, base, tmp_path):
+    """A preview must never be able to raise out of a denoising callback and
+    lose a render that was going to succeed."""
+    pipe = FakePipe()
+    pipe.scheduler = None
+    worker = loaded_worker(monkeypatch, base, pipe)
+    worker.generate(_request(tmp_path))
+    assert os.listdir(tmp_path) == ["fox.png"]

--- a/tests/test_ai_diffusers_worker.py
+++ b/tests/test_ai_diffusers_worker.py
@@ -312,12 +312,17 @@ class FakePipe:
     """
 
     def __init__(self, vae_class="AutoencoderKLFlux2", sigmas=None, on_read=None,
-                 latents=None):
+                 latents=None, latents_per_step=None):
         self.vae = type(vae_class, (), {})()
         self.scheduler = types.SimpleNamespace(
             sigmas=sigmas or [1.0, 0.9, 0.7, 0.4, 0.0])
         self.on_read = on_read
         self.latents = latents
+        #: One array per step, when a test needs the latents to actually MOVE —
+        #: identical latents mean zero velocity, and a zero velocity makes the
+        #: denoised estimate equal the latent at every sigma, which is how a
+        #: test can look like it pins the sigma indexing without pinning it.
+        self.latents_per_step = latents_per_step
         self.watch = None
 
     def __call__(self, prompt=None, height=None, width=None, guidance_scale=None,
@@ -329,8 +334,9 @@ class FakePipe:
         array = (self.latents if self.latents is not None
                  else numpy.zeros((1, tokens, 128), dtype=numpy.float32))
         for step in range(num_inference_steps):
+            held = array if self.latents_per_step is None else self.latents_per_step[step]
             callback_on_step_end(self, step, 0, {
-                "latents": FakeTensor(array, on_read=self.on_read)})
+                "latents": FakeTensor(held, on_read=self.on_read)})
             if self.watch is not None:
                 self.watch(step)
         return types.SimpleNamespace(images=[FakeSavedImage()])
@@ -413,39 +419,82 @@ def test_a_thumbnail_appears_from_the_SECOND_step_and_is_GONE_at_the_end(
     assert os.listdir(tmp_path) == ["fox.png"]
 
 
+def _frame_pixels(path):
+    from PIL import Image
+
+    import numpy
+
+    with Image.open(path) as image:
+        return image.size, numpy.frombuffer(
+            image.convert("RGB").tobytes(), dtype=numpy.uint8).tolist()
+
+
+def _expected_frame(preview, previous, current, sigma_previous, sigma_current):
+    """The bytes `_write` would produce for one estimate, computed the same way.
+
+    Through `preview`'s own `denoised` and `project` rather than a second
+    implementation of the arithmetic — what is under test here is which SIGMAS
+    the worker paired with which latents, not whether the maths is right (that
+    is `test_ai_image_preview.py`'s job).
+    """
+    import numpy
+
+    estimate = preview.denoised(previous, current, sigma_previous, sigma_current)
+    rgb = preview.project(estimate, "AutoencoderKLFlux2")
+    return numpy.asarray(rgb * 255.0 + 0.5, dtype=numpy.uint8).reshape(-1).tolist()
+
+
 def test_the_thumbnail_is_the_estimate_at_the_sigma_just_REACHED(
         monkeypatch, base, tmp_path):
     """The wiring's one real risk: an off-by-one on `scheduler.sigmas` reads the
-    level the run has LEFT rather than the one it arrived at, which is a preview
-    that is permanently one step stale and looks perfectly fine.
+    level the run has LEFT rather than the one it arrived at — a preview that is
+    permanently one step stale and looks perfectly fine.
 
-    The fake hands every step the same latents, so the velocity is zero and the
-    estimate is the latent itself — at the FINAL sigma of 0.0. Read one entry
-    earlier the last frame would be the estimate at 0.318, which these pixels
-    are not."""
+    Two things make this actually pin it, and both were missing:
+
+    * **The latents MOVE.** With the same array every step the velocity is zero,
+      and a zero velocity makes `denoised` return the latent at any sigma
+      whatsoever — so the assertion passed just as happily against
+      `sigmas[step]`.
+    * **The frame examined is not the LAST one.** The schedule ends at sigma 0,
+      where the estimate degenerates to the latent again for the same reason. So
+      this reads the frame written mid-render, where the two indexings give
+      genuinely different pixels — and asserts that it is the one and not the
+      other.
+    """
     import numpy
-    from PIL import Image
 
     rng = numpy.random.default_rng(7)
-    latents = rng.standard_normal((1, 32 * 32, 128)).astype(numpy.float32)
-    pipe = FakePipe(sigmas=[1.0, 0.9, 0.7, 0.318, 0.0], latents=latents)
+    sigmas = [1.0, 0.9, 0.7, 0.318, 0.0]
+    steps = [rng.standard_normal((1, 32 * 32, 128)).astype(numpy.float32) * 2.0
+             for _ in range(4)]
+    pipe = FakePipe(sigmas=sigmas, latents_per_step=steps)
     worker = loaded_worker(monkeypatch, base, pipe)
     # The worker's OWN reading of `preview.py` — a runner reaches it by path, so
     # `fused_render.ai.runners.preview` is a second module object with its own
     # `Sink` class, and patching that one would patch nothing the worker uses.
     preview = worker.preview
     request = _request(tmp_path)
-    # Keep the last frame: `generate`'s clean exit removes it, which is the
-    # behaviour the test above is about.
-    monkeypatch.setattr(preview.Sink, "discard", lambda self: None)
+    # Snapshot each frame as it lands: the clean exit removes the file, and the
+    # frame that discriminates is mid-render anyway.
+    shots = []
+    pipe.watch = lambda step: shots.append(
+        _frame_pixels(request["outPreview"])
+        if os.path.exists(request["outPreview"]) else None)
     worker.generate(request)
 
-    expected = preview.project(latents[0], "AutoencoderKLFlux2")
-    frame = numpy.asarray(expected * 255.0 + 0.5, dtype=numpy.uint8)
-    with Image.open(request["outPreview"]) as image:
-        assert image.size == (preview.MAX_SIDE, preview.MAX_SIDE)
-        got = numpy.frombuffer(image.convert("RGB").tobytes(), dtype=numpy.uint8)
-    assert got.tolist() == frame.reshape(-1).tolist()
+    # After step index 2 the pair is (latents[1] at sigmas[2], latents[2] at
+    # sigmas[3]) — the level the scheduler has ARRIVED at.
+    right = _expected_frame(preview, steps[1], steps[2], sigmas[2], sigmas[3])
+    # …and this is what reading `sigmas[step]` instead would have produced: the
+    # same two latents, paired with the two levels one entry earlier.
+    stale = _expected_frame(preview, steps[1], steps[2], sigmas[1], sigmas[2])
+    assert right != stale, "the schedule chosen cannot tell the two apart"
+
+    size, pixels = shots[2]
+    assert size == (preview.MAX_SIDE, preview.MAX_SIDE)
+    assert pixels == right
+    assert pixels != stale
 
 
 def _order_spies(monkeypatch, worker, base, events):

--- a/tests/test_ai_image_preview.py
+++ b/tests/test_ai_image_preview.py
@@ -1,0 +1,457 @@
+"""The live preview thumbnail: the picture WHILE it is being denoised.
+
+`fused.ai.image` writes its PNG once, at the end. A FLUX render is minutes, and
+for all of them the only thing on screen is a step counter — a progress bar for
+a process whose whole output is visual. This module is that fixed: one small
+PNG beside the image the request already named, overwritten every step, which a
+page points an `<img>` at.
+
+The rules being pinned here, in order of how expensive they are to get wrong:
+
+- **The projection is arithmetic, not a decode.** A 128-channel FLUX.2 token
+  goes to RGB through one fitted linear map; a transposed matrix or a dropped
+  bias produces a plausible-looking thumbnail that is wrong in a way no eye
+  catches on a 32x32 image, so the orientation is asserted rather than
+  eyeballed.
+- **The frame is the DENOISED ESTIMATE, never the raw latent.** klein is
+  step-wise distilled and its sigma is still >= 0.5 at step 14 of 16; projecting
+  what the callback holds shows noise for almost the whole render. Two
+  consecutive latents and their two sigmas recover the model's current guess at
+  the finished image, and that is what gets written.
+- **A reader never sees half a PNG.** The page reads this file through
+  `/api/fs/raw` while the worker rewrites it, so each frame lands by
+  `os.replace` from a temp file in the same directory — the byte-level analogue
+  of the whole-line flush rule `partial.py` documents.
+- **It is always removed.** On success, on cancel AND on error, which is where
+  this diverges from `partial.Sink`: a half-denoised 32x32 thumbnail is not
+  salvage the way 80 minutes of transcript is.
+- **One implementation, two engines.** A second copy under either image runner
+  would be free to drift and would fail no behavioural test, because both copies
+  would pass their own. The structural half of that is pinned at the bottom.
+
+No render happens here and none can: the real thing needs 10.8GB of weights and
+minutes of Metal. The arithmetic below was fitted and validated against a real
+GGUF render by hand (see `preview.py`'s module docstring for the provenance);
+what these tests defend is that the shipped code still does what was measured.
+"""
+import importlib.util
+import os
+import struct
+
+import pytest
+
+numpy = pytest.importorskip("numpy")
+
+_RUNNERS = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "fused_render", "ai", "runners",
+)
+PREVIEW_PATH = os.path.join(_RUNNERS, "preview.py")
+
+#: The one model key the shipped table has an entry for — the class name of
+#: FLUX.2 klein's VAE, which is what BOTH runners hand the sink (the torch one
+#: reads it off `type(pipe.vae).__name__`, the MLX one off its variant recipe).
+KEY = "AutoencoderKLFlux2"
+
+
+def _by_path(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None, path
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def preview():
+    """Imported by PATH, the way a runner reaches it — which is the reading that
+    ships. The server imports the same file as a package module to derive the
+    path it advertises, and `test_the_SERVER_reaches_the_same_module` below
+    pins that the two readings agree."""
+    return _by_path("runners_preview", PREVIEW_PATH)
+
+
+def _png_size(path):
+    """`(width, height)` straight out of the IHDR — no PIL, so a truncated file
+    fails here rather than being quietly repaired by a decoder."""
+    with open(path, "rb") as handle:
+        header = handle.read(24)
+    assert header[:8] == b"\x89PNG\r\n\x1a\n", header[:8]
+    return struct.unpack(">II", header[16:24])
+
+
+def _pixels(path):
+    from PIL import Image
+
+    with Image.open(path) as image:
+        data = image.convert("RGB").tobytes()
+    return [tuple(data[at:at + 3]) for at in range(0, len(data), 3)]
+
+
+def _tokens(value, count=16, channels=128):
+    return numpy.full((count, channels), value, dtype=numpy.float32)
+
+
+class Cancelled(Exception):
+    """Stands in for `worker_base.Cancelled`. Unlike `partial.Sink`, the preview
+    sink takes no `cancelled=` argument at all — every exit discards, so it
+    never has to tell one exception from another."""
+
+
+# -- the path the route, the workers and the page must agree on ------------------
+
+
+def test_the_preview_path_is_a_SIBLING_of_the_png_the_request_named(preview):
+    assert preview.preview_path("/x/y/20260101-120000-abc.png") == (
+        "/x/y/20260101-120000-abc.preview.png")
+
+
+def test_the_preview_path_replaces_the_extension_rather_than_appending(preview):
+    """`out.png.preview.png` would sort beside the render and read like one, in
+    a directory (`ai/images/`) a user browses."""
+    assert preview.preview_path("/x/out.png").endswith("/out.preview.png")
+
+
+def test_an_empty_out_path_has_no_preview_path(preview):
+    assert preview.preview_path("") is None
+    assert preview.preview_path(None) is None
+
+
+# -- the projection --------------------------------------------------------------
+
+
+def test_the_table_holds_a_128_TO_3_map_for_the_one_model_that_has_one(preview):
+    entry = preview.PROJECTIONS[KEY]
+    assert len(entry["factors"]) == 3
+    assert all(len(row) == 128 for row in entry["factors"])
+    assert len(entry["bias"]) == 3
+
+
+def test_the_fitted_numbers_are_the_ones_that_were_MEASURED(preview):
+    """A spot check against `factors.json`, so a re-typed or re-ordered constant
+    is a failing test rather than a subtly wrong thumbnail. Channels 12..15 are
+    the four with the largest positive weight in every output channel — the
+    patchified brightness quartet — which is also the signature that would
+    survive an accidental transpose, so a couple of small ones are here too."""
+    entry = preview.PROJECTIONS[KEY]
+    assert entry["factors"][0][13] == pytest.approx(0.03257348760962486, rel=1e-9)
+    assert entry["factors"][1][32] == pytest.approx(-0.04735724627971649, rel=1e-9)
+    assert entry["factors"][2][44] == pytest.approx(-0.016789274290204048, rel=1e-9)
+    assert entry["bias"] == pytest.approx(
+        [0.4698728024959564, 0.4328208565711975, 0.4053916037082672])
+
+
+def test_an_all_zero_token_projects_to_the_BIAS(preview):
+    """The constant term is the mean colour of the fit, and dropping it is the
+    single easiest way to ship a thumbnail that is dark and plausible."""
+    rgb = preview.project(_tokens(0.0, count=3), KEY)
+    assert rgb.shape == (3, 3)
+    assert rgb[0] == pytest.approx(preview.PROJECTIONS[KEY]["bias"], abs=1e-6)
+
+
+def test_the_matrix_is_applied_in_the_ORIENTATION_it_was_fitted_in(preview):
+    """`rgb = tokens @ factors.T + bias`, one row per token. A transpose here is
+    a shape error only by luck — 3 and 128 differ, but the same numbers read
+    the wrong way round would silently produce a colour field, and this asserts
+    against the per-channel weights rather than against a picture."""
+    entry = preview.PROJECTIONS[KEY]
+    token = numpy.zeros((1, 128), dtype=numpy.float32)
+    token[0, 13] = 2.0
+    rgb = preview.project(token, KEY)
+    expected = [entry["bias"][c] + 2.0 * entry["factors"][c][13] for c in range(3)]
+    assert rgb[0] == pytest.approx(expected, abs=1e-6)
+
+
+def test_the_projection_is_CLIPPED_to_a_displayable_range(preview):
+    """An early estimate is far outside the fit's range and the arithmetic is
+    unbounded; a page is handed a colour, not a float."""
+    bright = preview.project(_tokens(500.0, count=1), KEY)
+    dark = preview.project(_tokens(-500.0, count=1), KEY)
+    assert bright.max() <= 1.0 and bright.min() >= 0.0
+    assert dark.max() <= 1.0 and dark.min() >= 0.0
+    assert bright.max() == pytest.approx(1.0)
+    assert dark.min() == pytest.approx(0.0)
+
+
+def test_a_model_with_no_entry_has_no_projection(preview):
+    assert preview.project(_tokens(0.0), "AutoencoderKL") is None
+    assert preview.project(_tokens(0.0), None) is None
+
+
+# -- the denoised estimate -------------------------------------------------------
+
+
+def test_the_estimate_is_recovered_from_TWO_latents_and_TWO_sigmas(preview):
+    """`v = (x_next - x_prev) / (s_next - s_prev)`, `x1 = x_next - s_next * v`.
+    With x going 0 -> 1 as sigma goes 1.0 -> 0.5, the velocity is -2 and the
+    model's guess at the finished image is 2."""
+    x1 = preview.denoised(numpy.zeros(4, dtype=numpy.float32),
+                          numpy.ones(4, dtype=numpy.float32), 1.0, 0.5)
+    assert x1 == pytest.approx(numpy.full(4, 2.0))
+
+
+def test_the_estimate_at_sigma_zero_is_the_latent_itself(preview):
+    """The last step lands on sigma 0, where the estimate degenerates to what
+    the model just produced — so the final frame is the final image."""
+    x_next = numpy.array([0.25, -0.5, 1.0, 0.0], dtype=numpy.float32)
+    x1 = preview.denoised(numpy.zeros(4, dtype=numpy.float32), x_next, 0.3, 0.0)
+    assert x1 == pytest.approx(x_next)
+
+
+def test_two_identical_sigmas_have_no_estimate_rather_than_a_division_by_zero(preview):
+    assert preview.denoised(numpy.zeros(4), numpy.ones(4), 0.5, 0.5) is None
+
+
+# -- the sink --------------------------------------------------------------------
+
+
+def test_the_FIRST_step_writes_nothing_because_it_has_no_predecessor(preview, tmp_path):
+    """Step 1 has no previous latent, so there is no velocity and no estimate.
+    That is correct rather than a gap: a first frame projected from the raw
+    latent would be the noise this whole approach exists to avoid."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0), sigma=0.9, grid=(4, 4))
+        assert not os.path.exists(out)
+
+
+def test_the_SECOND_step_writes_a_thumbnail_of_the_estimate(preview, tmp_path):
+    """Verified legible from step 2 of 16 on a real render — and the pixels are
+    checkable exactly, because a zero estimate is the bias colour."""
+    out = str(tmp_path / "a.preview.png")
+    bias = preview.PROJECTIONS[KEY]["bias"]
+    expected = tuple(int(round(channel * 255)) for channel in bias)
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+        assert _png_size(out) == (4, 4)
+        assert set(_pixels(out)) == {expected}
+
+
+def test_every_later_step_OVERWRITES_the_one_file(preview, tmp_path):
+    """One file, not a filmstrip: a 100-step render would otherwise leave 100
+    thumbnails in a directory the user browses, and the page's `<img>` would
+    need to know which one is current."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        for step, sigma in enumerate([1.0, 0.8, 0.4, 0.0]):
+            sink.add(lambda: _tokens(0.0), sigma=sigma, grid=(4, 4))
+        assert os.listdir(tmp_path) == ["a.preview.png"]
+
+
+def test_the_thumbnail_is_CAPPED_however_big_the_render_is(preview, tmp_path):
+    """A 1024² render has a 64x64 token grid and a 2048² one has 128x128; the
+    cost that was measured (68ms/step, ~3KB) is the cost of a 32x32 PNG, and the
+    page blurs and upscales anyway."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0, count=64 * 64), sigma=1.0, grid=(64, 64))
+        sink.add(lambda: _tokens(0.0, count=64 * 64), sigma=0.5, grid=(64, 64))
+        assert _png_size(out) == (preview.MAX_SIDE, preview.MAX_SIDE)
+
+
+def test_a_NON_SQUARE_render_keeps_its_shape(preview, tmp_path):
+    """The grid is `image side / 16` per axis, so a landscape render is a
+    landscape thumbnail — an `<img>` sized to the final picture would otherwise
+    stretch it."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0, count=64 * 32), sigma=1.0, grid=(32, 64))
+        sink.add(lambda: _tokens(0.0, count=64 * 32), sigma=0.5, grid=(32, 64))
+        assert _png_size(out) == (preview.MAX_SIDE, preview.MAX_SIDE // 2)
+
+
+def test_PACKED_tokens_and_an_UNPACKED_grid_produce_the_same_frame(preview, tmp_path):
+    """diffusers hands the callback `(1, H*W, 128)` row-major packed tokens;
+    mflux may hand `(B, 128, h, w)` already unpatchified. Both are the same
+    picture and the sink takes either, because a runner reshaping it first is a
+    second copy of the unpack rule."""
+    rng = numpy.random.default_rng(0)
+    grid = rng.standard_normal((1, 128, 4, 4)).astype(numpy.float32)
+    packed = grid[0].transpose(1, 2, 0).reshape(1, 16, 128)
+    written = []
+    for name, latents in (("packed.preview.png", packed), ("grid.preview.png", grid)):
+        out = str(tmp_path / name)
+        with preview.sink(out, KEY) as sink:
+            sink.add(lambda: numpy.zeros_like(latents), sigma=1.0, grid=(4, 4))
+            sink.add(lambda: latents, sigma=0.0, grid=(4, 4))
+            written.append(_pixels(out))
+    assert written[0] == written[1]
+
+
+def test_two_steps_at_the_SAME_sigma_leave_the_previous_frame_alone(preview, tmp_path):
+    """No velocity, no estimate — and nothing written, rather than a frame
+    computed from a division that did not happen."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+        assert not os.path.exists(out)
+
+
+# -- the no-op, which is what keeps this additive --------------------------------
+
+
+def test_a_model_the_table_does_not_know_gets_NO_preview(preview, tmp_path):
+    """A pipeline whose latent space nobody has fitted a matrix for has to
+    render exactly as it did before this existed — no file, and no `if preview:`
+    branch in either denoising loop."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, "AutoencoderKL") as sink:
+        assert sink.wanted is False
+        sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+    assert os.listdir(tmp_path) == []
+
+
+def test_a_request_that_named_no_preview_file_gets_NO_preview(preview, tmp_path):
+    with preview.sink(None, KEY) as sink:
+        assert sink.wanted is False
+        sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+    assert os.listdir(tmp_path) == []
+
+
+def test_a_no_op_sink_never_asks_for_the_LATENTS(preview, tmp_path):
+    """The latents are handed over as a callable rather than as an array, and
+    this is why: reading them costs a device->CPU sync per step, which is most
+    of the 68ms the preview was measured at. A sink that is not writing must not
+    charge the render for it."""
+    def fetch():
+        raise AssertionError("a no-op sink pulled the latents off the device")
+
+    with preview.sink(None, KEY) as sink:
+        sink.add(fetch, sigma=1.0, grid=(4, 4))
+    with preview.sink(str(tmp_path / "a.preview.png"), "nope") as sink:
+        sink.add(fetch, sigma=1.0, grid=(4, 4))
+
+
+# -- atomicity -------------------------------------------------------------------
+
+
+def test_a_frame_lands_by_REPLACE_from_a_temp_file_in_the_SAME_directory(
+        preview, tmp_path, monkeypatch):
+    """The page is reading this file through `/api/fs/raw` while the worker
+    rewrites it, so a frame written in place is a torn read. Same directory
+    because `os.replace` is only atomic within one filesystem."""
+    out = str(tmp_path / "a.preview.png")
+    seen = []
+    real_replace = os.replace
+
+    def spy(src, dst):
+        seen.append((src, dst))
+        assert os.path.dirname(src) == os.path.dirname(dst), (src, dst)
+        assert src != dst
+        # Whatever a reader holds open at this instant is a COMPLETE frame:
+        # either nothing, or the previous one.
+        if os.path.exists(dst):
+            _png_size(dst)
+        real_replace(src, dst)
+
+    monkeypatch.setattr(preview.os, "replace", spy)
+    with preview.sink(out, KEY) as sink:
+        for sigma in (1.0, 0.8, 0.4):
+            sink.add(lambda: _tokens(0.0), sigma=sigma, grid=(4, 4))
+    assert [dst for _, dst in seen] == [out, out]
+
+
+def test_a_reader_ONLY_ever_sees_a_whole_png(preview, tmp_path):
+    """The observable half of the rule above: every byte that has ever been at
+    this path parses as a PNG of the expected size."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        for sigma in (1.0, 0.9, 0.7, 0.3, 0.0):
+            sink.add(lambda: _tokens(0.0), sigma=sigma, grid=(4, 4))
+            if os.path.exists(out):
+                assert _png_size(out) == (4, 4)
+
+
+# -- the lifecycle, and where it diverges from partial.Sink ----------------------
+
+
+def _render(preview, out, raising=None):
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+        assert os.path.exists(out)
+        if raising is not None:
+            raise raising
+
+
+def test_the_preview_is_GONE_once_the_real_image_lands(preview, tmp_path):
+    """A clean exit means the PNG the request named has been written, so the
+    preview is duplicate bytes at a lower resolution."""
+    out = str(tmp_path / "a.preview.png")
+    _render(preview, out)
+    assert os.listdir(tmp_path) == []
+
+
+def test_the_preview_is_GONE_when_the_render_is_cancelled(preview, tmp_path):
+    out = str(tmp_path / "a.preview.png")
+    with pytest.raises(Cancelled):
+        _render(preview, out, raising=Cancelled())
+    assert os.listdir(tmp_path) == []
+
+
+def test_the_preview_is_GONE_when_the_render_FAILS_too(preview, tmp_path):
+    """**The divergence from `partial.Sink`, which keeps its file on an error.**
+    A transcript that died at minute 80 of 90 has 80 minutes of words in it and
+    that file is the only salvage there is. A render that died at step 12 of 16
+    has a 32x32 blur of a picture that will never exist — not salvage, just a
+    file in `ai/images/` that no row explains and nothing will ever clean up."""
+    out = str(tmp_path / "a.preview.png")
+    with pytest.raises(RuntimeError):
+        _render(preview, out, raising=RuntimeError("the render exploded"))
+    assert os.listdir(tmp_path) == []
+
+
+def test_nothing_is_left_behind_when_a_frame_fails_MID_WRITE(preview, tmp_path,
+                                                             monkeypatch):
+    """The temp file is the one thing that can outlive its writer. It is in the
+    directory the user browses, so it goes with everything else."""
+    out = str(tmp_path / "a.preview.png")
+
+    def boom(src, dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(preview.os, "replace", boom)
+    with pytest.raises(OSError):
+        with preview.sink(out, KEY) as sink:
+            sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+            sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+    assert os.listdir(tmp_path) == []
+
+
+def test_discarding_a_preview_that_was_never_written_is_not_an_error(preview, tmp_path):
+    """A render cancelled on its first step arrives here having written
+    nothing, and a crash in the teardown would report a finished render as a
+    failed one — the trade `partial.Sink.discard` refuses to take."""
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY):
+        pass
+    assert os.listdir(tmp_path) == []
+
+
+# -- one implementation, two engines ---------------------------------------------
+
+
+def test_the_SERVER_reaches_the_same_module_through_the_package(preview):
+    """Two loaders, one module — the route derives the path it advertises from
+    `preview_path`, so a second copy under a second module name would let the
+    route and the worker name different files."""
+    from fused_render.ai.runners import preview as packaged
+
+    assert packaged.preview_path("/x/y.png") == preview.preview_path("/x/y.png")
+    assert packaged.PROJECTIONS.keys() == preview.PROJECTIONS.keys()
+
+
+def test_the_previewer_needs_NO_third_party_import_to_be_READ(preview):
+    """The server imports this file to derive the path it advertises, on an
+    interpreter where neither runner venv's packages exist. numpy and Pillow are
+    both present in both runner venvs and both are used — inside the functions
+    that need them, the way `diarize.py` keeps sherpa out of module scope."""
+    source = open(PREVIEW_PATH, encoding="utf-8").read()
+    assert "import fused_render" not in source
+    for line in source.splitlines():
+        assert not line.startswith("import numpy"), line
+        assert not line.startswith("from PIL"), line
+        assert not line.startswith("import PIL"), line

--- a/tests/test_ai_image_preview.py
+++ b/tests/test_ai_image_preview.py
@@ -325,6 +325,102 @@ def test_a_no_op_sink_never_asks_for_the_LATENTS(preview, tmp_path):
         sink.add(fetch, sigma=1.0, grid=(4, 4))
 
 
+# -- a preview may never cost a render -------------------------------------------
+#
+# The sink is called from inside a denoising callback, which is the one place a
+# minutes-long render can be interrupted. Anything that escapes `add` unwinds
+# `pipe()` / `generate_image()` and destroys work that was going to succeed —
+# so the whole of `add` is guarded, and the failures are real ones: a full disk
+# during `save`, a Windows lock held by the page's own <img> during `replace`
+# (the exact hazard `discard` already swallows), a shape nobody predicted.
+
+
+def test_a_frame_that_CANNOT_BE_WRITTEN_does_not_unwind_the_render(preview, tmp_path,
+                                                                   monkeypatch):
+    """A full disk at step 40 of 100 must cost the thumbnail, not the image."""
+    def boom(src, dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(preview.os, "replace", boom)
+    out = str(tmp_path / "a.preview.png")
+    with preview.sink(out, KEY) as sink:
+        sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+        # …and the temp file it failed on does not accumulate, one per step, in
+        # a directory the user browses.
+        assert os.listdir(tmp_path) == []
+
+
+def test_LATENTS_that_cannot_even_be_READ_do_not_unwind_the_render(preview, tmp_path):
+    """The closure runs inside the guard too: it is a device read, and a device
+    that has fallen over is not a reason to lose the render's other minutes."""
+    def fetch():
+        raise RuntimeError("the GPU disagreed")
+
+    with preview.sink(str(tmp_path / "a.preview.png"), KEY) as sink:
+        sink.add(fetch, sigma=1.0, grid=(4, 4))
+    assert os.listdir(tmp_path) == []
+
+
+def test_a_SHAPE_nobody_predicted_does_not_unwind_the_render(preview, tmp_path):
+    """`_tokens` raises on a grid that does not hold the tokens it was given —
+    loudly, because both workers compute the grid from a width and height they
+    already have. Loud must still mean "no preview", not "no picture"."""
+    with preview.sink(str(tmp_path / "a.preview.png"), KEY) as sink:
+        sink.add(lambda: _tokens(0.0, count=9), sigma=1.0, grid=(4, 4))
+        sink.add(lambda: _tokens(0.0, count=9), sigma=0.5, grid=(4, 4))
+    assert os.listdir(tmp_path) == []
+
+
+def test_a_sink_that_KEEPS_failing_switches_itself_off(preview, tmp_path, monkeypatch):
+    """A permanently broken write is a syscall per step for the rest of a
+    100-step render, plus a device sync per step to feed it. After
+    `MAX_FAILURES` in a row the sink stops asking for the latents at all —
+    which is the same no-op an unfitted model gets."""
+    def boom(src, dst):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(preview.os, "replace", boom)
+    reads = []
+    with preview.sink(str(tmp_path / "a.preview.png"), KEY) as sink:
+        for step in range(preview.MAX_FAILURES + 4):
+            def fetch():
+                reads.append(1)
+                return _tokens(0.0)
+
+            sink.add(fetch, sigma=1.0 - step * 0.1, grid=(4, 4))
+        assert sink.wanted is False
+    # One read for the first (predecessor-only) step, then one per failure.
+    assert len(reads) == preview.MAX_FAILURES + 1
+
+
+def test_a_frame_that_LANDS_forgives_the_ones_that_did_not(preview, tmp_path,
+                                                           monkeypatch):
+    """Consecutive, not cumulative: the Windows collision this guards against is
+    transient by nature — the page's `<img>` releases the file — and a sink that
+    latched off after three unlucky steps of a long render would have thrown the
+    feature away over nothing."""
+    real_replace = os.replace
+    failing = [True]
+
+    def flaky(src, dst):
+        if failing[0]:
+            raise PermissionError("the page has it open")
+        real_replace(src, dst)
+
+    monkeypatch.setattr(preview.os, "replace", flaky)
+    with preview.sink(str(tmp_path / "a.preview.png"), KEY) as sink:
+        for step in range(preview.MAX_FAILURES):
+            sink.add(lambda: _tokens(0.0), sigma=1.0 - step * 0.1, grid=(4, 4))
+        failing[0] = False
+        sink.add(lambda: _tokens(0.0), sigma=0.1, grid=(4, 4))
+        assert sink.wanted is True
+        failing[0] = True
+        for step in range(preview.MAX_FAILURES - 1):
+            sink.add(lambda: _tokens(0.0), sigma=0.05 - step * 0.01, grid=(4, 4))
+        assert sink.wanted is True
+
+
 # -- atomicity -------------------------------------------------------------------
 
 
@@ -404,20 +500,26 @@ def test_the_preview_is_GONE_when_the_render_FAILS_too(preview, tmp_path):
     assert os.listdir(tmp_path) == []
 
 
-def test_nothing_is_left_behind_when_a_frame_fails_MID_WRITE(preview, tmp_path,
-                                                             monkeypatch):
+def test_nothing_is_left_behind_when_the_RENDER_dies_mid_frame(preview, tmp_path,
+                                                               monkeypatch):
     """The temp file is the one thing that can outlive its writer. It is in the
-    directory the user browses, so it goes with everything else."""
+    directory the user browses, so it goes with everything else — including
+    when the render itself fails while a frame is half-written."""
     out = str(tmp_path / "a.preview.png")
+    real_replace = os.replace
 
-    def boom(src, dst):
-        raise OSError("no space left on device")
+    def leave_the_temp(src, dst):
+        # A `save` that landed and a `replace` that did not: the state a killed
+        # or failed write leaves behind.
+        raise RuntimeError("interrupted between save and replace")
 
-    monkeypatch.setattr(preview.os, "replace", boom)
-    with pytest.raises(OSError):
+    with pytest.raises(RuntimeError):
         with preview.sink(out, KEY) as sink:
             sink.add(lambda: _tokens(0.0), sigma=1.0, grid=(4, 4))
+            monkeypatch.setattr(preview.os, "replace", leave_the_temp)
             sink.add(lambda: _tokens(0.0), sigma=0.5, grid=(4, 4))
+            monkeypatch.setattr(preview.os, "replace", real_replace)
+            raise RuntimeError("the render exploded")
     assert os.listdir(tmp_path) == []
 
 

--- a/tests/test_ai_mflux_worker.py
+++ b/tests/test_ai_mflux_worker.py
@@ -559,6 +559,43 @@ def test_PACKED_and_UNPATCHIFIED_latents_are_both_understood(
     assert written[0] == written[1]
 
 
+def test_the_FRAME_is_written_BEFORE_the_tick_that_announces_it(monkeypatch, base,
+                                                                tmp_path):
+    """The same ordering rule as the diffusers runner's, pinned the same way and
+    for the same reason: `done` on the tick is what `runtime.js` turns into the
+    cache-busted `&step=N` preview URL, so reporting first can hand a page the
+    URL for a frame that is not on disk — and because that URL is keyed by the
+    step and never requested twice, a fetch in the window caches the PREVIOUS
+    frame's bytes under it for that step's whole duration.
+
+    Two engines, one order. It reads as arbitrary from either side."""
+    import numpy
+
+    rng = numpy.random.default_rng(11)
+    model = FakeModel(latents=FakeLatents(_packed(rng)),
+                      sigmas=[1.0, 0.9, 0.7, 0.4, 0.0])
+    worker, _ = _previewing_worker(monkeypatch, base, tmp_path, model=model)
+    events = []
+    real_write = worker.preview.Sink._write
+
+    def spy_write(self, rgb, grid):
+        events.append("frame")
+        return real_write(self, rgb, grid)
+
+    real_report = base.report_or_cancel
+
+    def spy_report(job=None, **fields):
+        events.append("tick %d" % fields["done"])
+        return real_report(job=job, **fields)
+
+    monkeypatch.setattr(worker.preview.Sink, "_write", spy_write)
+    monkeypatch.setattr(base, "report_or_cancel", spy_report)
+    worker.generate(_request(tmp_path, width=512, height=512, steps=4,
+                             outPreview=str(tmp_path / "fox.preview.png")))
+    assert events == ["tick 1", "frame", "tick 2", "frame", "tick 3",
+                      "frame", "tick 4"]
+
+
 def test_a_variant_that_names_NO_autoencoder_renders_exactly_as_BEFORE(
         monkeypatch, base, tmp_path):
     """No file, no branch — and no conversion either: the latents go over as a

--- a/tests/test_ai_mflux_worker.py
+++ b/tests/test_ai_mflux_worker.py
@@ -102,10 +102,24 @@ class FakeImage:
         self.written = target
 
 
+class FakeLatents:
+    """An mlx array, with the one call the preview's `_as_numpy` makes on it."""
+
+    def __init__(self, array, on_read=None):
+        self._array = array
+        self._on_read = on_read
+
+    def astype(self, dtype):
+        assert dtype == "float32", dtype
+        if self._on_read is not None:
+            self._on_read()
+        return self._array
+
+
 class FakeModel:
     """An mflux variant: a callback registry, and a loop that drives it."""
 
-    def __init__(self, steps_to_run=None):
+    def __init__(self, steps_to_run=None, latents=None, sigmas=None):
         self.callbacks = FakeRegistry()
         self.calls = []
         self.image = FakeImage()
@@ -113,6 +127,13 @@ class FakeModel:
         #: from what was asked (nothing does this today; it exists so a cancel
         #: mid-loop is expressible).
         self.steps_to_run = steps_to_run
+        #: What the loop hands the callback. None for the tests that are not
+        #: about the preview — which is also the honest shape of a run with no
+        #: schedule to read, so those tests pin that nothing breaks without one.
+        self.latents = latents
+        self.sigmas = sigmas
+        #: Called after each step, for a test that watches the preview appear.
+        self.watch = None
 
     def generate_image(self, seed, prompt, num_inference_steps=4, height=1024,
                        width=1024, guidance=1.0, **kwargs):
@@ -120,12 +141,19 @@ class FakeModel:
                            "num_inference_steps": num_inference_steps,
                            "height": height, "width": width, **kwargs})
         total = self.steps_to_run if self.steps_to_run is not None else num_inference_steps
+        config = None
+        if self.sigmas is not None:
+            config = types.SimpleNamespace(
+                scheduler=types.SimpleNamespace(sigmas=self.sigmas))
         for t in range(total):
             for callback in self.callbacks.callbacks:
                 # mflux calls it with keywords; the reporter's signature has to
                 # match, and a positional call here would hide a rename.
-                callback.call_in_loop(t=t, seed=seed, prompt=prompt, latents=None,
-                                      config=None, time_steps=None)
+                callback.call_in_loop(t=t, seed=seed, prompt=prompt,
+                                      latents=self.latents, config=config,
+                                      time_steps=None)
+            if self.watch is not None:
+                self.watch(t)
         return self.image
 
 
@@ -443,3 +471,161 @@ def test_the_worker_never_shells_out(monkeypatch, base):
     assert "import subprocess" not in source
     assert "subprocess." not in source
     assert "os.system" not in source and "Popen" not in source
+
+
+# -- the live preview (SPEC §40) -------------------------------------------------
+#
+# The same thumbnail the diffusers runner writes, from the same shared module,
+# out of a callback with a different signature and latents in a different
+# library's arrays. The arithmetic and the lifecycle are tested in
+# `test_ai_image_preview.py`; what is pinned HERE is that this engine's wiring
+# reaches it — and reaches it identically, since a page must not be able to tell
+# which one rendered.
+
+
+def _mlx_core():
+    """`mlx.core`, for the one attribute `_as_numpy` reads off it."""
+    return types.SimpleNamespace(float32="float32")
+
+
+def _previewing_worker(monkeypatch, base, tmp_path, *, model=None, vae=True):
+    """A loaded worker whose recipe does (or does not) name an autoencoder.
+
+    The table is reached through `worker.formats`, not through
+    `fused_render.ai.runners.formats`: a runner imports it by path off
+    `sys.path`, so the packaged module is a second object and patching it would
+    patch nothing this worker reads.
+    """
+    worker, made = load_worker(monkeypatch, base, model=model,
+                               mlx_core=_mlx_core())
+    recipe = dict(worker.formats.MFLUX_VARIANTS[MODEL])
+    if not vae:
+        recipe.pop("vae", None)
+    monkeypatch.setitem(worker.formats.MFLUX_VARIANTS, MODEL, recipe)
+    worker.load(MODEL, snapshot(tmp_path))
+    return worker, made
+
+
+def _packed(rng, tokens=32 * 32):
+    return rng.standard_normal((1, tokens, 128)).astype("float32")
+
+
+def test_a_thumbnail_appears_from_the_SECOND_step_and_is_GONE_at_the_end(
+        monkeypatch, base, tmp_path):
+    """Step 1 has no predecessor, so it has no velocity and no estimate — and
+    the last frame is duplicate bytes once the real PNG lands. The same two
+    sentences the diffusers runner's copy of this test carries, deliberately."""
+    import numpy
+
+    rng = numpy.random.default_rng(3)
+    model = FakeModel(latents=FakeLatents(_packed(rng)),
+                      sigmas=[1.0, 0.9, 0.7, 0.4, 0.0])
+    worker, made = _previewing_worker(monkeypatch, base, tmp_path, model=model)
+    request = _request(tmp_path, width=512, height=512, steps=4,
+                       outPreview=str(tmp_path / "fox.preview.png"))
+    seen = []
+    made.watch = lambda t: seen.append(os.path.exists(request["outPreview"]))
+    worker.generate(request)
+
+    assert seen == [False, True, True, True]
+    assert sorted(os.listdir(tmp_path)) == ["fox.png", "snap"]
+
+
+def test_PACKED_and_UNPATCHIFIED_latents_are_both_understood(
+        monkeypatch, base, tmp_path):
+    """mflux hands the callback `(B, N, 128)` on some paths and
+    `(B, 128, h, w)` on others. Both are the same picture, and neither runner
+    reshapes before handing it over — that would be a second copy of the unpack
+    rule `preview._tokens` owns."""
+    import numpy
+
+    rng = numpy.random.default_rng(4)
+    packed = _packed(rng, tokens=16)
+    grid = packed[0].reshape(4, 4, 128).transpose(2, 0, 1)[None]
+    written = []
+    for index, array in enumerate((packed, grid)):
+        # One directory each: `snapshot` makes a fresh repo layout per load.
+        room = tmp_path / str(index)
+        room.mkdir()
+        model = FakeModel(latents=FakeLatents(array), sigmas=[1.0, 0.5, 0.0])
+        worker, _ = _previewing_worker(monkeypatch, base, room, model=model)
+        request = _request(room, width=64, height=64, steps=2,
+                           out=str(room / "fox.png"),
+                           outPreview=str(room / "fox.preview.png"))
+        monkeypatch.setattr(worker.preview.Sink, "discard", lambda self: None)
+        worker.generate(request)
+        with open(request["outPreview"], "rb") as handle:
+            written.append(handle.read())
+    assert written[0] == written[1]
+
+
+def test_a_variant_that_names_NO_autoencoder_renders_exactly_as_BEFORE(
+        monkeypatch, base, tmp_path):
+    """No file, no branch — and no conversion either: the latents go over as a
+    closure precisely so a no-op sink never touches them."""
+    def touched():
+        raise AssertionError("a no-op preview converted the latents")
+
+    import numpy
+
+    rng = numpy.random.default_rng(5)
+    model = FakeModel(latents=FakeLatents(_packed(rng), on_read=touched),
+                      sigmas=[1.0, 0.9, 0.7, 0.4, 0.0])
+    worker, _ = _previewing_worker(monkeypatch, base, tmp_path, model=model,
+                                   vae=False)
+    worker.generate(_request(tmp_path, width=512, height=512, steps=4,
+                             outPreview=str(tmp_path / "fox.preview.png")))
+    assert sorted(os.listdir(tmp_path)) == ["fox.png", "snap"]
+
+
+def test_a_request_that_named_no_preview_file_renders_exactly_as_BEFORE(
+        monkeypatch, base, tmp_path):
+    """A worker request from before this feature carries no `outPreview`."""
+    def touched():
+        raise AssertionError("a no-op preview converted the latents")
+
+    import numpy
+
+    rng = numpy.random.default_rng(6)
+    model = FakeModel(latents=FakeLatents(_packed(rng), on_read=touched),
+                      sigmas=[1.0, 0.9, 0.7, 0.4, 0.0])
+    worker, _ = _previewing_worker(monkeypatch, base, tmp_path, model=model)
+    worker.generate(_request(tmp_path, width=512, height=512, steps=4))
+    assert sorted(os.listdir(tmp_path)) == ["fox.png", "snap"]
+
+
+def test_the_thumbnail_is_removed_when_the_render_is_CANCELLED(
+        monkeypatch, base, tmp_path):
+    """A ✕ means the user does not want this picture, at any resolution."""
+    import numpy
+
+    rng = numpy.random.default_rng(7)
+    model = FakeModel(latents=FakeLatents(_packed(rng)),
+                      sigmas=[1.0, 0.9, 0.7, 0.4, 0.0])
+    worker, _ = _previewing_worker(monkeypatch, base, tmp_path, model=model)
+    base.cancel_on_tick = 4          # the opening report, then three steps
+    with pytest.raises(base.Cancelled):
+        worker.generate(_request(tmp_path, width=512, height=512, steps=4,
+                                 outPreview=str(tmp_path / "fox.preview.png")))
+    assert os.listdir(tmp_path) == ["snap"]
+
+
+def test_both_image_workers_import_the_ONE_previewer_rather_than_a_copy():
+    """The structural half: a second `preview.py` under either runner folder is
+    the drift AI-10c forbids, and no behavioural test would catch it — both
+    copies would pass their own. Asserted from the SECOND runner's tests, the
+    way `test_ai_partial_transcript.py` does for the two whisper engines."""
+    runners = os.path.dirname(os.path.dirname(WORKER_PATH))
+    for folder in ("diffusers_image", "mflux_image"):
+        assert not os.path.exists(os.path.join(runners, folder, "preview.py")), folder
+        with open(os.path.join(runners, folder, "worker.py"), encoding="utf-8") as fh:
+            assert "import preview" in fh.read(), folder
+
+
+def test_the_key_BOTH_runners_use_is_the_same_string():
+    """The torch runner reads `type(pipe.vae).__name__` and this one reads its
+    variant recipe, and the two have to land on one row of one table — the whole
+    reason the projection lives at the runners root and not in either worker."""
+    from fused_render.ai.runners import formats, preview
+
+    assert formats.MFLUX_VARIANTS[MODEL]["vae"] in preview.PROJECTIONS

--- a/tests/test_ai_mflux_worker.py
+++ b/tests/test_ai_mflux_worker.py
@@ -119,7 +119,8 @@ class FakeLatents:
 class FakeModel:
     """An mflux variant: a callback registry, and a loop that drives it."""
 
-    def __init__(self, steps_to_run=None, latents=None, sigmas=None):
+    def __init__(self, steps_to_run=None, latents=None, sigmas=None,
+                 latents_per_step=None):
         self.callbacks = FakeRegistry()
         self.calls = []
         self.image = FakeImage()
@@ -132,6 +133,11 @@ class FakeModel:
         #: schedule to read, so those tests pin that nothing breaks without one.
         self.latents = latents
         self.sigmas = sigmas
+        #: One array per step, when a test needs the latents to actually MOVE.
+        #: Identical latents mean zero velocity, and a zero velocity makes the
+        #: denoised estimate equal the latent at every sigma — which is how a
+        #: test can look like it pins the sigma indexing without pinning it.
+        self.latents_per_step = latents_per_step
         #: Called after each step, for a test that watches the preview appear.
         self.watch = None
 
@@ -146,11 +152,13 @@ class FakeModel:
             config = types.SimpleNamespace(
                 scheduler=types.SimpleNamespace(sigmas=self.sigmas))
         for t in range(total):
+            held = (self.latents if self.latents_per_step is None
+                    else self.latents_per_step[t])
             for callback in self.callbacks.callbacks:
                 # mflux calls it with keywords; the reporter's signature has to
                 # match, and a positional call here would hide a rename.
                 callback.call_in_loop(t=t, seed=seed, prompt=prompt,
-                                      latents=self.latents, config=config,
+                                      latents=held, config=config,
                                       time_steps=None)
             if self.watch is not None:
                 self.watch(t)
@@ -536,18 +544,30 @@ def test_PACKED_and_UNPATCHIFIED_latents_are_both_understood(
     """mflux hands the callback `(B, N, 128)` on some paths and
     `(B, 128, h, w)` on others. Both are the same picture, and neither runner
     reshapes before handing it over — that would be a second copy of the unpack
-    rule `preview._tokens` owns."""
+    rule `preview._tokens` owns.
+
+    The two steps hold DIFFERENT latents, so the estimate is a real
+    extrapolation rather than the degenerate zero-velocity case: an unpack that
+    agreed on a constant field and disagreed on a moving one would otherwise
+    pass this.
+    """
     import numpy
 
     rng = numpy.random.default_rng(4)
+    first = _packed(rng, tokens=16)
     packed = _packed(rng, tokens=16)
-    grid = packed[0].reshape(4, 4, 128).transpose(2, 0, 1)[None]
+    shapes = [
+        (first, packed),
+        (first[0].reshape(4, 4, 128).transpose(2, 0, 1)[None],
+         packed[0].reshape(4, 4, 128).transpose(2, 0, 1)[None]),
+    ]
     written = []
-    for index, array in enumerate((packed, grid)):
+    for index, pair in enumerate(shapes):
         # One directory each: `snapshot` makes a fresh repo layout per load.
         room = tmp_path / str(index)
         room.mkdir()
-        model = FakeModel(latents=FakeLatents(array), sigmas=[1.0, 0.5, 0.0])
+        model = FakeModel(sigmas=[1.0, 0.5, 0.0],
+                          latents_per_step=[FakeLatents(a) for a in pair])
         worker, _ = _previewing_worker(monkeypatch, base, room, model=model)
         request = _request(room, width=64, height=64, steps=2,
                            out=str(room / "fox.png"),
@@ -557,6 +577,60 @@ def test_PACKED_and_UNPATCHIFIED_latents_are_both_understood(
         with open(request["outPreview"], "rb") as handle:
             written.append(handle.read())
     assert written[0] == written[1]
+
+
+def test_the_thumbnail_is_the_estimate_at_the_sigma_just_REACHED(
+        monkeypatch, base, tmp_path):
+    """`_sigma_after` is a SECOND copy of the off-by-one, against a second
+    library's schedule, and it had no test at all — the diffusers runner's
+    covered only its own.
+
+    The same two properties make this pin it rather than merely pass: the
+    latents MOVE (a zero velocity makes the estimate equal the latent at any
+    sigma, so any indexing would satisfy it) and the frame examined is
+    MID-RENDER (the schedule ends at sigma 0, where the estimate degenerates the
+    same way). Read one entry earlier, these pixels are different ones.
+    """
+    import numpy
+    from PIL import Image
+
+    rng = numpy.random.default_rng(21)
+    sigmas = [1.0, 0.9, 0.7, 0.318, 0.0]
+    steps = [_packed(rng, tokens=32 * 32) * 2.0 for _ in range(4)]
+    model = FakeModel(sigmas=sigmas,
+                      latents_per_step=[FakeLatents(a) for a in steps])
+    worker, made = _previewing_worker(monkeypatch, base, tmp_path, model=model)
+    preview = worker.preview
+    out = str(tmp_path / "fox.preview.png")
+    shots = []
+
+    def snapshot(t):
+        if not os.path.exists(out):
+            shots.append(None)
+            return
+        with Image.open(out) as image:
+            shots.append((image.size, numpy.frombuffer(
+                image.convert("RGB").tobytes(), dtype=numpy.uint8).tolist()))
+
+    made.watch = snapshot
+    worker.generate(_request(tmp_path, width=512, height=512, steps=4,
+                             outPreview=out))
+
+    def frame(sigma_previous, sigma_current):
+        estimate = preview.denoised(steps[1], steps[2], sigma_previous, sigma_current)
+        rgb = preview.project(estimate, "AutoencoderKLFlux2")
+        return numpy.asarray(rgb * 255.0 + 0.5, dtype=numpy.uint8).reshape(-1).tolist()
+
+    # After step index 2: latents[1] at sigmas[2], latents[2] at sigmas[3] — the
+    # level the schedule has ARRIVED at, not the one it left.
+    right = frame(sigmas[2], sigmas[3])
+    stale = frame(sigmas[1], sigmas[2])
+    assert right != stale, "the schedule chosen cannot tell the two apart"
+
+    size, pixels = shots[2]
+    assert size == (preview.MAX_SIDE, preview.MAX_SIDE)
+    assert pixels == right
+    assert pixels != stale
 
 
 def test_the_FRAME_is_written_BEFORE_the_tick_that_announces_it(monkeypatch, base,

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -3009,12 +3009,15 @@ def _run_ai_image(record='{state: "done"}', ticks="[]", preview='"/t/a.preview.p
     return json.loads(out.stdout)
 
 
+RUNNING = '{state: "running", done: %d, total: 4}'
+
+
 def test_every_progress_tick_carries_a_READY_TO_USE_preview_url():
     """A page sets this as an `<img>` src and gets a picture emerging out of
     noise. Built here rather than by every caller, for the same reason `url`
     is — and CACHE-BUSTED BY STEP, because the preview is one path overwritten
     in place and a browser handed the same URL twice shows frame 2 forever."""
-    settled = _run_ai_image(ticks='[{done: 1, total: 4}, {done: 2, total: 4}]')
+    settled = _run_ai_image(ticks="[%s, %s]" % (RUNNING % 1, RUNNING % 2))
     assert settled["ok"] is True, settled
     assert [tick["previewUrl"] for tick in settled["progress"]] == [
         "/api/fs/raw?path=/t/a.preview.png&step=1",
@@ -3025,27 +3028,44 @@ def test_every_progress_tick_carries_a_READY_TO_USE_preview_url():
 def test_the_tick_a_page_sees_is_a_COPY_of_the_row_the_manager_is_drawing():
     """The record belongs to the job manager and every other watcher of that
     row sees the same object — a field written onto it here would travel."""
-    settled = _run_ai_image(ticks='[{done: 1, total: 4}]')
-    assert settled["rows"] == [{"done": 1, "total": 4}]
+    settled = _run_ai_image(ticks="[%s]" % (RUNNING % 1))
+    assert settled["rows"] == [{"state": "running", "done": 1, "total": 4}]
     assert settled["progress"][0]["done"] == 1
 
 
-def test_the_resolved_image_carries_both_urls():
-    """`previewUrl` is on the resolved object too, and the doc comment says to
-    swap to `url`: the last preview is the finished picture at a thirtieth of
-    the resolution, and the file it points at is deleted the moment the real
-    PNG lands."""
+@pytest.mark.parametrize("state", ["done", "error", "cancelled"])
+def test_the_LAST_tick_has_no_preview_because_the_file_is_already_gone(state):
+    """`watch` calls back with the TERMINAL record too, and by the time a row
+    reaches one the worker's sink has discarded the preview — `Sink.__exit__`
+    runs before `generate()` returns, which is before the row can be marked.
+
+    So a page that keeps its `<img>` pointed at the latest `previewUrl` would
+    end every render on a guaranteed 404: a blank flash exactly where the
+    finished picture should appear. Null is the honest answer, and it is the
+    same answer on a cancel and an error — there is no frame there either."""
+    settled = _run_ai_image(record='{state: "%s"}' % state,
+                            ticks="[%s, {state: '%s', done: 4, total: 4}]"
+                                  % (RUNNING % 3, state))
+    ticks = settled["progress"]
+    assert ticks[0]["previewUrl"] == "/api/fs/raw?path=/t/a.preview.png&step=3"
+    assert ticks[1]["previewUrl"] is None, ticks[1]
+
+
+def test_the_resolved_image_carries_the_url_and_a_NULL_preview():
+    """Same fact from the other side: the resolved object names the real PNG,
+    and `previewUrl` is null because the file it would name has been deleted.
+    A URL to a file that is gone is worse than no URL — a page can test null."""
     settled = _run_ai_image()
     assert settled["ok"] is True, settled
     assert settled["value"]["url"] == "/api/fs/raw?path=/t/a.png"
-    assert settled["value"]["previewUrl"] == "/api/fs/raw?path=/t/a.preview.png&step=4"
+    assert settled["value"]["previewUrl"] is None
 
 
 def test_a_render_with_no_preview_hands_the_page_NULL_rather_than_a_dead_url():
     """A model whose latent space has no fitted projection writes no frames, and
     a URL pointing at a file that will never exist is worse than nothing: a page
     can test `previewUrl` but cannot test an `<img>` that 404s."""
-    settled = _run_ai_image(ticks='[{done: 1, total: 4}]', preview="undefined")
+    settled = _run_ai_image(ticks="[%s]" % (RUNNING % 1), preview="undefined")
     assert settled["ok"] is True, settled
     assert settled["progress"][0]["previewUrl"] is None
     assert settled["value"]["previewUrl"] is None

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -2955,6 +2955,102 @@ def test_the_transcription_bridge_resolves_with_the_words_and_the_url():
     assert value["url"] == "/api/fs/raw?path=/t/out.json"
 
 
+def _run_ai_image(record='{state: "done"}', ticks="[]", preview='"/t/a.preview.png"'):
+    """Run `aiImage` out of runtime.js under node, against stubs.
+
+    `_run_ai_transcribe`'s harness for the other half of the same API: the
+    function is lifted out and driven with its closure stubbed, because what
+    matters is the object it hands the page rather than the DOM it built it in.
+
+    `ticks` is a JS array of job records the fake watcher replays through
+    `onProgress`, and they are echoed back untouched so a test can prove the
+    bridge annotated a COPY rather than the row the manager is drawing.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which("node"):
+        pytest.skip("node is needed to run the page's own image glue")
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "fused_render", "static", "runtime.js")
+    source = open(path, encoding="utf-8").read()
+    start = source.index("  function aiImage(opts)")
+    end = source.index("\n  }\n", start) + 4
+    fn = source[start:end]
+
+    prelude = """
+      const started = {jobId: "sys:ai-image:x", path: "/t/a.png", seed: 7,
+                       steps: 4, previewPath: PREVIEW};
+      const window = {location: {search: "?path=/pages/p.html"}};
+      const aiPost = () => Promise.resolve(started);
+      const rawUrl = (p) => "/api/fs/raw?path=" + p;
+      const stat = () => Promise.reject(new Error("no stat"));
+      const rows = TICKS;
+      const watchJob = () => ({
+        watch: (cb) => {
+          for (const row of rows) if (cb) cb(row);
+          return Promise.resolve(RECORD);
+        },
+        get: () => Promise.resolve(RECORD),
+        stop() {}, cancel: () => Promise.resolve(true),
+      });
+      const progress = [];
+    """.replace("PREVIEW", preview).replace("TICKS", ticks).replace("RECORD", record)
+    call = """
+      aiImage({prompt: "a fox", onProgress: (job) => progress.push(job)}).then(
+        (value) => console.log(JSON.stringify({ok: true, value, progress, rows})),
+        (err) => console.log(JSON.stringify(
+          {ok: false, message: err.message, type: err.type, progress, rows})),
+      );
+    """
+    out = subprocess.run(["node", "-e", prelude + fn + call],
+                         capture_output=True, text=True)
+    assert out.returncode == 0, out.stderr
+    return json.loads(out.stdout)
+
+
+def test_every_progress_tick_carries_a_READY_TO_USE_preview_url():
+    """A page sets this as an `<img>` src and gets a picture emerging out of
+    noise. Built here rather than by every caller, for the same reason `url`
+    is — and CACHE-BUSTED BY STEP, because the preview is one path overwritten
+    in place and a browser handed the same URL twice shows frame 2 forever."""
+    settled = _run_ai_image(ticks='[{done: 1, total: 4}, {done: 2, total: 4}]')
+    assert settled["ok"] is True, settled
+    assert [tick["previewUrl"] for tick in settled["progress"]] == [
+        "/api/fs/raw?path=/t/a.preview.png&step=1",
+        "/api/fs/raw?path=/t/a.preview.png&step=2",
+    ]
+
+
+def test_the_tick_a_page_sees_is_a_COPY_of_the_row_the_manager_is_drawing():
+    """The record belongs to the job manager and every other watcher of that
+    row sees the same object — a field written onto it here would travel."""
+    settled = _run_ai_image(ticks='[{done: 1, total: 4}]')
+    assert settled["rows"] == [{"done": 1, "total": 4}]
+    assert settled["progress"][0]["done"] == 1
+
+
+def test_the_resolved_image_carries_both_urls():
+    """`previewUrl` is on the resolved object too, and the doc comment says to
+    swap to `url`: the last preview is the finished picture at a thirtieth of
+    the resolution, and the file it points at is deleted the moment the real
+    PNG lands."""
+    settled = _run_ai_image()
+    assert settled["ok"] is True, settled
+    assert settled["value"]["url"] == "/api/fs/raw?path=/t/a.png"
+    assert settled["value"]["previewUrl"] == "/api/fs/raw?path=/t/a.preview.png&step=4"
+
+
+def test_a_render_with_no_preview_hands_the_page_NULL_rather_than_a_dead_url():
+    """A model whose latent space has no fitted projection writes no frames, and
+    a URL pointing at a file that will never exist is worse than nothing: a page
+    can test `previewUrl` but cannot test an `<img>` that 404s."""
+    settled = _run_ai_image(ticks='[{done: 1, total: 4}]', preview="undefined")
+    assert settled["ok"] is True, settled
+    assert settled["progress"][0]["previewUrl"] is None
+    assert settled["value"]["previewUrl"] is None
+
+
 @pytest.mark.parametrize("opts", [
     '{path: "a.m4a", diarize: true, speakers: 0}',
     '{path: "a.m4a", diarize: true, speakers: -2}',

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1706,6 +1706,52 @@ def test_an_image_renders_to_disk_and_the_job_finishes(client, fake_image_runner
     assert open(started["path"], "rb").read(8) == b"\x89PNG\r\n\x1a\n"
 
 
+def test_the_reply_says_where_the_LIVE_PREVIEW_will_be(client, fake_image_runner):
+    """The third path this API hands out, and it is decided here for the same
+    reason the other two are: the server owns where user files go. Derived
+    through `preview.preview_path`, never string-munged out of `path` — the
+    worker that writes this file and the reply that advertises it have to name
+    the same one, and a second spelling of the suffix is how they disagree."""
+    from fused_render.ai.runners import preview
+
+    started = client.post("/api/ai/image", json={"prompt": "x"},
+                          headers={"X-Fused": "1"}).json()
+    assert started["previewPath"] == preview.preview_path(started["path"])
+    assert os.path.dirname(started["previewPath"]) == os.path.dirname(started["path"])
+    _wait_job(started["jobId"])
+
+
+def test_the_worker_is_told_where_to_write_the_preview(client, fake_image_runner,
+                                                       monkeypatch):
+    """The advertised path and the requested one are the same string, because
+    they come from the same call rather than from two agreeing spellings."""
+    captured = {}
+    real_start = supervisor.start_image
+
+    def spy(model, request, job):
+        captured.update(request)
+        return real_start(model, request, job)
+
+    monkeypatch.setattr(supervisor, "start_image", spy)
+    started = client.post("/api/ai/image", json={"prompt": "x"},
+                          headers={"X-Fused": "1"}).json()
+    assert captured["outPreview"] == started["previewPath"]
+    _wait_job(started["jobId"])
+
+
+def test_a_runner_that_writes_no_preview_leaves_NOTHING_behind(client,
+                                                               fake_image_runner):
+    """The preview is a promise about a path, not about a file. A model with no
+    fitted projection — and every worker built before this existed — renders
+    exactly as it did, and the advertised path simply never appears."""
+    started = client.post("/api/ai/image", json={"prompt": "x"},
+                          headers={"X-Fused": "1"}).json()
+    row = _wait_job(started["jobId"])
+    assert row["state"] == "done", row
+    assert os.path.isfile(started["path"])
+    assert not os.path.exists(started["previewPath"])
+
+
 def test_the_reply_carries_the_seed_even_when_none_was_asked_for(client, fake_image_runner):
     """A seed invented inside the worker and never surfaced would make every
     unseeded image unrepeatable — "make that one again" has to be possible."""

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1752,6 +1752,82 @@ def test_a_runner_that_writes_no_preview_leaves_NOTHING_behind(client,
     assert not os.path.exists(started["previewPath"])
 
 
+def _age(path, seconds):
+    """Backdate a file, so a sweep sees it as something nobody is writing."""
+    old = time.time() - seconds
+    os.utime(path, (old, old))
+
+
+def test_a_preview_ORPHANED_BY_A_KILL_is_swept_up(tmp_path):
+    """`Sink.discard` runs on a normal unwind, and a worker does not always get
+    one: `supervisor._terminate` / `_kill_tree` end it outright on an unload, an
+    app shutdown or a wedge. What is left is `<stem>.preview.png` — and possibly
+    a `.tmp` beside it — in `~/ai/images`, a directory the user browses, with no
+    job row to explain it and nothing that would ever remove it.
+
+    So the directory is swept when the next render asks for it: the one moment
+    this is free, since the caller is about to wait minutes anyway.
+    """
+    from fused_render.server.routers import ai_runtime
+
+    room = tmp_path / "images"
+    room.mkdir()
+    orphan = room / "20260101-120000-abc.preview.png"
+    temp = room / "20260101-120000-abc.preview.png.9999.tmp"
+    kept = room / "20260101-120000-abc.png"
+    for path in (orphan, temp, kept):
+        path.write_bytes(b"x")
+        _age(path, ai_runtime._PREVIEW_TTL + 60)
+
+    ai_runtime._sweep_previews(str(room))
+    # The render itself is the artefact and is never touched, however old.
+    assert sorted(p.name for p in room.iterdir()) == ["20260101-120000-abc.png"]
+
+
+def test_a_preview_a_RENDER_IS_STILL_WRITING_survives_the_sweep(tmp_path):
+    """The one thing this must not do. A live preview is rewritten every
+    denoising step, so its mtime is always seconds old — the age threshold is
+    what separates "nobody is writing this" from "somebody is", and it is why
+    the sweep does not need to know which renders are in flight."""
+    from fused_render.server.routers import ai_runtime
+
+    room = tmp_path / "images"
+    room.mkdir()
+    live = room / "20260101-120000-def.preview.png"
+    live.write_bytes(b"x")
+
+    ai_runtime._sweep_previews(str(room))
+    assert live.exists()
+
+
+def test_the_sweep_never_breaks_a_render(tmp_path):
+    """It runs on the way in to a request that is about to work. A directory
+    that cannot be listed, or a file that cannot be removed, is worth an untidy
+    folder and never a refused render."""
+    from fused_render.server.routers import ai_runtime
+
+    ai_runtime._sweep_previews(str(tmp_path / "nothing-here"))
+
+
+def test_a_render_SWEEPS_before_it_starts(client, fake_image_runner, monkeypatch,
+                                          tmp_path):
+    """Wired to the request rather than to a timer: there is no background
+    sweeper to own, and the directory only grows when renders happen."""
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path))
+    from fused_render.server.routers import ai_runtime
+
+    room = tmp_path / "ai" / "images"
+    room.mkdir(parents=True)
+    orphan = room / "20250101-000000-old.preview.png"
+    orphan.write_bytes(b"x")
+    _age(orphan, ai_runtime._PREVIEW_TTL + 60)
+
+    started = client.post("/api/ai/image", json={"prompt": "x"},
+                          headers={"X-Fused": "1"}).json()
+    assert not orphan.exists()
+    _wait_job(started["jobId"])
+
+
 def test_the_reply_carries_the_seed_even_when_none_was_asked_for(client, fake_image_runner):
     """A seed invented inside the worker and never surfaced would make every
     unseeded image unrepeatable — "make that one again" has to be possible."""

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1739,6 +1739,39 @@ def test_the_worker_is_told_where_to_write_the_preview(client, fake_image_runner
     _wait_job(started["jobId"])
 
 
+def _skill_section(title):
+    """The body of one `## ` section of `skills/fused-render-ai/SKILL.md`.
+
+    That file is what a page author actually reads — the bridge's own comments
+    are for whoever maintains the bridge — so it is the copy of this API that
+    can be wrong without anything noticing.
+    """
+    path = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                        "skills", "fused-render-ai", "SKILL.md")
+    source = open(path, encoding="utf-8").read()
+    start = source.index("## " + title)
+    end = source.find("\n## ", start + 1)
+    return source[start:end if end != -1 else len(source)]
+
+
+def test_the_SKILL_names_every_field_an_image_resolves_with(client, fake_image_runner):
+    """Read off the ENDPOINT rather than listed here, because a hand-written
+    list in a test is a third copy that can drift with the other two. This is
+    the check that would have caught `previewPath` and `previewUrl` shipping
+    with the skill still describing the API without them: the route grew two
+    fields and the document a page author reads did not.
+
+    `url` and `previewUrl` are added because they are the bridge's own, built
+    on top of the reply rather than returned by it.
+    """
+    started = client.post("/api/ai/image", json={"prompt": "x"},
+                          headers={"X-Fused": "1"}).json()
+    fields = set(started) | {"url", "previewUrl"}
+    section = _skill_section("Images: `fused.ai.image({prompt, ...})`")
+    assert sorted(field for field in fields if field not in section) == []
+    _wait_job(started["jobId"])
+
+
 def test_a_runner_that_writes_no_preview_leaves_NOTHING_behind(client,
                                                                fake_image_runner):
     """The preview is a promise about a path, not about a file. A model with no


### PR DESCRIPTION
## Summary

- **A render that takes minutes now has something to look at.** `fused.ai.image()` hands every `onProgress` tick a `previewUrl` — a ~32×32 thumbnail of the image-in-progress, rewritten each denoising step — so a page can show a picture emerging from noise instead of a counter going up. Blur and upscale it with CSS; that part is the page's taste, not the API's.
- **It costs ~1% of the render.** No VAE decode: the packed latents are projected through a fitted 128→3 matrix, which is a matmul and a 3KB PNG. Measured at 68 ms/step on a 512²/16-step render, so it is always on — no flag, no interval, no default-off hedge.
- **Both engines, one implementation.** `runners/preview.py` sits at the runners root beside `partial.py` for the reason that file documents: two engines serve one capability and a page must not be able to tell which one rendered. The BatchNorm buffers that define the latent space are bit-identical between the torch repo and the MLX conversion (max|diff| = 0.0, verified), so one matrix is correct for both.
- **Raw latents would have been useless here, and that drove the design.** FLUX.2 klein is step-wise distilled — σ is still ≥ 0.5 at step 14 of 16 — so projecting the latent directly gives noise for almost the whole render. What gets projected is the model's *denoised estimate*, recovered from two consecutive latents and the sigma schedule. Legible from step 2 of 16, verified against a real render.

## Visuals

One denoising step, from the worker's callback to the `<img>` on the page:

```mermaid
flowchart TD
    A[Denoising step ends] --> B[Callback holds packed latents]
    B --> C{Model has a<br/>fitted projection?}
    C -->|no| D[No preview, render unchanged]
    C -->|yes| E[Estimate finished image<br/>from two latents + sigmas]
    E --> F[Project 128 to RGB, clip, 32px]
    F --> G[Temp file, then os.replace]
    G --> H[onProgress tick carries previewUrl]
    H --> I[Page img src, cache-busted by step]
```

The file is one path overwritten in place, discarded when the real PNG lands.

## Usage

```js
const img = document.querySelector("img#preview");
img.onerror = () => { img.hidden = true; };   // early steps write no frame yet

const result = await fused.ai.image({
  prompt: "a red fox sitting in tall grass at sunrise",
  onProgress: (job) => {
    if (!job.previewUrl) return;
    img.hidden = false;
    img.src = job.previewUrl;                 // ~32px, blur it up in CSS
  },
});

img.src = result.url;                         // swap to the finished render
```

`previewUrl` is `null` when a render has no preview at all (a model whose latent space has no fitted projection). When it is a URL the file may still be missing — the first step writes no frame, because estimating a picture needs two latents — so a 404 there is ordinary, not an error. `POST /api/ai/image` gained a `previewPath` field alongside `path`; nothing existing changed shape.

## Test Plan

- [x] **`tests/test_ai_image_preview.py` (new, 31 tests)** — path derivation; matrix shape and spot-checked fitted values; projection orientation, bias and clipping; the estimate arithmetic including σ=0 and equal-σ; first step writes nothing; one file overwritten; the 32px cap and non-square grids; packed vs unpatchified equivalence; both no-op paths (and that a no-op sink never pulls latents off the device); temp-then-replace so a reader never sees a torn PNG; discard on success, cancel, error and mid-write failure; server and runner importing the same module; no third-party import at module scope.
- [x] **`tests/test_ai_diffusers_worker.py` (+8)**, **`tests/test_ai_mflux_worker.py` (+7)** — per-engine wiring, plus the structural pin that no second `preview.py` exists under either runner folder (the rule `test_ai_partial_transcript.py` already enforces for transcripts).
- [x] **`tests/test_ai_runtime.py` (+3 route, +4 node-driven bridge)** — `previewPath` advertised and canonicalised, `previewUrl` cache-busted per step, and the progress record copied rather than annotated.
- [x] Full suite run locally by the orchestrator before this PR left draft.
- [ ] **Manual, on an Apple Silicon machine:** open a page calling `fused.ai.image()` with the snippet above, watch the thumbnail refine over the render, confirm it disappears and is replaced by the full image on resolve, and confirm `<home>/ai/images` holds no leftover `.preview.png` afterwards. Repeat with the ✕ on the job row — the partial file must be gone there too.
- [ ] **Known unverified:** the mflux sigma index was taken from the spec rather than observed on a live MLX run. If mflux calls its in-loop callback before the step rather than after, every mflux preview is one step stale — still legible, just lagging. Worth one real render on the MLX engine before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
