### PR TITLE
Pin encoding to utf-8 in all subprocess text mode calls

### DIFF
--- a/core_apps/learn/check_env.py
+++ b/core_apps/learn/check_env.py
@@ -37,6 +37,8 @@ def main():
                     text=True,
                     env=env,
                     timeout=8,
+                    encoding="utf-8",
+                    errors="replace",
                 )
                 for line in out.stdout.splitlines():
                     cand = line.strip()
@@ -63,6 +65,8 @@ def main():
                 text=True,
                 env=env,
                 timeout=8,
+                encoding="utf-8",
+                errors="replace",
             )
             prefix = npm.stdout.strip().splitlines()
             if prefix:
@@ -83,6 +87,8 @@ def main():
                 text=True,
                 env=clean_env(),
                 timeout=5,
+                encoding="utf-8",
+                errors="replace",
             )
             v = (out.stdout or out.stderr or "").strip()
             return v or None

--- a/core_apps/sessions/sessions/suggest_name.py
+++ b/core_apps/sessions/sessions/suggest_name.py
@@ -163,8 +163,10 @@ def main(session: str = "", instruction: str = "") -> dict:
                 capture_output=True,
                 text=True,
                 # fused-render's executor kills the whole child at 30s — finish
-            # (or fail cleanly) inside that budget instead of being killed
-            timeout=25,
+                # (or fail cleanly) inside that budget instead of being killed
+                timeout=25,
+                encoding="utf-8",
+                errors="replace",
             )
         except (OSError, subprocess.TimeoutExpired) as e:
             return {"ok": False, "error": str(e)}

--- a/fused_render/_env_install_worker.py
+++ b/fused_render/_env_install_worker.py
@@ -213,6 +213,7 @@ def _acquire_python(version):
     # otherwise pop a fresh one for a console-subsystem child like uv.exe.
     proc = subprocess.run([uv, "python", "install", version], env=_uv_env(),
                           capture_output=True, text=True, close_fds=False,
+                          encoding="utf-8", errors="replace",
                           creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
     if proc.returncode != 0:
         # Verbatim, exactly like the requirements install below: uv's own text names
@@ -339,6 +340,7 @@ def _build(project_dir, venv_dir, uv_cache_dir, python_executable):
     # every other spawn in this codebase follows; see `_acquire_python` above.
     proc = subprocess.run(cmd, cwd=project_dir, env=env,
                           capture_output=True, text=True, close_fds=False,
+                          encoding="utf-8", errors="replace",
                           creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0)
     if proc.returncode != 0:
         # Verbatim: uv's own text names the real problem (no wheel for this

--- a/fused_render/account.py
+++ b/fused_render/account.py
@@ -193,6 +193,8 @@ def _start_login(cli, return_url: str | None) -> _ActiveLogin:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         env=env,
     )
     login = _ActiveLogin(proc=proc)
@@ -374,6 +376,8 @@ def _run_env_cmd(args: list[str]) -> JSONResponse | None:
             [*cli.command, "env", *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=ENV_CMD_TIMEOUT,
             env=child_env(cli),
         )
@@ -406,6 +410,8 @@ def _probe_orgs(cli) -> dict:
             [*cli.command, "cloud", "orgs"],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=ORGS_TIMEOUT,
             env=child_env(cli),
         )
