### PR TITLE
Unarchive: drag a card out of Archive, or press the button — the lane is derived

### DIFF
--- a/frontend/src/platform/lib/api.ts
+++ b/frontend/src/platform/lib/api.ts
@@ -1873,14 +1873,35 @@ export function markWholeTaskRead(
 // row, and it is exactly the row the old session-keyed triage write could not
 // touch.
 //
-// There is no unarchive. Archive is a locked lane (tasks-lib's drag matrix) and
-// the row draws no way back — which costs nothing, because archiving destroys
-// nothing: the conversation and its transcript are kept (D306).
+// The way back is `unarchiveTask` below — a drag, not a button. Nothing is
+// destroyed either way: the conversation and its transcript are kept (D306).
 export function archiveTask(
   key: string,
 ): Promise<{ ok: boolean; key: string; cancelled: number; filed: boolean }> {
   return postJson<{ ok: boolean; key: string; cancelled: number; filed: boolean }>(
     "/api/tasks/archive",
+    { key },
+  );
+}
+
+// Taking the filing back — the drag out of the Archive lane, and the exact
+// opposite of only ONE of archiving's two halves.
+//
+// NO LANE IS SENT, and that is the design rather than a missing field: leaving
+// Archive says "not put away any more" and nothing about what the work is doing,
+// so the server drops the filing and the task lands in whatever lane it DERIVES
+// into. `status` in the answer is that lane, which is the one thing the client
+// cannot know before its next poll — and it may not be the lane the card was
+// dropped on. That is intended, not a near miss (see tasks-lib's drag matrix).
+//
+// NOTHING RUNS. The work archiving cancelled stays cancelled, and a card dropped
+// onto In Progress unarchives like any other drop — In Progress is Claude's
+// output, never a lane a reader can put a task into.
+export function unarchiveTask(
+  key: string,
+): Promise<{ ok: boolean; key: string; unfiled: boolean; status: string }> {
+  return postJson<{ ok: boolean; key: string; unfiled: boolean; status: string }>(
+    "/api/tasks/unarchive",
     { key },
   );
 }

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -40,10 +40,11 @@ import {
   resendScheduledMessage,
   runScheduledNow,
   archiveTask,
+  unarchiveTask,
 } from "@platform/lib/api";
 import type { Task, TaskMessage } from "@platform/lib/api";
 import { navigateUrl } from "@platform/lib/router";
-import { BOARD_COLUMNS } from "./schedule-lib";
+import { BOARD_COLUMNS, columnLabel } from "./schedule-lib";
 import type { BoardColumn } from "./schedule-lib";
 import {
   EMPTY_FILTERS,
@@ -68,6 +69,7 @@ import {
   laneRolledUp,
   laneUnread,
   sortByLane,
+  statusColumn,
   markAllRead,
   markRead,
   markReadIntent,
@@ -2206,8 +2208,8 @@ export function TaskBoard({
     setDragging(null);
     setOverLane(null);
     if (!task || !allowed.has(lane)) return;
-    // Which of the two things this drop means — file the task, or run its next
-    // message early — is tasks-lib's decision, not this handler's.
+    // Which of the three things this drop means — file the task, un-file it, or
+    // run its next message early — is tasks-lib's decision, not this handler's.
     const action = dropAction(task, lane);
     if (!action) return;
     setNote(null);
@@ -2217,6 +2219,20 @@ export function TaskBoard({
         // left alone, so the thread reads as a run that happened early rather
         // than a schedule that was quietly rewritten.
         await runScheduledNow(action.entryId);
+      } else if (action.kind === "unarchive") {
+        // Archive → anywhere else. ONE meaning whatever `lane` is: the filing is
+        // dropped and the task lands in whatever lane it DERIVES to, which is
+        // frequently not the lane under the cursor. Nothing runs — including a
+        // drop onto In Progress, which is this same call: that lane is Claude's
+        // output, not a state a reader can assert, so the card goes there only
+        // if a turn genuinely is live.
+        //
+        // So the note says where it actually went. There is no flash or scroll
+        // on this board to point at the card with, and a card that silently
+        // reappears in a lane the person was not looking at is a gesture that
+        // seems to have done nothing.
+        const said = await unarchiveTask(task.key);
+        setNote(`Unarchived — back in ${columnLabel(statusColumn(said.status))}.`);
       } else {
         // → Archive. ONE call for both halves — the pending work is cancelled
         // and the session is filed — because a card dropped here that still

--- a/frontend/src/shell/ScheduleTaskViews.tsx
+++ b/frontend/src/shell/ScheduleTaskViews.tsx
@@ -52,12 +52,12 @@ import {
   LANE_CHOICE_KEY,
   LIST_MEMORY_KEY,
   UNREAD_LABEL,
-  archiveIntent,
   basename,
   cancelIntent,
   carryMarkToHeld,
   dropAction,
   dropLanes,
+  filingIntent,
   filterTasks,
   firstLine,
   groupByColumn,
@@ -69,6 +69,7 @@ import {
   laneRolledUp,
   laneUnread,
   sortByLane,
+  showsRowActions,
   statusColumn,
   markAllRead,
   markRead,
@@ -101,6 +102,7 @@ import {
   upcomingEditEntry,
 } from "./tasks-lib";
 import type {
+  FilingIntent,
   LaneChoices,
   ListMemory,
   OpenThreadIntent,
@@ -223,16 +225,27 @@ const ICON_RERUN = icon(
 // same glyph would read as a toggle that is currently checked.
 const ICON_MARK_READ = icon(
   <><path d="M18 6 7 17l-5-5" /><path d="m22 10-7.5 7.5L13 16" /></>, 13);
-// Filing away. lucide `archive`, and there is no counterpart: archiving is a
-// one-way door on every view now (tasks-lib's drag matrix — Archive is a locked
-// lane), so a second glyph would be an affordance for a gesture that does not
-// exist. It costs nothing, because the door being one-way does not make it a
-// shredder: the conversation and its transcript are kept (D306), and Archive is
-// a place to read them.
+// Filing away. lucide `archive`: a lidded box with a pull-slot in the front.
 const ICON_ARCHIVE = icon(
   <><rect x="2" y="3" width="20" height="5" rx="1" />
     <path d="M4 8v11a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8" />
     <path d="M10 12h4" /></>, 13);
+// Taking it back out. lucide `archive-restore` — the SAME box, opened at the
+// front, with something lifting out of it. That kinship is the whole reason for
+// using the pair rather than inventing a mark: the two buttons occupy ONE slot on
+// a row (`.tasks-rowmark`), never both at once, so a reader has to be able to tell
+// which one they are pointing at from the shape alone, and "same box, arrow out"
+// answers that in a glance where a generic undo curl would not.
+//
+// The box's walls are two short paths rather than one closed body, which is what
+// leaves the gap the arrow comes through. Same 13px, same stroke, same lid as
+// above, so the two glyphs sit on each other exactly.
+const ICON_UNARCHIVE = icon(
+  <><rect x="2" y="3" width="20" height="5" rx="1" />
+    <path d="M4 8v11a2 2 0 0 0 2 2h2" />
+    <path d="M20 8v11a2 2 0 0 1-2 2h-2" />
+    <path d="m9 15 3-3 3 3" />
+    <path d="M12 12v9" /></>, 13);
 
 // ---- leaf components ---------------------------------------------------------
 
@@ -703,6 +716,26 @@ async function performRun(intent: TaskRunIntent): Promise<string> {
   }
   await runScheduledNow(intent.entryId);
   return "";
+}
+
+/**
+ * Take one task back out of Archive, and return the sentence to show for it.
+ *
+ * THE SENTENCE IS THE POINT, and it is why this is a function rather than a call.
+ * Unarchiving names no lane: the server drops the filing and DERIVES where the
+ * task belongs from its thread, so the card is about to appear somewhere the
+ * reader did not choose and cannot predict — a different lane on the Board, a
+ * different rank on the List, quite possibly off screen. Three gestures reach
+ * this (the List's button, the card's button, the drag out of the lane) and all
+ * three need the same sentence; three copies of it is how they start telling the
+ * reader three different things.
+ *
+ * Refusals THROW, exactly like performRun, so each caller puts them in its own
+ * note line.
+ */
+async function performUnarchive(key: string): Promise<string> {
+  const said = await unarchiveTask(key);
+  return `Unarchived — back in ${columnLabel(statusColumn(said.status))}.`;
 }
 
 /**
@@ -1285,18 +1318,24 @@ function TaskNode({
   // drop can never fire different messages; the re-send half is the case the
   // drag deliberately does not have, because a gesture cannot consent to
   // creating work that was never scheduled.
-  const run = taskRunIntent(task);
-  // Archive. The Board's drop onto the Archive lane, reachable without
-  // switching view, expanding a collapsed lane and dragging — which is what
-  // "archive it" used to cost, and the reason the honest answer to "can a task
-  // be deleted?" (no: it is archived, D306) was barely true. tasks-lib decides
-  // everything, by asking dropAction the same question the drag does — so a row
+  //
+  // NOT ON AN ARCHIVED ROW, and neither is anything else below (`showsRowActions`):
+  // a task somebody put away has one decision left against it, and that is
+  // whether it is still put away. Offering Re-run next to Unarchive would also
+  // invite the one misread this whole gesture is written against — that coming
+  // back out of Archive runs something.
+  const acts = showsRowActions(task);
+  const run = acts ? taskRunIntent(task) : null;
+  // FILING, either direction. The Board's drop onto — or out of — the Archive
+  // lane, reachable without switching view, expanding a collapsed lane and
+  // dragging, which is what those moves used to cost. tasks-lib decides
+  // everything, by asking dropAction the same questions the drag does, so a row
   // draws the button exactly when the card would take the drop.
-  const file = archiveIntent(task);
+  const file = filingIntent(task);
   // Mark read — the whole task at once, so clearing 89 unread messages is not 89
   // clicks through 89 transcripts. Asked of the count this row is DRAWING, so
   // the button leaves on its own press rather than on the next poll.
-  const seen = markReadIntent(task, read, held);
+  const seen = acts ? markReadIntent(task, read, held) : null;
 
   // The one cancel in flight, by message id, and whatever the server said about
   // the last one that failed. Per MESSAGE rather than per thread: the sentence
@@ -1337,13 +1376,21 @@ function TaskNode({
     }
   };
 
-  // Archive. One call, and the same one the board's drop makes: the server
-  // cancels the work and files the session, so this side composes nothing.
-  const archive = async () => {
+  // Filing, either direction. One call each, and the same ones the board's drops
+  // make: the server cancels the work and files the session going in, and drops
+  // the filing coming out, so this side composes nothing but the sentence.
+  const refile = async (intent: FilingIntent) => {
     setActing(true);
     setNote("");
     try {
-      await archiveTask(task.key);
+      if (intent.kind === "archive") {
+        await archiveTask(task.key);
+      } else {
+        // WHERE IT WENT, said out loud — see performUnarchive. On a list sorted
+        // by lane the row is about to move somewhere the reader did not point at,
+        // and a sentence is the only pointer this view has.
+        setNote(await performUnarchive(task.key));
+      }
     } catch (e) {
       // The server's own sentence, in the same quiet line run-now uses. A
       // refusal here is news, not a fault: nothing was destroyed either way,
@@ -1703,9 +1750,14 @@ function TaskNode({
             unread={unread > 0}
             count={unread}
           />
-          {/* The Board's drag onto Archive, as a press — and there is no way
-              back, because Archive is a locked lane (tasks-lib.archiveIntent
-              decides both halves and refuses the reverse).
+          {/* The Board's drag onto Archive — or out of it — as a press. ONE
+              button in this slot, never two: a task is either put away or it is
+              not, so tasks-lib.filingIntent answers with a direction and this
+              draws that direction's glyph and calls that direction's verb.
+
+              ON AN ARCHIVED ROW IT IS THE ONLY BUTTON (showsRowActions, above).
+              Unarchive beside a Re-run would suggest the two are related, and the
+              one thing this gesture must never be read as is starting work.
 
               THE ONE ROW ACTION NOT BEHIND SHOW_ROW_ACTIONS (Akshil, 2026-08-18:
               bring the archive button back, visible on hover). Filing a task away
@@ -1726,16 +1778,16 @@ function TaskNode({
           {file && (
             <button
               type="button"
-              className="tasks-act tasks-act--archive"
+              className={"tasks-act tasks-act--" + file.kind}
               title={file.title}
               aria-label={file.label}
               disabled={acting}
               onClick={(e) => {
                 e.stopPropagation();
-                void archive();
+                void refile(file);
               }}
             >
-              {ICON_ARCHIVE}
+              {file.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
             </button>
           )}
         </span>
@@ -2227,12 +2279,12 @@ export function TaskBoard({
         // output, not a state a reader can assert, so the card goes there only
         // if a turn genuinely is live.
         //
-        // So the note says where it actually went. There is no flash or scroll
-        // on this board to point at the card with, and a card that silently
-        // reappears in a lane the person was not looking at is a gesture that
-        // seems to have done nothing.
-        const said = await unarchiveTask(task.key);
-        setNote(`Unarchived — back in ${columnLabel(statusColumn(said.status))}.`);
+        // So the note says where it actually went — the same sentence the two
+        // buttons show (performUnarchive). There is no flash or scroll on this
+        // board to point at the card with, and a card that silently reappears in
+        // a lane the person was not looking at is a gesture that seems to have
+        // done nothing.
+        setNote(await performUnarchive(task.key));
       } else {
         // → Archive. ONE call for both halves — the pending work is cancelled
         // and the session is filed — because a card dropped here that still
@@ -2249,14 +2301,20 @@ export function TaskBoard({
     onReload();
   };
 
-  // The same archive call the drop above makes, asked for by a card's own
-  // button instead of a gesture. It lives up here rather than in TaskCard so the
-  // refusal lands in the board's ONE note line, beside the drag's: a sentence
-  // tucked inside a 260px lane under one card is a sentence nobody reads.
-  const file = async (task: Task) => {
+  // The same two calls the drop above makes, asked for by a card's own button
+  // instead of a gesture. It lives up here rather than in TaskCard so the refusal
+  // lands in the board's ONE note line, beside the drag's: a sentence tucked
+  // inside a 260px lane under one card is a sentence nobody reads. The unarchive
+  // note is the same one the drop writes, for the same reason — the card is about
+  // to appear in a lane nobody pointed at.
+  const refile = async (task: Task, intent: FilingIntent) => {
     setNote(null);
     try {
-      await archiveTask(task.key);
+      if (intent.kind === "archive") {
+        await archiveTask(task.key);
+      } else {
+        setNote(await performUnarchive(task.key));
+      }
     } catch (e) {
       setNote((e as Error).message);
     }
@@ -2476,7 +2534,7 @@ export function TaskBoard({
                       setDragging(null);
                       setOverLane(null);
                     }}
-                    onArchive={() => file(task)}
+                    onFile={(intent) => refile(task, intent)}
                     onRun={runNow}
                     onOpen={(intent) => openCard(task, intent)}
                   />
@@ -2517,7 +2575,7 @@ function TaskCard({
   isDragging,
   onDragStart,
   onDragEnd,
-  onArchive,
+  onFile,
   onRun,
   onOpen,
 }: {
@@ -2532,9 +2590,10 @@ function TaskCard({
   isDragging: boolean;
   onDragStart: () => void;
   onDragEnd: () => void;
-  /** File this card away, or bring it back — the board owns the call so its
-   * refusal lands in the board's own note line. */
-  onArchive: () => Promise<void>;
+  /** File this card away, or bring it back out — the direction comes from the
+   * card's own filingIntent, and the board owns the call so its refusal (and, for
+   * an unarchive, the lane it landed in) lands in the board's own note line. */
+  onFile: (intent: FilingIntent) => Promise<void>;
   /** Run the task's next message now, or re-send the one that failed. Same
    * arrangement and same reason as onTriage: the board makes the call. */
   onRun: (intent: TaskRunIntent) => Promise<void>;
@@ -2555,22 +2614,28 @@ function TaskCard({
   // click does nothing at all: no navigation, and no mark either, since nothing
   // was shown to the reader.
   const open = openThreadIntent(task, unread);
-  // Archive without dragging. The drag stays as the accelerator, but it cannot
-  // be the ONLY way: the lane it aims at is collapsed by default, so the whole
-  // gesture starts with "expand Archive first". Same predicate as the drop, by
-  // construction — archiveIntent asks dropAction.
+  // Filing without dragging, in whichever direction this card has. The drag stays
+  // as the accelerator, but it cannot be the ONLY way: the Archive lane is
+  // collapsed by default, so BOTH gestures otherwise start with "expand Archive
+  // first" — and for a card already in there, a collapsed lane draws no card to
+  // drag at all. Same predicate as the drops, by construction: filingIntent asks
+  // dropAction.
   //
-  // One direction only, on both views and in the drag: there is no way back out
-  // of Archive, because a Board that offers a return the List does not draw is
-  // the divergence this page's whole vocabulary is written against.
-  const file = archiveIntent(task);
+  // Both views draw the same button from the same intent, which is the thing this
+  // page's vocabulary is most careful about: a Board that offered a return the
+  // List did not draw is exactly the divergence the old SHOW_UNARCHIVE was.
+  const file = filingIntent(task);
   // Run now / Re-run, which the List row and the calendar popover both already
   // offer and this card did not. The SAME function decides it here as there
   // (tasks-lib.taskRunIntent, which asks runNowIntent — the very function
   // dropAction asks), so the card's button, the List's button and the drag onto
   // In Progress can never fire different messages. Nothing about which message
   // or which call is re-derived on this side.
-  const run = taskRunIntent(task);
+  //
+  // NOT ON AN ARCHIVED CARD (showsRowActions) — same rule, same reason, as the
+  // List row: the only decision left against a card in Archive is whether it is
+  // still in Archive, so Unarchive is the only button it grows.
+  const run = showsRowActions(task) ? taskRunIntent(task) : null;
   // The run still to come, when this card's lane does not already order by it.
   const soon = nextRunChip(task);
   // The lane this card is IN. Not passed down: `groupByColumn` files every card
@@ -2585,10 +2650,10 @@ function TaskCard({
   // "disagrees": in the failed lane the two agree and the header has said it.
   const failedOffLane = isFailedTask(task) && lane !== "failed";
   const [busy, setBusy] = useState(false);
-  const archive = async () => {
+  const refile = async (intent: FilingIntent) => {
     setBusy(true);
     try {
-      await onArchive();
+      await onFile(intent);
     } finally {
       setBusy(false);
     }
@@ -2787,13 +2852,13 @@ function TaskCard({
           {file && (
             <button
               type="button"
-              className="tasks-act tasks-card-act tasks-act--archive"
+              className={"tasks-act tasks-card-act tasks-act--" + file.kind}
               title={file.title}
               aria-label={`${file.label} ${task.task_id}`}
               disabled={busy}
-              onClick={() => void archive()}
+              onClick={() => void refile(file)}
             >
-              {ICON_ARCHIVE}
+              {file.kind === "archive" ? ICON_ARCHIVE : ICON_UNARCHIVE}
             </button>
           )}
         </span>

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -17,7 +17,7 @@ import {
   NO_TIME,
   PREVIEW_MESSAGES,
   UNREAD_LABEL,
-  archiveIntent,
+  filingIntent,
   basename,
   canCancel,
   canRunNow,
@@ -46,6 +46,7 @@ import {
   laneRolledUp,
   laneUnread,
   LIST_ORDER,
+  showsRowActions,
   sortByLane,
   laneTime,
   lastRunAt,
@@ -1378,10 +1379,14 @@ describe("the unarchive drag", () => {
     const from = VIEWS.indexOf('const drop = async (lane: BoardColumn)');
     const handler = VIEWS.slice(from, VIEWS.indexOf("onReload();", from));
     expect(handler).toContain('action.kind === "unarchive"');
-    expect(handler).toContain("unarchiveTask(task.key)");
-    expect(handler).not.toContain("unarchiveTask(task.key, lane");
+    // Through the shared helper — one call over the task key, and the `lane` the
+    // drop was made on is not in it.
+    expect(handler).toContain("performUnarchive(task.key)");
+    expect(handler).not.toMatch(/performUnarchive\(task\.key,/);
+    expect(VIEWS).toContain("async function performUnarchive(key: string)");
+    expect(VIEWS).toContain("await unarchiveTask(key)");
     // And it says where the card actually went, because it may not be here.
-    expect(handler).toContain("statusColumn(said.status)");
+    expect(VIEWS).toContain("statusColumn(said.status)");
   });
 });
 
@@ -1571,9 +1576,10 @@ describe("taskRunIntent", () => {
 // kept" (D306), and that answer is only true while archiving is reachable. It
 // used to be one gesture on one view, onto a lane that starts COLLAPSED.
 
-describe("archiveIntent", () => {
+describe("filingIntent", () => {
   it("offers Archive on a task that has run", () => {
-    const a = archiveIntent(task({ status: "done" }))!;
+    const a = filingIntent(task({ status: "done" }))!;
+    expect(a.kind).toBe("archive");
     expect(a.label).toBe("Archive");
     expect(a.lane).toBe("archived");
     // The two halves a person reaching for Delete is actually asking about: the
@@ -1582,37 +1588,62 @@ describe("archiveIntent", () => {
     expect(a.title).toContain("calls off");
   });
 
-  it("offers no way back out of Archive", () => {
-    // Archive is a locked lane on the Board and the row draws no Unarchive, so
-    // there is one answer to "how do I get this back?" instead of two. It costs
-    // nothing: archiving destroys nothing (D306).
-    expect(archiveIntent(task({ status: "archived" }))).toBe(null);
+  it("offers Unarchive on an archived task, naming NO lane", () => {
+    // The way back is a button again (Akshil, 2026-08-19) — and the reason the
+    // old one was wrong is the field that is null here. Archive → In Progress
+    // asserted a verdict on work the reader had not watched; this asserts
+    // nothing, because the server derives where the task lands.
+    const a = filingIntent(task({ status: "archived" }))!;
+    expect(a.kind).toBe("unarchive");
+    expect(a.label).toBe("Unarchive");
+    expect(a.lane).toBe(null);
+    // Says the two things a person cannot see before pressing.
+    expect(a.title).toContain("Archive");
+    expect(a.title).toContain("nothing is re-run");
   });
 
-  it("offers nothing while a run is in flight", () => {
+  it("offers nothing while a run is in flight — the ONLY null now", () => {
     // In Progress is Claude's output. The card cannot leave that lane by any
     // gesture, and the button asks the same question the drop does.
-    expect(archiveIntent(task({ status: "in_progress" }))).toBe(null);
+    expect(filingIntent(task({ status: "in_progress" }))).toBe(null);
+    // Every other lane has a direction, which is the whole change: there is no
+    // longer a row whose filing simply cannot be changed.
+    for (const status of ["upcoming", "done", "archived", FAILED] as const) {
+      expect(filingIntent(task({ status }))).not.toBe(null);
+    }
   });
 
   it("offers Archive on a task with no session at all", () => {
     // `pending:<entry>` — the row the old session-keyed triage write could not
     // touch. Archiving is one verb over a TASK KEY now, and for a task that has
     // never run it means exactly "cancel the work", which the server does.
-    expect(archiveIntent(task({ key: "pending:e1", session_id: "", status: "upcoming" })))
+    expect(filingIntent(task({ key: "pending:e1", session_id: "", status: "upcoming" })))
       .not.toBe(null);
     const fresh = upcoming([T9], { key: "pending:e1", session_id: "" });
     expect(isDraggable(fresh)).toBe(true);
-    expect(archiveIntent(fresh)!.lane).toBe("archived");
+    expect(filingIntent(fresh)!.lane).toBe("archived");
+  });
+
+  it("offers Unarchive even where there is nothing to un-file server-side", () => {
+    // A card reads Archive because its every message was filed away, or because
+    // it has no session to hold a record at all. The button is still right: the
+    // server answers `unfiled: false` and the row lands in its derived lane,
+    // which is the outcome the press was asking for either way.
+    for (const t of [
+      task({ status: "archived", key: "pending:e1", session_id: "" }),
+      task({ status: "archived", messages: [msg({ state: "cancelled" })] }),
+    ]) {
+      expect(filingIntent(t)!.kind).toBe("unarchive");
+    }
   });
 
   it("is offered from every unlocked lane", () => {
     for (const status of ["upcoming", "done"] as const) {
-      expect(archiveIntent(task({ status }))).not.toBe(null);
+      expect(filingIntent(task({ status }))!.kind).toBe("archive");
     }
     // Including the one lane Done is refused from — filing a failed run away is
     // exactly what a person wants to do with it.
-    expect(archiveIntent(task({ status: FAILED }))!.lane).toBe("archived");
+    expect(filingIntent(task({ status: FAILED }))!.lane).toBe("archived");
   });
 
   it("never disagrees with the drop the Board already makes", () => {
@@ -1622,28 +1653,64 @@ describe("archiveIntent", () => {
       task({ status: "archived" }),
       task({ status: FAILED }),
       upcoming([T9]),
+      upcoming([T9], { status: "archived" }),
       upcoming([T18, T9], { status: FAILED }),
       task({ key: "pending:e1", session_id: "", status: "upcoming" }),
       upcoming([T9], { key: "pending:e1", session_id: "" }),
     ];
     for (const t of shapes) {
-      const a = archiveIntent(t);
-      for (const col of BOARD_COLUMNS) {
-        const action = dropAction(t, col.key);
-        if (a && col.key === a.lane) {
-          // The button makes the drop's call, on the drop's own lane.
-          expect(action).toEqual({ kind: "archive" });
-          expect(dropLanes(t)).toContain(a.lane);
-        } else if (!a) {
-          // Offering nothing is only correct while the drag has no ARCHIVE move
-          // either. Run-now and unarchive are different verbs and may still be
-          // legal on some lane — the second is exactly why the button stays
-          // absent from an archived card while its drag works.
-          expect(action === null || action.kind === "run"
-            || action.kind === "unarchive").toBe(true);
+      const a = filingIntent(t);
+      // NO BUTTON ⇒ NO FILING DROP ANYWHERE, in either direction. A run-now drop
+      // is a different verb and may still be legal.
+      if (!a) {
+        for (const col of BOARD_COLUMNS) {
+          const action = dropAction(t, col.key);
+          expect(action === null || action.kind === "run").toBe(true);
         }
+        continue;
+      }
+      // ARCHIVE names the lane the drag aims at, and makes the drag's call on it.
+      if (a.kind === "archive") {
+        expect(a.lane).toBe("archived");
+        expect(dropAction(t, "archived")).toEqual({ kind: "archive" });
+        expect(dropLanes(t)).toContain("archived");
+        continue;
+      }
+      // UNARCHIVE names no lane — so the agreement to check is that EVERY lane
+      // the drag offers answers this same verb. A button that could do something
+      // the drag would not is the divergence both directions have now had.
+      expect(a.lane).toBe(null);
+      expect(dropLanes(t).length).toBeGreaterThan(0);
+      for (const lane of dropLanes(t)) {
+        expect(dropAction(t, lane)).toEqual({ kind: "unarchive" });
       }
     }
+  });
+});
+
+describe("showsRowActions", () => {
+  it("is false on an archived task and true everywhere else", () => {
+    // Akshil, 2026-08-19: only the unarchive button on archived rows. A task
+    // somebody put away has one decision left against it.
+    expect(showsRowActions(task({ status: "archived" }))).toBe(false);
+    for (const status of ["upcoming", "in_progress", "done", FAILED] as const) {
+      expect(showsRowActions(task({ status }))).toBe(true);
+    }
+  });
+
+  it("is about the ROW's chrome, not about whether the work exists", () => {
+    // The underlying intents keep answering honestly — the calendar popover and
+    // anything else that asks needs the truth — so this cannot be folded into
+    // them. An archived task with a pending message still HAS a run to make.
+    const filed = upcoming([T9], { status: "archived" });
+    expect(showsRowActions(filed)).toBe(false);
+    expect(taskRunIntent(filed)).not.toBe(null);
+  });
+
+  it("does not gate opening: Archive is a place to READ things", () => {
+    // D306 — the transcript is kept, so the row link and Open chat keep working.
+    const filed = task({ status: "archived", messages: [msg({ unread: true })] });
+    expect(openThreadIntent(filed, 1)).not.toBe(null);
   });
 });
 
@@ -3431,48 +3498,60 @@ describe("the archive action", () => {
   it("sits in the List row's hover-revealed group, conditional on the intent", () => {
     const from = VIEWS.indexOf('className={"tasks-row"');
     const row = VIEWS.slice(from, VIEWS.indexOf("{open && (", from));
-    // Only when there is something to file — a session-less row grows nothing.
+    // Only when the filing can be changed at all — a mid-run row grows nothing.
     expect(row).toContain("{file && (");
-    // The same class Run now / Edit / Cancel wear, which is what makes it quiet.
-    expect(row).toContain("tasks-act--archive");
-    expect(row).toContain("ICON_ARCHIVE");
+    // The same class group Run now / Edit / Cancel wear, which is what makes it
+    // quiet — and the DIRECTION is a suffix, so one button covers both.
+    expect(row).toContain('"tasks-act tasks-act--" + file.kind');
+    expect(row).toContain("ICON_ARCHIVE : ICON_UNARCHIVE");
     // The words come from tasks-lib rather than from the row.
     expect(row).toContain("aria-label={file.label}");
   });
 
-  it("is a BUTTON one way only — the way back is the drag, and it is not a button", () => {
-    // No Unarchive control anywhere: not a button, not a glyph. It used to be
-    // written-but-hidden on the row and LIVE on the Board, which is two answers
-    // to one question — the divergence this page's vocabulary is written
-    // against. The way back exists (drag the card out of the lane, or say
-    // something in the conversation) and neither of those needs a label, which
-    // is the whole objection to the button: every label claims something about
-    // the work that leaving Archive does not know.
-    expect(VIEWS).not.toContain("SHOW_UNARCHIVE");
-    expect(VIEWS).not.toContain("ICON_UNARCHIVE");
-    expect(archiveIntent(task({ status: "archived" }))).toBe(null);
-    // The drag is the exception, and it is one verb with no destination.
-    expect(dropAction(task({ status: "archived" }), "done"))
-      .toEqual({ kind: "unarchive" });
-    // BOTH views read the same intent, and neither composes a status: the
-    // server verb is one call over the task key.
+  it("goes BOTH ways now, from one intent, on both views", () => {
+    // The way back is a button again (Akshil, 2026-08-19). It used to be
+    // written-but-hidden on the row and LIVE on the Board — two answers to one
+    // question, which is the divergence this page's vocabulary is written
+    // against — so the thing to hold is that ONE function decides it and BOTH
+    // views draw it.
+    // The old flag is gone as CODE — it may be named in prose, because what it
+    // was is why this button is shaped the way it is.
+    expect(VIEWS).not.toMatch(/^\s*(const|let)\s+SHOW_UNARCHIVE/m);
+    expect(VIEWS).not.toMatch(/SHOW_UNARCHIVE\s*&&/);
+    expect((VIEWS.match(/const file = filingIntent\(task\);/g) ?? []).length).toBe(2);
     for (const src of [ROW, CARD]) {
       expect(src).toContain("{file && (");
+      // One button per view, branching on the direction rather than two buttons
+      // that could both render (or both not).
+      expect((src.match(/\{file && \(/g) ?? []).length).toBe(1);
+      // The direction is a class SUFFIX and a glyph choice, so neither view can
+      // draw one direction's skin over the other's action.
+      expect(src).toContain('tasks-act--" + file.kind');
+      expect(src).toContain("ICON_ARCHIVE : ICON_UNARCHIVE");
     }
-    expect((VIEWS.match(/const file = archiveIntent\(task\);/g) ?? []).length).toBe(2);
-    // Lookbehind so `unarchiveTask` is not counted as one of these.
+    // And the old, wrong version of this button stays gone: its move named a
+    // lane (Archive → In Progress), and nothing here names one.
+    expect(filingIntent(task({ status: "archived" }))!.lane).toBe(null);
+    expect(dropAction(task({ status: "archived" }), "done"))
+      .toEqual({ kind: "unarchive" });
+    // Both directions are one server verb over the task key, composed nowhere on
+    // the client. Lookbehind so `unarchiveTask` is not counted as an archive.
     expect((VIEWS.match(/(?<!un)archiveTask\(task\.key\)/g) ?? []).length).toBe(3);
-    // And the way back is ONE call, made from the drop and from nowhere else —
-    // no button on either view reaches it.
-    expect((VIEWS.match(/unarchiveTask\(task\.key\)/g) ?? []).length).toBe(1);
-    for (const src of [ROW, CARD]) {
-      expect(src).not.toContain("unarchiveTask");
-    }
-    // Not hidden in CSS, the same rule the strip obeys: an `opacity: 0` button
-    // is still in the tab order.
-    expect(TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain(
-      ".tasks-act--unarchive",
-    );
+    // Unarchive goes through ONE helper (performUnarchive), because all three
+    // gestures owe the reader the same sentence about where the card went — so the
+    // api call appears exactly once, inside it, and never at a call site.
+    expect((VIEWS.match(/unarchiveTask\(/g) ?? []).length).toBe(1);
+    expect((VIEWS.match(/performUnarchive\(task\.key\)/g) ?? []).length).toBe(3);
+    // The glyph exists and is the archive box opened — same lid, same width, so
+    // the two read as one pair in one slot.
+    expect(VIEWS).toContain("const ICON_UNARCHIVE = icon(");
+    const box = '<rect x="2" y="3" width="20" height="5" rx="1" />';
+    expect(VIEWS.split(box).length - 1).toBe(2);
+    // Skinned in CSS, and NOT hidden there: the same rule the strip obeys — an
+    // `opacity: 0` button is still in the tab order.
+    const live = TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "");
+    expect(live).toContain(".tasks-act--unarchive:hover:not(:disabled)");
+    expect(live).not.toMatch(/\.tasks-act--unarchive[^{]*\{[^}]*display: none/);
   });
 
   it("is the ONE row action not behind SHOW_ROW_ACTIONS, on both views", () => {
@@ -3531,7 +3610,7 @@ describe("the archive action", () => {
 
   it("gives the board card the same action, so the drag is not the only way", () => {
     const card = VIEWS.slice(VIEWS.indexOf("function TaskCard("));
-    expect(card).toContain("archiveIntent(task)");
+    expect(card).toContain("filingIntent(task)");
     expect(card).toContain("tasks-card-act");
     // A button cannot be nested inside a button, which is what the wrapper is
     // for — and what it is positioned against.
@@ -3575,11 +3654,12 @@ describe("the archive action", () => {
     expect(from).toBeGreaterThan(-1);
     const slot = VIEWS.slice(from, VIEWS.indexOf("</span>", from));
     expect(slot).toContain("<StatusIcon");
-    expect(slot).toContain("tasks-act--archive");
+    expect(slot).toContain('"tasks-act tasks-act--" + file.kind');
     // It is drawn BEFORE the row's id chip — i.e. at the leading edge, where the
-    // ring is — and there is exactly one archive button on a row.
+    // ring is — and there is exactly one filing button on a row, whichever
+    // direction it is.
     expect(from).toBeLessThan(VIEWS.indexOf("<IdChip id={task.task_id}"));
-    expect((ROW.match(/tasks-act--archive/g) ?? []).length).toBe(1);
+    expect((ROW.match(/\{file && \(/g) ?? []).length).toBe(1);
 
     // NOTHING MOVES when they swap, and that is a claim about the CSS: the slot is
     // exactly the rail's width and the button is out of flow inside it, so the
@@ -3592,10 +3672,10 @@ describe("the archive action", () => {
     // No z-index on the SLOT: the row's stretched link has to keep painting over
     // the ring's box, exactly as it did when the ring was the flex child.
     expect(mark).not.toContain("z-index");
-    const button = block(
-      TASKS_CSS,
-      ".tasks-rowmark .tasks-act--archive",
-    );
+    // Keyed on `.tasks-act` and NOT on one direction's class: the geometry is a
+    // fact about the slot and its single occupant, so an archived row's Unarchive
+    // lands in exactly the same 22px the archive button does.
+    const button = block(TASKS_CSS, ".tasks-rowmark .tasks-act");
     expect(button).toContain("position: absolute");
     expect(button).toContain("transform: translate(-50%, -50%)");
 
@@ -3612,9 +3692,12 @@ describe("the archive action", () => {
     // way (the same rule the strip has always obeyed).
     expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-rowmark .schedule-ring");
     expect(TASKS_CSS).toContain(".tasks-act:focus-visible");
-    // A row with nothing to file keeps its ring under the pointer: a blank slot
-    // where the row's status was is worse than no swap at all.
-    expect(TASKS_CSS).toContain(":not(:has(.tasks-act--archive)) .schedule-ring");
+    // A row whose filing cannot be changed keeps its ring under the pointer: a
+    // blank slot where the row's status was is worse than no swap at all. Keyed on
+    // `.tasks-act`, or the archived row would keep its ring painted over the
+    // Unarchive button standing in the same box.
+    expect(TASKS_CSS).toContain(":not(:has(.tasks-act)) .schedule-ring");
+    expect(TASKS_CSS).not.toContain(":not(:has(.tasks-act--archive))");
 
     // AND THE INVISIBLE BUTTON CANNOT TAKE A PRESS (bugbot, 2026-08-18, HIGH).
     // `opacity: 0` alone left a live control at `z-index: 2` sitting over the
@@ -3639,7 +3722,7 @@ describe("the archive action", () => {
     // and its head has an empty right end the strip was measured against
     // (`--tasks-card-head-h`), so moving the button there would be a change with
     // nothing behind it.
-    expect(CARD).toContain("tasks-card-act tasks-act--archive");
+    expect(CARD).toContain('"tasks-act tasks-card-act tasks-act--" + file.kind');
     expect(CARD).not.toContain("tasks-rowmark");
     expect(TASKS_CSS).toMatch(/\.tasks-card-acts\s*\{[^}]*position: absolute/);
   });
@@ -3647,9 +3730,13 @@ describe("the archive action", () => {
   it("never paints it red — archiving destroys nothing", () => {
     // Cancel's hue is the destructive one and the two are one flick apart; using
     // it here would assert the very thing archiving exists to deny.
-    const at = TASKS_CSS.indexOf(".tasks-act--archive:hover");
-    expect(at).toBeGreaterThan(-1);
-    expect(TASKS_CSS.slice(at, TASKS_CSS.indexOf("}", at))).not.toContain("--error");
+    // Both directions, and they share one skin — see the CSS note: the two never
+    // appear together, so a hue telling them apart would contrast with nothing.
+    for (const sel of [".tasks-act--archive:hover", ".tasks-act--unarchive:hover"]) {
+      const at = TASKS_CSS.indexOf(sel);
+      expect(at).toBeGreaterThan(-1);
+      expect(TASKS_CSS.slice(at, TASKS_CSS.indexOf("}", at))).not.toContain("--error");
+    }
   });
 });
 
@@ -3872,16 +3959,16 @@ describe("the hidden row actions", () => {
     for (const kept of [
       "markReadIntent(task, read, held)",
       "taskRunIntent(task)",
-      "archiveIntent(task)",
+      "filingIntent(task)",
       "openThreadIntent(task, unread)",
       "const markSeen = async () => {",
-      "const archive = async () => {",
+      "const refile = async (intent: FilingIntent) => {",
       "const openChat = (intent: OpenThreadIntent)",
     ]) {
       expect(VIEWS).toContain(kept);
     }
     expect(CARD).toContain("void runNow(run)");
-    expect(CARD).toContain("void archive()");
+    expect(CARD).toContain("void refile(file)");
   });
 
   it("keeps the strip's geometry, which is what it comes back to", () => {
@@ -4327,7 +4414,7 @@ describe("opening a thread, from either view", () => {
     const acts = CARD.slice(actsAt);
     expect(acts).not.toContain("onOpen");
     expect(acts).toContain("void runNow(run)");
-    expect(acts).toContain("void archive()");
+    expect(acts).toContain("void refile(file)");
   });
 
   it("is the row ITSELF now, and a real link at that", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -1060,20 +1060,44 @@ describe("dropLanes", () => {
     expect(dropLanes(t)).toEqual([]);
   });
 
-  it("Archived goes nowhere, even with a run pending", () => {
-    const t = upcoming([T9], { status: "archived" });
-    expect(canRunNow(t)).toBe(true);
-    expect(dropLanes(t)).toEqual([]);
+  it("lets an archived card out to every other lane — one move, UNARCHIVE", () => {
+    // Leaving Archive says "not put away any more" and nothing about the work,
+    // so every lane is a legal place to LET GO and none of them is the
+    // destination: the task lands where it derives to, server-side.
+    const t = task({ status: "archived" });
+    expect(dropLanes(t)).toEqual(["upcoming", "in_progress", "done", "failed"]);
+    expect(isDraggable(t)).toBe(true);
+    for (const lane of dropLanes(t)) {
+      expect(dropAction(t, lane)).toEqual({ kind: "unarchive" });
+    }
   });
 
-  it("locks the two lanes that are Claude's, not the reader's", () => {
-    // In Progress is a run in flight: a card leaves it when the run ends and at
-    // no other moment. Archive is where things rest, and there is no way back
-    // out by dragging — the row draws no Unarchive either.
-    for (const status of ["in_progress", "archived"] as const) {
-      expect(dropLanes(task({ status }))).toEqual([]);
-      expect(isDraggable(task({ status }))).toBe(false);
+  it("unarchives with no precondition at all — and never runs", () => {
+    // The run's precondition belongs to the run. An archived card with a
+    // pending message is still unarchived, not run (the drop would otherwise
+    // fire a message on a task somebody had put away); one with NOTHING pending
+    // still lifts, which a run-shaped rule would have refused.
+    const pending = upcoming([T9], { status: "archived" });
+    expect(canRunNow(pending)).toBe(true);
+    for (const lane of dropLanes(pending)) {
+      expect(dropAction(pending, lane)).toEqual({ kind: "unarchive" });
     }
+    const spent = task({ status: "archived" }); // factory messages are `sent`
+    expect(canRunNow(spent)).toBe(false);
+    expect(dropAction(spent, "in_progress")).toEqual({ kind: "unarchive" });
+    // Including the never-run row with no session to un-file.
+    const fresh = task({ key: "pending:e1", session_id: "", status: "archived" });
+    expect(dropAction(fresh, "done")).toEqual({ kind: "unarchive" });
+  });
+
+  it("locks In Progress, and locks Archive only as a DESTINATION", () => {
+    // In Progress is a run in flight: a card leaves it when the run ends and at
+    // no other moment. Archive is a locked destination for a card already in it
+    // — "archive this archived task" is not a move — while remaining the one
+    // lane a card may be dragged OUT of into anything.
+    expect(dropLanes(task({ status: "in_progress" }))).toEqual([]);
+    expect(isDraggable(task({ status: "in_progress" }))).toBe(false);
+    expect(dropAction(task({ status: "archived" }), "archived")).toBe(null);
   });
 
   it("offers Archive from every unlocked lane, session or no session", () => {
@@ -1112,7 +1136,10 @@ describe("dropLanes", () => {
     // Upcoming: a task cannot be un-run. Failed: it is something that HAPPENED,
     // and a lane you can drag a healthy task into is a lane whose count means
     // nothing. Done: a run says that, not a reader.
-    for (const status of ["upcoming", "in_progress", "done", "archived"] as const) {
+    // Archived is excluded: those three ARE legal places to let an archived card
+    // go, and the move is unarchive rather than "make it that lane" — see the
+    // unarchive cases above.
+    for (const status of ["upcoming", "in_progress", "done"] as const) {
       for (const lane of ["upcoming", "failed", "done"] as const) {
         expect(dropLanes(task({ status })).includes(lane)).toBe(false);
       }
@@ -1266,15 +1293,95 @@ describe("dropAction", () => {
     expect(dropAction(task({ status: "upcoming" }), "in_progress")).toBe(null);
     expect(dropAction(task({ status: "done" }), "failed")).toBe(null);
     expect(dropAction(upcoming([T9], { status: FAILED }), "done")).toBe(null);
-    // Both locked lanes refuse everything.
+    // In Progress refuses everything as a SOURCE; Archive refuses only itself.
     for (const lane of ["in_progress", "archived"] as const) {
       expect(dropAction(task({ status: "in_progress" }), lane)).toBe(null);
-      expect(dropAction(task({ status: "archived" }), lane)).toBe(null);
     }
+    expect(dropAction(task({ status: "archived" }), "archived")).toBe(null);
+    // And the one move it does have never starts a run.
+    expect(dropAction(upcoming([T9], { status: "archived" }), "in_progress"))
+      .toEqual({ kind: "unarchive" });
     // A never-run task may now be filed as well as run: archiving is keyed by
     // task, not by session.
     const fresh = upcoming([T9], { key: "pending:e1", session_id: "" });
     expect(dropAction(fresh, "archived")).toEqual({ kind: "archive" });
+  });
+});
+
+// ---- dragging out of Archive ---------------------------------------------------
+// UNARCHIVE, and the whole point of the group is the two things the move is NOT:
+// it is not a choice of lane, and it is not a run.
+
+describe("the unarchive drag", () => {
+  const LANES = ["upcoming", "in_progress", "done", "failed"] as const;
+
+  it("is the same action on every lane the card may be dropped on", () => {
+    // The user does not pick the destination. Where the task lands is derived
+    // server-side from its messages, so a drop on Upcoming and a drop on Done
+    // are the same gesture and must not become two different calls.
+    for (const t of [
+      task({ status: "archived" }),
+      upcoming([T9], { status: "archived" }),
+      task({ status: "archived", key: "pending:e1", session_id: "" }),
+      task({ status: "archived", messages: [msg({ state: "cancelled" })] }),
+    ]) {
+      expect(dropLanes(t)).toEqual([...LANES]);
+      for (const lane of LANES) {
+        expect(dropAction(t, lane)).toEqual({ kind: "unarchive" });
+      }
+    }
+  });
+
+  it("NEVER produces a run, whatever the archived task has pending", () => {
+    // The one thing this drag must not do. An archived task can hold a pending
+    // message — archiving cancels the work, but a card can be archived and then
+    // scheduled into, and an older filing may predate the cancel — and dropping
+    // it on In Progress must not fire it. "Put this back on the board" is not
+    // consent to send a message.
+    const pending = upcoming([T9], { status: "archived" });
+    expect(canRunNow(pending)).toBe(true);
+    for (const lane of LANES) {
+      expect(dropAction(pending, lane)?.kind).not.toBe("run");
+    }
+    // No lane on the whole board reads as a run for an archived card, which is
+    // what the Board's `runLane` hint asks — so it draws no run outline.
+    for (const col of BOARD_COLUMNS) {
+      expect(dropAction(pending, col.key)?.kind === "run").toBe(false);
+    }
+  });
+
+  it("carries no payload — not even the lane it was dropped on", () => {
+    // A lane in the action is a lane the client would expect honoured, and the
+    // server refuses to honour one. Structural equality is the assertion: an
+    // extra field here would be a promise nothing keeps.
+    expect(Object.keys(dropAction(task({ status: "archived" }), "done") ?? {}))
+      .toEqual(["kind"]);
+  });
+
+  it("does not make Archive a destination for an archived card", () => {
+    // "Archive this archived task" is not a move, and dropping a card back on
+    // the lane it came from must be a no-op rather than a wasted un-file.
+    expect(dropAction(task({ status: "archived" }), "archived")).toBe(null);
+    expect(dropLanes(task({ status: "archived" }))).not.toContain("archived");
+  });
+
+  it("leaves In Progress locked as a SOURCE", () => {
+    // Accepting a drop is not the same as releasing one. A run in flight is
+    // Claude's output and the card leaves that lane when the run ends.
+    expect(dropLanes(task({ status: "in_progress" }))).toEqual([]);
+    expect(isDraggable(task({ status: "in_progress" }))).toBe(false);
+  });
+
+  it("is the call the Board makes, and it sends no lane", () => {
+    // The handler's own half of the rule, read out of the source: one call over
+    // the task key, and the `lane` the drop was made on is not in it.
+    const from = VIEWS.indexOf('const drop = async (lane: BoardColumn)');
+    const handler = VIEWS.slice(from, VIEWS.indexOf("onReload();", from));
+    expect(handler).toContain('action.kind === "unarchive"');
+    expect(handler).toContain("unarchiveTask(task.key)");
+    expect(handler).not.toContain("unarchiveTask(task.key, lane");
+    // And it says where the card actually went, because it may not be here.
+    expect(handler).toContain("statusColumn(said.status)");
   });
 });
 
@@ -1528,9 +1635,12 @@ describe("archiveIntent", () => {
           expect(action).toEqual({ kind: "archive" });
           expect(dropLanes(t)).toContain(a.lane);
         } else if (!a) {
-          // Offering nothing is only correct while the drag has no filing move
-          // either — a run-now drop is a different verb and may still be legal.
-          expect(action === null || action.kind === "run").toBe(true);
+          // Offering nothing is only correct while the drag has no ARCHIVE move
+          // either. Run-now and unarchive are different verbs and may still be
+          // legal on some lane — the second is exactly why the button stays
+          // absent from an archived card while its drag works.
+          expect(action === null || action.kind === "run"
+            || action.kind === "unarchive").toBe(true);
         }
       }
     }
@@ -3330,23 +3440,34 @@ describe("the archive action", () => {
     expect(row).toContain("aria-label={file.label}");
   });
 
-  it("is one-way, on both views and in the drag", () => {
-    // Archive is a locked lane (tasks-lib's drag matrix), so there is no
-    // Unarchive anywhere: not a button, not a glyph, not a drop. It used to be
+  it("is a BUTTON one way only — the way back is the drag, and it is not a button", () => {
+    // No Unarchive control anywhere: not a button, not a glyph. It used to be
     // written-but-hidden on the row and LIVE on the Board, which is two answers
     // to one question — the divergence this page's vocabulary is written
-    // against.
+    // against. The way back exists (drag the card out of the lane, or say
+    // something in the conversation) and neither of those needs a label, which
+    // is the whole objection to the button: every label claims something about
+    // the work that leaving Archive does not know.
     expect(VIEWS).not.toContain("SHOW_UNARCHIVE");
     expect(VIEWS).not.toContain("ICON_UNARCHIVE");
     expect(archiveIntent(task({ status: "archived" }))).toBe(null);
-    expect(dropLanes(task({ status: "archived" }))).toEqual([]);
+    // The drag is the exception, and it is one verb with no destination.
+    expect(dropAction(task({ status: "archived" }), "done"))
+      .toEqual({ kind: "unarchive" });
     // BOTH views read the same intent, and neither composes a status: the
     // server verb is one call over the task key.
     for (const src of [ROW, CARD]) {
       expect(src).toContain("{file && (");
     }
     expect((VIEWS.match(/const file = archiveIntent\(task\);/g) ?? []).length).toBe(2);
-    expect((VIEWS.match(/archiveTask\(task\.key\)/g) ?? []).length).toBe(3);
+    // Lookbehind so `unarchiveTask` is not counted as one of these.
+    expect((VIEWS.match(/(?<!un)archiveTask\(task\.key\)/g) ?? []).length).toBe(3);
+    // And the way back is ONE call, made from the drop and from nowhere else —
+    // no button on either view reaches it.
+    expect((VIEWS.match(/unarchiveTask\(task\.key\)/g) ?? []).length).toBe(1);
+    for (const src of [ROW, CARD]) {
+      expect(src).not.toContain("unarchiveTask");
+    }
     // Not hidden in CSS, the same rule the strip obeys: an `opacity: 0` button
     // is still in the tab order.
     expect(TASKS_CSS.replace(/\/\*[\s\S]*?\*\//g, "")).not.toContain(

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -359,8 +359,20 @@ export function threadRunning(messages: TaskMessage[]): boolean {
  * against is a snapshot of what the server said LAST time.
  */
 export function taskColumn(task: Task): BoardColumn {
-  const s: string = task.status;
-  const known = BOARD_COLUMNS.find((c) => c.key === s);
+  return statusColumn(task.status);
+}
+
+/**
+ * The same narrowing, over a status that is not attached to a row.
+ *
+ * One caller and it needs exactly this: `api.unarchiveTask` answers with the
+ * lane the task LANDED in — a bare word, from a server that may know a lane this
+ * bundle does not — and the Board turns it into a sentence before its next poll
+ * has a Task to ask about. Split out rather than duplicated so a fifth lane
+ * cannot be swallowed into Done in one of the two places and not the other.
+ */
+export function statusColumn(status: string): BoardColumn {
+  const known = BOARD_COLUMNS.find((c) => c.key === status);
   return known ? known.key : "done";
 }
 
@@ -1262,8 +1274,8 @@ export function messageEditEntry(m: TaskMessage): string | null {
 // ---- drag --------------------------------------------------------------------
 // THE WHOLE DRAG MATRIX, and it follows from one sentence: a lane is what
 // Claude's work is DOING, and the only thing a person decides about a task is
-// whether to run it or to put it away. So there are exactly two moves, and
-// three lanes a card may leave.
+// whether to run it, to put it away, or to take that away back. So there are
+// exactly three moves, and four lanes a card may leave.
 //
 //   Upcoming    → In Progress  RUN IT NOW. Not a filing decision, an
 //                              instruction (Akshil, 2026-08-16: "if I move a
@@ -1285,20 +1297,37 @@ export function messageEditEntry(m: TaskMessage): string | null {
 //   Failed      → In Progress  RETRY — the same run-now call, same
 //                              precondition (something pending to fire).
 //               → Archive
-//   Archived    → nowhere      LOCKED — and the way back is not a gesture at
-//                              all, it is ACTIVITY (Akshil, 2026-08-18: "if you
-//                              want to move it to in progress or done, just
-//                              type in a message inside that chat and it will
-//                              automatically move"). A message that arrives
-//                              after the filing drops the filing outright,
-//                              server-side, and the task rejoins whichever lane
-//                              it derives into. So there is no unarchive
-//                              control anywhere, on either view.
+//   Archived    → anywhere     UNARCHIVE, and it is ONE move however far the
+//                 else         card is carried. Lifting a card out of Archive
+//                              means "this is not put away any more" and
+//                              nothing else; it does not name a lane, because
+//                              the lane is not a person's to name (that is the
+//                              same rule that keeps Done and Failed
+//                              undroppable, below). The filing is dropped
+//                              server-side and the task lands wherever it
+//                              DERIVES to — Done, Failed, In Progress — which
+//                              may well not be the lane under the cursor. That
+//                              is the intended outcome, not a near miss: the
+//                              board shows what the work is doing.
 //
 // Nothing may be dropped INTO Upcoming (a task cannot be un-run), into Failed
 // (failure is something that HAPPENED, and a lane you can drag a healthy task
 // into is a lane whose count means nothing), or into Done (a run says that,
-// not a reader).
+// not a reader) — with the ONE exception above, and it is not really an
+// exception: an archived card dropped on any of them does not become that lane,
+// it becomes unfiled. The lane is the gesture's target, never its argument.
+//
+// THE OTHER WAY OUT OF ARCHIVE IS STILL ACTIVITY, and it is the older one
+// (Akshil, 2026-08-18: "if you want to move it to in progress or done, just type
+// in a message inside that chat and it will automatically move"). A message that
+// arrives after the filing drops the filing by itself, server-side, with nobody
+// dragging anything. The drag is the same drop of the same record, reached
+// deliberately — so the two cannot disagree.
+//
+// THERE IS STILL NO UNARCHIVE BUTTON, on either view. The drag says what it
+// does — a card leaves a lane — where a button would have to be labelled, and
+// every label for it ("Restore", "Back in play") claims something about the
+// work that this move does not know.
 //
 // Legality follows from what each move NEEDS, never from what triage happens to
 // be keyed by. Run-now needs a pending MESSAGE, so a scheduled task that has
@@ -1307,18 +1336,22 @@ export function messageEditEntry(m: TaskMessage): string | null {
 // task's key, because it is one server verb over the whole task
 // (`POST /api/tasks/archive`) rather than a triage write keyed by session — so
 // the never-run row can be filed away too, which is the case the old
-// session-keyed rule could not reach.
-
-/** The lanes a person may drop a card ON. Two, and the second is not a
- * synonym for the first: one starts work, the other ends it. */
-export const DROP_LANES: BoardColumn[] = ["in_progress", "archived"];
+// session-keyed rule could not reach. Unarchive needs nothing at all — the same
+// task key, and the record either was there to drop or was not — so an archived
+// card always lifts, including the never-run one and the pure-chat one.
+//
+// There is no DROP_LANES list any more. It said "the lanes a person may drop a
+// card on", which stopped being one list the moment leaving Archive became a
+// move: In Progress is the target of a run AND of an unarchive, and Done is the
+// target of an unarchive and nothing else. Which lanes accept THIS card is
+// `dropLanes`, and it was already the only caller anything had.
 
 /**
  * THE MATRIX ITSELF: where a card in each lane may go. The table above in
  * words, written down once so `dropLanes` reads it instead of reconstructing it.
  *
  * A TABLE AND NOT A PREDICATE, which is the correction (bugbot, PR #613). It
- * was "every unlocked lane may go anywhere in DROP_LANES, subject to a
+ * was "every unlocked lane may go anywhere droppable, subject to a
  * precondition", and that quietly offered Done → In Progress to any done task
  * with something pending — which is not a corner case on this branch, it is the
  * COMMONEST done card there is: a recurring task whose last run finished and
@@ -1346,8 +1379,13 @@ const LANE_EXITS: Record<BoardColumn, BoardColumn[]> = {
   done: ["archived"],
   // Retry, or file it away.
   failed: ["in_progress", "archived"],
-  // Locked: the way back out is activity, not a gesture. See archiveIntent.
-  archived: [],
+  // Out, and out is out: every lane that is not this one, because the move is
+  // UNARCHIVE and the drop target is only where the card was let go. Which of
+  // the four it lands in is derived server-side and is not this list's business
+  // — including In Progress, which accepts the card WITHOUT running anything
+  // (that lane stays locked as a SOURCE, and it is not a destination a person
+  // can assert either; see `laneAction`).
+  archived: ["upcoming", "in_progress", "done", "failed"],
 };
 
 /**
@@ -1653,21 +1691,18 @@ export function taskRunIntent(task: Task): TaskRunIntent | null {
 /**
  * Which lanes this card may be dropped on. Empty ⇒ do not let it lift.
  *
- * `LANE_EXITS` decides where the card MAY go; the loop only drops a move whose
- * precondition is missing. There is one such precondition and it belongs to the
- * run: In Progress needs a pending MESSAGE to fire, not a session to file under
- * (see the note above), so a scheduled task that has never run may be dragged
- * there and a pure-chat task may not. Archive has no precondition — it is one
- * server verb over the task's own key.
+ * ASKED OF `laneAction`, one lane at a time, rather than re-deriving the
+ * preconditions here: a lane is offered exactly when the drop on it has
+ * something to do, so "where may this card go" and "what happens when it lands"
+ * cannot answer differently. Before, this held the run's precondition itself and
+ * dropAction re-checked it through this function — fine while there was one
+ * precondition, and wrong the moment In Progress became the target of two
+ * different moves with different requirements (a run needs a pending message; an
+ * unarchive needs nothing).
  */
 export function dropLanes(task: Task): BoardColumn[] {
   const here = taskColumn(task);
-  const lanes: BoardColumn[] = [];
-  for (const lane of LANE_EXITS[here]) {
-    if (lane === "in_progress" && !canRunNow(task)) continue;
-    lanes.push(lane);
-  }
-  return lanes;
+  return LANE_EXITS[here].filter((lane) => laneAction(task, here, lane) !== null);
 }
 
 export function isDraggable(task: Task): boolean {
@@ -1675,23 +1710,54 @@ export function isDraggable(task: Task): boolean {
 }
 
 /**
- * What a drop on `lane` actually DOES — the one place the two meanings are told
- * apart, so the Board's handler holds no rule of its own beyond which call to
- * make. Null when the drop is illegal, which is the same answer dropLanes gave
- * before the card lifted: the two agree because this asks it.
+ * What a drop on `lane` actually DOES — the one place the three meanings are
+ * told apart, so the Board's handler holds no rule of its own beyond which call
+ * to make. Null when the drop is illegal, which is the same answer dropLanes
+ * gave before the card lifted: the two agree because dropLanes asks this.
  *
- * `archive` carries no payload. It used to be a triage status, composed here
- * and sent to a session-keyed endpoint; it is now one verb over the whole task
- * (`api.archiveTask`, which cancels the work and files the session in one
- * request), and a verb with one meaning has nothing left to parameterise.
+ * `archive` and `unarchive` carry no payload, for the same reason and it is not
+ * an omission. Archiving used to be a triage status composed here and sent to a
+ * session-keyed endpoint; both are now one verb over the whole task
+ * (`api.archiveTask` / `api.unarchiveTask`), and a verb with one meaning has
+ * nothing left to parameterise. `unarchive` in particular does NOT carry the
+ * lane it was dropped on — the server would refuse to honour it, because the
+ * landing lane is derived from the thread and never asserted by a reader.
  */
 export type DropAction =
   | { kind: "run"; entryId: string; messageId: string }
-  | { kind: "archive" };
+  | { kind: "archive" }
+  | { kind: "unarchive" };
 
 export function dropAction(task: Task, lane: BoardColumn): DropAction | null {
-  if (!dropLanes(task).includes(lane)) return null;
+  return laneAction(task, taskColumn(task), lane);
+}
+
+/**
+ * The whole decision, given the lane the card is IN as well as the one it was
+ * dropped on — which is what lets `dropLanes` and `dropAction` be the same rule
+ * read twice instead of two rules that agree by inspection.
+ *
+ * SOURCE FIRST, and that ordering is the unarchive rule: a card leaving Archive
+ * is unfiled whatever it was dropped on, so the target lane is only ever a
+ * legality check (`LANE_EXITS`) and never an argument. In Progress is the case
+ * worth being explicit about — it is a legal DROP for an archived card and it
+ * starts NOTHING. The lane stays locked as a source (a run in flight is Claude's
+ * output and leaves when it ends), and it is equally not something a reader can
+ * put a task into: dropping there unarchives, and the task lands in In Progress
+ * only if a turn genuinely is live.
+ */
+function laneAction(
+  task: Task,
+  here: BoardColumn,
+  lane: BoardColumn,
+): DropAction | null {
+  if (!LANE_EXITS[here].includes(lane)) return null;
+  if (here === "archived") return { kind: "unarchive" };
   if (lane === "archived") return { kind: "archive" };
+  // The one precondition, and it belongs to the run rather than to the lane:
+  // In Progress needs a pending MESSAGE to fire, not a session to file under, so
+  // a scheduled task that has never run may be dragged there and a pure-chat
+  // task with nothing pending may not.
   const m = runNowTarget(task);
   return m ? { kind: "run", entryId: m.entryId, messageId: m.messageId } : null;
 }
@@ -1712,18 +1778,22 @@ export function dropAction(task: Task, lane: BoardColumn): DropAction | null {
 // the same shape of function, and it is defined below the one function it is
 // only a re-reading of.
 //
-// THERE IS NO UNARCHIVE CONTROL, on either view. It used to compute a way back
-// — Archive → In Progress — because an action whose only direction is away is a
-// trap; the row never drew it (SHOW_UNARCHIVE) and the Board did, which is two
-// answers to one question. Archive is a LOCKED lane now (see the matrix above),
-// so there is one answer.
+// THERE IS NO UNARCHIVE BUTTON, on either view — and that is a different
+// statement from "there is no way back", which there now is twice. It used to
+// compute a button — Archive → In Progress — and the row never drew it
+// (SHOW_UNARCHIVE) while the Board did, which is two answers to one question.
+// The button is the part that was wrong, not the direction: it had to be
+// labelled, and every label for it claims something the move does not know
+// ("back in play" says nothing about whether the work is done, and Archive →
+// In Progress asserted a lane a reader has no business asserting).
 //
-// And the way back is not missing, it is somewhere better: ACTIVITY. Say
-// something in that conversation and the task comes back on its own — the
-// server drops the filing when a message arrives after it, so the card rejoins
-// the lane its thread puts it in rather than a lane a button guessed at. A
-// gesture would have had to guess: "back in play" says nothing about whether
-// the work is done.
+// The two ways back both refuse to name a lane, which is why they are fine:
+//
+//   * ACTIVITY. Say something in that conversation and the task comes back on
+//     its own — the server drops the filing when a message arrives after it.
+//   * THE DRAG. Lift the card out of the Archive lane (`dropAction` answers
+//     `unarchive`, whatever lane it was let go over). One server call, no run
+//     started, and the card lands where its thread puts it.
 //
 // Nothing is destroyed either way. The conversation is kept, the transcript is
 // kept (D306), and Archive is a place to read them.

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -1324,10 +1324,12 @@ export function messageEditEntry(m: TaskMessage): string | null {
 // dragging anything. The drag is the same drop of the same record, reached
 // deliberately — so the two cannot disagree.
 //
-// THERE IS STILL NO UNARCHIVE BUTTON, on either view. The drag says what it
-// does — a card leaves a lane — where a button would have to be labelled, and
-// every label for it ("Restore", "Back in play") claims something about the
-// work that this move does not know.
+// AND THERE IS A BUTTON FOR IT TOO, on both views (`filingIntent`) — the drag is
+// the accelerator, not the only route, because the Archive lane starts collapsed
+// and "expand the lane first" is how the archive button came to exist as well.
+// The button is safe to label because the move names no lane: "Unarchive" claims
+// exactly what happens, where the old Archive → In Progress button claimed a
+// verdict on work the reader had not watched.
 //
 // Legality follows from what each move NEEDS, never from what triage happens to
 // be keyed by. Run-now needs a pending MESSAGE, so a scheduled task that has
@@ -1762,46 +1764,61 @@ function laneAction(
   return m ? { kind: "run", entryId: m.entryId, messageId: m.messageId } : null;
 }
 
-// ---- filing it away, without the drag ----------------------------------------
+// ---- filing, without the drag ------------------------------------------------
 // "Can a task be deleted?" — no, and it never will be: a task IS a Claude
 // session and this app does not destroy transcripts (D306). What it can be is
 // ARCHIVED, which is the honest answer to that question — but only while
-// archiving is something a person can actually reach. Until now it was one
-// gesture on one view: drag the card onto the Archive lane, which starts
-// COLLAPSED. "Switch to Board, expand a lane, drag" is not an affordance.
+// archiving is something a person can actually reach. It was once one gesture on
+// one view: drag the card onto the Archive lane, which starts COLLAPSED. "Switch
+// to Board, expand a lane, drag" is not an affordance.
 //
-// So the same move gets a button, and the rule behind it lives here rather than
-// in either component. It is deliberately not a second predicate: the whole
-// decision is asked of dropAction, on the lane the Board's drag would have used,
-// so the button and the drop cannot disagree about who may archive what. That
-// is why this sits after dropAction instead of up beside runNowIntent — it is
-// the same shape of function, and it is defined below the one function it is
-// only a re-reading of.
+// So the move gets a button, and now BOTH directions do (Akshil, 2026-08-19).
+// The rule behind them lives here rather than in either component, and it is
+// deliberately not two predicates: the whole decision is asked of dropAction, on
+// the lanes the Board's drag would have used, so the buttons and the drops cannot
+// disagree about who may file what. That is why this sits after dropAction
+// instead of up beside runNowIntent — it is the same shape of function, and it is
+// defined below the one function it is only a re-reading of.
 //
-// THERE IS NO UNARCHIVE BUTTON, on either view — and that is a different
-// statement from "there is no way back", which there now is twice. It used to
-// compute a button — Archive → In Progress — and the row never drew it
-// (SHOW_UNARCHIVE) while the Board did, which is two answers to one question.
-// The button is the part that was wrong, not the direction: it had to be
-// labelled, and every label for it claims something the move does not know
-// ("back in play" says nothing about whether the work is done, and Archive →
-// In Progress asserted a lane a reader has no business asserting).
+// THE WAY BACK IS A BUTTON AGAIN, and this is the third answer that position has
+// had, so it is worth saying what changed. It was `SHOW_UNARCHIVE` — computed,
+// never drawn by the row, drawn by the Board, which is two answers to one
+// question — and its move was Archive → In Progress: a lane a reader was
+// asserting about work they had not watched. Then it was nothing at all, on the
+// reasoning that any label for it over-claims.
 //
-// The two ways back both refuse to name a lane, which is why they are fine:
+// What was wrong was never the button, it was the DESTINATION. Unarchive names
+// no lane now: the filing is dropped, the server derives the lane from the thread
+// (`api.unarchiveTask`), and the row draws that. So there is a label that claims
+// exactly what happens and no more — "Unarchive" — and the trap the old button
+// was is gone with the lane it used to pick.
 //
-//   * ACTIVITY. Say something in that conversation and the task comes back on
-//     its own — the server drops the filing when a message arrives after it.
-//   * THE DRAG. Lift the card out of the Archive lane (`dropAction` answers
-//     `unarchive`, whatever lane it was let go over). One server call, no run
-//     started, and the card lands where its thread puts it.
+// THE OTHER WAY BACK IS STILL ACTIVITY, and it needs no affordance at all: say
+// something in that conversation and the server drops the filing by itself. The
+// button is for the reader who has nothing to say in there and only wants the
+// card back — which was exactly the person the one-way door stranded.
 //
-// Nothing is destroyed either way. The conversation is kept, the transcript is
-// kept (D306), and Archive is a place to read them.
+// ONE BUTTON PER ROW, and on an archived row it is the ONLY button (see
+// showsRowActions). Nothing is destroyed in either direction: the conversation is
+// kept, the transcript is kept (D306), and Archive is a place to read them.
 
-export interface ArchiveIntent {
-  /** The lane this move puts the card in: the same lane the Board's drop would
-   * have targeted, which is what makes the two agree by construction. */
-  lane: BoardColumn;
+export interface FilingIntent {
+  /** WHICH DIRECTION, and therefore which call the caller makes
+   * (`api.archiveTask` / `api.unarchiveTask`). A row draws one or the other and
+   * never both: a task is either put away or it is not. */
+  kind: "archive" | "unarchive";
+  /**
+   * The lane this move puts the card in, when the move HAS one — the same lane
+   * the Board's drop would have targeted, which is what makes button and drag
+   * agree by construction.
+   *
+   * NULL FOR UNARCHIVE, and that is the model rather than a gap. Coming out of
+   * Archive says "not put away any more" and nothing about what the work is
+   * doing, so the lane is derived server-side from the thread and there is no
+   * lane for this to name. A `BoardColumn` here would be a promise nothing
+   * keeps — the value the old, deleted Archive → In Progress button asserted.
+   */
+  lane: BoardColumn | null;
   /** The button's accessible name, and the word it says. */
   label: string;
   /** The tooltip: what happens, and the thing a person deleting would fear. */
@@ -1809,29 +1826,82 @@ export interface ArchiveIntent {
 }
 
 /**
- * Whether this task can be filed away, and what that says. Null exactly when
- * the Board would refuse the same drop — a task already in Archive, and one
- * that is mid-run — because that is the question this asks.
+ * WHETHER THIS TASK'S FILING CAN BE CHANGED, and in which direction. One
+ * function for both halves, because it is one decision with one answer per row —
+ * two predicates would let a row draw both buttons, or neither, on a status
+ * neither of them had thought about.
  *
- * A never-run task DOES get the button now. Archiving is one verb over a task
+ * BOTH HALVES ARE ASKED OF THE DRAG, on the lanes the drag itself would use, so
+ * the button and the drop cannot disagree about who may file what. That is why
+ * this sits below dropAction: it adds no rule of its own, it only puts words on
+ * the one dropAction already answered.
+ *
+ * Null exactly when the Board would refuse every filing drop, which is the
+ * mid-run row and nothing else now: In Progress is Claude's output and its cards
+ * neither file nor un-file until the run ends.
+ *
+ * A never-run task gets the archive button. Archiving is one verb over a task
  * key (`api.archiveTask`), not a triage write keyed by session id, so the
  * `pending:<entry>` row that had no session to file is filed by cancelling its
  * work — which is what archiving a task that has not run has always meant.
  */
-export function archiveIntent(task: Task): ArchiveIntent | null {
-  const lane: BoardColumn = "archived";
-  // The one question, asked of the one function that already answers it.
-  const action = dropAction(task, lane);
-  if (!action || action.kind !== "archive") return null;
+export function filingIntent(task: Task): FilingIntent | null {
+  // AWAY, on the lane the drag aims at.
+  if (dropAction(task, "archived")?.kind === "archive")
+    return {
+      kind: "archive",
+      lane: "archived",
+      label: "Archive",
+      // Three clauses because a person reaching for Delete is asking all three:
+      // where does it go, what happens to work already booked, and can I get it
+      // back.
+      title:
+        "Archive — files this away and calls off any run still booked; the conversation is kept, and you can bring the task back",
+    };
+  // BACK OUT. Every lane an archived card may be dropped on answers the same
+  // verb, so ANY of them proves the move is available and none of them is the
+  // destination — which is why the intent carries no lane. Asked over dropLanes
+  // rather than by naming a lane here, so a matrix that stops offering one lane
+  // cannot silently take the button with it.
+  const back = dropLanes(task)
+    .map((lane) => dropAction(task, lane))
+    .some((action) => action?.kind === "unarchive");
+  if (!back) return null;
   return {
-    lane,
-    label: "Archive",
-    // Three clauses because a person reaching for Delete is asking all three:
-    // where does it go, what happens to work already booked, and can I get it
-    // back. The last one is the honest answer to a lane with no way out of it.
+    kind: "unarchive",
+    lane: null,
+    label: "Unarchive",
+    // Says the one thing a person cannot see before pressing: the card is about
+    // to appear somewhere they are not looking, and nothing is going to run.
     title:
-      "Archive — files this away and calls off any run still booked; the conversation is kept, and a new message in it brings the task back",
+      "Unarchive — takes this back out of Archive and into whatever lane its work is in; nothing is re-run",
   };
+}
+
+/**
+ * Whether a row draws its ORDINARY actions — run, re-run, mark read.
+ *
+ * OPENING IS NOT ONE OF THEM and is never withheld: Archive is a place to READ
+ * things (D306 — the transcript is kept), so the row link, the ring and the Open
+ * chat control all keep working on an archived task. What this gates is the
+ * controls that act on the WORK.
+ *
+ * False on an archived task, which is the whole of it (Akshil, 2026-08-19: only
+ * the unarchive button on archived rows). A card in Archive has exactly one
+ * decision left against it — whether it is still archived — and every other
+ * control on it is a control for work somebody has already said they are done
+ * with. Offering Re-run beside Unarchive also invites the misread this branch
+ * spent its whole design avoiding: that coming back out of Archive runs
+ * something.
+ *
+ * Not folded into `taskRunIntent` or `markReadIntent`: those two answer "is
+ * there a run to make / is there anything unread", which stays true of an
+ * archived task and is the honest answer for the calendar popover and any other
+ * surface that asks. This is a rule about a ROW's chrome, so it is its own
+ * function and the row asks it.
+ */
+export function showsRowActions(task: Task): boolean {
+  return taskColumn(task) !== "archived";
 }
 
 // ---- clearing a task, without opening it -------------------------------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -611,26 +611,44 @@ button.tasks-caret,
   border-color: var(--border);
 }
 
-/* Archive. Same group, same size, same silence at rest as Edit, Cancel and Run
-   now — and deliberately NEUTRAL under the pointer, not red.
+/* Archive, and Unarchive. Same group, same size, same silence at rest as Edit,
+   Cancel and Run now — and deliberately NEUTRAL under the pointer, not red.
    Filing a task away destroys nothing (a task IS a Claude session and the
    transcript is kept, D306), so borrowing Cancel's red would tell the reader
    this is the destructive one, which is the exact misunderstanding archiving
    exists to correct. The plain `.tasks-act` hover skin already says "this is a
-   control"; that is all this one needs to say. */
+   control"; that is all either of these needs to say.
+
+   ONE SKIN FOR BOTH DIRECTIONS, and not for brevity: the two never appear
+   together (a task is either put away or it is not, so `filingIntent` answers
+   with one direction and the row draws one button), so a hue that told them apart
+   would be a hue with nothing to contrast against. The GLYPH is what says which
+   way this one goes — lucide `archive` against `archive-restore`, the same box
+   closed and open — and it says it in the one place the pointer is already
+   looking. A colour would also have to mean something, and neither direction is
+   destructive or generative enough to earn one. */
 .tasks-act--archive:hover:not(:disabled),
-.prefs-section .tasks-act--archive:hover:not(:disabled) {
+.tasks-act--unarchive:hover:not(:disabled),
+.prefs-section .tasks-act--archive:hover:not(:disabled),
+.prefs-section .tasks-act--unarchive:hover:not(:disabled) {
   color: var(--fg);
   background: var(--bg-alt);
   border-color: var(--border);
 }
 
-/* -- The mark slot: ring at rest, Archive on hover ------------------------------
+/* -- The mark slot: ring at rest, the filing button on hover --------------------
    ONE BOX, TWO OCCUPANTS (2026-08-18). The row's leading mark is the status ring;
-   put a pointer on the row and the Archive button takes its place, in the same
+   put a pointer on the row and the filing button takes its place, in the same
    place. Archive used to live out by the folder chip, at the row's busiest end,
    which made filing a task a control the reader had to travel to — and left the
    quietest, most-scanned position in the row doing nothing while hovered.
+
+   THE BUTTON IS ARCHIVE OR UNARCHIVE, never both and never neither-when-there-is-
+   one (tasks-lib.filingIntent). Which is why every rule below keys on `.tasks-act`
+   inside the slot rather than on one direction's class: the geometry, the hit zone
+   and the handover are facts about the SLOT and its single occupant, and naming a
+   direction in them is how an archived row ended up with a button the ring never
+   moved out of the way for.
 
    NOTHING MOVES. The slot is sized to the ring (`--tasks-rail-w`, the width every
    rail on this page is measured from) and the button is taken OUT OF FLOW inside
@@ -656,12 +674,44 @@ button.tasks-caret,
   flex: 0 0 var(--tasks-rail-w);
 }
 
-.tasks-rowmark .tasks-act--archive,
-.prefs-section .tasks-rowmark .tasks-act--archive {
+.tasks-rowmark .tasks-act,
+.prefs-section .tasks-rowmark .tasks-act {
   position: absolute;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
+}
+
+/* BIGGER TO AIM AT THAN IT LOOKS (Akshil, 2026-08-18). 22px was still a small
+   target for a control the pointer arrives at sideways, travelling in from the
+   row it just hovered — the press missed and opened the conversation instead,
+   which is the one outcome archiving is not.
+
+   Grown by a transparent pseudo-element rather than by padding-and-negative-
+   margin (the caret's trick, `button.tasks-caret`): that pair works because the
+   caret is a FLEX CHILD, where padding grows the box and the margin takes the
+   growth back out of the layout. This button is out of flow and centred by
+   `translate(-50%, -50%)` on its own box, so padding would grow the box the
+   transform is measured from — and, worse, the box the hover skin paints. The
+   fill and border must stay 22px on a 16px ring; only the zone grows.
+
+   THE INSETS ARE WHAT THE ROW ACTUALLY HAS SPARE, not one round number:
+   - left 2px only. The caret's own enlarged zone (same `z-index: 2`, earlier in
+     the DOM, so this would win the overlap and quietly shrink the disclosure
+     gutter) ends half a `--tasks-row-gap` right of its glyph — 2px short of this
+     button's left edge. That 2px is the whole clearance there is.
+   - right 6px, into the gap before the next rail slot, which holds nothing.
+   - 5px top and bottom, well inside the row's own `--tasks-row-pad-y`: growth
+     past the row's edge would cover the NEIGHBOURING row's link.
+
+   `pointer-events` is inherited, so this zone is `none` at rest and `auto` with
+   the reveal exactly like the button it belongs to — an invisible control does
+   not get an invisible hit area either. */
+.tasks-rowmark .tasks-act::after {
+  content: "";
+  position: absolute;
+  inset: -5px -6px -5px -2px;
+  border-radius: 8px;
 }
 
 /* The handover. The ring fades as the button arrives — the same `opacity` swap,
@@ -682,11 +732,15 @@ button.tasks-caret,
   pointer-events: none;
 }
 
-/* Only where there IS a button to hand over to. A row with nothing to file
-   (`archiveIntent` → null, so no button is rendered) must keep its ring under the
-   pointer — the alternative is a blank slot where the row's status was. */
-.tasks-row:hover .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring,
-.tasks-row:focus-within .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring {
+/* Only where there IS a button to hand over to. A row whose filing cannot be
+   changed at all (`filingIntent` → null — a run in flight, and nothing else now,
+   so no button is rendered) must keep its ring under the pointer: the alternative
+   is a blank slot where the row's status was.
+
+   `.tasks-act` and not one direction's class, or the ARCHIVED row would keep its
+   ring painted over the Unarchive button standing in the same 22px. */
+.tasks-row:hover .tasks-rowmark:not(:has(.tasks-act)) .schedule-ring,
+.tasks-row:focus-within .tasks-rowmark:not(:has(.tasks-act)) .schedule-ring {
   opacity: 1;
 }
 

--- a/fused_render/server/routers/claude_sessions.py
+++ b/fused_render/server/routers/claude_sessions.py
@@ -436,12 +436,18 @@ def clear_triage(session_id: str) -> bool:
     """Take the filing back — drop `status` (and its stamp) from one session's
     record, keeping everything else in it. True when there was one to drop.
 
-    The Tasks router calls this when a task that was archived DOES SOMETHING
-    NEW: the way out of Archive is activity, not a gesture (there is no
-    unarchive control anywhere), so a message typed into an archived
-    conversation has to actually un-file it rather than be shown out of its lane
-    for one poll. See `_revived` there for which activity counts and why a run
-    that was already in flight when the filing happened does not.
+    TWO CALLERS in the Tasks router, and they are the two ways out of Archive:
+
+    * a task that was archived DOES SOMETHING NEW — a message typed into an
+      archived conversation has to actually un-file it rather than be shown out
+      of its lane for one poll. See `_revived` there for which activity counts,
+      and why a run already in flight when the filing happened does not.
+    * somebody drags the card out of the Archive lane (`api_task_unarchive`).
+      Which lane they dropped it on says nothing — the task lands wherever it
+      derives to — so that gesture has nothing to pass here either.
+
+    Both are the same one-line change to the same record, which is why it lives
+    here rather than in either caller.
 
     The record itself is NOT deleted — a note, a tag or a read mark on that
     session is somebody else's data and outlives the status the Board put on it.

--- a/fused_render/server/routers/tasks.py
+++ b/fused_render/server/routers/tasks.py
@@ -29,6 +29,9 @@ this file is written around:
 * ``POST /api/tasks/archive`` — file one task away. ONE gesture with two halves
   (cancel the work, archive the session), which is why it is a verb here rather
   than a triage write the client composes. See the archiving section at the end.
+* ``POST /api/tasks/unarchive`` — take that filing back, and nothing else: the
+  work archiving cancelled stays cancelled, no run starts, and the task lands in
+  whatever lane it DERIVES into rather than one a caller names. Same section.
 
 **What a message is.** A user prompt in the transcript, or a scheduled entry.
 Those two overlap: a scheduled message that fired IS a prompt in the transcript
@@ -653,12 +656,15 @@ def _filed_at(record: dict) -> float:
 def _revived(messages: list[dict], filed_at: float) -> bool:
     """Has this task DONE something since it was filed away?
 
-    THE WAY OUT OF ARCHIVE IS ACTIVITY (Akshil, 2026-08-18): "if you want to
-    move it to in progress or done, just type in a message inside that chat and
-    it will automatically move". There is no unarchive control anywhere — the
-    lane is drag-locked and the row draws no button — so this is the only door,
-    and it has to be a real one: the filing is dropped (`clear_triage`), not
-    overlooked for one poll.
+    THE AUTOMATIC WAY OUT OF ARCHIVE IS ACTIVITY (Akshil, 2026-08-18): "if you
+    want to move it to in progress or done, just type in a message inside that
+    chat and it will automatically move". This door has to be a real one: the
+    filing is dropped (`clear_triage`), not overlooked for one poll.
+
+    The other door is the drag — a card lifted out of the Archive lane
+    (`api_task_unarchive`) — and it is the SAME drop of the SAME record, which is
+    why neither has to know about the other. Nothing here changes because a
+    gesture exists: activity still un-files a task nobody dragged.
 
     WHICH ACTIVITY, and the distinction is the whole function. `ran_at` is when
     a message actually happened, so:
@@ -1612,6 +1618,62 @@ def api_task_archive(patch: ArchivePatch):
         sessions.write_triage(session_id, _FILED)
     return {"ok": True, "key": key, "cancelled": cancelled,
             "filed": bool(session_id)}
+
+
+class UnarchivePatch(BaseModel):
+    key: str
+
+
+@router.post("/api/tasks/unarchive")
+def api_task_unarchive(patch: UnarchivePatch):
+    """Take the filing back: drop the archive record, nothing else.
+
+    THE MOVE HAS ONE MEANING AND NO DESTINATION. Dragging a card out of the
+    Archive lane does not say which lane it should land in — the user drops it
+    somewhere because that is how a card leaves a lane, and where it goes is
+    DERIVED (`_status`) exactly as it is for every other task on the board. So
+    this verb takes a key and no status, and the lane the user happened to drop
+    on is not sent, not read and not honoured. `status` in the answer is where
+    the task actually landed, which is the one thing the client cannot work out
+    for itself before its next poll — and it may well not be the lane under the
+    cursor. That is correct: the board shows what the work is doing.
+
+    ONE HALF, unlike archiving's two. Archiving cancels the pending work AND
+    files the session; this only un-files. The cancelled runs stay cancelled —
+    a booked run that came back to life because somebody unarchived a card
+    would be a message firing that nobody asked for twice, and "put this back
+    on the board" is not consent to send it. Ask for the run again (or say
+    something in the conversation) if that is what is wanted.
+
+    NO RUN IS EVER STARTED HERE, which is why the drop onto In Progress is this
+    same call and not a run: In Progress is Claude's output, never a verdict a
+    reader hands down, so a card dropped there simply comes back and lands
+    wherever its thread puts it — Done, Failed or In Progress if a turn really
+    is live.
+
+    `clear_triage` keeps the rest of the record — a note, a tag, a read mark on
+    that session is somebody else's data and outlives the status the Board put
+    on it. Same function the revival rule calls (`_revived`), so the gesture and
+    the automatic way out of Archive drop the filing identically.
+    """
+    key = patch.key.strip()
+    if not key:
+        raise HTTPException(status_code=400, detail="missing task key")
+    task = _collect().get(key)
+    if task is None:
+        raise HTTPException(status_code=404, detail=f"no task with key {key!r}")
+
+    session_id = task["session_id"]
+    unfiled = bool(session_id) and sessions.clear_triage(session_id)
+    # Where it landed, read the same way the listing reads it — one row built
+    # from the same helpers, AFTER the filing is gone, so the answer is the lane
+    # the very next poll will draw rather than a guess about it.
+    _place(task)
+    row = _row(task, "", sessions._load_state("triage.json"),
+               tasks_store.read_state(), time.time(),
+               schedule.busy_sessions(schedule.list_entries()), [])
+    return {"ok": True, "key": key, "unfiled": unfiled,
+            "status": row["status"]}
 
 
 def _rules_behind(entries: list[dict]) -> list[str]:

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -1660,6 +1660,134 @@ def test_archiving_without_a_key_is_a_400(client):
                        json={"key": "  "}).status_code == 400
 
 
+# ------------------------------------------------------------- unarchiving it
+# `POST /api/tasks/unarchive` — the drag out of the Archive lane. ONE half of
+# archiving undone (the filing), no lane named, no run started.
+
+
+def test_unarchiving_drops_the_filing_and_the_task_lands_where_it_derives(
+        client, projects_dir, state_dir):
+    """The whole move. The user drops the card somewhere outside Archive; what
+    that MEANS is "not put away any more", and the lane it lands in is derived
+    from the thread — here `done`, because the one run ended."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "ran", T9, state=schedule.SENT, fired=T9,
+                           turn="ok", claude_session_id="sess-a")])
+    client.post("/api/tasks/archive", json={"key": "sess-a"})
+    assert _by_key(client)["sess-a"]["status"] == "archived"
+
+    r = client.post("/api/tasks/unarchive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"ok": True, "key": "sess-a", "unfiled": True,
+                        "status": "done"}
+    assert "status" not in json.loads(
+        (state_dir / "triage.json").read_text())["sess-a"]
+    assert _by_key(client)["sess-a"]["status"] == "done", "the derived lane is back"
+
+
+def test_unarchiving_reports_the_derived_lane_not_the_one_dropped_on(
+        client, projects_dir):
+    """A failed run derives `failed` however the card was dragged — and the verb
+    takes no lane to be told otherwise with, which is the design."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "broke", T12, state=schedule.SENT, fired=T12,
+                           turn="failed", claude_session_id="sess-a")])
+    client.post("/api/tasks/archive", json={"key": "sess-a"})
+
+    r = client.post("/api/tasks/unarchive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "failed"
+    assert _by_key(client)["sess-a"]["status"] == "failed"
+
+
+def test_unarchiving_keeps_the_note_the_tag_and_the_read_mark(client,
+                                                              projects_dir,
+                                                              state_dir):
+    """`clear_triage` drops the STATUS and its stamp, nothing else: a note, a
+    tag or a read mark on that session is somebody else's data."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    client.post("/api/tasks/archive", json={"key": "sess-a"})
+    triage_path = state_dir / "triage.json"
+    rec = json.loads(triage_path.read_text())
+    rec["sess-a"].update({"note": "keep me", "tags": ["blue"], "read": "1"})
+    triage_path.write_text(json.dumps(rec))
+
+    assert client.post("/api/tasks/unarchive",
+                       json={"key": "sess-a"}).status_code == 200
+    kept = json.loads(triage_path.read_text())["sess-a"]
+    assert kept == {"note": "keep me", "tags": ["blue"], "read": "1"}
+
+
+def test_unarchiving_starts_no_run_and_revives_no_cancelled_work(client,
+                                                                 projects_dir):
+    """The one thing this must never do. Archiving cancelled the run ahead; a
+    booked run that came back to life because somebody put the card back on the
+    board would be a message firing that nobody asked for twice."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([
+        _entry("e1", "ran", T9, state=schedule.SENT, fired=T9, turn="ok",
+               claude_session_id="sess-a"),
+        _entry("e2", "tomorrow", T12, claude_session_id="sess-a"),
+    ])
+    client.post("/api/tasks/archive", json={"key": "sess-a"})
+    before = {e["id"]: dict(e) for e in schedule.list_entries()}
+
+    r = client.post("/api/tasks/unarchive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert {e["id"]: dict(e) for e in schedule.list_entries()} == before, \
+        "the schedule is not touched at all — nothing sent, nothing revived"
+    assert r.json()["status"] == "done", "no pending work, so nothing is Upcoming"
+
+
+def test_unarchiving_a_task_that_was_not_filed_says_so_and_still_answers(
+        client, projects_dir):
+    """A card that reads Archive because its every message was filed away
+    (cancelled) has no triage record to drop. The verb is a no-op rather than an
+    error — and the honest `unfiled: False` is how the client knows the lane it
+    is being told about is not going to change."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "x", T9, state=schedule.CANCELLED,
+                           claude_session_id="sess-a")])
+    r = client.post("/api/tasks/unarchive", json={"key": "sess-a"})
+    assert r.status_code == 200, r.text
+    assert r.json()["unfiled"] is False
+
+
+def test_unarchiving_a_task_with_no_session_only_answers(client, tmp_path):
+    """Nothing to un-file — the row had no session to file in the first place."""
+    _seed_schedule([_entry("e1", "tomorrow", T12, target=str(tmp_path))])
+    key = _tasks(client)[0]["key"]
+    r = client.post("/api/tasks/unarchive", json={"key": key})
+    assert r.status_code == 200, r.text
+    assert r.json()["unfiled"] is False
+    assert r.json()["status"] == "upcoming"
+    assert schedule.list_entries()[0]["state"] == schedule.PENDING
+
+
+def test_unarchiving_a_task_that_is_not_there_is_a_404(client):
+    assert client.post("/api/tasks/unarchive",
+                       json={"key": "nope"}).status_code == 404
+
+
+def test_unarchiving_without_a_key_is_a_400(client):
+    assert client.post("/api/tasks/unarchive",
+                       json={"key": "  "}).status_code == 400
+
+
+def test_unarchiving_takes_no_lane(client, projects_dir):
+    """The lane a card was dropped on is not this verb's business, and a caller
+    that sends one must not be able to steer the answer with it."""
+    _write_transcript(projects_dir, "sess-a", "/p", [_user("hi", T9)])
+    _seed_schedule([_entry("e1", "ran", T9, state=schedule.SENT, fired=T9,
+                           turn="ok", claude_session_id="sess-a")])
+    client.post("/api/tasks/archive", json={"key": "sess-a"})
+    r = client.post("/api/tasks/unarchive",
+                    json={"key": "sess-a", "status": "in_progress",
+                          "lane": "in_progress"})
+    assert r.status_code == 200, r.text
+    assert r.json()["status"] == "done", "derived, not asserted"
+
+
 # ----------------------------------------------------------------- the unread
 
 


### PR DESCRIPTION
## What

A task can come back out of Archive. Two gestures, one meaning, one server verb:

- **Drag** an archived card out of the Archive lane on the board (`/tasks`, board view).
- **Press Unarchive** — hover-revealed, in the same slot the Archive button occupies on live rows (the List's ring-swap slot; the Board card's action strip).

## Semantics

- Both gestures mean **"not put away any more"** and nothing else. The user does **not** pick the destination.
- The filing is dropped and the task lands wherever `_status` **derives** it — which may not be the lane the card was dropped on, or any lane the reader was looking at. That is intended: the board shows what the work is doing. All three gestures say where it went through one helper (`performUnarchive`): `Unarchived — back in Done.`
- **No run is ever triggered.** The work archiving cancelled stays cancelled — a booked message revived because somebody put a card back would be a run nobody asked for twice.
- **In Progress stays locked as a SOURCE**, and is not a state a reader may assert: dropping an archived card there unarchives like any other drop, and the task reads In Progress only if a turn genuinely is live. Documented in `laneAction` and in the endpoint.
- On an archived row the Unarchive button is the **only** action button (`showsRowActions`) — no Run now, no Re-run, no Mark read. Re-run beside Unarchive invites the one misread this whole change is written against. **Opening is not gated**: Archive is a place to read things (D306), so the row link and Open chat keep working.

## Why the button is back, when it was deliberately deleted

`SHOW_UNARCHIVE` moved a card **Archive → In Progress** — a reader asserting a verdict on work they had not watched. It was written, hidden on the row, live on the Board, then removed.

What was wrong was the **destination**, not the button. Unarchive names no lane now: `FilingIntent.lane` is `null` for it, and the endpoint accepts none. So there is a label that claims exactly what happens and no more. The drag alone was not enough either — the Archive lane starts **collapsed**, which draws no cards at all, so "switch to Board, expand the lane, drag" was the same non-affordance that got the Archive button built in the first place.

## Endpoint

`POST /api/tasks/unarchive` — `{key}` → `{ok, key, unfiled, status}`.

Undoes exactly **one** of archiving's two halves. `clear_triage` is the same one-line change the revival rule (`_revived`, #613) already makes, so the gesture and the automatic door cannot disagree; a note, tag or read mark on that session is kept. `status` is the derived landing lane, read by building the one row the listing would have built. No lane is accepted from the caller.

## Matrix and intent

- `LANE_EXITS.archived`: `[]` → `["upcoming", "in_progress", "done", "failed"]`; `DropAction` gains `{kind: "unarchive"}`.
- `dropLanes` now asks a shared `laneAction` per lane instead of re-deriving the run's precondition, because In Progress became the target of two moves with different requirements (a run needs a pending message; an unarchive needs nothing). `DROP_LANES` is removed — "the lanes a person may drop a card on" stopped being one list, and `dropLanes` was its only reader.
- `archiveIntent` → **`filingIntent`**, answering `{kind: "archive" | "unarchive", lane, label, title}`. One function, because "can this task's filing be changed, and which way" is one question with one answer per row — two predicates is how a row ends up drawing both buttons, or neither. Both halves are asked of `dropAction`, so button and drag cannot disagree. Null now means only one thing: a run is in flight.

## Icon and CSS

lucide **`archive-restore`** against `archive` — the same box, opened, with something lifting out. Same lid, same width, so the two sit on each other exactly in the one slot they share. They also share one hover skin: the two never appear together, so a hue telling them apart would contrast with nothing, and neither direction is destructive enough to earn one.

The mark slot's rules re-key from `.tasks-act--archive` to `.tasks-act`. The geometry, the hit zone and the ring handover are facts about the **slot and its single occupant** — naming a direction in them is how the archived row would have got a button the ring never moved out of the way for. The slot contains exactly one `.tasks-act`, so the broader key is safe.

> **Heads-up for `agent/20260818-quick-five`:** the enlarged hit zone below is copied from that branch and re-keyed. Take **this** version on merge — it is the same values, keyed so both directions get the zone.
> ```css
> .tasks-rowmark .tasks-act::after {
>   content: "";
>   position: absolute;
>   inset: -5px -6px -5px -2px;
>   border-radius: 8px;
> }
> ```

## Tests

- **Frontend** — `describe("the unarchive drag")`: same action on every legal lane; **never** produces a run even with something pending (and no lane reads as a run, so the run-outline hint stays off); payload carries only `kind`; Archive is not a destination for an archived card; In Progress still locked as a source; the drop sends no lane. `describe("filingIntent")`: Unarchive names **no** lane; the only null is a run in flight; offered even where there is nothing to un-file server-side; and an agreement check that every lane the drag offers answers the same verb the button makes. `describe("showsRowActions")`: false only on archived, does not gate opening, and does not lie about whether the work exists. Plus the source-reading tests for both views' single branching button and the shared `performUnarchive`.
- **Backend** — 9 cases: filing dropped and derived lane returned; derived lane wins over the drop (`failed`); note/tags/read survive; the schedule is byte-identical afterwards (nothing sent, nothing revived); not-actually-filed and no-session rows answer honestly; 404/400; a caller's `status`/`lane` in the body is ignored.

## Gate

`npm run build` (boundaries + tsc + vite) · `bun test` 1862 pass / 0 fail · `pytest tests/` 8042 pass.

Two unrelated pre-existing failures (`test_ai_metrics.py::test_a_missing_claude_binary_is_counted`, `test_calls.py::test_an_abandoned_merge_closes_the_day_s_files`) fail identically with this diff stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)