### PR TITLE
Fix the three template tests #610 left pinning an expired spelling

### DIFF
--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -732,7 +732,10 @@ def test_claude_template_boots_into_chat_from_a_bare_run_param():
     the FOLDER, so this was already pinning the wrong page's boot."""
     page = _repo_text("fused_render", "templates", "claude", "template.html")
     assert 'fused.params.get("run")' in page
-    assert "await resumeRun(run_id)" in page
+    # The CALL, not its argument list: `resumeRun` grew an options object
+    # (`{ retryUnknown: true }`, #610) and this test is about the boot resuming
+    # the run at all, so it must not break every time an opt is added.
+    assert "await resumeRun(run_id" in page
 
 
 def test_run_param_survives_the_shell_runtime():

--- a/tests/test_claude_queue_persistence.py
+++ b/tests/test_claude_queue_persistence.py
@@ -287,7 +287,9 @@ def test_the_queue_is_restored_before_the_run_is_re_attached():
     entries restored after it would sit there until some later turn ended."""
     boot = _html()[_html().index("// ── boot:"):]
     assert "restoreQueue(" in boot, "the boot never restores the queue"
-    assert boot.index("restoreQueue(") < boot.index("resumeRun(run_id)")
+    # Matched without the closing paren: the call takes an options object now
+    # (#610) and this assertion is about ORDER, not about its arguments.
+    assert boot.index("restoreQueue(") < boot.index("resumeRun(run_id")
     assert boot.index("restoreQueue(") < boot.index("loadHistory(session_id)")
 
 

--- a/tests/test_claude_schedule_pill.py
+++ b/tests/test_claude_schedule_pill.py
@@ -94,8 +94,16 @@ def test_a_scheduled_turn_that_FINISHED_between_polls_is_appended(code):
     # whatever the reader last said
     assert "if (probeMsg) addUser(probeMsg);" in done
 
-    # and the reload caller keeps the conservative default — passing no opts
-    assert "await resumeRun(run_id);" in code
+    # and the reload caller keeps the conservative default for THIS opt. It no
+    # longer passes no opts at all — #610 gave it `{ retryUnknown: true }`, which
+    # is a different question (retry a run_id the server has not registered yet)
+    # — so what has to hold is that it does not opt into `neverShown`, which is
+    # the one that would make a reload append a turn the transcript may already
+    # hold.
+    reload_call = code[code.index("if (run_id) await resumeRun(run_id"):]
+    reload_call = reload_call[:reload_call.index(";") + 1]
+    assert "neverShown" not in reload_call, \
+        "the reload path must not claim the turn was never shown: " + reload_call
 
 
 def test_never_shown_kills_matching_rather_than_only_adding_a_branch(code):


### PR DESCRIPTION
Main is currently red: #610 changed the claude template's boot line to `resumeRun(run_id, { retryUnknown: true })` without updating three tests that pinned the old `resumeRun(run_id)` spelling. Every open PR's merge-based CI fails because of it.

- `test_apps_api` / `test_claude_queue_persistence`: now match `resumeRun(run_id` without the closing paren — one cares that boot resumes the run, the other about order relative to `restoreQueue(`; neither cares which opts ride along.
- `test_claude_schedule_pill`: restated as the actual invariant — the reload path must not opt into `neverShown` (the flag that double-appends a finished run) — rather than "passes no opts", which expired the moment a harmless opt appeared.

Verified: all three fail on pristine main, 92 pass with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; they preserve intended behavior checks while matching the updated template call shape.
> 
> **Overview**
> **Restores CI on main** by updating three tests that still expected the claude template boot to call `await resumeRun(run_id)` exactly, after #610 changed that line to pass `{ retryUnknown: true }`.
> 
> In **`test_apps_api`** and **`test_claude_queue_persistence`**, assertions now match `await resumeRun(run_id` without requiring a closing `)` — one still checks that boot resumes a run from the `run` param; the other still checks **`restoreQueue(`** runs **before** **`resumeRun`**, without caring which options are passed.
> 
> In **`test_claude_schedule_pill`**, the reload-path check no longer requires “passes no opts”; it extracts the reload `resumeRun` call and asserts **`neverShown`** is absent, preserving the real invariant that reload must not treat the turn as never shown (which would double-append), while allowing harmless opts like **`retryUnknown`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4743309c12af4cacf1e3e67e9e888163bf2fd5f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->