### PR TITLE
Refine AI Models UI: simplify discover tab and improve visual hierarchy

### DIFF
--- a/frontend/src/shell/AiModels.tsx
+++ b/frontend/src/shell/AiModels.tsx
@@ -1013,7 +1013,13 @@ export default function AiModels() {
         <div className="cc-page-head">
           <div>
             <h2 className="cc-heading">AI Models</h2>
-            <div className="cc-caption cc-mono">
+            {/* Monospace only for the cache PATH below — the Discover and
+                Engines captions are plain sentences, and the Engines tab's own
+                note (`.am-engines-note`) sits right under this one in the same
+                proportional font. Applying `.cc-mono` to every branch made
+                that one sentence look like a filesystem fact next to the other
+                that does not. */}
+            <div className={"cc-caption" + (tab === "local" && data ? " cc-mono" : "")}>
               {tab === "discover" ? (
                 // What the tab is FOR, and the constraint in the same breath.
                 // It said "Models on the Hugging Face Hub", which was true of a
@@ -1176,8 +1182,8 @@ export default function AiModels() {
                       on every card already answer — what only prose can carry
                       is that deleting one is safe, and that is what is left. */}
                   <p className="am-group-note">
-                    Nobody chose these — a runner fetched them to do its job, and deleting one
-                    only means the next run that needs it fetches it again.
+                    Automatically downloaded by a runner. If deleted, it will be downloaded
+                    again on next run.
                   </p>
                   <div className="cc-mdgrid am-grid">{grouped.components.repos.map(card)}</div>
                 </section>

--- a/frontend/src/shell/AiModelsDiscover.tsx
+++ b/frontend/src/shell/AiModelsDiscover.tsx
@@ -799,24 +799,6 @@ export default function AiModelsDiscover({
           </>
         ) : (
           <>
-            {/* Why these particular eleven, under the heading that named them.
-                The heading says WHICH grid this is; this says what "suggested"
-                was decided by, because "a handful somebody picked for this
-                machine" and "everything you can install" are very different
-                answers to the question the reader arrived with. It also names
-                the way out, since the control that answers "and if I want
-                something else?" is the box at the top of the tab.
-
-                It renders with the sections and never over the results grid
-                (`showsPreamble`, pinned in discoverView.test.ts): a line reading
-                "picked to run on this machine" standing over a page of Hub
-                search results describes cards that are not there. */}
-            {chrome.showsPreamble && catalog !== null && catalog.length > 0 && (
-              <p className="am-group-note am-suggested-lede">
-                Picked to run on this machine with the engines you have. Search above for
-                anything else on Hugging Face.
-              </p>
-            )}
             {catalog === null && <p className="cc-empty">Reading the model catalog…</p>}
             {catalog !== null && <Suggested catalog={suggested} downloads={downloads} />}
           </>

--- a/frontend/src/shell/aiModelGroups.test.ts
+++ b/frontend/src/shell/aiModelGroups.test.ts
@@ -204,10 +204,10 @@ describe("why Load is refused", () => {
   // The refusal has to agree with the heading the card is sitting under. Both
   // repos have `engine: null`, and one sentence for both told the reader that
   // the Wespeaker orphan had a format problem somebody had diagnosed — under a
-  // heading saying nothing here recognises it at all.
+  // heading saying its model type is not supported at all.
   it("does not blame the format for a repo it cannot identify at all", () => {
     const why = loadRefusal(WESPEAKER) ?? "";
-    expect(why).toContain("Nothing here recognises");
+    expect(why).toContain("not supported");
     expect(why).not.toContain("format");
   });
 
@@ -258,7 +258,7 @@ describe("the three surfaces on a no-engine card agree", () => {
   it("blames the format only where a format is the obstacle", () => {
     expect(noEngineReason(QWEN_NO_ENGINE)).toContain("weight format");
     expect(noEngineReason(WESPEAKER)).not.toContain("format");
-    expect(noEngineReason(WESPEAKER)).toContain("Nothing here recognises");
+    expect(noEngineReason(WESPEAKER)).toContain("not supported");
   });
 
   // Not a paraphrase of the hover: the same string, so the two cannot drift.
@@ -270,16 +270,13 @@ describe("the three surfaces on a no-engine card agree", () => {
 
   it("says what the Unrecognised heading over the card says", () => {
     const note = groupRepos([WESPEAKER]).models.groups[0].note ?? "";
-    for (const phrase of ["not a model this app can load", "part of one"]) {
-      expect(note).toContain(phrase);
-      expect(noEngineReason(WESPEAKER)).toContain(phrase);
-    }
+    expect(note).toBe(noEngineReason(WESPEAKER));
   });
 
   // A repo with a capability keeps its format problem, which is a real
   // diagnosis with a real fix: another engine, or another copy of the weights.
   // Flattening both cards onto one sentence would lose it.
-  it("does not tell a Qwen checkpoint that nothing recognises it", () => {
-    expect(noEngineReason(QWEN_NO_ENGINE)).not.toContain("Nothing here recognises");
+  it("does not tell a Qwen checkpoint that its model type is not supported", () => {
+    expect(noEngineReason(QWEN_NO_ENGINE)).not.toContain("not supported");
   });
 });

--- a/frontend/src/shell/aiModelGroups.ts
+++ b/frontend/src/shell/aiModelGroups.ts
@@ -60,12 +60,9 @@ export interface GroupedRepos {
  *  no engine, no owner. Without a group of its own it renders as `no engine`,
  *  which is the SAME tag a 4.6GB model the user deliberately downloaded wears,
  *  and there was no vocabulary anywhere on the page for "we do not know what
- *  this is". The copy has to say both halves, because either alone is the wrong
- *  reading: not a model this app can load, and not part of one either.
+ *  this is".
  */
-const UNRECOGNISED_NOTE =
-  "Nothing here recognises these — not a model this app can load, and not a " +
-  "part of one. Safe to delete.";
+const UNRECOGNISED_NOTE = "Cannot be loaded into Fused Render because the model type is not supported.";
 
 function totalSize(repos: AiModelRepo[]): number {
   return repos.reduce((bytes, repo) => bytes + repo.size, 0);
@@ -150,10 +147,7 @@ export function noEngineReason(repo: AiModelRepo): string {
   if (repo.capability === null) {
     // Agrees with the Unrecognised heading above the card, which is the only
     // other place on the page that has an opinion about this repo.
-    return (
-      "Nothing here recognises this repo — not a model this app can load, " +
-      "and not part of one."
-    );
+    return UNRECOGNISED_NOTE;
   }
   return (
     "No local engine reads this repo's weight format. The formats are not " +

--- a/frontend/src/shell/discoverView.test.ts
+++ b/frontend/src/shell/discoverView.test.ts
@@ -1,16 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { discoverChrome, gateChrome, localCopy, resultsSummary, suggestedSummary } from "./discoverView";
 
-// What the Discover tab is SHOWING, from the settled query alone. Three pieces
-// of chrome that must move together — the grid, the "these are suggestions"
-// preamble, and the "searching huggingface.co" caption — because every way
-// they can disagree is a page making a false claim about itself.
+// What the Discover tab is SHOWING, from the settled query alone. Two pieces
+// of chrome that must move together — the grid and the "searching
+// huggingface.co" caption — because every way they can disagree is a page
+// making a false claim about itself.
 describe("discoverChrome", () => {
   it("shows the curated shortlist when nothing has been asked for", () => {
     expect(discoverChrome("", "")).toEqual({
       view: "suggested",
       heading: "Suggested models",
-      showsPreamble: true,
       showsSearchNote: false,
       showsReset: false,
     });
@@ -20,7 +19,6 @@ describe("discoverChrome", () => {
     expect(discoverChrome("whisper", "")).toEqual({
       view: "results",
       heading: "Search results",
-      showsPreamble: false,
       showsSearchNote: true,
       showsReset: true,
     });
@@ -62,7 +60,6 @@ describe("discoverChrome", () => {
     expect(discoverChrome("", "")).toEqual({
       view: "suggested",
       heading: "Suggested models",
-      showsPreamble: true,
       showsSearchNote: false,
       showsReset: false,
     });
@@ -227,30 +224,11 @@ describe("heading summaries", () => {
     expect(discoverChrome("", "automatic-speech-recognition").view).toBe("results");
   });
 
-  it("takes the preamble away with the shortlist it describes", () => {
-    // The bug this rule exists to prevent: "Suggested models — picked to run
-    // on this machine" left standing over a grid of search results, which is a
-    // sentence describing cards that are no longer on screen.
-    for (const [q, task] of [["qwen", ""], ["", "text-to-image"], ["qwen", "text-to-image"]]) {
-      const chrome = discoverChrome(q, task);
-      expect(chrome.showsPreamble).toBe(false);
-      expect(chrome.view).toBe("results");
-    }
-  });
-
-  it("never shows the preamble and the search caption at once", () => {
-    // They describe two different pages. Whichever is true, the other is not.
-    for (const [q, task] of [["", ""], ["a", ""], ["", "t"], ["a", "t"]]) {
-      const chrome = discoverChrome(q, task);
-      expect(chrome.showsPreamble && chrome.showsSearchNote).toBe(false);
-    }
-  });
-
   it("is not fooled by whitespace", () => {
     // A box holding a space is a box nobody has typed a query into. Without
     // this, a stray keystroke swaps the shortlist out for "nothing matches
     // that", which reads as the app having lost its own catalog.
     expect(discoverChrome("   ", "").view).toBe("suggested");
-    expect(discoverChrome(" \t ", " ").showsPreamble).toBe(true);
+    expect(discoverChrome(" \t ", " ").view).toBe("suggested");
   });
 });

--- a/frontend/src/shell/discoverView.ts
+++ b/frontend/src/shell/discoverView.ts
@@ -1,14 +1,12 @@
 // What the Discover tab is showing, decided in one place.
 //
 // The tab has two mutually exclusive faces — a curated shortlist and a grid of
-// Hub search results — and five pieces of chrome that have to agree about
-// which one is on screen: the grid itself, the heading that NAMES it, the note
-// under that heading, the "searching huggingface.co" caption that discloses the
-// outbound request, and the control that goes BACK. Written inline they were
-// separate `&&`s over the same two strings, which is one chance per condition
-// to leave one behind: a preamble reading "picked to run on this machine"
-// standing over a grid of search results is the page describing cards that are
-// not there any more, and a missing way back is a page with no exit.
+// Hub search results — and four pieces of chrome that have to agree about
+// which one is on screen: the grid itself, the heading that NAMES it, the
+// "searching huggingface.co" caption that discloses the outbound request, and
+// the control that goes BACK. Written inline they were separate `&&`s over the
+// same two strings, which is one chance per condition to leave one behind: a
+// missing way back is a page with no exit.
 //
 // The heading is the newest of the four and the one the others hang off. The
 // faces used to differ only by whether a paragraph of prose was present, which
@@ -38,9 +36,6 @@ export interface DiscoverChrome {
    *  in the same slot with the same treatment, and this field is why exactly
    *  one of them can exist: they are one string, not two `&&`s. */
   heading: string;
-  /** The line that says the sections below are a curated pick rather than
-   *  everything installable. Only over the sections it describes. */
-  showsPreamble: boolean;
   /** The disclosure that this is the one place in the app asking a third party
    *  a question. Only while there is a question. */
   showsSearchNote: boolean;
@@ -76,9 +71,6 @@ export function discoverChrome(q: string, task: string): DiscoverChrome {
   return {
     view: asked ? "results" : "suggested",
     heading: asked ? "Search results" : "Suggested models",
-    // The two captions are exclusive by construction rather than by two
-    // conditions that happen to be opposites today.
-    showsPreamble: !asked,
     showsSearchNote: asked,
     // Asked a question, so there is a way back from the answer. Never in the
     // curated state, where the control would undo nothing and a permanent

--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -321,15 +321,18 @@
 }
 
 /* "Explore" is the local door — the model card view — and it wears .cc-iconbtn
-   like the ✕ beside it, so the card's actions read as one row of controls
-   rather than a word and some buttons. Still an <a>, because it navigates and
-   middle-click and copy-link have to keep working; this only restores the
-   dimensions and the hover the class expects on a <button>. */
+   like the ✕ beside it, so the card's actions read as one row of controls at
+   the same visual weight rather than a word and some buttons. Still an <a>,
+   because it navigates and middle-click and copy-link have to keep working;
+   this only restores the dimensions and the hover the class expects on a
+   <button>. No `color` override: `.cc-iconbtn` already sets the muted resting
+   colour, and an anchor here previously overrode it to `inherit`, which picked
+   up the card's full-brightness text instead — this Explore icon read heavier
+   than Delete right beside it, though both wear the same class. */
 .am-card-explore {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: inherit;
   text-decoration: none;
 }
 
@@ -711,10 +714,9 @@
   outline-offset: -1px;
 }
 
-/* The host disclosure, under the "Search results" heading — the same slot
-   .am-suggested-lede occupies under the other one, so the two faces of the tab
-   are heading, note, grid in that order either way. It rides .am-group-note's
-   spacing (the `:has` rule above binds it to its heading) and adds nothing. */
+/* The host disclosure, under the "Search results" heading. It rides
+   .am-group-note's spacing (the `:has` rule above binds it to its heading) and
+   adds nothing. */
 .am-hub-note {
   margin: 0 0 var(--am-gap-head);
 }
@@ -899,13 +901,19 @@
 /* Load / Unload. A word, not an icon: this is the one control on the page that
    spends MEMORY rather than disk, and an unlabelled glyph for "put 8GB of
    weights in RAM" is a guess the user should not have to make. Always visible
-   for the same reason. */
+   for the same reason.
+
+   Full `--fg`, not muted: it is the one action on the card worth spending
+   memory on, and it sat at the same dimness as the quiet icon row beside it
+   — Explore, the chevron, Delete — with nothing to tell an eye that this one
+   is the primary action rather than a fourth quiet control. `:disabled`'s
+   opacity still dims it for a refused or busy card. */
 .am-card-power {
   flex: 0 0 auto;
   padding: 3px 9px;
   font: inherit;
   font-size: 12px;
-  color: var(--fg-muted);
+  color: var(--fg);
   background: transparent;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -913,8 +921,9 @@
   white-space: nowrap;
 }
 
+/* Only the background moves: the text is already `--fg` at rest, so repeating
+   that here would be a no-op dressed up as a hover rule. */
 .am-card-power:hover:not(:disabled) {
-  color: var(--fg);
   background: var(--bg-alt);
 }
 
@@ -927,8 +936,9 @@
   cursor: not-allowed;
 }
 
+/* Only the border changes here now — `color: var(--fg)` used to be this rule's
+   own job, back when the resting state below it was muted. */
 .am-card-power-on {
-  color: var(--fg);
   border-color: var(--accent);
 }
 
@@ -1017,19 +1027,6 @@
    — the 62ch override that used to be here made these the narrowest prose on
    the page, and they are the longest sentences on it, and the -2px nudge that
    was here is now the `:has` rule's job for every note on both tabs. */
-
-/* Why these particular models, under the SUGGESTED MODELS heading and above
-   the first capability heading. Rides .am-group-note — it is the same kind of
-   sentence as the notes under the headings below it, and giving it its own size
-   or colour would make the tab's opening line look like a banner. The extra
-   bottom margin is the only difference: it is introducing a run of sections
-   rather than captioning the one grid under it. Its opposite number is
-   .am-hub-note, which sits in the same place under the other heading and keeps
-   the smaller gap because it captions ONE grid rather than introducing a run of
-   capabilities. */
-.am-suggested-lede {
-  margin-bottom: var(--am-gap-section);
-}
 
 .am-suggest-note {
   margin-top: 6px;


### PR DESCRIPTION
This PR refines the AI Models interface by removing redundant UI elements and improving visual hierarchy through better color and spacing choices.

## Summary
The changes simplify the Discover tab by removing the "preamble" explanation text and improve the visual prominence of primary actions on model cards through color adjustments. Several messaging updates also clarify the purpose of UI elements.

## Key Changes

- **Removed preamble from Discover tab**: Eliminated the "Picked to run on this machine" explanatory text that appeared above the suggested models grid. The heading and search functionality now sufficiently communicate the tab's purpose without the extra prose.

- **Improved Load/Unload button prominence**: Changed the button color from muted (`--fg-muted`) to full foreground (`--fg`) to make it visually distinct as the primary action on model cards, while secondary actions (Explore, Delete, chevron) remain at muted weight.

- **Fixed Explore icon color**: Removed the `color: inherit` override that was causing the Explore link to appear heavier than the Delete button despite both using the same `.cc-iconbtn` class. Now both icons render at the same visual weight.

- **Simplified hover states**: Removed redundant color changes from `.am-card-power:hover` and `.am-card-power-on` since the text is now already at full brightness at rest.

- **Removed `.am-suggested-lede` class**: Deleted the unused CSS class that was styling the preamble text.

- **Updated messaging**: 
  - Changed "Nothing here recognises" language to "model type is not supported" for clarity
  - Simplified the cached models explanation from "Nobody chose these..." to "Automatically downloaded by a runner..."

- **Fixed monospace font application**: The `.cc-mono` class now only applies to the cache path in the Local tab, not to all tab captions, preventing plain-text sentences from appearing as filesystem facts.

- **Updated tests**: Removed test cases validating the preamble behavior and updated assertions to match the new messaging.

## Implementation Details

The visual hierarchy improvements use existing CSS variables (`--fg`, `--fg-muted`, `--accent`) to create clear distinction between primary actions (Load/Unload) and secondary controls (Explore, Delete). The removal of the preamble simplifies the Discover tab's information architecture while maintaining clarity through the heading and search UI.

https://claude.ai/code/session_01276q6syFH4VhzHoR8KxGCi

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy, CSS, and Discover chrome only—no API or load/delete behavior changes; tests were updated for the new strings and removed preamble.
> 
> **Overview**
> **Discover tab** drops the curated shortlist preamble (“Picked to run on this machine…”) and the `showsPreamble` flag from `discoverChrome` / `AiModelsDiscover`, so the section heading and search UI carry the story without extra prose. Related tests and `.am-suggested-lede` CSS are removed.
> 
> **Local tab copy** rewrites the “Unrecognised” group note and `noEngineReason` for repos with no capability to **“model type is not supported”** (shared via `UNRECOGNISED_NOTE` so group note, tag hover, and Load refusal stay aligned). The “Fetched by engines” blurb is shortened to runner auto-download / re-fetch on delete.
> 
> **Page chrome** applies `.cc-mono` only on the Local tab when showing the cache path, not on Discover/Engines captions.
> 
> **Visual hierarchy on cards**: Load/Unload uses full `--fg` at rest; Explore drops `color: inherit` so it matches other `.cc-iconbtn` controls; hover rules for `.am-card-power` are trimmed accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1a299e2062d50d0fd724ceaca37032b43528890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->