### PR TITLE
Tasks: fresh form every open, Save explains itself, stable task id across edits

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -2526,6 +2526,16 @@ export function scheduleMessage(body: {
   // Only meaningful alongside `rule` or `repeats`; a one-off has no runs to
   // split apart.
   new_task_each_run?: boolean;
+  // The id of the entry this one REPLACES — set only by an edit, which is
+  // cancel + re-create and therefore mints a brand new entry id. A task that has
+  // not run yet is NUMBERED on that entry id (`pending:<entry-id>`), so without
+  // this the server allocated a second number and the task was renamed under the
+  // user: TASK-078 became TASK-079 on a time change, with no duplicate left
+  // behind to explain it. Sent so the number MOVES onto the new id instead.
+  //
+  // A no-op where there is nothing to move — a task whose session exists is
+  // numbered on the session id, and that key is untouched by an edit.
+  replaces?: string;
 }): Promise<{ entry: ScheduledMessage }> {
   return postJson<{ entry: ScheduledMessage }>("/api/schedule", body);
 }

--- a/frontend/src/platform/ui/modal/Modal.tsx
+++ b/frontend/src/platform/ui/modal/Modal.tsx
@@ -5,8 +5,10 @@
 //     `initialFocus` (or the first focusable), on unmount restore the element
 //     that was focused when the modal opened.
 //   • Esc / backdrop / ✕ close, gated by `busy`; ✕ disabled while busy.
-//   • optional `dirty` guard: the first close attempt shows an inline
-//     "close again to discard" hint and only the second (within ~2s) closes.
+//   • optional `dirty` guard: the first close attempt arms the ✕ and shows an
+//     inline "close again to discard" hint; only the second (within ~2s) closes.
+//     BOTH halves matter — the hint says it in words, the button says it where
+//     the press happened. See the ✕ below.
 // Chrome reuses the existing .deploy-* CSS (the body carries both `modal-body`
 // and `deploy-body` so descendant skins that key off .deploy-body keep working,
 // e.g. RowEditorModal).
