### PR TITLE
Claude Code health: tell the first run instead of failing at it

### DIFF
--- a/frontend/src/apps/builder/Apps.tsx
+++ b/frontend/src/apps/builder/Apps.tsx
@@ -21,6 +21,7 @@ import { useNavEpoch } from "@platform/lib/hooks";
 import { navigateUrl } from "@platform/lib/router";
 import { HomeHero } from "./HomeHero";
 import { SkeletonLines } from "@platform/ui/Skeleton";
+import { ClaudeHealthStrip } from "@platform/ui/ClaudeHealthStrip";
 
 type Loaded<T> = { status: "loading" } | { status: "ok"; data: T } | { status: "error"; message: string };
 
@@ -176,6 +177,14 @@ export default function Apps({ config }: { config: Config }) {
         {/* Same hero as Home: prompt composer that names, scaffolds, and lands
             in the new app's claude chat. Creating from here refreshes the grid. */}
         <HomeHero onCreated={() => setNonce((n) => n + 1)} />
+
+        {/* The hero's composer needs Claude Code, so the heads-up belongs
+            wherever the hero does — this page is the other front door, not a
+            second-class copy of Home. BELOW the hero here rather than above it:
+            the wordmark is this page's masthead, and pushing it down the page
+            would make a dismissible notice look like the app's own chrome.
+            Renders nothing when there is nothing to say. */}
+        <ClaudeHealthStrip />
 
         <div className="apps-toolbar">
           {/* Facet selector: which chip set filters the grid. Switching facets

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -178,9 +178,10 @@ export interface ClaudeHealth {
   /** Only ever true for a version we actually READ and that is below the
       floor — an unreadable version is never reported as outdated. */
   outdated: boolean;
-  /** true / false / null-for-unknown. null is macOS, whose credential lives in
-      the login Keychain: absence of a file proves nothing there, so the UI must
-      only offer a sign-in fix on an explicit `false`. */
+  /** true / false / null-for-unknown, from `claude auth status` — the only
+      party that actually knows, on every platform. null means it could not be
+      asked (no runnable CLI, or one predating the subcommand), NOT that it said
+      no: the UI may only offer a sign-in fix on an explicit `false`. */
   signed_in: boolean | null;
   config_dir: string;
   checked_at: number;

--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -154,6 +154,48 @@ export function getConfig(): Promise<Config> {
   return getJson<Config>("/api/config");
 }
 
+// -- Is Claude Code usable (fused_render/claude_health.py) -------------------
+//
+// The proactive counterpart to the TroubleCard's reactive classification: these
+// are the facts a first run can be TOLD, before a prompt has been spent finding
+// them out. NOT on Config — /api/config is read on every page load, and each
+// field here is backed by a process spawn behind a disk cache.
+
+export interface ClaudeHealth {
+  /** Whether the resolved binary is one we could actually run. A stale
+      FUSED_RENDER_CLAUDE_BIN reports a `path` and `found: false`. */
+  found: boolean;
+  path: string | null;
+  /** How it was found, and the reason this field exists rather than just a
+      boolean. "path" means the app can see it unaided — nothing to say. "shell"
+      means ONLY the user's login shell can, so the app's own PATH is the
+      problem and the fix is the override, not another install. */
+  source: "override" | "path" | "candidate" | "shell" | null;
+  /** What `claude --version` said, or null when it would not tell us. */
+  version: string | null;
+  /** The lowest version this app's spawn line is known to work with. */
+  min_version: string;
+  /** Only ever true for a version we actually READ and that is below the
+      floor — an unreadable version is never reported as outdated. */
+  outdated: boolean;
+  /** true / false / null-for-unknown. null is macOS, whose credential lives in
+      the login Keychain: absence of a file proves nothing there, so the UI must
+      only offer a sign-in fix on an explicit `false`. */
+  signed_in: boolean | null;
+  config_dir: string;
+  checked_at: number;
+}
+
+export function getClaudeHealth(): Promise<ClaudeHealth> {
+  return getJson<ClaudeHealth>("/api/claude/health");
+}
+
+/** Re-probe, ignoring the cache — what "Check again" means after the user has
+    gone and installed or signed into something. */
+export function refreshClaudeHealth(): Promise<ClaudeHealth> {
+  return postJson<ClaudeHealth>("/api/claude/health/refresh", {});
+}
+
 // -- Self-update (fused_render/server/routers/update.py) ---------------------
 
 export interface UpdateStatus {

--- a/frontend/src/platform/lib/claude-health.test.ts
+++ b/frontend/src/platform/lib/claude-health.test.ts
@@ -5,6 +5,9 @@
 // tell a user to install a CLI they have, or to sign into an account they are
 // signed into. Every one of those is the same wrong-advice failure the two-tier
 // matching in trouble.ts exists to prevent, arriving from the proactive side.
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { beforeEach, expect, test } from "bun:test";
 
 import {
@@ -250,4 +253,53 @@ test("unavailable storage reads as NOT dismissed, and never throws", () => {
   } finally {
     (globalThis as { localStorage?: unknown }).localStorage = real;
   }
+});
+
+// -- when the strip re-evaluates itself (ui/ClaudeHealthStrip) ---------------
+//
+// Behaviour of the component rather than this lib, pinned the way the shell's
+// own suites pin theirs — over the source, because the regressions here are
+// "the effect stopped running" and "a flag shadowed the check", neither of
+// which a render assertion would notice.
+
+const STRIP = readFileSync(
+  join(import.meta.dir, "..", "ui", "ClaudeHealthStrip.tsx"), "utf8");
+
+test("mounting always re-asks; the module cache only seeds the first paint", () => {
+  // The regression: `if (cached !== null) return` skipped the fetch, so the
+  // only thing that ever refreshed the strip was its own button. A user who
+  // signed in and navigated back still faced a card telling them to sign in.
+  expect(STRIP).not.toContain("if (cached !== null) return");
+  expect(STRIP).toContain("useEffect(() => {\n    load(false);\n  }, [load]);");
+});
+
+test("returning to the window re-checks, and only while something is showing", () => {
+  // Every fix this card asks for happens elsewhere — a terminal, an installer —
+  // so coming back is exactly when the claim should be re-tested and the card
+  // allowed to disappear on its own.
+  expect(STRIP).toContain('window.addEventListener("focus", onFocus)');
+  expect(STRIP).toContain('document.addEventListener("visibilitychange", onFocus)');
+  expect(STRIP).toContain("if (!showing) return;");
+  // Forced, because the server cache is age-bounded and a sign-in usually lands
+  // inside that window — a plain read is the one that would still say "signed out".
+  expect(STRIP).toContain("load(true);");
+  // Both listeners are removed, or navigating away leaves probes firing forever.
+  expect(STRIP).toContain('window.removeEventListener("focus", onFocus)');
+  expect(STRIP).toContain('document.removeEventListener("visibilitychange", onFocus)');
+});
+
+test("focus bursts collapse into one check", () => {
+  expect(STRIP).toContain("Date.now() - lastCheck.current < FOCUS_RECHECK_MS");
+});
+
+test("a hidden document does not count as coming back", () => {
+  expect(STRIP).toContain('document.visibilityState === "hidden"');
+});
+
+test("dismissal is decided only by the signature check, never a local flag", () => {
+  // A `closed` flag shadowed isDismissed and was wrong in the direction that
+  // matters: dismissing "not signed in" suppressed a LATER, different problem
+  // for the rest of the page's life.
+  expect(STRIP).not.toContain("setClosed");
+  expect(STRIP).toContain("!isDismissed(issues)");
 });

--- a/frontend/src/platform/lib/claude-health.test.ts
+++ b/frontend/src/platform/lib/claude-health.test.ts
@@ -106,14 +106,13 @@ test("a stale override is its own diagnosis, never 'install Claude Code'", () =>
 
 // -- the found-but-not-ready cases -------------------------------------------
 
-test("a shell-only install blames the app's PATH, not the install", () => {
-  const issues = claudeIssues(healthy({ source: "shell", path: "/opt/volta/bin/claude" }));
-  expect(issues.map((i) => i.id)).toEqual(["shell-only"]);
-  expect(issues[0].detail).toContain(CLAUDE_BIN_ENV);
-  expect(issues[0].detail).toContain("/opt/volta/bin/claude");
-  // Emphatically NOT an install prompt: it is already installed.
-  expect(issues[0].command).toBeUndefined();
-  expect(issues[0].title).not.toContain("can't find");
+test("a shell-only install is not something to mention", () => {
+  // It IS a real problem — neither spawn path shells out, so a volta/fnm/nvm
+  // install is invisible to both — but one the app fixes for itself: the server
+  // publishes the discovered path as the override the moment it probes
+  // (claude_health.adopt). Asking the user to set an environment variable we
+  // were holding the value for was asking them to do our work.
+  expect(ids(healthy({ source: "shell", path: "/opt/volta/bin/claude" }))).toEqual([]);
 });
 
 test("an override that works is not something to mention", () => {
@@ -150,10 +149,8 @@ test("a signed-out CLI is reported only on an explicit false", () => {
 });
 
 test("several problems on one install are all reported, blocking first", () => {
-  const issues = ids(healthy({
-    source: "shell", version: "1.0.88", outdated: true, signed_in: false,
-  }));
-  expect(issues).toEqual(["shell-only", "outdated", "signed-out"]);
+  const issues = ids(healthy({ version: "1.0.88", outdated: true, signed_in: false }));
+  expect(issues).toEqual(["outdated", "signed-out"]);
 });
 
 // -- help links ---------------------------------------------------------------
@@ -162,7 +159,6 @@ test("every issue deep-links to a real troubleshooting tab", () => {
   const cases: ClaudeHealth[] = [
     healthy({ found: false, source: null }),
     healthy({ found: false, source: "override" }),
-    healthy({ source: "shell" }),
     healthy({ outdated: true, version: "1.0.0" }),
     healthy({ signed_in: false }),
   ];

--- a/frontend/src/platform/lib/claude-health.test.ts
+++ b/frontend/src/platform/lib/claude-health.test.ts
@@ -1,0 +1,256 @@
+// What lib/claude-health gets wrong in ways no screenshot shows: which of
+// several problems leads, and whether dismissing one hides the next.
+//
+// The recurring assertion in here is the NEGATIVE one — that the strip does not
+// tell a user to install a CLI they have, or to sign into an account they are
+// signed into. Every one of those is the same wrong-advice failure the two-tier
+// matching in trouble.ts exists to prevent, arriving from the proactive side.
+import { beforeEach, expect, test } from "bun:test";
+
+import {
+  CLAUDE_BIN_ENV,
+  CLAUDE_UPDATE_COMMAND,
+  claudeIssues,
+  dismiss,
+  isDismissed,
+  issueHelpUrl,
+  issuesSignature,
+  undismiss,
+} from "./claude-health";
+import { CLAUDE_INSTALL_COMMAND } from "./trouble";
+import type { ClaudeHealth } from "./api";
+
+// A machine where everything is fine. Each test breaks exactly one thing, so
+// what it asserts is attributable to that one field.
+function healthy(over: Partial<ClaudeHealth> = {}): ClaudeHealth {
+  return {
+    found: true,
+    path: "/Users/x/.local/bin/claude",
+    source: "path",
+    version: "2.1.220",
+    min_version: "2.0.0",
+    outdated: false,
+    signed_in: true,
+    config_dir: "/Users/x/.claude",
+    checked_at: 1_700_000_000,
+    ...over,
+  };
+}
+
+const ids = (h: ClaudeHealth | null) => claudeIssues(h).map((i) => i.id);
+
+// bun's test runtime has no localStorage, and the dismissal state machine is
+// half of what this file is here to check — so stand one up. Kept as a real
+// (tiny) store rather than a spy: what matters is the round trip through a
+// string key, which is exactly where a signature bug would hide.
+const store = new Map<string, string>();
+(globalThis as { localStorage?: unknown }).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => void store.set(k, String(v)),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+};
+
+beforeEach(() => {
+  store.clear();
+  undismiss();
+});
+
+// -- nothing to say -----------------------------------------------------------
+
+test("a healthy machine produces no issues at all", () => {
+  expect(claudeIssues(healthy())).toEqual([]);
+});
+
+test("a null snapshot is not a finding", () => {
+  // A failed probe means OUR endpoint did not answer. Reporting "Claude Code is
+  // missing" off the back of our own failed request would be the app blaming
+  // the user's machine for its own fault.
+  expect(claudeIssues(null)).toEqual([]);
+});
+
+test("an unknown sign-in state says nothing about signing in", () => {
+  // null is macOS, whose credential lives in the login Keychain: absence of a
+  // file proves nothing, so there is nothing to report.
+  expect(ids(healthy({ signed_in: null }))).toEqual([]);
+});
+
+// -- the missing case short-circuits -----------------------------------------
+
+test("a missing CLI reports only that, with the install command", () => {
+  const issues = claudeIssues(healthy({
+    found: false, path: null, source: null, version: null,
+    // A machine with no claude is ALSO signed out and has no readable version.
+    // Reporting all three would bury the only one that matters under two
+    // consequences of it.
+    signed_in: false, outdated: false,
+  }));
+  expect(issues.map((i) => i.id)).toEqual(["missing"]);
+  expect(issues[0].command).toBe(CLAUDE_INSTALL_COMMAND);
+  expect(issues[0].helpKind).toBe("notfound");
+});
+
+test("a stale override is its own diagnosis, never 'install Claude Code'", () => {
+  // The user may well have Claude Code; what is broken is a setting they can
+  // see. Telling them to install it would be wrong twice.
+  const issues = claudeIssues(healthy({
+    found: false, source: "override", path: "/opt/gone/claude",
+  }));
+  expect(issues.map((i) => i.id)).toEqual(["unusable-override"]);
+  expect(issues[0].title).toContain(CLAUDE_BIN_ENV);
+  expect(issues[0].command).toBeUndefined();
+  // and the path is named, because it is the thing to correct
+  expect(issues[0].detail).toContain("/opt/gone/claude");
+});
+
+// -- the found-but-not-ready cases -------------------------------------------
+
+test("a shell-only install blames the app's PATH, not the install", () => {
+  const issues = claudeIssues(healthy({ source: "shell", path: "/opt/volta/bin/claude" }));
+  expect(issues.map((i) => i.id)).toEqual(["shell-only"]);
+  expect(issues[0].detail).toContain(CLAUDE_BIN_ENV);
+  expect(issues[0].detail).toContain("/opt/volta/bin/claude");
+  // Emphatically NOT an install prompt: it is already installed.
+  expect(issues[0].command).toBeUndefined();
+  expect(issues[0].title).not.toContain("can't find");
+});
+
+test("an override that works is not something to mention", () => {
+  // Someone who already set the override has solved this; saying anything would
+  // be nagging about a fixed problem.
+  expect(ids(healthy({ source: "override" }))).toEqual([]);
+});
+
+test("a candidate-dir install is not something to mention either", () => {
+  // We found it where Claude Code installs it. Nothing for the user to do.
+  expect(ids(healthy({ source: "candidate" }))).toEqual([]);
+});
+
+test("an outdated CLI offers `claude update` and names both versions", () => {
+  const issues = claudeIssues(healthy({ version: "1.0.88", outdated: true }));
+  expect(issues.map((i) => i.id)).toEqual(["outdated"]);
+  expect(issues[0].command).toBe(CLAUDE_UPDATE_COMMAND);
+  expect(issues[0].title).toContain("1.0.88");
+  expect(issues[0].detail).toContain("2.0.0");
+});
+
+test("outdated is driven by the server's flag, never re-derived here", () => {
+  // The server is the only side that knows an unreadable version must not count
+  // as old. A UI that compared the strings itself would reintroduce exactly
+  // that bug.
+  expect(ids(healthy({ version: null, outdated: false }))).toEqual([]);
+  expect(ids(healthy({ version: "0.1", outdated: false }))).toEqual([]);
+});
+
+test("a signed-out CLI is reported only on an explicit false", () => {
+  expect(ids(healthy({ signed_in: false }))).toEqual(["signed-out"]);
+  expect(ids(healthy({ signed_in: null }))).toEqual([]);
+  expect(ids(healthy({ signed_in: true }))).toEqual([]);
+});
+
+test("several problems on one install are all reported, blocking first", () => {
+  const issues = ids(healthy({
+    source: "shell", version: "1.0.88", outdated: true, signed_in: false,
+  }));
+  expect(issues).toEqual(["shell-only", "outdated", "signed-out"]);
+});
+
+// -- help links ---------------------------------------------------------------
+
+test("every issue deep-links to a real troubleshooting tab", () => {
+  const cases: ClaudeHealth[] = [
+    healthy({ found: false, source: null }),
+    healthy({ found: false, source: "override" }),
+    healthy({ source: "shell" }),
+    healthy({ outdated: true, version: "1.0.0" }),
+    healthy({ signed_in: false }),
+  ];
+  for (const h of cases) {
+    for (const issue of claudeIssues(h)) {
+      expect(issueHelpUrl(issue)).toMatch(
+        /^https:\/\/render\.fused\.io\/#troubleshooting-(notfound|login|limit|raw)$/,
+      );
+    }
+  }
+});
+
+test("a signed-out install links to the login tab, not the install tab", () => {
+  const [issue] = claudeIssues(healthy({ signed_in: false }));
+  expect(issueHelpUrl(issue)).toContain("#troubleshooting-login");
+});
+
+// -- dismissal ---------------------------------------------------------------
+
+test("nothing to say counts as dismissed, so the strip renders nothing", () => {
+  expect(isDismissed([])).toBe(true);
+});
+
+test("dismissing hides that exact set and nothing else", () => {
+  const signedOut = claudeIssues(healthy({ signed_in: false }));
+  dismiss(signedOut);
+  expect(isDismissed(signedOut)).toBe(true);
+
+  // THE CASE THIS EXISTS FOR: dismissed "not signed in" a week ago, signed in
+  // since, and has now upgraded into a version problem. They must hear about it.
+  const outdated = claudeIssues(healthy({ outdated: true, version: "1.0.0" }));
+  expect(isDismissed(outdated)).toBe(false);
+});
+
+test("a set that GREW is not dismissed", () => {
+  const one = claudeIssues(healthy({ signed_in: false }));
+  dismiss(one);
+  const two = claudeIssues(healthy({ signed_in: false, outdated: true, version: "1.0.0" }));
+  expect(isDismissed(two)).toBe(false);
+});
+
+test("the signature ignores presentation order", () => {
+  // claudeIssues' order is a display decision; it must not be able to
+  // invalidate a stored dismissal by changing.
+  const a = claudeIssues(healthy({ signed_in: false, outdated: true, version: "1.0.0" }));
+  expect(issuesSignature(a)).toBe(issuesSignature([...a].reverse()));
+});
+
+test("the signature ignores versions and paths", () => {
+  // Titles carry both, so keying on them would re-show a dealt-with strip on
+  // every patch upgrade.
+  const first = claudeIssues(healthy({ outdated: true, version: "1.0.88" }));
+  dismiss(first);
+  const later = claudeIssues(healthy({ outdated: true, version: "1.0.99" }));
+  expect(isDismissed(later)).toBe(true);
+});
+
+test("undismiss brings it back", () => {
+  const issues = claudeIssues(healthy({ signed_in: false }));
+  dismiss(issues);
+  expect(isDismissed(issues)).toBe(true);
+  undismiss();
+  expect(isDismissed(issues)).toBe(false);
+});
+
+test("unavailable storage reads as NOT dismissed, and never throws", () => {
+  // Private mode, a full quota, a locked-down origin. Showing the strip once too
+  // often is a far smaller harm than silently withholding the one fact that
+  // explains why nothing works — so the failure has to fall the safe way.
+  const real = (globalThis as { localStorage?: unknown }).localStorage;
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: () => {
+      throw new Error("denied");
+    },
+    setItem: () => {
+      throw new Error("denied");
+    },
+    removeItem: () => {
+      throw new Error("denied");
+    },
+  };
+  try {
+    const issues = claudeIssues(healthy({ signed_in: false }));
+    expect(() => dismiss(issues)).not.toThrow();
+    expect(isDismissed(issues)).toBe(false);
+    expect(() => undismiss()).not.toThrow();
+    // ...but "nothing to say" still short-circuits without touching storage.
+    expect(isDismissed([])).toBe(true);
+  } finally {
+    (globalThis as { localStorage?: unknown }).localStorage = real;
+  }
+});

--- a/frontend/src/platform/lib/claude-health.test.ts
+++ b/frontend/src/platform/lib/claude-health.test.ts
@@ -70,8 +70,9 @@ test("a null snapshot is not a finding", () => {
 });
 
 test("an unknown sign-in state says nothing about signing in", () => {
-  // null is macOS, whose credential lives in the login Keychain: absence of a
-  // file proves nothing, so there is nothing to report.
+  // null means `claude auth status` could not be asked (no runnable CLI, or one
+  // predating the subcommand) — not that it answered no. There is nothing to
+  // report, and reporting anyway would tell a signed-in user to go sign in.
   expect(ids(healthy({ signed_in: null }))).toEqual([]);
 });
 

--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -1,0 +1,197 @@
+// Turning a Claude Code health snapshot into the things worth SAYING about it,
+// and remembering what the user has already dismissed.
+//
+// **Why a module and not logic inside the strip.** This is a classifier with an
+// ordering argument and a dismissal state machine, and both are the kind of
+// thing that is wrong in ways no screenshot shows — the same reason lib/trouble
+// exists beside TroubleCard. A component effect is not a testable place to keep
+// "which of three problems leads" or "does dismissing one hide the next".
+//
+// It is the PROACTIVE half of lib/trouble. That module classifies a failure
+// that already happened, in the CLI's own words; this one reads facts gathered
+// before anything was attempted. They share a vocabulary on purpose: the
+// `helpKind` below is one of the download page's four tabs, so a heads-up and a
+// failure card send the user to the same place.
+import type { ClaudeHealth } from "./api";
+import { CLAUDE_INSTALL_COMMAND, troubleHelpUrl, type TroubleKind } from "./trouble";
+
+/** One thing worth telling the user, already in their terms. */
+export interface ClaudeIssue {
+  /** Stable id — the dismissal signature is built from these, so renaming one
+      un-dismisses it for everybody. Worth it when the MEANING changed; never
+      do it for wording. */
+  id: "missing" | "unusable-override" | "shell-only" | "outdated" | "signed-out";
+  /** The one-line statement. Says what is true, not what is polite. */
+  title: string;
+  /** What to do about it, in a sentence. */
+  detail: string;
+  /** Which troubleshooting tab this maps to, so the link is a deep link. */
+  helpKind: TroubleKind;
+  /** A terminal command that fixes it, when one does. */
+  command?: string;
+}
+
+/** `claude update`, the fix for an install that is merely old. Not in
+    lib/trouble because that module never had a case for it: an outdated CLI
+    fails with an unknown-option error, which classifies as `raw` and gets told
+    to work out what the error is about. Knowing the version is what turns that
+    into one command. */
+export const CLAUDE_UPDATE_COMMAND = "claude update";
+
+/** The env var that points the app at a CLI it cannot otherwise see. */
+export const CLAUDE_BIN_ENV = "FUSED_RENDER_CLAUDE_BIN";
+
+/**
+ * Everything unresolved about this snapshot, most-blocking first.
+ *
+ * ORDER IS THE CORRECTNESS ARGUMENT, the same one lib/trouble makes for its two
+ * tiers. A machine with no `claude` at all is also "not signed in" and also has
+ * no readable version, and reporting all three would bury the only one that
+ * matters under two consequences of it. So a missing install short-circuits, and
+ * everything after it is a statement about an install we know exists.
+ *
+ * An EMPTY array means "nothing to say" — which is the common case and the
+ * reason the strip renders nothing at all most of the time.
+ */
+export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
+  if (!health) return []; // a failed probe is not a finding — see the strip
+  const issues: ClaudeIssue[] = [];
+
+  if (!health.found) {
+    // A pointing-at-nothing override is its own diagnosis, and telling this
+    // user to install Claude Code would be wrong twice: they may well have it,
+    // and the thing actually breaking is a setting they can see.
+    if (health.source === "override") {
+      issues.push({
+        id: "unusable-override",
+        title: `${CLAUDE_BIN_ENV} points at something that cannot run`,
+        detail:
+          `The app was told to use ${health.path ?? "a specific path"}, and there ` +
+          "is no runnable file there. Correct it or unset it — with it unset, " +
+          "the app looks for Claude Code in the usual places.",
+        helpKind: "notfound",
+      });
+      return issues;
+    }
+    issues.push({
+      id: "missing",
+      title: "The app can't find Claude Code",
+      detail:
+        "Fused Render uses Claude Code on this computer to build and fix " +
+        "things. Install it, then use Check again.",
+      helpKind: "notfound",
+      command: CLAUDE_INSTALL_COMMAND,
+    });
+    return issues; // everything below is about an install that exists
+  }
+
+  // Found only by asking the login shell: the binary is fine, the app's PATH is
+  // not. A GUI-launched app inherits no shell profile, so this will keep
+  // happening on every start until the override is set — and "install Claude
+  // Code" would be exactly the wrong advice for it.
+  if (health.source === "shell") {
+    issues.push({
+      id: "shell-only",
+      title: "Claude Code is installed somewhere the app can't see",
+      detail:
+        `Your shell finds it at ${health.path}, but Fused Render does not ` +
+        `inherit your shell's PATH. Set ${CLAUDE_BIN_ENV} to that path so it ` +
+        "is found on every start.",
+      helpKind: "notfound",
+    });
+  }
+
+  // Only ever set for a version we actually read AND that is below the floor —
+  // the server never guesses this from an unreadable version string.
+  if (health.outdated) {
+    issues.push({
+      id: "outdated",
+      title: `Claude Code ${health.version} is older than this app needs`,
+      detail:
+        `Fused Render starts sessions with options added in ${health.min_version}. ` +
+        "Update it and the app will use the version you already have.",
+      helpKind: "raw",
+      command: CLAUDE_UPDATE_COMMAND,
+    });
+  }
+
+  // STRICTLY `false`, never falsy. `null` is macOS, whose credential lives in
+  // the login Keychain — absence of a file proves nothing there, and telling a
+  // signed-in user to go and sign in is the wrong-advice failure this whole
+  // module is arranged to avoid.
+  if (health.signed_in === false) {
+    issues.push({
+      id: "signed-out",
+      title: "Claude Code isn't signed in",
+      detail:
+        "Open a terminal, run `claude`, type /login and finish signing in. " +
+        "It happens once.",
+      helpKind: "login",
+    });
+  }
+
+  return issues;
+}
+
+/** The deep link for an issue — the download page's matching tab. */
+export function issueHelpUrl(issue: ClaudeIssue): string {
+  return troubleHelpUrl(issue.helpKind);
+}
+
+// -- dismissal ----------------------------------------------------------------
+//
+// The strip is a heads-up, so it has to be dismissible. What it must NOT be is
+// dismissible once and forever: the interesting case is a user who dismisses
+// "not signed in", signs in a week later, and then upgrades into a version
+// problem — and must hear about that one.
+
+const DISMISS_KEY = "fused-render.claude-health.dismissed";
+
+/**
+ * A stable identity for "this exact set of problems".
+ *
+ * Built from the issue IDS, sorted — never from the titles, which carry a path
+ * and a version and would therefore change signature on every patch upgrade,
+ * re-showing a strip the user has already dealt with. Sorted, because
+ * `claudeIssues`' order is a presentation decision and must not be able to
+ * invalidate a dismissal by changing.
+ */
+export function issuesSignature(issues: ClaudeIssue[]): string {
+  return issues.map((i) => i.id).sort().join(",");
+}
+
+/** Whether this set of problems has already been dismissed.
+ *
+ * A DIFFERENT set is not dismissed, which is the whole point: dismissing
+ * "signed-out" leaves a later "outdated" free to appear. Storage failures
+ * (private mode, a full quota) read as "not dismissed" — showing a strip too
+ * often is a much smaller harm than silently withholding the one fact that
+ * explains why nothing works. */
+export function isDismissed(issues: ClaudeIssue[]): boolean {
+  if (!issues.length) return true;
+  try {
+    return localStorage.getItem(DISMISS_KEY) === issuesSignature(issues);
+  } catch {
+    return false;
+  }
+}
+
+/** Remember this set as dismissed. */
+export function dismiss(issues: ClaudeIssue[]): void {
+  try {
+    localStorage.setItem(DISMISS_KEY, issuesSignature(issues));
+  } catch {
+    // Nothing to do and nothing worth saying: the strip closes either way, it
+    // just comes back on the next load.
+  }
+}
+
+/** Forget any dismissal — for the Preferences entry point, whose whole job is
+    to show the user this again on purpose. */
+export function undismiss(): void {
+  try {
+    localStorage.removeItem(DISMISS_KEY);
+  } catch {
+    // see dismiss()
+  }
+}

--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -20,7 +20,7 @@ export interface ClaudeIssue {
   /** Stable id — the dismissal signature is built from these, so renaming one
       un-dismisses it for everybody. Worth it when the MEANING changed; never
       do it for wording. */
-  id: "missing" | "unusable-override" | "shell-only" | "outdated" | "signed-out";
+  id: "missing" | "unusable-override" | "outdated" | "signed-out";
   /** The one-line statement. Says what is true, not what is polite. */
   title: string;
   /** What to do about it, in a sentence. */
@@ -85,21 +85,15 @@ export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
     return issues; // everything below is about an install that exists
   }
 
-  // Found only by asking the login shell: the binary is fine, the app's PATH is
-  // not. A GUI-launched app inherits no shell profile, so this will keep
-  // happening on every start until the override is set — and "install Claude
-  // Code" would be exactly the wrong advice for it.
-  if (health.source === "shell") {
-    issues.push({
-      id: "shell-only",
-      title: "Claude Code is installed somewhere the app can't see",
-      detail:
-        `Your shell finds it at ${health.path}, but Fused Render does not ` +
-        `inherit your shell's PATH. Set ${CLAUDE_BIN_ENV} to that path so it ` +
-        "is found on every start.",
-      helpKind: "notfound",
-    });
-  }
+  // NOTHING IS SAID ABOUT source === "shell", deliberately. A binary only the
+  // login shell can see is a real problem — a GUI-launched app inherits no
+  // shell profile, so neither spawn path would find it — but it is one the app
+  // fixes for itself: the server publishes the discovered path as the override
+  // the moment it probes (claude_health.adopt), and both spawn paths already
+  // honour that. Telling the user to go and set an environment variable we were
+  // holding the value for was asking them to do our work, so the message is
+  // gone rather than reworded. `source` stays on the payload because it is
+  // worth having in a bug report, not because the strip acts on it.
 
   // Only ever set for a version we actually read AND that is below the floor —
   // the server never guesses this from an unreadable version string.

--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -123,9 +123,7 @@ export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
     issues.push({
       id: "signed-out",
       title: "Claude Code isn't signed in",
-      detail:
-        "Open a terminal, run `claude`, type /login and finish signing in. " +
-        "It happens once.",
+      detail: "Open a terminal, run `claude`, type /login and finish signing in.",
       helpKind: "login",
     });
   }

--- a/frontend/src/platform/lib/claude-health.ts
+++ b/frontend/src/platform/lib/claude-health.ts
@@ -115,10 +115,10 @@ export function claudeIssues(health: ClaudeHealth | null): ClaudeIssue[] {
     });
   }
 
-  // STRICTLY `false`, never falsy. `null` is macOS, whose credential lives in
-  // the login Keychain — absence of a file proves nothing there, and telling a
-  // signed-in user to go and sign in is the wrong-advice failure this whole
-  // module is arranged to avoid.
+  // STRICTLY `false`, never falsy. `null` means the CLI could not be ASKED
+  // (missing, or older than `claude auth status`), which is not the same as it
+  // answering no — and telling a signed-in user to go and sign in is the
+  // wrong-advice failure this whole module is arranged to avoid.
   if (health.signed_in === false) {
     issues.push({
       id: "signed-out",

--- a/frontend/src/platform/ui/ClaudeHealthStrip.tsx
+++ b/frontend/src/platform/ui/ClaudeHealthStrip.tsx
@@ -1,0 +1,176 @@
+// The first-run heads-up: three lines on the front door saying whether Claude
+// Code is there, new enough, and signed in — BEFORE a prompt has been spent
+// finding out.
+//
+// **The failure this exists to prevent.** On a fresh install the Home hero
+// invites a prompt. The app folder gets created, the session fails, and the
+// TroubleCard explains it well — but the user has already typed a brief and
+// watched a folder appear before learning that the thing the app is built around
+// was never set up. `/api/config` had the right doctrine all along: it publishes
+// `learn_mount_ready` so the sidebar's Learn entry renders only when it works,
+// "so it's never a dead link". This is that gate for everything Claude-dependent.
+//
+// **It is not a wizard and not a gate.** The file explorer is completely useful
+// without Claude Code, and nothing here blocks it: the strip is a row above the
+// page that says what is wrong and how to fix it, and it disappears the moment
+// there is nothing to say. It renders NOTHING in the common case.
+//
+// The TroubleCard stays exactly as it is. Preflight is an addition, not a
+// replacement — a CLI can break between this check and the call.
+import { useCallback, useEffect, useState } from "react";
+
+import { getClaudeHealth, refreshClaudeHealth, type ClaudeHealth } from "@platform/lib/api";
+import {
+  claudeIssues,
+  dismiss as rememberDismissal,
+  isDismissed,
+  issueHelpUrl,
+  type ClaudeIssue,
+} from "@platform/lib/claude-health";
+
+// Module-scoped, so walking between Home and /apps — which both render this —
+// does not re-probe, and does not flash a strip that a moment ago was closed.
+// Deliberately NOT persisted: the snapshot is already cached server-side (on
+// disk, keyed on the binary's mtime), so a reload costs one small GET.
+let cached: ClaudeHealth | null = null;
+
+function CopyCommand({ command }: { command: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="update-badge-command">
+      <code>{command}</code>
+      <button
+        type="button"
+        className="update-badge-copy"
+        onClick={async () => {
+          try {
+            await navigator.clipboard.writeText(command);
+          } catch {
+            // Clipboard denied. The command is on screen either way, and a
+            // button stuck on "Copied" would be a lie about what happened.
+            return;
+          }
+          setCopied(true);
+          window.setTimeout(() => setCopied(false), 2000);
+        }}
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+function IssueRow({ issue }: { issue: ClaudeIssue }) {
+  return (
+    <li className="claude-health-issue">
+      <div className="claude-health-issue-title">{issue.title}</div>
+      <p className="claude-health-issue-detail">{issue.detail}</p>
+      {issue.command && <CopyCommand command={issue.command} />}
+      <a
+        className="version-panel-link"
+        href={issueHelpUrl(issue)}
+        target="_blank"
+        rel="noreferrer"
+      >
+        How to fix this ↗
+      </a>
+    </li>
+  );
+}
+
+export function ClaudeHealthStrip() {
+  const [health, setHealth] = useState<ClaudeHealth | null>(cached);
+  // A snapshot we have not fetched yet is NOT the same as one that says
+  // everything is fine, and rendering the strip before it arrives would flash a
+  // "can't find Claude Code" on every load of a perfectly healthy machine.
+  const [loaded, setLoaded] = useState(cached !== null);
+  const [busy, setBusy] = useState(false);
+  const [closed, setClosed] = useState(false);
+
+  useEffect(() => {
+    if (cached !== null) return;
+    let alive = true;
+    getClaudeHealth().then(
+      (h) => {
+        cached = h;
+        if (!alive) return;
+        setHealth(h);
+        setLoaded(true);
+      },
+      () => {
+        // A FAILED PROBE IS NOT A FINDING. If /api/claude/health itself cannot
+        // be reached then the server is what is wrong, and the app has louder
+        // ways of saying so (main.tsx's boot card, the status banner). Claiming
+        // Claude Code is missing on the strength of our own failed request would
+        // be the app blaming the user's machine for its own fault.
+        if (alive) setLoaded(true);
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  const check = useCallback(() => {
+    setBusy(true);
+    refreshClaudeHealth().then(
+      (h) => {
+        cached = h;
+        setHealth(h);
+        setBusy(false);
+      },
+      () => setBusy(false),
+    );
+  }, []);
+
+  const issues = claudeIssues(health);
+  if (!loaded || !issues.length || closed || isDismissed(issues)) return null;
+
+  const close = () => {
+    rememberDismissal(issues);
+    setClosed(true);
+  };
+
+  return (
+    <section className="claude-health" role="status" aria-label="Claude Code setup">
+      <div className="claude-health-head">
+        <h2 className="claude-health-title">
+          {/* Says what is still needed, not that something is broken: nothing IS
+              broken — the app is running and the explorer works. Same posture as
+              the TroubleCard's warning tint (SPEC §42: "Nothing red"). */}
+          Finish setting up Claude Code
+        </h2>
+        <div className="claude-health-head-actions">
+          <button
+            type="button"
+            className="version-panel-link"
+            onClick={check}
+            disabled={busy}
+          >
+            {busy ? "Checking…" : "Check again"}
+          </button>
+          <button
+            type="button"
+            className="claude-health-close"
+            onClick={close}
+            aria-label="Dismiss"
+            title="Dismiss"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <ul className="claude-health-issues">
+        {issues.map((issue) => (
+          <IssueRow key={issue.id} issue={issue} />
+        ))}
+      </ul>
+      <p className="claude-health-foot">
+        Everything else in Fused Render works without this — browsing, previews
+        and your own apps are unaffected.
+      </p>
+    </section>
+  );
+}
+
+export default ClaudeHealthStrip;

--- a/frontend/src/platform/ui/ClaudeHealthStrip.tsx
+++ b/frontend/src/platform/ui/ClaudeHealthStrip.tsx
@@ -165,10 +165,6 @@ export function ClaudeHealthStrip() {
           <IssueRow key={issue.id} issue={issue} />
         ))}
       </ul>
-      <p className="claude-health-foot">
-        Everything else in Fused Render works without this — browsing, previews
-        and your own apps are unaffected.
-      </p>
     </section>
   );
 }

--- a/frontend/src/platform/ui/ClaudeHealthStrip.tsx
+++ b/frontend/src/platform/ui/ClaudeHealthStrip.tsx
@@ -17,7 +17,7 @@
 //
 // The TroubleCard stays exactly as it is. Preflight is an addition, not a
 // replacement — a CLI can break between this check and the call.
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getClaudeHealth, refreshClaudeHealth, type ClaudeHealth } from "@platform/lib/api";
 import {
@@ -28,11 +28,22 @@ import {
   type ClaudeIssue,
 } from "@platform/lib/claude-health";
 
-// Module-scoped, so walking between Home and /apps — which both render this —
-// does not re-probe, and does not flash a strip that a moment ago was closed.
-// Deliberately NOT persisted: the snapshot is already cached server-side (on
-// disk, keyed on the binary's mtime), so a reload costs one small GET.
+// The last snapshot seen, so walking between Home and /apps — which both render
+// this — starts from what we already know instead of flashing an empty frame.
+//
+// A SEED, NOT A SHORT-CIRCUIT. It used to also skip the fetch, which is what
+// made the strip unable to notice its own problem being fixed: the only thing
+// that ever refreshed it was the button, so a user who signed in and came back
+// still faced a card telling them to sign in. The server holds the real cache
+// (on disk, and age-bounded), so re-asking on every mount is a small GET —
+// there was never anything to save here.
 let cached: ClaudeHealth | null = null;
+
+//: How long after a check a window-focus event is taken as "they may have gone
+//: and fixed it". Focus/blur flap in bursts (a click through the window, a
+//: notification, an OS overlay), and each forced re-check is real subprocess
+//: work, so near-simultaneous ones collapse into the first.
+const FOCUS_RECHECK_MS = 3000;
 
 function CopyCommand({ command }: { command: string }) {
   const [copied, setCopied] = useState(false);
@@ -85,50 +96,78 @@ export function ClaudeHealthStrip() {
   // "can't find Claude Code" on every load of a perfectly healthy machine.
   const [loaded, setLoaded] = useState(cached !== null);
   const [busy, setBusy] = useState(false);
-  const [closed, setClosed] = useState(false);
+  // Re-render after a dismissal. The dismissal ITSELF lives in lib/claude-health,
+  // keyed on which problems were dismissed; a local `closed` flag used to shadow
+  // it and was wrong in one direction that matters — dismissing "not signed in"
+  // suppressed a LATER, different problem for the rest of the page's life, when
+  // the signature check exists precisely so a new problem still gets through.
+  const [, redraw] = useState(0);
+  const lastCheck = useRef(0);
 
-  useEffect(() => {
-    if (cached !== null) return;
-    let alive = true;
-    getClaudeHealth().then(
+  const load = useCallback((force: boolean) => {
+    lastCheck.current = Date.now();
+    if (force) setBusy(true);
+    (force ? refreshClaudeHealth() : getClaudeHealth()).then(
       (h) => {
         cached = h;
-        if (!alive) return;
         setHealth(h);
         setLoaded(true);
+        setBusy(false);
       },
       () => {
         // A FAILED PROBE IS NOT A FINDING. If /api/claude/health itself cannot
         // be reached then the server is what is wrong, and the app has louder
         // ways of saying so (main.tsx's boot card, the status banner). Claiming
         // Claude Code is missing on the strength of our own failed request would
-        // be the app blaming the user's machine for its own fault.
-        if (alive) setLoaded(true);
-      },
-    );
-    return () => {
-      alive = false;
-    };
-  }, []);
-
-  const check = useCallback(() => {
-    setBusy(true);
-    refreshClaudeHealth().then(
-      (h) => {
-        cached = h;
-        setHealth(h);
+        // be the app blaming the user's machine for its own fault. Keep whatever
+        // we last knew rather than inventing a worse answer.
+        setLoaded(true);
         setBusy(false);
       },
-      () => setBusy(false),
     );
   }, []);
 
+  useEffect(() => {
+    load(false);
+  }, [load]);
+
   const issues = claudeIssues(health);
-  if (!loaded || !issues.length || closed || isDismissed(issues)) return null;
+  const showing = loaded && issues.length > 0 && !isDismissed(issues);
+
+  // COMING BACK TO THE WINDOW IS THE SIGNAL. Every fix this card asks for
+  // happens somewhere else — a terminal, an installer — so the moment the user
+  // returns is exactly when "is it still true?" should be re-asked, and the card
+  // should be able to answer by disappearing. Making them press a button to
+  // dismiss a warning they have already acted on is the app failing to notice
+  // its own advice was taken.
+  //
+  // Only while something IS showing: with nothing on screen there is no claim to
+  // re-check, and a healthy machine must not spawn probes for tabbing around.
+  // Forced rather than a plain read, because the server's cache is age-bounded
+  // and a sign-in usually lands well inside that window — the cheap read is
+  // exactly the one that would still say "signed out".
+  useEffect(() => {
+    if (!showing) return;
+    const onFocus = () => {
+      if (document.visibilityState === "hidden") return;
+      if (Date.now() - lastCheck.current < FOCUS_RECHECK_MS) return;
+      load(true);
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onFocus);
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onFocus);
+    };
+  }, [showing, load]);
+
+  if (!showing) return null;
+
+  const check = () => load(true);
 
   const close = () => {
     rememberDismissal(issues);
-    setClosed(true);
+    redraw((n) => n + 1);
   };
 
   return (

--- a/frontend/src/shell/Home.tsx
+++ b/frontend/src/shell/Home.tsx
@@ -22,6 +22,7 @@ import { hydrateRecents, loadRecents, recentFsPath, useRecentsVersion } from "@a
 import { FilesSearch } from "@apps/explorer/FilesHome";
 import { FolderPreviewCard, RecentPreviewCard } from "@apps/explorer/BookmarkCards";
 import { AppPreviewCard } from "@apps/builder/AppPreviewCard";
+import { ClaudeHealthStrip } from "@platform/ui/ClaudeHealthStrip";
 
 // One row per section: the page measures its own width and renders exactly
 // as many full-size cards as fit — no wrapping, no clipping, no scrolling.
@@ -166,6 +167,13 @@ export default function Home({ config }: { config: Config }) {
           // titles and "See all" stay flush with the cards' edges.
           <div ref={stripRef}>
             <div className="home-strips" style={{ width: count * (CARD_W + CARD_GAP) - CARD_GAP }}>
+            {/* Above the strips, because on a machine where Claude Code is not
+                set up this is the only thing on the page the user can act on —
+                and it renders nothing at all once there is nothing to say.
+                Inside the measured column so it lines up with the cards rather
+                than spanning the window. Hidden while a search is live for the
+                same reason the strips are: the search result IS the page then. */}
+            <ClaudeHealthStrip />
             <Section title="Fused Apps" seeAllHref="/apps">
               {apps === null ? (
                 <p className="fh-empty">Loading apps…</p>

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -292,9 +292,3 @@
   flex-wrap: wrap;
   margin-bottom: 8px;
 }
-
-.claude-health-foot {
-  margin: 12px 0 0;
-  color: var(--fg-muted);
-  font-size: 12px;
-}

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -209,8 +209,15 @@
 }
 
 /* Same quiet-control treatment as .trouble-actions — see the note there on why
-   these are peers in a row and not text links. */
-.claude-health-head-actions > button {
+   these are peers in a row and not text links.
+ *
+ * :not(.claude-health-close) is load-bearing, not defensive. `.x > button` is
+ * (0,1,1) and `.claude-health-close` is (0,1,0), so WITHOUT it this rule wins
+ * every property they share and the dismiss ✕ silently takes the bordered pill
+ * the rule below is written to keep off it. Excluding it here rather than
+ * out-specifying it there keeps the intent readable: this is the treatment for
+ * the ACTION buttons, and the ✕ is not one. */
+.claude-health-head-actions > button:not(.claude-health-close) {
   padding: 3px 10px;
   font: inherit;
   font-size: 12px;
@@ -221,12 +228,12 @@
   cursor: pointer;
 }
 
-.claude-health-head-actions > button:hover:not(:disabled) {
+.claude-health-head-actions > button:not(.claude-health-close):hover:not(:disabled) {
   background: var(--ctl-quiet-bg-hover);
   border-color: var(--ctl-quiet-border-hover);
 }
 
-.claude-health-head-actions > button:disabled {
+.claude-health-head-actions > button:not(.claude-health-close):disabled {
   cursor: default;
   color: var(--fg-muted);
 }

--- a/frontend/src/styles/dialogs.css
+++ b/frontend/src/styles/dialogs.css
@@ -158,3 +158,136 @@
   -webkit-line-clamp: 3;
   word-break: break-word;
 }
+
+/* -- The Claude Code first-run strip (ui/ClaudeHealthStrip) -------------------
+ *
+ * The PROACTIVE sibling of the trouble card above, and styled as one on purpose:
+ * same warning tint, same plate, same quiet action row. The two say related
+ * things at different times — "this will not work yet" and "this did not work" —
+ * and a user who meets both should recognise the second from the first.
+ *
+ * Toned like the card for the same reason, and it matters more here: at the
+ * moment this renders NOTHING is broken. The app just started, the explorer
+ * works, and one optional dependency is not ready. Red would be a lie about the
+ * app's state, on the first screen a new user ever sees.
+ *
+ * Full width of whatever column it lands in (the measured card column on Home,
+ * the page body on /apps) rather than the card's 640px cap: it sits above a grid
+ * as a band, and a narrow plate floating over wide content reads as a stray
+ * dialog rather than as the page telling you something. */
+.claude-health {
+  margin: 0 0 20px;
+  padding: 14px 16px;
+  border: 1px solid rgba(var(--warning-rgb), 0.5);
+  border-radius: 10px;
+  background: rgba(var(--warning-rgb), 0.06);
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.claude-health-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.claude-health-title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--warning-soft);
+}
+
+.claude-health-head-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Same quiet-control treatment as .trouble-actions — see the note there on why
+   these are peers in a row and not text links. */
+.claude-health-head-actions > button {
+  padding: 3px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg);
+  background: var(--ctl-quiet-bg);
+  border: 1px solid var(--ctl-quiet-border);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.claude-health-head-actions > button:hover:not(:disabled) {
+  background: var(--ctl-quiet-bg-hover);
+  border-color: var(--ctl-quiet-border-hover);
+}
+
+.claude-health-head-actions > button:disabled {
+  cursor: default;
+  color: var(--fg-muted);
+}
+
+/* The dismiss ✕ is the one control here that is not a peer of the others: it
+   declines the whole notice rather than acting on it, so it stays a bare glyph
+   instead of taking the bordered pill treatment. */
+.claude-health-close {
+  padding: 3px 7px;
+  border: 1px solid transparent;
+  background: none;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+  border-radius: 6px;
+}
+
+.claude-health-close:hover {
+  color: var(--fg);
+  background: var(--ctl-quiet-bg-hover);
+}
+
+.claude-health-issues {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Hairline between stacked problems, never above the first: on the common
+   one-problem strip there is nothing to separate, and a rule there would read as
+   an empty row. */
+.claude-health-issue + .claude-health-issue {
+  padding-top: 12px;
+  border-top: 1px solid rgba(var(--warning-rgb), 0.25);
+}
+
+.claude-health-issue-title {
+  font-weight: 600;
+  margin-bottom: 3px;
+}
+
+.claude-health-issue-detail {
+  margin: 0 0 8px;
+  color: var(--fg-muted);
+}
+
+/* The install/update command sits in the same .update-badge-command plate the
+   trouble card uses for it, so "here is a line to run" looks identical wherever
+   the app offers one. It needs to wrap here: this strip can be narrow (a single
+   card column on Home at a small window) and `curl … | bash` is long. */
+.claude-health .update-badge-command {
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+
+.claude-health-foot {
+  margin: 12px 0 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+}

--- a/fused_render/app.py
+++ b/fused_render/app.py
@@ -245,6 +245,12 @@ def _start_server_thread(port: int) -> tuple[uvicorn.Server, threading.Thread]:
     from fused_render import meta_migration
 
     meta_migration.run_once_in_background(start_dir)
+    # Probe Claude Code (found / version / signed-in) off the request path, so
+    # the first-run strip's GET is a disk read. Mirrors cli._run_serve — an entry
+    # point, never create_app.
+    from fused_render import claude_health
+
+    claude_health.warm_in_background()
     app = create_app(start_dir=start_dir)
     # Publish the real bound origin so runPython children (e.g. the zarr_aoi
     # tile daemon) read store bytes from THIS port, not the branch default.

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -482,9 +482,48 @@ def _fingerprint(path: Optional[str]) -> str:
                         os.environ.get("PATH", ""), path or "", stamp])
 
 
+def adopt(path: str) -> bool:
+    """Publish `path` as the override, so every spawn path finds it too.
+
+    THE SHELL PROBE'S ANSWER IS ONLY USEFUL IF SOMETHING ACTS ON IT. It is the
+    one resolver that can find a volta/fnm/asdf/nvm install, and it runs HERE —
+    but the two paths that actually start Claude Code (`server/ai.py:_claude_bin`
+    and the chat template's own copy) both go override → PATH → candidates, and
+    neither shells out. So without this, a shell-only install left the health
+    report saying "found" while every session still failed to start, and the
+    only way out was telling the user to go and set an environment variable we
+    were already holding the value for.
+
+    Setting the override is what closes that, and it is the right lever rather
+    than a clever one: it is the documented escape hatch, it is what the
+    `notfound` error text tells users to set, and BOTH spawn paths already
+    honour it — including the chat template, which cannot import this module
+    (D166) but does inherit the server's environment. One assignment reaches
+    code that is not allowed to know this module exists.
+
+    A USER'S OWN SETTING IS NEVER OVERWRITTEN. Someone who set the override
+    deliberately has said which binary to run, and a probe silently replacing it
+    would be the app overruling an explicit instruction — the same reason
+    `resolve` reports a stale override rather than falling through to something
+    that works.
+
+    Process-scoped on purpose: nothing is written to the user's config or shell
+    profile. The probe re-runs at the next start and re-adopts, so this can
+    never leave a stale path behind on a machine where the CLI has moved.
+    """
+    if os.environ.get(BIN_ENV):
+        return False
+    os.environ[BIN_ENV] = path
+    return True
+
+
 def _measure(allow_shell: bool = True) -> dict:
     """Run every probe and build a fresh snapshot. Never raises."""
     path, source = resolve(allow_shell=allow_shell)
+    # Before anything else reads it: a binary only the login shell could find is
+    # one the spawn paths cannot find at all until it is published (see `adopt`).
+    if source == "shell" and path:
+        adopt(path)
     version = probe_version(path) if path else None
     # `found` is "we can run it", not "we resolved a string": a stale override
     # resolves to a path that is reported (see `resolve`) and still is not a

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -178,15 +178,29 @@ def augmented_path() -> str:
     return os.pathsep.join(parts)
 
 
-def _executable(path: str) -> bool:
+def executable(path: str) -> bool:
     """Whether `path` is a file we could actually exec.
 
-    isfile AND access(X_OK), because the resolvers this replaces disagreed:
-    some checked only isfile (a non-executable file shadows a real install
-    further down the list) and some only access (which answers False for a
-    directory, but also for a file whose bit is merely unset by a broken
-    install — worth skipping past, not worth stopping on)."""
-    return os.path.isfile(path) and os.access(path, os.X_OK)
+    isfile AND the exec bit, because the resolvers this replaces disagreed:
+    some checked only isfile (so a non-executable file shadows a real install
+    further down the list, and then fails to spawn) and some only access.
+
+    PUBLIC, and `server/ai.py:_claude_bin` calls it rather than testing isfile
+    itself. The two now walk the same candidate list, so a check that differed
+    between them would put the health report and the spawn on different
+    binaries — health calling the install ready while the session dies on the
+    dud, which is precisely the contradiction this module exists to end.
+
+    The exec bit is only consulted off Windows. There it means nothing —
+    `os.access(X_OK)` is true for any existing file, so the test would be
+    isfile twice — and what actually decides runnability is the extension,
+    which the candidate list spells out (`.exe` ahead of `.cmd`). Skipping it
+    explicitly rather than relying on that no-op also keeps this honest under a
+    test that simulates Windows on a POSIX filesystem.
+    """
+    if not os.path.isfile(path):
+        return False
+    return os.name == "nt" or os.access(path, os.X_OK)
 
 
 def _shell_probe() -> Optional[str]:
@@ -218,7 +232,7 @@ def _shell_probe() -> Optional[str]:
         # `where` equivalent adds nothing over PATH + the candidate list.
         return None
     shell = os.environ.get("SHELL") or "/bin/bash"
-    if not _executable(shell):
+    if not executable(shell):
         return None
     env = {k: v for k, v in os.environ.items()
            if k not in ("PYTHONHOME", "PYTHONPATH")}
@@ -235,7 +249,7 @@ def _shell_probe() -> Optional[str]:
             # `command -v` may answer with a shell function or alias rather
             # than a path; only an executable file is something we can spawn.
             cand = line.strip()
-            if cand and _executable(cand):
+            if cand and executable(cand):
                 return cand
     return None
 
@@ -270,7 +284,7 @@ def resolve(allow_shell: bool = True) -> tuple:
         return found, "path"
     for candidate in candidates():
         path = os.path.expanduser(os.path.expandvars(candidate))
-        if _executable(path):
+        if executable(path):
             return path, "candidate"
     # One more pass over the candidate dirs through `which`, which is not
     # redundant on Windows: PATHEXT resolution is how a `claude.cmd` beside a
@@ -401,7 +415,7 @@ def _measure(allow_shell: bool = True) -> dict:
     # during resolution — `which` tests access(X_OK) itself, and the direct probe
     # is `_executable` — while an override is taken entirely on faith, which is
     # exactly why it is the one that can be wrong.
-    usable = bool(path) and (source != "override" or _executable(path))
+    usable = bool(path) and (source != "override" or executable(path))
     return {
         "found": usable,
         "path": path,
@@ -473,21 +487,32 @@ def warm_in_background() -> None:
     threading.Thread(target=_run, daemon=True, name="claude-health").start()
 
 
-def summary() -> dict:
-    """The snapshot without its cache bookkeeping — the endpoint's payload.
+def _public(data: dict) -> dict:
+    """A snapshot without its cache bookkeeping — the endpoint's payload shape.
 
     `fingerprint` is dropped: it is how this module decides whether to re-probe
     and means nothing to a caller, and it carries the machine's whole PATH,
     which has no business in a browser.
     """
-    data = snapshot()
     return {k: v for k, v in data.items() if k != "fingerprint"}
 
 
+def summary() -> dict:
+    """The cached snapshot, as the endpoint answers it."""
+    return _public(snapshot())
+
+
 def summary_refreshed() -> dict:
-    """`summary()` after a forced re-measure."""
-    snapshot(refresh=True)
-    return summary()
+    """`summary()` after a forced re-measure.
+
+    Returns the measurement it just took, rather than re-reading through
+    `summary()`. Two reasons, and the first is a bug: a cache write that failed
+    (an unwritable home, which this module deliberately tolerates) would leave
+    `summary()` re-reading the OLD file, so "Check again" would answer with the
+    snapshot the user pressed the button to get past. The second is simply that
+    re-reading costs a second full probe whenever there is no cache to read.
+    """
+    return _public(snapshot(refresh=True))
 
 
 def as_json(value: Any) -> str:  # pragma: no cover - debugging aid

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -1,0 +1,495 @@
+"""Whether Claude Code is usable on this machine — asked BEFORE anything needs it.
+
+Every Claude failure in this app used to be discovered the same way: the user
+did something, it failed, and a card explained the failure afterwards (SPEC §42
+handles that part well). This module is the other half — the facts a first run
+can be told *before* a prompt has been typed:
+
+  * is the `claude` binary there, and where did we find it
+  * is it new enough for the flag set `server/ai.py:_ai_cmd` spawns it with
+  * is it signed in
+
+`/api/config` already establishes the pattern: it publishes `learn_mount_ready`
+so the sidebar's Learn entry renders only when it works, "so it's never a dead
+link". Claude Code had no equivalent, so every Claude-dependent surface rendered
+as available and found out otherwise on click.
+
+**This module is the one place in the package that names an install directory.**
+`server/ai.py` imports its candidate tuples from here rather than keeping a
+second copy — that divergence is what let a CLI in `~/.bun/bin` produce a
+working Claude-config tab and an `ai_unavailable` from `fused.ai()` on the same
+machine, in the same second. `templates/claude/agent.py` keeps its own copy on
+purpose (a template is standalone user-forkable code and may not import the app,
+D166); `tests/test_claude_health.py` pins the two lists together so they cannot
+drift silently.
+
+**Nothing here raises.** Health is a report about the machine, and a report that
+500s is worth less than one that says "I could not tell". Every probe degrades
+to None/False and the caller still gets a whole answer.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from typing import Any, Optional
+
+from fused_render.shell import storage
+
+# The same two defaults every subprocess in claude_config/ is spawned with, and
+# for the same two reasons — see claude_config/lib.py:SUBPROCESS_KWARGS for the
+# full writeup. Short version: close_fds=False forces posix_spawn instead of
+# fork()+exec (a fork with libproj resident in the server dies SIGSEGV before
+# exec, rc -11, no output), and pinning UTF-8 keeps a GUI-launched server — which
+# inherits no LANG, so ASCII — from UnicodeDecodeError-ing on the first non-ASCII
+# byte a child prints.
+SUBPROCESS_KWARGS = {
+    "close_fds": False,
+    "text": True,
+    "encoding": "utf-8",
+    "errors": "replace",
+}
+
+# An explicit override beats every probe below. Named identically to
+# FUSED_RENDER_RCLONE_BIN, and it is what both the `notfound` error text and the
+# troubleshooting guide tell users to set — so it has to be honoured by
+# everything that resolves the CLI, not merely by most things.
+BIN_ENV = "FUSED_RENDER_CLAUDE_BIN"
+
+# Where Claude Code installs `claude`, for when it isn't on the PATH this process
+# inherited — a Finder/Dock-launched .app gets the supervisor's PATH, not a
+# shell's, so it misses ~/.local/bin and Homebrew. On Windows it is worse: a GUI
+# launch inherits the PATH of its login session, so an install that appended to
+# the *user* PATH afterwards stays invisible until the next sign-in.
+#
+# This is the UNION of the four lists that used to exist independently across
+# server/ai.py, claude_config/lib.py, core_apps/learn/check_env.py and
+# core_apps/sessions/analyze.py. A directory only one of them knew about was a
+# directory where the app disagreed with itself.
+#
+# Ordered most-canonical first, `.exe` ahead of any `.cmd` shim: a shim has to be
+# run through cmd.exe, which re-parses the command line (server/ai.py:_popen_cmd).
+WINDOWS_CANDIDATES = (
+    # native installer (irm https://claude.ai/install.ps1 | iex) — recommended
+    r"%USERPROFILE%\.local\bin\claude.exe",
+    # winget install Anthropic.ClaudeCode, via winget's own shim dir
+    r"%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe",
+    # npm install -g @anthropic-ai/claude-code, in npm's global prefix
+    r"%APPDATA%\npm\claude.exe",
+    r"%APPDATA%\npm\claude.cmd",
+    # legacy local npm install, written by older Claude Code versions
+    r"%USERPROFILE%\.claude\local\claude.exe",
+)
+POSIX_CANDIDATES = (
+    "~/.local/bin/claude",
+    "/opt/homebrew/bin/claude",
+    "/usr/local/bin/claude",
+    # legacy local npm install, written by older Claude Code versions
+    "~/.claude/local/claude",
+    "~/.bun/bin/claude",
+    "~/Library/pnpm/claude",
+    "~/.npm-global/bin/claude",
+)
+
+
+def candidates() -> tuple:
+    """The platform's known install locations, unexpanded."""
+    return WINDOWS_CANDIDATES if os.name == "nt" else POSIX_CANDIDATES
+
+
+# The lowest `claude` this app's spawn line is known to work with.
+#
+# DELIBERATELY CONSERVATIVE, and the conservatism is the point. `_ai_cmd` passes
+# --system-prompt-file, --tools=, --setting-sources=, --no-session-persistence
+# and --include-partial-messages; the chat template adds --effort, --plugin-dir
+# and --permission-prompt-tool. That set is verified against 2.1.220 (see the
+# --tools= comment in server/ai.py), and a 1.x CLI certainly predates it — but
+# nobody has bisected which 2.x minor introduced each flag. A floor of 2.0.0
+# therefore catches the genuinely ancient install without ever telling someone
+# whose 2.x CLI works fine that it is too old, which would be the same
+# wrong-advice failure the two-tier matching in trouble.ts exists to prevent.
+#
+# Raise this when a newly adopted flag needs more, and say which flag in the
+# commit message — this constant is the only written record of what the spawn
+# line requires.
+MIN_VERSION = "2.0.0"
+
+# `claude --version` prints a bare dotted version, sometimes with a trailing
+# product name ("2.1.220 (Claude Code)"). Take the first dotted run and ignore
+# the rest, so a change in the surrounding text can't break the parse.
+_VERSION_RE = re.compile(r"(\d+(?:\.\d+)*)")
+
+# How long a probe may take. A version probe is a local exec (fast, but Node's
+# startup is not free); a login-shell probe sources the user's whole profile,
+# which on a heavily-configured machine genuinely takes seconds.
+_VERSION_TIMEOUT_S = 10
+_SHELL_TIMEOUT_S = 8
+
+
+def parse_version(text: str) -> Optional[tuple]:
+    """The dotted version in `text` as a tuple of ints, or None.
+
+    Pure, so the parse is testable without a `claude` on the machine."""
+    if not text:
+        return None
+    match = _VERSION_RE.search(text)
+    if match is None:
+        return None
+    try:
+        return tuple(int(part) for part in match.group(1).split("."))
+    except ValueError:  # pragma: no cover - the regex admits only digits
+        return None
+
+
+def is_outdated(found: Optional[str], floor: str = MIN_VERSION) -> bool:
+    """Whether `found` is below `floor`.
+
+    UNPARSEABLE IS NOT OUTDATED. A version string we cannot read says nothing
+    about how old the CLI is, and answering True would put "your Claude Code is
+    too old" in front of someone whose install is fine — the one outcome this
+    check must never produce. Same for a missing version.
+    """
+    got, want = parse_version(found or ""), parse_version(floor)
+    if got is None or want is None:
+        return False
+    # Zero-pad the shorter side so ("2", "2.0.0") compares equal rather than low.
+    width = max(len(got), len(want))
+    return got + (0,) * (width - len(got)) < want + (0,) * (width - len(want))
+
+
+def augmented_path() -> str:
+    """PATH with the known install dirs appended (deduped, order preserved).
+
+    Passed through to the resolved `claude` as well as used to find it: the CLI
+    is a Node program that has to locate its own interpreter, and a stripped
+    GUI PATH is as short of `node` as it is of `claude`."""
+    seen, parts = set(), []
+    dirs = [os.path.dirname(os.path.expanduser(os.path.expandvars(c)))
+            for c in candidates()]
+    for part in (os.environ.get("PATH", "") or "").split(os.pathsep) + dirs:
+        if part and part not in seen:
+            seen.add(part)
+            parts.append(part)
+    return os.pathsep.join(parts)
+
+
+def _executable(path: str) -> bool:
+    """Whether `path` is a file we could actually exec.
+
+    isfile AND access(X_OK), because the resolvers this replaces disagreed:
+    some checked only isfile (a non-executable file shadows a real install
+    further down the list) and some only access (which answers False for a
+    directory, but also for a file whose bit is merely unset by a broken
+    install — worth skipping past, not worth stopping on)."""
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def _shell_probe() -> Optional[str]:
+    """Ask the user's LOGIN SHELL where `claude` is.
+
+    THE ONLY PROBE THAT ACTUALLY SOLVES THE PROBLEM ALL THE OTHERS EXIST FOR.
+    A static candidate list can only know the install layouts somebody thought
+    to write down; volta, fnm, asdf, nvm and a relocated npm prefix all put the
+    binary somewhere no list will ever guess, and all of them work by editing
+    the user's shell profile. Asking that profile is what finds them.
+
+    Ported from core_apps/learn/check_env.py, which has been doing this
+    correctly and alone. Its two hard-won details are kept:
+
+      * PYTHONHOME/PYTHONPATH are scrubbed. The packaged app runs a bundled
+        interpreter and exports both; a child that inherits them and is not
+        that interpreter dies with "No module named 'encodings'".
+      * three flag spellings are tried. `-lic` is what picks up an interactive
+        rc file (where nvm/volta shims are usually set up), but not every shell
+        accepts the combined form, and a shell that rejects its flags prints
+        nothing rather than failing loudly.
+
+    LAST RESORT, never first: it costs seconds and spawns the user's whole
+    profile. Only reached when the override, PATH and every candidate missed,
+    and its answer is cached like everything else here.
+    """
+    if os.name == "nt":
+        # cmd/PowerShell have no login-shell profile in this sense, and the
+        # `where` equivalent adds nothing over PATH + the candidate list.
+        return None
+    shell = os.environ.get("SHELL") or "/bin/bash"
+    if not _executable(shell):
+        return None
+    env = {k: v for k, v in os.environ.items()
+           if k not in ("PYTHONHOME", "PYTHONPATH")}
+    for flags in (["-lic"], ["-l", "-c"], ["-ic"]):
+        try:
+            out = subprocess.run(
+                [shell, *flags, "command -v claude"],
+                capture_output=True, timeout=_SHELL_TIMEOUT_S, env=env,
+                **SUBPROCESS_KWARGS,
+            ).stdout
+        except (OSError, subprocess.SubprocessError):
+            continue
+        for line in (out or "").splitlines():
+            # `command -v` may answer with a shell function or alias rather
+            # than a path; only an executable file is something we can spawn.
+            cand = line.strip()
+            if cand and _executable(cand):
+                return cand
+    return None
+
+
+def resolve(allow_shell: bool = True) -> tuple:
+    """`(path, source)` for the `claude` to run, or `(None, None)`.
+
+    `source` is reported all the way out to the UI, because WHERE we found it
+    is itself actionable: a binary only the login shell can see means the app's
+    own PATH is the problem, and the fix is FUSED_RENDER_CLAUDE_BIN rather than
+    another install. A resolver that returned only the path threw that away.
+
+    Order: explicit override, PATH, known install dirs, login shell.
+    """
+    forced = os.environ.get(BIN_ENV)
+    if forced:
+        # Reported even when it does not exist. A stale override is a REAL
+        # finding — it is why the app cannot start a session — and silently
+        # falling through to a working install would leave the user with an app
+        # that works today and breaks whenever the override is consulted by one
+        # of the paths that trusts it blindly.
+        return forced, "override"
+    # THE INHERITED PATH, not the augmented one, and the difference is the whole
+    # value of `source`. `augmented_path()` has the candidate dirs appended, so
+    # asking it here would resolve a ~/.bun/bin install and call it "path" —
+    # making "path" mean nothing and "candidate" unreachable. Probing the PATH we
+    # were actually launched with is what lets "path" mean *the app can see it
+    # unaided* and "candidate" mean *only because we knew where to look*, which
+    # is the fact the UI needs to decide whether to mention the override at all.
+    found = shutil.which("claude")
+    if found:
+        return found, "path"
+    for candidate in candidates():
+        path = os.path.expanduser(os.path.expandvars(candidate))
+        if _executable(path):
+            return path, "candidate"
+    # One more pass over the candidate dirs through `which`, which is not
+    # redundant on Windows: PATHEXT resolution is how a `claude.cmd` beside a
+    # missing `claude.exe` gets found, and spelling every extension into the
+    # candidate list by hand is what that list used to get wrong.
+    augmented = shutil.which("claude", path=augmented_path())
+    if augmented:
+        return augmented, "candidate"
+    if allow_shell:
+        via_shell = _shell_probe()
+        if via_shell:
+            return via_shell, "shell"
+    return None, None
+
+
+def probe_version(path: str) -> Optional[str]:
+    """What `path --version` says, or None if it would not tell us.
+
+    None covers every way this can fail — not on PATH any more, not executable,
+    hung, exited non-zero, printed nothing parseable — because they are one fact
+    to the caller: the version is unknown, so no version claim may be made.
+    """
+    try:
+        res = subprocess.run(
+            [path, "--version"], capture_output=True, timeout=_VERSION_TIMEOUT_S,
+            env={**os.environ, "PATH": augmented_path()}, **SUBPROCESS_KWARGS,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if res.returncode != 0:
+        return None
+    # stdout normally, stderr as a fallback: some builds greet on stderr, and a
+    # version on the wrong stream is still a version.
+    text = (res.stdout or "") + "\n" + (res.stderr or "")
+    match = _VERSION_RE.search(text)
+    return match.group(1) if match else None
+
+
+def config_dir() -> str:
+    """Claude Code's config dir.
+
+    CLAUDE_CONFIG_DIR is Claude Code's OWN variable and wins. CLAUDE_DIR is
+    read second only because claude_config/lib.py has always keyed off it, so a
+    dev or test that sets it expects this module to agree; neither is invented
+    here.
+    """
+    return (os.environ.get("CLAUDE_CONFIG_DIR")
+            or os.environ.get("CLAUDE_DIR")
+            or os.path.expanduser("~/.claude"))
+
+
+def signed_in() -> Optional[bool]:
+    """Whether Claude Code has a credential — True, False, or None for unknown.
+
+    TRI-STATE, and the None is the whole reason this is careful rather than a
+    boolean. Where the credential lives is platform-specific, and
+    supervisor/paths.py already had to learn this the hard way (see its
+    CLAUDE_CONFIG_DIR note — relocating the config dir logged Linux and Windows
+    users out of a CLI they were signed into, while macOS hid the bug):
+
+      * Linux/Windows — the credential is `.credentials.json` in the config
+        dir. We can see it, so its absence is REAL: False.
+      * macOS — the credential is in the login Keychain. We cannot read that
+        without risking an access prompt, and prompting the user for their
+        Keychain to draw a status line is not a trade worth making. Absence of
+        a file therefore proves nothing: None.
+
+    False means "signed out, and I checked". None means "I cannot tell from
+    here". The UI must only ever offer a sign-in fix on False — claiming a
+    signed-in macOS user is signed out is exactly the wrong-advice failure the
+    reactive path's `_account_error` was written to avoid.
+    """
+    # A token in the environment is a credential on every platform, and it is
+    # what a headless/CI run uses.
+    for name in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
+        if (os.environ.get(name) or "").strip():
+            return True
+    creds = os.path.join(config_dir(), ".credentials.json")
+    if os.path.isfile(creds):
+        return True
+    return None if sys.platform == "darwin" else False
+
+
+# --- the cached snapshot ------------------------------------------------------
+#
+# Resolution can cost seconds (the login-shell probe sources a whole profile)
+# and the version probe is a process spawn, so neither may run per request. The
+# snapshot lives on disk under the shell home so it survives a restart — the
+# facts it holds change when the user installs or signs into something, not when
+# a process starts.
+
+_CACHE_NAME = "claude-health.json"
+_LOCK = threading.Lock()
+
+
+def _cache_path() -> str:
+    return os.path.join(storage.home_dir(), _CACHE_NAME)
+
+
+def _fingerprint(path: Optional[str]) -> str:
+    """What must be unchanged for a cached snapshot to still be true.
+
+    The override and PATH decide WHICH binary we resolve; the binary's own mtime
+    is how an in-place upgrade announces itself, and is what makes the version
+    in the cache trustworthy rather than merely recent. `claude update` rewrites
+    the file, so this invalidates exactly when it should.
+    """
+    stamp = ""
+    if path:
+        try:
+            stamp = str(os.stat(path).st_mtime_ns)
+        except OSError:
+            stamp = "missing"
+    return "\x1f".join([os.environ.get(BIN_ENV, ""),
+                        os.environ.get("PATH", ""), path or "", stamp])
+
+
+def _measure(allow_shell: bool = True) -> dict:
+    """Run every probe and build a fresh snapshot. Never raises."""
+    path, source = resolve(allow_shell=allow_shell)
+    version = probe_version(path) if path else None
+    # `found` is "we can run it", not "we resolved a string": a stale override
+    # resolves to a path that is reported (see `resolve`) and still is not a
+    # usable install, and saying found=True for it would make the strip claim
+    # Claude Code is ready moments before a session fails to start.
+    #
+    # Only the override needs checking here. Every other source verified the file
+    # during resolution — `which` tests access(X_OK) itself, and the direct probe
+    # is `_executable` — while an override is taken entirely on faith, which is
+    # exactly why it is the one that can be wrong.
+    usable = bool(path) and (source != "override" or _executable(path))
+    return {
+        "found": usable,
+        "path": path,
+        "source": source,
+        "version": version,
+        "min_version": MIN_VERSION,
+        # Only ever True on a version we actually read AND that is below the
+        # floor — see is_outdated.
+        "outdated": is_outdated(version),
+        "signed_in": signed_in(),
+        "config_dir": config_dir(),
+        "checked_at": time.time(),
+        "fingerprint": _fingerprint(path),
+    }
+
+
+def _read_cache() -> Optional[dict]:
+    """The cached snapshot, or None when there isn't a usable one.
+
+    Read through `storage.read_json`, which answers None for a corrupt file as
+    well as a missing one. THAT IS CORRECT HERE and is not the silent-swallow
+    this module would otherwise object to: a cache is disposable and entirely
+    re-derivable, so a damaged one has nothing to recover and nothing to tell
+    the user about. Do not "fix" this to raise — user DATA is where corruption
+    has to surface, and none of it lives in this file.
+    """
+    data = storage.read_json(_cache_path())
+    return data if isinstance(data, dict) else None
+
+
+def snapshot(refresh: bool = False) -> dict:
+    """The health snapshot: cached when still valid, re-measured when not.
+
+    `refresh=True` re-measures unconditionally — what a "Check again" button
+    means after the user has gone and installed or signed into something.
+    """
+    with _LOCK:
+        if not refresh:
+            cached = _read_cache()
+            # Re-fingerprint against the cached PATH so an upgrade of the same
+            # binary, a new override, or a PATH change all invalidate; anything
+            # else is answered from disk for free.
+            if cached and cached.get("fingerprint") == _fingerprint(cached.get("path")):
+                return dict(cached)
+        fresh = _measure()
+        try:
+            storage.write_json(_cache_path(), fresh)
+        except OSError:
+            pass  # an unwritable home is not a reason to withhold the answer
+        return fresh
+
+
+def warm_in_background() -> None:
+    """Fill the cache off the request path, so the first GET is a disk read.
+
+    Called from the server entry points, never from create_app — the same rule
+    community.refresh_in_background follows, and for the same reason: importing
+    the server in a test must not spawn the user's login shell.
+
+    Failures are swallowed. A cold cache costs the first request its probe; a
+    thread that raised would cost the log a traceback and change nothing else.
+    """
+    def _run() -> None:
+        try:
+            snapshot()
+        except Exception:  # noqa: BLE001 - a warm-up must never be the failure
+            pass
+
+    threading.Thread(target=_run, daemon=True, name="claude-health").start()
+
+
+def summary() -> dict:
+    """The snapshot without its cache bookkeeping — the endpoint's payload.
+
+    `fingerprint` is dropped: it is how this module decides whether to re-probe
+    and means nothing to a caller, and it carries the machine's whole PATH,
+    which has no business in a browser.
+    """
+    data = snapshot()
+    return {k: v for k, v in data.items() if k != "fingerprint"}
+
+
+def summary_refreshed() -> dict:
+    """`summary()` after a forced re-measure."""
+    snapshot(refresh=True)
+    return summary()
+
+
+def as_json(value: Any) -> str:  # pragma: no cover - debugging aid
+    """Pretty snapshot, for `python -m` style poking at a live machine."""
+    return json.dumps(value, indent=2, sort_keys=True)

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -307,13 +307,31 @@ def resolve(allow_shell: bool = True) -> tuple:
     Order: explicit override, PATH, known install dirs, login shell.
     """
     forced = os.environ.get(BIN_ENV)
-    if forced:
-        # Reported even when it does not exist. A stale override is a REAL
-        # finding — it is why the app cannot start a session — and silently
-        # falling through to a working install would leave the user with an app
-        # that works today and breaks whenever the override is consulted by one
-        # of the paths that trusts it blindly.
+    if forced and forced != _ADOPTED:
+        # A value the USER set. Reported even when it does not exist: a stale
+        # override is a REAL finding — it is why the app cannot start a session
+        # — and silently falling through to a working install would leave them
+        # with an app that works today and breaks whenever the override is
+        # consulted by one of the paths that trusts it blindly.
         return forced, "override"
+    if forced:
+        # One WE published (see `adopt`), which is a convenience and must never
+        # become a trap. Two things follow, and both are the opposite of the
+        # branch above:
+        #
+        #   * It is VERIFIED rather than trusted. If the path has since gone —
+        #     the CLI was upgraded, volta switched versions, it was uninstalled
+        #     — the value is dropped and resolution falls through to the full
+        #     chain, including a fresh shell probe. Otherwise the process would
+        #     be stuck reporting a dead override until it restarted, and "Check
+        #     again" could never recover.
+        #   * It reports "shell", not "override". That is where it came from,
+        #     and it keeps `override` meaning "the user set this" — without
+        #     which a vanished adoption renders a card blaming them for an
+        #     environment variable they never set.
+        if executable(forced):
+            return forced, "shell"
+        _forget()
     # THE INHERITED PATH, not the augmented one, and the difference is the whole
     # value of `source`. `augmented_path()` has the candidate dirs appended, so
     # asking it here would resolve a ~/.bun/bin install and call it "path" —
@@ -482,6 +500,25 @@ def _fingerprint(path: Optional[str]) -> str:
                         os.environ.get("PATH", ""), path or "", stamp])
 
 
+#: The path THIS PROCESS published into the override (see `adopt`), so it can be
+#: told apart from one the user set. The distinction decides both whether a dead
+#: value is dropped and who gets blamed for it — see `resolve`.
+_ADOPTED: Optional[str] = None
+
+
+def _forget() -> None:
+    """Drop an adoption that no longer resolves, override and record together.
+
+    Both halves matter: leaving the env var would keep every spawn path pointed
+    at a dead file, and leaving `_ADOPTED` set would make the NEXT adoption of
+    the same path look like it was already published.
+    """
+    global _ADOPTED
+    if _ADOPTED is not None and os.environ.get(BIN_ENV) == _ADOPTED:
+        os.environ.pop(BIN_ENV, None)
+    _ADOPTED = None
+
+
 def adopt(path: str) -> bool:
     """Publish `path` as the override, so every spawn path finds it too.
 
@@ -511,9 +548,11 @@ def adopt(path: str) -> bool:
     profile. The probe re-runs at the next start and re-adopts, so this can
     never leave a stale path behind on a machine where the CLI has moved.
     """
+    global _ADOPTED
     if os.environ.get(BIN_ENV):
         return False
     os.environ[BIN_ENV] = path
+    _ADOPTED = path
     return True
 
 

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -477,6 +477,28 @@ def signed_in(path: Optional[str] = None) -> Optional[bool]:
 _CACHE_NAME = "claude-health.json"
 _LOCK = threading.Lock()
 
+#: Bumped whenever the MEANING of a field changes, so a snapshot written by an
+#: older build is discarded rather than served. Without it a cache is a record of
+#: what a previous version of this code believed: the sign-in probe used to
+#: answer `null` on macOS by rule, and every one of those snapshots would keep
+#: being served to the fixed code — the strip staying silent on a signed-out
+#: machine because a stale file said the question was unanswerable.
+_CACHE_VERSION = 2
+
+#: How long a snapshot may be served before it is re-measured.
+#:
+#: The fingerprint answers "is this the same binary", which is the whole truth
+#: for `path` and `version` and NO PART of the truth for `signed_in`. Signing out
+#: changes no path, no PATH and no mtime, so a fingerprint-only cache never
+#: notices it — on disk, so not even a restart clears it. That is not a staleness
+#: window, it is a permanent wrong answer, and it is the one fact here most
+#: likely to change while the app is running.
+#:
+#: A minute is the trade: page loads inside the window stay free, a logout is
+#: noticed on the next one after it, and the whole re-measure is ~1-2.5s of
+#: subprocess in a threadpool. "Check again" remains the instant path.
+_MAX_AGE_S = 60.0
+
 
 def _cache_path() -> str:
     return os.path.join(storage.home_dir(), _CACHE_NAME)
@@ -496,7 +518,7 @@ def _fingerprint(path: Optional[str]) -> str:
             stamp = str(os.stat(path).st_mtime_ns)
         except OSError:
             stamp = "missing"
-    return "\x1f".join([os.environ.get(BIN_ENV, ""),
+    return "\x1f".join([str(_CACHE_VERSION), os.environ.get(BIN_ENV, ""),
                         os.environ.get("PATH", ""), path or "", stamp])
 
 
@@ -593,6 +615,29 @@ def _measure(allow_shell: bool = True) -> dict:
     }
 
 
+def _too_old(cached: dict) -> bool:
+    """Whether `cached` has aged past the point of being trustworthy.
+
+    An unreadable or missing `checked_at` counts as too old: a snapshot that
+    cannot say when it was taken cannot be shown to be current, and re-measuring
+    costs a couple of seconds while serving it could mean a permanently wrong
+    answer.
+
+    A timestamp from the FUTURE counts as too old as well. That is not
+    defensive noise — the clock moving backwards (a correction, a suspended
+    laptop, a VM restore) would otherwise park a snapshot beyond every future
+    expiry check, which is the one way this could go stale forever again.
+    """
+    taken = cached.get("checked_at")
+    if not isinstance(taken, (int, float)) or isinstance(taken, bool):
+        return True
+    # Written as one bounded range rather than two rejections because that is
+    # also what makes it NaN-safe: every comparison against NaN is False, so a
+    # nonsense timestamp falls out of the `not` as "too old" instead of passing
+    # both `age < 0` and `age > MAX` and reading as permanently fresh.
+    return not 0 <= time.time() - taken <= _MAX_AGE_S
+
+
 def _read_cache() -> Optional[dict]:
     """The cached snapshot, or None when there isn't a usable one.
 
@@ -616,10 +661,15 @@ def snapshot(refresh: bool = False) -> dict:
     with _LOCK:
         if not refresh:
             cached = _read_cache()
-            # Re-fingerprint against the cached PATH so an upgrade of the same
-            # binary, a new override, or a PATH change all invalidate; anything
-            # else is answered from disk for free.
-            if cached and cached.get("fingerprint") == _fingerprint(cached.get("path")):
+            # TWO gates, because they answer different questions. The
+            # fingerprint asks "is this still the same binary" — an upgrade, a
+            # new override or a PATH change all invalidate. The age asks "could
+            # the answer have changed anyway", which is the only thing that ever
+            # catches a sign-out: it moves no path and touches no file, so the
+            # fingerprint is identical on both sides of it.
+            if (cached
+                    and cached.get("fingerprint") == _fingerprint(cached.get("path"))
+                    and not _too_old(cached)):
                 return dict(cached)
         fresh = _measure()
         try:

--- a/fused_render/claude_health.py
+++ b/fused_render/claude_health.py
@@ -34,7 +34,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import threading
 import time
 from typing import Any, Optional
@@ -129,6 +128,49 @@ _VERSION_RE = re.compile(r"(\d+(?:\.\d+)*)")
 # which on a heavily-configured machine genuinely takes seconds.
 _VERSION_TIMEOUT_S = 10
 _SHELL_TIMEOUT_S = 8
+# `claude auth status` measured at 0.6-1.5s (it reads local credential state;
+# it is not a round trip to the API). Bounded like everything else here so a
+# wedged CLI cannot pin the probe.
+_AUTH_TIMEOUT_S = 10
+
+
+def _probe_cmd(path: str, *args: str):
+    """How to spawn `path` with `args` for a probe: an argv list, or — behind a
+    Windows .cmd/.bat shim — one command STRING for the cmd.exe hop.
+
+    npm installs claude as a .cmd shim, which CreateProcess cannot run directly;
+    only cmd.exe can. Without this both probes below would raise OSError on
+    every npm-installed Windows CLI and report version and sign-in as "unknown"
+    — safe, since unknown never produces advice, but useless to the one platform
+    where the PATH problem this module exists for is worst.
+
+    server/ai.py:_popen_cmd solves the same problem for the completion spawn and
+    is not reused here: it cannot be (ai.py imports THIS module, so the
+    dependency only runs one way), and it does not need to be. Its difficulty is
+    quoting values that came from a caller; every argument here is a static
+    literal of ours plus a path we resolved, so the simple form is correct. A
+    path containing a quote is refused rather than mis-quoted — Windows paths
+    cannot contain one, so this is an assertion, not a fallback.
+    """
+    if not (os.name == "nt" and path.lower().endswith((".cmd", ".bat"))):
+        return [path, *args]
+    if '"' in path:
+        raise ValueError(f"path may not contain a double quote: {path!r}")
+    return " ".join(f'"{part}"' for part in (path, *args))
+
+
+def _run_probe(path: str, *args: str, timeout: float):
+    """Run a bounded probe, returning the completed process (or raising).
+
+    `shell=True` ONLY on the .cmd path, where `_probe_cmd` returned a string:
+    that is the cmd.exe hop, not a shell-injection surface — the payload is
+    ours, fully quoted, and carries no user text.
+    """
+    cmd = _probe_cmd(path, *args)
+    return subprocess.run(
+        cmd, capture_output=True, timeout=timeout, shell=isinstance(cmd, str),
+        env={**os.environ, "PATH": augmented_path()}, **SUBPROCESS_KWARGS,
+    )
 
 
 def parse_version(text: str) -> Optional[tuple]:
@@ -308,11 +350,8 @@ def probe_version(path: str) -> Optional[str]:
     to the caller: the version is unknown, so no version claim may be made.
     """
     try:
-        res = subprocess.run(
-            [path, "--version"], capture_output=True, timeout=_VERSION_TIMEOUT_S,
-            env={**os.environ, "PATH": augmented_path()}, **SUBPROCESS_KWARGS,
-        )
-    except (OSError, subprocess.SubprocessError):
+        res = _run_probe(path, "--version", timeout=_VERSION_TIMEOUT_S)
+    except (OSError, ValueError, subprocess.SubprocessError):
         return None
     if res.returncode != 0:
         return None
@@ -336,36 +375,77 @@ def config_dir() -> str:
             or os.path.expanduser("~/.claude"))
 
 
-def signed_in() -> Optional[bool]:
+def _auth_status(path: str) -> Optional[bool]:
+    """`claude auth status`'s own answer, or None when it did not give one.
+
+    THE CLI IS THE ONLY THING THAT ACTUALLY KNOWS. It prints JSON:
+
+        {"loggedIn": false, "authMethod": "none", "apiProvider": "firstParty"}
+
+    Parsed rather than trusted by exit code, and the parse is the compatibility
+    check too: a CLI too old for the subcommand exits 1 with
+    `error: unknown command 'status'` on stderr and NOTHING on stdout, so
+    "stdout is JSON carrying a boolean loggedIn" cleanly separates a real answer
+    from every way of not getting one. Any other shape is None, not False —
+    guessing "signed out" from output we could not read is how a signed-in user
+    gets told to go and sign in.
+    """
+    try:
+        res = _run_probe(path, "auth", "status", timeout=_AUTH_TIMEOUT_S)
+    except (OSError, ValueError, subprocess.SubprocessError):
+        return None
+    try:
+        data = json.loads(res.stdout or "")
+    except ValueError:
+        return None
+    value = data.get("loggedIn") if isinstance(data, dict) else None
+    return value if isinstance(value, bool) else None
+
+
+def signed_in(path: Optional[str] = None) -> Optional[bool]:
     """Whether Claude Code has a credential — True, False, or None for unknown.
 
-    TRI-STATE, and the None is the whole reason this is careful rather than a
-    boolean. Where the credential lives is platform-specific, and
-    supervisor/paths.py already had to learn this the hard way (see its
-    CLAUDE_CONFIG_DIR note — relocating the config dir logged Linux and Windows
-    users out of a CLI they were signed into, while macOS hid the bug):
+    TRI-STATE, and the None carries real weight: `False` is what puts "sign in"
+    in front of the user, so it may only ever come from an authoritative answer.
 
-      * Linux/Windows — the credential is `.credentials.json` in the config
-        dir. We can see it, so its absence is REAL: False.
-      * macOS — the credential is in the login Keychain. We cannot read that
-        without risking an access prompt, and prompting the user for their
-        Keychain to draw a status line is not a trade worth making. Absence of
-        a file therefore proves nothing: None.
+    Order, and the ordering is the correctness argument:
 
-    False means "signed out, and I checked". None means "I cannot tell from
-    here". The UI must only ever offer a sign-in fix on False — claiming a
-    signed-in macOS user is signed out is exactly the wrong-advice failure the
-    reactive path's `_account_error` was written to avoid.
+    1. **Ask the CLI** (`claude auth status`). It is the only party that knows,
+       and it knows on every platform.
+    2. **Positive evidence only** — an env token, or `.credentials.json` in the
+       config dir. Enough to say True when the CLI could not be asked (it is
+       missing, or predates the subcommand).
+    3. **Otherwise None.**
+
+    STEP 2 CAN NEVER ANSWER FALSE, and that is a correction rather than caution.
+    This used to conclude "no credential file on Linux/Windows, therefore signed
+    out", reasoning from supervisor/paths.py's note that macOS keeps its
+    credential in the login Keychain while the others keep it in the config dir.
+    That note is true and the inference from it was still wrong: a credential
+    can also arrive on an inherited file descriptor
+    (CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR), through a managed provider, or in
+    any other place a future release chooses. Measured on a container that is
+    demonstrably logged in (`claude auth status` → `"loggedIn": true`) with no
+    credentials file and no token in the environment, the old rule answered
+    False — the wrong-advice failure this module is arranged to avoid, produced
+    by the module itself.
+
+    So absence of a file is not evidence of being signed out, on any platform,
+    and the platform split is gone with it: what separates a real False from
+    "cannot tell" is whether the CLI answered, not which OS this is.
     """
+    if path:
+        answer = _auth_status(path)
+        if answer is not None:
+            return answer
     # A token in the environment is a credential on every platform, and it is
     # what a headless/CI run uses.
     for name in ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"):
         if (os.environ.get(name) or "").strip():
             return True
-    creds = os.path.join(config_dir(), ".credentials.json")
-    if os.path.isfile(creds):
+    if os.path.isfile(os.path.join(config_dir(), ".credentials.json")):
         return True
-    return None if sys.platform == "darwin" else False
+    return None
 
 
 # --- the cached snapshot ------------------------------------------------------
@@ -413,7 +493,7 @@ def _measure(allow_shell: bool = True) -> dict:
     #
     # Only the override needs checking here. Every other source verified the file
     # during resolution — `which` tests access(X_OK) itself, and the direct probe
-    # is `_executable` — while an override is taken entirely on faith, which is
+    # is `executable` — while an override is taken entirely on faith, which is
     # exactly why it is the one that can be wrong.
     usable = bool(path) and (source != "override" or executable(path))
     return {
@@ -425,7 +505,10 @@ def _measure(allow_shell: bool = True) -> dict:
         # Only ever True on a version we actually read AND that is below the
         # floor — see is_outdated.
         "outdated": is_outdated(version),
-        "signed_in": signed_in(),
+        # The resolved path only when it is RUNNABLE: asking a binary that
+        # isn't there for its auth state wastes a spawn on a certain failure,
+        # and the fallback below still answers True on positive evidence.
+        "signed_in": signed_in(path if usable else None),
         "config_dir": config_dir(),
         "checked_at": time.time(),
         "fingerprint": _fingerprint(path),

--- a/fused_render/cli.py
+++ b/fused_render/cli.py
@@ -146,6 +146,13 @@ def _run_serve(args: argparse.Namespace) -> None:
     from fused_render import community
 
     community.refresh_in_background()
+    # Probe Claude Code (found / version / signed-in) off the request path, so
+    # the first-run strip's GET is a disk read rather than a login-shell spawn.
+    # Same placement rule as the showcase refresh above: an entry point, never
+    # create_app, so importing the server in a test probes nothing.
+    from fused_render import claude_health
+
+    claude_health.warm_in_background()
     start_dir = os.path.abspath(os.path.expanduser(args.start_dir))
     app = create_app(start_dir=start_dir)
 

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -190,7 +190,14 @@ def _claude_bin() -> str | None:
         # expandvars for the %VAR% Windows entries, expanduser for the ~ POSIX
         # ones; each is a no-op on the other platform's shape.
         path = os.path.expanduser(os.path.expandvars(candidate))
-        if os.path.isfile(path):
+        # claude_health.executable, NOT a local isfile. This walks the SAME list
+        # claude_health.resolve does, so a check that differed between them would
+        # put the health report and the spawn on different binaries: a
+        # non-executable dud early in the list (a truncated download, a botched
+        # install) is skipped there and taken here, so the first-run strip would
+        # call the install ready while every session died on the dud. That is the
+        # exact contradiction the shared list was introduced to end.
+        if claude_health.executable(path):
             return path
     return None
 

--- a/fused_render/server/ai.py
+++ b/fused_render/server/ai.py
@@ -16,6 +16,7 @@ from fastapi.responses import (
     StreamingResponse,
 )
 
+from fused_render import claude_health
 from fused_render.server import ai_metrics
 from fused_render.server.common import _require_fused
 from fused_render.shell.prefs import default_model
@@ -89,7 +90,10 @@ _AI_TIMEOUT_S = 600.0
 # A reconfiguration step (/clear, set_model, effort) is local work; one that
 # takes longer than this means a wedged process — kill and respawn.
 _AI_CTRL_TIMEOUT_S = 10.0
-_AI_BIN_ENV = "FUSED_RENDER_CLAUDE_BIN"
+# The explicit override's name, owned by claude_health so the error text below,
+# the resolver, and the health endpoint cannot come to disagree about what the
+# user is being told to set.
+_AI_BIN_ENV = claude_health.BIN_ENV
 # Model ids/aliases are a closed charset. This is a SECURITY boundary, not
 # just validation: on the Windows .cmd-shim path argv is re-parsed by cmd.exe
 # (whose quoting cannot be escaped reliably), so every argv element must be a
@@ -150,28 +154,24 @@ def _claude_seconds(data: dict) -> float | None:
 # so an install that appended to the *user* PATH afterwards stays invisible
 # until the next sign-in.
 #
-# The claude chat template (templates/claude/agent.py) resolves the CLI the
-# same way and this list looks much like its own. That is deliberate
-# duplication, not a missing import: a template is standalone user-forkable
-# code, and the only thing the server and a template share is the fused api.
-# Neither side is authoritative for the other, so neither is held to the
-# other's list.
+# IMPORTED, not written here. These used to be two literal tuples, and the app
+# held four such lists across this module, claude_config/lib.py,
+# core_apps/learn/check_env.py and core_apps/sessions/analyze.py. Any directory
+# only some of them knew about was a directory where the app disagreed with
+# itself: a CLI in `~/.bun/bin` gave a working Preferences → Claude config tab
+# and an `ai_unavailable` from `fused.ai()` on the same machine. claude_health
+# owns the union now, and this name stays as the module-local alias every
+# function and test below already reads.
+#
+# The claude chat template (templates/claude/agent.py) still keeps its own copy.
+# That is deliberate duplication, not a missing import: a template is standalone
+# user-forkable code and may not import the app (D166). It is pinned to this
+# list by tests/test_claude_health.py rather than left to drift.
 #
 # Ordered most-canonical first, `.exe` ahead of any `.cmd` shim: a shim has to
 # be run through cmd.exe, which re-parses the command line (see _popen_argv).
-_CLAUDE_WINDOWS_CANDIDATES = (
-    # native installer (irm https://claude.ai/install.ps1 | iex) — recommended
-    r"%USERPROFILE%\.local\bin\claude.exe",
-    # winget install Anthropic.ClaudeCode, via winget's own shim dir
-    r"%LOCALAPPDATA%\Microsoft\WinGet\Links\claude.exe",
-    # npm install -g @anthropic-ai/claude-code, in npm's global prefix
-    r"%APPDATA%\npm\claude.exe",
-    r"%APPDATA%\npm\claude.cmd",
-    # legacy local npm install, written by older Claude Code versions
-    r"%USERPROFILE%\.claude\local\claude.exe",
-)
-_CLAUDE_POSIX_CANDIDATES = ("~/.local/bin/claude", "/opt/homebrew/bin/claude",
-                            "/usr/local/bin/claude")
+_CLAUDE_WINDOWS_CANDIDATES = claude_health.WINDOWS_CANDIDATES
+_CLAUDE_POSIX_CANDIDATES = claude_health.POSIX_CANDIDATES
 
 
 def _claude_bin() -> str | None:

--- a/fused_render/server/app.py
+++ b/fused_render/server/app.py
@@ -41,6 +41,7 @@ from fused_render.server.common import (
 from fused_render.server.routers.apps import router as apps_router
 from fused_render.server.routers.claude_artifacts import router as claude_artifacts_router
 from fused_render.server.routers.claude_config import router as claude_config_router
+from fused_render.server.routers.claude_health import router as claude_health_router
 from fused_render.server.routers.claude_sessions import router as claude_sessions_router
 from fused_render.server.routers.community import router as community_router
 from fused_render.server.routers.clipboard import router as clipboard_router
@@ -409,6 +410,16 @@ def create_app(start_dir: str) -> FastAPI:
     # fused_render/claude_config/ feature modules, plus a cheap availability
     # probe. Its POSTs mutate, so they carry the D3 X-Fused guard.
     app.include_router(claude_config_router)
+    # Is Claude Code usable at all (routers/claude_health.py): found / version /
+    # signed-in, so the first run can be TOLD rather than left to discover it by
+    # failing. Same doctrine as /api/config's learn_mount_ready, which gates the
+    # sidebar's Learn entry so it is never a dead link — this is that gate for
+    # everything Claude-dependent. Its own endpoint, not a /api/config field:
+    # the facts behind it are process spawns, and /api/config is read on every
+    # page load. The cache is warmed by the entry points (claude_health.
+    # warm_in_background), never from here — importing the server in a test must
+    # not spawn the user's login shell.
+    app.include_router(claude_health_router)
     # GitHub deep links (SPEC §26, D110): GET /clone confirm page +
     # POST /api/clone sparse-clone into ~/Fused. deeplink.py never
     # imports server, so the include stays acyclic like shell/*.

--- a/fused_render/server/routers/claude_health.py
+++ b/fused_render/server/routers/claude_health.py
@@ -1,0 +1,50 @@
+"""GET /api/claude/health — is Claude Code usable on this machine.
+
+Its own endpoint rather than a field on /api/config, deliberately: /api/config is
+read on every page load and by the status-banner poll, and the facts here are
+backed by process spawns behind a disk cache. Bolting them onto that payload
+would put a version probe on the hot path to pay for a strip that only renders
+while something is wrong.
+
+It is also NOT `/api/claude-config/status`, which stays what it is: one
+`isdir(~/.claude)` answering "is there config to edit". That was always an honest
+gate for the Preferences tab and was never a claim about whether Claude Code
+works — this endpoint is that claim.
+"""
+import logging
+
+from fastapi import APIRouter, Header
+from fastapi.concurrency import run_in_threadpool
+
+from fused_render import claude_health
+from fused_render.server.common import _require_fused
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/claude/health")
+async def api_claude_health():
+    """The cached snapshot. A read — no X-Fused guard.
+
+    In a threadpool because a cold cache measures inline (a `--version` spawn,
+    and possibly the login-shell probe), and blocking the event loop would stall
+    every other request in the app — including the ones the page fires beside
+    this one. A warm cache is a single small file read and returns immediately.
+    """
+    return await run_in_threadpool(claude_health.summary)
+
+
+@router.post("/api/claude/health/refresh")
+async def api_claude_health_refresh(x_fused: str | None = Header(default=None)):
+    """Re-probe now, ignoring the cache — the "Check again" action.
+
+    Carries the D3 X-Fused guard: it is a POST that spawns subprocesses (and on
+    POSIX the user's login shell), which is not something a blind cross-origin
+    form may kick off, even though what it writes is only a cache.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+    return await run_in_threadpool(claude_health.summary_refreshed)

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -372,6 +372,44 @@ def test_refresh_re_probes_even_on_a_valid_cache(tmp_path, monkeypatch):
     assert len(calls) == 2
 
 
+def test_refresh_answers_with_the_measurement_it_just_took(tmp_path, monkeypatch):
+    """"Check again" must never answer with the snapshot it was pressed to get
+    past.
+
+    An unwritable home is tolerated by design, so a refresh that re-read through
+    the cache would serve the STALE file — the user installs Claude Code, presses
+    the button, and is told again that it is missing (Bugbot #621).
+    """
+    bin_path = _fake_cli(tmp_path)
+    versions = iter(["1.0.88", "2.1.220"])
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: next(versions))
+
+    # First measurement: nothing on PATH, an old CLI. This one lands in the cache.
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    assert claude_health.summary()["version"] == "1.0.88"
+
+    # Now the cache cannot be updated — and the refresh must still answer fresh.
+    monkeypatch.setattr(claude_health.storage, "write_json",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    refreshed = claude_health.summary_refreshed()
+    assert refreshed["version"] == "2.1.220"
+    assert refreshed["outdated"] is False
+    # and it is still the endpoint's shape, not the internal one
+    assert "fingerprint" not in refreshed
+
+
+def test_refresh_does_not_probe_twice(tmp_path, monkeypatch):
+    """The old form measured, then re-read through summary() — which probed a
+    second time whenever there was no cache to read."""
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    calls = []
+    monkeypatch.setattr(claude_health, "probe_version",
+                        lambda p: calls.append(p) or "2.1.220")
+    claude_health.summary_refreshed()
+    assert len(calls) == 1
+
+
 def test_a_corrupt_cache_is_re_measured_not_raised(tmp_path, monkeypatch):
     """A cache is disposable and entirely re-derivable, so a damaged one has
     nothing to recover and nothing to report. (User DATA is the opposite case

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -18,6 +18,13 @@ import pytest
 from fused_render import claude_health
 
 
+# Captured before any fixture stubs them, so a test that wants the REAL probe
+# can ask for it by name. Cleaner than `monkeypatch.undo()`, which would drop
+# the whole isolation fixture along with the one stub the test wants gone.
+_REAL_SHELL_PROBE = claude_health._shell_probe
+_REAL_AUTH_STATUS = claude_health._auth_status
+
+
 @pytest.fixture(autouse=True)
 def _isolated_home(tmp_path, monkeypatch):
     """Every test gets its own shell home (so the cache file is its own) and a
@@ -29,10 +36,12 @@ def _isolated_home(tmp_path, monkeypatch):
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
-    # The login-shell probe is the one thing here that would spawn the SUITE
-    # RUNNER's shell and read its profile. Off by default; the tests that care
-    # about it turn it back on explicitly.
+    # The two probes that would spawn something real: the login-shell probe
+    # would source the SUITE RUNNER's own profile, and the auth probe would ask
+    # the developer's actual Claude Code whether they are signed in. Both off by
+    # default; the tests that care restore the real one by name.
     monkeypatch.setattr(claude_health, "_shell_probe", lambda: None)
+    monkeypatch.setattr(claude_health, "_auth_status", lambda path: None)
 
 
 def _fake_cli(tmp_path, name="claude", executable=True):
@@ -173,7 +182,6 @@ def test_shell_probe_scrubs_the_bundled_interpreter_vars(monkeypatch):
     """The packaged app exports PYTHONHOME/PYTHONPATH for its own interpreter;
     a child that inherits them and is not that interpreter dies with
     "No module named 'encodings'"."""
-    monkeypatch.undo()  # drop the autouse stub for _shell_probe
     monkeypatch.setenv("PYTHONHOME", "/bundle/python")
     monkeypatch.setenv("PYTHONPATH", "/bundle/lib")
     monkeypatch.setenv("SHELL", "/bin/sh")
@@ -187,7 +195,7 @@ def test_shell_probe_scrubs_the_bundled_interpreter_vars(monkeypatch):
         return R()
 
     monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
-    claude_health._shell_probe()
+    _REAL_SHELL_PROBE()  # the isolation fixture stubs the module attribute
     assert "PYTHONHOME" not in seen
     assert "PYTHONPATH" not in seen
 
@@ -250,6 +258,37 @@ def test_probe_version_survives_a_hung_or_missing_binary(monkeypatch):
     assert claude_health.probe_version("/x/claude") is None
 
 
+def test_a_windows_cmd_shim_goes_through_cmd_exe(monkeypatch):
+    """npm installs claude as a .cmd, which CreateProcess cannot run directly.
+    Without the hop both probes OSError on every npm-installed Windows CLI and
+    report everything as unknown."""
+    monkeypatch.setattr(claude_health.os, "name", "nt")
+    cmd = claude_health._probe_cmd(r"C:\Users\A B\npm\claude.cmd", "auth", "status")
+    assert isinstance(cmd, str)
+    # every element quoted, so a space in the path cannot re-split the line
+    assert cmd == r'"C:\Users\A B\npm\claude.cmd" "auth" "status"'
+    # ...and an .exe on the same platform stays a plain argv list
+    assert claude_health._probe_cmd(r"C:\npm\claude.exe", "--version") == [
+        r"C:\npm\claude.exe", "--version"]
+
+
+def test_a_posix_path_is_never_shelled(monkeypatch):
+    monkeypatch.setattr(claude_health.os, "name", "posix")
+    # a POSIX file that merely ENDS in .cmd is still exec'd directly
+    assert claude_health._probe_cmd("/home/a/claude.cmd", "--version") == [
+        "/home/a/claude.cmd", "--version"]
+
+
+def test_a_quote_in_the_path_is_refused_not_misquoted(monkeypatch):
+    monkeypatch.setattr(claude_health.os, "name", "nt")
+    with pytest.raises(ValueError):
+        claude_health._probe_cmd('C:\\ev"il\\claude.cmd', "auth", "status")
+    # and the probes turn that into "unknown" rather than a 500
+    monkeypatch.setattr(claude_health, "_auth_status", _REAL_AUTH_STATUS)
+    assert claude_health.probe_version('C:\\ev"il\\claude.cmd') is None
+    assert claude_health.signed_in('C:\\ev"il\\claude.cmd') is None
+
+
 def test_the_version_probe_never_forks(monkeypatch):
     """close_fds=False is what keeps CPython on posix_spawn: a fork() with
     libproj resident in the server runs PROJ's atfork handler into a SIGSEGV
@@ -275,7 +314,67 @@ def test_the_version_probe_never_forks(monkeypatch):
 # -- sign-in ------------------------------------------------------------------
 
 
-def test_signed_in_from_a_credentials_file(tmp_path, monkeypatch):
+def _auth_says(monkeypatch, stdout, returncode=0, stderr=""):
+    """Put the REAL `_auth_status` back (the isolation fixture stubs it) over a
+    fake `claude auth status`, so the parse itself is what's under test."""
+    monkeypatch.setattr(claude_health, "_auth_status", _REAL_AUTH_STATUS)
+
+    def fake_run(argv, **kwargs):
+        assert argv[1:] == ["auth", "status"], argv
+        return type("R", (), {"returncode": returncode, "stdout": stdout,
+                              "stderr": stderr})()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+
+
+def test_the_cli_is_asked_and_believed(monkeypatch):
+    """`claude auth status` is the only party that actually knows, and it knows
+    on every platform."""
+    _auth_says(monkeypatch, '{"loggedIn": false, "authMethod": "none"}')
+    assert claude_health.signed_in("/x/claude") is False
+    _auth_says(monkeypatch, '{"loggedIn": true, "authMethod": "oauth_token"}')
+    assert claude_health.signed_in("/x/claude") is True
+
+
+def test_the_cli_beats_local_evidence(monkeypatch, tmp_path):
+    """A credentials file left behind by a since-revoked login must not
+    outvote the CLI saying it is signed out."""
+    cfg = tmp_path / "claude"
+    cfg.mkdir()
+    (cfg / ".credentials.json").write_text("{}")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg))
+    _auth_says(monkeypatch, '{"loggedIn": false}')
+    assert claude_health.signed_in("/x/claude") is False
+
+
+@pytest.mark.parametrize("stdout,rc,stderr", [
+    # a CLI too old for the subcommand: nothing on stdout, error on stderr
+    ("", 1, "error: unknown command 'status'"),
+    ("not json at all", 0, ""),
+    ('{"loggedIn": "yes"}', 0, ""),     # right key, wrong type
+    ('{"authMethod": "none"}', 0, ""),  # no loggedIn at all
+    ("[]", 0, ""),                      # JSON, but not an object
+])
+def test_an_unreadable_answer_is_unknown_never_false(monkeypatch, stdout, rc, stderr):
+    """Guessing "signed out" from output we could not read is how a signed-in
+    user gets told to go and sign in."""
+    _auth_says(monkeypatch, stdout, returncode=rc, stderr=stderr)
+    assert claude_health.signed_in("/x/claude") is None
+
+
+def test_a_hung_or_missing_cli_is_unknown(monkeypatch):
+    import subprocess as sp
+
+    monkeypatch.setattr(claude_health, "_auth_status", _REAL_AUTH_STATUS)
+    monkeypatch.setattr(claude_health.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(sp.TimeoutExpired("claude", 1)))
+    assert claude_health.signed_in("/x/claude") is None
+    monkeypatch.setattr(claude_health.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("gone")))
+    assert claude_health.signed_in("/x/claude") is None
+
+
+def test_signed_in_from_a_credentials_file_when_the_cli_cannot_be_asked(tmp_path, monkeypatch):
     cfg = tmp_path / "claude"
     cfg.mkdir()
     (cfg / ".credentials.json").write_text("{}")
@@ -294,21 +393,33 @@ def test_a_blank_env_token_is_not_a_credential(monkeypatch):
     assert claude_health.signed_in() is not True
 
 
-def test_missing_credentials_is_false_on_linux_and_windows(monkeypatch):
-    """Both keep the credential in the config dir, so we can see it and its
-    absence is a real answer (supervisor/paths.py learned this the hard way)."""
-    monkeypatch.setattr(claude_health.sys, "platform", "linux")
-    assert claude_health.signed_in() is False
-    monkeypatch.setattr(claude_health.sys, "platform", "win32")
-    assert claude_health.signed_in() is False
+def test_absent_local_evidence_is_never_false_on_any_platform(monkeypatch):
+    """THE REGRESSION THIS REPLACED A PLATFORM RULE TO PREVENT.
+
+    This used to conclude "no credentials file on Linux/Windows, therefore
+    signed out". Measured on a container that is demonstrably logged in
+    (`claude auth status` → loggedIn: true) with no credentials file and no
+    token in the environment, that rule answered False: the credential arrived
+    on an inherited file descriptor. Absence of a file is not evidence of being
+    signed out, on any platform — only the CLI's own answer is.
+    """
+    for platform in ("linux", "win32", "darwin"):
+        monkeypatch.setattr(claude_health.os, "name",
+                            "nt" if platform == "win32" else "posix")
+        assert claude_health.signed_in() is None, platform
 
 
-def test_missing_credentials_is_unknown_on_macos(monkeypatch):
-    """macOS keeps it in the login Keychain, which we will not prompt for. An
-    absent file therefore proves nothing, and claiming False would tell a
-    signed-in user to go and sign in."""
-    monkeypatch.setattr(claude_health.sys, "platform", "darwin")
-    assert claude_health.signed_in() is None
+def test_a_missing_binary_is_not_asked_for_its_auth_state(monkeypatch):
+    """Nothing to spawn, so nothing to ask — and the answer stays unknown
+    rather than becoming a False nobody established."""
+    spawned = []
+    monkeypatch.setattr(claude_health.subprocess, "run",
+                        lambda *a, **k: spawned.append(a) or None)
+    monkeypatch.setattr(claude_health, "resolve", lambda **k: (None, None))
+    snap = claude_health._measure()
+    assert snap["found"] is False
+    assert snap["signed_in"] is None
+    assert spawned == []
 
 
 def test_config_dir_prefers_claude_code_s_own_variable(monkeypatch):

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -168,6 +168,50 @@ def test_nothing_installed_resolves_to_nothing():
     assert claude_health.resolve() == (None, None)
 
 
+def test_a_shell_only_install_is_adopted_as_the_override(monkeypatch):
+    """THE POINT OF PROBING THE SHELL AT ALL.
+
+    Neither spawn path shells out — server/ai.py:_claude_bin and the chat
+    template both go override → PATH → candidates — so a volta/fnm/nvm install
+    is invisible to both until the discovered path is published. Without this
+    the health report says "found" while every session still fails to start.
+    """
+    monkeypatch.delenv(claude_health.BIN_ENV, raising=False)
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: "/opt/volta/bin/claude")
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+
+    snap = claude_health._measure()
+    assert snap["source"] == "shell"          # still honest about HOW we found it
+    assert os.environ[claude_health.BIN_ENV] == "/opt/volta/bin/claude"
+
+    # ...and the spawn path now finds exactly that, which is the whole objective.
+    from fused_render.server import ai as _server_ai
+
+    assert _server_ai._claude_bin() == "/opt/volta/bin/claude"
+
+
+def test_adopting_never_overwrites_the_user_s_own_override(monkeypatch):
+    """Someone who set it deliberately has said which binary to run; a probe
+    replacing it would be the app overruling an explicit instruction."""
+    monkeypatch.setenv(claude_health.BIN_ENV, "/my/choice/claude")
+    assert claude_health.adopt("/opt/volta/bin/claude") is False
+    assert os.environ[claude_health.BIN_ENV] == "/my/choice/claude"
+
+
+def test_only_a_shell_find_is_adopted(tmp_path, monkeypatch):
+    """A binary already on PATH or in a candidate dir needs no publishing —
+    both spawn paths find it unaided, and pinning an override for one would
+    outlive the CLI later moving."""
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.delenv(claude_health.BIN_ENV, raising=False)
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+
+    snap = claude_health._measure()
+    assert snap["source"] == "path"
+    assert claude_health.BIN_ENV not in os.environ
+
+
 def test_shell_probe_is_the_last_resort_and_is_labelled(monkeypatch):
     """A binary only the login shell can see is a DIFFERENT diagnosis from a
     missing one: the app's own PATH is the problem, and the fix is the override

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -42,6 +42,10 @@ def _isolated_home(tmp_path, monkeypatch):
     # default; the tests that care restore the real one by name.
     monkeypatch.setattr(claude_health, "_shell_probe", lambda: None)
     monkeypatch.setattr(claude_health, "_auth_status", lambda path: None)
+    # Adoption is module state that outlives a test (it mirrors an env var the
+    # process publishes once). Without this reset, a test that adopts leaves the
+    # next one resolving through a path it never set up.
+    monkeypatch.setattr(claude_health, "_ADOPTED", None)
 
 
 def _fake_cli(tmp_path, name="claude", executable=True):
@@ -188,6 +192,76 @@ def test_a_shell_only_install_is_adopted_as_the_override(monkeypatch):
     from fused_render.server import ai as _server_ai
 
     assert _server_ai._claude_bin() == "/opt/volta/bin/claude"
+
+
+def test_an_adoption_that_goes_stale_recovers_instead_of_trapping(tmp_path, monkeypatch):
+    """AN ADOPTION IS A CONVENIENCE AND MUST NEVER BECOME A TRAP (Bugbot #621).
+
+    `resolve` trusts a user's override without checking it, on purpose. Applied
+    to a value we published ourselves that rule is a trap: when the path goes
+    (upgrade, volta switching versions, an uninstall) every later measure would
+    report a dead override, never fall through to PATH/candidates/a fresh shell
+    probe, and render a card blaming the user for an environment variable they
+    never set — with no recovery short of restarting the process.
+    """
+    gone = tmp_path / "volta" / "claude"
+    gone.parent.mkdir()
+    gone.write_text("#!/bin/sh\n")
+    gone.chmod(0o755)
+    monkeypatch.delenv(claude_health.BIN_ENV, raising=False)
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: str(gone))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+
+    assert claude_health._measure()["source"] == "shell"
+    assert os.environ[claude_health.BIN_ENV] == str(gone)
+
+    # The CLI moves. A later find must win rather than the dead adoption.
+    moved = tmp_path / "volta2" / "claude"
+    moved.parent.mkdir()
+    moved.write_text("#!/bin/sh\n")
+    moved.chmod(0o755)
+    gone.unlink()
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: str(moved))
+
+    snap = claude_health._measure()
+    assert snap["found"] is True
+    assert snap["path"] == str(moved)
+    # ...and emphatically NOT the user-blaming card
+    assert snap["source"] != "override"
+    assert os.environ[claude_health.BIN_ENV] == str(moved)
+
+
+def test_a_stale_adoption_with_nothing_to_fall_back_to_is_missing_not_override(
+        tmp_path, monkeypatch):
+    """With the CLI genuinely gone the honest answer is "not found", which the
+    strip turns into "install Claude Code" — never "your override is broken"
+    about a variable the user never set."""
+    gone = tmp_path / "volta" / "claude"
+    gone.parent.mkdir()
+    gone.write_text("#!/bin/sh\n")
+    gone.chmod(0o755)
+    monkeypatch.delenv(claude_health.BIN_ENV, raising=False)
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: str(gone))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+    claude_health._measure()
+
+    gone.unlink()
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: None)
+    snap = claude_health._measure()
+    assert snap["found"] is False
+    assert snap["source"] is None
+    assert claude_health.BIN_ENV not in os.environ
+
+
+def test_a_users_own_stale_override_is_still_reported_not_dropped(monkeypatch):
+    """The opposite case, and it must keep its old behaviour: a value the user
+    set is why their sessions fail, so it is named rather than quietly replaced
+    by something that happens to work."""
+    monkeypatch.setenv(claude_health.BIN_ENV, "/opt/gone/claude")
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: "/opt/volta/bin/claude")
+    path, source = claude_health.resolve()
+    assert (path, source) == ("/opt/gone/claude", "override")
+    assert os.environ[claude_health.BIN_ENV] == "/opt/gone/claude"
 
 
 def test_adopting_never_overwrites_the_user_s_own_override(monkeypatch):

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -12,6 +12,7 @@ module boundary (the same discipline as test_server_ai.py).
 """
 import json
 import os
+import time
 
 import pytest
 
@@ -637,6 +638,62 @@ def test_refresh_does_not_probe_twice(tmp_path, monkeypatch):
                         lambda p: calls.append(p) or "2.1.220")
     claude_health.summary_refreshed()
     assert len(calls) == 1
+
+
+def test_signing_out_is_noticed_without_pressing_check_again(tmp_path, monkeypatch):
+    """THE BUG A FINGERPRINT-ONLY CACHE CANNOT SEE.
+
+    Signing out moves no path, changes no PATH and touches no file, so the
+    fingerprint is identical on both sides of it — and the cache is on disk, so
+    not even a restart cleared it. The strip stayed silent on a signed-out
+    machine indefinitely, which is what this was reported as.
+    """
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+    state = {"in": True}
+    monkeypatch.setattr(claude_health, "signed_in", lambda path=None: state["in"])
+
+    assert claude_health.summary()["signed_in"] is True
+    state["in"] = False                      # the user runs /logout
+
+    # Inside the window the cached answer still stands...
+    assert claude_health.summary()["signed_in"] is True
+    # ...and past it, the next read re-measures on its own. The real clock is
+    # captured BEFORE patching: `claude_health.time` is the time module itself,
+    # so a lambda that re-imported it would call the patch from inside the patch.
+    real_time = time.time
+    monkeypatch.setattr(claude_health.time, "time",
+                        lambda: real_time() + claude_health._MAX_AGE_S + 1)
+    assert claude_health.summary()["signed_in"] is False
+
+
+def test_a_snapshot_from_an_older_build_is_discarded(tmp_path, monkeypatch):
+    """A cache is a record of what a PREVIOUS VERSION of this code believed. The
+    sign-in probe used to answer null on macOS by rule; without the version in
+    the fingerprint, every one of those snapshots would keep being served to the
+    fixed code — the strip silent because a stale file said so."""
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+    monkeypatch.setattr(claude_health, "signed_in", lambda path=None: None)
+    claude_health.summary()
+
+    monkeypatch.setattr(claude_health, "signed_in", lambda path=None: False)
+    monkeypatch.setattr(claude_health, "_CACHE_VERSION", claude_health._CACHE_VERSION + 1)
+    assert claude_health.summary()["signed_in"] is False
+
+
+@pytest.mark.parametrize("taken", [None, "recently", True, float("nan")])
+def test_a_snapshot_that_cannot_date_itself_is_re_measured(tmp_path, monkeypatch, taken):
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: None)
+    assert claude_health._too_old({"checked_at": taken}) is True
+
+
+def test_a_clock_that_went_backwards_does_not_park_a_snapshot(monkeypatch):
+    """A future timestamp would otherwise sit beyond every later expiry check —
+    the one way this could go permanently stale again."""
+    assert claude_health._too_old({"checked_at": time.time() + 3600}) is True
 
 
 def test_a_corrupt_cache_is_re_measured_not_raised(tmp_path, monkeypatch):

--- a/tests/test_claude_health.py
+++ b/tests/test_claude_health.py
@@ -1,0 +1,447 @@
+"""Tests for fused_render/claude_health.py and GET /api/claude/health.
+
+The point of this module is to say something TRUE about the machine before
+anything needs Claude Code, so the tests are mostly about the ways a health
+report can lie: claiming an install is too old when the version could not be
+read, claiming a macOS user is signed out because a file is missing, serving a
+cached answer after the binary changed underneath it.
+
+No test runs a real `claude`: resolution is driven through a fake tree plus a
+patched PATH, and the version probe's one subprocess hop is patched at the
+module boundary (the same discipline as test_server_ai.py).
+"""
+import json
+import os
+
+import pytest
+
+from fused_render import claude_health
+
+
+@pytest.fixture(autouse=True)
+def _isolated_home(tmp_path, monkeypatch):
+    """Every test gets its own shell home (so the cache file is its own) and a
+    PATH/override/credential environment that inherits nothing from the machine
+    running the suite — which may well have a real, signed-in Claude Code."""
+    monkeypatch.setenv("FUSED_RENDER_HOME", str(tmp_path / "home"))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
+    monkeypatch.delenv(claude_health.BIN_ENV, raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "claude"))
+    # The login-shell probe is the one thing here that would spawn the SUITE
+    # RUNNER's shell and read its profile. Off by default; the tests that care
+    # about it turn it back on explicitly.
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: None)
+
+
+def _fake_cli(tmp_path, name="claude", executable=True):
+    """An executable stand-in for the CLI, in its own dir. Returns the path."""
+    d = tmp_path / "fake-bin"
+    d.mkdir(exist_ok=True)
+    p = d / name
+    p.write_text("#!/bin/sh\necho 2.1.220\n")
+    p.chmod(0o755 if executable else 0o644)
+    return str(p)
+
+
+# -- version parsing and the floor -------------------------------------------
+
+
+@pytest.mark.parametrize("text,want", [
+    ("2.1.220", (2, 1, 220)),
+    ("2.1.220 (Claude Code)", (2, 1, 220)),
+    ("claude 1.0.88\n", (1, 0, 88)),
+    ("  2.0  ", (2, 0)),
+    ("", None),
+    ("no digits here", None),
+])
+def test_parse_version(text, want):
+    assert claude_health.parse_version(text) == want
+
+
+def test_is_outdated_compares_numerically_not_lexically():
+    # The bug a string compare would have: "2.1.9" > "2.1.10" lexically.
+    assert claude_health.is_outdated("2.1.9", "2.1.10") is True
+    assert claude_health.is_outdated("2.1.10", "2.1.9") is False
+
+
+def test_is_outdated_zero_pads_a_shorter_version():
+    """"2" is 2.0.0, not something below it — otherwise a CLI reporting a bare
+    major would be called stale for having a short version string."""
+    assert claude_health.is_outdated("2", "2.0.0") is False
+    assert claude_health.is_outdated("2.0", "2.0.0") is False
+    assert claude_health.is_outdated("1", "2.0.0") is True
+
+
+def test_unreadable_version_is_never_outdated():
+    """THE ASSERTION THAT MATTERS MOST HERE. A version we could not read says
+    nothing about age, and answering True would put "your Claude Code is too
+    old" in front of someone whose install is fine."""
+    assert claude_health.is_outdated(None) is False
+    assert claude_health.is_outdated("") is False
+    assert claude_health.is_outdated("unknown") is False
+
+
+def test_the_declared_floor_admits_the_verified_version():
+    """MIN_VERSION must not reject the version the spawn line is verified
+    against (server/ai.py's --tools= note pins that at 2.1.220)."""
+    assert claude_health.is_outdated("2.1.220") is False
+    assert claude_health.is_outdated("1.0.88") is True
+
+
+# -- resolution ---------------------------------------------------------------
+
+
+def test_override_wins_and_is_reported_as_such(tmp_path, monkeypatch):
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.setenv(claude_health.BIN_ENV, "/opt/custom/claude")
+    assert claude_health.resolve() == ("/opt/custom/claude", "override")
+
+
+def test_a_stale_override_is_reported_not_silently_replaced(tmp_path, monkeypatch):
+    """A pointing-at-nothing override is a real finding — it is exactly why a
+    session will not start — so it must not be papered over by a working install
+    that other code paths (which trust the override blindly) would never use."""
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.setenv(claude_health.BIN_ENV, str(tmp_path / "gone" / "claude"))
+    path, source = claude_health.resolve()
+    assert source == "override"
+    assert path != bin_path
+    # ...and it must not be called usable.
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: None)
+    assert claude_health._measure()["found"] is False
+
+
+def test_path_beats_the_candidate_list(tmp_path, monkeypatch):
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    assert claude_health.resolve() == (bin_path, "path")
+
+
+def test_candidate_dirs_are_probed_when_path_is_stripped(tmp_path, monkeypatch):
+    """A Finder/Dock-launched .app inherits the supervisor's PATH, not a
+    shell's, so the known install dirs are all that is left."""
+    home = tmp_path / "userhome"
+    (home / ".bun" / "bin").mkdir(parents=True)
+    cli = home / ".bun" / "bin" / "claude"
+    cli.write_text("#!/bin/sh\n")
+    cli.chmod(0o755)
+    monkeypatch.setattr(claude_health.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home), 1))
+    monkeypatch.setattr(claude_health.os, "name", "posix")
+    # ~/.bun/bin is the case that used to resolve for the Claude-config tab and
+    # not for fused.ai — the divergence the shared list closes.
+    assert claude_health.resolve() == (str(cli), "candidate")
+
+
+def test_a_non_executable_file_does_not_shadow_a_real_install(tmp_path, monkeypatch):
+    """isfile alone was not enough: a non-executable file in an earlier
+    candidate dir would win and then fail to spawn."""
+    home = tmp_path / "userhome"
+    (home / ".local" / "bin").mkdir(parents=True)
+    dud = home / ".local" / "bin" / "claude"
+    dud.write_text("not executable")
+    dud.chmod(0o644)
+    (home / ".bun" / "bin").mkdir(parents=True)
+    real = home / ".bun" / "bin" / "claude"
+    real.write_text("#!/bin/sh\n")
+    real.chmod(0o755)
+    monkeypatch.setattr(claude_health.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home), 1))
+    monkeypatch.setattr(claude_health.os, "name", "posix")
+    assert claude_health.resolve()[0] == str(real)
+
+
+def test_nothing_installed_resolves_to_nothing():
+    assert claude_health.resolve() == (None, None)
+
+
+def test_shell_probe_is_the_last_resort_and_is_labelled(monkeypatch):
+    """A binary only the login shell can see is a DIFFERENT diagnosis from a
+    missing one: the app's own PATH is the problem, and the fix is the override
+    rather than another install. `source` is how the UI can say so."""
+    monkeypatch.setattr(claude_health, "_shell_probe", lambda: "/opt/volta/bin/claude")
+    assert claude_health.resolve() == ("/opt/volta/bin/claude", "shell")
+    # ...and it is skippable, because it costs seconds.
+    assert claude_health.resolve(allow_shell=False) == (None, None)
+
+
+def test_shell_probe_scrubs_the_bundled_interpreter_vars(monkeypatch):
+    """The packaged app exports PYTHONHOME/PYTHONPATH for its own interpreter;
+    a child that inherits them and is not that interpreter dies with
+    "No module named 'encodings'"."""
+    monkeypatch.undo()  # drop the autouse stub for _shell_probe
+    monkeypatch.setenv("PYTHONHOME", "/bundle/python")
+    monkeypatch.setenv("PYTHONPATH", "/bundle/lib")
+    monkeypatch.setenv("SHELL", "/bin/sh")
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen.update(kwargs.get("env") or {})
+
+        class R:
+            stdout = ""
+        return R()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+    claude_health._shell_probe()
+    assert "PYTHONHOME" not in seen
+    assert "PYTHONPATH" not in seen
+
+
+def test_augmented_path_appends_install_dirs_without_duplicating(monkeypatch):
+    monkeypatch.setenv("PATH", "/usr/bin")
+    parts = claude_health.augmented_path().split(os.pathsep)
+    assert parts[0] == "/usr/bin"
+    assert len(parts) == len(set(parts))
+    assert "/opt/homebrew/bin" in parts
+
+
+# -- the version probe --------------------------------------------------------
+
+
+def test_probe_version_reads_stdout(tmp_path, monkeypatch):
+    def fake_run(argv, **kwargs):
+        class R:
+            returncode, stdout, stderr = 0, "2.1.220 (Claude Code)\n", ""
+        return R()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+    assert claude_health.probe_version("/x/claude") == "2.1.220"
+
+
+def test_probe_version_falls_back_to_stderr(monkeypatch):
+    def fake_run(argv, **kwargs):
+        class R:
+            returncode, stdout, stderr = 0, "", "2.0.5\n"
+        return R()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+    assert claude_health.probe_version("/x/claude") == "2.0.5"
+
+
+@pytest.mark.parametrize("outcome", [
+    {"returncode": 1, "stdout": "2.1.220", "stderr": ""},   # exited non-zero
+    {"returncode": 0, "stdout": "", "stderr": ""},           # said nothing
+    {"returncode": 0, "stdout": "nope", "stderr": ""},       # nothing parseable
+])
+def test_probe_version_is_none_when_it_would_not_tell_us(monkeypatch, outcome):
+    def fake_run(argv, **kwargs):
+        return type("R", (), outcome)()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+    assert claude_health.probe_version("/x/claude") is None
+
+
+def test_probe_version_survives_a_hung_or_missing_binary(monkeypatch):
+    import subprocess as sp
+
+    def boom(argv, **kwargs):
+        raise sp.TimeoutExpired(argv, 1)
+
+    monkeypatch.setattr(claude_health.subprocess, "run", boom)
+    assert claude_health.probe_version("/x/claude") is None
+
+    monkeypatch.setattr(claude_health.subprocess, "run",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("nope")))
+    assert claude_health.probe_version("/x/claude") is None
+
+
+def test_the_version_probe_never_forks(monkeypatch):
+    """close_fds=False is what keeps CPython on posix_spawn: a fork() with
+    libproj resident in the server runs PROJ's atfork handler into a SIGSEGV
+    before exec (rc -11, no output). Same discipline as every other subprocess
+    in the package."""
+    seen = {}
+
+    def fake_run(argv, **kwargs):
+        seen.update(kwargs)
+
+        class R:
+            returncode, stdout, stderr = 0, "2.1.220", ""
+        return R()
+
+    monkeypatch.setattr(claude_health.subprocess, "run", fake_run)
+    claude_health.probe_version("/x/claude")
+    assert seen["close_fds"] is False
+    assert seen["encoding"] == "utf-8"
+    assert seen["errors"] == "replace"
+    assert seen["timeout"] > 0
+
+
+# -- sign-in ------------------------------------------------------------------
+
+
+def test_signed_in_from_a_credentials_file(tmp_path, monkeypatch):
+    cfg = tmp_path / "claude"
+    cfg.mkdir()
+    (cfg / ".credentials.json").write_text("{}")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(cfg))
+    assert claude_health.signed_in() is True
+
+
+@pytest.mark.parametrize("name", ["ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"])
+def test_signed_in_from_an_env_token(monkeypatch, name):
+    monkeypatch.setenv(name, "sk-whatever")
+    assert claude_health.signed_in() is True
+
+
+def test_a_blank_env_token_is_not_a_credential(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "   ")
+    assert claude_health.signed_in() is not True
+
+
+def test_missing_credentials_is_false_on_linux_and_windows(monkeypatch):
+    """Both keep the credential in the config dir, so we can see it and its
+    absence is a real answer (supervisor/paths.py learned this the hard way)."""
+    monkeypatch.setattr(claude_health.sys, "platform", "linux")
+    assert claude_health.signed_in() is False
+    monkeypatch.setattr(claude_health.sys, "platform", "win32")
+    assert claude_health.signed_in() is False
+
+
+def test_missing_credentials_is_unknown_on_macos(monkeypatch):
+    """macOS keeps it in the login Keychain, which we will not prompt for. An
+    absent file therefore proves nothing, and claiming False would tell a
+    signed-in user to go and sign in."""
+    monkeypatch.setattr(claude_health.sys, "platform", "darwin")
+    assert claude_health.signed_in() is None
+
+
+def test_config_dir_prefers_claude_code_s_own_variable(monkeypatch):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", "/a")
+    monkeypatch.setenv("CLAUDE_DIR", "/b")
+    assert claude_health.config_dir() == "/a"
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR")
+    assert claude_health.config_dir() == "/b"
+
+
+# -- the cached snapshot ------------------------------------------------------
+
+
+def test_snapshot_is_cached_then_served_from_disk(tmp_path, monkeypatch):
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    calls = []
+    monkeypatch.setattr(claude_health, "probe_version",
+                        lambda p: calls.append(p) or "2.1.220")
+
+    first = claude_health.snapshot()
+    assert first["found"] is True and first["version"] == "2.1.220"
+    assert os.path.isfile(claude_health._cache_path())
+
+    second = claude_health.snapshot()
+    assert second["version"] == "2.1.220"
+    assert len(calls) == 1, "a warm cache must not re-probe"
+
+
+def test_an_upgraded_binary_invalidates_the_cache(tmp_path, monkeypatch):
+    """`claude update` rewrites the file in place, so mtime is how an upgrade
+    announces itself — without this the cache would keep reporting the old
+    version (and a stale `outdated`) forever."""
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    versions = iter(["2.0.1", "2.1.220"])
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: next(versions))
+
+    assert claude_health.snapshot()["version"] == "2.0.1"
+    os.utime(bin_path, (1, 1))  # an in-place upgrade
+    assert claude_health.snapshot()["version"] == "2.1.220"
+
+
+def test_a_new_override_invalidates_the_cache(tmp_path, monkeypatch):
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: "2.1.220")
+    assert claude_health.snapshot()["source"] == "path"
+    monkeypatch.setenv(claude_health.BIN_ENV, "/opt/custom/claude")
+    assert claude_health.snapshot()["source"] == "override"
+
+
+def test_refresh_re_probes_even_on_a_valid_cache(tmp_path, monkeypatch):
+    bin_path = _fake_cli(tmp_path)
+    monkeypatch.setenv("PATH", os.path.dirname(bin_path))
+    calls = []
+    monkeypatch.setattr(claude_health, "probe_version",
+                        lambda p: calls.append(p) or "2.1.220")
+    claude_health.snapshot()
+    claude_health.snapshot(refresh=True)
+    assert len(calls) == 2
+
+
+def test_a_corrupt_cache_is_re_measured_not_raised(tmp_path, monkeypatch):
+    """A cache is disposable and entirely re-derivable, so a damaged one has
+    nothing to recover and nothing to report. (User DATA is the opposite case
+    and is not what lives in this file.)"""
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: None)
+    os.makedirs(os.path.dirname(claude_health._cache_path()), exist_ok=True)
+    with open(claude_health._cache_path(), "w") as f:
+        f.write("{ this is not json")
+    assert claude_health.snapshot()["found"] is False
+
+
+def test_an_unwritable_home_still_answers(tmp_path, monkeypatch):
+    monkeypatch.setattr(claude_health.storage, "write_json",
+                        lambda *a, **k: (_ for _ in ()).throw(OSError("read-only")))
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: None)
+    assert "found" in claude_health.snapshot()
+
+
+def test_summary_withholds_the_fingerprint(tmp_path, monkeypatch):
+    """It is cache bookkeeping, and it carries the machine's whole PATH — which
+    has no business in a browser."""
+    monkeypatch.setattr(claude_health, "probe_version", lambda p: None)
+    summary = claude_health.summary()
+    assert "fingerprint" not in summary
+    assert "found" in summary and "min_version" in summary
+    # and it must survive a JSON round trip, being an HTTP payload
+    assert json.loads(json.dumps(summary))["min_version"] == claude_health.MIN_VERSION
+
+
+def test_warm_in_background_never_raises(monkeypatch):
+    monkeypatch.setattr(claude_health, "snapshot",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    claude_health.warm_in_background()  # must not propagate
+
+
+# -- the endpoint -------------------------------------------------------------
+
+
+def _client():
+    from starlette.testclient import TestClient
+
+    from fused_render.server.routers.claude_health import router
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    app.include_router(router)
+    return TestClient(app)
+
+
+def test_endpoint_answers_the_snapshot(monkeypatch):
+    monkeypatch.setattr(claude_health, "summary",
+                        lambda: {"found": True, "version": "2.1.220"})
+    body = _client().get("/api/claude/health").json()
+    assert body == {"found": True, "version": "2.1.220"}
+
+
+def test_refresh_requires_the_fused_header(monkeypatch):
+    called = []
+    monkeypatch.setattr(claude_health, "summary_refreshed",
+                        lambda: called.append(1) or {"found": False})
+    client = _client()
+    assert client.post("/api/claude/health/refresh").status_code != 200
+    assert called == []
+    ok = client.post("/api/claude/health/refresh", headers={"X-Fused": "1"})
+    assert ok.status_code == 200 and called == [1]
+
+
+def test_the_health_endpoint_is_not_on_api_config():
+    """/api/config is read on every page load and by the status-banner poll;
+    these facts are backed by process spawns and must stay off it."""
+    src = open(os.path.join(os.path.dirname(__file__), "..", "fused_render",
+                            "server", "routers", "config.py")).read()
+    assert "claude_health" not in src

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -995,7 +995,42 @@ def test_claude_bin_falls_back_to_install_dirs(monkeypatch, tmp_path):
 
     assert _server_ai._claude_bin() is None  # nothing installed anywhere
     bin_path.write_text("#!/bin/sh\n")
+    bin_path.chmod(0o755)
     assert _server_ai._claude_bin() == str(bin_path)
+
+
+def test_claude_bin_skips_a_non_executable_dud(monkeypatch, tmp_path):
+    """A dud early in the list must not shadow a real install further down.
+
+    The spawn and the health report walk the SAME candidate list now, and
+    claude_health.resolve skips a non-executable file. Testing only isfile here
+    would take the dud the health probe rejected — so the first-run strip would
+    call the install ready while every session died on the dud (Bugbot #621).
+    """
+    home = tmp_path / "home"
+    (home / ".local" / "bin").mkdir(parents=True)
+    dud = home / ".local" / "bin" / "claude"          # first in the list
+    dud.write_text("truncated download")
+    dud.chmod(0o644)
+    (home / ".bun" / "bin").mkdir(parents=True)
+    real = home / ".bun" / "bin" / "claude"           # later in the list
+    real.write_text("#!/bin/sh\n")
+    real.chmod(0o755)
+
+    monkeypatch.setattr(_server_ai.shutil, "which", lambda name: None)
+    monkeypatch.delenv("FUSED_RENDER_CLAUDE_BIN", raising=False)
+    monkeypatch.setattr(_server_ai.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home), 1))
+    monkeypatch.setattr(_server_ai.os, "name", "posix")
+
+    assert _server_ai._claude_bin() == str(real)
+    # ...and it is the same answer the health probe gives, which is the point.
+    from fused_render import claude_health
+
+    monkeypatch.setattr(claude_health.os.path, "expanduser",
+                        lambda p: p.replace("~", str(home), 1))
+    monkeypatch.setenv("PATH", str(tmp_path / "empty"))
+    assert claude_health.resolve(allow_shell=False)[0] == str(real)
 
 
 def test_posix_candidates_are_the_documented_install_locations():

