### PR TITLE
Comment out CSS width rule explanation in ai-models.css

### DIFF
--- a/frontend/src/styles/ai-models.css
+++ b/frontend/src/styles/ai-models.css
@@ -72,7 +72,7 @@
    its own chevron, its own metrics — which is what makes this control look
    like every other select in the app instead of like the platform's. What is
    left here is only how it behaves in this row. */
-   `width: 100%` fills the grid's control column, which is what makes all three
+/* `width: 100%` fills the grid's control column, which is what makes all three
    selects the same width no matter which option is showing — a select left to
    size itself grows to "MLX Whisper (Apple Silicon) — needs Apple Silicon…"
    the moment somebody picks it, and the column would move under the user's


### PR DESCRIPTION
## Summary
Updated a CSS comment in the ai-models stylesheet to properly comment out an explanatory line that was previously uncommented.

## Changes
- Commented out the line explaining the `width: 100%` CSS rule in the `.ai-model-select` control styling
- This preserves the existing comment block structure while ensuring the explanation line is treated as a comment rather than active documentation

## Details
The change affects a multi-line comment block that documents the behavior of the select control's width property. By adding `/*` at the beginning of the line, the entire explanation about how `width: 100%` fills the grid's control column is now properly enclosed within the comment block, maintaining consistency with the surrounding documentation style.

https://claude.ai/code/session_01XvTFNTGhQwmjiFjd6iEY9Y

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no impact on compiled CSS or runtime behavior.
> 
> **Overview**
> Fixes a **comment formatting** issue in `ai-models.css` above `.am-engine-select`: the line documenting why `width: 100%` is used was left as plain text after the opening `/*` block, so it could be parsed incorrectly. That line is now opened with `/*` so the full explanation sits inside the comment.
> 
> **No stylesheet behavior changes** — `.am-engine-select` still uses `width: 100%` and `min-width: 0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99206434c2ea7a959d0f59465fb5e5076498a87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->