### PR TITLE
Fix three claude-template assertions that pin an argument list to assert something else (main is red)

### DIFF
--- a/tests/test_apps_api.py
+++ b/tests/test_apps_api.py
@@ -732,7 +732,13 @@ def test_claude_template_boots_into_chat_from_a_bare_run_param():
     the FOLDER, so this was already pinning the wrong page's boot."""
     page = _repo_text("fused_render", "templates", "claude", "template.html")
     assert 'fused.params.get("run")' in page
-    assert "await resumeRun(run_id)" in page
+    # Anchored on the call-site PREFIX, not the whole `resumeRun(run_id)` call: the
+    # boot has since grown an opts argument (`{ retryUnknown: true }`, for the
+    # embedder-navigated frame whose run dir lags its first poll) and will likely grow
+    # more, none of which is this test's business. `await ` keeps it the boot CALL and
+    # not the `async function resumeRun(run_id, opts)` declaration, so deleting the
+    # re-attach still fails here.
+    assert "await resumeRun(run_id" in page
 
 
 def test_run_param_survives_the_shell_runtime():

--- a/tests/test_claude_queue_persistence.py
+++ b/tests/test_claude_queue_persistence.py
@@ -287,7 +287,13 @@ def test_the_queue_is_restored_before_the_run_is_re_attached():
     entries restored after it would sit there until some later turn ended."""
     boot = _html()[_html().index("// ── boot:"):]
     assert "restoreQueue(" in boot, "the boot never restores the queue"
-    assert boot.index("restoreQueue(") < boot.index("resumeRun(run_id)")
+    # Still an ORDERING assertion; only the way it locates the re-attach is looser.
+    # The exact `resumeRun(run_id)` form broke the moment the boot passed an opts
+    # argument (`{ retryUnknown: true }`), and `.index()` raising "substring not
+    # found" reads as a broken test rather than the drift it was pinning. The
+    # argument-agnostic `await resumeRun(run_id` still names that one call site.
+    assert "await resumeRun(run_id" in boot, "the boot never re-attaches to the run"
+    assert boot.index("restoreQueue(") < boot.index("await resumeRun(run_id")
     assert boot.index("restoreQueue(") < boot.index("loadHistory(session_id)")
 
 

--- a/tests/test_claude_schedule_pill.py
+++ b/tests/test_claude_schedule_pill.py
@@ -94,8 +94,16 @@ def test_a_scheduled_turn_that_FINISHED_between_polls_is_appended(code):
     # whatever the reader last said
     assert "if (probeMsg) addUser(probeMsg);" in done
 
-    # and the reload caller keeps the conservative default — passing no opts
-    assert "await resumeRun(run_id);" in code
+    # and the reload caller keeps the conservative default — it never opts into
+    # neverShown. Pinned as "this call does not ask for it" rather than the old
+    # "passing no opts at all" (`await resumeRun(run_id);`): the boot legitimately
+    # grew an unrelated `{ retryUnknown: true }`, and an exact-argument anchor made
+    # every future opt look like this test's regression.
+    assert "await resumeRun(run_id" in code, "the boot never re-attaches to the run"
+    reattach = code[code.index("await resumeRun(run_id"):]
+    reattach = reattach[:reattach.index(";")]
+    assert "neverShown" not in reattach, \
+        "the reload path must repair only what it can prove is missing"
 
 
 def test_never_shown_kills_matching_rather_than_only_adding_a_branch(code):


### PR DESCRIPTION
## Summary

- **`main` is red right now**, and has been since `a6714f11` (#610). Three tests assert a call-site string the claude template no longer contains, so every PR opened against `main` inherits three failures in four `test-python` lanes plus `fused-engine`. This fixes only that.
- **The tests were the wrong side, not the template.** `a6714f11`'s own message states the intent: the boot re-attach retries a briefly-unknown `run_id` (5 × 700ms) when the id came from the URL, because a just-spawned run's dir can lag the frame's first poll. `retryUnknown` is a purely additive opt; the boot call became `await resumeRun(run_id, { retryUnknown: true })` and three assertions were missed. No behaviour the tests guarded changed.
- **The anchors were brittle in a specific way: they pinned the exact argument list to assert something else.** Each is re-anchored on what it actually cares about, so a future added argument doesn't break them again — while still failing if the invariant is genuinely violated.

## Visuals

The boot sequence the three tests guard. Nothing here changes — only how the tests point at it.

```mermaid
flowchart TD
    B[boot: run_id from URL param] --> RQ[restoreQueue]
    RQ --> RR["await resumeRun(run_id, opts)"]
    RR --> D[drainQueue]
    RR -.->|retryUnknown: 5 x 700ms| U[unknown run_id retried, then cleared as stale]
```

The ordering test asserts the `restoreQueue → resumeRun` edge. The other two assert the `resumeRun` node exists at all. The `retryUnknown` branch is what #610 added.

## Usage

Not user-facing — test-only change. No template, runtime, or page behaviour is touched. `fused_render/templates/claude/template.html` is byte-identical to `main` (verified by hash, `05df7b06…`); the diff is three test files, +24/-4.

## Test Plan

- [x] **Red before, on clean `origin/main`** — `3 failed, 89 passed`: `test_apps_api.py::test_claude_template_boots_into_chat_from_a_bare_run_param`, `test_claude_queue_persistence.py::test_the_queue_is_restored_before_the_run_is_re_attached` (which raised `ValueError: substring not found` rather than failing cleanly), `test_claude_schedule_pill.py::test_a_scheduled_turn_that_FINISHED_between_polls_is_appended`.
- [x] **Green after** — `92 passed in 1.82s` across the three files.
- [x] **Proved the tests still bite.** Deleted the `await resumeRun(run_id, { retryUnknown: true });` line from the template → all three go red. Restored, verified byte-identical.
- [x] **Proved the ordering test is still an ordering test**, not a presence check. Moved the re-attach *above* `restoreQueue` → `test_the_queue_is_restored_before_the_run_is_re_attached` fails on the index comparison, everything else passes.
- [ ] CI — a green run here is also the confirmation that these three were `main`'s only red.

### What each anchor became, and why

| test | before | after |
|---|---|---|
| `test_apps_api.py:735` | `"await resumeRun(run_id)" in page` | `"await resumeRun(run_id" in page` |
| `test_claude_queue_persistence.py:290` | `boot.index("restoreQueue(") < boot.index("resumeRun(run_id)")` | presence assertion + same index comparison on `"await resumeRun(run_id"` |
| `test_claude_schedule_pill.py:98` | `"await resumeRun(run_id);" in code` | presence assertion + `"neverShown" not in` the call's own argument text |

`await ` is deliberately kept in every anchor: without it, `async function resumeRun(run_id, opts)` at `template.html:12288` would satisfy the assertion and deleting the boot call would still pass — the tests would be decorative.

The schedule-pill test is the one worth a reviewer's eye. Its trailing `;` was encoding *"passes no opts at all"* as a stand-in for its real subject, *"the reload path does not opt into `neverShown`"* (repair only what it can prove is missing). That is now asserted directly against the call's argument text, so unrelated future opts are fine and a `neverShown: true` on the reload path is still caught. Note `code` is comment-stripped by the module fixture, so the anchor can't be satisfied by prose, and `await resumeRun(run_id` occurs exactly once in the template.

Each edit carries a comment explaining why the exact-argument form was brittle, so the next person doesn't tighten it back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
