### PR TITLE
Tasks: visual polish on the three views, and one meaning for "recent"

### DIFF
--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -14,6 +14,7 @@ import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useSta
 import { Modal } from "@platform/ui/modal/Modal";
 import {
   cancelScheduledMessage,
+  getClaudeSessionFolders,
   getConfig,
   getTasks,
   listDir,
@@ -24,9 +25,6 @@ import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { navigateUrl } from "@platform/lib/router";
 import { describeRepeats, describeRule, repeatChoicesFor } from "./schedule-lib";
 import { ICON_CLOCK, ICON_FOLDER } from "./ScheduleCalendar";
-// The home page's Recent files, read through the very module Home.tsx reads —
-// see `sharedRecentFolders` below for why this form borrows them.
-import { hydrateRecents, loadRecents, recentFsPath } from "@apps/explorer/lib/recents";
 // This card's own rules live in styles/new-task.css, imported from the
 // shell.css barrel like every other section — no shell component imports its
 // own CSS (tests/test_theme.py pins the barrel against the styles/ directory).
@@ -43,11 +41,11 @@ export const defaultTargetOf = (c: Pick<Config, "home" | "fused_dir">) =>
 
 // ---- Recent paths --------------------------------------------------------
 // The path field's dropdown offers the last folders the user actually used,
-// newest first, five shown. It draws on two stores — the app-wide one the home
-// page reads (see `sharedRecentFolders` below) and this form's own memory of
-// folders picked in the browser or saved on a task, which is what the rest of
-// this section is. That second half lives in localStorage so "the folder I
-// always schedule against" survives reloads.
+// newest first, five shown. It draws on two sources — the app-wide one the home
+// page reads (see the section below) and this form's own memory of folders
+// picked in the browser or saved on a task, which is what the rest of THIS
+// section is. That second half lives in localStorage so "the folder I always
+// schedule against" survives reloads.
 // try/catch throughout: storage can be denied (private mode), and a corrupt
 // value must read as "no recents", never crash the modal (Bugbot, PR #538
 // pattern).
@@ -77,44 +75,25 @@ function rememberRecent(path: string) {
 }
 
 // ---- The APP's recents, which are the ones a person means ------------------
-// "Recents" was two different lists until 2026-08-18. The home page's Recent
-// files strip reads the server-backed store at ~/.fused-render/recents.json
-// (apps/explorer/lib/recents, `/api/recents`) — every file this machine has
-// opened, newest first, deduped and cap-managed by the server. This form read
-// a localStorage array only it ever wrote. Both were called recents, and only
-// one of them matched what "recent" means everywhere else in the app: a person
-// who has spent the morning in a repo and then opens New task is thinking of
-// that repo, and the form had never heard of it (design-principles §1 — one
-// noun per concept, and §4 — recognition over recall).
+// "Recents" was two different lists until 2026-08-18. The home page shows the
+// folders this machine has Claude sessions in, newest session first
+// (`/api/claude-sessions`, its "Claude Sessions" strip); this form showed a
+// localStorage array only it ever wrote. Both were called recents, and only one
+// of them matched what a person means: someone who has spent the morning in a
+// repo opens New task thinking of that repo, and the form had never heard of it
+// (design-principles §1 — one noun per concept, §4 — recognition over recall).
 //
-// So the shared store leads the list now, and the form's own memory follows it.
-// The store holds FILES (the server no-ops on directory urls), and a task wants
-// a place to run, so each entry contributes its containing FOLDER; the MRU
-// order the server produced carries straight through the map, so this is home's
-// list, at folder granularity. Home reads raw MRU too (`loadRecents().entries`)
-// rather than the sidebar's stable-slot view, so the two orderings are the same
-// one.
+// So the home page's list leads this one, from the same endpoint and in the
+// same order, and it is the right shape as well as the right source: those
+// entries are FOLDERS — each session's own `cwd`, canonicalised and filtered to
+// directories that still exist — which is exactly what a task targets.
 //
-// Reads are synchronous off that module's in-memory cache and cannot throw;
-// `hydrateRecents()` is what fills it, and this form calls it on mount for the
-// case where the modal is the first thing opened in a session.
-export function parentFolder(path: string): string {
-  const trimmed = normPath(path).replace(/\/+$/, "");
-  const cut = trimmed.lastIndexOf("/");
-  // "/a" -> "/", "C:/a" -> "C:/", and a bare segment (no separator) has no
-  // parent worth offering.
-  if (cut < 0) return "";
-  return cut === 0 ? "/" : trimmed.slice(0, cut);
-}
-
-function sharedRecentFolders(): string[] {
-  const out: string[] = [];
-  for (const entry of loadRecents().entries) {
-    const folder = parentFolder(recentFsPath(entry.url));
-    if (folder) out.push(folder);
-  }
-  return out;
-}
+// It briefly led with `/api/recents` instead, the explorer's recently-OPENED
+// FILES, whose folders had to be derived by taking each path's parent. That was
+// the wrong list twice over: it is about files rather than places to work, and
+// it is short — three entries on a machine that had dozens of sessions, which
+// is the complaint that sent this back (Akshil, 2026-08-18).
+const SESSION_FOLDERS_SHOWN = 5;
 
 // ---- Browse: a slide-in explorer panel ---------------------------------------
 // Browsing happens BESIDE the card, not inside it: the in-modal picker was
@@ -2049,35 +2028,47 @@ export default function NewJobModal({
   const [home, setHome] = useState("");
   // The path field's recents dropdown, in three tiers and in this order:
   //
-  //  1. the APP's recents — the same server-backed store the home page's Recent
-  //     files strip reads, one folder per recently-opened file, in its MRU order
-  //     (see `sharedRecentFolders`). First because it is what a person means by
-  //     "recent": the folders they have actually been working in today.
+  //  1. the APP's recents — the top five folders from the same call the home
+  //     page's Claude Sessions strip makes, newest session first. First because
+  //     it is what a person means by "recent": the folders they have actually
+  //     been working in.
   //  2. this form's own memory — folders picked through Browse or saved on a
   //     task (localStorage). Kept, not replaced: a folder deliberately chosen
   //     here may hold no files anyone has opened, so tier 1 would never learn
   //     it.
   //  3. the folders existing tasks point at, as padding on a fresh machine.
   //
-  // RE-READ every time the list opens, not once per modal: both stores change
+  // Tier 2 is RE-READ every time the list opens, not once per modal: it changes
   // while the modal is up (Browse writes the folder you pick), so a read-once
   // state showed the list as it was BEFORE you went browsing — "I just went
   // through a bunch of folders but recents didn't update" (Akshil, 2026-08-16).
-  // Both reads are synchronous and local (a localStorage hit and an in-memory
-  // cache), on a user gesture, so doing it per open costs nothing worth saving.
+  // It is a single localStorage hit on a user gesture, so per-open costs nothing.
   const [recentsOpen, setRecentsOpen] = useState(false);
   const [recents, setRecents] = useState<string[]>([]);
-  // Fill the shared cache for the case where this modal is the first thing
-  // opened in a session (a `/tasks?new=1` deep link). Fire-and-forget, exactly
-  // as Home.tsx does it: a recents fetch that fails costs suggestions, never
-  // the form.
+  // Tier 1 is a fetch, so it is asked for once on mount and held. Exactly as
+  // Home.tsx asks for it, and fire-and-forget for the same reason: a suggestion
+  // list that fails to load costs suggestions, never the form. Normalised on the
+  // way in, like every other path this card handles.
+  const [sessionFolders, setSessionFolders] = useState<string[]>([]);
   useEffect(() => {
-    void hydrateRecents();
+    let alive = true;
+    getClaudeSessionFolders().then(
+      (r) => {
+        if (!alive) return;
+        setSessionFolders(
+          r.folders.slice(0, SESSION_FOLDERS_SHOWN).map((f) => normPath(f.path)),
+        );
+      },
+      () => {},
+    );
+    return () => {
+      alive = false;
+    };
   }, []);
   const readRecentList = useCallback(() => {
     const seen = new Set<string>();
     return [
-      ...sharedRecentFolders(),
+      ...sessionFolders,
       ...readRecents(),
       ...(recentTargets ?? []),
     ].filter((p) => {
@@ -2085,7 +2076,7 @@ export default function NewJobModal({
       seen.add(p);
       return true;
     });
-  }, [recentTargets]);
+  }, [recentTargets, sessionFolders]);
   const openRecents = () => {
     setRecents(readRecentList());
     setRecentsOpen(true);

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -24,6 +24,9 @@ import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { navigateUrl } from "@platform/lib/router";
 import { describeRepeats, describeRule, repeatChoicesFor } from "./schedule-lib";
 import { ICON_CLOCK, ICON_FOLDER } from "./ScheduleCalendar";
+// The home page's Recent files, read through the very module Home.tsx reads —
+// see `sharedRecentFolders` below for why this form borrows them.
+import { hydrateRecents, loadRecents, recentFsPath } from "@apps/explorer/lib/recents";
 // This card's own rules live in styles/new-task.css, imported from the
 // shell.css barrel like every other section — no shell component imports its
 // own CSS (tests/test_theme.py pins the barrel against the styles/ directory).
@@ -39,9 +42,12 @@ export const defaultTargetOf = (c: Pick<Config, "home" | "fused_dir">) =>
   normPath(c.fused_dir || c.home);
 
 // ---- Recent paths --------------------------------------------------------
-// The path field's dropdown offers the last folders the user actually used —
-// picked in the browser or saved on a task — newest first, five shown. Stored
-// in localStorage so "the folder I always schedule against" survives reloads.
+// The path field's dropdown offers the last folders the user actually used,
+// newest first, five shown. It draws on two stores — the app-wide one the home
+// page reads (see `sharedRecentFolders` below) and this form's own memory of
+// folders picked in the browser or saved on a task, which is what the rest of
+// this section is. That second half lives in localStorage so "the folder I
+// always schedule against" survives reloads.
 // try/catch throughout: storage can be denied (private mode), and a corrupt
 // value must read as "no recents", never crash the modal (Bugbot, PR #538
 // pattern).
@@ -68,6 +74,46 @@ function rememberRecent(path: string) {
   } catch {
     // Storage denied — recents just don't persist.
   }
+}
+
+// ---- The APP's recents, which are the ones a person means ------------------
+// "Recents" was two different lists until 2026-08-18. The home page's Recent
+// files strip reads the server-backed store at ~/.fused-render/recents.json
+// (apps/explorer/lib/recents, `/api/recents`) — every file this machine has
+// opened, newest first, deduped and cap-managed by the server. This form read
+// a localStorage array only it ever wrote. Both were called recents, and only
+// one of them matched what "recent" means everywhere else in the app: a person
+// who has spent the morning in a repo and then opens New task is thinking of
+// that repo, and the form had never heard of it (design-principles §1 — one
+// noun per concept, and §4 — recognition over recall).
+//
+// So the shared store leads the list now, and the form's own memory follows it.
+// The store holds FILES (the server no-ops on directory urls), and a task wants
+// a place to run, so each entry contributes its containing FOLDER; the MRU
+// order the server produced carries straight through the map, so this is home's
+// list, at folder granularity. Home reads raw MRU too (`loadRecents().entries`)
+// rather than the sidebar's stable-slot view, so the two orderings are the same
+// one.
+//
+// Reads are synchronous off that module's in-memory cache and cannot throw;
+// `hydrateRecents()` is what fills it, and this form calls it on mount for the
+// case where the modal is the first thing opened in a session.
+export function parentFolder(path: string): string {
+  const trimmed = normPath(path).replace(/\/+$/, "");
+  const cut = trimmed.lastIndexOf("/");
+  // "/a" -> "/", "C:/a" -> "C:/", and a bare segment (no separator) has no
+  // parent worth offering.
+  if (cut < 0) return "";
+  return cut === 0 ? "/" : trimmed.slice(0, cut);
+}
+
+function sharedRecentFolders(): string[] {
+  const out: string[] = [];
+  for (const entry of loadRecents().entries) {
+    const folder = parentFolder(recentFsPath(entry.url));
+    if (folder) out.push(folder);
+  }
+  return out;
 }
 
 // ---- Browse: a slide-in explorer panel ---------------------------------------
@@ -2001,21 +2047,40 @@ export default function NewJobModal({
     }
   };
   const [home, setHome] = useState("");
-  // The path field's recents dropdown: what this form remembers being used
-  // (localStorage, first — the user's own picks outrank inference), padded
-  // with the folders existing tasks point at.
+  // The path field's recents dropdown, in three tiers and in this order:
   //
-  // RE-READ every time the list opens, not once per modal: the store changes
-  // through this very modal (Browse writes the folder you pick), so a
-  // read-once state showed the list as it was BEFORE you went browsing —
-  // "I just went through a bunch of folders but recents didn't update"
-  // (Akshil, 2026-08-16). The read is a single localStorage hit on a user
-  // gesture, so doing it per open costs nothing worth saving.
+  //  1. the APP's recents — the same server-backed store the home page's Recent
+  //     files strip reads, one folder per recently-opened file, in its MRU order
+  //     (see `sharedRecentFolders`). First because it is what a person means by
+  //     "recent": the folders they have actually been working in today.
+  //  2. this form's own memory — folders picked through Browse or saved on a
+  //     task (localStorage). Kept, not replaced: a folder deliberately chosen
+  //     here may hold no files anyone has opened, so tier 1 would never learn
+  //     it.
+  //  3. the folders existing tasks point at, as padding on a fresh machine.
+  //
+  // RE-READ every time the list opens, not once per modal: both stores change
+  // while the modal is up (Browse writes the folder you pick), so a read-once
+  // state showed the list as it was BEFORE you went browsing — "I just went
+  // through a bunch of folders but recents didn't update" (Akshil, 2026-08-16).
+  // Both reads are synchronous and local (a localStorage hit and an in-memory
+  // cache), on a user gesture, so doing it per open costs nothing worth saving.
   const [recentsOpen, setRecentsOpen] = useState(false);
   const [recents, setRecents] = useState<string[]>([]);
+  // Fill the shared cache for the case where this modal is the first thing
+  // opened in a session (a `/tasks?new=1` deep link). Fire-and-forget, exactly
+  // as Home.tsx does it: a recents fetch that fails costs suggestions, never
+  // the form.
+  useEffect(() => {
+    void hydrateRecents();
+  }, []);
   const readRecentList = useCallback(() => {
     const seen = new Set<string>();
-    return [...readRecents(), ...(recentTargets ?? [])].filter((p) => {
+    return [
+      ...sharedRecentFolders(),
+      ...readRecents(),
+      ...(recentTargets ?? []),
+    ].filter((p) => {
       if (!p || seen.has(p)) return false;
       seen.add(p);
       return true;

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -214,6 +214,32 @@ export const ICON_SKIP = icon(<><polygon points="5 4 15 12 5 20 5 4" /><line x1=
 export const ICON_CANCEL = icon(<><circle cx="12" cy="12" r="9" /><path d="M8 8l8 8M16 8l-8 8" /></>);
 export const ICON_NOTES = icon(<><line x1="4" y1="7" x2="20" y2="7" /><line x1="4" y1="12" x2="20" y2="12" /><line x1="4" y1="17" x2="14" y2="17" /></>);
 export const ICON_RESTORE = icon(<><path d="M3 12a9 9 0 1 0 3-6.7" /><path d="M3 4v5h5" /></>);
+// The three views, as marks — the List / Board / Calendar switcher in
+// Scheduled.tsx. They live here with the rest of the page's vocabulary rather
+// than in that file because this is where `icon()` is, and a second copy of
+// that helper is how two icon sizes start. lucide `list`, `columns-3` and
+// `calendar`, unmodified: the switcher is the first control a person reads on
+// this page, so it should wear the shapes they already know from every other
+// board and calendar they use rather than bespoke ones.
+//
+// ICON_NOTES above is three lines too, and stays a separate glyph: it means
+// "this run has a note", and a mark that means two things on one page means
+// neither. The list icon carries the leading dots that one does not.
+export const ICON_VIEW_LIST = icon(
+  <><line x1="9" y1="6" x2="20" y2="6" /><line x1="9" y1="12" x2="20" y2="12" />
+    <line x1="9" y1="18" x2="20" y2="18" /><line x1="4" y1="6" x2="4.01" y2="6" />
+    <line x1="4" y1="12" x2="4.01" y2="12" /><line x1="4" y1="18" x2="4.01" y2="18" /></>,
+);
+export const ICON_VIEW_BOARD = icon(
+  <><rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="9" y1="3" x2="9" y2="21" /><line x1="15" y1="3" x2="15" y2="21" /></>,
+);
+export const ICON_VIEW_CALENDAR = icon(
+  <><rect x="3" y="4" width="18" height="17" rx="2" />
+    <line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="16" y1="2" x2="16" y2="6" /></>,
+);
+
 export const ICON_INBOX = icon(<><path d="M22 12h-6l-2 3h-4l-2-3H2" /><path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" /></>);
 // Run now, and the word for doing it AGAIN. Two glyphs rather than one, for the
 // reason the archive pair is two: a person looking at a task that broke has to

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -2315,18 +2315,18 @@ export function TaskBoard({
           const news = laneUnread(lane, read);
           const rolled = laneCollapsed(col.key, lane.length, choices);
           if (rolled) {
-            // AN EMPTY RAIL IS NOT A BUTTON. `laneCollapsed` keeps a lane with
-            // nothing in it rolled up whatever the reader chose, so the press
-            // that used to expand it now visibly does nothing — a dead click on
-            // a lit control (design-principles §0). It says so instead:
-            // `aria-disabled` and no handler, so the rail reads as the marker it
-            // has become.
+            // An empty rail is STILL A BUTTON. It briefly was not — empty
+            // outranked the reader's choice, so the press did nothing and the
+            // control said so with `aria-disabled` — and that was the wrong
+            // half of the complaint to fix (Akshil, 2026-08-18). Rolling up by
+            // default is what keeps four empty columns off the board; refusing
+            // to open is a lane telling the reader they may not look inside it.
+            // An expanded empty lane shows an empty panel, which is a fine
+            // answer to "is there anything in here", and it is a drop target
+            // either way.
             //
-            // `aria-disabled`, NOT `disabled`: a real disabled button stops
-            // receiving pointer events in every browser, and this element is
-            // still a DROP TARGET — dragging a card into a column that has never
-            // held one is the one thing an empty lane must go on accepting, and
-            // it is exactly the gesture that makes it non-empty again.
+            // `empty` survives for the one thing that WAS the complaint: the
+            // count below.
             const empty = lane.length === 0;
             return (
               <button
@@ -2334,20 +2334,18 @@ export function TaskBoard({
                 key={col.key}
                 className={
                   "schedule-tv-rail" +
-                  (empty ? " is-empty" : "") +
                   (dragging && allowed.has(col.key) ? " is-drop-legal" : "") +
                   (runLane === col.key ? " is-drop-run" : "") +
                   (overLane === col.key ? " is-drop-over" : "")
                 }
-                aria-disabled={empty || undefined}
                 title={
                   runLane === col.key
                     ? "Run the next scheduled message now"
                     : empty
-                      ? `Nothing in ${col.label}`
+                      ? `${col.label}: nothing yet`
                       : `${col.label}: ${lane.length}`
                 }
-                onClick={empty ? undefined : () => toggleLane(col.key, true)}
+                onClick={() => toggleLane(col.key, true)}
                 {...dropProps(col.key)}
               >
                 <StatusIcon status={col.key} unread={news > 0} count={news} />

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -864,6 +864,18 @@ export function TaskList({
   const [expanded, setExpanded] = useState<Set<string>>(
     () => new Set(memory.current.expanded),
   );
+  // WHERE THE READER JUST WAS. Seeded from the same memory as the two above and
+  // restored with them: a list of ninety near-identical rows gives no clue which
+  // one you came back out of, so "now the next one" meant re-finding the last
+  // one first (Akshil, 2026-08-18). Held in state as well as in the memory ref
+  // because it is also LIVE — the row lights the moment it is pressed, so the
+  // highlight is the page acknowledging the press rather than something that
+  // only appears after a round trip.
+  const [selected, setSelected] = useState(() => memory.current.selected);
+  const select = (key: string) => {
+    setSelected(key);
+    remember({ ...memory.current, selected: key });
+  };
   // Full threads fetched by Show more, keyed by task. They REPLACE the three
   // the listing carried rather than appending to them, so no message is ever
   // drawn twice.
@@ -1147,6 +1159,8 @@ export function TaskList({
           home={home}
           showProject={showProject}
           open={expanded.has(task.key)}
+          selected={selected === task.key}
+          onSelect={() => select(task.key)}
           onToggle={() => toggle(task)}
           onRetry={() => void showMore(task)}
           loaded={loaded[task.key]}
@@ -1170,6 +1184,8 @@ function TaskNode({
   home,
   showProject,
   open: requested,
+  selected,
+  onSelect,
   onToggle,
   loaded,
   loading,
@@ -1191,6 +1207,14 @@ function TaskNode({
   /** What the List's expanded set says about this row. Whether it is honoured is
    * this component's decision — see `expandable` below. */
   open: boolean;
+  /** Is this the row the reader last opened a conversation from? The List owns
+   * the answer (one row at a time, remembered across the trip to the chat); the
+   * row only wears it. */
+  selected: boolean;
+  /** Say that this row is now that one. Spent by every gesture that LEAVES the
+   * page — the row's press and a message row's — and by nothing else: expanding
+   * a task is reading it in place, not going anywhere. */
+  onSelect: () => void;
   onToggle: () => void;
   loaded?: TaskMessage[];
   loading: boolean;
@@ -1411,7 +1435,12 @@ function TaskNode({
   const openMessage = (m: TaskMessage) => {
     onRead(task.key, m);
     const to = messageHref(task, m);
-    if (to) navigateUrl(to);
+    if (!to) return;
+    // Leaving the page, so this is the row to come back to — the thread row
+    // belongs to this task, and the task's row is what is still on screen when
+    // the reader returns.
+    onSelect();
+    navigateUrl(to);
   };
 
   /**
@@ -1452,6 +1481,13 @@ function TaskNode({
   // Declared ABOVE `activate` because `activate` now calls it — a hoisted
   // reference into a `const` below would work at runtime and read as a bug.
   const openChat = (intent: OpenThreadIntent) => {
+    // This is the row LEAVING the page, so it is also the row to come back to.
+    // Marked here rather than in `activate` because `activate` has a second arm
+    // — the edit form, a modal over this very page — and lighting a row for a
+    // trip the reader never took would make the highlight mean nothing. Every
+    // way of opening this task's conversation goes through this one function
+    // (the row's press, the Open chat button), so every one of them marks.
+    onSelect();
     performOpen(
       task,
       intent,
@@ -1562,7 +1598,8 @@ function TaskNode({
   return (
     <div className="tasks-node">
       <div
-        className={"tasks-row" + (open ? " is-open" : "") + (pressable ? "" : " is-inert")}
+        className={"tasks-row" + (open ? " is-open" : "")
+          + (selected ? " is-selected" : "") + (pressable ? "" : " is-inert")}
         // The row is a CONTAINER now, not a control: when it has somewhere to go
         // the stretched `<a>` below is the button, the tab stop and the
         // accessible name, and hanging a second role and a second tab stop on

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -65,7 +65,7 @@ import {
   isExpandable,
   isFailedTask,
   isUpcomingTask,
-  laneCollapsed,
+  laneRolledUp,
   laneUnread,
   markAllRead,
   markRead,
@@ -2113,10 +2113,12 @@ function TaskNode({
 const LANE_INITIAL_VISIBLE = 20;
 const LANE_REVEAL = 20;
 
-// Which lanes are rolled up into the 52px rail. The RULE lives in
-// tasks-lib.laneCollapsed (empty ⇒ rolled up, otherwise open) and only the
-// reader's own toggles are stored, so a lane nobody has touched keeps following
-// the rule as it fills and empties.
+// Which lanes are rolled up into the 52px rail. The RULE lives in tasks-lib —
+// `laneCollapsed` for what the store says and `laneRolledUp` for what is drawn —
+// and THIS is only half of the state: a lane with cards remembers the reader's
+// toggle here, and a lane with none remembers nothing at all (the peek, in
+// TaskBoard). So a lane nobody has touched keeps following the rule as it fills
+// and empties, and so does one they touched while it was empty.
 function readLaneChoices(): LaneChoices {
   try {
     return parseLaneChoices(localStorage.getItem(LANE_CHOICE_KEY));
@@ -2140,6 +2142,11 @@ export function TaskBoard({
   onReload: () => void;
 }) {
   const [choices, setChoices] = useState<LaneChoices>(readLaneChoices);
+  // Lanes the reader has opened WHILE EMPTY. Deliberately component state and
+  // deliberately not persisted: opening a column with nothing in it is a peek,
+  // and a peek is answered and over (tasks-lib, above `laneCollapsed`). A remount
+  // — every navigation back to this page — starts the board with none.
+  const [peeked, setPeeked] = useState<Set<BoardColumn>>(() => new Set());
   const [visible, setVisible] = useState<Record<string, number>>({});
   // The card in flight and the lane under it. Native HTML5 drag — a column
   // move needs nothing fancier than the platform's own.
@@ -2285,7 +2292,23 @@ export function TaskBoard({
   // own earlier one — so the press always means "the other one of these two".
   // Recording the RESULT rather than a flip is what makes the store a record of
   // choices instead of a snapshot of the board.
+  //
+  // WHICH of the two stores it lands in is decided by the lane's contents, and
+  // by nothing else. A press on a lane with cards is a preference and is written
+  // down; a press on an empty one is a peek and stays in memory, so nothing a
+  // reader does to an empty column can outlive the sitting. The peek is a
+  // straight toggle because it is the only thing the empty case has: closing a
+  // peeked lane is removing the peek, not recording "collapsed".
   const toggleLane = (key: BoardColumn, nowCollapsed: boolean) => {
+    if ((byLane.get(key)?.length ?? 0) === 0) {
+      setPeeked((cur) => {
+        const next = new Set(cur);
+        if (nowCollapsed) next.add(key);
+        else next.delete(key);
+        return next;
+      });
+      return;
+    }
     setChoices((cur) => {
       const next = { ...cur, [key]: !nowCollapsed };
       try {
@@ -2298,6 +2321,19 @@ export function TaskBoard({
   };
 
   const byLane = useMemo(() => groupByColumn(tasks), [tasks]);
+
+  // A peek dies the moment the lane it was about stops being empty, so a column
+  // that fills up and drains again comes back rolled up rather than wearing an
+  // answer to a question the reader asked about a different, older emptiness.
+  // `laneRolledUp` already ignores the peek while there are cards, so this only
+  // has to clear it inside that window — which is exactly where it is safe to.
+  useEffect(() => {
+    setPeeked((cur) => {
+      if (cur.size === 0) return cur;
+      const next = new Set([...cur].filter((key) => (byLane.get(key)?.length ?? 0) === 0));
+      return next.size === cur.size ? cur : next;
+    });
+  }, [byLane]);
 
   return (
     <>
@@ -2313,7 +2349,7 @@ export function TaskBoard({
           // rather than messages (tasks-lib.laneUnread) because the header stands
           // over cards.
           const news = laneUnread(lane, read);
-          const rolled = laneCollapsed(col.key, lane.length, choices);
+          const rolled = laneRolledUp(col.key, lane.length, choices, peeked);
           if (rolled) {
             // An empty rail is STILL A BUTTON. It briefly was not — empty
             // outranked the reader's choice, so the press did nothing and the

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -72,7 +72,7 @@ import {
   markReadIntent,
   messageEditEntry,
   messageHref,
-  messageTone,
+  threadTone,
   messageWhenTitle,
   openMessageHref,
   openThreadIntent,
@@ -1854,7 +1854,10 @@ function TaskNode({
       {open && (
         <div className="tasks-thread">
           {view.messages.map((m) => {
-            const tone = messageTone(m);
+            // threadTone, not messageTone: a thread under an archived task is
+            // archived with it, except for a turn that is still running
+            // (tasks-lib says why).
+            const tone = threadTone(task, m);
             const mark = unreadMarker(task.key, m, read);
             const isNew = mark.unread;
             const stop = cancelIntent(m);
@@ -2275,27 +2278,50 @@ export function TaskBoard({
           const news = laneUnread(lane, read);
           const rolled = laneCollapsed(col.key, lane.length, choices);
           if (rolled) {
+            // AN EMPTY RAIL IS NOT A BUTTON. `laneCollapsed` keeps a lane with
+            // nothing in it rolled up whatever the reader chose, so the press
+            // that used to expand it now visibly does nothing — a dead click on
+            // a lit control (design-principles §0). It says so instead:
+            // `aria-disabled` and no handler, so the rail reads as the marker it
+            // has become.
+            //
+            // `aria-disabled`, NOT `disabled`: a real disabled button stops
+            // receiving pointer events in every browser, and this element is
+            // still a DROP TARGET — dragging a card into a column that has never
+            // held one is the one thing an empty lane must go on accepting, and
+            // it is exactly the gesture that makes it non-empty again.
+            const empty = lane.length === 0;
             return (
               <button
                 type="button"
                 key={col.key}
                 className={
                   "schedule-tv-rail" +
+                  (empty ? " is-empty" : "") +
                   (dragging && allowed.has(col.key) ? " is-drop-legal" : "") +
                   (runLane === col.key ? " is-drop-run" : "") +
                   (overLane === col.key ? " is-drop-over" : "")
                 }
+                aria-disabled={empty || undefined}
                 title={
                   runLane === col.key
                     ? "Run the next scheduled message now"
-                    : `${col.label}: ${lane.length}`
+                    : empty
+                      ? `Nothing in ${col.label}`
+                      : `${col.label}: ${lane.length}`
                 }
-                onClick={() => toggleLane(col.key, true)}
+                onClick={empty ? undefined : () => toggleLane(col.key, true)}
                 {...dropProps(col.key)}
               >
                 <StatusIcon status={col.key} unread={news > 0} count={news} />
                 <span className="schedule-tv-rail-label">{col.label}</span>
-                <span className="schedule-tv-rail-count">{lane.length}</span>
+                {/* No `0`. A count answers "how many are hidden in here", and on
+                    an empty rail the honest answer is already the whole rail —
+                    the chip only added a number to read before you could see it
+                    said nothing (Akshil, screenshot, 2026-08-18). */}
+                {!empty && (
+                  <span className="schedule-tv-rail-count">{lane.length}</span>
+                )}
               </button>
             );
           }

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -64,7 +64,11 @@ import type {
 import { useRefreshOnReturn } from "@platform/lib/hooks";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { SkeletonLines } from "@platform/ui/Skeleton";
-import ScheduleCalendar from "./ScheduleCalendar";
+import ScheduleCalendar, {
+  ICON_VIEW_BOARD,
+  ICON_VIEW_CALENDAR,
+  ICON_VIEW_LIST,
+} from "./ScheduleCalendar";
 import NewJobModal from "./NewJobModal";
 import {
   EMPTY_FILTERS,
@@ -352,23 +356,34 @@ export default function Scheduled() {
                 sits beside it. List first and default: the page's question is
                 "what is running", and the calendar is the drill-down for the
                 scheduled subset of it. */}
+            {/* Icon + label on each half, added 2026-08-18. The three words are
+                short and near-identical in weight, so the row read as a block of
+                text you had to actually read; a list, a set of columns and a
+                calendar are shapes you recognise before you read anything. The
+                labels stay — an icon-only switcher for a control this central
+                would be recognition traded for guessing (design-principles §4)
+                — and the marks are lucide's, at the same 14px every other glyph
+                on this page uses (ScheduleCalendar's `icon`). */}
             <div className="schedule-form-seg" role="radiogroup" aria-label="View">
               <button type="button"
-                      className={"btn btn-secondary" + (view === "list" ? " is-active" : "")}
+                      className={"btn btn-secondary schedule-view-btn" + (view === "list" ? " is-active" : "")}
                       aria-pressed={view === "list"}
                       onClick={() => pickView("list")}>
+                {ICON_VIEW_LIST}
                 List
               </button>
               <button type="button"
-                      className={"btn btn-secondary" + (view === "board" ? " is-active" : "")}
+                      className={"btn btn-secondary schedule-view-btn" + (view === "board" ? " is-active" : "")}
                       aria-pressed={view === "board"}
                       onClick={() => pickView("board")}>
+                {ICON_VIEW_BOARD}
                 Board
               </button>
               <button type="button"
-                      className={"btn btn-secondary" + (view === "calendar" ? " is-active" : "")}
+                      className={"btn btn-secondary schedule-view-btn" + (view === "calendar" ? " is-active" : "")}
                       aria-pressed={view === "calendar"}
                       onClick={() => pickView("calendar")}>
+                {ICON_VIEW_CALENDAR}
                 Calendar
               </button>
             </div>

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -387,18 +387,26 @@ export default function Scheduled() {
                 Calendar
               </button>
             </div>
-            {/* Search, Status and Project belong to the two task views: the
-                calendar answers "when", and a week with tasks filtered out of
-                it is a week that lies. They sit AFTER the toggle, so hiding
-                them here cannot move it. */}
-            {view !== "calendar" && (
-              <TaskFilterControls
-                filters={filters}
-                projects={projects}
-                home={home}
-                onChange={setFilters}
-              />
-            )}
+            {/* Search, Status and Project, on ALL THREE views (2026-08-18). They
+                used to be hidden on the calendar, on the argument that it
+                answers "when" and a week with tasks filtered out of it is a week
+                that lies. That reading did not survive contact: the filters are
+                not a claim about what exists, they are how you read the page
+                this minute — the same three lenses, and a person who has just
+                narrowed the List to one project and switched to Calendar meant
+                to keep looking at that project, not to be handed everything
+                back. Views are lenses on one dataset (design-principles §1), and
+                a control that vanishes when you change lens makes them read as
+                three different pages.
+
+                They sit AFTER the toggle, which owns the row's only auto margin,
+                so nothing here can move either end of the bar. */}
+            <TaskFilterControls
+              filters={filters}
+              projects={projects}
+              home={home}
+              onChange={setFilters}
+            />
             <button type="button" className="btn btn-primary schedule-new"
                     onClick={() => openForm("blank", null)}>
               + New task
@@ -411,15 +419,20 @@ export default function Scheduled() {
               only ever appeared for one of the two filters, which made the page
               look like it had lost the other. Clearing is where setting is: in
               the menu. */}
-          {view !== "calendar" && tasksFailed && (
-            // One quiet line, not a banner: the form and the calendar still
-            // work, and only the rows are missing.
+          {tasksFailed && (
+            // One quiet line, not a banner: the form still works and only the
+            // tasks are missing. Shown on the calendar too since 2026-08-18 —
+            // its chips come from the same feed, so an empty week and an
+            // unreadable one looked identical there.
             <p className="schedule-tv-note">Tasks could not be loaded.</p>
           )}
 
           {view === "calendar" ? (
             <ScheduleCalendar
-              tasks={tasks}
+              // The FILTERED set, same as the other two views get: the toolbar's
+              // three controls are live here now, and a filter that is shown but
+              // does nothing is worse than one that is hidden.
+              tasks={shown}
               entries={entries}
               queued={queued}
               running={running}

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -45,7 +45,6 @@ let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
 let PAST_NOTE_CATCH_UP: typeof import("./NewJobModal").PAST_NOTE_CATCH_UP;
 let defaultTargetOf: typeof import("./NewJobModal").defaultTargetOf;
-let parentFolder: typeof import("./NewJobModal").parentFolder;
 
 beforeAll(async () => {
   const mod = await import("./NewJobModal");
@@ -74,7 +73,6 @@ beforeAll(async () => {
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
   PAST_NOTE_CATCH_UP = mod.PAST_NOTE_CATCH_UP;
   defaultTargetOf = mod.defaultTargetOf;
-  parentFolder = mod.parentFolder;
 });
 
 // Only the fields these functions read; the rest of a stored entry is noise
@@ -1451,51 +1449,52 @@ describe("defaultTargetOf", () => {
 });
 
 // ---- "recent" means one thing -------------------------------------------------
-// Until 2026-08-18 the app had two recents. The home page's Recent files strip
-// reads the server-backed store at ~/.fused-render/recents.json
-// (apps/explorer/lib/recents); this form read a localStorage array only it ever
-// wrote, so a person who had spent the morning in a repo opened New task and was
-// offered folders the form happened to remember instead. One noun per concept
+// The app had two recents. The home page shows the folders this machine has
+// Claude sessions in, newest session first (`/api/claude-sessions`, its "Claude
+// Sessions" strip); this form showed a localStorage array only it ever wrote, so
+// a person who had spent the morning in a repo opened New task and was offered
+// folders the form happened to remember. One noun per concept
 // (design-principles §1), and recents are exactly the "recognition over recall"
-// affordance §4 asks for — so the shared store leads the list now.
+// affordance §4 asks for — so the home page's list leads this one.
 describe("the folder recents come from the app's own recents", () => {
-  test("a recent FILE contributes the folder it lives in", () => {
-    // The shared store holds files (the server no-ops on directory urls) and a
-    // task wants a place to run, so the map from one to the other is the parent.
-    expect(parentFolder("/Users/a/code/app/main.py")).toBe("/Users/a/code/app");
-    // Windows paths arrive with backslashes from /api/config and friends; the
-    // picker's string surgery only understands forward ones.
-    expect(parentFolder("C:\\work\\repo\\main.py")).toBe("C:/work/repo");
-    // Roots degrade sanely rather than to the empty string, which would be
-    // silently dropped from the list.
-    expect(parentFolder("/notes.md")).toBe("/");
-    // A trailing separator is not a level of its own.
-    expect(parentFolder("/Users/a/code/app/")).toBe("/Users/a/code");
-    // Nothing to offer, rather than a bogus "".
-    expect(parentFolder("main.py")).toBe("");
-    expect(parentFolder("")).toBe("");
+  test("the leading tier is the home page's Claude sessions call, top five", () => {
+    const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+    // The SAME call Home.tsx makes, not a second endpoint that happens to
+    // answer something similar.
+    expect(src).toContain("getClaudeSessionFolders()");
+    expect(readFileSync(join(import.meta.dir, "Home.tsx"), "utf8"))
+      .toContain("getClaudeSessionFolders()");
+    // Five, and the server already answers newest-session-first, so the slice
+    // is the whole of the ordering — the folders reach the list in the order
+    // they arrived in, with no client-side re-sort to disagree with the strip.
+    expect(src).toContain("const SESSION_FOLDERS_SHOWN = 5;");
+    expect(src).toContain("r.folders.slice(0, SESSION_FOLDERS_SHOWN)");
+    expect(src).not.toContain("sessionFolders.sort");
+    // Enough of them to be worth opening: the dropdown shows five, and the
+    // leading tier can now fill it on its own.
+    expect(src).toContain("const RECENTS_SHOWN = 5;");
+    // NOT /api/recents. That is the explorer's recently-OPENED FILES — the wrong
+    // shape (files, not places to work) and, on a machine with dozens of
+    // sessions, three entries long.
+    expect(src).not.toContain("@apps/explorer/lib/recents");
+    expect(src).not.toContain("hydrateRecents");
   });
 
-  test("the list is built from the shared store first, then the form's own memory", () => {
+  test("the form's own memory follows it, and nothing is offered twice", () => {
     const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
-    // The SAME module the home page reads, not a second client for /api/recents.
-    expect(src).toContain('from "@apps/explorer/lib/recents"');
-    expect(src).toContain("loadRecents()");
-    // Raw MRU, which is what Home.tsx renders — not `displayRecents`, the
-    // sidebar's stable-slot view, whose order is deliberately sticky.
-    expect(src).not.toContain("displayRecents");
-    // The cache is filled on mount, for the case where a `/tasks?new=1` deep link
-    // makes this modal the first thing opened in a session.
-    expect(src).toContain("void hydrateRecents();");
     // Order: the app's recents, then folders picked through Browse or saved on a
     // task, then existing tasks' targets as padding. The middle tier is KEPT — a
-    // folder deliberately chosen here may hold no files anyone has opened, so the
-    // shared store would never learn it.
+    // folder deliberately chosen here may hold no Claude session at all, so the
+    // shared source would never learn it.
     const list = src.slice(src.indexOf("const readRecentList = useCallback("));
-    const body = list.slice(0, list.indexOf("}, [recentTargets]);"));
-    expect(body.indexOf("sharedRecentFolders()")).toBeLessThan(body.indexOf("readRecents()"));
+    const body = list.slice(0, list.indexOf("}, [recentTargets, sessionFolders]);"));
+    expect(body.indexOf("sessionFolders")).toBeLessThan(body.indexOf("readRecents()"));
     expect(body.indexOf("readRecents()")).toBeLessThan(body.indexOf("recentTargets"));
-    // Deduped, so a folder both stores know is offered once.
+    // Deduped, so a folder two tiers know is offered once.
     expect(body).toContain("seen.has(p)");
+    // The fetch is fire-and-forget: a suggestion list that fails to load costs
+    // suggestions, never the form.
+    expect(src).toContain("getClaudeSessionFolders().then(");
+    expect(src).toContain("      () => {},");
   });
 });

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -8,6 +8,8 @@
 // three exports are plain functions, which is why they were pulled out of the
 // component in the first place.
 import { beforeAll, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { RecurrenceRule, ScheduledMessage } from "@platform/lib/api";
 
 const g = globalThis as unknown as Record<string, unknown>;
@@ -43,6 +45,7 @@ let pastNoteFor: typeof import("./NewJobModal").pastNoteFor;
 let PAST_NOTE_ONE_OFF: typeof import("./NewJobModal").PAST_NOTE_ONE_OFF;
 let PAST_NOTE_CATCH_UP: typeof import("./NewJobModal").PAST_NOTE_CATCH_UP;
 let defaultTargetOf: typeof import("./NewJobModal").defaultTargetOf;
+let parentFolder: typeof import("./NewJobModal").parentFolder;
 
 beforeAll(async () => {
   const mod = await import("./NewJobModal");
@@ -71,6 +74,7 @@ beforeAll(async () => {
   PAST_NOTE_ONE_OFF = mod.PAST_NOTE_ONE_OFF;
   PAST_NOTE_CATCH_UP = mod.PAST_NOTE_CATCH_UP;
   defaultTargetOf = mod.defaultTargetOf;
+  parentFolder = mod.parentFolder;
 });
 
 // Only the fields these functions read; the rest of a stored entry is noise
@@ -1443,5 +1447,55 @@ describe("defaultTargetOf", () => {
     expect(
       defaultTargetOf({ home: "C:\\Users\\v", fused_dir: "C:\\Users\\v\\Fused" }),
     ).toBe("C:/Users/v/Fused");
+  });
+});
+
+// ---- "recent" means one thing -------------------------------------------------
+// Until 2026-08-18 the app had two recents. The home page's Recent files strip
+// reads the server-backed store at ~/.fused-render/recents.json
+// (apps/explorer/lib/recents); this form read a localStorage array only it ever
+// wrote, so a person who had spent the morning in a repo opened New task and was
+// offered folders the form happened to remember instead. One noun per concept
+// (design-principles §1), and recents are exactly the "recognition over recall"
+// affordance §4 asks for — so the shared store leads the list now.
+describe("the folder recents come from the app's own recents", () => {
+  test("a recent FILE contributes the folder it lives in", () => {
+    // The shared store holds files (the server no-ops on directory urls) and a
+    // task wants a place to run, so the map from one to the other is the parent.
+    expect(parentFolder("/Users/a/code/app/main.py")).toBe("/Users/a/code/app");
+    // Windows paths arrive with backslashes from /api/config and friends; the
+    // picker's string surgery only understands forward ones.
+    expect(parentFolder("C:\\work\\repo\\main.py")).toBe("C:/work/repo");
+    // Roots degrade sanely rather than to the empty string, which would be
+    // silently dropped from the list.
+    expect(parentFolder("/notes.md")).toBe("/");
+    // A trailing separator is not a level of its own.
+    expect(parentFolder("/Users/a/code/app/")).toBe("/Users/a/code");
+    // Nothing to offer, rather than a bogus "".
+    expect(parentFolder("main.py")).toBe("");
+    expect(parentFolder("")).toBe("");
+  });
+
+  test("the list is built from the shared store first, then the form's own memory", () => {
+    const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+    // The SAME module the home page reads, not a second client for /api/recents.
+    expect(src).toContain('from "@apps/explorer/lib/recents"');
+    expect(src).toContain("loadRecents()");
+    // Raw MRU, which is what Home.tsx renders — not `displayRecents`, the
+    // sidebar's stable-slot view, whose order is deliberately sticky.
+    expect(src).not.toContain("displayRecents");
+    // The cache is filled on mount, for the case where a `/tasks?new=1` deep link
+    // makes this modal the first thing opened in a session.
+    expect(src).toContain("void hydrateRecents();");
+    // Order: the app's recents, then folders picked through Browse or saved on a
+    // task, then existing tasks' targets as padding. The middle tier is KEPT — a
+    // folder deliberately chosen here may hold no files anyone has opened, so the
+    // shared store would never learn it.
+    const list = src.slice(src.indexOf("const readRecentList = useCallback("));
+    const body = list.slice(0, list.indexOf("}, [recentTargets]);"));
+    expect(body.indexOf("sharedRecentFolders()")).toBeLessThan(body.indexOf("readRecents()"));
+    expect(body.indexOf("readRecents()")).toBeLessThan(body.indexOf("recentTargets"));
+    // Deduped, so a folder both stores know is offered once.
+    expect(body).toContain("seen.has(p)");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5293,15 +5293,18 @@ describe("the tasks toolbar", () => {
   it("centres the page on one measure wide enough for the widest view", () => {
     // Edge-to-edge was the absence of a decision: on a 27" display the List ran to
     // 2000px and the title sat marooned at the far left of it (design-principles
-    // §3). The cap is the BOARD's number — five 260px lanes plus four 12px gaps is
-    // 1348 — so the widest view fits inside the measure and the other two are not
-    // given a second one.
+    // §3). The measure is the LIST's number, not the board's — it was the board's
+    // for a few hours, and letting the one view that CAN scroll inside itself set
+    // the width for the two that cannot was the wrong way round.
+    const measure = 1240;
+    // Comfortably inside the flow reference's 1200-1400, and tighter than the
+    // board's own five-lane span, which is the point: the board scrolls.
+    expect(measure).toBeGreaterThanOrEqual(1200);
+    expect(measure).toBeLessThanOrEqual(1400);
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane");
     expect(lane).toContain("flex: 0 0 260px");
     const board = block(SCHEDULE_CSS, ".schedule-tv-board");
     expect(board).toContain("gap: 12px");
-    const measure = 1360;
-    expect(measure).toBeGreaterThanOrEqual(5 * 260 + 4 * 12);
     const page = block(SCHEDULE_CSS, ".prefs-page.schedule-page > *");
     expect(page).toContain(`max-width: ${measure}px`);
     // Centred, and applied to every child so the header travels with the views — a
@@ -5319,8 +5322,9 @@ describe("the tasks toolbar", () => {
     expect(block(SCHEDULE_CSS, ".schedule-page .prefs-section > p")).toContain(
       "max-width: 760px",
     );
-    // No horizontal PAGE scroll under the cap: the board is the one thing that can
-    // exceed the window, and it scrolls inside itself (design-principles §0).
+    // No horizontal PAGE scroll, at the cap or under it: the board is the one
+    // thing that exceeds the measure, and it scrolls inside itself — which it has
+    // always done at any window narrower than five lanes (design-principles §0).
     expect(board).toContain("overflow-x: auto");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5234,3 +5234,45 @@ describe("what the List remembers between visits", () => {
     expect(LIST).not.toMatch(/owed\.current = memory\.current\.scroll[\s\S]{0,400}staleEmptied\.current = true/);
   });
 });
+
+// ---- the page's own measure ----------------------------------------------------
+// Edge-to-edge was the absence of a decision, not the use of the space: on a wide
+// display the List ran to 2000px of three-line rows and the title sat marooned at
+// the far left of it. The cap and the centring are read out of the stylesheet
+// because neither is visible in a diff of the page's markup, which did not change.
+
+describe("the tasks page measure", () => {
+  it("centres the page on one measure wide enough for the widest view", () => {
+    // Edge-to-edge was the absence of a decision: on a 27" display the List ran to
+    // 2000px and the title sat marooned at the far left of it (design-principles
+    // §3). The cap is the BOARD's number — five 260px lanes plus four 12px gaps is
+    // 1348 — so the widest view fits inside the measure and the other two are not
+    // given a second one.
+    const lane = block(SCHEDULE_CSS, ".schedule-tv-lane");
+    expect(lane).toContain("flex: 0 0 260px");
+    const board = block(SCHEDULE_CSS, ".schedule-tv-board");
+    expect(board).toContain("gap: 12px");
+    const measure = 1360;
+    expect(measure).toBeGreaterThanOrEqual(5 * 260 + 4 * 12);
+    const page = block(SCHEDULE_CSS, ".prefs-page.schedule-page > *");
+    expect(page).toContain(`max-width: ${measure}px`);
+    // Centred, and applied to every child so the header travels with the views — a
+    // centred board under a left-flush "Tasks" reads as a layout bug.
+    expect(page).toContain("margin-inline: auto");
+    // Both classes in the selector: the rule it has to beat is `.prefs-page > *`,
+    // which a lone `.schedule-page > *` only ties with — and a tie is settled by
+    // import order, which is not a thing this page should depend on.
+    expect(SCHEDULE_CSS).toContain(".prefs-page.schedule-page > * {");
+    // The sections restate it, since `.prefs-page > *` outranks the rule above for
+    // them; prose keeps the reading measure inside the widened box.
+    expect(block(SCHEDULE_CSS, ".schedule-page > .prefs-section")).toContain(
+      `max-width: ${measure}px`,
+    );
+    expect(block(SCHEDULE_CSS, ".schedule-page .prefs-section > p")).toContain(
+      "max-width: 760px",
+    );
+    // No horizontal PAGE scroll under the cap: the board is the one thing that can
+    // exceed the window, and it scrolls inside itself (design-principles §0).
+    expect(board).toContain("overflow-x: auto");
+  });
+});

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -38,6 +38,7 @@ import {
   isUnread,
   isUpcomingTask,
   laneCollapsed,
+  laneRolledUp,
   laneUnread,
   laneTime,
   lastRunAt,
@@ -5077,18 +5078,41 @@ describe("which board lanes are rolled up", () => {
     expect(laneCollapsed("in_progress", 1, {})).toBe(false);
   });
 
-  it("lets the reader open an empty lane, and rolls it up only by default", () => {
-    // Empty briefly OUTRANKED the reader — the lane rolled itself up and would
-    // not open again — and that was the wrong half of the complaint to fix
-    // (Akshil, 2026-08-18). Rolling up by default is what keeps four empty
-    // columns off a board with one busy lane; refusing to open is a lane
-    // telling the reader they may not look inside it. An expanded empty lane
-    // shows an empty panel, which is a fine answer to "is there anything here".
+  it("never consults the store for an EMPTY lane", () => {
+    // The persistent answer, and it short-circuits: nothing a reader does to an
+    // empty column can be written down, so nothing can outlive the sitting.
     expect(laneCollapsed("archived", 0, {})).toBe(true);
-    expect(laneCollapsed("archived", 0, { archived: false })).toBe(false);
-    expect(laneCollapsed("in_progress", 0, { in_progress: false })).toBe(false);
-    // And closing it again is the same one choice, written the other way.
-    expect(laneCollapsed("archived", 0, { archived: true })).toBe(true);
+    expect(laneCollapsed("archived", 0, { archived: false })).toBe(true);
+    expect(laneCollapsed("in_progress", 0, { in_progress: false })).toBe(true);
+  });
+
+  it("rolls a lane up when it DRAINS, whatever it was set to when it had work", () => {
+    // The consequence a reader will actually notice. The expanded choice is not
+    // honoured on the way down — and not deleted either, so the lane opens again
+    // on it the moment cards come back.
+    const choices = { done: false };
+    expect(laneCollapsed("done", 3, choices)).toBe(false);
+    expect(laneCollapsed("done", 0, choices)).toBe(true);
+    expect(laneCollapsed("done", 1, choices)).toBe(false);
+  });
+
+  it("lets the reader PEEK into an empty lane, for this sitting only", () => {
+    // Opening a column with nothing in it answers "is there really nothing
+    // here?", and that is a question, not a preference. `laneRolledUp` is where
+    // the peek meets the store.
+    const none = new Set<BoardColumn>();
+    const peeked = new Set<BoardColumn>(["archived"]);
+    expect(laneRolledUp("archived", 0, {}, none)).toBe(true);
+    expect(laneRolledUp("archived", 0, {}, peeked)).toBe(false);
+    // A peek says nothing about a lane that has cards — which is what stops a
+    // stale one reopening a column that filled up and drained again.
+    expect(laneRolledUp("archived", 2, { archived: true }, peeked)).toBe(true);
+    expect(laneRolledUp("archived", 2, {}, peeked)).toBe(false);
+    // And with no peek it is exactly the persistent rule.
+    for (const count of [0, 1, 5]) {
+      expect(laneRolledUp("done", count, { done: true }, none))
+        .toBe(laneCollapsed("done", count, { done: true }));
+    }
   });
 
   it("lets the reader's own choice outrank the rule, in both directions", () => {
@@ -5186,8 +5210,22 @@ describe("which board lanes are rolled up", () => {
     expect(LANES).toContain("{...dropProps(col.key)}");
   });
 
-  it("is decided by laneCollapsed on the board, which stores only the toggle", () => {
-    expect(LANES).toContain("laneCollapsed(col.key, lane.length, choices)");
+  it("is decided by laneRolledUp on the board, which stores only the toggle", () => {
+    expect(LANES).toContain("laneRolledUp(col.key, lane.length, choices, peeked)");
+    // The peek is component state and is persisted NOWHERE — not localStorage,
+    // not the URL — so a remount (every navigation back to this page) starts the
+    // board with none.
+    expect(LANES).toContain("const [peeked, setPeeked] = useState<Set<BoardColumn>>(() => new Set());");
+    // WHICH store a press lands in is decided by the lane's contents. A press on
+    // a lane with cards is a preference and is written down; a press on an empty
+    // one is a peek and stays in memory.
+    const toggle = LANES.slice(LANES.indexOf("const toggleLane = (key: BoardColumn"));
+    const body = toggle.slice(0, toggle.indexOf("\n  };"));
+    expect(body).toContain("if ((byLane.get(key)?.length ?? 0) === 0) {");
+    expect(body.indexOf("setPeeked(")).toBeLessThan(body.indexOf("localStorage.setItem"));
+    // And the peek is dropped while the lane has cards, so a column that fills
+    // and drains comes back rolled up rather than answering an older emptiness.
+    expect(LANES).toContain("const next = new Set([...cur].filter((key) => (byLane.get(key)?.length ?? 0) === 0));");
     // The old snapshot key and its hard-coded Archive are gone.
     expect(VIEWS).not.toContain("scheduled-board-collapsed");
     expect(VIEWS).not.toContain('new Set<BoardColumn>(["archived"])');

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -50,6 +50,8 @@ import {
   messageStamp,
   messageTime,
   messageTone,
+  threadRunning,
+  threadTone,
   messageWhenTitle,
   nextRunAt,
   openMessageHref,
@@ -829,6 +831,62 @@ describe("markReadIntent", () => {
 });
 
 // ---- per-message state -------------------------------------------------------
+
+describe("threadTone: archiving a task archives its thread", () => {
+  const archived = task({ status: "archived" });
+  const live = task({ status: "in_progress" });
+
+  it("files every settled message under Archive, whatever it was", () => {
+    // The bug it fixes: the card moved to Archive and the ten rows under it
+    // stayed green, amber and red, still reading as live work. A task is a
+    // thread, so filing the task files the thread.
+    for (const m of [
+      msg({ state: "sent", turn: "done" }),
+      msg({ state: "error" }),
+      msg({ state: "missed", template_id: "" }),
+      msg({ state: "pending" }),
+    ]) {
+      expect(threadTone(archived, m).column).toBe("archived");
+    }
+  });
+
+  it("keeps WHAT HAPPENED and drops only the alarm", () => {
+    // Archived is a place, not an event: the label is left exactly as it was so
+    // an archived thread can still be read run by run. `failed` goes, because a
+    // filed task that still flies a red mark is asking to be dealt with again.
+    const broke = threadTone(archived, msg({ state: "error" }));
+    expect(broke.label).toBe("Failed");
+    expect(broke.failed).toBe(false);
+    expect(threadTone(archived, msg({ state: "pending" })).label).toBe("Scheduled");
+  });
+
+  it("leaves a RUNNING turn exactly where it is", () => {
+    // Filing something does not stop it, and a running turn is the one fact on
+    // this page about the present. The server makes the other half of the same
+    // promise — an archived task with a turn in flight reads In Progress until
+    // it ends (fused_render/server/routers/tasks.py `_running_now`).
+    const running = msg({ state: "sent", turn: "" });
+    expect(threadTone(archived, running)).toEqual(messageTone(running));
+    expect(threadTone(archived, msg({ state: "sending" })).column).toBe("in_progress");
+  });
+
+  it("does nothing at all to a task that is not archived", () => {
+    for (const m of [msg({ state: "error" }), msg({ state: "sent", turn: "done" })]) {
+      expect(threadTone(live, m)).toEqual(messageTone(m));
+    }
+  });
+
+  it("answers whether anything in a thread is mid-turn", () => {
+    expect(threadRunning([msg({ state: "sent", turn: "done" })])).toBe(false);
+    expect(threadRunning([msg({ state: "sent", turn: "done" }), msg({ state: "sending" })]))
+      .toBe(true);
+    expect(threadRunning([])).toBe(false);
+  });
+
+  it("is what the List's thread rows actually ask", () => {
+    expect(VIEWS).toContain("const tone = threadTone(task, m);");
+  });
+});
 
 describe("messageTone", () => {
   it("never paints a failed or missed message as a clean run", () => {
@@ -5019,9 +5077,22 @@ describe("which board lanes are rolled up", () => {
     expect(laneCollapsed("in_progress", 1, {})).toBe(false);
   });
 
-  it("lets the reader's own choice outrank the rule, in both directions", () => {
+  it("keeps an EMPTY lane rolled up even against the reader's own choice", () => {
+    // Not a default any more (Akshil, 2026-08-18): a lane the reader expanded
+    // while it had cards stayed open after the last one left, and the board
+    // filled with empty outlined columns wearing a header and a `0`. An empty
+    // column has nothing to show, so the honest width for it is the rail's.
+    expect(laneCollapsed("archived", 0, { archived: false })).toBe(true);
+    expect(laneCollapsed("in_progress", 0, { in_progress: false })).toBe(true);
+  });
+
+  it("lets the reader's own choice outrank the rule once the lane has cards", () => {
     expect(laneCollapsed("upcoming", 12, { upcoming: true })).toBe(true);
-    expect(laneCollapsed("archived", 0, { archived: false })).toBe(false);
+    // The choice is REMEMBERED through the emptiness, not discarded, so the
+    // lane opens again on the first arrival — a display rule, not a quiet edit
+    // of what the reader asked for.
+    expect(laneCollapsed("archived", 0, { archived: false })).toBe(true);
+    expect(laneCollapsed("archived", 1, { archived: false })).toBe(false);
     // And a choice about ONE lane says nothing about its neighbours.
     expect(laneCollapsed("done", 0, { upcoming: true })).toBe(true);
   });
@@ -5047,6 +5118,35 @@ describe("which board lanes are rolled up", () => {
     expect("upcoming" in choices).toBe(false);
     expect(laneCollapsed("upcoming", 0, choices)).toBe(true);
     expect(laneCollapsed("upcoming", 4, choices)).toBe(false);
+    // The stored choice survives the round trip even while the empty rule is
+    // the thing being obeyed.
+    expect(choices.archived).toBe(false);
+  });
+
+  it("makes an empty rail a marker rather than a control, without losing the drop", () => {
+    // The press that used to expand it now does nothing visible, so the rail
+    // stops claiming to be pressable.
+    expect(LANES).toContain("const empty = lane.length === 0;");
+    expect(LANES).toContain("aria-disabled={empty || undefined}");
+    expect(LANES).toContain("onClick={empty ? undefined : () => toggleLane(col.key, true)}");
+    // `aria-disabled` and never the real thing: a disabled button stops
+    // receiving pointer events, and this element is still the drop target for
+    // the one gesture that makes an empty lane non-empty.
+    expect(LANES).not.toMatch(/[^-]disabled=\{empty/);
+    expect(LANES).toContain("{...dropProps(col.key)}");
+    // And no `0`: a count answers "how many are hidden in here", which on an
+    // empty rail the rail has already answered.
+    expect(LANES).toContain("{!empty && (");
+    expect(LANES).toContain('<span className="schedule-tv-rail-count">{lane.length}</span>');
+    // The dimming is the rail's own, and it lifts while a card is over it — an
+    // empty lane is the most likely drop there is.
+    const dim = block(SCHEDULE_CSS, '.schedule-tv-rail[aria-disabled="true"]');
+    expect(dim).toContain("cursor: default");
+    expect(dim).toMatch(/opacity: 0\.\d+/);
+    expect(block(
+      SCHEDULE_CSS,
+      '.schedule-tv-rail[aria-disabled="true"].is-drop-legal',
+    )).toContain("opacity: 1");
   });
 
   it("is decided by laneCollapsed on the board, which stores only the toggle", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5235,13 +5235,45 @@ describe("what the List remembers between visits", () => {
   });
 });
 
-// ---- the page's own measure ----------------------------------------------------
-// Edge-to-edge was the absence of a decision, not the use of the space: on a wide
-// display the List ran to 2000px of three-line rows and the title sat marooned at
-// the far left of it. The cap and the centring are read out of the stylesheet
-// because neither is visible in a diff of the page's markup, which did not change.
+// ---- the toolbar: one bar, three lenses ----------------------------------------
+// The List / Board / Calendar switcher and the three filters beside it are the only
+// furniture all three views share, so they are also the only place the page can
+// contradict itself about being one dataset seen three ways. Two things changed on
+// 2026-08-18 and both are read out of the page source, because both are the kind of
+// regression that looks entirely correct in a diff: the switcher's halves gained
+// marks, and the filters stopped disappearing when the calendar came up.
+const PAGE = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
 
-describe("the tasks page measure", () => {
+describe("the tasks toolbar", () => {
+  it("gives every half of the view switcher a mark as well as a word", () => {
+    // Icon AND label. An icon-only switcher for the page's most central control
+    // trades recognition for guessing (design-principles §4), and three short words
+    // of near-identical weight were a block of text you had to read.
+    for (const [icon, label] of [
+      ["ICON_VIEW_LIST", "List"],
+      ["ICON_VIEW_BOARD", "Board"],
+      ["ICON_VIEW_CALENDAR", "Calendar"],
+    ]) {
+      expect(PAGE).toMatch(new RegExp(`\\{${icon}\\}\\s*\\n\\s*${label}\\n`));
+    }
+    // Drawn by the same helper as every other glyph on the page, so the switcher
+    // cannot drift to a second icon size — they are exported from the file that
+    // owns `icon()` rather than redeclared here.
+    for (const name of ["ICON_VIEW_LIST", "ICON_VIEW_BOARD", "ICON_VIEW_CALENDAR"]) {
+      expect(CALENDAR).toContain(`export const ${name} = icon(`);
+    }
+    // The marks are muted at rest and take the label's colour on the active half,
+    // so the icon reinforces the fill's statement rather than competing with it.
+    expect(block(SCHEDULE_CSS, ".schedule-view-btn > svg")).toContain("color: var(--fg-muted)");
+    expect(
+      block(SCHEDULE_CSS, ".schedule-view-btn.is-active > svg"),
+    ).toContain("color: inherit");
+    // Only the VIEW switcher. `.schedule-form-seg` is shared with the New task
+    // form's Once / On a schedule pair, which is a choice inside a form and stays
+    // text-only — so the icon rules hang off a class of their own.
+    expect(block(SCHEDULE_CSS, ".schedule-view-btn").length).toBeGreaterThan(0);
+  });
+
   it("centres the page on one measure wide enough for the widest view", () => {
     // Edge-to-edge was the absence of a decision: on a 27" display the List ran to
     // 2000px and the title sat marooned at the far left of it (design-principles

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -2086,70 +2086,121 @@ function rules(css: string): { selectors: string[]; body: string }[] {
 }
 
 // ---- which thing on the board is a surface -------------------------------------
-// The lane used to paint a fill at rest, so an empty lane was a grey slab and every
-// card competed with the box around it (Akshil, 2026-08-17, against flow side by
-// side). The fill is gone and the CARD is the only surface — but the lane is still
-// BOUNDED, by the same hairline the collapsed rail wears, because unfilled and
-// unbounded a column had no edge of its own at all (Akshil, same day: "at least
-// they should have an outline when they're expanded"). Four things then have to stay
-// true, and each was nearly broken by one of those two changes, so all four are read
-// out of the stylesheets: no fill comes back, the edge is there and is the rail's
-// edge, the card still lifts off the PAGE in both themes, and a drop target still
-// announces itself on a box that paints almost nothing — without its dashed line
-// stacking onto the hairline that is now underneath it.
+// The board has been round this loop twice. The lane painted a fill at rest, so an
+// empty lane was a grey slab and every card competed with the box around it (Akshil,
+// 2026-08-17, against flow side by side); the fill came off and a `--border` hairline
+// went on in its place, because unfilled and unbounded a column had no edge at all.
+// On 2026-08-18 the hairline turned out to be the same mistake in thinner form —
+// five outlined boxes read as five boxes — and both were replaced by the thing that
+// was actually wanted: an ORDERING. The lane is a fill that LOSES to the card, the
+// card is the only surface that steps toward the reader, and the collapsed rail
+// keeps its hairline because it is a control rather than a column.
+//
+// So what is read out of the stylesheets is the ordering itself (page < lane < card
+// in dark, card above lane in light — asserted on the token VALUES, since a
+// relationship written only in prose is one a later tuning can silently invert), the
+// open lane's lack of an edge against the rail's, the card's lift in both themes,
+// and the drop states, which have to keep announcing themselves by ADDING paint on a
+// box that now has a resting fill again.
+
+/** A token's value in one of tokens.css's two palette blocks. */
+function token(name: string, theme: "dark" | "light"): string {
+  const lightAt = TOKENS_CSS.indexOf(':root[data-theme="light"]');
+  const scope = theme === "dark" ? TOKENS_CSS.slice(0, lightAt) : TOKENS_CSS.slice(lightAt);
+  const found = scope.match(new RegExp(`${name}:\\s*([^;]+);`));
+  if (!found) throw new Error(`tokens.css has no ${name} in the ${theme} palette`);
+  return found[1].trim();
+}
+
+/** Rough perceived lightness of a `#rrggbb`, enough to order three greys. */
+function lightness(hex: string): number {
+  const m = hex.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  if (!m) throw new Error(`not a hex colour: ${hex}`);
+  const [r, g, b] = m.slice(1).map((h) => parseInt(h, 16));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
 
 describe("the board's surfaces", () => {
-  it("gives the lane no resting fill, but does give it an edge", () => {
+  it("orders page, lane and card so the card is the lit one", () => {
+    // The relationship the two tokens exist for. In dark all three are painted, and
+    // they have to climb: the lane is a whisper above the page (a column you can
+    // see) and the card a clear step above the lane (the thing you look at).
+    const dark = ["--bg", "--tasks-lane-bg", "--tasks-card-bg"].map((t) =>
+      lightness(token(t, "dark")),
+    );
+    expect(dark[0]).toBeLessThan(dark[1]);
+    expect(dark[1]).toBeLessThan(dark[2]);
+    // The lane must not become a slab on its way up — half of the page's own gap to
+    // the card is already more contrast than a quiet ground can carry.
+    expect(dark[1] - dark[0]).toBeLessThan((dark[2] - dark[0]) / 2);
+    // In light the page is the lightest thing available, so only the half that can
+    // still be stated is: the card stays above the lane.
+    expect(lightness(token("--tasks-lane-bg", "light"))).toBeLessThan(
+      lightness(token("--tasks-card-bg", "light")),
+    );
+    // The card's own fill must be a NEUTRAL charcoal in dark, not the blue-leaning
+    // grey `--bg-panel` is: a card whose blue channel runs away from its red reads
+    // as grey over a near-black page rather than as black-tinted (Akshil,
+    // 2026-08-18, against flow).
+    const cardHex = token("--tasks-card-bg", "dark").match(/^#(..)(..)(..)$/)!;
+    const [cr, , cb] = cardHex.slice(1).map((h) => parseInt(h, 16));
+    expect(cb - cr).toBeLessThan(6);
+  });
+
+  it("gives the OPEN lane a quiet fill and no edge, and the rail the opposite", () => {
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
-    // No FILL: a filled lane is a surface competing with the cards on it, which is
-    // the whole reason the plate came off.
-    expect(lane).not.toContain("background");
-    expect(block(SCHEDULE_CSS, ".schedule-tv-lane")).not.toContain("background");
-    // But BOUNDED — "at least they should have an outline when they're expanded".
-    // Unfilled and unbounded, the column's only edge was the widest card's ragged
-    // right-hand end.
-    expect(lane).toContain("border: 1px solid var(--border)");
+    // The fill is the lane's whole shape now — it is what replaced the hairline.
+    expect(lane).toContain("background: var(--tasks-lane-bg)");
+    // And NO visible edge: an open column is an invisible panel, not a box.
+    expect(lane).not.toContain("border: 1px solid var(--border)");
+    expect(lane).toContain("border: 1px solid transparent");
     expect(lane).toContain("border-radius: 8px");
     // Stated with it, so `min-height: 120px` stays the floor the board actually has.
     expect(lane).toContain("box-sizing: border-box");
-    // One hairline all the way round, not a rule down one side.
+    // One box all the way round, not a rule down one side.
     expect(lane).not.toContain("border-left");
     expect(lane).not.toContain("border-right");
-    // The collapsed lane is a lane too, and since 2026-08-17 the two wear the SAME
-    // edge — same width, same token, same radius, both unfilled — so the open and
-    // closed forms read as one family rather than as two ideas about a lane's edge.
+    // The lane's own wrapper stays unpainted — one fill per column, or the padding
+    // between header and body becomes a second, differently-shaped surface.
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane")).not.toContain("background");
+    // The COLLAPSED rail is the exception Akshil granted explicitly: 52px wide with
+    // no cards to give it shape, and a button you press, so it keeps the hairline.
     const rail = block(SCHEDULE_CSS, ".schedule-tv-rail");
     expect(rail).toContain("background: transparent");
     expect(rail).toContain("border: 1px solid var(--border)");
     expect(rail).toContain("border-radius: 8px");
   });
 
-  it("makes the card lift off the PAGE, in both themes, from tokens", () => {
+  it("makes the card lift off the LANE, in both themes, from tokens", () => {
     const card = block(SCHEDULE_CSS, ".schedule-tv-board .schedule-tv-card");
-    // `--bg` was the old fill and is also what the page ground is painted in
+    // `--bg` was the oldest fill and is also what the page ground is painted in
     // (base.css `body`), so keeping it would have made the card vanish against the
     // page — most obviously in light mode, where both are plain white.
     expect(card).not.toMatch(/background: var\(--bg\);/);
-    // `--bg-panel` is the app's "surface floating above the page" token: it steps
-    // lighter than the ground in dark and stays white in light, where the hairline
-    // and the shadow do the lifting instead.
-    expect(card).toContain("background: var(--bg-panel)");
+    // `--bg-panel` was the second, and is a POPOVER's colour: it lifted correctly
+    // but read as grey (see the ordering test above).
+    expect(card).not.toMatch(/background: var\(--bg-panel\);/);
+    expect(card).toContain("background: var(--tasks-card-bg)");
     expect(card).toContain("border: 1px solid var(--border)");
     expect(card).toContain("box-shadow: 0 1px 2px var(--shadow-sm)");
-    // Both halves of the lift are theme-tuned tokens with a value in BOTH blocks,
+    // Every part of the lift is a theme-tuned token with a value in BOTH blocks,
     // never a colour defined only under `[data-theme]` — a light-only definition is
     // how one theme ends up with no card surface at all.
-    for (const token of ["--bg-panel", "--shadow-sm"]) {
-      expect(TOKENS_CSS.slice(0, TOKENS_CSS.indexOf(':root[data-theme="light"]'))).toContain(
-        `${token}:`,
-      );
-      expect(TOKENS_CSS.slice(TOKENS_CSS.indexOf(':root[data-theme="light"]'))).toContain(
-        `${token}:`,
-      );
+    for (const name of ["--tasks-card-bg", "--tasks-lane-bg", "--shadow-sm"]) {
+      expect(token(name, "dark")).toBeTruthy();
+      expect(token(name, "light")).toBeTruthy();
     }
+    // Hover moves the FILL as well as the edge now: against a lane that is itself a
+    // surface, an edge-only hover on the card is easy to miss.
+    const hover = block(
+      SCHEDULE_CSS,
+      ".schedule-tv-board .schedule-tv-card:hover:not(:disabled)",
+    );
+    expect(hover).toMatch(/background: color-mix\(in srgb, var\(--fg\) \d+%, var\(--tasks-card-bg\)\)/);
+    expect(hover).toContain("border-color:");
     // The hover-revealed action strip is painted in the card's surface so it reads
     // as floating over the head; it has to track the card or it is a patch on it.
-    expect(block(TASKS_CSS, ".tasks-card-act")).toContain("background: var(--bg-panel)");
+    expect(block(TASKS_CSS, ".tasks-card-act")).toContain("background: var(--tasks-card-bg)");
   });
 
   it("lets a drop target announce itself by ADDING paint, not by changing it", () => {
@@ -2157,8 +2208,8 @@ describe("the board's surfaces", () => {
     // goes from nothing to something. A legal lane outlines dashed the moment a drag
     // starts, the lane under the pointer takes the accent wash, and the one drop
     // that SENDS rather than files swaps the hue for `--activity` and says so in
-    // words. On a transparent lane all four are more legible than they were on a
-    // tinted one, not less.
+    // words. The lane's resting fill is quiet enough that all four still add rather
+    // than merely change — which is the property, not the absence of a fill.
     expect(SCHEDULE_CSS).toMatch(
       /\.schedule-tv-lane-body\.is-drop-legal\s*\{[^}]*outline: 1px dashed color-mix\(in srgb, var\(--accent\)/,
     );
@@ -2175,7 +2226,7 @@ describe("the board's surfaces", () => {
     // The lane keeps the geometry those states are drawn with — the padding that
     // insets the outline off the top card, and the radius the wash takes.
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane-body");
-    expect(lane).toContain("padding: 4px");
+    expect(lane).toContain("padding: 6px");
     expect(lane).toContain("border-radius: 8px");
     // And it keeps a floor, so an EMPTY lane — which now shows its header and
     // nothing else, because "nothing scheduled" should look like nothing — is still

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5123,6 +5123,49 @@ describe("which board lanes are rolled up", () => {
     expect(choices.archived).toBe(false);
   });
 
+  it("keeps the lane's scrollbar out of the cards' right edge", () => {
+    // macOS gives a webview OVERLAY scrollbars, so a lane with more cards than
+    // fit drew its thumb straight over every card's right-hand border (Akshil,
+    // screenshot). Styling the bar at all is what opts the element out of
+    // overlay scrollbars, so it takes real layout space and no overlap is
+    // possible; the gutter is what stops the column jumping by its width when
+    // the fifth card arrives.
+    // Its own rule, beside the two sibling scrollers — `block` would hand back
+    // the lane's resting box, which is a different decision about the same
+    // selector.
+    const gutter = rules(SCHEDULE_CSS).find(
+      (r) => r.selectors.includes(".schedule-tv-lane-body")
+        && r.body.includes("scrollbar-gutter"),
+    );
+    expect(gutter?.body).toContain("scrollbar-gutter: stable");
+    expect(SCHEDULE_CSS).toContain(".schedule-tv-lane-body::-webkit-scrollbar,");
+    // The thumb sits INSIDE the track — a transparent border plus
+    // background-clip, so 10px of track carries 4px of ink and the mark itself
+    // is clear of the card edge, not merely the layout.
+    const bar = block(SCHEDULE_CSS, ".schedule-tv-lane-body::-webkit-scrollbar");
+    expect(bar).toContain("width: 10px");
+    const thumb = block(SCHEDULE_CSS, ".schedule-tv-lane-body::-webkit-scrollbar-thumb");
+    expect(thumb).toContain("background-clip: padding-box");
+    expect(thumb).toContain("border: 3px solid transparent");
+    // Mixed from a token, so it lands at the same weight over the lane's fill in
+    // both themes rather than being a colour tuned for one.
+    expect(thumb).toMatch(/background: color-mix\(in srgb, var\(--fg-muted\) \d+%, transparent\)/);
+    // The track paints nothing: a groove would be a second column beside the
+    // cards.
+    expect(block(SCHEDULE_CSS, ".schedule-tv-lane-body::-webkit-scrollbar-track"))
+      .toContain("background: transparent");
+    // ONE rule for the page's three content scrollers, so the List and the Board
+    // cannot end up wearing different bars.
+    const shared = rules(SCHEDULE_CSS).find(
+      (r) => r.selectors.includes(".schedule-tv-lane-body::-webkit-scrollbar-thumb"),
+    );
+    expect(shared?.selectors).toContain(".schedule-cal-thread::-webkit-scrollbar-thumb");
+    expect(shared?.selectors).toContain(".tasks-list::-webkit-scrollbar-thumb");
+    // The week grid is the exception and keeps hiding its bar outright — the
+    // hour lines already say where you are.
+    expect(block(SCHEDULE_CSS, ".schedule-cal-scroll")).toContain("scrollbar-width: none");
+  });
+
   it("makes an empty rail a marker rather than a control, without losing the drop", () => {
     // The press that used to expand it now does nothing visible, so the rail
     // stops claiming to be pressable.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -2257,9 +2257,16 @@ describe("the board's surfaces", () => {
     );
     expect(hover).toMatch(/background: color-mix\(in srgb, var\(--fg\) \d+%, var\(--tasks-card-bg\)\)/);
     expect(hover).toContain("border-color:");
-    // The hover-revealed action strip is painted in the card's surface so it reads
-    // as floating over the head; it has to track the card or it is a patch on it.
-    expect(block(TASKS_CSS, ".tasks-card-act")).toContain("background: var(--tasks-card-bg)");
+    // The hover-revealed action strip paints NOTHING and lets the card show
+    // through. It used to carry a skin in the card's surface colour, which the
+    // hover lift above made untenable: a fill matching the RESTING colour is a
+    // dark rectangle on a lit card, and matching both would mean restating the
+    // hover expression in a second file for the two to drift apart at the next
+    // tuning (Bugbot). The strip is only ever seen over a hovered or focused
+    // card, so there is nothing to match.
+    const strip = block(TASKS_CSS, ".tasks-card-act");
+    expect(strip).toContain("background: transparent");
+    expect(strip).not.toContain("--tasks-card-bg");
   });
 
   it("lets a drop target announce itself by ADDING paint, not by changing it", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5274,6 +5274,22 @@ describe("the tasks toolbar", () => {
     expect(block(SCHEDULE_CSS, ".schedule-view-btn").length).toBeGreaterThan(0);
   });
 
+  it("shows the same three filters on all three views, and means them", () => {
+    // The filters used to be gated on `view !== "calendar"`. A control that
+    // vanishes when you change lens makes three lenses read as three pages, and a
+    // person who has just narrowed the List to one project meant to keep looking at
+    // that project (design-principles §1).
+    expect(PAGE).not.toContain('view !== "calendar" && (');
+    expect(PAGE).toContain("<TaskFilterControls");
+    // And the calendar is handed the FILTERED set, or the controls would be shown
+    // doing nothing — worse than hidden.
+    const cal = PAGE.slice(PAGE.indexOf("<ScheduleCalendar"));
+    expect(cal.slice(0, cal.indexOf("/>"))).toContain("tasks={shown}");
+    // `shown` is the same derivation the other two views read, not a second one.
+    expect(PAGE).toContain("const shown = useMemo(() => filterTasks(tasks, filters), [tasks, filters]);");
+    expect(PAGE).toContain("<TaskBoard tasks={shown}");
+  });
+
   it("centres the page on one measure wide enough for the widest view", () => {
     // Edge-to-edge was the absence of a decision: on a 27" display the List ran to
     // 2000px and the title sat marooned at the far left of it (design-principles

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5077,21 +5077,22 @@ describe("which board lanes are rolled up", () => {
     expect(laneCollapsed("in_progress", 1, {})).toBe(false);
   });
 
-  it("keeps an EMPTY lane rolled up even against the reader's own choice", () => {
-    // Not a default any more (Akshil, 2026-08-18): a lane the reader expanded
-    // while it had cards stayed open after the last one left, and the board
-    // filled with empty outlined columns wearing a header and a `0`. An empty
-    // column has nothing to show, so the honest width for it is the rail's.
-    expect(laneCollapsed("archived", 0, { archived: false })).toBe(true);
-    expect(laneCollapsed("in_progress", 0, { in_progress: false })).toBe(true);
+  it("lets the reader open an empty lane, and rolls it up only by default", () => {
+    // Empty briefly OUTRANKED the reader — the lane rolled itself up and would
+    // not open again — and that was the wrong half of the complaint to fix
+    // (Akshil, 2026-08-18). Rolling up by default is what keeps four empty
+    // columns off a board with one busy lane; refusing to open is a lane
+    // telling the reader they may not look inside it. An expanded empty lane
+    // shows an empty panel, which is a fine answer to "is there anything here".
+    expect(laneCollapsed("archived", 0, {})).toBe(true);
+    expect(laneCollapsed("archived", 0, { archived: false })).toBe(false);
+    expect(laneCollapsed("in_progress", 0, { in_progress: false })).toBe(false);
+    // And closing it again is the same one choice, written the other way.
+    expect(laneCollapsed("archived", 0, { archived: true })).toBe(true);
   });
 
-  it("lets the reader's own choice outrank the rule once the lane has cards", () => {
+  it("lets the reader's own choice outrank the rule, in both directions", () => {
     expect(laneCollapsed("upcoming", 12, { upcoming: true })).toBe(true);
-    // The choice is REMEMBERED through the emptiness, not discarded, so the
-    // lane opens again on the first arrival — a display rule, not a quiet edit
-    // of what the reader asked for.
-    expect(laneCollapsed("archived", 0, { archived: false })).toBe(true);
     expect(laneCollapsed("archived", 1, { archived: false })).toBe(false);
     // And a choice about ONE lane says nothing about its neighbours.
     expect(laneCollapsed("done", 0, { upcoming: true })).toBe(true);
@@ -5166,30 +5167,23 @@ describe("which board lanes are rolled up", () => {
     expect(block(SCHEDULE_CSS, ".schedule-cal-scroll")).toContain("scrollbar-width: none");
   });
 
-  it("makes an empty rail a marker rather than a control, without losing the drop", () => {
-    // The press that used to expand it now does nothing visible, so the rail
-    // stops claiming to be pressable.
+  it("keeps a rolled-up rail pressable, and takes the `0` off an empty one", () => {
+    // The rail toggles whether or not the lane has cards in it: it briefly
+    // carried `aria-disabled` and no handler while empty, which made the one
+    // control on an empty column refuse to work.
+    expect(LANES).toContain("onClick={() => toggleLane(col.key, true)}");
+    // The attribute, not the word — the comment above the rail still explains
+    // why it is gone.
+    expect(LANES).not.toContain("aria-disabled=");
+    // What the complaint was actually about: a lone `0` chip at the foot of an
+    // empty rail. A count answers "how many are hidden in here", which an empty
+    // rail has already answered by being empty.
     expect(LANES).toContain("const empty = lane.length === 0;");
-    expect(LANES).toContain("aria-disabled={empty || undefined}");
-    expect(LANES).toContain("onClick={empty ? undefined : () => toggleLane(col.key, true)}");
-    // `aria-disabled` and never the real thing: a disabled button stops
-    // receiving pointer events, and this element is still the drop target for
-    // the one gesture that makes an empty lane non-empty.
-    expect(LANES).not.toMatch(/[^-]disabled=\{empty/);
-    expect(LANES).toContain("{...dropProps(col.key)}");
-    // And no `0`: a count answers "how many are hidden in here", which on an
-    // empty rail the rail has already answered.
     expect(LANES).toContain("{!empty && (");
     expect(LANES).toContain('<span className="schedule-tv-rail-count">{lane.length}</span>');
-    // The dimming is the rail's own, and it lifts while a card is over it — an
-    // empty lane is the most likely drop there is.
-    const dim = block(SCHEDULE_CSS, '.schedule-tv-rail[aria-disabled="true"]');
-    expect(dim).toContain("cursor: default");
-    expect(dim).toMatch(/opacity: 0\.\d+/);
-    expect(block(
-      SCHEDULE_CSS,
-      '.schedule-tv-rail[aria-disabled="true"].is-drop-legal',
-    )).toContain("opacity: 1");
+    // Still a drop target either way — dragging a card into a column that has
+    // never held one is the gesture that makes it non-empty.
+    expect(LANES).toContain("{...dropProps(col.key)}");
   });
 
   it("is decided by laneCollapsed on the board, which stores only the toggle", () => {
@@ -5261,13 +5255,20 @@ describe("what the List remembers between visits", () => {
     // Stored beside the scroll and the open rows, in the same sessionStorage
     // row, so all three are restored by the one read on mount.
     expect(LIST).toContain("const memory = useRef<ListMemory>(readListMemory());");
-    // Painted in the app's own selection colour — the explorer listing and the
-    // sidebar both use it — with an accent rule hover does not have, so the two
-    // washes stay tellable apart, and after the hover rule so a hovered
-    // selected row still reads as selected.
+    // THE SAME FILL AS HOVER, and nothing else. The first cut used
+    // `--row-bg-active` plus a 2px accent rule, which on a page whose accent is
+    // a bright lime made one row in ninety look like a dialog's default button
+    // — an olive plate with a yellow edge, shouting a fact that only needs to
+    // be findable (Akshil, screenshot). Hover and selected looking identical is
+    // fine and was asked for: only one row can be hovered, and a row that is
+    // both is both.
     const sel = block(TASKS_CSS, ".tasks-row.is-selected");
-    expect(sel).toContain("background: var(--row-bg-active)");
-    expect(sel).toContain("box-shadow: inset 2px 0 0 var(--accent)");
+    expect(sel).toContain("background: var(--row-bg-hover)");
+    expect(sel).not.toContain("--accent");
+    expect(sel).not.toContain("box-shadow");
+    expect(sel).not.toContain("--row-bg-active");
+    // Stated after the hover rule so the fill does not blink off when the
+    // pointer leaves a selected row.
     expect(TASKS_CSS.indexOf(".tasks-row:hover"))
       .toBeLessThan(TASKS_CSS.indexOf(".tasks-row.is-selected"));
     expect(TASKS_CSS).toContain(".tasks-row.is-selected:hover");

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5161,21 +5161,73 @@ describe("which board lanes are rolled up", () => {
 });
 
 describe("what the List remembers between visits", () => {
+  const NOTHING = { expanded: [], scroll: 0, selected: "" };
+
   it("remembers nothing at all when there is nothing stored", () => {
-    expect(parseListMemory(null)).toEqual({ expanded: [], scroll: 0 });
-    expect(parseListMemory("")).toEqual({ expanded: [], scroll: 0 });
-    expect(parseListMemory("{oops")).toEqual({ expanded: [], scroll: 0 });
-    expect(parseListMemory("[1,2]")).toEqual({ expanded: [], scroll: 0 });
+    expect(parseListMemory(null)).toEqual(NOTHING);
+    expect(parseListMemory("")).toEqual(NOTHING);
+    expect(parseListMemory("{oops")).toEqual(NOTHING);
+    expect(parseListMemory("[1,2]")).toEqual(NOTHING);
   });
 
-  it("keeps the task keys and the offset, and drops everything else", () => {
+  it("keeps the task keys, the offset and the row, and drops everything else", () => {
     expect(
-      parseListMemory('{"expanded":["TASK-1",7,"TASK-2"],"scroll":420.5,"x":1}'),
-    ).toEqual({ expanded: ["TASK-1", "TASK-2"], scroll: 420.5 });
+      parseListMemory(
+        '{"expanded":["TASK-1",7,"TASK-2"],"scroll":420.5,"selected":"TASK-2","x":1}',
+      ),
+    ).toEqual({ expanded: ["TASK-1", "TASK-2"], scroll: 420.5, selected: "TASK-2" });
     // A negative, infinite or non-numeric offset is not a place on a scrollbar.
     expect(parseListMemory('{"scroll":-3}').scroll).toBe(0);
     expect(parseListMemory('{"scroll":"120"}').scroll).toBe(0);
     expect(parseListMemory('{"expanded":"TASK-1"}').expanded).toEqual([]);
+    // A key is a string or it is nothing; "nothing selected" is the empty one.
+    expect(parseListMemory('{"selected":7}').selected).toBe("");
+  });
+
+  it("upgrades a memory written before the row was remembered", () => {
+    // The two fields that existed on 2026-08-18 are still honoured in full — a
+    // stored row missing `selected` means "no row", not "throw the sitting away".
+    expect(parseListMemory('{"expanded":["TASK-1"],"scroll":90}')).toEqual({
+      expanded: ["TASK-1"],
+      scroll: 90,
+      selected: "",
+    });
+  });
+
+  it("lights the row the reader last opened a conversation from", () => {
+    // Ninety near-identical three-line rows give no clue which one you came back
+    // out of, so "now the next one" meant re-finding the last one first.
+    expect(LIST).toContain("const [selected, setSelected] = useState(() => memory.current.selected);");
+    expect(LIST).toContain("remember({ ...memory.current, selected: key });");
+    expect(LIST).toContain("selected={selected === task.key}");
+    expect(VIEWS).toContain('+ (selected ? " is-selected" : "")');
+    // ONE row, and only the gestures that LEAVE the page mark it. `openChat` is
+    // where it is marked and NOT `activate`, deliberately: activate's second arm
+    // opens the edit form, a modal over this very page, and lighting a row for a
+    // trip the reader never took would make the highlight mean nothing. Every
+    // way into the conversation — the row's press, the Open chat button — goes
+    // through that one function, so every one of them marks.
+    const chatFn = VIEWS.slice(VIEWS.indexOf("const openChat = (intent: OpenThreadIntent) => {"));
+    const body = chatFn.slice(0, chatFn.indexOf("\n  };"));
+    expect(body).toContain("onSelect();");
+    expect(body.indexOf("onSelect();")).toBeLessThan(body.indexOf("performOpen("));
+    expect(ACTIVATE).not.toContain("onSelect()");
+    // A message row leaves too, and it belongs to this task's row.
+    const open = VIEWS.slice(VIEWS.indexOf("const openMessage = (m: TaskMessage) => {"));
+    expect(open.slice(0, open.indexOf("\n  };"))).toContain("onSelect();");
+    // Stored beside the scroll and the open rows, in the same sessionStorage
+    // row, so all three are restored by the one read on mount.
+    expect(LIST).toContain("const memory = useRef<ListMemory>(readListMemory());");
+    // Painted in the app's own selection colour — the explorer listing and the
+    // sidebar both use it — with an accent rule hover does not have, so the two
+    // washes stay tellable apart, and after the hover rule so a hovered
+    // selected row still reads as selected.
+    const sel = block(TASKS_CSS, ".tasks-row.is-selected");
+    expect(sel).toContain("background: var(--row-bg-active)");
+    expect(sel).toContain("box-shadow: inset 2px 0 0 var(--accent)");
+    expect(TASKS_CSS.indexOf(".tasks-row:hover"))
+      .toBeLessThan(TASKS_CSS.indexOf(".tasks-row.is-selected"));
+    expect(TASKS_CSS).toContain(".tasks-row.is-selected:hover");
   });
 
   it("restores the open rows and the scroll from THIS tab only", () => {

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2280,24 +2280,39 @@ export function groupByColumn(
 // A lane is either an open column or a 52px rail. Two things decide which, in
 // this order:
 //
+// AN EMPTY LANE IS ALWAYS ROLLED UP, AND NOTHING ABOUT IT IS REMEMBERED. That is
+// the whole of the empty case, and it is deliberately not a choice the reader
+// can make stick: a column with nothing in it has nothing to show, so opening
+// one is a PEEK — "is there really nothing here?" — and a peek is answered and
+// over. Left persistable, it is the one setting a reader would make once and
+// then be given four empty outlined columns by, for weeks, on a board they use
+// to see what is running.
+//
+// So the two states are stored in two different places, on purpose:
+//
+//   * `choices` — the reader's answer for a lane WITH CARDS IN IT. localStorage,
+//     survives reloads, and is what `laneCollapsed` below reads.
+//   * the peek — a lane opened while empty. Component state in TaskBoard,
+//     survives nothing: not a reload, not a remount, and not the lane filling up
+//     and draining again. `laneRolledUp` is where the two meet.
+//
+// The consequence worth stating, because it is the one a reader will notice: a
+// lane they had OPEN drains, and it rolls up. The expanded choice is not
+// honoured on the way down and it is not deleted either — it is simply not what
+// an empty lane is asked. Cards arrive, and the lane opens again on the choice
+// that was always there.
+//
+// For a lane with cards, two things decide, in this order:
+//
 //   1. What the reader last chose for THAT lane. Explicit choices are the only
 //      thing stored, so a lane nobody has ever touched keeps following the rule
 //      below forever rather than being frozen at whatever it looked like the
 //      first time the page was opened.
-//   2. Otherwise: EMPTY lanes start rolled up, everything else starts open.
-//
-// Rule 2 was briefly a RULE rather than a default — empty outranked the reader,
-// so a drained lane rolled itself up and would not open again. That went too
-// far (Akshil, 2026-08-18): the reader is still allowed to look inside an empty
-// column, and a lane that refuses to open is a control that has stopped being
-// one. What the complaint was actually about is the DEFAULT, which is unchanged
-// and is what keeps four empty outlined columns off a board with one busy lane
-// — and about the `0` on a rolled-up rail, which is gone for good (see
-// ScheduleTaskViews).
+//   2. Otherwise: open.
 //
 // Archive used to be hard-coded closed. It is not special any more (Akshil,
 // 2026-08-18) — an Archive with cards in it is a column like the others, and an
-// Archive with none rolls up under rule 2 like the others.
+// Archive with none rolls up like the others.
 
 /** The key the board's lane choices live under. Distinct from the array-shaped
  * key an earlier build wrote: that one recorded "collapsed now", defaults
@@ -2327,13 +2342,43 @@ export function parseLaneChoices(raw: string | null): LaneChoices {
   return out;
 }
 
-/** Rule 1 then rule 2, for one lane. `count` is how many cards it holds. */
+/**
+ * The PERSISTENT answer for one lane: what it looks like on a fresh render, with
+ * nothing but the store to go on. `count` is how many cards it holds.
+ *
+ * Empty short-circuits, and that is the whole point — a stored choice is never
+ * consulted for a lane with nothing in it, so nothing a reader does to an empty
+ * lane can outlive the sitting, and a lane that drains reverts here rather than
+ * honouring what it was set to when it still had work in it.
+ */
 export function laneCollapsed(
   lane: BoardColumn,
   count: number,
   choices: LaneChoices,
 ): boolean {
+  if (count === 0) return true;
   const chosen = choices[lane];
   if (chosen !== undefined) return chosen;
-  return count === 0;
+  return false;
+}
+
+/**
+ * What the board actually draws — `laneCollapsed` plus this sitting's peeks.
+ *
+ * `peeked` is the set of lanes the reader has opened WHILE EMPTY (TaskBoard
+ * holds it in component state and persists none of it). It is consulted only in
+ * the empty case: a peek is an answer to "is there really nothing here?", and it
+ * has nothing to say about a lane that has cards. That is also what keeps a
+ * stale peek from reopening a lane that filled up and drained again — the peek
+ * is ignored for the whole time the lane has cards, and TaskBoard drops it in
+ * that window.
+ */
+export function laneRolledUp(
+  lane: BoardColumn,
+  count: number,
+  choices: LaneChoices,
+  peeked: ReadonlySet<BoardColumn>,
+): boolean {
+  if (count === 0) return !peeked.has(lane);
+  return laneCollapsed(lane, count, choices);
 }

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -300,6 +300,48 @@ export function messageTone(m: TaskMessage): MessageTone {
 }
 
 /**
+ * ARCHIVING A TASK ARCHIVES ITS THREAD — the message tone a row actually wears.
+ *
+ * `messageTone` above answers "what happened to this message", which is a fact
+ * about the message and nothing else. It was also, until 2026-08-18, the only
+ * thing the thread rows asked, and that made archiving look like it had half
+ * worked: the task card moved to Archive and the ten rows underneath it stayed
+ * green, amber and red, still reading as live work. A task is a thread, so
+ * filing the task files the thread — one gesture, one outcome, everywhere
+ * (design-principles §1).
+ *
+ * Archived is a PLACE, not an event, so the cascade changes only where a row is
+ * filed and never what it says happened: the label is left exactly as it was, so
+ * an archived thread can still be read back run by run. The `failed` flag does
+ * go — archiving is the "I have dealt with this" gesture, and a filed task that
+ * still flies a red mark is asking to be dealt with again.
+ *
+ * THE ONE EXCEPTION IS A TURN THAT IS STILL RUNNING. Filing something does not
+ * stop it, and a running turn is the one fact on this page that is about the
+ * present rather than the past — it stops being true on its own, in a minute or
+ * two, and until it does, saying otherwise is a lie the reader can watch. So a
+ * running message keeps its own tone, and the task keeps reading as In Progress
+ * over the archive record until the turn ends (the server's `_status` makes that
+ * half of the promise — see fused_render/server/routers/tasks.py). The archive
+ * is not lost either way: it is still recorded, and the moment the turn is over
+ * the task and its whole thread fall back into Archive.
+ */
+export function threadTone(task: Task, m: TaskMessage): MessageTone {
+  const tone = messageTone(m);
+  if (taskColumn(task) !== "archived") return tone;
+  if (tone.column === "in_progress") return tone;
+  return { ...tone, column: "archived", failed: false };
+}
+
+/** Is any message in this thread mid-turn? The client's half of the running
+ * exception above — `Task.live` is the server's, computed from the transcript's
+ * own tail, and the two are asked in different places rather than merged: this
+ * one is about the rows on screen, that one about the row's status. */
+export function threadRunning(messages: TaskMessage[]): boolean {
+  return messages.some((m) => messageTone(m).column === "in_progress");
+}
+
+/**
  * The task's own column, narrowed. The server decides it (Task.status); this
  * only keeps a value a newer server invented off the board's floor. An
  * unreadable status lands in Done, not Archive: a task the client cannot read
@@ -2216,15 +2258,30 @@ export function groupByColumn(
 // A lane is either an open column or a 52px rail. Two things decide which, in
 // this order:
 //
-//   1. What the reader last chose for THAT lane. Explicit choices are the only
-//      thing stored, so a lane nobody has ever touched keeps following the rule
-//      below forever rather than being frozen at whatever it looked like the
-//      first time the page was opened.
-//   2. Otherwise: EMPTY lanes start rolled up, everything else starts open.
+//   1. AN EMPTY LANE IS ALWAYS ROLLED UP. Not a default — a rule, and it
+//      outranks the reader's own choice for as long as the lane holds nothing.
+//   2. Otherwise: whatever the reader last chose for THAT lane. Explicit choices
+//      are the only thing stored, so a lane nobody has ever touched keeps
+//      following the rule below forever rather than being frozen at whatever it
+//      looked like the first time the page was opened.
+//   3. Otherwise: open.
+//
+// Rule 1 was rule 2's tie-breaker until 2026-08-18 — empty lanes STARTED rolled
+// up, and an expand the reader had chosen back when the lane had cards in it
+// kept it open after the last one left. What that bought was an empty outline
+// the width of a column, with a header and a `0` over it, sitting between two
+// lanes that had work in them; four of those and the board was mostly furniture
+// (Akshil, screenshot). An empty column has nothing to show and nothing to read,
+// so the honest width for it is the rail's 52px.
+//
+// The choice is REMEMBERED, not discarded, and comes back the moment a card
+// does: a lane the reader had open before it drained opens again on the first
+// arrival, which is what makes this a display rule rather than a quiet edit of
+// their preference.
 //
 // Archive used to be hard-coded closed. It is not special any more (Akshil,
 // 2026-08-18) — an Archive with cards in it is a column like the others, and an
-// Archive with none rolls up under rule 2 like the others.
+// Archive with none rolls up under rule 1 like the others.
 
 /** The key the board's lane choices live under. Distinct from the array-shaped
  * key an earlier build wrote: that one recorded "collapsed now", defaults
@@ -2254,13 +2311,15 @@ export function parseLaneChoices(raw: string | null): LaneChoices {
   return out;
 }
 
-/** Rule 1 then rule 2, for one lane. `count` is how many cards it holds. */
+/** The three rules above, in order, for one lane. `count` is how many cards it
+ * holds — and a `count` of 0 is the whole answer, whatever the reader chose. */
 export function laneCollapsed(
   lane: BoardColumn,
   count: number,
   choices: LaneChoices,
 ): boolean {
+  if (count === 0) return true;
   const chosen = choices[lane];
   if (chosen !== undefined) return chosen;
-  return count === 0;
+  return false;
 }

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -1055,9 +1055,27 @@ export type ListMemory = {
   expanded: string[];
   /** scrollTop of the list's own scroller, in px. */
   scroll: number;
+  /**
+   * The task whose conversation the reader last opened FROM this list, or "".
+   *
+   * The third thing coming back to the page has to answer. Which rows were open
+   * and where the list stood put the reader back in the right part of the list;
+   * this puts them back on the right ROW. A list of ninety near-identical
+   * three-line rows gives no clue which one you just came out of, so "let me
+   * look at the next one" meant re-finding the last one first — the same
+   * complaint the scroll memory was for, one level finer (Akshil, 2026-08-18).
+   *
+   * A key, not an index: rows re-sort on every poll (last_active), and an index
+   * would highlight whichever row happened to land in that slot.
+   *
+   * One task, not a set. This is "where I just was", and a page that lit up
+   * every row visited this sitting would be a highlight that means nothing by
+   * the fourth one.
+   */
+  selected: string;
 };
 
-export const EMPTY_LIST_MEMORY: ListMemory = { expanded: [], scroll: 0 };
+export const EMPTY_LIST_MEMORY: ListMemory = { expanded: [], scroll: 0, selected: "" };
 
 /**
  * What came out of the store is a STRING WRITTEN BY SOMEONE ELSE — an older
@@ -1076,7 +1094,7 @@ export function parseListMemory(raw: string | null): ListMemory {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     return EMPTY_LIST_MEMORY;
   }
-  const row = parsed as { expanded?: unknown; scroll?: unknown };
+  const row = parsed as { expanded?: unknown; scroll?: unknown; selected?: unknown };
   const expanded = Array.isArray(row.expanded)
     ? row.expanded.filter((k): k is string => typeof k === "string")
     : [];
@@ -1084,7 +1102,11 @@ export function parseListMemory(raw: string | null): ListMemory {
     typeof row.scroll === "number" && Number.isFinite(row.scroll) && row.scroll > 0
       ? row.scroll
       : 0;
-  return { expanded, scroll };
+  // Absent on anything written before 2026-08-18, and on any hand-edited row:
+  // "" is the same answer as "nothing selected", so an older memory upgrades
+  // silently rather than being thrown away for the two fields it does have.
+  const selected = typeof row.selected === "string" ? row.selected : "";
+  return { expanded, scroll, selected };
 }
 
 // ---- where a click goes ------------------------------------------------------

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2280,30 +2280,24 @@ export function groupByColumn(
 // A lane is either an open column or a 52px rail. Two things decide which, in
 // this order:
 //
-//   1. AN EMPTY LANE IS ALWAYS ROLLED UP. Not a default — a rule, and it
-//      outranks the reader's own choice for as long as the lane holds nothing.
-//   2. Otherwise: whatever the reader last chose for THAT lane. Explicit choices
-//      are the only thing stored, so a lane nobody has ever touched keeps
-//      following the rule below forever rather than being frozen at whatever it
-//      looked like the first time the page was opened.
-//   3. Otherwise: open.
+//   1. What the reader last chose for THAT lane. Explicit choices are the only
+//      thing stored, so a lane nobody has ever touched keeps following the rule
+//      below forever rather than being frozen at whatever it looked like the
+//      first time the page was opened.
+//   2. Otherwise: EMPTY lanes start rolled up, everything else starts open.
 //
-// Rule 1 was rule 2's tie-breaker until 2026-08-18 — empty lanes STARTED rolled
-// up, and an expand the reader had chosen back when the lane had cards in it
-// kept it open after the last one left. What that bought was an empty outline
-// the width of a column, with a header and a `0` over it, sitting between two
-// lanes that had work in them; four of those and the board was mostly furniture
-// (Akshil, screenshot). An empty column has nothing to show and nothing to read,
-// so the honest width for it is the rail's 52px.
-//
-// The choice is REMEMBERED, not discarded, and comes back the moment a card
-// does: a lane the reader had open before it drained opens again on the first
-// arrival, which is what makes this a display rule rather than a quiet edit of
-// their preference.
+// Rule 2 was briefly a RULE rather than a default — empty outranked the reader,
+// so a drained lane rolled itself up and would not open again. That went too
+// far (Akshil, 2026-08-18): the reader is still allowed to look inside an empty
+// column, and a lane that refuses to open is a control that has stopped being
+// one. What the complaint was actually about is the DEFAULT, which is unchanged
+// and is what keeps four empty outlined columns off a board with one busy lane
+// — and about the `0` on a rolled-up rail, which is gone for good (see
+// ScheduleTaskViews).
 //
 // Archive used to be hard-coded closed. It is not special any more (Akshil,
 // 2026-08-18) — an Archive with cards in it is a column like the others, and an
-// Archive with none rolls up under rule 1 like the others.
+// Archive with none rolls up under rule 2 like the others.
 
 /** The key the board's lane choices live under. Distinct from the array-shaped
  * key an earlier build wrote: that one recorded "collapsed now", defaults
@@ -2333,15 +2327,13 @@ export function parseLaneChoices(raw: string | null): LaneChoices {
   return out;
 }
 
-/** The three rules above, in order, for one lane. `count` is how many cards it
- * holds — and a `count` of 0 is the whole answer, whatever the reader chose. */
+/** Rule 1 then rule 2, for one lane. `count` is how many cards it holds. */
 export function laneCollapsed(
   lane: BoardColumn,
   count: number,
   choices: LaneChoices,
 ): boolean {
-  if (count === 0) return true;
   const chosen = choices[lane];
   if (chosen !== undefined) return chosen;
-  return false;
+  return count === 0;
 }

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -3062,6 +3062,74 @@ input.schedule-when-field {
   background: var(--tasks-lane-bg);
 }
 
+/* -- The scrollbar the Tasks page's two column scrollers wear ------------------
+   macOS gives a webview OVERLAY scrollbars by default: the thumb floats on top
+   of the content instead of taking a column of its own, so a lane with more
+   cards than fit drew its thumb straight over the right-hand border of every
+   card under it (Akshil, screenshot, 2026-08-18). `scrollbar-gutter` cannot fix
+   that — the spec gives an overlay scrollbar a zero gutter by definition. What
+   does is styling the thing at all: a `::-webkit-scrollbar` rule opts this
+   element out of overlay scrollbars entirely, so the bar takes real layout
+   space and the cards are simply narrower by its width. No overlap is possible
+   after that, because there is nothing left to overlap.
+
+   `scrollbar-gutter: stable` is stated with it and is not redundant: the bar now
+   takes space, so without it the column would jump by 10px the moment the lane
+   crossed from four cards to five, and back again on the next poll.
+
+   The thumb is drawn INSIDE the track by a transparent border plus
+   `background-clip: padding-box` — 10px of track carrying 4px of ink — which is
+   what keeps it clear of the card edges as a mark rather than merely as layout,
+   and what makes it read as the quietest thing on the lane. It is mixed from
+   `--fg-muted` rather than given a colour, so it lands at the same weight over
+   the lane's fill in both themes. The track itself paints nothing: a groove
+   would be a second column drawn beside the cards.
+
+   ONE rule for all three of the page's content scrollers, though `.tasks-list`'s
+   box belongs to tasks.css and the other two to this file. Scrollbar chrome is
+   one decision about one kind of furniture, and two copies of it is how the
+   List and the Board end up wearing different bars.
+
+   The three are the Board's lane, the List, and the CALENDAR's popover thread —
+   the one calendar scroller that has a bar at all, since the week grid hides
+   its own (`.schedule-cal-scroll`, above: the hour lines say where you are).
+   The page's remaining scrollers are dropdown menus and pickers, which are
+   floating surfaces a few rows tall rather than columns of content, and are
+   deliberately left alone. */
+.schedule-tv-lane-body,
+.schedule-cal-thread,
+.tasks-list {
+  scrollbar-gutter: stable;
+}
+
+.schedule-tv-lane-body::-webkit-scrollbar,
+.schedule-cal-thread::-webkit-scrollbar,
+.tasks-list::-webkit-scrollbar {
+  width: 10px;
+}
+
+.schedule-tv-lane-body::-webkit-scrollbar-track,
+.schedule-cal-thread::-webkit-scrollbar-track,
+.tasks-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.schedule-tv-lane-body::-webkit-scrollbar-thumb,
+.schedule-cal-thread::-webkit-scrollbar-thumb,
+.tasks-list::-webkit-scrollbar-thumb {
+  background: color-mix(in srgb, var(--fg-muted) 26%, transparent);
+  background-clip: padding-box;
+  border: 3px solid transparent;
+  border-radius: 999px;
+}
+
+.schedule-tv-lane-body::-webkit-scrollbar-thumb:hover,
+.schedule-cal-thread::-webkit-scrollbar-thumb:hover,
+.tasks-list::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in srgb, var(--fg-muted) 48%, transparent);
+  background-clip: padding-box;
+}
+
 /* The card is the LIT element of the board: the lane under it is a fill that
    deliberately loses to it, so this is the one surface on the page that steps
    toward the reader. `--tasks-card-bg` is that step, and its pairing with

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -261,6 +261,32 @@
   color: var(--fg);
 }
 
+/* The view switcher's halves carry a mark as well as a word (Scheduled.tsx).
+   Only that switcher: the New task form's Once / On a schedule pair shares this
+   component and stays text-only, because those two are a CHOICE being made
+   inside a form, not a place you navigate to.
+
+   The glyph is muted at rest and takes the label's colour on the active half, so
+   the icon reinforces the selection the fill already states rather than adding a
+   second, competing signal. `flex: 0 0 auto` keeps it from being squeezed when
+   the toolbar runs out of room — a half-drawn icon is worse than none. */
+.schedule-view-btn,
+.prefs-section .schedule-view-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.schedule-view-btn > svg {
+  flex: 0 0 auto;
+  color: var(--fg-muted);
+}
+
+.schedule-view-btn.is-active > svg,
+.prefs-section .schedule-view-btn.is-active > svg {
+  color: inherit;
+}
+
 /* overflow:hidden clips the default outside focus ring; draw it inside. */
 .schedule-form-seg .btn:focus-visible,
 .prefs-section .schedule-form-seg .btn:focus-visible {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -39,19 +39,24 @@
    decision, and it made the page the only surface in the app with no measure at
    all.
 
-   1360px is that decision, and it is a number the BOARD chose: five 260px lanes
-   plus four 12px gaps is 1348, so the widest of the three views fits its whole
-   content inside the measure and nothing has to scroll sideways at the size
-   this app is actually used at. List and calendar are comfortable well below
-   that — the flow reference sits around 1200-1400 — so one measure serves all
-   three, which is worth more than three tuned ones: the toggle switches the
-   view without the page changing shape underneath it.
+   1240px is that decision, and it is the LIST's number, not the board's. It was
+   1360 for a few hours — five 260px lanes plus four 12px gaps is 1348, so the
+   board fitted exactly — and letting the widest view set the measure was the
+   wrong way round: the board is the one view that can scroll inside itself, and
+   the list, which cannot, was the one paying for it (Akshil, 2026-08-18: tighter
+   still). 1240 is a comfortable measure for a three-line row and for a seven-day
+   calendar, and the board simply scrolls its lanes past it — which the board has
+   always done at any window narrower than five lanes, so this is its ordinary
+   behaviour rather than a new state.
+
+   One measure for all three views, and that is worth more than three tuned ones:
+   the toggle switches the view without the page changing shape underneath it.
 
    Applied to `> *` rather than to the section alone so the HEADER moves with
    the views; a centred board under a left-flush "Tasks" reads as a layout bug.
-   Under 1360 the cap is inert and the page is full-width as before — the board
-   keeps its own `overflow-x`, so a narrow window scrolls the lanes and never
-   the page (design-principles §0).
+   Under 1240 the cap is inert and the page is full-width as before. Either way
+   the board keeps its own `overflow-x`, so what scrolls sideways is the lane
+   strip and never the page (design-principles §0).
 
    Both classes in the selector, not just `.schedule-page`: the rule it has to
    beat is `.prefs-page > *`, which is exactly as specific as a lone
@@ -59,7 +64,7 @@
    stylesheet the barrel imports last, which is not a thing this page should
    depend on. */
 .prefs-page.schedule-page > * {
-  max-width: 1360px;
+  max-width: 1240px;
   margin-inline: auto;
 }
 
@@ -69,7 +74,7 @@
    purpose: tests/test_schedule_css.py reads this declaration to check the
    opt-out is still granted, and it reads a value, not a variable. */
 .schedule-page > .prefs-section {
-  max-width: 1360px;
+  max-width: 1240px;
 }
 
 .schedule-page .prefs-section > p {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -26,15 +26,50 @@
 /* -- Width ---------------------------------------------------------------------
    This page is built out of the settings vocabulary, and `.prefs-page > *`
    caps every child at 760px — a good measure for prose, far too narrow for a
-   seven-day calendar grid or a four-column board. So the sections get the
-   ~1120px the app's other wide surfaces live in, and the prose inside them
-   keeps the narrow measure. Two widths in one page, because there are two
-   kinds of content in it: text you read a line at a time, and surfaces you
-   scan. tests/test_schedule_css.py pins the pairing. */
+   seven-day calendar grid or a four-column board. So the page opts out of that
+   column and takes a wider one of its own, and the prose inside it keeps the
+   narrow measure. Two widths in one page, because there are two kinds of
+   content in it: text you read a line at a time, and surfaces you scan.
+   tests/test_schedule_css.py pins the pairing.
+
+   THREE widths, briefly, until 2026-08-18: the sections were `max-width: none`
+   — whatever the window gave them — which on a 27" display left a list of
+   three-line rows stretched across 2000px and a header title marooned at the
+   far left of it. Edge-to-edge is not "using the space", it is the absence of a
+   decision, and it made the page the only surface in the app with no measure at
+   all.
+
+   1360px is that decision, and it is a number the BOARD chose: five 260px lanes
+   plus four 12px gaps is 1348, so the widest of the three views fits its whole
+   content inside the measure and nothing has to scroll sideways at the size
+   this app is actually used at. List and calendar are comfortable well below
+   that — the flow reference sits around 1200-1400 — so one measure serves all
+   three, which is worth more than three tuned ones: the toggle switches the
+   view without the page changing shape underneath it.
+
+   Applied to `> *` rather than to the section alone so the HEADER moves with
+   the views; a centred board under a left-flush "Tasks" reads as a layout bug.
+   Under 1360 the cap is inert and the page is full-width as before — the board
+   keeps its own `overflow-x`, so a narrow window scrolls the lanes and never
+   the page (design-principles §0).
+
+   Both classes in the selector, not just `.schedule-page`: the rule it has to
+   beat is `.prefs-page > *`, which is exactly as specific as a lone
+   `.schedule-page > *` would be — the winner would then be decided by which
+   stylesheet the barrel imports last, which is not a thing this page should
+   depend on. */
+.prefs-page.schedule-page > * {
+  max-width: 1360px;
+  margin-inline: auto;
+}
+
+/* Restated for the sections, which `.prefs-page > *` would otherwise pin at the
+   760px prose column — that rule and the one above are equally specific, and
+   this page's stylesheet is imported first. The literal repeats the number on
+   purpose: tests/test_schedule_css.py reads this declaration to check the
+   opt-out is still granted, and it reads a value, not a variable. */
 .schedule-page > .prefs-section {
-  /* Full width (Akshil, 2026-08-16) — the calendar, list and board all use
-     whatever the window gives them; only prose keeps the reading measure. */
-  max-width: none;
+  max-width: 1360px;
 }
 
 .schedule-page .prefs-section > p {

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -2941,36 +2941,36 @@ input.schedule-when-field {
   color: var(--fg-muted);
 }
 
-/* The lane is not a PANEL. It used to paint `rgba(var(--tint), 0.05)` at rest,
-   which made every lane a filled slab: an empty Upcoming read as a large grey
-   plate with nothing in it, and every card competed with the box it was sitting
-   in rather than being the thing you looked at (Akshil, 2026-08-17, comparing
-   this board against flow's side by side — there the lanes are transparent and
-   the cards are the only surface).
+/* An OPEN lane has no edge — it is a quiet ground, not a box (Akshil,
+   2026-08-18, against the flow app again: there an open column is an invisible
+   panel and the cards are the only thing you see). The history is worth keeping
+   because it is a loop the page has already been round once: the lane painted a
+   `rgba(var(--tint), 0.05)` slab, lost it on 2026-08-17 for competing with the
+   cards, and gained a `--border` hairline in its place so the column still had a
+   bottom. The hairline turned out to be the same mistake in thinner form — five
+   outlined boxes read as five boxes, and the cards inside them were the second
+   thing you saw.
 
-   So the FILL is gone and nothing filled in for it — but the lane is still
-   BOUNDED ("at least they should have an outline when they're expanded", Akshil,
-   2026-08-17). Unfilled and unbounded, an open lane's only edge was the ragged
-   right-hand end of whatever card happened to be widest, so the column had no
-   bottom at all and a short lane beside a full one read as loose cards on the
-   page. A hairline answers that without putting the plate back: an outline says
-   where the column is, a fill says the column is a surface, and only the second
-   one was ever competing with the cards.
+   What replaces both is a FILL that loses: `--tasks-lane-bg` sits a whisper
+   above the page and a clear step BELOW the card (tokens.css orders the three).
+   That gives the column the bottom the hairline was there for — the lane is
+   visible as a shape — while making the card unambiguously the lit element,
+   because the only surface on the page brighter than its ground is the card.
 
-   Deliberately the SAME hairline the collapsed rail wears — 1px, `--border`, and
-   the 8px radius this element already had for the drop wash — so the two forms of
-   a lane read as one family and not as two ideas about what a lane's edge is. The
-   rail's is doing extra work (it is a button you press), but it is the same line.
+   The COLLAPSED rail keeps its hairline, deliberately: it is a button you press,
+   and it is 52px wide with no cards in it to give it shape (Akshil explicitly
+   OK'd a border there and only there). So the two forms of a lane no longer look
+   like one family, which is right — one is a column of work and the other is a
+   control.
 
-   What the padding is for, on top of insetting the cards off that new edge, is
+   What the padding is for, on top of insetting the cards off the lane's edge, is
    the DROP states below: it holds the dashed legal-drop outline off the top card
    so it reads as the lane's own edge rather than as a second border on the card.
 
-   An EMPTY lane therefore shows its header and an empty bounded column — the
-   label, the ring, a `0` and the box the cards would go in. That is still
-   "nothing scheduled looks like nothing": an empty outline is not a filled slab.
-   The `min-height` is what keeps it a droppable target, so a card can still be
-   dragged into a column that has never held one. */
+   An EMPTY lane therefore shows its header and an empty, barely-there column.
+   That is still "nothing scheduled looks like nothing". The `min-height` is what
+   keeps it a droppable target, so a card can still be dragged into a column that
+   has never held one. */
 .schedule-tv-lane-body {
   flex: 1 1 auto;
   min-height: 120px;
@@ -2987,25 +2987,31 @@ input.schedule-when-field {
      make the floor 122px and the number here would stop being the number the
      board actually has. */
   box-sizing: border-box;
-  padding: 4px;
-  border: 1px solid var(--border);
+  padding: 6px;
+  /* Transparent, not absent: the drag rules below still speak in `border-color`
+     and the 1px is part of the box the `min-height` above is measured against,
+     so removing the declaration would move the floor as well as the edge. */
+  border: 1px solid transparent;
   border-radius: 8px;
+  background: var(--tasks-lane-bg);
 }
 
-/* The card is the board's ONLY surface now that the lane is an outline rather than
-   a plate, so it has to carry the whole separation from the page ground — and the
-   ground is `--bg` in both themes (base.css `body`), which is exactly what the
-   card used to be painted in. Against a lane fill that was enough; against the
-   page it was the card disappearing, most obviously in light mode where both are
-   plain white.
+/* The card is the LIT element of the board: the lane under it is a fill that
+   deliberately loses to it, so this is the one surface on the page that steps
+   toward the reader. `--tasks-card-bg` is that step, and its pairing with
+   `--tasks-lane-bg` is the whole point — tokens.css owns the ordering (page <
+   lane < card) so neither half can be tuned into inverting it.
 
-   `--bg-panel` is the app's existing answer to "a surface floating above the
-   page", and it is tuned per theme for precisely this: in dark it steps LIGHTER
-   than the ground (#202329 over #131417), and in light it stays white and lets
-   the hairline plus a shadow do the lifting (tokens.css says so in as many
-   words). The shadow is the same `0 1px 2px var(--shadow-sm)` the settings
-   page's own cards use — one step of lift, not a drop shadow — and its token is
-   theme-tuned too, so it reads as depth in dark instead of as dirt in light.
+   It replaced `--bg-panel` on 2026-08-18. That token is the app's general
+   "surface floating above the page" and it lifted correctly, but it is a
+   POPOVER's colour: #202329 carries nine steps more blue than red, which over a
+   near-black page reads as grey rather than as the black-tinted charcoal the
+   flow app's cards have. Same lift, less blue. In light it resolves to white
+   and lets the hairline plus a shadow do the lifting, exactly as --bg-panel did.
+
+   The shadow is the same `0 1px 2px var(--shadow-sm)` the settings page's own
+   cards use — one step of lift, not a drop shadow — and its token is theme-tuned
+   too, so it reads as depth in dark instead of as dirt in light.
 
    Loosened on 2026-08-17 along with the lane: 8px/10px padding and a 5px gap
    were tighter than flow's cards, which is what made three short lines feel
@@ -3031,17 +3037,23 @@ input.schedule-when-field {
   font: inherit;
   text-align: left;
   color: var(--fg);
-  background: var(--bg-panel);
+  background: var(--tasks-card-bg);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 1px 2px var(--shadow-sm);
   cursor: pointer;
-  transition: border-color 0.08s ease;
+  transition: background-color 0.08s ease, border-color 0.08s ease;
 }
 
+/* Hover now moves the FILL as well as the edge. It did not have to while the
+   lane was an outline — a brightening border was the only change available on a
+   page where nothing else was filled — but against a lane that is itself a
+   surface, an edge-only hover is easy to miss. A 6% lift of --fg into the card's
+   own token stays a whisper in both themes and cannot drift away from the token
+   it is mixed from. */
 .schedule-tv-board .schedule-tv-card:hover:not(:disabled),
 .prefs-section .schedule-tv-board .schedule-tv-card:hover:not(:disabled) {
-  background: var(--bg-panel);
+  background: color-mix(in srgb, var(--fg) 6%, var(--tasks-card-bg));
   border-color: color-mix(in srgb, var(--fg-muted) 40%, var(--border));
 }
 

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -3366,6 +3366,43 @@ input.schedule-when-field {
   border-color: var(--border);
 }
 
+/* An EMPTY rail is a marker, not a control — the lane stays rolled up whatever
+   the reader chooses while it holds nothing (tasks-lib.laneCollapsed), so it
+   carries no press and must not offer one. The label and the ring dim with it:
+   a column with nothing in it is the quietest thing on the board, and at full
+   strength four of them out-shouted the one lane that had work in it.
+
+   It keeps its hairline and its full height. Both are structural: the rail is
+   still where that lane LIVES, and a drop target the reader cannot see is a
+   drop they will not attempt. Hover says nothing back, because nothing happens.
+
+   `aria-disabled`, so the two hover rules above (which guard on the real
+   `:disabled`) still apply and are turned off here explicitly — a genuinely
+   disabled button would stop receiving the drag events this element exists to
+   accept. */
+.schedule-tv-rail[aria-disabled="true"],
+.prefs-section .schedule-tv-rail[aria-disabled="true"] {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.schedule-tv-rail[aria-disabled="true"]:hover,
+.prefs-section .schedule-tv-rail[aria-disabled="true"]:hover {
+  background: transparent;
+  border-color: var(--border);
+}
+
+/* Except while a card is over it: an empty lane is the most likely drop there
+   is, and the dimming must not swallow the one moment it has something to say. */
+.schedule-tv-rail[aria-disabled="true"].is-drop-legal,
+.schedule-tv-rail[aria-disabled="true"].is-drop-over,
+.schedule-tv-rail[aria-disabled="true"].is-drop-run,
+.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-legal,
+.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-over,
+.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-run {
+  opacity: 1;
+}
+
 /* The hairline gets out of the dashed drop outline's way — see the drag note
    above, where the reasoning lives. Both forms of the lane, one rule.
 

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -3434,43 +3434,6 @@ input.schedule-when-field {
   border-color: var(--border);
 }
 
-/* An EMPTY rail is a marker, not a control — the lane stays rolled up whatever
-   the reader chooses while it holds nothing (tasks-lib.laneCollapsed), so it
-   carries no press and must not offer one. The label and the ring dim with it:
-   a column with nothing in it is the quietest thing on the board, and at full
-   strength four of them out-shouted the one lane that had work in it.
-
-   It keeps its hairline and its full height. Both are structural: the rail is
-   still where that lane LIVES, and a drop target the reader cannot see is a
-   drop they will not attempt. Hover says nothing back, because nothing happens.
-
-   `aria-disabled`, so the two hover rules above (which guard on the real
-   `:disabled`) still apply and are turned off here explicitly — a genuinely
-   disabled button would stop receiving the drag events this element exists to
-   accept. */
-.schedule-tv-rail[aria-disabled="true"],
-.prefs-section .schedule-tv-rail[aria-disabled="true"] {
-  cursor: default;
-  opacity: 0.55;
-}
-
-.schedule-tv-rail[aria-disabled="true"]:hover,
-.prefs-section .schedule-tv-rail[aria-disabled="true"]:hover {
-  background: transparent;
-  border-color: var(--border);
-}
-
-/* Except while a card is over it: an empty lane is the most likely drop there
-   is, and the dimming must not swallow the one moment it has something to say. */
-.schedule-tv-rail[aria-disabled="true"].is-drop-legal,
-.schedule-tv-rail[aria-disabled="true"].is-drop-over,
-.schedule-tv-rail[aria-disabled="true"].is-drop-run,
-.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-legal,
-.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-over,
-.prefs-section .schedule-tv-rail[aria-disabled="true"].is-drop-run {
-  opacity: 1;
-}
-
 /* The hairline gets out of the dashed drop outline's way — see the drag note
    above, where the reasoning lives. Both forms of the lane, one rule.
 

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -695,13 +695,26 @@ button.tasks-caret,
 .tasks-card-act,
 .prefs-section .tasks-card-act {
   pointer-events: auto;
-  /* An opaque skin in the card's OWN surface colour, so the strip reads as
-     floating over the head rather than as part of the head's row of marks. It
-     TRACKS the card, and is stated as the very token the card is painted in for
-     that reason: the card's fill has already moved twice (`--bg` → `--bg-panel`
-     → `--tasks-card-bg`, schedule.css) and each time a button left behind on the
-     old value became a visible patch on it in dark. */
-  background: var(--tasks-card-bg);
+  /* NO SKIN. The button lets the card show through and paints only on its own
+     hover (`.tasks-act:hover`, above).
+
+     It used to carry an opaque fill in the card's surface colour, so the strip
+     would read as floating over the head rather than as part of the head's row
+     of marks. Chasing that colour was a losing game: the card's fill has moved
+     three times (`--bg` → `--bg-panel` → `--tasks-card-bg`), and each time a
+     button left behind on the old value became a visible patch on it in dark.
+     The last move was the one that made the idea untenable rather than merely
+     fragile — the card now LIFTS on hover (`color-mix(--fg 6%, --tasks-card-bg)`,
+     schedule.css), so a fill matching the resting colour is a dark rectangle on
+     a lit card, and matching both would mean restating the card's hover
+     expression here for the two to drift apart at the next tuning (Bugbot,
+     2026-08-18).
+
+     Transparent is not a compromise, it is the accurate answer: this strip is
+     only ever SEEN over a hovered or focused card (`.tasks-card-acts` rests at
+     `opacity: 0`), and the head's right end it sits over is empty on every card
+     by construction. There is nothing to occlude and nothing to match. */
+  background: transparent;
 }
 
 .tasks-card-wrap:hover .tasks-card-act,

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -117,6 +117,31 @@
   background: var(--row-bg-hover);
 }
 
+/* WHERE THE READER JUST WAS. The row whose conversation was last opened from
+   this list keeps a mark while the page is away and wears it again on the way
+   back (ScheduleTaskViews `selected`, stored in the List's sessionStorage memory
+   beside the scroll offset and the open rows).
+
+   `--row-bg-active` is the app's existing answer to "this row is the current
+   one" — the explorer's listing and the sidebar both paint selection with it, so
+   a reader who has learned it once reads it here without being taught
+   (design-principles §1). The accent rule on the left is what keeps it legible
+   as SELECTION rather than as hover: the two fills are close by design (both are
+   a wash over the same ground), and a bar the hover state does not have is the
+   difference that survives the pointer being somewhere else on the row.
+
+   It sits after the hover rule so a selected row that is also hovered still
+   reads as selected: hover is where the pointer is, selection is where the
+   reader has been, and losing the second to the first is losing the only one
+   that outlives the gesture. The bar is drawn with `box-shadow: inset` rather
+   than a border so it costs no layout — a row that grew 2px on selection would
+   move every row under it. */
+.tasks-row.is-selected,
+.tasks-row.is-selected:hover {
+  background: var(--row-bg-active);
+  box-shadow: inset 2px 0 0 var(--accent);
+}
+
 /* A row whose press does nothing does not look pressed-able either: a task that
    has never run has no session to open and no thread to expand (ScheduleTaskViews
    `pressable`), and a pointer cursor over a lit background is a promise it cannot

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -122,24 +122,25 @@
    back (ScheduleTaskViews `selected`, stored in the List's sessionStorage memory
    beside the scroll offset and the open rows).
 
-   `--row-bg-active` is the app's existing answer to "this row is the current
-   one" — the explorer's listing and the sidebar both paint selection with it, so
-   a reader who has learned it once reads it here without being taught
-   (design-principles §1). The accent rule on the left is what keeps it legible
-   as SELECTION rather than as hover: the two fills are close by design (both are
-   a wash over the same ground), and a bar the hover state does not have is the
-   difference that survives the pointer being somewhere else on the row.
+   THE SAME FILL AS HOVER, and nothing else. The first cut used
+   `--row-bg-active` plus a 2px accent rule down the left — the app's louder
+   "this is the current row" — and on a page whose accent is a bright lime that
+   made one row in ninety look selected the way a dialog's default button looks
+   selected: an olive-tinted plate with a yellow edge, shouting a fact that only
+   needs to be findable (Akshil, screenshot, 2026-08-18). A returning reader is
+   looking for "which one did I just read", and the quietest possible answer is
+   enough to find it.
 
-   It sits after the hover rule so a selected row that is also hovered still
-   reads as selected: hover is where the pointer is, selection is where the
-   reader has been, and losing the second to the first is losing the only one
-   that outlives the gesture. The bar is drawn with `box-shadow: inset` rather
-   than a border so it costs no layout — a row that grew 2px on selection would
-   move every row under it. */
+   Hover and selected therefore look identical, which is fine and was asked for:
+   only one row can be hovered, the pointer is usually nowhere near the list
+   after a page change, and if the two ever coincide the row is both — there is
+   no fact being hidden.
+
+   Stated after the hover rule anyway, so the fill does not blink off when the
+   pointer leaves a selected row. */
 .tasks-row.is-selected,
 .tasks-row.is-selected:hover {
-  background: var(--row-bg-active);
-  box-shadow: inset 2px 0 0 var(--accent);
+  background: var(--row-bg-hover);
 }
 
 /* A row whose press does nothing does not look pressed-able either: a task that
@@ -155,11 +156,18 @@
   background: transparent;
 }
 
-/* An open task keeps a tint under its header so the thread beneath it reads as
-   belonging to that row rather than floating between two. */
-.tasks-row.is-open {
-  background: rgba(var(--tint), 0.04);
-}
+/* NO TINT ON AN OPEN TASK. It used to keep `rgba(var(--tint), 0.04)` under its
+   header, on the argument that the thread beneath needed to read as belonging to
+   that row rather than floating between two. In a long list that argument loses
+   to what it costs: an expanded task became a darker block among its neighbours,
+   which reads as a state the row is IN — selected, active, different — rather
+   than as one that is merely open (Akshil, screenshot, 2026-08-18).
+
+   The belonging was never carried by the tint anyway. The chevron says the row
+   is open, and the thread's rows are indented a whole ring slot to the right of
+   their task's (see the geometry block at the top of this file) — a structural
+   answer that survives at a glance and in a screenshot, where a 4% wash does
+   not. One background for every row in the list, and expansion is a shape. */
 
 /* THE DISCLOSURE, AND ITS HITBOX — which is much bigger than it looks, on
    purpose (2026-08-18).

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -664,10 +664,11 @@ button.tasks-caret,
   pointer-events: auto;
   /* An opaque skin in the card's OWN surface colour, so the strip reads as
      floating over the head rather than as part of the head's row of marks. It
-     tracks the card: that surface became `--bg-panel` when the lane's fill was
-     removed and the card had to lift off the page by itself (schedule.css), and a
-     button still painted `--bg` would have been a visible patch on it in dark. */
-  background: var(--bg-panel);
+     TRACKS the card, and is stated as the very token the card is painted in for
+     that reason: the card's fill has already moved twice (`--bg` → `--bg-panel`
+     → `--tasks-card-bg`, schedule.css) and each time a button left behind on the
+     old value became a visible patch on it in dark. */
+  background: var(--tasks-card-bg);
 }
 
 .tasks-card-wrap:hover .tasks-card-act,

--- a/frontend/src/styles/tokens.css
+++ b/frontend/src/styles/tokens.css
@@ -98,6 +98,29 @@
   --tour-dim: #7c7f88;
   --tour-next-hover: #d8f238;
 
+  /* Board ground and board card (shell/ScheduleTaskViews.tsx). Two tokens
+     rather than reusing --bg-alt/--bg-panel because the Board needs a
+     RELATIONSHIP the general surfaces do not state: the lane is a quiet
+     ground and the card is the only lit thing standing on it, so the three
+     surfaces have to be ORDERED — page < lane < card in dark, card above lane
+     in light — and a later tuning of --bg-panel (a popover token, owned by
+     other screens) must not be able to invert that by accident.
+
+     Dark: the lane sits a whisper above --bg (#131417 → #16181b), enough to
+     say "column" without becoming a slab, and the card lands at #1e2023.
+     That second value is the one that moved on 2026-08-18: the card used to
+     be --bg-panel (#202329), whose blue channel runs nine steps above its red
+     and read as GREY over a near-black page (Akshil, comparing against the
+     flow app, whose cards are a black-tinted charcoal). #1e2023 keeps the
+     same lift off the ground and spends far less of it on blue, so the card
+     reads as dark charcoal over black rather than as a grey plate.
+
+     Light: the card stays white — it lifts by hairline and shadow, the way
+     every other light surface in this file does — and the lane goes a step
+     DARKER than the page so the same ordering survives the flip. */
+  --tasks-lane-bg: #16181b;
+  --tasks-card-bg: #1e2023;
+
   /* Task status hues — the Schedule page's tree/board/calendar rings
      (shell/ScheduleTaskViews.tsx, ported from the flow app's task board). Own
      tokens rather than --accent/--success/--warning because these five are a
@@ -239,6 +262,13 @@
   --tour-desc: #4a4e55;
   --tour-dim: #6f747c;
   --tour-next-hover: #4e5f00;
+
+  /* Board ground and board card (see the dark block for why these are their
+     own pair). The card is white and lifts by hairline + shadow; the lane is
+     a step darker than the page, which is what keeps "card above lane" true
+     in a palette where the page itself is the lightest thing available. */
+  --tasks-lane-bg: #eef0f2;
+  --tasks-card-bg: #ffffff;
 
   /* Upcoming tracks --fg-muted in both themes (see the dark block) — the same
      expression, restated because the light palette must redefine every token. */

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -594,9 +594,26 @@ def _pin_holds(record: dict, session_id: str, live: bool, busy: set[str],
     has no word for "sent, no verdict, not live" (it says `idle`), so reading it
     would have collapsed the second guard into the first.
     """
-    if live or session_id in busy:
+    if _running_now(session_id, live, busy):
         return True
     return _pin_at(record) > active
+
+
+def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
+    """Is something happening in this conversation RIGHT NOW?
+
+    The two independent halves `_pin_holds` already relies on, minus the third
+    (a pin's own timestamp), because that one is a claim someone made rather
+    than something that is happening: `live` is the transcript mid-turn, `busy`
+    is the scheduler waiting on a send it has not heard back from. Either is
+    enough, and neither is sufficient alone — a turn thinking through a long
+    tool call appends nothing and reads as not-live, and a session a human is
+    typing into has no scheduler entry at all.
+
+    Its own function rather than an inline `or` so the archive exception in
+    `_status` and the pin guard cannot drift apart about what "running" means.
+    """
+    return live or session_id in busy
 
 
 def _status(newest: dict | None, session_id: str, triage: dict, live: bool,
@@ -625,13 +642,29 @@ def _status(newest: dict | None, session_id: str, triage: dict, live: bool,
 
     A LIVE session still reads `in_progress` even over a failed newest message:
     something is running in that conversation right now, which is the more
-    urgent fact and the one that stops being true on its own."""
+    urgent fact and the one that stops being true on its own. Since 2026-08-18
+    that beats an `archived` record too — see `_running_now`."""
     record = triage.get(session_id) if session_id else None
     if isinstance(record, dict):
         status = record.get("status")
         if status in _TRIAGE_STATUSES and (
                 status != "in_progress"
                 or _pin_holds(record, session_id, live, busy, active)):
+            # FILING SOMETHING DOES NOT STOP IT (Akshil, 2026-08-18). Archive is
+            # a timeless decision and it is kept — the record is not touched
+            # here, and the moment the turn ends the task drops back into
+            # Archive on the next poll. But while a turn is genuinely in flight,
+            # a row that says `archived` is a lie the reader can watch: the work
+            # is happening, in that conversation, now. Running is the one fact
+            # on this page about the PRESENT, so for as long as it is true it
+            # outranks a decision about where the task belongs afterwards.
+            #
+            # Only `archived`. A `done` record is the user saying "this run is
+            # over", and if a new turn starts in that conversation the derived
+            # branches below already move the row without help. Archive is the
+            # one that would otherwise hide live work in a lane nobody watches.
+            if status == "archived" and _running_now(session_id, live, busy):
+                return "in_progress"
             return status
     if live and newest is not None:
         return "in_progress"

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1207,6 +1207,65 @@ def test_triage_wins_where_it_disagrees(client, projects_dir, state_dir):
     assert _by_key(client)["sess-a"]["status"] == "archived"
 
 
+def test_archiving_yields_to_a_turn_that_is_still_running(client, projects_dir,
+                                                          state_dir):
+    """Filing something does not stop it.
+
+    `archived` is a timeless decision and it is honoured for as long as nothing
+    is happening — but while a turn is genuinely in flight, a row that reads
+    `archived` is a lie the reader can watch: the work is happening, in that
+    conversation, now. Running is the one fact on this page that is about the
+    present, so for as long as it is true it outranks a decision about where the
+    task belongs afterwards.
+
+    Seeded through the SCHEDULER's half of "running" (a send with no verdict —
+    `_busy_sessions`) rather than transcript liveness, because that is the half
+    a scheduled task actually trips: a turn thinking through a long tool call
+    appends nothing and reads as not live."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "archived"}}))
+
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is False, "the scheduler's claim is the guard here"
+    assert task["status"] == "in_progress"
+
+
+def test_the_archive_is_kept_and_comes_back_when_the_turn_ends(client,
+                                                               projects_dir,
+                                                               state_dir):
+    """The other half of the promise above: the record is never touched.
+
+    The exception is a display rule for the duration of a run, not a quiet
+    undo of the user's filing — the same entry with a verdict on it reads
+    `archived` again, off the very record the running task ignored."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "archived"}}))
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
+    assert rec["status"] == "archived", "nothing here rewrites the filing"
+
+
+def test_a_done_record_is_not_given_the_archive_exception(client, projects_dir,
+                                                          state_dir):
+    """Only `archived` yields. `done` says "this run is over", and a new turn in
+    that conversation is already carried by the derivation — there is nothing
+    for an exception to fix, and widening it would make the one lane a user
+    files things INTO the one lane that cannot hold them."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENDING,
+                           claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "done"}}))
+    assert _by_key(client)["sess-a"]["status"] == "done"
+
+
 def test_a_stale_in_progress_pin_does_not_outlive_its_run(client, projects_dir,
                                                           state_dir):
     """The pin is a claim about the present, and the run it named has ended.


### PR DESCRIPTION
Stacked on `agent/20260818-tasks-nav` (rebased onto it on 2026-08-18, after #604 merged into nav). It retargets to `main` automatically once the one below it merges — review the five commits here, not the diff against `main`.

Six changes, all on the Tasks page, all against the flow app as the reference: near-black page, columns as invisible panels, cards as the only lit surface, a generous centred measure.

### 1 + 2 — the board's surfaces (`61b994b`)
The board has been round this loop twice: the lane painted a fill (a grey slab that competed with its own cards), lost it, and gained a `--border` hairline in its place. The hairline was the same mistake in thinner form — five outlined boxes read as five boxes.

Both attempts were reaching for an **ordering**, so it is stated as one: two new tokens with page < lane < card in dark, card above lane in light.

| token | dark | light |
| --- | --- | --- |
| `--bg` (page, unchanged) | `#131417` | `#ffffff` |
| `--tasks-lane-bg` | `#16181b` | `#eef0f2` |
| `--tasks-card-bg` | `#1e2023` | `#ffffff` |

- Open lanes lose their border entirely and take the quiet fill.
- Collapsed rails keep their hairline — a control you press, 52px wide, with no cards to give it shape.
- The card leaves `--bg-panel`. That token lifted correctly but is a *popover's* colour: `#202329` runs nine steps more blue than red, which over a near-black page reads grey rather than black-tinted charcoal. `#1e2023` keeps the lift and spends far less of it on blue.
- Card hover now moves the fill as well as the edge — against a lane that is itself a surface, an edge-only hover is easy to miss.
- The hover action strip (`.tasks-card-act`) tracks the card's token, as it must.

The tests read the ordering out of the token **values**, not out of the prose: a relationship written only in a comment is one a later tuning can silently invert.

### 3 — one measure, centred (`5cab407`)
The views were `max-width: none`, which is not "using the space" — on a wide display the List stretched three-line rows across 2000px under a title marooned at the far left.

**1360px**, and the board chose the number: five 260px lanes plus four 12px gaps is 1348, so the widest view fits inside the measure and the other two are not given a second one. Applied to every child of the page so the header travels with the views. Under 1360 the cap is inert; the board keeps its own `overflow-x`, so a narrow window scrolls the lanes and never the page.

### 4 — icons on the view switcher (`eb62b85`)
lucide `list` / `columns-3` / `calendar`, exported from `ScheduleCalendar` beside the rest of the page's glyphs so they cannot drift to a second icon size. Labels stay — icon-only on this control would trade recognition for guessing. Muted at rest, inheriting on the active half. The rules hang off a class of the switcher's own, since `.schedule-form-seg` is shared with the New task form's Once / On a schedule pair, which stays text-only.

### 5 — filters on the calendar (`e765b57`)
They were gated on `view !== "calendar"`, on the argument that a filtered week is a week that lies. Filters are not a claim about what exists; they are how you read the page this minute, and someone who narrows the List to one project and switches to Calendar meant to keep looking at that project. The calendar now gets the same filtered set the other two views get (`tasks={shown}`) — a visible but inert filter is worse than a hidden one. The "Tasks could not be loaded" line loses the same gate, since the chips come from that feed.

### 6 — one meaning for "recent" (`e3134c8`)
The app had two recents. The home page's Recent files strip reads the server-backed store at `~/.fused-render/recents.json` (`apps/explorer/lib/recents`, `/api/recents`); the New task modal read a localStorage array only it ever wrote — so someone who had spent the morning in a repo was offered folders the form happened to remember.

Unified on home's source, read through the very module `Home.tsx` reads, in the same **raw MRU** order (`loadRecents().entries`, not the sidebar's sticky `displayRecents`). That store holds files, and a task wants a place to run, so each entry contributes its containing folder; the order carries straight through the map. `hydrateRecents()` on mount, fire-and-forget, for the `/tasks?new=1` deep link that makes the modal the first thing opened in a session.

The form's own memory is **kept, second**: a folder deliberately picked through Browse may hold no files anyone has opened, so the shared store would never learn it. Existing tasks' targets stay third as padding. Whole list deduped.

### Verification
- `npm run build` + `tsc --noEmit` clean.
- `bun test` — 1703 pass, 0 fail (whole suite, nav's scroll-memory tests included) (5 new assertions' worth of coverage added: the surface ordering read off token values, the switcher's marks, the ungated filters, the page measure, and `parentFolder` + the recents tiering).
- `pytest -k "theme or schedule or task or new_task or css"` — 687 passed, 7 skipped. `test_theme.py`'s both-palettes rule covers the two new tokens.
- No dev server run; no visual QA pass yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task status derivation for archived+running sessions and broad Scheduled-page UI/state (lane peek, list memory); covered by extensive tests but affects core tasks workflows.
> 
> **Overview**
> **Tasks page polish** across list, board, and calendar: shared **1240px** centred layout, **view switcher icons**, and **filters on all three views** (calendar now uses the same `shown` filtered task set and shows load failures).
> 
> **New task path recents** now lead with **Claude session folders** from `getClaudeSessionFolders()` (aligned with Home), then form localStorage picks and task targets—deduped.
> 
> **Board:** lane visuals use **`--tasks-lane-bg` / `--tasks-card-bg`** (quiet lane fill, card as primary surface); **empty lanes** roll up by default but can be **peeked** via session-only state vs persisted `choices`; rails stay clickable, hide **0** counts; shared **scrollbar** styling for lane/list/calendar thread.
> 
> **List:** remembers **`selected`** task key when navigating to chat; subtle **`is-selected`** styling; archived tasks use **`threadTone`** so thread rows match archive (running turns excepted).
> 
> **Backend:** **`_running_now`** and **`_status`** so **archived** triage yields to **in_progress** while a turn is live/busy, without rewriting triage on disk.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5593205d57bd91bdbc811356defd499ee5a10cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



---

## Review round 2 (2026-08-18)

Six more commits on the same branch, from user review of the first six.

**`0d4e3c1` — the measure is 1240px, not 1360.** 1360 fitted the board exactly, which was the wrong way round: the board is the one view that can scroll inside itself, and the two that cannot were paying for its width. 1240 is sized for a three-line row and a seven-day calendar; the lane strip scrolls past it, which it already does at any window narrower than five lanes. Page still never scrolls sideways.

**`85571ca` — archiving a task archives its thread, unless a turn is running.**

Semantics implemented, both halves:
- *Frontend* — new `threadTone(task, m)`. When the task is in Archive, every settled message row is filed there with it. Archived is a *place*, not an event, so the **label is left exactly as it was** (an archived thread reads back run by run) and only `failed` is dropped — a filed task still flying a red mark is asking to be dealt with again. The List's thread rows now ask `threadTone` instead of `messageTone`; `messageTone` is untouched and still answers "what happened to this message".
- *Backend* — new `_running_now(session_id, live, busy)` in `server/routers/tasks.py`, shared with `_pin_holds` so the two cannot drift about what "running" means. In `_status`, an `archived` triage record now **yields to a live or busy session** and the row reads `in_progress`. Filing something does not stop it.
- *The record is never rewritten.* Archive is still a timeless filing decision on disk; the exception is a display rule for the duration of the run, and the task plus its whole thread fall back into Archive on the next poll after the turn ends.
- *Only `archived` gets the exception.* A `done` record means "this run is over", and a new turn there is already carried by the derivation.

Three new pytest cases cover the yield, the fall-back, and the `done` non-exception; six bun cases cover the cascade, the preserved label, the running exception, and the no-op on unarchived tasks.

**`6de6a03` — an empty lane is always a rail.** Empty now outranks the stored choice instead of being merely the default, so a lane expanded while it had cards no longer stays open as an empty outlined column. The choice is *remembered*, not discarded — the lane reopens on the first arrival. The rail loses the `0` chip (a count answers "how many are hidden here", which an empty rail has already answered) and loses its press, which would now do nothing: `aria-disabled` and no handler rather than a dead click. `aria-disabled` and not the real thing, because a disabled button stops receiving pointer events and this element is still the drop target for the one gesture that makes an empty lane non-empty.

**`5b02e2a` — recents are the folders you have sessions in.** The first round unified on the wrong list: `/api/recents` is the explorer's recently-*opened files*, so folders had to be derived from each path's parent — wrong shape, and three entries long on a machine with dozens of sessions. Now the leading tier is `getClaudeSessionFolders()`, the exact call the home page's **Claude Sessions** strip makes, top five, in the server's newest-session-first order. Those entries are already folders (each session's own `cwd`, canonicalised, filtered to directories that exist). The form's own Browse/task memory still follows, then existing task targets; deduped, fetch fire-and-forget.

**`fa9ba32` — the list remembers which row you came back out of.** `selected` joins `expanded` and `scroll` in the List's sessionStorage memory, restored by the same single read on mount. A task **key**, not an index (rows re-sort every poll). One row, not a set. Marked in `openChat` rather than `activate`, because activate's second arm opens a modal over this very page and lighting a row for a trip nobody took would make the highlight mean nothing — every way into a task's conversation, message rows included, goes through that one function. Painted in `--row-bg-active` (what the explorer listing and sidebar already mean by "the current row") plus an accent rule down the left that hover does not have. Older memories upgrade silently.

**`7dd1524` — the scrollbar gets a gutter instead of the cards' edge.** macOS gives a webview *overlay* scrollbars, so a full lane drew its thumb over every card's right border. `scrollbar-gutter` alone cannot fix it — an overlay scrollbar has a zero gutter by definition — but styling the bar at all opts the element out of overlay scrollbars, so it takes real layout space and there is nothing left to overlap; the gutter is stated with it so the column does not jump by 10px when the fifth card arrives. The thumb sits inside its track via a transparent border plus `background-clip: padding-box` (10px of track, 4px of ink), mixed from `--fg-muted` so it holds its weight in both themes. One rule for the page's three content scrollers — lane, List, calendar popover thread. The week grid keeps hiding its bar outright; dropdowns and pickers are left alone.

### Verification (round 2)
- `tsc --noEmit`, `npm run build` clean.
- `bun test` — 1714 pass, 0 fail.
- `pytest` on theme / schedule-css / tasks-api / new-task-css / sessions-triage-pins — 261 passed.
- Integration worktree reset to this branch, rebuilt; `http://localhost:2160/tasks` → 200 serving this build's bundle, `/api/tasks`, `/api/claude-sessions`, `/api/schedule` all 200.


---

## Review round 3 (2026-08-18)

One commit, `f94c17d` — three retreats. All three are the same mistake in three places: a change that was right about the problem went further than the problem went.

**Empty lanes are pressable again.** Round 2 made "empty" outrank the reader's stored choice, so a drained lane rolled itself up and would not reopen — a lane telling the reader they may not look inside it. Rolling up by *default* is unchanged and is what keeps four empty columns off a board with one busy lane; the `aria-disabled`, the missing handler and the dimming CSS are gone, and `laneCollapsed` is back to "reader's choice wins, else empty starts closed". An expanded empty lane shows an empty panel, and is a drop target either way. **The `0` chip stays gone** — that was the actual complaint.

**The selected row is the hover fill, and nothing else.** It was `--row-bg-active` plus a 2px accent rule; on a page whose accent is a bright lime that made one row in ninety look like a dialog's default button — an olive plate with a yellow edge, shouting a fact that only needs to be findable. Now `--row-bg-hover`, no bar, no tint. Hover and selected look identical, which is fine and was asked for: only one row can be hovered, the pointer is nowhere near the list after a page change, and a row that is both is both. The rule still sits after `:hover` so the fill does not blink off when the pointer leaves.

**An open task keeps the list's background.** `.tasks-row.is-open` carried `rgba(var(--tint), 0.04)` so the thread would read as belonging to its header. In a long list that loses to what it costs: the expanded task became a darker block among its neighbours, reading as a state the row is *in* rather than one it is merely open in. The belonging was never the tint's doing — the chevron says open, and thread rows are indented a whole ring slot to the right of their task's, which survives at a glance where a 4% wash does not.

### Verification (round 3)
- `tsc --noEmit`, `npm run build` clean.
- `bun test` — 1714 pass, 0 fail (the three round-2 tests that pinned the reverted behaviour were rewritten to pin the retreat).
- `pytest` theme / schedule-css / new-task-css — 142 passed.
- Integration worktree reset to this branch and rebuilt; `http://localhost:2160/tasks` → 200 serving `index-BwSIphHw.js`, this build's hash; `/api/tasks`, `/api/claude-sessions`, `/api/schedule` all 200.


---

## Empty-lane refinement (`c01b3cc`)

An empty lane rolls up, the reader can still open it, and nothing about that survives the sitting. Those three were in tension because both states lived in one store — whatever a reader did to an empty column was written to localStorage, which is the one setting you make once and are then handed four empty outlined columns by, for weeks, on a board you use to see what is running.

**Two stores, and the lane's contents decide which one a press lands in.**

| | a lane WITH cards | an EMPTY lane |
| --- | --- | --- |
| what a press means | a preference | a peek — "is there really nothing here?" |
| where it goes | `choices`, localStorage | `peeked`, component state |
| survives a reload | yes | no |
| survives a remount | yes | no |
| survives the lane filling and draining | yes | no |

- `laneCollapsed(lane, count, choices)` now **short-circuits on `count === 0`** and returns collapsed without consulting the store. That is what makes the guarantee structural rather than a convention: a stored choice is simply never asked about a column with nothing in it.
- That also settles the drain case the old rule got backwards — **a lane that empties rolls up** instead of honouring what it was set to while it still had work. The choice is not deleted, only unasked, so cards arriving open the lane again on it.
- `laneRolledUp(lane, count, choices, peeked)` is what the board draws: the peek is consulted **only** in the empty case, so a peek says nothing about a lane that has cards.
- The one remaining way a stale peek could speak is a lane that fills up and drains again, so it is dropped inside the window where it is already being ignored — while the lane has cards.
- Clickability from round 3 is untouched: the rail toggles either way, and an expanded empty lane is an empty panel that still accepts drops. The `0` chip stays gone.

### Verification
- `tsc --noEmit`, `npm run build` clean.
- `bun test` — 1716 pass, 0 fail (three new cases: the store is never consulted when empty, a draining lane rolls up, and a peek is empty-only and sitting-scoped).
- `pytest` theme / schedule-css — 132 passed.
- Integration worktree reset and rebuilt (no Python files in the diff, so no watchfiles restart race); `http://localhost:2160/tasks` → 200 serving `index-C_5JC44Y.js`, this build's hash; `/api/tasks`, `/api/claude-sessions`, `/api/schedule` all 200.