@@ -617,6 +623,8 @@ def api_account_setup(body: dict = Body(...), x_fused: str | None = Header(defau
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 env=child,
             )
         except OSError as e:
@@ -714,7 +722,8 @@ def api_account_logout(
         args += ["--env", env_name]
     try:
         proc = subprocess.run(
-            args, capture_output=True, text=True, timeout=LOGOUT_TIMEOUT, env=child_env(cli)
+            args, capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=LOGOUT_TIMEOUT, env=child_env(cli)
         )
     except subprocess.TimeoutExpired:
         return _error(f"`fused cloud logout` timed out after {int(LOGOUT_TIMEOUT)}s")

--- a/fused_render/app_git.py
+++ b/fused_render/app_git.py
@@ -99,6 +99,7 @@ def _git(app_dir: str, *args: str) -> subprocess.CompletedProcess:
     return subprocess.run(
         [_git_bin(), "-C", app_dir, *_IDENTITY, *args],
         capture_output=True, text=True, timeout=_GIT_TIMEOUT,
+        encoding="utf-8", errors="replace",
         close_fds=False,
         creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
     )

--- a/fused_render/canvases.py
+++ b/fused_render/canvases.py
@@ -166,6 +166,8 @@ def _run_cli(args: list[str], timeout: float) -> tuple[subprocess.CompletedProce
             [*cli.command, *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=_cli_env(cli),
         )
@@ -363,6 +365,8 @@ def api_canvases_token(x_fused: str | None = Header(default=None)):
                 [sys.executable, shim],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=TOKEN_TIMEOUT,
                 env=_cli_env(cli),
             )
@@ -656,6 +660,8 @@ class _SyncManager:
                 [*cli.command, "workbench", "canvas", "push", self.dir, "--canvas", self.name],
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=PUSH_TIMEOUT,
                 env=_cli_env(cli),
             )
@@ -705,6 +711,7 @@ class _SyncManager:
             probe = subprocess.run(
                 [*cli.command, *base, "--dry-run"],
                 capture_output=True, text=True, timeout=PULL_TIMEOUT,
+                encoding="utf-8", errors="replace",
                 env=_cli_env(cli),
             )
         except (subprocess.TimeoutExpired, OSError):
@@ -721,6 +728,7 @@ class _SyncManager:
             applied = subprocess.run(
                 [*cli.command, *base, "--force"],
                 capture_output=True, text=True, timeout=PULL_TIMEOUT,
+                encoding="utf-8", errors="replace",
                 env=_cli_env(cli),
             )
         except (subprocess.TimeoutExpired, OSError):
@@ -735,6 +743,7 @@ class _SyncManager:
             recheck = subprocess.run(
                 [*cli.command, *base, "--dry-run"],
                 capture_output=True, text=True, timeout=PULL_TIMEOUT,
+                encoding="utf-8", errors="replace",
                 env=_cli_env(cli),
             )
         except (subprocess.TimeoutExpired, OSError):

--- a/fused_render/claude_spawn.py
+++ b/fused_render/claude_spawn.py
@@ -132,13 +132,23 @@ def spawn_helper(target: str, prompt: str, permission_mode: str,
 
     The prompt never enters argv (`input=`, and `message_via_stdin` on the far
     side): this runs inside the server process, whose argv every local user can
-    read with `ps`."""
+    read with `ps`.
+
+    text=True alone decodes stdout/stderr with locale.getpreferredencoding(False),
+    which is ASCII on a GUI-launched server with no LANG/LC_ALL — see
+    claude_config/lib.py's SUBPROCESS_KWARGS for the fuller writeup of this same
+    bug. The helper's JSON result routinely carries non-ASCII bytes (the prompt
+    echoed back, a scaffolded app's name/title, model output), so without
+    encoding="utf-8" the first em dash or curly quote raises UnicodeDecodeError
+    here and the whole app-creation call reports "failed to start Claude
+    session" instead of the real result."""
     proc = subprocess.run(
         [sys.executable, "-c", SESSION_HELPER],
         input=json.dumps(
             {"agent": agent_path(), "file": target, "message": prompt,
              "session_id": session_id, "permission_mode": permission_mode}),
-        capture_output=True, text=True, timeout=60, close_fds=False,
+        capture_output=True, text=True, encoding="utf-8", errors="replace",
+        timeout=60, close_fds=False,
     )
     if proc.returncode != 0:
         stderr = (proc.stderr or "").strip()

--- a/fused_render/community.py
+++ b/fused_render/community.py
@@ -148,6 +148,7 @@ def _git(cwd, *args, timeout=GIT_TIMEOUT):
         return subprocess.run(
             [_git_bin(), "-C", cwd, *IDENTITY, *args],
             capture_output=True, text=True, timeout=timeout, env=env,
+            encoding="utf-8", errors="replace",
             close_fds=False,
             creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
         )

--- a/fused_render/deeplink.py
+++ b/fused_render/deeplink.py
@@ -256,6 +256,8 @@ def _git(args: list[str], timeout: int = 300) -> str:
             stderr=subprocess.PIPE,
             timeout=timeout,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             env=_git_env(),
         )
     except FileNotFoundError:

--- a/fused_render/deploy.py
+++ b/fused_render/deploy.py
@@ -228,6 +228,8 @@ def install_fused() -> dict:
             [sys.executable, "-m", "pip", "install", requirement],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=INSTALL_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
@@ -284,6 +286,8 @@ def _run_share(env_name: str, args: list[str], timeout: float = SHARE_TIMEOUT):
             [*cli.command, "share", *args],
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=_child_env(cli, env_name),
         )

