### PR TITLE
AI runners: pin MLX streams per device, and bound every inference engine

### DIFF
--- a/fused_render/ai/runners/diffusers_image/pyproject.toml
+++ b/fused_render/ai/runners/diffusers_image/pyproject.toml
@@ -19,12 +19,26 @@
 # rule stands anyway, because a source build in this environment is minutes of
 # compiling on a user's laptop for something a wheel already answers.
 #
+# **The runtime lines carry CEILINGS**, for the reason
+# `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
+# these manifests and `uv sync` runs bare, so an unbounded requirement is
+# re-resolved from PyPI on every new venv key and a major bump lands on users
+# with no commit behind it. The FLOORS are left where they were — `diffusers`
+# keeps `>=0.39` rather than gaining the installed patch, and `transformers`
+# gains a ceiling with NO floor added, because this runner has never declared one
+# and inventing one here would forbid versions that are currently allowed while
+# also disagreeing with `transformers_text`'s deliberate `>=4.51`. A ceiling only
+# removes the future; a floor removes the present.
+#
 # What each earns:
-#   torch          the tensors and the device (CUDA / MPS / CPU)
+#   torch          the tensors and the device (CUDA / MPS / CPU). `<3` — the
+#                  major is the whole ABI and every wheel behind it.
 #   diffusers      the pipelines. `>=0.39` because that is the first RELEASE
 #                  carrying Flux2KleinPipeline — this used to track
 #                  git+https://github.com/huggingface/diffusers.git for exactly
-#                  that class, back when it existed only on main (D266).
+#                  that class, back when it existed only on main (D266). `<0.40`
+#                  because a pre-1.0 minor is where this library moves pipeline
+#                  signatures, and `worker.py` drives one directly.
 #   transformers   the text encoder every text-to-image pipeline puts in front
 #   accelerate     device placement / offload for models bigger than the GPU
 #   sentencepiece  the tokenizer format those text encoders use
@@ -38,10 +52,10 @@ name = "fused-render-runner-diffusers-image"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "torch",
-    "diffusers>=0.39",
-    "transformers",
-    "accelerate",
+    "torch>=2.13,<3",
+    "diffusers>=0.39,<0.40",
+    "transformers<6",
+    "accelerate>=1.14,<2",
     "sentencepiece",
     "protobuf",
     "gguf",

--- a/fused_render/ai/runners/faster_whisper/pyproject.toml
+++ b/fused_render/ai/runners/faster_whisper/pyproject.toml
@@ -14,6 +14,15 @@
 # inside this file. That is the property the runner-folder design exists to
 # preserve, and it is why `worker.py` never calls `subprocess`.
 #
+# **The engine lines carry CEILINGS**, for the reason
+# `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
+# these manifests and `uv sync` runs bare, so an unbounded requirement is
+# re-resolved from PyPI on every new venv key and a major bump lands on users
+# with no commit behind it. `sherpa-onnx-core` stays unbounded on purpose —
+# sherpa-onnx's own wheels declare `Requires-Dist: sherpa-onnx-core==<its own
+# version>`, so the bound on the primary already governs the companion and a
+# second range could only ever contradict it.
+#
 # What each earns:
 #   faster-whisper  the model, the decoder and the VAD. Pulls in ctranslate2
 #                   (which builds wheels for macOS on both architectures, Linux
@@ -56,10 +65,10 @@ name = "fused-render-runner-faster-whisper"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "faster-whisper",
+    "faster-whisper>=1.2,<2",
     "huggingface_hub",
     "psutil",
-    "sherpa-onnx",
+    "sherpa-onnx>=1.13,<2",
     # The other half of sherpa-onnx, which its own metadata cannot get into the
     # lock. See the comment above before removing this as a duplicate.
     "sherpa-onnx-core",

--- a/fused_render/ai/runners/mflux_image/pyproject.toml
+++ b/fused_render/ai/runners/mflux_image/pyproject.toml
@@ -20,6 +20,17 @@
 #                   itself; both are load-bearing here and neither is named
 #                   again, for the reason the whisper runner names `av` —
 #                   a dependency this file relies on should be visible in it.
+#                   **BOUNDED, and the bound was earned.** `mflux` used to be
+#                   named here with no version at all, and the `uv.lock` beside
+#                   this file is gitignored — so the first environment built
+#                   after mflux 0.19.0 shipped re-resolved 0.18.1 -> 0.19.0,
+#                   which pins `mlx>=0.32,<0.33`, and mlx 0.32 is the release
+#                   that made default streams per-thread. Every local render
+#                   started aborting on its first denoising step with no repo
+#                   change behind it (see `worker.py::_pin_stream`). A minor
+#                   range means the next such move is a deliberate bump with a
+#                   render behind it rather than a silent one on a user's
+#                   machine.
 #   huggingface_hub downloads
 #   psutil          the RSS half of "how much memory is this costing"; the MLX
 #                   half comes from mlx's own allocator (see `memory()`)
@@ -31,7 +42,7 @@ name = "fused-render-runner-mflux-image"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "mflux",
+    "mflux>=0.19,<0.20",
     "huggingface_hub",
     "psutil",
 ]

--- a/fused_render/ai/runners/mflux_image/pyproject.toml
+++ b/fused_render/ai/runners/mflux_image/pyproject.toml
@@ -37,6 +37,25 @@
 #
 # No `av`, unlike the transcription runner: nothing here decodes media. The
 # no-subprocess rule still holds — `worker.py` never shells out.
+#
+# **Why every runner's inference lines carry a CEILING, stated once here because
+# this is where it was learned.** None of these folders has a committed
+# `uv.lock`: `.gitignore` ignores lockfiles globally and negates only
+# `templates/`, and `_env_install_worker` runs a BARE `uv sync` deliberately (its
+# own comment says why — a lock a user cannot have is worse than a resolve). So
+# an unbounded requirement does not mean "whatever was current when the feature
+# shipped", it means *resolved again from PyPI every time a venv key changes* —
+# a new checkout path, a new runner folder, a reinstall. That is not a wide
+# range, it is no range: the version a user runs is decided by PyPI on the day
+# they press Download, and when it changes there is no commit to point at. The
+# floors are the installed MINOR rather than the installed patch, so patch fixes
+# still flow; the ceiling is the next minor for a 0.x library (where a minor IS
+# the breaking release) and the next major otherwise. Bumping one is a normal
+# change with a render or a transcription behind it.
+# `tests/test_ai_runtime.py::test_every_runner_BOUNDS_its_model_runtimes`
+# enforces it for all seven manifests, against an allow-list of the dependencies
+# that are exempt — so the next unbounded library is a red test rather than a
+# discovery, and the exemptions have written reasons.
 [project]
 name = "fused-render-runner-mflux-image"
 version = "0.1.0"