@@ -215,11 +217,27 @@ export function Modal({
       >
         <div className="modal-head deploy-head">
           <h2 id={titleId}>{title}</h2>
+          {/* ARMED, ON THE BUTTON ITSELF. The footer hint below says the same
+              thing, and on its own it was not enough: the press happens at the
+              top-right corner of the card and the hint appears at the bottom-left
+              of the footer — 12px, muted, up to 500px away, and gone again in two
+              seconds. A user watching their own cursor saw a click that did
+              nothing (QA, 2026-08-18).
+
+              So the control that was pressed changes too. Same two-step guard,
+              same 2s window, same second press to discard — this only makes the
+              first press visible where the user is already looking. `is-armed`
+              is the vocabulary the New task card's Delete button already uses for
+              exactly this "the next press does it" state. */}
           <button
             type="button"
-            className="modal-close deploy-close"
-            aria-label="Close"
-            title={closeTitle ?? "Close"}
+            className={"modal-close deploy-close" + (confirmClose ? " is-armed" : "")}
+            // The label carries the state for a screen reader, which has no
+            // corner to look at. The footer hint is `role="status"` and is
+            // announced too; this is what the button itself answers to when the
+            // user tabs back to it.
+            aria-label={confirmClose ? "Close and discard changes" : "Close"}
+            title={confirmClose ? "Press again to discard" : (closeTitle ?? "Close")}
             disabled={busy}
             onClick={attemptClose}
           >

--- a/frontend/src/platform/ui/modal/modal-dirty-guard.test.ts
+++ b/frontend/src/platform/ui/modal/modal-dirty-guard.test.ts
@@ -1,0 +1,71 @@
+// The dirty guard's VISIBLE half (Modal.tsx).
+//
+// The guard itself — first close attempt arms, a second within ~2s discards —
+// has been there since the chassis was written. What was missing is that the
+// first press LOOKED like nothing happened: the only feedback was a 12px muted
+// line in the footer, at the opposite corner from the ✕ the user had just
+// clicked, gone again after two seconds. A tester pressed it and reported a
+// dead click (QA, 2026-08-18).
+//
+// So the armed state is now on the button too, and these tests hold the three
+// pieces together — the markup that sets the class, the stylesheet that gives it
+// a look, and the wording. There is no DOM renderer in this suite (nothing here
+// mounts React), so this reads the source, which is the same thing
+// `new-task-form.test.ts` does for the `ready` expression.
+import { beforeAll, describe, expect, test } from "bun:test";
+
+let modal: string;
+let css: string;
+
+beforeAll(async () => {
+  modal = await Bun.file(new URL("./Modal.tsx", import.meta.url).pathname).text();
+  css = await Bun.file(
+    new URL("../../../styles/buttons-modal.css", import.meta.url).pathname,
+  ).text();
+});
+
+describe("the armed ✕", () => {
+  test("the close button carries the armed class while the guard is up", () => {
+    // The class is conditional on `confirmClose` — the same state the footer
+    // hint already keys off, so the two halves cannot disagree about whether the
+    // guard is up.
+    expect(modal).toContain('(confirmClose ? " is-armed" : "")');
+  });
+
+  test("…and the stylesheet actually gives that class a look", () => {
+    // The half a typo would silently eat: a class nothing styles is exactly the
+    // dead click this fixes. Pinned to the selector, and to the fact that it
+    // repeats itself for :hover — without that, moving the mouse cools the
+    // button back down while the guard is still live.
+    expect(css).toContain(".deploy-close.is-armed");
+    expect(css).toContain(".deploy-close.is-armed:hover:not(:disabled)");
+  });
+
+  test("it says what the next press will do, in the tooltip and to a screen reader", () => {
+    // A screen reader has no corner to look at, so the accessible name carries
+    // the state rather than only the colour doing it.
+    expect(modal).toContain('"Press again to discard"');
+    expect(modal).toContain('"Close and discard changes"');
+    // …and it goes back to being an ordinary Close when the window lapses, with
+    // the caller's own `closeTitle` still honoured on that side.
+    expect(modal).toContain("(closeTitle ?? \"Close\")");
+  });
+
+  test("the footer hint stays — the button is an addition, not a replacement", () => {
+    // Two channels on purpose: the button says WHERE, the hint says WHAT. The
+    // hint is also `role="status"`, which is what announces the change at the
+    // moment it happens.
+    expect(modal).toContain("modal-dirty-hint");
+    expect(modal).toContain("Unsaved changes — close again to discard");
+    expect(modal).toContain('role="status"');
+  });
+
+  test("the two-step guard and its 2s window are unchanged", () => {
+    // This pass is about visibility only. A first press on a dirty form still
+    // arms rather than closes, and the arming still lapses after 2s so a form
+    // left alone does not stay one stray click from being discarded.
+    expect(modal).toContain("if (dirty && !confirmClose)");
+    expect(modal).toContain("setConfirmClose(true)");
+    expect(modal).toContain("setConfirmClose(false), 2000");
+  });
+});

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1472,6 +1472,13 @@ export function buildSchedulePayload(form: {
   // instead of the default, which is every run landing in this task's own
   // thread (design §6).
   newTaskEachRun: boolean;
+  // The id of the entry being EDITED, and "" for a new task. An edit is cancel
+  // + re-create, so the entry the user is looking at is about to stop existing
+  // and a new one with a new id take its place — and a task that has not run yet
+  // is NUMBERED on that entry id. Carrying it lets the server move the number
+  // across rather than allocate a second one, which is what renamed TASK-078 to
+  // TASK-079 when only its time had changed.
+  replacesEntryId?: string;
 }): SchedulePayload {
   const repeating = form.rule !== null || form.repeat === "cron";
   const trimmedTitle = form.title.trim();
@@ -1523,6 +1530,10 @@ export function buildSchedulePayload(form: {
     // Only ever sent on a repeating task: on a one-off there is no "each run"
     // for it to mean anything about.
     ...(repeating && form.newTaskEachRun ? { new_task_each_run: true } : {}),
+    // Only on an edit, and only as a non-empty string: a new task replaces
+    // nothing, and the key is left off the wire rather than sent as "" for the
+    // same reason `title` is.
+    ...(form.replacesEntryId ? { replaces: form.replacesEntryId } : {}),
   };
 }
 
@@ -2206,6 +2217,9 @@ export default function NewJobModal({
           sessionId: (!learnedSession && editing?.session_id) || chatSessionId || "",
           learnedSessionId: learnedSession,
           newTaskEachRun,
+          // The task's NUMBER has to survive the re-create an edit is; see
+          // `replacesEntryId`. Empty on a new task, which replaces nothing.
+          replacesEntryId: editing?.id ?? "",
         }),
       );
       rememberRecent(target);

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1540,9 +1540,9 @@ export function buildSchedulePayload(form: {
 // after the message it is scheduling.
 //
 // Both use `.trim()`, because a textarea full of newlines is not an instruction
-// and a title of spaces is not a name. Save is `disabled` on a false — nothing
-// here is a submit handler that could be reached another way — and both fields
-// carry `aria-required` so the disabled button is not the only hint.
+// and a title of spaces is not a name. Both fields carry `aria-required`, and
+// pressing Save while one is empty SAYS SO — see `saveBlockedReason`, which is
+// the same set of rules read out loud.
 export function saveEnabled(f: {
   // The ask / description. Required.
   message: string;
@@ -1572,6 +1572,59 @@ export function saveEnabled(f: {
     (f.repeatOn && f.repeat === "custom" ? f.customRule !== null : true) &&
     (f.repeat === "cron" ? f.legacyCron !== "" : f.pickedOk)
   );
+}
+
+// WHICH FIELD, and where the caret should go. The other half of `saveEnabled`:
+// the same rules, in the same order, said as a sentence a person can act on.
+//
+// Save used to be `disabled` on a false `saveEnabled`, and that is a dead
+// control, not a hint. The commonest way to meet it is the commonest thing to
+// forget — open the form, type a name, press Save — and a disabled button
+// answers by doing NOTHING: no error, no focus move, the modal just sits there
+// (QA, 2026-08-18). The requirement itself is right and stays: an empty
+// description is a task with nothing to do, and the server refuses it too
+// (`schedule.create`: "message: cannot be empty"). What was wrong was refusing
+// it in silence.
+//
+// So Save stays pressable and this is what a press finds. `field` is the ref key
+// to focus, because a sentence naming a field the user then has to hunt for is
+// half an answer — `null` for the reasons that are not a field (an already-saved
+// edit, an unreachable path).
+//
+// ORDER IS THE READING ORDER OF THE CARD: title, description, folder, time,
+// repeat. One reason at a time, the topmost — a form that lists everything wrong
+// at once reads as a scolding, and fixing the first often fixes the rest.
+export function saveBlockedReason(f: Parameters<typeof saveEnabled>[0]): {
+  text: string;
+  field: "title" | "message" | "target" | null;
+} | null {
+  if (f.replaced) {
+    return {
+      text: "This task is already saved — close the card and edit it again to change it.",
+      field: null,
+    };
+  }
+  if (f.title.trim() === "") {
+    return { text: "Give the task a name, so you can find it in the list.", field: "title" };
+  }
+  if (f.message.trim() === "") {
+    return { text: "Say what Claude should do — a task with no instructions has nothing to run.", field: "message" };
+  }
+  if (f.target.trim() === "") {
+    return { text: "Pick the folder or file this task runs against.", field: "target" };
+  }
+  // The path check has already written its own sentence into the field; naming
+  // it again in the banner would say the same thing twice.
+  if (f.pathError !== null) {
+    return { text: f.pathError, field: "target" };
+  }
+  if (f.repeatOn && f.repeat === "custom" && f.customRule === null) {
+    return { text: "Finish the custom repeat, or pick one of the presets.", field: null };
+  }
+  if (f.repeat === "cron" ? f.legacyCron === "" : !f.pickedOk) {
+    return { text: "Pick a date and a time for the first run.", field: null };
+  }
+  return null;
 }
 
 export default function NewJobModal({
@@ -1842,6 +1895,11 @@ export default function NewJobModal({
   // measure. Measured on every change because "auto then scrollHeight" is the
   // one reflow-safe way to shrink back when lines are deleted.
   const askRef = useRef<HTMLTextAreaElement>(null);
+  // Title is the third field a refused Save can send the caret to (see
+  // trySubmit); the ask has `askRef` above and the path already has `pathRef`.
+  // Refs rather than a querySelector, because the card is a portal and there can
+  // be a second one mid-exit-animation when a deep link swaps the entry.
+  const titleRef = useRef<HTMLInputElement>(null);
   const pathRef = useRef<HTMLInputElement>(null);
   // Escape-from-a-row hands focus back to the field WITHOUT reopening the
   // list it just dismissed — the input's onFocus otherwise undoes the close
@@ -2200,7 +2258,7 @@ export default function NewJobModal({
   const pastNote = pastNoteFor(pickedOk ? picked : null, repeatOn, rule, new Date());
 
   // See saveEnabled: both prose fields are required now, Title included.
-  const ready = saveEnabled({
+  const gate = {
     message,
     title,
     target,
@@ -2211,7 +2269,27 @@ export default function NewJobModal({
     legacyCron,
     pickedOk,
     replaced,
-  });
+  };
+  const ready = saveEnabled(gate);
+
+  // What a press does when the form is not ready. Save is NOT disabled on that
+  // any more — see saveBlockedReason for why a dead button was the wrong answer
+  // — so this is the press's whole job: say the first thing that is missing and
+  // put the caret in it. `setError` is the banner the submit failures already
+  // use, so there is one place on the card that says why nothing happened.
+  const trySubmit = () => {
+    const blocked = saveBlockedReason(gate);
+    if (!blocked) {
+      submit();
+      return;
+    }
+    setError(blocked.text);
+    const el = blocked.field === "title" ? titleRef.current
+      : blocked.field === "message" ? askRef.current
+        : blocked.field === "target" ? pathRef.current
+          : null;
+    el?.focus();
+  };
 
   return (
     <Modal
@@ -2251,8 +2329,20 @@ export default function NewJobModal({
               {backConfirm ? "Discard changes?" : "Back to chat"}
             </button>
           )}
+          {/* NOT disabled on `!ready`. A dead button is not a hint: the
+              commonest way to reach it is the commonest thing to forget (type a
+              name, press Save, leave the description empty) and the answer was
+              nothing at all — no message, no focus move, the card just sat there
+              (QA, 2026-08-18). The rules are unchanged; a press on a form that
+              cannot be saved now SAYS which field is missing and puts the caret
+              in it. See trySubmit / saveBlockedReason.
+
+              `aria-disabled` rather than `disabled` so the state is still
+              announced, while the button stays focusable and pressable — which
+              is the whole point. Only `busy` truly disables it: a second press
+              mid-save would schedule the message twice. */}
           <button type="button" className="btn btn-primary schedule-save"
-                  disabled={busy || !ready} onClick={submit}>
+                  disabled={busy} aria-disabled={!ready} onClick={trySubmit}>
             {busy ? "Saving…" : "Save"}
           </button>
         </>
@@ -2296,6 +2386,7 @@ export default function NewJobModal({
             when it does not — see `.new-task-title` in new-task.css. */}
         <div className="new-task-write">
           <input
+            ref={titleRef}
             type="text"
             className="new-task-field new-task-title"
             aria-label="Title"

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -121,6 +121,33 @@ export default function Scheduled() {
   // OCCURRENCE means editing its rule: the template is what gets edited, and
   // the resolver below is what makes a click on any run land there.
   const [editing, setEditing] = useState<ScheduledMessage | null>(null);
+  // WHICH OPENING THIS IS. Bumped every time the form is opened, and part of the
+  // modal's `key` below, so no two openings can ever share a React identity.
+  //
+  // The form reads `editing` in `useState` initialisers — they run ONCE, on
+  // mount — so an opening that reuses the previous one's mount inherits every
+  // value the user left behind. The key was `editing ? "edit:<id>" : "new"`,
+  // which is not an identity but a MODE: two different new-task openings, and
+  // two clicks on two different calendar slots, are the same string. That is how
+  // a fresh card came up with Repeat ticked on "Weekly on Monday, 5 times" and a
+  // date in three weeks — settings from a form the user had opened earlier and
+  // never chosen here (QA, 2026-08-18). A stale recurrence is not a cosmetic
+  // slip: pressing Save on it schedules a repeating task nobody asked for.
+  //
+  // A counter rather than more fields in the key, because the bug is not about
+  // WHAT the openings differ in — it is that "this is a new opening" was never
+  // stated at all, and any key built out of the form's inputs collides again the
+  // moment two openings happen to share them.
+  const [openSeq, setOpenSeq] = useState(0);
+  // The single door into the form, so "clean slate" is one rule in one place: a
+  // new opening is a new mount, and opening a NEW task drops whatever was being
+  // edited (leaving it set kept the card in Edit mode under a "+ New task"
+  // press).
+  const openForm = (at: Date | "blank" | null, entry: ScheduledMessage | null) => {
+    setOpenSeq((n) => n + 1);
+    setEditing(entry);
+    setCreating(at);
+  };
   // What a deep link named (see the effect below); all null for every other
   // way of opening the form.
   const [newTarget, setNewTarget] = useState<string | null>(null);
@@ -165,7 +192,7 @@ export default function Scheduled() {
     setNewMessage(q.get("message"));
     setNewSession(q.get("session_id"));
     setNewBack(q.get("back"));
-    setCreating(new Date(Date.now() + NEW_LINK_LEAD_MS));
+    openForm(new Date(Date.now() + NEW_LINK_LEAD_MS), null);
     q.delete("new");
     q.delete("target");
     q.delete("message");
@@ -249,8 +276,7 @@ export default function Scheduled() {
     const template = entry.template_id
       ? entries.find((e) => e.id === entry.template_id)
       : null;
-    setEditing(template ?? entry);
-    setCreating(null);
+    openForm(null, template ?? entry);
   };
 
   // Resolve `?edit=<entry id>` once the schedule has actually arrived. The chat
@@ -272,8 +298,7 @@ export default function Scheduled() {
       ? all.find((e) => e.id === entry.template_id)
       : null;
     if (entry) {
-      setEditing(template ?? entry);
-      setCreating(null);
+      openForm(null, template ?? entry);
     }
     setEditId(null);
   }, [editId, state]);
@@ -336,7 +361,7 @@ export default function Scheduled() {
               />
             )}
             <button type="button" className="btn btn-primary schedule-new"
-                    onClick={() => setCreating("blank")}>
+                    onClick={() => openForm("blank", null)}>
               + New task
             </button>
           </div>
@@ -360,7 +385,7 @@ export default function Scheduled() {
               queued={queued}
               running={running}
               onReload={reload}
-              onCreateAt={(t) => setCreating(t)}
+              onCreateAt={(t) => openForm(t, null)}
               onEditEntry={editEntry}
             />
           ) : view === "board" ? (
@@ -386,14 +411,23 @@ export default function Scheduled() {
 
       {(creating !== null || editing) && state && (
         <NewJobModal
-          // Keyed on WHAT is being edited, because the form reads `editing` in
-          // `useState` initialisers — they run once, on mount. The `?edit=<id>`
-          // deep link cannot avoid arriving in two steps: it opens the modal
-          // immediately and can only resolve the entry once the schedule fetch
-          // answers, so without a key the card mounted on `editing = null` and
-          // then sat there with both fields blank under an "Edit task" heading.
-          // Changing the key remounts it on the entry it is actually for.
-          key={editing ? `edit:${editing.id}` : "new"}
+          // Keyed on WHICH OPENING this is, and on what is being edited, because
+          // the form reads `editing` in `useState` initialisers — they run once,
+          // on mount.
+          //
+          // The entry half is what the `?edit=<id>` deep link needs: it cannot
+          // avoid arriving in two steps — it opens the modal immediately and can
+          // only resolve the entry once the schedule fetch answers — so without
+          // it the card mounted on `editing = null` and then sat there with both
+          // fields blank under an "Edit task" heading.
+          //
+          // `openSeq` is the other half and the one that makes this an IDENTITY
+          // rather than a mode: `"new"` was the same string for every new-task
+          // opening and for every calendar slot, so React reused the mount and
+          // the card came up wearing the last form's answers — a Repeat rule the
+          // user never chose, one Save away from a real repeating task. See
+          // `openSeq` above.
+          key={`${editing ? `edit:${editing.id}` : "new"}#${openSeq}`}
           initialTime={creating instanceof Date ? creating : null}
           initialTarget={newTarget}
           initialMessage={newMessage}

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -33,6 +33,7 @@ let shortTitle: typeof import("./NewJobModal").shortTitle;
 let TITLE_MAX: typeof import("./NewJobModal").TITLE_MAX;
 let deletePress: typeof import("./NewJobModal").deletePress;
 let saveEnabled: typeof import("./NewJobModal").saveEnabled;
+let saveBlockedReason: typeof import("./NewJobModal").saveBlockedReason;
 let TITLE_PLACEHOLDER: typeof import("./NewJobModal").TITLE_PLACEHOLDER;
 let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
@@ -55,6 +56,7 @@ beforeAll(async () => {
   TITLE_MAX = mod.TITLE_MAX;
   deletePress = mod.deletePress;
   saveEnabled = mod.saveEnabled;
+  saveBlockedReason = mod.saveBlockedReason;
   TITLE_PLACEHOLDER = mod.TITLE_PLACEHOLDER;
   pastNoteFor = mod.pastNoteFor;
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
@@ -223,6 +225,7 @@ describe("the payload", () => {
       buildSchedulePayload(form({ sessionId: "abc", rule: DAILY, repeat: "daily" })).session_id,
     ).toBeUndefined();
   });
+
 });
 
 // BOTH prominent fields are required now (Akshil, 2026-08-17): the description
@@ -284,6 +287,86 @@ describe("what Save refuses", () => {
     expect(saveEnabled(gate({ repeat: "cron", legacyCron: "0 9 * * *", pickedOk: false }))).toBe(
       true,
     );
+  });
+
+  // WHY A REFUSAL HAS TO SPEAK. Save used to be `disabled` on a false
+  // `saveEnabled`, and a dead button answers a press with nothing at all — no
+  // message, no caret moved, the card just sitting there. The commonest way to
+  // meet it is the commonest thing to forget: open the form, type a name, press
+  // Save, and the description is still empty (QA, 2026-08-18). The rules did not
+  // change — an empty description is a task with nothing to do, and
+  // `schedule.create` refuses it on the server too — only the silence did.
+  describe("…and how it says so", () => {
+    test("a form that saves has nothing to say", () => {
+      expect(saveBlockedReason(gate())).toBe(null);
+    });
+
+    test("every refusal names a field, and the sentence is a thing to DO", () => {
+      // Each of the two prose fields answers for itself rather than sharing one
+      // "fill in the required fields" — the point is to say WHICH.
+      const noAsk = saveBlockedReason(gate({ message: "" }));
+      expect(noAsk?.field).toBe("message");
+      expect(noAsk?.text).toContain("Say what Claude should do");
+      // Whitespace is refused, and refused with the same sentence: a textarea
+      // full of newlines is not an instruction.
+      expect(saveBlockedReason(gate({ message: "\n\n  \t" }))?.text).toBe(noAsk?.text);
+
+      const noTitle = saveBlockedReason(gate({ title: "   " }));
+      expect(noTitle?.field).toBe("title");
+      expect(noTitle?.text).toContain("name");
+
+      expect(saveBlockedReason(gate({ target: "" }))?.field).toBe("target");
+      // A path that failed its existence check already wrote a sentence for a
+      // human; the banner repeats THAT rather than inventing a second one.
+      expect(saveBlockedReason(gate({ pathError: "This folder or file doesn't exist" })))
+        .toEqual({ text: "This folder or file doesn't exist", field: "target" });
+    });
+
+    test("the reasons that are not a field still say something, and focus nothing", () => {
+      // Nothing to put a caret in: the repeat lives behind a dialog and the
+      // date-time behind two popovers, so the sentence is the whole answer.
+      for (const over of [
+        { repeatOn: true, repeat: "custom", customRule: null },
+        { pickedOk: false },
+        { repeat: "cron", legacyCron: "" },
+        { replaced: true },
+      ]) {
+        const blocked = saveBlockedReason(gate(over));
+        expect(blocked?.field).toBe(null);
+        expect((blocked?.text ?? "").length).toBeGreaterThan(0);
+      }
+    });
+
+    test("it agrees with saveEnabled on every case saveEnabled decides", () => {
+      // The two are ONE rule set with two readers, so they must not drift: a
+      // form saveEnabled refuses has a reason, and one it allows has none. This
+      // is what keeps a new refusal from being added silently to only one of
+      // them.
+      const cases: Partial<Parameters<typeof saveEnabled>[0]>[] = [
+        {}, { message: "" }, { message: "  " }, { title: "" }, { title: "\t" },
+        { target: "" }, { pathError: "no such folder" }, { replaced: true },
+        { pickedOk: false }, { repeatOn: true, repeat: "custom", customRule: null },
+        { repeatOn: true, repeat: "custom", customRule: DAILY },
+        { repeat: "cron", legacyCron: "" },
+        { repeat: "cron", legacyCron: "0 9 * * *", pickedOk: false },
+        { title: "", message: "" },
+      ];
+      for (const over of cases) {
+        expect(saveBlockedReason(gate(over)) === null).toBe(saveEnabled(gate(over)));
+      }
+    });
+
+    test("the topmost problem is the one reported, in the card's reading order", () => {
+      // One reason at a time. A form with everything wrong reads back the FIRST
+      // field on the card, not a list — fixing the top one often fixes the rest,
+      // and a scolding is not a hint.
+      expect(saveBlockedReason(gate({ title: "", message: "", target: "" }))?.field).toBe("title");
+      expect(saveBlockedReason(gate({ message: "", target: "" }))?.field).toBe("message");
+      // Except `replaced`, which outranks everything: the task IS saved, so
+      // naming a missing field would be telling the user to fix a form whose
+      // work is already done.
+      expect(saveBlockedReason(gate({ replaced: true, title: "" }))?.field).toBe(null);
+    });
   });
 });
 

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -226,6 +226,33 @@ describe("the payload", () => {
     ).toBeUndefined();
   });
 
+  // THE TASK NUMBER SURVIVES AN EDIT. Editing is cancel + re-create — there is
+  // no PATCH — so the entry the user was looking at is replaced by one with a
+  // brand new id, and a task that has not run yet is NUMBERED on that id
+  // (`pending:<entry-id>`). Nothing said the two were the same task, so the
+  // server allocated the next number in the project and TASK-078 became TASK-079
+  // on a change of time, with no duplicate row to explain where it went (QA,
+  // 2026-08-18). `replaces` is what says it, and the server moves the number
+  // across instead of minting a second one.
+  test("an edit says which entry it replaces, so the task keeps its number", () => {
+    expect(
+      buildSchedulePayload(form({ replacesEntryId: "20260818-090000-abc123" })).replaces,
+    ).toBe("20260818-090000-abc123");
+    // It rides with everything else, including a repeat — a rule's template is
+    // an entry like any other and is re-created the same way.
+    expect(
+      buildSchedulePayload(
+        form({ replacesEntryId: "e1", rule: DAILY, repeat: "daily" }),
+      ),
+    ).toMatchObject({ replaces: "e1", rule: DAILY });
+  });
+
+  test("…and a NEW task replaces nothing, so the key stays off the wire", () => {
+    // Same discipline as `title`: absent means "there isn't one", and a builder
+    // that sent "" would be naming an entry id that does not exist.
+    expect("replaces" in buildSchedulePayload(form())).toBe(false);
+    expect("replaces" in buildSchedulePayload(form({ replacesEntryId: "" }))).toBe(false);
+  });
 });
 
 // BOTH prominent fields are required now (Akshil, 2026-08-17): the description

--- a/frontend/src/styles/buttons-modal.css
+++ b/frontend/src/styles/buttons-modal.css
@@ -126,3 +126,19 @@
   margin-right: auto;
 }
 
+/* ARMED ✕ — the next press discards. The hint in the footer says it in words;
+   this says it at the corner the user actually pressed, which is the half that
+   was missing (QA, 2026-08-18: the first press "looked like a dead click").
+
+   Reads as WARM rather than destructive: discarding a draft is not deleting a
+   task, and borrowing the Delete button's filled --error treatment would
+   overstate it. The hover rule is repeated for the same reason it is on
+   `.new-task-delete.is-armed` — moving the mouse must not cool the state back
+   down while it is still live. */
+.deploy-close.is-armed,
+.deploy-close.is-armed:hover:not(:disabled) {
+  background: rgba(var(--warning-rgb), 0.16);
+  color: var(--warning);
+  border-radius: 4px;
+}
+

--- a/fused_render/server/routers/schedule.py
+++ b/fused_render/server/routers/schedule.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Body, Header
 
-from fused_render import recur, schedule
+from fused_render import recur, schedule, tasks_store
 from fused_render.server.common import _error, _require_fused
 
 router = APIRouter()
@@ -191,6 +191,36 @@ def api_schedule_create(body: dict = Body(...),
             session_learned=body.get("session_learned"))
     except ValueError as exc:
         return _error(str(exc), status=400)
+
+    # THE TASK NUMBER SURVIVES AN EDIT. Editing a scheduled message is cancel +
+    # re-create — there is no PATCH — so the entry the user was looking at stops
+    # existing and this one, with a brand new id, takes its place. A task that
+    # has not run yet is numbered on that entry id (`pending:<entry-id>`, §5 of
+    # the design), so the listing saw a key it had never seen, allocated the next
+    # number in the project, and the user watched TASK-078 become TASK-079 for a
+    # task whose only change was its time — with no duplicate row to explain it.
+    # `allocate once, never renumber` is the rule that broke.
+    #
+    # `rekey` is the same move a first run already makes when a pending key
+    # becomes a session id, with the same guarantees: it MOVES a number rather
+    # than minting one, refuses to overwrite a number the new key somehow already
+    # has, and never releases one (so the project's high-water mark stands and no
+    # number is ever handed out twice).
+    #
+    # A no-op in every case but the one it is for: an entry with no number (it
+    # ran, so its task is keyed on the session id, which an edit does not touch),
+    # a `replaces` naming nothing, or a caller that is not the edit form.
+    #
+    # Failure here is not the caller's problem — the message IS scheduled, and a
+    # read-only state dir must not turn that into a 500. The row keeps the number
+    # it would have got anyway.
+    replaces = str(body.get("replaces") or "").strip()
+    if replaces:
+        try:
+            tasks_store.rekey(tasks_store.pending_key(replaces),
+                              tasks_store.pending_key(str(entry.get("id") or "")))
+        except OSError:
+            pass
     return {"entry": entry}
 
 

--- a/tests/test_claude_schedule_button.py
+++ b/tests/test_claude_schedule_button.py
@@ -312,7 +312,12 @@ def test_the_link_opens_the_form_immediately(page):
     read as two."""
     effect = page[page.index('q.get("new")'):]
     effect = effect[:effect.index("}, []);")]
-    assert "setCreating(new Date(" in effect
+    # `openForm` rather than `setCreating` since 2026-08-18: every opening of the
+    # form goes through one door, and that door is what bumps the modal's React
+    # key so a fresh card cannot inherit the previous one's answers. The deep link
+    # is an opening like any other, and what this test cares about is unchanged —
+    # it opens on arrival, prefilled, with no button left to press.
+    assert "openForm(new Date(" in effect
     assert "setNewTarget(" in effect
 
 

--- a/tests/test_schedule_api.py
+++ b/tests/test_schedule_api.py
@@ -10,7 +10,7 @@ Nothing here spawns a real claude — no test lets a message come due.
 import pytest
 from fastapi.testclient import TestClient
 
-from fused_render import schedule, schedule_wake
+from fused_render import schedule, schedule_wake, tasks_store
 from fused_render.server import create_app
 from fused_render.shell import mounts as mounts_mod
 
@@ -343,3 +343,77 @@ def test_restore_is_guarded_and_unskips_over_http(client, target):
     again = client.post("/api/schedule/restore", headers=WRITE,
                         json={"id": occurrence["id"]})
     assert again.status_code == 404
+
+
+# ------------------------------------------------ the number an edit must keep
+
+@pytest.fixture()
+def task_state(tmp_path, monkeypatch):
+    """`tasks_store`'s own store, redirected at a tmp dir.
+
+    It is NOT under FUSED_RENDER_HOME: task numbers are deliberately global (a
+    session numbered from a worktree keeps that number on main), so the module
+    resolves STATE_DIR at import and the only way to move it is to patch it.
+    """
+    d = tmp_path / "task-state"
+    d.mkdir()
+    monkeypatch.setattr(tasks_store, "STATE_DIR", str(d))
+    return d
+
+
+def _number_for(entry_id):
+    return tasks_store.task_number(tasks_store.pending_key(entry_id))
+
+
+def test_an_edit_carries_its_task_number_onto_the_entry_that_replaces_it(
+        client, target, task_state):
+    """TASK-078 must not become TASK-079 because the user changed the time.
+
+    Editing a scheduled message is cancel + re-create — there is no PATCH — so
+    the entry stops existing and a new one with a new id takes its place. A task
+    that has not run yet is numbered on that entry id, so the listing saw a key
+    it had never seen and allocated the next number in the project; the user
+    watched the row rename itself, with no duplicate to explain it (QA,
+    2026-08-18). `replaces` is how the form says the two are one task.
+    """
+    first = client.post("/api/schedule", headers=WRITE,
+                        json={"target": str(target), "message": "pull the news",
+                              "due": "2030-01-01T09:00:00Z"}).json()["entry"]
+    # The number the user has seen. Allocated the way the listing allocates it.
+    tasks_store.ensure_ids([(tasks_store.pending_key(first["id"]), str(target), 1.0)])
+    seen = _number_for(first["id"])
+    assert seen == "TASK-001"
+
+    second = client.post("/api/schedule", headers=WRITE,
+                         json={"target": str(target), "message": "pull the news",
+                               "due": "2030-01-02T09:00:00Z",
+                               "replaces": first["id"]}).json()["entry"]
+    assert second["id"] != first["id"]
+    # Moved, not copied and not re-minted: the new entry IS TASK-001 and the old
+    # key no longer answers to anything.
+    assert _number_for(second["id"]) == seen
+    assert _number_for(first["id"]) == ""
+
+    # And the number is not spent twice: the next task in this project gets 002,
+    # not 001 — allocate-once survives the move.
+    third = client.post("/api/schedule", headers=WRITE,
+                        json={"target": str(target), "message": "something else",
+                              "due": "2030-01-03T09:00:00Z"}).json()["entry"]
+    tasks_store.ensure_ids([(tasks_store.pending_key(third["id"]), str(target), 2.0)])
+    assert _number_for(third["id"]) == "TASK-002"
+
+
+def test_replaces_is_a_no_op_when_there_is_nothing_to_move(client, target, task_state):
+    """Everything that is not the case above, and none of it may cost a send.
+
+    A `replaces` naming an entry that never had a number — it ran, so its task is
+    keyed on the session id, which an edit does not touch — leaves the new entry
+    to be numbered normally. An absent `replaces` (every new task) does the same.
+    Neither is an error: the message is scheduled either way.
+    """
+    for body in ({"replaces": "no-such-entry"}, {"replaces": ""}, {}):
+        res = client.post("/api/schedule", headers=WRITE,
+                          json={"target": str(target), "message": "x",
+                                "due": "2030-02-01T09:00:00Z", **body})
+        assert res.status_code == 200
+        assert _number_for(res.json()["entry"]["id"]) == ""


### PR DESCRIPTION
Three user-reported bugs on the tasks UI, each fixed + verified in-browser:

- **Fresh form every open** — the New Task modal's React key was a mode ("new"), not an identity, so React reused the mount and stale state (e.g. phantom recurrence) leaked between openings. Every entry point now funnels through one `openForm(at, entry)` with an `openSeq` key.
- **Save explains itself** — Save with a missing required field used to silently no-op. New `saveBlockedReason` renders the reason inline, `aria-disabled` Save, and focuses the offending field.
- **Stable task id across edits** — editing a scheduled task (cancel + re-create under the hood) allocated a new TASK number. `POST /api/schedule` now carries `replaces` and the route rekeys the number so it moves with the edit.
- Dirty-close ✕ now visibly arms ("Press again to discard", amber) instead of looking like a dead click.

Known gap (out of scope): occurrences of *recurring* templates still renumber on template edit — numbering is per entry id, fixing it changes task identity semantics.

Tests: frontend 1609 pass; targeted pytest 197 pass; full suite failures confirmed pre-existing on stashed HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Schedule create now rekeys task IDs (data path change) alongside UX-only modal/form changes; behavior is covered by new API and frontend tests but edits touch numbering semantics for pending tasks.
> 
> **Overview**
> Addresses several QA-reported tasks UI issues around the New/Edit task flow and schedule edits.
> 
> **Fresh form on every open** — `Scheduled.tsx` routes all modal opens through `openForm` and bumps an `openSeq` counter in `NewJobModal`'s React `key`, so a new calendar slot or "+ New task" cannot reuse the previous mount's state (e.g. phantom recurrence).
> 
> **Save speaks instead of silently disabling** — `saveBlockedReason` mirrors `saveEnabled` with actionable copy and a field to focus; Save stays clickable (`trySubmit` + `aria-disabled`) and only `busy` truly disables it.
> 
> **TASK number survives edit** — Edits send `replaces` with the old entry id; `POST /api/schedule` calls `tasks_store.rekey` from `pending:<old>` to `pending:<new>` so pending tasks keep TASK-078 instead of minting TASK-079 after cancel+re-create.
> 
> **Dirty-close visibility** — Shared `Modal` arms the ✕ with `is-armed` styling and updated labels/tooltips alongside the existing footer hint.
> 
> Tests cover payload/`replaces`, `saveBlockedReason` parity, modal armed markup/CSS, and API rekey behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fabd61907d1e8d9da4705455549410aa43aaade9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->