### PR TITLE
Inform Claude session that a known Python interpreter should be used

### DIFF
--- a/fused_render/server/routers/env.py
+++ b/fused_render/server/routers/env.py
@@ -20,13 +20,6 @@ from fused_render.server.common import _error, _require_fused
 
 router = APIRouter()
 
-# The bundled data-stack packages a first-party reader (duckdb/xlsx/sqlite/
-# structure) actually uses. Reported by /api/env/interpreter so a caller (a
-# Claude Code session embedded beside a file preview, in particular) can learn
-# the real versions instead of shelling out to a fresh interpreter that has no
-# relationship to the one that rendered the file.
-_REPORTED_PACKAGES = ("duckdb", "pyarrow", "pandas")
-
 
 def _project_for(body: dict):
     """(project_dir, error_response) for a {py, html} body, or (None, resp).
@@ -143,8 +136,7 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
     structure readers execute in-process (D72), and everything else without a
     declared project runs as a subprocess of this same interpreter
     (executor.py's `[sys.executable, CHILD]`) — so this process's own
-    `sys.executable` and its already-installed duckdb/pyarrow/pandas are
-    exactly what a reader used, not a guess.
+    `sys.executable` is exactly what a reader used, not a guess.
 
     This exists because a shell probe (`which python3`, a fresh `sys.
     executable`) run from outside this app — e.g. a Claude Code session
@@ -152,6 +144,15 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
     THAT SHELL'S PATH, which has no relationship to the interpreter
     fused-render itself used to render the file. That mismatch is silent: the
     shell probe always succeeds, it just answers a different question.
+
+    Deliberately does NOT report package versions: that caller runs on the
+    same machine as this interpreter (a local desktop app; a Claude session is
+    a subprocess of this same server), so once it has the real `interpreter`
+    path it can ask that interpreter about ANY package itself
+    (`<interpreter> -c "import x; print(x.__version__)"`) — more flexibly
+    than this endpoint hardcoding a guess at which packages matter. This
+    endpoint's only job is the one fact a caller cannot get any other way:
+    which interpreter is ground truth.
     """
     guard = _require_fused(x_fused)
     if guard is not None:
@@ -182,17 +183,14 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
     engine = shell_prefs.effective_engine()
 
     python_version = None
-    packages = None
     if project:
         from fused_render import envinstall
         interpreter = envinstall.venv_python_for(project)
         source = (f"{projectenv.display_name(project)}'s own project "
                   "environment (declared in its pyproject.toml)")
-        # Neither this process's own Python version nor its packages — that
-        # venv can pin a different Python than the app (SPEC PY-16 lets a
-        # project declare its own), and probing it here would cost a
-        # subprocess spawn for an answer most callers (no declared project)
-        # never need.
+        # Not this process's own Python version — that venv can pin a
+        # different Python than the app (SPEC PY-16 lets a project declare its
+        # own), and this process's sys.version is not known to match it.
     else:
         if engine == "fused":
             from fused_render import engine as _engine
@@ -201,12 +199,6 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
             interpreter = sys.executable
         source = "this app's own interpreter (no project declares one, SPEC PY-17)"
         python_version = sys.version
-        packages = {}
-        for name in _REPORTED_PACKAGES:
-            try:
-                packages[name] = getattr(__import__(name), "__version__", None)
-            except ImportError:
-                pass
 
     return JSONResponse({
         "ok": True,
@@ -214,7 +206,6 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
         "interpreter": interpreter,
         "source": source,
         "python_version": python_version,
-        "packages": packages,
     })
 
 

--- a/fused_render/server/routers/env.py
+++ b/fused_render/server/routers/env.py
@@ -157,27 +157,42 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
     if guard is not None:
         return guard
 
+    # Same resolution rule (and the same error wording) as /api/env/install's
+    # `_project_for`: a `py` this endpoint cannot resolve is answered as an
+    # error, never silently folded into "no project declares one" — that
+    # would assert a fact (no project) that resolution never actually
+    # established.
     project = None
     if py:
-        resolved = py if os.path.isabs(py) else (
-            os.path.normpath(os.path.join(os.path.dirname(html), py))
-            if html else None)
-        if resolved and os.path.isfile(resolved):
-            from fused_render import projectenv
-            project = projectenv.project_env_for(resolved)
+        if os.path.isabs(py):
+            resolved = py
+        elif html:
+            resolved = os.path.normpath(os.path.join(os.path.dirname(html), py))
+        else:
+            return _error(
+                "'py' is a relative path but 'html' was not provided; "
+                "either send an absolute 'py' path or include 'html' so it can be resolved"
+            )
+        if not os.path.isfile(resolved):
+            return _error(f"no such Python file: {resolved}")
+        from fused_render import projectenv
+        project = projectenv.project_env_for(resolved)
 
     from fused_render.shell import prefs as shell_prefs
     engine = shell_prefs.effective_engine()
 
+    python_version = None
     packages = None
     if project:
         from fused_render import envinstall
         interpreter = envinstall.venv_python_for(project)
         source = (f"{projectenv.display_name(project)}'s own project "
                   "environment (declared in its pyproject.toml)")
-        # Not this process's own packages — that venv is a different
-        # interpreter, and probing it here would cost a subprocess spawn for
-        # an answer most callers (no declared project) never need.
+        # Neither this process's own Python version nor its packages — that
+        # venv can pin a different Python than the app (SPEC PY-16 lets a
+        # project declare its own), and probing it here would cost a
+        # subprocess spawn for an answer most callers (no declared project)
+        # never need.
     else:
         if engine == "fused":
             from fused_render import engine as _engine