--- a/fused_render/ai/runners/mflux_image/worker.py
+++ b/fused_render/ai/runners/mflux_image/worker.py
@@ -39,6 +39,7 @@ for.
 
 import os
 import sys
+import threading
 import time
 
 # The base sits one directory up, in `runners/` — see mlx_text/worker.py.
@@ -50,6 +51,74 @@ import worker_base  # noqa: E402 - the path insert above is what makes it import
 
 #: The loaded model. One per process.
 _loaded = {}
+
+#: The MLX streams every thread in this process works on, keyed by device name —
+#: ONE PER DEVICE, which is the whole point. See `_pin_stream`.
+_STREAMS = {}
+_STREAMS_LOCK = threading.Lock()
+
+
+def _pin_stream():
+    """Put this thread's MLX work on the process's shared streams — EVERY device.
+
+    **MLX default streams are per-thread from mlx 0.32 on, and this worker is
+    threaded.** `load` runs on `worker_base.serve`'s bring-up thread, which then
+    exits; `generate` arrives on a `ThreadingTCPServer` request thread. An
+    UNEVALUATED array is a graph pinned to the stream it was built on, and
+    forcing it from another thread throws
+    `std::runtime_error("There is no Stream(cpu, 0) in current thread")` — see
+    `load` for what that costs and `mlx_whisper/worker.py::_pin_stream` for the
+    same mechanism written out at length.
+
+    **`mx.cpu` as well as the default device, which is where a verbatim copy of
+    the whisper runner's version would have been wrong.** The default stream is
+    per (thread, DEVICE): `set_default_stream` is documented to replace the
+    default "for the stream's device", so pinning `default_device()` alone — the
+    GPU — leaves this thread's CPU default exactly where it was. Measured on
+    0.32.1: a gpu-only pin on both threads does not fix this runner, it only
+    moves the index in the abort (`There is no Stream(cpu, 2)`), while the
+    cpu pin alone renders. Both are pinned anyway, because which device holds
+    the next version's lazy graph is not something to re-measure per release.
+
+    Pinning a CPU stream does NOT move the default DEVICE — measured:
+    `mx.default_device()` is still `Device(gpu, 0)` after a render, and the
+    render's own speed is unchanged.
+
+    `new_thread_unsafe_stream` is mlx's own answer: a stream not owned by the
+    thread that made it. **The sharing is the mechanism** — one stream per
+    device for the whole process, so a graph built on any thread is forceable on
+    any other. "Unsafe" means it must not be driven by two threads AT ONCE,
+    which this worker already guarantees: `worker_base.GENERATE_LOCK` serializes
+    renders and the load completes before the server accepts a request.
+
+    A no-op on an mlx too old to have the call, which is the right answer:
+    streams were process-wide there and there was nothing to pin.
+    """
+    import mlx.core as mx
+
+    make = getattr(mx, "new_thread_unsafe_stream", None)
+    pin = getattr(mx, "set_default_stream", None)
+    if make is None or pin is None:
+        return None
+    # `default_device()` rather than `mx.gpu`, and CPU FIRST: on a build with no
+    # Metal the two are the same device and this dedupes to one stream, rather
+    # than naming a device this mlx may not have.
+    devices = [mx.cpu, mx.default_device()]
+    with _STREAMS_LOCK:
+        streams = []
+        for device in devices:
+            key = str(device)
+            # `if key not in`, NOT `setdefault(key, make(device))`: the latter
+            # evaluates `make` on every call and would mint a fresh stream per
+            # thread while keeping the first — the shared stream is the whole
+            # mechanism, so quietly making unshared ones is the bug this guards.
+            if key not in _STREAMS:
+                _STREAMS[key] = make(device)
+            if _STREAMS[key] not in streams:
+                streams.append(_STREAMS[key])
+    for stream in streams:
+        pin(stream)
+    return streams
 
 
 #: Repo id -> the mflux VARIANT class that loads it and the model config that
@@ -125,34 +194,67 @@ def load(model_id, fetched):
     # network — which matters because `download` has already reported those
     # bytes to the job row, and a second fetch inside `load` would be an
     # unreported download the user watches as a stalled "Loading…".
-    # **This runner is threaded exactly like `mlx_whisper/worker.py` and needs
-    # no `_pin_stream`, and here is why — because "same shape, but fine" is the
-    # claim that rots silently when a dependency moves.**
+    # **This runner is threaded exactly like `mlx_whisper/worker.py`, and from
+    # mlx 0.32 it needs the same `_pin_stream` — on BOTH devices.** This comment
+    # used to say the opposite, at length, and it was true: under mlx 0.31.x
+    # streams were process-wide and there was nothing to pin. `mflux` declared no
+    # version bound, so the first venv provisioned after mflux 0.19.0 shipped
+    # re-resolved to it, mflux 0.19 pins `mlx>=0.32,<0.33`, and every render
+    # afterwards died on its first denoising step. The dependency moved; the
+    # claim did not. Hence the bound now in this folder's `pyproject.toml`.
     #
-    # The shape: mlx 0.32 gives every thread its own default stream, `load` runs
-    # on `worker_base`'s bring-up thread (which then exits), and `generate` runs
-    # on a `ThreadingTCPServer` request thread. An UNEVALUATED array is a graph
-    # owned by the stream it was built on, so forcing one from another thread
-    # throws out of `metal::get_command_encoder` — an uncaught C++ exception
-    # that aborts the worker with no Python traceback. That is what took out
-    # every MLX Whisper transcription; the whisper runner's `_pin_stream`
-    # docstring has the mechanism in full.
+    # The shape: mlx 0.32 gives every thread its own default stream PER DEVICE,
+    # `load` runs on `worker_base`'s bring-up thread (which then exits), and
+    # `generate` runs on a `ThreadingTCPServer` request thread. An UNEVALUATED
+    # array is a graph owned by the stream it was built on, so forcing one from
+    # another thread throws an uncaught C++ exception that aborts the worker with
+    # no Python traceback. See `_pin_stream` above, and the whisper runner's for
+    # the mechanism in full.
     #
