### PR TITLE
Switch default Fused environment from unstable to prod

### DIFF
--- a/fused_render/canvases.py
+++ b/fused_render/canvases.py
@@ -130,8 +130,9 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9_]{1,128}$")
 # Fused environment the canvases feature targets. One knob drives BOTH the
 # workspace iframe URL and the CLI runs (`fused --env`, via the FUSED_ENV
 # variable it reads) so the canvas the iframe shows is the same one the local
-# clone syncs against. Unstable is the current default while embed-auth ships
-# there first; FUSED_RENDER_WORKBENCH_URL still overrides the iframe URL alone.
+# clone syncs against. Prod is the default; set FUSED_RENDER_WORKBENCH_ENV=
+# unstable to point canvases back at the unstable environment.
+# FUSED_RENDER_WORKBENCH_URL still overrides the iframe URL alone.
 # Resolved in fusedcli.workbench_env because the `fused` wrapper handed to
 # Claude sessions bakes in the same default (D334) — one knob, one reader.
 WORKBENCH_ENV = workbench_env()
@@ -151,7 +152,7 @@ _ENV_WEB_URLS = {
 }
 
 WORKBENCH_BASE_URL = os.environ.get("FUSED_RENDER_WORKBENCH_URL") or _ENV_WEB_URLS.get(
-    WORKBENCH_ENV, "https://unstable.fused.io"
+    WORKBENCH_ENV, "https://www.fused.io"
 )
 
 

--- a/fused_render/fusedcli.py
+++ b/fused_render/fusedcli.py
@@ -69,13 +69,13 @@ def fused_cli() -> FusedCli | None:
 
 def workbench_env() -> str:
     """The Fused environment the workbench features target — ONE knob
-    (FUSED_RENDER_WORKBENCH_ENV, default unstable) shared by canvases.py's
+    (FUSED_RENDER_WORKBENCH_ENV, default prod) shared by canvases.py's
     iframe URL + CLI runs AND the `fused` wrapper handed to Claude sessions
     (export_fused_cli_env), so what Claude pushes lands in the same
     environment the canvases iframe shows. Lives here rather than in
     canvases.py because canvases imports this module, not the other way
-    around."""
-    return os.environ.get("FUSED_RENDER_WORKBENCH_ENV", "unstable")
+    around. Set FUSED_RENDER_WORKBENCH_ENV=unstable to switch back."""
+    return os.environ.get("FUSED_RENDER_WORKBENCH_ENV", "prod")
 
 
 # The env var that carries the wrapper dir to the templates (SPEC PY-15):

--- a/tests/test_fused_cli_export.py
+++ b/tests/test_fused_cli_export.py
@@ -126,7 +126,7 @@ def test_wrapper_default_matches_the_canvases_default(monkeypatch):
     reads it rather than keeping a default of its own (D146: a duplicated
     rule needs a test)."""
     monkeypatch.delenv("FUSED_RENDER_WORKBENCH_ENV", raising=False)
-    assert fusedcli.workbench_env() == "unstable"
+    assert fusedcli.workbench_env() == "prod"
     import fused_render.canvases as canvases
     src = open(canvases.__file__, encoding="utf-8").read()
     assert "WORKBENCH_ENV = workbench_env()" in src


### PR DESCRIPTION
## Summary
This change updates the default Fused environment from `unstable` to `prod` across the codebase, while maintaining the ability to override this default via the `FUSED_RENDER_WORKBENCH_ENV` environment variable.

## Key Changes
- **fusedcli.py**: Updated `workbench_env()` function to return `"prod"` as the default instead of `"unstable"`
- **canvases.py**: 
  - Changed the fallback URL from `https://unstable.fused.io` to `https://www.fused.io` (prod)
  - Updated documentation to reflect that prod is now the default, with instructions on how to switch back to unstable via the environment variable
- **test_fused_cli_export.py**: Updated test assertion to expect `"prod"` as the default value

## Implementation Details
- The `FUSED_RENDER_WORKBENCH_ENV` environment variable remains the single control point for selecting the workbench environment
- Users can still opt into the unstable environment by setting `FUSED_RENDER_WORKBENCH_ENV=unstable`
- The `FUSED_RENDER_WORKBENCH_URL` environment variable continues to override the iframe URL independently
- Documentation has been updated to clarify the new default and how to revert to unstable if needed

https://claude.ai/code/session_01EHuTirzVta7wFfmGvzyEtv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration default only; behavior is unchanged when the env var is set explicitly, and no auth or data-path logic is modified.
> 
> **Overview**
> **Default workbench target is now production** instead of unstable when `FUSED_RENDER_WORKBENCH_ENV` is unset.
> 
> `workbench_env()` in `fusedcli.py` now defaults to `"prod"`, which drives the canvases iframe base URL (fallback `https://www.fused.io` instead of unstable), CLI `FUSED_ENV` on canvas sync, and the generated `fused` wrapper for Claude sessions. **Unstable is still available** via `FUSED_RENDER_WORKBENCH_ENV=unstable`; `FUSED_RENDER_WORKBENCH_URL` continues to override only the iframe URL.
> 
> Comments and `test_wrapper_default_matches_the_canvases_default` were updated to match the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50e31dbc52b9e7e6876f45a362cd87eb11b6fa33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->