### PR TITLE
Apps hub: learn-oriented category chips come first

### DIFF
--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -4,8 +4,8 @@
 // scaled, non-interactive iframe (AppPreviewCard). The list is narrowed by a
 // filter row — a Category/Repo mode selector with chips derived from the apps
 // themselves (categories from each folder's metadata.json, ordered learn-first
-// by app-categories; repos from the top-level tag dirs, plain alphabetical) —
-// and a search box (name/title/tag/category,
+// then locale-alphabetical by app-categories; repos from the top-level tag
+// dirs, plain code-unit sort) — and a search box (name/title/tag/category,
 // case-insensitive). Order is always recently-opened (modified time stands in
 // for an app never opened — appEntry.sortApps); filtering never reorders cards
 // relative to each other.
@@ -146,9 +146,11 @@ export default function Apps({ config }: { config: Config }) {
   const all = apps.status === "ok" ? apps.data : [];
   const tags = useMemo(() => [...new Set(all.map((a) => a.tag))].sort(), [all]);
   // Categories scanned from the apps themselves (metadata.json `category`).
-  // Apps without one carry null and so only ever appear under All. Ordered
-  // learn-first (orderCategories), not plain alphabetical, so the tutorial and
-  // starter chips lead the row; card order in the grid is unaffected.
+  // Apps without one carry null and so only ever appear under All. Ordered by
+  // orderCategories: learn-first so the tutorial and starter chips lead the
+  // row, then locale-alphabetical (which also replaces the code-unit sort the
+  // repo chips still use — see app-categories). Card order in the grid is
+  // unaffected.
   const categories = useMemo(
     () => orderCategories(all.map((a) => a.category).filter((c): c is string => !!c)),
     [all],

--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -3,8 +3,9 @@
 // of big preview cards — each thumbnail is the app itself rendered in a
 // scaled, non-interactive iframe (AppPreviewCard). The list is narrowed by a
 // filter row — a Category/Repo mode selector with chips derived from the apps
-// themselves (categories from each folder's metadata.json, repos from the
-// top-level tag dirs) — and a search box (name/title/tag/category,
+// themselves (categories from each folder's metadata.json, ordered learn-first
+// by app-categories; repos from the top-level tag dirs, plain alphabetical) —
+// and a search box (name/title/tag/category,
 // case-insensitive). Order is always recently-opened (modified time stands in
 // for an app never opened — appEntry.sortApps); filtering never reorders cards
 // relative to each other.
@@ -17,6 +18,7 @@ import { runCommunity, SHOWCASE_TAG } from "@platform/lib/community";
 import ContextMenu, { type MenuEntry } from "@platform/ui/ContextMenu";
 import { ErrorBanner } from "@platform/ui/ErrorBanner";
 import { AppPreviewCard } from "@apps/builder/AppPreviewCard";
+import { orderCategories } from "@apps/builder/app-categories";
 import { useNavEpoch } from "@platform/lib/hooks";
 import { navigateUrl } from "@platform/lib/router";
 import { HomeHero } from "./HomeHero";
@@ -144,9 +146,11 @@ export default function Apps({ config }: { config: Config }) {
   const all = apps.status === "ok" ? apps.data : [];
   const tags = useMemo(() => [...new Set(all.map((a) => a.tag))].sort(), [all]);
   // Categories scanned from the apps themselves (metadata.json `category`).
-  // Apps without one carry null and so only ever appear under All.
+  // Apps without one carry null and so only ever appear under All. Ordered
+  // learn-first (orderCategories), not plain alphabetical, so the tutorial and
+  // starter chips lead the row; card order in the grid is unaffected.
   const categories = useMemo(
-    () => [...new Set(all.map((a) => a.category).filter((c): c is string => !!c))].sort(),
+    () => orderCategories(all.map((a) => a.category).filter((c): c is string => !!c)),
     [all],
   );
   const clonedSlugs = useShowcaseSync(() => setNonce((n) => n + 1));

--- a/frontend/src/apps/builder/app-categories.test.ts
+++ b/frontend/src/apps/builder/app-categories.test.ts
@@ -23,12 +23,14 @@ describe("orderCategories", () => {
     ]);
   });
 
-  it("ranks a category the same however its name is cased or separated", () => {
-    expect(orderCategories(["zebra", "How It Works", "how_to"])).toEqual([
-      "How It Works",
-      "how_to",
-      "zebra",
-    ]);
+  it("ranks a learn category the same however its name is cased or separated", () => {
+    // "aaa" wins on locale order, so each spelling below only leads the row if
+    // normalize actually matched it against LEARN_ORDER's "howitworks" — drop
+    // the case-folding or the separator stripping and the ordering breaks, not
+    // just the rank-equality check.
+    expect(orderCategories(["aaa", "How It Works"])).toEqual(["How It Works", "aaa"]);
+    expect(orderCategories(["aaa", "how_it_works"])).toEqual(["how_it_works", "aaa"]);
+    expect(orderCategories(["aaa", "How-It-Works"])).toEqual(["How-It-Works", "aaa"]);
     expect(learnRank("how-it-works")).toBe(learnRank("How_It Works"));
   });
 

--- a/frontend/src/apps/builder/app-categories.test.ts
+++ b/frontend/src/apps/builder/app-categories.test.ts
@@ -1,0 +1,54 @@
+// The one rule the Apps hub's category chips add on top of "alphabetical":
+// a newcomer must meet the learning categories (starters, tutorials, …)
+// before the topical ones. Everything below is about that boundary holding —
+// including for authored spellings that differ only in case or separators.
+import { describe, expect, it } from "bun:test";
+import { learnRank, orderCategories } from "./app-categories";
+
+describe("orderCategories", () => {
+  it("puts learn categories first, in the authored priority order", () => {
+    expect(orderCategories(["guides", "tutorials", "starters"])).toEqual([
+      "starters",
+      "tutorials",
+      "guides",
+    ]);
+  });
+
+  it("sorts the non-priority tail alphabetically after every learn one", () => {
+    expect(orderCategories(["productivity", "geospatial", "local-ai", "starters"])).toEqual([
+      "starters",
+      "geospatial",
+      "local-ai",
+      "productivity",
+    ]);
+  });
+
+  it("ranks a category the same however its name is cased or separated", () => {
+    expect(orderCategories(["zebra", "How It Works", "how_to"])).toEqual([
+      "How It Works",
+      "how_to",
+      "zebra",
+    ]);
+    expect(learnRank("how-it-works")).toBe(learnRank("How_It Works"));
+  });
+
+  it("dedups repeats and survives an empty list", () => {
+    expect(orderCategories([])).toEqual([]);
+    expect(orderCategories(["starters", "starters", "geospatial"])).toEqual([
+      "starters",
+      "geospatial",
+    ]);
+  });
+
+  it("never lets an unknown category outrank a learn one", () => {
+    // "aaa" wins on plain alphabetical order; the learn rank must beat it.
+    expect(orderCategories(["aaa", "tutorials"])).toEqual(["tutorials", "aaa"]);
+    expect(learnRank("aaa")).toBeGreaterThan(learnRank("examples"));
+  });
+
+  it("leaves the input array untouched", () => {
+    const input = ["zebra", "starters"];
+    orderCategories(input);
+    expect(input).toEqual(["zebra", "starters"]);
+  });
+});

--- a/frontend/src/apps/builder/app-categories.ts
+++ b/frontend/src/apps/builder/app-categories.ts
@@ -3,7 +3,13 @@
 // workspace happens to contain — but a newcomer landing on /apps should meet
 // the learning apps first, not whichever topic sorts earliest. So the chips
 // lead with the learn-oriented categories in the order below and put
-// everything else after them, alphabetically as before.
+// everything else after them, locale-alphabetically.
+//
+// That tail order is deliberately NOT the previous one: the chips used to come
+// out of a bare Array#sort, i.e. UTF-16 code-unit order, where "Zebra" sorts
+// before "apple" because every capital does. These names are freehand author
+// strings, so localeCompare's collation — case-insensitive-ish, and kinder to
+// punctuation like the "-" in "local-ai" — is what a reader expects to see.
 
 // Learn-oriented category names, in intended display order. Compared in
 // normalized form (see normalize), so an author writing "How It Works" or

--- a/frontend/src/apps/builder/app-categories.ts
+++ b/frontend/src/apps/builder/app-categories.ts
@@ -1,0 +1,39 @@
+// Chip order for the Apps hub's Category facet. Categories are authored, one
+// per app, in each app folder's metadata.json, so the set is whatever the
+// workspace happens to contain — but a newcomer landing on /apps should meet
+// the learning apps first, not whichever topic sorts earliest. So the chips
+// lead with the learn-oriented categories in the order below and put
+// everything else after them, alphabetically as before.
+
+// Learn-oriented category names, in intended display order. Compared in
+// normalized form (see normalize), so an author writing "How It Works" or
+// "how_it_works" lands in the same slot as "howitworks".
+const LEARN_ORDER = [
+  "starters",
+  "tutorials",
+  "learn",
+  "howitworks",
+  "guides",
+  "basics",
+  "examples",
+];
+
+// Authored spellings vary: lower-case it and drop the separators authors reach
+// for interchangeably (-, _, whitespace) so all of them rank alike.
+const normalize = (c: string) => c.toLowerCase().replace(/[-_\s]+/g, "");
+
+const RANKS = new Map(LEARN_ORDER.map((c, i) => [c, i]));
+
+// Sort key: position in LEARN_ORDER, or one past the end for anything else —
+// so no non-learn category can ever outrank a learn one, whatever its name.
+export const learnRank = (category: string): number =>
+  RANKS.get(normalize(category)) ?? LEARN_ORDER.length;
+
+// Dedup + order a raw list of authored category names for the chip row. Learn
+// rank first, then localeCompare — which decides both ties within a rank and
+// the whole non-priority tail.
+export function orderCategories(categories: string[]): string[] {
+  return [...new Set(categories)].sort(
+    (a, b) => learnRank(a) - learnRank(b) || a.localeCompare(b),
+  );
+}


### PR DESCRIPTION
## Summary

- On the Apps hub (`/apps`), the **Category** chip row led with whichever topic sorted earliest alphabetically — a newcomer met `geospatial` before `starters`. Chips now lead with the learning-oriented categories, so the tutorial/starter apps are the first thing on offer.
- Learn categories come in an authored order (`starters, tutorials, learn, howitworks, guides, basics, examples`); everything else follows after all of them, locale-alphabetically. That tail order is deliberately *not* byte-identical to before: the old code used a bare `Array#sort` (UTF-16 code-unit order), so `["Zebra", "apple"]` used to render `Zebra · apple` and now renders `apple · Zebra`. Locale collation is the right call for freehand author-written strings.
- Category names are authored freehand in each app's `metadata.json`, so matching is case-insensitive and ignores `-`, `_`, and spaces — `how_it_works`, `how-it-works`, and `How It Works` all rank in the same slot.
- Scope is the chip row only. **Repo** chips stay plain alphabetical, and card order in the grid is still recently-opened (`sortApps`) — untouched.

In a stock local workspace (`geospatial`, `local-ai`, `productivity`, `starters`) the row goes from `All · geospatial · local-ai · productivity · starters` to `All · starters · geospatial · local-ai · productivity`.

## Visuals

The ordering moves out of `Apps.tsx`'s inline `.sort()` into a testable `orderCategories` helper:

```mermaid
flowchart TD
    A[GET /api/apps] --> B[metadata.json category per app]
    B --> C[orderCategories: dedup]
    C --> D{learnRank}
    D -->|in LEARN_ORDER| E[chips, priority order]
    D -->|anything else| F[chips, alphabetical tail]
```

`learnRank` returns a category's index in `LEARN_ORDER`, or one past the end for everything else, so no non-learn name can outrank a learn one. `localeCompare` then breaks ties and orders the tail.

## Usage

Not directly invocable — it's the ordering of an existing UI control. To see it: open the Apps hub, keep the facet selector on **Category**, and read the chip row left to right. Learn categories lead. Clicking a chip still filters via `?category=<name>` as before.

## Test Plan

- [x] New unit tests `frontend/src/apps/builder/app-categories.test.ts` (6 cases): priority ordering, locale-alphabetical non-priority tail (the real workspace case), case/separator normalization, dedup + empty input, unknown-never-outranks-a-learn-one, input array left unmutated. Run with `cd frontend && bun test src/apps/builder/app-categories.test.ts` — 6 pass. The normalization case orders each spelling of `how it works` against an alphabetically-earlier unknown, so it fails if `normalize` stops stripping separators (verified by temporarily breaking `normalize`).
- [x] `cd frontend && bunx tsc --noEmit` clean; `node scripts/check-boundaries.mjs` OK (280 files).
- [x] Full local suite: frontend `bun test` 1703 pass / 0 fail; `pytest -n auto` 8055 pass with 2 failures + 2 errors that are the known macOS-local baseline noise (`test_calls`, `test_fs_raw_bearer_proxy`, a joblib template import collision) — none in the changed code path.
- [x] CI green on all jobs. One `test-python (3.12)` red on the first push was `test_schedule_queue::test_ten_one_offs_missed_over_two_weeks_all_fire`, an ordering flake in Python scheduling code this PR does not touch (main is red on the same suite); it passed on rerun.
- [ ] Manual: open `/apps` with the facet on **Category** and confirm `starters` leads the row, that switching to **Repo** still shows plain-alphabetical tags, and that card order inside the grid is unchanged.