-    # Why it does not reach here: an EVALUATED array crosses threads freely, and
-    # nothing in this construction stays lazy. Every array in the model arrives
-    # through `WeightLoader` → `mx.load(...)`, which returns materialised
-    # safetensors data rather than a graph, and `WeightApplier` installs it with
-    # `model.update(...)`. On a pre-quantized repo — which is all this runner
-    # loads — `apply_and_quantize` takes the `stored_q is not None` branch, so
-    # `nn.quantize` runs FIRST and the loaded weights then overwrite what it
-    # computed. Nothing is derived-and-kept the way whisper's underscored
-    # `_positional_embedding` and `_mask` are, and those were the whole leak.
+    # **The array that actually kills it, because the old note named the wrong
+    # one.** That note claimed "every array in the model arrives through
+    # `WeightLoader` -> `mx.load(...)`, which returns materialised safetensors
+    # data rather than a graph". `mx.load` does no such thing: it returns a LAZY
+    # graph whose single node is MLX's `Load` primitive, and `Load` is scheduled
+    # on the CPU stream whatever the default device is. mflux 0.19's FLUX.2 path
+    # never forces it — `WeightLoader._try_load_mflux_format` reads the shards,
+    # `WeightApplier.apply_and_quantize` installs them with `model.update(...)`
+    # and `nn.quantize(...)`, and `flux2_initializer.py` has no `mx.eval` at all
+    # (unlike the krea2 and ideogram4 initializers, which do). So the
+    # transformer, text encoder and VAE weights reach the request thread as live
+    # `Load` graphs owned by the BRING-UP thread's cpu stream. Whisper's leak was
+    # two derived tensors `parameters()` could not see; this one is the weights
+    # themselves.
     #
-    # Measured, not reasoned: building this variant on a thread that then exits
-    # and forcing `mx.eval` over all 1558 arrays reachable in the model — every
-    # attribute, underscored ones included — from a second thread evaluates
-    # cleanly; and a real 4-step 256² render through this worker, load thread
-    # gone, returned a PNG. Re-run both if mflux or mlx is bumped.
+    # **Measured, not reasoned (mflux 0.19.0, mlx 0.32.1 — 0.32.0 carries the
+    # same hazard, so treat this as 0.32.x):**
+    #   * Unfixed, this exact code — `load` on a thread that then exits, then
+    #     `generate` on a second thread, 2 steps at 256x256 — dies at mflux's
+    #     per-step `mx.eval(latents)` (`flux2_klein.generate_image`) with
+    #     `There is no Stream(cpu, 0) in current thread`. That is the
+    #     supervisor's dropped connection and the page's "the image process did
+    #     not answer".
+    #   * `mx.default_stream(...)` on 0.32.1 reports `Stream(cpu, 0)` and
+    #     `Stream(gpu, 1)` on the first thread to touch MLX, 2/3 on the next and
+    #     4/5 on the one after — the default stream is per (thread, DEVICE).
+    #   * Pinning `default_device()` alone, on BOTH threads, does not fix it:
+    #     the same run dies with `There is no Stream(cpu, 2)`. Pinning cpu alone
+    #     renders. Both are pinned; see `_pin_stream`.
+    #   * With `_pin_stream` on both threads the same run returns a 256x256 PNG
+    #     in ~8.5s, and `mx.default_device()` is still `Device(gpu, 0)`.
+    #
+    # **Whether the LIVE PREVIEW is on changes only how the failure looks, not
+    # whether it happens.** mflux calls `ctx.in_loop(t, latents)` one line BEFORE
+    # its own `mx.eval(latents)`, so with a preview sink attached `_as_numpy`
+    # forces the graph first, across numpy's `__array__` boundary — which is
+    # `noexcept`, so the process ABORTS (`libc++abi:`) and `preview.Sink.add`'s
+    # `except Exception` cannot see it by construction. With no sink, mflux's own
+    # `mx.eval` forces it and the same fault surfaces as a catchable
+    # `RuntimeError`. The fix is the pin; the preview is not the problem.
+    #
+    # Re-run all of the above if mflux or mlx is bumped — an expired measurement
+    # is exactly what happened last time.
+    _pin_stream()
     model = variant_cls(model_config=model_config, model_path=fetched)
     # ONE registration, at load time. `CallbackRegistry.register` APPENDS, and
     # the registry belongs to the model rather than to a call — so registering
@@ -234,6 +336,12 @@ def _sigma_after(config, t):
     None when there is no schedule to read, which mflux always has — but a
     preview must not be able to raise out of the one callback this runner
     cancels through and lose a render that was going to succeed.
+
+    `float(sigmas[t + 1])` is a second MLX force inside this callback, and it is
+    safe for a different reason than `_as_numpy`: the schedule is built per
+    `generate_image()` call, so it is a graph this very thread made. Worth
+    knowing if the schedule ever becomes something `load` computes once — that
+    would put it on the bring-up thread, where `_pin_stream` is what saves it.
     """
     sigmas = getattr(getattr(config, "scheduler", None), "sigmas", None)
     if sigmas is None or len(sigmas) <= t + 1:
@@ -251,9 +359,12 @@ def _as_numpy(latents):
 
     **This costs the render nothing.** Touching the array forces the same
     `mx.eval` the generation loop performs immediately after the callback
-    returns, and it happens ON that thread — so there is no unevaluated graph
-    crossing a thread boundary and no `_pin_stream` concern (see `load`'s
-    docstring for the failure mode that would be).
+    returns — one line later, in fact, which is why this is where a stream fault
+    surfaces first and as an ABORT rather than an exception: numpy's `__array__`
+    boundary is `noexcept`, so `preview.Sink.add`'s `except Exception` cannot
+    catch one. That is a reason to keep `_pin_stream` correct, not a reason to
+    move this call; the same fault without a preview sink only changes which
+    line reports it. See `load`.
     """
     import mlx.core as mx
     import numpy
@@ -331,6 +442,10 @@ def generate(body):
     model = _loaded.get("model")
     if model is None:
         raise RuntimeError("no model is loaded")
+    # BEFORE anything touches the model: this is a request thread, the weights it
+    # is about to force were built on the bring-up thread, and mlx 0.32's default
+    # streams are per (thread, device). See `_pin_stream`.
+    _pin_stream()
 
     prompt = str(body.get("prompt") or "")
     width = int(body.get("width") or 1024)

