### PR TITLE
Make home section titles clickable

### DIFF
--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -60,7 +60,14 @@ function useStripCount() {
 }
 
 // Section chrome: title row with the "See all" action on the right edge.
-// An <a> so cmd/ctrl-click opens the full page in a new tab like any link.
+// Both title and "See all" are <a>s so cmd/ctrl-click opens the full page in
+// a new tab like any link.
+function softNavigate(e: React.MouseEvent, href: string) {
+  if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+  e.preventDefault();
+  navigateUrl(href);
+}
+
 function Section({
   title,
   seeAllHref,
@@ -73,17 +80,12 @@ function Section({
   return (
     <section className="fh-section home-section">
       <div className="home-sec-head">
-        <h2 className="home-sec-title">{title}</h2>
-        <a
-          className="home-sec-more"
-          href={seeAllHref}
-          onClick={(e) => {
-            if (e.defaultPrevented || e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey)
-              return;
-            e.preventDefault();
-            navigateUrl(seeAllHref);
-          }}
-        >
+        <h2 className="home-sec-title">
+          <a className="home-sec-title-link" href={seeAllHref} onClick={(e) => softNavigate(e, seeAllHref)}>
+            {title}
+          </a>
+        </h2>
+        <a className="home-sec-more" href={seeAllHref} onClick={(e) => softNavigate(e, seeAllHref)}>
           See all
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
             <path d="M9 6l6 6-6 6" />

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -302,7 +302,7 @@
 }
 
 .home-sec-title-link:hover {
-  text-decoration: underline;
+  color: var(--accent);
 }
 
 .home-sec-more {

--- a/frontend/src/styles/preferences.css
+++ b/frontend/src/styles/preferences.css
@@ -296,6 +296,15 @@
   font-weight: 700;
 }
 
+.home-sec-title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.home-sec-title-link:hover {
+  text-decoration: underline;
+}
+
 .home-sec-more {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
Home page section labels ("Fused Apps", "Recents", etc.) are now links to the same page as the "See all" action on their right. Same soft-navigation behavior (cmd/ctrl-click opens a new tab); title keeps its heading look with underline on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell UI change on the home page only; no auth, data, or routing contract changes beyond reusing existing `seeAllHref` values.
> 
> **Overview**
> **Home section titles** (e.g. Fused Apps, Claude Sessions) now navigate to the same destinations as the adjacent **See all** control.
> 
> Navigation is factored into a shared `softNavigate` helper used by both links: normal clicks use in-app routing via `navigateUrl`, while modified clicks (cmd/ctrl/shift/alt or non-primary button) keep default browser behavior so links open in a new tab.
> 
> Titles are wrapped in `<a class="home-sec-title-link">` inside the existing `h2`, with styles that preserve the heading look (inherited color, no underline) and switch to the accent color on hover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44360a640ae7f948f3011c1c39421c6850e51249. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->