--- a/fused_render/engine.py
+++ b/fused_render/engine.py
@@ -237,6 +237,7 @@ def _probe(exe: str) -> tuple[dict | None, str, bool]:
         proc = subprocess.run(
             [exe, "-c", _PROBE],
             capture_output=True, text=True, timeout=_PROBE_TIMEOUT_S, env=_child_env(),
+            encoding="utf-8", errors="replace",
             close_fds=False,
         )
     except (FileNotFoundError, PermissionError, NotADirectoryError) as e:
@@ -490,6 +491,7 @@ def _probe_app_packages(exe: str) -> dict | None:
         proc = subprocess.run(
             [exe, "-c", _APP_PACKAGES_PROBE],
             capture_output=True, text=True, timeout=_PROBE_TIMEOUT_S, env=_child_env(),
+            encoding="utf-8", errors="replace",
             close_fds=False,
         )
     except (OSError, subprocess.SubprocessError) as e:

--- a/fused_render/envinstall.py
+++ b/fused_render/envinstall.py
@@ -321,6 +321,7 @@ def _probe_python(path: str) -> bool:
         proc = subprocess.run(
             [path, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
             capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
             # close_fds=False for posix_spawn instead of fork()+exec, the discipline
             # `venvs.py` documents at module level: this server has almost certainly
             # touched pyproj/rasterio, and a forked child runs PROJ's atfork handler,
@@ -401,6 +402,7 @@ def _resolve_script_python() -> tuple[str | None, bool]:
             [uv, "python", "find", "--managed-python", "--no-project", "--system",
              SCRIPT_PYTHON_VERSION],
             capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
             timeout=_SCRIPT_PYTHON_TIMEOUT_S, close_fds=False,
         )
     except (OSError, subprocess.SubprocessError):
@@ -544,6 +546,7 @@ def _venv_runs(venv_dir: str) -> bool | None:
         proc = subprocess.run(
             [exe, "-c", ""],
             capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
             timeout=_VENV_PROBE_TIMEOUT_S, env=_child_env(),
             # close_fds=False for posix_spawn instead of fork()+exec — the same
             # discipline `_probe_python` above already follows, and the site
@@ -1079,6 +1082,7 @@ def _pid_alive(pid: int) -> bool:
         out = subprocess.run(
             ["tasklist", "/FI", f"PID eq {pid}", "/NH"],
             capture_output=True, text=True,
+            encoding="utf-8", errors="replace",
         )
         return str(pid) in (out.stdout or "")
     # Reap it first if WE spawned it. `start_new_session=True` does not reparent

--- a/fused_render/executor.py
+++ b/fused_render/executor.py
@@ -344,6 +344,8 @@ def _run_python(path: str, params: dict, timeout: float) -> dict:
             input=request,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             # The child inherits os.environ untouched: no `env=` and, in
             # particular, no PYTHONPATH injection. This used to append THIS

--- a/fused_render/shell/mounts/credentials.py
+++ b/fused_render/shell/mounts/credentials.py
@@ -111,7 +111,8 @@ def _rclone_config_dump(bin_: str) -> dict:
     _remote_label just degrades to bare names rather than raising."""
     try:
         out = subprocess.run(
-            [bin_, "config", "dump"], capture_output=True, text=True, timeout=10
+            [bin_, "config", "dump"], capture_output=True, text=True, timeout=10,
+            encoding="utf-8", errors="replace"
         ).stdout
         cfg = json.loads(out) if out.strip() else {}
         return cfg if isinstance(cfg, dict) else {}
@@ -231,10 +232,12 @@ def _rclone_state() -> dict:
     if bin_:
         try:
             version = subprocess.run(
-                [bin_, "version"], capture_output=True, text=True, timeout=10
+                [bin_, "version"], capture_output=True, text=True, timeout=10,
+                encoding="utf-8", errors="replace"
             ).stdout.splitlines()[0]
             remotes_out = subprocess.run(
-                [bin_, "listremotes"], capture_output=True, text=True, timeout=10
+                [bin_, "listremotes"], capture_output=True, text=True, timeout=10,
+                encoding="utf-8", errors="replace"
             ).stdout
             names = [r.strip() for r in remotes_out.splitlines() if r.strip()]
             return _rclone_state_view(version, names, bin_)
@@ -494,7 +497,8 @@ def _credential_probe(bin_: str, name: str) -> str:
             [bin_, "lsd", f"{name}:", "--max-depth", "1",
              "--contimeout", "5s", "--timeout", "10s",
              "--retries", "1", "--low-level-retries", "2"],
-            capture_output=True, text=True, timeout=30)
+            capture_output=True, text=True, timeout=30,
+            encoding="utf-8", errors="replace")
     except (OSError, subprocess.TimeoutExpired):
         return "inconclusive"
     if r.returncode == 0:

--- a/fused_render/shell/mounts/endpoints.py
+++ b/fused_render/shell/mounts/endpoints.py
@@ -498,6 +498,7 @@ def _spawn_authorize(bin_: str, backend: str,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         text=True,
+        encoding="utf-8", errors="replace",
         env={**os.environ, **(env_extra or {})},
     )
 
@@ -947,7 +948,8 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
     for k, v in sugg["params"].items():
         cmd += [k, v]
     try:
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=30,
+                           encoding="utf-8", errors="replace")
     except subprocess.TimeoutExpired:
         return JSONResponse({"error": "rclone config create timed out (30s)"}, status_code=502)
     if r.returncode != 0:
@@ -964,7 +966,8 @@ def create_detected_remote(body: dict = Body(...), x_fused: str | None = Header(
             # the next detect and re-invite the doomed mount.
             try:
                 d = subprocess.run([bin_, "config", "delete", name],
-                                   capture_output=True, text=True, timeout=30)
+                                   capture_output=True, text=True, timeout=30,
+                                   encoding="utf-8", errors="replace")
                 removed = d.returncode == 0
             except (OSError, subprocess.TimeoutExpired):
                 removed = False

--- a/fused_render/shell/mounts/lifecycle.py
+++ b/fused_render/shell/mounts/lifecycle.py
@@ -502,7 +502,8 @@ def _force_unmount(mp: str) -> str | None:
     last = ""
     for cmd in attempts:
         try:
-            r = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=15,
+                               encoding="utf-8", errors="replace")
             last = (r.stderr or r.stdout or "").strip()
         except (OSError, subprocess.TimeoutExpired) as e:
             last = str(e)

--- a/fused_render/shell/mounts/rcd.py
+++ b/fused_render/shell/mounts/rcd.py
@@ -208,6 +208,7 @@ def _pid_looks_like_rcd(pid: int) -> bool:
         out = subprocess.run(
             ["ps", "-o", "command=", "-p", str(pid)],
             capture_output=True, text=True, timeout=_PS_TIMEOUT_S,
+            encoding="utf-8", errors="replace",
         ).stdout.lower()
     except (OSError, subprocess.SubprocessError):
         return False

--- a/fused_render/supervisor/_linux/ui.py
+++ b/fused_render/supervisor/_linux/ui.py
@@ -35,7 +35,8 @@ def _dialog_tool() -> str:
 
 def _run(argv: list[str]) -> "subprocess.CompletedProcess | None":
     try:
-        return subprocess.run(argv, capture_output=True, text=True, timeout=_DIALOG_TIMEOUT_S)
+        return subprocess.run(argv, capture_output=True, text=True, encoding="utf-8",
+                              errors="replace", timeout=_DIALOG_TIMEOUT_S)
     except (OSError, subprocess.TimeoutExpired):
         return None
 

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -1707,7 +1707,8 @@ def _commit_turn(file: str, message: str) -> None:
         return subprocess.run(
             [shutil.which("git") or "git", "-C", app_dir, "-c", "user.name=Fused",
              "-c", "user.email=apps@fused.io", *args],
-            capture_output=True, text=True, timeout=30, close_fds=False)
+            capture_output=True, text=True, timeout=30, close_fds=False,
+            encoding="utf-8", errors="replace")
 
     try:
         # Legacy defense (D83-reversal, D205): sidecars now live under

--- a/fused_render/templates/geotiff/_tiff_core.py
+++ b/fused_render/templates/geotiff/_tiff_core.py
@@ -512,7 +512,8 @@ def _read_system(params):
     here = (os.path.dirname(os.path.abspath(__file__)) if "__file__" in globals()
             else os.path.abspath(sys.path[0]))  # runner exec()s without __file__
     r = subprocess.run([py, "-c", _WORKER, here], input=json.dumps(params),
-                       capture_output=True, text=True, timeout=120, env=env)
+                       capture_output=True, text=True, timeout=120, env=env,
+                       encoding="utf-8", errors="replace")
     if r.returncode != 0:
         return {"error": f"system engine failed: {r.stderr[-500:]}"}
     return json.loads(r.stdout.strip().splitlines()[-1])

--- a/fused_render/templates/geotiff/tiff_reader.py
+++ b/fused_render/templates/geotiff/tiff_reader.py
@@ -242,7 +242,8 @@ def _decode_system(file, frac, max_cells):
     env = {k: v for k, v in os.environ.items() if not k.startswith("PYTHON")}
     r = subprocess.run([py, "-c", _SYS_WORKER],
                        input=json.dumps({"file": file, "frac": frac, "max_cells": max_cells}),
-                       capture_output=True, text=True, timeout=120, env=env)
+                       capture_output=True, text=True, timeout=120, env=env,
+                       encoding="utf-8", errors="replace")
     if r.returncode != 0:
         raise T.Unsupported(f"system engine failed: {r.stderr[-400:]}")
     d = json.loads(r.stdout.strip().splitlines()[-1])

--- a/fused_render/templates/las/las_reader.py
+++ b/fused_render/templates/las/las_reader.py
@@ -137,7 +137,8 @@ def main(file: str = "", max_points: int = 400000):
             return {"error": f"venv setup failed: {e}"}
         env = {k: v for k, v in os.environ.items() if k not in ("PYTHONHOME", "PYTHONPATH")}
         r = subprocess.run([py, "-c", WORKER, file, npz, str(max_points)],
-                           capture_output=True, text=True, env=env, timeout=600)
+                           capture_output=True, text=True, env=env, timeout=600,
+                           encoding="utf-8", errors="replace")
         if r.returncode != 0:
             return {"error": f"could not read point cloud: {r.stderr.strip()[-800:]}"}
 

--- a/fused_render/templates/latex/engine.py
+++ b/fused_render/templates/latex/engine.py
@@ -268,7 +268,8 @@ def _pandoc_convert(src, to, out, extra):
         args = json.dumps({"src": src, "to": to, "out": out, "extra": extra})
         p = subprocess.run([vpy, "-c", code, args], capture_output=True, text=True,
                            env=_clean_env(),
-                           creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0)
+                           creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+                           encoding="utf-8", errors="replace")
         if p.returncode != 0 or not os.path.exists(out):
             detail = (p.stderr or p.stdout or "").strip().splitlines()
             raise RuntimeError(detail[-1] if detail else "pandoc conversion failed")
@@ -437,7 +438,8 @@ def _run_tectonic(cmd, env, cwd, hard_timeout: int = 28):
     .stdout/.stderr carry the run's output for the usual diagnostics parsing."""
     p = subprocess.Popen(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env,
-        cwd=cwd, creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0)
+        cwd=cwd, creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+        encoding="utf-8", errors="replace")
     out_chunks, err_chunks = [], []
 
     def _drain(stream, sink):

--- a/fused_render/templates/latex/install_worker.py
+++ b/fused_render/templates/latex/install_worker.py
@@ -75,7 +75,8 @@ def _warm_base(cache_dir, warm_dir, tectonic_bin):
         subprocess.run(
             [tectonic_bin, "-X", "compile", "--keep-logs", "--outdir", scratch, doc],
             env=env, cwd=scratch, capture_output=True, text=True, timeout=WARM_TIMEOUT_S,
-            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0)
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+            encoding="utf-8", errors="replace")
     except subprocess.TimeoutExpired:
         _warm_progress(warm_dir, "error", "package fetch timed out", done=True,
                        error="Preparing the LaTeX packages took too long — check your "

--- a/fused_render/templates/latex/warm_worker.py
+++ b/fused_render/templates/latex/warm_worker.py
@@ -50,7 +50,8 @@ def warm(bin_path, cache_dir, warm_dir, main_path, build_dir):
              "--outdir", build_dir, main_path],
             env=env, cwd=os.path.dirname(main_path), capture_output=True, text=True,
             timeout=WARM_TIMEOUT_S,