--- a/fused_render/ai/runners/mflux_image/worker.py
+++ b/fused_render/ai/runners/mflux_image/worker.py
@@ -241,7 +241,17 @@ def load(model_id, fetched):
     #     the same run dies with `There is no Stream(cpu, 2)`. Pinning cpu alone
     #     renders. Both are pinned; see `_pin_stream`.
     #   * With `_pin_stream` on both threads the same run returns a 256x256 PNG
-    #     in ~8.5s, and `mx.default_device()` is still `Device(gpu, 0)`.
+    #     and `mx.default_device()` is still `Device(gpu, 0)`. Both timings below
+    #     are `generate`'s OWN clock — the render, with the model already loaded
+    #     and the load excluded: ~8.5s for the FIRST render after a load (its
+    #     first step alone is ~6s, Metal compiling kernels), ~3.3-3.4s for every
+    #     warm render after that. Compare like for like when re-running: the
+    #     first number is not reproducible twice in one process.
+    #   * A different configuration, for scale rather than comparison: the same
+    #     fix driven end-to-end through the server at 512x512 / 4 steps, warm HF
+    #     cache, produced a 512x512 RGB PNG with per-step times 8.09s, 6.09s,
+    #     5.50s, 5.78s and ~51s of total wall clock INCLUDING the model load —
+    #     and no `libc++abi` or `Stream(cpu` line in the worker log.
     #
     # **Whether the LIVE PREVIEW is on changes only how the failure looks, not
     # whether it happens.** mflux calls `ctx.in_loop(t, latents)` one line BEFORE

--- a/fused_render/ai/runners/mlx_text/pyproject.toml
+++ b/fused_render/ai/runners/mlx_text/pyproject.toml
@@ -11,6 +11,13 @@
 # Three packages, and each earns its place: mlx-lm loads and generates,
 # huggingface_hub downloads, psutil answers "how much memory is this costing".
 #
+# `mlx-lm` carries a CEILING for the reason `mflux_image/pyproject.toml` states
+# at length: no lockfile is committed beside these manifests and `uv sync` runs
+# bare, so an unbounded line re-resolves from PyPI on every new venv key — which
+# is how an mlx minor bump reached users' machines with no commit behind it.
+# `>=0.31,<0.32` because mlx-lm is pre-1.0, where a minor is the breaking one,
+# and because it is the package that pins `mlx` for this runner.
+#
 # tqdm used to be here, for a `tqdm_class` shim that reported hf's progress bars
 # to the download manager. It is gone with the shim (AI-5b): that hook only
 # exposes the outer FILE counter, which is how a 4.6GB pull came to read
@@ -20,7 +27,7 @@ name = "fused-render-runner-mlx-text"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "mlx-lm",
+    "mlx-lm>=0.31,<0.32",
     "huggingface_hub",
     "psutil",
 ]

--- a/fused_render/ai/runners/mlx_whisper/pyproject.toml
+++ b/fused_render/ai/runners/mlx_whisper/pyproject.toml
@@ -20,6 +20,15 @@
 # decodes with `av` itself and passes the waveform — and `av` is named here
 # rather than left to arrive as somebody else's transitive dependency.
 #
+# **The engine lines carry CEILINGS**, for the reason
+# `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
+# these manifests and `uv sync` runs bare, so an unbounded requirement is
+# re-resolved from PyPI on every new venv key — which is exactly how an `mlx`
+# minor bump reached users' machines with no commit behind it. `mlx-whisper` is
+# the line that pins `mlx` here, so it is the line that matters most. `av` is
+# left open (a decoder, not a runtime) and `sherpa-onnx-core` is left open
+# because sherpa-onnx's wheels pin it to their own version themselves.
+#
 # What each earns:
 #   mlx-whisper     the model and the decoder, on Metal. Pulls mlx and
 #                   huggingface_hub in itself; both are named where they are
@@ -74,12 +83,12 @@ name = "fused-render-runner-mlx-whisper"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "mlx-whisper",
+    "mlx-whisper>=0.4,<0.5",
     "huggingface_hub",
     "psutil",
     "av",
-    "onnxruntime",
-    "sherpa-onnx",
+    "onnxruntime>=1.28,<2",
+    "sherpa-onnx>=1.13,<2",
     # The other half of sherpa-onnx, which its own metadata cannot get into the
     # lock. See the comment above before removing this as a duplicate.
     "sherpa-onnx-core",

--- a/fused_render/ai/runners/mlx_whisper/worker.py
+++ b/fused_render/ai/runners/mlx_whisper/worker.py
@@ -119,8 +119,12 @@ def _pin_stream():
     lazy, where a list of two attribute names would not.
 
     The invariant this protects, and the one to test any sibling runner against:
-    **nothing lazy may survive the loading thread.** `mflux_image/worker.py`
-    documents why it satisfies that already and needs no pin.
+    **nothing lazy may survive the loading thread.** `mflux_image/worker.py` used
+    to document why it satisfied that already and needed no pin; it does not, and
+    now pins too. Read its `load` before trusting a "same shape, but fine"
+    argument here — it also records the part this function does NOT cover: the
+    default stream is per (thread, DEVICE), so `make(mx.default_device())` below
+    pins the GPU only and leaves this thread's CPU default alone.
 
     `new_thread_unsafe_stream` is mlx's own answer: a stream not owned by the
     thread that made it. "Unsafe" means it must not be driven by two threads AT

--- a/fused_render/ai/runners/parakeet_mlx/pyproject.toml
+++ b/fused_render/ai/runners/parakeet_mlx/pyproject.toml
@@ -23,6 +23,14 @@
 # "FFmpeg is not installed or not in your PATH" without one. So `worker.py`
 # decodes with `av` and hands the waveform over in place of the path.
 #
+# **The engine lines carry CEILINGS**, for the reason
+# `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
+# these manifests and `uv sync` runs bare, so an unbounded requirement is
+# re-resolved from PyPI on every new venv key — which is exactly how an `mlx`
+# minor bump reached users' machines with no commit behind it. `parakeet-mlx` is
+# the line that carries `mlx` and `numpy` pins into this venv, so bounding it is
+# what keeps this folder's resolution from drifting on its own.
+#
 # What each earns:
 #   parakeet-mlx    the model and the transducer decoder, on Metal. Pulls mlx,
 #                   librosa, numpy, dacite and huggingface_hub in itself; the
