### PR TITLE
Tasks: bigger lanes, lanes that remember, and a list that remembers

### DIFF
--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -23,7 +23,14 @@
 // one page. Those live in styles/schedule.css; everything this file adds (the
 // accordion, the thread rows, the id chips, the unread dot) is in
 // styles/tasks.css.
-import { Fragment, useEffect, useMemo, useRef, useState } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type { DragEvent as ReactDragEvent } from "react";
 import {
   cancelScheduledMessage,
@@ -40,7 +47,9 @@ import { BOARD_COLUMNS } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   EMPTY_FILTERS,
+  EMPTY_LIST_MEMORY,
   LANE_CHOICE_KEY,
+  LIST_MEMORY_KEY,
   UNREAD_LABEL,
   archiveIntent,
   basename,
@@ -69,6 +78,7 @@ import {
   openThreadIntent,
   opensElsewhere,
   parseLaneChoices,
+  parseListMemory,
   projectOptions,
   relativeWhen,
   settleMarkAllRead,
@@ -89,6 +99,7 @@ import {
 import type {
   ArchiveStatus,
   LaneChoices,
+  ListMemory,
   OpenThreadIntent,
   TaskFilters,
   TaskRunIntent,
@@ -780,6 +791,33 @@ function performOpen(
 
 // ---- List view: one accordion per task ---------------------------------------
 
+/** How long the list keeps trying to reach the offset it was left at. Rows grow
+ * as their threads land, so the target is unreachable for the first few frames;
+ * past this it is a list that simply cannot be that tall any more. */
+const RESTORE_WINDOW_MS = 3000;
+/** Scroll fires per frame; the store is written once the reader pauses. */
+const WRITE_DEBOUNCE_MS = 150;
+
+/** Per-TAB, per-sitting (sessionStorage): "where I was a moment ago" is not a
+ * preference, and a week-old offset restored into a list of different rows is a
+ * surprise rather than a memory. A blocked store costs the memory, never the
+ * page — the read runs during first render. */
+function readListMemory(): ListMemory {
+  try {
+    return parseListMemory(sessionStorage.getItem(LIST_MEMORY_KEY));
+  } catch {
+    return EMPTY_LIST_MEMORY;
+  }
+}
+
+function writeListMemory(memory: ListMemory): void {
+  try {
+    sessionStorage.setItem(LIST_MEMORY_KEY, JSON.stringify(memory));
+  } catch {
+    // best-effort; a full or blocked store never breaks the list
+  }
+}
+
 export function TaskList({
   tasks,
   home = "",
@@ -808,8 +846,16 @@ export function TaskList({
 }) {
   // Collapsed by default (§8), so the set holds what is OPEN — an empty set is
   // the resting state and needs no seeding from a list that changes on every
-  // poll.
-  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+  // poll. Seeded from THIS TAB's memory, though: opening a task's chat leaves the
+  // page, and coming back to a collapsed list scrolled to the top made reading
+  // three threads out of ninety three trips through the same scrollbar.
+  //
+  // Read once, into a ref, because both halves of the memory are initial state:
+  // re-reading it later would fight the writes below.
+  const memory = useRef<ListMemory>(readListMemory());
+  const [expanded, setExpanded] = useState<Set<string>>(
+    () => new Set(memory.current.expanded),
+  );
   // Full threads fetched by Show more, keyed by task. They REPLACE the three
   // the listing carried rather than appending to them, so no message is ever
   // drawn twice.
@@ -902,12 +948,100 @@ export function TaskList({
     }
   };
 
+  // A row restored from memory was never TOGGLED, so nothing went and got the
+  // rest of its thread — it would sit there showing the listing's three messages
+  // with no button left to ask for the other twenty-three. Same trip the chevron
+  // makes, made once, the first time a task list arrives.
+  const restoredThreads = useRef(false);
+  useEffect(() => {
+    if (restoredThreads.current || tasks.length === 0) return;
+    restoredThreads.current = true;
+    for (const key of memory.current.expanded) {
+      const task = tasks.find((t) => t.key === key);
+      if (task && threadView(task).more) void showMore(task);
+    }
+    // Runs on every poll and does something exactly once — the guard above is
+    // what makes it a restore rather than a refetch loop.
+  }, [tasks]);
+
+  // ---- where the list stood ---------------------------------------------------
+  // `.tasks-list` is its own scroller (styles/tasks.css), so this is one element's
+  // scrollTop and not the window's — which is also why restoring it cannot fight
+  // the explorer's msg-anchor scroll: that happens on a different page entirely.
+  const listRef = useRef<HTMLDivElement | null>(null);
+  // The offset still owed to the reader, or null once it has been paid (or given
+  // up on). Rows grow as their fetched threads land, so the wanted offset is
+  // often past the end of the list for the first few frames; it is re-applied
+  // every render until the content is tall enough to honour it.
+  const owed = useRef<number | null>(memory.current.scroll || null);
+  // The last offset THIS code set, so a scroll event can be told apart from the
+  // reader's own — theirs cancels the restore, and nothing else does.
+  const settled = useRef<number | null>(null);
+
+  useLayoutEffect(() => {
+    const el = listRef.current;
+    if (owed.current === null || !el) return;
+    const top = Math.min(owed.current, Math.max(el.scrollHeight - el.clientHeight, 0));
+    if (Math.abs(el.scrollTop - top) > 1) el.scrollTop = top;
+    settled.current = el.scrollTop;
+    if (top >= owed.current - 1) owed.current = null;
+  });
+
+  // The restore window closes on its own. Without this, a list that can never
+  // grow tall enough (rows deleted since the visit) would keep pinning itself to
+  // the bottom on every poll.
+  useEffect(() => {
+    const t = setTimeout(() => {
+      owed.current = null;
+    }, RESTORE_WINDOW_MS);
+    return () => clearTimeout(t);
+  }, []);
+
+  // One writer for both halves, so the stored row is always whole. Debounced,
+  // because the scroll half fires per frame and this leaves the page by pushState
+  // (an unmount that a dropped write would silently lose is not worth the risk of
+  // relying on).
+  const writeTimer = useRef<number | null>(null);
+  const remember = (next: ListMemory) => {
+    memory.current = next;
+    if (writeTimer.current !== null) clearTimeout(writeTimer.current);
+    writeTimer.current = window.setTimeout(() => {
+      writeTimer.current = null;
+      writeListMemory(memory.current);
+    }, WRITE_DEBOUNCE_MS);
+  };
+  useEffect(
+    () => () => {
+      if (writeTimer.current !== null) {
+        clearTimeout(writeTimer.current);
+        writeListMemory(memory.current);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    remember({ ...memory.current, expanded: [...expanded] });
+  }, [expanded]);
+
+  const onScroll = () => {
+    const el = listRef.current;
+    if (!el) return;
+    // A scroll the reader made, rather than one this code just made, means they
+    // have chosen where to be — the owed offset stops being owed.
+    if (settled.current === null || Math.abs(el.scrollTop - settled.current) > 1) {
+      owed.current = null;
+    }
+    settled.current = el.scrollTop;
+    remember({ ...memory.current, scroll: el.scrollTop });
+  };
+
   if (tasks.length === 0) {
     return <p className="schedule-tv-empty">{emptyLabel}</p>;
   }
 
   return (
-    <div className="tasks-list">
+    <div className="tasks-list" ref={listRef} onScroll={onScroll}>
       {tasks.map((task) => (
         <TaskNode
           key={task.key}

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -990,12 +990,24 @@ export function TaskList({
   // The restore window closes on its own. Without this, a list that can never
   // grow tall enough (rows deleted since the visit) would keep pinning itself to
   // the bottom on every poll.
+  //
+  // IT OPENS ON THE FIRST ROWS, NOT ON MOUNT (bugbot, 2026-08-18). Tasks arrive
+  // from a fetch, so this component mounts against an empty list and stays that
+  // way for as long as the request takes; a deadline started at mount was
+  // therefore spending most of itself — sometimes all of it, on a cold server or
+  // a slow disk — waiting for the rows it was meant to be measuring. The window
+  // is supposed to be "a few seconds of settling once there is something to
+  // settle", so `hasRows` is what starts the clock. It goes false→true once, so
+  // this arms once too, and a filter that empties the list later cannot rewind
+  // it (by then the restore is long since paid or given up on).
+  const hasRows = tasks.length > 0;
   useEffect(() => {
+    if (!hasRows) return;
     const t = setTimeout(() => {
       owed.current = null;
     }, RESTORE_WINDOW_MS);
     return () => clearTimeout(t);
-  }, []);
+  }, [hasRows]);
 
   // One writer for both halves, so the stored row is always whole. Debounced,
   // because the scroll half fires per frame and this leaves the page by pushState
@@ -1027,16 +1039,51 @@ export function TaskList({
   const onScroll = () => {
     const el = listRef.current;
     if (!el) return;
-    // A scroll the reader made, rather than one this code just made, means they
-    // have chosen where to be — the owed offset stops being owed.
-    if (settled.current === null || Math.abs(el.scrollTop - settled.current) > 1) {
-      owed.current = null;
-    }
+    // Whose scroll was this? The layout effect above records every offset IT
+    // sets in `settled`, so an event landing on that exact offset is the echo of
+    // this code's own write and an event landing anywhere else is the reader.
+    const mine = settled.current !== null && Math.abs(el.scrollTop - settled.current) <= 1;
     settled.current = el.scrollTop;
+    // A RESTORE IN PROGRESS WRITES NOTHING (bugbot, 2026-08-18). The restore is
+    // paid in instalments — the wanted offset is past the end of a list whose
+    // rows are still growing as their threads land, so the layout effect gets
+    // partway there, and partway again, until the content is tall enough. Every
+    // one of those partial offsets used to be saved over the real one, so a
+    // reader who left at 1200px and came back to a list that momentarily only
+    // reached 300 had their position quietly rewritten to 300 — the memory
+    // destroyed by the act of restoring it. Only the reader's own scroll is a
+    // statement about where they want to be, so only the reader's own is stored.
+    if (mine) return;
+    // And their scroll means they have chosen where to be: the owed offset stops
+    // being owed.
+    owed.current = null;
     remember({ ...memory.current, scroll: el.scrollTop });
   };
 
-  if (tasks.length === 0) {
+  // AN EMPTY LIST IS A POSITION TOO, and it is the top (bugbot, 2026-08-18).
+  // Typing in the search box until nothing matches unmounts the scroller, and the
+  // scroller is the only thing that reports scrolling — so the last offset from
+  // before the filter narrowed just sat in the store, describing a list that is
+  // no longer on screen. Clearing the search then restored it, and the reader who
+  // had scrolled to the top to start typing was thrown back down the list by a
+  // number they had stopped meaning several keystrokes ago. There is nothing
+  // below an empty state to be scrolled to, so the honest memory is zero, and
+  // nothing is owed either: whatever restore was pending has nowhere to land.
+  //
+  // ONLY FOR A LIST THAT EMPTIED, never for one that has not filled yet: this
+  // component mounts against an empty `tasks` while the fetch is out, and zeroing
+  // the memory there would erase the very offset this whole section exists to pay
+  // back, before the rows it belongs to have even arrived.
+  const hadRows = useRef(false);
+  if (hasRows) hadRows.current = true;
+  useEffect(() => {
+    if (hasRows || !hadRows.current) return;
+    owed.current = null;
+    settled.current = null;
+    remember({ ...memory.current, scroll: 0 });
+  }, [hasRows]);
+
+  if (!hasRows) {
     return <p className="schedule-tv-empty">{emptyLabel}</p>;
   }
 

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1831,8 +1831,11 @@ function TaskNode({
 
 // ---- Board view: columns of tasks --------------------------------------------
 
-const LANE_INITIAL_VISIBLE = 10;
-const LANE_REVEAL = 10;
+// A lane opens on twenty cards and reveals twenty at a time. Ten was two presses
+// to read a busy column (Akshil, 2026-08-18) and the lane scrolls anyway, so the
+// window is about how much is rendered, not about how much fits.
+const LANE_INITIAL_VISIBLE = 20;
+const LANE_REVEAL = 20;
 
 // Which lanes are rolled up into the 52px rail, remembered across visits —
 // Archive is closed by default because it is the one lane nobody opens the page

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -40,6 +40,7 @@ import { BOARD_COLUMNS } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   EMPTY_FILTERS,
+  LANE_CHOICE_KEY,
   UNREAD_LABEL,
   archiveIntent,
   basename,
@@ -55,6 +56,7 @@ import {
   isExpandable,
   isFailedTask,
   isUpcomingTask,
+  laneCollapsed,
   laneUnread,
   markAllRead,
   markRead,
@@ -66,6 +68,7 @@ import {
   openMessageHref,
   openThreadIntent,
   opensElsewhere,
+  parseLaneChoices,
   projectOptions,
   relativeWhen,
   settleMarkAllRead,
@@ -85,6 +88,7 @@ import {
 } from "./tasks-lib";
 import type {
   ArchiveStatus,
+  LaneChoices,
   OpenThreadIntent,
   TaskFilters,
   TaskRunIntent,
@@ -1837,22 +1841,17 @@ function TaskNode({
 const LANE_INITIAL_VISIBLE = 20;
 const LANE_REVEAL = 20;
 
-// Which lanes are rolled up into the 52px rail, remembered across visits —
-// Archive is closed by default because it is the one lane nobody opens the page
-// to read.
-const COLLAPSED_KEY = "fused-render:scheduled-board-collapsed";
-
-function readCollapsed(): Set<BoardColumn> {
+// Which lanes are rolled up into the 52px rail. The RULE lives in
+// tasks-lib.laneCollapsed (empty ⇒ rolled up, otherwise open) and only the
+// reader's own toggles are stored, so a lane nobody has touched keeps following
+// the rule as it fills and empties.
+function readLaneChoices(): LaneChoices {
   try {
-    const raw = localStorage.getItem(COLLAPSED_KEY);
-    if (raw) {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) return new Set(parsed as BoardColumn[]);
-    }
+    return parseLaneChoices(localStorage.getItem(LANE_CHOICE_KEY));
   } catch {
     // A blocked/private store costs the memory, never the board.
+    return {};
   }
-  return new Set<BoardColumn>(["archived"]);
 }
 
 export function TaskBoard({
@@ -1868,7 +1867,7 @@ export function TaskBoard({
   /** Re-read the list after a drop lands (or fails). */
   onReload: () => void;
 }) {
-  const [collapsed, setCollapsed] = useState<Set<BoardColumn>>(readCollapsed);
+  const [choices, setChoices] = useState<LaneChoices>(readLaneChoices);
   const [visible, setVisible] = useState<Record<string, number>>({});
   // The card in flight and the lane under it. Native HTML5 drag — a column
   // move needs nothing fancier than the platform's own.
@@ -1991,8 +1990,9 @@ export function TaskBoard({
     performOpen(task, intent, { clearAll, restoreAll, settleAll }, heldMessages(task));
   };
 
-  // Shared by expanded lane bodies AND collapsed rails, so Archive — collapsed
-  // by default — still catches the drop most cards are allowed.
+  // Shared by expanded lane bodies AND collapsed rails, so a rolled-up lane —
+  // an empty one, or one the reader closed — still catches the drop most cards
+  // are allowed.
   const dropProps = (lane: BoardColumn) => ({
     onDragOver: (ev: ReactDragEvent) => {
       if (!dragging || !allowed.has(lane)) return;
@@ -2009,13 +2009,15 @@ export function TaskBoard({
     },
   });
 
-  const toggleLane = (key: BoardColumn) => {
-    setCollapsed((cur) => {
-      const next = new Set(cur);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
+  // `nowCollapsed` is what the reader is looking at — the rule's answer or their
+  // own earlier one — so the press always means "the other one of these two".
+  // Recording the RESULT rather than a flip is what makes the store a record of
+  // choices instead of a snapshot of the board.
+  const toggleLane = (key: BoardColumn, nowCollapsed: boolean) => {
+    setChoices((cur) => {
+      const next = { ...cur, [key]: !nowCollapsed };
       try {
-        localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...next]));
+        localStorage.setItem(LANE_CHOICE_KEY, JSON.stringify(next));
       } catch {
         // best-effort; a full or blocked store never breaks the board
       }
@@ -2039,7 +2041,8 @@ export function TaskBoard({
           // rather than messages (tasks-lib.laneUnread) because the header stands
           // over cards.
           const news = laneUnread(lane, read);
-          if (collapsed.has(col.key)) {
+          const rolled = laneCollapsed(col.key, lane.length, choices);
+          if (rolled) {
             return (
               <button
                 type="button"
@@ -2055,7 +2058,7 @@ export function TaskBoard({
                     ? "Run the next scheduled message now"
                     : `${col.label}: ${lane.length}`
                 }
-                onClick={() => toggleLane(col.key)}
+                onClick={() => toggleLane(col.key, true)}
                 {...dropProps(col.key)}
               >
                 <StatusIcon status={col.key} unread={news > 0} count={news} />
@@ -2073,7 +2076,7 @@ export function TaskBoard({
                 type="button"
                 className="schedule-tv-lane-head"
                 title={`Collapse ${col.label}`}
-                onClick={() => toggleLane(col.key)}
+                onClick={() => toggleLane(col.key, false)}
               >
                 {/* The group header's own unread mark, the same ring the cards
                     under it wear — filled while any of them holds something

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -56,6 +56,7 @@ import {
   openThreadIntent,
   opensElsewhere,
   parseLaneChoices,
+  parseListMemory,
   projectOptions,
   relativeWhen,
   ranOffSchedule,
@@ -4910,13 +4911,21 @@ describe("opensElsewhere", () => {
 });
 
 // ---- what the two views remember ---------------------------------------------
-// Read out of the source, because "how many cards does a lane open on" is a
-// number the constant and the button's label have to agree about.
+// Three complaints, one shape (Akshil, 2026-08-18): a lane that opens ten cards
+// at a time, an Archive lane nailed shut, and a List that forgets everything the
+// moment you open one of its threads. The RULES are here; the source assertions
+// beside them check the views ask these functions rather than keeping a second
+// copy of the answer.
 
 /** The Board, ending where the card it draws begins. */
 const LANES = VIEWS.slice(
   VIEWS.indexOf("export function TaskBoard("),
   VIEWS.indexOf("function TaskCard("),
+);
+/** The List, ending where the row it draws begins. */
+const LIST = VIEWS.slice(
+  VIEWS.indexOf("export function TaskList("),
+  VIEWS.indexOf("function TaskNode("),
 );
 
 describe("a board lane's page size", () => {
@@ -4977,5 +4986,42 @@ describe("which board lanes are rolled up", () => {
     // What is written is the RESULT of the press, for that one lane.
     expect(LANES).toContain("const next = { ...cur, [key]: !nowCollapsed };");
     expect(LANES).toContain("localStorage.setItem(LANE_CHOICE_KEY");
+  });
+});
+
+describe("what the List remembers between visits", () => {
+  it("remembers nothing at all when there is nothing stored", () => {
+    expect(parseListMemory(null)).toEqual({ expanded: [], scroll: 0 });
+    expect(parseListMemory("")).toEqual({ expanded: [], scroll: 0 });
+    expect(parseListMemory("{oops")).toEqual({ expanded: [], scroll: 0 });
+    expect(parseListMemory("[1,2]")).toEqual({ expanded: [], scroll: 0 });
+  });
+
+  it("keeps the task keys and the offset, and drops everything else", () => {
+    expect(
+      parseListMemory('{"expanded":["TASK-1",7,"TASK-2"],"scroll":420.5,"x":1}'),
+    ).toEqual({ expanded: ["TASK-1", "TASK-2"], scroll: 420.5 });
+    // A negative, infinite or non-numeric offset is not a place on a scrollbar.
+    expect(parseListMemory('{"scroll":-3}').scroll).toBe(0);
+    expect(parseListMemory('{"scroll":"120"}').scroll).toBe(0);
+    expect(parseListMemory('{"expanded":"TASK-1"}').expanded).toEqual([]);
+  });
+
+  it("restores the open rows and the scroll from THIS tab only", () => {
+    // sessionStorage: "where I was a moment ago" is true for this sitting, and a
+    // week-old offset restored into different rows is a surprise, not a memory.
+    expect(VIEWS).toContain("sessionStorage.getItem(LIST_MEMORY_KEY)");
+    expect(VIEWS).toContain("sessionStorage.setItem(LIST_MEMORY_KEY");
+    expect(VIEWS).not.toContain("localStorage.getItem(LIST_MEMORY_KEY)");
+    expect(LIST).toContain("new Set(memory.current.expanded)");
+    // The list's own scroller, not the window's — which is also why this cannot
+    // fight the chat's msg-anchor scroll on the other page.
+    expect(LIST).toContain(
+      '<div className="tasks-list" ref={listRef} onScroll={onScroll}>',
+    );
+    expect(LIST).toContain("el.scrollTop = top;");
+    // A row restored from memory was never toggled, so nothing fetched the rest
+    // of its thread; the restore makes that trip itself, once.
+    expect(LIST).toContain("if (task && threadView(task).more) void showMore(task);");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -37,6 +37,7 @@ import {
   isPastDue,
   isUnread,
   isUpcomingTask,
+  laneCollapsed,
   laneUnread,
   laneTime,
   lastRunAt,
@@ -54,6 +55,7 @@ import {
   openMessageHref,
   openThreadIntent,
   opensElsewhere,
+  parseLaneChoices,
   projectOptions,
   relativeWhen,
   ranOffSchedule,
@@ -4924,5 +4926,56 @@ describe("a board lane's page size", () => {
     // The button's label is arithmetic over the same constant, so it cannot say
     // ten while twenty arrive.
     expect(LANES).toContain("Show {Math.min(LANE_REVEAL, hidden)} more");
+  });
+});
+
+describe("which board lanes are rolled up", () => {
+  it("rolls up an empty lane and opens every other one, Archive included", () => {
+    // Archive was hard-coded closed. It is a lane like the others now: cards ⇒
+    // open, none ⇒ rolled up.
+    expect(laneCollapsed("archived", 3, {})).toBe(false);
+    expect(laneCollapsed("archived", 0, {})).toBe(true);
+    expect(laneCollapsed("upcoming", 0, {})).toBe(true);
+    expect(laneCollapsed("in_progress", 1, {})).toBe(false);
+  });
+
+  it("lets the reader's own choice outrank the rule, in both directions", () => {
+    expect(laneCollapsed("upcoming", 12, { upcoming: true })).toBe(true);
+    expect(laneCollapsed("archived", 0, { archived: false })).toBe(false);
+    // And a choice about ONE lane says nothing about its neighbours.
+    expect(laneCollapsed("done", 0, { upcoming: true })).toBe(true);
+  });
+
+  it("reads back only booleans it recognises, and never throws on junk", () => {
+    // What is in the store is a string written by someone else — an older build
+    // that wrote an ARRAY there, or a hand-edited devtools row.
+    expect(parseLaneChoices(null)).toEqual({});
+    expect(parseLaneChoices("not json")).toEqual({});
+    expect(parseLaneChoices('["archived"]')).toEqual({});
+    expect(parseLaneChoices('{"archived":true,"nonsense":true,"done":"yes"}')).toEqual({
+      archived: true,
+    });
+    expect(parseLaneChoices('{"upcoming":false}')).toEqual({ upcoming: false });
+  });
+
+  it("stores choices, not the board — an untouched lane keeps following the rule", () => {
+    // The distinction the old array-shaped key could not make: it recorded what
+    // was collapsed RIGHT NOW, defaults included, so the first visit froze every
+    // lane's state forever. Round-tripping a choice map keeps the absence of a
+    // choice absent.
+    const choices = parseLaneChoices(JSON.stringify({ archived: false }));
+    expect("upcoming" in choices).toBe(false);
+    expect(laneCollapsed("upcoming", 0, choices)).toBe(true);
+    expect(laneCollapsed("upcoming", 4, choices)).toBe(false);
+  });
+
+  it("is decided by laneCollapsed on the board, which stores only the toggle", () => {
+    expect(LANES).toContain("laneCollapsed(col.key, lane.length, choices)");
+    // The old snapshot key and its hard-coded Archive are gone.
+    expect(VIEWS).not.toContain("scheduled-board-collapsed");
+    expect(VIEWS).not.toContain('new Set<BoardColumn>(["archived"])');
+    // What is written is the RESULT of the press, for that one lane.
+    expect(LANES).toContain("const next = { ...cur, [key]: !nowCollapsed };");
+    expect(LANES).toContain("localStorage.setItem(LANE_CHOICE_KEY");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5024,4 +5024,61 @@ describe("what the List remembers between visits", () => {
     // of its thread; the restore makes that trip itself, once.
     expect(LIST).toContain("if (task && threadView(task).more) void showMore(task);");
   });
+
+  it("does not let the restore overwrite the offset it is restoring", () => {
+    // The restore is paid in instalments: rows grow as their threads land, so the
+    // layout effect reaches part of the wanted offset, then more of it. Those
+    // partial positions used to be written straight back into the memory, so a
+    // reader who left at 1200 and came back to a list that momentarily only
+    // reached 300 had 300 saved over it — the memory destroyed by restoring it.
+    //
+    // `settled` is how the two are told apart: the layout effect records every
+    // offset it sets, so an event on that offset is this code's own echo.
+    expect(LIST).toContain(
+      "const mine = settled.current !== null && Math.abs(el.scrollTop - settled.current) <= 1;",
+    );
+    // And a programmatic scroll leaves BEFORE the write — it neither stores an
+    // offset nor cancels what is still owed.
+    const scroll = LIST.slice(LIST.indexOf("const onScroll = () => {"));
+    const body = scroll.slice(0, scroll.indexOf("\n  };"));
+    expect(body).toContain("if (mine) return;");
+    expect(body.indexOf("if (mine) return;")).toBeLessThan(
+      body.indexOf("remember({ ...memory.current, scroll: el.scrollTop });"),
+    );
+    expect(body.indexOf("if (mine) return;")).toBeLessThan(body.indexOf("owed.current = null;"));
+  });
+
+  it("starts the restore deadline when rows arrive, not when the page mounts", () => {
+    // Tasks come from a fetch, so the component mounts against an empty list. A
+    // deadline armed at mount spent itself waiting for the rows it was meant to
+    // be measuring, and on a slow load the window was gone before the first row
+    // existed — the restore silently never happened.
+    expect(LIST).toContain("const hasRows = tasks.length > 0;");
+    const deadline = LIST.slice(LIST.indexOf("const t = setTimeout(() => {"));
+    expect(deadline.slice(0, deadline.indexOf("}, ["))).toContain("RESTORE_WINDOW_MS");
+    expect(LIST).toContain("if (!hasRows) return;");
+    // Armed off `hasRows`, which flips once, so the window opens once.
+    expect(LIST).toMatch(/return \(\) => clearTimeout\(t\);\s*\}, \[hasRows\]\);/);
+  });
+
+  it("forgets the offset when a filter empties the list, but not before it fills", () => {
+    // The empty state unmounts the scroller, and the scroller is the only thing
+    // that reports scrolling — so the offset from before the search narrowed sat
+    // there describing a list nobody can see, and clearing the search threw the
+    // reader back down to it.
+    expect(LIST).toContain("remember({ ...memory.current, scroll: 0 });");
+    // Nothing is owed either: a pending restore has nowhere to land.
+    const empty = LIST.slice(LIST.indexOf("if (hasRows || !hadRows.current) return;"));
+    const body = empty.slice(0, empty.indexOf("}, [hasRows]);"));
+    expect(body).toContain("owed.current = null;");
+    expect(body).toContain("settled.current = null;");
+    // ONLY for a list that emptied. On the first paint `tasks` is empty because
+    // the fetch is still out, and zeroing there would erase the very offset the
+    // restore exists to pay back.
+    expect(LIST).toContain("const hadRows = useRef(false);");
+    expect(LIST).toContain("if (hasRows) hadRows.current = true;");
+    // The empty state is asked the same question as everything else above it.
+    expect(LIST).toContain("if (!hasRows) {");
+    expect(LIST).not.toContain("if (tasks.length === 0) {");
+  });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -4906,3 +4906,23 @@ describe("opensElsewhere", () => {
     expect(opensElsewhere({ metaKey: false, ctrlKey: false, button: 0 })).toBe(false);
   });
 });
+
+// ---- what the two views remember ---------------------------------------------
+// Read out of the source, because "how many cards does a lane open on" is a
+// number the constant and the button's label have to agree about.
+
+/** The Board, ending where the card it draws begins. */
+const LANES = VIEWS.slice(
+  VIEWS.indexOf("export function TaskBoard("),
+  VIEWS.indexOf("function TaskCard("),
+);
+
+describe("a board lane's page size", () => {
+  it("opens on twenty cards and reveals twenty more", () => {
+    expect(VIEWS).toContain("const LANE_INITIAL_VISIBLE = 20;");
+    expect(VIEWS).toContain("const LANE_REVEAL = 20;");
+    // The button's label is arithmetic over the same constant, so it cannot say
+    // ten while twenty arrive.
+    expect(LANES).toContain("Show {Math.min(LANE_REVEAL, hidden)} more");
+  });
+});

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2160,3 +2160,56 @@ export function groupByColumn(
   }
   return map;
 }
+
+// ---- which lanes are rolled up -----------------------------------------------
+// A lane is either an open column or a 52px rail. Two things decide which, in
+// this order:
+//
+//   1. What the reader last chose for THAT lane. Explicit choices are the only
+//      thing stored, so a lane nobody has ever touched keeps following the rule
+//      below forever rather than being frozen at whatever it looked like the
+//      first time the page was opened.
+//   2. Otherwise: EMPTY lanes start rolled up, everything else starts open.
+//
+// Archive used to be hard-coded closed. It is not special any more (Akshil,
+// 2026-08-18) — an Archive with cards in it is a column like the others, and an
+// Archive with none rolls up under rule 2 like the others.
+
+/** The key the board's lane choices live under. Distinct from the array-shaped
+ * key an earlier build wrote: that one recorded "collapsed now", defaults
+ * included, which cannot be told apart from "the reader chose this". */
+export const LANE_CHOICE_KEY = "fused-render:scheduled-board-lanes";
+
+/** Lane → the reader's own answer to "collapsed?". Absent ⇒ never chosen. */
+export type LaneChoices = Partial<Record<BoardColumn, boolean>>;
+
+/** Same contract as parseListMemory: a stored string is untrusted input, and an
+ * unreadable one means "no choices yet", never a thrown render. */
+export function parseLaneChoices(raw: string | null): LaneChoices {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const row = parsed as Record<string, unknown>;
+  const out: LaneChoices = {};
+  for (const col of BOARD_COLUMNS) {
+    const v = row[col.key];
+    if (typeof v === "boolean") out[col.key] = v;
+  }
+  return out;
+}
+
+/** Rule 1 then rule 2, for one lane. `count` is how many cards it holds. */
+export function laneCollapsed(
+  lane: BoardColumn,
+  count: number,
+  choices: LaneChoices,
+): boolean {
+  const chosen = choices[lane];
+  if (chosen !== undefined) return chosen;
+  return count === 0;
+}

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -994,6 +994,57 @@ export function opensElsewhere(e: {
   );
 }
 
+// ---- what the List remembers between visits ----------------------------------
+// Opening a task's chat LEAVES the Tasks page, and coming back used to hand the
+// reader a fully collapsed list scrolled to the top — so reading three threads
+// out of ninety meant re-finding the same row three times (Akshil, 2026-08-18).
+// The page now remembers which rows were open and where the list stood.
+//
+// sessionStorage, not localStorage: this is "where I was a moment ago", which is
+// true for this tab and this sitting only. A week-old scroll offset restored into
+// a list whose rows have all changed is not a memory, it is a surprise.
+
+/** The key the List's per-tab memory lives under. */
+export const LIST_MEMORY_KEY = "fused-render:tasks-list-memory";
+
+export type ListMemory = {
+  /** Task keys the reader had open. Keys that no longer exist simply never match
+   * a row, so a stale entry costs nothing and needs no pruning. */
+  expanded: string[];
+  /** scrollTop of the list's own scroller, in px. */
+  scroll: number;
+};
+
+export const EMPTY_LIST_MEMORY: ListMemory = { expanded: [], scroll: 0 };
+
+/**
+ * What came out of the store is a STRING WRITTEN BY SOMEONE ELSE — an older
+ * build, a hand-edited devtools row — so every field is checked and anything
+ * unrecognisable degrades to "remember nothing" rather than throwing during a
+ * render.
+ */
+export function parseListMemory(raw: string | null): ListMemory {
+  if (!raw) return EMPTY_LIST_MEMORY;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return EMPTY_LIST_MEMORY;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return EMPTY_LIST_MEMORY;
+  }
+  const row = parsed as { expanded?: unknown; scroll?: unknown };
+  const expanded = Array.isArray(row.expanded)
+    ? row.expanded.filter((k): k is string => typeof k === "string")
+    : [];
+  const scroll =
+    typeof row.scroll === "number" && Number.isFinite(row.scroll) && row.scroll > 0
+      ? row.scroll
+      : 0;
+  return { expanded, scroll };
+}
+
 // ---- where a click goes ------------------------------------------------------
 // schedule-lib.explorerUrl is the app's one answer to "open this session in the
 // explorer, with the Claude pane on it". A message adds one thing: WHICH turn


### PR DESCRIPTION
Stacked on #596 (`agent/20260818-unread-rows`) — retargets to `main` once that merges.

Four things the Tasks page was getting wrong, all of them about the page forgetting or under-showing what the reader asked for.

## Board

- **Lanes open on 20 cards and reveal 20** (was 10/10). The lane scrolls either way, so the window is about how much is rendered, not what fits; ten was two presses to read a busy column. The `Show N more` label is arithmetic over the same constant, so it cannot say ten while twenty arrive.
- **An empty lane starts rolled up; every other lane starts open — Archive included.** Archive was hard-coded closed, which hid a triaged pile behind a 52px rail; an empty lane still took a full 260px column to say nothing. One rule now, `tasks-lib.laneCollapsed`: empty ⇒ rail, otherwise ⇒ column.
- **Your own toggles stick.** The old localStorage key stored *the set of collapsed lanes* — defaults included — which cannot be told apart from a choice, so the first visit froze every lane forever. It now stores a lane → boolean map of **presses only**, under a new key (the old rows are the wrong shape, and reading them as choices would resurrect the freeze). A lane nobody has touched keeps following the rule as it fills and empties.

## List

- **Comes back to the rows you had open, where you left them.** Opening a task's chat leaves the page, and returning gave a fully collapsed list scrolled to the top — three threads out of ninety meant three trips down the same scrollbar. The open task keys and the list's scroll offset are remembered in **sessionStorage** (per tab, per sitting: a week-old offset restored into different rows is a surprise, not a memory).

Three details in there worth knowing:

- A restored row was never *toggled*, so nothing fetched the rest of its thread — it would show the listing's three messages with no button left to ask for the other twenty-three. The restore makes that trip itself, once.
- Rows grow as their threads land, so the target offset is unreachable for the first few frames: it is re-applied every render until the content is tall enough, and the window closes after 3s so a list that can never be that tall stops pinning itself to the bottom.
- A scroll **the reader** made cancels the restore; one this code just made does not.

This is `.tasks-list`'s own `scrollTop`, not the window's — it has nothing to do with, and cannot fight, the chat's `msg-anchor` scroll on the explorer page.

## Tests

New unit tests for the two pure rules (`laneCollapsed`, `parseLaneChoices`, `parseListMemory` — including the junk-in-the-store cases), plus source assertions that the views ask those functions instead of keeping a second copy of the answer. `bun test`: 1639 pass / 0 fail. `npm run build` and `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only Tasks UI state (session/local storage and scroll/expand behavior); no auth or API contract changes. Edge-case bugs could affect scroll position or lane collapse until refresh.
> 
> **Overview**
> Improves the Tasks **Board** and **List** so the UI remembers layout and scroll instead of resetting on every visit.
> 
> **Board:** Lane paging goes from **10 → 20** cards initially and per “Show more”. Collapse behavior moves from a frozen “collapsed lanes” array (Archive always shut) to **`laneCollapsed`**: empty lanes start as rails, non-empty lanes start open, with **per-lane overrides** stored in a new `localStorage` map (`LANE_CHOICE_KEY`) that records only explicit toggles.
> 
> **List:** **`sessionStorage`** (`LIST_MEMORY_KEY`) saves expanded task keys and `.tasks-list` **scrollTop**. Returning from chat restores open rows and scroll; restored expansions trigger a one-time full thread fetch. Scroll restore retries until content height catches up (3s cap), ignores programmatic scroll echoes during restore, clears scroll when a filter empties the list (not on initial empty fetch), and debounces writes.
> 
> **`tasks-lib`:** Adds `parseListMemory`, `parseLaneChoices`, and `laneCollapsed` with defensive parsing. Tests cover the rules plus source assertions that views call the shared helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a5b6066e4f3425a1763ebf55c9d4364ffca92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->