@@ -185,6 +200,7 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
         else:
             interpreter = sys.executable
         source = "this app's own interpreter (no project declares one, SPEC PY-17)"
+        python_version = sys.version
         packages = {}
         for name in _REPORTED_PACKAGES:
             try:
@@ -197,7 +213,7 @@ def api_env_interpreter(py: str | None = None, html: str | None = None,
         "engine": engine,
         "interpreter": interpreter,
         "source": source,
-        "python_version": sys.version,
+        "python_version": python_version,
         "packages": packages,
     })
 

--- a/fused_render/server/routers/env.py
+++ b/fused_render/server/routers/env.py
@@ -11,6 +11,7 @@ and one source for both is the only way that stays true.
 """
 
 import os
+import sys
 
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
@@ -18,6 +19,13 @@ from fastapi.responses import JSONResponse
 from fused_render.server.common import _error, _require_fused
 
 router = APIRouter()
+
+# The bundled data-stack packages a first-party reader (duckdb/xlsx/sqlite/
+# structure) actually uses. Reported by /api/env/interpreter so a caller (a
+# Claude Code session embedded beside a file preview, in particular) can learn
+# the real versions instead of shelling out to a fresh interpreter that has no
+# relationship to the one that rendered the file.
+_REPORTED_PACKAGES = ("duckdb", "pyarrow", "pandas")
 
 
 def _project_for(body: dict):
@@ -121,6 +129,77 @@ def api_env_progress(key: str, x_fused: str | None = Header(default=None)):
     except (ImportError, RuntimeError) as e:
         return _error(str(e))
     return JSONResponse({"ok": True, "key": key, "progress": prog})
+
+
+@router.get("/api/env/interpreter")
+def api_env_interpreter(py: str | None = None, html: str | None = None,
+                        x_fused: str | None = Header(default=None)):
+    """Which interpreter actually runs *py* — the ground truth PY-16/PY-17
+    otherwise has no way to reach a caller outside this process.
+
+    Without `py` (the common case: a data file with no project of its own —
+    every core template, and most quick-look files) this answers for THE APP'S
+    OWN interpreter, which is what ran it: the built-in duckdb/xlsx/sqlite/
+    structure readers execute in-process (D72), and everything else without a
+    declared project runs as a subprocess of this same interpreter
+    (executor.py's `[sys.executable, CHILD]`) — so this process's own
+    `sys.executable` and its already-installed duckdb/pyarrow/pandas are
+    exactly what a reader used, not a guess.
+
+    This exists because a shell probe (`which python3`, a fresh `sys.
+    executable`) run from outside this app — e.g. a Claude Code session
+    embedded beside a file's preview — reports whatever happens to be first on
+    THAT SHELL'S PATH, which has no relationship to the interpreter
+    fused-render itself used to render the file. That mismatch is silent: the
+    shell probe always succeeds, it just answers a different question.
+    """
+    guard = _require_fused(x_fused)
+    if guard is not None:
+        return guard
+
+    project = None
+    if py:
+        resolved = py if os.path.isabs(py) else (
+            os.path.normpath(os.path.join(os.path.dirname(html), py))
+            if html else None)
+        if resolved and os.path.isfile(resolved):
+            from fused_render import projectenv
+            project = projectenv.project_env_for(resolved)
+
+    from fused_render.shell import prefs as shell_prefs
+    engine = shell_prefs.effective_engine()
+
+    packages = None
+    if project:
+        from fused_render import envinstall
+        interpreter = envinstall.venv_python_for(project)
+        source = (f"{projectenv.display_name(project)}'s own project "
+                  "environment (declared in its pyproject.toml)")
+        # Not this process's own packages — that venv is a different
+        # interpreter, and probing it here would cost a subprocess spawn for
+        # an answer most callers (no declared project) never need.
+    else:
+        if engine == "fused":
+            from fused_render import engine as _engine
+            interpreter = _engine.app_interpreter()
+        else:
+            interpreter = sys.executable
+        source = "this app's own interpreter (no project declares one, SPEC PY-17)"
+        packages = {}
+        for name in _REPORTED_PACKAGES:
+            try:
+                packages[name] = getattr(__import__(name), "__version__", None)
+            except ImportError:
+                pass
+
+    return JSONResponse({
+        "ok": True,
+        "engine": engine,
+        "interpreter": interpreter,
+        "source": source,
+        "python_version": sys.version,
+        "packages": packages,
+    })
 
 
 @router.post("/api/env/cancel")

--- a/fused_render/server/routers/env.py
+++ b/fused_render/server/routers/env.py
@@ -11,7 +11,6 @@ and one source for both is the only way that stays true.
 """
 
 import os
-import sys
 
 from fastapi import APIRouter, Body, Header
 from fastapi.responses import JSONResponse
@@ -124,89 +123,62 @@ def api_env_progress(key: str, x_fused: str | None = Header(default=None)):
     return JSONResponse({"ok": True, "key": key, "progress": prog})
 
 
-@router.get("/api/env/interpreter")
-def api_env_interpreter(py: str | None = None, html: str | None = None,
-                        x_fused: str | None = Header(default=None)):
-    """Which interpreter actually runs *py* — the ground truth PY-16/PY-17
-    otherwise has no way to reach a caller outside this process.
+@router.get("/api/env/custom-env")
+def api_env_custom_env(file: str, x_fused: str | None = Header(default=None)):
+    """Does *file*'s own reader run on a declared project environment, or on
+    this app's own bundled interpreter?
 
-    Without `py` (the common case: a data file with no project of its own —
-    every core template, and most quick-look files) this answers for THE APP'S
-    OWN interpreter, which is what ran it: the built-in duckdb/xlsx/sqlite/
-    structure readers execute in-process (D72), and everything else without a
-    declared project runs as a subprocess of this same interpreter
-    (executor.py's `[sys.executable, CHILD]`) — so this process's own
-    `sys.executable` is exactly what a reader used, not a guess.
+    A Claude Code session embedded beside a file's preview already knows its
+    OWN interpreter (`sys.executable` — the claude template's folder never
+    declares a project, so agent.py's own process always runs on the app's own
+    interpreter, SPEC PY-17). What it cannot know on its own is whether THAT
+    matches what actually reads `file`: a `.py` file may sit inside a project
+    declaring dependencies (SPEC PY-16), and some core templates ship their own
+    `pyproject.toml` too (D276 — `map`/`vector`/`pdf_studio`/…, moved out of
+    the bundled app on purpose), in which case the file's real reader runs on
+    a dedicated venv instead. Guessing which templates those are would drift
+    the moment a new one adds its own deps, so this asks the two real sources
+    instead of hardcoding a list:
 
-    This exists because a shell probe (`which python3`, a fresh `sys.
-    executable`) run from outside this app — e.g. a Claude Code session
-    embedded beside a file's preview — reports whatever happens to be first on
-    THAT SHELL'S PATH, which has no relationship to the interpreter
-    fused-render itself used to render the file. That mismatch is silent: the
-    shell probe always succeeds, it just answers a different question.
+    * a `.py` file IS the script `/api/run` would execute, so its own
+      `project_env_for` is the direct, exact answer.
+    * anything else is served by whichever template's reader the registry
+      resolves for it (`server/templates._templates_for`, the same match
+      `/render` uses) — the FIRST (default, SPEC PT-7) entry's folder is
+      checked for a declared environment. A conditional template that gates
+      out the default at request time is a known, accepted imprecision here;
+      this is advisory, not a guarantee.
 
-    Deliberately does NOT report package versions: that caller runs on the
-    same machine as this interpreter (a local desktop app; a Claude session is
-    a subprocess of this same server), so once it has the real `interpreter`
-    path it can ask that interpreter about ANY package itself
-    (`<interpreter> -c "import x; print(x.__version__)"`) — more flexibly
-    than this endpoint hardcoding a guess at which packages matter. This
-    endpoint's only job is the one fact a caller cannot get any other way:
-    which interpreter is ground truth.
+    `custom_env: true` means "don't trust the session's own interpreter for
+    this file" (a declared project, an unresolvable file, or a file type this
+    app has no template for at all — safest default when unsure). `false`
+    means the session's own interpreter genuinely is what ran it.
     """
     guard = _require_fused(x_fused)
     if guard is not None:
         return guard
+    if not os.path.exists(file):
+        return _error(f"no such file or directory: {file}")
 
-    # Same resolution rule (and the same error wording) as /api/env/install's
-    # `_project_for`: a `py` this endpoint cannot resolve is answered as an
-    # error, never silently folded into "no project declares one" — that
-    # would assert a fact (no project) that resolution never actually
-    # established.
-    project = None
-    if py:
-        if os.path.isabs(py):
-            resolved = py
-        elif html:
-            resolved = os.path.normpath(os.path.join(os.path.dirname(html), py))
-        else:
-            return _error(
-                "'py' is a relative path but 'html' was not provided; "
-                "either send an absolute 'py' path or include 'html' so it can be resolved"
-            )
-        if not os.path.isfile(resolved):
-            return _error(f"no such Python file: {resolved}")
-        from fused_render import projectenv
-        project = projectenv.project_env_for(resolved)
+    from fused_render import projectenv
 
-    from fused_render.shell import prefs as shell_prefs
-    engine = shell_prefs.effective_engine()
+    is_dir = os.path.isdir(file)
+    if not is_dir and file.endswith(".py"):
+        custom_env = projectenv.project_env_for(file) is not None
+        return JSONResponse({"ok": True, "custom_env": custom_env})
 
-    python_version = None
-    if project:
-        from fused_render import envinstall
-        interpreter = envinstall.venv_python_for(project)
-        source = (f"{projectenv.display_name(project)}'s own project "
-                  "environment (declared in its pyproject.toml)")
-        # Not this process's own Python version — that venv can pin a
-        # different Python than the app (SPEC PY-16 lets a project declare its
-        # own), and this process's sys.version is not known to match it.
-    else:
-        if engine == "fused":
-            from fused_render import engine as _engine
-            interpreter = _engine.app_interpreter()
-        else:
-            interpreter = sys.executable
-        source = "this app's own interpreter (no project declares one, SPEC PY-17)"
-        python_version = sys.version
+    from fused_render.server import templates as _server_templates
 
-    return JSONResponse({
-        "ok": True,
-        "engine": engine,
-        "interpreter": interpreter,
-        "source": source,
-        "python_version": python_version,
-    })
+    entries, _template_error = _server_templates._templates_for(file, is_dir)
+    default_path = entries[0].get("path") if entries else None
+    if not default_path:
+        # No template resolved (unmapped file type) or the default entry is a
+        # sentinel with no folder (e.g. `_render`) — nothing to check, so the
+        # safe answer is "don't know, don't trust it."
+        return JSONResponse({"ok": True, "custom_env": True})
+    folder = os.path.dirname(default_path)
+    return JSONResponse({"ok": True,
+                         "custom_env": projectenv.has_project_env(folder)})
 
 
 @router.post("/api/env/cancel")

--- a/fused_render/server/routers/env.py
+++ b/fused_render/server/routers/env.py
@@ -163,7 +163,12 @@ def api_env_custom_env(file: str, x_fused: str | None = Header(default=None)):
     from fused_render import projectenv
 
     is_dir = os.path.isdir(file)
-    if not is_dir and file.endswith(".py"):
+    # Case-INsensitive, matching _match_registry's own basename lowercasing
+    # below: a `script.PY` must take the same direct-project_env_for path a
+    # `script.py` does, or it falls through to the registry's "code" template
+    # (no pyproject.toml of its own) and reports `custom_env: false` for a
+    # file that may actually run on a project's venv.
+    if not is_dir and file.lower().endswith(".py"):
         custom_env = projectenv.project_env_for(file) is not None
         return JSONResponse({"ok": True, "custom_env": custom_env})
 

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -78,6 +78,9 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 
 # The fused engine execs this script without setting __file__; it puts the
 # script's own directory first on sys.path, so rebuild __file__ from it. Under
@@ -527,6 +530,26 @@ def _workdir(file: str) -> str:
     return file if os.path.isdir(file) else os.path.dirname(file)
 
 
+def _custom_env(origin: str, file: str) -> bool | None:
+    """Does *file*'s own reader need a declared project environment, per
+    `/api/env/custom-env`? None when the app couldn't be asked — a network
+    hiccup on this prompt-building nicety must never fail the spawn, so any
+    error (timeout, connection refused, a malformed response) is swallowed
+    exactly like every other read in this module that decorates a screen
+    rather than gating it (see artifacts.py's own "NOTHING HERE RAISES").
+    `None` and `True` both mean "say nothing" downstream — the only value
+    that unlocks the interpreter fact is a confirmed `False`.
+    """
+    try:
+        url = origin + "/api/env/custom-env?" + urllib.parse.urlencode({"file": file})
+        req = urllib.request.Request(url, headers={"X-Fused": "1"})
+        with urllib.request.urlopen(req, timeout=2) as r:
+            data = json.loads(r.read().decode("utf-8"))
+        return bool(data.get("custom_env", True))
+    except Exception:  # noqa: BLE001 — see docstring
+        return None
+
+
 def _system_prompt(file: str) -> str:
     """The FILE target's prompt: what to work on, plus the same app-state
     disclosure the directory prompt makes (D235).
@@ -544,24 +567,23 @@ def _system_prompt(file: str) -> str:
     name = os.path.basename(file)
     tool = "mcp__%s__%s" % (PERMISSION_SERVER, APP_STATE_TOOL)
     origin = _origin()
-    # A fact about how the PREVIEW was produced, not about the file's content —
-    # this is what stops "which python env retrieved this?" being answered by
-    # a `which python3` / fresh `sys.executable` probe, which reports whichever
-    # interpreter this shell's own PATH happens to resolve first (some ambient
-    # conda/homebrew env) and has no relationship to the interpreter
-    # fused-render itself used: its built-in duckdb/xlsx/sqlite/structure
-    # readers run in-process on the app's own interpreter (D72), and everything
-    # else runs there too unless the file sits in a project that declares its
-    # own environment (SPEC PY-16/PY-17). `origin` is None only when there is no
-    # server to ask (e.g. a bare test), in which case saying nothing is honest.
+    # This session's OWN interpreter is a fact worth stating only when it is
+    # KNOWN to be the one that read `file` — never a caveated guess. The claude
+    # template's own folder never declares a project (SPEC PY-17), so this
+    # process always runs on the app's own bundled interpreter; whether that
+    # matches `file`'s actual reader depends on `file` itself, which
+    # /api/env/custom-env resolves properly (a `.py` in a declared project, or
+    # a data file whose template ships its own pyproject.toml — D276's
+    # map/vector/pdf_studio and any future one — answers `custom_env: true`,
+    # and this says nothing rather than assert a fact that might be wrong).
+    # `origin` is None only when there is no server to ask (e.g. a bare test).
+    custom_env = _custom_env(origin, file) if origin else None
     env_note = (
-        f" If asked which Python interpreter produced {name}'s preview: `GET "
-        f"{origin}/api/env/interpreter` (header `X-Fused: 1`) answers with "
-        "the real interpreter and engine fused-render itself used — that is "
-        "the ground truth, not a shell probe of this session's own PATH. For "
-        "package versions, run that interpreter directly (you are on the "
-        "same machine): `<interpreter> -c \"import x; print(x.__version__)\"`."
-    ) if origin else ""
+        f" If asked which Python interpreter produced {name}'s preview: this "
+        f"session's own interpreter IS it — {sys.executable} (Python "
+        f"{sys.version.split()[0]}) — ground truth, not a guess from a shell "
+        "probe of this session's own PATH."
+    ) if custom_env is False else ""
     return (
         f"You are embedded in a local file viewer, opened on {file}. "
         f"The user is looking at {name} right now; treat that file as the "

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -88,6 +88,7 @@ if "__file__" not in globals():
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.join(os.path.dirname(HERE), "shared"))
 from appenv import fused_cli_dir as _fused_cli_dir
+from appenv import origin as _origin
 from appenv import skill_plugin_dir as _skill_plugin_dir
 from appenv import workspace_dir as _workspace_dir
 from private_dir import private_dir as _private_dir_under
@@ -542,6 +543,24 @@ def _system_prompt(file: str) -> str:
     """
     name = os.path.basename(file)
     tool = "mcp__%s__%s" % (PERMISSION_SERVER, APP_STATE_TOOL)
+    origin = _origin()
+    # A fact about how the PREVIEW was produced, not about the file's content —
+    # this is what stops "which python env retrieved this?" being answered by
+    # a `which python3` / fresh `sys.executable` probe, which reports whichever
+    # interpreter this shell's own PATH happens to resolve first (some ambient
+    # conda/homebrew env) and has no relationship to the interpreter
+    # fused-render itself used: its built-in duckdb/xlsx/sqlite/structure
+    # readers run in-process on the app's own interpreter (D72), and everything
+    # else runs there too unless the file sits in a project that declares its
+    # own environment (SPEC PY-16/PY-17). `origin` is None only when there is no
+    # server to ask (e.g. a bare test), in which case saying nothing is honest.
+    env_note = (
+        f" If asked which Python interpreter or package versions produced "
+        f"{name}'s preview: `GET {origin}/api/env/interpreter` (header "
+        "`X-Fused: 1`) answers with the real interpreter, engine and "
+        "duckdb/pyarrow/pandas versions fused-render itself used — that is "
+        "the ground truth, not a shell probe of this session's own PATH."
+    ) if origin else ""
     return (
         f"You are embedded in a local file viewer, opened on {file}. "
         f"The user is looking at {name} right now; treat that file as the "
@@ -559,7 +578,7 @@ def _system_prompt(file: str) -> str:
         "reloads itself when the file changes). Anything the user annotates or "
         f"screenshots in that pane is a part of {name}, not of the viewer. A "
         f"<{APP_STATE_TAG}> block on their message is the same reading taken "
-        "at send time, and goes stale as soon as you edit anything."
+        f"at send time, and goes stale as soon as you edit anything.{env_note}"
     )
 
 

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -579,10 +579,9 @@ def _system_prompt(file: str) -> str:
     # `origin` is None only when there is no server to ask (e.g. a bare test).
     custom_env = _custom_env(origin, file) if origin else None
     env_note = (
-        f" If asked which Python interpreter produced {name}'s preview: this "
-        f"session's own interpreter IS it — {sys.executable} (Python "
-        f"{sys.version.split()[0]}) — ground truth, not a guess from a shell "
-        "probe of this session's own PATH."
+        f" For Python-based inspection of {name}, invoke the exact executable "
+        f"`{sys.executable}`. Do not substitute `python` or `python3` from "
+        "PATH; they may refer to a different environment."
     ) if custom_env is False else ""
     return (
         f"You are embedded in a local file viewer, opened on {file}. "

--- a/fused_render/templates/claude/agent.py
+++ b/fused_render/templates/claude/agent.py
@@ -555,11 +555,12 @@ def _system_prompt(file: str) -> str:
     # own environment (SPEC PY-16/PY-17). `origin` is None only when there is no
     # server to ask (e.g. a bare test), in which case saying nothing is honest.
     env_note = (
-        f" If asked which Python interpreter or package versions produced "
-        f"{name}'s preview: `GET {origin}/api/env/interpreter` (header "
-        "`X-Fused: 1`) answers with the real interpreter, engine and "
-        "duckdb/pyarrow/pandas versions fused-render itself used — that is "
-        "the ground truth, not a shell probe of this session's own PATH."
+        f" If asked which Python interpreter produced {name}'s preview: `GET "
+        f"{origin}/api/env/interpreter` (header `X-Fused: 1`) answers with "
+        "the real interpreter and engine fused-render itself used — that is "
+        "the ground truth, not a shell probe of this session's own PATH. For "
+        "package versions, run that interpreter directly (you are on the "
+        "same machine): `<interpreter> -c \"import x; print(x.__version__)\"`."
     ) if origin else ""
     return (
         f"You are embedded in a local file viewer, opened on {file}. "

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -379,6 +379,33 @@ def test_a_declared_project_reports_its_own_venv_not_this_process(tmp_path):
         "that venv's packages are not this process's — reporting them here "
         "would be a guess dressed up as an answer"
     )
+    assert body["python_version"] is None, (
+        "the venv can pin a different Python than the app (SPEC PY-16) — "
+        "this process's own sys.version is not known to match it"
+    )
+
+
+def test_a_py_that_cannot_be_resolved_is_an_error_not_a_guess(tmp_path):
+    """A relative `py` with no `html` to resolve it against, or a `py` that
+    resolves to nothing on disk, means resolution FAILED — the endpoint must
+    say so (mirroring /api/env/install's `_project_for`), not fall through to
+    "no project declares one", which asserts a fact resolution never actually
+    established.
+    """
+    client = _client(tmp_path)
+
+    resp = client.get("/api/env/interpreter", params={"py": "declared.py"},
+                      headers=HEADERS)
+    assert resp.status_code == 400, resp.text
+    assert "'html'" in resp.json()["error"]
+
+    resp = client.get(
+        "/api/env/interpreter",
+        params={"py": str(tmp_path / "nope.py")},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 400, resp.text
+    assert "no such Python file" in resp.json()["error"]
 
 
 def test_interpreter_resolves_a_relative_py_against_the_page(tmp_path):

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -327,6 +327,80 @@ def test_an_engine_that_cannot_answer_is_reported_not_500ed(tmp_path, monkeypatc
     assert str(boom) in resp.json()["error"]
 
 
+# --- /api/env/interpreter: the ground truth for "which python ran this?" ------
+#
+# Exists because a shell probe (`which python3`, a fresh `sys.executable`) run
+# from OUTSIDE this app — a Claude Code session embedded beside a file's
+# preview, say — reports whatever that shell's own PATH resolves first, which
+# has no relationship to the interpreter fused-render itself used.
+
+
+def test_interpreter_endpoint_requires_the_x_fused_header(tmp_path):
+    client = _client(tmp_path)
+    assert client.get("/api/env/interpreter").status_code == 403
+
+
+def test_a_file_with_no_project_reports_this_process_as_the_interpreter(tmp_path):
+    """The common case (every core template, most quick-look files): no
+    `pyproject.toml` anywhere above it, so it ran on the app's own interpreter
+    (SPEC PY-17) — which, under the test suite's pinned `builtin` engine
+    (conftest.py), is simply `sys.executable` of the process answering.
+    """
+    import sys
+
+    client = _client(tmp_path)
+    resp = client.get("/api/env/interpreter", headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["engine"] == "builtin"
+    assert body["interpreter"] == sys.executable
+    assert body["packages"]["duckdb"], "duckdb ships with the app; a version must be reported"
+
+
+def test_a_declared_project_reports_its_own_venv_not_this_process(tmp_path):
+    """A file under a project that declares dependencies runs in THAT project's
+    venv (SPEC PY-16), never on this process's own interpreter — so the
+    endpoint must resolve through the same `project_env_for` the run itself
+    uses, not report `sys.executable` for a file that never touches it.
+    """
+    from fused_render import envinstall
+
+    client = _client(tmp_path)
+    _declare(tmp_path, '"pyproj"')
+    target = _py(tmp_path, "declared.py", "def main():\n    return 1\n")
+
+    resp = client.get("/api/env/interpreter", params={"py": str(target)},
+                      headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["interpreter"] == envinstall.venv_python_for(str(tmp_path))
+    assert body["packages"] is None, (
+        "that venv's packages are not this process's — reporting them here "
+        "would be a guess dressed up as an answer"
+    )
+
+
+def test_interpreter_resolves_a_relative_py_against_the_page(tmp_path):
+    """Mirrors /api/env/install's own rule (test_install_resolves_a_relative_py_
+    against_the_page above): the loader and this endpoint must derive the same
+    project from the same `py`+`html` pair, or a caller could get two different
+    answers about the one file."""
+    from fused_render import envinstall
+
+    client = _client(tmp_path)
+    _declare(tmp_path, '"pyproj"')
+    _py(tmp_path, "declared.py", "def main():\n    return 1\n")
+
+    resp = client.get(
+        "/api/env/interpreter",
+        params={"py": "declared.py", "html": str(tmp_path / "p.html")},
+        headers=HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["interpreter"] == envinstall.venv_python_for(str(tmp_path))
+
+
 # --- the loader's own JS, executed ---------------------------------------------
 #
 # The structural assertions below cannot see behaviour, and both bugs these two

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -355,7 +355,7 @@ def test_a_file_with_no_project_reports_this_process_as_the_interpreter(tmp_path
     assert body["ok"] is True
     assert body["engine"] == "builtin"
     assert body["interpreter"] == sys.executable
-    assert body["packages"]["duckdb"], "duckdb ships with the app; a version must be reported"
+    assert body["python_version"] == sys.version
 
 
 def test_a_declared_project_reports_its_own_venv_not_this_process(tmp_path):
@@ -375,10 +375,6 @@ def test_a_declared_project_reports_its_own_venv_not_this_process(tmp_path):
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["interpreter"] == envinstall.venv_python_for(str(tmp_path))
-    assert body["packages"] is None, (
-        "that venv's packages are not this process's — reporting them here "
-        "would be a guess dressed up as an answer"
-    )
     assert body["python_version"] is None, (
         "the venv can pin a different Python than the app (SPEC PY-16) — "
         "this process's own sys.version is not known to match it"

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -327,101 +327,90 @@ def test_an_engine_that_cannot_answer_is_reported_not_500ed(tmp_path, monkeypatc
     assert str(boom) in resp.json()["error"]
 
 
-# --- /api/env/interpreter: the ground truth for "which python ran this?" ------
+# --- /api/env/custom-env: "is MY OWN interpreter the one that read this?" ----
 #
-# Exists because a shell probe (`which python3`, a fresh `sys.executable`) run
-# from OUTSIDE this app — a Claude Code session embedded beside a file's
-# preview, say — reports whatever that shell's own PATH resolves first, which
-# has no relationship to the interpreter fused-render itself used.
+# A Claude Code session embedded beside a file's preview already knows its own
+# `sys.executable` — the claude template's folder never declares a project, so
+# its process always runs on the app's own interpreter (SPEC PY-17). What it
+# cannot know on its own is whether that MATCHES the file's actual reader: a
+# `.py` may sit in a project declaring dependencies (SPEC PY-16), and some
+# core templates ship their own pyproject.toml too (D276). This endpoint is
+# the one confirmable fact, so the session states its own interpreter only
+# when this says `false` — never a caveated guess.
 
 
-def test_interpreter_endpoint_requires_the_x_fused_header(tmp_path):
+def test_custom_env_endpoint_requires_the_x_fused_header(tmp_path):
     client = _client(tmp_path)
-    assert client.get("/api/env/interpreter").status_code == 403
+    assert client.get("/api/env/custom-env", params={"file": str(tmp_path)}).status_code == 403
 
 
-def test_a_file_with_no_project_reports_this_process_as_the_interpreter(tmp_path):
-    """The common case (every core template, most quick-look files): no
-    `pyproject.toml` anywhere above it, so it ran on the app's own interpreter
-    (SPEC PY-17) — which, under the test suite's pinned `builtin` engine
-    (conftest.py), is simply `sys.executable` of the process answering.
+def test_nonexistent_file_is_an_error_not_a_guess(tmp_path):
+    client = _client(tmp_path)
+    resp = client.get("/api/env/custom-env", params={"file": str(tmp_path / "nope.parquet")},
+                      headers=HEADERS)
+    assert resp.status_code == 400, resp.text
+    assert "no such file or directory" in resp.json()["error"]
+
+
+def test_a_py_file_with_no_project_is_not_custom(tmp_path):
+    """A `.py` IS the script /api/run would execute, so its own
+    `project_env_for` is the direct, exact answer — no project here means the
+    app's own interpreter (agent.py's own `sys.executable`) really did run it.
     """
-    import sys
-
+    target = _py(tmp_path, "a.py", "def main():\n    return 1\n")
     client = _client(tmp_path)
-    resp = client.get("/api/env/interpreter", headers=HEADERS)
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
     assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["ok"] is True
-    assert body["engine"] == "builtin"
-    assert body["interpreter"] == sys.executable
-    assert body["python_version"] == sys.version
+    assert resp.json() == {"ok": True, "custom_env": False}
 
 
-def test_a_declared_project_reports_its_own_venv_not_this_process(tmp_path):
-    """A file under a project that declares dependencies runs in THAT project's
-    venv (SPEC PY-16), never on this process's own interpreter — so the
-    endpoint must resolve through the same `project_env_for` the run itself
-    uses, not report `sys.executable` for a file that never touches it.
-    """
-    from fused_render import envinstall
-
-    client = _client(tmp_path)
+def test_a_py_file_in_a_declared_project_is_custom(tmp_path):
+    """A `.py` inside a project declaring dependencies (SPEC PY-16) runs on
+    THAT project's venv, not the app's own interpreter — the one case the
+    claude session's own `sys.executable` would be a wrong answer for."""
     _declare(tmp_path, '"pyproj"')
     target = _py(tmp_path, "declared.py", "def main():\n    return 1\n")
-
-    resp = client.get("/api/env/interpreter", params={"py": str(target)},
-                      headers=HEADERS)
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["interpreter"] == envinstall.venv_python_for(str(tmp_path))
-    assert body["python_version"] is None, (
-        "the venv can pin a different Python than the app (SPEC PY-16) — "
-        "this process's own sys.version is not known to match it"
-    )
-
-
-def test_a_py_that_cannot_be_resolved_is_an_error_not_a_guess(tmp_path):
-    """A relative `py` with no `html` to resolve it against, or a `py` that
-    resolves to nothing on disk, means resolution FAILED — the endpoint must
-    say so (mirroring /api/env/install's `_project_for`), not fall through to
-    "no project declares one", which asserts a fact resolution never actually
-    established.
-    """
     client = _client(tmp_path)
-
-    resp = client.get("/api/env/interpreter", params={"py": "declared.py"},
-                      headers=HEADERS)
-    assert resp.status_code == 400, resp.text
-    assert "'html'" in resp.json()["error"]
-
-    resp = client.get(
-        "/api/env/interpreter",
-        params={"py": str(tmp_path / "nope.py")},
-        headers=HEADERS,
-    )
-    assert resp.status_code == 400, resp.text
-    assert "no such Python file" in resp.json()["error"]
-
-
-def test_interpreter_resolves_a_relative_py_against_the_page(tmp_path):
-    """Mirrors /api/env/install's own rule (test_install_resolves_a_relative_py_
-    against_the_page above): the loader and this endpoint must derive the same
-    project from the same `py`+`html` pair, or a caller could get two different
-    answers about the one file."""
-    from fused_render import envinstall
-
-    client = _client(tmp_path)
-    _declare(tmp_path, '"pyproj"')
-    _py(tmp_path, "declared.py", "def main():\n    return 1\n")
-
-    resp = client.get(
-        "/api/env/interpreter",
-        params={"py": "declared.py", "html": str(tmp_path / "p.html")},
-        headers=HEADERS,
-    )
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
     assert resp.status_code == 200, resp.text
-    assert resp.json()["interpreter"] == envinstall.venv_python_for(str(tmp_path))
+    assert resp.json() == {"ok": True, "custom_env": True}
+
+
+def test_a_data_file_served_by_a_bare_template_is_not_custom(tmp_path):
+    """A `.parquet`'s default template (duckdb, SPEC PT-7 first-wins) declares
+    no project of its own, so the app's own interpreter genuinely read it —
+    the exact scenario that motivated this endpoint."""
+    target = tmp_path / "data.parquet"
+    target.write_bytes(b"")
+    client = _client(tmp_path)
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "custom_env": False}
+
+
+def test_a_data_file_served_by_a_templated_env_is_custom(tmp_path):
+    """A `.shp`'s default template (vector) ships its own pyproject.toml
+    (D276) — a dedicated venv reads it once built, never the app's own
+    interpreter, so this must say `true` rather than assume "data file ->
+    app's own interpreter" the way the original bug did."""
+    target = tmp_path / "data.shp"
+    target.write_bytes(b"")
+    client = _client(tmp_path)
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "custom_env": True}
+
+
+def test_an_unmapped_file_type_is_custom_by_default(tmp_path):
+    """No template resolves for this extension at all — nothing to check, so
+    the safe answer when genuinely unsure is `true` (don't trust it), never a
+    confident `false` resolution never actually established."""
+    target = tmp_path / "data.zzz-not-a-real-extension"
+    target.write_bytes(b"\x00binary\x01")
+    client = _client(tmp_path)
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "custom_env": True}
 
 
 # --- the loader's own JS, executed ---------------------------------------------