@@ -56,12 +64,12 @@ name = "fused-render-runner-parakeet-mlx"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "parakeet-mlx",
+    "parakeet-mlx>=0.5,<0.6",
     "huggingface_hub",
     "psutil",
     "av",
-    "onnxruntime",
-    "sherpa-onnx",
+    "onnxruntime>=1.28,<2",
+    "sherpa-onnx>=1.13,<2",
     # The other half of sherpa-onnx, which its own metadata cannot get into the
     # lock. See the comment above before removing this as a duplicate.
     "sherpa-onnx-core",

--- a/fused_render/ai/runners/transformers_text/pyproject.toml
+++ b/fused_render/ai/runners/transformers_text/pyproject.toml
@@ -34,8 +34,19 @@
 # That report is `worker.py`'s `load()` calling `worker_base.set_state(device=…)`
 # — the field `/health` carries and the page draws (see `worker_base.STATE`).
 #
+# **The runtime lines carry CEILINGS**, for the reason
+# `mflux_image/pyproject.toml` states at length: no lockfile is committed beside
+# these manifests and `uv sync` runs bare, so an unbounded requirement is
+# re-resolved from PyPI on every new venv key and a major bump lands on users
+# with no commit behind it. `transformers` keeps its `>=4.51` floor and gains
+# only `<6` — the installed version is 5.x, but raising the floor to it would
+# forbid the 4.x this runner is currently happy on, which is a change to what is
+# allowed TODAY rather than protection against tomorrow. The floor's job (stated
+# below) is qwen3 support; the ceiling's job is the next rewrite.
+#
 # What each earns:
-#   torch           the tensors and the device (CUDA / MPS / CPU)
+#   torch           the tensors and the device (CUDA / MPS / CPU). `<3` — the
+#                   major is the whole ABI and every wheel behind it.
 #   transformers    the model classes, the chat templates and TextIteratorStreamer.
 #                   `>=4.51` because that is the release that knows what a
 #                   `qwen3` is, and three of the four models this runner's
@@ -54,9 +65,9 @@ name = "fused-render-runner-transformers-text"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "torch",
-    "transformers>=4.51",
-    "accelerate",
+    "torch>=2.13,<3",
+    "transformers>=4.51,<6",
+    "accelerate>=1.14,<2",
     "sentencepiece",
     "protobuf",
     "huggingface_hub",

--- a/tests/test_ai_mflux_worker.py
+++ b/tests/test_ai_mflux_worker.py
@@ -18,6 +18,7 @@ ran that path for real.
 import importlib.util
 import os
 import sys
+import threading
 import types
 
 import pytest
@@ -193,6 +194,46 @@ def make_mflux(model=None):
     return made, variants, config_mod
 
 
