### PR TITLE
Sidebar: a Tasks entry that says what is running, and a list row that swaps its ring for Archive

### DIFF
--- a/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
+++ b/frontend/src/apps/explorer/sidebar/BookmarksSection.tsx
@@ -312,7 +312,9 @@ function FolderRow({ folder, child, parentId, collapsed, activeHint, isRenaming,
       ) : (
         <span className="bookmark-name folder-name">{folder.name}</span>
       )}
-      <span className="folder-count">{folder.children.length}</span>
+      {/* The chip's skin is the sidebar-wide one (`.sidebar-count-chip`); this
+          class carries only the folder row's own placement and hover fade. */}
+      <span className="sidebar-count-chip folder-count">{folder.children.length}</span>
       {/* Hidden mid-rename for the same reason as a bookmark row's cluster. */}
       {!isRenaming && (
         <span className="bookmark-actions">
@@ -905,7 +907,12 @@ export default function BookmarksSection() {
         onClick={toggleSectionCollapsed}
       >
         Bookmarks
-        {sectionCollapsed && <span className="recents-count">{countBookmarks(items)}</span>}
+        {/* `.sidebar-count-chip` is the shared skin every count in this sidebar
+            wears — the folder rows' nested count and the Tasks entry's unread
+            count are the same element (sidebar.css). */}
+        {sectionCollapsed && (
+          <span className="sidebar-count-chip recents-count">{countBookmarks(items)}</span>
+        )}
       </div>
       {!sectionCollapsed &&
         (items.length === 0 ? (

--- a/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
+++ b/frontend/src/platform/ui/sidebar/SidebarFrame.tsx
@@ -46,6 +46,11 @@ export interface SidebarRailItem {
   /** Override the exact-pathname highlight, mirroring NavItem's `active` —
       for icons that are "home" to a family of routes. */
   active?: boolean;
+  /** A mark ON the icon — the collapsed rail's only way to say anything about
+      the page behind it, since there is no label to hang a count on (the
+      shell's Tasks dot). Drawn inside the button, which is the positioned
+      ancestor it resolves against; the frame never says what it means. */
+  badge?: React.ReactNode;
 }
 
 export interface SidebarFrameProps {
@@ -69,13 +74,20 @@ export function NavItem({
   icon,
   id,
   extra,
+  trailing,
   active,
 }: {
   href: string;
   label: string;
   icon: React.ReactNode;
   id?: string;
+  /** A mark ON the icon (the Settings row's resident-model dot). */
   extra?: React.ReactNode;
+  /** Content AFTER the label, pushed to the row's trailing edge — where a count
+      or a status readout goes once there is a label for it to belong to. The
+      expanded sidebar's answer to the rail's `badge`: same fact, stated in
+      words rather than as a dot, because here there is room for words. */
+  trailing?: React.ReactNode;
   /** Override the exact-pathname highlight — for entries that are "home" to a
       whole family of routes (the global sidebar's Explorer row is active on
       every fs-path/panel/tab route, not just /explorer itself). */
@@ -96,6 +108,7 @@ export function NavItem({
         {extra}
       </span>{" "}
       {label}
+      {trailing && <span className="sidebar-item-trail">{trailing}</span>}
     </a>
   );
 }
@@ -203,6 +216,7 @@ export function SidebarFrame({ title, version, homeHref = "/apps", rail, childre
                   }}
                 >
                   {item.icon}
+                  {item.badge}
                 </a>
               </React.Fragment>
             ))}

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -252,42 +252,45 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   const homeActive = pathname === "/home";
   const tasksActive = pathname === "/tasks";
 
-  // WHAT THE TASKS ENTRY KNOWS, and it is two numbers: what is running, and what
-  // finished that nobody has read (shell/tasksPulse — one poll shared with the
-  // page, which publishes into it). Two numbers rather than a badge count
-  // because they are two different sentences: yellow is "the machine is working
-  // for you", green is "go and look". Yellow WINS whenever both are true — a
-  // reader who is being told work is still in flight does not also need to be
-  // sent to the page mid-flight, and the trip is still waiting when it settles.
+  // WHAT THE TASKS ENTRY KNOWS: what is running, and what finished with
+  // something unread (shell/tasksPulse — one poll shared with the page, which
+  // publishes into it). Two facts rather than a badge count, because they are two
+  // different sentences: yellow is "the machine is working for you", green is
+  // "go and look". Yellow WINS whenever both are true — a reader being told work
+  // is still in flight does not also need sending to the page mid-run, and the
+  // trip is still waiting when it settles.
   const pulse = useTasksPulse();
-  // LANDING ON THE PAGE IS THE DISMISSAL. Not a button and not a per-row read:
-  // "an in-progress task completed" is news exactly until the reader has been
-  // where it is shown. Repeated on every pulse while the entry is active so the
-  // mark stays gone while the page is open; it comes back only for a completion
-  // stamped after the visit (tasks-lib.seenAfterVisit), which is why the
-  // dismissal is a stamp per task and not a flag.
+  // LANDING ON THE PAGE IS THE DISMISSAL — OF THE DOT, and only the dot. Not a
+  // button and not a per-row read: "an in-progress task completed" is news
+  // exactly until the reader has been where it is shown. Repeated on every pulse
+  // while the entry is active so the mark stays gone while the page is open; it
+  // comes back only for a completion stamped after the visit
+  // (tasks-lib.seenAfterVisit), which is why the dismissal is a stamp per task
+  // and not a flag.
   useEffect(() => {
     if (tasksActive) markTasksSeen();
   }, [tasksActive, pulse]);
-  // AND WHILE THE READER IS ON /tasks, THERE IS NO COUNT AT ALL. The dismissal
-  // above needs a poll to land before it can stamp anything, so a completion that
-  // arrives in the same tick as the navigation would flash a chip beside the row
-  // of the page being looked at, then clear itself. Suppressed here rather than
-  // fixed in the store, because it is not a timing detail: a "go and look" mark
-  // pointing at the open page is noise whatever the clock says. RUNNING is not
-  // suppressed — it is a live state, not an errand.
-  const shown = { running: pulse.running, doneUnread: tasksActive ? 0 : pulse.doneUnread };
-  const tasksTip = pulseTitle(shown);
+  // THE DOT AND THE CHIP COUNT DIFFERENT THINGS, on purpose (Akshil,
+  // 2026-08-18). `unseen` is dismissal-gated and is the dot: an interruption
+  // that has done its job once the reader has been where it points — and it is
+  // suppressed outright while that page IS the one on screen, since the stamp
+  // needs a poll to land and a dot flashing beside the open page is noise. The
+  // CHIP reads `doneUnread`, the raw state, and no visit touches it: "three
+  // finished things are waiting" stays true until they are read, and a number
+  // that cleared itself for being glanced at would be a number nobody could
+  // trust. See tasks-lib.isDoneUnread / isUnseenCompletion.
+  const unseen = tasksActive ? 0 : pulse.unseen;
+  const tasksTip = pulseTitle(pulse);
 
   // The collapsed rail has no label to hang a word on, so the whole signal is
   // one dot in the icon's top-right corner: yellow while anything runs, green
-  // for unread completions, nothing at all otherwise. The hues are the status
-  // ring's own (--status-progress / --status-done, schedule.css) — one status,
-  // one colour, on every surface that names it (design-principles §1).
+  // for completions not yet shown, nothing at all otherwise. The hues are the
+  // status ring's own (--status-progress / --status-done, schedule.css) — one
+  // status, one colour, on every surface that names it (design-principles §1).
   const tasksDot =
-    shown.running > 0 ? (
+    pulse.running > 0 ? (
       <span className="sidebar-rail-dot is-running" title={tasksTip} />
-    ) : shown.doneUnread > 0 ? (
+    ) : unseen > 0 ? (
       <span className="sidebar-rail-dot is-unread" title={tasksTip} />
     ) : undefined;
 
@@ -297,16 +300,16 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   // the same element for the same kind of fact, not a lookalike. NO DOT here:
   // a dot on the icon plus a readout beside the label is one fact stated twice.
   const tasksTrailing =
-    shown.running > 0 || shown.doneUnread > 0 ? (
+    pulse.running > 0 || pulse.doneUnread > 0 ? (
       <>
-        {shown.running > 0 && (
+        {pulse.running > 0 && (
           <span className="sidebar-running" title={tasksTip}>
-            {runningLabel(shown.running)}
+            {runningLabel(pulse.running)}
           </span>
         )}
-        {shown.doneUnread > 0 && (
+        {pulse.doneUnread > 0 && (
           <span className="sidebar-count-chip" title={tasksTip}>
-            {shown.doneUnread}
+            {pulse.doneUnread}
           </span>
         )}
       </>

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -267,6 +267,12 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   // comes back only for a completion stamped after the visit
   // (tasks-lib.seenAfterVisit), which is why the dismissal is a stamp per task
   // and not a flag.
+  //
+  // It fires on the FIRST render here too, before any answer has landed, and the
+  // store is what makes that harmless: markTasksSeen is a no-op until a real
+  // fetch has come back, because stamping "everything on screen" over an empty
+  // store would write an empty map and throw away every dismissal the reader
+  // had (bugbot, 2026-08-18).
   useEffect(() => {
     if (tasksActive) markTasksSeen();
   }, [tasksActive, pulse]);

--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -18,6 +18,8 @@ import { navigateUrl } from "@platform/lib/router";
 import { useUrlVersion, useLearnMountReady } from "@platform/lib/hooks";
 import { useClaudeConfigAvailable } from "@apps/claude_config/available";
 import { useAiRuntime } from "@shell/aiRuntime";
+import { markTasksSeen, useTasksPulse } from "@shell/tasksPulse";
+import { pulseTitle, runningLabel } from "@shell/tasks-lib";
 import { formatSize } from "@platform/lib/format";
 import BookmarksSection from "@apps/explorer/sidebar/BookmarksSection";
 
@@ -250,6 +252,66 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   const homeActive = pathname === "/home";
   const tasksActive = pathname === "/tasks";
 
+  // WHAT THE TASKS ENTRY KNOWS, and it is two numbers: what is running, and what
+  // finished that nobody has read (shell/tasksPulse — one poll shared with the
+  // page, which publishes into it). Two numbers rather than a badge count
+  // because they are two different sentences: yellow is "the machine is working
+  // for you", green is "go and look". Yellow WINS whenever both are true — a
+  // reader who is being told work is still in flight does not also need to be
+  // sent to the page mid-flight, and the trip is still waiting when it settles.
+  const pulse = useTasksPulse();
+  // LANDING ON THE PAGE IS THE DISMISSAL. Not a button and not a per-row read:
+  // "an in-progress task completed" is news exactly until the reader has been
+  // where it is shown. Repeated on every pulse while the entry is active so the
+  // mark stays gone while the page is open; it comes back only for a completion
+  // stamped after the visit (tasks-lib.seenAfterVisit), which is why the
+  // dismissal is a stamp per task and not a flag.
+  useEffect(() => {
+    if (tasksActive) markTasksSeen();
+  }, [tasksActive, pulse]);
+  // AND WHILE THE READER IS ON /tasks, THERE IS NO COUNT AT ALL. The dismissal
+  // above needs a poll to land before it can stamp anything, so a completion that
+  // arrives in the same tick as the navigation would flash a chip beside the row
+  // of the page being looked at, then clear itself. Suppressed here rather than
+  // fixed in the store, because it is not a timing detail: a "go and look" mark
+  // pointing at the open page is noise whatever the clock says. RUNNING is not
+  // suppressed — it is a live state, not an errand.
+  const shown = { running: pulse.running, doneUnread: tasksActive ? 0 : pulse.doneUnread };
+  const tasksTip = pulseTitle(shown);
+
+  // The collapsed rail has no label to hang a word on, so the whole signal is
+  // one dot in the icon's top-right corner: yellow while anything runs, green
+  // for unread completions, nothing at all otherwise. The hues are the status
+  // ring's own (--status-progress / --status-done, schedule.css) — one status,
+  // one colour, on every surface that names it (design-principles §1).
+  const tasksDot =
+    shown.running > 0 ? (
+      <span className="sidebar-rail-dot is-running" title={tasksTip} />
+    ) : shown.doneUnread > 0 ? (
+      <span className="sidebar-rail-dot is-unread" title={tasksTip} />
+    ) : undefined;
+
+  // Expanded, the same two facts get words: a shimmering "N running" (the ink
+  // moves while the work does, and prefers-reduced-motion pins it), and the
+  // count chip the bookmark folders wear (`.sidebar-count-chip`, sidebar.css) —
+  // the same element for the same kind of fact, not a lookalike. NO DOT here:
+  // a dot on the icon plus a readout beside the label is one fact stated twice.
+  const tasksTrailing =
+    shown.running > 0 || shown.doneUnread > 0 ? (
+      <>
+        {shown.running > 0 && (
+          <span className="sidebar-running" title={tasksTip}>
+            {runningLabel(shown.running)}
+          </span>
+        )}
+        {shown.doneUnread > 0 && (
+          <span className="sidebar-count-chip" title={tasksTip}>
+            {shown.doneUnread}
+          </span>
+        )}
+      </>
+    ) : undefined;
+
   // Everything that is not primary nav lives in the bottom menu for now:
   // the former sidebar entries (Config / App Basics), then the settings
   // pages. Same gates as before — an entry a machine can't use stays hidden.
@@ -299,7 +361,14 @@ export default function GlobalSidebar({ config }: { config: Config }) {
 
   const rail: SidebarRailItem[] = [
     { key: "home", label: "Home", icon: HOME_ICON, href: "/home", active: homeActive },
-    { key: "tasks", label: "Tasks", icon: SCHEDULED_ICON, href: "/tasks", active: tasksActive },
+    {
+      key: "tasks",
+      label: tasksTip ? `Tasks — ${tasksTip}` : "Tasks",
+      icon: SCHEDULED_ICON,
+      href: "/tasks",
+      active: tasksActive,
+      badge: tasksDot,
+    },
     {
       key: "preferences",
       label: "Preferences",
@@ -337,6 +406,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
             label="Tasks"
             icon={SCHEDULED_ICON}
             active={tasksActive}
+            trailing={tasksTrailing}
           />
         </div>
         <BookmarksSection />

--- a/frontend/src/shell/ScheduleCalendar.tsx
+++ b/frontend/src/shell/ScheduleCalendar.tsx
@@ -165,7 +165,7 @@ import type { CalendarChip, CalendarRange, MsgCancelKind, QueueRole } from "./sc
 // The pill used to answer a different question (the day's worst run) and could
 // therefore contradict the button — see the `pill` memo below.
 import {
-  isRunningNow,
+  isRunningIn,
   messageTone as taskMessageTone,
   openMessageHref,
   taskColumn,
@@ -1106,7 +1106,15 @@ export default function ScheduleCalendar({
                         // other two views file a card by — and the CSS is a
                         // shimmer that sweeps the chip, with a static highlight
                         // under prefers-reduced-motion.
-                        (isRunningNow(chip.task, chip.anchor) ? " is-running" : "") +
+                        //
+                        // ASKED OF THE WHOLE CHIP, not of its anchor (bugbot,
+                        // 2026-08-18). A chip is a task on a DAY and the anchor
+                        // is only that day's EARLIEST message, so a day whose
+                        // 05:00 run has finished and whose 14:00 run is in flight
+                        // was asking about the finished one — while the running
+                        // mark landed on whichever day held the task's newest
+                        // row, routinely tomorrow's pending occurrence.
+                        (isRunningIn(chip.task, chip.messages) ? " is-running" : "") +
                         (chip.time < now ? " is-past" : "") +
                         // Three lanes leave a chip ~70px wide, which cannot hold
                         // both the title and the clock — the title collapsed to

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -1679,12 +1679,64 @@ function TaskNode({
             that a reader has to pair up. `unread` is the merged count this row is
             DRAWING, so the ring hollows on the row's own press rather than on the
             next poll, and it is the count the tooltip names. */}
-        <StatusIcon
-          status={taskColumn(task)}
-          failed={task.failed}
-          unread={unread > 0}
-          count={unread}
-        />
+        {/* THE MARK SLOT: the ring at rest, the Archive button under the pointer,
+            in the same box (`.tasks-rowmark`, tasks.css).
+
+            The two used to be at opposite ends of the row — the ring in the rail
+            and Archive out by the folder chip — which made "file this away" a
+            control the reader had to travel to, and put a hover-revealed button
+            in the one part of the row that is already the busiest (id, folder,
+            two times). The swap costs nothing to read: a row being pointed at is
+            a row whose status the reader has just read, and it is the same
+            gesture every list of this shape uses.
+
+            The button is ABSOLUTELY positioned inside a slot sized to the ring,
+            so it is out of flow and no pixel of the row can move when it appears
+            — the rail (`--tasks-rail-x`), the thread's indent under it and the
+            caret's hit zone to its left are all untouched. */}
+        <span className="tasks-rowmark">
+          <StatusIcon
+            status={taskColumn(task)}
+            failed={task.failed}
+            unread={unread > 0}
+            count={unread}
+          />
+          {/* The Board's drag onto Archive, as a press — and there is no way
+              back, because Archive is a locked lane (tasks-lib.archiveIntent
+              decides both halves and refuses the reverse).
+
+              THE ONE ROW ACTION NOT BEHIND SHOW_ROW_ACTIONS (Akshil, 2026-08-18:
+              bring the archive button back, visible on hover). Filing a task away
+              had no press anywhere in the List while the strip was off — the only
+              route was switching to the Board, expanding the Archive lane and
+              dragging — which made the honest answer to "can a task be deleted?"
+              (no: it is archived) barely true on this view.
+
+              HOVER-REVEALED, not permanent: a list at rest must grow no chrome
+              (§2 — only critical actions get visible buttons), and this is one
+              button on every row that has ever run. `.tasks-act` in tasks.css
+              owns that, and it does it with `opacity` plus a `:focus-visible` arm
+              rather than `visibility`/`display`, so the button stays in the tab
+              order and lights up for a keyboard that lands on it. It is still not
+              rendered at all on a task with nothing to file, which is the
+              difference that matters: hidden-until-hover is for a live control,
+              not for a dead one. */}
+          {file && (
+            <button
+              type="button"
+              className="tasks-act tasks-act--archive"
+              title={file.title}
+              aria-label={file.label}
+              disabled={acting}
+              onClick={(e) => {
+                e.stopPropagation();
+                void archive();
+              }}
+            >
+              {ICON_ARCHIVE}
+            </button>
+          )}
+        </span>
         <IdChip id={task.task_id} kind="task" />
         {/* Greyed while the work is still ahead of it (tasks-lib.isUpcomingTask):
             a list is mostly history, and the rows that have not happened yet are
@@ -1702,13 +1754,12 @@ function TaskNode({
             right-hand group in the middle of the row instead of at its end. */}
         <span className="tasks-grow" />
 
-        {/* THE STRIP IS BEHIND SHOW_ROW_ACTIONS — with ONE exception, Archive,
-            which came back on 2026-08-18 (Akshil). Each button carries its own
-            guard rather than the group carrying one, so the four keep their
-            hard-won ORDER whichever of them are rendered: pulling Archive out into
-            a block of its own beside the flagged fragment would file it before Mark
-            read and Run now the day the flag flips, and the strip's order is read
-            left-to-right as "clear it, run it, file it, open it". */}
+        {/* THE STRIP IS BEHIND SHOW_ROW_ACTIONS, all of it. Archive is the one
+            row action that is live, and it is no longer part of this strip at all
+            — it moved into the mark slot at the row's leading edge on 2026-08-18
+            (see `.tasks-rowmark` above). Each button still carries its own guard
+            rather than the group carrying one, so the three keep their hard-won
+            ORDER whichever of them are rendered: "clear it, run it, open it". */}
         {/* The drag from Upcoming into In Progress, without the drag — and on
             a task that broke, the word for doing it again over whichever call
             can actually do it: run-now while a message is still pending,
@@ -1754,41 +1805,12 @@ function TaskNode({
             {run.rerun ? ICON_RERUN : ICON_PLAY}
           </button>
         )}
-        {/* The Board's drag onto Archive, as a press — and on an already
-            archived row, the way back, because an action with only one
-            direction is a trap. tasks-lib.archiveIntent decides both halves.
-
-            THE ONE ROW ACTION NOT BEHIND THE FLAG (Akshil, 2026-08-18: bring the
-            archive button back, visible on hover). Filing a task away had no press
-            anywhere in the List while the strip was off — the only route was
-            switching to the Board, expanding the Archive lane and dragging — which
-            made the honest answer to "can a task be deleted?" (no: it is archived)
-            barely true on this view.
-
-            HOVER-REVEALED, not permanent: a list at rest must grow no chrome
-            (§2 — only critical actions get visible buttons), and this is one
-            button on every row that has ever run. `.tasks-act` in tasks.css owns
-            that, and it does it with `opacity` plus a `:focus-visible` arm rather
-            than `visibility`/`display`, so the button stays in the tab order and
-            lights up for a keyboard that lands on it. It is still not rendered at
-            all on a task with nothing to file, which is the difference that
-            matters: hidden-until-hover is for a live control, not for a dead
-            one. */}
-        {file && (
-          <button
-            type="button"
-            className="tasks-act tasks-act--archive"
-            title={file.title}
-            aria-label={file.label}
-            disabled={acting}
-            onClick={(e) => {
-              e.stopPropagation();
-              void archive();
-            }}
-          >
-            {ICON_ARCHIVE}
-          </button>
-        )}
+        {/* ARCHIVE IS NOT HERE ANY MORE (2026-08-18). It sat between Run now and
+            Open chat, out by the folder chip; it is in the row's MARK SLOT now,
+            swapping with the status ring on hover (see `.tasks-rowmark` above).
+            The strip's remaining order still reads left-to-right as "clear it,
+            run it, open it", and the day SHOW_ROW_ACTIONS flips there is no
+            fourth button to find a place for. */}
         {/* The one gesture in this row that OPENS a MULTI-message conversation
             — so it is the one that also clears the thread, exactly as the Board
             card's click does: it lands the reader in the very thread this row's

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -79,7 +79,7 @@ import {
   projectOptions,
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
-import { publishTasks } from "./tasksPulse";
+import { publishTasks, useTasksFeeder } from "./tasksPulse";
 import { viewFromSearch, viewUrl } from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 
@@ -108,6 +108,12 @@ const VIEW_KEY = "fused-render:scheduled-view";
 const NEW_LINK_LEAD_MS = 120_000;
 
 export default function Scheduled() {
+  // THIS PAGE IS THE POLLER while it is open. The sidebar's Tasks entry reads the
+  // same rows (shell/tasksPulse) and would otherwise run a timer of its own
+  // alongside this one — two calls to /api/tasks for one answer, at two
+  // cadences. Holding a feeder for the page's lifetime says "take my answers,
+  // make no calls", so the shared store stands down until this unmounts.
+  useTasksFeeder();
   const [state, setState] = useState<ScheduleResult | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [tasksFailed, setTasksFailed] = useState(false);

--- a/frontend/src/shell/Scheduled.tsx
+++ b/frontend/src/shell/Scheduled.tsx
@@ -79,6 +79,7 @@ import {
   projectOptions,
 } from "./ScheduleTaskViews";
 import type { TaskFilters } from "./ScheduleTaskViews";
+import { publishTasks } from "./tasksPulse";
 import { viewFromSearch, viewUrl } from "./tasks-lib";
 import type { TaskView } from "./tasks-lib";
 
@@ -243,6 +244,12 @@ export default function Scheduled() {
       (r) => {
         setTasks(r.tasks ?? []);
         setTasksFailed(false);
+        // The sidebar's Tasks entry reads the same rows (shell/tasksPulse): the
+        // dot and the counts beside the label are this answer, not a second poll
+        // of their own — two polls would show a dot the page disagrees with for
+        // twenty seconds at a time. Publishing also restarts that module's own
+        // timer, so while this page is open nothing else calls /api/tasks.
+        publishTasks(r.tasks ?? []);
       },
       () => {
         setTasks([]);

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -1,0 +1,275 @@
+// What the sidebar's Tasks entry says about the page behind it, and how it stops
+// saying it.
+//
+// Two halves, both here: the DERIVATION (tasks-lib.tasksPulse and the dismissal
+// it is gated on — pure, so it is exercised directly) and the WIRING (which mark
+// each collapse state draws, where the numbers come from, and the CSS that the
+// count chip is shared rather than approximated). The second half is read out of
+// the source, the way the rest of this suite reads claims a DOM-less test cannot
+// otherwise hold.
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Task } from "@platform/lib/api";
+import {
+  EMPTY_TASKS_PULSE,
+  TASKS_SEEN_KEY,
+  isDoneUnread,
+  parseTasksSeen,
+  pulseTitle,
+  runningLabel,
+  sameSeen,
+  samePulse,
+  seenAfterVisit,
+  tasksPulse,
+} from "./tasks-lib";
+import type { TasksSeen } from "./tasks-lib";
+
+const SHELL = new URL(".", import.meta.url).pathname;
+const SIDEBAR = readFileSync(join(SHELL, "GlobalSidebar.tsx"), "utf8");
+const STORE = readFileSync(join(SHELL, "tasksPulse.ts"), "utf8");
+const FRAME = readFileSync(
+  join(SHELL, "../platform/ui/sidebar/SidebarFrame.tsx"),
+  "utf8",
+);
+const BOOKMARKS = readFileSync(
+  join(SHELL, "../apps/explorer/sidebar/BookmarksSection.tsx"),
+  "utf8",
+);
+const SCHEDULED = readFileSync(join(SHELL, "Scheduled.tsx"), "utf8");
+const SIDEBAR_CSS = readFileSync(join(SHELL, "../styles/sidebar.css"), "utf8");
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    key: "sess-1",
+    task_id: "TASK-001",
+    project: "/Users/x/proj",
+    target: "/Users/x/proj",
+    session_id: "sess-1",
+    title: "pull the news",
+    title_source: "user",
+    description: "",
+    status: "done",
+    failed: false,
+    live: false,
+    unread: 0,
+    last_active: 1_000,
+    message_count: 1,
+    messages: [],
+    ...over,
+  } as Task;
+}
+
+describe("the sidebar's tasks pulse", () => {
+  it("counts what is running and what finished unread, and nothing else", () => {
+    const tasks = [
+      task({ key: "a", status: "in_progress" }),
+      task({ key: "b", status: "done", unread: 2 }),
+      // Read: the completion has been looked at, so there is nothing to send
+      // anybody to the page for.
+      task({ key: "c", status: "done", unread: 0 }),
+      // Not a completion at all.
+      task({ key: "d", status: "upcoming" }),
+      task({ key: "e", status: "archived", unread: 3 }),
+    ];
+    expect(tasksPulse(tasks, {})).toEqual({ running: 1, doneUnread: 1 });
+    expect(tasksPulse([], {})).toEqual(EMPTY_TASKS_PULSE);
+  });
+
+  it("does not paint a FAILED run green", () => {
+    // Failed is a status of its own on this page (taskColumn), and the green mark
+    // means "work you were waiting on is ready". A broken run wearing the done
+    // hue would be the one place in the app where a colour disagreed with the
+    // ring the row itself draws (design-principles §1).
+    const broke = [task({ key: "f", status: "failed", unread: 1 })];
+    expect(tasksPulse(broke, {})).toEqual({ running: 0, doneUnread: 0 });
+  });
+
+  it("clears on a visit, and only for the completions that visit showed", () => {
+    const finished = task({ key: "b", status: "done", unread: 1, last_active: 500 });
+    const running = task({ key: "a", status: "in_progress" });
+    const before = [running, finished];
+    expect(tasksPulse(before, {}).doneUnread).toBe(1);
+
+    // Landing on /tasks stamps every DONE task with the completion on screen.
+    const seen = seenAfterVisit(before);
+    expect(seen).toEqual({ b: 500 });
+    expect(tasksPulse(before, seen).doneUnread).toBe(0);
+    // Still nothing after a poll that changes nothing — the whole point of
+    // persisting the stamp rather than a "dismissed" flag on the session.
+    expect(tasksPulse([...before], seen).doneUnread).toBe(0);
+
+    // The RUNNING task completing is a new completion: it was never stamped,
+    // because its completion had not happened when the reader was there.
+    const settled = [task({ key: "a", status: "done", unread: 1 }), finished];
+    expect(tasksPulse(settled, seen).doneUnread).toBe(1);
+
+    // And so is the SAME task running again and finishing again: `last_active`
+    // moves, so the stamp no longer describes what is on screen. A bare set of
+    // dismissed keys would have swallowed this one forever.
+    const again = [task({ key: "b", status: "done", unread: 1, last_active: 900 })];
+    expect(tasksPulse(again, seen).doneUnread).toBe(1);
+    expect(isDoneUnread(again[0], seen)).toBe(true);
+  });
+
+  it("prunes the dismissal to the tasks in the answer", () => {
+    // The row is written to localStorage on every visit, so it must not grow by
+    // one key per task the machine has ever had.
+    const seen = seenAfterVisit([task({ key: "b", status: "done" })]);
+    expect(Object.keys(seenAfterVisit([task({ key: "z", status: "done" })]))).toEqual(["z"]);
+    expect(seen).not.toHaveProperty("z");
+    // A running task is deliberately NOT pre-stamped: stamping a completion that
+    // has not happened is how the one mark this feature exists for is never drawn.
+    expect(seenAfterVisit([task({ key: "a", status: "in_progress" })])).toEqual({});
+  });
+
+  it("reads a hand-edited or ancient store as 'nothing dismissed'", () => {
+    // One extra dot is the failure mode; a throw inside a render is not.
+    for (const raw of [null, "", "not json", "[]", '"x"', "7"]) {
+      expect(parseTasksSeen(raw)).toEqual({});
+    }
+    // Unusable VALUES are dropped one by one rather than costing the whole row.
+    expect(parseTasksSeen('{"a": 5, "b": "no", "c": null}')).toEqual({ a: 5 });
+    expect(TASKS_SEEN_KEY.startsWith("fused-render:")).toBe(true);
+  });
+
+  it("compares pulses and dismissals by value", () => {
+    // The store publishes only on a CHANGED pair, and the sidebar's own
+    // mark-seen effect runs on every published pulse — value equality is what
+    // keeps that from looping.
+    expect(samePulse({ running: 1, doneUnread: 0 }, { running: 1, doneUnread: 0 })).toBe(true);
+    expect(samePulse({ running: 1, doneUnread: 0 }, { running: 1, doneUnread: 2 })).toBe(false);
+    const a: TasksSeen = { x: 1, y: 2 };
+    expect(sameSeen(a, { y: 2, x: 1 })).toBe(true);
+    expect(sameSeen(a, { x: 1 })).toBe(false);
+    expect(sameSeen(a, { x: 1, y: 3 })).toBe(false);
+  });
+
+  it("says the same sentence in both collapse states", () => {
+    expect(runningLabel(1)).toBe("1 running");
+    expect(pulseTitle({ running: 2, doneUnread: 1 })).toBe("2 running · 1 finished, not read");
+    expect(pulseTitle({ running: 0, doneUnread: 3 })).toBe("3 finished, not read");
+    expect(pulseTitle(EMPTY_TASKS_PULSE)).toBe("");
+  });
+});
+
+describe("one poll behind both readers", () => {
+  it("has the page publish its own rows instead of a second poll", () => {
+    // Two polls of /api/tasks would be two answers, and the sidebar would show a
+    // dot the page disagreed with for up to twenty seconds at a time.
+    expect(SCHEDULED).toContain("publishTasks(r.tasks ?? [])");
+    expect(SIDEBAR).toContain("useTasksPulse()");
+    expect(SIDEBAR).not.toContain("getTasks(");
+    // Polling belongs to the subscribers: it starts with the first reader and
+    // stops with the last, like aiRuntime's.
+    expect(STORE).toContain("listeners.add(setCurrent)");
+    expect(STORE).toContain("listeners.delete(setCurrent)");
+    expect(STORE).toMatch(/if \(listeners\.size === 0\)/);
+    // Cadence follows the state, and idle is slower than the page's own 20s.
+    expect(STORE).toContain("pulse.running > 0 ? ACTIVE_MS : IDLE_MS");
+    expect(STORE).toContain("const IDLE_MS = 30_000");
+  });
+
+  it("keeps the route in the sidebar and the storage in the store", () => {
+    // A store that reads location.pathname is a store that has to be told when
+    // the pathname changed. The sidebar owns "the reader is on /tasks".
+    // Read past the prose, which names the rule it is obeying.
+    const code = STORE.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    expect(code).not.toContain("location.pathname");
+    expect(SIDEBAR).toContain("if (tasksActive) markTasksSeen();");
+    // And the count is not drawn at all while that page is the one on screen —
+    // the dismissal needs a poll to land, and a chip that flashes beside the row
+    // of the open page and then clears itself is worse than no chip.
+    expect(SIDEBAR).toContain("doneUnread: tasksActive ? 0 : pulse.doneUnread");
+    // localStorage is only ever touched inside a try — a blocked store costs the
+    // dismissal, never the sidebar (the same rule Scheduled.tsx's view memory
+    // follows).
+    expect(STORE).toContain("localStorage.getItem(TASKS_SEEN_KEY)");
+    expect(STORE).toContain("localStorage.setItem(TASKS_SEEN_KEY");
+    expect((STORE.match(/try \{/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("the Tasks entry's two marks", () => {
+  it("draws ONE dot on the collapsed rail, yellow winning over green", () => {
+    // The rail has no label, so the whole signal is a dot on the icon — and it is
+    // one dot: two in a corner is not a state this can draw, and "something is
+    // running" is the fact that outranks "something is ready".
+    expect(SIDEBAR).toContain("sidebar-rail-dot is-running");
+    expect(SIDEBAR).toContain("sidebar-rail-dot is-unread");
+    expect(SIDEBAR.indexOf("shown.running > 0 ? (")).toBeLessThan(
+      SIDEBAR.indexOf("shown.doneUnread > 0 ? ("),
+    );
+    // Nothing at all when there is nothing to say.
+    expect(SIDEBAR).toContain("badge: tasksDot");
+    expect(FRAME).toContain("{item.badge}");
+    // Positioned against the rail button, which is what makes an absolutely
+    // placed dot land on the glyph instead of resolving against the viewport (the
+    // bug account.css records for the Settings dot).
+    expect(SIDEBAR_CSS).toMatch(/\.sidebar-rail-btn \{[^}]*position: relative/);
+    const dot = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf(".sidebar-rail-dot {"));
+    expect(dot.slice(0, dot.indexOf("}"))).toContain("position: absolute");
+  });
+
+  it("draws NO dot when expanded — words instead, in the same hues", () => {
+    // A dot on the icon plus a readout beside the label is one fact stated twice.
+    const trailing = SIDEBAR.slice(
+      SIDEBAR.indexOf("const tasksTrailing ="),
+      SIDEBAR.indexOf("// Everything that is not primary nav"),
+    );
+    expect(trailing).not.toContain("sidebar-rail-dot");
+    expect(trailing).toContain("runningLabel(shown.running)");
+    expect(trailing).toContain("{shown.doneUnread}");
+    expect(SIDEBAR).toContain("trailing={tasksTrailing}");
+    expect(FRAME).toContain('<span className="sidebar-item-trail">{trailing}</span>');
+    // Both marks name the state in the status ring's own tokens, so the sidebar
+    // and the page cannot describe one status in two colours.
+    expect(SIDEBAR_CSS).toContain("background: var(--status-progress)");
+    expect(SIDEBAR_CSS).toContain("background: var(--status-done)");
+    expect(SIDEBAR_CSS).toMatch(/\.sidebar-running \{[^}]*color: var\(--status-progress\)/);
+  });
+
+  it("wears the bookmark folder's count chip rather than a lookalike", () => {
+    // The folder row's nested count is where this shape was settled. The skin is
+    // stated ONCE and all three counts wear it; a second hand-tuned 10.5px pill is
+    // how two counts in one sidebar end up half a pixel and one shade apart.
+    const chip = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf(".sidebar-count-chip {"));
+    const body = chip.slice(0, chip.indexOf("}"));
+    for (const decl of [
+      "font-size: 10.5px",
+      "color: var(--fg-muted)",
+      "background: rgba(var(--tint), 0.07)",
+      "border-radius: 8px",
+      "padding: 3px 6px",
+    ]) {
+      expect(body).toContain(decl);
+    }
+    expect(BOOKMARKS).toContain('className="sidebar-count-chip folder-count"');
+    expect(BOOKMARKS).toContain('className="sidebar-count-chip recents-count"');
+    expect(SIDEBAR).toContain('className="sidebar-count-chip"');
+    // And the folder row's own class keeps ONLY what is peculiar to it — its
+    // placement over the hover actions and the fade that hands them the slot.
+    const folder = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf(".folder-count {"));
+    const folderBody = folder.slice(0, folder.indexOf("}"));
+    expect(folderBody).toContain("position: absolute");
+    expect(folderBody).not.toContain("font-size");
+    expect(folderBody).not.toContain("background:");
+  });
+
+  it("shimmers while work is in flight, and states it flatly when motion is off", () => {
+    // The animation is load-bearing: it is what separates "2 running" as a live
+    // readout from a number that might be stale.
+    expect(SIDEBAR_CSS).toContain("animation: sidebar-running-shimmer");
+    expect(SIDEBAR_CSS).toContain("@keyframes sidebar-running-shimmer");
+    expect(SIDEBAR_CSS).toContain("background-clip: text");
+    // The blanket reduced-motion rule runs an animation ONCE at 0.01ms, which
+    // would park this gradient mid-travel and leave the words half-faded — a
+    // dimmed readout reads as stale, the opposite of what it says. So the
+    // gradient is dropped and the ink is the flat status hue.
+    const rm = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf("@media (prefers-reduced-motion: reduce)"));
+    expect(rm).toContain(".sidebar-running");
+    expect(rm).toContain("animation: none");
+    expect(rm).toContain("background-image: none");
+    expect(rm).toContain("-webkit-text-fill-color: var(--status-progress)");
+  });
+});

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -321,6 +321,36 @@ describe("the Tasks entry's two marks", () => {
     expect(cycle).not.toContain("opacity");
     expect(cycle).not.toContain("color");
 
+    // AND IT NEVER GOES AWAY EITHER (Akshil, screenshot, 2026-08-18: the label
+    // animated in and out). With `background-clip: text` plus a transparent fill,
+    // the glyphs are a window onto the background — so anywhere the background
+    // does not reach, the letters are not drawn at all. Two holes, both closed:
+    //
+    // 1. THE SWEEP RAN OFF THE BOX. `no-repeat` and a travel from 150% to -150%
+    //    left the gradient entirely outside the element for most of the cycle,
+    //    blanking the label and bringing it back. Every stop of the travel must
+    //    stay inside 0%-100%, where a 300%-wide image still covers the box.
+    const stops = [...cycle.matchAll(/background-position:\s*(-?\d+)%/g)].map((m) =>
+      Number(m[1]),
+    );
+    expect(stops.length).toBeGreaterThanOrEqual(2);
+    for (const stop of stops) {
+      expect(stop).toBeGreaterThanOrEqual(0);
+      expect(stop).toBeLessThanOrEqual(100);
+    }
+    // ...with the fill repeating, so not even a rounding error at the ends of the
+    // travel can expose an unpainted letter.
+    expect(grad).toContain("background-repeat: repeat");
+    expect(grad).not.toContain("no-repeat");
+
+    // 2. THE GLYPHS OVERFLOWED THE CLIP BOX. At `line-height: 1` the painted area
+    //    is shorter than the type it is clipped to, and the descender of the "g"
+    //    in "running" came out chipped. The box has to hold the whole glyph.
+    const lh = grad.match(/line-height:\s*([\d.]+)/);
+    expect(lh).not.toBe(null);
+    expect(Number(lh![1])).toBeGreaterThanOrEqual(1.4);
+    expect(grad).toMatch(/padding:\s*\d+px/);
+
     // The blanket reduced-motion rule runs an animation ONCE at 0.01ms, which
     // would park this gradient wherever it stopped — a readout whose ink depends
     // on an animation frame. So the gradient is dropped and the ink is the flat

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -221,6 +221,10 @@ describe("one poll behind both readers", () => {
     // hint about timing: it says this module is not the poller, and the timer
     // does not run at all while one is held.
     expect(STORE).toContain("export function useTasksFeeder()");
+    // Including the sidebar's own mount read: it remounts on every navigation
+    // (App keys it on the nav epoch), so an unconditional fetch there would
+    // spend the same double-poll per trip to /tasks instead of per tick.
+    expect(STORE).toContain("if (feeders === 0) void poll();");
     expect(STORE).toContain("feeders++");
     expect(STORE).toContain("feeders--");
     expect(SCHEDULED).toContain("useTasksFeeder();");

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -236,6 +236,20 @@ describe("one poll behind both readers", () => {
     );
   });
 
+  it("drops a stale self-poll that resolves after a fresher publish", () => {
+    // BUGBOT, 2026-08-18: a self-poll already in the air when the page starts
+    // feeding (or when a fresher publish lands) must LOSE, not overwrite. The
+    // poll captures the generation on departure and publishes only if nothing
+    // moved it while the request was in flight.
+    expect(STORE).toContain("const departed = generation;");
+    expect(STORE).toMatch(
+      /if \(feeders === 0 && generation === departed\) publishTasks\(answer\);/,
+    );
+    // Every publish — the page's or a poll's own — is a new generation, so two
+    // racing polls can't both win either.
+    expect(STORE).toMatch(/generation \+= 1;\s*\n\s*tasks = next;/);
+  });
+
   it("keeps the route in the sidebar and the storage in the store", () => {
     // A store that reads location.pathname is a store that has to be told when
     // the pathname changed. The sidebar owns "the reader is on /tasks".

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -15,6 +15,7 @@ import {
   EMPTY_TASKS_PULSE,
   TASKS_SEEN_KEY,
   isDoneUnread,
+  isUnseenCompletion,
   parseTasksSeen,
   pulseTitle,
   runningLabel,
@@ -65,14 +66,13 @@ describe("the sidebar's tasks pulse", () => {
     const tasks = [
       task({ key: "a", status: "in_progress" }),
       task({ key: "b", status: "done", unread: 2 }),
-      // Read: the completion has been looked at, so there is nothing to send
-      // anybody to the page for.
+      // Read: the completion has been dealt with, so there is nothing waiting.
       task({ key: "c", status: "done", unread: 0 }),
       // Not a completion at all.
       task({ key: "d", status: "upcoming" }),
       task({ key: "e", status: "archived", unread: 3 }),
     ];
-    expect(tasksPulse(tasks, {})).toEqual({ running: 1, doneUnread: 1 });
+    expect(tasksPulse(tasks, {})).toEqual({ running: 1, doneUnread: 1, unseen: 1 });
     expect(tasksPulse([], {})).toEqual(EMPTY_TASKS_PULSE);
   });
 
@@ -82,34 +82,52 @@ describe("the sidebar's tasks pulse", () => {
     // hue would be the one place in the app where a colour disagreed with the
     // ring the row itself draws (design-principles §1).
     const broke = [task({ key: "f", status: "failed", unread: 1 })];
-    expect(tasksPulse(broke, {})).toEqual({ running: 0, doneUnread: 0 });
+    expect(tasksPulse(broke, {})).toEqual({ running: 0, doneUnread: 0, unseen: 0 });
   });
 
-  it("clears on a visit, and only for the completions that visit showed", () => {
+  it("keeps the COUNT through a visit and drops only the dot", () => {
+    // The two are different kinds of statement (Akshil, 2026-08-18). The dot is
+    // an interruption and the visit answers it; the count is a standing fact
+    // about unread work, and glancing at the list does not make it untrue.
     const finished = task({ key: "b", status: "done", unread: 1, last_active: 500 });
-    const running = task({ key: "a", status: "in_progress" });
-    const before = [running, finished];
-    expect(tasksPulse(before, {}).doneUnread).toBe(1);
+    const before = [task({ key: "a", status: "in_progress" }), finished];
+    expect(tasksPulse(before, {})).toEqual({ running: 1, doneUnread: 1, unseen: 1 });
 
+    const seen = seenAfterVisit(before);
+    const after = tasksPulse(before, seen);
+    expect(after.unseen).toBe(0);
+    expect(after.doneUnread).toBe(1);
+    // The count falls when the work is READ — the server's own `unread`, nothing
+    // this module stores.
+    const read = [task({ key: "b", status: "done", unread: 0, last_active: 500 })];
+    expect(tasksPulse(read, seen).doneUnread).toBe(0);
+    expect(isDoneUnread(finished)).toBe(true);
+    expect(isDoneUnread(read[0])).toBe(false);
+  });
+
+  it("brings the dot back for a completion the visit never showed", () => {
+    const finished = task({ key: "b", status: "done", unread: 1, last_active: 500 });
+    const before = [task({ key: "a", status: "in_progress" }), finished];
     // Landing on /tasks stamps every DONE task with the completion on screen.
     const seen = seenAfterVisit(before);
     expect(seen).toEqual({ b: 500 });
-    expect(tasksPulse(before, seen).doneUnread).toBe(0);
+    expect(tasksPulse(before, seen).unseen).toBe(0);
     // Still nothing after a poll that changes nothing — the whole point of
     // persisting the stamp rather than a "dismissed" flag on the session.
-    expect(tasksPulse([...before], seen).doneUnread).toBe(0);
+    expect(tasksPulse([...before], seen).unseen).toBe(0);
 
     // The RUNNING task completing is a new completion: it was never stamped,
     // because its completion had not happened when the reader was there.
     const settled = [task({ key: "a", status: "done", unread: 1 }), finished];
-    expect(tasksPulse(settled, seen).doneUnread).toBe(1);
+    expect(tasksPulse(settled, seen).unseen).toBe(1);
 
     // And so is the SAME task running again and finishing again: `last_active`
     // moves, so the stamp no longer describes what is on screen. A bare set of
     // dismissed keys would have swallowed this one forever.
     const again = [task({ key: "b", status: "done", unread: 1, last_active: 900 })];
-    expect(tasksPulse(again, seen).doneUnread).toBe(1);
-    expect(isDoneUnread(again[0], seen)).toBe(true);
+    expect(tasksPulse(again, seen).unseen).toBe(1);
+    expect(isUnseenCompletion(again[0], seen)).toBe(true);
+    expect(isUnseenCompletion(finished, seen)).toBe(false);
   });
 
   it("prunes the dismissal to the tasks in the answer", () => {
@@ -134,11 +152,15 @@ describe("the sidebar's tasks pulse", () => {
   });
 
   it("compares pulses and dismissals by value", () => {
-    // The store publishes only on a CHANGED pair, and the sidebar's own
+    // The store publishes only on a CHANGED triple, and the sidebar's own
     // mark-seen effect runs on every published pulse — value equality is what
-    // keeps that from looping.
-    expect(samePulse({ running: 1, doneUnread: 0 }, { running: 1, doneUnread: 0 })).toBe(true);
-    expect(samePulse({ running: 1, doneUnread: 0 }, { running: 1, doneUnread: 2 })).toBe(false);
+    // keeps that from looping. `unseen` is in the comparison: it is the field the
+    // dismissal moves, and a publish that skipped it would leave the dot up.
+    const p = { running: 1, doneUnread: 1, unseen: 1 };
+    expect(samePulse(p, { running: 1, doneUnread: 1, unseen: 1 })).toBe(true);
+    expect(samePulse(p, { running: 1, doneUnread: 1, unseen: 0 })).toBe(false);
+    expect(samePulse(p, { running: 1, doneUnread: 2, unseen: 1 })).toBe(false);
+    expect(samePulse(p, { running: 0, doneUnread: 1, unseen: 1 })).toBe(false);
     const a: TasksSeen = { x: 1, y: 2 };
     expect(sameSeen(a, { y: 2, x: 1 })).toBe(true);
     expect(sameSeen(a, { x: 1 })).toBe(false);
@@ -146,9 +168,12 @@ describe("the sidebar's tasks pulse", () => {
   });
 
   it("says the same sentence in both collapse states", () => {
+    // The tooltip names the STATE, not the dismissal, so a dot and a chip on the
+    // same entry cannot quote different numbers.
     expect(runningLabel(1)).toBe("1 running");
-    expect(pulseTitle({ running: 2, doneUnread: 1 })).toBe("2 running · 1 finished, not read");
-    expect(pulseTitle({ running: 0, doneUnread: 3 })).toBe("3 finished, not read");
+    expect(pulseTitle({ running: 2, doneUnread: 1, unseen: 0 }))
+      .toBe("2 running \u00b7 1 finished, not read");
+    expect(pulseTitle({ running: 0, doneUnread: 3, unseen: 1 })).toBe("3 finished, not read");
     expect(pulseTitle(EMPTY_TASKS_PULSE)).toBe("");
   });
 });
@@ -180,7 +205,12 @@ describe("one poll behind both readers", () => {
     // And the count is not drawn at all while that page is the one on screen —
     // the dismissal needs a poll to land, and a chip that flashes beside the row
     // of the open page and then clears itself is worse than no chip.
-    expect(SIDEBAR).toContain("doneUnread: tasksActive ? 0 : pulse.doneUnread");
+    // And the DOT is not drawn at all while that page is the one on screen — the
+    // stamp needs a poll to land, and a dot flashing beside the open page and
+    // then clearing itself is worse than no dot. The CHIP is untouched by the
+    // visit on purpose (see the pulse tests above).
+    expect(SIDEBAR).toContain("const unseen = tasksActive ? 0 : pulse.unseen;");
+    expect(SIDEBAR).not.toContain("tasksActive ? 0 : pulse.doneUnread");
     // localStorage is only ever touched inside a try — a blocked store costs the
     // dismissal, never the sidebar (the same rule Scheduled.tsx's view memory
     // follows).
@@ -197,9 +227,12 @@ describe("the Tasks entry's two marks", () => {
     // running" is the fact that outranks "something is ready".
     expect(SIDEBAR).toContain("sidebar-rail-dot is-running");
     expect(SIDEBAR).toContain("sidebar-rail-dot is-unread");
-    expect(SIDEBAR.indexOf("shown.running > 0 ? (")).toBeLessThan(
-      SIDEBAR.indexOf("shown.doneUnread > 0 ? ("),
+    expect(SIDEBAR.indexOf("pulse.running > 0 ? (")).toBeLessThan(
+      SIDEBAR.indexOf("unseen > 0 ? ("),
     );
+    // The dot reads the DISMISSAL-GATED number, which is the whole difference
+    // between it and the chip beside the label.
+    expect(SIDEBAR).toContain(") : unseen > 0 ? (");
     // Nothing at all when there is nothing to say.
     expect(SIDEBAR).toContain("badge: tasksDot");
     expect(FRAME).toContain("{item.badge}");
@@ -218,8 +251,11 @@ describe("the Tasks entry's two marks", () => {
       SIDEBAR.indexOf("// Everything that is not primary nav"),
     );
     expect(trailing).not.toContain("sidebar-rail-dot");
-    expect(trailing).toContain("runningLabel(shown.running)");
-    expect(trailing).toContain("{shown.doneUnread}");
+    expect(trailing).toContain("runningLabel(pulse.running)");
+    // The chip reads the RAW state — no dismissal, no visit suppression: it says
+    // what is waiting to be read until it is read.
+    expect(trailing).toContain("{pulse.doneUnread}");
+    expect(trailing).not.toContain("unseen");
     expect(SIDEBAR).toContain("trailing={tasksTrailing}");
     expect(FRAME).toContain('<span className="sidebar-item-trail">{trailing}</span>');
     // Both marks name the state in the status ring's own tokens, so the sidebar
@@ -262,10 +298,33 @@ describe("the Tasks entry's two marks", () => {
     expect(SIDEBAR_CSS).toContain("animation: sidebar-running-shimmer");
     expect(SIDEBAR_CSS).toContain("@keyframes sidebar-running-shimmer");
     expect(SIDEBAR_CSS).toContain("background-clip: text");
+
+    // AND THE WORDS NEVER VANISH (Akshil, 2026-08-18). A band that sweeps toward
+    // the page colour takes each letter down to a whisper as it passes — a blink,
+    // not a shimmer, with the readout barely there for a third of the cycle.
+    // Every stop is the full status hue or the status hue mixed toward `--fg`, so
+    // the travelling band is BRIGHTER than the resting ink and the animation's
+    // floor is the flat, fully readable label.
+    const grad = SIDEBAR_CSS.slice(
+      SIDEBAR_CSS.indexOf(".sidebar-running {"),
+      SIDEBAR_CSS.indexOf("@keyframes sidebar-running-shimmer"),
+    );
+    expect(grad).toContain("color-mix(in srgb, var(--status-progress) 65%, var(--fg))");
+    expect(grad).not.toContain("var(--bg)");
+    expect(grad).not.toContain("transparent)");
+    // The sweep is a background POSITION and nothing else: no opacity in the
+    // cycle, no colour keyframes — nothing that can take the element towards
+    // invisible on its way past.
+    const frames = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf("@keyframes sidebar-running-shimmer"));
+    const cycle = frames.slice(0, frames.indexOf("\n}"));
+    expect(cycle).toContain("background-position");
+    expect(cycle).not.toContain("opacity");
+    expect(cycle).not.toContain("color");
+
     // The blanket reduced-motion rule runs an animation ONCE at 0.01ms, which
-    // would park this gradient mid-travel and leave the words half-faded — a
-    // dimmed readout reads as stale, the opposite of what it says. So the
-    // gradient is dropped and the ink is the flat status hue.
+    // would park this gradient wherever it stopped — a readout whose ink depends
+    // on an animation frame. So the gradient is dropped and the ink is the flat
+    // status hue: the same label the moving version rests on.
     const rm = SIDEBAR_CSS.slice(SIDEBAR_CSS.indexOf("@media (prefers-reduced-motion: reduce)"));
     expect(rm).toContain(".sidebar-running");
     expect(rm).toContain("animation: none");

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -141,6 +141,24 @@ describe("the sidebar's tasks pulse", () => {
     expect(seenAfterVisit([task({ key: "a", status: "in_progress" })])).toEqual({});
   });
 
+  it("merges a visit's stamps over the ones already held", () => {
+    // BUGBOT, 2026-08-18: rebuilding the map out of the DONE rows alone dropped
+    // the stamp of any task that was momentarily something else. A finished task
+    // that has just been re-run reads `in_progress` for the length of that run,
+    // so the old rule threw its stamp away mid-run and the PREVIOUS completion
+    // popped back as unseen the moment the new one landed.
+    const prev: TasksSeen = { a: 100, b: 200 };
+    const rerunning = task({ key: "a", status: "in_progress", last_active: 400 });
+    const finished = task({ key: "b", status: "done", unread: 1, last_active: 250 });
+    const next = seenAfterVisit([rerunning, finished], prev);
+    expect(next).toEqual({ a: 100, b: 250 });
+    // The prune is the ANSWER'S OWN membership: a task that has left the list
+    // takes its stamp with it, so the row cannot grow without bound.
+    expect(seenAfterVisit([finished], prev)).toEqual({ b: 250 });
+    // With nothing held, a merge is the plain stamping it always was.
+    expect(seenAfterVisit([finished])).toEqual({ b: 250 });
+  });
+
   it("reads a hand-edited or ancient store as 'nothing dismissed'", () => {
     // One extra dot is the failure mode; a throw inside a render is not.
     for (const raw of [null, "", "not json", "[]", '"x"', "7"]) {
@@ -189,10 +207,29 @@ describe("one poll behind both readers", () => {
     // stops with the last, like aiRuntime's.
     expect(STORE).toContain("listeners.add(setCurrent)");
     expect(STORE).toContain("listeners.delete(setCurrent)");
-    expect(STORE).toMatch(/if \(listeners\.size === 0\)/);
+    expect(STORE).toMatch(/if \(listeners\.size === 0 \|\| feeders > 0\) return;/);
     // Cadence follows the state, and idle is slower than the page's own 20s.
     expect(STORE).toContain("pulse.running > 0 ? ACTIVE_MS : IDLE_MS");
     expect(STORE).toContain("const IDLE_MS = 30_000");
+  });
+
+  it("stands down completely while the page is the poller", () => {
+    // BUGBOT, 2026-08-18: restarting the timer on every publish was not enough.
+    // The page polls every 20s and this module re-armed at ACTIVE_MS (10s)
+    // whenever anything was running — so the busiest case, /tasks open with work
+    // in flight, fired an EXTRA request between the page's own. A feeder is not a
+    // hint about timing: it says this module is not the poller, and the timer
+    // does not run at all while one is held.
+    expect(STORE).toContain("export function useTasksFeeder()");
+    expect(STORE).toContain("feeders++");
+    expect(STORE).toContain("feeders--");
+    expect(SCHEDULED).toContain("useTasksFeeder();");
+    // Held for the page's whole life, so it is armed exactly while the page's own
+    // poll is — not toggled per fetch, where a failed round would hand the job
+    // back mid-visit.
+    expect(SCHEDULED.indexOf("useTasksFeeder();")).toBeLessThan(
+      SCHEDULED.indexOf("const reload = () =>"),
+    );
   });
 
   it("keeps the route in the sidebar and the storage in the store", () => {
@@ -217,6 +254,27 @@ describe("one poll behind both readers", () => {
     expect(STORE).toContain("localStorage.getItem(TASKS_SEEN_KEY)");
     expect(STORE).toContain("localStorage.setItem(TASKS_SEEN_KEY");
     expect((STORE.match(/try \{/g) ?? []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("never stamps from a store that has not been filled yet", () => {
+    // BUGBOT, 2026-08-18: the sidebar's effect runs on the FIRST render on
+    // /tasks, before the fetch answers. Stamping "every done task on screen"
+    // over an empty store wrote `{}` and threw away every dismissal the reader
+    // had — and someone who opened the page and left before the first poll came
+    // back lost them permanently. `[]` before the first answer and `[]` on a
+    // machine with no tasks are different facts, so the store records which one
+    // it is holding.
+    expect(STORE).toContain("let loaded = false;");
+    expect(STORE).toContain("loaded = true;");
+    expect(STORE).toMatch(/export function markTasksSeen\(\) \{\n  if \(!loaded\) return;/);
+    // Only a real answer sets it: the flag is raised where the rows arrive.
+    const publish = STORE.slice(
+      STORE.indexOf("export function publishTasks"),
+      STORE.indexOf("}", STORE.indexOf("export function publishTasks")),
+    );
+    expect(publish).toContain("loaded = true;");
+    // And the write MERGES over what is already stored rather than replacing it.
+    expect(STORE).toContain("seenAfterVisit(tasks, seen)");
   });
 });
 

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -36,6 +36,9 @@ import {
   isFailedTask,
   isMessageRunning,
   isRunningNow,
+  isRunningIn,
+  activeMessage,
+  hasStarted,
   isPastDue,
   isUnread,
   isUpcomingTask,
@@ -5892,5 +5895,99 @@ describe("isRunningNow", () => {
     const idle = msg({ message_id: "MSG-001", state: "sent", turn: "idle" });
     const t = task({ status: "done", live: false, messages: [idle] });
     expect(isRunningNow(t, idle)).toBe(false);
+  });
+
+  // BUGBOT, 2026-08-18: "the newest row" was doing the work of "the active
+  // message", and on a RECURRING task those are routinely different rows. `at`
+  // is when a message is DUE, so `messages[0]` on a task that runs daily is
+  // tomorrow's `pending` occurrence — which has never run and cannot be what the
+  // task is doing now. The shimmer went to tomorrow's chip while this afternoon's
+  // real run wore nothing.
+  it("never calls a future promise the work in flight", () => {
+    const TODAY = Math.floor(Date.parse("2026-08-16T09:00:00") / 1000);
+    const TOMORROW = Math.floor(Date.parse("2026-08-17T09:00:00") / 1000);
+    // What the server sends for a daily rule mid-run: tomorrow's occurrence is
+    // the newest row, today's is the one being worked on.
+    const promise = msg({ message_id: "MSG-002", at: TOMORROW, ran_at: 0, state: "pending" });
+    const today = msg({
+      message_id: "MSG-001", at: TODAY, ran_at: TODAY, state: "sent", turn: "idle",
+    });
+    const t = task({ status: "in_progress", live: false, messages: [promise, today] });
+
+    expect(isRunningNow(t, promise)).toBe(false);
+    expect(isRunningNow(t, today)).toBe(true);
+    expect(activeMessage(t)?.message_id).toBe("MSG-001");
+  });
+
+  it("picks the newest STARTED message, and knows which states those are", () => {
+    // Only a message the scheduler has actually spent can be the active one.
+    for (const state of ["sending", "sent", "error"] as const) {
+      expect(hasStarted(msg({ state }))).toBe(true);
+    }
+    for (const state of ["pending", "missed", "cancelled", "skipped"] as const) {
+      expect(hasStarted(msg({ state }))).toBe(false);
+    }
+    const at = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+    const older = msg({ message_id: "MSG-001", at: at("2026-08-16T05:00:00"), state: "sent" });
+    const newer = msg({ message_id: "MSG-002", at: at("2026-08-16T14:00:00"), state: "sent" });
+    const skipped = msg({
+      message_id: "MSG-003", at: at("2026-08-16T20:00:00"), state: "skipped",
+    });
+    expect(activeMessage(task({ messages: [skipped, newer, older] }))?.message_id)
+      .toBe("MSG-002");
+    // A task that has only ever been scheduled has no active message at all, and
+    // therefore nothing for the task's own verdict to land on.
+    const never = task({ status: "in_progress", messages: [msg({ state: "pending" })] });
+    expect(activeMessage(never)).toBe(null);
+    expect(isRunningNow(never, never.messages[0])).toBe(false);
+  });
+});
+
+// ---- and what a calendar CHIP asks ---------------------------------------------
+// A chip is not a message: it is one task on one DAY, anchored at that day's
+// earliest message with the rest nested inside it (schedule-lib.taskChips). Two
+// questions therefore go wrong when the chip asks about its anchor alone, and the
+// second is the one bugbot caught.
+
+describe("isRunningIn", () => {
+  const at = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+  // A daily task, mid-afternoon: this morning's run finished, the 14:00 run is in
+  // flight, and tomorrow's occurrence is already on the books as the newest row.
+  const morning = msg({
+    message_id: "MSG-001", at: at("2026-08-16T05:00:00"),
+    ran_at: at("2026-08-16T05:00:00"), state: "sent", turn: "done",
+  });
+  const afternoon = msg({
+    message_id: "MSG-002", at: at("2026-08-16T14:00:00"),
+    ran_at: at("2026-08-16T14:00:00"), state: "sent", turn: "idle",
+  });
+  const tomorrow = msg({
+    message_id: "MSG-003", at: at("2026-08-17T05:00:00"), ran_at: 0, state: "pending",
+  });
+  const daily = task({
+    status: "in_progress", live: false, messages: [tomorrow, afternoon, morning],
+  });
+
+  it("shimmers today's chip and leaves tomorrow's alone", () => {
+    // Today's chip holds both of today's messages and is ANCHORED on the finished
+    // 05:00 one — asking the anchor would say no.
+    expect(isRunningIn(daily, [morning, afternoon])).toBe(true);
+    expect(isRunningNow(daily, morning)).toBe(false);
+    // And tomorrow's chip is a promise, on a task that happens to be running.
+    expect(isRunningIn(daily, [tomorrow])).toBe(false);
+  });
+
+  it("says no when nothing under the chip is the active run", () => {
+    const settled = task({ status: "done", messages: [tomorrow, afternoon, morning] });
+    expect(isRunningIn(settled, [morning, afternoon])).toBe(false);
+    expect(isRunningIn(daily, [])).toBe(false);
+  });
+
+  it("is what the calendar actually asks", () => {
+    // The claim that cannot be held by the pure half: the view must hand over the
+    // CHIP's messages, not `chip.anchor`.
+    const CAL = readFileSync(join(SHELL, "ScheduleCalendar.tsx"), "utf8");
+    expect(CAL).toContain('isRunningIn(chip.task, chip.messages) ? " is-running" : ""');
+    expect(CAL).not.toContain("isRunningNow(chip.task, chip.anchor)");
   });
 });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3433,7 +3433,14 @@ describe("the archive action", () => {
     // The strip is invisible chrome over a card that IS a button, so the gap
     // between its children must not swallow the press that opens the chat.
     expect(TASKS_CSS).toMatch(/\.tasks-card-acts\s*\{[^}]*pointer-events: none/);
+    // The button takes its events back with its INK, not at rest: an invisible
+    // control over a card that is itself a button ate the press that should have
+    // opened the chat (bugbot, 2026-08-18 — the row's own fix, applied to the
+    // card for the same reason).
     expect(TASKS_CSS).toMatch(
+      /\.tasks-card-wrap:hover \.tasks-card-act,\n[^{]*\{[^}]*pointer-events: auto/,
+    );
+    expect(TASKS_CSS).not.toMatch(
       /\.tasks-card-act,\n\.prefs-section \.tasks-card-act \{[^}]*pointer-events: auto/,
     );
   });
@@ -3487,6 +3494,23 @@ describe("the archive action", () => {
     // A row with nothing to file keeps its ring under the pointer: a blank slot
     // where the row's status was is worse than no swap at all.
     expect(TASKS_CSS).toContain(":not(:has(.tasks-act--archive)) .schedule-ring");
+
+    // AND THE INVISIBLE BUTTON CANNOT TAKE A PRESS (bugbot, 2026-08-18, HIGH).
+    // `opacity: 0` alone left a live control at `z-index: 2` sitting over the
+    // ring and the row's stretched link, so a click on the row's most-aimed-at
+    // mark hit a button nobody could see and did nothing — a dead click, which
+    // design-principles §0 forbids outright. The events come back with the ink
+    // and not a moment before.
+    const rest = block(TASKS_CSS, ".tasks-act");
+    expect(rest).toContain("pointer-events: none");
+    const reveal = block(TASKS_CSS, ".tasks-row:hover .tasks-act");
+    expect(reveal).toContain("opacity: 1");
+    expect(reveal).toContain("pointer-events: auto");
+    // The keyboard arm is in the SAME rule, so a tabbed-to button is graspable
+    // too rather than visible-but-inert.
+    expect(TASKS_CSS).toMatch(
+      /\.tasks-act:focus-visible \{\n\s*opacity: 1;\n\s*pointer-events: auto;/,
+    );
   });
 
   it("leaves the board card's archive exactly where it was", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3363,17 +3363,18 @@ describe("the archive action", () => {
     expect(ROW).toMatch(/\{file && \(\s*<button/);
     expect(CARD).toMatch(/\{file && \(\s*<button/);
     // Its neighbours are all still gated, each by its own guard rather than by a
-    // group's — which is what lets Archive keep its place in the strip's order
-    // (clear it, run it, file it, open it) instead of jumping to the front the day
-    // the flag flips.
+    // group's, and their order survives whichever of them are rendered.
     for (const guarded of ["seen", "run", "chat"]) {
       expect(ROW).toContain(`{SHOW_ROW_ACTIONS && ${guarded} && (`);
     }
     expect(ROW.indexOf("{SHOW_ROW_ACTIONS && run && (")).toBeLessThan(
-      ROW.indexOf("{file && ("),
-    );
-    expect(ROW.indexOf("{file && (")).toBeLessThan(
       ROW.indexOf("{SHOW_ROW_ACTIONS && chat && ("),
+    );
+    // And Archive is no longer IN that strip at all (2026-08-18): it is at the
+    // row's LEADING edge, in the mark slot, ahead of every one of them — see "the
+    // archive button swaps with the status ring" below.
+    expect(ROW.indexOf("{file && (")).toBeLessThan(
+      ROW.indexOf("{SHOW_ROW_ACTIONS && seen && ("),
     );
     // Hidden by OPACITY and not by `display`/`visibility`, deliberately: the
     // button has to stay in the tab order and light up when a keyboard reaches
@@ -3432,6 +3433,67 @@ describe("the archive action", () => {
     expect(TASKS_CSS).toMatch(
       /\.tasks-card-act,\n\.prefs-section \.tasks-card-act \{[^}]*pointer-events: auto/,
     );
+  });
+
+  it("swaps with the status ring on a List row, in the ring's own box", () => {
+    // The button used to sit out by the folder chip, at the row's busiest end.
+    // It is in the MARK SLOT now: ring at rest, Archive under the pointer, same
+    // place. Both occupants are inside one wrapper, which is the only way the two
+    // can be held to one box.
+    const from = VIEWS.indexOf('<span className="tasks-rowmark">');
+    expect(from).toBeGreaterThan(-1);
+    const slot = VIEWS.slice(from, VIEWS.indexOf("</span>", from));
+    expect(slot).toContain("<StatusIcon");
+    expect(slot).toContain("tasks-act--archive");
+    // It is drawn BEFORE the row's id chip — i.e. at the leading edge, where the
+    // ring is — and there is exactly one archive button on a row.
+    expect(from).toBeLessThan(VIEWS.indexOf("<IdChip id={task.task_id}"));
+    expect((ROW.match(/tasks-act--archive/g) ?? []).length).toBe(1);
+
+    // NOTHING MOVES when they swap, and that is a claim about the CSS: the slot is
+    // exactly the rail's width and the button is out of flow inside it, so the
+    // rail, the thread's indent under it and the caret's box beside it cannot
+    // shift by a pixel whichever occupant is showing.
+    const mark = block(TASKS_CSS, ".tasks-rowmark");
+    expect(mark).toContain("width: var(--tasks-rail-w)");
+    expect(mark).toContain("flex: 0 0 var(--tasks-rail-w)");
+    expect(mark).toContain("position: relative");
+    // No z-index on the SLOT: the row's stretched link has to keep painting over
+    // the ring's box, exactly as it did when the ring was the flex child.
+    expect(mark).not.toContain("z-index");
+    const button = block(
+      TASKS_CSS,
+      ".tasks-rowmark .tasks-act--archive",
+    );
+    expect(button).toContain("position: absolute");
+    expect(button).toContain("transform: translate(-50%, -50%)");
+
+    // The handover itself: the ring fades on the same triggers that reveal the
+    // button, and stops collecting presses while it is invisible.
+    const fade = block(
+      TASKS_CSS,
+      ".tasks-row:hover .tasks-rowmark .schedule-ring",
+    );
+    expect(fade).toContain("opacity: 0");
+    expect(fade).toContain("pointer-events: none");
+    // Keyboard reachability is why `:focus-within` is in the trigger list — a tab
+    // onto the button reveals it, and the ring in front of it must get out of the
+    // way (the same rule the strip has always obeyed).
+    expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-rowmark .schedule-ring");
+    expect(TASKS_CSS).toContain(".tasks-act:focus-visible");
+    // A row with nothing to file keeps its ring under the pointer: a blank slot
+    // where the row's status was is worse than no swap at all.
+    expect(TASKS_CSS).toContain(":not(:has(.tasks-act--archive)) .schedule-ring");
+  });
+
+  it("leaves the board card's archive exactly where it was", () => {
+    // The swap is the LIST's, and only the List's. A card's ring is not in a rail
+    // and its head has an empty right end the strip was measured against
+    // (`--tasks-card-head-h`), so moving the button there would be a change with
+    // nothing behind it.
+    expect(CARD).toContain("tasks-card-act tasks-act--archive");
+    expect(CARD).not.toContain("tasks-rowmark");
+    expect(TASKS_CSS).toMatch(/\.tasks-card-acts\s*\{[^}]*position: absolute/);
   });
 
   it("never paints it red — archiving destroys nothing", () => {
@@ -5602,11 +5664,16 @@ describe("the tasks toolbar", () => {
     // §3). The measure is the LIST's number, not the board's — it was the board's
     // for a few hours, and letting the one view that CAN scroll inside itself set
     // the width for the two that cannot was the wrong way round.
-    const measure = 1240;
-    // Comfortably inside the flow reference's 1200-1400, and tighter than the
-    // board's own five-lane span, which is the point: the board scrolls.
-    expect(measure).toBeGreaterThanOrEqual(1200);
-    expect(measure).toBeLessThanOrEqual(1400);
+    const measure = 1050;
+    // 15% off the 1240 it was for a day (Akshil, 2026-08-18), rounded to the
+    // nearest 50: a row's ink is an id, a title and two short times, and the
+    // measure is what stops the title's ellipsis sitting a screen away from the
+    // times it is being clipped for. Still far wider than the 760px prose column
+    // this page opts out of, and still tighter than the board's own five-lane
+    // span — which is the point: the board is the view that can scroll.
+    expect(measure).toBeGreaterThanOrEqual(1000);
+    expect(measure).toBeLessThanOrEqual(1100);
+    expect(Math.round(1240 * 0.85 / 50) * 50).toBe(measure);
     const lane = block(SCHEDULE_CSS, ".schedule-tv-lane");
     expect(lane).toContain("flex: 0 0 260px");
     const board = block(SCHEDULE_CSS, ".schedule-tv-board");

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2624,36 +2624,65 @@ export function parseTasksSeen(raw: string | null): TasksSeen {
   return out;
 }
 
-/** Has this task finished work nobody has looked at yet, given what has already
- *  been dismissed? */
-export function isDoneUnread(task: Task, seen: TasksSeen): boolean {
-  if (taskColumn(task) !== "done") return false;
-  if (!(task.unread > 0)) return false;
-  return seen[task.key] !== task.last_active;
+/**
+ * Has this task finished work nobody has READ?
+ *
+ * The state, with no dismissal in it. This is what the expanded sidebar's count
+ * prints, and it falls only when the work is actually read — visiting the page
+ * does not make a number about unread work untrue.
+ */
+export function isDoneUnread(task: Task): boolean {
+  return taskColumn(task) === "done" && task.unread > 0;
+}
+
+/**
+ * The same completion, NOT YET SHOWN to the reader: the state above, minus what
+ * a visit to the page has already stamped (TasksSeen).
+ *
+ * The two exist apart because a count and a dot are different kinds of
+ * statement. A COUNT is a standing fact — "three finished things are waiting" —
+ * and it is still true after you have glanced at the list; it goes away by being
+ * dealt with. A DOT is an interruption, and an interruption that survives the
+ * reader going where it points is just a decoration. So the collapsed rail's dot
+ * clears on the visit and the expanded row's chip does not, and neither is a bug
+ * in the other (Akshil, 2026-08-18).
+ */
+export function isUnseenCompletion(task: Task, seen: TasksSeen): boolean {
+  return isDoneUnread(task) && seen[task.key] !== task.last_active;
 }
 
 export interface TasksPulse {
-  /** Tasks whose work is in flight — the yellow half. */
+  /** Tasks whose work is in flight — the yellow half, in both modes. */
   running: number;
-  /** Tasks that finished and have not been looked at — the green half. */
+  /** Tasks that finished with something unread, dismissal or no dismissal —
+   *  the expanded row's count chip. */
   doneUnread: number;
+  /** Of those, the ones the reader has not been shown yet — the collapsed
+   *  rail's green dot, which a visit to /tasks clears. */
+  unseen: number;
 }
 
-export const EMPTY_TASKS_PULSE: TasksPulse = { running: 0, doneUnread: 0 };
+export const EMPTY_TASKS_PULSE: TasksPulse = { running: 0, doneUnread: 0, unseen: 0 };
 
 /** The whole sidebar signal, from the rows the page already has. */
 export function tasksPulse(tasks: Task[], seen: TasksSeen): TasksPulse {
   let running = 0;
   let doneUnread = 0;
+  let unseen = 0;
   for (const t of tasks) {
-    if (taskColumn(t) === "in_progress") running++;
-    else if (isDoneUnread(t, seen)) doneUnread++;
+    if (taskColumn(t) === "in_progress") {
+      running++;
+      continue;
+    }
+    if (!isDoneUnread(t)) continue;
+    doneUnread++;
+    if (isUnseenCompletion(t, seen)) unseen++;
   }
-  return { running, doneUnread };
+  return { running, doneUnread, unseen };
 }
 
 export function samePulse(a: TasksPulse, b: TasksPulse): boolean {
-  return a.running === b.running && a.doneUnread === b.doneUnread;
+  return a.running === b.running && a.doneUnread === b.doneUnread && a.unseen === b.unseen;
 }
 
 /**

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2568,3 +2568,129 @@ export function isRunningNow(task: Task, m: TaskMessage): boolean {
   const newest = task.messages?.[0];
   return !!newest && !!m.message_id && m.message_id === newest.message_id;
 }
+
+// ---- the sidebar's two-number summary of this page ----------------------------
+// The Tasks entry in the global sidebar has to say two things without being the
+// page: something is RUNNING, and something FINISHED that nobody has looked at.
+// Both are read off the very rows the page draws (`taskColumn` — the server's
+// status, narrowed, so the sidebar cannot invent a sixth state), never off a
+// second endpoint of their own.
+//
+// WHY "done and unread" IS NOT JUST "unread". Unread exists on rows that are
+// still going and on rows nobody ever expected to read; the signal being asked
+// for here is the completion of work the reader was waiting on, which is exactly
+// `done` + `unread > 0`. `failed` is deliberately NOT counted: it is a status of
+// its own on this page (see taskColumn), and a green "go and look" mark over a
+// run that broke would be the one place in the app where a hue disagreed with
+// the ring the row wears (design-principles §1).
+
+/** Where the sidebar's dismissal lives. Per COMPLETION, not per task — see
+ *  TasksSeen. */
+export const TASKS_SEEN_KEY = "fused-render:tasks-seen";
+
+/**
+ * Which completions the reader has already been shown, as `task key ->
+ * last_active`.
+ *
+ * The value is what makes "the same completions" a checkable claim. A bare set
+ * of keys would dismiss a task FOREVER — the second time it ran and finished,
+ * the mark it earned would be swallowed by the first visit's dismissal. The
+ * task's `last_active` moves with every new message, so a stored stamp that no
+ * longer matches means "this is a different completion" and the mark comes back.
+ *
+ * A stamp rather than a global watermark for the same reason from the other
+ * side: catch-up runs can finish out of order (Scheduled.tsx's docstring — work
+ * that came due while the app was closed runs when it opens), and one
+ * high-water mark would silently swallow every completion stamped before it.
+ */
+export type TasksSeen = Record<string, number>;
+
+/** What came out of localStorage is a string written by SOMEONE ELSE (an older
+ *  build, a hand-edited devtools row): anything unreadable degrades to "nothing
+ *  dismissed" — one extra dot — rather than throwing inside a render. */
+export function parseTasksSeen(raw: string | null): TasksSeen {
+  if (!raw) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {};
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+  const out: TasksSeen = {};
+  for (const [key, at] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof at === "number" && Number.isFinite(at)) out[key] = at;
+  }
+  return out;
+}
+
+/** Has this task finished work nobody has looked at yet, given what has already
+ *  been dismissed? */
+export function isDoneUnread(task: Task, seen: TasksSeen): boolean {
+  if (taskColumn(task) !== "done") return false;
+  if (!(task.unread > 0)) return false;
+  return seen[task.key] !== task.last_active;
+}
+
+export interface TasksPulse {
+  /** Tasks whose work is in flight — the yellow half. */
+  running: number;
+  /** Tasks that finished and have not been looked at — the green half. */
+  doneUnread: number;
+}
+
+export const EMPTY_TASKS_PULSE: TasksPulse = { running: 0, doneUnread: 0 };
+
+/** The whole sidebar signal, from the rows the page already has. */
+export function tasksPulse(tasks: Task[], seen: TasksSeen): TasksPulse {
+  let running = 0;
+  let doneUnread = 0;
+  for (const t of tasks) {
+    if (taskColumn(t) === "in_progress") running++;
+    else if (isDoneUnread(t, seen)) doneUnread++;
+  }
+  return { running, doneUnread };
+}
+
+export function samePulse(a: TasksPulse, b: TasksPulse): boolean {
+  return a.running === b.running && a.doneUnread === b.doneUnread;
+}
+
+/**
+ * The dismissal a visit to /tasks earns: every DONE task on screen, stamped
+ * with the completion that was on screen.
+ *
+ * Done tasks only, and only the ones in this answer — which is also the pruning
+ * rule, so the row cannot grow without bound as tasks come and go. A running
+ * task is deliberately not stamped: its completion has not happened yet, and
+ * pre-dismissing it is how the one mark this feature exists for would never be
+ * drawn.
+ */
+export function seenAfterVisit(tasks: Task[]): TasksSeen {
+  const next: TasksSeen = {};
+  for (const t of tasks) {
+    if (taskColumn(t) === "done") next[t.key] = t.last_active;
+  }
+  return next;
+}
+
+export function sameSeen(a: TasksSeen, b: TasksSeen): boolean {
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  return keys.every((k) => a[k] === b[k]);
+}
+
+/** "2 running" — the expanded row's yellow readout. Plural because one is the
+ *  common case and "1 running" is what a person would say out loud. */
+export function runningLabel(n: number): string {
+  return `${n} running`;
+}
+
+/** The collapsed dot's tooltip, and the expanded chip's — the sidebar's ONE
+ *  sentence about the page, so the two modes cannot describe it differently. */
+export function pulseTitle(pulse: TasksPulse): string {
+  const parts: string[] = [];
+  if (pulse.running > 0) parts.push(runningLabel(pulse.running));
+  if (pulse.doneUnread > 0) parts.push(`${pulse.doneUnread} finished, not read`);
+  return parts.join(" · ");
+}

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2739,19 +2739,31 @@ export function samePulse(a: TasksPulse, b: TasksPulse): boolean {
 }
 
 /**
- * The dismissal a visit to /tasks earns: every DONE task on screen, stamped
- * with the completion that was on screen.
+ * The dismissal a visit to /tasks earns: every DONE task on screen, stamped with
+ * the completion that was on screen — MERGED over what was already known.
  *
- * Done tasks only, and only the ones in this answer — which is also the pruning
- * rule, so the row cannot grow without bound as tasks come and go. A running
- * task is deliberately not stamped: its completion has not happened yet, and
- * pre-dismissing it is how the one mark this feature exists for would never be
- * drawn.
+ * Done tasks only. A running task is deliberately not stamped: its completion
+ * has not happened yet, and pre-dismissing it is how the one mark this feature
+ * exists for would never be drawn.
+ *
+ * A MERGE, NOT A REPLACEMENT (bugbot, 2026-08-18). Rebuilding the map out of the
+ * done rows alone silently dropped the stamp of any task that was momentarily
+ * something else — a finished task that has just been re-run reads `in_progress`
+ * for the length of that run, and the old rule threw its stamp away mid-run, so
+ * the PREVIOUS completion popped back as unseen the moment the new one landed.
+ * Anything this answer still lists keeps what was known about it.
+ *
+ * The PRUNE is the answer's own membership: a key absent from `tasks` is
+ * dropped, so the row cannot grow without bound as tasks come and go. That is
+ * only sound against a REAL answer — tasksPulse.markTasksSeen refuses to run
+ * this before the first fetch has landed, because an empty store and an empty
+ * machine are not the same fact.
  */
-export function seenAfterVisit(tasks: Task[]): TasksSeen {
+export function seenAfterVisit(tasks: Task[], prev: TasksSeen = {}): TasksSeen {
   const next: TasksSeen = {};
   for (const t of tasks) {
     if (taskColumn(t) === "done") next[t.key] = t.last_active;
+    else if (prev[t.key] !== undefined) next[t.key] = prev[t.key];
   }
   return next;
 }

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2546,11 +2546,41 @@ export function isMessageRunning(m: TaskMessage): boolean {
 }
 
 /**
+ * Has this message's run STARTED — is there a turn behind it at all?
+ *
+ * The three states that mean the scheduler has spent it: `sending` (spawned, no
+ * answer yet), `sent` (gone) and `error` (tried and broke). Everything else has
+ * never run and may never run — `pending` is a promise about the future,
+ * `missed`/`cancelled`/`skipped` are promises that expired. A PROJECTED
+ * occurrence (schedule-lib's ghosts: cron arithmetic, not rows) is only ever
+ * minted `pending` or `missed`, so it cannot pass this either.
+ */
+export function hasStarted(m: TaskMessage): boolean {
+  return m.state === "sending" || m.state === "sent" || m.state === "error";
+}
+
+/**
+ * The message a task's CURRENT work belongs to: the newest one that has actually
+ * started, or null on a task that has never run.
+ */
+export function activeMessage(task: Task): TaskMessage | null {
+  let best: TaskMessage | null = null;
+  for (const m of task.messages ?? []) {
+    if (!hasStarted(m)) continue;
+    // Read off `at` rather than off the array order: the answer wanted here is
+    // "the latest run", and `messages` being newest-first is a convention of the
+    // endpoint rather than something this rule should depend on.
+    if (!best || m.at > best.at) best = m;
+  }
+  return best;
+}
+
+/**
  * Is THIS message the work this task is doing right now?
  *
  * Two ways, and the second is what a live chat turn needs — including the one
  * a live TRANSCRIPT cannot see. A message can say so itself (above), and
- * otherwise the newest message borrows the task's own verdict: `taskColumn`
+ * otherwise the ACTIVE message borrows the task's own verdict: `taskColumn`
  * reads `task.status`, which the server derives in `_status` from THREE
  * independent signals (`_message_running`, `live`, and `schedule.busy_sessions`)
  * — not just the two (`state`/`turn`, `task.live`) this function could see on
@@ -2558,15 +2588,38 @@ export function isMessageRunning(m: TaskMessage): boolean {
  * `idle` still files the task `in_progress` while a scheduled send is in
  * flight (`busy_sessions`); asking `taskColumn` instead of re-deriving that
  * third signal here is what keeps the calendar chip agreeing with the List
- * and Board, which read the same `task.status`. Older messages in an
- * in-progress task are not running: their turns ended when the next prompt
- * arrived.
+ * and Board, which read the same `task.status`.
+ *
+ * THE ACTIVE MESSAGE IS NOT THE NEWEST ROW (bugbot, 2026-08-18). `at` is when a
+ * message is DUE, so on a recurring task the newest row is routinely tomorrow's
+ * `pending` occurrence — never run, and impossible as "what this task is doing
+ * now". It is the newest STARTED message (activeMessage). Older started messages
+ * are not running either: their turns ended when the next prompt arrived.
  */
 export function isRunningNow(task: Task, m: TaskMessage): boolean {
   if (isMessageRunning(m)) return true;
   if (taskColumn(task) !== "in_progress") return false;
-  const newest = task.messages?.[0];
-  return !!newest && !!m.message_id && m.message_id === newest.message_id;
+  // A message with no run behind it cannot be borrowing the task's verdict,
+  // whatever else is true — the belt to activeMessage's braces, and what makes
+  // the rule safe to ask of a projected occurrence.
+  if (!hasStarted(m)) return false;
+  const active = activeMessage(task);
+  return !!active && !!m.message_id && m.message_id === active.message_id;
+}
+
+/**
+ * Is any of these messages the work happening right now?
+ *
+ * What a CALENDAR CHIP has to ask, because a chip is not a message: it is one
+ * task on one DAY, anchored at that day's EARLIEST message with the rest of the
+ * day nested inside it (schedule-lib.taskChips). Asking only about the anchor
+ * asks about the wrong occurrence in both directions — a day whose 05:00 run has
+ * finished and whose 14:00 run is in flight is anchored on the finished one, and
+ * before this rule a task whose newest row was tomorrow's promise put the
+ * shimmer on TOMORROW's chip. A chip is running when anything under it is.
+ */
+export function isRunningIn(task: Task, messages: TaskMessage[]): boolean {
+  return messages.some((m) => isRunningNow(task, m));
 }
 
 // ---- the sidebar's two-number summary of this page ----------------------------

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -42,6 +42,14 @@ let seen: TasksSeen = readSeen();
 let pulse: TasksPulse = EMPTY_TASKS_PULSE;
 let timer: number | null = null;
 let inFlight = false;
+/** Has a real answer landed? `tasks` is `[]` both before the first read and on a
+ *  machine with no tasks, and those two must not be treated alike — see
+ *  markTasksSeen, where mistaking one for the other throws away the reader's
+ *  dismissals. */
+let loaded = false;
+/** How many owners are feeding this store from their OWN poll (the Tasks page).
+ *  While there is one, this module does not poll at all — see schedule. */
+let feeders = 0;
 const listeners = new Set<(p: TasksPulse) => void>();
 
 function readSeen(): TasksSeen {
@@ -90,21 +98,49 @@ async function poll() {
   }
 }
 
+/**
+ * Arm the next self-poll — or, deliberately, do not.
+ *
+ * NOTHING IS POLLED WHILE SOMEONE ELSE IS FEEDING US (bugbot, 2026-08-18).
+ * Restarting the timer on every publish was not enough: the page polls every 20s
+ * and this module re-armed at 10s whenever anything was running, so the busiest
+ * case — the Tasks page open with work in flight — fired an EXTRA request between
+ * the page's own, which is exactly the double-poll the shared store exists to
+ * prevent. A feeder is not a hint about timing, it is a statement that this
+ * module is not the poller, so the timer simply does not run.
+ */
 function schedule() {
   if (timer !== null) window.clearTimeout(timer);
-  if (listeners.size === 0) {
-    timer = null;
-    return;
-  }
+  timer = null;
+  if (listeners.size === 0 || feeders > 0) return;
   timer = window.setTimeout(poll, pulse.running > 0 ? ACTIVE_MS : IDLE_MS);
 }
 
-/** Hand over a known-fresh answer — what the Tasks page's own poll returned — so
- *  the sidebar tracks the page for free and this module's timer starts over. */
+/** Hand over a known-fresh answer — what the Tasks page's own poll returned. */
 export function publishTasks(next: Task[]) {
   tasks = next;
+  loaded = true;
   recompute();
   schedule();
+}
+
+/**
+ * "I poll this endpoint myself; take my answers and do not make your own calls."
+ *
+ * The Tasks page holds one of these for as long as it is mounted, which is
+ * exactly as long as its own poll is running. Mount/unmount rather than a
+ * timestamp heuristic: the store then knows whether it is the poller instead of
+ * guessing from how recently someone published.
+ */
+export function useTasksFeeder() {
+  useEffect(() => {
+    feeders++;
+    schedule();
+    return () => {
+      feeders--;
+      schedule();
+    };
+  }, []);
 }
 
 /**
@@ -114,9 +150,19 @@ export function publishTasks(next: Task[]) {
  * makes the mark stay gone while the page is open — a dot pointing at a row the
  * reader is looking at is noise. It comes back when a task completes after the
  * visit, because that completion was never stamped (tasks-lib.seenAfterVisit).
+ *
+ * A NO-OP UNTIL A REAL ANSWER HAS LANDED (bugbot, 2026-08-18). The first render
+ * on /tasks runs this against an EMPTY store — the fetch has not come back yet —
+ * and stamping "every done task on screen" over an empty screen wrote `{}` and
+ * threw away every dismissal the reader had. Someone who opened the page and
+ * left before the first poll answered lost the lot, permanently. `loaded` is the
+ * difference between "no tasks" and "no answer yet", and the write MERGES over
+ * the answer (tasks-lib.seenAfterVisit) rather than replacing the map, so a
+ * stamp survives anything short of its task leaving the list.
  */
 export function markTasksSeen() {
-  writeSeen(seenAfterVisit(tasks));
+  if (!loaded) return;
+  writeSeen(seenAfterVisit(tasks, seen));
 }
 
 /** Subscribe to the summary. Polling starts with the first reader and stops with

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -173,7 +173,14 @@ export function useTasksPulse(): TasksPulse {
     listeners.add(setCurrent);
     // Read immediately rather than waiting out an interval: a sidebar that has
     // just mounted should not claim "nothing is running" for ten seconds first.
-    void poll();
+    //
+    // UNLESS SOMEONE IS FEEDING US. The sidebar remounts on every navigation
+    // (App keys it on the nav epoch), so an unconditional read here would fire a
+    // second /api/tasks alongside the Tasks page's own on every trip to that
+    // page — the same double-poll the feeder exists to prevent, just spent per
+    // navigation instead of per tick. A feeder's answer is already on its way.
+    if (feeders === 0) void poll();
+    else schedule();
     return () => {
       listeners.delete(setCurrent);
       schedule();

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -42,6 +42,11 @@ let seen: TasksSeen = readSeen();
 let pulse: TasksPulse = EMPTY_TASKS_PULSE;
 let timer: number | null = null;
 let inFlight = false;
+/** Which answer is newest. Every publish bumps it; a self-poll captures it on
+ *  departure and publishes only if nothing fresher landed while it was in
+ *  flight (bugbot, 2026-08-18: a stale self-poll resolving after the page's
+ *  own publish must lose, not overwrite). */
+let generation = 0;
 /** Has a real answer landed? `tasks` is `[]` both before the first read and on a
  *  machine with no tasks, and those two must not be treated alike — see
  *  markTasksSeen, where mistaking one for the other throws away the reader's
@@ -87,8 +92,12 @@ function recompute() {
 async function poll() {
   if (inFlight) return;
   inFlight = true;
+  const departed = generation;
   try {
-    publishTasks((await getTasks()).tasks ?? []);
+    const answer = (await getTasks()).tasks ?? [];
+    // A feeder took over, or a fresher publish landed, while this request was
+    // in the air: this answer is already history. Drop it.
+    if (feeders === 0 && generation === departed) publishTasks(answer);
   } catch {
     // A failed read is not news: the sidebar keeps the last answer it had rather
     // than dropping a dot because one poll lost a race with a restart.
@@ -118,6 +127,7 @@ function schedule() {
 
 /** Hand over a known-fresh answer — what the Tasks page's own poll returned. */
 export function publishTasks(next: Task[]) {
+  generation += 1;
   tasks = next;
   loaded = true;
   recompute();

--- a/frontend/src/shell/tasksPulse.ts
+++ b/frontend/src/shell/tasksPulse.ts
@@ -1,0 +1,137 @@
+// What the sidebar's Tasks entry knows about the Tasks page, shared by the two
+// readers of it: the entry itself (GlobalSidebar) and the page (Scheduled).
+//
+// ONE POLL, TWO READERS — the shape aiRuntime.ts established for the AI Models
+// dot, for the same reason. The sidebar needs two numbers and the page needs
+// every row; polling twice would ask the same endpoint twice a minute for one
+// answer, and worse, the two would disagree for a beat after anything changed.
+// So the poll lives here, the sidebar subscribes, and the PAGE publishes what
+// its own poll returned (publishTasks) — which resets the timer below, so while
+// the page is open this module never calls the server at all.
+//
+// The cadence follows the state, not the clock: while something is running the
+// dot's colour can change on any tick, and while nothing is running the only
+// thing that can move is a completion nobody is waiting on this second. An idle
+// machine costs one `GET /api/tasks` every 30 seconds.
+//
+// WHAT IS NOT HERE: the route. "The reader has landed on /tasks" is the
+// sidebar's fact, not this module's — it calls markTasksSeen() — because a store
+// that reads location.pathname is a store that has to be told when the pathname
+// changes.
+import { useEffect, useState } from "react";
+import { getTasks } from "@platform/lib/api";
+import type { Task } from "@platform/lib/api";
+import {
+  EMPTY_TASKS_PULSE,
+  TASKS_SEEN_KEY,
+  parseTasksSeen,
+  sameSeen,
+  samePulse,
+  seenAfterVisit,
+  tasksPulse,
+} from "./tasks-lib";
+import type { TasksPulse, TasksSeen } from "./tasks-lib";
+
+/** While something is running. Faster than the page's own 20s poll on purpose:
+ *  this is the interval a "it finished" mark waits out. */
+const ACTIVE_MS = 10_000;
+const IDLE_MS = 30_000;
+
+let tasks: Task[] = [];
+let seen: TasksSeen = readSeen();
+let pulse: TasksPulse = EMPTY_TASKS_PULSE;
+let timer: number | null = null;
+let inFlight = false;
+const listeners = new Set<(p: TasksPulse) => void>();
+
+function readSeen(): TasksSeen {
+  try {
+    return parseTasksSeen(localStorage.getItem(TASKS_SEEN_KEY));
+  } catch {
+    // A blocked or throwing store (private mode, locked-down webviews) costs
+    // the dismissal — one dot too many — never the sidebar.
+    return {};
+  }
+}
+
+function writeSeen(next: TasksSeen) {
+  if (sameSeen(seen, next)) return;
+  seen = next;
+  try {
+    localStorage.setItem(TASKS_SEEN_KEY, JSON.stringify(next));
+  } catch {
+    // Same trade as readSeen: the dismissal is a convenience, not the feature.
+  }
+  recompute();
+}
+
+/** Publish only on a CHANGED pair. Every poll and every page publish lands here,
+ *  and the sidebar re-rendering four times a minute over two identical numbers
+ *  is the sort of cost that is invisible until it is not. It is also what stops
+ *  the sidebar's own "mark seen while on /tasks" effect from looping. */
+function recompute() {
+  const next = tasksPulse(tasks, seen);
+  if (samePulse(pulse, next)) return;
+  pulse = next;
+  for (const listener of listeners) listener(next);
+}
+
+async function poll() {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    publishTasks((await getTasks()).tasks ?? []);
+  } catch {
+    // A failed read is not news: the sidebar keeps the last answer it had rather
+    // than dropping a dot because one poll lost a race with a restart.
+  } finally {
+    inFlight = false;
+    schedule();
+  }
+}
+
+function schedule() {
+  if (timer !== null) window.clearTimeout(timer);
+  if (listeners.size === 0) {
+    timer = null;
+    return;
+  }
+  timer = window.setTimeout(poll, pulse.running > 0 ? ACTIVE_MS : IDLE_MS);
+}
+
+/** Hand over a known-fresh answer — what the Tasks page's own poll returned — so
+ *  the sidebar tracks the page for free and this module's timer starts over. */
+export function publishTasks(next: Task[]) {
+  tasks = next;
+  recompute();
+  schedule();
+}
+
+/**
+ * The reader is looking at the page: every completion on screen counts as shown.
+ *
+ * Called on landing AND on every poll while the entry is active, which is what
+ * makes the mark stay gone while the page is open — a dot pointing at a row the
+ * reader is looking at is noise. It comes back when a task completes after the
+ * visit, because that completion was never stamped (tasks-lib.seenAfterVisit).
+ */
+export function markTasksSeen() {
+  writeSeen(seenAfterVisit(tasks));
+}
+
+/** Subscribe to the summary. Polling starts with the first reader and stops with
+ *  the last — nothing polls on behalf of a sidebar nobody has mounted. */
+export function useTasksPulse(): TasksPulse {
+  const [current, setCurrent] = useState<TasksPulse>(pulse);
+  useEffect(() => {
+    listeners.add(setCurrent);
+    // Read immediately rather than waiting out an interval: a sidebar that has
+    // just mounted should not claim "nothing is running" for ten seconds first.
+    void poll();
+    return () => {
+      listeners.delete(setCurrent);
+      schedule();
+    };
+  }, []);
+  return current;
+}

--- a/frontend/src/styles/schedule.css
+++ b/frontend/src/styles/schedule.css
@@ -39,22 +39,24 @@
    decision, and it made the page the only surface in the app with no measure at
    all.
 
-   1240px is that decision, and it is the LIST's number, not the board's. It was
+   1050px is that decision, and it is the LIST's number, not the board's. It was
    1360 for a few hours — five 260px lanes plus four 12px gaps is 1348, so the
    board fitted exactly — and letting the widest view set the measure was the
    wrong way round: the board is the one view that can scroll inside itself, and
    the list, which cannot, was the one paying for it (Akshil, 2026-08-18: tighter
-   still). 1240 is a comfortable measure for a three-line row and for a seven-day
-   calendar, and the board simply scrolls its lanes past it — which the board has
-   always done at any window narrower than five lanes, so this is its ordinary
-   behaviour rather than a new state.
+   still). Then 1240 for a day, and 1050 after it — 15% off, rounded to the
+   nearest 50, at Akshil's request: a task row's ink is an id, a title and two
+   short times, and at 1240 the title's ellipsis was hundreds of pixels from the
+   times it was being clipped for. The board simply scrolls its lanes past the
+   cap — which it has always done at any window narrower than five lanes, so this
+   is its ordinary behaviour rather than a new state.
 
    One measure for all three views, and that is worth more than three tuned ones:
    the toggle switches the view without the page changing shape underneath it.
 
    Applied to `> *` rather than to the section alone so the HEADER moves with
    the views; a centred board under a left-flush "Tasks" reads as a layout bug.
-   Under 1240 the cap is inert and the page is full-width as before. Either way
+   Under 1050 the cap is inert and the page is full-width as before. Either way
    the board keeps its own `overflow-x`, so what scrolls sideways is the lane
    strip and never the page (design-principles §0).
 
@@ -64,7 +66,7 @@
    stylesheet the barrel imports last, which is not a thing this page should
    depend on. */
 .prefs-page.schedule-page > * {
-  max-width: 1240px;
+  max-width: 1050px;
   margin-inline: auto;
 }
 
@@ -74,7 +76,7 @@
    purpose: tests/test_schedule_css.py reads this declaration to check the
    opt-out is still granted, and it reads a value, not a variable. */
 .schedule-page > .prefs-section {
-  max-width: 1240px;
+  max-width: 1050px;
 }
 
 .schedule-page .prefs-section > p {

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -312,10 +312,35 @@ a.sidebar-rail-btn {
    `--fg`, which raises contrast against the sidebar in BOTH themes (dark `--fg`
    over the light theme's amber, light `--fg` over the dark theme's yellow). The
    floor of the animation is therefore the flat, fully readable label the
-   reduced-motion arm below draws, and the motion only ever adds to it. */
+   reduced-motion arm below draws, and the motion only ever adds to it.
+
+   AND IT NEVER DISAPPEARS EITHER (Akshil, screenshot, 2026-08-18: the label
+   animated in and out). Not a fade and not a mount — a hole in the PAINT. With
+   `background-clip: text` the glyphs are a window onto the background and
+   `-webkit-text-fill-color: transparent` means there is no ink of their own
+   behind it, so anywhere the background does not reach, the letters are simply
+   not drawn. Two ways that was happening, and both are fixed here:
+
+     * THE SWEEP RAN OFF THE BOX. `no-repeat` plus a travel from 150% to -150%
+       put the whole gradient outside the element for most of the cycle, which
+       blanked the label and then brought it back — read, correctly, as the text
+       animating in and out. The travel now stays inside 100% → 0% (with a
+       300%-wide image, every position in that range still covers the box) and
+       the fill repeats, so there is no reachable frame with bare box in it.
+     * THE GLYPHS OVERFLOWED IT. At `line-height: 1` the background box is
+       shorter than the type it is clipped to, so the descender of the "g" in
+       "running" fell outside the paint and came out chipped. The box is given
+       room to hold the whole glyph — leading plus a hair of vertical padding —
+       rather than the text being trimmed to fit it.
+
+   Both are why the two rules below are load-bearing rather than cosmetic: no
+   part of the cycle may leave any part of a letter unpainted. */
 .sidebar-running {
   font-size: 10.5px;
-  line-height: 1;
+  /* The CLIP BOX, not just the text's spacing: ascenders and descenders have to
+     fall inside the painted area or they are not drawn at all. */
+  line-height: 1.6;
+  padding: 1px 1px;
   color: var(--status-progress);
   background-image: linear-gradient(
     100deg,
@@ -324,7 +349,11 @@ a.sidebar-rail-btn {
     var(--status-progress) 70%
   );
   background-size: 300% 100%;
-  background-repeat: no-repeat;
+  /* Belt to the in-range keyframes' braces: even a rounding error at the ends of
+     the travel tiles the fill rather than exposing an unpainted letter. The
+     gradient's first and last stops are the same hue, so a tile boundary is
+     invisible. */
+  background-repeat: repeat;
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -332,12 +361,17 @@ a.sidebar-rail-btn {
   white-space: nowrap;
 }
 
+/* ONE property animates, and it is the position of the highlight — never
+   opacity, never the fill, never anything that could take a letter away. The
+   range is 100% → 0%: with a background 300% the width of the box, both ends (and
+   everything between) still paint every pixel of it, so the label is fully
+   visible at every frame and only the bright band moves. */
 @keyframes sidebar-running-shimmer {
   from {
-    background-position: 150% 0;
+    background-position: 100% 0;
   }
   to {
-    background-position: -150% 0;
+    background-position: 0% 0;
   }
 }
 

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -256,6 +256,130 @@ a.sidebar-rail-btn {
   opacity: 0.85;
 }
 
+/* -- The trailing slot on a nav row -------------------------------------------
+   Whatever the row has to say about the page behind it (SidebarFrame.NavItem's
+   `trailing`): the Tasks entry's "N running" and its unread count. ONE auto
+   margin, so the group parks at the row's end and the label keeps its place at
+   the start — a second one anywhere in this row would split the free space and
+   leave the group floating in the middle. */
+.sidebar-item-trail {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+  /* The row's `gap: 10px` already stands between the label and this; without
+     shrink-0 a long label would squeeze the count instead of ellipsising. */
+  flex: 0 0 auto;
+}
+
+/* -- The count chip, once ------------------------------------------------------
+   The bookmark FOLDER's nested count is where this shape was settled (a folder
+   row says "7" at its trailing edge), and the Tasks row's unread count is the
+   same kind of fact about a different container — so it is the same element,
+   not a lookalike. The skin lives here and both wear it; `.folder-count` keeps
+   only what is peculiar to a folder row (it is absolutely positioned over the
+   hover actions and fades for them, which a nav row has none of). A second
+   hand-tuned 10.5px pill is exactly how two counts in one sidebar end up half a
+   pixel and one shade apart. */
+.sidebar-count-chip {
+  font-size: 10.5px;
+  line-height: 1;
+  color: var(--fg-muted);
+  background: rgba(var(--tint), 0.07);
+  border-radius: 8px;
+  padding: 3px 6px;
+  letter-spacing: normal;
+}
+
+/* -- "N running" ---------------------------------------------------------------
+   The In Progress hue (--status-progress: the status ring's own yellow, so the
+   sidebar and the page name the state in one colour), with the ink SHIMMERING
+   while the work does — the same "something is happening that I am not driving"
+   a thinking indicator states. It is the one animation in this sidebar, and it
+   is load-bearing: it is what separates "2 running" as a live readout from "2
+   running" as a number that might be stale.
+
+   Drawn as a moving highlight through the text itself (background-clip: text)
+   rather than as a sweeping overlay, because the element is 60px of small type
+   with nothing behind it to sweep across. */
+.sidebar-running {
+  font-size: 10.5px;
+  line-height: 1;
+  color: var(--status-progress);
+  background-image: linear-gradient(
+    100deg,
+    var(--status-progress) 20%,
+    color-mix(in srgb, var(--status-progress) 35%, var(--bg)) 40%,
+    var(--status-progress) 60%
+  );
+  background-size: 300% 100%;
+  background-repeat: no-repeat;
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: sidebar-running-shimmer 2.2s linear infinite;
+  white-space: nowrap;
+}
+
+@keyframes sidebar-running-shimmer {
+  from {
+    background-position: 150% 0;
+  }
+  to {
+    background-position: -150% 0;
+  }
+}
+
+/* The blanket reduced-motion rule (reduced-motion.css) collapses the duration
+   and runs the sweep ONCE, which would park the gradient mid-travel and leave
+   the words half-faded — a dimmed readout reads as "stale", the opposite of
+   what this says. So the whole gradient is dropped instead and the text is the
+   flat status hue: the fact, stated statically. */
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-running {
+    animation: none;
+    background-image: none;
+    -webkit-text-fill-color: var(--status-progress);
+  }
+}
+
+/* -- The collapsed rail's dot --------------------------------------------------
+   The rail has no label, so the entry's whole signal is one 7px dot in the
+   icon's top-right corner. Same shape as the Settings row's resident-model dot
+   (.account-signedin-dot, account.css) — a dot on a nav icon means "there is
+   something behind this" everywhere in this sidebar — and the same border-hole
+   trick, so the mark reads as sitting ON the glyph rather than merging with it.
+
+   Positioned against the 28px button, not the 16px glyph: the icon has no box
+   of its own here (the rail renders the owner's svg directly), and 5px in from
+   the button's corner IS the glyph's corner. */
+.sidebar-rail-btn {
+  position: relative;
+}
+
+.sidebar-rail-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1px solid var(--bg);
+  box-sizing: content-box;
+}
+
+/* The two states, in the status ring's own hues (schedule.css): yellow while
+   anything is in flight, green for work that finished and has not been read.
+   Yellow outranks green in the MARKUP (GlobalSidebar picks one), not here — two
+   dots in one corner is not a state this can draw. */
+.sidebar-rail-dot.is-running {
+  background: var(--status-progress);
+}
+
+.sidebar-rail-dot.is-unread {
+  background: var(--status-done);
+}
+
 /* Bottom Preferences trigger (GlobalSidebar): a <button> wearing the
    .sidebar-item look — resets the UA button chrome so it sits in the list
    like the <a> rows above it. */
@@ -345,15 +469,11 @@ button.sidebar-prefs-trigger {
   user-select: none;
 }
 
-.recents-count {
-  font-size: 10.5px;
-  line-height: 1;
-  color: var(--fg-muted);
-  background: rgba(var(--tint), 0.07);
-  border-radius: 8px;
-  padding: 3px 6px;
-  letter-spacing: normal;
-}
+/* The heading's collapsed count. No skin of its own since 2026-08-18: it wears
+   `.sidebar-count-chip` (above) alongside this class, which now exists only to
+   name the element. The three counts in this sidebar — a folder's children, a
+   collapsed section's leaves, the Tasks entry's unread — are one shape stated
+   once. */
 
 .recent-row {
   text-decoration: none;
@@ -478,6 +598,9 @@ button.sidebar-prefs-trigger {
   cursor: pointer;
 }
 
+/* The chip's SKIN is `.sidebar-count-chip`, which this element wears as well
+   (one count shape for the whole sidebar — see that rule). What is left here is
+   only what is peculiar to a folder row. */
 .folder-count {
   /* Overlays the always-reserved (but invisible until hover) actions area,
      so it sits at the row's far right without shifting the name. */
@@ -485,12 +608,6 @@ button.sidebar-prefs-trigger {
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
-  font-size: 10.5px;
-  line-height: 1;
-  color: var(--fg-muted);
-  background: rgba(var(--tint), 0.07);
-  border-radius: 8px;
-  padding: 3px 6px;
   /* Hidden on hover so the action buttons can take the slot. Faded rather than
      `display: none`d: the count and the buttons overlay the same spot, so this
      one has to disappear — but a display flip can't ease, which made the

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -301,16 +301,27 @@ a.sidebar-rail-btn {
 
    Drawn as a moving highlight through the text itself (background-clip: text)
    rather than as a sweeping overlay, because the element is 60px of small type
-   with nothing behind it to sweep across. */
+   with nothing behind it to sweep across.
+
+   THE WORDS NEVER FADE (Akshil, 2026-08-18: the label must stay readable the
+   whole way through). The first cut swept toward `--bg`, so the band travelling
+   across the text took each letter down to a whisper of the page colour as it
+   passed — a blink, not a shimmer, and for a third of the cycle the readout was
+   barely there. The travelling band is BRIGHTER than the resting ink now, never
+   dimmer: every stop is the full status hue or the status hue mixed toward
+   `--fg`, which raises contrast against the sidebar in BOTH themes (dark `--fg`
+   over the light theme's amber, light `--fg` over the dark theme's yellow). The
+   floor of the animation is therefore the flat, fully readable label the
+   reduced-motion arm below draws, and the motion only ever adds to it. */
 .sidebar-running {
   font-size: 10.5px;
   line-height: 1;
   color: var(--status-progress);
   background-image: linear-gradient(
     100deg,
-    var(--status-progress) 20%,
-    color-mix(in srgb, var(--status-progress) 35%, var(--bg)) 40%,
-    var(--status-progress) 60%
+    var(--status-progress) 30%,
+    color-mix(in srgb, var(--status-progress) 65%, var(--fg)) 50%,
+    var(--status-progress) 70%
   );
   background-size: 300% 100%;
   background-repeat: no-repeat;
@@ -331,10 +342,10 @@ a.sidebar-rail-btn {
 }
 
 /* The blanket reduced-motion rule (reduced-motion.css) collapses the duration
-   and runs the sweep ONCE, which would park the gradient mid-travel and leave
-   the words half-faded — a dimmed readout reads as "stale", the opposite of
-   what this says. So the whole gradient is dropped instead and the text is the
-   flat status hue: the fact, stated statically. */
+   and runs the sweep ONCE, which would park the gradient wherever 0.01ms leaves
+   it — a readout whose ink depends on where an animation stopped. So the whole
+   gradient is dropped instead and the text is the flat status hue: the same
+   fully-readable label the moving version rests on, stated statically. */
 @media (prefers-reduced-motion: reduce) {
   .sidebar-running {
     animation: none;

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -615,6 +615,75 @@ button.tasks-caret,
   border-color: var(--border);
 }
 
+/* -- The mark slot: ring at rest, Archive on hover ------------------------------
+   ONE BOX, TWO OCCUPANTS (2026-08-18). The row's leading mark is the status ring;
+   put a pointer on the row and the Archive button takes its place, in the same
+   place. Archive used to live out by the folder chip, at the row's busiest end,
+   which made filing a task a control the reader had to travel to — and left the
+   quietest, most-scanned position in the row doing nothing while hovered.
+
+   NOTHING MOVES. The slot is sized to the ring (`--tasks-rail-w`, the width every
+   rail on this page is measured from) and the button is taken OUT OF FLOW inside
+   it, so the swap cannot change the row's metrics: `--tasks-rail-x`, the thread's
+   indent under it, the caret's hit zone to its left and the chevron's own box are
+   all untouched, whichever of the two is showing. The button is 22px against a
+   16px ring on purpose — a 16px hit target is too small to aim at — and it is
+   CENTRED on the slot, so the extra 3px hangs symmetrically over the gap on
+   either side rather than pushing anything.
+
+   The slot itself takes no `z-index`: `.tasks-rowlink` (z-index 1) must keep
+   painting over it, so the ring area still opens the conversation exactly as it
+   did when the ring was the flex child. The BUTTON's own `z-index: 2` (see
+   `.tasks-act`) is what lifts it back above that link, and only where it is. */
+.tasks-rowmark {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: content-box;
+  width: var(--tasks-rail-w);
+  height: var(--tasks-rail-w);
+  flex: 0 0 var(--tasks-rail-w);
+}
+
+.tasks-rowmark .tasks-act--archive,
+.prefs-section .tasks-rowmark .tasks-act--archive {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* The handover. The ring fades as the button arrives — the same `opacity` swap,
+   on the same triggers, that the bookmarks sidebar's folder count uses to hand
+   its slot to the row's actions (`.folder-count`, sidebar.css), and for the same
+   reason: two things overlaying one box means one has to go, and a `display` flip
+   cannot ease, which made the handover the sharpest pop on the page.
+
+   `pointer-events` travels with the fade, or the invisible ring would keep
+   collecting the presses meant for the button under it.
+
+   `:focus-within` is in the list because the button must be reachable by
+   keyboard: a tab onto it reveals it (`.tasks-act:focus-visible`) and the ring it
+   is standing in front of has to get out of the way for it. */
+.tasks-row:hover .tasks-rowmark .schedule-ring,
+.tasks-row:focus-within .tasks-rowmark .schedule-ring {
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Only where there IS a button to hand over to. A row with nothing to file
+   (`archiveIntent` → null, so no button is rendered) must keep its ring under the
+   pointer — the alternative is a blank slot where the row's status was. */
+.tasks-row:hover .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring,
+.tasks-row:focus-within .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring {
+  opacity: 1;
+}
+
+.tasks-rowmark .schedule-ring {
+  transition: opacity 0.08s ease;
+}
+
 /* -- The same actions on a board card ------------------------------------------
    The card is a `<button>`, so the actions cannot live inside it — nested buttons
    do not parse. They are siblings, and this wrapper is what they are positioned

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -548,6 +548,15 @@ button.tasks-caret,
      one of these buttons would navigate instead of acting. */
   position: relative;
   z-index: 2;
+  /* AND INVISIBLE MEANS INTANGIBLE (bugbot, 2026-08-18). `opacity: 0` alone
+     leaves a live control sitting at `z-index: 2` over the row's stretched link,
+     so a press there hits a button nobody can see and NOTHING happens — the dead
+     click design-principles §0 forbids. It was harmless while these sat in their
+     own reserved boxes at the row's end; it stopped being harmless the moment
+     Archive moved on top of the status ring, where it covered the one mark a
+     reader is most likely to aim at. The reveal below hands the events back
+     with the ink, so a control is graspable exactly when it is visible. */
+  pointer-events: none;
 }
 
 .tasks-row:hover .tasks-act,
@@ -556,6 +565,7 @@ button.tasks-caret,
 .tasks-msg:focus-within .tasks-act,
 .tasks-act:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 .tasks-act:hover:not(:disabled),
@@ -761,7 +771,11 @@ button.tasks-caret,
 
 .tasks-card-act,
 .prefs-section .tasks-card-act {
-  pointer-events: auto;
+  /* The events come back with the INK (see the reveal rule below), not here.
+     This used to be an unconditional `auto`, which put an invisible button over
+     a card that is itself a button: a press on that corner at rest hit the
+     hidden control and did nothing, instead of opening the chat like the rest of
+     the card. Same rule as the row's `.tasks-act` — visible or intangible. */
   /* NO SKIN. The button lets the card show through and paints only on its own
      hover (`.tasks-act:hover`, above).
 
@@ -788,6 +802,7 @@ button.tasks-caret,
 .tasks-card-wrap:focus-within .tasks-card-act,
 .tasks-card-act:focus-visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 /* Mid-write, same as the row's: the card is being pointed at, so full opacity is

--- a/tests/test_schedule_css.py
+++ b/tests/test_schedule_css.py
@@ -199,4 +199,13 @@ def test_a_running_chip_says_so_and_stops_saying_it_on_request():
     assert guarded, "the static fallback must sit inside a reduced-motion block"
     assert "animation: none" in guarded[0]
     # And the rule hangs off a class the view actually sets.
-    assert 'isRunningNow(chip.task, chip.anchor) ? " is-running" : ""' in _read(_CAL)
+    #
+    # Asked of the CHIP's whole day, not of its anchor (bugbot, 2026-08-18). A
+    # chip is one task on one day, anchored at that day's EARLIEST message, so
+    # the anchor is the wrong occurrence twice over: a day whose 05:00 run has
+    # finished and whose 14:00 run is in flight was asking about the finished
+    # one, and the mark landed on whichever day held the task's newest row —
+    # routinely tomorrow's pending occurrence. tasks-lib.isRunningIn asks every
+    # message under the chip; the class, the CSS above and the reduced-motion
+    # fallback are untouched.
+    assert 'isRunningIn(chip.task, chip.messages) ? " is-running" : ""' in _read(_CAL)


### PR DESCRIPTION
**Stacks on #613** (`agent/20260818-status-model` — this PR reuses its status derivation, `tasks-lib.taskColumn`). Review that one first; this branch is rebased on its tip.

Four changes, all on the Tasks surface and the sidebar entry that points at it.

### 1. Collapsed sidebar: one dot on the Tasks icon
- **Yellow** while any task is in progress. **Green** when tasks finished and nobody has read them. Nothing otherwise. Yellow wins over green: a reader being told work is in flight does not also need sending to the page mid-run, and the trip is still waiting when it settles.
- Hues are the status ring's own tokens (`--status-progress` / `--status-done`), so one status is one colour on every surface that names it.
- **Landing on `/tasks` dismisses the green dot**, and the dismissal persists: a stamp per task (`task key -> last_active`) in `localStorage`, not a flag. A bare set of dismissed keys would swallow the mark forever the second time that task ran; the stamp means the mark comes back for any completion the visit did not show — including the same task finishing again.

### 2. Expanded sidebar: words instead of a dot
- `N running` in the In Progress yellow, with a shimmer while the work is live (`background-clip: text`), and a flat status hue under `prefers-reduced-motion` — the blanket reduced-motion rule runs an animation once at 0.01ms, which would park the gradient mid-travel and leave the words half-faded.
- The done-unread **count wears the bookmark folder's chip**. That skin is now stated once as `.sidebar-count-chip` and all three counts in the sidebar wear it (`.folder-count` keeps only its own placement and hover fade); nothing was re-tuned by eye.
- No dot when expanded — a dot on the icon plus a readout beside the label is one fact stated twice.

### Data source
One poll behind both readers, the shape `aiRuntime.ts` already set for the AI Models dot: `shell/tasksPulse.ts` polls `GET /api/tasks`, the **Tasks page publishes its own answer into it** (`publishTasks`), and publishing restarts the timer — so while the page is open nothing else calls the endpoint, and the sidebar can never show a dot the page disagrees with. Cadence follows the state: 10s while something runs, 30s idle, and polling starts with the first subscriber and stops with the last. The route stays in the sidebar (`markTasksSeen()`), not in the store.

### 3. The page's measure: 1240px → 1050px
15% off, rounded to the nearest 50, one token change plus the prose that explains it. A row's ink is an id, a title and two short times; at 1240 the title's ellipsis sat hundreds of pixels from the times it was being clipped for.

### 4. List row: Archive replaces the status ring on hover
- Archive sat out by the folder chip, at the row's busiest end. It is in the **mark slot** now: ring at rest, button on hover **or focus-visible**, same position.
- **Nothing shifts.** The slot is exactly `--tasks-rail-w` and the button is out of flow inside it, so `--tasks-rail-x`, the thread's indent under it, and the caret's expand zone are untouched. The ring fades (a `display` flip cannot ease) and gives up its pointer events with its ink. A row with nothing to file keeps its ring under the pointer.
- **Board cards keep their current treatment** — asserted, not assumed.

### Tests
`npm run build` (boundaries + tsc + vite) and `bun test` green: **1839 pass, 0 fail**. New `src/shell/sidebar-tasks.test.ts` covers the derivation directly (counts, failed-is-not-green, the dismissal reappearing for a new completion, the pruning, a hand-edited store) and reads the wiring out of the source per this repo's idiom — one poll, route out of the store, which mark each collapse state draws, the shared chip, the reduced-motion arm. The archive swap and the new measure are pinned in `tasks-lib.test.ts`; `tests/test_schedule_css.py` still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared sidebar polling, localStorage dismissal semantics, and hover/focus pointer-event behavior on task rows; logic is heavily tested but regressions could show wrong dots or dead clicks on the status ring.
> 
> **Overview**
> The **Tasks** sidebar entry now surfaces live state: collapsed rail shows a single **yellow** (in progress) or **green** (done, unread) dot via new `badge` on rail items; expanded mode uses **`trailing`** for shimmering “N running” and a shared **`.sidebar-count-chip`** (bookmarks use the same skin). Green-dot dismissal is **`localStorage`** stamps per task (`last_active`), cleared on `/tasks` via `markTasksSeen()` while the expanded unread count stays server-driven.
> 
> **`tasksPulse.ts`** centralizes one `GET /api/tasks` subscriber set: **`Scheduled`** publishes with `publishTasks` and holds **`useTasksFeeder()`** so the store does not double-poll while the page is open; generation guards drop stale in-flight polls.
> 
> **`tasks-lib`** adds `tasksPulse` / `seenAfterVisit` and fixes “running” for recurring work: **`activeMessage`** / **`hasStarted`** replace “newest row”; calendar chips use **`isRunningIn(task, messages)`** instead of anchor-only **`isRunningNow`**.
> 
> List rows move **Archive** into **`.tasks-rowmark`** (ring fades on hover/focus; button gets `pointer-events` only when visible). Schedule page max width **1240px → 1050px**. New **`sidebar-tasks.test.ts`** and extended **`tasks-lib.test.ts`** / CSS tests cover pulse, polling, and wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 102a37bff717192be15bb9bf90096932550f6f8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->