--- a/tests/test_server_ai.py
+++ b/tests/test_server_ai.py
@@ -999,9 +999,33 @@ def test_claude_bin_falls_back_to_install_dirs(monkeypatch, tmp_path):
 
 
 def test_posix_candidates_are_the_documented_install_locations():
-    assert _server_ai._CLAUDE_POSIX_CANDIDATES == (
+    """The three canonical locations, canonical-first — and nothing hand-written.
+
+    This used to pin the tuple exactly, which is what let the list here drift
+    from the three OTHER lists the app kept (claude_config/lib.py,
+    core_apps/learn/check_env.py, core_apps/sessions/analyze.py): each was
+    correct against its own test and none agreed with the others, so a CLI in
+    `~/.bun/bin` was found by the Claude-config tab and not by fused.ai. The
+    union lives in claude_health now; the identity assertion is what keeps this
+    module from growing a fourth copy.
+    """
+    from fused_render import claude_health
+
+    assert _server_ai._CLAUDE_POSIX_CANDIDATES is claude_health.POSIX_CANDIDATES
+    assert _server_ai._CLAUDE_WINDOWS_CANDIDATES is claude_health.WINDOWS_CANDIDATES
+    # The canonical three still lead, in order: an install found in two places
+    # must resolve to the one Claude Code's own installer writes.
+    assert _server_ai._CLAUDE_POSIX_CANDIDATES[:3] == (
         "~/.local/bin/claude", "/opt/homebrew/bin/claude",
         "/usr/local/bin/claude")
+    # The dirs the other resolvers knew about and this one did not.
+    for late in ("~/.claude/local/claude", "~/.bun/bin/claude",
+                 "~/Library/pnpm/claude", "~/.npm-global/bin/claude"):
+        assert late in _server_ai._CLAUDE_POSIX_CANDIDATES
+    # Every entry is absolute or ~-rooted — never a bare relative path that
+    # would resolve against the server's cwd (the Windows list is checked for
+    # the same property below).
+    assert all(c.startswith(("~", "/")) for c in _server_ai._CLAUDE_POSIX_CANDIDATES)
 
 
 def test_windows_candidates_cover_the_windows_install_locations():


### PR DESCRIPTION
Every Claude Code failure in this app is discovered the same way: the user does something, it fails, and a `TroubleCard` explains it afterwards. That reactive half is good — SPEC §42 / D328 classifies four cases, deep-links help, and hands over a paste-ready report plus an agent brief. On a fresh install it still means typing a brief and watching an app folder appear before learning that the thing the app is built around was never set up.

`/api/config` already had the right doctrine. It publishes `learn_mount_ready` so the sidebar's Learn entry renders only when it works, *"so it's never a dead link"*. There was no equivalent for Claude Code, so every Claude-dependent surface rendered as available and found out otherwise on click. **This is that gate for everything Claude-dependent.**

## What's here

**`fused_render/claude_health.py`** — resolution, version, sign-in state. Cached to disk under the shell home and invalidated by the binary's mtime, which is how `claude update` announces itself. Nothing in it raises: a report about the machine that 500s is worth less than one that says "I could not tell".

**`GET /api/claude/health`** + **`POST /api/claude/health/refresh`** (X-Fused guarded — it spawns subprocesses). Its own endpoint, deliberately *not* a field on `/api/config`: that payload is read on every page load and by the status-banner poll, and each fact here is backed by a process spawn.

**The first-run strip** on Home and `/apps` — what is still needed, with the command that fixes it and a *Check again*. It renders nothing when there is nothing to say, and it is not a gate: the explorer is completely useful without Claude Code.

## One resolver, one answer

This module is now the one place in the package that names an install directory. `server/ai.py` imports its candidate tuples from here instead of keeping a second copy.

That closes a real contradiction. The app held four independent lists — `server/ai.py`, `claude_config/lib.py`, `core_apps/learn/check_env.py`, `core_apps/sessions/analyze.py` — each correct against its own test and none agreeing with the others. A CLI in `~/.bun/bin` gave a *working* Preferences → Claude config tab and an `ai_unavailable` from `fused.ai()` on the same machine, in the same second. The list is now their union, plus `check_env.py`'s login-shell probe, which is the only approach that finds volta/fnm/asdf/nvm installs and the only one that actually solves the GUI-PATH problem all four exist for.

`templates/claude/agent.py` keeps its own copy on purpose (a template is user-forkable and may not import the app, D166) and is pinned to this one by test rather than left to drift.

## Three things it refuses to claim

- **An unreadable version is never "outdated".** Telling someone whose install is fine that it's too old is the wrong-advice failure `trouble.ts`'s two-tier matching exists to prevent, arriving from the proactive side. `MIN_VERSION` is `2.0.0` — conservative on purpose: it catches 1.x, which certainly predates the flag set `_ai_cmd` spawns with, without guessing which 2.x minor added what.
- **Sign-in is tri-state.** Linux and Windows keep the credential in the config dir, so its absence is a real answer; macOS keeps it in the login Keychain, which we will not prompt for, so absence proves nothing and the answer is `null`. The UI only offers a sign-in fix on an explicit `false`. (`supervisor/paths.py` learned this platform split the hard way.)
- **A failed probe is not a finding.** If `/api/claude/health` itself can't be reached then the server is what's wrong, and the app has louder ways of saying so. Blaming the user's machine for our own fault isn't one of them.

## Two details worth a reviewer's eye

`source` is reported all the way to the UI because *where* it was found is itself actionable: `"shell"` means only the login shell can see it, so the app's PATH is the problem and the fix is `FUSED_RENDER_CLAUDE_BIN` rather than another install. Resolution therefore probes the **inherited** PATH, not the augmented one — asking the augmented path resolves a candidate-dir install and labels it `"path"`, which makes the distinction meaningless. (My own test caught this.)

Dismissal is keyed on a signature of the issue **IDs** — not a boolean, not the titles. Dismissing "not signed in" must leave a later "outdated" free to appear, and a title carrying a version would re-show a dealt-with strip on every patch upgrade.

The `TroubleCard` is untouched. Preflight is an addition, not a replacement — a CLI can break between the check and the call.

## Testing

- `tests/test_claude_health.py` — 44 tests, weighted toward the negative assertions above.
- `frontend/src/platform/lib/claude-health.test.ts` — 21 tests, same weighting.
- `tests/test_server_ai.py`'s candidate-list test now asserts the shared identity rather than pinning a literal tuple, which is what let the four lists drift in the first place.
- `npm run build` clean (boundaries + `tsc --noEmit` + vite). Endpoint verified end-to-end against a real `create_app`, including the guard returning 403 and `/api/config` gaining no Claude field.

**On the full suite:** 19 tests fail in this container, and they fail identically with my changes stashed — pre-existing environment issues (the geo stack in `templates/map`, `PYTHONHOME` handling in `test_engine.py`, and three Claude-template tests). I verified the attribution by running that set on both sides: 8 failed / 122 passed either way. Leaving CI to be the authority on that rather than asserting it from here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014ywTFTWoot92s73RgheEeq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CLI resolution, subprocess probes, and env adoption used by AI spawn paths; mistakes could mis-report readiness or point sessions at the wrong binary, though behavior is heavily tested and failures degrade to “unknown” rather than blocking the app.
> 
> **Overview**
> Adds **proactive Claude Code readiness** so Home and `/apps` can warn users before they spend a prompt, instead of only via `TroubleCard` after a failure.
> 
> **Backend:** New `fused_render/claude_health.py` resolves the CLI (override → PATH → install candidates → login shell), probes version and `claude auth status`, caches on disk with fingerprint + ~60s age invalidation, and **auto-adopts** shell-only finds into `FUSED_RENDER_CLAUDE_BIN` so sessions match the health report. **`GET /api/claude/health`** and **`POST /api/claude/health/refresh`** (X-Fused) expose this without bloating `/api/config`. **`server/ai.py`** now imports the unified candidate lists and `executable()` from here so spawn and health stay aligned. Server entry points call **`warm_in_background()`** on startup.
> 
> **Frontend:** `lib/claude-health.ts` classifies snapshots into ordered issues (missing vs bad override, outdated, signed-out only on explicit `false`), dismissal by issue-id signature, and help links shared with `trouble.ts`. **`ClaudeHealthStrip`** on Home and Apps fetches on mount, re-probes on focus when visible, and renders nothing when healthy or dismissed.
> 
> **Tests:** Large `test_claude_health.py` and `claude-health.test.ts` focus on wrong-advice regressions (unreadable version ≠ outdated, tri-state sign-in, stale adoption, cache after logout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f6e694aa302c5902802448c1f5dfc1dd8042ac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->