-            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0)
+            creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+            encoding="utf-8", errors="replace")
         # A .log means Tectonic fetched what it needed and started typesetting, so
         # the cache is warm even if the doc then failed — mark it and let the page's
         # recompile surface the real diagnostics. Only a run that wrote no log

--- a/fused_render/templates/netcdf/_zarr_core.py
+++ b/fused_render/templates/netcdf/_zarr_core.py
@@ -719,7 +719,8 @@ def _read_system(store, var, index, bins, max_cells):
             else os.path.abspath(sys.path[0]))  # runner exec()s without __file__
     params = {"store": store, "var": var, "index": index, "bins": bins, "max_cells": max_cells}
     r = subprocess.run([py, "-c", _WORKER, here], input=json.dumps(params),
-                       capture_output=True, text=True, timeout=120, env=env)
+                       capture_output=True, text=True, timeout=120, env=env,
+                       encoding="utf-8", errors="replace")
     if r.returncode != 0:
         return {"error": f"system engine failed: {r.stderr[-500:]}"}
     return json.loads(r.stdout.strip().splitlines()[-1])

--- a/fused_render/templates/netcdf/grid_tile_server.py
+++ b/fused_render/templates/netcdf/grid_tile_server.py
@@ -413,7 +413,8 @@ print(json.dumps({"npz": tmp.name + ".npz" if not tmp.name.endswith(".npz") else
         # host override intact.
         env.setdefault("HDF5_USE_FILE_LOCKING", "FALSE")
         r = subprocess.run([py, "-c", code], input=json.dumps(params),
-                           capture_output=True, text=True, timeout=180, env=env)
+                           capture_output=True, text=True, timeout=180, env=env,
+                           encoding="utf-8", errors="replace")
         if r.returncode != 0:
             raise RuntimeError(f"system engine failed: {r.stderr[-400:]}")
         d = json.loads(r.stdout.strip().splitlines()[-1])

--- a/fused_render/templates/pyramid/overview_pyramid.py
+++ b/fused_render/templates/pyramid/overview_pyramid.py
@@ -731,7 +731,8 @@ def main(file: str = "", action: str = "analyze", resampling: str = "",
         # path is gone. The worker is short-lived and needs no inherited fds.
         proc = subprocess.run([vpy, wpath, file, action, json.dumps(opts)],
                               capture_output=True, text=True, timeout=900,
-                              env=env, close_fds=False)
+                              env=env, close_fds=False,
+                              encoding="utf-8", errors="replace")
         if proc.returncode != 0:
             tail = (proc.stderr or "").strip().splitlines()
             return {"error": "worker failed: " + (tail[-1] if tail else "unknown error")}

--- a/fused_render/update/mac.py
+++ b/fused_render/update/mac.py
@@ -90,7 +90,8 @@ def detect_method(bundle: str | None, *, brew: str | None = None,
         return "dmg"
     try:
         listed = run([brew, "list", "--cask", CASK_NAME],
-                     capture_output=True, text=True, timeout=30)
+                     capture_output=True, text=True, encoding="utf-8", errors="replace",
+                     timeout=30)
     except (OSError, subprocess.TimeoutExpired):
         return "dmg"
     if listed.returncode != 0:

--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -535,6 +535,12 @@ def test_spawn_runs_agent_start_in_a_helper_subprocess_not_in_process(
     assert seen["kwargs"]["close_fds"] is False
     assert "cwd" not in seen["kwargs"]
     assert "start_new_session" not in seen["kwargs"]
+    # text=True alone decodes stdout/stderr with locale.getpreferredencoding —
+    # ASCII on a GUI-launched server with no LANG/LC_ALL — so the first em dash
+    # or curly quote in the helper's JSON result (echoed prompt, app name/title,
+    # model output) raised UnicodeDecodeError instead of returning a run_id.
+    assert seen["kwargs"]["encoding"] == "utf-8"
+    assert seen["kwargs"]["errors"] == "replace"
     assert started_threads  # the sidecar-recording poll thread was kicked off
 
 

--- a/tests/test_subprocess_encoding.py
+++ b/tests/test_subprocess_encoding.py
@@ -1,0 +1,91 @@
+"""Every `subprocess.run`/`Popen`/`check_output`/`check_call` call in the
+shipped source tree that asks for text mode must pin an encoding.
+
+`text=True` (or `universal_newlines=True`) with no `encoding=` decodes the
+child's stdout/stderr with `locale.getpreferredencoding(False)`. A
+GUI-launched fused-render process inherits no LANG/LC_ALL, which resolves
+that to ASCII — so the first non-ASCII byte a child prints (an em dash, a
+curly quote, a unicode file path, a git commit message, an rclone remote
+name) raises UnicodeDecodeError and kills whatever feature made the call.
+This exact bug shipped once already: `claude_spawn.spawn_helper` crashed
+app-creation this way (see its own comment for the full incident writeup).
+`claude_config/lib.py`'s `SUBPROCESS_KWARGS` fixed every call in that one
+package and was pinned by an equivalent AST check scoped to it — this test
+is the same check widened to the whole shipped tree, since the bug turned
+out to recur in about thirty other files the narrower guard never saw.
+
+AST-based, not grep-based: this file's own docstring and every fix's commit
+message say "text=True" in prose, and a regex would flag itself.
+"""
+import ast
+import os
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Every one of these is shipped/executed source: the main package, its
+# templates (child processes that can't import fused_render at all, D166,
+# so they pin the kwargs inline rather than sharing a constant), and the
+# core_apps that ship as builtin html+py apps. Dev-only tooling (scripts/,
+# prototypes/) is deliberately excluded — it runs from a developer's own
+# terminal, which has a real LANG, not the GUI-launched server this bug
+# needs.
+ROOTS = ["fused_render", "core_apps"]
+SKIP_DIRS = {"__pycache__", "node_modules", "vendor", "shell-dist"}
+
+# Documented exceptions, `<relpath>: <reason>`. Keep this EMPTY if you
+# possibly can.
+ALLOWED = {}
+
+
+def _py_files():
+    for root in ROOTS:
+        base = os.path.join(REPO_ROOT, root)
+        for dirpath, dirnames, filenames in os.walk(base):
+            dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+            for name in sorted(filenames):
+                if name.endswith(".py"):
+                    path = os.path.join(dirpath, name)
+                    yield os.path.relpath(path, REPO_ROOT)
+
+
+def _bare_text_calls(relpath):
+    """(lineno, func name) for every subprocess spawn in `relpath` that asks
+    for text mode but neither pins an encoding nor spreads kwargs (a spread
+    like `**SUBPROCESS_KWARGS` cannot be inspected here, so it is trusted —
+    exactly as the claude_config-scoped version of this check already does)."""
+    with open(os.path.join(REPO_ROOT, relpath), encoding="utf-8") as f:
+        src = f.read()
+    out = []
+    for node in ast.walk(ast.parse(src, filename=relpath)):
+        if not isinstance(node, ast.Call):
+            continue
+        fn = node.func
+        if not (isinstance(fn, ast.Attribute)
+                and fn.attr in ("run", "Popen", "check_output", "check_call")
+                and isinstance(fn.value, ast.Name) and fn.value.id == "subprocess"):
+            continue
+        keywords = node.keywords
+        has_text = any(kw.arg in ("text", "universal_newlines")
+                       and isinstance(kw.value, ast.Constant) and kw.value.value is True
+                       for kw in keywords)
+        if not has_text:
+            continue
+        has_spread = any(kw.arg is None for kw in keywords)
+        has_encoding = any(kw.arg == "encoding" for kw in keywords)
+        if not has_spread and not has_encoding:
+            out.append((node.lineno, fn.attr))
+    return out
+
+
+def test_every_subprocess_text_call_pins_an_encoding():
+    violations = []
+    checked = 0
+    for relpath in _py_files():
+        if relpath in ALLOWED:
+            continue
+        for lineno, func in _bare_text_calls(relpath):
+            violations.append(f"{relpath}:{lineno} subprocess.{func}(text=True, ...) with no encoding=")
+        checked += 1
+    assert violations == []
+    # A guard that silently walked zero files would pass forever.
+    assert checked > 200


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where subprocess calls using `text=True` without an explicit `encoding=` parameter could fail with `UnicodeDecodeError` on GUI-launched servers that inherit no LANG/LC_ALL environment variables (defaulting to ASCII encoding).

## Changes

- **Added AST-based test** (`tests/test_subprocess_encoding.py`): A new test that scans the entire shipped source tree (`fused_render/` and `core_apps/`) to ensure every `subprocess.run()`, `Popen()`, `check_output()`, and `check_call()` call that uses `text=True` or `universal_newlines=True` also explicitly pins `encoding="utf-8"` (unless using kwargs spreading like `**SUBPROCESS_KWARGS`).

- **Fixed 30+ subprocess calls** across the codebase by adding `encoding="utf-8", errors="replace"` to all text-mode subprocess calls in:
  - `fused_render/claude_spawn.py` - Claude session helper
  - `fused_render/account.py` - Account login and CLI operations
  - `fused_render/canvases.py` - Canvas operations
  - `fused_render/shell/mounts/credentials.py` - rclone credential handling
  - `fused_render/shell/mounts/endpoints.py` - Mount endpoint operations
  - `fused_render/deploy.py` - Package installation
  - `fused_render/envinstall.py` - Python environment probing
  - `fused_render/executor.py` - Python execution
  - `fused_render/deeplink.py` - Git operations
  - `fused_render/engine.py` - Engine probing
  - `fused_render/app_git.py` - App git operations
  - `fused_render/community.py` - Community git operations
  - `fused_render/templates/` - Various template workers (LaTeX, NetCDF, GeoTIFF, LAS, Pyramid)
  - `fused_render/supervisor/_linux/ui.py` - Dialog operations
  - `fused_render/update/mac.py` - macOS update detection
  - `core_apps/learn/check_env.py` - Environment checking
  - `core_apps/sessions/sessions/suggest_name.py` - Session naming

- **Updated test assertion** (`tests/test_apps_api.py`): Added explicit assertions verifying that the Claude spawn helper call includes `encoding="utf-8"` and `errors="replace"`.

## Implementation Details

- The `errors="replace"` parameter is used alongside `encoding="utf-8"` to gracefully handle any unexpected non-UTF-8 bytes by replacing them with the Unicode replacement character, preventing crashes while preserving output for diagnostics.

- The test uses AST parsing rather than regex to avoid false positives from docstrings and comments mentioning "text=True".

- The test trusts kwargs spreading (e.g., `**SUBPROCESS_KWARGS`) since it cannot be inspected statically, matching the existing pattern in `claude_config/lib.py`.

- Dev-only tooling in `scripts/` and `prototypes/` is deliberately excluded since those run from developer terminals with proper LANG settings.

This fixes the root cause of the bug that previously crashed app-creation when the Claude spawn helper encountered non-ASCII characters in JSON output.

https://claude.ai/code/session_01TWtCTLUPt2s1wLgnMWJPuD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical decode-default change with `errors="replace"`; broad touch surface but same pattern already used in `claude_config/lib.py`, guarded by a new AST test.
> 
> **Overview**
> **Fixes `UnicodeDecodeError` when capturing subprocess stdout/stderr on GUI-launched servers** where `text=True` without `encoding=` decodes using locale (often ASCII with no `LANG`/`LC_ALL`). That already broke app creation via `claude_spawn.spawn_helper` when JSON contained smart quotes or similar.
> 
> The PR **adds `encoding="utf-8", errors="replace"`** to every `subprocess.run` / `Popen` text capture in **`fused_render/`**, **`core_apps/`**, and template workers (CLI login, git, uv installs, rclone, deploy, executor, geospatial/LaTeX helpers, etc.). **`claude_spawn.py`** documents the same issue inline.
> 
> **Regression guard:** new **`tests/test_subprocess_encoding.py`** walks shipped Python with AST and fails if any `text=True` subprocess call lacks an explicit `encoding=` (kwargs spreads like `**SUBPROCESS_KWARGS` are trusted). **`test_apps_api.py`** asserts the spawn helper passes the UTF-8 kwargs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c799cb1a8af17e0bcbaf4aa709459e905e061ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->