+class FakeMlxCore(types.ModuleType):
+    """`mlx.core` as this runner uses it: two DEVICES and their STREAMS.
+
+    The same double `tests/test_ai_mlx_whisper_worker.py` keeps, with the one
+    difference that broke this runner: from mlx 0.32 the default stream is per
+    (thread, DEVICE), so a worker that pins only `default_device()` — the GPU —
+    still aborts on `Stream(cpu, 0)`. Both devices are therefore distinct
+    objects here, and every `new_thread_unsafe_stream` records which one it was
+    asked for.
+    """
+
+    def __init__(self, **extra):
+        super().__init__("mlx.core")
+        self.float32 = "float32"
+        self.cpu = "CPU"
+        self.gpu = "GPU"
+        #: the device of every `new_thread_unsafe_stream`, in order.
+        self.made = []
+        #: (thread name, stream) for every `set_default_stream`.
+        self.pinned = []
+        self._lock = threading.Lock()
+        for name, value in extra.items():
+            setattr(self, name, value)
+
+    def default_device(self):
+        return self.gpu
+
+    def new_thread_unsafe_stream(self, device):
+        with self._lock:
+            self.made.append(device)
+            return f"SHARED-{device}-STREAM"
+
+    def set_default_stream(self, stream):
+        with self._lock:
+            self.pinned.append((threading.current_thread().name, stream))
+
+    def get_active_memory(self):
+        return 0
+
+
 def load_worker(monkeypatch, base, with_mflux=True, model=None, mlx_core=None):
     """A fresh import of the mflux worker against the fakes.
 
@@ -213,11 +254,17 @@ def load_worker(monkeypatch, base, with_mflux=True, model=None, mlx_core=None):
             ("mflux.models.common.config", config_mod),
         ):
             monkeypatch.setitem(sys.modules, name, module)
-    if mlx_core is not None:
-        mlx = types.ModuleType("mlx")
-        mlx.core = mlx_core
-        monkeypatch.setitem(sys.modules, "mlx", mlx)
-        monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
+    # `mlx.core` is no longer only `memory()`'s business: `load` and `generate`
+    # both pin this process's shared streams (`_pin_stream`), so a render test
+    # that left it out would be testing an import that cannot happen in
+    # production. A caller may still hand in its own — an mlx too old to have
+    # thread-local streams, say — and gets exactly that.
+    if mlx_core is None:
+        mlx_core = FakeMlxCore()
+    mlx = types.ModuleType("mlx")
+    mlx.core = mlx_core
+    monkeypatch.setitem(sys.modules, "mlx", mlx)
+    monkeypatch.setitem(sys.modules, "mlx.core", mlx_core)
     spec = importlib.util.spec_from_file_location("mflux_worker_under_test", WORKER_PATH)
     assert spec is not None and spec.loader is not None, WORKER_PATH
     module = importlib.util.module_from_spec(spec)
@@ -400,6 +447,69 @@ def test_the_snapshot_DIRECTORY_is_what_mflux_is_given(monkeypatch, base, tmp_pa
     assert model.built["model_path"] == path
     assert model.built["model_config"] == "FLUX2_KLEIN_4B_CONFIG"
     assert base.state == {"device": "mps"}
+
+
+def _pinned_run(monkeypatch, base, tmp_path, mlx_core):
+    """A load and a render, on the threads production uses.
+
+    `load` runs on `worker_base.serve`'s bring-up thread, which then EXITS, and
+    `generate` arrives on a `ThreadingTCPServer` request thread — which is the
+    whole of the bug, so the test has to reproduce the threading and not just
+    the calls.
+    """
+    worker, model = load_worker(monkeypatch, base, mlx_core=mlx_core)
+    loader = threading.Thread(
+        target=worker.load, args=(MODEL, snapshot(tmp_path)), name="bring-up")
+    loader.start()
+    loader.join()
+    render = threading.Thread(
+        target=worker.generate, args=(_request(tmp_path, steps=2),), name="request-1")
+    render.start()
+    render.join()
+    return worker, model
+
+
+def test_the_load_and_the_render_share_ONE_mlx_stream_PER_DEVICE(
+        monkeypatch, base, tmp_path):
+    """From mlx 0.32 the default stream belongs to the THREAD that made it, and
+    an unevaluated array forced anywhere else throws a C++ exception nothing
+    catches. This runner loads on the bring-up thread and renders on a request
+    thread, so every render died on its first denoising step: "the image process
+    did not answer: Remote end closed connection without response", with one
+    `libc++abi: … There is no Stream(cpu, 0) in current thread` line in the
+    worker log.
+
+    **BOTH devices, which is the difference from the whisper runner.** The
+    default stream is per (thread, DEVICE) — measured on mlx 0.32.1, where one
+    thread reports `Stream(cpu, 0)` and `Stream(gpu, 1)` and the next gets 2 and
+    3 — so pinning `default_device()` alone leaves the CPU half of the graph
+    owned by whichever thread first touched it. That is precisely the stream the
+    abort named.
+    """
+    mlx_core = FakeMlxCore()
+
+    _pinned_run(monkeypatch, base, tmp_path, mlx_core)
+
+    threads = {name for name, _stream in mlx_core.pinned}
+    streams = {stream for _name, stream in mlx_core.pinned}
+    assert len(threads) > 1, f"only one thread pinned a stream: {mlx_core.pinned}"
+    assert streams == {"SHARED-CPU-STREAM", "SHARED-GPU-STREAM"}, mlx_core.pinned
+    # One stream per device for the whole process, not one per thread: a second
+    # would be a second owner, which is the thing being prevented.
+    assert sorted(mlx_core.made) == ["CPU", "GPU"], mlx_core.made
+
+
+def test_an_mlx_without_thread_local_streams_is_left_alone(
+        monkeypatch, base, tmp_path):
+    """Streams were process-wide before 0.32 and there was nothing to pin. A
+    runner that insisted on the newer call would turn a version skew into a
+    worker that cannot render at all."""
+    mlx_core = types.SimpleNamespace(float32="float32", cpu="CPU", gpu="GPU",
+                                     get_active_memory=lambda: 0)
+
+    _worker, model = _pinned_run(monkeypatch, base, tmp_path, mlx_core)
+
+    assert model.image.saved, "the render never produced an image"
 
 
 def test_the_whole_repo_is_downloaded_with_nothing_skipped(monkeypatch, base):

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1065,6 +1065,28 @@ def test_no_runner_declares_a_dependency_that_has_to_be_BUILT():
                 f"{runner.code} declares a source build: {dependency}")
 
 
+def test_the_mflux_runner_BOUNDS_mflux():
+    """`mflux` was declared with no version at all, and the `uv.lock` beside it
+    is gitignored — so every environment provisioned after mflux 0.19.0 shipped
+    re-resolved 0.18.1 -> 0.19.0, whose own `mlx>=0.32,<0.33` bound pulled in the
+    mlx release that made default streams per-thread. Local image generation
+    started aborting on its first denoising step with no commit behind it
+    (`mflux_image/worker.py::_pin_stream`).
+
+    Only this dependency, and deliberately not "every runner bounds everything":
+    the claim being pinned is not a house style, it is that THIS library's next
+    minor is a deliberate bump with a real render behind it, because its last one
+    silently changed the threading contract of the code that drives it.
+    """
+    from fused_render import projectenv
+
+    runner = next(r for r in registry.all_runners() if r.code == "mflux-image")
+    declared = projectenv.dependencies_of(runner.folder)
+    bounds = [d for d in declared if d.replace(" ", "").startswith("mflux")]
+    assert bounds, f"mflux is not declared at all: {declared}"
+    assert bounds[0].replace(" ", "") == "mflux>=0.19,<0.20", bounds
+
+
 # -- the supervisor -------------------------------------------------------------
 
 

--- a/tests/test_ai_runtime.py
+++ b/tests/test_ai_runtime.py
@@ -1073,10 +1073,10 @@ def test_the_mflux_runner_BOUNDS_mflux():
     started aborting on its first denoising step with no commit behind it
     (`mflux_image/worker.py::_pin_stream`).
 
-    Only this dependency, and deliberately not "every runner bounds everything":
-    the claim being pinned is not a house style, it is that THIS library's next
-    minor is a deliberate bump with a real render behind it, because its last one
-    silently changed the threading contract of the code that drives it.
+    The EXACT string, not merely "has a ceiling" like the test below: this is the
+    one bound with a reproduced abort behind it, and the pair of numbers is the
+    fact itself. `test_every_runner_BOUNDS_its_model_runtimes` is the
+    general rule this incident produced; this stays as its worked example.
     """
     from fused_render import projectenv
 
@@ -1085,6 +1085,88 @@ def test_the_mflux_runner_BOUNDS_mflux():
     bounds = [d for d in declared if d.replace(" ", "").startswith("mflux")]
     assert bounds, f"mflux is not declared at all: {declared}"
     assert bounds[0].replace(" ", "") == "mflux>=0.19,<0.20", bounds
