### PR TITLE
Tasks: five small fixes — the sidebar dot, Archive's hitbox and its stuck state, the new-task time, and the Done/Failed order

### DIFF
--- a/frontend/src/shell/GlobalSidebar.tsx
+++ b/frontend/src/shell/GlobalSidebar.tsx
@@ -288,11 +288,20 @@ export default function GlobalSidebar({ config }: { config: Config }) {
   const unseen = tasksActive ? 0 : pulse.unseen;
   const tasksTip = pulseTitle(pulse);
 
-  // The collapsed rail has no label to hang a word on, so the whole signal is
-  // one dot in the icon's top-right corner: yellow while anything runs, green
-  // for completions not yet shown, nothing at all otherwise. The hues are the
-  // status ring's own (--status-progress / --status-done, schedule.css) — one
-  // status, one colour, on every surface that names it (design-principles §1).
+  // ONE DOT ON THE ICON, IN BOTH MODES (Akshil, 2026-08-18): yellow while
+  // anything runs, green for completions not yet shown, nothing at all
+  // otherwise. It began as the collapsed rail's whole signal — no label there to
+  // hang a word on — and the expanded row deliberately went without it. That was
+  // wrong in use: the icon is where the eye lands whatever the sidebar's width,
+  // so a mark that shows collapsed and vanishes on expand reads as the STATE
+  // going away rather than the sidebar changing shape. The dot is now the
+  // constant, and expanding ADDS words beside it ("N running" + the count chip)
+  // instead of trading the dot for them.
+  //
+  // Still ONE dot: yellow outranks green — a reader told work is in flight does
+  // not also need sending to the page mid-run. The hues are the status ring's
+  // own (--status-progress / --status-done, schedule.css) — one status, one
+  // colour, on every surface that names it (design-principles §1).
   const tasksDot =
     pulse.running > 0 ? (
       <span className="sidebar-rail-dot is-running" title={tasksTip} />
@@ -300,11 +309,12 @@ export default function GlobalSidebar({ config }: { config: Config }) {
       <span className="sidebar-rail-dot is-unread" title={tasksTip} />
     ) : undefined;
 
-  // Expanded, the same two facts get words: a shimmering "N running" (the ink
-  // moves while the work does, and prefers-reduced-motion pins it), and the
-  // count chip the bookmark folders wear (`.sidebar-count-chip`, sidebar.css) —
-  // the same element for the same kind of fact, not a lookalike. NO DOT here:
-  // a dot on the icon plus a readout beside the label is one fact stated twice.
+  // Expanded, the same two facts ALSO get words, beside the dot rather than
+  // instead of it: a shimmering "N running" (the ink moves while the work does,
+  // and prefers-reduced-motion pins it), and the count chip the bookmark folders
+  // wear (`.sidebar-count-chip`, sidebar.css) — the same element for the same
+  // kind of fact, not a lookalike. The dot says THAT there is something; the
+  // words say how much, and the chip's number is the ungated one (see above).
   const tasksTrailing =
     pulse.running > 0 || pulse.doneUnread > 0 ? (
       <>
@@ -415,6 +425,7 @@ export default function GlobalSidebar({ config }: { config: Config }) {
             label="Tasks"
             icon={SCHEDULED_ICON}
             active={tasksActive}
+            extra={tasksDot}
             trailing={tasksTrailing}
           />
         </div>

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1558,6 +1558,13 @@ export function firstRuleSlot(rule: RecurrenceRule, anchor: Date): Date | null {
   return first;
 }
 
+// Midnight-safe start of the minute `d` falls in, as epoch ms. Field arithmetic
+// rather than `- (seconds * 1000)`, for the reason schedule-lib's day helpers give:
+// a constructed local date cannot be knocked into the wrong hour by a DST edge.
+const startOfMinute = (d: Date) =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
+    .getTime();
+
 // The note the when-row prints, or null for silence. Silence is the answer for
 // a future time, and also for the two repeats with no anchor to catch up FROM:
 // a legacy cron template (`create` computes its first run from now by
@@ -1585,10 +1592,6 @@ export function pastNoteFor(
   const first = firstRuleSlot(rule, picked);
   return first !== null && first.getTime() < cutoff ? PAST_NOTE_CATCH_UP : null;
 }
-
-const startOfMinute = (d: Date) =>
-  new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
-    .getTime();
 
 // ---- The first message ---------------------------------------------------
 // TITLE AND DESCRIPTION ARE ONE MESSAGE (Akshil, 2026-08-18). The card collects

--- a/frontend/src/shell/NewJobModal.tsx
+++ b/frontend/src/shell/NewJobModal.tsx
@@ -1572,14 +1572,23 @@ export function pastNoteFor(
   now: Date,
 ): string | null {
   if (!picked || Number.isNaN(picked.getTime())) return null;
-  if (picked.getTime() > now.getTime()) return null;
+  // COMPARED AT THE FIELD'S OWN PRECISION (2026-08-18). The picker is
+  // minute-precision, so the current minute is not a time that has "passed" — it
+  // is the only way this form can say "now", and it is what the card now opens on.
+  // Comparing against `now` to the millisecond made that default print a warning
+  // about itself for the 59 seconds after the minute turned. Seconds the reader
+  // cannot see cannot be the thing that decides.
+  const cutoff = startOfMinute(now);
+  if (picked.getTime() >= cutoff) return null;
   if (!repeatOn) return PAST_NOTE_ONE_OFF;
   if (!rule) return null;
   const first = firstRuleSlot(rule, picked);
-  return first !== null && first.getTime() <= now.getTime()
-    ? PAST_NOTE_CATCH_UP
-    : null;
+  return first !== null && first.getTime() < cutoff ? PAST_NOTE_CATCH_UP : null;
 }
+
+const startOfMinute = (d: Date) =>
+  new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
+    .getTime();
 
 // ---- The first message ---------------------------------------------------
 // TITLE AND DESCRIPTION ARE ONE MESSAGE (Akshil, 2026-08-18). The card collects
@@ -1907,11 +1916,21 @@ export default function NewJobModal({
   const [target, setTarget] = useState(editing?.target ?? initialTarget ?? "");
   // ONE date-time drives everything: a one-off runs at it, and every derived
   // repeat choice reads its parts (minute, time, weekday) — Google's model.
+  //
+  // THE DEFAULT IS NOW, NOT AN HOUR FROM NOW (Akshil, 2026-08-18). It used to open
+  // on now + 1h, a time nobody had asked for: a task typed into this card is
+  // overwhelmingly one to RUN, so the commonest case was a two-step — wind the
+  // time back, then save. Now is also the value that needs no reading, because it
+  // matches the clock on the wall: a reader who does not care about the when-row
+  // can ignore it, and one who does is editing from the moment they are standing
+  // in rather than undoing an offset. Scheduling for later stays one edit away,
+  // which is what the row is for.
+  //
+  // The field is minute-precision, so this lands on the current minute with the
+  // seconds dropped — and `pastNoteFor` compares at that same precision, so the
+  // form cannot open printing a warning about its own default.
   const [when, setWhen] = useState(() =>
-    toLocalInput(
-      editing?.due ? new Date(editing.due)
-        : (initialTime ?? new Date(Date.now() + 3600_000)),
-    ),
+    toLocalInput(editing?.due ? new Date(editing.due) : (initialTime ?? new Date())),
   );
   // The repeat CHOICE (a key into repeatChoicesFor) plus the one choice that
   // carries its own data: a custom rule from the recurrence dialog. Legacy

--- a/frontend/src/shell/new-task-form.test.ts
+++ b/frontend/src/shell/new-task-form.test.ts
@@ -1337,8 +1337,15 @@ describe("the past-time note", () => {
 
   test("a past one-off says it runs as soon as it can", () => {
     expect(note(TUE, false, null)).toBe(PAST_NOTE_ONE_OFF);
-    // The boundary is inclusive: this instant has passed.
-    expect(note(NOW, false, null)).toBe(PAST_NOTE_ONE_OFF);
+    // THE BOUNDARY IS THE MINUTE, not the millisecond (2026-08-18): the picker has
+    // minute precision, and the current minute is the only way it can say "now" —
+    // which is the value the card now opens on, so this minute is silent...
+    expect(note(NOW, false, null)).toBeNull();
+    expect(
+      note(at("2026-08-19T10:00"), false, null, at("2026-08-19T10:00:45")),
+    ).toBeNull();
+    // ...and the minute before it is not.
+    expect(note(at("2026-08-19T09:59"), false, null)).toBe(PAST_NOTE_ONE_OFF);
   });
 
   test("a past ANCHOR under a ticked Repeat says its own thing instead", () => {
@@ -1445,6 +1452,23 @@ describe("defaultTargetOf", () => {
     expect(
       defaultTargetOf({ home: "C:\\Users\\v", fused_dir: "C:\\Users\\v\\Fused" }),
     ).toBe("C:/Users/v/Fused");
+  });
+});
+
+// ---- the when-row opens on now -------------------------------------------------
+describe("the when-row's default", () => {
+  test("is the current time, not an hour from it", () => {
+    const src = readFileSync(join(import.meta.dir, "NewJobModal.tsx"), "utf8");
+    // A task typed into this card is overwhelmingly one to RUN (Akshil,
+    // 2026-08-18). Opening an hour out made the commonest case a two-step: wind
+    // the time back, then save.
+    expect(src).toContain("initialTime ?? new Date()");
+    expect(src).not.toContain("3600_000");
+    // Anything the CALLER hands in still wins — a deep link that names a time,
+    // and an Edit's stored `due` ahead of both.
+    const init = src.slice(src.indexOf("const [when, setWhen] = useState("));
+    const body = init.slice(0, init.indexOf(");"));
+    expect(body.indexOf("editing?.due")).toBeLessThan(body.indexOf("initialTime"));
   });
 });
 

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -268,11 +268,19 @@ export function assignLanes<T extends { time: Date }>(
 // consistent." Failure used to be a red ring inside Done — a visual with no
 // word — which meant the calendar had to keep its own vocabulary to say what
 // had happened. It says it here instead, once, for every view.
+//
+// FAILED BEFORE DONE, swapped on 2026-08-18 (Akshil, "swap places for failed and
+// done status in list and kanban board"). The board is read left to right, and a
+// lane that wants a person's hands belongs on the near side of one that wants
+// only their eyes: a failed run needs a decision, a done run needs reading. The
+// LIST swapped the other way in the same pass (tasks-lib.LIST_ORDER puts Done
+// above Failed), and that is deliberate — the two views rank the same five facts
+// for two different questions, and neither order is the other's.
 export const BOARD_COLUMNS = [
   { key: "upcoming", label: "Upcoming" },
   { key: "in_progress", label: "In Progress" },
-  { key: "done", label: "Done" },
   { key: "failed", label: "Failed" },
+  { key: "done", label: "Done" },
   { key: "archived", label: "Archive" },
 ] as const;
 

--- a/frontend/src/shell/schedule-lib.ts
+++ b/frontend/src/shell/schedule-lib.ts
@@ -272,10 +272,12 @@ export function assignLanes<T extends { time: Date }>(
 // FAILED BEFORE DONE, swapped on 2026-08-18 (Akshil, "swap places for failed and
 // done status in list and kanban board"). The board is read left to right, and a
 // lane that wants a person's hands belongs on the near side of one that wants
-// only their eyes: a failed run needs a decision, a done run needs reading. The
-// LIST swapped the other way in the same pass (tasks-lib.LIST_ORDER puts Done
-// above Failed), and that is deliberate — the two views rank the same five facts
-// for two different questions, and neither order is the other's.
+// only their eyes: a failed run needs a decision, a done run needs reading.
+//
+// THIS IS THE LIST'S ORDER TOO, and a test holds the two arrays to the same
+// sequence (tasks-lib.LIST_ORDER, whose note carries the argument): a reader
+// moving between the views carries ONE mental picture of where a status sits, so
+// the five facts are ranked here once and the list follows.
 export const BOARD_COLUMNS = [
   { key: "upcoming", label: "Upcoming" },
   { key: "in_progress", label: "In Progress" },

--- a/frontend/src/shell/sidebar-tasks.test.ts
+++ b/frontend/src/shell/sidebar-tasks.test.ts
@@ -297,9 +297,8 @@ describe("one poll behind both readers", () => {
 });
 
 describe("the Tasks entry's two marks", () => {
-  it("draws ONE dot on the collapsed rail, yellow winning over green", () => {
-    // The rail has no label, so the whole signal is a dot on the icon — and it is
-    // one dot: two in a corner is not a state this can draw, and "something is
+  it("draws ONE dot on the icon, yellow winning over green", () => {
+    // One dot: two in a corner is not a state this can draw, and "something is
     // running" is the fact that outranks "something is ready".
     expect(SIDEBAR).toContain("sidebar-rail-dot is-running");
     expect(SIDEBAR).toContain("sidebar-rail-dot is-unread");
@@ -320,13 +319,23 @@ describe("the Tasks entry's two marks", () => {
     expect(dot.slice(0, dot.indexOf("}"))).toContain("position: absolute");
   });
 
-  it("draws NO dot when expanded — words instead, in the same hues", () => {
-    // A dot on the icon plus a readout beside the label is one fact stated twice.
+  it("wears the SAME dot when expanded, and adds words to it", () => {
+    // The dot is the constant across both modes (Akshil, 2026-08-18): the icon is
+    // where the eye lands at either width, so a mark that shows collapsed and
+    // vanishes on expand reads as the state going away. Same node, both slots —
+    // the rail's `badge` and the row's `extra`.
+    expect(SIDEBAR).toContain("badge: tasksDot");
+    expect(SIDEBAR).toContain("extra={tasksDot}");
+    expect(FRAME).toContain("{extra}");
+    // And the glyph's own span anchors it there, or it resolves against the
+    // viewport and drags a scrollbar in with it (account.css).
+    expect(SIDEBAR_CSS).toMatch(/\.sidebar-item \.icon \{[^}]*position: relative/);
+    expect(SIDEBAR_CSS).toContain(".sidebar-item .icon > .sidebar-rail-dot {");
+    // Expanded ADDS words beside the dot rather than trading it for them.
     const trailing = SIDEBAR.slice(
       SIDEBAR.indexOf("const tasksTrailing ="),
       SIDEBAR.indexOf("// Everything that is not primary nav"),
     );
-    expect(trailing).not.toContain("sidebar-rail-dot");
     expect(trailing).toContain("runningLabel(pulse.running)");
     // The chip reads the RAW state — no dismissal, no visit suppression: it says
     // what is waiting to be read until it is read.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -960,8 +960,12 @@ describe("taskColumn", () => {
     for (const col of BOARD_COLUMNS) {
       expect(taskColumn({ ...task(), status: col.key as Task["status"] })).toBe(col.key);
     }
+    // Lane order, left to right. Failed sits BEFORE Done (Akshil, 2026-08-18): a
+    // lane that wants a person's hands comes before one that wants only their
+    // eyes. The List ranks the pair the other way round on purpose — see
+    // LIST_ORDER's own test.
     expect(BOARD_COLUMNS.map((c) => c.key)).toEqual([
-      "upcoming", "in_progress", "done", "failed", "archived",
+      "upcoming", "in_progress", "failed", "done", "archived",
     ]);
   });
 });
@@ -5771,13 +5775,18 @@ describe("the tasks toolbar", () => {
 
 describe("sortByLane", () => {
   it("names every lane exactly once, in the list's order", () => {
+    // Done above Failed (Akshil, 2026-08-18) — the reader comes to this list for
+    // the output waiting to be read, and a failure is something to come back to
+    // rather than the first thing in the way of everything else. The BOARD swapped
+    // the pair the other way in the same pass; the two views are not one order.
     expect(LIST_ORDER).toEqual([
       "upcoming",
       "in_progress",
-      "failed",
       "done",
+      "failed",
       "archived",
     ]);
+    expect(LIST_ORDER).not.toEqual(BOARD_COLUMNS.map((c) => c.key));
     // Same set as the Board's — a sixth lane cannot be silently unsortable.
     expect([...LIST_ORDER].sort()).toEqual(
       BOARD_COLUMNS.map((c) => c.key).slice().sort(),
@@ -5787,15 +5796,15 @@ describe("sortByLane", () => {
   it("returns ONE flat list, not groups", () => {
     const rows = [
       task({ key: "d", status: "archived" }),
-      task({ key: "c", status: "done" }),
-      task({ key: "b", status: FAILED }),
+      task({ key: "c", status: FAILED }),
+      task({ key: "b", status: "done" }),
       task({ key: "a", status: "upcoming" }),
     ];
     expect(sortByLane(rows).map((t) => t.key)).toEqual(["a", "b", "c", "d"]);
     expect(sortByLane([])).toEqual([]);
   });
 
-  it("puts Failed above Done and Archive last, whatever the input order", () => {
+  it("puts Done above Failed and Archive last, whatever the input order", () => {
     const rows = [
       task({ key: "done", status: "done" }),
       task({ key: "arch", status: "archived" }),
@@ -5804,7 +5813,7 @@ describe("sortByLane", () => {
       task({ key: "soon", status: "upcoming" }),
     ];
     expect(sortByLane(rows).map((t) => t.key))
-      .toEqual(["soon", "run", "fail", "done", "arch"]);
+      .toEqual(["soon", "run", "done", "fail", "arch"]);
   });
 
   it("keeps the server's order inside a rank, and never re-sorts", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -962,8 +962,8 @@ describe("taskColumn", () => {
     }
     // Lane order, left to right. Failed sits BEFORE Done (Akshil, 2026-08-18): a
     // lane that wants a person's hands comes before one that wants only their
-    // eyes. The List ranks the pair the other way round on purpose — see
-    // LIST_ORDER's own test.
+    // eyes. The List reads the SAME sequence — LIST_ORDER's own test holds the two
+    // arrays equal.
     expect(BOARD_COLUMNS.map((c) => c.key)).toEqual([
       "upcoming", "in_progress", "failed", "done", "archived",
     ]);
@@ -5788,19 +5788,26 @@ describe("the tasks toolbar", () => {
 
 describe("sortByLane", () => {
   it("names every lane exactly once, in the list's order", () => {
-    // Done above Failed (Akshil, 2026-08-18) — the reader comes to this list for
-    // the output waiting to be read, and a failure is something to come back to
-    // rather than the first thing in the way of everything else. The BOARD swapped
-    // the pair the other way in the same pass; the two views are not one order.
     expect(LIST_ORDER).toEqual([
       "upcoming",
       "in_progress",
-      "done",
       "failed",
+      "done",
       "archived",
     ]);
-    expect(LIST_ORDER).not.toEqual(BOARD_COLUMNS.map((c) => c.key));
-    // Same set as the Board's — a sixth lane cannot be silently unsortable.
+    // ONE ORDER FOR BOTH VIEWS (Akshil, 2026-08-18, the final ruling). The two
+    // briefly disagreed about Failed and Done — the List ranking work owed, the
+    // Board running a pipeline — and a reader moving between them carries one
+    // mental picture of where a status sits, so the disagreement was wrong in
+    // whichever view they were not looking at. The SEQUENCE is asserted identical,
+    // not merely the same set: that is what a drift would break.
+    expect(LIST_ORDER).toEqual(BOARD_COLUMNS.map((c) => c.key));
+    // And Failed is the one before Done in both — the pair this pass was about.
+    const failedFirst = (keys: readonly string[]) =>
+      keys.indexOf("failed") < keys.indexOf("done");
+    expect(failedFirst(LIST_ORDER)).toBe(true);
+    expect(failedFirst(BOARD_COLUMNS.map((c) => c.key))).toBe(true);
+    // Same set, so a sixth lane cannot be silently unsortable.
     expect([...LIST_ORDER].sort()).toEqual(
       BOARD_COLUMNS.map((c) => c.key).slice().sort(),
     );
@@ -5809,15 +5816,15 @@ describe("sortByLane", () => {
   it("returns ONE flat list, not groups", () => {
     const rows = [
       task({ key: "d", status: "archived" }),
-      task({ key: "c", status: FAILED }),
-      task({ key: "b", status: "done" }),
+      task({ key: "c", status: "done" }),
+      task({ key: "b", status: FAILED }),
       task({ key: "a", status: "upcoming" }),
     ];
     expect(sortByLane(rows).map((t) => t.key)).toEqual(["a", "b", "c", "d"]);
     expect(sortByLane([])).toEqual([]);
   });
 
-  it("puts Done above Failed and Archive last, whatever the input order", () => {
+  it("puts Failed above Done and Archive last, whatever the input order", () => {
     const rows = [
       task({ key: "done", status: "done" }),
       task({ key: "arch", status: "archived" }),
@@ -5826,7 +5833,7 @@ describe("sortByLane", () => {
       task({ key: "soon", status: "upcoming" }),
     ];
     expect(sortByLane(rows).map((t) => t.key))
-      .toEqual(["soon", "run", "done", "fail", "arch"]);
+      .toEqual(["soon", "run", "fail", "done", "arch"]);
   });
 
   it("keeps the server's order inside a rank, and never re-sorts", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3539,16 +3539,29 @@ describe("the archive action", () => {
     // paints.
     const zone = block(TASKS_CSS, ".tasks-rowmark .tasks-act--archive::after");
     expect(zone).toContain("position: absolute");
-    expect(zone).toMatch(/inset: -\d+px/);
     // The painted box is untouched — still the 22px every `.tasks-act` is.
     const button = block(TASKS_CSS, ".tasks-rowmark .tasks-act--archive");
     expect(button).not.toContain("padding");
     expect(button).not.toContain("width");
-    // And the growth stops short of the chevron's own enlarged gutter, which sits at
-    // the same `z-index: 2` earlier in the DOM and would lose the overlap: the left
-    // inset is the smallest of the four on purpose.
+
+    // THE VERTICAL REACH IS DERIVED, NOT TYPED (2026-08-18, second pass — the
+    // first zone was still too small to feel). It is the row's full height to the
+    // pixel: the button overhangs its slot by (22px - rail) / 2, so the room left
+    // before the row's edge is one `--tasks-row-pad-y` less that overhang. A typed
+    // number would not follow the row's padding, and growth PAST the row's edge is
+    // this button covering the NEIGHBOURING row's link.
+    expect(zone).toContain("(22px - var(--tasks-rail-w)) / 2 - var(--tasks-row-pad-y)");
     const insets = (zone.match(/inset: ([^;]+);/) ?? ["", ""])[1].trim().split(/\s+/);
     expect(insets).toHaveLength(4);
+    // Top and bottom are the same derived reach...
+    expect(insets[0]).toBe(insets[2]);
+    expect(insets[0]).toBe("var(--tasks-archive-reach-y)");
+    // ...the right takes the whole gap before the next rail slot, which is empty...
+    expect(insets[1]).toBe("-10px");
+    // ...and the LEFT is the smallest of the four on purpose: the chevron's own
+    // enlarged zone sits at the same `z-index: 2` earlier in the DOM, so growing
+    // over it would win the overlap and quietly shrink the disclosure gutter.
+    expect(insets[3]).toBe("-2px");
     const px = (v: string) => Math.abs(parseFloat(v));
     expect(px(insets[3])).toBeLessThan(px(insets[1]));
   });

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3513,6 +3513,28 @@ describe("the archive action", () => {
     );
   });
 
+  it("is bigger to aim at than it is to look at", () => {
+    // 22px was a small target for a control the pointer arrives at sideways, so the
+    // ZONE grows and the SKIN does not (Akshil, 2026-08-18). A pseudo-element and
+    // not padding: the button is out of flow and centred by a transform on its own
+    // box, so padding would move the centre and, worse, grow the box the hover fill
+    // paints.
+    const zone = block(TASKS_CSS, ".tasks-rowmark .tasks-act--archive::after");
+    expect(zone).toContain("position: absolute");
+    expect(zone).toMatch(/inset: -\d+px/);
+    // The painted box is untouched — still the 22px every `.tasks-act` is.
+    const button = block(TASKS_CSS, ".tasks-rowmark .tasks-act--archive");
+    expect(button).not.toContain("padding");
+    expect(button).not.toContain("width");
+    // And the growth stops short of the chevron's own enlarged gutter, which sits at
+    // the same `z-index: 2` earlier in the DOM and would lose the overlap: the left
+    // inset is the smallest of the four on purpose.
+    const insets = (zone.match(/inset: ([^;]+);/) ?? ["", ""])[1].trim().split(/\s+/);
+    expect(insets).toHaveLength(4);
+    const px = (v: string) => Math.abs(parseFloat(v));
+    expect(px(insets[3])).toBeLessThan(px(insets[1]));
+  });
+
   it("leaves the board card's archive exactly where it was", () => {
     // The swap is the LIST's, and only the List's. A card's ring is not in a rail
     // and its head has an empty right end the strip was measured against

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3397,10 +3397,20 @@ describe("the archive action", () => {
     expect(TASKS_CSS.slice(head, TASKS_CSS.indexOf("}", head))).toContain("opacity: 0;");
     // ...and both a pointer and a keyboard bring it back, on the row...
     expect(TASKS_CSS).toContain(".tasks-row:hover .tasks-act");
-    expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-act");
+    expect(TASKS_CSS).toContain(".tasks-row:has(.tasks-act:focus-visible) .tasks-act");
     // ...and on a board card, which is not a row and needs its own pair.
     expect(TASKS_CSS).toContain(".tasks-card-wrap:hover .tasks-card-act");
-    expect(TASKS_CSS).toContain(".tasks-card-wrap:focus-within .tasks-card-act");
+    expect(TASKS_CSS).toContain(
+      ".tasks-card-wrap:has(.tasks-card-act:focus-visible) .tasks-card-act",
+    );
+    // AND NEVER `:focus-within` ON THE CONTAINER (Akshil, 2026-08-18 — the stuck
+    // Archive). A row contains the chevron and the stretched rowlink, and a card
+    // wrap contains the card, all of them focusable by a plain click: `:focus-within`
+    // kept the reveal alive on a row the pointer had already left. Mouse-out must
+    // undo mouse-in.
+    expect(TASKS_CSS).not.toContain(":focus-within .tasks-act");
+    expect(TASKS_CSS).not.toContain(":focus-within .tasks-card-act");
+    expect(TASKS_CSS).not.toContain(":focus-within .tasks-rowmark");
     // Reachable with a visible ring either way.
     expect(TASKS_CSS).toContain(".tasks-act:focus-visible");
     // House rule: never the property that animates layout and skin together.
@@ -3486,10 +3496,14 @@ describe("the archive action", () => {
     );
     expect(fade).toContain("opacity: 0");
     expect(fade).toContain("pointer-events: none");
-    // Keyboard reachability is why `:focus-within` is in the trigger list — a tab
-    // onto the button reveals it, and the ring in front of it must get out of the
-    // way (the same rule the strip has always obeyed).
-    expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-rowmark .schedule-ring");
+    // Keyboard reachability is why there is a second arm — a tab onto the button
+    // reveals it, and the ring in front of it must get out of the way (the same rule
+    // the strip has always obeyed). It asks for THAT BUTTON's `:focus-visible`, not
+    // the row's `:focus-within`, or a chevron click would fade the ring of a row
+    // nobody is pointing at any more.
+    expect(TASKS_CSS).toContain(
+      ".tasks-row .tasks-rowmark:has(.tasks-act--archive:focus-visible) .schedule-ring",
+    );
     expect(TASKS_CSS).toContain(".tasks-act:focus-visible");
     // A row with nothing to file keeps its ring under the pointer: a blank slot
     // where the row's status was is worse than no swap at all.
@@ -3749,7 +3763,7 @@ describe("the hidden row actions", () => {
     // The reveal rules are untouched — they are what the actions come back to, and
     // the stylesheet says so rather than being tidied away.
     expect(TASKS_CSS).toContain(".tasks-msg:hover .tasks-act");
-    expect(TASKS_CSS).toContain(".tasks-row:focus-within .tasks-act");
+    expect(TASKS_CSS).toContain(".tasks-row:has(.tasks-act:focus-visible) .tasks-act");
     // Edit and Cancel are still WRITTEN, just not rendered: the user's second pass
     // covered them too ("hide the hover actions for now, that's what I said", said
     // of the pencil on a message row), so they are behind the same flag.

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -3544,26 +3544,29 @@ describe("the archive action", () => {
     expect(button).not.toContain("padding");
     expect(button).not.toContain("width");
 
-    // THE VERTICAL REACH IS DERIVED, NOT TYPED (2026-08-18, second pass — the
-    // first zone was still too small to feel). It is the row's full height to the
-    // pixel: the button overhangs its slot by (22px - rail) / 2, so the room left
-    // before the row's edge is one `--tasks-row-pad-y` less that overhang. A typed
-    // number would not follow the row's padding, and growth PAST the row's edge is
-    // this button covering the NEIGHBOURING row's link.
-    expect(zone).toContain("(22px - var(--tasks-rail-w)) / 2 - var(--tasks-row-pad-y)");
-    const insets = (zone.match(/inset: ([^;]+);/) ?? ["", ""])[1].trim().split(/\s+/);
+    // EVERY INSET IS DERIVED, NOT TYPED, and the reason is a bug a typed number
+    // caused: a `-10px` right reach lapped 3px OVER the id chip, so a press aimed
+    // at the id fired Archive (Bugbot, MEDIUM, 2026-08-18). The button already
+    // hangs `--tasks-archive-overhang` past its 16px slot before it grows at all,
+    // so the free space on a side is that side's spacing token LESS the overhang —
+    // and a typed number is the same mistake waiting for the next retune.
+    expect(zone).toContain("--tasks-archive-overhang: calc((22px - var(--tasks-rail-w)) / 2)");
+    expect(zone).toContain("var(--tasks-archive-overhang) - var(--tasks-row-pad-y)");
+    expect(zone).toContain("var(--tasks-archive-overhang) - var(--tasks-row-gap)");
+    // No literal length survives in the inset itself.
+    const insets = (zone.match(/inset: ([^;]+);/s) ?? ["", ""])[1].trim().split(/\s+/);
     expect(insets).toHaveLength(4);
-    // Top and bottom are the same derived reach...
-    expect(insets[0]).toBe(insets[2]);
+    expect(insets.join(" ")).not.toMatch(/-?\d+px/);
+    // Top and bottom are the one vertical reach — the row's full height, never past
+    // it, or this button covers the NEIGHBOURING row's link.
     expect(insets[0]).toBe("var(--tasks-archive-reach-y)");
-    // ...the right takes the whole gap before the next rail slot, which is empty...
-    expect(insets[1]).toBe("-10px");
-    // ...and the LEFT is the smallest of the four on purpose: the chevron's own
-    // enlarged zone sits at the same `z-index: 2` earlier in the DOM, so growing
-    // over it would win the overlap and quietly shrink the disclosure gutter.
-    expect(insets[3]).toBe("-2px");
-    const px = (v: string) => Math.abs(parseFloat(v));
-    expect(px(insets[3])).toBeLessThan(px(insets[1]));
+    expect(insets[2]).toBe("var(--tasks-archive-reach-y)");
+    // Right stops on the id chip's edge; left stops on the caret's enlarged zone,
+    // which sits at the same `z-index: 2` earlier in the DOM and would lose the
+    // overlap. Left is half a gap shorter than right, which is what keeps them apart.
+    expect(insets[1]).toBe("var(--tasks-archive-reach-r)");
+    expect(insets[3]).toBe("var(--tasks-archive-reach-l)");
+    expect(zone).toContain("var(--tasks-archive-reach-r) + var(--tasks-row-gap) / 2");
   });
 
   it("leaves the board card's archive exactly where it was", () => {

--- a/frontend/src/shell/tasks-lib.test.ts
+++ b/frontend/src/shell/tasks-lib.test.ts
@@ -5801,12 +5801,10 @@ describe("sortByLane", () => {
     // mental picture of where a status sits, so the disagreement was wrong in
     // whichever view they were not looking at. The SEQUENCE is asserted identical,
     // not merely the same set: that is what a drift would break.
+    // The literal above already pins Failed before Done, so this equality is the
+    // whole of the second view's order too — no separate per-array check, which
+    // would only be able to fail if this line had already failed.
     expect(LIST_ORDER).toEqual(BOARD_COLUMNS.map((c) => c.key));
-    // And Failed is the one before Done in both — the pair this pass was about.
-    const failedFirst = (keys: readonly string[]) =>
-      keys.indexOf("failed") < keys.indexOf("done");
-    expect(failedFirst(LIST_ORDER)).toBe(true);
-    expect(failedFirst(BOARD_COLUMNS.map((c) => c.key))).toBe(true);
     // Same set, so a sixth lane cannot be silently unsortable.
     expect([...LIST_ORDER].sort()).toEqual(
       BOARD_COLUMNS.map((c) => c.key).slice().sort(),

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2444,18 +2444,24 @@ export function laneRolledUp(
 // navigable; grouping you can only feel is a claim about priority, which is what
 // this actually is.
 //
-// THE ORDER IS NOT THE BOARD'S, and that difference stays. A board is read left
-// to right as a pipeline; a list is read top to bottom as work owed. The two
-// SWAPPED Done and Failed on 2026-08-18 (Akshil, "swap places for failed and
-// done status in list and kanban board") — each away from what it had, so the
-// difference between the views survived the change:
+// THE ORDER IS THE BOARD'S — the same five words in the same sequence (Akshil,
+// 2026-08-18, the final ruling on "swap places for failed and done status in list
+// and kanban board"):
 //
-//   Upcoming → In Progress → Done → Failed → Archive
+//   Upcoming → In Progress → Failed → Done → Archive
 //
-// Done above Failed here: what a reader comes to this list for is the output
-// waiting to be read, and a failure is a thing to come back to rather than the
-// first thing in the way of everything else. Archive stays last either way —
-// it is not a status, it is where things go to stop being read.
+// It briefly was not, and the reason it is now is worth keeping. The List ranked
+// "work owed" and the Board ran a pipeline, and each argument was sound on its
+// own — but a reader moving between the two views carries ONE mental picture of
+// where a status sits, so two orders means that picture is wrong in whichever
+// view they are not looking at. One sequence for one set of statuses
+// (design-principles §1). The BOARD is the view that moved; this list kept the
+// rank it always had. Failed before Done in both: a failed run wants a person's
+// hands, a done one wants only their eyes. Archive is last in both — it is not a
+// status, it is where things go to stop being read.
+//
+// The test holds this array and BOARD_COLUMNS to the same sequence, so the two
+// cannot quietly drift apart again.
 //
 // WITHIN a rank nothing is re-sorted: the server's order is the list's order and
 // always has been (TaskList takes `tasks` "in the SERVER's order"). A stable
@@ -2469,8 +2475,8 @@ export function laneRolledUp(
 export const LIST_ORDER: BoardColumn[] = [
   "upcoming",
   "in_progress",
-  "done",
   "failed",
+  "done",
   "archived",
 ];
 

--- a/frontend/src/shell/tasks-lib.ts
+++ b/frontend/src/shell/tasks-lib.ts
@@ -2445,14 +2445,17 @@ export function laneRolledUp(
 // this actually is.
 //
 // THE ORDER IS NOT THE BOARD'S, and that difference stays. A board is read left
-// to right as a pipeline (Upcoming, In Progress, Done, Failed, Archive); a list
-// is read top to bottom as work owed, so the ranks that want a person's hands
-// come first and the settled ones sink:
+// to right as a pipeline; a list is read top to bottom as work owed. The two
+// SWAPPED Done and Failed on 2026-08-18 (Akshil, "swap places for failed and
+// done status in list and kanban board") — each away from what it had, so the
+// difference between the views survived the change:
 //
-//   Upcoming → In Progress → Failed → Done → Archive
+//   Upcoming → In Progress → Done → Failed → Archive
 //
-// Failed above Done because a broken run is still owed, and Done above Archive
-// because Archive is not a status, it is where things go to stop being read.
+// Done above Failed here: what a reader comes to this list for is the output
+// waiting to be read, and a failure is a thing to come back to rather than the
+// first thing in the way of everything else. Archive stays last either way —
+// it is not a status, it is where things go to stop being read.
 //
 // WITHIN a rank nothing is re-sorted: the server's order is the list's order and
 // always has been (TaskList takes `tasks` "in the SERVER's order"). A stable
@@ -2466,8 +2469,8 @@ export function laneRolledUp(
 export const LIST_ORDER: BoardColumn[] = [
   "upcoming",
   "in_progress",
-  "failed",
   "done",
+  "failed",
   "archived",
 ];
 

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -254,6 +254,15 @@ a.sidebar-rail-btn {
 
 .sidebar-item .icon {
   opacity: 0.85;
+  /* Anchors a dot the row wears ON its glyph (NavItem's `extra` — the Tasks
+     pulse dot). Without a positioned ancestor an absolutely-placed dot resolves
+     against the viewport and overflows the page by its own offset, which costs a
+     scrollbar in each axis — the bug account.css records for the Settings dot,
+     and the same reason .sidebar-rail-btn is relative. `inline-flex` so the span
+     is the glyph's own box: as an inline box its line-height would sit the
+     bottom edge below the svg and drop the dot off-centre. */
+  position: relative;
+  display: inline-flex;
 }
 
 /* -- The trailing slot on a nav row -------------------------------------------
@@ -388,16 +397,19 @@ a.sidebar-rail-btn {
   }
 }
 
-/* -- The collapsed rail's dot --------------------------------------------------
-   The rail has no label, so the entry's whole signal is one 7px dot in the
-   icon's top-right corner. Same shape as the Settings row's resident-model dot
-   (.account-signedin-dot, account.css) — a dot on a nav icon means "there is
-   something behind this" everywhere in this sidebar — and the same border-hole
-   trick, so the mark reads as sitting ON the glyph rather than merging with it.
+/* -- The Tasks entry's dot -----------------------------------------------------
+   One 7px dot in the icon's top-right corner, worn in BOTH sidebar modes (the
+   class keeps its `rail` name because that is where it started). Same shape as
+   the Settings row's resident-model dot (.account-signedin-dot, account.css) —
+   a dot on a nav icon means "there is something behind this" everywhere in this
+   sidebar — and the same border-hole trick, so the mark reads as sitting ON the
+   glyph rather than merging with it.
 
-   Positioned against the 28px button, not the 16px glyph: the icon has no box
-   of its own here (the rail renders the owner's svg directly), and 5px in from
-   the button's corner IS the glyph's corner. */
+   The offsets below are the RAIL's: positioned against the 28px button, not the
+   16px glyph, because the icon has no box of its own there (the rail renders the
+   owner's svg directly) and 4px in from the button's corner IS the glyph's
+   corner. The expanded row, whose .icon span IS the glyph's box, re-places it
+   just below. */
 .sidebar-rail-btn {
   position: relative;
 }
@@ -411,6 +423,15 @@ a.sidebar-rail-btn {
   border-radius: 50%;
   border: 1px solid var(--bg);
   box-sizing: content-box;
+}
+
+/* On the expanded row the anchor is the glyph itself, so the same dot needs the
+   Settings dot's offsets — hanging just off the top-right corner rather than
+   inset from a button that is not there. */
+.sidebar-item .icon > .sidebar-rail-dot {
+  top: -2px;
+  right: -3px;
+  border-color: var(--bg-alt);
 }
 
 /* The two states, in the status ring's own hues (schedule.css): yellow while

--- a/frontend/src/styles/sidebar.css
+++ b/frontend/src/styles/sidebar.css
@@ -258,11 +258,13 @@ a.sidebar-rail-btn {
      pulse dot). Without a positioned ancestor an absolutely-placed dot resolves
      against the viewport and overflows the page by its own offset, which costs a
      scrollbar in each axis — the bug account.css records for the Settings dot,
-     and the same reason .sidebar-rail-btn is relative. `inline-flex` so the span
-     is the glyph's own box: as an inline box its line-height would sit the
-     bottom edge below the svg and drop the dot off-centre. */
+     and the same reason .sidebar-rail-btn is relative.
+
+     POSITION ONLY — no `display` alongside it. `.sidebar-item` is a flex
+     container, so this span is a flex item and already blockified: its box is the
+     16px glyph exactly (measured — the span and the svg share one rect), which is
+     what the dot's -2px/-3px corner offsets are measured from. */
   position: relative;
-  display: inline-flex;
 }
 
 /* -- The trailing slot on a nav row -------------------------------------------

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -694,14 +694,26 @@ button.tasks-caret,
    transform is measured from — and, worse, the box the hover skin paints. The
    fill and border must stay 22px on a 16px ring; only the zone grows.
 
-   THE INSETS ARE WHAT THE ROW ACTUALLY HAS SPARE, not one round number:
-   - left 2px only. The caret's own enlarged zone (same `z-index: 2`, earlier in
-     the DOM, so this would win the overlap and quietly shrink the disclosure
-     gutter) ends half a `--tasks-row-gap` right of its glyph — 2px short of this
-     button's left edge. That 2px is the whole clearance there is.
-   - right 6px, into the gap before the next rail slot, which holds nothing.
-   - 5px top and bottom, well inside the row's own `--tasks-row-pad-y`: growth
-     past the row's edge would cover the NEIGHBOURING row's link.
+   THE INSETS ARE WHAT THE ROW ACTUALLY HAS SPARE, not one round number, and each
+   one is at its ceiling (grown again on 2026-08-18 — the first pass at this was
+   still too small to feel):
+   - TOP AND BOTTOM: the row's full height, to the pixel, and derived so it stays
+     that way. The button overhangs its 16px slot by (22px - `--tasks-rail-w`) / 2
+     = 3px, so what is left before the row's own edge is one
+     `--tasks-row-pad-y` less that overhang: 7px at today's 10px padding, for a
+     zone exactly as tall as the 36px row. Written as the calc and not as `-7px`
+     because a row that breathes differently must move this with it — growth PAST
+     the row's edge would put this button over the NEIGHBOURING row's link, which
+     is how one row's Archive ends up pressed from another row.
+   - RIGHT 10px: the whole gap before the next rail slot, which holds nothing.
+   - LEFT 2px only, and this one is small because the space is not ours. The
+     caret's own enlarged zone (same `z-index: 2`, earlier in the DOM, so this
+     would win the overlap and quietly shrink the disclosure gutter) ends half a
+     `--tasks-row-gap` right of its glyph — 2px short of this button's left edge.
+     That 2px is the whole clearance there is.
+
+   So: a 36 x 34 target for a 22px button, and the pointer arrives from the right
+   (the row it was reading) where the room is.
 
    `pointer-events` is inherited, so this zone is `none` at rest and `auto` with
    the reveal exactly like the button it belongs to — an invisible control does
@@ -709,7 +721,10 @@ button.tasks-caret,
 .tasks-rowmark .tasks-act--archive::after {
   content: "";
   position: absolute;
-  inset: -5px -6px -5px -2px;
+  --tasks-archive-reach-y: calc(
+    (22px - var(--tasks-rail-w)) / 2 - var(--tasks-row-pad-y)
+  );
+  inset: var(--tasks-archive-reach-y) -10px var(--tasks-archive-reach-y) -2px;
   border-radius: 8px;
 }
 

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -694,26 +694,30 @@ button.tasks-caret,
    transform is measured from — and, worse, the box the hover skin paints. The
    fill and border must stay 22px on a 16px ring; only the zone grows.
 
-   THE INSETS ARE WHAT THE ROW ACTUALLY HAS SPARE, not one round number, and each
-   one is at its ceiling (grown again on 2026-08-18 — the first pass at this was
-   still too small to feel):
-   - TOP AND BOTTOM: the row's full height, to the pixel, and derived so it stays
-     that way. The button overhangs its 16px slot by (22px - `--tasks-rail-w`) / 2
-     = 3px, so what is left before the row's own edge is one
-     `--tasks-row-pad-y` less that overhang: 7px at today's 10px padding, for a
-     zone exactly as tall as the 36px row. Written as the calc and not as `-7px`
-     because a row that breathes differently must move this with it — growth PAST
-     the row's edge would put this button over the NEIGHBOURING row's link, which
-     is how one row's Archive ends up pressed from another row.
-   - RIGHT 10px: the whole gap before the next rail slot, which holds nothing.
-   - LEFT 2px only, and this one is small because the space is not ours. The
-     caret's own enlarged zone (same `z-index: 2`, earlier in the DOM, so this
-     would win the overlap and quietly shrink the disclosure gutter) ends half a
-     `--tasks-row-gap` right of its glyph — 2px short of this button's left edge.
-     That 2px is the whole clearance there is.
+   EVERY INSET IS THE FREE SPACE ON THAT SIDE, DERIVED — no typed numbers, and
+   none of the four crosses into anything (grown on 2026-08-18, then corrected the
+   same day: a `-10px` right reach was 3px INTO the id chip, Bugbot, MEDIUM).
 
-   So: a 36 x 34 target for a 22px button, and the pointer arrives from the right
-   (the row it was reading) where the room is.
+   THE OVERHANG IS WHY A TYPED NUMBER GETS THIS WRONG. The button is 22px over a
+   16px slot, so it already hangs `--tasks-archive-overhang` = 3px past the slot on
+   every side, eating that much of the gap before it grows at all. The free space
+   on a side is therefore that side's own spacing token LESS the overhang:
+
+   - TOP / BOTTOM: `--tasks-row-pad-y` - 3px = 7px, which makes the zone exactly as
+     tall as the 36px row and no taller. Growth past the row's edge would put this
+     button over the NEIGHBOURING row's link — one row's Archive pressed from
+     another row.
+   - RIGHT: `--tasks-row-gap` - 3px = 7px, which lands the edge exactly on the id
+     chip's left edge. At 10px it lapped 3px OVER the chip, so a press aimed at the
+     id fired Archive instead: this button sits at `z-index: 2` and the chip does
+     not, so the overlap always resolved this way.
+   - LEFT: the right reach plus half a gap back, = 2px. The caret's own enlarged
+     zone (same `z-index: 2`, earlier in the DOM, so this would win the overlap and
+     quietly shrink the disclosure gutter) ends half a `--tasks-row-gap` right of
+     its glyph, and 2px is the whole clearance between the two.
+
+   So: a 36 x 31 target for a 22px button, tiling exactly against the caret's zone
+   on one side and the id chip on the other, with no overlap in either direction.
 
    `pointer-events` is inherited, so this zone is `none` at rest and `auto` with
    the reveal exactly like the button it belongs to — an invisible control does
@@ -721,10 +725,19 @@ button.tasks-caret,
 .tasks-rowmark .tasks-act--archive::after {
   content: "";
   position: absolute;
+  /* How far the 22px button already hangs past its 16px slot on every side. */
+  --tasks-archive-overhang: calc((22px - var(--tasks-rail-w)) / 2);
   --tasks-archive-reach-y: calc(
-    (22px - var(--tasks-rail-w)) / 2 - var(--tasks-row-pad-y)
+    var(--tasks-archive-overhang) - var(--tasks-row-pad-y)
   );
-  inset: var(--tasks-archive-reach-y) -10px var(--tasks-archive-reach-y) -2px;
+  --tasks-archive-reach-r: calc(
+    var(--tasks-archive-overhang) - var(--tasks-row-gap)
+  );
+  --tasks-archive-reach-l: calc(
+    var(--tasks-archive-reach-r) + var(--tasks-row-gap) / 2
+  );
+  inset: var(--tasks-archive-reach-y) var(--tasks-archive-reach-r)
+    var(--tasks-archive-reach-y) var(--tasks-archive-reach-l);
   border-radius: 8px;
 }
 

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -664,6 +664,38 @@ button.tasks-caret,
   transform: translate(-50%, -50%);
 }
 
+/* BIGGER TO AIM AT THAN IT LOOKS (Akshil, 2026-08-18). 22px was still a small
+   target for a control the pointer arrives at sideways, travelling in from the
+   row it just hovered — the press missed and opened the conversation instead,
+   which is the one outcome archiving is not.
+
+   Grown by a transparent pseudo-element rather than by padding-and-negative-
+   margin (the caret's trick, `button.tasks-caret`): that pair works because the
+   caret is a FLEX CHILD, where padding grows the box and the margin takes the
+   growth back out of the layout. This button is out of flow and centred by
+   `translate(-50%, -50%)` on its own box, so padding would grow the box the
+   transform is measured from — and, worse, the box the hover skin paints. The
+   fill and border must stay 22px on a 16px ring; only the zone grows.
+
+   THE INSETS ARE WHAT THE ROW ACTUALLY HAS SPARE, not one round number:
+   - left 2px only. The caret's own enlarged zone (same `z-index: 2`, earlier in
+     the DOM, so this would win the overlap and quietly shrink the disclosure
+     gutter) ends half a `--tasks-row-gap` right of its glyph — 2px short of this
+     button's left edge. That 2px is the whole clearance there is.
+   - right 6px, into the gap before the next rail slot, which holds nothing.
+   - 5px top and bottom, well inside the row's own `--tasks-row-pad-y`: growth
+     past the row's edge would cover the NEIGHBOURING row's link.
+
+   `pointer-events` is inherited, so this zone is `none` at rest and `auto` with
+   the reveal exactly like the button it belongs to — an invisible control does
+   not get an invisible hit area either. */
+.tasks-rowmark .tasks-act--archive::after {
+  content: "";
+  position: absolute;
+  inset: -5px -6px -5px -2px;
+  border-radius: 8px;
+}
+
 /* The handover. The ring fades as the button arrives — the same `opacity` swap,
    on the same triggers, that the bookmarks sidebar's folder count uses to hand
    its slot to the row's actions (`.folder-count`, sidebar.css), and for the same

--- a/frontend/src/styles/tasks.css
+++ b/frontend/src/styles/tasks.css
@@ -513,7 +513,8 @@ button.tasks-caret,
 /* -- Quiet row action (Open chat) ---------------------------------------------
    Hidden until the row is pointed at: it applies to every task that has run,
    and a permanent icon on every row would out-shout the work itself. Kept
-   reachable by keyboard — focus-within reveals it.
+   reachable by keyboard — a tab onto it reveals it (see the reveal rule below for
+   why that arm asks for the button's own `:focus-visible`).
 
    NOTE, 2026-08-17, amended 2026-08-18: most of the TASK ROW's and the BOARD
    CARD's strip is still not rendered at all — `SHOW_ROW_ACTIONS` in
@@ -559,10 +560,26 @@ button.tasks-caret,
   pointer-events: none;
 }
 
+/* THE KEYBOARD ARM IS `:has(… :focus-visible)`, NOT `:focus-within` (Akshil,
+   2026-08-18 — the stuck-Archive bug). `:focus-within` matches when ANY
+   descendant holds focus, and a row's descendants include the disclosure chevron
+   and the stretched `.tasks-rowlink`. So clicking the chevron to expand a row
+   left focus on it, the row kept matching after the pointer left, and Archive
+   stayed sitting in the status ring's slot — on a row nobody was pointing at any
+   more, with the ring it had displaced still faded out. Mouse-out has to put the
+   row back exactly as it found it.
+
+   `:focus-visible` is the whole difference: it is the UA's own "this focus came
+   from the keyboard" answer, so a tab onto Archive still reveals it (and its
+   siblings, which is how one tab-stop's worth of the group stays findable) while
+   a click anywhere in the row reveals nothing that outlives the pointer. Scoped
+   to `.tasks-act` rather than left as bare `:has(:focus-visible)` so a
+   keyboard-focused chevron — which needs nothing revealed — does not do it
+   either. */
 .tasks-row:hover .tasks-act,
-.tasks-row:focus-within .tasks-act,
+.tasks-row:has(.tasks-act:focus-visible) .tasks-act,
 .tasks-msg:hover .tasks-act,
-.tasks-msg:focus-within .tasks-act,
+.tasks-msg:has(.tasks-act:focus-visible) .tasks-act,
 .tasks-act:focus-visible {
   opacity: 1;
   pointer-events: auto;
@@ -705,20 +722,24 @@ button.tasks-caret,
    `pointer-events` travels with the fade, or the invisible ring would keep
    collecting the presses meant for the button under it.
 
-   `:focus-within` is in the list because the button must be reachable by
-   keyboard: a tab onto it reveals it (`.tasks-act:focus-visible`) and the ring it
-   is standing in front of has to get out of the way for it. */
+   The keyboard arm is here because the button must be reachable that way: a tab
+   onto it reveals it (`.tasks-act:focus-visible`) and the ring it stands in front
+   of has to get out of the way for it. It asks for that button's OWN
+   `:focus-visible` and not the row's `:focus-within` — see the long note on the
+   reveal above: a chevron click is focus inside the row too, and this rule used
+   to leave the ring faded out on a row the pointer had long left. */
 .tasks-row:hover .tasks-rowmark .schedule-ring,
-.tasks-row:focus-within .tasks-rowmark .schedule-ring {
+.tasks-row .tasks-rowmark:has(.tasks-act--archive:focus-visible) .schedule-ring {
   opacity: 0;
   pointer-events: none;
 }
 
 /* Only where there IS a button to hand over to. A row with nothing to file
    (`archiveIntent` → null, so no button is rendered) must keep its ring under the
-   pointer — the alternative is a blank slot where the row's status was. */
-.tasks-row:hover .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring,
-.tasks-row:focus-within .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring {
+   pointer — the alternative is a blank slot where the row's status was.
+   Hover only: the keyboard arm above now asks for a focused Archive button inside
+   this very slot, which a slot without one cannot satisfy. */
+.tasks-row:hover .tasks-rowmark:not(:has(.tasks-act--archive)) .schedule-ring {
   opacity: 1;
 }
 
@@ -830,8 +851,12 @@ button.tasks-caret,
   background: transparent;
 }
 
+/* Keyboard arm as `:has(… :focus-visible)`, for the reason the row's reveal
+   spells out: the wrapper's descendant is the CARD, itself a button, so
+   `:focus-within` meant a click on the card left this strip stuck visible after
+   the pointer moved on. */
 .tasks-card-wrap:hover .tasks-card-act,
-.tasks-card-wrap:focus-within .tasks-card-act,
+.tasks-card-wrap:has(.tasks-card-act:focus-visible) .tasks-card-act,
 .tasks-card-act:focus-visible {
   opacity: 1;
   pointer-events: auto;
@@ -840,7 +865,7 @@ button.tasks-caret,
 /* Mid-write, same as the row's: the card is being pointed at, so full opacity is
    already on and dropping it is what says "asked, not answered yet". */
 .tasks-card-wrap:hover .tasks-card-act:disabled,
-.tasks-card-wrap:focus-within .tasks-card-act:disabled,
+.tasks-card-wrap:has(.tasks-card-act:focus-visible) .tasks-card-act:disabled,
 .tasks-card-act:disabled:focus-visible {
   opacity: 0.4;
   cursor: default;
@@ -869,9 +894,9 @@ button.tasks-caret,
    already at full opacity — dropping it is what says "asked, not answered yet"
    without swapping the glyph for a spinner the width of the row. */
 .tasks-row:hover .tasks-act:disabled,
-.tasks-row:focus-within .tasks-act:disabled,
+.tasks-row:has(.tasks-act:focus-visible) .tasks-act:disabled,
 .tasks-msg:hover .tasks-act:disabled,
-.tasks-msg:focus-within .tasks-act:disabled,
+.tasks-msg:has(.tasks-act:focus-visible) .tasks-act:disabled,
 .tasks-act:disabled:focus-visible {
   opacity: 0.4;
   cursor: default;


### PR DESCRIPTION
Five independent fixes on the Tasks surfaces, one commit each (plus two follow-up commits from review). Branched off `main` (#620 is merged).

### 1. The sidebar's Tasks dot shows in both modes
The yellow (running) / green (unseen completion) corner dot was the collapsed rail's whole signal, and the expanded row deliberately traded it for words. In use that read as the *state* going away rather than the sidebar changing shape — the icon is where the eye lands at either width. The dot is the constant now, and expanding **adds** the "N running" shimmer and the count chip beside it. Same precedence (yellow over green, one dot) and the same visit-to-clear semantics. The row's `.icon` span gains `position: relative` so the absolutely placed dot lands on the glyph rather than the viewport.

### 2. A much bigger hit area for the row's Archive button
22px was a small target for a control the pointer arrives at sideways, and a miss opened the conversation instead. The **zone** grows and the **skin** does not: a transparent `::after`, not the caret's padding-and-negative-margin pair, because this button is out of flow and centred by a transform on its own box.

The zone is now the row's **full height** and reaches into the empty gap to its right — a 36×34 target for a 22px button. Top and bottom are derived, not typed: the button overhangs its 16px slot by `(22px - --tasks-rail-w) / 2`, so the room left before the row's edge is one `--tasks-row-pad-y` less that overhang, and it follows the row if the padding is ever retuned. Growth past the row's edge would put this button over the *neighbouring* row's link.

Measured in the browser: the zone's edges land exactly on the row's (101/137 on a 36px row), and its left edge abuts the chevron's own enlarged gutter at 102px with **zero overlap** — the two zones tile the leading edge without either stealing from the other. `pointer-events` is inherited, so the zone appears and vanishes with the ink.

### 3. New task opens on the current time
It opened on now + 1h, so the commonest case (a task to run) was a two-step: wind the time back, then save. `pastNoteFor` now compares at the field's own minute precision, so the form does not open printing "this time has passed" about its own default. A caller's `initialTime`, and an Edit's stored `due`, still win.

### 4. Archive no longer sticks visible after a chevron click
**Root cause:** the reveal's keyboard arm was `:focus-within` on the row. Clicking the chevron leaves focus on it, the row keeps matching, and Archive stays sitting in the status ring's slot on a row the pointer has left — with the displaced ring still faded out. The stretched `.tasks-rowlink` and the board card did the same, since a plain click focuses both. The arm is `:has(.tasks-act:focus-visible)` now, so a tab onto the button still reveals it and no click reveals anything that outlives the pointer.

### 5. One status order for both views
Both the list and the board now read the same five words in the same sequence:

| | before | after |
|---|---|---|
| List (`LIST_ORDER`) | upcoming → in_progress → failed → done → archived | *unchanged* |
| Board (`BOARD_COLUMNS`) | upcoming → in_progress → **done → failed** → archived | upcoming → in_progress → **failed → done** → archived |

The two briefly disagreed (the list ranking work owed, the board running a pipeline) and each argument was sound alone — but a reader moving between the views carries one mental picture of where a status sits, so the disagreement was wrong in whichever view they were not looking at. The board is the view that moved. The test asserts the two arrays are the same **sequence**, not merely the same set, and that Failed precedes Done in both.

### Gate
`npm run build` (boundaries + `tsc --noEmit` + vite) clean; `bun test` 1853 pass / 0 fail. Tests updated alongside each fix — the sidebar's "no dot when expanded" test is now "the same dot, plus words"; the past-note boundary is pinned at the minute; the archive zone's derived reach is pinned; both order arrays are pinned and asserted equal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontend-only UX and CSS with targeted tests; no auth, API, or data-layer changes.
> 
> **Overview**
> **Sidebar:** The Tasks running/unread dot now appears on the nav icon in **both** collapsed and expanded sidebar modes (`extra={tasksDot}`), with CSS anchoring it on `.sidebar-item .icon`; expanded mode still adds “N running” and the count chip beside the dot.
> 
> **New task modal:** Default schedule time changes from **now + 1h** to **now**; `pastNoteFor` compares at **minute** precision via `startOfMinute`, so the current minute is not treated as “in the past” and the default no longer triggers a self-warning.
> 
> **List / board:** `BOARD_COLUMNS` swaps **Failed** before **Done** to match `LIST_ORDER`; docs and tests assert the two sequences stay identical.
> 
> **Archive on task rows/cards:** Hover/focus reveal rules drop `:focus-within` in favor of `:has(… :focus-visible)` so chevron or card clicks do not leave Archive stuck visible; the list archive control gets a larger transparent `::after` hit zone with **derived** insets (no overlap with the id chip or neighbor rows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 793a01387037c047506c95513c65a2721c78f701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->