--- a/tests/test_server_env_install.py
+++ b/tests/test_server_env_install.py
@@ -376,6 +376,20 @@ def test_a_py_file_in_a_declared_project_is_custom(tmp_path):
     assert resp.json() == {"ok": True, "custom_env": True}
 
 
+def test_an_uppercase_py_extension_in_a_declared_project_is_custom(tmp_path):
+    """`_match_registry` lowercases basenames before matching, so a `script.PY`
+    must take the SAME direct `project_env_for` path a `script.py` does — not
+    fall through to the registry's `code` template (no pyproject.toml of its
+    own) and report `false` for a file that actually runs on the project's
+    venv (Bugbot on #634)."""
+    _declare(tmp_path, '"pyproj"')
+    target = _py(tmp_path, "DECLARED.PY", "def main():\n    return 1\n")
+    client = _client(tmp_path)
+    resp = client.get("/api/env/custom-env", params={"file": str(target)}, headers=HEADERS)
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {"ok": True, "custom_env": True}
+
+
 def test_a_data_file_served_by_a_bare_template_is_not_custom(tmp_path):
     """A `.parquet`'s default template (duckdb, SPEC PT-7 first-wins) declares
     no project of its own, so the app's own interpreter genuinely read it —


### PR DESCRIPTION
## Summary
Adds a new `/api/env/interpreter` endpoint that reports the actual Python interpreter and package versions used to render a file, addressing the problem where external tools (like Claude Code sessions) cannot reliably determine which Python environment was used by querying the shell's PATH.

## Key Changes

- **New endpoint `/api/env/interpreter`**: Returns ground truth information about which Python interpreter and engine rendered a file, including:
  - The interpreter path (`sys.executable` or project venv)
  - Engine type (fused/builtin)
  - Python version
  - Installed package versions (duckdb, pyarrow, pandas) for the app's own interpreter
  - A human-readable source description

- **Environment detection logic**:
  - For files without a declared project: reports the app's own interpreter and its installed packages
  - For files in a project with `pyproject.toml`: reports that project's venv interpreter (without probing its packages to avoid subprocess overhead)
  - Resolves relative `py` paths against `html` parameter, mirroring the behavior of `/api/env/install`

- **Claude agent integration**: Updated the system prompt in `agent.py` to inform Claude Code sessions about the availability of this endpoint, directing them to use it instead of shell probes for accurate environment information

- **Comprehensive test coverage**: Added tests validating:
  - X-Fused header requirement
  - Correct interpreter reporting for files without projects
  - Correct venv reporting for declared projects
  - Relative path resolution against HTML context

## Implementation Details

- Requires `X-Fused` header for security (consistent with other env endpoints)
- Introduced `_REPORTED_PACKAGES` constant to define which packages are reported for the app's own interpreter
- Leverages existing `projectenv` and `envinstall` modules for project detection and venv resolution
- Gracefully handles missing packages with try/except ImportError

https://claude.ai/code/session_01WkThr2joq9psRBem2dWeC5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Advisory read-only endpoint and optional prompt text; agent failures are swallowed. Minor risk from relying on internal `_templates_for` and defaulting to conservative `custom_env: true` when resolution is unclear.
> 
> **Overview**
> Adds **`GET /api/env/custom-env`** (requires **`X-Fused`**) so callers can tell whether the **preview/runtime for a path** uses a **declared project or template venv** versus the app’s **bundled interpreter**. For **`.py`** files it uses **`project_env_for`** (with **case-insensitive** `.py` handling); for other paths it checks the **default template** from the same registry **`/render`** uses and whether that template folder has a project env. Missing paths return **400**; unknown or unmapped templates default to **`custom_env: true`** (don’t trust the session interpreter).
> 
> The **Claude `agent.py`** file target prompt calls this endpoint when **`origin`** is set; on a confirmed **`custom_env: false`** it tells the model to use **`sys.executable`** for Python inspection instead of **`python`/`python3` on PATH**. Network or parse failures are ignored so spawn never fails.
> 
> Tests cover auth, error cases, `.py` with/without projects, uppercase extensions, parquet vs shapefile templates, and unmapped extensions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21edb88d330de360164767d87ca2f546e5ac3c65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->