+
+
+#: Runner dependencies allowed to stay open-ended, and what each one buys by it.
+#:
+#: **An ALLOW-LIST, and the direction is the whole design.** A table of packages
+#: that MUST be bounded could only ever protect the libraries somebody already
+#: thought about; the next `mflux` would be added to a manifest, resolve freely on
+#: every new venv key, and the suite would stay green. Inverting it means an
+#: unrecognised dependency is a FAILING one until a person either bounds it or
+#: writes down here why it does not need bounding — which is the review that was
+#: missing when `mflux` went in unbounded.
+#:
+#: What earns a place: a package whose next major cannot change what a model
+#: computes or which runtime it computes on. Downloaders, codecs, tokenizer
+#: formats and instrumentation qualify. Inference engines and model runtimes do
+#: not — those are the ones whose transitive pins moved under us.
+UNBOUNDED_RUNNER_DEPENDENCIES = {
+    "huggingface-hub": "a download client; it fetches weights, it does not run them",
+    "psutil": "reads RSS for the memory column and nothing else",
+    "pillow": "writes the PNG",
+    "sentencepiece": "a tokenizer file format, fixed by the checkpoints that use it",
+    "protobuf": "sentencepiece's on-disk format, same argument",
+    "av": "the ffmpeg libraries, for decoding to a waveform — not inference",
+    "gguf": "a quantized-weight FILE reader; the tensors it returns are diffusers'",
+    "sherpa-onnx-core": (
+        "carries libonnxruntime for sherpa-onnx and is version-locked to it by "
+        "sherpa's own `Requires-Dist: sherpa-onnx-core==<same version>`, so the "
+        "bound on `sherpa-onnx` already governs both"
+    ),
+}
+
+
+@pytest.mark.parametrize("runner", registry.all_runners(), ids=lambda r: r.code)
+def test_every_runner_BOUNDS_its_model_runtimes(runner):
+    """The generalisation of the mflux abort, applied to all seven manifests.
+
+    None of these folders has a committed `uv.lock` (`.gitignore` ignores them
+    globally and negates only `templates/`), and `_env_install_worker` runs a
+    BARE `uv sync` on purpose — so an unbounded requirement is not "latest at
+    install time", it is *re-resolved from scratch every time a venv key changes*,
+    on a user's machine, with no diff anywhere to explain the new behaviour. That
+    is how mflux 0.18.1 -> 0.19.0 -> mlx 0.32 arrived and aborted every render.
+
+    A ceiling is asserted rather than an exact string because the numbers are
+    supposed to move: bumping one is a normal change with a run behind it. What
+    must not move silently is the major/minor, so the failure a new unbounded
+    dependency produces is a prompt to decide, not a chore.
+    """
+    from fused_render import projectenv
+
+    for requirement in projectenv.dependencies_of(runner.folder):
+        name = requirement.split("[")[0].split(";")[0]
+        for operator in ("==", ">=", "<=", "~=", "!=", ">", "<"):
+            name = name.split(operator)[0]
+        name = name.strip().replace("_", "-").lower()
+        if name in UNBOUNDED_RUNNER_DEPENDENCIES:
+            continue
+        assert "<" in requirement or "==" in requirement, (
+            f"{os.path.relpath(runner.pyproject)} declares `{requirement}` with "
+            f"no upper bound. These runners have no committed uv.lock and "
+            f"`uv sync` runs bare, so every new venv key re-resolves this from "
+            f"PyPI — a major bump lands on users with no commit behind it "
+            f"(the mflux abort above). Add a ceiling, or add `{name}` to "
+            f"UNBOUNDED_RUNNER_DEPENDENCIES in {os.path.basename(__file__)} "
+            f"with the reason it cannot change what a model computes.")
+
+
+def test_the_unbounded_allow_list_is_not_quietly_unused():
+    """An entry nothing declares is an exemption that has stopped exempting —
+    the dependency dropped, the reason left behind reading as a decision. Same
+    rule `test_the_split_table_is_not_quietly_unused` enforces next door."""
+    from fused_render import projectenv
+
+    declared = set()
+    for runner in registry.all_runners():
+        for requirement in projectenv.dependencies_of(runner.folder):
+            name = re.split(r"[\[;<>=!~ ]", requirement, 1)[0]
+            declared.add(name.strip().replace("_", "-").lower())
+    for name in UNBOUNDED_RUNNER_DEPENDENCIES:
+        assert name in declared, (
+            f"no runner declares {name} any more — delete its exemption rather "
+            f"than leaving a rule that cannot fire")
 
 
 # -- the supervisor -------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two halves, same root cause: an unbounded dependency in a runner manifest whose `uv.lock` is gitignored, so a transitive bump breaks a user's machine with no commit to bisect.

- **Local image generation was completely broken on `main`** — every render through the `mflux-image` runner (FLUX.2 Klein 4B MLX) aborted its worker on the first denoising step, surfacing as `the image process did not answer: Remote end closed connection without response (ai_error)`. Last successful render was 2026-08-17 23:59; every attempt after that failed.
- **No repo change caused it.** `mflux` was declared with no version bound, so the first venv provisioned after mflux 0.19.0 shipped re-resolved `0.18.1 → 0.19.0`, which pins `mlx>=0.32,<0.33`. **mlx 0.32 made default MLX streams per-thread**, and this worker loads on `worker_base`'s bring-up thread (which then exits) while rendering on a `ThreadingTCPServer` request thread. The weights `mx.load` returns are lazy `Load` graphs owned by the dead thread's stream; forcing them aborts the process with an uncaught C++ exception and no Python traceback.
- **Fix: pin one shared MLX stream per device**, on both the bring-up thread and the request thread. Pinning only `default_device()` — the shape the sibling `mlx_whisper` runner uses — is **not** sufficient: `set_default_stream` is device-scoped, so a GPU pin leaves the thread's CPU default untouched and the abort merely moves index. Measured: gpu-only pin still dies, cpu-only pin renders. Both are pinned.
- **Then bound the whole class, not just the one that bit us.** All seven AI runner manifests declared their inference engine with no ceiling. Each now carries one, set to the version actually installed and working on the machine that hit this bug — read from `mflux_image/uv.lock` and from the `.dist-info` in each provisioned venv, not guessed. A parametrized test makes a *future* unbounded dependency red until someone either bounds it or writes down why it doesn't need bounding.
- A long comment in the runner asserted this file needed no stream pinning, and specifically claimed `mx.load` "returns materialised safetensors data rather than a graph". That was true under mlx 0.31.x and is now false. It is replaced with the measurements, versions attached.

## Visuals

The delta: both threads now pin the same per-device streams, so a graph built during load is forceable during a render.

```mermaid
flowchart TD
    L[bring-up thread: load] --> P1[pin cpu + gpu streams]
    P1 --> W[mx.load weights are lazy Load graphs]
    R[request thread: generate] --> P2[pin the SAME streams]
    P2 --> F[force latents each step]
    W --> S[(one shared stream per device)]
    F --> S
```

Without the pin, `W` and `F` sit on different per-thread streams and `F` aborts the process. Note `Load` is always scheduled on the **CPU** stream regardless of default device — which is why the GPU-only pin failed.

## Usage

Not a new feature — this restores existing behavior. To exercise it: open a page that calls `fused.ai.image` (e.g. `~/Fused/showcase/local-image/index.html`), pick **FLUX.2 klein 4B (MLX 4-bit)**, and Generate. It should return an image instead of `ai_error`.

