### PR TITLE
Tasks: a status the messages decide, list sections, and a two-move drag matrix

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1861,6 +1861,30 @@ export function markWholeTaskRead(
   });
 }
 
+// Filing a task away. ONE call, because it is one gesture with two halves that
+// must not come apart: the work still booked is cancelled (a run that fires
+// tomorrow un-archives the task by itself, which is the one thing filing
+// something away must never do) and the session is filed in the same
+// triage.json the Inbox reads. The server does both — see
+// routers/tasks.py `api_task_archive` — so no client has to remember the second
+// half, and a task with no session yet is still archivable by the first.
+//
+// Keyed by TASK, not by session: `pending:<entry-id>` is a real key and a real
+// row, and it is exactly the row the old session-keyed triage write could not
+// touch.
+//
+// There is no unarchive. Archive is a locked lane (tasks-lib's drag matrix) and
+// the row draws no way back — which costs nothing, because archiving destroys
+// nothing: the conversation and its transcript are kept (D306).
+export function archiveTask(
+  key: string,
+): Promise<{ ok: boolean; key: string; cancelled: number; filed: boolean }> {
+  return postJson<{ ok: boolean; key: string; cancelled: number; filed: boolean }>(
+    "/api/tasks/archive",
+    { key },
+  );
+}
+
 // Every scheduled message in a time window, which is the one question the
 // listing above cannot answer: `Task.messages` holds only the three most recent,
 // and a calendar draws a week. Without this the grid under-draws — a task whose

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -165,6 +165,7 @@ import type { CalendarChip, CalendarRange, MsgCancelKind, QueueRole } from "./sc
 // The pill used to answer a different question (the day's worst run) and could
 // therefore contradict the button — see the `pill` memo below.
 import {
+  isRunningNow,
   messageTone as taskMessageTone,
   openMessageHref,
   taskColumn,
@@ -554,6 +555,10 @@ function ChipPopover({
 
   const nowSec = Math.floor(Date.now() / 1000);
 
+  // What the popover's own title says, so a row that would only repeat it can
+  // stay quiet. See `showBody` in `row`.
+  const headline = firstLine(task.title || chip.anchor.body);
+
   const row = (m: TaskMessage, sameDayRow: boolean) => {
     const status = runStatus(m, taskMessageTone(m));
     const role = queueRole(m, roles, nowSec);
@@ -569,13 +574,20 @@ function ChipPopover({
     // draw it is a different situation, and only the race justifies the offer.
     const kind = msgCancelKind(m, role);
     const note = msgNote(m, kind);
+    // Empty when this row's prompt is the title again — see the JSX below.
+    const body = firstLine(m.body);
+    const showBody = body && body !== headline ? body : "";
     return (
       <li key={m.message_id} className="schedule-cal-msg">
         <button
           type="button"
           className={"schedule-cal-msg-open" + (canOpen(m) ? "" : " is-inert")}
           onClick={() => openMessage(m)}
-          title={note ? `${t.toLocaleString()} — ${note}` : t.toLocaleString()}
+          // The status WORD moved in here when it left the row's ink: the ring
+          // carries the fact and the tooltip carries the name for it, which is
+          // the same division the row's time already makes (relative in the
+          // ink, exact in the title).
+          title={[t.toLocaleString(), status.label, note].filter(Boolean).join(" — ")}
         >
           {/* The Board's ring, at row scale. `is-ghost` is the one thing the
               Board has no case for: a projected run, dashed because the word
@@ -596,7 +608,20 @@ function ChipPopover({
               ? clockTime(t)
               : t.toLocaleDateString(undefined, { month: "short", day: "numeric" })}
           </span>
-          <span className="schedule-cal-msg-body">{firstLine(m.body) || "(no prompt)"}</span>
+          {/* THE BODY, ONLY WHEN IT SAYS SOMETHING THE PANEL HAS NOT (Akshil,
+              2026-08-18). This popover is about ONE task, and a scheduled
+              occurrence carries the task's own message verbatim — so on the
+              common row the body was the title printed a second time, four
+              lines under the title.
+
+              It is not dropped outright, because a THREAD is not always one
+              message repeated: a chat prompt typed into the same session, or a
+              re-sent message that was edited, genuinely distinguishes its row
+              from the others. So the row keeps whatever the panel has not
+              already said, and drops the echo. */}
+          {showBody && (
+            <span className="schedule-cal-msg-body">{showBody}</span>
+          )}
           {/* No `.schedule-cal-msg-unread` dot here any more (2026-08-18). It was
               a 6px accent disc after the body and it was this view's OWN unread
               vocabulary — the List and the Board said the same thing with a
@@ -611,8 +636,18 @@ function ChipPopover({
               {note}
             </span>
           )}
-          {/* The app's word, and only ever one of its five. */}
-          <span className="schedule-cal-msg-state">{status.label}</span>
+          {/* NO STATUS WORD HERE ANY MORE (Akshil, 2026-08-18). The header's
+              pill already says the task's state in the app's own vocabulary,
+              and on a one-occurrence popover — which is most of them — the row
+              was printing that same word a second time, at the other end of the
+              same small panel.
+
+              The RING is what carries it now, which is not a downgrade: it is
+              the same mark the List's thread rows and the Board's cards use for
+              exactly this fact, its hue IS the status, and the word is still
+              one hover away in the row's own title. What distinguishes one
+              occurrence from another is the TIME and whether it can still be
+              stopped — and those are what is left. */}
         </button>
         {kind === "held" ? (
           // A claimed entry has no cancel, so the slot holds a turning glyph
@@ -676,8 +711,31 @@ function ChipPopover({
         </span>
       </div>
 
-      <p className="schedule-pop-title">{task.title || firstLine(chip.anchor.body)}</p>
+      {/* TITLE THEN DESCRIPTION, as one writing block, exactly as the New task
+          modal presents the same two fields (new-task.css `.new-task-write`).
+          They are what the user WROTE, and a form that asks for a title above a
+          description and then plays them back as a heading and an icon-led fact
+          row has made the same pair look like two different kinds of thing.
 
+          So the description loses its icon and its place in the fact list. It
+          was drawn there with a notes glyph, which put "what this task is" in
+          the same register as "which folder it runs in" — one is prose to read,
+          the other is a value to recognise, and the icon column is for the
+          second. Smaller and muted under the title says the same hierarchy
+          without spending a glyph.
+
+          The title takes the size the hierarchy needs: it is the first thing
+          read in this panel and it was the same 14px as the fact rows' 12px,
+          which is not a step. */}
+      <div className="schedule-pop-write">
+        <p className="schedule-pop-title">{task.title || firstLine(chip.anchor.body)}</p>
+        {task.description && (
+          <p className="schedule-pop-desc">{task.description}</p>
+        )}
+      </div>
+
+      {/* Then the facts that are recognised rather than read — where it runs,
+          and how often — each led by its icon. */}
       <div className="schedule-pop-rows">
         {repeat && (
           <span className="schedule-pop-row">
@@ -689,12 +747,6 @@ function ChipPopover({
           {ICON_FOLDER}
           <code title={task.target}>{task.target}</code>
         </span>
-        {task.description && (
-          <span className="schedule-pop-row">
-            {ICON_NOTES}
-            <span>{task.description}</span>
-          </span>
-        )}
       </div>
 
       <div className="schedule-cal-thread">
@@ -1045,6 +1097,16 @@ export default function ScheduleCalendar({
                       className={
                         "schedule-cal-chip schedule-cal-chip--" + chip.tone +
                         (chip.projected ? " is-projected" : "") +
+                        // RUNNING RIGHT NOW. The List has an In Progress section
+                        // and the Board an In Progress lane; a calendar is
+                        // ordered by time and has neither, so until now the one
+                        // chip on today's grid that was actually working looked
+                        // exactly like the four that had finished. The rule is
+                        // tasks-lib's — the same reading of state and turn the
+                        // other two views file a card by — and the CSS is a
+                        // shimmer that sweeps the chip, with a static highlight
+                        // under prefers-reduced-motion.
+                        (isRunningNow(chip.task, chip.anchor) ? " is-running" : "") +
                         (chip.time < now ? " is-past" : "") +
                         // Three lanes leave a chip ~70px wide, which cannot hold
                         // both the title and the clock — the title collapsed to

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -39,7 +39,7 @@ import {
   markWholeTaskRead,
   resendScheduledMessage,
   runScheduledNow,
-  setSessionTriage,
+  archiveTask,
 } from "@platform/lib/api";
 import type { Task, TaskMessage } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
@@ -67,6 +67,7 @@ import {
   isUpcomingTask,
   laneRolledUp,
   laneUnread,
+  listSections,
   markAllRead,
   markRead,
   markReadIntent,
@@ -74,6 +75,7 @@ import {
   messageHref,
   threadTone,
   messageWhenTitle,
+  nextRunChip,
   openMessageHref,
   openThreadIntent,
   opensElsewhere,
@@ -97,7 +99,6 @@ import {
   upcomingEditEntry,
 } from "./tasks-lib";
 import type {
-  ArchiveStatus,
   LaneChoices,
   ListMemory,
   OpenThreadIntent,
@@ -163,34 +164,6 @@ export type { TaskFilters };
  */
 const SHOW_ROW_ACTIONS: boolean = false;
 
-/**
- * Whether the ARCHIVE button's other direction — Unarchive — is drawn.
- *
- * OFF at Akshil's request, 2026-08-18: keep the archive button, hide unarchive for
- * now. Archive itself stays out from behind SHOW_ROW_ACTIONS on both views; this
- * takes away only the way BACK, which is what an already-archived row or card
- * offers (tasks-lib.archiveIntent decides the direction, `restore: true`).
- *
- * A SECOND FLAG rather than a second value of the first, because they are two
- * different requests and neither should move when the other is answered: one hid
- * the whole hover strip, this hides one direction of one surviving button. Same
- * shape, same `boolean` annotation, so flipping either is a value change and the
- * guarded branch is never narrowed to dead code.
- *
- * NOTHING UNDERNEATH IS TOUCHED, which is the point of gating rather than
- * deleting. `archiveIntent` still computes both directions and is still tested
- * both ways; `triage` still takes either status; the Board's DRAG still moves a
- * card out of the Archive lane, which is the way back that survives this and is
- * why hiding the button costs a shortcut rather than a capability. ICON_UNARCHIVE
- * stays too — it is still the glyph the button reaches for the day this flips, and
- * the pair only reads as a pair while both are written down together.
- *
- * NOT RENDERED rather than hidden with CSS, for the same reason as the strip
- * above: `.tasks-act` rests at `opacity: 0`, so hiding this one in the stylesheet
- * would leave a button in the tab order that a keyboard could focus and press
- * blind.
- */
-const SHOW_UNARCHIVE: boolean = false;
 
 // ---- icons -------------------------------------------------------------------
 // The page's own recipe (ScheduleCalendar's `icon`): a 24-viewBox lucide
@@ -248,25 +221,16 @@ const ICON_RERUN = icon(
 // same glyph would read as a toggle that is currently checked.
 const ICON_MARK_READ = icon(
   <><path d="M18 6 7 17l-5-5" /><path d="m22 10-7.5 7.5L13 16" /></>, 13);
-// Filing away, and the way back. Drawn apart because the second is not the first
-// greyed out: a person looking at an archived row has to be able to SEE that the
-// door opens both ways, and one glyph with two meanings cannot say that
-// (tasks-lib.archiveIntent).
-//
-// The first is lucide `archive`. The second is lucide `archive-restore`'s ARROW
-// on the same closed box, rather than that icon whole: `archive-restore` splits
-// the box's two walls apart, and at 13px the gap reads as a broken glyph instead
-// of an open one (checked at 6x). Keeping the body identical and changing only
-// the mark inside it — a dash, or an arrow coming out — is what makes the pair
-// legible at the size it is actually drawn.
+// Filing away. lucide `archive`, and there is no counterpart: archiving is a
+// one-way door on every view now (tasks-lib's drag matrix — Archive is a locked
+// lane), so a second glyph would be an affordance for a gesture that does not
+// exist. It costs nothing, because the door being one-way does not make it a
+// shredder: the conversation and its transcript are kept (D306), and Archive is
+// a place to read them.
 const ICON_ARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
     <path d="M10 12h4" /></>, 13);
-const ICON_UNARCHIVE = icon(
-  <><rect x="2" y="3" width="20" height="5" rx="1" />
-    <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
-    <path d="m9 15 3-3 3 3" /><path d="M12 12v6" /></>, 13);
 
 // ---- leaf components ---------------------------------------------------------
 
@@ -900,6 +864,11 @@ export function TaskList({
   // on every keystroke of the search box.
   const showProject = useMemo(() => spansProjects(tasks), [tasks]);
 
+  // The list's sections, in their fixed order, empties dropped. Memoised for the
+  // same reason `showProject` is: this runs on every keystroke of the search box
+  // and the answer only moves when the rows do.
+  const sections = useMemo(() => listSections(tasks), [tasks]);
+
   /**
    * Open or close a task — and, on the way OPEN, fetch the rest of its thread.
    *
@@ -1152,28 +1121,51 @@ export function TaskList({
 
   return (
     <div className="tasks-list" ref={listRef} onScroll={onScroll}>
-      {tasks.map((task) => (
-        <TaskNode
-          key={task.key}
-          task={task}
-          home={home}
-          showProject={showProject}
-          open={expanded.has(task.key)}
-          selected={selected === task.key}
-          onSelect={() => select(task.key)}
-          onToggle={() => toggle(task)}
-          onRetry={() => void showMore(task)}
-          loaded={loaded[task.key]}
-          loading={!!loading[task.key]}
-          error={errors[task.key]}
-          onEditEntry={onEditEntry}
-          onReload={onReload}
-          read={read}
-          onRead={clear}
-          onReadAll={clearAll}
-          onUnreadAll={restoreAll}
-          onSettleAll={settleAll}
-        />
+      {/* GROUPED BY THE SAME FACT THE BOARD GROUPS BY (tasks-lib.listSections):
+          same nouns, same colours, same ring, so the two views are two lenses on
+          one dataset rather than two vocabularies. The ORDER is the list's own —
+          Upcoming, In Progress, Failed, Done, Archive — because a list is read
+          top to bottom as work owed, and a board left to right as a pipeline.
+
+          Empty sections are absent, header and all: a board's empty column is
+          information (nothing is failing), a list's empty header is a table of
+          contents for a page with nothing on it.
+
+          The section header is NOT sticky and NOT a button. Sticky headers over
+          an accordion whose rows change height on every disclosure fight the
+          scroll memory this list keeps; and a header that could be pressed would
+          be the second collapsible thing in a view whose rows already collapse. */}
+      {sections.map((section) => (
+        <Fragment key={section.key}>
+          <div className="tasks-section">
+            <StatusIcon status={section.key} />
+            <span className="tasks-section-label">{section.label}</span>
+            <span className="tasks-section-count">{section.tasks.length}</span>
+          </div>
+          {section.tasks.map((task) => (
+            <TaskNode
+              key={task.key}
+              task={task}
+              home={home}
+              showProject={showProject}
+              open={expanded.has(task.key)}
+              selected={selected === task.key}
+              onSelect={() => select(task.key)}
+              onToggle={() => toggle(task)}
+              onRetry={() => void showMore(task)}
+              loaded={loaded[task.key]}
+              loading={!!loading[task.key]}
+              error={errors[task.key]}
+              onEditEntry={onEditEntry}
+              onReload={onReload}
+              read={read}
+              onRead={clear}
+              onReadAll={clearAll}
+              onUnreadAll={restoreAll}
+              onSettleAll={settleAll}
+            />
+          ))}
+        </Fragment>
       ))}
     </div>
   );
@@ -1296,6 +1288,8 @@ function TaskNode({
   // reads LANE_SORTS, the same map the Board's lanes are ordered by), and null when
   // the task has neither, in which case nothing is drawn.
   const when = taskWhen(task);
+  // The run still to come, when the row's own time is not already it.
+  const soon = nextRunChip(task);
   // Run now / Re-run. tasks-lib decides all of it — whether it is offered,
   // which message it acts on, and WHICH CALL that is. The run-now half comes
   // from the same function the drag asks (runNowIntent), so the button and the
@@ -1303,19 +1297,13 @@ function TaskNode({
   // drag deliberately does not have, because a gesture cannot consent to
   // creating work that was never scheduled.
   const run = taskRunIntent(task);
-  // Archive / Unarchive. The Board's drop onto the Archive lane, reachable
-  // without switching view, expanding a collapsed lane and dragging — which is
-  // what "archive it" used to cost, and the reason the honest answer to "can a
-  // task be deleted?" (no: it is archived, D306) was barely true. tasks-lib
-  // decides everything, by asking dropAction the same question the drag does.
-  //
-  // The intent is computed BOTH ways and only the rendering is gated: `restore`
-  // is the way back, hidden for now behind SHOW_UNARCHIVE. Filtering here rather
-  // than in the JSX keeps `file` meaning exactly "the filing button this row
-  // draws", so the button's own markup needs no second condition and the strip
-  // below cannot be drawn for a button that is not there.
-  const filing = archiveIntent(task);
-  const file = filing && (SHOW_UNARCHIVE || !filing.restore) ? filing : null;
+  // Archive. The Board's drop onto the Archive lane, reachable without
+  // switching view, expanding a collapsed lane and dragging — which is what
+  // "archive it" used to cost, and the reason the honest answer to "can a task
+  // be deleted?" (no: it is archived, D306) was barely true. tasks-lib decides
+  // everything, by asking dropAction the same question the drag does — so a row
+  // draws the button exactly when the card would take the drop.
+  const file = archiveIntent(task);
   // Mark read — the whole task at once, so clearing 89 unread messages is not 89
   // clicks through 89 transcripts. Asked of the count this row is DRAWING, so
   // the button leaves on its own press rather than on the next poll.
@@ -1360,13 +1348,13 @@ function TaskNode({
     }
   };
 
-  // Archive / Unarchive. One call, and the same one the board's drop makes;
-  // `status` came out of tasks-lib and is only spent here.
-  const triage = async (status: ArchiveStatus) => {
+  // Archive. One call, and the same one the board's drop makes: the server
+  // cancels the work and files the session, so this side composes nothing.
+  const archive = async () => {
     setActing(true);
     setNote("");
     try {
-      await setSessionTriage(task.session_id, status);
+      await archiveTask(task.key);
     } catch (e) {
       // The server's own sentence, in the same quiet line run-now uses. A
       // refusal here is news, not a fault: nothing was destroyed either way,
@@ -1802,18 +1790,16 @@ function TaskNode({
         {file && (
           <button
             type="button"
-            className={
-              "tasks-act " + (file.restore ? "tasks-act--unarchive" : "tasks-act--archive")
-            }
+            className="tasks-act tasks-act--archive"
             title={file.title}
             aria-label={file.label}
             disabled={acting}
             onClick={(e) => {
               e.stopPropagation();
-              void triage(file.status);
+              void archive();
             }}
           >
-            {file.restore ? ICON_UNARCHIVE : ICON_ARCHIVE}
+            {ICON_ARCHIVE}
           </button>
         )}
         {/* The one gesture in this row that OPENS a MULTI-message conversation
@@ -1879,6 +1865,25 @@ function TaskNode({
             dash belongs in exactly the register the times beside it are in — it IS
             one of the column's values, not a different kind of thing — and
             `.tasks-row-time` already sizes, colours and aligns it. */}
+        {/* AND THE RUN THAT IS STILL COMING, when the time beside it is not
+            already that (tasks-lib.nextRunChip).
+
+            A recurring task whose last run finished sits in DONE now, not
+            Upcoming — the output nobody has read is what needs eyes, and a
+            promise is not a verdict (server `_message_verdict`). That is the
+            right lane and it drops one true fact off the row: the task is not
+            over. So the row says it, once, in the vocabulary every other time
+            here speaks (relativeWhen, absolute instant in the tooltip).
+
+            A CHIP and not a second time column: `.tasks-row-time` is the row's
+            one time slot and this is a different question, so it is marked
+            rather than aligned. Nothing is drawn on an Upcoming row, where the
+            time IS the next run and the chip would say it twice. */}
+        {soon && (
+          <span className="tasks-row-next" title={soon.title}>
+            {soon.text}
+          </span>
+        )}
         <span className="tasks-row-time" title={when.title}>
           {when.text}
         </span>
@@ -2170,6 +2175,7 @@ export function TaskBoard({
   // that holds one — the reader is looking at all five columns at once.
   const showProject = useMemo(() => spansProjects(tasks), [tasks]);
 
+
   const allowed = useMemo(
     () => new Set(dragging ? dropLanes(dragging) : []),
     [dragging],
@@ -2203,7 +2209,10 @@ export function TaskBoard({
         // than a schedule that was quietly rewritten.
         await runScheduledNow(action.entryId);
       } else {
-        await setSessionTriage(task.session_id, action.status);
+        // → Archive. ONE call for both halves — the pending work is cancelled
+        // and the session is filed — because a card dropped here that still
+        // fires tomorrow un-archives itself.
+        await archiveTask(task.key);
       }
     } catch (e) {
       // A refusal here is a real answer, not a bug — the scheduler's loop may
@@ -2215,14 +2224,14 @@ export function TaskBoard({
     onReload();
   };
 
-  // The same triage write the drop above makes, asked for by a card's own
+  // The same archive call the drop above makes, asked for by a card's own
   // button instead of a gesture. It lives up here rather than in TaskCard so the
   // refusal lands in the board's ONE note line, beside the drag's: a sentence
   // tucked inside a 260px lane under one card is a sentence nobody reads.
-  const triage = async (task: Task, status: ArchiveStatus) => {
+  const file = async (task: Task) => {
     setNote(null);
     try {
-      await setSessionTriage(task.session_id, status);
+      await archiveTask(task.key);
     } catch (e) {
       setNote((e as Error).message);
     }
@@ -2442,7 +2451,7 @@ export function TaskBoard({
                       setDragging(null);
                       setOverLane(null);
                     }}
-                    onTriage={(status) => triage(task, status)}
+                    onArchive={() => file(task)}
                     onRun={runNow}
                     onOpen={(intent) => openCard(task, intent)}
                   />
@@ -2483,7 +2492,7 @@ function TaskCard({
   isDragging,
   onDragStart,
   onDragEnd,
-  onTriage,
+  onArchive,
   onRun,
   onOpen,
 }: {
@@ -2500,7 +2509,7 @@ function TaskCard({
   onDragEnd: () => void;
   /** File this card away, or bring it back — the board owns the call so its
    * refusal lands in the board's own note line. */
-  onTriage: (status: ArchiveStatus) => Promise<void>;
+  onArchive: () => Promise<void>;
   /** Run the task's next message now, or re-send the one that failed. Same
    * arrangement and same reason as onTriage: the board makes the call. */
   onRun: (intent: TaskRunIntent) => Promise<void>;
@@ -2526,13 +2535,10 @@ function TaskCard({
   // gesture starts with "expand Archive first". Same predicate as the drop, by
   // construction — archiveIntent asks dropAction.
   //
-  // Gated exactly as the List row's is, and from the same flag: Unarchive is
-  // hidden for now (SHOW_UNARCHIVE), Archive is not. One flag for both views,
-  // because a Board that offers the way back where the List does not is the
-  // divergence this page's whole vocabulary is written against. The card's DRAG
-  // out of the Archive lane is untouched and is the way back that survives.
-  const filing = archiveIntent(task);
-  const file = filing && (SHOW_UNARCHIVE || !filing.restore) ? filing : null;
+  // One direction only, on both views and in the drag: there is no way back out
+  // of Archive, because a Board that offers a return the List does not draw is
+  // the divergence this page's whole vocabulary is written against.
+  const file = archiveIntent(task);
   // Run now / Re-run, which the List row and the calendar popover both already
   // offer and this card did not. The SAME function decides it here as there
   // (tasks-lib.taskRunIntent, which asks runNowIntent — the very function
@@ -2540,6 +2546,8 @@ function TaskCard({
   // In Progress can never fire different messages. Nothing about which message
   // or which call is re-derived on this side.
   const run = taskRunIntent(task);
+  // The run still to come, when this card's lane does not already order by it.
+  const soon = nextRunChip(task);
   // The lane this card is IN. Not passed down: `groupByColumn` files every card
   // by `taskColumn`, so asking it here is asking the same function that decided
   // which lane header the card is sitting under — a prop would be a second
@@ -2552,10 +2560,10 @@ function TaskCard({
   // "disagrees": in the failed lane the two agree and the header has said it.
   const failedOffLane = isFailedTask(task) && lane !== "failed";
   const [busy, setBusy] = useState(false);
-  const triage = async (status: ArchiveStatus) => {
+  const archive = async () => {
     setBusy(true);
     try {
-      await onTriage(status);
+      await onArchive();
     } finally {
       setBusy(false);
     }
@@ -2693,12 +2701,23 @@ function TaskCard({
             <span className="tasks-said">{`, ${taskUnreadLabel(unread)}`}</span>
           )}
         </span>
-        {/* The foot is the folder and nothing else, so when the folder says nothing
-            (spansProjects — every card in a board filtered to one project repeats
-            it) the whole line goes rather than an empty row of padding. */}
-        {showProject && (
+        {/* The foot is the folder and the run ahead, so when neither says
+            anything (spansProjects — every card in a board filtered to one
+            project repeats it — and a card with no run coming) the whole line
+            goes rather than leaving an empty row of padding. */}
+        {(showProject || soon) && (
           <span className="schedule-tv-card-foot">
-            <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />
+            {showProject && (
+              <IdentityChip name={basename(task.project)} title={tildePath(task.project, home)} />
+            )}
+            {/* Same fact, same function, same words as the List row's
+                (tasks-lib.nextRunChip): a settled card whose task is due again
+                would otherwise show nothing about the run ahead. */}
+            {soon && (
+              <span className="tasks-row-next" title={soon.title}>
+                {soon.text}
+              </span>
+            )}
           </span>
         )}
       </button>
@@ -2743,16 +2762,13 @@ function TaskCard({
           {file && (
             <button
               type="button"
-              className={
-                "tasks-act tasks-card-act " +
-                (file.restore ? "tasks-act--unarchive" : "tasks-act--archive")
-              }
+              className="tasks-act tasks-card-act tasks-act--archive"
               title={file.title}
               aria-label={`${file.label} ${task.task_id}`}
               disabled={busy}
-              onClick={() => void triage(file.status)}
+              onClick={() => void archive()}
             >
-              {file.restore ? ICON_UNARCHIVE : ICON_ARCHIVE}
+              {ICON_ARCHIVE}
             </button>
           )}
         </span>

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -67,7 +67,7 @@ import {
   isUpcomingTask,
   laneRolledUp,
   laneUnread,
-  listSections,
+  sortByLane,
   markAllRead,
   markRead,
   markReadIntent,
@@ -864,10 +864,10 @@ export function TaskList({
   // on every keystroke of the search box.
   const showProject = useMemo(() => spansProjects(tasks), [tasks]);
 
-  // The list's sections, in their fixed order, empties dropped. Memoised for the
-  // same reason `showProject` is: this runs on every keystroke of the search box
-  // and the answer only moves when the rows do.
-  const sections = useMemo(() => listSections(tasks), [tasks]);
+  // The list's rows, in rank order (tasks-lib.sortByLane). Memoised for the same
+  // reason `showProject` is: this runs on every keystroke of the search box and
+  // the answer only moves when the rows do.
+  const rows = useMemo(() => sortByLane(tasks), [tasks]);
 
   /**
    * Open or close a task — and, on the way OPEN, fetch the rest of its thread.
@@ -1121,51 +1121,38 @@ export function TaskList({
 
   return (
     <div className="tasks-list" ref={listRef} onScroll={onScroll}>
-      {/* GROUPED BY THE SAME FACT THE BOARD GROUPS BY (tasks-lib.listSections):
-          same nouns, same colours, same ring, so the two views are two lenses on
-          one dataset rather than two vocabularies. The ORDER is the list's own —
-          Upcoming, In Progress, Failed, Done, Archive — because a list is read
-          top to bottom as work owed, and a board left to right as a pipeline.
+      {/* ORDERED BY STATUS, NOT GROUPED BY IT (tasks-lib.sortByLane): Upcoming,
+          In Progress, Failed, Done, Archive — rank order, server order inside
+          each rank, and no headers, dividers or counts between them.
 
-          Empty sections are absent, header and all: a board's empty column is
-          information (nothing is failing), a list's empty header is a table of
-          contents for a page with nothing on it.
-
-          The section header is NOT sticky and NOT a button. Sticky headers over
-          an accordion whose rows change height on every disclosure fight the
-          scroll memory this list keeps; and a header that could be pressed would
-          be the second collapsible thing in a view whose rows already collapse. */}
-      {sections.map((section) => (
-        <Fragment key={section.key}>
-          <div className="tasks-section">
-            <StatusIcon status={section.key} />
-            <span className="tasks-section-label">{section.label}</span>
-            <span className="tasks-section-count">{section.tasks.length}</span>
-          </div>
-          {section.tasks.map((task) => (
-            <TaskNode
-              key={task.key}
-              task={task}
-              home={home}
-              showProject={showProject}
-              open={expanded.has(task.key)}
-              selected={selected === task.key}
-              onSelect={() => select(task.key)}
-              onToggle={() => toggle(task)}
-              onRetry={() => void showMore(task)}
-              loaded={loaded[task.key]}
-              loading={!!loading[task.key]}
-              error={errors[task.key]}
-              onEditEntry={onEditEntry}
-              onReload={onReload}
-              read={read}
-              onRead={clear}
-              onReadAll={clearAll}
-              onUnreadAll={restoreAll}
-              onSettleAll={settleAll}
-            />
-          ))}
-        </Fragment>
+          The grouping is a SORT and nothing more (Akshil, 2026-08-18). Headers
+          lived here for a round and were wrong on a list: the Board's lanes are
+          a fixed frame, so a lane header labels the frame and earns its ink,
+          where a list has no frame and five headers are five interruptions in
+          the one column a person is scanning. The order already says what they
+          said. */}
+      {rows.map((task) => (
+        <TaskNode
+          key={task.key}
+          task={task}
+          home={home}
+          showProject={showProject}
+          open={expanded.has(task.key)}
+          selected={selected === task.key}
+          onSelect={() => select(task.key)}
+          onToggle={() => toggle(task)}
+          onRetry={() => void showMore(task)}
+          loaded={loaded[task.key]}
+          loading={!!loading[task.key]}
+          error={errors[task.key]}
+          onEditEntry={onEditEntry}
+          onReload={onReload}
+          read={read}
+          onRead={clear}
+          onReadAll={clearAll}
+          onUnreadAll={restoreAll}
+          onSettleAll={settleAll}
+        />
       ))}
     </div>
   );

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5791,7 +5791,7 @@ describe("isMessageRunning", () => {
 
 describe("isRunningNow", () => {
   it("reads a live session's NEWEST message as the turn that is live", () => {
-    const t = task({ live: true }, 3);
+    const t = task({ live: true, status: "in_progress" }, 3);
     expect(isRunningNow(t, t.messages[0])).toBe(true);
     // The older ones are not: their turns ended when the next prompt arrived.
     expect(isRunningNow(t, t.messages[1])).toBe(false);
@@ -5807,5 +5807,23 @@ describe("isRunningNow", () => {
   it("says no on a quiet task", () => {
     const t = task({ live: false }, 2);
     expect(isRunningNow(t, t.messages[0])).toBe(false);
+  });
+
+  // BUGBOT: `sent` + a turn already rewritten to `idle` reads as not-running
+  // by state/turn alone, but `busy_sessions` can still be holding the task
+  // `in_progress` on the server (a scheduled send it has not heard back from
+  // yet) — the same task.status List and Board read. The chip has to agree
+  // with that server verdict rather than re-deriving liveness from `state`
+  // and `turn` on its own, or it goes stale while the other two views spin.
+  it("agrees with the server: task filed in_progress ⇒ its newest sent-but-idle message is running", () => {
+    const idle = msg({ message_id: "MSG-001", state: "sent", turn: "idle" });
+    const t = task({ status: "in_progress", live: false, messages: [idle] });
+    expect(isRunningNow(t, idle)).toBe(true);
+  });
+
+  it("does not read a done task's sent-but-idle message as running", () => {
+    const idle = msg({ message_id: "MSG-001", state: "sent", turn: "idle" });
+    const t = task({ status: "done", live: false, messages: [idle] });
+    expect(isRunningNow(t, idle)).toBe(false);
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Task, TaskMessage } from "@platform/lib/api";
-import { BOARD_COLUMNS } from "./schedule-lib";
+import { BOARD_COLUMNS, columnLabel } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   ALL_MESSAGES,
@@ -40,6 +40,8 @@ import {
   laneCollapsed,
   laneRolledUp,
   laneUnread,
+  LIST_SECTIONS,
+  listSections,
   laneTime,
   lastRunAt,
   markAllRead,
@@ -54,6 +56,7 @@ import {
   threadRunning,
   threadTone,
   messageWhenTitle,
+  nextRunChip,
   nextRunAt,
   openMessageHref,
   openThreadIntent,
@@ -80,7 +83,6 @@ import {
   threadView,
   tildePath,
   toggleExpanded,
-  triageStatus,
   unmarkAllRead,
   unmarkRead,
   unreadMarker,
@@ -988,29 +990,31 @@ const T18 = Math.floor(Date.parse("2026-08-17T18:00:00") / 1000);
 const FAILED = "failed" as Task["status"];
 
 describe("dropLanes", () => {
-  it("a task with no session has nothing to triage, so it cannot lift", () => {
-    // ...and nothing pending either, so there is nothing to run early.
+  it("locks the two lanes that are Claude's, not the reader's", () => {
+    // In Progress is a run in flight: a card leaves it when the run ends and at
+    // no other moment. Archive is where things rest, and there is no way back
+    // out by dragging — the row draws no Unarchive either.
+    for (const status of ["in_progress", "archived"] as const) {
+      expect(dropLanes(task({ status }))).toEqual([]);
+      expect(isDraggable(task({ status }))).toBe(false);
+    }
+  });
+
+  it("offers Archive from every unlocked lane, session or no session", () => {
+    // Archiving is one verb over a TASK KEY now (api.archiveTask), so the
+    // never-run row — which has no session to file under — is filed by
+    // cancelling its work. That row could not be archived at all before.
     const pending = task({ key: "pending:e1", session_id: "", status: "upcoming" });
-    expect(dropLanes(pending)).toEqual([]);
-    expect(isDraggable(pending)).toBe(false);
-  });
-
-  it("offers the other two triage lanes, never the one it is already in", () => {
-    expect(dropLanes(task({ status: "done" }))).toEqual(["in_progress", "archived"]);
-    expect(dropLanes(task({ status: "in_progress" }))).toEqual(["done", "archived"]);
-    expect(isDraggable(task({ status: "done" }))).toBe(true);
-  });
-
-  it("refuses to send a lane setSessionTriage does not accept", () => {
-    expect(triageStatus("upcoming")).toBe(null);
-    expect(triageStatus("done")).toBe("done");
+    expect(dropLanes(pending)).toEqual(["archived"]);
+    expect(isDraggable(pending)).toBe(true);
+    expect(dropLanes(task({ status: "done" }))).toEqual(["archived"]);
   });
 
   // Upcoming → In Progress is a RUN, not a filing (Akshil, 2026-08-16). Its
   // precondition is therefore a message to send, not a session to file under.
   it("lets a never-run scheduled task into In Progress: run needs no session", () => {
     const t = upcoming([T9], { key: "pending:e1", session_id: "" });
-    expect(dropLanes(t)).toEqual(["in_progress"]);
+    expect(dropLanes(t)).toEqual(["in_progress", "archived"]);
     expect(isDraggable(t)).toBe(true);
   });
 
@@ -1019,7 +1023,7 @@ describe("dropLanes", () => {
     // nothing to fire — so the drop is illegal BEFORE the card lands rather
     // than a call that fails after it.
     const chat = task({ status: "upcoming" }); // factory messages are `sent`
-    expect(dropLanes(chat)).toEqual(["done", "archived"]);
+    expect(dropLanes(chat)).toEqual(["archived"]);
     // Same for one whose only scheduled message was already cancelled.
     const dead = task({
       status: "upcoming",
@@ -1028,18 +1032,19 @@ describe("dropLanes", () => {
     expect(dropLanes(dead).includes("in_progress")).toBe(false);
   });
 
-  // Failed is the fifth lane and it is asymmetric: nothing goes in, and out of
-  // it there are exactly two moves.
-  it("never offers Failed as a destination, from any lane", () => {
+  it("never offers Upcoming, Failed or Done as a destination", () => {
+    // Upcoming: a task cannot be un-run. Failed: it is something that HAPPENED,
+    // and a lane you can drag a healthy task into is a lane whose count means
+    // nothing. Done: a run says that, not a reader.
     for (const status of ["upcoming", "in_progress", "done", "archived"] as const) {
-      expect(dropLanes(task({ status })).includes("failed")).toBe(false);
+      for (const lane of ["upcoming", "failed", "done"] as const) {
+        expect(dropLanes(task({ status })).includes(lane)).toBe(false);
+      }
     }
-    expect(dropLanes(upcoming([T9])).includes("failed")).toBe(false);
+    expect(dropLanes(upcoming([T9]))).toEqual(["in_progress", "archived"]);
   });
 
-  it("lets a failed task out to In Progress (re-run) and Archive, never Done", () => {
-    // A run that broke did not finish, so filing it as Done would put back the
-    // exact lie the lane exists to remove.
+  it("lets a failed task out to In Progress (re-run) and Archive", () => {
     const retryable = upcoming([T9], { status: FAILED });
     expect(dropLanes(retryable)).toEqual(["in_progress", "archived"]);
     // With nothing pending there is nothing to re-run — but it can still be
@@ -1157,15 +1162,13 @@ describe("dropAction", () => {
     });
   });
 
-  it("reads every other legal drop as a triage write", () => {
-    expect(dropAction(upcoming([T9]), "archived")).toEqual({
-      kind: "triage",
-      status: "archived",
-    });
-    expect(dropAction(task({ status: "done" }), "in_progress")).toEqual({
-      kind: "triage",
-      status: "in_progress",
-    });
+  it("reads a drop on Archive as the archive verb, with no payload", () => {
+    // One call over the task key (api.archiveTask) — it cancels the work and
+    // files the session — so there is nothing left for the drop to compose.
+    expect(dropAction(upcoming([T9]), "archived")).toEqual({ kind: "archive" });
+    expect(dropAction(task({ status: "done" }), "archived")).toEqual({ kind: "archive" });
+    // And Done → In Progress is not a move at all any more.
+    expect(dropAction(task({ status: "done" }), "in_progress")).toBe(null);
   });
 
   it("reads Failed → In Progress as a re-run, not a triage write", () => {
@@ -1175,23 +1178,27 @@ describe("dropAction", () => {
       messageId: "MSG-001",
     });
     // ...and Failed → Archive as an ordinary filing.
-    expect(dropAction(upcoming([T9], { status: FAILED }), "archived")).toEqual({
-      kind: "triage",
-      status: "archived",
-    });
+    expect(dropAction(upcoming([T9], { status: FAILED }), "archived"))
+      .toEqual({ kind: "archive" });
   });
 
   it("is null for anything dropLanes would not have allowed", () => {
-    // The lane it is already in, a lane triage cannot express, and the run lane
-    // on a task with nothing to run.
+    // The lane it is already in, a lane nothing may be dropped into, and the
+    // run lane on a task with nothing to run.
     expect(dropAction(task({ status: "done" }), "done")).toBe(null);
     expect(dropAction(task({ status: "done" }), "upcoming")).toBe(null);
     expect(dropAction(task({ status: "upcoming" }), "in_progress")).toBe(null);
     expect(dropAction(task({ status: "done" }), "failed")).toBe(null);
     expect(dropAction(upcoming([T9], { status: FAILED }), "done")).toBe(null);
-    // A never-run task may run, but may not be filed.
+    // Both locked lanes refuse everything.
+    for (const lane of ["in_progress", "archived"] as const) {
+      expect(dropAction(task({ status: "in_progress" }), lane)).toBe(null);
+      expect(dropAction(task({ status: "archived" }), lane)).toBe(null);
+    }
+    // A never-run task may now be filed as well as run: archiving is keyed by
+    // task, not by session.
     const fresh = upcoming([T9], { key: "pending:e1", session_id: "" });
-    expect(dropAction(fresh, "archived")).toBe(null);
+    expect(dropAction(fresh, "archived")).toEqual({ kind: "archive" });
   });
 });
 
@@ -1368,10 +1375,10 @@ describe("taskRunIntent", () => {
     const spent = broke();
     expect(dropLanes(spent)).toEqual(["archived"]);
     expect(dropAction(spent, "in_progress")).toBe(null);
-    // And every legal drop is still a run or a triage write, never a resend.
+    // And every legal drop is still a run or an archive, never a resend.
     for (const lane of ["in_progress", "done", "archived"] as const) {
       const action = dropAction(upcoming([T9], { status: FAILED }), lane);
-      if (action) expect(["run", "triage"]).toContain(action.kind);
+      if (action) expect(["run", "archive"]).toContain(action.kind);
     }
   });
 });
@@ -1385,44 +1392,44 @@ describe("archiveIntent", () => {
   it("offers Archive on a task that has run", () => {
     const a = archiveIntent(task({ status: "done" }))!;
     expect(a.label).toBe("Archive");
-    expect(a.status).toBe("archived");
     expect(a.lane).toBe("archived");
-    expect(a.restore).toBe(false);
-    // The half a person reaching for Delete is actually asking about.
+    // The two halves a person reaching for Delete is actually asking about: the
+    // run still booked is called off, and the conversation is not destroyed.
     expect(a.title).toContain("kept");
+    expect(a.title).toContain("calls off");
   });
 
-  it("offers the way BACK on a task already archived", () => {
-    // Archiving with no way out is a trap, and the Board's drag can already
-    // pull a card out of Archive — so the List must not be a one-way door.
-    const a = archiveIntent(task({ status: "archived" }))!;
-    expect(a.label).toBe("Unarchive");
-    expect(a.status).toBe("in_progress");
-    expect(a.lane).toBe("in_progress");
-    expect(a.restore).toBe(true);
-    // Never Done: archiving recorded nothing about whether the work finished.
-    expect(a.status).not.toBe("done");
+  it("offers no way back out of Archive", () => {
+    // Archive is a locked lane on the Board and the row draws no Unarchive, so
+    // there is one answer to "how do I get this back?" instead of two. It costs
+    // nothing: archiving destroys nothing (D306).
+    expect(archiveIntent(task({ status: "archived" }))).toBe(null);
   });
 
-  it("offers nothing on a task with no session to triage", () => {
-    // `pending:<entry>` — triage is an overlay on triage.json keyed by SESSION
-    // id, and a task that has never run has none. A button here would be a
-    // button that can only fail.
+  it("offers nothing while a run is in flight", () => {
+    // In Progress is Claude's output. The card cannot leave that lane by any
+    // gesture, and the button asks the same question the drop does.
+    expect(archiveIntent(task({ status: "in_progress" }))).toBe(null);
+  });
+
+  it("offers Archive on a task with no session at all", () => {
+    // `pending:<entry>` — the row the old session-keyed triage write could not
+    // touch. Archiving is one verb over a TASK KEY now, and for a task that has
+    // never run it means exactly "cancel the work", which the server does.
     expect(archiveIntent(task({ key: "pending:e1", session_id: "", status: "upcoming" })))
-      .toBe(null);
-    // ...even when it is otherwise draggable, because run-now needs no session.
+      .not.toBe(null);
     const fresh = upcoming([T9], { key: "pending:e1", session_id: "" });
     expect(isDraggable(fresh)).toBe(true);
-    expect(archiveIntent(fresh)).toBe(null);
+    expect(archiveIntent(fresh)!.lane).toBe("archived");
   });
 
-  it("is offered from every lane a session-bearing task can sit in", () => {
-    for (const status of ["upcoming", "in_progress", "done", "archived"] as const) {
+  it("is offered from every unlocked lane", () => {
+    for (const status of ["upcoming", "done"] as const) {
       expect(archiveIntent(task({ status }))).not.toBe(null);
     }
     // Including the one lane Done is refused from — filing a failed run away is
     // exactly what a person wants to do with it.
-    expect(archiveIntent(task({ status: FAILED }))!.status).toBe("archived");
+    expect(archiveIntent(task({ status: FAILED }))!.lane).toBe("archived");
   });
 
   it("never disagrees with the drop the Board already makes", () => {
@@ -1433,7 +1440,6 @@ describe("archiveIntent", () => {
       task({ status: FAILED }),
       upcoming([T9]),
       upcoming([T18, T9], { status: FAILED }),
-      // The two that offer nothing.
       task({ key: "pending:e1", session_id: "", status: "upcoming" }),
       upcoming([T9], { key: "pending:e1", session_id: "" }),
     ];
@@ -1443,7 +1449,7 @@ describe("archiveIntent", () => {
         const action = dropAction(t, col.key);
         if (a && col.key === a.lane) {
           // The button makes the drop's call, on the drop's own lane.
-          expect(action).toEqual({ kind: "triage", status: a.status });
+          expect(action).toEqual({ kind: "archive" });
           expect(dropLanes(t)).toContain(a.lane);
         } else if (!a) {
           // Offering nothing is only correct while the drag has no filing move
@@ -3242,47 +3248,33 @@ describe("the archive action", () => {
     // Only when there is something to file — a session-less row grows nothing.
     expect(row).toContain("{file && (");
     // The same class Run now / Edit / Cancel wear, which is what makes it quiet.
-    expect(row).toMatch(/"tasks-act (?:.|\n)*?tasks-act--unarchive/);
+    expect(row).toContain("tasks-act--archive");
     expect(row).toContain("ICON_ARCHIVE");
-    expect(row).toContain("ICON_UNARCHIVE");
-    // Both directions are still WRITTEN — which of them is drawn is SHOW_UNARCHIVE's
-    // business, below — and the label comes from tasks-lib rather than the row.
-    expect(row).toContain("file.status");
+    // The words come from tasks-lib rather than from the row.
     expect(row).toContain("aria-label={file.label}");
   });
 
-  it("hides the way BACK for now, without deleting it", () => {
-    // Akshil, 2026-08-18: keep archive, hide unarchive. A second flag rather than a
-    // second value of SHOW_ROW_ACTIONS, because they are two different requests and
-    // neither should move when the other is answered.
-    expect(VIEWS).toMatch(/const SHOW_UNARCHIVE: boolean = false;/);
-    // Gated where the intent is READ, not in the markup: `file` then means exactly
-    // "the filing button this row draws", so the button needs no second condition
-    // and the card's strip cannot be drawn around a button that is not there.
-    expect(
-      (VIEWS.match(
-        /const file = filing && \(SHOW_UNARCHIVE \|\| !filing\.restore\) \? filing : null;/g,
-      ) ?? []).length,
-    ).toBe(2);
-    // BOTH views, from ONE flag: a Board that offers the way back where the List
-    // does not is the divergence this page's vocabulary is written against.
+  it("is one-way, on both views and in the drag", () => {
+    // Archive is a locked lane (tasks-lib's drag matrix), so there is no
+    // Unarchive anywhere: not a button, not a glyph, not a drop. It used to be
+    // written-but-hidden on the row and LIVE on the Board, which is two answers
+    // to one question — the divergence this page's vocabulary is written
+    // against.
+    expect(VIEWS).not.toContain("SHOW_UNARCHIVE");
+    expect(VIEWS).not.toContain("ICON_UNARCHIVE");
+    expect(archiveIntent(task({ status: "archived" }))).toBe(null);
+    expect(dropLanes(task({ status: "archived" }))).toEqual([]);
+    // BOTH views read the same intent, and neither composes a status: the
+    // server verb is one call over the task key.
     for (const src of [ROW, CARD]) {
       expect(src).toContain("{file && (");
     }
-    expect((VIEWS.match(/const filing = archiveIntent\(task\);/g) ?? []).length).toBe(2);
-    // NOTHING UNDERNEATH IS DELETED — that is the difference between gating and
-    // removing. The intent still computes both directions and is still tested both
-    // ways; the handler still takes either status; the glyph is still written down
-    // beside its pair, because the two only read as a pair together.
-    expect(archiveIntent(task({ status: "archived" }))!.restore).toBe(true);
-    expect(archiveIntent(task({ status: "done" }))!.restore).toBe(false);
-    expect(VIEWS).toContain("const ICON_UNARCHIVE = icon(");
-    expect(VIEWS).toContain("{file.restore ? ICON_UNARCHIVE : ICON_ARCHIVE}");
-    expect(VIEWS).toContain("const triage = async (status: ArchiveStatus)");
-    // Not rendered rather than hidden in CSS, the same rule the strip obeys: an
-    // `opacity: 0` button is still in the tab order.
+    expect((VIEWS.match(/const file = archiveIntent\(task\);/g) ?? []).length).toBe(2);
+    expect((VIEWS.match(/archiveTask\(task\.key\)/g) ?? []).length).toBe(3);
+    // Not hidden in CSS, the same rule the strip obeys: an `opacity: 0` button
+    // is still in the tab order.
     expect(TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain(
-      ".tasks-act--unarchive { display: none",
+      ".tasks-act--unarchive",
     );
   });
 
@@ -3600,13 +3592,13 @@ describe("the hidden row actions", () => {
       "archiveIntent(task)",
       "openThreadIntent(task, unread)",
       "const markSeen = async () => {",
-      "const triage = async (status: ArchiveStatus)",
+      "const archive = async () => {",
       "const openChat = (intent: OpenThreadIntent)",
     ]) {
       expect(VIEWS).toContain(kept);
     }
     expect(CARD).toContain("void runNow(run)");
-    expect(CARD).toContain("void triage(file.status)");
+    expect(CARD).toContain("void archive()");
   });
 
   it("keeps the strip's geometry, which is what it comes back to", () => {
@@ -3708,7 +3700,7 @@ describe("the folder chip on a row and a card", () => {
     // On the card the chip is the only thing in the foot, so the foot goes with it
     // rather than leaving a line of padding.
     expect(CARD).toMatch(
-      /\{showProject && \(\s*<span className="schedule-tv-card-foot">/,
+      /\{\(showProject \|\| soon\) && \(\s*<span className="schedule-tv-card-foot">/,
     );
     // The path is still on the row itself, so nothing is unreachable: the row's
     // `title` is the task's own, and the chip's tooltip was never the only copy.
@@ -4052,7 +4044,7 @@ describe("opening a thread, from either view", () => {
     const acts = CARD.slice(actsAt);
     expect(acts).not.toContain("onOpen");
     expect(acts).toContain("void runNow(run)");
-    expect(acts).toContain("void triage(file.status)");
+    expect(acts).toContain("void archive()");
   });
 
   it("is the row ITSELF now, and a real link at that", () => {
@@ -5567,5 +5559,118 @@ describe("the tasks toolbar", () => {
     // thing that exceeds the measure, and it scrolls inside itself — which it has
     // always done at any window narrower than five lanes (design-principles §0).
     expect(board).toContain("overflow-x: auto");
+  });
+});
+
+// ---- the List's sections -----------------------------------------------------
+// The List is grouped by the same fact the Board is (taskColumn), in the List's
+// own order, with the empties dropped.
+
+describe("listSections", () => {
+  it("names every lane exactly once, in the list's order", () => {
+    expect(LIST_SECTIONS).toEqual([
+      "upcoming",
+      "in_progress",
+      "failed",
+      "done",
+      "archived",
+    ]);
+    // Same set as the Board's — a sixth lane cannot be silently unlistable.
+    expect([...LIST_SECTIONS].sort()).toEqual(
+      BOARD_COLUMNS.map((c) => c.key).slice().sort(),
+    );
+  });
+
+  it("drops empty sections entirely, header and all", () => {
+    const rows = [task({ key: "a", status: "done" }), task({ key: "b", status: "done" })];
+    const sections = listSections(rows);
+    expect(sections.map((s) => s.key)).toEqual(["done"]);
+    expect(sections[0].tasks).toHaveLength(2);
+    expect(listSections([])).toEqual([]);
+  });
+
+  it("orders Failed above Done and Archive last, whatever the input order", () => {
+    const rows = [
+      task({ key: "d", status: "archived" }),
+      task({ key: "c", status: "done" }),
+      task({ key: "b", status: FAILED }),
+      task({ key: "a", status: "upcoming" }),
+    ];
+    expect(listSections(rows).map((s) => s.key)).toEqual([
+      "upcoming",
+      "failed",
+      "done",
+      "archived",
+    ]);
+  });
+
+  it("keeps the server's order inside a section, and never re-sorts", () => {
+    const rows = [
+      task({ key: "first", status: "done", last_active: 1 }),
+      task({ key: "second", status: "done", last_active: 999 }),
+    ];
+    expect(listSections(rows)[0].tasks.map((t) => t.key)).toEqual(["first", "second"]);
+  });
+
+  it("speaks the Board's own words, never a second spelling", () => {
+    const rows = LIST_SECTIONS.map((status, i) => task({ key: `k${i}`, status }));
+    for (const section of listSections(rows)) {
+      expect(section.label).toBe(columnLabel(section.key));
+    }
+  });
+
+  it("loses no task: every row lands in exactly one section", () => {
+    const rows = [
+      task({ key: "a", status: "upcoming" }),
+      task({ key: "b", status: "in_progress" }),
+      task({ key: "c", status: FAILED }),
+      task({ key: "d", status: "done" }),
+      task({ key: "e", status: "archived" }),
+      // An unreadable status lands in Done, exactly as taskColumn says.
+      task({ key: "f", status: "invented" as Task["status"] }),
+    ];
+    const landed = listSections(rows).flatMap((s) => s.tasks.map((t) => t.key));
+    expect(landed.slice().sort()).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+});
+
+// ---- "and it runs again on Tuesday" ------------------------------------------
+
+describe("nextRunChip", () => {
+  const AHEAD = Math.floor(NOW / 1000) + 3600;
+
+  it("says the run ahead on a settled task that has one", () => {
+    // The recurring case: the last run finished (so the task sits in Done) and
+    // the next occurrence is booked. Without this the row loses that fact.
+    const t = task({ status: "done", next_run: AHEAD, next_run_entry: "e2" });
+    const chip = nextRunChip(t, NOW)!;
+    expect(chip.at).toBe(AHEAD);
+    expect(chip.text).toBe(`next ${relativeWhen(AHEAD, NOW)}`);
+    expect(chip.text).toContain("in 1h");
+    // The exact instant is in the tooltip, like every other time on the page.
+    expect(chip.title).toContain("Next run");
+  });
+
+  it("says nothing on an Upcoming row, whose own time is already that run", () => {
+    // taskWhen reads LANE_SORTS: Upcoming is ordered and stamped by the run
+    // ahead, so a chip there would print the number beside it twice.
+    const t = upcoming([AHEAD]);
+    expect(taskWhen(t, NOW).kind).toBe("next");
+    expect(nextRunChip(t, NOW)).toBe(null);
+  });
+
+  it("says nothing when there is no run ahead at all", () => {
+    expect(nextRunChip(task({ status: "done" }), NOW)).toBe(null);
+  });
+
+  it("says nothing about a run whose time has already passed", () => {
+    // An overdue pending is not news about what happens NEXT; it is the work
+    // the Upcoming lane already surfaces.
+    const t = task({
+      status: "done",
+      next_run: Math.floor(NOW / 1000) - 60,
+      next_run_entry: "e2",
+    });
+    expect(nextRunChip(t, NOW)).toBe(null);
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -992,6 +992,46 @@ const T18 = Math.floor(Date.parse("2026-08-17T18:00:00") / 1000);
 const FAILED = "failed" as Task["status"];
 
 describe("dropLanes", () => {
+  // THE MATRIX, ONE LANE PER CASE. Written out per lane rather than as a loop
+  // over a table, because a loop over the same table the code reads would agree
+  // with a wrong table (bugbot, PR #613 — the rule used to be a predicate that
+  // let Done offer In Progress).
+  //
+  // Every case is a task WITH a pending message, so the run-now precondition is
+  // satisfied everywhere and the only thing under test is the lane's own rule.
+  it("Upcoming may run early or be called off", () => {
+    expect(dropLanes(upcoming([T9]))).toEqual(["in_progress", "archived"]);
+  });
+
+  it("Failed may retry or be filed away", () => {
+    expect(dropLanes(upcoming([T9], { status: FAILED })))
+      .toEqual(["in_progress", "archived"]);
+  });
+
+  it("Done may ONLY be archived, even with a run pending", () => {
+    // The regression this pins, and it is the commonest Done card on the page:
+    // a recurring task whose last run finished and whose next occurrence is
+    // booked sits in Done by design (the server's `_message_verdict`). The old
+    // predicate offered In Progress for exactly that shape, and the drop would
+    // have fired a real run — "do it again" is not something a drag may say.
+    const recurring = upcoming([T18], { status: "done" });
+    expect(canRunNow(recurring)).toBe(true);
+    expect(dropLanes(recurring)).toEqual(["archived"]);
+    expect(dropAction(recurring, "in_progress")).toBe(null);
+  });
+
+  it("In Progress goes nowhere, even with a run pending", () => {
+    const t = upcoming([T9], { status: "in_progress" });
+    expect(canRunNow(t)).toBe(true);
+    expect(dropLanes(t)).toEqual([]);
+  });
+
+  it("Archived goes nowhere, even with a run pending", () => {
+    const t = upcoming([T9], { status: "archived" });
+    expect(canRunNow(t)).toBe(true);
+    expect(dropLanes(t)).toEqual([]);
+  });
+
   it("locks the two lanes that are Claude's, not the reader's", () => {
     // In Progress is a run in flight: a card leaves it when the run ends and at
     // no other moment. Archive is where things rest, and there is no way back

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { Task, TaskMessage } from "@platform/lib/api";
-import { BOARD_COLUMNS, columnLabel } from "./schedule-lib";
+import { BOARD_COLUMNS } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   ALL_MESSAGES,
@@ -42,8 +42,8 @@ import {
   laneCollapsed,
   laneRolledUp,
   laneUnread,
-  LIST_SECTIONS,
-  listSections,
+  LIST_ORDER,
+  sortByLane,
   laneTime,
   lastRunAt,
   markAllRead,
@@ -1001,6 +1001,37 @@ describe("dropLanes", () => {
   // satisfied everywhere and the only thing under test is the lane's own rule.
   it("Upcoming may run early or be called off", () => {
     expect(dropLanes(upcoming([T9]))).toEqual(["in_progress", "archived"]);
+  });
+
+  it("Upcoming may be dragged into In Progress — the REAL server shape", () => {
+    // Not a task hand-fed a pending message: the row exactly as `/api/tasks`
+    // sends one for a message scheduled into a session that has not run it yet
+    // — one pending message with its entry id, no run behind it, `next_run`
+    // naming the same entry. This is the drag the user reported broken, and it
+    // is asserted end to end: the card lifts, the lane accepts it, and the
+    // action is a RUN of that entry rather than a filing.
+    const realUpcoming: Task = {
+      ...task({
+        key: "6f4c4f5c-38ff-4fc6-9abc-000000000001",
+        session_id: "6f4c4f5c-38ff-4fc6-9abc-000000000001",
+        status: "upcoming",
+        title: "pull today's news",
+        message_count: 1,
+        next_run: T18,
+        next_run_entry: "e1",
+      }),
+      messages: [
+        msg({ message_id: "MSG-001", state: "pending", entry_id: "e1",
+              at: T18, ran_at: 0, turn: "" }),
+      ],
+    };
+    expect(isDraggable(realUpcoming)).toBe(true);
+    expect(dropLanes(realUpcoming)).toEqual(["in_progress", "archived"]);
+    expect(dropAction(realUpcoming, "in_progress")).toEqual({
+      kind: "run",
+      entryId: "e1",
+      messageId: "MSG-001",
+    });
   });
 
   it("Failed may retry or be filed away", () => {
@@ -5604,64 +5635,67 @@ describe("the tasks toolbar", () => {
   });
 });
 
-// ---- the List's sections -----------------------------------------------------
-// The List is grouped by the same fact the Board is (taskColumn), in the List's
-// own order, with the empties dropped.
+// ---- the List's order --------------------------------------------------------
+// The rank order is a SORT and nothing more: no headers, no dividers, no counts
+// (Akshil, 2026-08-18).
 
-describe("listSections", () => {
+describe("sortByLane", () => {
   it("names every lane exactly once, in the list's order", () => {
-    expect(LIST_SECTIONS).toEqual([
+    expect(LIST_ORDER).toEqual([
       "upcoming",
       "in_progress",
       "failed",
       "done",
       "archived",
     ]);
-    // Same set as the Board's — a sixth lane cannot be silently unlistable.
-    expect([...LIST_SECTIONS].sort()).toEqual(
+    // Same set as the Board's — a sixth lane cannot be silently unsortable.
+    expect([...LIST_ORDER].sort()).toEqual(
       BOARD_COLUMNS.map((c) => c.key).slice().sort(),
     );
   });
 
-  it("drops empty sections entirely, header and all", () => {
-    const rows = [task({ key: "a", status: "done" }), task({ key: "b", status: "done" })];
-    const sections = listSections(rows);
-    expect(sections.map((s) => s.key)).toEqual(["done"]);
-    expect(sections[0].tasks).toHaveLength(2);
-    expect(listSections([])).toEqual([]);
-  });
-
-  it("orders Failed above Done and Archive last, whatever the input order", () => {
+  it("returns ONE flat list, not groups", () => {
     const rows = [
       task({ key: "d", status: "archived" }),
       task({ key: "c", status: "done" }),
       task({ key: "b", status: FAILED }),
       task({ key: "a", status: "upcoming" }),
     ];
-    expect(listSections(rows).map((s) => s.key)).toEqual([
-      "upcoming",
-      "failed",
-      "done",
-      "archived",
-    ]);
+    expect(sortByLane(rows).map((t) => t.key)).toEqual(["a", "b", "c", "d"]);
+    expect(sortByLane([])).toEqual([]);
   });
 
-  it("keeps the server's order inside a section, and never re-sorts", () => {
+  it("puts Failed above Done and Archive last, whatever the input order", () => {
+    const rows = [
+      task({ key: "done", status: "done" }),
+      task({ key: "arch", status: "archived" }),
+      task({ key: "fail", status: FAILED }),
+      task({ key: "run", status: "in_progress" }),
+      task({ key: "soon", status: "upcoming" }),
+    ];
+    expect(sortByLane(rows).map((t) => t.key))
+      .toEqual(["soon", "run", "fail", "done", "arch"]);
+  });
+
+  it("keeps the server's order inside a rank, and never re-sorts", () => {
     const rows = [
       task({ key: "first", status: "done", last_active: 1 }),
       task({ key: "second", status: "done", last_active: 999 }),
     ];
-    expect(listSections(rows)[0].tasks.map((t) => t.key)).toEqual(["first", "second"]);
+    expect(sortByLane(rows).map((t) => t.key)).toEqual(["first", "second"]);
   });
 
-  it("speaks the Board's own words, never a second spelling", () => {
-    const rows = LIST_SECTIONS.map((status, i) => task({ key: `k${i}`, status }));
-    for (const section of listSections(rows)) {
-      expect(section.label).toBe(columnLabel(section.key));
-    }
+  it("never mutates the polled list React is still holding", () => {
+    const rows = [
+      task({ key: "b", status: "done" }),
+      task({ key: "a", status: "upcoming" }),
+    ];
+    const before = rows.map((t) => t.key);
+    sortByLane(rows);
+    expect(rows.map((t) => t.key)).toEqual(before);
   });
 
-  it("loses no task: every row lands in exactly one section", () => {
+  it("loses no task and duplicates none", () => {
     const rows = [
       task({ key: "a", status: "upcoming" }),
       task({ key: "b", status: "in_progress" }),
@@ -5671,8 +5705,21 @@ describe("listSections", () => {
       // An unreadable status lands in Done, exactly as taskColumn says.
       task({ key: "f", status: "invented" as Task["status"] }),
     ];
-    const landed = listSections(rows).flatMap((s) => s.tasks.map((t) => t.key));
-    expect(landed.slice().sort()).toEqual(["a", "b", "c", "d", "e", "f"]);
+    const out = sortByLane(rows);
+    expect(out).toHaveLength(rows.length);
+    expect(out.map((t) => t.key).sort()).toEqual(["a", "b", "c", "d", "e", "f"]);
+  });
+
+  it("draws no headers, dividers or counts in the List", () => {
+    // The whole of the correction, read out of the source: grouping you can see
+    // claims the groups are navigable, and this one is a claim about priority.
+    for (const gone of ["tasks-section", "listSections", "TaskSection"]) {
+      expect(VIEWS).not.toContain(gone);
+    }
+    expect(TASKS_CSS).not.toContain(".tasks-section");
+    // And the rows are drawn straight off the sorted list.
+    expect(VIEWS).toContain("const rows = useMemo(() => sortByLane(tasks), [tasks]);");
+    expect(VIEWS).toContain("{rows.map((task) => (");
   });
 });
 

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -34,6 +34,8 @@ import {
   isDraggable,
   isExpandable,
   isFailedTask,
+  isMessageRunning,
+  isRunningNow,
   isPastDue,
   isUnread,
   isUpcomingTask,
@@ -5672,5 +5674,51 @@ describe("nextRunChip", () => {
       next_run_entry: "e2",
     });
     expect(nextRunChip(t, NOW)).toBe(null);
+  });
+});
+
+// ---- what is happening right now ---------------------------------------------
+// The calendar has no In Progress lane, so its chips ask this instead.
+
+describe("isMessageRunning", () => {
+  it("says yes to a send in flight and to a turn still working", () => {
+    expect(isMessageRunning(msg({ state: "sending" }))).toBe(true);
+    // "" is what the server writes while a turn is in flight (_entry_turn).
+    expect(isMessageRunning(msg({ state: "sent", turn: "" }))).toBe(true);
+  });
+
+  it("says no to a turn that ended, and to one nobody can report on", () => {
+    expect(isMessageRunning(msg({ state: "sent", turn: "done" }))).toBe(false);
+    // The watcher stopped being able to tell. Reporting that as running is the
+    // frozen-progress-bar lie.
+    expect(isMessageRunning(msg({ state: "sent", turn: "unknown" }))).toBe(false);
+    expect(isMessageRunning(msg({ state: "idle" as TaskMessage["state"] }))).toBe(false);
+  });
+
+  it("says no to a message that never went out", () => {
+    for (const state of ["pending", "cancelled", "skipped", "error"] as const) {
+      expect(isMessageRunning(msg({ state }))).toBe(false);
+    }
+  });
+});
+
+describe("isRunningNow", () => {
+  it("reads a live session's NEWEST message as the turn that is live", () => {
+    const t = task({ live: true }, 3);
+    expect(isRunningNow(t, t.messages[0])).toBe(true);
+    // The older ones are not: their turns ended when the next prompt arrived.
+    expect(isRunningNow(t, t.messages[1])).toBe(false);
+  });
+
+  it("still reads a message that says so itself, in a session that is not live", () => {
+    const running = msg({ message_id: "MSG-009", state: "sending" });
+    const t = task({ live: false, messages: [msg({ message_id: "MSG-010" }), running] });
+    expect(isRunningNow(t, running)).toBe(true);
+    expect(isRunningNow(t, t.messages[0])).toBe(false);
+  });
+
+  it("says no on a quiet task", () => {
+    const t = task({ live: false }, 2);
+    expect(isRunningNow(t, t.messages[0])).toBe(false);
   });
 });

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -35,7 +35,7 @@
 // status is re-derived, no lane membership is re-decided (taskColumn still asks
 // the server), and every key is a time the server itself sent.
 import type { Task, TaskMessage } from "@platform/lib/api";
-import { BOARD_COLUMNS, columnLabel, explorerUrl, isProjected, turnPhase } from "./schedule-lib";
+import { BOARD_COLUMNS, explorerUrl, isProjected, turnPhase } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 
 // How many messages the LISTING carries per task — the server's window, not a
@@ -2430,35 +2430,40 @@ export function laneRolledUp(
   return laneCollapsed(lane, count, choices);
 }
 
-// ---- the List's own sections -------------------------------------------------
-// The List and the Board are two lenses on ONE dataset, so the List is grouped
-// by the same fact the Board is: `taskColumn`. Same nouns, same colours, same
-// ring — a reader who learns "Failed" on one view has learned it on both, and a
-// row that moves lane on the Board moves section here.
+// ---- the List's order --------------------------------------------------------
+// The List and the Board read the same fact — `taskColumn`, so a row that moves
+// lane on the Board moves position here — but the List spends it as a SORT and
+// nothing else (Akshil, 2026-08-18). No headers, no dividers, no counts: one
+// flat list whose rows happen to arrive in status order.
 //
-// THE ORDER IS NOT THE BOARD'S, and the difference is deliberate. A board is
-// read left to right as a pipeline (Upcoming, In Progress, Done, Failed,
-// Archive); a list is read top to bottom as a to-do, so the two sections that
-// want a person's hands come first and the two that are finished sink:
+// IT WAS HEADERS FIRST, and they were wrong on a list. The Board's lanes are a
+// fixed frame, so a lane header is the frame's label and earns its ink; a list
+// has no frame, so five headers over a few dozen rows are five interruptions in
+// the one column a person is scanning — and the ORDER already says everything
+// the headers were saying. Grouping you can see is a claim that the groups are
+// navigable; grouping you can only feel is a claim about priority, which is what
+// this actually is.
+//
+// THE ORDER IS NOT THE BOARD'S, and that difference stays. A board is read left
+// to right as a pipeline (Upcoming, In Progress, Done, Failed, Archive); a list
+// is read top to bottom as work owed, so the ranks that want a person's hands
+// come first and the settled ones sink:
 //
 //   Upcoming → In Progress → Failed → Done → Archive
 //
-// Failed above Done because a broken run is work that is still owed, and Done
-// above Archive because Archive is not a status, it is where things go to stop
-// being read.
+// Failed above Done because a broken run is still owed, and Done above Archive
+// because Archive is not a status, it is where things go to stop being read.
 //
-// EMPTY SECTIONS ARE NOT DRAWN AT ALL — no header, no zero. The Board's lanes
-// are a fixed frame and an empty column there is information (nothing is
-// failing); a list has no frame, and five headers over three rows is a table of
-// contents for a page with nothing on it.
-//
-// WITHIN a section nothing is re-sorted: the server's order is the list's order
-// and always has been (TaskList takes `tasks` "in the SERVER's order. Never
-// re-sorted here"). Bucketing preserves it.
+// WITHIN a rank nothing is re-sorted: the server's order is the list's order and
+// always has been (TaskList takes `tasks` "in the SERVER's order"). A stable
+// bucketing keeps it, which is why this is a bucket-and-concat rather than a
+// comparator — `Array.prototype.sort` is stable in every engine this ships to,
+// but a comparator would also invite a second sort key later, and there is not
+// one: rank, then whatever the server said.
 
-/** Section order, top to bottom. Every BoardColumn appears exactly once — the
- * test holds it to that, so a sixth lane cannot be silently unlistable. */
-export const LIST_SECTIONS: BoardColumn[] = [
+/** Rank order, top to bottom. Every BoardColumn appears exactly once — the test
+ * holds it to that, so a sixth lane cannot be silently unsortable. */
+export const LIST_ORDER: BoardColumn[] = [
   "upcoming",
   "in_progress",
   "failed",
@@ -2466,27 +2471,15 @@ export const LIST_SECTIONS: BoardColumn[] = [
   "archived",
 ];
 
-export interface TaskSection {
-  key: BoardColumn;
-  /** The Board's own word for this lane (schedule-lib.columnLabel) — never a
-   * second spelling of it. */
-  label: string;
-  /** Non-empty, always: an empty section is absent rather than headed. */
-  tasks: Task[];
-}
-
-export function listSections(tasks: Task[]): TaskSection[] {
+/** The list's rows, in rank order, server order preserved inside each rank. A
+ * new array; the input is never mutated (it is the polled list, which React is
+ * still holding). */
+export function sortByLane(tasks: Task[]): Task[] {
   const buckets = new Map<BoardColumn, Task[]>(
-    LIST_SECTIONS.map((key) => [key, [] as Task[]]),
+    LIST_ORDER.map((key) => [key, [] as Task[]]),
   );
   for (const task of tasks) buckets.get(taskColumn(task))?.push(task);
-  const sections: TaskSection[] = [];
-  for (const key of LIST_SECTIONS) {
-    const held = buckets.get(key) ?? [];
-    if (held.length === 0) continue;
-    sections.push({ key, label: columnLabel(key), tasks: held });
-  }
-  return sections;
+  return LIST_ORDER.flatMap((key) => buckets.get(key) ?? []);
 }
 
 // ---- "and it runs again on Tuesday" ------------------------------------------

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -1313,9 +1313,42 @@ export function messageEditEntry(m: TaskMessage): string | null {
  * synonym for the first: one starts work, the other ends it. */
 export const DROP_LANES: BoardColumn[] = ["in_progress", "archived"];
 
-/** The lanes a card may be dragged OUT of. The other two are Claude's:
- * In Progress is a run in flight, and Archive is where things rest. */
-const UNLOCKED: BoardColumn[] = ["upcoming", "done", "failed"];
+/**
+ * THE MATRIX ITSELF: where a card in each lane may go. The table above in
+ * words, written down once so `dropLanes` reads it instead of reconstructing it.
+ *
+ * A TABLE AND NOT A PREDICATE, which is the correction (bugbot, PR #613). It
+ * was "every unlocked lane may go anywhere in DROP_LANES, subject to a
+ * precondition", and that quietly offered Done → In Progress to any done task
+ * with something pending — which is not a corner case on this branch, it is the
+ * COMMONEST done card there is: a recurring task whose last run finished and
+ * whose next occurrence is booked now sits in Done by design (see
+ * `_message_verdict`, server side). So the lane a person is most likely to drag
+ * from was the one lane whose rules were wrong, and the drop would have fired a
+ * real run.
+ *
+ * Re-running a task that finished is deliberately not a gesture. "Run this
+ * again" on work that succeeded is an ask better made in the chat, where the
+ * person can say what they want differently this time — the same reasoning
+ * `taskRunIntent` gives for offering Re-send on a failed task and nowhere else.
+ *
+ * Every BoardColumn is a key, so a sixth lane is a type error here rather than a
+ * lane that silently permits nothing (or everything).
+ */
+const LANE_EXITS: Record<BoardColumn, BoardColumn[]> = {
+  // Run it early, or call it off.
+  upcoming: ["in_progress", "archived"],
+  // Locked: a run in flight is Claude's output, and it leaves this lane when it
+  // ends, not when a card is dragged.
+  in_progress: [],
+  // Archive only. "Not finished after all" is not something a drag can make
+  // true, and neither is "do it again".
+  done: ["archived"],
+  // Retry, or file it away.
+  failed: ["in_progress", "archived"],
+  // Locked: the way back out is activity, not a gesture. See archiveIntent.
+  archived: [],
+};
 
 /**
  * The next run the ROW ITSELF names, when it names one: the server's `next_run`
@@ -1617,16 +1650,23 @@ export function taskRunIntent(task: Task): TaskRunIntent | null {
   };
 }
 
-/** Which lanes this card may be dropped on. Empty ⇒ do not let it lift. */
+/**
+ * Which lanes this card may be dropped on. Empty ⇒ do not let it lift.
+ *
+ * `LANE_EXITS` decides where the card MAY go; the loop only drops a move whose
+ * precondition is missing. There is one such precondition and it belongs to the
+ * run: In Progress needs a pending MESSAGE to fire, not a session to file under
+ * (see the note above), so a scheduled task that has never run may be dragged
+ * there and a pure-chat task may not. Archive has no precondition — it is one
+ * server verb over the task's own key.
+ */
 export function dropLanes(task: Task): BoardColumn[] {
   const here = taskColumn(task);
-  if (!UNLOCKED.includes(here)) return [];
   const lanes: BoardColumn[] = [];
-  // The run-now lane. Its precondition is a pending message, NOT a session:
-  // see the note above. It is the same move from either side — Upcoming runs
-  // the message early, Failed runs it again — and the same call makes both.
-  if (canRunNow(task)) lanes.push("in_progress");
-  lanes.push("archived");
+  for (const lane of LANE_EXITS[here]) {
+    if (lane === "in_progress" && !canRunNow(task)) continue;
+    lanes.push(lane);
+  }
   return lanes;
 }
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -35,7 +35,7 @@
 // status is re-derived, no lane membership is re-decided (taskColumn still asks
 // the server), and every key is a time the server itself sent.
 import type { Task, TaskMessage } from "@platform/lib/api";
-import { BOARD_COLUMNS, explorerUrl, isProjected, turnPhase } from "./schedule-lib";
+import { BOARD_COLUMNS, columnLabel, explorerUrl, isProjected, turnPhase } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 
 // How many messages the LISTING carries per task — the server's window, not a
@@ -1256,45 +1256,57 @@ export function messageEditEntry(m: TaskMessage): string | null {
 }
 
 // ---- drag --------------------------------------------------------------------
-// A drop on the Board means one of TWO things, and which one is decided by
-// where the card came from.
+// THE WHOLE DRAG MATRIX, and it follows from one sentence: a lane is what
+// Claude's work is DOING, and the only thing a person decides about a task is
+// whether to run it or to put it away. So there are exactly two moves, and
+// three lanes a card may leave.
 //
-// 1. TRIAGE. Every other move writes triage.json through setSessionTriage,
-//    which is keyed by SESSION. A task that has not run has no session id (§5)
-//    — there is nothing to triage — so it must be non-draggable rather than
-//    draggable into a call that can only fail.
+//   Upcoming    → In Progress  RUN IT NOW. Not a filing decision, an
+//                              instruction (Akshil, 2026-08-16: "if I move a
+//                              task from upcoming to in progress, don't change
+//                              the time of it, but run it and run it at that
+//                              point"). The server sends the pending message
+//                              immediately and leaves its `due` alone, so the
+//                              row keeps reading as the time it was MEANT to
+//                              run and the thread honestly shows a run that
+//                              happened early.
+//               → Archive      CANCEL. Filing a task away calls off the work
+//                              in it; a run still booked for tomorrow on a
+//                              task somebody archived would un-archive itself.
+//   In Progress → nowhere      LOCKED. In Progress is Claude's output, not a
+//                              verdict a reader hands down: a card leaves this
+//                              lane when the run ends and at no other moment.
+//   Done        → Archive      and nothing else. "Not finished after all" is
+//                              not a thing a drag can make true.
+//   Failed      → In Progress  RETRY — the same run-now call, same
+//                              precondition (something pending to fire).
+//               → Archive
+//   Archived    → nowhere      LOCKED, which is the same answer the row gives:
+//                              Unarchive is not drawn (SHOW_UNARCHIVE), and an
+//                              affordance the Board offers while the row hides
+//                              it is two answers to one question.
 //
-// 2. RUN IT NOW. Upcoming → In Progress is not a filing decision, it is an
-//    instruction (Akshil, 2026-08-16: "if I move a task from upcoming to in
-//    progress, don't change the time of it, but run it and run it at that
-//    point"). The server sends the pending message immediately and leaves its
-//    `due` alone, so the row goes on reading as the time it was MEANT to run
-//    and the thread honestly shows a run that happened early.
+// Nothing may be dropped INTO Upcoming (a task cannot be un-run), into Failed
+// (failure is something that HAPPENED, and a lane you can drag a healthy task
+// into is a lane whose count means nothing), or into Done (a run says that,
+// not a reader).
 //
-// The consequence for legality: a run-now drop needs a MESSAGE to fire, not a
-// session to file under, so a scheduled task that has never run — no session
-// id at all — may still be dragged into In Progress. And a pure-chat task,
-// which has nothing pending anywhere in it, may not: that drop is refused by
-// dropLanes before the card ever lifts, rather than by the server after it
-// lands.
-//
-// FAILED, the fifth lane, is asymmetric on purpose:
-//
-//   * nothing may be dropped INTO it. Failure is something that HAPPENED, not
-//     a verdict a person hands down, and a lane you can drag a healthy task
-//     into is a lane whose count means nothing.
-//   * out of it there are exactly two moves — In Progress re-runs the task
-//     (the same run-now path, with the same precondition: something pending to
-//     fire), and Archive files it away. Done is deliberately not offered: a run
-//     that broke did not finish, and letting it be filed as Done would put the
-//     lie back in the one place this lane exists to take it out of.
+// Legality follows from what each move NEEDS, never from what triage happens to
+// be keyed by. Run-now needs a pending MESSAGE, so a scheduled task that has
+// never run — no session id at all — may still be dragged into In Progress,
+// while a pure-chat task with nothing pending may not. Archive needs only the
+// task's key, because it is one server verb over the whole task
+// (`POST /api/tasks/archive`) rather than a triage write keyed by session — so
+// the never-run row can be filed away too, which is the case the old
+// session-keyed rule could not reach.
 
-/** The lanes a person may drop a card ON. `failed` is not among them — see
- * above — and `upcoming` never was: a task cannot be un-run. */
-export const TRIAGE_LANES: BoardColumn[] = ["in_progress", "done", "archived"];
+/** The lanes a person may drop a card ON. Two, and the second is not a
+ * synonym for the first: one starts work, the other ends it. */
+export const DROP_LANES: BoardColumn[] = ["in_progress", "archived"];
 
-/** Where a card may go once it is IN the failed lane. */
-const OUT_OF_FAILED: BoardColumn[] = ["in_progress", "archived"];
+/** The lanes a card may be dragged OUT of. The other two are Claude's:
+ * In Progress is a run in flight, and Archive is where things rest. */
+const UNLOCKED: BoardColumn[] = ["upcoming", "done", "failed"];
 
 /**
  * The next run the ROW ITSELF names, when it names one: the server's `next_run`
@@ -1599,19 +1611,13 @@ export function taskRunIntent(task: Task): TaskRunIntent | null {
 /** Which lanes this card may be dropped on. Empty ⇒ do not let it lift. */
 export function dropLanes(task: Task): BoardColumn[] {
   const here = taskColumn(task);
+  if (!UNLOCKED.includes(here)) return [];
   const lanes: BoardColumn[] = [];
-  for (const lane of TRIAGE_LANES) {
-    if (lane === here) continue;
-    if (here === "failed" && !OUT_OF_FAILED.includes(lane)) continue;
-    // The run-now lane. Its precondition is a pending message, NOT a session:
-    // see the note above. It is the same move from either side — Upcoming runs
-    // the message early, Failed runs it again — and the same call makes both.
-    if (lane === "in_progress" && (here === "upcoming" || here === "failed")) {
-      if (canRunNow(task)) lanes.push(lane);
-      continue;
-    }
-    if (task.session_id) lanes.push(lane);
-  }
+  // The run-now lane. Its precondition is a pending message, NOT a session:
+  // see the note above. It is the same move from either side — Upcoming runs
+  // the message early, Failed runs it again — and the same call makes both.
+  if (canRunNow(task)) lanes.push("in_progress");
+  lanes.push("archived");
   return lanes;
 }
 
@@ -1619,34 +1625,26 @@ export function isDraggable(task: Task): boolean {
   return dropLanes(task).length > 0;
 }
 
-/** setSessionTriage's own union — a lane that is not one of the three cannot
- * be sent, and this is what proves it to the type checker at the call site. */
-export function triageStatus(
-  lane: BoardColumn,
-): "in_progress" | "done" | "archived" | null {
-  return lane === "in_progress" || lane === "done" || lane === "archived" ? lane : null;
-}
-
 /**
  * What a drop on `lane` actually DOES — the one place the two meanings are told
  * apart, so the Board's handler holds no rule of its own beyond which call to
  * make. Null when the drop is illegal, which is the same answer dropLanes gave
  * before the card lifted: the two agree because this asks it.
+ *
+ * `archive` carries no payload. It used to be a triage status, composed here
+ * and sent to a session-keyed endpoint; it is now one verb over the whole task
+ * (`api.archiveTask`, which cancels the work and files the session in one
+ * request), and a verb with one meaning has nothing left to parameterise.
  */
 export type DropAction =
   | { kind: "run"; entryId: string; messageId: string }
-  | { kind: "triage"; status: "in_progress" | "done" | "archived" };
+  | { kind: "archive" };
 
 export function dropAction(task: Task, lane: BoardColumn): DropAction | null {
   if (!dropLanes(task).includes(lane)) return null;
-  const here = taskColumn(task);
-  if (lane === "in_progress" && (here === "upcoming" || here === "failed")) {
-    const m = runNowTarget(task);
-    return m ? { kind: "run", entryId: m.entryId, messageId: m.messageId } : null;
-  }
-  const status = triageStatus(lane);
-  if (!status || !task.session_id) return null;
-  return { kind: "triage", status };
+  if (lane === "archived") return { kind: "archive" };
+  const m = runNowTarget(task);
+  return m ? { kind: "run", entryId: m.entryId, messageId: m.messageId } : null;
 }
 
 // ---- filing it away, without the drag ----------------------------------------
@@ -1665,25 +1663,21 @@ export function dropAction(task: Task, lane: BoardColumn): DropAction | null {
 // the same shape of function, and it is defined below the one function it is
 // only a re-reading of.
 //
-// It is a TWO-WAY door on purpose. The Board's drag can already pull a card back
-// out of Archive, and an action whose only direction is away is a trap: the row
-// that offers Archive must be the row that offers the way back once it is taken.
-// Returning to In Progress rather than Done is the same choice dropLanes makes
-// for a drag out of Archive — "back in play" is a claim about attention, and
-// Done would assert something about the work that archiving never recorded.
-
-/** The two statuses this action ever sends — setSessionTriage's union, less
- * `done`, which filing away and un-filing never means. */
-export type ArchiveStatus = "archived" | "in_progress";
+// IT IS A ONE-WAY DOOR, and that is now true on both views rather than only on
+// the row. It used to compute a way back — Archive → In Progress — because an
+// action whose only direction is away is a trap; the row never drew it
+// (SHOW_UNARCHIVE) and the Board did, which is two answers to one question.
+// Archive is a LOCKED lane now (see the matrix above), so there is one answer:
+// nothing comes back out by dragging, and nothing pretends to.
+//
+// What makes that honest rather than a trap is that archiving destroys nothing.
+// The conversation is kept, the transcript is kept (D306), and the Archive lane
+// is a place to read them — the door is one-way, not a shredder.
 
 export interface ArchiveIntent {
   /** The lane this move puts the card in: the same lane the Board's drop would
    * have targeted, which is what makes the two agree by construction. */
   lane: BoardColumn;
-  /** What setSessionTriage is given. */
-  status: ArchiveStatus;
-  /** Whether this is the way BACK — i.e. the task is archived right now. */
-  restore: boolean;
   /** The button's accessible name, and the word it says. */
   label: string;
   /** The tooltip: what happens, and the thing a person deleting would fear. */
@@ -1691,29 +1685,24 @@ export interface ArchiveIntent {
 }
 
 /**
- * Whether this task can be filed away (or brought back), and what that says.
- * Null when there is nothing to triage — which is exactly the `pending:<entry>`
- * case: triage is an overlay on triage.json keyed by SESSION id, and a task
- * that has never run has no session to key. Offering a button there would be
- * offering a call that can only fail, so it is offered nowhere instead.
+ * Whether this task can be filed away, and what that says. Null exactly when
+ * the Board would refuse the same drop — a task already in Archive, and one
+ * that is mid-run — because that is the question this asks.
+ *
+ * A never-run task DOES get the button now. Archiving is one verb over a task
+ * key (`api.archiveTask`), not a triage write keyed by session id, so the
+ * `pending:<entry>` row that had no session to file is filed by cancelling its
+ * work — which is what archiving a task that has not run has always meant.
  */
 export function archiveIntent(task: Task): ArchiveIntent | null {
-  const restore = taskColumn(task) === "archived";
-  const lane: BoardColumn = restore ? "in_progress" : "archived";
+  const lane: BoardColumn = "archived";
   // The one question, asked of the one function that already answers it.
   const action = dropAction(task, lane);
-  if (!action || action.kind !== "triage") return null;
-  // Narrowing, not a re-decision: dropAction's status IS the lane it was asked
-  // about, and neither of the two lanes above is `done`.
-  if (action.status === "done") return null;
+  if (!action || action.kind !== "archive") return null;
   return {
     lane,
-    status: action.status,
-    restore,
-    label: restore ? "Unarchive" : "Archive",
-    title: restore
-      ? "Unarchive — puts this back in In Progress"
-      : "Archive — files this away; the conversation is kept",
+    label: "Archive",
+    title: "Archive — files this away and calls off any run still booked; the conversation is kept",
   };
 }
 
@@ -2381,4 +2370,106 @@ export function laneRolledUp(
 ): boolean {
   if (count === 0) return !peeked.has(lane);
   return laneCollapsed(lane, count, choices);
+}
+
+// ---- the List's own sections -------------------------------------------------
+// The List and the Board are two lenses on ONE dataset, so the List is grouped
+// by the same fact the Board is: `taskColumn`. Same nouns, same colours, same
+// ring — a reader who learns "Failed" on one view has learned it on both, and a
+// row that moves lane on the Board moves section here.
+//
+// THE ORDER IS NOT THE BOARD'S, and the difference is deliberate. A board is
+// read left to right as a pipeline (Upcoming, In Progress, Done, Failed,
+// Archive); a list is read top to bottom as a to-do, so the two sections that
+// want a person's hands come first and the two that are finished sink:
+//
+//   Upcoming → In Progress → Failed → Done → Archive
+//
+// Failed above Done because a broken run is work that is still owed, and Done
+// above Archive because Archive is not a status, it is where things go to stop
+// being read.
+//
+// EMPTY SECTIONS ARE NOT DRAWN AT ALL — no header, no zero. The Board's lanes
+// are a fixed frame and an empty column there is information (nothing is
+// failing); a list has no frame, and five headers over three rows is a table of
+// contents for a page with nothing on it.
+//
+// WITHIN a section nothing is re-sorted: the server's order is the list's order
+// and always has been (TaskList takes `tasks` "in the SERVER's order. Never
+// re-sorted here"). Bucketing preserves it.
+
+/** Section order, top to bottom. Every BoardColumn appears exactly once — the
+ * test holds it to that, so a sixth lane cannot be silently unlistable. */
+export const LIST_SECTIONS: BoardColumn[] = [
+  "upcoming",
+  "in_progress",
+  "failed",
+  "done",
+  "archived",
+];
+
+export interface TaskSection {
+  key: BoardColumn;
+  /** The Board's own word for this lane (schedule-lib.columnLabel) — never a
+   * second spelling of it. */
+  label: string;
+  /** Non-empty, always: an empty section is absent rather than headed. */
+  tasks: Task[];
+}
+
+export function listSections(tasks: Task[]): TaskSection[] {
+  const buckets = new Map<BoardColumn, Task[]>(
+    LIST_SECTIONS.map((key) => [key, [] as Task[]]),
+  );
+  for (const task of tasks) buckets.get(taskColumn(task))?.push(task);
+  const sections: TaskSection[] = [];
+  for (const key of LIST_SECTIONS) {
+    const held = buckets.get(key) ?? [];
+    if (held.length === 0) continue;
+    sections.push({ key, label: columnLabel(key), tasks: held });
+  }
+  return sections;
+}
+
+// ---- "and it runs again on Tuesday" ------------------------------------------
+// A recurring task whose last run finished sits in DONE now, not Upcoming: the
+// output nobody has read is the thing that needs eyes, and a promise is not a
+// verdict (server routers/tasks.py `_message_verdict`). That is the right lane
+// and it drops one true fact off the row — that the task is not over.
+//
+// So the row says it. A CHIP, not a second time column: `taskWhen` already owns
+// the row's one time and, on a settled task, that time is the last run. This is
+// the other one, marked as such, in the same vocabulary (relativeWhen) with the
+// absolute instant in the tooltip like every other time on the page.
+
+export interface NextRunChip {
+  /** Epoch seconds, so a caller can order or test by it. */
+  at: number;
+  /** What the chip prints: "next in 2h". */
+  text: string;
+  /** The tooltip: which run, and exactly when. */
+  title: string;
+}
+
+/**
+ * The next run worth mentioning ON TOP of the row's own time, or null.
+ *
+ * Two conditions, and both are about not saying the same thing twice:
+ *
+ *   * the row's time is NOT already the next run (`taskWhen`, which reads
+ *     LANE_SORTS: Upcoming's rows are ordered and stamped by the run ahead, so
+ *     a chip there would repeat the number beside it);
+ *   * there IS a run ahead — `nextRunAt`, strictly in the future. A pending
+ *     message whose time has passed is not news about what happens next, it is
+ *     the overdue work the Upcoming lane already surfaces.
+ */
+export function nextRunChip(task: Task, now: number = Date.now()): NextRunChip | null {
+  if (taskWhen(task, now).kind === "next") return null;
+  const at = nextRunAt(task);
+  if (at === null || at * 1000 <= now) return null;
+  return {
+    at,
+    text: `next ${relativeWhen(at, now)}`,
+    title: `Next run ${messageStamp(at)}`,
+  };
 }

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2473,3 +2473,38 @@ export function nextRunChip(task: Task, now: number = Date.now()): NextRunChip |
     title: `Next run ${messageStamp(at)}`,
   };
 }
+
+// ---- what is happening RIGHT NOW ---------------------------------------------
+// The List has the In Progress section and the Board has the In Progress lane;
+// the calendar has neither, because a calendar is ordered by time and not by
+// state. Its chips sat in the grid saying nothing about which of them was
+// running at that moment — the one fact a person glancing at today most wants.
+//
+// So the chip gets the fact, and the RULE lives here rather than in the view:
+// it is the same reading of `state` and `turn` the server's `_message_running`
+// makes, and the same one messageTone collapses into `in_progress`. Three views
+// asking three questions about "is this going?" is how they start disagreeing.
+
+/** Is this message's own run in flight? `sending` is a send the scheduler has
+ * spawned and not heard back from; `sent` with a turn that has not reported an
+ * end is a turn still working (turnPhase — `unknown` is NOT running, it is a
+ * watcher that stopped being able to tell). */
+export function isMessageRunning(m: TaskMessage): boolean {
+  if (m.state === "sending") return true;
+  return m.state === "sent" && turnPhase(m.turn) === "running";
+}
+
+/**
+ * Is THIS message the work this task is doing right now?
+ *
+ * Two ways, and the second is what a live chat turn needs. A message can say so
+ * itself (above), and a LIVE session says it about its newest message — the
+ * transcript is mid-turn, and the newest prompt is the one that turn is
+ * answering. Older messages in a live session are not running: their turns
+ * ended when the next prompt arrived.
+ */
+export function isRunningNow(task: Task, m: TaskMessage): boolean {
+  if (isMessageRunning(m)) return true;
+  const newest = task.messages?.[0];
+  return !!task.live && !!newest && !!m.message_id && m.message_id === newest.message_id;
+}

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -336,9 +336,13 @@ export function threadTone(task: Task, m: TaskMessage): MessageTone {
 /** Is any message in this thread mid-turn? The client's half of the running
  * exception above — `Task.live` is the server's, computed from the transcript's
  * own tail, and the two are asked in different places rather than merged: this
- * one is about the rows on screen, that one about the row's status. */
+ * one is about the rows on screen, that one about the row's status.
+ *
+ * The per-message reading is `isMessageRunning` (bottom of this file), the same
+ * function the calendar's chip asks, so "running" is one rule here and not
+ * three views' worth of `=== "in_progress"`. */
 export function threadRunning(messages: TaskMessage[]): boolean {
-  return messages.some((m) => messageTone(m).column === "in_progress");
+  return messages.some(isMessageRunning);
 }
 
 /**
@@ -1281,10 +1285,15 @@ export function messageEditEntry(m: TaskMessage): string | null {
 //   Failed      → In Progress  RETRY — the same run-now call, same
 //                              precondition (something pending to fire).
 //               → Archive
-//   Archived    → nowhere      LOCKED, which is the same answer the row gives:
-//                              Unarchive is not drawn (SHOW_UNARCHIVE), and an
-//                              affordance the Board offers while the row hides
-//                              it is two answers to one question.
+//   Archived    → nowhere      LOCKED — and the way back is not a gesture at
+//                              all, it is ACTIVITY (Akshil, 2026-08-18: "if you
+//                              want to move it to in progress or done, just
+//                              type in a message inside that chat and it will
+//                              automatically move"). A message that arrives
+//                              after the filing drops the filing outright,
+//                              server-side, and the task rejoins whichever lane
+//                              it derives into. So there is no unarchive
+//                              control anywhere, on either view.
 //
 // Nothing may be dropped INTO Upcoming (a task cannot be un-run), into Failed
 // (failure is something that HAPPENED, and a lane you can drag a healthy task
@@ -1663,16 +1672,21 @@ export function dropAction(task: Task, lane: BoardColumn): DropAction | null {
 // the same shape of function, and it is defined below the one function it is
 // only a re-reading of.
 //
-// IT IS A ONE-WAY DOOR, and that is now true on both views rather than only on
-// the row. It used to compute a way back — Archive → In Progress — because an
-// action whose only direction is away is a trap; the row never drew it
-// (SHOW_UNARCHIVE) and the Board did, which is two answers to one question.
-// Archive is a LOCKED lane now (see the matrix above), so there is one answer:
-// nothing comes back out by dragging, and nothing pretends to.
+// THERE IS NO UNARCHIVE CONTROL, on either view. It used to compute a way back
+// — Archive → In Progress — because an action whose only direction is away is a
+// trap; the row never drew it (SHOW_UNARCHIVE) and the Board did, which is two
+// answers to one question. Archive is a LOCKED lane now (see the matrix above),
+// so there is one answer.
 //
-// What makes that honest rather than a trap is that archiving destroys nothing.
-// The conversation is kept, the transcript is kept (D306), and the Archive lane
-// is a place to read them — the door is one-way, not a shredder.
+// And the way back is not missing, it is somewhere better: ACTIVITY. Say
+// something in that conversation and the task comes back on its own — the
+// server drops the filing when a message arrives after it, so the card rejoins
+// the lane its thread puts it in rather than a lane a button guessed at. A
+// gesture would have had to guess: "back in play" says nothing about whether
+// the work is done.
+//
+// Nothing is destroyed either way. The conversation is kept, the transcript is
+// kept (D306), and Archive is a place to read them.
 
 export interface ArchiveIntent {
   /** The lane this move puts the card in: the same lane the Board's drop would
@@ -1702,7 +1716,11 @@ export function archiveIntent(task: Task): ArchiveIntent | null {
   return {
     lane,
     label: "Archive",
-    title: "Archive — files this away and calls off any run still booked; the conversation is kept",
+    // Three clauses because a person reaching for Delete is asking all three:
+    // where does it go, what happens to work already booked, and can I get it
+    // back. The last one is the honest answer to a lane with no way out of it.
+    title:
+      "Archive — files this away and calls off any run still booked; the conversation is kept, and a new message in it brings the task back",
   };
 }
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2548,14 +2548,23 @@ export function isMessageRunning(m: TaskMessage): boolean {
 /**
  * Is THIS message the work this task is doing right now?
  *
- * Two ways, and the second is what a live chat turn needs. A message can say so
- * itself (above), and a LIVE session says it about its newest message — the
- * transcript is mid-turn, and the newest prompt is the one that turn is
- * answering. Older messages in a live session are not running: their turns
- * ended when the next prompt arrived.
+ * Two ways, and the second is what a live chat turn needs — including the one
+ * a live TRANSCRIPT cannot see. A message can say so itself (above), and
+ * otherwise the newest message borrows the task's own verdict: `taskColumn`
+ * reads `task.status`, which the server derives in `_status` from THREE
+ * independent signals (`_message_running`, `live`, and `schedule.busy_sessions`)
+ * — not just the two (`state`/`turn`, `task.live`) this function could see on
+ * its own. A `sent` message whose turn the server has already rewritten to
+ * `idle` still files the task `in_progress` while a scheduled send is in
+ * flight (`busy_sessions`); asking `taskColumn` instead of re-deriving that
+ * third signal here is what keeps the calendar chip agreeing with the List
+ * and Board, which read the same `task.status`. Older messages in an
+ * in-progress task are not running: their turns ended when the next prompt
+ * arrived.
  */
 export function isRunningNow(task: Task, m: TaskMessage): boolean {
   if (isMessageRunning(m)) return true;
+  if (taskColumn(task) !== "in_progress") return false;
   const newest = task.messages?.[0];
-  return !!task.live && !!newest && !!m.message_id && m.message_id === newest.message_id;
+  return !!newest && !!m.message_id && m.message_id === newest.message_id;
 }

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -1206,29 +1206,15 @@
 
 /* -- The one status vocabulary on a pill ----------------------------------------
    Upcoming / In Progress / Done / Failed / Archive — the app's five words, worn
-   by the calendar popover's header. Only work HAPPENING and work that BROKE take
-   a colour; the rest stay quiet, because a popover that opens with a coloured
-   badge on every task says nothing. */
-.schedule-state--upcoming,
-.schedule-state--done,
-.schedule-state--archived {
-  color: var(--fg-muted);
-}
+   by the calendar popover's header.
 
-.schedule-state--in_progress {
-  color: var(--accent-soft);
-  border-color: var(--accent);
-}
-
-/* Failure is a WORD now, not a red ring inside Done (Akshil, 2026-08-17): "if we
-   can't show failed tasks, then let's have a failed status, and show it
-   everywhere". The red stays as reinforcement — the same token
-   `.schedule-ring--failed` uses — but it is no longer the only thing carrying
-   the fact. */
-.schedule-state--failed {
-  color: var(--error);
-  border-color: currentColor;
-}
+   Their HUES are at the end of this file, with the rule that gives each of the
+   five its own tint. They used to be here, and only two of them existed: In
+   Progress borrowed the accent and Failed the error red, on the argument that a
+   badge on every task says nothing. It said too little instead — Done, Archive
+   and Upcoming were one grey badge between them, while the RING two lines under
+   the pill had already been painting all five for a round. One vocabulary means
+   one palette as well as one word. */
 
 /* A projected run keeps its word too ("Upcoming"), and the dashes are what say
    nothing has been written down yet — the pill of a ghost chip. */
@@ -3499,4 +3485,142 @@ input.schedule-when-field {
 .prefs-section .schedule-tv-pop-item:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
+}
+
+/* -- The popover's writing block ------------------------------------------------
+   Title over description, one block, the same shape the New task modal asks for
+   them in (new-task.css `.new-task-write`). They are the two things the user
+   WROTE, and playing them back as a heading and an icon-led fact row made one
+   pair look like two kinds of thing.
+
+   The title gains its step of size here rather than in `.schedule-pop-title`'s
+   own rule so that rule keeps meaning "the popover's headline, clamped" — this
+   is the hierarchy, and it is the whole reason the block exists: at 14px over a
+   12px fact list the title was the same size as the metadata under it. */
+.schedule-pop-write {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.schedule-pop-write .schedule-pop-title {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+/* The description: smaller, muted, NO glyph. It is prose to be read, not a
+   value to be recognised, so it does not belong in the icon column — and
+   without an icon it needs no indent either. Clamped like the title, because a
+   long description must not push the thread and the actions out of a panel
+   whose height is capped at 70vh. */
+.schedule-pop-desc {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--fg-muted);
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* -- The status pill's own hue --------------------------------------------------
+   The five words wear the five status colours — the SAME tokens the ring wears
+   (`--status-done`, `--status-failed`, …), so the pill and the ring beside it
+   cannot disagree about what green means. Until now only In Progress and Failed
+   were coloured and the rest were grey, which made "Done" and "Archive" the same
+   badge and left the pill saying less than the ring two lines under it.
+
+   A TINT, never a fill. The pill is text first: `color-mix` puts the hue behind
+   the word at a weight that survives both themes and leaves the label at the
+   hue's own full strength on top, which is what keeps it readable — a
+   fully-saturated pill would need a second text colour per status per theme.
+
+   Upcoming keeps the neutral it already had: `--status-upcoming` IS `--fg-muted`
+   (tokens.css), so its tint is a grey wash and the lane that means "nothing has
+   happened yet" stays the quiet one. */
+.schedule-state--upcoming,
+.schedule-state--in_progress,
+.schedule-state--done,
+.schedule-state--failed,
+.schedule-state--archived {
+  color: var(--pill);
+  background: color-mix(in srgb, var(--pill) 14%, var(--bg));
+  border-color: color-mix(in srgb, var(--pill) 34%, transparent);
+}
+
+.schedule-state--upcoming {
+  --pill: var(--status-upcoming);
+}
+
+.schedule-state--in_progress {
+  --pill: var(--status-progress);
+}
+
+.schedule-state--done {
+  --pill: var(--status-done);
+}
+
+.schedule-state--failed {
+  --pill: var(--status-failed);
+}
+
+.schedule-state--archived {
+  --pill: var(--status-archived);
+}
+
+/* -- A chip that is running RIGHT NOW -------------------------------------------
+   The List has an In Progress section and the Board an In Progress lane. A
+   calendar is ordered by time, so it has neither — and the one chip on today's
+   grid that is actually working looked exactly like the ones that finished
+   hours ago.
+
+   A SHIMMER, not a colour. Every other cue on a chip is already spent: the fill
+   is the PROJECT (eight hues, --task-c0…7), the dashes are "projected", the
+   fade is "past". There is no static property left that would not collide with
+   one of those — and motion is the honest signal anyway, because "running" is
+   the only thing a chip says that is true only for as long as you are looking
+   at it. A sweep is what a thing in progress looks like.
+
+   It rides in a PSEUDO-ELEMENT over the chip's own background rather than
+   animating that background, so the project hue underneath is untouched and the
+   text keeps its contrast: the sweep is a low-alpha highlight passing across,
+   the way a loading skeleton reads, at 2s — slow enough to be ambient and never
+   the fastest thing on a page that may hold several.
+
+   `pointer-events: none` because the chip is a button and the sweep must not
+   eat its clicks; `overflow: hidden` is already on the chip, so the highlight
+   is clipped to the rounded box. */
+.schedule-cal .schedule-cal-chip.is-running::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(
+    100deg,
+    transparent 20%,
+    color-mix(in srgb, var(--fg) 22%, transparent) 50%,
+    transparent 80%
+  );
+  background-size: 220% 100%;
+  animation: schedule-cal-shimmer 2s linear infinite;
+}
+
+@keyframes schedule-cal-shimmer {
+  from { background-position: 160% 0; }
+  to { background-position: -60% 0; }
+}
+
+/* A person who has asked for less motion still has to be able to see which run
+   is going, so the fallback is not "nothing" — it is the same highlight, held
+   still. A static wash over the project hue, plus the left bar at full strength,
+   which together read as "this one is lit" without moving. */
+@media (prefers-reduced-motion: reduce) {
+  .schedule-cal .schedule-cal-chip.is-running::after {
+    animation: none;
+    background: color-mix(in srgb, var(--fg) 10%, transparent);
+  }
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -601,17 +601,15 @@ button.tasks-caret,
   border-color: var(--border);
 }
 
-/* Archive / Unarchive. Same group, same size, same silence at rest as Edit,
-   Cancel and Run now — and deliberately NEUTRAL under the pointer, not red.
+/* Archive. Same group, same size, same silence at rest as Edit, Cancel and Run
+   now — and deliberately NEUTRAL under the pointer, not red.
    Filing a task away destroys nothing (a task IS a Claude session and the
    transcript is kept, D306), so borrowing Cancel's red would tell the reader
    this is the destructive one, which is the exact misunderstanding archiving
    exists to correct. The plain `.tasks-act` hover skin already says "this is a
    control"; that is all this one needs to say. */
 .tasks-act--archive:hover:not(:disabled),
-.tasks-act--unarchive:hover:not(:disabled),
-.prefs-section .tasks-act--archive:hover:not(:disabled),
-.prefs-section .tasks-act--unarchive:hover:not(:disabled) {
+.prefs-section .tasks-act--archive:hover:not(:disabled) {
   color: var(--fg);
   background: var(--bg-alt);
   border-color: var(--border);
@@ -1036,4 +1034,64 @@ button.tasks-caret,
 .prefs-section .tasks-retry:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
+}
+
+/* ---- the List's section headers --------------------------------------------
+   The Board's lane header, flattened onto a list. Same ring, same word, same
+   uppercase register, same muted colour and the same count on the right — it IS
+   `.schedule-tv-lane-head` without the parts that only a column needs (the
+   press that collapses it, the hover ground, the full-width slab), because the
+   two views are two lenses on one dataset and a second spelling of "Failed" is
+   how they start drifting apart.
+
+   NOT A BUTTON and not sticky. A row in this list is already an accordion, so a
+   second collapsible thing on the same axis is two disclosure models in one
+   column; and a sticky header over rows that change height on every disclosure
+   fights the scroll memory the list keeps (see TaskList's `owed`).
+
+   The space above it is what does the grouping work — a header is a gap with a
+   word in it — and there is none above the FIRST one, which needs no separation
+   from a page edge. */
+.tasks-section {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 2px;
+  margin-top: 18px;
+}
+
+.tasks-section:first-child {
+  margin-top: 0;
+}
+
+.tasks-section-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+
+.tasks-section-count {
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--fg-muted);
+}
+
+/* ---- "and it runs again on Tuesday" ----------------------------------------
+   The run still to come, on a row whose own time is the run that already
+   happened (tasks-lib.nextRunChip) — a recurring task in Done, which is where a
+   finished run with unread output belongs.
+
+   Quieter than the time beside it and marked as a different kind of thing: it
+   is prefixed with the word "next" rather than aligned into the time column, so
+   two times on one row cannot be misread as one time in two places. Same size,
+   same tabular figures, so the pair still reads as one register. */
+.tasks-row-next {
+  flex: 0 0 auto;
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+  opacity: 0.85;
 }

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -1036,48 +1036,6 @@ button.tasks-caret,
   outline-offset: -2px;
 }
 
-/* ---- the List's section headers --------------------------------------------
-   The Board's lane header, flattened onto a list. Same ring, same word, same
-   uppercase register, same muted colour and the same count on the right — it IS
-   `.schedule-tv-lane-head` without the parts that only a column needs (the
-   press that collapses it, the hover ground, the full-width slab), because the
-   two views are two lenses on one dataset and a second spelling of "Failed" is
-   how they start drifting apart.
-
-   NOT A BUTTON and not sticky. A row in this list is already an accordion, so a
-   second collapsible thing on the same axis is two disclosure models in one
-   column; and a sticky header over rows that change height on every disclosure
-   fights the scroll memory the list keeps (see TaskList's `owed`).
-
-   The space above it is what does the grouping work — a header is a gap with a
-   word in it — and there is none above the FIRST one, which needs no separation
-   from a page edge. */
-.tasks-section {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 2px;
-  margin-top: 18px;
-}
-
-.tasks-section:first-child {
-  margin-top: 0;
-}
-
-.tasks-section-label {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--fg-muted);
-}
-
-.tasks-section-count {
-  font-size: 11px;
-  font-variant-numeric: tabular-nums;
-  color: var(--fg-muted);
-}
-
 /* ---- "and it runs again on Tuesday" ----------------------------------------
    The run still to come, on a row whose own time is the run that already
    happened (tasks-lib.nextRunChip) — a recurring task in Done, which is where a

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -404,7 +404,17 @@ def api_claude_session_triage(patch: TriagePatch):
         raise HTTPException(status_code=400, detail="missing session id")
     if patch.status not in ("in_progress", "done", "archived"):
         raise HTTPException(status_code=400, detail=f"unknown status {patch.status!r}")
+    write_triage(session_id, patch.status)
+    return {"ok": True, "session_id": session_id, "status": patch.status}
 
+
+def write_triage(session_id: str, status: str) -> None:
+    """The write itself, without the HTTP around it — so a second router can
+    file a session away without going back out through its own server. The
+    Tasks router's archive verb is the caller: archiving a TASK is one gesture
+    that both cancels its scheduled work and files its session, and both halves
+    have to be the same write the Inbox makes or the two views would keep two
+    different truths about the same session."""
     os.makedirs(STATE_DIR, exist_ok=True)
     triage_path = os.path.join(STATE_DIR, "triage.json")
     lock_path = triage_path + ".lock"
@@ -415,9 +425,8 @@ def api_claude_session_triage(patch: TriagePatch):
         rec = triage.get(session_id)
         if not isinstance(rec, dict):
             rec = {}
-        rec["status"] = patch.status
+        rec["status"] = status
         rec["at"] = str(datetime.now(timezone.utc).timestamp())
         triage[session_id] = rec
         with open(triage_path, "w", encoding="utf-8") as f:
             json.dump(triage, f, indent=2, ensure_ascii=False)
-    return {"ok": True, "session_id": session_id, "status": patch.status}

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -430,3 +430,35 @@ def write_triage(session_id: str, status: str) -> None:
         triage[session_id] = rec
         with open(triage_path, "w", encoding="utf-8") as f:
             json.dump(triage, f, indent=2, ensure_ascii=False)
+
+
+def clear_triage(session_id: str) -> bool:
+    """Take the filing back — drop `status` (and its stamp) from one session's
+    record, keeping everything else in it. True when there was one to drop.
+
+    The Tasks router calls this when a task that was archived DOES SOMETHING
+    NEW: the way out of Archive is activity, not a gesture (there is no
+    unarchive control anywhere), so a message typed into an archived
+    conversation has to actually un-file it rather than be shown out of its lane
+    for one poll. See `_revived` there for which activity counts and why a run
+    that was already in flight when the filing happened does not.
+
+    The record itself is NOT deleted — a note, a tag or a read mark on that
+    session is somebody else's data and outlives the status the Board put on it.
+    Same file, same lock, same merge semantics as the write above."""
+    os.makedirs(STATE_DIR, exist_ok=True)
+    triage_path = os.path.join(STATE_DIR, "triage.json")
+    lock_path = triage_path + ".lock"
+    with open(lock_path, "w") as lock:
+        if fcntl is not None:
+            fcntl.flock(lock, fcntl.LOCK_EX)
+        triage = _load_state("triage.json")
+        rec = triage.get(session_id)
+        if not isinstance(rec, dict) or "status" not in rec:
+            return False
+        rec.pop("status", None)
+        rec.pop("at", None)
+        triage[session_id] = rec
+        with open(triage_path, "w", encoding="utf-8") as f:
+            json.dump(triage, f, indent=2, ensure_ascii=False)
+    return True

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -26,6 +26,9 @@ this file is written around:
   wrong for a time axis, and one field cannot mean both.
 * ``POST /api/tasks/read`` — mark one message read, or (``all: true``) every
   message in one task, in one request and one store write.
+* ``POST /api/tasks/archive`` — file one task away. ONE gesture with two halves
+  (cancel the work, archive the session), which is why it is a verb here rather
+  than a triage write the client composes. See the archiving section at the end.
 
 **What a message is.** A user prompt in the transcript, or a scheduled entry.
 Those two overlap: a scheduled message that fired IS a prompt in the transcript
@@ -93,7 +96,18 @@ router = APIRouter()
 # view that did not simply lost the news. One decision, made once, on the
 # server.
 STATUSES = ("upcoming", "in_progress", "done", "failed", "archived")
-_TRIAGE_STATUSES = ("in_progress", "done", "archived")
+
+# The ONE triage word this router still reads. `archived` is a FILING state —
+# the user put the task away — and filing is the only decision about a task that
+# is the user's to make. `in_progress` and `done` were read here too and are
+# not any more: a task's status is now derived from what its messages did (see
+# `_status`), and In Progress in particular is Claude's output rather than a
+# lane a person may drop a card into. A recorded `in_progress` (the sessions
+# Inbox's `autoFlow` writes one for every session it sees running, and cannot
+# take it back once its page closes) is therefore ignored rather than reaped —
+# which is the same outcome the reaping machinery was built to reach, without
+# the machinery.
+_FILED = "archived"
 
 # How many messages a listing row carries. The accordion shows three and offers
 # "Show more"; the fourth costs another row of tail to keep in memory for every
@@ -494,195 +508,175 @@ def _turn_of_newest_chat(messages: list[dict], live: bool) -> None:
 # --------------------------------------------------------------- the statuses
 
 
-def _board_column(message: dict | None) -> str:
-    """A task's status from its newest message, mapped state for state.
+def _message_running(message: dict) -> bool:
+    """Is THIS message's run happening right now?
 
-    Two mappings are worth naming because they look alike and are not:
+    Two shapes and no third. `sending` is the scheduler holding a send it has
+    spawned and not heard back from; `sent` with a turn that has not reported an
+    end is a turn in flight. `_entry_turn` writes "" for exactly that case (and
+    `_turn_of_newest_chat` writes "" over the newest typed prompt while the
+    transcript is live), which is why the empty string is the running answer
+    here rather than an absence to be defaulted away.
 
-    * **`error` is `failed`**, its own column. A run that started and broke is
-      news, and filing it under `done` meant every view had to remember to read
-      the `failed` flag separately to say so.
-    * **`cancelled` and `skipped` are `archived`**, NOT failed. A skipped
-      occurrence was filed away and never attempted — the coalescer dropped it,
-      or the user did — which is a different thing from a run that tried and
-      broke.
-
-    `missed` stays `done`, unchanged and deliberately not touched here. It is
-    only reachable at all on an install that set FUSED_RENDER_SCHEDULE_MAX_LATE
-    (a missed OCCURRENCE reads as `skipped` and archives above), and by the
-    reasoning that archives a skip it arguably belongs there too — but that is a
-    separate decision from this one and nobody has made it.
+    `unknown` is deliberately NOT running: the watcher said it stopped being
+    able to tell, and reporting that as work in progress is the frozen
+    progress-bar lie.
     """
-    if message is None:
-        return "done"  # a task with nothing in it happened and is over
     state = message["state"]
-    if state in ("cancelled", "skipped"):
-        return "archived"
     if state == "sending":
-        return "in_progress"
+        return True
+    return state == "sent" and message["turn"] in ("", "running")
+
+
+def _message_archived(message: dict, filed: bool) -> bool:
+    """Is this message filed away — out of the conversation the task is having?
+
+    TWO ways in, and the second is the cascade:
+
+    * the message's own state says so. `cancelled` and `skipped` are the two —
+      a run the user called off, and an occurrence that never happened. Neither
+      is an outcome anybody is waiting to read.
+    * the TASK is archived, and archiving a task archives what is in it. The one
+      exception is a message that is still RUNNING: a run cannot be filed away
+      while it is happening, so it keeps going, the task keeps reading In
+      Progress (`_status` asks about running first), and the whole task falls
+      into Archive by itself the moment the run ends. Nothing has to remember to
+      finish the job later — the derivation simply answers differently once the
+      last message stops running.
+    """
+    if message["state"] in ("cancelled", "skipped"):
+        return True
+    return filed and not _message_running(message)
+
+
+def _message_verdict(message: dict) -> str | None:
+    """What this message has to SAY about how it went — or None when it has
+    nothing to say yet.
+
+    None is the interesting answer and it is what makes a recurring task read
+    correctly. A `pending` message is a promise, not a report: a task whose last
+    run finished and whose next occurrence is already on the books has unread
+    OUTPUT sitting in it, and filing it under Upcoming because the newest row in
+    the thread happens to be in the future hides exactly the thing the person
+    has to look at. So a pending message says nothing and the run before it
+    speaks (`_status`).
+
+    `missed` stays `done`, unchanged: it is only reachable at all on an install
+    that set FUSED_RENDER_SCHEDULE_MAX_LATE (a missed OCCURRENCE reads as
+    `skipped`), the row already paints it red off the `failed` flag, and
+    promoting it to the Failed lane is a separate decision nobody has made.
+    """
+    state = message["state"]
     if state == "error":
         return "failed"
-    if state in ("sent", "missed"):
+    if state == "sent":
+        return "failed" if message["turn"] == "unknown" else "done"
+    if state == "missed":
         return "done"
-    return "upcoming"
+    return None
 
 
-def _pin_at(record: dict) -> float:
-    """When an `in_progress` pin was placed, or 0.0 for one that does not say.
+def _speaker(messages: list[dict], filed: bool) -> dict | None:
+    """The message a task's status is reading off: the most recent one that is
+    neither filed away nor still waiting to happen.
 
-    0.0 is the answer for every pin the Inbox's `autoFlow` wrote — it sends
-    `{status}` and nothing else — and for every pin written before the stamp
-    existed. Both are exactly the pins that have to be reapable, so the absence
-    reads as "older than anything that has happened", which is what 0.0 is.
-
-    Stored as a string because that is the shape of the record: `set_triage.py`
-    coerces every field it writes with `str(value).strip()`, so `read` is "1"
-    and not 1. Parsed defensively for the same reason — a hand-edited file must
-    cost a pin, not the page."""
-    try:
-        return float(record.get("at") or 0.0)
-    except (TypeError, ValueError):
-        return 0.0
-
-
-def _pin_holds(record: dict, session_id: str, live: bool, busy: set[str],
-               active: float) -> bool:
-    """Is a recorded `in_progress` still describing something?
-
-    This is the one triage word that is a CLAIM ABOUT THE PRESENT. `done` and
-    `archived` are filing decisions and are timeless — they stay true however
-    long the card sits in the lane — so they are never asked this question and
-    never reaped. "Something is running in this conversation" is falsifiable,
-    and nothing was falsifying it.
-
-    Why it had to be: the sessions Inbox's `autoFlow` writes `in_progress` for
-    every session it sees running, and only writes it back to `done` if THAT
-    SAME PAGE is still open to witness the stop — it gates on an in-memory
-    `RUNNING` set that is empty on every load. So every run whose finish no
-    Inbox tab watched leaves a pin on disk that outlives it forever, and
-    `_status` honoured them unconditionally as "the user's own act". The board
-    held five cards in In Progress for days over runs that had recorded `done`
-    hours or a day earlier. The Inbox's own `_summarize` names this exact
-    failure ("a session that finished while nothing was watching shouldn't sit
-    in in_progress forever") and then only guards the untriaged default, which
-    is the half that was never the problem.
-
-    THREE independent reasons to hold, and a pin needs only one. They are
-    independent on purpose, because each one is wrong on its own in a different
-    direction:
-
-    * **`live`** — the shared liveness rule says the transcript is mid-turn.
-      Not sufficient alone: a turn thinking through a long tool call appends
-      nothing for minutes and reads as not-live while genuinely running.
-    * **`busy`** — `schedule.busy_sessions`, the scheduler's own record of a
-      send it has not heard back from (`sending`, or `sent` with no verdict).
-      This is what covers the liveness gap above for a scheduled run, and it is
-      the scheduler's answer rather than a second one of ours. Not sufficient
-      alone either: a session a human is typing into has no entry at all.
-    * **a stamp later than the session's last activity** — a deliberate pin
-      that no run has contradicted. This is what keeps the reopen drag (a
-      `done` card dropped back on In Progress, which `dropLanes` offers) from
-      being undone on the next 20s poll. `active` is therefore what HAPPENED
-      and only that: a due time in the future is later than any stamp a user
-      can make, so admitting one here inverts this guard for exactly the tasks
-      that have work coming. `_row` keeps the two apart.
-
-    A turn is therefore only reaped when the session is quiet, the scheduler is
-    waiting on nothing in it, and the pin predates the last thing that happened
-    — three ways of being over, all at once. What is NOT relied on is the
-    rendered message's `turn`: `_entry_turn` folds liveness into that field and
-    has no word for "sent, no verdict, not live" (it says `idle`), so reading it
-    would have collapsed the second guard into the first.
+    "Most recent" is position in the thread, which `_merge` has already ordered
+    by time. Skipping the archived ones is what makes filing a message a real
+    gesture: cancel the newest message and the one before it speaks again.
     """
-    if _running_now(session_id, live, busy):
-        return True
-    return _pin_at(record) > active
+    for message in reversed(messages):
+        if _message_archived(message, filed):
+            continue
+        if _message_verdict(message) is not None:
+            return message
+    return None
+
+
+def _filed(session_id: str, triage: dict) -> bool:
+    """Has the user put this task away? The only triage word still read here —
+    see `_FILED`."""
+    record = triage.get(session_id) if session_id else None
+    return isinstance(record, dict) and record.get("status") == _FILED
 
 
 def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
-    """Is something happening in this conversation RIGHT NOW?
+    """Is something happening in this conversation RIGHT NOW, whatever its
+    messages say?
 
-    The two independent halves `_pin_holds` already relies on, minus the third
-    (a pin's own timestamp), because that one is a claim someone made rather
-    than something that is happening: `live` is the transcript mid-turn, `busy`
-    is the scheduler waiting on a send it has not heard back from. Either is
-    enough, and neither is sufficient alone — a turn thinking through a long
-    tool call appends nothing and reads as not-live, and a session a human is
-    typing into has no scheduler entry at all.
+    Two independent halves, either of which is enough and neither of which is
+    sufficient alone: `live` is the transcript mid-turn, `busy` is the scheduler
+    waiting on a send it has not heard back from. A turn thinking through a long
+    tool call appends nothing and reads as not-live; a session a human is typing
+    into has no scheduler entry at all.
 
-    Its own function rather than an inline `or` so the archive exception in
-    `_status` and the pin guard cannot drift apart about what "running" means.
+    Its own function so `_status`'s first rule and anything else that has to ask
+    cannot drift apart about what "running" means. The third way — a message of
+    this task's own that is in flight — is `_message_running`, and `_status`
+    asks both.
     """
-    return live or session_id in busy
+    return live or (bool(session_id) and session_id in busy)
 
 
-def _status(newest: dict | None, session_id: str, triage: dict, live: bool,
-            busy: set[str], active: float) -> str:
+def _status(messages: list[dict], session_id: str, triage: dict, live: bool,
+            busy: set[str]) -> str:
     """The status a task sits in — ONE decision, made here, for every view.
 
-    Derived from the newest message, then overridden by an explicit triage
-    record. Triage wins on disagreement because it is the user's own act: they
-    dragged the card, and a derivation that undid that on the next poll would
-    make the board unusable. Only a RECORDED status overrides — the default
-    claude_sessions applies to an untriaged session (running -> in_progress) is
-    a derivation too, and a weaker one than the message's own state. Triage has
-    only three words, so a user cannot file a task as `failed`; that is a fact
-    about the run, not a place to put it.
+    Derived from the MESSAGES, in this order, and the order is the whole model:
 
-    The one exception to triage winning is a stale `in_progress` — a pin whose
-    run has ended, which is not the user's act at all but a claim the Inbox
-    wrote automatically and had no way to take back. See `_pin_holds`.
+    1. **Anything running ⇒ In Progress.** Activity beats recency: a task whose
+       newest message is next Tuesday's occurrence, with a run still going in
+       it, is a task that is working. Three things say a run is happening and a
+       task needs only one — a message of its own that is in flight
+       (`_message_running`), a transcript that is live, and `schedule.busy_sessions`,
+       the scheduler's record of a send it has not heard back from. They are
+       independent because each is wrong on its own in a different direction: a
+       turn thinking through a long tool call appends nothing for minutes and
+       reads as not-live, and a session a human is typing into has no busy entry
+       at all.
+    2. **Archived is a filing state.** The task the user put away is archived,
+       and so is a task whose every message ended up filed (cancelling the last
+       live message in a thread archives the task, without anybody having to say
+       so twice). Step 1 is above this on purpose: a run in flight when the task
+       was filed keeps running and the card reads In Progress until it stops.
+    3. **Otherwise the newest message that has something to say speaks** —
+       `failed` for a run that broke, `done` for one that ended. See `_speaker`.
+    4. **Nothing to say ⇒ Upcoming.** Never run, or nothing but promises: the
+       lane means "no output yet" and nothing else.
 
-    `failed` is decided here rather than left to the `failed` boolean beside it
-    because a broken run is not a kind of `done`, and a status every view reads
-    is the only way to be sure every view says so. It covers both halves of
-    `_failed`: a message whose state is `error`, and one whose watcher stopped
-    being able to say how the turn went (`turn: unknown`) — the second is
-    invisible to `_board_column`, which only sees the state.
+    What is NOT here any more is triage's other two words. A person cannot file
+    a task as In Progress (the lane is Claude's output, and the Board no longer
+    offers the drop) and cannot file one as Done (a run says that, not a
+    reader) — so the stale-pin machinery that used to decide when an automatic
+    `in_progress` had outlived its run is gone with the pin it guarded.
 
-    A LIVE session still reads `in_progress` even over a failed newest message:
-    something is running in that conversation right now, which is the more
-    urgent fact and the one that stops being true on its own. Since 2026-08-18
-    that beats an `archived` record too — see `_running_now`."""
-    record = triage.get(session_id) if session_id else None
-    if isinstance(record, dict):
-        status = record.get("status")
-        if status in _TRIAGE_STATUSES and (
-                status != "in_progress"
-                or _pin_holds(record, session_id, live, busy, active)):
-            # FILING SOMETHING DOES NOT STOP IT (Akshil, 2026-08-18). Archive is
-            # a timeless decision and it is kept — the record is not touched
-            # here, and the moment the turn ends the task drops back into
-            # Archive on the next poll. But while a turn is genuinely in flight,
-            # a row that says `archived` is a lie the reader can watch: the work
-            # is happening, in that conversation, now. Running is the one fact
-            # on this page about the PRESENT, so for as long as it is true it
-            # outranks a decision about where the task belongs afterwards.
-            #
-            # Only `archived`. A `done` record is the user saying "this run is
-            # over", and if a new turn starts in that conversation the derived
-            # branches below already move the row without help. Archive is the
-            # one that would otherwise hide live work in a lane nobody watches.
-            if status == "archived" and _running_now(session_id, live, busy):
-                return "in_progress"
-            return status
-    if live and newest is not None:
+    FILING SOMETHING DOES NOT STOP IT (Akshil, 2026-08-18), which is rule 1
+    standing above rule 2 and nothing more: Archive is a timeless decision and
+    the record is never touched here, but while a turn is genuinely in flight a
+    row that says `archived` is a lie the reader can watch. The moment the run
+    ends the task drops back into Archive on the next poll.
+    """
+    if messages and (_running_now(session_id, live, busy)
+                     or any(_message_running(m) for m in messages)):
         return "in_progress"
-    if _failed(newest):
-        return "failed"
-    return _board_column(newest)
+    filed = _filed(session_id, triage)
+    if filed:
+        return "archived"
+    if messages and all(_message_archived(m, filed) for m in messages):
+        return "archived"
+    verdict = _message_verdict(_speaker(messages, filed) or {"state": "", "turn": ""})
+    return verdict or "upcoming"
 
 
-def _failed(newest: dict | None) -> bool:
-    """Did the newest message's run break?
+def _failed(speaker: dict | None) -> bool:
+    """Did the run this task is reading off break?
 
     Kept as its own field on the row as well as feeding `status` above, because
     the two can disagree in exactly one direction and the difference is worth
-    keeping: a user who has triaged a task to `done`, or a session that is live
-    again, reads `status` as something other than `failed` while this stays
-    true. Anything that only wants "which column" should read `status`."""
-    return newest is not None and (
-        newest["state"] == "error" or newest["turn"] == "unknown")
+    keeping: a task that is archived, or live again, reads `status` as something
+    other than `failed` while this stays true. Anything that only wants "which
+    column" should read `status`."""
+    return speaker is not None and (
+        speaker["state"] == "error" or speaker["turn"] == "unknown")
 
 
 # ----------------------------------------------------------------- the titles
@@ -789,7 +783,7 @@ def _entry_session(entry: dict) -> str:
 # States that mean a scheduled message will never run and never did. In
 # `_entry_state`'s vocabulary, so a cancelled or missed OCCURRENCE — which reads
 # as `skipped` — is covered by the same tuple, and `error` is NOT: a send that
-# broke is news, and `_board_column` gives it its own column.
+# broke is news, and `_message_verdict` reports it as `failed`.
 #
 # `sent` and `sending` are obviously excluded, and so is `pending`: a message
 # waiting for its time is work that has not happened yet, not work that never
@@ -1022,7 +1016,8 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     """One listing row. The tail parse only: three messages, and a count.
 
     `busy` is `schedule.busy_sessions` over the WHOLE store, computed once by
-    the caller — see `_pin_holds`. Over the whole store rather than this task's
+    the caller — one of the three things that say a run is happening (see
+    `_status`). Over the whole store rather than this task's
     own entries because a resume that forked is filed under the session it RAN
     in (`_entry_session` reads the answer first) while it still holds the
     session it NAMED busy, and that one is another row."""
@@ -1041,28 +1036,31 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     # prompts and the unfired entries — a prompt outside that window cannot be
     # in the last three of a list it is in the same order as. Their ids follow
     # from the total, whatever else is below them.
-    tail = _merge(prompts, task["entries"], live)
+    merged = _merge(prompts, task["entries"], live)
     # BEFORE the cut, from the whole set: the one fact about the future that the
     # three-message window cannot be trusted to hold. See `_next_run`.
     next_run, next_run_entry = _next_run(task["entries"])
-    tail = tail[-_LISTING_MESSAGES:]
+    tail = merged[-_LISTING_MESSAGES:]
+    # The tail's dicts ARE the merged list's dicts (a slice shares them), so the
+    # liveness this writes onto the newest chat message is visible to the status
+    # derivation below, which reads the whole thread.
     _turn_of_newest_chat(tail, live)
     for offset, message in enumerate(reversed(tail)):
         message["message_id"] = tasks_store.format_message_id(total - offset)
     _mark_unread(tail, task["key"], read)
 
     newest = tail[-1] if tail else None
+    # Which message the status is reading off — asked once here so the row's
+    # `failed` flag and its `status` cannot be reading two different runs.
+    speaker = _speaker(merged, _filed(task["session_id"], triage))
     # TWO times, because "recent" is two questions here and one number could
     # only answer them by lying to one of them.
     #
     # `active` is the last thing that actually HAPPENED in this session, and
-    # nothing that has not happened may enter it — it is the clock `_pin_holds`
-    # measures a deliberate `in_progress` stamp against. `ran_at` is when a
-    # message ran (a caught-up run is news today, whatever day it was due) and
-    # 0.0 until it does; `at` is the due time, which never moves and can be in
-    # the FUTURE (see `_entry_at`). Reading `at` here was reaping every pin on a
-    # task with a message still to come, because no stamp a user can make is
-    # later than tomorrow — the exact reopen the stamp exists to protect.
+    # nothing that has not happened may enter it. `ran_at` is when a message ran
+    # (a caught-up run is news today, whatever day it was due) and 0.0 until it
+    # does; `at` is the due time, which never moves and can be in the FUTURE
+    # (see `_entry_at`).
     if newest is not None:
         active = max(active, newest["ran_at"] or 0.0)
     if not active and task["entries"]:
@@ -1094,11 +1092,12 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # an LLM call. Read from the entry so a store that grows the field later
         # starts working without a change here.
         "description": _description(task),
-        # `active`, not `surfaced`: a pin is stale exactly when it predates the
-        # last thing that HAPPENED, and a run still ahead has not happened.
-        "status": _status(newest, task["session_id"], triage, live, busy,
-                          active),
-        "failed": _failed(newest),
+        # Over the WHOLE merged thread, not the three-message tail: "is anything
+        # running in this task?" and "is every message filed away?" are both
+        # questions about all of it, and a run pushed out of the window by two
+        # later occurrences is exactly the run that must not be lost.
+        "status": _status(merged, task["session_id"], triage, live, busy),
+        "failed": _failed(speaker),
         "live": live,
         "unread": _unread_count(task, total, unfired, read),
         "last_active": surfaced,
@@ -1182,7 +1181,7 @@ def api_tasks():
     now = time.time()
     tasks = _collect()
     # One pass over the store for every row: which conversations the scheduler
-    # is still waiting on. See `_pin_holds`.
+    # is still waiting on. See `_status`.
     busy = schedule.busy_sessions(schedule.list_entries())
     for task in tasks.values():
         _place(task)
@@ -1420,3 +1419,88 @@ def _read_whole_task(key: str) -> dict:
         tasks_store.mark_read_many(key, unread_ids)
         _mark_unread(messages, key, tasks_store.read_state())
     return {"ok": True, "unread": sum(1 for m in messages if m["unread"])}
+
+
+# ------------------------------------------------------------------ archiving
+# Archiving is the only filing decision a person makes about a task, and it is
+# ONE gesture with two halves — which is why it is a verb here and not a triage
+# write from the client:
+#
+#   * the SESSION is filed (triage.json `archived`, the same record the Inbox
+#     writes and reads), so the transcript keeps its place and its notes;
+#   * the WORK IS CALLED OFF. A task with a run booked for tomorrow that is
+#     "archived" but still fires is not archived at all — it is a card that
+#     re-appears in Upcoming on its own, which is the one thing filing something
+#     away must never do. So every pending message is cancelled, and so is every
+#     recurring RULE behind one, because a rule that keeps materialising
+#     occurrences is a rule that keeps un-archiving the task.
+#
+# WHAT IS NOT TOUCHED is a run that is happening. `sending` is not cancellable
+# (schedule.cancel refuses it, and rightly: the helper is away and the turn may
+# have started) and neither is a live turn. Those keep going, the task keeps
+# reading In Progress while they do, and it settles into Archive by itself when
+# they end — see `_message_archived`. Nothing has to come back and finish the
+# job; the derivation simply answers differently once nothing is running.
+#
+# Deleting is still not on offer and never will be: a task IS a Claude session
+# and this app does not destroy transcripts (D306). The one place a row does
+# disappear is a task that never ran and has no session to keep — cancelling its
+# only message leaves nothing for a row to be about, which is `_is_task`'s rule
+# and predates this endpoint.
+
+
+class ArchivePatch(BaseModel):
+    key: str
+
+
+@router.post("/api/tasks/archive")
+def api_task_archive(patch: ArchivePatch):
+    """File one task away: cancel its pending work, archive its session.
+
+    Answers what it actually did — how many messages were called off, and
+    whether the session was filed — rather than a bare ok, because the two
+    halves can legitimately come apart (a task with no session id has only the
+    first, a pure-chat task has only the second) and the client's note line is
+    the place a person finds out which.
+    """
+    key = patch.key.strip()
+    if not key:
+        raise HTTPException(status_code=400, detail="missing task key")
+    task = _collect().get(key)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"no task with key {key!r}")
+
+    cancelled = 0
+    # The rules FIRST: cancelling a template also cancels the occurrence it has
+    # already materialised, so doing it the other way round would cancel one
+    # occurrence and let the rule mint the next.
+    for template_id in _rules_behind(task["entries"]):
+        if schedule.cancel(template_id) is not None:
+            cancelled += 1
+    for entry in task["entries"]:
+        if str(entry.get("state") or "") != schedule.PENDING:
+            continue
+        entry_id = str(entry.get("id") or "")
+        if entry_id and schedule.cancel(entry_id) is not None:
+            cancelled += 1
+
+    session_id = task["session_id"]
+    if session_id:
+        sessions.write_triage(session_id, _FILED)
+    return {"ok": True, "key": key, "cancelled": cancelled,
+            "filed": bool(session_id)}
+
+
+def _rules_behind(entries: list[dict]) -> list[str]:
+    """The recurring templates this task's still-pending occurrences came from,
+    each named once. Only PENDING occurrences count: a template whose runs are
+    all spent is not going to produce another one on its own, and cancelling it
+    would be this verb reaching past the task it was asked about."""
+    rules: list[str] = []
+    for entry in entries:
+        if str(entry.get("state") or "") != schedule.PENDING:
+            continue
+        template_id = str(entry.get("template_id") or "")
+        if template_id and template_id not in rules:
+            rules.append(template_id)
+    return rules

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -592,11 +592,68 @@ def _speaker(messages: list[dict], filed: bool) -> dict | None:
     return None
 
 
-def _filed(session_id: str, triage: dict) -> bool:
-    """Has the user put this task away? The only triage word still read here —
-    see `_FILED`."""
+def _archive_record(session_id: str, triage: dict) -> dict | None:
+    """This session's `archived` record, or None. The only triage word still
+    read here — see `_FILED`."""
     record = triage.get(session_id) if session_id else None
-    return isinstance(record, dict) and record.get("status") == _FILED
+    if isinstance(record, dict) and record.get("status") == _FILED:
+        return record
+    return None
+
+
+def _filed_at(record: dict) -> float:
+    """When the filing was made, epoch seconds, or 0.0 for a record that does
+    not say.
+
+    Stored as a string because that is the shape of the record (`set_triage.py`
+    coerces every field it writes, so `at` is "1.0" and not 1.0), and parsed
+    defensively for the same reason: a hand-edited file must cost a filing, not
+    the page.
+
+    0.0 means the record does not say WHEN, and `_revived` reads that as "no
+    revival": a filing whose date is unknown cannot be shown to have been
+    overtaken, and the alternative — treating it as older than everything —
+    would make every archive the sessions Inbox has ever written (its own
+    `set_triage.py` stamps nothing) revive itself on the very next poll. Every
+    archive this app writes carries a stamp (`claude_sessions.write_triage`),
+    so the door below is open for every filing a person can make here."""
+    try:
+        return float(record.get("at") or 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _revived(messages: list[dict], filed_at: float) -> bool:
+    """Has this task DONE something since it was filed away?
+
+    THE WAY OUT OF ARCHIVE IS ACTIVITY (Akshil, 2026-08-18): "if you want to
+    move it to in progress or done, just type in a message inside that chat and
+    it will automatically move". There is no unarchive control anywhere — the
+    lane is drag-locked and the row draws no button — so this is the only door,
+    and it has to be a real one: the filing is dropped (`clear_triage`), not
+    overlooked for one poll.
+
+    WHICH ACTIVITY, and the distinction is the whole function. `ran_at` is when
+    a message actually happened, so:
+
+    * a run that was ALREADY IN FLIGHT when the task was filed started before
+      the stamp. It does not revive anything — it keeps going, the card reads In
+      Progress while it does (rule 1 in `_status`), and the task settles back
+      into Archive when it ends. That is the promise the archive cascade already
+      makes and it is unchanged.
+    * a message that arrives AFTERWARDS — a prompt typed into the conversation,
+      a run someone started — happened after the stamp, and that is new work in
+      a task somebody had finished with. The filing is stale and goes.
+
+    A message that has not happened yet does not count: `ran_at` is 0.0 until it
+    does, so a run scheduled into an archived task revives it when it RUNS,
+    which is when there is something to come back for.
+
+    An unstamped filing revives on nothing at all — see `_filed_at`.
+    """
+    if filed_at <= 0:
+        return False
+    return any((m["ran_at"] or 0.0) > filed_at for m in messages)
 
 
 def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
@@ -617,7 +674,7 @@ def _running_now(session_id: str, live: bool, busy: set[str]) -> bool:
     return live or (bool(session_id) and session_id in busy)
 
 
-def _status(messages: list[dict], session_id: str, triage: dict, live: bool,
+def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
             busy: set[str]) -> str:
     """The status a task sits in — ONE decision, made here, for every view.
 
@@ -654,11 +711,15 @@ def _status(messages: list[dict], session_id: str, triage: dict, live: bool,
     the record is never touched here, but while a turn is genuinely in flight a
     row that says `archived` is a lie the reader can watch. The moment the run
     ends the task drops back into Archive on the next poll.
+
+    `filed` is the ANSWER, not the record: the caller has already asked whether
+    the filing still stands (`_archive_record` and `_revived`), because a filing
+    a new message has overtaken is dropped from disk rather than argued with on
+    every poll. This function reads no triage of its own.
     """
     if messages and (_running_now(session_id, live, busy)
                      or any(_message_running(m) for m in messages)):
         return "in_progress"
-    filed = _filed(session_id, triage)
     if filed:
         return "archived"
     if messages and all(_message_archived(m, filed) for m in messages):
@@ -1012,7 +1073,7 @@ def _next_run(entries: list[dict]) -> tuple[float, str]:
 
 
 def _row(task: dict, number: str, triage: dict, read: dict, now: float,
-         busy: set[str]) -> dict:
+         busy: set[str], revived: list[str]) -> dict:
     """One listing row. The tail parse only: three messages, and a count.
 
     `busy` is `schedule.busy_sessions` over the WHOLE store, computed once by
@@ -1020,7 +1081,13 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     `_status`). Over the whole store rather than this task's
     own entries because a resume that forked is filed under the session it RAN
     in (`_entry_session` reads the answer first) while it still holds the
-    session it NAMED busy, and that one is another row."""
+    session it NAMED busy, and that one is another row.
+
+    `revived` is an OUT parameter and the only one: a session whose archive
+    record this row has just found stale is appended to it, and the caller does
+    the write. Collected rather than written here because building a row is
+    inside a per-task `try` that swallows IO errors — a failed write would cost
+    the row instead of costing the filing."""
     rec = _scan(task["path"]) if task["path"] else None
     live, active = _live(task["path"], now)
     prompts = list(rec["tail"]) if rec else []
@@ -1050,9 +1117,19 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
     _mark_unread(tail, task["key"], read)
 
     newest = tail[-1] if tail else None
+    # DOES THE FILING STILL STAND? Asked once, here, and spent by both the
+    # status and the speaker below so they cannot read the task as archived and
+    # not-archived in the same row. A record the thread has overtaken is not
+    # merely ignored — its session id goes into `revived`, and the caller drops
+    # it from disk. See `_revived`.
+    record = _archive_record(task["session_id"], triage)
+    filed = record is not None
+    if record is not None and _revived(merged, _filed_at(record)):
+        filed = False
+        revived.append(task["session_id"])
     # Which message the status is reading off — asked once here so the row's
     # `failed` flag and its `status` cannot be reading two different runs.
-    speaker = _speaker(merged, _filed(task["session_id"], triage))
+    speaker = _speaker(merged, filed)
     # TWO times, because "recent" is two questions here and one number could
     # only answer them by lying to one of them.
     #
@@ -1096,7 +1173,7 @@ def _row(task: dict, number: str, triage: dict, read: dict, now: float,
         # running in this task?" and "is every message filed away?" are both
         # questions about all of it, and a run pushed out of the window by two
         # later occurrences is exactly the run that must not be lost.
-        "status": _status(merged, task["session_id"], triage, live, busy),
+        "status": _status(merged, filed, task["session_id"], live, busy),
         "failed": _failed(speaker),
         "live": live,
         "unread": _unread_count(task, total, unfired, read),
@@ -1187,13 +1264,27 @@ def api_tasks():
         _place(task)
     numbers = _numbers(tasks)
     rows = []
+    # Sessions whose archive record the thread has outlived — see `_revived`.
+    # Collected across the loop and written once, after it, so the listing is
+    # not doing IO in the middle of building rows.
+    revived: list[str] = []
     for task in tasks.values():
         try:
             row = _row(task, numbers.get(task["key"], ""), triage, read, now,
-                       busy)
+                       busy, revived)
         except (OSError, ValueError, KeyError, TypeError):
             continue  # one unreadable task, not an unreadable page
         rows.append(row)
+    for session_id in revived:
+        # THE WAY OUT OF ARCHIVE IS ACTIVITY, and it has to be a real way out:
+        # the row already reads as its derived lane above, and leaving the
+        # record on disk would put the task back in Archive the moment it went
+        # quiet again. Best-effort — a filing we could not drop costs one poll's
+        # worth of the row coming back, never the listing.
+        try:
+            sessions.clear_triage(session_id)
+        except OSError:
+            pass
     # Day one: everything that already exists is read. Done HERE, from the
     # counts the rows just produced, because this is the only place that knows
     # them — and done after the rows are built rather than before, so it costs

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -576,6 +576,33 @@ def _message_verdict(message: dict) -> str | None:
     return None
 
 
+def _waiting(messages: list[dict], filed: bool) -> bool:
+    """Is there anything in this task still to come?
+
+    THE OTHER HALF OF UPCOMING, and the half that was missing (Akshil,
+    2026-08-18: an Upcoming card could not be dragged into In Progress any more).
+    "No output yet" was read as enough on its own, which put every session whose
+    transcript surfaces no prompt at all — one that ran only `/clear`, or
+    `/making-a-release` — into Upcoming. On one real machine that was every card
+    in the lane: nine of them, each with `message_count: 0`.
+
+    Those cards are unrunnable BY CONSTRUCTION and correctly so — the drag into
+    In Progress fires a pending message and they have none — so the lane filled
+    up with the only cards in it that could not do the one thing it exists for.
+    The lane was the lie, not the drag: `dropLanes` was refusing a drop on a card
+    that had nothing to drop.
+
+    So Upcoming means work that has not happened but is going to, which is a
+    message still WAITING: not filed away, and with no verdict yet
+    (`_message_verdict` answers None for exactly the promises). A task with none
+    of those and nothing to report is over, and `done` is where it goes — the
+    same answer this server gave before the derivation landed ("a task with
+    nothing in it happened and is over"), for the same reason.
+    """
+    return any(not _message_archived(m, filed) and _message_verdict(m) is None
+               for m in messages)
+
+
 def _speaker(messages: list[dict], filed: bool) -> dict | None:
     """The message a task's status is reading off: the most recent one that is
     neither filed away nor still waiting to happen.
@@ -697,8 +724,11 @@ def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
        was filed keeps running and the card reads In Progress until it stops.
     3. **Otherwise the newest message that has something to say speaks** —
        `failed` for a run that broke, `done` for one that ended. See `_speaker`.
-    4. **Nothing to say ⇒ Upcoming.** Never run, or nothing but promises: the
-       lane means "no output yet" and nothing else.
+    4. **Nothing said yet, but something COMING ⇒ Upcoming**, and that second
+       half is the whole of it: the lane is what has not happened *yet*, so it
+       needs a message still waiting to happen. A task with nothing coming and
+       nothing to report is over, and `done` is where a spent session goes — see
+       `_waiting`.
 
     What is NOT here any more is triage's other two words. A person cannot file
     a task as In Progress (the lane is Claude's output, and the Board no longer
@@ -724,8 +754,10 @@ def _status(messages: list[dict], filed: bool, session_id: str, live: bool,
         return "archived"
     if messages and all(_message_archived(m, filed) for m in messages):
         return "archived"
-    verdict = _message_verdict(_speaker(messages, filed) or {"state": "", "turn": ""})
-    return verdict or "upcoming"
+    speaker = _speaker(messages, filed)
+    if speaker is not None:
+        return _message_verdict(speaker) or "done"
+    return "upcoming" if _waiting(messages, filed) else "done"
 
 
 def _failed(speaker: dict | None) -> bool:

--- a/tests/test_schedule_css.py
+++ b/tests/test_schedule_css.py
@@ -107,3 +107,96 @@ def test_tree_titles_hold_one_line():
     css = _read(_CSS)
     assert _decl(css, ".schedule-tv-title", "white-space") == "nowrap"
     assert _decl(css, ".schedule-tv-title", "text-overflow") == "ellipsis"
+
+
+# -- 3. the calendar popover and its chips -------------------------------------
+# The popover is the calendar's whole detail surface, and three of its claims
+# are pixels rather than markup.
+
+_CAL = os.path.join(REPO_ROOT, "frontend", "src", "shell", "ScheduleCalendar.tsx")
+_TOKENS = os.path.join(REPO_ROOT, "frontend", "src", "styles", "tokens.css")
+
+
+def test_the_popover_title_outranks_the_facts_under_it():
+    """Title over description as ONE written block, and the title a real step
+    bigger than the 12px fact rows below — at 14px against 12px it was the same
+    size as its own metadata, which is not a hierarchy."""
+    css = _read(_CSS)
+    size = _decl(css, ".schedule-pop-write .schedule-pop-title", "font-size")
+    assert size and int(re.match(r"(\d+)px", size).group(1)) >= 16
+    rows = _decl(css, ".schedule-pop-rows", "font-size")
+    assert rows == "12px"
+    assert _decl(css, ".schedule-pop-desc", "color") == "var(--fg-muted)"
+
+
+def test_the_description_is_prose_and_wears_no_icon():
+    """It is read, not recognised, so it does not belong in the icon column with
+    the folder and the repeat rule."""
+    cal = _read(_CAL)
+    assert '<p className="schedule-pop-desc">{task.description}</p>' in cal
+    # The notes glyph is no longer led by the description row anywhere.
+    assert "{ICON_NOTES}" not in cal
+
+
+def test_the_occurrence_row_does_not_repeat_the_panel():
+    """A popover about ONE task printed its title again on the row and its
+    status word again beside it. The ring carries the state; the tooltip carries
+    the word."""
+    cal = _read(_CAL)
+    assert '<span className="schedule-cal-msg-state">' not in cal
+    # The body is kept only when it says something the title has not.
+    assert 'const showBody = body && body !== headline ? body : "";' in cal
+    assert "status.label" in cal, "the word must survive in the row's tooltip"
+
+
+@pytest.mark.parametrize("status,token", [
+    ("upcoming", "--status-upcoming"),
+    ("in_progress", "--status-progress"),
+    ("done", "--status-done"),
+    ("failed", "--status-failed"),
+    ("archived", "--status-archived"),
+])
+def test_every_status_pill_wears_its_own_status_token(status, token):
+    """One vocabulary means one palette. The pill and the ring beside it read
+    the SAME token, so green cannot mean two things two lines apart."""
+    css = _read(_CSS)
+    assert _decl(css, f".schedule-state--{status}", "--pill") == f"var({token})"
+    # And the token is real, not a name nothing defines.
+    assert f"{token}:" in _read(_TOKENS)
+
+
+def test_the_pill_tints_rather_than_fills():
+    """Text first: the label keeps the hue at full strength and the hue sits
+    behind it at a weight that survives both themes. A saturated fill would need
+    a second text colour per status per theme."""
+    css = _read(_CSS)
+    selector = (".schedule-state--upcoming,\n.schedule-state--in_progress,\n"
+                ".schedule-state--done,\n.schedule-state--failed,\n"
+                ".schedule-state--archived")
+    assert _decl(css, selector, "color") == "var(--pill)"
+    background = _decl(css, selector, "background")
+    assert background and background.startswith("color-mix(")
+
+
+def test_a_running_chip_says_so_and_stops_saying_it_on_request():
+    """The calendar has no In Progress lane, so the chip itself has to carry
+    the one fact that is only true while you are looking at it. Motion is the
+    signal — every static property on a chip is already spent on the project
+    hue, the projected dashes and the past fade — and a reader who has asked for
+    less of it still gets a static highlight."""
+    css = _read(_CSS)
+    assert "@keyframes schedule-cal-shimmer" in css
+    running = ".schedule-cal .schedule-cal-chip.is-running::after"
+    assert _decl(css, running, "animation") == "schedule-cal-shimmer 2s linear infinite"
+    # It must not eat the chip's own clicks: the chip is a button.
+    assert _decl(css, running, "pointer-events") == "none"
+    # The fallback is INSIDE a reduced-motion block, not merely after one: the
+    # whole point is that it applies only to the reader who asked for it.
+    blocks = re.findall(
+        r"@media \(prefers-reduced-motion: reduce\)\s*\{(.*?)\n\}\n",
+        css, re.DOTALL)
+    guarded = [b for b in blocks if "is-running" in b]
+    assert guarded, "the static fallback must sit inside a reduced-motion block"
+    assert "animation: none" in guarded[0]
+    # And the rule hangs off a class the view actually sets.
+    assert 'isRunningNow(chip.task, chip.anchor) ? " is-running" : ""' in _read(_CAL)

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -521,16 +521,19 @@ def test_a_recurring_template_is_not_a_message(client, projects_dir):
     assert task["messages"][0]["template_id"] == "tpl"
 
 
-def test_a_skipped_occurrence_reads_as_skipped_and_archives_the_task(
+def test_a_skipped_occurrence_reads_as_skipped_and_files_itself_away(
         client, projects_dir):
     """The user's skip and the loop's own missed verdict are the same fact about
-    a repeating run, and schedule-lib.ts files both under Archive."""
+    a repeating run, and schedule-lib.ts files both under Archive.
+
+    The MESSAGE is filed; the task is only archived when everything in it is
+    (`_message_archived`), so here the session's own prompt still speaks."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("occ", "every morning", T12, state=schedule.MISSED,
                            claude_session_id="sess-a", template_id="tpl")])
     task = _by_key(client)["sess-a"]
     assert task["messages"][0]["state"] == "skipped"
-    assert task["status"] == "archived"
+    assert task["status"] == "done"
 
 
 def test_a_task_whose_session_has_no_transcript_still_lists(client, tmp_path):
@@ -759,12 +762,16 @@ def test_a_session_keeps_its_row_with_every_entry_cancelled(client,
                                                             projects_dir):
     """A task that has run is a Claude session with a real transcript, and this
     app does not destroy transcripts (D306). Archive is the honest resting place
-    for that one — the row stays, whatever happened to its entries."""
+    for that one — the row stays, whatever happened to its entries.
+
+    Its STATUS is what the transcript's own prompt says, not `archived`:
+    cancelling a scheduled message files that message, and the turn it did not
+    replace is still the newest thing in the thread with something to say."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("e1", "later", T12, state=schedule.CANCELLED,
                            claude_session_id="sess-a")])
     task = _by_key(client)["sess-a"]
-    assert task["status"] == "archived"
+    assert task["status"] == "done"
     assert task["messages"][0]["state"] == "cancelled"
 
 
@@ -1175,36 +1182,39 @@ def test_a_never_run_message_that_was_cancelled_draws_no_chip(client, tmp_path):
 
 
 # ----------------------------------------------------------------- the status
+# The derivation, in the order `_status` applies it: anything running wins,
+# archived is a filing state that cascades onto the messages, otherwise the
+# newest message with something to say speaks, and a task with nothing to say is
+# Upcoming.
 
 
 @pytest.mark.parametrize("fields,expected", [
-    ({}, "upcoming"),
+    # A message with nothing to say yet leaves the run BEFORE it speaking — the
+    # transcript's own prompt, which ran. See the recurring case below for why
+    # that is the whole point rather than an accident.
+    ({}, "done"),
     ({"state": schedule.SENDING}, "in_progress"),
     ({"state": schedule.SENT, "turn": "ok", "fired": T12}, "done"),
     ({"state": schedule.MISSED}, "done"),
-    ({"state": schedule.CANCELLED}, "archived"),
+    # Cancelled is filed away, so the message under it speaks again.
+    ({"state": schedule.CANCELLED}, "done"),
     ({"state": schedule.ERROR, "error": "target vanished"}, "failed"),
     ({"state": schedule.SENT, "turn": "failed", "fired": T12}, "failed"),
     ({"state": schedule.SENT, "turn": "unknown", "fired": T12}, "failed"),
 ])
-def test_status_follows_the_newest_message(client, projects_dir, fields,
-                                           expected):
+def test_the_newest_message_with_a_verdict_speaks(client, projects_dir, fields,
+                                                  expected):
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("e1", "later", T12, claude_session_id="sess-a",
                            **fields)])
     assert _by_key(client)["sess-a"]["status"] == expected
 
 
-def test_triage_wins_where_it_disagrees(client, projects_dir, state_dir):
-    """The user dragged the card. A derivation that undid that on the next poll
-    would make the board unusable."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "later", T12, claude_session_id="sess-a")])
-    assert _by_key(client)["sess-a"]["status"] == "upcoming"
-
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "archived"}}))
-    assert _by_key(client)["sess-a"]["status"] == "archived"
+def test_a_task_that_has_never_run_is_upcoming(client, tmp_path):
+    """Upcoming means "no output yet" and nothing else: a promise is not a
+    verdict, so a task holding only pending messages has nothing to report."""
+    _seed_schedule([_entry("e1", "tomorrow", T12, target=str(tmp_path))])
+    assert _tasks(client)[0]["status"] == "upcoming"
 
 
 def test_archiving_yields_to_a_turn_that_is_still_running(client, projects_dir,
@@ -1252,173 +1262,149 @@ def test_the_archive_is_kept_and_comes_back_when_the_turn_ends(client,
     assert rec["status"] == "archived", "nothing here rewrites the filing"
 
 
-def test_a_done_record_is_not_given_the_archive_exception(client, projects_dir,
-                                                          state_dir):
-    """Only `archived` yields. `done` says "this run is over", and a new turn in
-    that conversation is already carried by the derivation — there is nothing
-    for an exception to fix, and widening it would make the one lane a user
-    files things INTO the one lane that cannot hold them."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENDING,
-                           claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "done"}}))
-    assert _by_key(client)["sess-a"]["status"] == "done"
+def test_a_finished_run_with_the_next_one_booked_sits_in_done(client,
+                                                              projects_dir):
+    """THE RECURRING CASE, and the reason a pending message says nothing.
 
-
-def test_a_stale_in_progress_pin_does_not_outlive_its_run(client, projects_dir,
-                                                          state_dir):
-    """The pin is a claim about the present, and the run it named has ended.
-
-    The Inbox's `autoFlow` writes `in_progress` for every session it sees
-    running and only writes it back to `done` if that same page is still open
-    to witness the stop, so a run nobody watched finish leaves the pin behind
-    forever. Honouring it was five cards stuck in In Progress for days over
-    entries whose turns were recorded `done`."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
-                           turn="ok", claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "in_progress"}}))
-
+    A daily job that ran this morning and is due again tomorrow has OUTPUT in
+    it that nobody has read. Reading the status off the newest message filed it
+    under Upcoming — the lane a person scans for what has not happened yet —
+    and the run they actually have to look at was hidden behind tomorrow's
+    promise. The next run is still named on the row (`next_run`), which is what
+    the chip beside the title shows."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("pull the news", T9, uuid="a1")])
+    _seed_schedule([
+        _entry("e1", "pull the news", T9, state=schedule.SENT, fired=T9,
+               turn="ok", template_id="tpl", claude_session_id="sess-a"),
+        _entry("e2", "pull the news", T12, template_id="tpl",
+               session_id="sess-a"),
+    ])
     task = _by_key(client)["sess-a"]
-    assert task["live"] is False
-    assert task["messages"][0]["turn"] == "done"
     assert task["status"] == "done"
+    assert task["next_run_entry"] == "e2", "the run ahead is still named"
 
 
-def test_a_stale_in_progress_pin_on_an_empty_thread_is_dropped(client,
-                                                               projects_dir,
-                                                               state_dir):
-    """The one the board showed with no messages at all. Nothing is running and
-    there is no turn to still be open, so the pin is the only thing holding it
-    in the lane."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.CANCELLED,
-                           claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "in_progress"}}))
-    assert _by_key(client)["sess-a"]["status"] == "archived"
+def test_a_run_in_flight_beats_a_newer_message_that_is_only_a_promise(
+        client, projects_dir):
+    """Activity beats recency. The newest message is next week's occurrence;
+    the one under it is still going, and that is what the task IS doing."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("go", T9)])
+    _seed_schedule([
+        _entry("e1", "go", T9, state=schedule.SENDING, template_id="tpl",
+               claude_session_id="sess-a"),
+        _entry("e2", "go", T12, template_id="tpl", session_id="sess-a"),
+    ])
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
 
 
-def test_an_in_progress_pin_holds_while_the_turn_is_still_open(client,
-                                                               projects_dir,
-                                                               state_dir):
-    """The guard that protects a genuinely running turn from the reap above.
-
-    A turn thinking through a long tool call appends nothing to its transcript
-    for minutes and reads as NOT live, so liveness alone would reap it. The
-    store still has the send in flight — spawned, no `turn` verdict — which is
-    `_busy_sessions`, the second guard, and the one that is right here.
-
-    Note what this asserts about the RENDERED turn: it is `idle`, because
-    `_entry_turn` folds liveness in and has no word for "sent, no verdict, not
-    live". So the message the row carries cannot be the guard; the store's own
-    claim has to be."""
+def test_a_send_the_scheduler_is_still_waiting_on_reads_as_running(
+        client, projects_dir):
+    """The transcript is not live — a turn thinking through a long tool call
+    appends nothing for minutes — but the store still has the send in flight.
+    `schedule.busy_sessions` is the scheduler's own answer and the one that is
+    right here; the RENDERED turn cannot be the guard, because `_entry_turn`
+    folds liveness in and writes `idle` for exactly this case."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
                            turn="", claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "in_progress"}}))
-
     task = _by_key(client)["sess-a"]
     assert task["live"] is False
     assert task["messages"][0]["turn"] == "idle"
     assert task["status"] == "in_progress"
 
 
-def test_an_in_progress_pin_holds_over_a_send_in_flight(client, projects_dir,
-                                                        state_dir):
-    """A `sending` claim has not reached a transcript at all, so there is no
-    turn to have settled and nothing to reap."""
+def test_a_finished_run_is_not_in_progress_however_it_was_pinned(
+        client, projects_dir, state_dir):
+    """The stale-pin bug, gone by construction rather than by reaping.
+
+    The sessions Inbox's `autoFlow` writes `in_progress` for every session it
+    sees running and only writes it back if that same page is still open to
+    witness the stop, so a run nobody watched finish left a pin on disk that
+    outlived it forever — and the board held cards in In Progress for days over
+    runs recorded `done` a day earlier. In Progress is now Claude's output and
+    nothing else, so the record is simply not read."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENDING,
-                           claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "in_progress"}}))
-    assert _by_key(client)["sess-a"]["status"] == "in_progress"
-
-
-def test_a_stale_pin_does_not_hide_the_next_occurrence(client, projects_dir,
-                                                       state_dir):
-    """A recurring task whose last run left a pin behind, and whose next
-    occurrence has since materialised. The card belongs in Upcoming — the pin
-    is describing a run that is over, and honouring it hides the fact that this
-    task is due again.
-
-    Note that a user cannot have MEANT this pin: dropping an upcoming card on
-    In Progress is `dropAction`'s run-now move, not a triage write, so the only
-    thing that puts an `in_progress` pin on an upcoming task is a stale one."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([
-        _entry("e1", "every day", T9, state=schedule.SENT, fired=T9, turn="ok",
-               template_id="tpl", claude_session_id="sess-a"),
-        _entry("e2", "every day", T12, template_id="tpl", session_id="sess-a"),
-    ])
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "in_progress"}}))
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="ok", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
 
     task = _by_key(client)["sess-a"]
-    assert task["status"] == "upcoming"
-    assert task["next_run_entry"] == "e2"
+    assert task["live"] is False
+    assert task["status"] == "done"
 
 
-def test_a_pin_placed_after_the_run_ended_is_the_users_own_and_sticks(
-        client, projects_dir, state_dir):
-    """The reopen drag: a `done` card dropped back on In Progress. `dropLanes`
-    offers that lane for a done task, so it is a real gesture, and a derivation
-    that undid it on the next 20s poll would make the board unusable.
+def test_a_recorded_done_does_not_overrule_a_broken_run(client, projects_dir,
+                                                        state_dir):
+    """Done is a fact about a run, not a place a reader may put a card — the
+    Board offers no drop on that lane at all any more. A record left over from
+    when it did must not paint a failure green."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
+                           turn="failed", claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "done"}}))
+    task = _by_key(client)["sess-a"]
+    assert task["status"] == "failed"
+    assert task["failed"] is True
 
-    A stamp is what tells it apart from the Inbox's automatic pin. `autoFlow`
-    writes `{status}` and nothing else, so its pins carry no `at` and are
-    reapable; the shell stamps its own writes, and a stamp later than anything
-    that has happened in the session is a decision no run has contradicted."""
+
+def test_archiving_a_task_files_every_message_with_it(client, projects_dir,
+                                                      state_dir):
+    """The filing state. The task is archived, so what is in it is archived —
+    including the run that finished, which would otherwise keep speaking."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
                            turn="ok", claude_session_id="sess-a")])
     assert _by_key(client)["sess-a"]["status"] == "done"
 
-    (state_dir / "triage.json").write_text(json.dumps(
-        {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "archived"}}))
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
+def test_an_archived_task_with_a_run_still_going_stays_in_progress(
+        client, projects_dir, state_dir):
+    """A run cannot be filed away while it is happening. It keeps going, the
+    card keeps reading In Progress, and the task falls into Archive by itself
+    once the run ends — nothing has to come back and finish the job."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENDING,
+                           claude_session_id="sess-a")])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "archived"}}))
     assert _by_key(client)["sess-a"]["status"] == "in_progress"
 
 
-def test_a_pin_holds_on_a_task_that_still_has_work_ahead_of_it(
-        client, projects_dir, state_dir):
-    """The same deliberate pin, on a task whose next run has not happened yet.
-
-    This is where measuring the stamp against "the last activity" went wrong.
-    The row's newest message is one due TOMORROW, and a scheduled message's `at`
-    is the time it was ASKED FOR — it never moves and it is not a thing that has
-    occurred (see `_entry_at`). Folded into the activity the pin is compared
-    against, it made every stamp a user could make look older than the session,
-    so the reap fired on the next 20s poll for exactly the tasks that have work
-    coming.
-
-    The gesture is reachable: `archiveIntent` and `dropLanes` both put a card
-    coming back out of Archive into In Progress, whatever it has scheduled, and
-    that write is stamped by the triage endpoint.
-
-    `last_active` deliberately still reads the due time — the List surfaces a
-    message due tomorrow near the top so it can be seen BEFORE it fires — which
-    is why the two are separate values and this asserts both."""
-    soon = time.strftime("%Y-%m-%dT%H:%M:%SZ",
-                         time.gmtime(time.time() + 86400))
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+def test_a_thread_whose_every_message_is_filed_is_archived(client,
+                                                           projects_dir):
+    """The other way in. Nobody said "archive this task"; every message in it
+    was cancelled, which is the same thing said one message at a time."""
+    _write_transcript(projects_dir, "sess-a", "/p", [])
     _seed_schedule([
-        _entry("e1", "every day", T9, state=schedule.SENT, fired=T9, turn="ok",
-               template_id="tpl", claude_session_id="sess-a"),
-        _entry("e2", "every day", soon, template_id="tpl",
-               session_id="sess-a"),
+        _entry("e1", "x", T9, state=schedule.CANCELLED,
+               claude_session_id="sess-a"),
+        _entry("e2", "y", T12, state=schedule.CANCELLED,
+               claude_session_id="sess-a"),
     ])
-    (state_dir / "triage.json").write_text(json.dumps(
-        {"sess-a": {"status": "in_progress", "at": str(time.time())}}))
+    assert _by_key(client)["sess-a"]["status"] == "archived"
 
-    task = _by_key(client)["sess-a"]
-    assert task["next_run"] > time.time(), "the upcoming run is the whole case"
-    assert task["status"] == "in_progress"
-    assert task["last_active"] == task["next_run"], \
-        "the sort still surfaces the run ahead; only the pin's clock changed"
+
+def test_filing_the_newest_message_hands_the_word_back_to_the_one_before(
+        client, projects_dir):
+    """Cancel the message on top and the run under it speaks again — which is
+    what makes filing one message a real gesture rather than a way to silence a
+    whole thread."""
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("pull the news", T9, uuid="a1")])
+    _seed_schedule([
+        _entry("e1", "pull the news", T9, state=schedule.SENT, fired=T9,
+               turn="failed", claude_session_id="sess-a"),
+        _entry("e2", "and again", T12, state=schedule.CANCELLED,
+               claude_session_id="sess-a"),
+    ])
+    assert _by_key(client)["sess-a"]["status"] == "failed"
 
 
 def test_an_unreadable_created_stamp_still_leaves_a_row(client, tmp_path):
@@ -1431,50 +1417,6 @@ def test_an_unreadable_created_stamp_still_leaves_a_row(client, tmp_path):
     task = _tasks(client)[0]
     assert task["status"] == "upcoming"
     assert task["last_active"] > 0, "the due time still surfaces it"
-
-
-def test_a_pin_placed_before_the_run_ended_is_reaped(client, projects_dir,
-                                                     state_dir):
-    """The other side of the stamp. A pin from before the last run finished is
-    describing that run, and the run answered it."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
-                           turn="ok", claude_session_id="sess-a")])
-    (state_dir / "triage.json").write_text(json.dumps(
-        {"sess-a": {"status": "in_progress", "at": "1.0"}}))
-    assert _by_key(client)["sess-a"]["status"] == "done"
-
-
-def test_the_triage_write_stamps_the_pin(client, projects_dir, state_dir):
-    """The stamp the reap above reads has to actually be written, or every pin
-    the shell makes is reaped on the next poll."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
-                           turn="ok", claude_session_id="sess-a")])
-    r = client.post("/api/claude-sessions/triage",
-                    json={"session_id": "sess-a", "status": "in_progress"})
-    assert r.status_code == 200, r.text
-
-    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
-    assert float(rec["at"]) > 0
-    assert _by_key(client)["sess-a"]["status"] == "in_progress"
-
-
-@pytest.mark.parametrize("pinned", ["done", "archived"])
-def test_the_timeless_pins_still_win_over_a_settled_run(client, projects_dir,
-                                                        state_dir, pinned):
-    """Only `in_progress` is falsifiable. `done` and `archived` are filing
-    decisions that stay true however long the card sits there, so the reap must
-    not touch them — the user dragged the card and a derivation that undid it on
-    the next poll would make the board unusable."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.ERROR,
-                           error="target vanished", claude_session_id="sess-a")])
-    assert _by_key(client)["sess-a"]["status"] == "failed"
-
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": pinned}}))
-    assert _by_key(client)["sess-a"]["status"] == pinned
 
 
 def test_a_dead_turn_is_reported_as_a_failure(client, projects_dir):
@@ -1494,10 +1436,12 @@ def test_a_dead_turn_is_reported_as_a_failure(client, projects_dir):
     assert task["status"] == "failed"
 
 
-def test_a_skipped_occurrence_is_archived_and_not_failed(client, projects_dir):
+def test_a_skipped_occurrence_does_not_speak_for_the_task(client,
+                                                          projects_dir):
     """A run the coalescer dropped was filed away and never attempted. Only
     something that actually ran can fail, and calling a routine skip a failure
-    makes ordinary behaviour look like breakage."""
+    makes ordinary behaviour look like breakage — so it says nothing at all and
+    the session's own prompt speaks."""
     _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
     _seed_schedule([_entry("e1", "every morning", T12, template_id="tpl",
                            state=schedule.MISSED,
@@ -1505,24 +1449,92 @@ def test_a_skipped_occurrence_is_archived_and_not_failed(client, projects_dir):
                            claude_session_id="sess-a")])
     task = _by_key(client)["sess-a"]
     assert task["messages"][0]["state"] == "skipped"
-    assert task["status"] == "archived"
+    assert task["status"] == "done"
     assert task["failed"] is False
 
 
-def test_triage_still_wins_over_a_failure(client, projects_dir, state_dir):
-    """`failed` is derived and triage is the user's own act, so filing a broken
-    run under done is allowed to stick. The `failed` flag stays true underneath
-    it, which is the one direction the two are meant to disagree in."""
-    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
-    _seed_schedule([_entry("e1", "x", T12, state=schedule.SENT, fired=T12,
-                           turn="failed", claude_session_id="sess-a")])
-    assert _by_key(client)["sess-a"]["status"] == "failed"
+# --------------------------------------------------------------- archiving it
+# `POST /api/tasks/archive` — one gesture with two halves: the work is called
+# off and the session is filed.
 
-    (state_dir / "triage.json").write_text(
-        json.dumps({"sess-a": {"status": "done"}}))
-    task = _by_key(client)["sess-a"]
-    assert task["status"] == "done"
-    assert task["failed"] is True
+
+def test_archiving_cancels_the_work_and_files_the_session(client, projects_dir,
+                                                          state_dir):
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([
+        _entry("e1", "ran", T9, state=schedule.SENT, fired=T9, turn="ok",
+               claude_session_id="sess-a"),
+        _entry("e2", "tomorrow", T12, claude_session_id="sess-a"),
+    ])
+    r = client.post("/api/tasks/archive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["cancelled"] == 1
+    assert r.json()["filed"] is True
+
+    states = {e["id"]: e["state"] for e in schedule.list_entries()}
+    assert states["e2"] == schedule.CANCELLED, "the run ahead is called off"
+    assert states["e1"] == schedule.SENT, "what already ran is left alone"
+    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
+    assert rec["status"] == "archived"
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
+def test_archiving_stops_the_rule_behind_the_next_occurrence(client,
+                                                             projects_dir):
+    """A recurring rule that keeps materialising occurrences is a rule that
+    keeps un-archiving the task — the one thing filing something away must
+    never do."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([
+        _entry("tpl", "every day", T9, state=schedule.RECURRING,
+               repeats="0 9 * * *", claude_session_id="sess-a"),
+        _entry("e2", "every day", T12, template_id="tpl",
+               claude_session_id="sess-a"),
+    ])
+    r = client.post("/api/tasks/archive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+
+    states = {e["id"]: e["state"] for e in schedule.list_entries()}
+    assert states["tpl"] == schedule.CANCELLED
+    assert states["e2"] == schedule.CANCELLED
+    assert r.json()["cancelled"] == 1, "the rule takes its occurrence with it"
+
+
+def test_archiving_leaves_a_send_already_away_alone(client, projects_dir):
+    """`sending` means the helper is away and the turn may have started, so
+    "cancelled" would be a claim this server cannot make good on. It runs, the
+    card reads In Progress, and Archive collects it afterwards."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T9, state=schedule.SENDING,
+                           claude_session_id="sess-a")])
+    r = client.post("/api/tasks/archive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["cancelled"] == 0
+    assert schedule.list_entries()[0]["state"] == schedule.SENDING
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+
+
+def test_archiving_a_task_with_no_session_only_cancels(client, tmp_path):
+    """A message scheduled for tomorrow that has never run has no session to
+    file. Cancelling it leaves nothing for a row to be about, which is
+    `_is_task`'s rule and older than this endpoint."""
+    _seed_schedule([_entry("e1", "tomorrow", T12, target=str(tmp_path))])
+    key = _tasks(client)[0]["key"]
+    r = client.post("/api/tasks/archive", json={"key": key})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "key": key, "cancelled": 1, "filed": False}
+    assert schedule.list_entries()[0]["state"] == schedule.CANCELLED
+    assert _tasks(client) == []
+
+
+def test_archiving_a_task_that_is_not_there_is_a_404(client):
+    assert client.post("/api/tasks/archive",
+                       json={"key": "nope"}).status_code == 404
+
+
+def test_archiving_without_a_key_is_a_400(client):
+    assert client.post("/api/tasks/archive",
+                       json={"key": "  "}).status_code == 400
 
 
 # ----------------------------------------------------------------- the unread

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1262,6 +1262,98 @@ def test_the_archive_is_kept_and_comes_back_when_the_turn_ends(client,
     assert rec["status"] == "archived", "nothing here rewrites the filing"
 
 
+# -- the way out of Archive is activity ----------------------------------------
+# There is no unarchive control anywhere — the lane is drag-locked and the row
+# draws no button — so a message typed into an archived conversation IS the
+# door, and it has to be a real one. These two tests are the pair that keeps
+# that from swallowing the cascade's own promise.
+
+
+def _filed_now(state_dir, session_id="sess-a", at=None):
+    """An archive record with a STAMP, which is what every filing this app
+    writes carries (`claude_sessions.write_triage`) and what the revival rule
+    measures a message against."""
+    (state_dir / "triage.json").write_text(json.dumps(
+        {session_id: {"status": "archived",
+                      "at": str(time.time() if at is None else at)}}))
+
+
+def test_a_message_that_arrives_after_the_filing_revives_the_task(
+        client, projects_dir, state_dir):
+    """New work in a task somebody had finished with. The filing is stale, so it
+    goes — from disk, not just from this response: leaving it there would put
+    the task back in Archive the moment the conversation went quiet again."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T9, state=schedule.SENT, fired=T9,
+                           turn="ok", claude_session_id="sess-a")])
+    _filed_now(state_dir, at=time.time() - 60)
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+    # ...and then someone types into that conversation.
+    later = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() + 1))
+    _write_transcript(projects_dir, "sess-a", "/p", [
+        _user("hi", T9, uuid="u1"), _user("actually, one more thing", later,
+                                          uuid="u2")])
+    tasks_mod.reset_cache()
+
+    # In Progress, not Done: the transcript was just written to, so the session
+    # is live and rule 1 answers first. The point is that it is not `archived`
+    # any more and will settle into its derived lane when the turn ends.
+    task = _by_key(client)["sess-a"]
+    assert task["live"] is True
+    assert task["status"] == "in_progress"
+    rec = json.loads((state_dir / "triage.json").read_text()).get("sess-a", {})
+    assert "status" not in rec, "the filing is dropped, not merely outvoted"
+
+
+def test_the_record_survives_everything_but_the_status(client, projects_dir,
+                                                       state_dir):
+    """A note or a read mark on that session is somebody else's data and
+    outlives the status the Board put on it."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    (state_dir / "triage.json").write_text(json.dumps(
+        {"sess-a": {"status": "archived", "at": "1.0", "note": "keep me"}}))
+    _by_key(client)
+
+    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
+    assert rec == {"note": "keep me"}
+
+
+def test_a_run_already_in_flight_when_it_was_filed_does_not_revive_it(
+        client, projects_dir, state_dir):
+    """The distinction the whole rule turns on.
+
+    That run started BEFORE the filing, so it is not new work — it is the work
+    the user archived on top of. The cascade's promise stands unchanged: it
+    keeps going, the card reads In Progress while it does, and the task settles
+    back into Archive the moment it ends, off the very record it ignored."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T9, state=schedule.SENT, fired=T9,
+                           turn="", claude_session_id="sess-a")])
+    _filed_now(state_dir)  # stamped NOW: the run above happened long before it
+    assert _by_key(client)["sess-a"]["status"] == "in_progress"
+    rec = json.loads((state_dir / "triage.json").read_text())["sess-a"]
+    assert rec["status"] == "archived", "yielding is not un-filing"
+
+    # The turn ends. Same entry, now with a verdict — and the task goes back.
+    _seed_schedule([_entry("e1", "x", T9, state=schedule.SENT, fired=T9,
+                           turn="ok", claude_session_id="sess-a")])
+    tasks_mod.reset_cache()
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
+def test_an_unstamped_filing_revives_on_nothing(client, projects_dir,
+                                                state_dir):
+    """A filing that does not say WHEN cannot be shown to have been overtaken.
+    The sessions Inbox's own `set_triage.py` stamps nothing, and reading those
+    as older-than-everything would revive every archive it has ever written on
+    the next poll."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    (state_dir / "triage.json").write_text(
+        json.dumps({"sess-a": {"status": "archived"}}))
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+
 def test_a_finished_run_with_the_next_one_booked_sits_in_done(client,
                                                               projects_dir):
     """THE RECURRING CASE, and the reason a pending message says nothing.

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1354,6 +1354,37 @@ def test_an_unstamped_filing_revives_on_nothing(client, projects_dir,
     assert _by_key(client)["sess-a"]["status"] == "archived"
 
 
+def test_a_session_with_nothing_in_it_at_all_is_over_not_upcoming(
+        client, projects_dir):
+    """UPCOMING NEEDS SOMETHING COMING, and this is the row that proved it.
+
+    A session whose transcript surfaces no prompt — one that ran only a slash
+    command, whose envelope `strip_machinery` drops — has no output AND nothing
+    scheduled. Filing it under Upcoming put a card in the lane that cannot do
+    the one thing the lane is for: the drag into In Progress fires a pending
+    message and there is none, so `dropLanes` refused it and an Upcoming card
+    became undraggable. On one real machine every card in the lane was this
+    shape — nine of them, `/clear` and `/making-a-release` and `/mcp`.
+    """
+    _write_transcript(projects_dir, "sess-a", "/p", [_assistant("done", T9)])
+    task = _by_key(client)["sess-a"]
+    assert task["message_count"] == 0, "the shape under test: nothing in it"
+    assert task["status"] == "done"
+
+
+def test_a_task_with_a_run_still_coming_is_upcoming_whatever_else_it_holds(
+        client, projects_dir):
+    """The other side: one message still waiting is enough, and it is what makes
+    every card in Upcoming runnable."""
+    _write_transcript(projects_dir, "sess-a", "/p", [])
+    _seed_schedule([_entry("e1", "tomorrow", T12, claude_session_id="sess-a")])
+    task = _by_key(client)["sess-a"]
+    assert task["status"] == "upcoming"
+    # And the row carries what the drag needs to fire.
+    assert task["messages"][0]["state"] == schedule.PENDING
+    assert task["messages"][0]["entry_id"] == "e1"
+
+
 def test_a_finished_run_with_the_next_one_booked_sits_in_done(client,
                                                               projects_dir):
     """THE RECURRING CASE, and the reason a pending message says nothing.


### PR DESCRIPTION
Stacked on `agent/20260818-tasks-polish2` (PR #607 — now frozen). PR#9 of the tasks train; base this on the train tip, not `main`.

## A. A task's status is derived from its thread

`_status` (server `routers/tasks.py`) now reads the whole merged thread in one order, and the order *is* the model:

1. **Anything running ⇒ In Progress.** Activity beats recency — a task whose newest message is next Tuesday's occurrence, with a run still going in it, is working. Three independent signals, any one is enough: a message of its own in flight, a live transcript, `schedule.busy_sessions`.
2. **Archived is a filing state**, and it cascades: the task's messages archive with it *except* one that is still running (rule 1 sits above this), and a thread whose every message is filed is archived without anybody saying so twice.
3. **Otherwise the newest message with a verdict speaks** — `failed`, or `done`.
4. **Nothing to say ⇒ Upcoming** — never run, or nothing but promises.

Two consequences worth naming:

- **The recurring edge.** A daily job that ran this morning and is due again tomorrow now sits in **Done**, not Upcoming: the output nobody has read is what needs eyes, and a promise is not a verdict. The run ahead is still on the row — a `next in 2h` chip beside the time, on both the list row and the board card.
- **Cancelling the newest message hands the word back to the one before it**, which is what makes filing one message a real gesture rather than a way to silence a thread.

The stale-`in_progress` pin is gone along with the machinery that reaped it (`_pin_at`, `_pin_holds`): In Progress is Claude's output, not a lane a person may file a card in, so the record is simply not read. Nor is `done` — a run says that, not a reader.

## B. The list is grouped

`listSections` buckets by `taskColumn` — the same function the board files cards by — with the board's own words, ring and colours. Order is the list's own: **Upcoming → In Progress → Failed → Done → Archive**, because a list is read top-to-bottom as work owed where a board is read left-to-right as a pipeline. Empty sections are absent, header and all. Nothing is re-sorted inside a section; the server's order stands.

## C. The drag matrix, replaced

| from | to | means |
|---|---|---|
| Upcoming | In Progress | **run now** (`/api/schedule/run-now`, `due` untouched) |
| Upcoming | Archive | **cancel** — including the never-run row |
| In Progress | — | locked: the status is Claude's output |
| Done | Archive | only |
| Failed | In Progress | **retry** (same run-now call) |
| Failed | Archive | |
| Archived | — | locked |

Nothing drops into Upcoming, Failed or Done. Illegal drops are refused by `dropLanes` before the card lifts, so the existing no-drop affordances answer them.

`SHOW_UNARCHIVE` and `ICON_UNARCHIVE` are deleted rather than gated: the row never drew unarchive and the board's drag did, which was two answers to one question.

## D. Archiving is one server verb

`POST /api/tasks/archive` — one gesture, two halves: it cancels every pending message *and* the recurring rules behind them (a rule that keeps materialising occurrences keeps un-archiving the task), then files the session in the same `triage.json` the Inbox reads. Keyed by **task**, not session, which is what lets `pending:<entry-id>` be archived at all.

**The way out of Archive is activity** — there is no unarchive control anywhere. A message whose `ran_at` is after the filing's own stamp drops the filing from disk (`claude_sessions.clear_triage`, which keeps notes/tags/read marks), and the task rejoins its derived lane. A run that was *already in flight* when the task was filed started before the stamp, so it does not revive anything: #607's cascade promise is unchanged — it keeps going, the card reads In Progress, and it settles back into Archive when it ends. Both cases are pinned by tests.

## E. Calendar popover + chips (scope added mid-PR)

- **Reordered:** id + status chip, then title (16px) over description (12px, muted, no glyph) as one written block — the shape the New task modal asks for them in — then the folder/repeat facts, then the day block, then the actions.
- **Occurrence rows stop repeating the panel:** the body survives only where it says something the title has not, and the status word moves into the row's tooltip. The ring carries the state, as it does on the other two views.
- **The status pill wears the status colours** — all five, from the same `--status-*` tokens the ring reads, as a tint behind a full-strength label. Only In Progress and Failed were coloured before, so Done/Archive/Upcoming were one grey badge between them.
- **A chip whose run is happening now shimmers** (2s sweep in a pseudo-element over the project hue, static highlight under `prefers-reduced-motion`). A calendar has no In Progress lane; every static property on a chip was already spent on the project hue, the projected dashes and the past fade.

## Gates

- `npm run build` ✅ · `tsc --noEmit` ✅ · `bun test` 1732 pass, 0 fail ✅
- `pytest tests/test_tasks_api.py tests/test_tasks_store.py tests/test_schedule*.py` — 301 passed ✅
- Rebased onto the latest `agent/20260818-tasks-polish2`; the `_status` / archive-cascade conflicts with #607's `_running_now` were resolved keeping both (its helper is now what rule 1 asks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to task status derivation, triage/archive lifecycle, and scheduling cancellation affect listing, board drag, and inbox consistency; mistakes could mis-lane tasks or revive/stick archive incorrectly.
> 
> **Overview**
> Reworks how tasks get their **status** on the server: `_status` walks the full merged thread (running beats filing, archive cascades, then the latest message with a verdict; pending-only threads stay **Upcoming**, recurring “done + next run” stays **Done**). Stale `in_progress` triage pins and Done→In Progress drags go away; activity after an archive stamp clears triage via `clear_triage`.
> 
> **Archiving** becomes `POST /api/tasks/archive` / `archiveTask(key)`—cancel pending work (and recurring templates) plus file the session—replacing client `setSessionTriage` and removing **Unarchive** everywhere.
> 
> **Board/list** share a fixed **drag matrix** (`LANE_EXITS`): run-now or archive from unlocked lanes only; list rows use `sortByLane` (no section headers). **`nextRunChip`** and **`isRunningNow`** surface the next run and in-flight work on list/board/calendar chips (shimmer + reduced-motion fallback).
> 
> **Calendar popover** gets title/description layout, less repeated row text, five tinted status pills, and CSS/tests for the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05effda8cdf7aedbffae2d04c809585763cb1624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->