Nothing about the API, page code, or model selection changes. Existing venvs already holding mflux 0.19.x need no rebuild — the fix is in the worker, not the environment.

### The bounds added

| runner | dependency | before | after | installed |
|---|---|---|---|---|
| mflux_image | mflux | `mflux` | `mflux>=0.19,<0.20` | 0.19.0 |
| mlx_text | mlx-lm | `mlx-lm` | `mlx-lm>=0.31,<0.32` | 0.31.3 |
| mlx_whisper | mlx-whisper | `mlx-whisper` | `mlx-whisper>=0.4,<0.5` | 0.4.3 |
| parakeet_mlx | parakeet-mlx | `parakeet-mlx` | `parakeet-mlx>=0.5,<0.6` | 0.5.2 |
| diffusers_image | torch / diffusers / transformers / accelerate | unbounded / `>=0.39` / unbounded / unbounded | `>=2.13,<3` / `>=0.39,<0.40` / `<6` / `>=1.14,<2` | 2.13.0 / 0.39.0 / 5.15.0 / 1.14.0 |
| transformers_text | torch / transformers / accelerate | unbounded / `>=4.51` / unbounded | `>=2.13,<3` / `>=4.51,<6` / `>=1.14,<2` | same |
| faster_whisper | faster-whisper / sherpa-onnx | unbounded | `>=1.2,<2` / `>=1.13,<2` | 1.2.1 / 1.13.5 |
| mlx_whisper, parakeet_mlx | onnxruntime / sherpa-onnx | unbounded | `>=1.28,<2` / `>=1.13,<2` | 1.28.0 / 1.13.5 |

Existing floors were **not** raised to match installed versions — `transformers>=4.51` keeps its floor (which exists for qwen3 support, not recency) and gains `<6`; `diffusers>=0.39` likewise. Raising a floor forbids versions that are permitted today, which is a different change from adding a ceiling. `mlx` is deliberately **not** added as a direct dependency anywhere — it is bounded transitively by bounding the four packages that declare it.

Left unbounded on purpose, recorded in the manifests and in the test's allow-list: `huggingface_hub`, `psutil`, `pillow`, `sentencepiece`, `protobuf`, `av`, `gguf` (downloaders, codecs, formats, instrumentation — none decides what a model computes), and `sherpa-onnx-core` (pinned by `sherpa-onnx`'s own `==` requirement, so a second range could only contradict it).

## Test Plan

- [x] **Reproduced first, on unchanged code**: `load` on a thread that then exits, `generate` on a second thread, 2 steps @256² → `There is no Stream(cpu, 0) in current thread`, no PNG.
- [x] **Real render after the fix**: 256×256 RGB PNG, 59205 bytes, validated via PIL — run both with and without a preview sink attached (the sink is the variant that turns the fault into a hard abort).
- [x] **Device-specificity measured**: per-thread defaults are `cpu 0 / gpu 1`, then `2 / 3`, then `4 / 5`. GPU-only pin on both threads → still aborts at `Stream(cpu, 2)`. CPU-only pin → renders. `mx.default_device()` remains `Device(gpu, 0)` after the fix, and render speed is unchanged.
- [x] **New automated tests** (fake `mlx.core` with two devices, so no Metal needed in CI):
  - `test_ai_mflux_worker.py::test_the_load_and_the_render_share_ONE_mlx_stream_PER_DEVICE` — both threads pin, streams are shared, exactly one stream minted per device. Verified red before the fix.
  - `test_ai_mflux_worker.py::test_an_mlx_without_thread_local_streams_is_left_alone` — no-op on older mlx.
  - `test_ai_runtime.py::test_every_runner_BOUNDS_its_model_runtimes` — parametrized over every runner; red on 6 of 7 before the manifest edits, green after.
  - `test_ai_runtime.py::test_the_unbounded_allow_list_is_not_quietly_unused` — staleness guard, so the exemption list can't rot into a blanket pass.
- [x] Scoped runs green: `test_ai_runtime.py` 236 passed; `test_ai_runner_deps.py` 9 passed; with `test_env_install.py`, `test_ai_formats.py`, `test_ai_models_api.py`, `test_ai_engine_options.py` → 273 passed.
- [ ] **Full suite** — running; reconciled against a pre-change baseline by failing-id *set*, since this suite has ~15-19 pre-existing failures on macOS and the count alone is not a signal.
- [ ] **CI** — pending on this push.
- [x] **End-to-end verified** through the real server path: a render request through `/api/ai/image` on a server running this branch returns a valid PNG.

### Risks worth a reviewer's eye

- **`torch>=2.13,<3` is the pin to scrutinize.** It is the only one here whose floor was raised from nothing on a package that needs wheels for macOS, Linux/CUDA **and** Windows-CPU. 2.13.0 is what this Mac resolved; it was **not** verified that 2.13.x publishes wheels for every platform and interpreter `requires-python = ">=3.10"` promises. If some platform lacks a 2.13 wheel, `uv sync` for `diffusers_image` and `transformers_text` now fails where it previously fell back to an older torch. Same shape, smaller blast radius, for `onnxruntime>=1.28,<2` (VAD only) and `faster-whisper>=1.2,<2` (drags ctranslate2 4.8.x). The mlx-family pins carry no cross-platform risk — those runners are Apple-Silicon-only by registry.
- **`transformers_text` has no provisioned venv on this machine.** Its versions were taken from the `diffusers_image` venv, which declares the same packages and resolved on the same machine. That is same-machine resolution evidence, not evidence of that runner having run.

### Known follow-ups, deliberately not in this PR

- **The real structural fix is committing the runner `uv.lock` files**, exactly as `.gitignore:14` already does for templates — whose comment says why: it "stops a released build resolving against PyPI the first time anyone renders that template". Version ceilings narrow the window; a lock closes it. Not done here because it changes what ships in the wheel.
- **`mlx_whisper/worker.py` and `parakeet_mlx/worker.py` pin `default_device()` only** — the same latent hole this PR fixed in mflux, dormant only because their upstreams happen to end load on `mx.eval`. `mlx_text/worker.py` has no stream pinning at all. Bounding versions freezes today's working state; it does not fix that code.
- No `DECISIONS.md` entry or `SPEC.md` update records the new ceiling policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
